### PR TITLE
Add sui_getStakesByIds to retrieve stake information and rename sui_getDelegatedStakes

### DIFF
--- a/apps/wallet/src/ui/app/staking/useGetDelegatedStake.tsx
+++ b/apps/wallet/src/ui/app/staking/useGetDelegatedStake.tsx
@@ -11,6 +11,6 @@ export function useGetDelegatedStake(
 ): UseQueryResult<DelegatedStake[], Error> {
     const rpc = useRpcClient();
     return useQuery(['validator', address], () =>
-        rpc.getDelegatedStakes({ owner: address })
+        rpc.getStakes({ owner: address })
     );
 }

--- a/crates/sui-indexer/src/apis/governance_api.rs
+++ b/crates/sui-indexer/src/apis/governance_api.rs
@@ -10,7 +10,7 @@ use sui_json_rpc::SuiRpcModule;
 use sui_json_rpc_types::DelegatedStake;
 use sui_json_rpc_types::SuiCommittee;
 use sui_open_rpc::Module;
-use sui_types::base_types::{EpochId, SuiAddress};
+use sui_types::base_types::{EpochId, ObjectID, SuiAddress};
 use sui_types::sui_system_state::sui_system_state_summary::SuiSystemStateSummary;
 
 pub(crate) struct GovernanceReadApi {
@@ -27,8 +27,14 @@ impl GovernanceReadApi {
 
 #[async_trait]
 impl GovernanceReadApiServer for GovernanceReadApi {
-    async fn get_delegated_stakes(&self, owner: SuiAddress) -> RpcResult<Vec<DelegatedStake>> {
-        self.fullnode.get_delegated_stakes(owner).await
+    async fn get_stakes_by_ids(
+        &self,
+        staked_sui_id: Vec<ObjectID>,
+    ) -> RpcResult<Vec<DelegatedStake>> {
+        self.fullnode.get_stakes_by_ids(staked_sui_id).await
+    }
+    async fn get_stakes(&self, owner: SuiAddress) -> RpcResult<Vec<DelegatedStake>> {
+        self.fullnode.get_stakes(owner).await
     }
 
     async fn get_committee_info(&self, epoch: Option<EpochId>) -> RpcResult<SuiCommittee> {

--- a/crates/sui-json-rpc/src/api/governance.rs
+++ b/crates/sui-json-rpc/src/api/governance.rs
@@ -6,7 +6,7 @@ use jsonrpsee_proc_macros::rpc;
 
 use sui_json_rpc_types::{DelegatedStake, SuiCommittee};
 use sui_open_rpc_macros::open_rpc;
-use sui_types::base_types::SuiAddress;
+use sui_types::base_types::{ObjectID, SuiAddress};
 
 use sui_types::committee::EpochId;
 
@@ -15,9 +15,16 @@ use sui_types::sui_system_state::sui_system_state_summary::SuiSystemStateSummary
 #[open_rpc(namespace = "sui", tag = "Governance Read API")]
 #[rpc(server, client, namespace = "sui")]
 pub trait GovernanceReadApi {
+    /// Return one or more [DelegatedStake]
+    #[method(name = "getStakesByIds")]
+    async fn get_stakes_by_ids(
+        &self,
+        staked_sui_id: Vec<ObjectID>,
+    ) -> RpcResult<Vec<DelegatedStake>>;
+
     /// Return all [DelegatedStake].
-    #[method(name = "getDelegatedStakes")]
-    async fn get_delegated_stakes(&self, owner: SuiAddress) -> RpcResult<Vec<DelegatedStake>>;
+    #[method(name = "getStakes")]
+    async fn get_stakes(&self, owner: SuiAddress) -> RpcResult<Vec<DelegatedStake>>;
 
     /// Return the committee information for the asked `epoch`.
     #[method(name = "getCommitteeInfo")]

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -834,7 +834,7 @@ async fn test_staking() -> Result<(), anyhow::Error> {
     assert_eq!(5, objects.data.len());
 
     // Check StakedSui object before test
-    let staked_sui: Vec<DelegatedStake> = http_client.get_delegated_stakes(*address).await?;
+    let staked_sui: Vec<DelegatedStake> = http_client.get_stakes(*address).await?;
     assert!(staked_sui.is_empty());
 
     let validator = http_client
@@ -864,13 +864,20 @@ async fn test_staking() -> Result<(), anyhow::Error> {
         .await?;
 
     // Check DelegatedStake object
-    let staked_sui: Vec<DelegatedStake> = http_client.get_delegated_stakes(*address).await?;
+    let staked_sui: Vec<DelegatedStake> = http_client.get_stakes(*address).await?;
     assert_eq!(1, staked_sui.len());
     assert_eq!(1000000, staked_sui[0].stakes[0].principal);
     assert!(matches!(
         staked_sui[0].stakes[0].status,
         StakeStatus::Pending
     ));
+    let staked_sui_copy = http_client
+        .get_stakes_by_ids(vec![staked_sui[0].stakes[0].staked_sui_id])
+        .await?;
+    assert_eq!(
+        staked_sui[0].stakes[0].staked_sui_id,
+        staked_sui_copy[0].stakes[0].staked_sui_id
+    );
     Ok(())
 }
 
@@ -887,7 +894,7 @@ async fn test_staking_multiple_coins() -> Result<(), anyhow::Error> {
     let genesis_coin_amount = coins.data[0].balance;
 
     // Check StakedSui object before test
-    let staked_sui: Vec<DelegatedStake> = http_client.get_delegated_stakes(*address).await?;
+    let staked_sui: Vec<DelegatedStake> = http_client.get_stakes(*address).await?;
     assert!(staked_sui.is_empty());
 
     let validator = http_client
@@ -926,7 +933,7 @@ async fn test_staking_multiple_coins() -> Result<(), anyhow::Error> {
         .await?;
 
     // Check DelegatedStake object
-    let staked_sui: Vec<DelegatedStake> = http_client.get_delegated_stakes(*address).await?;
+    let staked_sui: Vec<DelegatedStake> = http_client.get_stakes(*address).await?;
     assert_eq!(1, staked_sui.len());
     assert_eq!(1000000, staked_sui[0].stakes[0].principal);
     assert!(matches!(

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -546,34 +546,6 @@
       }
     },
     {
-      "name": "sui_getDelegatedStakes",
-      "tags": [
-        {
-          "name": "Governance Read API"
-        }
-      ],
-      "description": "Return all [DelegatedStake].",
-      "params": [
-        {
-          "name": "owner",
-          "required": true,
-          "schema": {
-            "$ref": "#/components/schemas/SuiAddress"
-          }
-        }
-      ],
-      "result": {
-        "name": "Vec<DelegatedStake>",
-        "required": true,
-        "schema": {
-          "type": "array",
-          "items": {
-            "$ref": "#/components/schemas/DelegatedStake"
-          }
-        }
-      }
-    },
-    {
       "name": "sui_getDynamicFieldObject",
       "tags": [
         {
@@ -1167,6 +1139,65 @@
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0
+        }
+      }
+    },
+    {
+      "name": "sui_getStakes",
+      "tags": [
+        {
+          "name": "Governance Read API"
+        }
+      ],
+      "description": "Return all [DelegatedStake].",
+      "params": [
+        {
+          "name": "owner",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/SuiAddress"
+          }
+        }
+      ],
+      "result": {
+        "name": "Vec<DelegatedStake>",
+        "required": true,
+        "schema": {
+          "type": "array",
+          "items": {
+            "$ref": "#/components/schemas/DelegatedStake"
+          }
+        }
+      }
+    },
+    {
+      "name": "sui_getStakesByIds",
+      "tags": [
+        {
+          "name": "Governance Read API"
+        }
+      ],
+      "description": "Return one or more [DelegatedStake]",
+      "params": [
+        {
+          "name": "staked_sui_id",
+          "required": true,
+          "schema": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ObjectID"
+            }
+          }
+        }
+      ],
+      "result": {
+        "name": "Vec<DelegatedStake>",
+        "required": true,
+        "schema": {
+          "type": "array",
+          "items": {
+            "$ref": "#/components/schemas/DelegatedStake"
+          }
         }
       }
     },

--- a/crates/sui-rosetta/src/account.rs
+++ b/crates/sui-rosetta/src/account.rs
@@ -63,10 +63,7 @@ async fn get_sub_account_balances(
 ) -> Result<Vec<Amount>, Error> {
     let balances: HashMap<_, u128> = match account_type {
         SubAccountType::DelegatedSui => {
-            let delegations = client
-                .governance_api()
-                .get_delegated_stakes(address)
-                .await?;
+            let delegations = client.governance_api().get_stakes(address).await?;
             delegations
                 .into_iter()
                 .fold(HashMap::new(), |mut balances, stakes| {
@@ -79,10 +76,7 @@ async fn get_sub_account_balances(
                 })
         }
         SubAccountType::PendingDelegation => {
-            let delegations = client
-                .governance_api()
-                .get_delegated_stakes(address)
-                .await?;
+            let delegations = client.governance_api().get_stakes(address).await?;
             delegations
                 .into_iter()
                 .fold(HashMap::new(), |mut balances, stakes| {

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -534,11 +534,8 @@ impl GovernanceApi {
     }
 
     /// Return all [DelegatedStake].
-    pub async fn get_delegated_stakes(
-        &self,
-        owner: SuiAddress,
-    ) -> SuiRpcResult<Vec<DelegatedStake>> {
-        Ok(self.api.http.get_delegated_stakes(owner).await?)
+    pub async fn get_stakes(&self, owner: SuiAddress) -> SuiRpcResult<Vec<DelegatedStake>> {
+        Ok(self.api.http.get_stakes(owner).await?)
     }
 
     /// Return the committee information for the asked `epoch`.

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -1537,10 +1537,7 @@ async fn test_stake_with_none_amount() -> Result<(), anyhow::Error> {
     ])
     .await?;
 
-    let stake = client
-        .governance_api()
-        .get_delegated_stakes(address)
-        .await?;
+    let stake = client.governance_api().get_stakes(address).await?;
 
     assert_eq!(1, stake.len());
     assert_eq!(
@@ -1592,10 +1589,7 @@ async fn test_stake_with_u64_amount() -> Result<(), anyhow::Error> {
     ])
     .await?;
 
-    let stake = client
-        .governance_api()
-        .get_delegated_stakes(address)
-        .await?;
+    let stake = client.governance_api().get_stakes(address).await?;
 
     assert_eq!(1, stake.len());
     assert_eq!(

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -842,9 +842,7 @@ export class JsonRpcProvider {
   /**
    * Return the delegated stakes for an address
    */
-  async getDelegatedStakes(input: {
-    owner: SuiAddress;
-  }): Promise<DelegatedStake[]> {
+  async getStakes(input: { owner: SuiAddress }): Promise<DelegatedStake[]> {
     try {
       if (
         !input.owner ||
@@ -853,14 +851,14 @@ export class JsonRpcProvider {
         throw new Error('Invalid Sui address');
       }
       const resp = await this.client.requestWithType(
-        'sui_getDelegatedStakes',
+        'sui_getStakes',
         [input.owner],
         array(DelegatedStake),
         this.options.skipDataValidation,
       );
       return resp;
     } catch (err) {
-      throw new Error(`Error in getDelegatedStakes: ${err}`);
+      throw new Error(`Error in getStakes: ${err}`);
     }
   }
 

--- a/sdk/typescript/test/e2e/governance.test.ts
+++ b/sdk/typescript/test/e2e/governance.test.ts
@@ -27,7 +27,7 @@ describe('Governance API', () => {
   });
 
   it('test getDelegatedStakes', async () => {
-    const stakes = await toolbox.provider.getDelegatedStakes({
+    const stakes = await toolbox.provider.getStakes({
       owner: toolbox.address(),
     });
     expect(stakes.length).greaterThan(0);


### PR DESCRIPTION
## Description 

Add sui_getStakesByIds method with which will be possible to query the delegated stakes using a vector of staked sui ids.
Also renaming sui_getDelegatedStakes to sui_getStakes.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
