### PR TITLE
indexer: harden txn response type for type safety

### DIFF
--- a/crates/sui-indexer/migrations/2022-11-18-195259_transactions/up.sql
+++ b/crates/sui-indexer/migrations/2022-11-18-195259_transactions/up.sql
@@ -9,7 +9,7 @@ CREATE TABLE transactions (
     sender                      VARCHAR(255) NOT NULL,
     recipients                  TEXT[]       NOT NULL,
     checkpoint_sequence_number  BIGINT       NOT NULL,
-    transaction_time            TIMESTAMP,
+    timestamp_ms                BIGINT       NOT NULL,
     transaction_kind            TEXT         NOT NULL,
     -- object related
     created                     TEXT[]       NOT NULL,
@@ -40,7 +40,7 @@ CREATE TABLE transactions (
 );
 
 CREATE INDEX transactions_transaction_digest ON transactions (transaction_digest);
-CREATE INDEX transactions_transaction_time ON transactions (transaction_time);
+CREATE INDEX transactions_timestamp_ms ON transactions (timestamp_ms);
 CREATE INDEX transactions_sender ON transactions (sender);
 CREATE INDEX transactions_gas_object_id ON transactions (gas_object_id);
 CREATE INDEX transactions_checkpoint_sequence_number ON transactions (checkpoint_sequence_number);

--- a/crates/sui-indexer/migrations/2022-11-28-204251_addresses/up.sql
+++ b/crates/sui-indexer/migrations/2022-11-28-204251_addresses/up.sql
@@ -1,8 +1,9 @@
 CREATE TABLE addresses
 (
-    account_address       address PRIMARY KEY,
-    first_appearance_tx   base58digest NOT NULL,
-    first_appearance_time TIMESTAMP
+    account_address       address       PRIMARY KEY,
+    first_appearance_tx   base58digest  NOT NULL,
+    first_appearance_time BIGINT        NOT NULL
 );
 CREATE INDEX addresses_account_address ON addresses (account_address);
-
+CREATE INDEX addresses_first_appearance_tx ON addresses (first_appearance_tx);
+CREATE INDEX addresses_first_appearance_time ON addresses (first_appearance_time);

--- a/crates/sui-indexer/src/lib.rs
+++ b/crates/sui-indexer/src/lib.rs
@@ -20,13 +20,17 @@ use errors::IndexerError;
 use mysten_metrics::spawn_monitored_task;
 use sui_core::event_handler::EventHandler;
 use sui_json_rpc::{JsonRpcServerBuilder, ServerHandle, CLIENT_SDK_TYPE_HEADER};
+use sui_json_rpc_types::SuiTransactionResponseOptions;
+use sui_sdk::apis::ReadApi as SuiReadApi;
 use sui_sdk::{SuiClient, SuiClientBuilder};
+use sui_types::base_types::TransactionDigest;
 
 use crate::apis::{
     CoinReadApi, EventReadApi, GovernanceReadApi, ReadApi, TransactionBuilderApi, WriteApi,
 };
 use crate::handlers::checkpoint_handler::CheckpointHandler;
 use crate::store::IndexerStore;
+use crate::types::SuiTransactionFullResponse;
 
 pub mod apis;
 pub mod errors;
@@ -36,6 +40,7 @@ pub mod models;
 pub mod processors;
 pub mod schema;
 pub mod store;
+pub mod types;
 pub mod utils;
 
 pub type PgConnectionPool = Pool<ConnectionManager<PgConnection>>;
@@ -186,4 +191,37 @@ pub async fn build_json_rpc_server<S: IndexerStore + Sync + Send + 'static + Clo
         config.rpc_server_port,
     );
     Ok(builder.start(default_socket_addr).await?)
