### PR TITLE
[package-upgrades] Enforce max Move binary (bytecode) limit during module deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8978,6 +8978,7 @@ dependencies = [
  "sui-macros",
  "sui-open-rpc",
  "sui-open-rpc-macros",
+ "sui-protocol-config",
  "sui-sdk",
  "sui-simulator",
  "sui-transaction-builder",

--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -494,7 +494,13 @@ fn advance_epoch<S: BackingPackageStore + ParentSync + ChildObjectResolver>(
     for (version, modules, dependencies) in change_epoch.system_packages.into_iter() {
         let modules: Vec<_> = modules
             .into_iter()
-            .map(|m| CompiledModule::deserialize(&m).unwrap())
+            .map(|m| {
+                CompiledModule::deserialize_with_max_version(
+                    &m,
+                    protocol_config.move_binary_format_version(),
+                )
+                .unwrap()
+            })
             .collect();
 
         let mut new_package =

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -424,8 +424,8 @@ impl AuthorityMetrics {
             consensus_handler_processed: register_int_counter_vec_with_registry!("consensus_handler_processed", "Number of transactions processed by consensus handler", &["class"], registry)
                 .unwrap(),
             consensus_handler_num_low_scoring_authorities: register_int_gauge_with_registry!(
-                "consensus_handler_num_low_scoring_authorities", 
-                "Number of low scoring authorities based on reputation scores from consensus", 
+                "consensus_handler_num_low_scoring_authorities",
+                "Number of low scoring authorities based on reputation scores from consensus",
                 registry
             ).unwrap(),
             consensus_handler_scores: register_int_gauge_vec_with_registry!(
@@ -2990,6 +2990,7 @@ impl AuthorityState {
             SuiSystem::ID,
             sui_system_injection::get_modules(self.name),
             SuiSystem::transitive_dependencies(),
+            max_binary_format_version,
         ).await else {
             return vec![];
         };

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2964,11 +2964,15 @@ impl AuthorityState {
 
     /// Get the set of system packages that are compiled in to this build, if those packages are
     /// compatible with the current versions of those packages on-chain.
-    pub async fn get_available_system_packages(&self) -> Vec<ObjectRef> {
+    pub async fn get_available_system_packages(
+        &self,
+        max_binary_format_version: u32,
+    ) -> Vec<ObjectRef> {
         let Some(move_stdlib) = self.compare_system_package(
             MoveStdlib::ID,
             MoveStdlib::as_modules(),
             MoveStdlib::transitive_dependencies(),
+            max_binary_format_version,
         ).await else {
             return vec![];
         };
@@ -2977,6 +2981,7 @@ impl AuthorityState {
             SuiFramework::ID,
             SuiFramework::as_modules(),
             SuiFramework::transitive_dependencies(),
+            max_binary_format_version,
         ).await else {
             return vec![];
         };
@@ -3008,6 +3013,7 @@ impl AuthorityState {
         id: ObjectID,
         modules: Vec<CompiledModule>,
         dependencies: Vec<ObjectID>,
+        max_binary_format_version: u32,
     ) -> Option<ObjectRef> {
         let cur_object = match self.get_object(&id).await {
             Ok(Some(cur_object)) => cur_object,
@@ -3056,8 +3062,14 @@ impl AuthorityState {
             .try_as_package_mut()
             .expect("Created as package");
 
-        let cur_normalized = cur_pkg.normalize().expect("Normalize existing package");
-        let mut new_normalized = new_pkg.normalize().ok()?;
+        let cur_normalized = match cur_pkg.normalize(max_binary_format_version) {
+            Ok(v) => v,
+            Err(e) => {
+                error!("Could not normalize existing package: {e:?}");
+                return None;
+            }
+        };
+        let mut new_normalized = new_pkg.normalize(max_binary_format_version).ok()?;
 
         for (name, cur_module) in cur_normalized {
             let Some(new_module) = new_normalized.remove(&name) else {
@@ -3090,6 +3102,7 @@ impl AuthorityState {
     async fn get_system_package_bytes(
         &self,
         system_packages: Vec<ObjectRef>,
+        move_binary_format_version: u32,
     ) -> Option<Vec<(SequenceNumber, Vec<Vec<u8>>, Vec<ObjectID>)>> {
         let ids: Vec<_> = system_packages.iter().map(|(id, _, _)| *id).collect();
         let objects = self.get_objects(&ids).await.expect("read cannot fail");
@@ -3125,7 +3138,10 @@ impl AuthorityState {
             let new_object = Object::new_system_package(
                 bytes
                     .iter()
-                    .map(|m| CompiledModule::deserialize(m).unwrap())
+                    .map(|m| {
+                        CompiledModule::deserialize_with_max_version(m, move_binary_format_version)
+                            .unwrap()
+                    })
                     .collect(),
                 system_package.1,
                 dependencies.clone(),
@@ -3263,8 +3279,10 @@ impl AuthorityState {
                 buffer_stake_bps,
             );
 
+        // since system packages are created during the current epoch, they should abide by the
+        // rules of the current epoch, including the current epoch's max Move binary format version
         let Some(next_epoch_system_package_bytes) = self.get_system_package_bytes(
-            next_epoch_system_packages.clone()
+            next_epoch_system_packages.clone(), epoch_store.protocol_config().move_binary_format_version()
         ).await else {
             error!(
                 "upgraded system packages {:?} are not locally available, cannot create \

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -798,6 +798,7 @@ impl AuthorityStore {
             written,
             deleted,
             events,
+            max_binary_format_version: _,
         } = inner_temporary_store;
         trace!(written =? written.values().map(|((obj_id, ver, _), _, _)| (obj_id, ver)).collect::<Vec<_>>(),
                "batch_update_objects: temp store written");

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -31,7 +31,6 @@ use serde_json::json;
 use sui_framework::{make_system_objects, make_system_packages, system_package_ids};
 use tracing::info;
 
-use sui_framework::{make_system_objects, make_system_packages};
 use sui_json_rpc_types::{
     SuiArgument, SuiExecutionResult, SuiExecutionStatus, SuiGasCostSummary,
     SuiTransactionEffectsAPI, SuiTypeTag,

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -31,6 +31,7 @@ use serde_json::json;
 use sui_framework::{make_system_objects, make_system_packages, system_package_ids};
 use tracing::info;
 
+use sui_framework::{make_system_objects, make_system_packages};
 use sui_json_rpc_types::{
     SuiArgument, SuiExecutionResult, SuiExecutionStatus, SuiGasCostSummary,
     SuiTransactionEffectsAPI, SuiTypeTag,

--- a/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -197,7 +197,9 @@ async fn test_upgrade_package_happy_path() {
         .get_package(&new_package.0 .0)
         .unwrap()
         .unwrap();
-    let normalized_modules = package.normalize().unwrap();
+    let normalized_modules = package
+        .normalize(ProtocolConfig::get_for_max_version().move_binary_format_version())
+        .unwrap();
     assert!(normalized_modules.contains_key("new_module"));
     assert!(normalized_modules["new_module"]
         .exposed_functions

--- a/crates/sui-framework/src/lib.rs
+++ b/crates/sui-framework/src/lib.rs
@@ -45,6 +45,8 @@ macro_rules! define_system_package {
 
             fn as_modules() -> Vec<CompiledModule> {
                 static MODULES: Lazy<Vec<CompiledModule>> = Lazy::new(|| {
+                    // deserialization here uses overall max version of supported Move bytecode
+                    // rather than the max supported by the framework but it's OK
                     $Package::as_bytes().into_iter().map(|m| CompiledModule::deserialize(&m).unwrap()).collect()
                 });
                 Lazy::force(&MODULES).to_owned()

--- a/crates/sui-json-rpc/Cargo.toml
+++ b/crates/sui-json-rpc/Cargo.toml
@@ -39,6 +39,7 @@ sui-types = { path = "../sui-types" }
 sui-json = { path = "../sui-json" }
 sui-open-rpc = { path = "../sui-open-rpc" }
 sui-open-rpc-macros = { path = "../sui-open-rpc-macros" }
+sui-protocol-config = { path = "../sui-protocol-config" }
 sui-json-rpc-types = { path = "../sui-json-rpc-types" }
 sui-transaction-builder = { path = "../sui-transaction-builder" }
 mysten-metrics = { path = "../mysten-metrics" }

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -34,7 +34,6 @@ use sui_json_rpc_types::{
     SuiTransactionResponseOptions, SuiTransactionResponseQuery, TransactionsPage,
 };
 use sui_open_rpc::Module;
-use sui_protocol_config::ProtocolConfig;
 use sui_types::base_types::{
     ObjectID, SequenceNumber, SuiAddress, TransactionDigest, TxSequenceNumber,
 };
@@ -1022,12 +1021,11 @@ pub async fn get_move_modules_by_package(
     Ok(match object_read {
         ObjectRead::Exists(_obj_ref, object, _layout) => match object.data {
             Data::Package(p) => {
-                // TODO: is it OK to use it here since it's not on the actual validator?
-                let max_binary_format_version =
-                    ProtocolConfig::get_for_max_version().move_binary_format_version();
+                // we are on the read path - it's OK to use VERSION_MAX of the supported Move
+                // binary format
                 normalize_modules(
                     p.serialized_module_map().values(),
-                    max_binary_format_version,
+                    /* max_binary_format_version */ VERSION_MAX,
                 )
                 .map_err(|e| anyhow!("{e}"))
             }

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -12,7 +12,10 @@ use itertools::Itertools;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::RpcModule;
 use linked_hash_map::LinkedHashMap;
-use move_binary_format::normalized::{Module as NormalizedModule, Type};
+use move_binary_format::{
+    file_format_common::VERSION_MAX,
+    normalized::{Module as NormalizedModule, Type},
+};
 use move_bytecode_utils::module_cache::GetModule;
 use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::StructTag;
@@ -741,14 +744,11 @@ impl ReadApiServer for ReadApi {
         let normalized = match object_read {
             ObjectRead::Exists(_obj_ref, object, _layout) => match object.data {
                 Data::Package(p) => {
-                    let max_binary_format_version = self
-                        .state
-                        .load_epoch_store_one_call_per_task()
-                        .protocol_config()
-                        .move_binary_format_version();
+                    // we are on the read path - it's OK to use VERSION_MAX of the supported Move
+                    // binary format
                     normalize_modules(
                         p.serialized_module_map().values(),
-                        max_binary_format_version,
+                        /* max_binary_format_version */ VERSION_MAX,
                     )
                     .map_err(|e| anyhow!("{e}"))
                 }

--- a/crates/sui-json/src/lib.rs
+++ b/crates/sui-json/src/lib.rs
@@ -793,9 +793,10 @@ pub fn resolve_move_function_args(
     type_args: &[TypeTag],
     combined_args_json: Vec<SuiJsonValue>,
     allow_arbitrary_function_call: bool,
+    max_binary_format_version: u32,
 ) -> Result<Vec<(ResolvedCallArg, SignatureToken)>, anyhow::Error> {
     // Extract the expected function signature
-    let module = package.deserialize_module(&module_ident)?;
+    let module = package.deserialize_module(&module_ident, max_binary_format_version)?;
     let function_str = function.as_ident_str();
     let fdef = module
         .function_defs

--- a/crates/sui-json/src/lib.rs
+++ b/crates/sui-json/src/lib.rs
@@ -9,6 +9,7 @@ use anyhow::{anyhow, bail};
 use fastcrypto::encoding::{Encoding, Hex};
 use move_binary_format::{
     access::ModuleAccess, binary_views::BinaryIndexedView, file_format::SignatureToken,
+    file_format_common::VERSION_MAX,
 };
 use move_core_types::account_address::AccountAddress;
 use move_core_types::identifier::IdentStr;
@@ -793,10 +794,9 @@ pub fn resolve_move_function_args(
     type_args: &[TypeTag],
     combined_args_json: Vec<SuiJsonValue>,
     allow_arbitrary_function_call: bool,
-    max_binary_format_version: u32,
 ) -> Result<Vec<(ResolvedCallArg, SignatureToken)>, anyhow::Error> {
     // Extract the expected function signature
-    let module = package.deserialize_module(&module_ident, max_binary_format_version)?;
+    let module = package.deserialize_module(&module_ident, VERSION_MAX)?;
     let function_str = function.as_ident_str();
     let fdef = module
         .function_defs

--- a/crates/sui-json/src/tests.rs
+++ b/crates/sui-json/src/tests.rs
@@ -5,7 +5,6 @@ use std::path::Path;
 use std::str::FromStr;
 
 use fastcrypto::encoding::{Encoding, Hex};
-use move_binary_format::file_format_common::VERSION_MAX;
 use move_core_types::language_storage::StructTag;
 use move_core_types::u256::U256;
 use move_core_types::value::{MoveFieldLayout, MoveStructLayout};
@@ -483,7 +482,6 @@ fn test_basic_args_linter_top_level() {
         &[],
         args,
         /* allow_arbitrary_function_call */ false,
-        VERSION_MAX,
     )
     .unwrap();
 
@@ -531,7 +529,6 @@ fn test_basic_args_linter_top_level() {
         &[],
         args,
         /* allow_arbitrary_function_call */ false,
-        VERSION_MAX
     )
     .is_err());
 
@@ -577,7 +574,6 @@ fn test_basic_args_linter_top_level() {
         &[],
         args,
         /* allow_arbitrary_function_call */ false,
-        VERSION_MAX,
     )
     .unwrap();
 
@@ -622,7 +618,6 @@ fn test_basic_args_linter_top_level() {
         &[],
         args,
         /* allow_arbitrary_function_call */ false,
-        VERSION_MAX,
     )
     .unwrap();
 
@@ -676,7 +671,6 @@ fn test_basic_args_linter_top_level() {
         &[],
         args,
         /* allow_arbitrary_function_call */ false,
-        VERSION_MAX,
     )
     .unwrap();
 

--- a/crates/sui-json/src/tests.rs
+++ b/crates/sui-json/src/tests.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use std::str::FromStr;
 
 use fastcrypto::encoding::{Encoding, Hex};
+use move_binary_format::file_format_common::VERSION_MAX;
 use move_core_types::language_storage::StructTag;
 use move_core_types::u256::U256;
 use move_core_types::value::{MoveFieldLayout, MoveStructLayout};
@@ -482,6 +483,7 @@ fn test_basic_args_linter_top_level() {
         &[],
         args,
         /* allow_arbitrary_function_call */ false,
+        VERSION_MAX,
     )
     .unwrap();
 
@@ -528,7 +530,8 @@ fn test_basic_args_linter_top_level() {
         function,
         &[],
         args,
-        /* allow_arbitrary_function_call */ false
+        /* allow_arbitrary_function_call */ false,
+        VERSION_MAX
     )
     .is_err());
 
@@ -574,6 +577,7 @@ fn test_basic_args_linter_top_level() {
         &[],
         args,
         /* allow_arbitrary_function_call */ false,
+        VERSION_MAX,
     )
     .unwrap();
 
@@ -618,6 +622,7 @@ fn test_basic_args_linter_top_level() {
         &[],
         args,
         /* allow_arbitrary_function_call */ false,
+        VERSION_MAX,
     )
     .unwrap();
 
@@ -671,6 +676,7 @@ fn test_basic_args_linter_top_level() {
         &[],
         args,
         /* allow_arbitrary_function_call */ false,
+        VERSION_MAX,
     )
     .unwrap();
 

--- a/crates/sui-move/src/disassemble.rs
+++ b/crates/sui-move/src/disassemble.rs
@@ -57,6 +57,7 @@ impl Disassemble {
         let mut bytes = Vec::new();
         let mut file = BufReader::new(File::open(self.module_path)?);
         file.read_to_end(&mut bytes)?;
+        // this deserialized a module to the max version of the bytecode but it's OK here
         let module = CompiledModule::deserialize(&bytes)?;
 
         if self.debug {

--- a/crates/sui-move/src/disassemble.rs
+++ b/crates/sui-move/src/disassemble.rs
@@ -57,7 +57,8 @@ impl Disassemble {
         let mut bytes = Vec::new();
         let mut file = BufReader::new(File::open(self.module_path)?);
         file.read_to_end(&mut bytes)?;
-        // this deserialized a module to the max version of the bytecode but it's OK here
+        // this deserialized a module to the max version of the bytecode but it's OK here because
+        // it's not run as part of the deterministic replicated state machine.
         let module = CompiledModule::deserialize(&bytes)?;
 
         if self.debug {

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -875,13 +875,19 @@ impl SuiNode {
             if let Some(components) = &*self.validator_components.lock().await {
                 // TODO: without this sleep, the consensus message is not delivered reliably.
                 tokio::time::sleep(Duration::from_millis(1)).await;
+
+                let max_binary_format_version = cur_epoch_store
+                    .protocol_config()
+                    .move_binary_format_version();
                 let transaction =
                     ConsensusTransaction::new_capability_notification(AuthorityCapabilities::new(
                         self.state.name,
                         self.config
                             .supported_protocol_versions
                             .expect("Supported versions should be populated"),
-                        self.state.get_available_system_packages().await,
+                        self.state
+                            .get_available_system_packages(max_binary_format_version)
+                            .await,
                     ));
                 info!(?transaction, "submitting capabilities to consensus");
                 components

--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -408,6 +408,11 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
             package.linkage_table,
         )?;
 
+        // this value of max Move binary format version is used to deserialize a module for the
+        // purpose of obtaining types of for a Move call being constructed - using the max available
+        // format should be OK in this case
+        let max_binary_format_version =
+            ProtocolConfig::get_for_max_version().move_binary_format_version();
         let json_args_and_tokens = resolve_move_function_args(
             &package,
             module.clone(),
@@ -415,6 +420,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
             type_args,
             json_args,
             Mode::allow_arbitrary_function_calls(),
+            max_binary_format_version,
         )?;
         let mut check_args = Vec::new();
         let mut objects = BTreeMap::new();
@@ -436,7 +442,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
                 }
             })
         }
-        let compiled_module = package.deserialize_module(module)?;
+        let compiled_module = package.deserialize_module(module, max_binary_format_version)?;
 
         // TODO set the Mode from outside?
         resolve_and_type_check::<Mode>(

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -262,7 +262,7 @@ pub enum SuiError {
     // Move module publishing related errors
     #[error("Failed to verify the Move module, reason: {error:?}.")]
     ModuleVerificationFailure { error: String },
-    #[error("Failed to verify the Move module, reason: {error:?}.")]
+    #[error("Failed to deserialize the Move module, reason: {error:?}.")]
     ModuleDeserializationFailure { error: String },
     #[error("Failed to publish the Move module(s), reason: {error:?}.")]
     ModulePublishFailure { error: String },

--- a/crates/sui-types/src/move_package.rs
+++ b/crates/sui-types/src/move_package.rs
@@ -421,7 +421,11 @@ impl MovePackage {
         (*module.address()).into()
     }
 
-    pub fn deserialize_module(&self, module: &Identifier) -> SuiResult<CompiledModule> {
+    pub fn deserialize_module(
+        &self,
+        module: &Identifier,
+        max_binary_format_version: u32,
+    ) -> SuiResult<CompiledModule> {
         // TODO use the session's cache
         let bytes = self
             .serialized_module_map()
@@ -429,16 +433,22 @@ impl MovePackage {
             .ok_or_else(|| SuiError::ModuleNotFound {
                 module_name: module.to_string(),
             })?;
-        Ok(CompiledModule::deserialize(bytes)
-            .expect("Unwrap safe because Sui serializes/verifies modules before publishing them"))
+        CompiledModule::deserialize_with_max_version(bytes, max_binary_format_version).map_err(
+            |error| SuiError::ModuleDeserializationFailure {
+                error: error.to_string(),
+            },
+        )
     }
 
     pub fn disassemble(&self) -> SuiResult<BTreeMap<String, Value>> {
         disassemble_modules(self.module_map.values())
     }
 
-    pub fn normalize(&self) -> SuiResult<BTreeMap<String, normalized::Module>> {
-        normalize_modules(self.module_map.values())
+    pub fn normalize(
+        &self,
+        max_binary_format_version: u32,
+    ) -> SuiResult<BTreeMap<String, normalized::Module>> {
+        normalize_modules(self.module_map.values(), max_binary_format_version)
     }
 }
 
@@ -501,6 +511,8 @@ where
 {
     let mut disassembled = BTreeMap::new();
     for bytecode in modules {
+        // TODO: this function is only from JSON RPC - is it then OK to deserialize with max Move
+        // binary version?
         let module = CompiledModule::deserialize(bytecode).map_err(|error| {
             SuiError::ModuleDeserializationFailure {
                 error: error.to_string(),
@@ -522,17 +534,20 @@ where
     Ok(disassembled)
 }
 
-pub fn normalize_modules<'a, I>(modules: I) -> SuiResult<BTreeMap<String, normalized::Module>>
+pub fn normalize_modules<'a, I>(
+    modules: I,
+    max_binary_format_version: u32,
+) -> SuiResult<BTreeMap<String, normalized::Module>>
 where
     I: Iterator<Item = &'a Vec<u8>>,
 {
     let mut normalized_modules = BTreeMap::new();
     for bytecode in modules {
-        let module = CompiledModule::deserialize(bytecode).map_err(|error| {
-            SuiError::ModuleDeserializationFailure {
-                error: error.to_string(),
-            }
-        })?;
+        let module =
+            CompiledModule::deserialize_with_max_version(bytecode, max_binary_format_version)
+                .map_err(|error| SuiError::ModuleDeserializationFailure {
+                    error: error.to_string(),
+                })?;
         let normalized_module = normalized::Module::new(&module);
         normalized_modules.insert(normalized_module.name.to_string(), normalized_module);
     }
@@ -559,6 +574,9 @@ fn build_linkage_table<'p>(
     let mut dep_linkage_tables = vec![];
 
     for transitive_dep in transitive_dependencies.into_iter() {
+        // TODO: original_package_id will deserialized a module but only for the purpose of
+        // obtaining "original ID" of the package containing it; do we still have to make sure that
+        // deserialization obeys the rules set by the protocol config?
         let original_id = transitive_dep.original_package_id();
 
         if immediate_dependencies.remove(&original_id) {

--- a/crates/sui-types/src/move_package.rs
+++ b/crates/sui-types/src/move_package.rs
@@ -574,9 +574,9 @@ fn build_linkage_table<'p>(
     let mut dep_linkage_tables = vec![];
 
     for transitive_dep in transitive_dependencies.into_iter() {
-        // TODO: original_package_id will deserialized a module but only for the purpose of
-        // obtaining "original ID" of the package containing it; do we still have to make sure that
-        // deserialization obeys the rules set by the protocol config?
+        // original_package_id will deserialize a module but only for the purpose of obtaining
+        // "original ID" of the package containing it so using max Move binary version during
+        // deserialization is OK
         let original_id = transitive_dep.original_package_id();
 
         if immediate_dependencies.remove(&original_id) {

--- a/crates/sui-types/src/move_package.rs
+++ b/crates/sui-types/src/move_package.rs
@@ -511,8 +511,8 @@ where
 {
     let mut disassembled = BTreeMap::new();
     for bytecode in modules {
-        // TODO: this function is only from JSON RPC - is it then OK to deserialize with max Move
-        // binary version?
+        // this function is only from JSON RPC - it is OK to deserialize with max Move binary
+        // version
         let module = CompiledModule::deserialize(bytecode).map_err(|error| {
             SuiError::ModuleDeserializationFailure {
                 error: error.to_string(),

--- a/crates/sui-types/src/temporary_store.rs
+++ b/crates/sui-types/src/temporary_store.rs
@@ -248,10 +248,7 @@ impl<S> TemporaryStore<S> {
             written,
             deleted,
             events: TransactionEvents { data: self.events },
-            max_binary_format_version: ProtocolConfig::get_for_version(
-                self.protocol_config.version,
-            )
-            .move_binary_format_version(),
+            max_binary_format_version: self.protocol_config.move_binary_format_version(),
         }
     }
 
@@ -1112,8 +1109,7 @@ impl<S: GetModule<Error = SuiError, Item = CompiledModule>> GetModule for Tempor
                     .expect("Bad object type--expected package")
                     .deserialize_module(
                         &module_id.name().to_owned(),
-                        ProtocolConfig::get_for_version(self.protocol_config.version)
-                            .move_binary_format_version(),
+                        self.protocol_config.move_binary_format_version(),
                     )?,
             ))
         } else {


### PR DESCRIPTION
## Description 

Attempts to impose max Move binary (bytecode) limit on module deserialization. Admittedly, though, in places the required changes touch the code that I don't fully understand so the changes might have been both overzealous and also missing in some places where we actually should impose this limit

## Test Plan 

TBD