### PR TITLE
Few fixes for gas charging

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/size_limits/event_limits_tests.move
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/event_limits_tests.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Test limts on number and sizes of emitted events
+// Test limits on number and sizes of emitted events
 
 //# init --addresses Test=0x0
 
@@ -60,7 +60,7 @@ module Test::M1 {
 //# run Test::M1::emit_n_small_events --args 1 --gas-budget 1000000
 
 // emit at event count limit should succeed
-//# run Test::M1::emit_n_small_events --args 256 --gas-budget 1000000
+//# run Test::M1::emit_n_small_events --args 256 --gas-budget 2000000
 
 // emit above event count limit should fail
 //# run Test::M1::emit_n_small_events --args 257 --gas-budget 1000000
@@ -69,7 +69,7 @@ module Test::M1 {
 //# run Test::M1::emit_n_small_events --args 300 --gas-budget 1000000
 
 // emit below event size limit should succeed
-//# run Test::M1::emit_object_with_approx_size --args 200000 --gas-budget 1000000
+//# run Test::M1::emit_object_with_approx_size --args 200000 --gas-budget 2000000
 
 // emit above event size limit should fail
 //# run Test::M1::emit_object_with_approx_size --args 259000 --gas-budget 1000000

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/move_object_size_limit.move
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/move_object_size_limit.move
@@ -77,20 +77,20 @@ module Test::M1 {
 }
 
 // create above size limit should fail
-//# run Test::M1::transfer_object_with_size --args 256001 --sender A --gas-budget 1000000
+//# run Test::M1::transfer_object_with_size --args 256001 --sender A --gas-budget 2000000
 
 // create under size limit should succeed
-//# run Test::M1::transfer_object_with_size --args 255999 --sender A --gas-budget 1000000
+//# run Test::M1::transfer_object_with_size --args 255999 --sender A --gas-budget 2000000
 
 // create at size limit should succeed
-//# run Test::M1::transfer_object_with_size --args 256000 --sender A --gas-budget 1000000
+//# run Test::M1::transfer_object_with_size --args 256000 --sender A --gas-budget 2000000
 
 // adding 1 byte to an object at the size limit should fail
-//# run Test::M1::add_byte --args object(110) --sender A --gas-budget 1000000
+//# run Test::M1::add_byte --args object(110) --sender A --gas-budget 2000000
 
 // create at size limit, wrap, increase to over size limit while wrapped, then unwrap. should fail
-//# run Test::M1::transfer_object_with_size --args 255968 --sender A --gas-budget 1000000
+//# run Test::M1::transfer_object_with_size --args 255968 --sender A --gas-budget 2000000
 
-//# run Test::M1::wrap --args object(113) --sender A --gas-budget 1000000
+//# run Test::M1::wrap --args object(113) --sender A --gas-budget 2000000
 
-//# run Test::M1::add_bytes_then_unwrap --args object(115) 33 --sender A --gas-budget 1000000
+//# run Test::M1::add_bytes_then_unwrap --args object(115) 33 --sender A --gas-budget 2000000

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/new_id_limits_tests.exp
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/new_id_limits_tests.exp
@@ -12,7 +12,7 @@ written: object(106)
 
 task 4 'run'. lines 41-43:
 written: object(107)
-gas summary: computation_cost: 36966, storage_cost: 13,  storage_rebate: 0
+gas summary: computation_cost: 50000, storage_cost: 13,  storage_rebate: 0
 
 task 5 'run'. lines 44-46:
 Error: Transaction Effects Status: Move Primitive Runtime Error. Location: sui::tx_context::derive_id (function index 5) at offset 0. Arithmetic error, stack overflow, max value depth, etc.

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/vector_len_limits.move
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/vector_len_limits.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Test limts on length of vectors
+// Test limits on length of vectors
 
 //# init --addresses Test=0x0
 
@@ -34,7 +34,7 @@ module Test::M1 {
 //# run Test::M1::push_n_items --args 256 --gas-budget 1000000
 
 // run at vec len limit should succeed
-//# run Test::M1::push_n_items --args 262144 --gas-budget 1000000
+//# run Test::M1::push_n_items --args 262144 --gas-budget 2000000
 
 // run above vec len limit should fail
-//# run Test::M1::push_n_items --args 262145 --gas-budget 1000000
+//# run Test::M1::push_n_items --args 262145 --gas-budget 2000000

--- a/crates/sui-adapter-transactional-tests/tests/sui/coin_transfer.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/coin_transfer.exp
@@ -6,7 +6,7 @@ A: object(100), B: object(101), C: object(102)
 task 1 'view-object'. lines 8-8:
 Owner: Account Address ( B )
 Version: 1
-Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(101)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 1000000u64}}
+Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(101)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 2000000u64}}
 
 task 2 'run'. lines 10-10:
 created: object(107)
