### PR TITLE
Fix gas budget verification code

### DIFF
--- a/crates/sui-types/src/gas.rs
+++ b/crates/sui-types/src/gas.rs
@@ -551,15 +551,16 @@ pub fn check_gas_balance(
 
     let max_gas_budget = cost_table.max_gas_budget as u128 * gas_price as u128;
     let min_gas_budget = cost_table.min_gas_budget_external() as u128 * gas_price as u128;
+    let required_gas_amount = gas_budget as u128;
 
-    if (gas_budget as u128) > max_gas_budget {
+    if required_gas_amount > max_gas_budget {
         return Err(UserInputError::GasBudgetTooHigh {
             gas_budget,
             max_budget: cost_table.max_gas_budget,
         });
     }
 
-    if (gas_budget as u128) < min_gas_budget {
+    if required_gas_amount < min_gas_budget {
         return Err(UserInputError::GasBudgetTooLow {
             gas_budget,
             min_budget: cost_table.min_gas_budget_external(),
@@ -567,7 +568,6 @@ pub fn check_gas_balance(
     }
 
     let mut gas_balance = get_gas_balance(gas_object)? as u128;
-    let required_gas_amount = (gas_budget as u128) * (gas_price as u128);
     for extra_obj in more_gas_objs {
         gas_balance += get_gas_balance(&extra_obj)? as u128;
     }


### PR DESCRIPTION
## Description 

Gas budget is now in SUI so multiplying the value by the gas price when checking for balance is wrong and with a RGP of 1000 it is pretty disruptive

## Test Plan 

Existing test and more coming

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
