### PR TITLE
[Rocksdb] use 64MiB block cache and memtable bloom filter by default

### DIFF
--- a/narwhal/storage/src/node_store.rs
+++ b/narwhal/storage/src/node_store.rs
@@ -5,6 +5,8 @@ use crate::{CertificateStore, ProposerStore};
 use config::WorkerId;
 use crypto::PublicKey;
 use std::sync::Arc;
+use std::time::Duration;
+use store::metrics::SamplingInterval;
 use store::rocks::DBMap;
 use store::rocks::{open_cf, MetricConf, ReadWriteOptions};
 use store::{reopen, Store};
@@ -43,10 +45,12 @@ impl NodeStorage {
 
     /// Open or reopen all the storage of the node.
     pub fn reopen<Path: AsRef<std::path::Path> + Send>(store_path: Path) -> Self {
+        let mut metrics_conf = MetricConf::with_db_name("consensus_epoch");
+        metrics_conf.read_sample_interval = SamplingInterval::new(Duration::from_secs(60), 0);
         let rocksdb = open_cf(
             store_path,
             None,
-            MetricConf::with_db_name("consensus_epoch"),
+            metrics_conf,
             &[
                 Self::LAST_PROPOSED_CF,
                 Self::VOTES_CF,


### PR DESCRIPTION
## Description 

Tables with `default_db_options()` instead of `point_lookup_db_options()` in both Sui and Narwhal see increasing read latencies over time. The biggest difference seems to be the lower blockcache size in `default_db_options()`. I copied over most additional configs in `point_lookup_db_options()` except adding hash to block index.

e.g.
![image](https://user-images.githubusercontent.com/81660174/225170662-9e27da4a-0c08-4b1a-aeb4-58d601c414b3.png)

## Test Plan 

Will deploy to private testnet.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
