### PR TITLE
Increase coin amount in gas coins for benchmark testing

### DIFF
--- a/crates/sui-benchmark/src/workloads/batch_payment.rs
+++ b/crates/sui-benchmark/src/workloads/batch_payment.rs
@@ -28,7 +28,7 @@ use super::workload::{Workload, MAX_GAS_FOR_TESTING};
 /// Value of each address's "primary coin" in mist. The first transaction gives
 /// each address a coin worth PRIMARY_COIN_VALUE, and all subsequent transfers
 /// send TRANSFER_AMOUNT coins each time
-const PRIMARY_COIN_VALUE: u64 = 10_000_000;
+const PRIMARY_COIN_VALUE: u64 = 100_000_000;
 
 /// Number of mist sent to each address on each batch transfer
 const TRANSFER_AMOUNT: u64 = 1;

--- a/crates/sui-benchmark/src/workloads/workload.rs
+++ b/crates/sui-benchmark/src/workloads/workload.rs
@@ -12,7 +12,7 @@ use crate::ValidatorProxy;
 
 // This is the maximum gas we will transfer from primary coin into any gas coin
 // for running the benchmark
-pub const MAX_GAS_FOR_TESTING: u64 = 1_000_000_000;
+pub const MAX_GAS_FOR_TESTING: u64 = 100_000_000_000;
 
 #[async_trait]
 pub trait WorkloadBuilder<T: Payload + ?Sized>: Send + Sync + std::fmt::Debug {


### PR DESCRIPTION
## Description 

Without this we cannot support batch_size >= 100 as after splitting it in batch payload, per coin amount `PRIMARY_COIN_VALUE` is 10_000_000 and `MAX_GAS_FOR_TESTING` is 1_000_000_000. We run out of gas after some time with 10M primary coin, so increasing it which requires increasing gas coin value as well.

## Test Plan 

Existing tests