@@ -15,7 +15,7 @@ written: object(101), object(106)
 task 3 'view-object'. lines 12-12:
 Owner: Account Address ( B )
 Version: 2
-Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(101)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 999990u64}}
+Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(101)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 1999990u64}}
 
 task 4 'view-object'. lines 14-14:
 Owner: Account Address ( A )
@@ -28,4 +28,4 @@ Error: Transaction was not signed by the correct sender: Object 0xbea8d80a001a7a
 task 6 'view-object'. lines 18-18:
 Owner: Account Address ( B )
 Version: 2
-Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(101)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 999990u64}}
+Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(101)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 1999990u64}}

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/transfer_coin.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/transfer_coin.exp
@@ -6,7 +6,7 @@ A: object(100), B: object(101)
 task 1 'view-object'. lines 8-8:
 Owner: Account Address ( A )
 Version: 1
-Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(100)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 1000000u64}}
+Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(100)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 2000000u64}}
 
 task 2 'transfer-object'. lines 10-10:
 written: object(100), object(105)
@@ -14,4 +14,4 @@ written: object(100), object(105)
 task 3 'view-object'. lines 12-12:
 Owner: Account Address ( B )
 Version: 2
-Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(100)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 1000000u64}}
+Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(100)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 2000000u64}}

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -120,12 +120,9 @@ async fn test_native_transfer_sufficient_gas() -> SuiResult {
     let gas_size = gas_object.object_size_for_gas_metering();
 
     gas_status.charge_storage_read(obj_size + gas_size)?;
+    gas_status.bucketize_computation()?;
     gas_status.charge_storage_mutation(obj_size, 0.into())?;
     gas_status.charge_storage_mutation(gas_size, 0.into())?;
-    // computation gas is for both read and writes, so on a simple transfer is twice the objects
-    // (transfer object and gas coin)
-    gas_status.charge_computation_gas_for_storage_mutation((obj_size + gas_size) as u64 * 2)?;
-    gas_status.bucketize_computation()?;
     let summary = gas_status.summary();
     assert_eq!(gas_cost, &summary);
     Ok(())

--- a/crates/sui-core/src/unit_tests/pay_sui_tests.rs
+++ b/crates/sui-core/src/unit_tests/pay_sui_tests.rs
@@ -147,7 +147,7 @@ async fn test_pay_sui_failure_insufficient_total_balance_multiple_input_coins() 
 async fn test_pay_sui_success_one_input_coin() -> anyhow::Result<()> {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
     let object_id = ObjectID::random();
-    let coin_obj = Object::with_id_owner_gas_for_testing(object_id, sender, 2000);
+    let coin_obj = Object::with_id_owner_gas_for_testing(object_id, sender, 2500);
     let recipient1 = dbg_addr(1);
     let recipient2 = dbg_addr(2);
     let recipient3 = dbg_addr(3);
@@ -159,7 +159,7 @@ async fn test_pay_sui_success_one_input_coin() -> anyhow::Result<()> {
         vec![100, 200, 300],
         sender,
         sender_key,
-        1000,
+        1500,
     )
     .await;
 
@@ -213,7 +213,7 @@ async fn test_pay_sui_success_one_input_coin() -> anyhow::Result<()> {
     let gas_object = res.authority_state.get_object(&object_id).await?.unwrap();
     assert_eq!(
         GasCoin::try_from(&gas_object)?.value(),
-        2000 - 100 - 200 - 300 - gas_used,
+        2500 - 100 - 200 - 300 - gas_used,
     );
 
     Ok(())
@@ -225,7 +225,7 @@ async fn test_pay_sui_success_multiple_input_coins() -> anyhow::Result<()> {
     let object_id1 = ObjectID::random();
     let object_id2 = ObjectID::random();
     let object_id3 = ObjectID::random();
-    let coin_obj1 = Object::with_id_owner_gas_for_testing(object_id1, sender, 1000);
+    let coin_obj1 = Object::with_id_owner_gas_for_testing(object_id1, sender, 2000);
     let coin_obj2 = Object::with_id_owner_gas_for_testing(object_id2, sender, 1000);
     let coin_obj3 = Object::with_id_owner_gas_for_testing(object_id3, sender, 1000);
     let recipient1 = dbg_addr(1);
@@ -237,7 +237,7 @@ async fn test_pay_sui_success_multiple_input_coins() -> anyhow::Result<()> {
         vec![500, 1500],
         sender,
         sender_key,
-        1000,
+        2000,
     )
     .await;
     let recipient_amount_map: HashMap<_, u64> =
@@ -279,7 +279,7 @@ async fn test_pay_sui_success_multiple_input_coins() -> anyhow::Result<()> {
     let gas_object = res.authority_state.get_object(&object_id1).await?.unwrap();
     assert_eq!(
         GasCoin::try_from(&gas_object)?.value(),
-        3000 - 500 - 1500 - gas_used,
+        4000 - 500 - 1500 - gas_used,
     );
 
     // make sure the second and third input coins are deleted
@@ -327,9 +327,9 @@ async fn test_pay_all_sui_failure_insufficient_gas_budget_multiple_input_coins()
 async fn test_pay_all_sui_success_one_input_coin() -> anyhow::Result<()> {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
     let object_id = ObjectID::random();
-    let coin_obj = Object::with_id_owner_gas_for_testing(object_id, sender, 2000);
+    let coin_obj = Object::with_id_owner_gas_for_testing(object_id, sender, 3000);
     let recipient = dbg_addr(2);
-    let res = execute_pay_all_sui(vec![&coin_obj], recipient, sender, sender_key, 1000).await;
+    let res = execute_pay_all_sui(vec![&coin_obj], recipient, sender, sender_key, 2000).await;
 
     let effects = res.txn_result.unwrap().into_data();
     assert_eq!(*effects.status(), ExecutionStatus::Success);
@@ -342,7 +342,7 @@ async fn test_pay_all_sui_success_one_input_coin() -> anyhow::Result<()> {
 
     let gas_used = effects.gas_cost_summary().gas_used();
     let gas_object = res.authority_state.get_object(&object_id).await?.unwrap();
-    assert_eq!(GasCoin::try_from(&gas_object)?.value(), 2000 - gas_used,);
+    assert_eq!(GasCoin::try_from(&gas_object)?.value(), 3000 - gas_used,);
     Ok(())
 }
 
@@ -359,7 +359,7 @@ async fn test_pay_all_sui_success_multiple_input_coins() -> anyhow::Result<()> {
         recipient,
         sender,
         sender_key,
-        1000,
+        2000,
     )
     .await;
 

--- a/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot.snap
+++ b/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot.snap
@@ -5,47 +5,47 @@ expression: common_costs_actual
 ---
 {
   "MergeCoin": {
-    "computationCost": 156,
+    "computationCost": 1000,
     "storageCost": 26,
     "storageRebate": 0
   },
   "Publish": {
-    "computationCost": 640,
+    "computationCost": 1000,
     "storageCost": 154,
     "storageRebate": 0
   },
   "SharedCounterAssertValue": {
-    "computationCost": 205,
+    "computationCost": 1000,
     "storageCost": 34,
     "storageRebate": 21
   },
   "SharedCounterCreate": {
-    "computationCost": 209,
+    "computationCost": 1000,
     "storageCost": 34,
     "storageRebate": 0
   },
   "SharedCounterIncrement": {
-    "computationCost": 205,
+    "computationCost": 1000,
     "storageCost": 34,
     "storageRebate": 21
   },
   "SplitCoin": {
-    "computationCost": 265,
+    "computationCost": 1000,
     "storageCost": 65,
     "storageRebate": 0
   },
   "TransferPortionSuiCoin": {
-    "computationCost": 129,
+    "computationCost": 1000,
     "storageCost": 26,
     "storageRebate": 0
   },
   "TransferWholeCoin": {
-    "computationCost": 136,
+    "computationCost": 1000,
     "storageCost": 26,
     "storageRebate": 0
   },
   "TransferWholeSuiCoin": {
-    "computationCost": 124,
+    "computationCost": 1000,
     "storageCost": 13,
     "storageRebate": 0
   }

--- a/crates/sui-indexer/tests/integration_tests.rs
+++ b/crates/sui-indexer/tests/integration_tests.rs
@@ -91,7 +91,7 @@ mod pg_integration {
                 *address,
                 *gas_objects.first().unwrap(),
                 Some(*gas_objects.last().unwrap()),
-                1000,
+                2000,
                 *recipient_address,
             )
             .await?;

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -783,7 +783,7 @@ async fn test_locked_sui() -> Result<(), anyhow::Error> {
                 SuiJsonValue::from_bcs_bytes(&bcs::to_bytes(&"20")?)?,
             ],
             None,
-            1000,
+            2000,
             None,
         )
         .await?;

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -214,9 +214,9 @@ pub async fn metadata(
     let (total_required_amount, objects, budget) = match &option.internal_operation {
         InternalOperation::PaySui { amounts, .. } => {
             let amount = amounts.iter().sum::<u64>();
-            (Some(amount), vec![], 1000)
+            (Some(amount), vec![], 2000)
         }
-        InternalOperation::Stake { amount, .. } => (*amount, vec![], 1200),
+        InternalOperation::Stake { amount, .. } => (*amount, vec![], 2000),
         InternalOperation::WithdrawStake { sender, stake_ids } => {
             let stake_ids = if stake_ids.is_empty() {
                 // unstake all
@@ -255,7 +255,7 @@ pub async fn metadata(
                 .collect::<Result<Vec<_>, _>>()
                 .map_err(SuiError::from)?;
 
-            (Some(0), stake_refs, 2000)
+            (Some(0), stake_refs, 10000)
         }
     };
 

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -31,7 +31,7 @@ use crate::{
 use crate::{MOVE_STDLIB_OBJECT_ID, SUI_FRAMEWORK_OBJECT_ID};
 use sui_protocol_config::ProtocolConfig;
 
-pub const GAS_VALUE_FOR_TESTING: u64 = 1_000_000_u64;
+pub const GAS_VALUE_FOR_TESTING: u64 = 2_000_000_u64;
 pub const OBJECT_START_VERSION: SequenceNumber = SequenceNumber::from_u64(1);
 
 #[serde_as]

--- a/crates/sui-types/src/temporary_store.rs
+++ b/crates/sui-types/src/temporary_store.rs
@@ -541,22 +541,13 @@ impl<S> TemporaryStore<S> {
             self.reset(gas, gas_status);
         }
 
-        if let Err(err) = self
-            .charge_gas_for_storage_changes(gas_status, gas_object_id)
-            .and_then(|total_bytes_written_deleted| {
-                gas_status.charge_computation_gas_for_storage_mutation(total_bytes_written_deleted)
-            })
-        {
+        if let Err(err) = self.charge_gas_for_storage_changes(gas_status, gas_object_id) {
             // Ran out of gas while charging for storage changes. reset store, now at state just after gas smashing
             self.reset(gas, gas_status);
 
             // charge for storage again. This will now account only for the storage cost of gas coins
             if self
                 .charge_gas_for_storage_changes(gas_status, gas_object_id)
-                .and_then(|total_bytes_written_deleted| {
-                    gas_status
-                        .charge_computation_gas_for_storage_mutation(total_bytes_written_deleted)
-                })
                 .is_err()
             {
                 // TODO: this shouldn't happen, because we should check that the budget is enough to cover the storage costs of gas coins at signing time


### PR DESCRIPTION
## Description 

Few gas fixes. We are not charging for gas computation any longer as the buckets, the initial read charge and the native charging for dynamic loading take care of it. 
Also making the computation of buckets correct for the last bucket. On the last bucket it may happen that what was charged up to that point was more than the max charge in the bucket and so that would result in a overflow. We now check for it and if we underflow we do nothing which translate to charging as much as we have up to that point

## Test Plan 

Existing tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