+}
+
+pub async fn multi_get_full_transactions(
+    read_api: &SuiReadApi,
+    digests: Vec<TransactionDigest>,
+) -> Result<Vec<SuiTransactionFullResponse>, IndexerError> {
+    let sui_transactions = read_api
+        .multi_get_transactions_with_options(
+            digests.clone(),
+            SuiTransactionResponseOptions::new()
+                .with_input()
+                .with_effects()
+                .with_events(),
+        )
+        .await
+        .map_err(|e| {
+            IndexerError::FullNodeReadingError(format!(
+                "Failed to get transactions {:?} with error: {:?}",
+                digests.clone(),
+                e
+            ))
+        })?;
+    let sui_full_transactions: Vec<SuiTransactionFullResponse> = sui_transactions
+        .into_iter()
+        .map(SuiTransactionFullResponse::try_from)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| {
+            IndexerError::FullNodeReadingError(format!(
+                "Unexpected None value in SuiTransactionFullResponse of digests {:?} with error {:?}",
+                digests, e
+            ))
+        })?;
+    Ok(sui_full_transactions)
 }

--- a/crates/sui-indexer/src/models/addresses.rs
+++ b/crates/sui-indexer/src/models/addresses.rs
@@ -4,7 +4,6 @@
 use crate::models::transactions::Transaction;
 use crate::schema::addresses;
 
-use chrono::NaiveDateTime;
 use diesel::prelude::*;
 
 #[derive(Queryable, Insertable, Debug)]
@@ -12,7 +11,7 @@ use diesel::prelude::*;
 pub struct Address {
     pub account_address: String,
     pub first_appearance_tx: String,
-    pub first_appearance_time: Option<NaiveDateTime>,
+    pub first_appearance_time: i64,
 }
 
 impl From<&Transaction> for Address {
@@ -20,7 +19,7 @@ impl From<&Transaction> for Address {
         Address {
             account_address: txn.sender.clone(),
             first_appearance_tx: txn.transaction_digest.clone(),
-            first_appearance_time: txn.transaction_time,
+            first_appearance_time: txn.timestamp_ms,
         }
     }
 }

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -20,7 +20,7 @@ diesel::table! {
     addresses (account_address) {
         account_address -> Varchar,
         first_appearance_tx -> Varchar,
-        first_appearance_time -> Nullable<Timestamp>,
+        first_appearance_time -> Int8,
     }
 }
 
