### PR TITLE
[workloads] add adversarial workload

### DIFF
--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -139,6 +139,17 @@ impl ExecutionEffects {
             Owner::ObjectOwner(_) | Owner::Shared { .. } | Owner::Immutable => unreachable!(), // owner of gas object is always an address
         }
     }
+
+    pub fn is_ok(&self) -> bool {
+        match self {
+            ExecutionEffects::CertifiedTransactionEffects(certified_effects, ..) => {
+                certified_effects.data().status().is_ok()
+            }
+            ExecutionEffects::SuiTransactionEffects(sui_tx_effects) => {
+                sui_tx_effects.status().is_ok()
+            }
+        }
+    }
 }
 
 #[async_trait]

--- a/crates/sui-benchmark/src/options.rs
+++ b/crates/sui-benchmark/src/options.rs
@@ -130,18 +130,11 @@ pub enum RunSpec {
     // will likely change in future to support
     // more representative workloads.
     Bench {
+        // ----- workloads ----
         // relative weight of shared counter
         // transaction in the benchmark workload
         #[clap(long, default_value = "0")]
         shared_counter: u32,
-        // 100 for max hotness i.e all requests target
-        // just the same shared counter, 0 for no hotness
-        // i.e. all requests target a different shared
-        // counter. The way total number of counters to
-        // create is computed roughly as:
-        // total_shared_counters = max(1, qps * (1.0 - hotness/100.0))
-        #[clap(long, default_value = "50")]
-        shared_counter_hotness_factor: u32,
         // relative weight of transfer object
         // transactions in the benchmark workload
         #[clap(long, default_value = "1")]
@@ -152,9 +145,24 @@ pub enum RunSpec {
         // relative weight of batch payment transactions in the benchmark workload
         #[clap(long, default_value = "0")]
         batch_payment: u32,
+        // relative weight of adversarial transactions in the benchmark workload
+        #[clap(long, default_value = "0")]
+        adversarial: u32,
+
+        // --- workload-specific options --- (TODO: use subcommands or similar)
+        // 100 for max hotness i.e all requests target
+        // just the same shared counter, 0 for no hotness
+        // i.e. all requests target a different shared
+        // counter. The way total number of counters to
+        // create is computed roughly as:
+        // total_shared_counters = max(1, qps * (1.0 - hotness/100.0))
+        #[clap(long, default_value = "50")]
+        shared_counter_hotness_factor: u32,
         // batch size use for batch payment workload
         #[clap(long, default_value = "15")]
         batch_payment_size: u32,
+
+        // --- generic options ---
         // Target qps
         #[clap(long, default_value = "1000", global = true)]
         target_qps: u64,

--- a/crates/sui-benchmark/src/workloads/adversarial.rs
+++ b/crates/sui-benchmark/src/workloads/adversarial.rs
@@ -1,0 +1,216 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+use sui_types::{base_types::ObjectID, object::Owner};
+use test_utils::messages::create_publish_move_package_transaction;
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use sui_types::{base_types::SuiAddress, crypto::get_key_pair, messages::VerifiedTransaction};
+
+use crate::in_memory_wallet::InMemoryWallet;
+use crate::system_state_observer::SystemStateObserver;
+use crate::workloads::payload::Payload;
+use crate::workloads::{Gas, GasCoinConfig};
+use crate::{ExecutionEffects, ValidatorProxy};
+
+use super::{
+    workload::{Workload, WorkloadBuilder, MAX_GAS_FOR_TESTING},
+    WorkloadBuilderInfo, WorkloadParams,
+};
+
+// TODO: copied from protocol_config, but maybe we can put this in SystemStateObserver
+const MAX_TX_GAS: u64 = 10_000_000_000;
+
+// TODO: copied from protocol_config, but maybe we can put this in SystemStateObserver
+/// Number of max size objects to create in the max object payload
+const NUM_OBJECTS: u64 = 32;
+// TODO: make this big once https://github.com/MystenLabs/sui/pull/9394 lands
+//const NUM_OBJECTS: u64 = 2048;
+
+/*enum PayloadType {
+    /// create NUM_OBJECTS objects with the max object size. This will write out a lot of object data
+    MaxObjects,
+    // TODO:
+    // - MaxReads (by creating a bunch of shared objects in the module init for adversarial, then taking them all as input)
+    // - MaxDynamicFields (by reading a bunch of dynamic fields at runtime)
+    // - MaxEffects (by creating a bunch of small objects)
+    // - MaxEvents (max out VM's event size limit)
+}*/
+
+#[derive(Debug)]
+pub struct AdversarialTestPayload {
+    /// ID of the Move package with adversarial utility functions
+    package_id: ObjectID,
+    /// address to send adversarial transactions from
+    sender: SuiAddress,
+    state: InMemoryWallet,
+    system_state_observer: Arc<SystemStateObserver>,
+}
+
+impl std::fmt::Display for AdversarialTestPayload {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "adversarial")
+    }
+}
+
+impl Payload for AdversarialTestPayload {
+    fn make_new_payload(&mut self, effects: &ExecutionEffects) {
+        // important to keep this as a sanity check that we don't hit protocol limits or run out of gas as things change elsewhere.
+        // adversarial tests aren't much use if they don't have effects :)
+        debug_assert!(
+            effects.is_ok(),
+            "Adversarial transactions should never abort"
+        );
+
+        self.state.update(effects);
+    }
+
+    fn make_transaction(&mut self) -> VerifiedTransaction {
+        // TODO: default benchmarking gas coins are too small to use MAX_TX_GAS. But we will want to be able to use that much to hit some limits
+        let gas_budget = MAX_TX_GAS / 100;
+        // TODO: generate random number, convert it to a PayloadType, call the appropriate function
+        self.state.move_call(
+            self.sender,
+            self.package_id,
+            "adversarial",
+            "create_max_size_owned_objects",
+            vec![],
+            vec![NUM_OBJECTS.into()],
+            gas_budget,
+            *self.system_state_observer.reference_gas_price.borrow(),
+        )
+    }
+}
+
+#[derive(Debug)]
+pub struct AdversarialWorkloadBuilder {
+    num_payloads: u64,
+}
+
+#[async_trait]
+impl WorkloadBuilder<dyn Payload> for AdversarialWorkloadBuilder {
+    async fn generate_coin_config_for_init(&self) -> Vec<GasCoinConfig> {
+        // Gas coin for publishing adversarial package
+        let (address, keypair) = get_key_pair();
+        vec![GasCoinConfig {
+            amount: MAX_GAS_FOR_TESTING,
+            address,
+            keypair: Arc::new(keypair),
+        }]
+    }
+
+    async fn generate_coin_config_for_payloads(&self) -> Vec<GasCoinConfig> {
+        let mut configs = vec![];
+        // Gas coins for running workload
+        for _i in 0..self.num_payloads {
+            let (address, keypair) = get_key_pair();
+            configs.push(GasCoinConfig {
+                amount: MAX_GAS_FOR_TESTING,
+                address,
+                keypair: Arc::new(keypair),
+            });
+        }
+        configs
+    }
+
+    async fn build(
+        &self,
+        mut init_gas: Vec<Gas>,
+        payload_gas: Vec<Gas>,
+    ) -> Box<dyn Workload<dyn Payload>> {
+        Box::<dyn Workload<dyn Payload>>::from(Box::new(AdversarialWorkload {
+            package_id: ObjectID::ZERO,
+            init_gas: init_gas.pop().unwrap(),
+            payload_gas,
+        }))
+    }
+}
+
+impl AdversarialWorkloadBuilder {
+    pub fn from(
+        workload_weight: f32,
+        target_qps: u64,
+        num_workers: u64,
+        in_flight_ratio: u64,
+    ) -> Option<WorkloadBuilderInfo> {
+        let target_qps = (workload_weight * target_qps as f32) as u64;
+        let num_workers = (workload_weight * num_workers as f32).ceil() as u64;
+        let max_ops = target_qps * in_flight_ratio;
+        if max_ops == 0 || num_workers == 0 {
+            None
+        } else {
+            let workload_params = WorkloadParams {
+                target_qps,
+                num_workers,
+                max_ops,
+            };
+            let workload_builder = Box::<dyn WorkloadBuilder<dyn Payload>>::from(Box::new(
+                AdversarialWorkloadBuilder {
+                    num_payloads: max_ops,
+                },
+            ));
+            let builder_info = WorkloadBuilderInfo {
+                workload_params,
+                workload_builder,
+            };
+            Some(builder_info)
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct AdversarialWorkload {
+    /// ID of the Move package with adversarial utility functions
+    package_id: ObjectID,
+    pub init_gas: Gas,
+    pub payload_gas: Vec<Gas>,
+}
+
+#[async_trait]
+impl Workload<dyn Payload> for AdversarialWorkload {
+    async fn init(
+        &mut self,
+        proxy: Arc<dyn ValidatorProxy + Sync + Send>,
+        system_state_observer: Arc<SystemStateObserver>,
+    ) {
+        let gas = &self.init_gas;
+        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.push("src/workloads/data/adversarial");
+        let gas_price = *system_state_observer.reference_gas_price.borrow();
+        let transaction =
+            create_publish_move_package_transaction(gas.0, path, gas.1, &gas.2, Some(gas_price));
+        let effects = proxy.execute_transaction(transaction.into()).await.unwrap();
+        let created = effects.created();
+        // should only create the package object + upgrade cap. otherwise, there are some object initializers running and we will need to disambiguate
+        assert_eq!(created.len(), 2);
+        let package_obj = created
+            .iter()
+            .find(|o| matches!(o.1, Owner::Immutable))
+            .unwrap();
+        self.package_id = package_obj.0 .0;
+    }
+
+    async fn make_test_payloads(
+        &self,
+        _proxy: Arc<dyn ValidatorProxy + Sync + Send>,
+        system_state_observer: Arc<SystemStateObserver>,
+    ) -> Vec<Box<dyn Payload>> {
+        let mut payloads = Vec::new();
+
+        for gas in &self.payload_gas {
+            payloads.push(AdversarialTestPayload {
+                package_id: self.package_id,
+                sender: gas.1,
+                state: InMemoryWallet::new(gas),
+                system_state_observer: system_state_observer.clone(),
+            })
+        }
+        payloads
+            .into_iter()
+            .map(|b| Box::<dyn Payload>::from(Box::new(b)))
+            .collect()
+    }
+}

--- a/crates/sui-benchmark/src/workloads/batch_payment.rs
+++ b/crates/sui-benchmark/src/workloads/batch_payment.rs
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
-use sui_types::base_types::ObjectID;
+use sui_types::base_types::{ObjectID, SequenceNumber};
+use sui_types::digests::ObjectDigest;
 use sui_types::object::Owner;
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use sui_types::{
@@ -32,11 +33,11 @@ const PRIMARY_COIN_VALUE: u64 = 10_000_000;
 /// Number of mist sent to each address on each batch transfer
 const TRANSFER_AMOUNT: u64 = 1;
 
+const DUMMY_GAS: ObjectRef = (ObjectID::ZERO, SequenceNumber::MIN, ObjectDigest::MIN);
+
 #[derive(Debug)]
 pub struct BatchPaymentTestPayload {
     state: InMemoryWallet,
-    // largest value coins owned by each address
-    primary_coins: BTreeMap<SuiAddress, ObjectID>,
     /// total number of payments made, to be used in reporting batch TPS
     num_payments: usize,
     /// address of the first sender. important because in the beginning, only one address has any coins.
@@ -57,7 +58,7 @@ impl Payload for BatchPaymentTestPayload {
         if self.num_payments == 0 {
             for (coin_obj, owner) in effects.created().into_iter().chain(effects.mutated()) {
                 if let Owner::AddressOwner(addr) = owner {
-                    self.primary_coins.insert(addr, coin_obj.0);
+                    self.state.account_mut(&addr).unwrap().gas = coin_obj;
                 } else {
                     unreachable!("Initial payment should only send to addresses")
                 }
@@ -77,10 +78,7 @@ impl Payload for BatchPaymentTestPayload {
             addrs[self.num_payments % num_recipients]
         };
         // we're only using gas objects in this benchmark, so safe to assume everything owned by an address is a gas object
-        let gas_obj = self
-            .state
-            .owned_object(&sender, self.primary_coins.get(&sender).unwrap())
-            .unwrap();
+        let gas_obj = self.state.gas(&sender).unwrap();
         let amount = if self.num_payments == 0 {
             PRIMARY_COIN_VALUE
         } else {
@@ -208,21 +206,20 @@ impl Workload<dyn Payload> for BatchPaymentWorkload {
         for (addr, gas) in gas_by_address {
             let mut state = InMemoryWallet::default();
             let key = gas[0].2.clone();
-            let gas_objs: Vec<ObjectRef> = gas.into_iter().map(|g| g.0).collect();
-            let primary_coin = gas_objs[0].0;
-            state.add_account(addr, key, gas_objs);
-            let mut primary_coins = BTreeMap::new();
-            primary_coins.insert(addr, primary_coin);
+            let mut objs: Vec<ObjectRef> = gas.into_iter().map(|g| g.0).collect();
+            let gas_coin = objs.pop().unwrap();
+            state.add_account(addr, key, gas_coin, objs);
             // add empty accounts for `addr` to transfer to
             for _ in 0..self.batch_size - 1 {
                 let (a, key) = get_key_pair();
-                state.add_account(a, Arc::new(key), Vec::new());
+                // we'll replace this after the first send
+                let gas = DUMMY_GAS;
+                state.add_account(a, Arc::new(key), gas, Vec::new());
             }
             payloads.push(Box::new(BatchPaymentTestPayload {
                 state,
                 num_payments: 0,
                 first_sender: addr,
-                primary_coins,
                 system_state_observer: system_state_observer.clone(),
             }));
         }

--- a/crates/sui-benchmark/src/workloads/data/adversarial/Move.toml
+++ b/crates/sui-benchmark/src/workloads/data/adversarial/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "adversarial"
+version = "0.0.1"
+
+[dependencies]
+Sui = { local = "../../../../../sui-framework" }
+
+[addresses]
+adversarial =  "0x0"
+sui =  "0000000000000000000000000000000000000000000000000000000000000002"

--- a/crates/sui-benchmark/src/workloads/data/adversarial/sources/adversarial.move
+++ b/crates/sui-benchmark/src/workloads/data/adversarial/sources/adversarial.move
@@ -1,0 +1,69 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module adversarial::adversarial {
+    use std::vector;
+    use sui::bcs;
+    use sui::object::{Self, UID};
+    use sui::tx_context::{Self, TxContext};
+    use sui::transfer;
+
+    struct S has key, store {
+        id: UID,
+        contents: vector<u8>
+    }
+
+    struct Wrapper has key {
+        id: UID,
+        s: S,
+    }
+
+    const MAX_OBJ_SIZE: u64 = 25600;
+
+    // create an object whose Move BCS representation is `n` bytes
+    public fun create_object_with_size(n: u64, ctx: &mut TxContext): S {
+        // minimum object size for S is 32 bytes for UID + 1 byte for vector length
+        assert!(n > std::address::length() + 1, 0);
+        let contents = vector[];
+        let i = 0;
+        let bytes_to_add = n - (std::address::length() + 1);
+        while (i < bytes_to_add) {
+            vector::push_back(&mut contents, 9);
+            i = i + 1;
+        };
+        let s = S { id: object::new(ctx), contents };
+        let size = vector::length(&bcs::to_bytes(&s));
+        // shrink by 1 byte until we match size. mismatch happens because of len(UID) + vector length byte
+        while (size > n) {
+            let _ = vector::pop_back(&mut s.contents);
+            // hack: assume this doesn't change the size of the BCS length byte
+            size = size - 1;
+        };
+        // double-check that we got the size right
+        assert!(vector::length(&bcs::to_bytes(&s)) == n, 1);
+        s
+    }
+
+    public fun create_max_size_object(ctx: &mut TxContext): S {
+        create_object_with_size(MAX_OBJ_SIZE, ctx)
+    }
+
+    /// Create `n` max size objects and transfer them to the tx sender
+    public fun create_max_size_owned_objects(n: u64, ctx: &mut TxContext) {
+        let i = 0;
+        let sender = tx_context::sender(ctx);
+        while (i < n) {
+            transfer::transfer(create_max_size_object(ctx), sender);
+            i = i + 1
+        }
+    }
+
+    /// Create `n` max size objects and share them
+    public fun create_max_size_shared_objects(n: u64, ctx: &mut TxContext) {
+        let i = 0;
+        while (i < n) {
+            transfer::share_object(create_max_size_object(ctx));
+            i = i + 1
+        }
+    }
+}

--- a/crates/sui-benchmark/src/workloads/mod.rs
+++ b/crates/sui-benchmark/src/workloads/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod adversarial;
 pub mod batch_payment;
 pub mod delegation;
 pub mod payload;

--- a/crates/sui-benchmark/src/workloads/workload_configuration.rs
+++ b/crates/sui-benchmark/src/workloads/workload_configuration.rs
@@ -12,6 +12,8 @@ use crate::workloads::WorkloadInfo;
 use anyhow::Result;
 use std::sync::Arc;
 
+use super::adversarial::AdversarialWorkloadBuilder;
+
 pub struct WorkloadConfiguration;
 
 impl WorkloadConfiguration {
@@ -29,6 +31,7 @@ impl WorkloadConfiguration {
                 transfer_object,
                 delegation,
                 batch_payment,
+                adversarial,
                 batch_payment_size,
                 shared_counter_hotness_factor,
                 ..
@@ -40,6 +43,7 @@ impl WorkloadConfiguration {
                     transfer_object,
                     delegation,
                     batch_payment,
+                    adversarial,
                     batch_payment_size,
                     shared_counter_hotness_factor,
                     target_qps,
@@ -60,6 +64,7 @@ impl WorkloadConfiguration {
         transfer_object_weight: u32,
         delegation_weight: u32,
         batch_payment_weight: u32,
+        adversarial_weight: u32,
         batch_payment_size: u32,
         shared_counter_hotness_factor: u32,
         target_qps: u64,
@@ -71,7 +76,8 @@ impl WorkloadConfiguration {
         let total_weight = shared_counter_weight
             + transfer_object_weight
             + delegation_weight
-            + batch_payment_weight;
+            + batch_payment_weight
+            + adversarial_weight;
         let mut workload_builders = vec![];
         let shared_workload = SharedCounterWorkloadBuilder::from(
             shared_counter_weight as f32 / total_weight as f32,
@@ -104,6 +110,13 @@ impl WorkloadConfiguration {
             batch_payment_size,
         );
         workload_builders.push(batch_payment_workload);
+        let adversarial_workload = AdversarialWorkloadBuilder::from(
+            adversarial_weight as f32 / total_weight as f32,
+            target_qps,
+            num_workers,
+            in_flight_ratio,
+        );
+        workload_builders.push(adversarial_workload);
         let (workload_params, workload_builders): (Vec<_>, Vec<_>) = workload_builders
             .into_iter()
             .flatten()

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -253,6 +253,7 @@ mod test {
         let num_transfer_accounts = 2;
         let delegation_weight = 1;
         let batch_payment_weight = 1;
+        let adversarial_weight = 1;
         let shared_counter_hotness_factor = 50;
 
         let workloads = WorkloadConfiguration::build_workloads(
@@ -262,6 +263,7 @@ mod test {
             transfer_object_weight,
             delegation_weight,
             batch_payment_weight,
+            adversarial_weight,
             batch_payment_size,
             shared_counter_hotness_factor,
             target_qps,

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -267,6 +267,48 @@ impl CallArg {
     }
 }
 
+impl From<bool> for CallArg {
+    fn from(b: bool) -> Self {
+        // unwrap safe because every u8 value is BCS-serializable
+        CallArg::Pure(bcs::to_bytes(&b).unwrap())
+    }
+}
+
+impl From<u8> for CallArg {
+    fn from(n: u8) -> Self {
+        // unwrap safe because every u8 value is BCS-serializable
+        CallArg::Pure(bcs::to_bytes(&n).unwrap())
+    }
+}
+
+impl From<u16> for CallArg {
+    fn from(n: u16) -> Self {
+        // unwrap safe because every u16 value is BCS-serializable
+        CallArg::Pure(bcs::to_bytes(&n).unwrap())
+    }
+}
+
+impl From<u32> for CallArg {
+    fn from(n: u32) -> Self {
+        // unwrap safe because every u32 value is BCS-serializable
+        CallArg::Pure(bcs::to_bytes(&n).unwrap())
+    }
+}
+
+impl From<u64> for CallArg {
+    fn from(n: u64) -> Self {
+        // unwrap safe because every u64 value is BCS-serializable
+        CallArg::Pure(bcs::to_bytes(&n).unwrap())
+    }
+}
+
+impl From<u128> for CallArg {
+    fn from(n: u128) -> Self {
+        // unwrap safe because every u128 value is BCS-serializable
+        CallArg::Pure(bcs::to_bytes(&n).unwrap())
+    }
+}
+
 impl ObjectArg {
     pub fn id(&self) -> ObjectID {
         match self {


### PR DESCRIPTION
## Description 

A new workload type that tries to push against system limits. For starters, I added logic for generating as many objects of the max size as possible without going over a limit. Some other ideas for extensions to this workload:

- MaxReads (by creating a bunch of shared objects in the module init for adversarial, then taking them all as input)
- MaxDynamicFields (by reading a bunch of dynamic fields at runtime)
- MaxEffects (by creating a bunch of small objects)
- MaxEvents (max out VM's event size limit)

Hopefully this will be useful for simtests/stress-testing.

## Test Plan 

```
cargo run --package sui-benchmark --bin stress --  --num-client-threads 1 --num-server-threads 20 bench --target-qps 10 --in-flight-ratio 1 --transfer-object 0 --adversarial 1 --run-duration 100s 
```

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration