### PR TITLE
Add extra_fields as Bag to all system state types

### DIFF
--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
@@ -238,11 +238,15 @@ validators:
         next_epoch_p2p_address: ~
         next_epoch_primary_address: ~
         next_epoch_worker_address: ~
+        extra_fields:
+          id:
+            id: "0x4d3f360db730ab473ac315c7d5c96840698e1bf49b8e5bb3d49047c8d131519b"
+          size: 0
       voting_power: 10000
-      operation_cap_id: "0x16bb51edad1714f14cae3a3b1265f619900cee6126bafed1e743e68f2928a536"
+      operation_cap_id: "0xeca89a922a8cc4f984973ba697f4a4c4c1f37f41bddaa96e29de0d1e924ad550"
       gas_price: 1
       staking_pool:
-        id: "0xb0cf62387a5526d51debd3ee28576c60417ba2e8187b94f7d311a312ba0c4c08"
+        id: "0x573252ac8bfd8475152372841be3a290ded6e1b090000670f0f656e8417e3863"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 25000000000000000
@@ -250,36 +254,52 @@ validators:
           value: 0
         pool_token_balance: 25000000000000000
         exchange_rates:
-          id: "0x4d3f360db730ab473ac315c7d5c96840698e1bf49b8e5bb3d49047c8d131519b"
+          id: "0xb0cf62387a5526d51debd3ee28576c60417ba2e8187b94f7d311a312ba0c4c08"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
+        extra_fields:
+          id:
+            id: "0x16bb51edad1714f14cae3a3b1265f619900cee6126bafed1e743e68f2928a536"
+          size: 0
       commission_rate: 0
       next_epoch_stake: 25000000000000000
       next_epoch_gas_price: 1
       next_epoch_commission_rate: 0
+      extra_fields:
+        id:
+          id: "0x3461b4ad7e16e4f2e9477d40f0c47ab4c7019fb761e3b4e312ba2ce69c84a3cc"
+        size: 0
   pending_active_validators:
     contents:
-      id: "0xeca89a922a8cc4f984973ba697f4a4c4c1f37f41bddaa96e29de0d1e924ad550"
+      id: "0x94f5520912a05485fbdc573c6c296ffac0b54393b43a0165a37ec0a3e5cf02d5"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0x21b9800ce7318a8f51d3672e177e67635cbcec39fc0f36ea64e620967b4a63dd"
+    id: "0x5285255b1da4e1124de1ec08c5e632851134bb18966e8eddf0b8a1f84b50edca"
     size: 1
   inactive_validators:
-    id: "0x3461b4ad7e16e4f2e9477d40f0c47ab4c7019fb761e3b4e312ba2ce69c84a3cc"
+    id: "0x7b7518fd5e2126cc81ed33ef007fd509700cc3824ee5d028e44a2f660a2974f5"
     size: 0
   validator_candidates:
-    id: "0x5285255b1da4e1124de1ec08c5e632851134bb18966e8eddf0b8a1f84b50edca"
+    id: "0x5308cca8b1cd80e2079ae89f5444e020390e95dc05eb9619c589e4556fa5f14f"
     size: 0
   at_risk_validators:
     contents: []
+  extra_fields:
+    id:
+      id: "0xe2c30224c6c7b50090540a31dbae5b8efb19977b8534b95bb12368a3dbf9ffac"
+    size: 0
 storage_fund:
   value: 0
 parameters:
   governance_start_epoch: 0
   epoch_duration_ms: 86400000
+  extra_fields:
+    id:
+      id: "0xd423e04f18d3c73e2eb201df5f944f5b875c581cae923f6c17a9fc9e05153566"
+    size: 0
 reference_gas_price: 1
 validator_report_records:
   contents: []
@@ -288,6 +308,14 @@ stake_subsidy:
   balance:
     value: 100000000000000000
   current_epoch_amount: 1000000000000000
+  extra_fields:
+    id:
+      id: "0x59c6a21fbff082bab20de9a0dbd8a6e1124ca564a2b6ef068f4fbc4279e21684"
+    size: 0
 safe_mode: false
 epoch_start_timestamp_ms: 10
+extra_fields:
+  id:
+    id: "0x0ec3454677f2bca2e93dab20023925572417e57ab35b9d7a1e52bd633e1ee7af"
+  size: 0
 

--- a/crates/sui-framework/docs/stake_subsidy.md
+++ b/crates/sui-framework/docs/stake_subsidy.md
@@ -12,9 +12,11 @@
 -  [Function `current_epoch_subsidy_amount`](#0x2_stake_subsidy_current_epoch_subsidy_amount)
 
 
-<pre><code><b>use</b> <a href="balance.md#0x2_balance">0x2::balance</a>;
+<pre><code><b>use</b> <a href="bag.md#0x2_bag">0x2::bag</a>;
+<b>use</b> <a href="balance.md#0x2_balance">0x2::balance</a>;
 <b>use</b> <a href="math.md#0x2_math">0x2::math</a>;
 <b>use</b> <a href="sui.md#0x2_sui">0x2::sui</a>;
+<b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
 </code></pre>
 
 
@@ -54,6 +56,12 @@
 <dd>
  The amount of stake subsidy to be drawn down per epoch.
  This amount decays and decreases over time.
+</dd>
+<dt>
+<code>extra_fields: <a href="bag.md#0x2_bag_Bag">bag::Bag</a></code>
+</dt>
+<dd>
+ Any extra fields that's not defined statically.
 </dd>
 </dl>
 
@@ -98,7 +106,7 @@
 
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake_subsidy.md#0x2_stake_subsidy_create">create</a>(<a href="balance.md#0x2_balance">balance</a>: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, initial_stake_subsidy_amount: u64): <a href="stake_subsidy.md#0x2_stake_subsidy_StakeSubsidy">stake_subsidy::StakeSubsidy</a>
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake_subsidy.md#0x2_stake_subsidy_create">create</a>(<a href="balance.md#0x2_balance">balance</a>: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, initial_stake_subsidy_amount: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="stake_subsidy.md#0x2_stake_subsidy_StakeSubsidy">stake_subsidy::StakeSubsidy</a>
 </code></pre>
 
 
@@ -107,11 +115,16 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake_subsidy.md#0x2_stake_subsidy_create">create</a>(<a href="balance.md#0x2_balance">balance</a>: Balance&lt;SUI&gt;, initial_stake_subsidy_amount: u64): <a href="stake_subsidy.md#0x2_stake_subsidy_StakeSubsidy">StakeSubsidy</a> {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="stake_subsidy.md#0x2_stake_subsidy_create">create</a>(
+    <a href="balance.md#0x2_balance">balance</a>: Balance&lt;SUI&gt;,
+    initial_stake_subsidy_amount: u64,
+    ctx: &<b>mut</b> TxContext,
+): <a href="stake_subsidy.md#0x2_stake_subsidy_StakeSubsidy">StakeSubsidy</a> {
     <a href="stake_subsidy.md#0x2_stake_subsidy_StakeSubsidy">StakeSubsidy</a> {
         epoch_counter: 0,
         <a href="balance.md#0x2_balance">balance</a>,
         current_epoch_amount: initial_stake_subsidy_amount,
+        extra_fields: <a href="bag.md#0x2_bag_new">bag::new</a>(ctx),
     }
 }
 </code></pre>

--- a/crates/sui-framework/docs/staking_pool.md
+++ b/crates/sui-framework/docs/staking_pool.md
@@ -43,6 +43,7 @@
 
 
 <pre><code><b>use</b> <a href="">0x1::option</a>;
+<b>use</b> <a href="bag.md#0x2_bag">0x2::bag</a>;
 <b>use</b> <a href="balance.md#0x2_balance">0x2::balance</a>;
 <b>use</b> <a href="coin.md#0x2_coin">0x2::coin</a>;
 <b>use</b> <a href="math.md#0x2_math">0x2::math</a>;
@@ -137,6 +138,12 @@ A staking pool embedded in each validator struct in the system state object.
 </dt>
 <dd>
  Pending pool token withdrawn during the current epoch, emptied at epoch boundaries.
+</dd>
+<dt>
+<code>extra_fields: <a href="bag.md#0x2_bag_Bag">bag::Bag</a></code>
+</dt>
+<dd>
+ Any extra fields that's not defined statically.
 </dd>
 </dl>
 
@@ -425,6 +432,7 @@ Create a new, empty staking pool.
         pending_stake: 0,
         pending_total_sui_withdraw: 0,
         pending_pool_token_withdraw: 0,
+        extra_fields: <a href="bag.md#0x2_bag_new">bag::new</a>(ctx),
     }
 }
 </code></pre>

--- a/crates/sui-framework/docs/sui_system_state_inner.md
+++ b/crates/sui-framework/docs/sui_system_state_inner.md
@@ -62,6 +62,7 @@
 <pre><code><b>use</b> <a href="">0x1::ascii</a>;
 <b>use</b> <a href="">0x1::option</a>;
 <b>use</b> <a href="">0x1::string</a>;
+<b>use</b> <a href="bag.md#0x2_bag">0x2::bag</a>;
 <b>use</b> <a href="balance.md#0x2_balance">0x2::balance</a>;
 <b>use</b> <a href="coin.md#0x2_coin">0x2::coin</a>;
 <b>use</b> <a href="event.md#0x2_event">0x2::event</a>;
@@ -114,6 +115,12 @@ A list of system config parameters.
 </dt>
 <dd>
  The duration of an epoch, in milliseconds.
+</dd>
+<dt>
+<code>extra_fields: <a href="bag.md#0x2_bag_Bag">bag::Bag</a></code>
+</dt>
+<dd>
+ Any extra fields that's not defined statically.
 </dd>
 </dl>
 
@@ -215,6 +222,12 @@ The top-level object containing all information of the Sui system.
 </dt>
 <dd>
  Unix timestamp of the current epoch start
+</dd>
+<dt>
+<code>extra_fields: <a href="bag.md#0x2_bag_Bag">bag::Bag</a></code>
+</dt>
+<dd>
+ Any extra fields that's not defined statically.
 </dd>
 </dl>
 
@@ -513,12 +526,14 @@ This function will be called only once in genesis.
         parameters: <a href="sui_system_state_inner.md#0x2_sui_system_state_inner_SystemParameters">SystemParameters</a> {
             governance_start_epoch,
             epoch_duration_ms,
+            extra_fields: <a href="bag.md#0x2_bag_new">bag::new</a>(ctx),
         },
         reference_gas_price,
         validator_report_records: <a href="vec_map.md#0x2_vec_map_empty">vec_map::empty</a>(),
-        <a href="stake_subsidy.md#0x2_stake_subsidy">stake_subsidy</a>: <a href="stake_subsidy.md#0x2_stake_subsidy_create">stake_subsidy::create</a>(stake_subsidy_fund, initial_stake_subsidy_amount),
+        <a href="stake_subsidy.md#0x2_stake_subsidy">stake_subsidy</a>: <a href="stake_subsidy.md#0x2_stake_subsidy_create">stake_subsidy::create</a>(stake_subsidy_fund, initial_stake_subsidy_amount, ctx),
         safe_mode: <b>false</b>,
         epoch_start_timestamp_ms,
+        extra_fields: <a href="bag.md#0x2_bag_new">bag::new</a>(ctx),
     };
     system_state
 }

--- a/crates/sui-framework/docs/validator.md
+++ b/crates/sui-framework/docs/validator.md
@@ -89,6 +89,7 @@
 <b>use</b> <a href="">0x1::bcs</a>;
 <b>use</b> <a href="">0x1::option</a>;
 <b>use</b> <a href="">0x1::string</a>;
