### PR TITLE
Add type tag to SuiMoveNormalizedType

### DIFF
--- a/.changeset/few-ants-give.md
+++ b/.changeset/few-ants-give.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Changed the SuiMoveNormalizedType type to have a tag field, and content field where necessary. Adjusted the type guard and fix the getPureSerializationType existent bug.

--- a/apps/explorer/src/components/module/ModuleView.tsx
+++ b/apps/explorer/src/components/module/ModuleView.tsx
@@ -42,10 +42,14 @@ function unwrapTypeReference(
     type: SuiMoveNormalizedType
 ): null | TypeReference {
     if (typeof type === 'object') {
-        if (type.type === "Struct") {
+        if (type.type === 'Struct') {
             return type.content;
         }
-        if (type.type === "Reference" || type.type === "MutableReference" || type.type === "Vector") {
+        if (
+            type.type === 'Reference' ||
+            type.type === 'MutableReference' ||
+            type.type === 'Vector'
+        ) {
             return unwrapTypeReference(type.content);
         }
     }

--- a/apps/explorer/src/components/module/ModuleView.tsx
+++ b/apps/explorer/src/components/module/ModuleView.tsx
@@ -42,17 +42,11 @@ function unwrapTypeReference(
     type: SuiMoveNormalizedType
 ): null | TypeReference {
     if (typeof type === 'object') {
-        if ('Struct' in type) {
-            return type.Struct;
+        if (type.type === "Struct") {
+            return type.content;
         }
-        if ('Reference' in type) {
-            return unwrapTypeReference(type.Reference);
-        }
-        if ('MutableReference' in type) {
-            return unwrapTypeReference(type.MutableReference);
-        }
-        if ('Vector' in type) {
-            return unwrapTypeReference(type.Vector);
+        if (type.type === "Reference" || type.type === "MutableReference" || type.type === "Vector") {
+            return unwrapTypeReference(type.content);
         }
     }
     return null;

--- a/apps/explorer/src/components/module/utils.ts
+++ b/apps/explorer/src/components/module/utils.ts
@@ -18,36 +18,34 @@ export function normalizedFunctionParameterTypeToString(
     functionTypeArgNames?: string[],
     str = ''
 ): string {
-    if (typeof param === 'string') {
-        return str + param;
+    if (["Bool", "U8", "U16", "U32", "U64", "U128", "U256", "Address", "Signer"].indexOf(param.type) !== -1) {
+        return str + param.content;
     }
-    if ('TypeParameter' in param) {
+    if ('TypeParameter' === param.type) {
         return (
             str +
-            (functionTypeArgNames?.[param.TypeParameter] ??
-                `T${param.TypeParameter}`)
+            (functionTypeArgNames?.[param.content] ??
+                `T${param.content}`)
         );
     }
-    if ('Reference' in param || 'MutableReference' in param) {
-        const p =
-            'Reference' in param ? param.Reference : param.MutableReference;
+    if ('Reference' === param.type || 'MutableReference' === param.type) {
         return normalizedFunctionParameterTypeToString(
-            p,
+            param.content,
             functionTypeArgNames,
             str
         );
     }
-    if ('Vector' in param) {
+    if ('Vector' === param.type) {
         return (
             normalizedFunctionParameterTypeToString(
-                param.Vector,
+                param.content,
                 functionTypeArgNames,
                 `${str}Vector<`
             ) + '>'
         );
     }
-    if ('Struct' in param) {
-        const theType = param.Struct;
+    if ('Struct' === param.type) {
+        const theType = param.content;
         const theTypeArgs = theType.typeArguments;
         const theTypeArgsStr = theTypeArgs
             .map((aTypeArg) =>

--- a/apps/explorer/src/components/module/utils.ts
+++ b/apps/explorer/src/components/module/utils.ts
@@ -18,14 +18,24 @@ export function normalizedFunctionParameterTypeToString(
     functionTypeArgNames?: string[],
     str = ''
 ): string {
-    if (["Bool", "U8", "U16", "U32", "U64", "U128", "U256", "Address", "Signer"].indexOf(param.type) !== -1) {
-        return str + param.content;
+    if (
+        [
+            'Bool',
+            'U8',
+            'U16',
+            'U32',
+            'U64',
+            'U128',
+            'U256',
+            'Address',
+            'Signer',
+        ].indexOf(param.type) !== -1
+    ) {
+        return str + param.type;
     }
     if ('TypeParameter' === param.type) {
         return (
-            str +
-            (functionTypeArgNames?.[param.content] ??
-                `T${param.content}`)
+            str + (functionTypeArgNames?.[param.content] ?? `T${param.type}`)
         );
     }
     if ('Reference' === param.type || 'MutableReference' === param.type) {

--- a/apps/wallet/configs/ts/tsconfig.common.json
+++ b/apps/wallet/configs/ts/tsconfig.common.json
@@ -2,6 +2,7 @@
     "compilerOptions": {
         "target": "es2020",
         "module": "esnext",
+        "lib": ["dom", "esnext"],
         "allowJs": true,
         "skipLibCheck": true,
         "allowSyntheticDefaultImports": true,

--- a/apps/wallet/src/ui/app/pages/approval-request/transaction-request/utils/normalize.ts
+++ b/apps/wallet/src/ui/app/pages/approval-request/transaction-request/utils/normalize.ts
@@ -17,17 +17,11 @@ export function unwrapTypeReference(
     type: SuiMoveNormalizedType
 ): null | TypeReference {
     if (typeof type === 'object') {
-        if ('Struct' in type) {
-            return type.Struct;
+        if ('Struct' === type.type) {
+            return type.content;
         }
-        if ('Reference' in type) {
-            return unwrapTypeReference(type.Reference);
-        }
-        if ('MutableReference' in type) {
-            return unwrapTypeReference(type.MutableReference);
-        }
-        if ('Vector' in type) {
-            return unwrapTypeReference(type.Vector);
+        if (type.type === "Reference" || type.type === "MutableReference" || type.type === "Vector") {
+            return unwrapTypeReference(type.content);
         }
     }
     return null;

--- a/apps/wallet/src/ui/app/pages/approval-request/transaction-request/utils/normalize.ts
+++ b/apps/wallet/src/ui/app/pages/approval-request/transaction-request/utils/normalize.ts
@@ -20,7 +20,11 @@ export function unwrapTypeReference(
         if ('Struct' === type.type) {
             return type.content;
         }
-        if (type.type === "Reference" || type.type === "MutableReference" || type.type === "Vector") {
+        if (
+            type.type === 'Reference' ||
+            type.type === 'MutableReference' ||
+            type.type === 'Vector'
+        ) {
             return unwrapTypeReference(type.content);
         }
     }

--- a/crates/sui-json-rpc-types/src/sui_move.rs
+++ b/crates/sui-json-rpc-types/src/sui_move.rs
@@ -67,6 +67,7 @@ pub struct SuiMoveNormalizedStruct {
 }
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(tag = "type", content = "content")]
 pub enum SuiMoveNormalizedType {
     Bool,
     U8,

--- a/crates/sui-json-rpc-types/src/sui_object.rs
+++ b/crates/sui-json-rpc-types/src/sui_object.rs
@@ -270,6 +270,10 @@ impl SuiObjectDataOptions {
         self.show_previous_transaction = true;
         self
     }
+
+    pub fn is_not_in_object_info(&self) -> bool {
+        self.show_bcs || self.show_content || self.show_display || self.show_storage_rebate
+    }
 }
 
 impl TryFrom<(ObjectRead, SuiObjectDataOptions)> for SuiObjectResponse {

--- a/crates/sui-json-rpc/src/api/mod.rs
+++ b/crates/sui-json-rpc/src/api/mod.rs
@@ -29,7 +29,6 @@ pub use read::ReadApiClient;
 pub use read::ReadApiOpenRpc;
 pub use read::ReadApiServer;
 
-// use anyhow::anyhow;
 pub use transaction_builder::TransactionBuilderClient;
 pub use transaction_builder::TransactionBuilderOpenRpc;
 pub use transaction_builder::TransactionBuilderServer;
@@ -50,16 +49,6 @@ pub fn cap_page_limit(limit: Option<usize>) -> usize {
         QUERY_MAX_RESULT_LIMIT
     } else {
         limit
-    }
-}
-
-pub fn cap_page_objects_limit(limit: Option<usize>) -> Result<usize, anyhow::Error> {
-    let limit = limit.unwrap_or(MAX_GET_OWNED_OBJECT_LIMIT);
-    if limit > MAX_GET_OWNED_OBJECT_LIMIT || limit == 0 {
-        Ok(MAX_GET_OWNED_OBJECT_LIMIT)
-        // MUSTFIXD(jian): implement this error: Err(anyhow!("limit is greater than max get owned object size"))
-    } else {
-        Ok(limit)
     }
 }
 

--- a/crates/sui-json-rpc/src/transaction_builder_api.rs
+++ b/crates/sui-json-rpc/src/transaction_builder_api.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::api::TransactionBuilderServer;
+use crate::api::{validate_limit, TransactionBuilderServer};
 use crate::SuiRpcModule;
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
@@ -22,7 +22,7 @@ use fastcrypto::encoding::Base64;
 use jsonrpsee::RpcModule;
 use sui_adapter::execution_mode::{DevInspect, Normal};
 
-use crate::api::cap_page_objects_limit;
+use crate::api::MAX_GET_OWNED_OBJECT_LIMIT;
 use crate::error::Error;
 use anyhow::anyhow;
 use sui_json::SuiJsonValue;
@@ -65,7 +65,7 @@ impl DataReader for AuthorityStateDataReader {
             return Err(anyhow!("at_checkpoint param currently not supported"));
         }
 
-        let limit = cap_page_objects_limit(limit)?;
+        let limit = validate_limit(limit, MAX_GET_OWNED_OBJECT_LIMIT)?;
         let SuiObjectResponseQuery { filter, options } = query.unwrap_or_default();
 
         let options = options.unwrap_or_default();

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -5598,26 +5598,139 @@
       "SuiMoveNormalizedType": {
         "oneOf": [
           {
-            "type": "string",
-            "enum": [
-              "Bool",
-              "U8",
-              "U16",
-              "U32",
-              "U64",
-              "U128",
-              "U256",
-              "Address",
-              "Signer"
-            ]
+            "type": "object",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "Bool"
+                ]
+              }
+            }
           },
           {
             "type": "object",
             "required": [
-              "Struct"
+              "type"
             ],
             "properties": {
-              "Struct": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "U8"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "U16"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "U32"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "U64"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "U128"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "U256"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "Address"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "Signer"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "content",
+              "type"
+            ],
+            "properties": {
+              "content": {
                 "type": "object",
                 "required": [
                   "address",
@@ -5642,59 +5755,88 @@
                     }
                   }
                 }
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "Struct"
+                ]
               }
-            },
-            "additionalProperties": false
+            }
           },
           {
             "type": "object",
             "required": [
-              "Vector"
+              "content",
+              "type"
             ],
             "properties": {
-              "Vector": {
+              "content": {
                 "$ref": "#/components/schemas/SuiMoveNormalizedType"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "Vector"
+                ]
               }
-            },
-            "additionalProperties": false
+            }
           },
           {
             "type": "object",
             "required": [
-              "TypeParameter"
+              "content",
+              "type"
             ],
             "properties": {
-              "TypeParameter": {
+              "content": {
                 "type": "integer",
                 "format": "uint16",
                 "minimum": 0.0
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "TypeParameter"
+                ]
               }
-            },
-            "additionalProperties": false
+            }
           },
           {
             "type": "object",
             "required": [
-              "Reference"
+              "content",
+              "type"
             ],
             "properties": {
-              "Reference": {
+              "content": {
                 "$ref": "#/components/schemas/SuiMoveNormalizedType"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "Reference"
+                ]
               }
-            },
-            "additionalProperties": false
+            }
           },
           {
             "type": "object",
             "required": [
-              "MutableReference"
+              "content",
+              "type"
             ],
             "properties": {
-              "MutableReference": {
+              "content": {
                 "$ref": "#/components/schemas/SuiMoveNormalizedType"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "MutableReference"
+                ]
               }
-            },
-            "additionalProperties": false
+            }
           }
         ]
       },

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -817,7 +817,6 @@ impl SuiClientCommands {
                 let client = context.get_client().await?;
                 let address_object = client
                     .read_api()
-                    // TODO: (jian) fill in later
                     .get_owned_objects(
                         address,
                         Some(SuiObjectResponseQuery::new_with_options(
@@ -1358,7 +1357,6 @@ impl Display for SuiClientCommandResult {
                 )?;
                 writeln!(writer, "{}", ["-"; 165].join(""))?;
                 for oref in object_refs {
-                    // TODO (jian): fix unwrap and clone later
                     let obj = oref.clone().into_object().unwrap();
 
                     let owner_type = match obj.owner {

--- a/crates/sui/src/console.rs
+++ b/crates/sui/src/console.rs
@@ -137,7 +137,6 @@ async fn handle_command(
             SuiClientCommandResult::Objects(ref objects) => {
                 let objects = objects
                     .iter()
-                    // TODO (jian): fix unwrap and clone later
                     .map(|oref| format!("{}", oref.clone().into_object().unwrap().object_id))
                     .collect::<Vec<_>>();
                 cache.insert(CacheKey::new("object", "--id"), objects.clone());

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -1050,10 +1050,7 @@ async fn test_switch_command() -> Result<(), anyhow::Error> {
         .get_owned_objects(
             addr1,
             Some(SuiObjectResponseQuery::new_with_options(
-                SuiObjectDataOptions::new()
-                    .with_type()
-                    .with_owner()
-                    .with_previous_transaction(),
+                SuiObjectDataOptions::full_content(),
             )),
             None,
             None,

--- a/crates/test-utils/src/messages.rs
+++ b/crates/test-utils/src/messages.rs
@@ -75,7 +75,6 @@ pub async fn get_gas_object_with_wallet_context(
     if res.is_empty() {
         None
     } else {
-        // TODO (jian): handle unwrap error
         Some(res.swap_remove(0).into_object().unwrap().object_ref())
     }
 }

--- a/doc/src/build/rust-sdk.md
+++ b/doc/src/build/rust-sdk.md
@@ -39,7 +39,6 @@ use std::str::FromStr;
 use sui_sdk::types::base_types::SuiAddress;
 use sui_sdk::{SuiClient, SuiClientBuilder};
 
-// TODO: (jian) update example after pagination changes
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     let sui = SuiClientBuilder::default().build(
@@ -47,7 +46,7 @@ async fn main() -> Result<(), anyhow::Error> {
     ).await.unwrap();
     let address = SuiAddress::from_str("0xbcab7526033aa0e014f634bf51316715dda0907a7fab5a8d7e3bd44e634a4d44")?;
     let objects = sui.read_api().get_owned_objects(address).await?;
-    println!("{:?}", objects);
+    println!("{:?}", objects.data);
     Ok(())
 }
 ```

--- a/sdk/typescript/src/builder/Transaction.ts
+++ b/sdk/typescript/src/builder/Transaction.ts
@@ -496,7 +496,7 @@ export class Transaction {
             const structVal = extractStructTag(param);
             if (
               structVal != null ||
-              (typeof param === 'object' && 'TypeParameter' in param)
+              (typeof param === 'object' && 'TypeParameter' === param.type)
             ) {
               if (typeof inputValue !== 'string') {
                 throw new Error(

--- a/sdk/typescript/src/builder/serializer.ts
+++ b/sdk/typescript/src/builder/serializer.ts
@@ -84,30 +84,30 @@ export function getPureSerializationType(
   argVal: SuiJsonValue | undefined,
 ): string | undefined {
   if (
-    typeof normalizedType === 'string' &&
-    allowedTypes.includes(normalizedType)
+    typeof normalizedType.content === 'string' &&
+    allowedTypes.includes(normalizedType.type)
   ) {
-    if (normalizedType in ['U8', 'U16', 'U32', 'U64', 'U128', 'U256']) {
+    if (['U8', 'U16', 'U32', 'U64', 'U128', 'U256'].indexOf(normalizedType.type) !== -1) {
       expectType('number', argVal);
-    } else if (normalizedType === 'Bool') {
+    } else if (normalizedType.type === 'Bool') {
       expectType('boolean', argVal);
-    } else if (normalizedType === 'Address') {
+    } else if (normalizedType.type === 'Address') {
       expectType('string', argVal);
       if (argVal && !isValidSuiAddress(argVal as string)) {
         throw new Error('Invalid Sui Address');
       }
     }
-    return normalizedType.toLowerCase();
-  } else if (typeof normalizedType === 'string') {
+    return normalizedType.content.toLowerCase();
+  } else if (typeof normalizedType.content === 'string') {
     throw new Error(
       `Unknown pure normalized type ${JSON.stringify(normalizedType, null, 2)}`,
     );
   }
 
-  if ('Vector' in normalizedType) {
+  if (normalizedType.type === "Vector") {
     if (
       (argVal === undefined || typeof argVal === 'string') &&
-      normalizedType.Vector === 'U8'
+      normalizedType.content.type === 'U8'
     ) {
       return 'string';
     }
@@ -119,7 +119,7 @@ export function getPureSerializationType(
     }
 
     const innerType = getPureSerializationType(
-      normalizedType.Vector,
+      normalizedType.content,
       // undefined when argVal is empty
       argVal ? argVal[0] : undefined,
     );
@@ -131,16 +131,16 @@ export function getPureSerializationType(
     return `vector<${innerType}>`;
   }
 
-  if ('Struct' in normalizedType) {
-    if (isSameStruct(normalizedType.Struct, RESOLVED_ASCII_STR)) {
+  if (normalizedType.type === "Struct") {
+    if (isSameStruct(normalizedType.content, RESOLVED_ASCII_STR)) {
       return 'string';
-    } else if (isSameStruct(normalizedType.Struct, RESOLVED_UTF8_STR)) {
+    } else if (isSameStruct(normalizedType.content, RESOLVED_UTF8_STR)) {
       return 'utf8string';
-    } else if (isSameStruct(normalizedType.Struct, RESOLVED_SUI_ID)) {
+    } else if (isSameStruct(normalizedType.content, RESOLVED_SUI_ID)) {
       return 'address';
-    } else if (isSameStruct(normalizedType.Struct, RESOLVED_STD_OPTION)) {
+    } else if (isSameStruct(normalizedType.content, RESOLVED_STD_OPTION)) {
       const optionToVec: SuiMoveNormalizedType = {
-        Vector: normalizedType.Struct.typeArguments[0],
+        type: "Vector", content: normalizedType.content.typeArguments[0],
       };
       return getPureSerializationType(optionToVec, argVal);
     }

--- a/sdk/typescript/src/builder/serializer.ts
+++ b/sdk/typescript/src/builder/serializer.ts
@@ -83,11 +83,12 @@ export function getPureSerializationType(
   normalizedType: SuiMoveNormalizedType,
   argVal: SuiJsonValue | undefined,
 ): string | undefined {
-  if (
-    typeof normalizedType.content === 'string' &&
-    allowedTypes.includes(normalizedType.type)
-  ) {
-    if (['U8', 'U16', 'U32', 'U64', 'U128', 'U256'].indexOf(normalizedType.type) !== -1) {
+  if (allowedTypes.includes(normalizedType.type)) {
+    if (
+      ['U8', 'U16', 'U32', 'U64', 'U128', 'U256'].indexOf(
+        normalizedType.type,
+      ) !== -1
+    ) {
       expectType('number', argVal);
     } else if (normalizedType.type === 'Bool') {
       expectType('boolean', argVal);
@@ -97,14 +98,10 @@ export function getPureSerializationType(
         throw new Error('Invalid Sui Address');
       }
     }
-    return normalizedType.content.toLowerCase();
-  } else if (typeof normalizedType.content === 'string') {
-    throw new Error(
-      `Unknown pure normalized type ${JSON.stringify(normalizedType, null, 2)}`,
-    );
+    return normalizedType.type.toLowerCase();
   }
 
-  if (normalizedType.type === "Vector") {
+  if (normalizedType.type === 'Vector') {
     if (
       (argVal === undefined || typeof argVal === 'string') &&
       normalizedType.content.type === 'U8'
@@ -131,7 +128,7 @@ export function getPureSerializationType(
     return `vector<${innerType}>`;
   }
 
-  if (normalizedType.type === "Struct") {
+  if (normalizedType.type === 'Struct') {
     if (isSameStruct(normalizedType.content, RESOLVED_ASCII_STR)) {
       return 'string';
     } else if (isSameStruct(normalizedType.content, RESOLVED_UTF8_STR)) {
@@ -140,7 +137,8 @@ export function getPureSerializationType(
       return 'address';
     } else if (isSameStruct(normalizedType.content, RESOLVED_STD_OPTION)) {
       const optionToVec: SuiMoveNormalizedType = {
-        type: "Vector", content: normalizedType.content.typeArguments[0],
+        type: 'Vector',
+        content: normalizedType.content.typeArguments[0],
       };
       return getPureSerializationType(optionToVec, argVal);
     }

--- a/sdk/typescript/src/builder/serializer.ts
+++ b/sdk/typescript/src/builder/serializer.ts
@@ -61,10 +61,10 @@ function expectType(typeNames: string[], argVal?: SuiJsonValue) {
   if (typeof argVal === 'undefined') {
     return;
   }
-  const check = typeNames.some(typeName =>  typeof argVal === typeName);
-  if (check) {
+  const check = typeNames.some((typeName) => typeof argVal === typeName);
+  if (!check) {
     throw new Error(
-      `Expect ${argVal} to be  of type in ${typeNames}, received ${typeof argVal}`,
+      `Expect ${argVal} to be of type: ${typeNames}, received: ${typeof argVal}`,
     );
   }
 }

--- a/sdk/typescript/src/builder/serializer.ts
+++ b/sdk/typescript/src/builder/serializer.ts
@@ -57,13 +57,14 @@ export function isTxContext(param: SuiMoveNormalizedType): boolean {
   );
 }
 
-function expectType(typeName: string, argVal?: SuiJsonValue) {
+function expectType(typeNames: string[], argVal?: SuiJsonValue) {
   if (typeof argVal === 'undefined') {
     return;
   }
-  if (typeof argVal !== typeName) {
+  const check = typeNames.some(typeName =>  typeof argVal === typeName);
+  if (check) {
     throw new Error(
-      `Expect ${argVal} to be ${typeName}, received ${typeof argVal}`,
+      `Expect ${argVal} to be  of type in ${typeNames}, received ${typeof argVal}`,
     );
   }
 }
@@ -89,11 +90,11 @@ export function getPureSerializationType(
         normalizedType.type,
       ) !== -1
     ) {
-      expectType('number', argVal);
+      expectType(['string', 'number'], argVal);
     } else if (normalizedType.type === 'Bool') {
-      expectType('boolean', argVal);
+      expectType(['boolean'], argVal);
     } else if (normalizedType.type === 'Address') {
-      expectType('string', argVal);
+      expectType(['string'], argVal);
       if (argVal && !isValidSuiAddress(argVal as string)) {
         throw new Error('Invalid Sui Address');
       }

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -27,6 +27,7 @@ export * from './types';
 export * from './utils/format';
 export * from './utils/intent';
 export * from './utils/verify';
+export * from './utils/errors';
 
 export * from './framework';
 

--- a/sdk/typescript/src/rpc/faucet-client.ts
+++ b/sdk/typescript/src/rpc/faucet-client.ts
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { FaucetResponse, SuiAddress } from '../types';
+import { FaucetRateLimitError } from '../utils/errors';
 import { HttpHeaders } from './client';
-
-export class FaucetRateLimitError extends Error {}
 
 export async function requestSuiFromFaucet(
   endpoint: string,

--- a/sdk/typescript/src/types/normalized.ts
+++ b/sdk/typescript/src/types/normalized.ts
@@ -60,33 +60,31 @@ export type SuiMoveNormalizedTypeParameterType = Infer<
   typeof SuiMoveNormalizedTypeParameterType
 >;
 
-// export type SuiMoveNormalizedType =
-//   | { type: 'Bool' }
-//   | { type: 'U8' }
-//   | { type: 'U16' }
-//   | { type: 'U32' }
-//   | { type: 'U64' }
-//   | { type: 'U128' }
-//   | { type: 'U256' }
-//   | { type: 'Address' }
-//   | { type: 'Signer' }
-//   | {
-//       type: 'Struct';
-//       content: {
-//         address: string;
-//         module: string;
-//         name: string;
-//         typeArguments: SuiMoveNormalizedType[];
-//       };
-//     }
-//   | { type: 'Vector'; content: SuiMoveNormalizedType }
-//   | { type: 'TypeParameter'; content: number }
-//   | { type: 'Reference'; content: SuiMoveNormalizedType }
-//   | { type: 'MutableReference'; content: SuiMoveNormalizedType };
+export type SuiMoveNormalizedType =
+  | { type: 'Bool' }
+  | { type: 'U8' }
+  | { type: 'U16' }
+  | { type: 'U32' }
+  | { type: 'U64' }
+  | { type: 'U128' }
+  | { type: 'U256' }
+  | { type: 'Address' }
+  | { type: 'Signer' }
+  | {
+      type: 'Struct';
+      content: {
+        address: string;
+        module: string;
+        name: string;
+        typeArguments: SuiMoveNormalizedType[];
+      };
+    }
+  | { type: 'Vector'; content: SuiMoveNormalizedType }
+  | { type: 'TypeParameter'; content: number }
+  | { type: 'Reference'; content: SuiMoveNormalizedType }
+  | { type: 'MutableReference'; content: SuiMoveNormalizedType };
 
-export type SuiMoveNormalizedType = { type: string; content?: any };
-
-function isSuiMoveNormalizedType(
+export function isSuiMoveNormalizedType(
   value: unknown,
 ): value is SuiMoveNormalizedType {
   if (!value) return false;
@@ -110,7 +108,7 @@ function isSuiMoveNormalizedType(
     ['Vector', 'Reference', 'MutableReference'].includes(
       valueProperties.type,
     ) &&
-    is(valueProperties.content, SuiMoveNormalizedType)
+    isSuiMoveNormalizedType(valueProperties.content)
   )
     return true;
   if (
@@ -123,15 +121,15 @@ function isSuiMoveNormalizedType(
     return (
       typeof contents.address === 'string' &&
       typeof contents.module === 'string' &&
-      typeof name === 'string' &&
+      typeof contents.name === 'string' &&
       Array.isArray(contents.typeArguments) &&
-      contents.typeArguments.every((value) => is(value, SuiMoveNormalizedType))
+      contents.typeArguments.every((value) => isSuiMoveNormalizedType(value))
     );
   }
   return false;
 }
 
-export const SuiMoveNormalizedType = define<SuiMoveNormalizedType>(
+const SuiMoveNormalizedType = define<SuiMoveNormalizedType>(
   'SuiMoveNormalizedType',
   isSuiMoveNormalizedType,
 );
@@ -219,7 +217,7 @@ export function extractMutableReference(
 ): SuiMoveNormalizedType | undefined {
   return typeof normalizedType === 'object' &&
     'MutableReference' === normalizedType.type &&
-    typeof normalizedType.content === 'object'
+    is(normalizedType.content, SuiMoveNormalizedType)
     ? normalizedType.content
     : undefined;
 }

--- a/sdk/typescript/src/types/normalized.ts
+++ b/sdk/typescript/src/types/normalized.ts
@@ -60,29 +60,31 @@ export type SuiMoveNormalizedTypeParameterType = Infer<
   typeof SuiMoveNormalizedTypeParameterType
 >;
 
-export type SuiMoveNormalizedType =
-  | { type: 'Bool' }
-  | { type: 'U8' }
-  | { type: 'U16' }
-  | { type: 'U32' }
-  | { type: 'U64' }
-  | { type: 'U128' }
-  | { type: 'U256' }
-  | { type: 'Address' }
-  | { type: 'Signer' }
-  | {
-      type: 'Struct';
-      content: {
-        address: string;
-        module: string;
-        name: string;
-        typeArguments: SuiMoveNormalizedType[];
-      };
-    }
-  | { type: 'Vector'; content: SuiMoveNormalizedType }
-  | { type: 'TypeParameter'; content: number }
-  | { type: 'Reference'; content: SuiMoveNormalizedType }
-  | { type: 'MutableReference'; content: SuiMoveNormalizedType };
+// export type SuiMoveNormalizedType =
+//   | { type: 'Bool' }
+//   | { type: 'U8' }
+//   | { type: 'U16' }
+//   | { type: 'U32' }
+//   | { type: 'U64' }
+//   | { type: 'U128' }
+//   | { type: 'U256' }
+//   | { type: 'Address' }
+//   | { type: 'Signer' }
+//   | {
+//       type: 'Struct';
+//       content: {
+//         address: string;
+//         module: string;
+//         name: string;
+//         typeArguments: SuiMoveNormalizedType[];
+//       };
+//     }
+//   | { type: 'Vector'; content: SuiMoveNormalizedType }
+//   | { type: 'TypeParameter'; content: number }
+//   | { type: 'Reference'; content: SuiMoveNormalizedType }
+//   | { type: 'MutableReference'; content: SuiMoveNormalizedType };
+
+export type SuiMoveNormalizedType = { type: string; content?: any };
 
 function isSuiMoveNormalizedType(
   value: unknown,

--- a/sdk/typescript/src/types/normalized.ts
+++ b/sdk/typescript/src/types/normalized.ts
@@ -60,13 +60,21 @@ export type SuiMoveNormalizedTypeParameterType = Infer<
   typeof SuiMoveNormalizedTypeParameterType
 >;
 
-export type SuiMoveNormalizedType =
-  | string
-  | SuiMoveNormalizedTypeParameterType
-  | { Reference: SuiMoveNormalizedType }
-  | { MutableReference: SuiMoveNormalizedType }
-  | { Vector: SuiMoveNormalizedType }
-  | SuiMoveNormalizedStructType;
+export type SuiMoveNormalizedType = 
+ | {type: "Bool", content: string}
+ | {type: "U8", content: string}
+ | {type: "U16", content: string}
+ | {type: "U32", content: string}
+ | {type: "U64", content: string}
+ | {type: "U128", content: string}
+ | {type: "U256", content: string}
+ | {type: "Address", content: string}
+ | {type: "Signer", content: string}
+ | {type: "Struct", content: {address: string, module: string, name: string, typeArguments: SuiMoveNormalizedType[]}}
+ | {type: "Vector", content: SuiMoveNormalizedType}
+ | {type: "TypeParameter", content: number}
+ | {type: "Reference", content: SuiMoveNormalizedType}
+ | {type: "MutableReference", content: SuiMoveNormalizedType}
 
 function isSuiMoveNormalizedType(
   value: unknown,
@@ -171,35 +179,35 @@ export function extractMutableReference(
   normalizedType: SuiMoveNormalizedType,
 ): SuiMoveNormalizedType | undefined {
   return typeof normalizedType === 'object' &&
-    'MutableReference' in normalizedType
-    ? normalizedType.MutableReference
+    'MutableReference' === normalizedType.type
+    ? normalizedType.content
     : undefined;
 }
 
 export function extractReference(
   normalizedType: SuiMoveNormalizedType,
 ): SuiMoveNormalizedType | undefined {
-  return typeof normalizedType === 'object' && 'Reference' in normalizedType
-    ? normalizedType.Reference
+  return typeof normalizedType === 'object' && 'Reference' === normalizedType.type
+    ? normalizedType.content
     : undefined;
 }
 
 export function extractStructTag(
   normalizedType: SuiMoveNormalizedType,
 ): SuiMoveNormalizedStructType | undefined {
-  if (typeof normalizedType === 'object' && 'Struct' in normalizedType) {
-    return normalizedType;
+  if (typeof normalizedType === 'object' && 'Struct' === normalizedType.type) {
+    return {Struct: normalizedType.content};
   }
 
   const ref = extractReference(normalizedType);
   const mutRef = extractMutableReference(normalizedType);
 
-  if (typeof ref === 'object' && 'Struct' in ref) {
-    return ref;
+  if (typeof ref === 'object' && ref.type === "Struct") {
+    return {Struct: ref.content};
   }
 
-  if (typeof mutRef === 'object' && 'Struct' in mutRef) {
-    return mutRef;
+  if (typeof mutRef === 'object' && mutRef.type === "Struct") {
+    return {Struct: mutRef.content};
   }
   return undefined;
 }

--- a/sdk/typescript/src/types/normalized.ts
+++ b/sdk/typescript/src/types/normalized.ts
@@ -13,7 +13,6 @@ import {
   literal,
   record,
   is,
-  unknown,
 } from 'superstruct';
 
 export type SuiMoveFunctionArgTypesResponse = Infer<
@@ -61,48 +60,72 @@ export type SuiMoveNormalizedTypeParameterType = Infer<
   typeof SuiMoveNormalizedTypeParameterType
 >;
 
-export type SuiMoveNormalizedType = 
- | {type: "Bool", content: string}
- | {type: "U8", content: string}
- | {type: "U16", content: string}
- | {type: "U32", content: string}
- | {type: "U64", content: string}
- | {type: "U128", content: string}
- | {type: "U256", content: string}
- | {type: "Address", content: string}
- | {type: "Signer", content: string}
- | {type: "Struct", content: {address: string, module: string, name: string, typeArguments: SuiMoveNormalizedType[]}}
- | {type: "Vector", content: SuiMoveNormalizedType}
- | {type: "TypeParameter", content: number}
- | {type: "Reference", content: SuiMoveNormalizedType}
- | {type: "MutableReference", content: SuiMoveNormalizedType}
+export type SuiMoveNormalizedType =
+  | { type: 'Bool' }
+  | { type: 'U8' }
+  | { type: 'U16' }
+  | { type: 'U32' }
+  | { type: 'U64' }
+  | { type: 'U128' }
+  | { type: 'U256' }
+  | { type: 'Address' }
+  | { type: 'Signer' }
+  | {
+      type: 'Struct';
+      content: {
+        address: string;
+        module: string;
+        name: string;
+        typeArguments: SuiMoveNormalizedType[];
+      };
+    }
+  | { type: 'Vector'; content: SuiMoveNormalizedType }
+  | { type: 'TypeParameter'; content: number }
+  | { type: 'Reference'; content: SuiMoveNormalizedType }
+  | { type: 'MutableReference'; content: SuiMoveNormalizedType };
 
 function isSuiMoveNormalizedType(
   value: unknown,
 ): value is SuiMoveNormalizedType {
   if (!value) return false;
-  // if (typeof value.content === 'string') return true;
-  // if (is(value.content, SuiMoveNormalizedTypeParameterType)) return true;
-  // if (isSuiMoveNormalizedStructType(value)) return true;
-  // if (typeof value !== 'object') return false;
-  const valueProperties = value as {type: string, content: unknown};
+  const valueProperties = value as { type: string; content: unknown };
 
-  if (["Bool", "U8", "U16", "U32", "U64", "U128", "U256", "Address", "Signer"].includes(valueProperties.type) && typeof valueProperties.content === "string")
+  if (
+    [
+      'Bool',
+      'U8',
+      'U16',
+      'U32',
+      'U64',
+      'U128',
+      'U256',
+      'Address',
+      'Signer',
+    ].includes(valueProperties.type)
+  )
     return true;
-  if (["Vector", "Reference", "MutableReference"].includes(valueProperties.type) && is(valueProperties.content, SuiMoveNormalizedType))
+  if (
+    ['Vector', 'Reference', 'MutableReference'].includes(
+      valueProperties.type,
+    ) &&
+    is(valueProperties.content, SuiMoveNormalizedType)
+  )
     return true;
-  if (valueProperties.type === "TypeParameter" && typeof valueProperties.content === "number")
+  if (
+    valueProperties.type === 'TypeParameter' &&
+    typeof valueProperties.content === 'number'
+  )
     return true;
-  if(valueProperties.type === "Struct") {
+  if (valueProperties.type === 'Struct') {
     const contents = valueProperties.content as Record<string, unknown>;
-    return (typeof contents.address === "string" && typeof contents.module === "string" &&
-      typeof name === "string" && Array.isArray(contents.typeArguments) &&
-      contents.typeArguments.every(value => is(value, SuiMoveNormalizedType)))
+    return (
+      typeof contents.address === 'string' &&
+      typeof contents.module === 'string' &&
+      typeof name === 'string' &&
+      Array.isArray(contents.typeArguments) &&
+      contents.typeArguments.every((value) => is(value, SuiMoveNormalizedType))
+    );
   }
-  // const valueProperties = value as Record<string, unknown>;
-  // if (is(valueProperties.Reference, SuiMoveNormalizedType)) return true;
-  // if (is(valueProperties.MutableReference, SuiMoveNormalizedType)) return true;
-  // if (is(valueProperties.Vector, SuiMoveNormalizedType)) return true;
   return false;
 }
 
@@ -193,7 +216,8 @@ export function extractMutableReference(
   normalizedType: SuiMoveNormalizedType,
 ): SuiMoveNormalizedType | undefined {
   return typeof normalizedType === 'object' &&
-    'MutableReference' === normalizedType.type
+    'MutableReference' === normalizedType.type &&
+    typeof normalizedType.content === 'object'
     ? normalizedType.content
     : undefined;
 }
@@ -201,7 +225,8 @@ export function extractMutableReference(
 export function extractReference(
   normalizedType: SuiMoveNormalizedType,
 ): SuiMoveNormalizedType | undefined {
-  return typeof normalizedType === 'object' && 'Reference' === normalizedType.type
+  return typeof normalizedType === 'object' &&
+    'Reference' === normalizedType.type
     ? normalizedType.content
     : undefined;
 }
@@ -210,18 +235,18 @@ export function extractStructTag(
   normalizedType: SuiMoveNormalizedType,
 ): SuiMoveNormalizedStructType | undefined {
   if (typeof normalizedType === 'object' && 'Struct' === normalizedType.type) {
-    return {Struct: normalizedType.content};
+    return { Struct: normalizedType.content };
   }
 
   const ref = extractReference(normalizedType);
   const mutRef = extractMutableReference(normalizedType);
 
-  if (typeof ref === 'object' && ref.type === "Struct") {
-    return {Struct: ref.content};
+  if (typeof ref === 'object' && ref.type === 'Struct') {
+    return { Struct: ref.content };
   }
 
-  if (typeof mutRef === 'object' && mutRef.type === "Struct") {
-    return {Struct: mutRef.content};
+  if (typeof mutRef === 'object' && mutRef.type === 'Struct') {
+    return { Struct: mutRef.content };
   }
   return undefined;
 }

--- a/sdk/typescript/src/utils/errors.ts
+++ b/sdk/typescript/src/utils/errors.ts
@@ -1,0 +1,49 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { RequestParamsLike } from 'jayson';
+
+interface RPCErrorRequest {
+  method: string;
+  args: RequestParamsLike;
+}
+
+export class RPCError extends Error {
+  req: RPCErrorRequest;
+  code?: unknown;
+  data?: unknown;
+
+  constructor(options: {
+    req: RPCErrorRequest;
+    code?: unknown;
+    data?: unknown;
+    cause?: Error;
+  }) {
+    super('RPC Error', { cause: options.cause });
+
+    this.req = options.req;
+    this.code = options.code;
+    this.data = options.data;
+  }
+}
+
+export class RPCValidationError extends Error {
+  req: RPCErrorRequest;
+  result?: unknown;
+
+  constructor(options: {
+    req: RPCErrorRequest;
+    result?: unknown;
+    cause?: Error;
+  }) {
+    super(
+      'RPC Validation Error: The response returned from RPC server does not match the TypeScript definition. This is likely because the SDK version is not compatible with the RPC server.',
+      { cause: options.cause },
+    );
+
+    this.req = options.req;
+    this.result = options.result;
+  }
+}
+
+export class FaucetRateLimitError extends Error {}

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -21,9 +21,9 @@ import {
   SuiAddress,
   ObjectId,
   normalizeSuiObjectId,
+  FaucetRateLimitError,
 } from '../../../src';
 import { retry } from 'ts-retry-promise';
-import { FaucetRateLimitError } from '../../../src/rpc/faucet-client';
 
 const TEST_ENDPOINTS = localnetConnection;
 const DEFAULT_FAUCET_URL =


### PR DESCRIPTION
## Description 

Serialize SuiMoveNormalizedType into an object with {type, content} fields.

## Test Plan 

Existing tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
