### PR TITLE
Fix local benchmark

### DIFF
--- a/crates/sui-benchmark/src/benchmark_setup.rs
+++ b/crates/sui-benchmark/src/benchmark_setup.rs
@@ -130,7 +130,12 @@ impl Env {
                 // Setup the network
                 let _validators: Vec<_> =
                     spawn_test_authorities(generated_gas.clone(), &cloned_config).await;
-                let _fullnode = spawn_fullnode(generated_gas.clone(), &cloned_config, Some(fullnode_rpc_port)).await;
+                let _fullnode = spawn_fullnode(
+                    generated_gas.clone(),
+                    &cloned_config,
+                    Some(fullnode_rpc_port),
+                )
+                .await;
                 fullnode_barrier_clone.wait().await;
                 barrier.wait().await;
                 recv.await.expect("Unable to wait for terminate signal");

--- a/crates/sui-benchmark/src/benchmark_setup.rs
+++ b/crates/sui-benchmark/src/benchmark_setup.rs
@@ -130,12 +130,8 @@ impl Env {
                 // Setup the network
                 let _validators: Vec<_> =
                     spawn_test_authorities(generated_gas.clone(), &cloned_config).await;
-                let _fullnode = spawn_fullnode(
-                    generated_gas.clone(),
-                    &cloned_config,
-                    Some(fullnode_rpc_port),
-                )
-                .await;
+                let _fullnode =
+                    spawn_fullnode(generated_gas, &cloned_config, Some(fullnode_rpc_port)).await;
                 fullnode_barrier_clone.wait().await;
                 barrier.wait().await;
                 recv.await.expect("Unable to wait for terminate signal");

--- a/crates/sui-benchmark/src/benchmark_setup.rs
+++ b/crates/sui-benchmark/src/benchmark_setup.rs
@@ -129,8 +129,8 @@ impl Env {
             server_runtime.block_on(async move {
                 // Setup the network
                 let _validators: Vec<_> =
-                    spawn_test_authorities(generated_gas, &cloned_config).await;
-                let _fullnode = spawn_fullnode(&cloned_config, Some(fullnode_rpc_port)).await;
+                    spawn_test_authorities(generated_gas.clone(), &cloned_config).await;
+                let _fullnode = spawn_fullnode(generated_gas.clone(), &cloned_config, Some(fullnode_rpc_port)).await;
                 fullnode_barrier_clone.wait().await;
                 barrier.wait().await;
                 recv.await.expect("Unable to wait for terminate signal");

--- a/crates/sui/tests/onsite_reconfig_observer_tests.rs
+++ b/crates/sui/tests/onsite_reconfig_observer_tests.rs
@@ -18,7 +18,7 @@ async fn test_onsite_reconfig_observer_basic() {
     telemetry_subscribers::init_for_testing();
     let config = test_authority_configs();
     let authorities = spawn_test_authorities([].into_iter(), &config).await;
-    let fullnode = spawn_fullnode(&config, None).await;
+    let fullnode = spawn_fullnode(&[], &config, None).await;
 
     let _observer_handle = fullnode
         .with_async(|node| async {

--- a/crates/sui/tests/onsite_reconfig_observer_tests.rs
+++ b/crates/sui/tests/onsite_reconfig_observer_tests.rs
@@ -18,7 +18,7 @@ async fn test_onsite_reconfig_observer_basic() {
     telemetry_subscribers::init_for_testing();
     let config = test_authority_configs();
     let authorities = spawn_test_authorities([].into_iter(), &config).await;
-    let fullnode = spawn_fullnode(&[], &config, None).await;
+    let fullnode = spawn_fullnode([], &config, None).await;
 
     let _observer_handle = fullnode
         .with_async(|node| async {

--- a/crates/sui/tests/onsite_reconfig_observer_tests.rs
+++ b/crates/sui/tests/onsite_reconfig_observer_tests.rs
@@ -17,7 +17,7 @@ use sui_macros::sim_test;
 async fn test_onsite_reconfig_observer_basic() {
     telemetry_subscribers::init_for_testing();
     let config = test_authority_configs();
-    let authorities = spawn_test_authorities([].into_iter(), &config).await;
+    let authorities = spawn_test_authorities([], &config).await;
     let fullnode = spawn_fullnode([], &config, None).await;
 
     let _observer_handle = fullnode

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -38,7 +38,7 @@ use tracing::{info, warn};
 
 #[sim_test]
 async fn advance_epoch_tx_test() {
-    let authorities = spawn_test_authorities([].into_iter(), &test_authority_configs()).await;
+    let authorities = spawn_test_authorities([], &test_authority_configs()).await;
     let states: Vec<_> = authorities
         .iter()
         .map(|authority| authority.with(|node| node.state()))
@@ -79,7 +79,7 @@ async fn advance_epoch_tx_test() {
 async fn basic_reconfig_end_to_end_test() {
     // TODO remove this sleep when this test passes consistently
     sleep(Duration::from_secs(1)).await;
-    let authorities = spawn_test_authorities([].into_iter(), &test_authority_configs()).await;
+    let authorities = spawn_test_authorities([], &test_authority_configs()).await;
     trigger_reconfiguration(&authorities).await;
 }
 

--- a/crates/sui/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui/tests/transaction_orchestrator_tests.rs
@@ -172,8 +172,8 @@ async fn test_fullnode_wal_log() -> Result<(), anyhow::Error> {
 async fn test_transaction_orchestrator_reconfig() {
     telemetry_subscribers::init_for_testing();
     let config = test_authority_configs();
-    let authorities = spawn_test_authorities([].into_iter(), &config).await;
-    let fullnode = spawn_fullnode([].into_iter(), &config, None).await;
+    let authorities = spawn_test_authorities([], &config).await;
+    let fullnode = spawn_fullnode([], &config, None).await;
     let epoch = fullnode.with(|node| {
         node.transaction_orchestrator()
             .unwrap()

--- a/crates/sui/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui/tests/transaction_orchestrator_tests.rs
@@ -173,7 +173,7 @@ async fn test_transaction_orchestrator_reconfig() {
     telemetry_subscribers::init_for_testing();
     let config = test_authority_configs();
     let authorities = spawn_test_authorities([].into_iter(), &config).await;
-    let fullnode = spawn_fullnode(&config, None).await;
+    let fullnode = spawn_fullnode([].into_iter(), &config, None).await;
     let epoch = fullnode.with(|node| {
         node.transaction_orchestrator()
             .unwrap()
@@ -218,7 +218,7 @@ async fn test_tx_across_epoch_boundaries() {
 
     let (config, mut gas_objects) = test_authority_configs_with_objects(gas_objects);
     let authorities = spawn_test_authorities([], &config).await;
-    let fullnode = spawn_fullnode(&config, None).await;
+    let fullnode = spawn_fullnode([], &config, None).await;
     let gas_object = gas_objects.swap_remove(0);
     let data = TransactionData::new_transfer_sui_with_dummy_gas_price(
         get_key_pair::<AccountKeyPair>().0,

--- a/crates/test-utils/src/authority.rs
+++ b/crates/test-utils/src/authority.rs
@@ -138,10 +138,14 @@ where
 
 /// This function can be called after `spawn_test_authorities` to
 /// start a fullnode.
-pub async fn spawn_fullnode<I>(objects: I, config: &NetworkConfig, rpc_port: Option<u16>) -> SuiNodeHandle
+pub async fn spawn_fullnode<I>(
+    objects: I,
+    config: &NetworkConfig,
+    rpc_port: Option<u16>,
+) -> SuiNodeHandle
 where
     I: IntoIterator<Item = Object> + Clone,
- {
+{
     let registry_service = RegistryService::new(Registry::new());
 
     let mut builder = config.fullnode_config_builder();

--- a/crates/test-utils/src/authority.rs
+++ b/crates/test-utils/src/authority.rs
@@ -138,7 +138,10 @@ where
 
 /// This function can be called after `spawn_test_authorities` to
 /// start a fullnode.
-pub async fn spawn_fullnode(config: &NetworkConfig, rpc_port: Option<u16>) -> SuiNodeHandle {
+pub async fn spawn_fullnode<I>(objects: I, config: &NetworkConfig, rpc_port: Option<u16>) -> SuiNodeHandle
+where
+    I: IntoIterator<Item = Object> + Clone,
+ {
     let registry_service = RegistryService::new(Registry::new());
 
     let mut builder = config.fullnode_config_builder();
@@ -156,7 +159,19 @@ pub async fn spawn_fullnode(config: &NetworkConfig, rpc_port: Option<u16>) -> Su
     }
 
     let fullnode_config = builder.build().unwrap();
-    start_node(&fullnode_config, registry_service).await
+    let node = start_node(&fullnode_config, registry_service).await;
+
+    let objects = objects.clone();
+
+    node.with_async(|node| async move {
+        let state = node.state();
+        for o in objects {
+            state.insert_genesis_object(o).await
+        }
+    })
+    .await;
+
+    node
 }
 
 /// Get a network client to communicate with the consensus.


### PR DESCRIPTION
## Description 

This fixes the local benchmark: the full node that is started along with a number of validators was not seeded with the local objects were the validators, and as a result checkpoints could not be executed, since transactions were missing objects.

## Test Plan 

Test suite; and local execution.
