### PR TITLE
[sui-move] Use Sui's gas schedule instead of the one from Move for unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9317,6 +9317,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sui-core",
+ "sui-cost-tables",
  "sui-framework",
  "sui-framework-build",
  "sui-macros",

--- a/crates/sui-move/Cargo.toml
+++ b/crates/sui-move/Cargo.toml
@@ -23,6 +23,7 @@ sui-framework = { path = "../sui-framework" }
 sui-framework-build = { path = "../sui-framework-build" }
 sui-protocol-config = { path = "../sui-protocol-config" }
 sui-types = { path = "../sui-types" }
+sui-cost-tables = { path = "../sui-cost-tables" }
 
 
 fastcrypto.workspace = true

--- a/crates/sui-move/src/unit_test.rs
+++ b/crates/sui-move/src/unit_test.rs
@@ -10,13 +10,13 @@ use move_cli::base::{
 use move_package::BuildConfig;
 use move_unit_test::{extensions::set_extension_hook, UnitTestingConfig};
 use move_vm_runtime::native_extensions::NativeContextExtensions;
-use move_vm_test_utils::gas_schedule::INITIAL_COST_SCHEDULE;
 use once_cell::sync::Lazy;
 use std::{
     collections::BTreeMap,
     path::{Path, PathBuf},
 };
 use sui_core::authority::TemporaryStore;
+use sui_cost_tables::bytecode_tables::INITIAL_COST_SCHEDULE;
 use sui_framework::natives::{self, object_runtime::ObjectRuntime, NativesCostTable};
 use sui_protocol_config::ProtocolConfig;
 use sui_types::{
@@ -90,10 +90,30 @@ pub fn run_move_unit_tests(
             ..config
         },
         natives::all_natives(MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS),
-        Some(INITIAL_COST_SCHEDULE.clone()),
+        Some(initial_cost_schedule()),
         compute_coverage,
         &mut std::io::stdout(),
     )
+}
+
+// Convert from our representation of gas costs to the type that the MoveVM expects.
+// We don't want our gas depending on the MoveVM test utils and we don't want to fix our
+// representation to whatever is there, so instead we perform this translation from our gas units
+// and cost schedule to the one expected by the Move unit tests.
+fn initial_cost_schedule() -> move_vm_test_utils::gas_schedule::CostTable {
+    move_vm_test_utils::gas_schedule::CostTable {
+        instruction_table: INITIAL_COST_SCHEDULE
+            .clone()
+            .instruction_table
+            .into_iter()
+            .map(|gas_cost| {
+                move_vm_test_utils::gas_schedule::GasCost::new(
+                    gas_cost.instruction_gas,
+                    gas_cost.memory_gas,
+                )
+            })
+            .collect(),
+    }
 }
 
 fn new_testing_object_and_natives_cost_runtime(ext: &mut NativeContextExtensions) {


### PR DESCRIPTION
Previously in unit tests we were using Move's built-in initial cost schedule for testing but we should really be using our own and converting into the right type on the Move side.

Eventually what we will want to do is remove `test_utils` altogether on the Move side, and trait-ify the gas meter for unit testing. However, there are better things to be doing at the moment, so this should suffice for now :)  