### PR TITLE
[fix] connectivity monitor metrics

### DIFF
--- a/narwhal/network/src/connectivity.rs
+++ b/narwhal/network/src/connectivity.rs
@@ -68,10 +68,6 @@ impl ConnectionMonitor {
                 .set(0)
         }
 
-        self.connection_metrics
-            .network_peers
-            .set(connected_peers.len() as i64);
-
         // now report the connected peers
         for peer_id in connected_peers {
             self.handle_peer_status_change(peer_id, ConnectionStatus::Connected)
@@ -116,5 +112,117 @@ impl ConnectionMonitor {
         }
 
         self.connection_statuses.insert(peer_id, connection_status);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::connectivity::{ConnectionMonitor, ConnectionStatus};
+    use crate::metrics::NetworkConnectionMetrics;
+    use anemo::{Network, Request, Response};
+    use bytes::Bytes;
+    use prometheus::Registry;
+    use std::collections::HashMap;
+    use std::convert::Infallible;
+    use std::time::Duration;
+    use tokio::time::{sleep, timeout};
+    use tower::util::BoxCloneService;
+
+    #[tokio::test]
+    async fn test_connectivity() {
+        // GIVEN
+        let network_1 = build_network().unwrap();
+        let network_2 = build_network().unwrap();
+        let network_3 = build_network().unwrap();
+
+        let registry = Registry::new();
+        let metrics = NetworkConnectionMetrics::new("primary", &registry);
+
+        // AND we connect to peer 2
+        let peer_2 = network_1.connect(network_2.local_addr()).await.unwrap();
+
+        // WHEN bring up the monitor
+        let (_h, statuses) =
+            ConnectionMonitor::spawn(network_1.downgrade(), metrics.clone(), HashMap::new());
+
+        // THEN peer 2 should be already connected
+        assert_network_peers(metrics.clone(), 1).await;
+        assert_eq!(
+            *statuses.get(&peer_2).unwrap().value(),
+            ConnectionStatus::Connected
+        );
+
+        // WHEN connect to peer 3
+        let peer_3 = network_1.connect(network_3.local_addr()).await.unwrap();
+
+        // THEN
+        assert_network_peers(metrics.clone(), 2).await;
+        assert_eq!(
+            *statuses.get(&peer_3).unwrap().value(),
+            ConnectionStatus::Connected
+        );
+
+        // AND disconnect peer 2
+        network_1.disconnect(peer_2).unwrap();
+
+        // THEN
+        assert_network_peers(metrics.clone(), 1).await;
+        assert_eq!(
+            *statuses.get(&peer_2).unwrap().value(),
+            ConnectionStatus::Disconnected
+        );
+
+        // AND disconnect peer 3
+        network_1.disconnect(peer_3).unwrap();
+
+        // THEN
+        assert_network_peers(metrics.clone(), 0).await;
+        assert_eq!(
+            *statuses.get(&peer_3).unwrap().value(),
+            ConnectionStatus::Disconnected
+        );
+    }
+
+    async fn assert_network_peers(metrics: NetworkConnectionMetrics, value: i64) {
+        let m = metrics.clone();
+        timeout(Duration::from_secs(5), async move {
+            while m.network_peers.get() != value {
+                sleep(Duration::from_millis(500)).await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "Timeout while waiting for connectivity results for value {}",
+                value
+            )
+        });
+
+        assert_eq!(metrics.network_peers.get(), value);
+    }
+
+    fn build_network() -> anyhow::Result<Network> {
+        let network = Network::bind("localhost:0")
+            .private_key(random_private_key())
+            .server_name("test")
+            .start(echo_service())?;
+        Ok(network)
+    }
+
+    fn echo_service() -> BoxCloneService<Request<Bytes>, Response<Bytes>, Infallible> {
+        let handle = move |request: Request<Bytes>| async move {
+            let response = Response::new(request.into_body());
+            Result::<Response<Bytes>, Infallible>::Ok(response)
+        };
+
+        tower::ServiceExt::boxed_clone(tower::service_fn(handle))
+    }
+
+    fn random_private_key() -> [u8; 32] {
+        let mut rng = rand::thread_rng();
+        let mut bytes = [0u8; 32];
+        rand::RngCore::fill_bytes(&mut rng, &mut bytes[..]);
+
+        bytes
     }
 }

--- a/narwhal/network/src/connectivity.rs
+++ b/narwhal/network/src/connectivity.rs
@@ -97,13 +97,18 @@ impl ConnectionMonitor {
         peer_id: PeerId,
         connection_status: ConnectionStatus,
     ) {
-        self.connection_metrics.network_peers.inc();
+        let int_status = match connection_status {
+            ConnectionStatus::Connected => {
+                self.connection_metrics.network_peers.inc();
+                1
+            }
+            ConnectionStatus::Disconnected => {
+                self.connection_metrics.network_peers.dec();
+                0
+            }
+        };
 
         if let Some(ty) = self.peer_id_types.get(&peer_id) {
-            let int_status = match connection_status {
-                ConnectionStatus::Connected => 1,
-                ConnectionStatus::Disconnected => 0,
-            };
             self.connection_metrics
                 .network_peer_connected
                 .with_label_values(&[&format!("{peer_id}"), ty])


### PR DESCRIPTION
## Description 

Connectivity monitor metrics seemed to be broken, as the `network_peers` metrics was always getting increasing. The PR is fixing the issue ensuring that the `decr` gets called whenever a disconnection happens + introduces some testing to ensure we won't accidentally break things as metrics appear to be quite important.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