@@ -197,7 +197,7 @@ diesel::table! {
         sender -> Varchar,
         recipients -> Array<Nullable<Text>>,
         checkpoint_sequence_number -> Int8,
-        transaction_time -> Nullable<Timestamp>,
+        timestamp_ms -> Int8,
         transaction_kind -> Text,
         created -> Array<Nullable<Text>>,
         mutated -> Array<Nullable<Text>>,

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -11,10 +11,10 @@ use crate::models::owners::ObjectOwner;
 use crate::models::packages::Package;
 use crate::models::recipients::Recipient;
 use crate::models::transactions::Transaction;
+use crate::types::SuiTransactionFullResponse;
 use async_trait::async_trait;
 use sui_json_rpc_types::{
     Checkpoint as RpcCheckpoint, CheckpointId, EventFilter, EventPage, SuiObjectData,
-    SuiTransactionResponse,
 };
 use sui_types::base_types::{ObjectID, SequenceNumber};
 use sui_types::event::EventID;
@@ -124,9 +124,10 @@ pub trait IndexerStore {
     fn module_cache(&self) -> &Self::ModuleCache;
 }
 
+#[derive(Clone, Debug)]
 pub struct CheckpointData {
     pub checkpoint: RpcCheckpoint,
-    pub transactions: Vec<SuiTransactionResponse>,
+    pub transactions: Vec<SuiTransactionFullResponse>,
     pub changed_objects: Vec<(ObjectStatus, SuiObjectData)>,
 }
 

--- a/crates/sui-indexer/src/types.rs
+++ b/crates/sui-indexer/src/types.rs
@@ -1,0 +1,121 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use sui_json_rpc_types::{
+    BalanceChange, ObjectChange, SuiTransaction, SuiTransactionEffects, SuiTransactionEvents,
+    SuiTransactionResponse,
+};
+use sui_types::digests::TransactionDigest;
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+
+#[derive(Debug, Clone)]
+pub struct SuiTransactionFullResponse {
+    pub digest: TransactionDigest,
+    /// Transaction input data
+    pub transaction: SuiTransaction,
+    pub effects: SuiTransactionEffects,
+    pub events: SuiTransactionEvents,
+    pub object_changes: Option<Vec<ObjectChange>>,
+    pub balance_changes: Option<Vec<BalanceChange>>,
+    pub timestamp_ms: u64,
+    pub confirmed_local_execution: Option<bool>,
+    pub checkpoint: CheckpointSequenceNumber,
+}
+
+impl TryFrom<SuiTransactionResponse> for SuiTransactionFullResponse {
+    type Error = anyhow::Error;
+
+    fn try_from(response: SuiTransactionResponse) -> Result<Self, Self::Error> {
+        let SuiTransactionResponse {
+            digest,
+            transaction,
+            effects,
+            events,
+            object_changes,
+            balance_changes,
+            timestamp_ms,
+            confirmed_local_execution,
+            checkpoint,
+            errors,
+        } = response;
+
+        let transaction = transaction.ok_or_else(|| {
+            anyhow::anyhow!(
+                "Transaction is None in SuiTransactionFullResponse of digest {:?}.",
+                digest
+            )
+        })?;
+        let effects = effects.ok_or_else(|| {
+            anyhow::anyhow!(
+                "Effects is None in SuiTransactionFullResponse of digest {:?}.",
+                digest
+            )
+        })?;
+        let events = events.ok_or_else(|| {
+            anyhow::anyhow!(
+                "Events is None in SuiTransactionFullResponse of digest {:?}.",
+                digest
+            )
+        })?;
+        let timestamp_ms = timestamp_ms.ok_or_else(|| {
+            anyhow::anyhow!(
+                "TimestampMs is None in SuiTransactionFullResponse of digest {:?}.",
+                digest
+            )
+        })?;
+        let checkpoint = checkpoint.ok_or_else(|| {
+            anyhow::anyhow!(
+                "Checkpoint is None in SuiTransactionFullResponse of digest {:?}.",
+                digest
+            )
+        })?;
+        if !errors.is_empty() {
+            return Err(anyhow::anyhow!(
+                "Errors in SuiTransactionFullResponse of digest {:?}: {:?}",
+                digest,
+                errors
+            ));
+        }
+
+        Ok(SuiTransactionFullResponse {
+            digest,
+            transaction,
+            effects,
+            events,
+            object_changes,
+            balance_changes,
+            timestamp_ms,
+            confirmed_local_execution,
+            checkpoint,
+        })
+    }
+}
+
+impl From<SuiTransactionFullResponse> for SuiTransactionResponse {
+    fn from(response: SuiTransactionFullResponse) -> Self {
+        let SuiTransactionFullResponse {
+            digest,
+            transaction,
+            effects,
+            events,
+            object_changes,
+            balance_changes,
+            timestamp_ms,
+            confirmed_local_execution,
+            checkpoint,
+        } = response;
+
+        SuiTransactionResponse {
+            digest,
+            transaction: Some(transaction),
+            effects: Some(effects),
+            events: Some(events),
+            object_changes,
+            balance_changes,
+            timestamp_ms: Some(timestamp_ms),
+            confirmed_local_execution,
+            checkpoint: Some(checkpoint),
+            errors: vec![],
+        }
+    }
+}


### PR DESCRIPTION
## Description 

- change txn response type on indexer end to SuiTransactionFullResponse, which has no unexpected None values; If unexpected None happens, indexer will retry and also log errors to k8 pod.
- other minor changes like always use ms rather than naiveDateTime

## Test Plan 

- CI
- local test run with local validator
