### PR TITLE
[Narwhal] swap typed_store::Store with DBMap

### DIFF
--- a/narwhal/primary/src/block_remover.rs
+++ b/narwhal/primary/src/block_remover.rs
@@ -10,13 +10,12 @@ use futures::future::try_join_all;
 use itertools::Either;
 use network::PrimaryToWorkerRpc;
 use std::{collections::HashMap, sync::Arc};
-use storage::{CertificateStore, PayloadStore};
-use store::{rocks::TypedStoreError, Store};
+use storage::{CertificateStore, HeaderStore, PayloadStore};
+use store::rocks::TypedStoreError;
 
 use tracing::{debug, instrument, warn};
 use types::{
-    metered_channel::Sender, BatchDigest, Certificate, CertificateDigest, Header, HeaderDigest,
-    Round,
+    metered_channel::Sender, BatchDigest, Certificate, CertificateDigest, HeaderDigest, Round,
 };
 
 #[cfg(test)]
@@ -39,7 +38,7 @@ pub struct BlockRemover {
     certificate_store: CertificateStore,
 
     /// Storage that keeps the headers by their digest id
-    header_store: Store<HeaderDigest, Header>,
+    header_store: HeaderStore,
 
     /// The persistent storage for payload markers from workers.
     payload_store: PayloadStore,
@@ -60,7 +59,7 @@ impl BlockRemover {
         name: PublicKey,
         worker_cache: WorkerCache,
         certificate_store: CertificateStore,
-        header_store: Store<HeaderDigest, Header>,
+        header_store: HeaderStore,
         payload_store: PayloadStore,
         dag: Option<Arc<Dag>>,
         worker_network: anemo::Network,
@@ -133,7 +132,6 @@ impl BlockRemover {
 
         self.header_store
             .remove_all(header_digests)
-            .await
             .map_err(Either::Left)?;
 
         // delete batch from the payload store as well

--- a/narwhal/primary/src/block_synchronizer/mod.rs
+++ b/narwhal/primary/src/block_synchronizer/mod.rs
@@ -26,8 +26,7 @@ use std::{
     collections::{HashMap, HashSet},
     time::Duration,
 };
-use storage::{CertificateStore, PayloadToken};
-use store::Store;
+use storage::{CertificateStore, PayloadStore};
 use thiserror::Error;
 use tokio::{sync::mpsc::Sender, task::JoinHandle, time::timeout};
 use tracing::{debug, error, info, instrument, trace, warn};
@@ -171,7 +170,7 @@ pub struct BlockSynchronizer {
     certificate_store: CertificateStore,
 
     /// The persistent storage for payload markers from workers
-    payload_store: Store<(BatchDigest, WorkerId), PayloadToken>,
+    payload_store: PayloadStore,
 
     /// Timeout when synchronizing the certificates
     certificates_synchronize_timeout: Duration,
@@ -192,7 +191,7 @@ impl BlockSynchronizer {
         rx_shutdown: ConditionalBroadcastReceiver,
         rx_block_synchronizer_commands: metered_channel::Receiver<Command>,
         network: anemo::Network,
-        payload_store: Store<(BatchDigest, WorkerId), PayloadToken>,
+        payload_store: PayloadStore,
         certificate_store: CertificateStore,
         parameters: Parameters,
     ) -> JoinHandle<()> {
@@ -548,7 +547,7 @@ impl BlockSynchronizer {
                     "Certificate with id {} not our own, checking in storage.",
                     certificate.digest()
                 );
-                match self.payload_store.read_all(payload).await {
+                match self.payload_store.read_all(payload) {
                     Ok(payload_result) => {
                         payload_result.into_iter().all(|x| x.is_some()).to_owned()
                     }
@@ -663,7 +662,7 @@ impl BlockSynchronizer {
     #[instrument(level = "trace", skip_all, fields(request_id, certificate=?certificate.header.digest()))]
     async fn wait_for_block_payload<'a>(
         payload_synchronize_timeout: Duration,
-        payload_store: Store<(BatchDigest, WorkerId), PayloadToken>,
+        payload_store: PayloadStore,
         certificate: Certificate,
     ) -> State {
         let futures = certificate
@@ -671,18 +670,13 @@ impl BlockSynchronizer {
             .payload
             .iter()
             .map(|(batch_digest, (worker_id, _))| {
-                payload_store.notify_read((*batch_digest, *worker_id))
+                payload_store.notify_read(*batch_digest, *worker_id)
             })
             .collect::<Vec<_>>();
 
         // Wait for all the items to sync - have a timeout
         let result = timeout(payload_synchronize_timeout, join_all(futures)).await;
-        if result.is_err()
-            || result
-                .unwrap()
-                .into_iter()
-                .any(|r| r.map_or_else(|_| true, |f| f.is_none()))
-        {
+        if result.is_err() {
             return State::PayloadSynchronized {
                 result: Err(SyncError::Timeout {
                     digest: certificate.digest(),

--- a/narwhal/primary/src/block_synchronizer/mod.rs
+++ b/narwhal/primary/src/block_synchronizer/mod.rs
@@ -670,7 +670,7 @@ impl BlockSynchronizer {
             .payload
             .iter()
             .map(|(batch_digest, (worker_id, _))| {
-                payload_store.notify_read(*batch_digest, *worker_id)
+                payload_store.notify_contains(*batch_digest, *worker_id)
             })
             .collect::<Vec<_>>();
 

--- a/narwhal/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
+++ b/narwhal/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
@@ -307,7 +307,7 @@ async fn test_successful_payload_synchronization() {
                 // Assume that the request is the correct one and just immediately
                 // store the batch to the payload store.
                 for digest in m.digests {
-                    payload_store.async_write((digest, worker), 1).await;
+                    payload_store.write(digest, worker).unwrap();
                 }
             }
         }
@@ -618,7 +618,7 @@ async fn test_reply_with_payload_already_in_storage() {
             certificate_store.write(certificate.clone()).unwrap();
 
             for (digest, (worker_id, _)) in certificate.header.payload {
-                payload_store.async_write((digest, worker_id), 1).await;
+                payload_store.write(digest, worker_id).unwrap();
             }
         }
     }

--- a/narwhal/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
+++ b/narwhal/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
@@ -307,7 +307,7 @@ async fn test_successful_payload_synchronization() {
                 // Assume that the request is the correct one and just immediately
                 // store the batch to the payload store.
                 for digest in m.digests {
-                    payload_store.write(digest, worker).unwrap();
+                    payload_store.write(&digest, &worker).unwrap();
                 }
             }
         }
@@ -617,7 +617,7 @@ async fn test_reply_with_payload_already_in_storage() {
         if i > NUM_OF_CERTIFICATES_WITH_MISSING_PAYLOAD {
             certificate_store.write(certificate.clone()).unwrap();
 
-            for (digest, (worker_id, _)) in certificate.header.payload {
+            for (digest, (worker_id, _)) in &certificate.header.payload {
                 payload_store.write(digest, worker_id).unwrap();
             }
         }

--- a/narwhal/primary/src/block_synchronizer/tests/handler_tests.rs
+++ b/narwhal/primary/src/block_synchronizer/tests/handler_tests.rs
@@ -277,7 +277,7 @@ async fn test_synchronize_block_payload() {
         .build()
         .unwrap();
     let cert_stored = fixture.certificate(&header);
-    for (digest, (worker_id, _)) in cert_stored.clone().header.payload {
+    for (digest, (worker_id, _)) in &cert_stored.clone().header.payload {
         payload_store.write(digest, worker_id).unwrap();
     }
 

--- a/narwhal/primary/src/block_synchronizer/tests/handler_tests.rs
+++ b/narwhal/primary/src/block_synchronizer/tests/handler_tests.rs
@@ -278,7 +278,7 @@ async fn test_synchronize_block_payload() {
         .unwrap();
     let cert_stored = fixture.certificate(&header);
     for (digest, (worker_id, _)) in cert_stored.clone().header.payload {
-        payload_store.async_write((digest, worker_id), 1).await;
+        payload_store.write(digest, worker_id).unwrap();
     }
 
     // AND a certificate with payload NOT available

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -1167,7 +1167,7 @@ impl WorkerToPrimary for WorkerReceiverHandler {
     ) -> Result<anemo::Response<()>, anemo::rpc::Status> {
         let message = request.into_body();
         self.payload_store
-            .write(message.digest, message.worker_id)
+            .write(&message.digest, &message.worker_id)
             .map_err(|e| anemo::rpc::Status::internal(e.to_string()))?;
         Ok(anemo::Response::new(()))
     }

--- a/narwhal/primary/src/synchronizer.rs
+++ b/narwhal/primary/src/synchronizer.rs
@@ -861,7 +861,7 @@ impl Synchronizer {
             //      4. The last good node will never be able to sync as it will keep sending its sync requests
             //         to workers #1 (rather than workers #0). Also, clients will never be able to retrieve batch
             //         X as they will be querying worker #1.
-            if inner.payload_store.read(*digest, *worker_id)?.is_none() {
+            if !inner.payload_store.contains(*digest, *worker_id)? {
                 missing
                     .entry(*worker_id)
                     .or_insert_with(Vec::new)
@@ -899,10 +899,10 @@ impl Synchronizer {
                         backoff::Error::transient(DagError::NetworkError(format!("{e:?}")))
                     });
                     if result.is_ok() {
-                        for digest in digests.clone() {
+                        for digest in &digests {
                             inner
                                 .payload_store
-                                .write(digest, worker_id)
+                                .write(digest, &worker_id)
                                 .map_err(|e| backoff::Error::permanent(DagError::StoreError(e)))?
                         }
                     }

--- a/narwhal/primary/src/synchronizer.rs
+++ b/narwhal/primary/src/synchronizer.rs
@@ -2,7 +2,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use anemo::{rpc::Status, Network, Request, Response};
-use config::{Committee, Epoch, WorkerCache, WorkerId};
+use config::{Committee, Epoch, WorkerCache};
 use consensus::consensus::ConsensusRound;
 use consensus::dag::Dag;
 use crypto::{NetworkPublicKey, PublicKey};
@@ -25,8 +25,7 @@ use std::{
     },
     time::Duration,
 };
-use storage::{CertificateStore, PayloadToken};
-use store::Store;
+use storage::{CertificateStore, PayloadStore};
 use tokio::{
     sync::{broadcast, mpsc, oneshot, watch, MutexGuard},
     task::JoinSet,
@@ -37,9 +36,8 @@ use types::{
     ensure,
     error::{AcceptNotification, DagError, DagResult},
     metered_channel::Sender,
-    BatchDigest, Certificate, CertificateDigest, Header, PrimaryToPrimaryClient,
-    PrimaryToWorkerClient, Round, SendCertificateRequest, SendCertificateResponse,
-    WorkerSynchronizeMessage,
+    Certificate, CertificateDigest, Header, PrimaryToPrimaryClient, PrimaryToWorkerClient, Round,
+    SendCertificateRequest, SendCertificateResponse, WorkerSynchronizeMessage,
 };
 
 use crate::{aggregators::CertificatesAggregator, metrics::PrimaryMetrics, CHANNEL_CAPACITY};
@@ -65,7 +63,9 @@ struct Inner {
     highest_received_round: AtomicU64,
     /// The persistent storage tables.
     certificate_store: CertificateStore,
-    payload_store: Store<(BatchDigest, WorkerId), PayloadToken>,
+    /// The persistent store of the available batch digests produced either via our own workers
+    /// or others workers.
+    payload_store: PayloadStore,
     /// Send missing certificates to the `CertificateFetcher`.
     tx_certificate_fetcher: Sender<Certificate>,
     /// Send certificates to be accepted into a separate task that runs
@@ -263,7 +263,7 @@ impl Synchronizer {
         worker_cache: WorkerCache,
         gc_depth: Round,
         certificate_store: CertificateStore,
-        payload_store: Store<(BatchDigest, WorkerId), PayloadToken>,
+        payload_store: PayloadStore,
         tx_certificate_fetcher: Sender<Certificate>,
         tx_new_certificates: Sender<Certificate>,
         tx_parents: Sender<(Vec<Certificate>, Round, Epoch)>,
@@ -861,12 +861,7 @@ impl Synchronizer {
             //      4. The last good node will never be able to sync as it will keep sending its sync requests
             //         to workers #1 (rather than workers #0). Also, clients will never be able to retrieve batch
             //         X as they will be querying worker #1.
-            if inner
-                .payload_store
-                .read((*digest, *worker_id))
-                .await?
-                .is_none()
-            {
+            if inner.payload_store.read(*digest, *worker_id)?.is_none() {
                 missing
                     .entry(*worker_id)
                     .or_insert_with(Vec::new)
@@ -907,8 +902,8 @@ impl Synchronizer {
                         for digest in digests.clone() {
                             inner
                                 .payload_store
-                                .async_write((digest, worker_id), 0u8)
-                                .await;
+                                .write(digest, worker_id)
+                                .map_err(|e| backoff::Error::permanent(DagError::StoreError(e)))?
                         }
                     }
                     result

--- a/narwhal/primary/src/tests/block_remover_tests.rs
+++ b/narwhal/primary/src/tests/block_remover_tests.rs
@@ -93,11 +93,10 @@ async fn test_successful_blocks_delete() {
 
         // write the batches to payload store
         payload_store
-            .sync_write_all(vec![
-                ((batch_1.clone().digest(), worker_id_0), 0),
-                ((batch_2.clone().digest(), worker_id_1), 0),
+            .write_all(vec![
+                (batch_1.clone().digest(), worker_id_0),
+                (batch_2.clone().digest(), worker_id_1),
             ])
-            .await
             .expect("couldn't store batches");
 
         digests.push(digest);
@@ -162,11 +161,7 @@ async fn test_successful_blocks_delete() {
     for (worker_id, batch_digests) in worker_batches {
         for digest in batch_digests {
             assert!(
-                payload_store
-                    .read((digest, worker_id))
-                    .await
-                    .unwrap()
-                    .is_none(),
+                payload_store.read(digest, worker_id).unwrap().is_none(),
                 "Payload shouldn't exist"
             );
         }
@@ -266,11 +261,10 @@ async fn test_failed_blocks_delete() {
 
         // write the batches to payload store
         payload_store
-            .sync_write_all(vec![
-                ((batch_1.clone().digest(), worker_id_0), 0),
-                ((batch_2.clone().digest(), worker_id_1), 0),
+            .write_all(vec![
+                (batch_1.clone().digest(), worker_id_0),
+                (batch_2.clone().digest(), worker_id_1),
             ])
-            .await
             .expect("couldn't store batches");
 
         digests.push(digest);
@@ -330,11 +324,7 @@ async fn test_failed_blocks_delete() {
     }
     for (worker_id, batch_digests) in worker_batches {
         for digest in batch_digests {
-            assert!(payload_store
-                .read((digest, worker_id))
-                .await
-                .unwrap()
-                .is_some());
+            assert!(payload_store.read(digest, worker_id).unwrap().is_some());
         }
     }
     let mut total_deleted = 0;

--- a/narwhal/primary/src/tests/block_remover_tests.rs
+++ b/narwhal/primary/src/tests/block_remover_tests.rs
@@ -159,7 +159,7 @@ async fn test_successful_blocks_delete() {
     for (worker_id, batch_digests) in worker_batches {
         for digest in batch_digests {
             assert!(
-                payload_store.read(digest, worker_id).unwrap().is_none(),
+                !payload_store.contains(digest, worker_id).unwrap(),
                 "Payload shouldn't exist"
             );
         }
@@ -320,7 +320,7 @@ async fn test_failed_blocks_delete() {
     }
     for (worker_id, batch_digests) in worker_batches {
         for digest in batch_digests {
-            assert!(payload_store.read(digest, worker_id).unwrap().is_some());
+            assert!(payload_store.contains(digest, worker_id).unwrap());
         }
     }
     let mut total_deleted = 0;

--- a/narwhal/primary/src/tests/block_remover_tests.rs
+++ b/narwhal/primary/src/tests/block_remover_tests.rs
@@ -85,9 +85,7 @@ async fn test_successful_blocks_delete() {
         dag.insert(certificate).await.unwrap();
 
         // write the header
-        header_store
-            .async_write(header.clone().digest(), header.clone())
-            .await;
+        header_store.write(&header).unwrap();
 
         header_ids.push(header.clone().digest());
 
@@ -152,7 +150,7 @@ async fn test_successful_blocks_delete() {
     // ensure that headers have been deleted from store
     for header_id in header_ids {
         assert!(
-            header_store.read(header_id).await.unwrap().is_none(),
+            header_store.read(&header_id).unwrap().is_none(),
             "Header shouldn't exist"
         );
     }
@@ -253,9 +251,7 @@ async fn test_failed_blocks_delete() {
         dag.insert(certificate).await.unwrap();
 
         // write the header
-        header_store
-            .async_write(header.clone().digest(), header.clone())
-            .await;
+        header_store.write(&header).unwrap();
 
         header_ids.push(header.clone().digest());
 
@@ -320,7 +316,7 @@ async fn test_failed_blocks_delete() {
         assert!(certificate_store.read(digest).unwrap().is_some());
     }
     for header_id in header_ids {
-        assert!(header_store.read(header_id).await.unwrap().is_some());
+        assert!(header_store.read(&header_id).unwrap().is_some());
     }
     for (worker_id, batch_digests) in worker_batches {
         for digest in batch_digests {

--- a/narwhal/primary/src/tests/certificate_fetcher_tests.rs
+++ b/narwhal/primary/src/tests/certificate_fetcher_tests.rs
@@ -237,7 +237,7 @@ async fn fetch_certificates_basic() {
 
     // Avoid any sort of missing payload by pre-populating the batch
     for (digest, (worker_id, _)) in headers.iter().flat_map(|h| h.payload.iter()) {
-        payload_store.async_write((*digest, *worker_id), 0u8).await;
+        payload_store.write(*digest, *worker_id).unwrap();
     }
 
     let total_certificates = fixture.authorities().count() * rounds as usize;

--- a/narwhal/primary/src/tests/certificate_fetcher_tests.rs
+++ b/narwhal/primary/src/tests/certificate_fetcher_tests.rs
@@ -237,7 +237,7 @@ async fn fetch_certificates_basic() {
 
     // Avoid any sort of missing payload by pre-populating the batch
     for (digest, (worker_id, _)) in headers.iter().flat_map(|h| h.payload.iter()) {
-        payload_store.write(*digest, *worker_id).unwrap();
+        payload_store.write(digest, worker_id).unwrap();
     }
 
     let total_certificates = fixture.authorities().count() * rounds as usize;

--- a/narwhal/primary/src/tests/common.rs
+++ b/narwhal/primary/src/tests/common.rs
@@ -3,8 +3,8 @@
 use config::WorkerId;
 use crypto::NetworkKeyPair;
 use std::time::Duration;
-use storage::{CertificateStore, PayloadStore};
-use store::{reopen, rocks, rocks::DBMap, rocks::ReadWriteOptions, Store};
+use storage::{CertificateStore, HeaderStore, PayloadStore};
+use store::{reopen, rocks, rocks::DBMap, rocks::ReadWriteOptions};
 use test_utils::{
     temp_dir, PrimaryToWorkerMockServer, CERTIFICATES_CF, CERTIFICATE_DIGEST_BY_ORIGIN_CF,
     CERTIFICATE_DIGEST_BY_ROUND_CF, HEADERS_CF, PAYLOAD_CF,
@@ -19,7 +19,7 @@ use storage::PayloadToken;
 use store::rocks::MetricConf;
 use tokio::{task::JoinHandle, time::Instant};
 
-pub fn create_db_stores() -> (Store<HeaderDigest, Header>, CertificateStore, PayloadStore) {
+pub fn create_db_stores() -> (HeaderStore, CertificateStore, PayloadStore) {
     // Create a new test store.
     let rocksdb = rocks::open_cf(
         temp_dir(),
@@ -49,7 +49,7 @@ pub fn create_db_stores() -> (Store<HeaderDigest, Header>, CertificateStore, Pay
         PAYLOAD_CF;<(BatchDigest, WorkerId), PayloadToken>);
 
     (
-        Store::new(header_map),
+        HeaderStore::new(header_map),
         CertificateStore::new(
             certificate_map,
             certificate_digest_by_round_map,

--- a/narwhal/primary/src/tests/common.rs
+++ b/narwhal/primary/src/tests/common.rs
@@ -3,7 +3,7 @@
 use config::WorkerId;
 use crypto::NetworkKeyPair;
 use std::time::Duration;
-use storage::CertificateStore;
+use storage::{CertificateStore, PayloadStore};
 use store::{reopen, rocks, rocks::DBMap, rocks::ReadWriteOptions, Store};
 use test_utils::{
     temp_dir, PrimaryToWorkerMockServer, CERTIFICATES_CF, CERTIFICATE_DIGEST_BY_ORIGIN_CF,
@@ -19,11 +19,7 @@ use storage::PayloadToken;
 use store::rocks::MetricConf;
 use tokio::{task::JoinHandle, time::Instant};
 
-pub fn create_db_stores() -> (
-    Store<HeaderDigest, Header>,
-    CertificateStore,
-    Store<(BatchDigest, WorkerId), PayloadToken>,
-) {
+pub fn create_db_stores() -> (Store<HeaderDigest, Header>, CertificateStore, PayloadStore) {
     // Create a new test store.
     let rocksdb = rocks::open_cf(
         temp_dir(),
@@ -59,7 +55,7 @@ pub fn create_db_stores() -> (
             certificate_digest_by_round_map,
             certificate_digest_by_origin_map,
         ),
-        Store::new(payload_map),
+        PayloadStore::new(payload_map),
     )
 }
 

--- a/narwhal/primary/src/tests/common.rs
+++ b/narwhal/primary/src/tests/common.rs
@@ -7,14 +7,14 @@ use storage::CertificateStore;
 use store::{reopen, rocks, rocks::DBMap, rocks::ReadWriteOptions, Store};
 use test_utils::{
     temp_dir, PrimaryToWorkerMockServer, CERTIFICATES_CF, CERTIFICATE_DIGEST_BY_ORIGIN_CF,
-    CERTIFICATE_DIGEST_BY_ROUND_CF, HEADERS_CF, PAYLOAD_CF, VOTES_CF,
+    CERTIFICATE_DIGEST_BY_ROUND_CF, HEADERS_CF, PAYLOAD_CF,
 };
 use types::{
-    BatchDigest, Certificate, CertificateDigest, Header, HeaderDigest, Round, VoteInfo,
+    BatchDigest, Certificate, CertificateDigest, Header, HeaderDigest, Round,
     WorkerSynchronizeMessage,
 };
 
-use crypto::{PublicKey, PublicKeyBytes};
+use crypto::PublicKeyBytes;
 use storage::PayloadToken;
 use store::rocks::MetricConf;
 use tokio::{task::JoinHandle, time::Instant};
@@ -61,14 +61,6 @@ pub fn create_db_stores() -> (
         ),
         Store::new(payload_map),
     )
-}
-
-pub fn create_test_vote_store() -> Store<PublicKey, VoteInfo> {
-    // Create a new test store.
-    let rocksdb = rocks::open_cf(temp_dir(), None, MetricConf::default(), &[VOTES_CF])
-        .expect("Failed creating database");
-    let votes_map = reopen!(&rocksdb, VOTES_CF;<PublicKey, VoteInfo>);
-    Store::new(votes_map)
 }
 
 #[must_use]

--- a/narwhal/primary/src/tests/primary_tests.rs
+++ b/narwhal/primary/src/tests/primary_tests.rs
@@ -27,9 +27,9 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use storage::CertificateStore;
 use storage::NodeStorage;
 use storage::PayloadToken;
+use storage::{CertificateStore, VoteDigestStore};
 use store::rocks::{DBMap, MetricConf, ReadWriteOptions};
 use store::Store;
 use test_utils::{make_optimal_signed_certificates, temp_dir, CommitteeFixture};
@@ -341,7 +341,7 @@ async fn test_request_vote_send_missing_parents() {
         header_store: header_store.clone(),
         certificate_store: certificate_store.clone(),
         payload_store: payload_store.clone(),
-        vote_digest_store: crate::common::create_test_vote_store(),
+        vote_digest_store: VoteDigestStore::new_for_tests(),
         rx_narwhal_round_updates,
         metrics: metrics.clone(),
     };
@@ -485,7 +485,7 @@ async fn test_request_vote_accept_missing_parents() {
         header_store: header_store.clone(),
         certificate_store: certificate_store.clone(),
         payload_store: payload_store.clone(),
-        vote_digest_store: crate::common::create_test_vote_store(),
+        vote_digest_store: VoteDigestStore::new_for_tests(),
         rx_narwhal_round_updates,
         metrics: metrics.clone(),
     };
@@ -621,7 +621,7 @@ async fn test_request_vote_missing_batches() {
         header_store: header_store.clone(),
         certificate_store: certificate_store.clone(),
         payload_store: payload_store.clone(),
-        vote_digest_store: crate::common::create_test_vote_store(),
+        vote_digest_store: VoteDigestStore::new_for_tests(),
         rx_narwhal_round_updates,
         metrics: metrics.clone(),
     };
@@ -746,7 +746,7 @@ async fn test_request_vote_already_voted() {
         header_store: header_store.clone(),
         certificate_store: certificate_store.clone(),
         payload_store: payload_store.clone(),
-        vote_digest_store: crate::common::create_test_vote_store(),
+        vote_digest_store: VoteDigestStore::new_for_tests(),
         rx_narwhal_round_updates,
         metrics: metrics.clone(),
     };
@@ -904,7 +904,7 @@ async fn test_fetch_certificates_handler() {
         header_store: header_store.clone(),
         certificate_store: certificate_store.clone(),
         payload_store: payload_store.clone(),
-        vote_digest_store: crate::common::create_test_vote_store(),
+        vote_digest_store: VoteDigestStore::new_for_tests(),
         rx_narwhal_round_updates,
         metrics: metrics.clone(),
     };
@@ -1073,7 +1073,7 @@ async fn test_process_payload_availability_success() {
         header_store: header_store.clone(),
         certificate_store: certificate_store.clone(),
         payload_store: payload_store.clone(),
-        vote_digest_store: crate::common::create_test_vote_store(),
+        vote_digest_store: VoteDigestStore::new_for_tests(),
         rx_narwhal_round_updates,
         metrics: metrics.clone(),
     };
@@ -1224,7 +1224,7 @@ async fn test_process_payload_availability_when_failures() {
         header_store: header_store.clone(),
         certificate_store: certificate_store.clone(),
         payload_store: payload_store.clone(),
-        vote_digest_store: crate::common::create_test_vote_store(),
+        vote_digest_store: VoteDigestStore::new_for_tests(),
         rx_narwhal_round_updates,
         metrics: metrics.clone(),
     };
@@ -1323,7 +1323,7 @@ async fn test_request_vote_created_at_in_future() {
         header_store: header_store.clone(),
         certificate_store: certificate_store.clone(),
         payload_store: payload_store.clone(),
-        vote_digest_store: crate::common::create_test_vote_store(),
+        vote_digest_store: VoteDigestStore::new_for_tests(),
         rx_narwhal_round_updates,
         metrics: metrics.clone(),
     };

--- a/narwhal/primary/src/tests/primary_tests.rs
+++ b/narwhal/primary/src/tests/primary_tests.rs
@@ -374,7 +374,7 @@ async fn test_request_vote_send_missing_parents() {
     // into the storage as parents of round 2 certificates. But to test phase 2 they are left out.
     for cert in round_2_parents {
         for (digest, (worker_id, _)) in &cert.header.payload {
-            payload_store.write(*digest, *worker_id).unwrap();
+            payload_store.write(digest, worker_id).unwrap();
         }
         certificate_store.write(cert.clone()).unwrap();
     }
@@ -519,19 +519,19 @@ async fn test_request_vote_accept_missing_parents() {
     // should be able to get accepted.
     for cert in round_1_certs {
         for (digest, (worker_id, _)) in &cert.header.payload {
-            payload_store.write(*digest, *worker_id).unwrap();
+            payload_store.write(digest, worker_id).unwrap();
         }
         certificate_store.write(cert.clone()).unwrap();
     }
     for cert in round_2_parents {
         for (digest, (worker_id, _)) in &cert.header.payload {
-            payload_store.write(*digest, *worker_id).unwrap();
+            payload_store.write(digest, worker_id).unwrap();
         }
         certificate_store.write(cert.clone()).unwrap();
     }
     // Populate new header payload so they don't have to be retrieved.
     for (digest, (worker_id, _)) in &test_header.payload {
-        payload_store.write(*digest, *worker_id).unwrap();
+        payload_store.write(digest, worker_id).unwrap();
     }
 
     // TEST PHASE 1: Handler should report missing parent certificates to caller.
@@ -639,7 +639,7 @@ async fn test_request_vote_missing_batches() {
 
         certificates.insert(digest, certificate.clone());
         certificate_store.write(certificate.clone()).unwrap();
-        for (digest, (worker_id, _)) in certificate.header.payload {
+        for (digest, (worker_id, _)) in &certificate.header.payload {
             payload_store.write(digest, worker_id).unwrap();
         }
     }
@@ -764,7 +764,7 @@ async fn test_request_vote_already_voted() {
 
         certificates.insert(digest, certificate.clone());
         certificate_store.write(certificate.clone()).unwrap();
-        for (digest, (worker_id, _)) in certificate.header.payload {
+        for (digest, (worker_id, _)) in &certificate.header.payload {
             payload_store.write(digest, worker_id).unwrap();
         }
     }
@@ -1100,7 +1100,7 @@ async fn test_process_payload_availability_success() {
             // write the certificate
             certificate_store.write(certificate.clone()).unwrap();
 
-            for (digest, (worker_id, _)) in certificate.header.payload {
+            for (digest, (worker_id, _)) in &certificate.header.payload {
                 payload_store.write(digest, worker_id).unwrap();
             }
         } else {
@@ -1341,7 +1341,7 @@ async fn test_request_vote_created_at_in_future() {
 
         certificates.insert(digest, certificate.clone());
         certificate_store.write(certificate.clone()).unwrap();
-        for (digest, (worker_id, _)) in certificate.header.payload {
+        for (digest, (worker_id, _)) in &certificate.header.payload {
             payload_store.write(digest, worker_id).unwrap();
         }
     }

--- a/narwhal/primary/src/tests/synchronizer_tests.rs
+++ b/narwhal/primary/src/tests/synchronizer_tests.rs
@@ -798,7 +798,7 @@ async fn sync_batches_drops_old() {
         certificates.insert(digest, certificate.clone());
         certificate_store.write(certificate.clone()).unwrap();
         for (digest, (worker_id, _)) in certificate.header.payload {
-            payload_store.async_write((digest, worker_id), 1).await;
+            payload_store.write(digest, worker_id).unwrap();
         }
     }
     let test_header = author

--- a/narwhal/primary/src/tests/synchronizer_tests.rs
+++ b/narwhal/primary/src/tests/synchronizer_tests.rs
@@ -797,7 +797,7 @@ async fn sync_batches_drops_old() {
 
         certificates.insert(digest, certificate.clone());
         certificate_store.write(certificate.clone()).unwrap();
-        for (digest, (worker_id, _)) in certificate.header.payload {
+        for (digest, (worker_id, _)) in &certificate.header.payload {
             payload_store.write(digest, worker_id).unwrap();
         }
     }

--- a/narwhal/primary/tests/integration_tests_validator_api.rs
+++ b/narwhal/primary/tests/integration_tests_validator_api.rs
@@ -16,9 +16,9 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use storage::CertificateStore;
+use storage::{CertificateStore, HeaderStore};
 use storage::{NodeStorage, PayloadStore};
-use store::{rocks::DBMap, Map, Store};
+use store::{rocks::DBMap, Map};
 use test_utils::{
     fixture_batch_with_transactions, make_optimal_certificates, make_optimal_signed_certificates,
     temp_dir, AuthorityFixture, CommitteeFixture,
@@ -27,9 +27,8 @@ use tokio::sync::watch;
 use tonic::transport::Channel;
 use types::{
     Batch, BatchDigest, Certificate, CertificateDigest, CertificateDigestProto,
-    CollectionRetrievalResult, Empty, GetCollectionsRequest, Header, HeaderDigest,
-    PreSubscribedBroadcastSender, ReadCausalRequest, RemoveCollectionsRequest, RetrievalResult,
-    Transaction, ValidatorClient,
+    CollectionRetrievalResult, Empty, GetCollectionsRequest, PreSubscribedBroadcastSender,
+    ReadCausalRequest, RemoveCollectionsRequest, RetrievalResult, Transaction, ValidatorClient,
 };
 use worker::{metrics::initialise_metrics, TrivialTransactionValidator, Worker};
 
@@ -77,10 +76,7 @@ async fn test_get_collections() {
         store.certificate_store.write(certificate.clone()).unwrap();
 
         // Write the header
-        store
-            .header_store
-            .async_write(header.clone().digest(), header.clone())
-            .await;
+        store.header_store.write(&header).unwrap();
 
         header_digests.push(header.clone().digest());
 
@@ -293,10 +289,7 @@ async fn test_remove_collections() {
         dag.insert(certificate.clone()).await.unwrap();
 
         // Write the header
-        store
-            .header_store
-            .async_write(header.clone().digest(), header.clone())
-            .await;
+        store.header_store.write(&header).unwrap();
 
         header_digests.push(header.clone().digest());
 
@@ -1177,7 +1170,7 @@ async fn fixture_certificate(
     authority: &AuthorityFixture,
     committee: &Committee,
     fixture: &CommitteeFixture,
-    header_store: Store<HeaderDigest, Header>,
+    header_store: HeaderStore,
     certificate_store: CertificateStore,
     payload_store: PayloadStore,
     batch_store: DBMap<BatchDigest, Batch>,
@@ -1202,9 +1195,7 @@ async fn fixture_certificate(
     certificate_store.write(certificate.clone()).unwrap();
 
     // Write the header
-    header_store
-        .async_write(header.clone().digest(), header.clone())
-        .await;
+    header_store.write(&header).unwrap();
 
     // Write the batches to payload store
     payload_store

--- a/narwhal/storage/src/header_store.rs
+++ b/narwhal/storage/src/header_store.rs
@@ -1,0 +1,48 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::NodeStorage;
+use store::rocks::ReadWriteOptions;
+use store::rocks::{open_cf, DBMap, MetricConf};
+use store::{reopen, Map, TypedStoreError};
+use types::{Header, HeaderDigest};
+
+#[derive(Clone)]
+pub struct HeaderStore {
+    store: DBMap<HeaderDigest, Header>,
+}
+
+impl HeaderStore {
+    pub fn new(header_store: DBMap<HeaderDigest, Header>) -> Self {
+        Self {
+            store: header_store,
+        }
+    }
+
+    pub fn new_for_tests() -> Self {
+        let rocksdb = open_cf(
+            tempfile::tempdir().unwrap(),
+            None,
+            MetricConf::default(),
+            &[NodeStorage::HEADERS_CF],
+        )
+        .expect("Cannot open database");
+        let map = reopen!(&rocksdb, NodeStorage::HEADERS_CF;<HeaderDigest, Header>);
+        Self::new(map)
+    }
+
+    pub fn read(&self, id: &HeaderDigest) -> Result<Option<Header>, TypedStoreError> {
+        self.store.get(id)
+    }
+
+    pub fn write(&self, header: &Header) -> Result<(), TypedStoreError> {
+        self.store.insert(&header.digest(), header)
+    }
+
+    pub fn remove_all(
+        &self,
+        keys: impl IntoIterator<Item = HeaderDigest>,
+    ) -> Result<(), TypedStoreError> {
+        self.store.multi_remove(keys)
+    }
+}

--- a/narwhal/storage/src/lib.rs
+++ b/narwhal/storage/src/lib.rs
@@ -4,7 +4,9 @@
 mod certificate_store;
 mod node_store;
 mod proposer_store;
+mod vote_digest_store;
 
 pub use certificate_store::*;
 pub use node_store::*;
 pub use proposer_store::*;
+pub use vote_digest_store::*;

--- a/narwhal/storage/src/lib.rs
+++ b/narwhal/storage/src/lib.rs
@@ -3,10 +3,12 @@
 
 mod certificate_store;
 mod node_store;
+mod payload_store;
 mod proposer_store;
 mod vote_digest_store;
 
 pub use certificate_store::*;
 pub use node_store::*;
+pub use payload_store::*;
 pub use proposer_store::*;
 pub use vote_digest_store::*;

--- a/narwhal/storage/src/lib.rs
+++ b/narwhal/storage/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod certificate_store;
+mod header_store;
 mod node_store;
 mod payload_store;
 mod proposer_store;
@@ -9,6 +10,7 @@ mod vote_digest_store;
 
 pub use certificate_store::*;
 use dashmap::DashMap;
+pub use header_store::*;
 pub use node_store::*;
 pub use payload_store::*;
 pub use proposer_store::*;

--- a/narwhal/storage/src/node_store.rs
+++ b/narwhal/storage/src/node_store.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crate::proposer_store::ProposerKey;
+use crate::vote_digest_store::VoteDigestStore;
 use crate::{CertificateStore, ProposerStore};
 use config::WorkerId;
 use crypto::{PublicKey, PublicKeyBytes};
@@ -22,7 +23,7 @@ pub type PayloadToken = u8;
 #[derive(Clone)]
 pub struct NodeStorage {
     pub proposer_store: ProposerStore,
-    pub vote_digest_store: Store<PublicKey, VoteInfo>,
+    pub vote_digest_store: VoteDigestStore,
     pub header_store: Store<HeaderDigest, Header>,
     pub certificate_store: CertificateStore,
     pub payload_store: Store<(BatchDigest, WorkerId), PayloadToken>,
@@ -32,16 +33,16 @@ pub struct NodeStorage {
 
 impl NodeStorage {
     /// The datastore column family names.
-    const LAST_PROPOSED_CF: &'static str = "last_proposed";
-    const VOTES_CF: &'static str = "votes";
-    const HEADERS_CF: &'static str = "headers";
-    const CERTIFICATES_CF: &'static str = "certificates";
-    const CERTIFICATE_DIGEST_BY_ROUND_CF: &'static str = "certificate_digest_by_round";
-    const CERTIFICATE_DIGEST_BY_ORIGIN_CF: &'static str = "certificate_digest_by_origin";
-    const PAYLOAD_CF: &'static str = "payload";
-    const BATCHES_CF: &'static str = "batches";
-    const LAST_COMMITTED_CF: &'static str = "last_committed";
-    const SUB_DAG_INDEX_CF: &'static str = "sub_dag";
+    pub(crate) const LAST_PROPOSED_CF: &'static str = "last_proposed";
+    pub(crate) const VOTES_CF: &'static str = "votes";
+    pub(crate) const HEADERS_CF: &'static str = "headers";
+    pub(crate) const CERTIFICATES_CF: &'static str = "certificates";
+    pub(crate) const CERTIFICATE_DIGEST_BY_ROUND_CF: &'static str = "certificate_digest_by_round";
+    pub(crate) const CERTIFICATE_DIGEST_BY_ORIGIN_CF: &'static str = "certificate_digest_by_origin";
+    pub(crate) const PAYLOAD_CF: &'static str = "payload";
+    pub(crate) const BATCHES_CF: &'static str = "batches";
+    pub(crate) const LAST_COMMITTED_CF: &'static str = "last_committed";
+    pub(crate) const SUB_DAG_INDEX_CF: &'static str = "sub_dag";
 
     /// Open or reopen all the storage of the node.
     pub fn reopen<Path: AsRef<std::path::Path> + Send>(store_path: Path) -> Self {
@@ -91,7 +92,7 @@ impl NodeStorage {
         );
 
         let proposer_store = ProposerStore::new(last_proposed_map);
-        let vote_digest_store = Store::new(votes_map);
+        let vote_digest_store = VoteDigestStore::new(votes_map);
         let header_store = Store::new(header_map);
         let certificate_store = CertificateStore::new(
             certificate_map,

--- a/narwhal/storage/src/node_store.rs
+++ b/narwhal/storage/src/node_store.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+use crate::payload_store::PayloadStore;
 use crate::proposer_store::ProposerKey;
 use crate::vote_digest_store::VoteDigestStore;
 use crate::{CertificateStore, ProposerStore};
@@ -26,7 +27,7 @@ pub struct NodeStorage {
     pub vote_digest_store: VoteDigestStore,
     pub header_store: Store<HeaderDigest, Header>,
     pub certificate_store: CertificateStore,
-    pub payload_store: Store<(BatchDigest, WorkerId), PayloadToken>,
+    pub payload_store: PayloadStore,
     pub batch_store: DBMap<BatchDigest, Batch>,
     pub consensus_store: Arc<ConsensusStore>,
 }
@@ -99,7 +100,7 @@ impl NodeStorage {
             certificate_digest_by_round_map,
             certificate_digest_by_origin_map,
         );
-        let payload_store = Store::new(payload_map);
+        let payload_store = PayloadStore::new(payload_map);
         let batch_store = batch_map;
         let consensus_store = Arc::new(ConsensusStore::new(last_committed_map, sub_dag_index_map));
 

--- a/narwhal/storage/src/node_store.rs
+++ b/narwhal/storage/src/node_store.rs
@@ -3,15 +3,15 @@
 use crate::payload_store::PayloadStore;
 use crate::proposer_store::ProposerKey;
 use crate::vote_digest_store::VoteDigestStore;
-use crate::{CertificateStore, ProposerStore};
+use crate::{CertificateStore, HeaderStore, ProposerStore};
 use config::WorkerId;
 use crypto::{PublicKey, PublicKeyBytes};
 use std::sync::Arc;
 use std::time::Duration;
 use store::metrics::SamplingInterval;
+use store::reopen;
 use store::rocks::DBMap;
 use store::rocks::{open_cf, MetricConf, ReadWriteOptions};
-use store::{reopen, Store};
 use types::{
     Batch, BatchDigest, Certificate, CertificateDigest, CommittedSubDagShell, ConsensusStore,
     Header, HeaderDigest, Round, SequenceNumber, VoteInfo,
@@ -25,7 +25,7 @@ pub type PayloadToken = u8;
 pub struct NodeStorage {
     pub proposer_store: ProposerStore,
     pub vote_digest_store: VoteDigestStore,
-    pub header_store: Store<HeaderDigest, Header>,
+    pub header_store: HeaderStore,
     pub certificate_store: CertificateStore,
     pub payload_store: PayloadStore,
     pub batch_store: DBMap<BatchDigest, Batch>,
@@ -94,7 +94,7 @@ impl NodeStorage {
 
         let proposer_store = ProposerStore::new(last_proposed_map);
         let vote_digest_store = VoteDigestStore::new(votes_map);
-        let header_store = Store::new(header_map);
+        let header_store = HeaderStore::new(header_map);
         let certificate_store = CertificateStore::new(
             certificate_map,
             certificate_digest_by_round_map,

--- a/narwhal/storage/src/payload_store.rs
+++ b/narwhal/storage/src/payload_store.rs
@@ -1,0 +1,131 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{NodeStorage, PayloadToken};
+use config::WorkerId;
+use dashmap::DashMap;
+use std::collections::VecDeque;
+use std::sync::Arc;
+use store::reopen;
+use store::rocks::{open_cf, MetricConf, ReadWriteOptions};
+use store::{rocks::DBMap, Map, TypedStoreError};
+use tokio::sync::oneshot;
+use tokio::sync::oneshot::Sender;
+use tracing::warn;
+use types::BatchDigest;
+
+/// Store of the batch digests for the primary node for the own created batches.
+#[derive(Clone)]
+pub struct PayloadStore {
+    store: DBMap<(BatchDigest, WorkerId), PayloadToken>,
+
+    /// Senders to notify for a write that happened for the specified batch digest and worker id
+    notify_on_write_subscribers:
+        Arc<DashMap<(BatchDigest, WorkerId), VecDeque<Sender<PayloadToken>>>>,
+}
+
+impl PayloadStore {
+    pub fn new(payload_store: DBMap<(BatchDigest, WorkerId), PayloadToken>) -> PayloadStore {
+        Self {
+            store: payload_store,
+            notify_on_write_subscribers: Arc::new(DashMap::new()),
+        }
+    }
+
+    pub fn new_for_tests() -> PayloadStore {
+        let rocksdb = open_cf(
+            tempfile::tempdir().unwrap(),
+            None,
+            MetricConf::default(),
+            &[NodeStorage::PAYLOAD_CF],
+        )
+        .expect("Cannot open database");
+        let map =
+            reopen!(&rocksdb, NodeStorage::PAYLOAD_CF;<(BatchDigest, WorkerId), PayloadToken>);
+        PayloadStore::new(map)
+    }
+
+    pub fn write(&self, digest: BatchDigest, worker_id: WorkerId) -> Result<(), TypedStoreError> {
+        self.store.insert(&(digest, worker_id), &0u8)?;
+        self.notify_subscribers(digest, worker_id, 0u8);
+        Ok(())
+    }
+
+    pub fn write_all(
+        &self,
+        keys: impl IntoIterator<Item = (BatchDigest, WorkerId)> + Clone,
+    ) -> Result<(), TypedStoreError> {
+        self.store
+            .multi_insert(keys.clone().into_iter().map(|e| (e, 0u8)))?;
+
+        keys.into_iter().for_each(|(digest, worker_id)| {
+            self.notify_subscribers(digest, worker_id, 0u8);
+        });
+        Ok(())
+    }
+
+    pub fn read(
+        &self,
+        digest: BatchDigest,
+        worker_id: WorkerId,
+    ) -> Result<Option<PayloadToken>, TypedStoreError> {
+        self.store.get(&(digest, worker_id))
+    }
+
+    pub async fn notify_read(
+        &self,
+        digest: BatchDigest,
+        worker_id: WorkerId,
+    ) -> Result<PayloadToken, TypedStoreError> {
+        // we register our interest to be notified with the value
+        let (sender, receiver) = oneshot::channel();
+        self.notify_on_write_subscribers
+            .entry((digest, worker_id))
+            .or_insert_with(VecDeque::new)
+            .push_back(sender);
+
+        // let's read the value because we might have missed the opportunity
+        // to get notified about it
+        if let Ok(Some(token)) = self.read(digest, worker_id) {
+            // notify any obligations - and remove the entries
+            self.notify_subscribers(digest, worker_id, token);
+
+            // reply directly
+            return Ok(token);
+        }
+
+        // now wait to hear back the result
+        let result = receiver
+            .await
+            .expect("Irrecoverable error while waiting to receive the notify_read result");
+
+        Ok(result)
+    }
+
+    pub fn read_all(
+        &self,
+        keys: impl IntoIterator<Item = (BatchDigest, WorkerId)>,
+    ) -> Result<Vec<Option<PayloadToken>>, TypedStoreError> {
+        self.store.multi_get(keys)
+    }
+
+    pub fn remove_all(
+        &self,
+        keys: impl IntoIterator<Item = (BatchDigest, WorkerId)>,
+    ) -> Result<(), TypedStoreError> {
+        self.store.multi_remove(keys)
+    }
+
+    fn notify_subscribers(&self, digest: BatchDigest, worker_id: WorkerId, value: PayloadToken) {
+        if let Some((_, mut senders)) = self
+            .notify_on_write_subscribers
+            .remove(&(digest, worker_id))
+        {
+            while let Some(s) = senders.pop_front() {
+                if s.send(value).is_err() {
+                    warn!("Couldn't notify obligation for batch with digest {digest} & worker with id {worker_id}");
+                }
+            }
+        }
+    }
+}

--- a/narwhal/storage/src/payload_store.rs
+++ b/narwhal/storage/src/payload_store.rs
@@ -18,14 +18,14 @@ pub struct PayloadStore {
 }
 
 impl PayloadStore {
-    pub fn new(payload_store: DBMap<(BatchDigest, WorkerId), PayloadToken>) -> PayloadStore {
+    pub fn new(payload_store: DBMap<(BatchDigest, WorkerId), PayloadToken>) -> Self {
         Self {
             store: payload_store,
             notify_subscribers: NotifySubscribers::new(),
         }
     }
 
-    pub fn new_for_tests() -> PayloadStore {
+    pub fn new_for_tests() -> Self {
         let rocksdb = open_cf(
             tempfile::tempdir().unwrap(),
             None,

--- a/narwhal/storage/src/vote_digest_store.rs
+++ b/narwhal/storage/src/vote_digest_store.rs
@@ -1,0 +1,46 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::NodeStorage;
+use crypto::PublicKey;
+use store::reopen;
+use store::rocks::{open_cf, MetricConf, ReadWriteOptions};
+use store::{rocks::DBMap, Map, TypedStoreError};
+use types::{Vote, VoteInfo};
+
+/// The storage for the last votes digests per authority
+#[derive(Clone)]
+pub struct VoteDigestStore {
+    store: DBMap<PublicKey, VoteInfo>,
+}
+
+impl VoteDigestStore {
+    pub fn new(vote_digest_store: DBMap<PublicKey, VoteInfo>) -> VoteDigestStore {
+        Self {
+            store: vote_digest_store,
+        }
+    }
+
+    pub fn new_for_tests() -> VoteDigestStore {
+        let rocksdb = open_cf(
+            tempfile::tempdir().unwrap(),
+            None,
+            MetricConf::default(),
+            &[NodeStorage::VOTES_CF],
+        )
+        .expect("Cannot open database");
+        let map = reopen!(&rocksdb, NodeStorage::VOTES_CF;<PublicKey, VoteInfo>);
+        VoteDigestStore::new(map)
+    }
+
+    /// Insert the vote's basic details into the database for the corresponding
+    /// header author key.
+    pub fn write(&self, vote: &Vote) -> Result<(), TypedStoreError> {
+        self.store.insert(&vote.origin, &vote.into())
+    }
+
+    /// Read the vote info based on the provided corresponding header author key
+    pub fn read(&self, header_author: &PublicKey) -> Result<Option<VoteInfo>, TypedStoreError> {
+        self.store.get(header_author)
+    }
+}

--- a/narwhal/types/src/primary.rs
+++ b/narwhal/types/src/primary.rs
@@ -1020,6 +1020,16 @@ pub struct VoteInfo {
     pub vote_digest: VoteDigest,
 }
 
+impl From<&Vote> for VoteInfo {
+    fn from(vote: &Vote) -> Self {
+        VoteInfo {
+            epoch: vote.epoch,
+            round: vote.round,
+            vote_digest: vote.digest(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{Batch, Metadata, Timestamp};


### PR DESCRIPTION
## Description 

This PR swaps for Narwhal all the `typed_store::Store` instances with `DBMap`. Also, I've wrapped the `DBMaps` behind dedicated structs so we can make things easier if we consider to swap later on `DBMaps` with something different in the future + make it easier to add additional methods on each store if needed in the future (ex update additional secondary index stores in batch fashion etc).

## Test Plan 

Existing & new unit and integration tests.

## TODO:
- [ ] wrap the `batch_store` DBMap behind a dedicated struct

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