+<b>use</b> <a href="bag.md#0x2_bag">0x2::bag</a>;
 <b>use</b> <a href="balance.md#0x2_balance">0x2::balance</a>;
 <b>use</b> <a href="event.md#0x2_event">0x2::event</a>;
 <b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
@@ -107,7 +108,7 @@
 
 
 
-<pre><code><b>struct</b> <a href="validator.md#0x2_validator_ValidatorMetadata">ValidatorMetadata</a> <b>has</b> <b>copy</b>, drop, store
+<pre><code><b>struct</b> <a href="validator.md#0x2_validator_ValidatorMetadata">ValidatorMetadata</a> <b>has</b> store
 </code></pre>
 
 
@@ -247,6 +248,12 @@
 <dd>
 
 </dd>
+<dt>
+<code>extra_fields: <a href="bag.md#0x2_bag_Bag">bag::Bag</a></code>
+</dt>
+<dd>
+ Any extra fields that's not defined statically.
+</dd>
 </dl>
 
 
@@ -322,6 +329,12 @@
 </dt>
 <dd>
  The commission rate of the validator starting the next epoch, in basis point.
+</dd>
+<dt>
+<code>extra_fields: <a href="bag.md#0x2_bag_Bag">bag::Bag</a></code>
+</dt>
+<dd>
+ Any extra fields that's not defined statically.
 </dd>
 </dl>
 
@@ -584,7 +597,7 @@ Intended validator is not a candidate one.
 
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_new_metadata">new_metadata</a>(sui_address: <b>address</b>, protocol_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, network_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, worker_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, proof_of_possession: <a href="">vector</a>&lt;u8&gt;, name: <a href="_String">string::String</a>, description: <a href="_String">string::String</a>, image_url: <a href="url.md#0x2_url_Url">url::Url</a>, project_url: <a href="url.md#0x2_url_Url">url::Url</a>, net_address: <a href="_String">string::String</a>, p2p_address: <a href="_String">string::String</a>, primary_address: <a href="_String">string::String</a>, worker_address: <a href="_String">string::String</a>): <a href="validator.md#0x2_validator_ValidatorMetadata">validator::ValidatorMetadata</a>
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="validator.md#0x2_validator_new_metadata">new_metadata</a>(sui_address: <b>address</b>, protocol_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, network_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, worker_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, proof_of_possession: <a href="">vector</a>&lt;u8&gt;, name: <a href="_String">string::String</a>, description: <a href="_String">string::String</a>, image_url: <a href="url.md#0x2_url_Url">url::Url</a>, project_url: <a href="url.md#0x2_url_Url">url::Url</a>, net_address: <a href="_String">string::String</a>, p2p_address: <a href="_String">string::String</a>, primary_address: <a href="_String">string::String</a>, worker_address: <a href="_String">string::String</a>, extra_fields: <a href="bag.md#0x2_bag_Bag">bag::Bag</a>): <a href="validator.md#0x2_validator_ValidatorMetadata">validator::ValidatorMetadata</a>
 </code></pre>
 
 
@@ -607,6 +620,7 @@ Intended validator is not a candidate one.
     p2p_address: String,
     primary_address: String,
     worker_address: String,
+    extra_fields: Bag,
 ): <a href="validator.md#0x2_validator_ValidatorMetadata">ValidatorMetadata</a> {
     <b>let</b> metadata = <a href="validator.md#0x2_validator_ValidatorMetadata">ValidatorMetadata</a> {
         sui_address,
@@ -630,6 +644,7 @@ Intended validator is not a candidate one.
         next_epoch_p2p_address: <a href="_none">option::none</a>(),
         next_epoch_primary_address: <a href="_none">option::none</a>(),
         next_epoch_worker_address: <a href="_none">option::none</a>(),
+        extra_fields,
     };
     metadata
 }
@@ -699,6 +714,7 @@ Intended validator is not a candidate one.
         <a href="_from_ascii">string::from_ascii</a>(<a href="_string">ascii::string</a>(p2p_address)),
         <a href="_from_ascii">string::from_ascii</a>(<a href="_string">ascii::string</a>(primary_address)),
         <a href="_from_ascii">string::from_ascii</a>(<a href="_string">ascii::string</a>(worker_address)),
+        <a href="bag.md#0x2_bag_new">bag::new</a>(ctx),
     );
 
     <a href="validator.md#0x2_validator_validate_metadata">validate_metadata</a>(&metadata);
@@ -2660,6 +2676,7 @@ Create a new validator from the given <code><a href="validator.md#0x2_validator_
         next_epoch_stake: stake_amount,
         next_epoch_gas_price: gas_price,
         next_epoch_commission_rate: commission_rate,
+        extra_fields: <a href="bag.md#0x2_bag_new">bag::new</a>(ctx),
     }
 }
 </code></pre>

--- a/crates/sui-framework/docs/validator_set.md
+++ b/crates/sui-framework/docs/validator_set.md
@@ -68,6 +68,7 @@
 
 <pre><code><b>use</b> <a href="">0x1::option</a>;
 <b>use</b> <a href="">0x1::vector</a>;
+<b>use</b> <a href="bag.md#0x2_bag">0x2::bag</a>;
 <b>use</b> <a href="balance.md#0x2_balance">0x2::balance</a>;
 <b>use</b> <a href="event.md#0x2_event">0x2::event</a>;
 <b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
@@ -158,6 +159,12 @@
 </dt>
 <dd>
  Table storing the number of epochs during which a validator's stake has been below the low stake threshold.
+</dd>
+<dt>
+<code>extra_fields: <a href="bag.md#0x2_bag_Bag">bag::Bag</a></code>
+</dt>
+<dd>
+ Any extra fields that's not defined statically.
 </dd>
 </dl>
 
