### PR TITLE
[RPC] - Change results property of DevInspectResult

### DIFF
--- a/.changeset/young-mangos-complain.md
+++ b/.changeset/young-mangos-complain.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Changed the getOwnerObjectsForAddress api to getOwnedObjects, and added options/ pagination to the parameters

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8641,7 +8641,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "sui"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -8882,7 +8882,7 @@ dependencies = [
 
 [[package]]
 name = "sui-core"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -9006,7 +9006,7 @@ dependencies = [
 
 [[package]]
 name = "sui-faucet"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9283,7 +9283,7 @@ dependencies = [
 
 [[package]]
 name = "sui-move"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9363,7 +9363,7 @@ dependencies = [
 
 [[package]]
 name = "sui-node"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -9520,7 +9520,7 @@ dependencies = [
 
 [[package]]
 name = "sui-sdk"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -9728,7 +9728,7 @@ dependencies = [
 
 [[package]]
 name = "sui-tool"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anemo",
  "anemo-cli",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8641,7 +8641,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "sui"
-version = "0.29.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -8882,7 +8882,7 @@ dependencies = [
 
 [[package]]
 name = "sui-core"
-version = "0.29.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -9006,7 +9006,7 @@ dependencies = [
 
 [[package]]
 name = "sui-faucet"
-version = "0.29.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9283,7 +9283,7 @@ dependencies = [
 
 [[package]]
 name = "sui-move"
-version = "0.29.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9363,7 +9363,7 @@ dependencies = [
 
 [[package]]
 name = "sui-node"
-version = "0.29.0"
+version = "0.28.0"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -9520,7 +9520,7 @@ dependencies = [
 
 [[package]]
 name = "sui-sdk"
-version = "0.29.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -9728,7 +9728,7 @@ dependencies = [
 
 [[package]]
 name = "sui-tool"
-version = "0.29.0"
+version = "0.28.0"
 dependencies = [
  "anemo",
  "anemo-cli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ members = [
 
 [workspace.package]
 # This version string will be inherited by sui-core, sui-faucet, sui-node, sui-tools, sui-sdk, and sui crates
-version = "0.29.0"
+version = "0.28.0"
 
 [profile.release]
 # debug = 1 means line charts only, which is minimum needed for good stack traces

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ members = [
 
 [workspace.package]
 # This version string will be inherited by sui-core, sui-faucet, sui-node, sui-tools, sui-sdk, and sui crates
-version = "0.28.0"
+version = "0.28.1"
 
 [profile.release]
 # debug = 1 means line charts only, which is minimum needed for good stack traces

--- a/apps/explorer/src/components/ownedobjects/OwnedObjects.tsx
+++ b/apps/explorer/src/components/ownedobjects/OwnedObjects.tsx
@@ -58,7 +58,7 @@ function OwnedObject({ id, byAddress }: { id: string; byAddress: boolean }) {
         setIsFail(false);
         setIsLoaded(false);
         const req = byAddress
-            ? rpc.getObjectsOwnedByAddress({ owner: id })
+            ? rpc.getOwnedObjects({ owner: id })
             : rpc.getDynamicFields({ parentId: id });
 
         req.then((objects) => {

--- a/apps/explorer/src/utils/api/searchUtil.ts
+++ b/apps/explorer/src/utils/api/searchUtil.ts
@@ -35,7 +35,7 @@ export const navigateWithUnknown = async (
     else if (isValidSuiAddress(input) || isGenesisLibAddress(input)) {
         const addrObjPromise = Promise.allSettled([
             rpc(network)
-                .getObjectsOwnedByAddress({ owner: input })
+                .getOwnedObjects({ owner: input })
                 .then((data) => {
                     if (data.length <= 0)
                         throw new Error('No objects for Address');

--- a/apps/wallet/src/ui/app/hooks/useObjectsOwnedByAddress.ts
+++ b/apps/wallet/src/ui/app/hooks/useObjectsOwnedByAddress.ts
@@ -10,7 +10,7 @@ export function useObjectsOwnedByAddress(address?: SuiAddress | null) {
     const rpc = useRpcClient();
     return useQuery(
         ['objects-owned', address],
-        () => rpc.getObjectsOwnedByAddress({ owner: address! }),
+        () => rpc.getOwnedObjects({ owner: address! }),
         {
             enabled: !!address,
         }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2149,9 +2149,14 @@ impl AuthorityState {
             .map(|o| o.owner)
     }
 
-    pub fn get_owner_objects(&self, owner: SuiAddress) -> SuiResult<Vec<ObjectInfo>> {
+    pub fn get_owner_objects(
+        &self,
+        owner: SuiAddress,
+        cursor: Option<ObjectID>,
+        limit: usize,
+    ) -> SuiResult<Vec<ObjectInfo>> {
         if let Some(indexes) = &self.indexes {
-            indexes.get_owner_objects(owner)
+            indexes.get_owner_objects(owner, cursor, limit)
         } else {
             Err(SuiError::IndexStoreNotAvailable)
         }

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2,15 +2,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::*;
-use crate::authority::move_integration_tests::build_and_publish_test_package_with_upgrade_cap;
-use crate::consensus_handler::SequencedConsensusTransaction;
-use crate::{
-    authority_client::{AuthorityAPI, NetworkAuthorityClient},
-    authority_server::AuthorityServer,
-    checkpoints::CheckpointServiceNoop,
-    test_utils::init_state_parameters_from_rng,
-};
+use std::collections::HashSet;
+use std::fs;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::{convert::TryInto, env};
+
 use bcs;
 use futures::{stream::FuturesUnordered, StreamExt};
 use move_binary_format::{
@@ -19,6 +17,7 @@ use move_binary_format::{
 };
 use move_core_types::identifier::IdentStr;
 use move_core_types::language_storage::StructTag;
+use move_core_types::parser::parse_type_tag;
 use move_core_types::{
     account_address::AccountAddress, ident_str, identifier::Identifier, language_storage::TypeTag,
 };
@@ -28,34 +27,26 @@ use rand::{
     Rng, SeedableRng,
 };
 use serde_json::json;
-use std::collections::HashSet;
-use std::fs;
-use std::future::Future;
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use tracing::info;
+
 use sui_json_rpc_types::{
     SuiArgument, SuiExecutionResult, SuiExecutionStatus, SuiGasCostSummary,
     SuiTransactionEffectsAPI, SuiTypeTag,
 };
-use sui_types::error::UserInputError;
-use sui_types::gas_coin::GasCoin;
-use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
-use sui_types::utils::{
-    make_committee_key, mock_certified_checkpoint, to_sender_signed_transaction,
-    to_sender_signed_transaction_with_multi_signers,
-};
-use sui_types::{SUI_CLOCK_OBJECT_ID, SUI_CLOCK_OBJECT_SHARED_VERSION, SUI_FRAMEWORK_OBJECT_ID};
-
-use crate::epoch::epoch_metrics::EpochMetrics;
-use move_core_types::parser::parse_type_tag;
-use std::{convert::TryInto, env};
 use sui_macros::sim_test;
 use sui_protocol_config::{ProtocolConfig, SupportedProtocolVersions};
 use sui_types::dynamic_field::DynamicFieldType;
 use sui_types::epoch_data::EpochData;
+use sui_types::error::UserInputError;
+use sui_types::gas_coin::GasCoin;
 use sui_types::object::Data;
+use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemState;
 use sui_types::sui_system_state::SuiSystemStateWrapper;
+use sui_types::utils::{make_committee_key, mock_certified_checkpoint};
+use sui_types::utils::{
+    to_sender_signed_transaction, to_sender_signed_transaction_with_multi_signers,
+};
 use sui_types::{
     base_types::dbg_addr,
     crypto::{get_key_pair, Signature},
@@ -65,7 +56,19 @@ use sui_types::{
     object::{Owner, GAS_VALUE_FOR_TESTING, OBJECT_START_VERSION},
     SUI_SYSTEM_STATE_OBJECT_ID,
 };
-use tracing::info;
+use sui_types::{SUI_CLOCK_OBJECT_ID, SUI_CLOCK_OBJECT_SHARED_VERSION, SUI_FRAMEWORK_OBJECT_ID};
+
+use crate::authority::move_integration_tests::build_and_publish_test_package_with_upgrade_cap;
+use crate::consensus_handler::SequencedConsensusTransaction;
+use crate::epoch::epoch_metrics::EpochMetrics;
+use crate::{
+    authority_client::{AuthorityAPI, NetworkAuthorityClient},
+    authority_server::AuthorityServer,
+    checkpoints::CheckpointServiceNoop,
+    test_utils::init_state_parameters_from_rng,
+};
+
+use super::*;
 
 pub enum TestCallArg {
     Pure(Vec<u8>),
@@ -5323,4 +5326,77 @@ async fn test_gas_smashing() {
     run_and_check(reference_gas_used, 30, reference_gas_used, false).await;
     // use a small amount less than what 3 coins above reported (with success)
     run_and_check(three_coin_gas, 3, three_coin_gas - 1, false).await;
+}
+
+#[tokio::test]
+async fn test_for_inc_201_dev_inspect() {
+    use sui_framework_build::compiled_package::BuildConfig;
+
+    let (sender, _sender_key): (_, AccountKeyPair) = get_key_pair();
+    let gas_object_id = ObjectID::random();
+    let (_, fullnode, _) =
+        init_state_with_ids_and_object_basics_with_fullnode(vec![(sender, gas_object_id)]).await;
+
+    // Module bytes
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("src/unit_tests/data/publish_with_event");
+    let modules = BuildConfig::new_for_testing()
+        .build(path)
+        .unwrap()
+        .get_package_bytes(false);
+
+    let mut builder = ProgrammableTransactionBuilder::new();
+    builder.command(Command::Publish(modules));
+    let kind = TransactionKind::programmable(builder.finish());
+    let DevInspectResults { events, .. } = fullnode
+        .dev_inspect_transaction(sender, kind, Some(1))
+        .await
+        .unwrap();
+
+    assert_eq!(1, events.data.len());
+    assert_eq!(
+        "PublishEvent".to_string(),
+        events.data[0].type_.name.to_string()
+    );
+    assert_eq!(json!({"foo":"bar"}), events.data[0].parsed_json);
+}
+
+#[tokio::test]
+async fn test_for_inc_201_dry_run() {
+    use sui_framework_build::compiled_package::BuildConfig;
+
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let gas_object_id = ObjectID::random();
+    let (_, fullnode, _) =
+        init_state_with_ids_and_object_basics_with_fullnode(vec![(sender, gas_object_id)]).await;
+
+    // Module bytes
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("src/unit_tests/data/publish_with_event");
+    let modules = BuildConfig::new_for_testing()
+        .build(path)
+        .unwrap()
+        .get_package_bytes(false);
+
+    let mut builder = ProgrammableTransactionBuilder::new();
+    builder.publish_immutable(modules);
+    let kind = TransactionKind::programmable(builder.finish());
+
+    let txn_data = TransactionData::new_with_gas_coins(kind, sender, vec![], 10000, 1);
+
+    let signed = to_sender_signed_transaction(txn_data, &sender_key);
+    let DryRunTransactionResponse { events, .. } = fullnode
+        .dry_exec_transaction(
+            signed.data().intent_message().value.clone(),
+            *signed.digest(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(1, events.data.len());
+    assert_eq!(
+        "PublishEvent".to_string(),
+        events.data[0].type_.name.to_string()
+    );
+    assert_eq!(json!({"foo":"bar"}), events.data[0].parsed_json);
 }

--- a/crates/sui-core/src/unit_tests/data/publish_with_event/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/publish_with_event/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "Examples"
+version = "0.0.1"
+
+[dependencies]
+Sui = { local = "../../../../../sui-framework" }
+
+[addresses]
+examples = "0x0"

--- a/crates/sui-core/src/unit_tests/data/publish_with_event/sources/publish.move
+++ b/crates/sui-core/src/unit_tests/data/publish_with_event/sources/publish.move
@@ -1,0 +1,17 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module examples::publish_with_event {
+    use std::ascii::{Self, String};
+
+    use sui::event;
+    use sui::tx_context::TxContext;
+
+    struct PublishEvent has copy, drop {
+        foo: String
+    }
+
+    fun init(_ctx: &mut TxContext) {
+        event::emit(PublishEvent { foo: ascii::string(b"bar") })
+    }
+}

--- a/crates/sui-indexer/src/apis/read_api.rs
+++ b/crates/sui-indexer/src/apis/read_api.rs
@@ -11,9 +11,9 @@ use std::collections::BTreeMap;
 use sui_json_rpc::api::{cap_page_limit, ReadApiClient, ReadApiServer};
 use sui_json_rpc::SuiRpcModule;
 use sui_json_rpc_types::{
-    Checkpoint, CheckpointId, DynamicFieldPage, MoveFunctionArgType, Page, SuiGetPastObjectRequest,
-    SuiMoveNormalizedFunction, SuiMoveNormalizedModule, SuiMoveNormalizedStruct,
-    SuiObjectDataOptions, SuiObjectInfo, SuiObjectResponse, SuiPastObjectResponse,
+    Checkpoint, CheckpointId, DynamicFieldPage, MoveFunctionArgType, ObjectsPage, Page,
+    SuiGetPastObjectRequest, SuiMoveNormalizedFunction, SuiMoveNormalizedModule,
+    SuiMoveNormalizedStruct, SuiObjectDataOptions, SuiObjectResponse, SuiPastObjectResponse,
     SuiTransactionResponse, SuiTransactionResponseOptions, SuiTransactionResponseQuery,
     TransactionsPage,
 };
@@ -212,11 +212,17 @@ impl<S> ReadApiServer for ReadApi<S>
 where
     S: IndexerStore + Sync + Send + 'static,
 {
-    async fn get_objects_owned_by_address(
+    async fn get_owned_objects(
         &self,
         address: SuiAddress,
-    ) -> RpcResult<Vec<SuiObjectInfo>> {
-        self.fullnode.get_objects_owned_by_address(address).await
+        options: Option<SuiObjectDataOptions>,
+        cursor: Option<ObjectID>,
+        limit: Option<usize>,
+        at_checkpoint: Option<CheckpointId>,
+    ) -> RpcResult<ObjectsPage> {
+        self.fullnode
+            .get_owned_objects(address, options, cursor, limit, at_checkpoint)
+            .await
     }
 
     async fn get_object_with_options(

--- a/crates/sui-json-rpc/src/api/mod.rs
+++ b/crates/sui-json-rpc/src/api/mod.rs
@@ -28,6 +28,7 @@ pub use read::ReadApiClient;
 pub use read::ReadApiOpenRpc;
 pub use read::ReadApiServer;
 
+// use anyhow::anyhow;
 pub use transaction_builder::TransactionBuilderClient;
 pub use transaction_builder::TransactionBuilderOpenRpc;
 pub use transaction_builder::TransactionBuilderServer;
@@ -38,11 +39,23 @@ pub use transaction_builder::TransactionBuilderServer;
 /// for document purposes.
 pub const QUERY_MAX_RESULT_LIMIT: usize = 1000;
 
+pub const MAX_GET_OWNED_OBJECT_LIMIT: usize = 256;
+
 pub fn cap_page_limit(limit: Option<usize>) -> usize {
     let limit = limit.unwrap_or_default();
     if limit > QUERY_MAX_RESULT_LIMIT || limit == 0 {
         QUERY_MAX_RESULT_LIMIT
     } else {
         limit
+    }
+}
+
+pub fn cap_page_objects_limit(limit: Option<usize>) -> Result<usize, anyhow::Error> {
+    let limit = limit.unwrap_or(MAX_GET_OWNED_OBJECT_LIMIT);
+    if limit > MAX_GET_OWNED_OBJECT_LIMIT || limit == 0 {
+        Ok(MAX_GET_OWNED_OBJECT_LIMIT)
+        // MUSTFIXD(jian): implement this error: Err(anyhow!("limit is greater than max get owned object size"))
+    } else {
+        Ok(limit)
     }
 }

--- a/crates/sui-json-rpc/src/api/read.rs
+++ b/crates/sui-json-rpc/src/api/read.rs
@@ -5,9 +5,9 @@ use jsonrpsee::core::RpcResult;
 use jsonrpsee_proc_macros::rpc;
 use std::collections::BTreeMap;
 use sui_json_rpc_types::{
-    Checkpoint, CheckpointId, DynamicFieldPage, MoveFunctionArgType, SuiGetPastObjectRequest,
-    SuiMoveNormalizedFunction, SuiMoveNormalizedModule, SuiMoveNormalizedStruct,
-    SuiObjectDataOptions, SuiObjectInfo, SuiObjectResponse, SuiPastObjectResponse,
+    Checkpoint, CheckpointId, DynamicFieldPage, MoveFunctionArgType, ObjectsPage,
+    SuiGetPastObjectRequest, SuiMoveNormalizedFunction, SuiMoveNormalizedModule,
+    SuiMoveNormalizedStruct, SuiObjectDataOptions, SuiObjectResponse, SuiPastObjectResponse,
     SuiTransactionResponse, SuiTransactionResponseOptions, SuiTransactionResponseQuery,
     TransactionsPage,
 };
@@ -22,12 +22,20 @@ use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 #[rpc(server, client, namespace = "sui")]
 pub trait ReadApi {
     /// Return the list of objects owned by an address.
-    #[method(name = "getObjectsOwnedByAddress")]
-    async fn get_objects_owned_by_address(
+    #[method(name = "getOwnedObjects")]
+    async fn get_owned_objects(
         &self,
         /// the owner's Sui address
         address: SuiAddress,
-    ) -> RpcResult<Vec<SuiObjectInfo>>;
+        /// options for specifying the content to be returned
+        options: Option<SuiObjectDataOptions>,
+        /// Optional paging cursor
+        cursor: Option<ObjectID>,
+        /// Max number of items returned per page, default to [MAX_GET_OWNED_OBJECT_SIZE] if not specified.
+        limit: Option<usize>,
+        /// If not specified, objects may be created or deleted across pagination requests. This parameter is only supported when the sui-indexer instance is running.
+        at_checkpoint: Option<CheckpointId>,
+    ) -> RpcResult<ObjectsPage>;
 
     /// Return the list of dynamic field objects owned by an object.
     #[method(name = "getDynamicFields")]

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -9,12 +9,13 @@ use sui_config::SUI_KEYSTORE_FILENAME;
 use sui_framework_build::compiled_package::BuildConfig;
 use sui_json::SuiJsonValue;
 use sui_json_rpc_types::ObjectChange;
+use sui_json_rpc_types::ObjectsPage;
+use sui_json_rpc_types::SuiTransactionResponseQuery;
 use sui_json_rpc_types::{
     Balance, CoinPage, DelegatedStake, StakeStatus, SuiCoinMetadata, SuiExecutionStatus,
     SuiObjectDataOptions, SuiObjectResponse, SuiTransactionEffectsAPI, SuiTransactionResponse,
     SuiTransactionResponseOptions, TransactionBytes,
 };
-use sui_json_rpc_types::{SuiObjectInfo, SuiTransactionResponseQuery};
 use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use sui_macros::sim_test;
 use sui_types::balance::Supply;
@@ -40,11 +41,23 @@ async fn test_get_objects() -> Result<(), anyhow::Error> {
     let http_client = cluster.rpc_client();
     let address = cluster.accounts.first().unwrap();
 
-    let objects = http_client.get_objects_owned_by_address(*address).await?;
-    assert_eq!(5, objects.len());
+    let objects = http_client
+        .get_owned_objects(
+            *address,
+            Some(SuiObjectDataOptions::new()),
+            None,
+            None,
+            None,
+        )
+        .await?;
+    assert_eq!(5, objects.data.len());
 
     // Multiget objectIDs test
-    let object_digests = objects.iter().map(|o| o.object_id).collect();
+    let object_digests = objects
+        .data
+        .iter()
+        .map(|o| o.object().unwrap().object_id)
+        .collect();
 
     let object_resp = http_client
         .multi_get_object_with_options(object_digests, None)
@@ -59,16 +72,22 @@ async fn test_public_transfer_object() -> Result<(), anyhow::Error> {
     let http_client = cluster.rpc_client();
     let address = cluster.accounts.first().unwrap();
 
-    let objects = http_client.get_objects_owned_by_address(*address).await?;
+    let objects = http_client
+        .get_owned_objects(
+            *address,
+            Some(SuiObjectDataOptions::full_content()),
+            None,
+            None,
+            None,
+        )
+        .await?
+        .data;
+
+    let obj = objects.clone().first().unwrap().object().unwrap().object_id;
+    let gas = objects.clone().last().unwrap().object().unwrap().object_id;
 
     let transaction_bytes: TransactionBytes = http_client
-        .transfer_object(
-            *address,
-            objects.first().unwrap().object_id,
-            Some(objects.last().unwrap().object_id),
-            1000,
-            *address,
-        )
+        .transfer_object(*address, obj, Some(gas), 1000, *address)
         .await?;
 
     let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);
@@ -101,8 +120,16 @@ async fn test_publish() -> Result<(), anyhow::Error> {
     let http_client = cluster.rpc_client();
     let address = cluster.accounts.first().unwrap();
 
-    let objects = http_client.get_objects_owned_by_address(*address).await?;
-    let gas = objects.first().unwrap();
+    let objects = http_client
+        .get_owned_objects(
+            *address,
+            Some(SuiObjectDataOptions::full_content()),
+            None,
+            None,
+            None,
+        )
+        .await?;
+    let gas = objects.data.first().unwrap().object().unwrap();
 
     let compiled_modules = BuildConfig::new_for_testing()
         .build(Path::new("../../sui_programmability/examples/fungible_tokens").to_path_buf())?
@@ -135,9 +162,19 @@ async fn test_move_call() -> Result<(), anyhow::Error> {
     let http_client = cluster.rpc_client();
     let address = cluster.accounts.first().unwrap();
 
-    let objects = http_client.get_objects_owned_by_address(*address).await?;
-    let gas = objects.first().unwrap();
-    let coin = &objects[1];
+    let objects = http_client
+        .get_owned_objects(
+            *address,
+            Some(SuiObjectDataOptions::full_content()),
+            None,
+            None,
+            None,
+        )
+        .await?
+        .data;
+
+    let gas = objects.first().unwrap().object().unwrap();
+    let coin = &objects[1].object()?;
 
     // now do the call
     let package_id = ObjectID::new(SUI_FRAMEWORK_ADDRESS.into_bytes());
@@ -186,9 +223,19 @@ async fn test_get_object_info() -> Result<(), anyhow::Error> {
     let cluster = TestClusterBuilder::new().build().await?;
     let http_client = cluster.rpc_client();
     let address = cluster.accounts.first().unwrap();
-    let objects = http_client.get_objects_owned_by_address(*address).await?;
+    let objects = http_client
+        .get_owned_objects(
+            *address,
+            Some(SuiObjectDataOptions::full_content()),
+            None,
+            None,
+            None,
+        )
+        .await?
+        .data;
 
-    for oref in objects {
+    for obj in objects {
+        let oref = obj.into_object().unwrap();
         let result = http_client
             .get_object_with_options(
                 oref.object_id,
@@ -265,8 +312,18 @@ async fn test_get_metadata() -> Result<(), anyhow::Error> {
     let http_client = cluster.rpc_client();
     let address = cluster.accounts.first().unwrap();
 
-    let objects = http_client.get_objects_owned_by_address(*address).await?;
-    let gas = objects.first().unwrap();
+    let objects = http_client
+        .get_owned_objects(
+            *address,
+            Some(SuiObjectDataOptions::full_content()),
+            None,
+            None,
+            None,
+        )
+        .await?
+        .data;
+
+    let gas = objects.first().unwrap().object().unwrap();
 
     // Publish test coin package
     let compiled_modules = BuildConfig::default()
@@ -326,8 +383,17 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
     let http_client = cluster.rpc_client();
     let address = cluster.accounts.first().unwrap();
 
-    let objects = http_client.get_objects_owned_by_address(*address).await?;
-    let gas = objects.first().unwrap();
+    let objects = http_client
+        .get_owned_objects(
+            *address,
+            Some(SuiObjectDataOptions::full_content()),
+            None,
+            None,
+            None,
+        )
+        .await?
+        .data;
+    let gas = objects.first().unwrap().object().unwrap();
 
     // Publish test coin package
     let compiled_modules = BuildConfig::new_for_testing()
@@ -445,12 +511,22 @@ async fn test_get_transaction() -> Result<(), anyhow::Error> {
     let http_client = cluster.rpc_client();
     let address = cluster.accounts.first().unwrap();
 
-    let objects = http_client.get_objects_owned_by_address(*address).await?;
-    let gas_id = objects.last().unwrap().object_id;
+    let objects = http_client
+        .get_owned_objects(
+            *address,
+            Some(SuiObjectDataOptions::full_content()),
+            None,
+            None,
+            None,
+        )
+        .await?
+        .data;
+    let gas_id = objects.last().unwrap().object().unwrap().object_id;
 
     // Make some transactions
     let mut tx_responses: Vec<SuiTransactionResponse> = Vec::new();
-    for oref in &objects[..objects.len() - 1] {
+    for obj in &objects[..objects.len() - 1] {
+        let oref = obj.object().unwrap();
         let transaction_bytes: TransactionBytes = http_client
             .transfer_object(*address, oref.object_id, Some(gas_id), 1000, *address)
             .await?;
@@ -525,13 +601,20 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
     for address in cluster.accounts.iter() {
         let objects = client
             .read_api()
-            .get_objects_owned_by_address(*address)
-            .await
-            .unwrap();
-        let gas_id = objects.last().unwrap().object_id;
+            .get_owned_objects(
+                *address,
+                Some(SuiObjectDataOptions::full_content()),
+                None,
+                None,
+                None,
+            )
+            .await?
+            .data;
+        let gas_id = objects.last().unwrap().object().unwrap().object_id;
 
         // Make some transactions
-        for oref in &objects[..objects.len() - 1] {
+        for obj in &objects[..objects.len() - 1] {
+            let oref = obj.object().unwrap();
             let data = client
                 .transaction_builder()
                 .transfer_object(*address, oref.object_id, Some(gas_id), 1000, *address)
@@ -663,7 +746,16 @@ async fn test_locked_sui() -> Result<(), anyhow::Error> {
     let http_client = cluster.rpc_client();
     let address = cluster.accounts.first().unwrap();
 
-    let objects = http_client.get_objects_owned_by_address(*address).await?;
+    let objects = http_client
+        .get_owned_objects(
+            *address,
+            Some(SuiObjectDataOptions::full_content()),
+            None,
+            None,
+            None,
+        )
+        .await?
+        .data;
     assert_eq!(5, objects.len());
     // verify coins and balance before test
     let coins: CoinPage = http_client.get_coins(*address, None, None, None).await?;
@@ -730,8 +822,16 @@ async fn test_staking() -> Result<(), anyhow::Error> {
     let http_client = cluster.rpc_client();
     let address = cluster.accounts.first().unwrap();
 
-    let objects: Vec<SuiObjectInfo> = http_client.get_objects_owned_by_address(*address).await?;
-    assert_eq!(5, objects.len());
+    let objects: ObjectsPage = http_client
+        .get_owned_objects(
+            *address,
+            Some(SuiObjectDataOptions::full_content()),
+            None,
+            None,
+            None,
+        )
+        .await?;
+    assert_eq!(5, objects.data.len());
 
     // Check StakedSui object before test
     let staked_sui: Vec<DelegatedStake> = http_client.get_delegated_stakes(*address).await?;
@@ -743,16 +843,10 @@ async fn test_staking() -> Result<(), anyhow::Error> {
         .active_validators[0]
         .sui_address;
 
+    let coin = objects.data[0].object()?.object_id;
     // Delegate some SUI
     let transaction_bytes: TransactionBytes = http_client
-        .request_add_stake(
-            *address,
-            vec![objects[0].object_id],
-            Some(1000000),
-            validator,
-            None,
-            10000,
-        )
+        .request_add_stake(*address, vec![coin], Some(1000000), validator, None, 10000)
         .await?;
     let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);
     let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -12,7 +12,7 @@
       "name": "Apache-2.0",
       "url": "https://raw.githubusercontent.com/MystenLabs/sui/main/LICENSE"
     },
-    "version": "0.28.0"
+    "version": "0.28.1"
   },
   "methods": [
     {

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -147,12 +147,12 @@
           "params": [
             {
               "name": "tx_bytes",
-              "value": "AAACACBVfcQqrv7rjBVNfdxFa4rqoxMsdANTHcmOg/bhmNLX0QEAe6kd3H5xfPcIyTcGDwQEhzbsM/sXRtmZpeWM1cZ37YACAAAAAAAAACDMyql6Asw6mAQWcOFgnbcU6YWMlunkaYVfHPO/35foZQEBAQEBAAEAAKLbPvxciHXLx8I/1oaODgBen0UVV1O1GrcY0djTxpZ5AU+C8chYe5jWTAC/tGw4Q72L9sz6fGWoYThpjNH9ysPcAgAAAAAAAAAg6NjHzoY/MT2j29kqg+8m0Si4j+Zr8m4ODQnNr3J9HYSi2z78XIh1y8fCP9aGjg4AXp9FFVdTtRq3GNHY08aWeQEAAAAAAAAA6AMAAAAAAAAA"
+              "value": "AAACACB7qR3cfnF89wjJNwYPBASHNuwz+xdG2Zml5YzVxnftgAEAT4LxyFh7mNZMAL+0bDhDvYv2zPp8ZahhOGmM0f3Kw9wCAAAAAAAAACCxDABG4pPAjOwPQHg9msS/SrtNf4IGR/2F0ZGD3ufH/wEBAQEBAAEAAGH7tbTzQqQL2/h/5KlGueONGM+P/HsAALl1F1x7apV2AejYx86GPzE9o9vZKoPvJtEouI/ma/JuDg0Jza9yfR2EAgAAAAAAAAAgzMqpegLMOpgEFnDhYJ23FOmFjJbp5GmFXxzzv9+X6GVh+7W080KkC9v4f+SpRrnjjRjPj/x7AAC5dRdce2qVdgEAAAAAAAAA6AMAAAAAAAAA"
             },
             {
               "name": "signatures",
               "value": [
-                "AAmK13oLtvzqPaCtoKa6iV3mqatbj2TBOlIcirVXwiBMayaDlXrG8IXFukdPrz6rfys2rBuLs5Y4npPzU/0DLQxtqSk/XTlS5stFH/W02Kxeyb0TWYjhlUjBKhMcXPgTNg=="
+                "ALhGcUtEV3kT9ukC4ItNjlv5/gATBGmWEQan7ri2YKHzbtI2rSMpWvxUg7CN+Jap2zPyhfXIes+xt9Q60H2Ylw1Dij1TvBYKLcfLNo8fq6GASb9yfo6uvuwNUBGkTf54wQ=="
               ]
             },
             {
@@ -173,15 +173,15 @@
           "result": {
             "name": "Result",
             "value": {
-              "digest": "7Z7obfSwcXXZ3UJ5opYvSo2d9X8mWqLCKD1fx7T4nvZT",
+              "digest": "2Hjgdebhao13ea4AUoE2cxQqrWYSz6iK88tqf53WdaWY",
               "transaction": {
                 "data": {
                   "messageVersion": "v1",
                   "transaction": {
                     "kind": "ProgrammableTransaction",
                     "inputs": [
-                      "0x557dc42aaefeeb8c154d7ddc456b8aeaa3132c7403531dc98e83f6e198d2d7d1",
-                      "7ba91ddc7e717cf708c937060f04048736ec33fb1746d999a5e58cd5c677ed80"
+                      "0x7ba91ddc7e717cf708c937060f04048736ec33fb1746d999a5e58cd5c677ed80",
+                      "4f82f1c8587b98d64c00bfb46c3843bd8bf6ccfa7c65a86138698cd1fdcac3dc"
                     ],
                     "commands": [
                       {
@@ -198,22 +198,22 @@
                       }
                     ]
                   },
-                  "sender": "0xa2db3efc5c8875cbc7c23fd6868e0e005e9f45155753b51ab718d1d8d3c69679",
+                  "sender": "0x61fbb5b4f342a40bdbf87fe4a946b9e38d18cf8ffc7b0000b975175c7b6a9576",
                   "gasData": {
                     "payment": [
                       {
-                        "objectId": "0x4f82f1c8587b98d64c00bfb46c3843bd8bf6ccfa7c65a86138698cd1fdcac3dc",
+                        "objectId": "0xe8d8c7ce863f313da3dbd92a83ef26d128b88fe66bf26e0e0d09cdaf727d1d84",
                         "version": 2,
-                        "digest": "GfwJqw63FK6AVQnKKkQprvrk3cVLziMBqhMfNkDuCHj9"
+                        "digest": "EnRQXe1hDGAJCFyF2ds2GmPHdvf9V6yxf24LisEsDkYt"
                       }
                     ],
-                    "owner": "0xa2db3efc5c8875cbc7c23fd6868e0e005e9f45155753b51ab718d1d8d3c69679",
+                    "owner": "0x61fbb5b4f342a40bdbf87fe4a946b9e38d18cf8ffc7b0000b975175c7b6a9576",
                     "price": 1,
                     "budget": 1000
                   }
                 },
                 "txSignatures": [
-                  "AAmK13oLtvzqPaCtoKa6iV3mqatbj2TBOlIcirVXwiBMayaDlXrG8IXFukdPrz6rfys2rBuLs5Y4npPzU/0DLQxtqSk/XTlS5stFH/W02Kxeyb0TWYjhlUjBKhMcXPgTNg=="
+                  "ALhGcUtEV3kT9ukC4ItNjlv5/gATBGmWEQan7ri2YKHzbtI2rSMpWvxUg7CN+Jap2zPyhfXIes+xt9Q60H2Ylw1Dij1TvBYKLcfLNo8fq6GASb9yfo6uvuwNUBGkTf54wQ=="
                 ]
               },
               "effects": {
@@ -227,52 +227,52 @@
                   "storageCost": 100,
                   "storageRebate": 10
                 },
-                "transactionDigest": "B3xLC8EbyvTxy5pgiwTNUzHLa6kS7uwD6sZdErKB8F8f",
+                "transactionDigest": "8UExPV121BEfWkbymSPDYhh23rVNh3MSWtC5juJ9JGMJ",
                 "mutated": [
                   {
                     "owner": {
-                      "AddressOwner": "0xa2db3efc5c8875cbc7c23fd6868e0e005e9f45155753b51ab718d1d8d3c69679"
+                      "AddressOwner": "0x61fbb5b4f342a40bdbf87fe4a946b9e38d18cf8ffc7b0000b975175c7b6a9576"
                     },
                     "reference": {
-                      "objectId": "0x4f82f1c8587b98d64c00bfb46c3843bd8bf6ccfa7c65a86138698cd1fdcac3dc",
+                      "objectId": "0xe8d8c7ce863f313da3dbd92a83ef26d128b88fe66bf26e0e0d09cdaf727d1d84",
                       "version": 2,
-                      "digest": "GfwJqw63FK6AVQnKKkQprvrk3cVLziMBqhMfNkDuCHj9"
+                      "digest": "EnRQXe1hDGAJCFyF2ds2GmPHdvf9V6yxf24LisEsDkYt"
                     }
                   },
                   {
                     "owner": {
-                      "AddressOwner": "0x557dc42aaefeeb8c154d7ddc456b8aeaa3132c7403531dc98e83f6e198d2d7d1"
+                      "AddressOwner": "0x7ba91ddc7e717cf708c937060f04048736ec33fb1746d999a5e58cd5c677ed80"
                     },
                     "reference": {
-                      "objectId": "0x7ba91ddc7e717cf708c937060f04048736ec33fb1746d999a5e58cd5c677ed80",
+                      "objectId": "0x4f82f1c8587b98d64c00bfb46c3843bd8bf6ccfa7c65a86138698cd1fdcac3dc",
                       "version": 2,
-                      "digest": "EnRQXe1hDGAJCFyF2ds2GmPHdvf9V6yxf24LisEsDkYt"
+                      "digest": "Cv7n2YaM7Am1ssZGu4khsFkcKHnpgVhwFCSs4kLjrtLW"
                     }
                   }
                 ],
                 "gasObject": {
                   "owner": {
-                    "ObjectOwner": "0xa2db3efc5c8875cbc7c23fd6868e0e005e9f45155753b51ab718d1d8d3c69679"
+                    "ObjectOwner": "0x61fbb5b4f342a40bdbf87fe4a946b9e38d18cf8ffc7b0000b975175c7b6a9576"
                   },
                   "reference": {
-                    "objectId": "0x4f82f1c8587b98d64c00bfb46c3843bd8bf6ccfa7c65a86138698cd1fdcac3dc",
+                    "objectId": "0xe8d8c7ce863f313da3dbd92a83ef26d128b88fe66bf26e0e0d09cdaf727d1d84",
                     "version": 2,
-                    "digest": "GfwJqw63FK6AVQnKKkQprvrk3cVLziMBqhMfNkDuCHj9"
+                    "digest": "EnRQXe1hDGAJCFyF2ds2GmPHdvf9V6yxf24LisEsDkYt"
                   }
                 },
-                "eventsDigest": "8UExPV121BEfWkbymSPDYhh23rVNh3MSWtC5juJ9JGMJ"
+                "eventsDigest": "55TNn3v5vpuXjQfjqamw76P9GZD522pumo4NuT7RYeFB"
               },
               "objectChanges": [
                 {
                   "type": "transferred",
-                  "sender": "0xa2db3efc5c8875cbc7c23fd6868e0e005e9f45155753b51ab718d1d8d3c69679",
+                  "sender": "0x61fbb5b4f342a40bdbf87fe4a946b9e38d18cf8ffc7b0000b975175c7b6a9576",
                   "recipient": {
-                    "AddressOwner": "0x557dc42aaefeeb8c154d7ddc456b8aeaa3132c7403531dc98e83f6e198d2d7d1"
+                    "AddressOwner": "0x7ba91ddc7e717cf708c937060f04048736ec33fb1746d999a5e58cd5c677ed80"
                   },
                   "objectType": "0x2::example::Object",
-                  "objectId": "0x7ba91ddc7e717cf708c937060f04048736ec33fb1746d999a5e58cd5c677ed80",
+                  "objectId": "0x4f82f1c8587b98d64c00bfb46c3843bd8bf6ccfa7c65a86138698cd1fdcac3dc",
                   "version": 2,
-                  "digest": "Cv7n2YaM7Am1ssZGu4khsFkcKHnpgVhwFCSs4kLjrtLW"
+                  "digest": "B3xLC8EbyvTxy5pgiwTNUzHLa6kS7uwD6sZdErKB8F8f"
                 }
               ]
             }
@@ -424,9 +424,9 @@
             "value": {
               "epoch": 5000,
               "sequenceNumber": 1000,
-              "digest": "55TNn3v5vpuXjQfjqamw76P9GZD522pumo4NuT7RYeFB",
+              "digest": "GMkZ4a6i2fffTRY1K8PpKt275xuk9SmYykpLhAgMLekq",
               "networkTotalTransactions": 792385,
-              "previousDigest": "GMkZ4a6i2fffTRY1K8PpKt275xuk9SmYykpLhAgMLekq",
+              "previousDigest": "5toSLTmiTe8VRSUbHxuW9w5JXVxjjE1MyajzG5tb52UQ",
               "epochRollingGasCostSummary": {
                 "computationCost": 0,
                 "storageCost": 0,
@@ -435,7 +435,7 @@
               "timestampMs": 1676911928,
               "endOfEpochData": null,
               "transactions": [
-                "5toSLTmiTe8VRSUbHxuW9w5JXVxjjE1MyajzG5tb52UQ"
+                "3bpzHaSLTQ6p4trLDk2euZxzQ6XqLeWDmUNTAdEXXL2c"
               ],
               "checkpointCommitments": []
             }
@@ -683,7 +683,7 @@
           "params": [
             {
               "name": "transaction_digest",
-              "value": "9DxQjFvr8wPTJUA92FNGAxwN13ZQXUaG6pkLKgvmykMy"
+              "value": "Bo1wDt96tFw2NjYMr5z8YBVyG1vn1RttXfgx1rQWUZ9x"
             }
           ],
           "result": {
@@ -695,9 +695,9 @@
                     "txDigest": "11a72GCQ5hGNpWGh2QhQkkusTEGS6EDqifJqxr7nSYX",
                     "eventSeq": 0
                   },
-                  "packageId": "0x5f01a29887a1d95e5b548b616da63b0ce07d816e89ef7b9a382177b4422bbaa2",
+                  "packageId": "0x7f7e625ea319aa0a1848666ffed2291ae24a3f8177353a05220d765ca9c421a3",
                   "transactionModule": "test_module",
-                  "sender": "0x7f7e625ea319aa0a1848666ffed2291ae24a3f8177353a05220d765ca9c421a3",
+                  "sender": "0x68083f18fe472f39557dc42aaefeeb8c154d7ddc456b8aeaa3132c7403531dc9",
                   "type": "0x9::test::TestEvent",
                   "parsedJson": {
                     "test": "example value"
@@ -1016,7 +1016,7 @@
       ]
     },
     {
-      "name": "sui_getObjectsOwnedByAddress",
+      "name": "sui_getOwnedObjects",
       "tags": [
         {
           "name": "Read API"
@@ -1031,16 +1031,43 @@
           "schema": {
             "$ref": "#/components/schemas/SuiAddress"
           }
+        },
+        {
+          "name": "options",
+          "description": "options for specifying the content to be returned",
+          "schema": {
+            "$ref": "#/components/schemas/ObjectDataOptions"
+          }
+        },
+        {
+          "name": "cursor",
+          "description": "Optional paging cursor",
+          "schema": {
+            "$ref": "#/components/schemas/ObjectID"
+          }
+        },
+        {
+          "name": "limit",
+          "description": "Max number of items returned per page, default to [MAX_GET_OWNED_OBJECT_SIZE] if not specified.",
+          "schema": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "at_checkpoint",
+          "description": "If not specified, objects may be created or deleted across pagination requests. This parameter is only supported when the sui-indexer instance is running.",
+          "schema": {
+            "$ref": "#/components/schemas/CheckpointId"
+          }
         }
       ],
       "result": {
-        "name": "Vec<SuiObjectInfo>",
+        "name": "ObjectsPage",
         "required": true,
         "schema": {
-          "type": "array",
-          "items": {
-            "$ref": "#/components/schemas/ObjectInfo"
-          }
+          "$ref": "#/components/schemas/Page_for_ObjectRead_and_ObjectID"
         }
       },
       "examples": [
@@ -1050,6 +1077,30 @@
             {
               "name": "address",
               "value": "0x4e049913233eb918c11638af89d575beb99003d30a245ac74a02e26e45cb80ee"
+            },
+            {
+              "name": "options",
+              "value": {
+                "showType": true,
+                "showOwner": true,
+                "showPreviousTransaction": true,
+                "showDisplay": false,
+                "showContent": false,
+                "showBcs": false,
+                "showStorageRebate": false
+              }
+            },
+            {
+              "name": "cursor",
+              "value": "0x9c683fb7d0526e29d77e89e7bfefd4f73ada3d19ac87d45351f0196a880b95c3"
+            },
+            {
+              "name": "limit",
+              "value": 100
+            },
+            {
+              "name": "at_checkpoint",
+              "value": null
             }
           ],
           "result": {
@@ -1212,7 +1263,7 @@
           "params": [
             {
               "name": "digest",
-              "value": "76scJ6B6r7wNb8KeHJJAcjBBdfGjSPfKcSNJWMWFt5Fk"
+              "value": "GRNP6yJU4XF11j6MXwi1MEJZxcWk2BnyZczNwnS5QgSC"
             },
             {
               "name": "options",
@@ -1228,15 +1279,15 @@
           "result": {
             "name": "Result",
             "value": {
-              "digest": "76scJ6B6r7wNb8KeHJJAcjBBdfGjSPfKcSNJWMWFt5Fk",
+              "digest": "GRNP6yJU4XF11j6MXwi1MEJZxcWk2BnyZczNwnS5QgSC",
               "transaction": {
                 "data": {
                   "messageVersion": "v1",
                   "transaction": {
                     "kind": "ProgrammableTransaction",
                     "inputs": [
-                      "0xd77e89e7bfefd4f73ada3d19ac87d45351f0196a880b95c3ea244dd060d2b653",
-                      "8196d048b7a6d04c8edc89579d86fd3fc90c52f9a14c6b812b94fe613c5bcebb"
+                      "0x8196d048b7a6d04c8edc89579d86fd3fc90c52f9a14c6b812b94fe613c5bcebb",
+                      "5eeb1d449e2516166d57d71fdeb154d0dc9ecdb7b30057d0a932684cac352cdc"
                     ],
                     "commands": [
                       {
@@ -1253,22 +1304,22 @@
                       }
                     ]
                   },
-                  "sender": "0x1214a50dfc9d141ad616f59c5cff25533c785de130619e37be93d586f77c1832",
+                  "sender": "0x82179c57d5895babfb655cd62e8e886a53334b5e7be9be658eb759cc35e3fc66",
                   "gasData": {
                     "payment": [
                       {
-                        "objectId": "0x5eeb1d449e2516166d57d71fdeb154d0dc9ecdb7b30057d0a932684cac352cdc",
+                        "objectId": "0x1a3e898029d024eec1d44c6af5e2facded84d03b5373514f16e3d66e00081051",
                         "version": 2,
-                        "digest": "2mSugTSEhVgVmbVxjz9r61odXT3pBhqb1C6xk4AGguYL"
+                        "digest": "7nDZ5J4VyvYGUbX2f6mQdhkr3RFrb3vZqui1ogoyApD9"
                       }
                     ],
-                    "owner": "0x1214a50dfc9d141ad616f59c5cff25533c785de130619e37be93d586f77c1832",
+                    "owner": "0x82179c57d5895babfb655cd62e8e886a53334b5e7be9be658eb759cc35e3fc66",
                     "price": 1,
                     "budget": 1000
                   }
                 },
                 "txSignatures": [
-                  "AGUMKbUYlbfzb63VUoHTSG/0Z29XguyZyqQtZ7VTXwFK4hi6kqY5B5d1EHODlaEom/eYma3iQSaJBNa6cpVk0wBQKU4RyKWd3xUxrXzYXuLAWeHGehyEWP1S9XPAYKkWZw=="
+                  "ALwMcYis9u/ynkzVhCb8UNtgS8kWOk6MaMWXlWOXONq5KDbfEv49Z0cEvz2tObRkDjaS9kxNSc+Cjfe1F0PtEwptCxWrqsEEHAdxoMDwblU5hyWJ8H3zFvk20E2fO5bzHA=="
                 ]
               },
               "effects": {
@@ -1282,52 +1333,52 @@
                   "storageCost": 100,
                   "storageRebate": 10
                 },
-                "transactionDigest": "64UQ3a7m1mjWuzgyGoH8RnMyPGDN4XYTC9dS4qiSfdK4",
+                "transactionDigest": "6AyFnAuKAKCqm1cD94EyGzBqJCDDJ716ojjmsKF2rqoi",
                 "mutated": [
                   {
                     "owner": {
-                      "AddressOwner": "0x1214a50dfc9d141ad616f59c5cff25533c785de130619e37be93d586f77c1832"
+                      "AddressOwner": "0x82179c57d5895babfb655cd62e8e886a53334b5e7be9be658eb759cc35e3fc66"
                     },
                     "reference": {
-                      "objectId": "0x5eeb1d449e2516166d57d71fdeb154d0dc9ecdb7b30057d0a932684cac352cdc",
+                      "objectId": "0x1a3e898029d024eec1d44c6af5e2facded84d03b5373514f16e3d66e00081051",
                       "version": 2,
-                      "digest": "2mSugTSEhVgVmbVxjz9r61odXT3pBhqb1C6xk4AGguYL"
+                      "digest": "7nDZ5J4VyvYGUbX2f6mQdhkr3RFrb3vZqui1ogoyApD9"
                     }
                   },
                   {
                     "owner": {
-                      "AddressOwner": "0xd77e89e7bfefd4f73ada3d19ac87d45351f0196a880b95c3ea244dd060d2b653"
+                      "AddressOwner": "0x8196d048b7a6d04c8edc89579d86fd3fc90c52f9a14c6b812b94fe613c5bcebb"
                     },
                     "reference": {
-                      "objectId": "0x8196d048b7a6d04c8edc89579d86fd3fc90c52f9a14c6b812b94fe613c5bcebb",
+                      "objectId": "0x5eeb1d449e2516166d57d71fdeb154d0dc9ecdb7b30057d0a932684cac352cdc",
                       "version": 2,
-                      "digest": "7nDZ5J4VyvYGUbX2f6mQdhkr3RFrb3vZqui1ogoyApD9"
+                      "digest": "GK4NxEKSrK88XkPNeuBqtJYPmU9yMTWMD7K9TdU4ybKN"
                     }
                   }
                 ],
                 "gasObject": {
                   "owner": {
-                    "ObjectOwner": "0x1214a50dfc9d141ad616f59c5cff25533c785de130619e37be93d586f77c1832"
+                    "ObjectOwner": "0x82179c57d5895babfb655cd62e8e886a53334b5e7be9be658eb759cc35e3fc66"
                   },
                   "reference": {
-                    "objectId": "0x5eeb1d449e2516166d57d71fdeb154d0dc9ecdb7b30057d0a932684cac352cdc",
+                    "objectId": "0x1a3e898029d024eec1d44c6af5e2facded84d03b5373514f16e3d66e00081051",
                     "version": 2,
-                    "digest": "2mSugTSEhVgVmbVxjz9r61odXT3pBhqb1C6xk4AGguYL"
+                    "digest": "7nDZ5J4VyvYGUbX2f6mQdhkr3RFrb3vZqui1ogoyApD9"
                   }
                 },
-                "eventsDigest": "6AyFnAuKAKCqm1cD94EyGzBqJCDDJ716ojjmsKF2rqoi"
+                "eventsDigest": "9BQobwxQvJ1JxSXNn8v8htZPTu8FEzJJGgcD4kgLUuMd"
               },
               "objectChanges": [
                 {
                   "type": "transferred",
-                  "sender": "0x1214a50dfc9d141ad616f59c5cff25533c785de130619e37be93d586f77c1832",
+                  "sender": "0x82179c57d5895babfb655cd62e8e886a53334b5e7be9be658eb759cc35e3fc66",
                   "recipient": {
-                    "AddressOwner": "0xd77e89e7bfefd4f73ada3d19ac87d45351f0196a880b95c3ea244dd060d2b653"
+                    "AddressOwner": "0x8196d048b7a6d04c8edc89579d86fd3fc90c52f9a14c6b812b94fe613c5bcebb"
                   },
                   "objectType": "0x2::example::Object",
-                  "objectId": "0x8196d048b7a6d04c8edc89579d86fd3fc90c52f9a14c6b812b94fe613c5bcebb",
+                  "objectId": "0x5eeb1d449e2516166d57d71fdeb154d0dc9ecdb7b30057d0a932684cac352cdc",
                   "version": 2,
-                  "digest": "GK4NxEKSrK88XkPNeuBqtJYPmU9yMTWMD7K9TdU4ybKN"
+                  "digest": "64UQ3a7m1mjWuzgyGoH8RnMyPGDN4XYTC9dS4qiSfdK4"
                 }
               ]
             }
@@ -1559,12 +1610,12 @@
             {
               "name": "query",
               "value": {
-                "InputObject": "0x29692fdc7d2ff374c3f870f36fb728ab4187831206d15181ff7c50772417586a"
+                "InputObject": "0x93633829fcba6d6e0ccb13d3dbfe7614b81ea76b255e5d435032cd8595f37eb8"
               }
             },
             {
               "name": "cursor",
-              "value": "AvLgYFSEW12Ac2uBFYcbznKdBj9CowNrpBuHMq53f8mu"
+              "value": "HxidAfFfyr4kXSiWeVq1J6Tk526YUVDoSUY5PSnS4tEJ"
             },
             {
               "name": "limit",
@@ -1580,9 +1631,6 @@
             "value": {
               "data": [
                 {
-                  "digest": "9BQobwxQvJ1JxSXNn8v8htZPTu8FEzJJGgcD4kgLUuMd"
-                },
-                {
                   "digest": "GUPcK4cmRmgsTFr52ab9f6fnzNVg3Lz6hF2aXFcsRzaD"
                 },
                 {
@@ -1590,9 +1638,12 @@
                 },
                 {
                   "digest": "8QrPa4x9iNG5r2zQfmeH8pJoVjjtq9AGzp8rp2fxi8Sk"
+                },
+                {
+                  "digest": "3nek86HEjXZ7K3EtrAcBG4wMrCS21gqr8BqwwC6M6P7F"
                 }
               ],
-              "nextCursor": "8QrPa4x9iNG5r2zQfmeH8pJoVjjtq9AGzp8rp2fxi8Sk",
+              "nextCursor": "3nek86HEjXZ7K3EtrAcBG4wMrCS21gqr8BqwwC6M6P7F",
               "hasNextPage": false
             }
           }
@@ -4278,37 +4329,6 @@
       "ObjectID": {
         "$ref": "#/components/schemas/Hex"
       },
-      "ObjectInfo": {
-        "type": "object",
-        "required": [
-          "digest",
-          "objectId",
-          "owner",
-          "previousTransaction",
-          "type",
-          "version"
-        ],
-        "properties": {
-          "digest": {
-            "$ref": "#/components/schemas/ObjectDigest"
-          },
-          "objectId": {
-            "$ref": "#/components/schemas/ObjectID"
-          },
-          "owner": {
-            "$ref": "#/components/schemas/Owner"
-          },
-          "previousTransaction": {
-            "$ref": "#/components/schemas/TransactionDigest"
-          },
-          "type": {
-            "type": "string"
-          },
-          "version": {
-            "$ref": "#/components/schemas/SequenceNumber"
-          }
-        }
-      },
       "ObjectRead": {
         "oneOf": [
           {
@@ -4566,6 +4586,35 @@
             "anyOf": [
               {
                 "$ref": "#/components/schemas/EventID"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      },
+      "Page_for_ObjectRead_and_ObjectID": {
+        "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
+        "type": "object",
+        "required": [
+          "data",
+          "hasNextPage"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ObjectRead"
+            }
+          },
+          "hasNextPage": {
+            "type": "boolean"
+          },
+          "nextCursor": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ObjectID"
               },
               {
                 "type": "null"

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -12,7 +12,7 @@
       "name": "Apache-2.0",
       "url": "https://raw.githubusercontent.com/MystenLabs/sui/main/LICENSE"
     },
-    "version": "0.29.0"
+    "version": "0.28.0"
   },
   "methods": [
     {

--- a/crates/sui-sdk/examples/get_owned_objects.rs
+++ b/crates/sui-sdk/examples/get_owned_objects.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::str::FromStr;
+use sui_json_rpc_types::SuiObjectDataOptions;
 use sui_sdk::types::base_types::SuiAddress;
 use sui_sdk::SuiClientBuilder;
 
@@ -11,7 +12,16 @@ async fn main() -> Result<(), anyhow::Error> {
         .build("https://fullnode.devnet.sui.io:443")
         .await?;
     let address = SuiAddress::from_str("0xec11cad080d0496a53bafcea629fcbcfff2a9866")?;
-    let objects = sui.read_api().get_objects_owned_by_address(address).await?;
+    let objects = sui
+        .read_api()
+        .get_owned_objects(
+            address,
+            Some(SuiObjectDataOptions::default()),
+            None,
+            None,
+            None,
+        )
+        .await?;
     println!("{:?}", objects);
     Ok(())
 }

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -14,9 +14,9 @@ use std::time::{Duration, Instant};
 use sui_json_rpc::api::GovernanceReadApiClient;
 use sui_json_rpc_types::{
     Balance, Checkpoint, CheckpointId, Coin, CoinPage, DelegatedStake, DryRunTransactionResponse,
-    DynamicFieldPage, EventFilter, EventPage, SuiCoinMetadata, SuiCommittee, SuiEvent,
-    SuiGetPastObjectRequest, SuiMoveNormalizedModule, SuiObjectDataOptions, SuiObjectInfo,
-    SuiObjectResponse, SuiPastObjectResponse, SuiTransactionEffectsAPI, SuiTransactionResponse,
+    DynamicFieldPage, EventFilter, EventPage, ObjectsPage, SuiCoinMetadata, SuiCommittee, SuiEvent,
+    SuiGetPastObjectRequest, SuiMoveNormalizedModule, SuiObjectDataOptions, SuiObjectResponse,
+    SuiPastObjectResponse, SuiTransactionEffectsAPI, SuiTransactionResponse,
     SuiTransactionResponseOptions, SuiTransactionResponseQuery, TransactionsPage,
 };
 use sui_types::balance::Supply;
@@ -43,11 +43,19 @@ impl ReadApi {
         Self { api }
     }
 
-    pub async fn get_objects_owned_by_address(
+    pub async fn get_owned_objects(
         &self,
         address: SuiAddress,
-    ) -> SuiRpcResult<Vec<SuiObjectInfo>> {
-        Ok(self.api.http.get_objects_owned_by_address(address).await?)
+        options: Option<SuiObjectDataOptions>,
+        cursor: Option<ObjectID>,
+        limit: Option<usize>,
+        checkpoint: Option<CheckpointId>,
+    ) -> SuiRpcResult<ObjectsPage> {
+        Ok(self
+            .api
+            .http
+            .get_owned_objects(address, options, cursor, limit, checkpoint)
+            .await?)
     }
 
     pub async fn get_dynamic_fields(

--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -22,7 +22,7 @@ use sui_json_rpc::{
     CLIENT_SDK_TYPE_HEADER, CLIENT_SDK_VERSION_HEADER, CLIENT_TARGET_API_VERSION_HEADER,
 };
 pub use sui_json_rpc_types as rpc_types;
-use sui_json_rpc_types::{SuiObjectDataOptions, SuiObjectInfo, SuiObjectResponse};
+use sui_json_rpc_types::{CheckpointId, ObjectsPage, SuiObjectDataOptions, SuiObjectResponse};
 use sui_transaction_builder::{DataReader, TransactionBuilder};
 pub use sui_types as types;
 use sui_types::base_types::{ObjectID, SuiAddress};
@@ -247,11 +247,17 @@ impl SuiClient {
 
 #[async_trait]
 impl DataReader for ReadApi {
-    async fn get_objects_owned_by_address(
+    async fn get_owned_objects(
         &self,
         address: SuiAddress,
-    ) -> Result<Vec<SuiObjectInfo>, anyhow::Error> {
-        Ok(self.get_objects_owned_by_address(address).await?)
+        options: Option<SuiObjectDataOptions>,
+        cursor: Option<ObjectID>,
+        limit: Option<usize>,
+        checkpoint: Option<CheckpointId>,
+    ) -> Result<ObjectsPage, anyhow::Error> {
+        Ok(self
+            .get_owned_objects(address, options, cursor, limit, checkpoint)
+            .await?)
     }
 
     async fn get_object_with_options(

--- a/crates/sui-storage/src/indexes.rs
+++ b/crates/sui-storage/src/indexes.rs
@@ -848,9 +848,19 @@ impl IndexStore {
             .map(|(_, object_info)| object_info.object_id))
     }
 
-    pub fn get_owner_objects(&self, owner: SuiAddress) -> SuiResult<Vec<ObjectInfo>> {
+    pub fn get_owner_objects(
+        &self,
+        owner: SuiAddress,
+        cursor: Option<ObjectID>,
+        limit: usize,
+    ) -> SuiResult<Vec<ObjectInfo>> {
+        let cursor = match cursor {
+            Some(cursor) => cursor,
+            None => ObjectID::ZERO,
+        };
+
         Ok(self
-            .get_owner_objects_iterator(owner, ObjectID::ZERO, MAX_GET_OWNED_OBJECT_SIZE)?
+            .get_owner_objects_iterator(owner, cursor, limit)?
             .collect())
     }
 
@@ -862,7 +872,8 @@ impl IndexStore {
         starting_object_id: ObjectID,
         count: usize,
     ) -> SuiResult<impl Iterator<Item = ObjectInfo> + '_> {
-        let count = min(count, MAX_GET_OWNED_OBJECT_SIZE);
+        // We use +1 to grab the next cursor
+        let count = min(count, MAX_GET_OWNED_OBJECT_SIZE + 1);
         debug!(?owner, ?count, ?starting_object_id, "get_owner_objects");
         Ok(self
             .tables

--- a/crates/sui/src/console.rs
+++ b/crates/sui/src/console.rs
@@ -137,7 +137,8 @@ async fn handle_command(
             SuiClientCommandResult::Objects(ref objects) => {
                 let objects = objects
                     .iter()
-                    .map(|oref| format!("{}", oref.object_id))
+                    // TODO (jian): fix unwrap and clone later
+                    .map(|oref| format!("{}", oref.clone().into_object().unwrap().object_id))
                     .collect::<Vec<_>>();
                 cache.insert(CacheKey::new("object", "--id"), objects.clone());
                 cache.insert(CacheKey::flag("--gas"), objects.clone());

--- a/crates/test-utils/src/messages.rs
+++ b/crates/test-utils/src/messages.rs
@@ -9,7 +9,7 @@ use sui::client_commands::WalletContext;
 use sui::client_commands::{SuiClientCommandResult, SuiClientCommands};
 use sui_core::test_utils::dummy_transaction_effects;
 use sui_framework_build::compiled_package::BuildConfig;
-use sui_json_rpc_types::SuiObjectInfo;
+use sui_json_rpc_types::SuiObjectResponse;
 use sui_keys::keystore::AccountKeystore;
 use sui_keys::keystore::Keystore;
 use sui_types::base_types::ObjectRef;
@@ -75,7 +75,8 @@ pub async fn get_gas_object_with_wallet_context(
     if res.is_empty() {
         None
     } else {
-        Some(res.swap_remove(0).to_object_ref())
+        // TODO (jian): handle unwrap error
+        Some(res.swap_remove(0).into_object().unwrap().object_ref())
     }
 }
 
@@ -87,9 +88,10 @@ pub async fn get_sui_gas_object_with_wallet_context(
     let res = get_gas_objects_with_wallet_context(context, address).await;
     res.iter()
         .map(|obj| {
+            let obj_data = obj.clone().into_object().unwrap();
             (
-                parse_sui_struct_tag(&obj.type_).unwrap(),
-                obj.to_object_ref(),
+                parse_sui_struct_tag(&obj_data.type_.clone().unwrap().to_string()).unwrap(),
+                obj_data.object_ref(),
             )
         })
         .collect()
@@ -98,21 +100,26 @@ pub async fn get_sui_gas_object_with_wallet_context(
 pub async fn get_gas_objects_with_wallet_context(
     context: &WalletContext,
     address: &SuiAddress,
-) -> Vec<SuiObjectInfo> {
+) -> Vec<SuiObjectResponse> {
     context
         .gas_objects(*address)
         .await
         .unwrap()
         .into_iter()
-        .map(|(_val, _object, object_ref)| object_ref)
+        .map(|(_val, object_data)| SuiObjectResponse::Exists(object_data))
         .collect()
+    // .try_fold(vec![], |mut acc, (_val, object_data)| {
+    //     let obj_resp = SuiObjectResponse::Exists(object_data);
+    //     acc.push(obj_resp);
+    //     Ok::<Vec<SuiObjectResponse>, Error>(acc)
+    // })?
 }
 
 /// A helper function to get all accounts and their owned gas objects
 /// with a WalletContext.
 pub async fn get_account_and_gas_objects(
     context: &WalletContext,
-) -> Vec<(SuiAddress, Vec<SuiObjectInfo>)> {
+) -> Vec<(SuiAddress, Vec<SuiObjectResponse>)> {
     let owned_gas_objects = futures::future::join_all(
         context
             .config
@@ -157,7 +164,8 @@ pub async fn make_transactions_with_wallet_context(
                 recipient,
                 *address,
                 Some(2),
-                obj.to_object_ref(),
+                // TODO (jian)
+                obj.clone().into_object().expect("REASON").object_ref(),
                 MAX_GAS,
             );
             let tx = to_sender_signed_transaction(

--- a/crates/test-utils/src/transaction.rs
+++ b/crates/test-utils/src/transaction.rs
@@ -13,8 +13,8 @@ use sui_config::ValidatorInfo;
 use sui_core::authority_client::AuthorityAPI;
 pub use sui_core::test_utils::{compile_basics_package, wait_for_all_txes, wait_for_tx};
 use sui_json_rpc_types::{
-    SuiObjectResponse, SuiTransactionDataAPI, SuiTransactionEffectsAPI, SuiTransactionResponse,
-    SuiTransactionResponseOptions,
+    SuiObjectDataOptions, SuiObjectResponse, SuiTransactionDataAPI, SuiTransactionEffectsAPI,
+    SuiTransactionResponse, SuiTransactionResponseOptions,
 };
 use sui_keys::keystore::AccountKeystore;
 use sui_sdk::json::SuiJsonValue;
@@ -320,9 +320,22 @@ pub async fn transfer_coin(
     let client = context.get_client().await.unwrap();
     let object_refs = client
         .read_api()
-        .get_objects_owned_by_address(sender)
+        .get_owned_objects(
+            sender,
+            Some(SuiObjectDataOptions::full_content()),
+            None,
+            None,
+            None,
+        )
         .await?;
-    let object_to_send = object_refs.get(1).unwrap().object_id;
+    let object_to_send = object_refs
+        .data
+        .get(1)
+        .expect("REASON")
+        .clone()
+        .into_object()
+        .unwrap()
+        .object_id;
 
     // Send an object
     info!(

--- a/dapps/frenemies/src/network/queries/use-raw.ts
+++ b/dapps/frenemies/src/network/queries/use-raw.ts
@@ -26,8 +26,7 @@ function useObjectsOwnedByAddress() {
   const { currentAccount } = useWalletKit();
   return useQuery(
     ["owned", currentAccount?.address],
-    async () =>
-      provider.getObjectsOwnedByAddress({ owner: currentAccount?.address! }),
+    async () => provider.getOwnedObjects({ owner: currentAccount?.address! }),
     {
       enabled: !!currentAccount?.address,
       refetchInterval: 2 * 60 * 1000,

--- a/doc/src/build/json-rpc.md
+++ b/doc/src/build/json-rpc.md
@@ -44,7 +44,7 @@ curl --location --request POST $SUI_RPC_HOST \
 The examples in this section demonstrate how to create transfer transactions. To use the example commands, replace the values between double brackets ({{ example_ID }} with actual values.
 
 Objects IDs for `{{coin_object_id}}` and `{{gas_object_id}}` must
-be owned by the address specified for `{{owner_address}}` for the command to succeed. Use [`sui_getOwnedObjectsByAddress`](#sui_getObjectsOwnedByAddress) to return object IDs. 
+be owned by the address specified for `{{owner_address}}` for the command to succeed. Use [`sui_getOwnedObjects`](#sui_getOwnedObjects) to return object IDs. 
 
 **Important:** As a security best practice, you should serialize data from the JSON-RPC service locally in the same location as the signer. This reduces the risk of trusting data from the service directly.
 

--- a/doc/src/build/rust-sdk.md
+++ b/doc/src/build/rust-sdk.md
@@ -41,13 +41,14 @@ use std::str::FromStr;
 use sui_sdk::types::base_types::SuiAddress;
 use sui_sdk::{SuiClient, SuiClientBuilder};
 
+// TODO: (jian) update example after pagination changes
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     let sui = SuiClientBuilder::default().build(
       "https://fullnode.devnet.sui.io:443",
     ).await.unwrap();
-    let address = SuiAddress::from_str("0xec11cad080d0496a53bafcea629fcbcfff2a9866")?;
-    let objects = sui.read_api().get_objects_owned_by_address(address).await?;
+    let address = SuiAddress::from_str("0xbcab7526033aa0e014f634bf51316715dda0907a7fab5a8d7e3bd44e634a4d44")?;
+    let objects = sui.read_api().get_owned_objects(address).await?;
     println!("{:?}", objects);
     Ok(())
 }

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -128,7 +128,7 @@ Fetch objects owned by the address `0xbff6ccc8707aa517b4f1b95750a2a8c666012df3`
 ```typescript
 import { JsonRpcProvider } from '@mysten/sui.js';
 const provider = new JsonRpcProvider();
-const objects = await provider.getObjectsOwnedByAddress({
+const objects = await provider.getOwnedObjects({
   owner: '0xbff6ccc8707aa517b4f1b95750a2a8c666012df3',
 });
 ```

--- a/sdk/typescript/src/types/objects.ts
+++ b/sdk/typescript/src/types/objects.ts
@@ -362,3 +362,10 @@ export function getMovePackageContent(
   }
   return (suiObject.content as SuiMovePackage).disassembled;
 }
+
+export const PaginatedObjectsResponse = object({
+  data: array(SuiObjectResponse),
+  nextCursor: union([ObjectId, literal(null)]),
+  hasNextPage: boolean(),
+});
+export type PaginatedObjectsResponse = Infer<typeof PaginatedObjectsResponse>;

--- a/sdk/typescript/test/e2e/dynamic-fields.test.ts
+++ b/sdk/typescript/test/e2e/dynamic-fields.test.ts
@@ -15,7 +15,10 @@ describe('Dynamic Fields Reading API', () => {
     ({ packageId } = await publishPackage(packagePath, toolbox));
 
     await toolbox.provider
-      .getObjectsOwnedByAddress({ owner: toolbox.address() })
+      .getOwnedObjects({
+        owner: toolbox.address(),
+        options: { showType: true },
+      })
       .then(function (objects) {
         const obj = objects.filter(
           (o) => o.type === `${packageId}::dynamic_fields_test::Test`,

--- a/sdk/typescript/test/e2e/invalid-ids.test.ts
+++ b/sdk/typescript/test/e2e/invalid-ids.test.ts
@@ -15,7 +15,7 @@ describe('Object id/Address/Transaction digest validation', () => {
   it('Test all functions with invalid Sui Address', async () => {
     //empty id
     expect(
-      toolbox.provider.getObjectsOwnedByAddress({ owner: '' }),
+      toolbox.provider.getOwnedObjects({ owner: '' }),
     ).rejects.toThrowError(/Invalid Sui address/);
 
     //wrong id

--- a/sdk/typescript/test/e2e/object-display-standard.test.ts
+++ b/sdk/typescript/test/e2e/object-display-standard.test.ts
@@ -17,9 +17,10 @@ describe('Test Object Display Standard', () => {
 
   it('Test getting Display fields', async () => {
     const boarId = (
-      await toolbox.provider.getObjectsOwnedByAddress({
+      await toolbox.provider.getOwnedObjects({
         owner: toolbox.address(),
         typeFilter: `${packageId}::boars::Boar`,
+        options: { showDisplay: true, showType: true },
       })
     )[0].objectId;
     const display = getObjectDisplay(

--- a/sdk/typescript/test/e2e/objects.test.ts
+++ b/sdk/typescript/test/e2e/objects.test.ts
@@ -13,7 +13,7 @@ describe('Object Reading API', () => {
   });
 
   it('Get Owned Objects', async () => {
-    const gasObjects = await toolbox.provider.getObjectsOwnedByAddress({
+    const gasObjects = await toolbox.provider.getOwnedObjects({
       owner: toolbox.address(),
     });
     expect(gasObjects.length).to.greaterThan(0);

--- a/sdk/typescript/test/e2e/rpc-endpoint.test.ts
+++ b/sdk/typescript/test/e2e/rpc-endpoint.test.ts
@@ -11,20 +11,25 @@ describe('Invoke any RPC endpoint', () => {
     toolbox = await setup();
   });
 
-  it('sui_getObjectsOwnedByAddress', async () => {
-    const gasObjectsExpected = await toolbox.provider.getObjectsOwnedByAddress({
+  it('sui_getOwnedObjects', async () => {
+    const gasObjectsExpected = await toolbox.provider.getOwnedObjects({
       owner: toolbox.address(),
     });
-    const gasObjects = await toolbox.provider.call(
-      'sui_getObjectsOwnedByAddress',
-      [toolbox.address()],
-    );
-    expect(gasObjects).toStrictEqual(gasObjectsExpected);
+    const gasObjects = await toolbox.provider.call('sui_getOwnedObjects', [
+      toolbox.address(),
+    ]);
+    // TODO (jian): fix this test in the upcoming PR because sui_getOwnedObjects returns a paginated response which our API
+    // currently doesn't consume
+    for (let i = 0; i < gasObjectsExpected.length; i++) {
+      expect(gasObjects.data[i].details.objectId).toStrictEqual(
+        gasObjectsExpected[i].objectId,
+      );
+    }
   });
 
   it('sui_getObjectOwnedByAddress Error', async () => {
     expect(
-      toolbox.provider.call('sui_getObjectsOwnedByAddress', []),
+      toolbox.provider.call('sui_getOwnedObjects', []),
     ).rejects.toThrowError();
   });
 

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -51,10 +51,10 @@ export class TestToolbox {
   }
 
   async getGasObjectsOwnedByAddress() {
-    const objects = await this.provider.getObjectsOwnedByAddress({
+    const objects = await this.provider.getOwnedObjects({
       owner: this.address(),
+      options: { showType: true, showContent: true, showOwner: true },
     });
-
     return objects.filter((obj) => Coin.isSUI(obj));
   }
 


### PR DESCRIPTION
## Description 

Change results property of DevInspectResult from Result<Vec<SuiExecutionResult>, String> to 2 different properties.
pub results: Option<Vec<SuiExecutionResult>> and pub error: Option<String>

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
