### PR TITLE
In-progress tx must eventually succeed

### DIFF
--- a/crates/sui-core/src/execution_driver.rs
+++ b/crates/sui-core/src/execution_driver.rs
@@ -22,7 +22,7 @@ mod execution_driver_tests;
 
 // Execution should not encounter permanent failures, so any failure can and needs
 // to be retried.
-const EXECUTION_MAX_ATTEMPTS: usize = 10;
+pub const EXECUTION_MAX_ATTEMPTS: u32 = 10;
 const EXECUTION_FAILURE_RETRY_INTERVAL: Duration = Duration::from_secs(1);
 
 /// When a notification that a new pending transaction is received we activate


### PR DESCRIPTION
This PR removes two checks on retry num:
1. In acquire tx guard: we don't need this one because returning error there doesn't help. Eventually the caller (in execution driver) will hit 10 times of failure and panic anyway.
2. In recovery processing: these must succeed. Panic after 10 retries.