### PR TITLE
[cherrypick][upgrades] Upgraded framework packages modified_at previous versions

### DIFF
--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -796,6 +796,11 @@ impl SequenceNumber {
         *self = next;
     }
 
+    pub fn decrement(&mut self) {
+        assert_ne!(self.0, 0);
+        self.0 -= 1;
+    }
+
     pub fn decrement_to(&mut self, prev: SequenceNumber) {
         debug_assert!(prev < *self, "Not a decrement: {} to {}", self, prev);
         *self = prev;

--- a/crates/sui-types/src/move_package.rs
+++ b/crates/sui-types/src/move_package.rs
@@ -171,6 +171,10 @@ impl MovePackage {
         self.version
     }
 
+    pub fn decrement_version(&mut self) {
+        self.version.decrement();
+    }
+
     pub fn increment_version(&mut self) {
         self.version.increment();
     }


### PR DESCRIPTION
Cherry pick of #9392.

## Description

BUGFIX, fixing interaction between framework upgrades and object pruning.

Previously, the effects of a change epoch transaction that performed a framework upgrade would state that the upgrade framework was modified at the version it was created at.

Unfortunately, the object pruner uses `modified_at_versions` as a cue for which versions of an object to remove in eligible checkpoints, which caused a bug where the newly upgraded framework was pruned out, effectively downgrading the framework.

The fix is to move the logic for bumping package versions into `TemporaryStore`, which is responsible for calculating `modified_at_versions`, so that it can record the package's previous version before it does so. To make this work, we also need to decrement the package's version before writing it out.

## Test Plan

```
$ cargo simtest
$ env SUI_SKIP_SIMTESTS=1 cargo nextest
```

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

