### PR TITLE
wallet-ext: ui tweaks

### DIFF
--- a/apps/wallet/src/background/Window.ts
+++ b/apps/wallet/src/background/Window.ts
@@ -26,8 +26,8 @@ export class Window {
         const w = await Browser.windows.create({
             url: this._url,
             focused: true,
-            width: 380,
-            height: 640,
+            width: 360,
+            height: 623,
             type: 'popup',
             top: top,
             left: Math.floor(left + width - 450),

--- a/apps/wallet/tailwind.config.js
+++ b/apps/wallet/tailwind.config.js
@@ -43,7 +43,7 @@ module.exports = {
                 '4lg': '1rem',
             },
             gridTemplateColumns: {
-                header: '1fr fit-content(160px) 1fr',
+                header: '1fr fit-content(162px) 1fr',
             },
             height: {
                 header: '4.25rem',


### PR DESCRIPTION
## Description 

* resize the popup window to make sure the background image is not visible
* slightly increase the max width of the middle content of the header to avoid Approve transaction title being truncated

<img width="385" alt="Screenshot 2023-03-15 at 22 13 35" src="https://user-images.githubusercontent.com/10210143/225459407-59c4d86e-dc90-477e-bf9b-31e316913f67.png">
