### PR TITLE
Wallet Tokenomics nits

### DIFF
--- a/apps/core/src/utils/calculateAPY.ts
+++ b/apps/core/src/utils/calculateAPY.ts
@@ -18,15 +18,15 @@ export function calculateAPY(
         poolTokenBalance,
     } = validator;
 
-    // If the staking pool is active then we calculate its APY.
-    if (stakingPoolActivationEpoch) {
-        const num_epochs_participated = +epoch - +stakingPoolActivationEpoch;
+    // If the staking pool is active then we calculate its APY. Or if staking started in epoch 0
+    if (stakingPoolActivationEpoch || stakingPoolActivationEpoch === 0) {
+        const numEpochsParticipated = epoch - stakingPoolActivationEpoch;
         apy =
             Math.pow(
                 1 +
                     (+stakingPoolSuiBalance - +poolTokenBalance) /
                         +poolTokenBalance,
-                365 / num_epochs_participated
+                365 / numEpochsParticipated
             ) - 1;
     } else {
         apy = 0;

--- a/apps/wallet/src/ui/app/components/receipt-card/StakeTxnCard.tsx
+++ b/apps/wallet/src/ui/app/components/receipt-card/StakeTxnCard.tsx
@@ -40,15 +40,12 @@ export function StakeTxnCard({ event }: StakeTxnCardProps) {
     }, [validatorData, system]);
 
     // Reward will be available after 2 epochs
-    const startEarningRewardsEpoch =
-        Number(event.parsedJson?.epoch || 0) + NUM_OF_EPOCH_BEFORE_EARNING;
+    // TODO: Get epochStartTimestampMs/StartDate for staking epoch + NUM_OF_EPOCH_BEFORE_EARNING
+    const startEarningRewardsEpoch = stakedEpoch + NUM_OF_EPOCH_BEFORE_EARNING;
 
     const { data: timeToEarnStakeRewards } = useGetTimeBeforeEpochNumber(
         startEarningRewardsEpoch
     );
-
-    // TODO: Get epochStartTimestampMs/StartDate for staking epoch + NUM_OF_EPOCH_BEFORE_EARNING
-    const stakeingStartDate = stakedEpoch + NUM_OF_EPOCH_BEFORE_EARNING;
 
     return (
         <>
@@ -112,7 +109,7 @@ export function StakeTxnCard({ event }: StakeTxnCardProps) {
                             weight="medium"
                             color="steel-darker"
                         >
-                            Epoch #{stakeingStartDate}
+                            Epoch #{startEarningRewardsEpoch}
                         </Text>
                     )}
                 </div>

--- a/apps/wallet/src/ui/app/components/receipt-card/StakeTxnCard.tsx
+++ b/apps/wallet/src/ui/app/components/receipt-card/StakeTxnCard.tsx
@@ -5,94 +5,71 @@ import { calculateAPY } from '@mysten/core';
 import { SUI_TYPE_ARG } from '@mysten/sui.js';
 import { useMemo } from 'react';
 
+import { useGetTimeBeforeEpochNumber } from '_app/staking/useGetTimeBeforeEpochNumber';
 import { ValidatorLogo } from '_app/staking/validators/ValidatorLogo';
 import { TxnAmount } from '_components/receipt-card/TxnAmount';
+import { NUM_OF_EPOCH_BEFORE_EARNING } from '_src/shared/constants';
+import { CountDownTimer } from '_src/ui/app/shared/countdown-timer';
 import { Text } from '_src/ui/app/shared/text';
 import { IconTooltip } from '_src/ui/app/shared/tooltip';
 import { useSystemState } from '_src/ui/app/staking/useSystemState';
 
-import type { TransactionEffects, TransactionEvents } from '@mysten/sui.js';
+import type { SuiEvent } from '@mysten/sui.js';
 
 type StakeTxnCardProps = {
-    txnEffects: TransactionEffects;
-    events: TransactionEvents;
+    event: SuiEvent;
 };
 
-const REQUEST_DELEGATION_EVENT = '0x2::validator_set::StakingRequestEvent';
-
-// TODO: moveEvents is will be changing
 // For Staked Transaction use moveEvent Field to get the validator address, delegation amount, epoch
-export function StakeTxnCard({ txnEffects, events }: StakeTxnCardProps) {
-    const stakingData = useMemo(() => {
-        if (!events) return null;
-
-        const event = events.find(
-            (event) => event.type === REQUEST_DELEGATION_EVENT
-        );
-        return event ?? null;
-    }, [events]);
-
+export function StakeTxnCard({ event }: StakeTxnCardProps) {
     const { data: system } = useSystemState();
+    const validatorAddress = event.parsedJson?.validator_address;
+    const stakedAmount = event.parsedJson?.amount;
+    const stakedEpoch = event.parsedJson?.epoch || 0;
 
     const validatorData = useMemo(() => {
-        if (
-            !system ||
-            !stakingData ||
-            !stakingData.parsedJson?.validatorAddress
-        )
-            return null;
+        if (!system || !validatorAddress) return null;
         return system.activeValidators.find(
-            (av) => av.suiAddress === stakingData.parsedJson?.validator_address
+            ({ suiAddress }) => suiAddress === validatorAddress
         );
-    }, [stakingData, system]);
+    }, [system, validatorAddress]);
 
     const apy = useMemo(() => {
         if (!validatorData || !system) return 0;
         return calculateAPY(validatorData, +system.epoch);
     }, [validatorData, system]);
 
-    const rewardEpoch = useMemo(() => {
-        if (!system || !stakingData?.parsedJson?.epoch) return 0;
-        // show reward epoch only after 2 epochs
-        const rewardStarts = +stakingData.parsedJson?.epoch + 2;
-        return +system.epoch > rewardStarts ? rewardStarts : 0;
-    }, [stakingData, system]);
+    // Reward will be available after 2 epochs
+    const startEarningRewardsEpoch =
+        Number(event.parsedJson?.epoch || 0) + NUM_OF_EPOCH_BEFORE_EARNING;
+
+    const { data: timeToEarnStakeRewards } = useGetTimeBeforeEpochNumber(
+        startEarningRewardsEpoch
+    );
+
+    // TODO: Get epochStartTimestampMs/StartDate for staking epoch + NUM_OF_EPOCH_BEFORE_EARNING
+    const stakeingStartDate = stakedEpoch + NUM_OF_EPOCH_BEFORE_EARNING;
 
     return (
         <>
-            {stakingData?.parsedJson?.validator_address && (
+            {validatorAddress && (
                 <div className="mb-3.5 w-full">
                     <ValidatorLogo
-                        validatorAddress={
-                            stakingData.parsedJson?.validator_address
-                        }
+                        validatorAddress={validatorAddress}
                         showAddress
                         iconSize="md"
                         size="body"
                     />
                 </div>
             )}
-
-            <div className="flex justify-between w-full py-3.5">
-                <div className="flex gap-1 items-baseline text-steel">
-                    <Text variant="body" weight="medium" color="steel-darker">
-                        APY
-                    </Text>
-                    <IconTooltip tip="This is the Annualized Percentage Yield of the a specific validator’s past operations. Note there is no guarantee this APY will be true in the future." />
-                </div>
-                <Text variant="body" weight="medium" color="steel-darker">
-                    {apy && apy > 0 ? apy + ' %' : '--'}
-                </Text>
-            </div>
-
-            {stakingData?.parsedJson?.amount && (
+            {stakedAmount && (
                 <TxnAmount
-                    amount={stakingData.parsedJson?.amount}
+                    amount={stakedAmount}
                     coinType={SUI_TYPE_ARG}
                     label="Stake"
                 />
             )}
-            {rewardEpoch > 0 && (
+            <div className="flex flex-col">
                 <div className="flex justify-between w-full py-3.5">
                     <div className="flex gap-1 items-baseline text-steel">
                         <Text
@@ -100,16 +77,46 @@ export function StakeTxnCard({ txnEffects, events }: StakeTxnCardProps) {
                             weight="medium"
                             color="steel-darker"
                         >
-                            Staking Rewards Start
+                            APY
                         </Text>
                         <IconTooltip tip="This is the Annualized Percentage Yield of the a specific validator’s past operations. Note there is no guarantee this APY will be true in the future." />
                     </div>
-
                     <Text variant="body" weight="medium" color="steel-darker">
-                        Epoch #{rewardEpoch}
+                        {apy && apy > 0 ? apy + ' %' : '--'}
                     </Text>
                 </div>
-            )}
+                <div className="flex justify-between w-full py-3.5">
+                    <div className="flex gap-1 items-baseline text-steel">
+                        <Text
+                            variant="body"
+                            weight="medium"
+                            color="steel-darker"
+                        >
+                            {timeToEarnStakeRewards > 0
+                                ? 'Staking Rewards Start'
+                                : 'Staking Rewards Started'}
+                        </Text>
+                    </div>
+                    {timeToEarnStakeRewards > 0 ? (
+                        <CountDownTimer
+                            timestamp={timeToEarnStakeRewards}
+                            variant="body"
+                            color="steel-darker"
+                            weight="medium"
+                            label="in"
+                            endLabel="--"
+                        />
+                    ) : (
+                        <Text
+                            variant="body"
+                            weight="medium"
+                            color="steel-darker"
+                        >
+                            Epoch #{stakeingStartDate}
+                        </Text>
+                    )}
+                </div>
+            </div>
         </>
     );
 }

--- a/apps/wallet/src/ui/app/components/receipt-card/UnstakeTxnCard.tsx
+++ b/apps/wallet/src/ui/app/components/receipt-card/UnstakeTxnCard.tsx
@@ -1,30 +1,77 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { useFormatCoin } from '@mysten/core';
 import { SUI_TYPE_ARG } from '@mysten/sui.js';
 
+import { ValidatorLogo } from '_app/staking/validators/ValidatorLogo';
 import { TxnAmount } from '_components/receipt-card/TxnAmount';
+import { Text } from '_src/ui/app/shared/text';
 
-import type { SuiTransactionResponse } from '@mysten/sui.js';
+import type { SuiEvent } from '@mysten/sui.js';
 
-type StakeTxnCardProps = {
-    txn: SuiTransactionResponse;
-    amount: number;
-    activeAddress: string;
+type UnStakeTxnCardProps = {
+    event: SuiEvent;
 };
 
-// TODO For unstake Transaction there is no reliable way to get the validator address, reward
-// For now show the amount
-export function UnStakeTxnCard({ amount }: StakeTxnCardProps) {
+export function UnStakeTxnCard({ event }: UnStakeTxnCardProps) {
+    const principalAmount = event.parsedJson?.principal_amount || 0;
+    const rewardAmount = event.parsedJson?.reward_amount || 0;
+    const validatorAddress = event.parsedJson?.validator_address;
+    const totalAmount = +principalAmount + +rewardAmount;
+    const [formatPrinciple, symbol] = useFormatCoin(
+        principalAmount,
+        SUI_TYPE_ARG
+    );
+    const [formatRewards] = useFormatCoin(rewardAmount || 0, SUI_TYPE_ARG);
+
     return (
         <>
-            {amount && (
+            {validatorAddress && (
+                <div className="mb-3.5 w-full">
+                    <ValidatorLogo
+                        validatorAddress={validatorAddress}
+                        showAddress
+                        iconSize="md"
+                        size="body"
+                    />
+                </div>
+            )}
+            {totalAmount && (
                 <TxnAmount
-                    amount={amount}
+                    amount={totalAmount}
                     coinType={SUI_TYPE_ARG}
-                    label="Unstake"
+                    label="Total"
                 />
             )}
+
+            <div className="flex justify-between w-full py-3.5">
+                <div className="flex gap-1 items-baseline text-steel">
+                    <Text variant="body" weight="medium" color="steel-darker">
+                        Your SUI Stake
+                    </Text>
+                </div>
+
+                <div className="flex gap-1 items-baseline text-steel">
+                    <Text variant="body" weight="medium" color="steel-darker">
+                        {formatPrinciple} {symbol}
+                    </Text>
+                </div>
+            </div>
+
+            <div className="flex justify-between w-full py-3.5">
+                <div className="flex gap-1 items-baseline text-steel">
+                    <Text variant="body" weight="medium" color="steel-darker">
+                        Staking Rewards Earned
+                    </Text>
+                </div>
+
+                <div className="flex gap-1 items-baseline text-steel">
+                    <Text variant="body" weight="medium" color="steel-darker">
+                        {formatRewards} {symbol}
+                    </Text>
+                </div>
+            </div>
         </>
     );
 }

--- a/apps/wallet/src/ui/app/components/receipt-card/index.tsx
+++ b/apps/wallet/src/ui/app/components/receipt-card/index.tsx
@@ -22,8 +22,10 @@ import { StatusIcon } from './StatusIcon';
 import { TxnAddressLink } from './TxnAddressLink';
 import ExplorerLink from '_components/explorer-link';
 import { ExplorerLinkType } from '_components/explorer-link/ExplorerLinkType';
+import { StakeTxnCard } from '_components/receipt-card/StakeTxnCard';
 import { TxnAddress } from '_components/receipt-card/TxnAddress';
 import { TxnAmount } from '_components/receipt-card/TxnAmount';
+import { UnStakeTxnCard } from '_components/receipt-card/UnstakeTxnCard';
 // import { TxnImage } from '_components/transactions-card/TxnImage';
 import { useGetTxnRecipientAddress, useGetTransferAmount } from '_hooks';
 import { TxnGasSummary } from '_src/ui/app/components/receipt-card/TxnGasSummary';
@@ -37,7 +39,7 @@ type ReceiptCardProps = {
 };
 
 function ReceiptCard({ txn, activeAddress }: ReceiptCardProps) {
-    // const { events } = txn;
+    const { events } = txn;
     const timestamp = txn.timestampMs;
     const executionStatus = getExecutionStatusType(txn);
     const error = useMemo(() => getExecutionStatusError(txn), [txn]);
@@ -74,6 +76,13 @@ function ReceiptCard({ txn, activeAddress }: ReceiptCardProps) {
 
     const showGasSummary = isSuccessful && isSender && gasTotal;
     const showSponsorInfo = !isSuccessful && isSender && isSponsoredTransaction;
+    const stakedTxn = events?.find(
+        ({ type }) => type === '0x2::validator::StakingRequestEvent'
+    );
+
+    const unstakeTxn = events?.find(
+        ({ type }) => type === '0x2::validator::UnstakingRequestEvent'
+    );
 
     let txnGasSummary: JSX.Element | undefined;
     if (showGasSummary && isSponsoredTransaction) {
@@ -124,23 +133,9 @@ function ReceiptCard({ txn, activeAddress }: ReceiptCardProps) {
                             </Text>
                         </div>
                     )}
+                    {stakedTxn ? <StakeTxnCard event={stakedTxn} /> : null}
+                    {unstakeTxn ? <UnStakeTxnCard event={unstakeTxn} /> : null}
 
-                    {/* TODO: Support programmable transactions: */}
-                    {/* {isStakeTxn ? (
-                        moveCallLabel === 'Staked' ? (
-                            <StakeTxnCard
-                                txnEffects={effects!}
-                                events={events!}
-                            />
-                        ) : (
-                            <UnStakeTxnCard
-                                txn={txn}
-                                activeAddress={activeAddress}
-                                amount={totalSuiAmount || 0}
-                            />
-                        )
-                    ) 
-                    )} */}
                     <>
                         {/* {objectId && (
                             <TxnImage

--- a/apps/wallet/src/ui/app/pages/home/receipt/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/receipt/index.tsx
@@ -30,6 +30,7 @@ function ReceiptPage() {
             return rpc.getTransaction({
                 digest: transactionId!,
                 options: {
+                    showObjectChanges: true,
                     showInput: true,
                     showEffects: true,
                     showEvents: true,

--- a/apps/wallet/src/ui/app/shared/Badge.stories.tsx
+++ b/apps/wallet/src/ui/app/shared/Badge.stories.tsx
@@ -3,20 +3,20 @@
 
 import { type Meta, type StoryObj } from '@storybook/react';
 
-import { BadgeUI } from './BadgeUI';
+import { Badge } from './Badge';
 
 export default {
-    component: BadgeUI,
-} as Meta<typeof BadgeUI>;
+    component: Badge,
+} as Meta<typeof Badge>;
 
-export const Success: StoryObj<typeof BadgeUI> = {
+export const Success: StoryObj<typeof Badge> = {
     args: {
         label: 'New',
         variant: 'success',
     },
 };
 
-export const Warning: StoryObj<typeof BadgeUI> = {
+export const Warning: StoryObj<typeof Badge> = {
     args: {
         label: 'At Risk',
         variant: 'warning',

--- a/apps/wallet/src/ui/app/shared/Badge.tsx
+++ b/apps/wallet/src/ui/app/shared/Badge.tsx
@@ -17,10 +17,10 @@ const badgeStyle = cva(
     }
 );
 
-export interface CountDownTimerProps extends VariantProps<typeof badgeStyle> {
+export interface BadgeProps extends VariantProps<typeof badgeStyle> {
     label: string;
 }
 
-export function BadgeUI({ label, ...styles }: CountDownTimerProps) {
+export function Badge({ label, ...styles }: BadgeProps) {
     return <div className={badgeStyle(styles)}>{label}</div>;
 }

--- a/apps/wallet/src/ui/app/staking/validators/SelectValidatorCard.tsx
+++ b/apps/wallet/src/ui/app/staking/validators/SelectValidatorCard.tsx
@@ -53,29 +53,15 @@ export function SelectValidatorCard() {
         if (!data) return [];
 
         const sortedAsc = data.activeValidators
-            .map((validator) => {
-                const stakingPoolActivationEpoch =
-                    validator.stakingPoolActivationEpoch || 0;
-
-                return {
-                    name: validator.name,
-                    address: validator.suiAddress,
-                    apy: calculateAPY(validator, +data.epoch),
-                    stakeShare: calculateStakeShare(
-                        BigInt(validator.stakingPoolSuiBalance),
-                        BigInt(totalStake)
-                    ),
-                    // flag for if the validator is at risk of being removed from the active set
-                    atRiskValidator: data.atRiskValidators.some(
-                        (item) => item[0] === validator.suiAddress
-                    ),
-                    // flag new validators that have been activated in the current epoch
-                    // for genesis validators, this will be false
-                    newValidator:
-                        data.epoch - stakingPoolActivationEpoch <= 1 &&
-                        data.epoch !== 0,
-                };
-            })
+            .map((validator) => ({
+                name: validator.name,
+                address: validator.suiAddress,
+                apy: calculateAPY(validator, +data.epoch),
+                stakeShare: calculateStakeShare(
+                    BigInt(validator.stakingPoolSuiBalance),
+                    BigInt(totalStake)
+                ),
+            }))
             .sort((a, b) => {
                 if (sortKey === 'name') {
                     return a[sortKey].localeCompare(b[sortKey], 'en', {
@@ -187,8 +173,6 @@ export function SelectValidatorCard() {
                                             ? '-'
                                             : `${validator[sortKey]}%`
                                     }
-                                    newValidator={validator.newValidator}
-                                    atRisk={validator.atRiskValidator}
                                 />
                             </div>
                         ))}

--- a/apps/wallet/src/ui/app/staking/validators/SelectValidatorCard.tsx
+++ b/apps/wallet/src/ui/app/staking/validators/SelectValidatorCard.tsx
@@ -53,24 +53,29 @@ export function SelectValidatorCard() {
         if (!data) return [];
 
         const sortedAsc = data.activeValidators
-            .map((validator) => ({
-                name: validator.name,
-                address: validator.suiAddress,
-                apy: calculateAPY(validator, +data.epoch),
-                stakeShare: calculateStakeShare(
-                    BigInt(validator.stakingPoolSuiBalance),
-                    BigInt(totalStake)
-                ),
-                // flag for if the validator is at risk of being removed from the active set
-                atRiskValidator: data.atRiskValidators.some(
-                    (item) => item[0] === validator.suiAddress
-                ),
-                // flag new validators that have been activated in the current epoch
-                // for genesis validators, this will be false
-                newValidator:
-                    validator.stakingPoolActivationEpoch === +data.epoch &&
-                    data.epoch > 0,
-            }))
+            .map((validator) => {
+                const stakingPoolActivationEpoch =
+                    validator.stakingPoolActivationEpoch || 0;
+
+                return {
+                    name: validator.name,
+                    address: validator.suiAddress,
+                    apy: calculateAPY(validator, +data.epoch),
+                    stakeShare: calculateStakeShare(
+                        BigInt(validator.stakingPoolSuiBalance),
+                        BigInt(totalStake)
+                    ),
+                    // flag for if the validator is at risk of being removed from the active set
+                    atRiskValidator: data.atRiskValidators.some(
+                        (item) => item[0] === validator.suiAddress
+                    ),
+                    // flag new validators that have been activated in the current epoch
+                    // for genesis validators, this will be false
+                    newValidator:
+                        data.epoch - stakingPoolActivationEpoch <= 1 &&
+                        data.epoch !== 0,
+                };
+            })
             .sort((a, b) => {
                 if (sortKey === 'name') {
                     return a[sortKey].localeCompare(b[sortKey], 'en', {
@@ -182,6 +187,8 @@ export function SelectValidatorCard() {
                                             ? '-'
                                             : `${validator[sortKey]}%`
                                     }
+                                    newValidator={validator.newValidator}
+                                    atRisk={validator.atRiskValidator}
                                 />
                             </div>
                         ))}

--- a/apps/wallet/src/ui/app/staking/validators/ValidatorListItem.tsx
+++ b/apps/wallet/src/ui/app/staking/validators/ValidatorListItem.tsx
@@ -7,7 +7,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { ValidatorLogo } from './ValidatorLogo';
 import { Text } from '_app/shared/text';
 import Icon, { SuiIcons } from '_components/icon';
-import { BadgeUI } from '_src/ui/app/shared/BadgeUI';
+import { Badge } from '_src/ui/app/shared/Badge';
 
 type ValidatorListItemProp = {
     selected?: boolean;
@@ -54,13 +54,10 @@ export function ValidatorListItem({
                             </div>
                             <div className="-ml-4 flex gap-1">
                                 {newValidator && (
-                                    <BadgeUI label="New" variant="success" />
+                                    <Badge label="New" variant="success" />
                                 )}
                                 {atRisk && (
-                                    <BadgeUI
-                                        label="At Risk"
-                                        variant="warning"
-                                    />
+                                    <Badge label="At Risk" variant="warning" />
                                 )}
                             </div>
                         </div>

--- a/apps/wallet/src/ui/app/staking/validators/ValidatorListItem.tsx
+++ b/apps/wallet/src/ui/app/staking/validators/ValidatorListItem.tsx
@@ -7,21 +7,16 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { ValidatorLogo } from './ValidatorLogo';
 import { Text } from '_app/shared/text';
 import Icon, { SuiIcons } from '_components/icon';
-import { Badge } from '_src/ui/app/shared/Badge';
 
 type ValidatorListItemProp = {
     selected?: boolean;
     value: string | number;
     validatorAddress: string;
-    atRisk?: boolean;
-    newValidator?: boolean;
 };
 export function ValidatorListItem({
     selected,
     value,
     validatorAddress,
-    atRisk,
-    newValidator,
 }: ValidatorListItemProp) {
     return (
         <AnimatePresence>
@@ -44,22 +39,13 @@ export function ValidatorListItem({
                                     className="absolute text-success text-heading6 translate-x-4 -translate-y-1 rounded-full bg-white"
                                 />
                             )}
-                            <div className="flex">
-                                <ValidatorLogo
-                                    validatorAddress={validatorAddress}
-                                    showAddress
-                                    iconSize="md"
-                                    size="body"
-                                />
-                            </div>
-                            <div className="-ml-4 flex gap-1">
-                                {newValidator && (
-                                    <Badge label="New" variant="success" />
-                                )}
-                                {atRisk && (
-                                    <Badge label="At Risk" variant="warning" />
-                                )}
-                            </div>
+                            <ValidatorLogo
+                                validatorAddress={validatorAddress}
+                                showAddress
+                                iconSize="md"
+                                size="body"
+                                showActiveStatus
+                            />
                         </div>
                     </div>
                     <div className="flex gap-0.5 items-center">

--- a/apps/wallet/src/ui/app/staking/validators/ValidatorLogo.tsx
+++ b/apps/wallet/src/ui/app/staking/validators/ValidatorLogo.tsx
@@ -11,6 +11,7 @@ import { ImageIcon } from '_app/shared/image-icon';
 import { Text } from '_app/shared/text';
 import ExplorerLink from '_components/explorer-link';
 import { ExplorerLinkType } from '_components/explorer-link/ExplorerLinkType';
+import { Badge } from '_src/ui/app/shared/Badge';
 
 interface ValidatorLogoProps {
     validatorAddress: SuiAddress;
@@ -19,6 +20,7 @@ interface ValidatorLogoProps {
     isTitle?: boolean;
     size: 'body' | 'subtitle';
     iconSize: 'sm' | 'md';
+    showActiveStatus?: boolean;
 }
 
 export function ValidatorLogo({
@@ -28,22 +30,35 @@ export function ValidatorLogo({
     isTitle,
     size,
     stacked,
+    showActiveStatus = false,
 }: ValidatorLogoProps) {
     const { data, isLoading } = useSystemState();
 
     const validatorMeta = useMemo(() => {
         if (!data) return null;
 
-        const validator = data.activeValidators.find(
-            (validator) => validator.suiAddress === validatorAddress
+        return (
+            data.activeValidators.find(
+                (validator) => validator.suiAddress === validatorAddress
+            ) || null
         );
-        if (!validator) return null;
-
-        return {
-            name: validator.name,
-            logo: validator.imageUrl,
-        };
     }, [validatorAddress, data]);
+
+    const stakingPoolActivationEpoch =
+        validatorMeta?.stakingPoolActivationEpoch || 0;
+    const currentEpoch = data?.epoch || 0;
+
+    // flag as new validator if the validator was activated in the last epoch
+    // for genesis validators, this will be false
+    const newValidator =
+        currentEpoch - stakingPoolActivationEpoch <= 1 && currentEpoch !== 0;
+
+    // flag for if the validator is at risk of being removed from the active set
+    const isAtRisk = useMemo(
+        () =>
+            data?.atRiskValidators.some((item) => item[0] === validatorAddress),
+        [data, validatorAddress]
+    );
 
     if (isLoading) {
         return <div className="flex justify-center items-center">...</div>;
@@ -58,22 +73,40 @@ export function ValidatorLogo({
             )}
         >
             <ImageIcon
-                src={validatorMeta.logo}
+                src={validatorMeta.imageUrl}
                 label={validatorMeta.name}
                 fallback={validatorMeta.name}
                 size={iconSize}
                 circle
             />
             <div className="flex flex-col gap-1.5">
-                {isTitle ? (
-                    <Heading as="h4" variant="heading4" color="steel-darker">
-                        {validatorMeta.name}
-                    </Heading>
-                ) : (
-                    <Text color="gray-90" variant={size} weight="semibold">
-                        {validatorMeta.name}
-                    </Text>
-                )}
+                <div className="flex">
+                    {isTitle ? (
+                        <Heading
+                            as="h4"
+                            variant="heading4"
+                            color="steel-darker"
+                            truncate
+                        >
+                            {validatorMeta.name}
+                        </Heading>
+                    ) : (
+                        <Text color="gray-90" variant={size} weight="semibold">
+                            {validatorMeta.name}
+                        </Text>
+                    )}
+
+                    {showActiveStatus && (
+                        <div className="ml-1 flex gap-1">
+                            {newValidator && (
+                                <Badge label="New" variant="success" />
+                            )}
+                            {isAtRisk && (
+                                <Badge label="At Risk" variant="warning" />
+                            )}
+                        </div>
+                    )}
+                </div>
                 {showAddress && (
                     <ExplorerLink
                         type={ExplorerLinkType.validator}

--- a/apps/wallet/src/ui/app/staking/validators/ValidatorLogo.tsx
+++ b/apps/wallet/src/ui/app/staking/validators/ValidatorLogo.tsx
@@ -53,11 +53,9 @@ export function ValidatorLogo({
     const newValidator =
         currentEpoch - stakingPoolActivationEpoch <= 1 && currentEpoch !== 0;
 
-    // flag for if the validator is at risk of being removed from the active set
-    const isAtRisk = useMemo(
-        () =>
-            data?.atRiskValidators.some((item) => item[0] === validatorAddress),
-        [data, validatorAddress]
+    // flag if the validator is at risk of being removed from the active set
+    const isAtRisk = data?.atRiskValidators.some(
+        (item) => item[0] === validatorAddress
     );
 
     if (isLoading) {

--- a/apps/wallet/src/ui/app/staking/validators/ValidatorsCard.tsx
+++ b/apps/wallet/src/ui/app/staking/validators/ValidatorsCard.tsx
@@ -95,7 +95,7 @@ export function ValidatorsCard() {
                         <Card
                             padding="none"
                             header={
-                                <div className="py-2.5 flex px-3.75 justify-start w-full">
+                                <div className="py-2.5 flex px-3.75 justify-center w-full">
                                     <Text
                                         variant="captionSmall"
                                         weight="semibold"


### PR DESCRIPTION
## Description 

Describe the changes or additions included in this PR.

- Update APY calc to include epoch 0
- Update the receipt section to include staking details 
- Rename BadgeUI to Badge component 
- small nits

## Test Plan 

Unstake receipt card 
<img width="366" alt="Screenshot 2023-03-16 at 11 01 55 AM" src="https://user-images.githubusercontent.com/126525197/225658592-6ebfb6d5-f816-4b05-9fdc-5c4a9a78580a.png">

Stake
<img width="371" alt="Screenshot 2023-03-16 at 11 03 04 AM" src="https://user-images.githubusercontent.com/126525197/225658971-e975b6fa-2dd7-4fb4-af41-08cbf51d8d73.png">


How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