@@ -509,6 +516,7 @@ The epoch value corresponds to the first epoch this change takes place.
         inactive_validators: <a href="table.md#0x2_table_new">table::new</a>(ctx),
         validator_candidates: <a href="table.md#0x2_table_new">table::new</a>(ctx),
         at_risk_validators: <a href="vec_map.md#0x2_vec_map_empty">vec_map::empty</a>(),
+        extra_fields: <a href="bag.md#0x2_bag_new">bag::new</a>(ctx),
     };
     <a href="voting_power.md#0x2_voting_power_set_voting_power">voting_power::set_voting_power</a>(&<b>mut</b> validators.active_validators);
     validators

--- a/crates/sui-framework/sources/governance/stake_subsidy.move
+++ b/crates/sui-framework/sources/governance/stake_subsidy.move
@@ -5,6 +5,9 @@ module sui::stake_subsidy {
     use sui::balance::{Self, Balance};
     use sui::math;
     use sui::sui::SUI;
+    use sui::bag::Bag;
+    use sui::bag;
+    use sui::tx_context::TxContext;
 
     friend sui::sui_system_state_inner;
 
@@ -17,6 +20,8 @@ module sui::stake_subsidy {
         /// The amount of stake subsidy to be drawn down per epoch.
         /// This amount decays and decreases over time.
         current_epoch_amount: u64,
+        /// Any extra fields that's not defined statically.
+        extra_fields: Bag,
     }
 
     const BASIS_POINT_DENOMINATOR: u128 = 10000;
@@ -25,11 +30,16 @@ module sui::stake_subsidy {
     const STAKE_SUBSIDY_DECREASE_RATE: u128 = 1000; // in basis point
     const STAKE_SUBSIDY_PERIOD_LENGTH: u64 = 10; // in number of epochs
 
-    public(friend) fun create(balance: Balance<SUI>, initial_stake_subsidy_amount: u64): StakeSubsidy {
+    public(friend) fun create(
+        balance: Balance<SUI>,
+        initial_stake_subsidy_amount: u64,
+        ctx: &mut TxContext,
+    ): StakeSubsidy {
         StakeSubsidy {
             epoch_counter: 0,
             balance,
             current_epoch_amount: initial_stake_subsidy_amount,
+            extra_fields: bag::new(ctx),
         }
     }
 

--- a/crates/sui-framework/sources/governance/staking_pool.move
+++ b/crates/sui-framework/sources/governance/staking_pool.move
@@ -11,6 +11,8 @@ module sui::staking_pool {
     use sui::coin;
     use sui::math;
     use sui::table::{Self, Table};
+    use sui::bag::Bag;
+    use sui::bag;
 
     friend sui::validator;
     friend sui::validator_set;
@@ -61,6 +63,8 @@ module sui::staking_pool {
         pending_total_sui_withdraw: u64,
         /// Pending pool token withdrawn during the current epoch, emptied at epoch boundaries.
         pending_pool_token_withdraw: u64,
+        /// Any extra fields that's not defined statically.
+        extra_fields: Bag,
     }
 
     /// Struct representing the exchange rate of the stake pool token to SUI.
@@ -98,6 +102,7 @@ module sui::staking_pool {
             pending_stake: 0,
             pending_total_sui_withdraw: 0,
             pending_pool_token_withdraw: 0,
+            extra_fields: bag::new(ctx),
         }
     }
 

--- a/crates/sui-framework/sources/governance/sui_system_state_inner.move
+++ b/crates/sui-framework/sources/governance/sui_system_state_inner.move
@@ -23,6 +23,8 @@ module sui::sui_system_state_inner {
     use sui::url;
     use std::string;
     use std::ascii;
+    use sui::bag::Bag;
+    use sui::bag;
 
     friend sui::sui_system;
 
@@ -51,6 +53,9 @@ module sui::sui_system_state_inner {
 
         /// The duration of an epoch, in milliseconds.
         epoch_duration_ms: u64,
+
+        /// Any extra fields that's not defined statically.
+        extra_fields: Bag,
     }
 
     /// The top-level object containing all information of the Sui system.
@@ -91,6 +96,8 @@ module sui::sui_system_state_inner {
         safe_mode: bool,
         /// Unix timestamp of the current epoch start
         epoch_start_timestamp_ms: u64,
+        /// Any extra fields that's not defined statically.
+        extra_fields: Bag,
     }
 
     /// Event containing system-level epoch information, emitted during
@@ -164,12 +171,14 @@ module sui::sui_system_state_inner {
             parameters: SystemParameters {
                 governance_start_epoch,
                 epoch_duration_ms,
+                extra_fields: bag::new(ctx),
             },
             reference_gas_price,
             validator_report_records: vec_map::empty(),
-            stake_subsidy: stake_subsidy::create(stake_subsidy_fund, initial_stake_subsidy_amount),
+            stake_subsidy: stake_subsidy::create(stake_subsidy_fund, initial_stake_subsidy_amount, ctx),
             safe_mode: false,
             epoch_start_timestamp_ms,
+            extra_fields: bag::new(ctx),
         };
         system_state
     }

--- a/crates/sui-framework/sources/governance/validator.move
+++ b/crates/sui-framework/sources/governance/validator.move
@@ -17,6 +17,8 @@ module sui::validator {
     use sui::url::Url;
     use sui::url;
     use sui::event;
+    use sui::bag::Bag;
+    use sui::bag;
     friend sui::genesis;
     friend sui::sui_system_state_inner;
     friend sui::validator_wrapper;
@@ -70,7 +72,7 @@ module sui::validator {
 
     const MAX_COMMISSION_RATE: u64 = 10_000; // Max rate is 100%, which is 10K base points
 
-    struct ValidatorMetadata has store, drop, copy {
+    struct ValidatorMetadata has store {
         /// The Sui Address of the validator. This is the sender that created the Validator object,
         /// and also the address to send validator/coins to during withdraws.
         sui_address: address,
@@ -108,6 +110,9 @@ module sui::validator {
         next_epoch_p2p_address: Option<String>,
         next_epoch_primary_address: Option<String>,
         next_epoch_worker_address: Option<String>,
+
+        /// Any extra fields that's not defined statically.
+        extra_fields: Bag,
     }
 
     struct Validator has store {
@@ -130,6 +135,8 @@ module sui::validator {
         next_epoch_gas_price: u64,
         /// The commission rate of the validator starting the next epoch, in basis point.
         next_epoch_commission_rate: u64,
+        /// Any extra fields that's not defined statically.
+        extra_fields: Bag,
     }
 
     /// Event emitted when a new stake request is received.
@@ -166,6 +173,7 @@ module sui::validator {
         p2p_address: String,
         primary_address: String,
         worker_address: String,
+        extra_fields: Bag,
     ): ValidatorMetadata {
         let metadata = ValidatorMetadata {
             sui_address,
@@ -189,6 +197,7 @@ module sui::validator {
             next_epoch_p2p_address: option::none(),
             next_epoch_primary_address: option::none(),
             next_epoch_worker_address: option::none(),
+            extra_fields,
         };
         metadata
     }
@@ -238,6 +247,7 @@ module sui::validator {
             string::from_ascii(ascii::string(p2p_address)),
             string::from_ascii(ascii::string(primary_address)),
             string::from_ascii(ascii::string(worker_address)),
+            bag::new(ctx),
         );
 
         validate_metadata(&metadata);
@@ -775,6 +785,7 @@ module sui::validator {
             next_epoch_stake: stake_amount,
             next_epoch_gas_price: gas_price,
             next_epoch_commission_rate: commission_rate,
+            extra_fields: bag::new(ctx),
         }
     }
 
@@ -819,6 +830,7 @@ module sui::validator {
                 string::from_ascii(ascii::string(p2p_address)),
                 string::from_ascii(ascii::string(primary_address)),
                 string::from_ascii(ascii::string(worker_address)),
+                bag::new(ctx),
             ),
             initial_stake_option,
             gas_price,

--- a/crates/sui-framework/sources/governance/validator_set.move
+++ b/crates/sui-framework/sources/governance/validator_set.move
@@ -21,6 +21,8 @@ module sui::validator_set {
     use sui::voting_power;
     use sui::validator_wrapper::ValidatorWrapper;
     use sui::validator_wrapper;
+    use sui::bag::Bag;
+    use sui::bag;
 
     friend sui::sui_system_state_inner;
 
@@ -62,6 +64,9 @@ module sui::validator_set {
 
         /// Table storing the number of epochs during which a validator's stake has been below the low stake threshold.
         at_risk_validators: VecMap<address, u64>,
+
+        /// Any extra fields that's not defined statically.
+        extra_fields: Bag,
     }
 
     /// Event containing staking and rewards related information of
@@ -139,6 +144,7 @@ module sui::validator_set {
             inactive_validators: table::new(ctx),
             validator_candidates: table::new(ctx),
             at_risk_validators: vec_map::empty(),
+            extra_fields: bag::new(ctx),
         };
         voting_power::set_voting_power(&mut validators.active_validators);
         validators

--- a/crates/sui-framework/tests/validator_tests.move
+++ b/crates/sui-framework/tests/validator_tests.move
@@ -17,16 +17,17 @@ module sui::validator_tests {
     use sui::staking_pool::{Self, StakedSui};
     use std::vector;
     use sui::test_utils;
+    use sui::bag;
 
     const VALID_NET_PUBKEY: vector<u8> = vector[171, 2, 39, 3, 139, 105, 166, 171, 153, 151, 102, 197, 151, 186, 140, 116, 114, 90, 213, 225, 20, 167, 60, 69, 203, 12, 180, 198, 9, 217, 117, 38];
 
     const VALID_WORKER_PUBKEY: vector<u8> = vector[171, 2, 39, 3, 139, 105, 166, 171, 153, 151, 102, 197, 151, 186, 140, 116, 114, 90, 213, 225, 20, 167, 60, 69, 203, 12, 180, 198, 9, 217, 117, 38];
 
-    // A valid proof of posession must be generated using the same account address and protocol public key. 
+    // A valid proof of possession must be generated using the same account address and protocol public key.
     // If either VALID_ADDRESS or VALID_PUBKEY changed, PoP must be regenerated using [fn test_proof_of_possession].
     const VALID_ADDRESS: address = @0xaf76afe6f866d8426d2be85d6ef0b11f871a251d043b2f11e15563bf418f5a5a;
     const VALID_PUBKEY: vector<u8> = x"99f25ef61f8032b914636460982c5cc6f134ef1ddae76657f2cbfec1ebfc8d097374080df6fcf0dcb8bc4b0d8e0af5d80ebbff2b4c599f54f42d6312dfc314276078c1cc347ebbbec5198be258513f386b930d02c2749a803e2330955ebd1a10";
-    const PROOF_OF_POSESSION: vector<u8> = x"b01cc86f421beca7ab4cfca87c0799c4d038c199dd399fbec1924d4d4367866dba9e84d514710b91feb65316e4ceef43";
+    const PROOF_OF_POSSESSION: vector<u8> = x"b01cc86f421beca7ab4cfca87c0799c4d038c199dd399fbec1924d4d4367866dba9e84d514710b91feb65316e4ceef43";
 
     const VALID_NET_ADDR: vector<u8> = b"/ip4/127.0.0.1/tcp/80";
     const VALID_P2P_ADDR: vector<u8> = b"/ip4/127.0.0.1/udp/80";
@@ -40,7 +41,7 @@ module sui::validator_tests {
             VALID_PUBKEY,
             VALID_NET_PUBKEY,
             VALID_WORKER_PUBKEY,
-            PROOF_OF_POSESSION,
+            PROOF_OF_POSSESSION,
             b"Validator1",
             b"Validator1",
             b"Validator1",
@@ -137,12 +138,14 @@ module sui::validator_tests {
 
     #[test]
     fun test_metadata() {
+        let scenario_val = test_scenario::begin(VALID_ADDRESS);
+        let ctx = test_scenario::ctx(&mut scenario_val);
         let metadata = validator::new_metadata(
             VALID_ADDRESS,
             VALID_PUBKEY,
             VALID_NET_PUBKEY,
             VALID_WORKER_PUBKEY,
-            PROOF_OF_POSESSION,
+            PROOF_OF_POSSESSION,
             string::from_ascii(ascii::string(b"Validator1")),
             string::from_ascii(ascii::string(b"Validator1")),
             url::new_unsafe_from_bytes(b"image_url1"),
@@ -151,20 +154,25 @@ module sui::validator_tests {
             string::from_ascii(ascii::string(VALID_P2P_ADDR)),
             string::from_ascii(ascii::string(VALID_CONSENSUS_ADDR)),
             string::from_ascii(ascii::string(VALID_WORKER_ADDR)),
+            bag::new(ctx),
         );
 
         validator::validate_metadata(&metadata);
+        test_utils::destroy(metadata);
+        test_scenario::end(scenario_val);
     }
 
     #[test]
     #[expected_failure(abort_code = validator::EMetadataInvalidPubkey)]
     fun test_metadata_invalid_pubkey() {
+        let scenario_val = test_scenario::begin(VALID_ADDRESS);
+        let ctx = test_scenario::ctx(&mut scenario_val);
         let metadata = validator::new_metadata(
             VALID_ADDRESS,
             vector[42],
             VALID_NET_PUBKEY,
             VALID_WORKER_PUBKEY,
-            PROOF_OF_POSESSION,
+            PROOF_OF_POSSESSION,
             string::from_ascii(ascii::string(b"Validator1")),
             string::from_ascii(ascii::string(b"Validator1")),
             url::new_unsafe_from_bytes(b"image_url1"),
@@ -173,20 +181,25 @@ module sui::validator_tests {
             string::from_ascii(ascii::string(VALID_P2P_ADDR)),
             string::from_ascii(ascii::string(VALID_CONSENSUS_ADDR)),
             string::from_ascii(ascii::string(VALID_WORKER_ADDR)),
+            bag::new(ctx),
         );
 
         validator::validate_metadata(&metadata);
+        test_utils::destroy(metadata);
+        test_scenario::end(scenario_val);
     }
 
     #[test]
     #[expected_failure(abort_code = validator::EMetadataInvalidNetPubkey)]
     fun test_metadata_invalid_net_pubkey() {
+        let scenario_val = test_scenario::begin(VALID_ADDRESS);
+        let ctx = test_scenario::ctx(&mut scenario_val);
         let metadata = validator::new_metadata(
             VALID_ADDRESS,
             VALID_PUBKEY,
             vector[42],
             VALID_WORKER_PUBKEY,
-            PROOF_OF_POSESSION,
+            PROOF_OF_POSSESSION,
             string::from_ascii(ascii::string(b"Validator1")),
             string::from_ascii(ascii::string(b"Validator1")),
             url::new_unsafe_from_bytes(b"image_url1"),
@@ -195,20 +208,25 @@ module sui::validator_tests {
             string::from_ascii(ascii::string(VALID_P2P_ADDR)),
             string::from_ascii(ascii::string(VALID_CONSENSUS_ADDR)),
             string::from_ascii(ascii::string(VALID_WORKER_ADDR)),
+            bag::new(ctx),
         );
 
         validator::validate_metadata(&metadata);
+        test_utils::destroy(metadata);
+        test_scenario::end(scenario_val);
     }
 
     #[test]
     #[expected_failure(abort_code = validator::EMetadataInvalidWorkerPubkey)]
     fun test_metadata_invalid_worker_pubkey() {
+        let scenario_val = test_scenario::begin(VALID_ADDRESS);
+        let ctx = test_scenario::ctx(&mut scenario_val);
         let metadata = validator::new_metadata(
             VALID_ADDRESS,
             VALID_PUBKEY,
             VALID_NET_PUBKEY,
             vector[42],
-            PROOF_OF_POSESSION,
+            PROOF_OF_POSSESSION,
             string::from_ascii(ascii::string(b"Validator1")),
             string::from_ascii(ascii::string(b"Validator1")),
             url::new_unsafe_from_bytes(b"image_url1"),
@@ -217,20 +235,25 @@ module sui::validator_tests {
             string::from_ascii(ascii::string(VALID_P2P_ADDR)),
             string::from_ascii(ascii::string(VALID_CONSENSUS_ADDR)),
             string::from_ascii(ascii::string(VALID_WORKER_ADDR)),
+            bag::new(ctx),
         );
 
         validator::validate_metadata(&metadata);
+        test_utils::destroy(metadata);
+        test_scenario::end(scenario_val);
     }
 
     #[test]
     #[expected_failure(abort_code = validator::EMetadataInvalidNetAddr)]
     fun test_metadata_invalid_net_addr() {
+        let scenario_val = test_scenario::begin(VALID_ADDRESS);
+        let ctx = test_scenario::ctx(&mut scenario_val);
         let metadata = validator::new_metadata(
             VALID_ADDRESS,
             VALID_PUBKEY,
             VALID_NET_PUBKEY,
             VALID_WORKER_PUBKEY,
-            PROOF_OF_POSESSION,
+            PROOF_OF_POSSESSION,
             string::from_ascii(ascii::string(b"Validator1")),
             string::from_ascii(ascii::string(b"Validator1")),
             url::new_unsafe_from_bytes(b"image_url1"),
@@ -239,20 +262,25 @@ module sui::validator_tests {
             string::from_ascii(ascii::string(VALID_P2P_ADDR)),
             string::from_ascii(ascii::string(VALID_CONSENSUS_ADDR)),
             string::from_ascii(ascii::string(VALID_WORKER_ADDR)),
+            bag::new(ctx),
         );
 
         validator::validate_metadata(&metadata);
+        test_utils::destroy(metadata);
+        test_scenario::end(scenario_val);
     }
 
     #[test]
     #[expected_failure(abort_code = validator::EMetadataInvalidP2pAddr)]
     fun test_metadata_invalid_p2p_addr() {
+        let scenario_val = test_scenario::begin(VALID_ADDRESS);
+        let ctx = test_scenario::ctx(&mut scenario_val);
         let metadata = validator::new_metadata(
             VALID_ADDRESS,
             VALID_PUBKEY,
             VALID_NET_PUBKEY,
             VALID_WORKER_PUBKEY,
-            PROOF_OF_POSESSION,
+            PROOF_OF_POSSESSION,
             string::from_ascii(ascii::string(b"Validator1")),
             string::from_ascii(ascii::string(b"Validator1")),
             url::new_unsafe_from_bytes(b"image_url1"),
@@ -261,20 +289,25 @@ module sui::validator_tests {
             string::from_ascii(ascii::string(b"42")),
             string::from_ascii(ascii::string(VALID_CONSENSUS_ADDR)),
             string::from_ascii(ascii::string(VALID_WORKER_ADDR)),
+            bag::new(ctx),
         );
 
         validator::validate_metadata(&metadata);
+        test_utils::destroy(metadata);
+        test_scenario::end(scenario_val);
     }
 
     #[test]
     #[expected_failure(abort_code = validator::EMetadataInvalidPrimaryAddr)]
     fun test_metadata_invalid_consensus_addr() {
+        let scenario_val = test_scenario::begin(VALID_ADDRESS);
+        let ctx = test_scenario::ctx(&mut scenario_val);
         let metadata = validator::new_metadata(
             VALID_ADDRESS,
             VALID_PUBKEY,
             VALID_NET_PUBKEY,
             VALID_WORKER_PUBKEY,
-            PROOF_OF_POSESSION,
+            PROOF_OF_POSSESSION,
             string::from_ascii(ascii::string(b"Validator1")),
             string::from_ascii(ascii::string(b"Validator1")),
             url::new_unsafe_from_bytes(b"image_url1"),
@@ -283,20 +316,25 @@ module sui::validator_tests {
             string::from_ascii(ascii::string(VALID_P2P_ADDR)),
             string::from_ascii(ascii::string(b"42")),
             string::from_ascii(ascii::string(VALID_WORKER_ADDR)),
+            bag::new(ctx),
         );
 
         validator::validate_metadata(&metadata);
+        test_utils::destroy(metadata);
+        test_scenario::end(scenario_val);
     }
 
     #[test]
     #[expected_failure(abort_code = validator::EMetadataInvalidWorkerAddr)]
     fun test_metadata_invalid_worker_addr() {
+        let scenario_val = test_scenario::begin(VALID_ADDRESS);
+        let ctx = test_scenario::ctx(&mut scenario_val);
         let metadata = validator::new_metadata(
             VALID_ADDRESS,
             VALID_PUBKEY,
             VALID_NET_PUBKEY,
             VALID_WORKER_PUBKEY,
-            PROOF_OF_POSESSION,
+            PROOF_OF_POSSESSION,
             string::from_ascii(ascii::string(b"Validator1")),
             string::from_ascii(ascii::string(b"Validator1")),
             url::new_unsafe_from_bytes(b"image_url1"),
@@ -305,14 +343,17 @@ module sui::validator_tests {
             string::from_ascii(ascii::string(VALID_P2P_ADDR)),
             string::from_ascii(ascii::string(VALID_CONSENSUS_ADDR)),
             string::from_ascii(ascii::string(b"42")),
+            bag::new(ctx),
         );
 
         validator::validate_metadata(&metadata);
+        test_utils::destroy(metadata);
+        test_scenario::end(scenario_val);
     }
 
     #[test]
     fun test_validator_update_metadata_ok() {
-        let sender = VALID_ADDRESS;  
+        let sender = VALID_ADDRESS;
         let scenario_val = test_scenario::begin(sender);
         let scenario = &mut scenario_val;
         let ctx = test_scenario::ctx(scenario);
@@ -362,7 +403,7 @@ module sui::validator_tests {
             assert!(validator::primary_address(&validator) == &string::from_ascii(ascii::string(VALID_CONSENSUS_ADDR)), 0);
             assert!(validator::worker_address(&validator) == &string::from_ascii(ascii::string(VALID_WORKER_ADDR)), 0);
             assert!(validator::protocol_pubkey_bytes(&validator) == &VALID_PUBKEY, 0);
-            assert!(validator::proof_of_possession(&validator) == &PROOF_OF_POSESSION, 0);
+            assert!(validator::proof_of_possession(&validator) == &PROOF_OF_POSSESSION, 0);
             assert!(validator::network_pubkey_bytes(&validator) == &VALID_NET_PUBKEY, 0);
             assert!(validator::worker_pubkey_bytes(&validator) == &VALID_WORKER_PUBKEY, 0);
 

--- a/crates/sui-types/src/collection_types.rs
+++ b/crates/sui-types/src/collection_types.rs
@@ -4,6 +4,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::base_types::{ObjectID, SuiAddress};
+use crate::id::UID;
 
 /// Rust version of the Move sui::vec_map::VecMap type
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
@@ -73,6 +74,22 @@ impl<K> Default for LinkedTable<K> {
             size: 0,
             head: None,
             tail: None,
+        }
+    }
+}
+
+/// Rust version of the Move sui::bag::Bag type.
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
+pub struct Bag {
+    pub id: UID,
+    pub size: u64,
+}
+
+impl Default for Bag {
+    fn default() -> Self {
+        Self {
+            id: UID::new(ObjectID::ZERO),
+            size: 0,
         }
     }
 }

--- a/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
@@ -3,7 +3,7 @@
 
 use crate::balance::Balance;
 use crate::base_types::{EpochId, ObjectID, SuiAddress};
-use crate::collection_types::{Table, TableVec, VecMap, VecSet};
+use crate::collection_types::{Bag, Table, TableVec, VecMap, VecSet};
 use crate::committee::{Committee, CommitteeWithNetworkMetadata, NetworkMetadata, ProtocolVersion};
 use crate::crypto::verify_proof_of_possession;
 use crate::crypto::AuthorityPublicKeyBytes;
@@ -34,6 +34,7 @@ const E_METADATA_INVALID_WORKER_ADDR: u64 = 7;
 pub struct SystemParametersV1 {
     pub governance_start_epoch: u64,
     pub epoch_duration_ms: u64,
+    pub extra_fields: Bag,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
@@ -59,6 +60,7 @@ pub struct ValidatorMetadataV1 {
     pub next_epoch_p2p_address: Option<String>,
     pub next_epoch_primary_address: Option<String>,
     pub next_epoch_worker_address: Option<String>,
+    pub extra_fields: Bag,
 }
 
 #[derive(derivative::Derivative, Clone, Eq, PartialEq)]
@@ -271,6 +273,7 @@ pub struct ValidatorV1 {
     pub next_epoch_stake: u64,
     pub next_epoch_gas_price: u64,
     pub next_epoch_commission_rate: u64,
+    pub extra_fields: Bag,
 }
 
 impl ValidatorV1 {
@@ -307,6 +310,7 @@ impl ValidatorV1 {
                     next_epoch_p2p_address,
                     next_epoch_primary_address,
                     next_epoch_worker_address,
+                    extra_fields: _,
                 },
             verified_metadata: _,
             voting_power,
@@ -328,11 +332,13 @@ impl ValidatorV1 {
                     pending_stake,
                     pending_total_sui_withdraw,
                     pending_pool_token_withdraw,
+                    extra_fields: _,
                 },
             commission_rate,
             next_epoch_stake,
             next_epoch_gas_price,
             next_epoch_commission_rate,
+            extra_fields: _,
         } = self;
         SuiValidatorSummary {
             sui_address,
@@ -391,6 +397,7 @@ pub struct StakingPoolV1 {
     pub pending_stake: u64,
     pub pending_total_sui_withdraw: u64,
     pub pending_pool_token_withdraw: u64,
+    pub extra_fields: Bag,
 }
 
 /// Rust version of the Move sui::validator_set::ValidatorSet type
@@ -404,6 +411,7 @@ pub struct ValidatorSetV1 {
     pub inactive_validators: Table,
     pub validator_candidates: Table,
     pub at_risk_validators: VecMap<SuiAddress, u64>,
+    pub extra_fields: Bag,
 }
 
 /// Rust version of the Move sui::sui_system::SuiSystemStateInner type
@@ -421,6 +429,7 @@ pub struct SuiSystemStateInnerV1 {
     pub stake_subsidy: StakeSubsidyV1,
     pub safe_mode: bool,
     pub epoch_start_timestamp_ms: u64,
+    pub extra_fields: Bag,
     // TODO: Use getters instead of all pub.
 }
 
@@ -438,6 +447,7 @@ pub struct StakeSubsidyV1 {
     pub epoch_counter: u64,
     pub balance: Balance,
     pub current_epoch_amount: u64,
+    pub extra_fields: Bag,
 }
 
 impl SuiSystemStateTrait for SuiSystemStateInnerV1 {
@@ -558,12 +568,14 @@ impl SuiSystemStateTrait for SuiSystemStateInnerV1 {
                         VecMap {
                             contents: at_risk_validators,
                         },
+                    extra_fields: _,
                 },
             storage_fund,
             parameters:
                 SystemParametersV1 {
                     governance_start_epoch,
                     epoch_duration_ms,
+                    extra_fields: _,
                 },
             reference_gas_price,
             validator_report_records:
@@ -575,9 +587,11 @@ impl SuiSystemStateTrait for SuiSystemStateInnerV1 {
                     epoch_counter: stake_subsidy_epoch_counter,
                     balance: stake_subsidy_balance,
                     current_epoch_amount: stake_subsidy_current_epoch_amount,
+                    extra_fields: _,
                 },
             safe_mode,
             epoch_start_timestamp_ms,
+            extra_fields: _,
         } = self;
         SuiSystemStateSummary {
             epoch,
@@ -630,6 +644,7 @@ impl Default for SuiSystemStateInnerV1 {
             inactive_validators: Table::default(),
             validator_candidates: Table::default(),
             at_risk_validators: VecMap { contents: vec![] },
+            extra_fields: Default::default(),
         };
         Self {
             epoch: 0,
@@ -640,6 +655,7 @@ impl Default for SuiSystemStateInnerV1 {
             parameters: SystemParametersV1 {
                 governance_start_epoch: 0,
                 epoch_duration_ms: 10000,
+                extra_fields: Default::default(),
             },
             reference_gas_price: 1,
             validator_report_records: VecMap { contents: vec![] },
@@ -647,9 +663,11 @@ impl Default for SuiSystemStateInnerV1 {
                 epoch_counter: 0,
                 balance: Balance::new(0),
                 current_epoch_amount: 0,
+                extra_fields: Default::default(),
             },
             safe_mode: false,
             epoch_start_timestamp_ms: 0,
+            extra_fields: Default::default(),
         }
     }
 }


### PR DESCRIPTION
This will provide a relatively more convenient way to upgrade the system state types if we are in a hurry or if the change is minor and we can live with extensions.