### PR TITLE
[jsonrpc] - add modify at version to object change, also include coin changes in object change

### DIFF
--- a/crates/sui-json-rpc-types/src/object_changes.rs
+++ b/crates/sui-json-rpc-types/src/object_changes.rs
@@ -45,6 +45,7 @@ pub enum ObjectChange {
         object_type: StructTag,
         object_id: ObjectID,
         version: SequenceNumber,
+        previous_version: SequenceNumber,
         digest: ObjectDigest,
     },
     /// Delete object

--- a/crates/sui-json-rpc/src/object_changes.rs
+++ b/crates/sui-json-rpc/src/object_changes.rs
@@ -43,7 +43,7 @@ pub async fn get_object_change_from_effect<P: ObjectProvider<Error = E>, E>(
                     object_type,
                     object_id: *id,
                     version: *version,
-                    // modify_at_version should be always available for mutated object
+                    // modify_at_version should always be available for mutated object
                     previous_version: modify_at_version.get(id).cloned().unwrap_or_default(),
                     digest: *digest,
                 }),

--- a/crates/sui-json-rpc/src/object_changes.rs
+++ b/crates/sui-json-rpc/src/object_changes.rs
@@ -1,12 +1,17 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::ObjectProvider;
+use std::collections::BTreeMap;
+
 use sui_json_rpc_types::ObjectChange;
 use sui_types::base_types::{MoveObjectType, SuiAddress};
+use sui_types::coin::Coin;
+use sui_types::gas_coin::GasCoin;
 use sui_types::governance::StakedSui;
 use sui_types::messages::TransactionEffectsAPI;
 use sui_types::storage::{DeleteKind, WriteKind};
+
+use crate::ObjectProvider;
 
 pub async fn get_object_change_from_effect<P: ObjectProvider<Error = E>, E>(
     object_provider: &P,
@@ -15,35 +20,42 @@ pub async fn get_object_change_from_effect<P: ObjectProvider<Error = E>, E>(
 ) -> Result<Vec<ObjectChange>, E> {
     let mut object_changes = vec![];
 
+    let modify_at_version = effects
+        .modified_at_versions()
+        .iter()
+        .cloned()
+        .collect::<BTreeMap<_, _>>();
+
     for ((id, version, digest), owner, kind) in effects.all_changed_objects() {
         let o = object_provider.get_object(id, version).await?;
         if let Some(type_) = o.type_() {
-            let type_ = match type_ {
-                MoveObjectType::Other(type_) => Some(type_.clone()),
-                MoveObjectType::StakedSui => Some(StakedSui::type_()),
-                _ => None,
+            let object_type = match type_ {
+                MoveObjectType::Other(type_) => type_.clone(),
+                MoveObjectType::StakedSui => StakedSui::type_(),
+                MoveObjectType::GasCoin => GasCoin::type_(),
+                MoveObjectType::Coin(t) => Coin::type_(t.clone()),
             };
 
-            if let Some(object_type) = type_ {
-                match kind {
-                    WriteKind::Mutate => object_changes.push(ObjectChange::Mutated {
-                        sender,
-                        owner: *owner,
-                        object_type,
-                        object_id: *id,
-                        version: *version,
-                        digest: *digest,
-                    }),
-                    WriteKind::Create => object_changes.push(ObjectChange::Created {
-                        sender,
-                        owner: *owner,
-                        object_type,
-                        object_id: *id,
-                        version: *version,
-                        digest: *digest,
-                    }),
-                    _ => {}
-                }
+            match kind {
+                WriteKind::Mutate => object_changes.push(ObjectChange::Mutated {
+                    sender,
+                    owner: *owner,
+                    object_type,
+                    object_id: *id,
+                    version: *version,
+                    // modify_at_version should be always available for mutated object
+                    previous_version: modify_at_version.get(id).cloned().unwrap_or_default(),
+                    digest: *digest,
+                }),
+                WriteKind::Create => object_changes.push(ObjectChange::Created {
+                    sender,
+                    owner: *owner,
+                    object_type,
+                    object_id: *id,
+                    version: *version,
+                    digest: *digest,
+                }),
+                _ => {}
             }
         } else if let Some(p) = o.data.try_as_package() {
             if kind == WriteKind::Create {

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -4154,6 +4154,7 @@
               "objectId",
               "objectType",
               "owner",
+              "previousVersion",
               "sender",
               "type",
               "version"
@@ -4170,6 +4171,9 @@
               },
               "owner": {
                 "$ref": "#/components/schemas/Owner"
+              },
+              "previousVersion": {
+                "$ref": "#/components/schemas/SequenceNumber"
               },
               "sender": {
                 "$ref": "#/components/schemas/SuiAddress"

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -302,6 +302,7 @@ export const SuiObjectChangeMutated = object({
   objectType: string(),
   objectId: ObjectId,
   version: SequenceNumber,
+  previousVersion: SequenceNumber,
   digest: ObjectDigest,
 });
 export type SuiObjectChangeMutated = Infer<typeof SuiObjectChangeMutated>;


### PR DESCRIPTION
## Description 

add modify at version to object change, also include coin changes in object change to make it easier to track individual coin changes.

## Test Plan 
Object Changes is covered by unit test
