### PR TITLE
RPC - Change results property of DevInspectResult

### DIFF
--- a/.changeset/few-coins-hang.md
+++ b/.changeset/few-coins-hang.md
@@ -1,0 +1,6 @@
+---
+"@mysten/sui.js": minor
+---
+
+Removed DevInspectResultsType and now DevInspectResults has a property results of ExecutionResultType and a property error  
+

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -561,12 +561,12 @@ async fn test_dev_inspect_dynamic_field() {
         }))],
     };
     let kind = TransactionKind::programmable(pt);
-    let DevInspectResults { results, .. } = fullnode
+    let DevInspectResults { error, .. } = fullnode
         .dev_inspect_transaction(sender, kind, Some(1))
         .await
         .unwrap();
     // produces an error
-    let err = results.unwrap_err();
+    let err = error.unwrap();
     assert!(
         err.contains("kind: CircularObjectOwnership"),
         "unexpected error: {}",

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -577,7 +577,11 @@ pub struct DevInspectResults {
     /// Events that likely would be generated if the transaction is actually run.
     pub events: SuiTransactionEvents,
     /// Execution results (including return values) from executing the transaction commands
-    pub results: Result<Vec<SuiExecutionResult>, String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub results: Option<Vec<SuiExecutionResult>>,
+    /// Execution error from executing the transaction commands
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -605,31 +609,37 @@ impl DevInspectResults {
         resolver: &impl GetModule,
     ) -> Result<Self, anyhow::Error> {
         let tx_digest = *effects.transaction_digest();
-        let results = match return_values {
-            Err(e) => Err(format!("{}", e)),
-            Ok(srvs) => Ok(srvs
-                .into_iter()
-                .map(|srv| {
-                    let (mutable_reference_outputs, return_values) = srv;
-                    let mutable_reference_outputs = mutable_reference_outputs
-                        .into_iter()
-                        .map(|(a, bytes, tag)| (a.into(), bytes, SuiTypeTag::from(tag)))
-                        .collect();
-                    let return_values = return_values
-                        .into_iter()
-                        .map(|(bytes, tag)| (bytes, SuiTypeTag::from(tag)))
-                        .collect();
-                    SuiExecutionResult {
-                        mutable_reference_outputs,
-                        return_values,
-                    }
-                })
-                .collect()),
+        let mut error = None;
+        let mut results = None;
+        match return_values {
+            Err(e) => error = Some(e.to_string()),
+            Ok(srvs) => {
+                results = Some(
+                    srvs.into_iter()
+                        .map(|srv| {
+                            let (mutable_reference_outputs, return_values) = srv;
+                            let mutable_reference_outputs = mutable_reference_outputs
+                                .into_iter()
+                                .map(|(a, bytes, tag)| (a.into(), bytes, SuiTypeTag::from(tag)))
+                                .collect();
+                            let return_values = return_values
+                                .into_iter()
+                                .map(|(bytes, tag)| (bytes, SuiTypeTag::from(tag)))
+                                .collect();
+                            SuiExecutionResult {
+                                mutable_reference_outputs,
+                                return_values,
+                            }
+                        })
+                        .collect(),
+                )
+            }
         };
         Ok(Self {
             effects: effects.try_into()?,
             events: SuiTransactionEvents::try_from(events, tx_digest, None, resolver)?,
             results,
+            error,
         })
     }
 }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -3062,8 +3062,7 @@
         "type": "object",
         "required": [
           "effects",
-          "events",
-          "results"
+          "events"
         ],
         "properties": {
           "effects": {
@@ -3072,6 +3071,13 @@
               {
                 "$ref": "#/components/schemas/TransactionEffects"
               }
+            ]
+          },
+          "error": {
+            "description": "Execution error from executing the transaction commands",
+            "type": [
+              "string",
+              "null"
             ]
           },
           "events": {
@@ -3083,11 +3089,13 @@
           },
           "results": {
             "description": "Execution results (including return values) from executing the transaction commands",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Result_of_Array_of_SuiExecutionResult_or_String"
-              }
-            ]
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/SuiExecutionResult"
+            }
           }
         }
       },
@@ -4783,35 +4791,6 @@
               },
               "version": {
                 "$ref": "#/components/schemas/SequenceNumber"
-              }
-            }
-          }
-        ]
-      },
-      "Result_of_Array_of_SuiExecutionResult_or_String": {
-        "oneOf": [
-          {
-            "type": "object",
-            "required": [
-              "Ok"
-            ],
-            "properties": {
-              "Ok": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/SuiExecutionResult"
-                }
-              }
-            }
-          },
-          {
-            "type": "object",
-            "required": [
-              "Err"
-            ],
-            "properties": {
-              "Err": {
-                "type": "string"
               }
             }
           }

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -232,15 +232,11 @@ const ExecutionResultType = object({
   returnValues: optional(array(ReturnValueType)),
 });
 
-const DevInspectResultsType = union([
-  object({ Ok: array(ExecutionResultType) }),
-  object({ Err: string() }),
-]);
-
 export const DevInspectResults = object({
   effects: TransactionEffects,
   events: TransactionEvents,
-  results: DevInspectResultsType,
+  results: optional(array(ExecutionResultType)),
+  error: optional(string()),
 });
 export type DevInspectResults = Infer<typeof DevInspectResults>;
 


### PR DESCRIPTION
## Description 

Change results property of DevInspectResult from Result<Vec<SuiExecutionResult>, String> to 2 different properties.
pub results: Option<Vec<SuiExecutionResult>> and pub error: Option<String>

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
