### PR TITLE
[upgrades] Abstraction over system packages

### DIFF
--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -17,6 +17,7 @@ use std::convert::TryInto;
 use std::{fs, path::Path};
 use sui_adapter::adapter::MoveVM;
 use sui_adapter::{adapter, execution_mode, programmable_transactions};
+use sui_framework::{MoveStdlib, SuiFramework, SystemPackage};
 use sui_protocol_config::ProtocolConfig;
 use sui_types::base_types::{ExecutionDigests, TransactionDigest};
 use sui_types::base_types::{ObjectID, SequenceNumber, SuiAddress};
@@ -888,12 +889,12 @@ fn build_unsigned_genesis_data(
     // Get Move and Sui Framework
     let modules = [
         (
-            sui_framework::get_move_stdlib(),
-            sui_framework::get_move_stdlib_transitive_dependencies(),
+            MoveStdlib::as_modules(),
+            MoveStdlib::transitive_dependencies(),
         ),
         (
-            sui_framework::get_sui_framework(),
-            sui_framework::get_sui_framework_transitive_dependencies(),
+            SuiFramework::as_modules(),
+            SuiFramework::transitive_dependencies(),
         ),
     ];
 

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -24,6 +24,7 @@ use prometheus::{
 };
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use sui_framework::{MoveStdlib, SuiFramework, SystemPackage};
 use tap::{TapFallible, TapOptional};
 use tokio::sync::mpsc::unbounded_channel;
 use tokio::sync::oneshot;
@@ -77,8 +78,6 @@ use sui_types::sui_system_state::SuiSystemState;
 use sui_types::sui_system_state::SuiSystemStateTrait;
 pub use sui_types::temporary_store::TemporaryStore;
 use sui_types::temporary_store::{InnerTemporaryStore, TemporaryModuleResolver};
-use sui_types::MOVE_STDLIB_OBJECT_ID;
-use sui_types::SUI_FRAMEWORK_OBJECT_ID;
 use sui_types::{
     base_types::*,
     committee::Committee,
@@ -2927,17 +2926,17 @@ impl AuthorityState {
     /// compatible with the current versions of those packages on-chain.
     pub async fn get_available_system_packages(&self) -> Vec<ObjectRef> {
         let Some(move_stdlib) = self.compare_system_package(
-            MOVE_STDLIB_OBJECT_ID,
-            sui_framework::get_move_stdlib(),
-            sui_framework::get_move_stdlib_transitive_dependencies(),
+            MoveStdlib::ID,
+            MoveStdlib::as_modules(),
+            MoveStdlib::transitive_dependencies(),
         ).await else {
             return vec![];
         };
 
         let Some(sui_framework) = self.compare_system_package(
-            SUI_FRAMEWORK_OBJECT_ID,
+            SuiFramework::ID,
             sui_framework_injection::get_modules(self.name),
-            sui_framework::get_sui_framework_transitive_dependencies(),
+            SuiFramework::transitive_dependencies(),
         ).await else {
             return vec![];
         };
@@ -3060,13 +3059,13 @@ impl AuthorityState {
             }
 
             let (bytes, dependencies) = match system_package.0 {
-                MOVE_STDLIB_OBJECT_ID => (
-                    sui_framework::get_move_stdlib_bytes(),
-                    sui_framework::get_move_stdlib_transitive_dependencies(),
+                MoveStdlib::ID => (
+                    MoveStdlib::as_bytes(),
+                    MoveStdlib::transitive_dependencies(),
                 ),
-                SUI_FRAMEWORK_OBJECT_ID => (
+                SuiFramework::ID => (
                     sui_framework_injection::get_bytes(self.name),
-                    sui_framework::get_sui_framework_transitive_dependencies(),
+                    SuiFramework::transitive_dependencies(),
                 ),
                 _ => panic!("Unrecognised framework: {}", system_package.0),
             };
@@ -3549,20 +3548,20 @@ pub mod sui_framework_injection {
 
     pub fn get_bytes(name: AuthorityName) -> Vec<Vec<u8>> {
         OVERRIDE.with(|cfg| match &*cfg.borrow() {
-            FrameworkOverrideConfig::Default => sui_framework::get_sui_framework_bytes(),
+            FrameworkOverrideConfig::Default => SuiFramework::as_bytes(),
             FrameworkOverrideConfig::Global(framework) => compiled_modules_to_bytes(framework),
             FrameworkOverrideConfig::PerValidator(func) => func(name)
                 .map(|fw| compiled_modules_to_bytes(&fw))
-                .unwrap_or_else(sui_framework::get_sui_framework_bytes),
+                .unwrap_or_else(SuiFramework::as_bytes),
         })
     }
 
     pub fn get_modules(name: AuthorityName) -> Vec<CompiledModule> {
         OVERRIDE.with(|cfg| match &*cfg.borrow() {
-            FrameworkOverrideConfig::Default => sui_framework::get_sui_framework(),
+            FrameworkOverrideConfig::Default => SuiFramework::as_modules(),
             FrameworkOverrideConfig::Global(framework) => framework.clone(),
             FrameworkOverrideConfig::PerValidator(func) => {
-                func(name).unwrap_or_else(sui_framework::get_sui_framework)
+                func(name).unwrap_or_else(SuiFramework::as_modules)
             }
         })
     }
@@ -3575,10 +3574,10 @@ pub mod sui_framework_injection {
     use super::*;
 
     pub fn get_bytes(_name: AuthorityName) -> Vec<Vec<u8>> {
-        sui_framework::get_sui_framework_bytes()
+        SuiFramework::as_bytes()
     }
 
     pub fn get_modules(_name: AuthorityName) -> Vec<CompiledModule> {
-        sui_framework::get_sui_framework()
+        SuiFramework::as_modules()
     }
 }

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -3143,7 +3143,9 @@ async fn test_genesis_sui_system_state_object() {
 async fn test_sui_system_state_nop_upgrade() {
     use sui_adapter::programmable_transactions;
     use sui_types::sui_system_state::SUI_SYSTEM_STATE_TESTING_VERSION1;
-    use sui_types::{MOVE_STDLIB_ADDRESS, SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION};
+    use sui_types::{
+        MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS, SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
+    };
 
     let authority_state = init_state().await;
 

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -28,7 +28,7 @@ use rand::{
     Rng, SeedableRng,
 };
 use serde_json::json;
-use sui_framework::{make_system_objects, make_system_packages};
+use sui_framework::{make_system_objects, make_system_packages, system_package_ids};
 use tracing::info;
 
 use sui_json_rpc_types::{
@@ -57,10 +57,7 @@ use sui_types::{
     object::{Owner, GAS_VALUE_FOR_TESTING, OBJECT_START_VERSION},
     SUI_SYSTEM_STATE_OBJECT_ID,
 };
-use sui_types::{
-    MOVE_STDLIB_OBJECT_ID, SUI_CLOCK_OBJECT_ID, SUI_CLOCK_OBJECT_SHARED_VERSION,
-    SUI_FRAMEWORK_OBJECT_ID,
-};
+use sui_types::{SUI_CLOCK_OBJECT_ID, SUI_CLOCK_OBJECT_SHARED_VERSION};
 
 use crate::authority::move_integration_tests::build_and_publish_test_package_with_upgrade_cap;
 use crate::consensus_handler::SequencedConsensusTransaction;
@@ -4689,7 +4686,7 @@ async fn make_test_transaction(
 
     let data = TransactionData::new_move_call_with_dummy_gas_price(
         *sender,
-        SUI_FRAMEWORK_OBJECT_ID,
+        SuiFramework::ID,
         ident_str!(module).to_owned(),
         ident_str!(function).to_owned(),
         /* type_args */ vec![],
@@ -5225,10 +5222,7 @@ async fn test_for_inc_201_dev_inspect() {
         .get_package_bytes(false);
 
     let mut builder = ProgrammableTransactionBuilder::new();
-    builder.command(Command::Publish(
-        modules,
-        vec![MOVE_STDLIB_OBJECT_ID, SUI_FRAMEWORK_OBJECT_ID],
-    ));
+    builder.command(Command::Publish(modules, system_package_ids()));
     let kind = TransactionKind::programmable(builder.finish());
     let DevInspectResults { events, .. } = fullnode
         .dev_inspect_transaction(sender, kind, Some(1))
@@ -5261,10 +5255,7 @@ async fn test_for_inc_201_dry_run() {
         .get_package_bytes(false);
 
     let mut builder = ProgrammableTransactionBuilder::new();
-    builder.publish_immutable(
-        modules,
-        vec![MOVE_STDLIB_OBJECT_ID, SUI_FRAMEWORK_OBJECT_ID],
-    );
+    builder.publish_immutable(modules, system_package_ids());
     let kind = TransactionKind::programmable(builder.finish());
 
     let txn_data = TransactionData::new_with_gas_coins(kind, sender, vec![], 10000, 1);
@@ -5415,18 +5406,10 @@ async fn test_publish_transitive_dependencies_ok() {
         .get_package_bytes(/* with_unpublished_deps */ false);
 
     let mut builder = ProgrammableTransactionBuilder::new();
-
-    builder.publish_immutable(
-        modules,
-        vec![
-            // Note: root depends on A, B, C.
-            *package_a_id,
-            *package_b_id,
-            *package_c_id,
-            SUI_FRAMEWORK_OBJECT_ID,
-            MOVE_STDLIB_OBJECT_ID,
-        ],
-    );
+    let mut deps = system_package_ids();
+    // Note: root depends on A, B, C.
+    deps.extend([*package_a_id, *package_b_id, *package_c_id]);
+    builder.publish_immutable(modules, deps);
 
     let kind = TransactionKind::programmable(builder.finish());
     let txn_data = TransactionData::new_with_gas_coins(kind, sender, vec![gas_ref], 10000, 1);
@@ -5464,7 +5447,7 @@ async fn test_publish_missing_dependency() {
         .get_package_bytes(/* with_unpublished_deps */ false);
 
     let mut builder = ProgrammableTransactionBuilder::new();
-    builder.publish_immutable(modules, vec![SUI_FRAMEWORK_OBJECT_ID]);
+    builder.publish_immutable(modules, vec![SuiFramework::ID]);
     let kind = TransactionKind::programmable(builder.finish());
 
     let txn_data = TransactionData::new_with_gas_coins(kind, sender, vec![gas_ref], 10000, 1);
@@ -5506,7 +5489,7 @@ async fn test_publish_missing_transitive_dependency() {
         .get_package_bytes(/* with_unpublished_deps */ false);
 
     let mut builder = ProgrammableTransactionBuilder::new();
-    builder.publish_immutable(modules, vec![MOVE_STDLIB_OBJECT_ID]);
+    builder.publish_immutable(modules, vec![MoveStdlib::ID]);
     let kind = TransactionKind::programmable(builder.finish());
 
     let txn_data = TransactionData::new_with_gas_coins(kind, sender, vec![gas_ref], 10000, 1);
@@ -5548,15 +5531,10 @@ async fn test_publish_not_a_package_dependency() {
         .get_package_bytes(/* with_unpublished_deps */ false);
 
     let mut builder = ProgrammableTransactionBuilder::new();
-    builder.publish_immutable(
-        modules,
-        // One of these things is not like the others
-        vec![
-            MOVE_STDLIB_OBJECT_ID,
-            SUI_FRAMEWORK_OBJECT_ID,
-            SUI_SYSTEM_STATE_OBJECT_ID,
-        ],
-    );
+    let mut deps = system_package_ids();
+    // One of these things is not like the others
+    deps.push(SUI_SYSTEM_STATE_OBJECT_ID);
+    builder.publish_immutable(modules, deps);
     let kind = TransactionKind::programmable(builder.finish());
 
     let txn_data = TransactionData::new_with_gas_coins(kind, sender, vec![gas_ref], 10000, 1);

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -13,10 +13,11 @@ use move_core_types::{
     language_storage::StructTag,
     u256::U256,
 };
+use sui_framework::system_package_ids;
 use sui_types::{
     error::ExecutionErrorKind, object::Data,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
-    utils::to_sender_signed_transaction, MOVE_STDLIB_OBJECT_ID, SUI_FRAMEWORK_OBJECT_ID,
+    utils::to_sender_signed_transaction,
 };
 
 use move_core_types::language_storage::TypeTag;
@@ -173,7 +174,7 @@ async fn test_publish_duplicate_modules() {
         sender,
         gas_object_ref,
         modules,
-        vec![MOVE_STDLIB_OBJECT_ID, SUI_FRAMEWORK_OBJECT_ID],
+        system_package_ids(),
         MAX_GAS,
     );
     let transaction = to_sender_signed_transaction(data, &sender_key);

--- a/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use move_core_types::{account_address::AccountAddress, ident_str};
+use sui_framework::{system_package_ids, MoveStdlib, SuiFramework, SystemPackage};
 use sui_framework_build::compiled_package::BuildConfig;
 use sui_protocol_config::ProtocolConfig;
 use sui_types::{
@@ -15,7 +16,6 @@ use sui_types::{
     object::{Object, Owner},
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     storage::BackingPackageStore,
-    MOVE_STDLIB_OBJECT_ID, SUI_FRAMEWORK_OBJECT_ID,
 };
 
 use std::{collections::BTreeSet, path::PathBuf, sync::Arc};
@@ -173,12 +173,12 @@ async fn test_upgrade_package_happy_path() {
         let digest_arg = builder.pure(digest).unwrap();
         let upgrade_ticket = move_call! {
             builder,
-            (SUI_FRAMEWORK_OBJECT_ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
+            (SuiFramework::ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
         };
         let upgrade_receipt = builder.upgrade(current_package_id, upgrade_ticket, vec![], modules);
         move_call! {
             builder,
-            (SUI_FRAMEWORK_OBJECT_ID)::package::commit_upgrade(Argument::Input(0), upgrade_receipt)
+            (SuiFramework::ID)::package::commit_upgrade(Argument::Input(0), upgrade_receipt)
         };
 
         builder.finish()
@@ -229,12 +229,12 @@ async fn test_upgrade_incompatible() {
         let digest_arg = builder.pure(digest).unwrap();
         let upgrade_ticket = move_call! {
             builder,
-            (SUI_FRAMEWORK_OBJECT_ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
+            (SuiFramework::ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
         };
         let upgrade_receipt = builder.upgrade(current_package_id, upgrade_ticket, vec![], modules);
         move_call! {
             builder,
-            (SUI_FRAMEWORK_OBJECT_ID)::package::commit_upgrade(Argument::Input(0), upgrade_receipt)
+            (SuiFramework::ID)::package::commit_upgrade(Argument::Input(0), upgrade_receipt)
         };
 
         builder.finish()
@@ -260,7 +260,7 @@ async fn test_upgrade_package_incorrect_digest() {
         let digest_arg = builder.pure(bad_digest).unwrap();
         let upgrade_ticket = move_call! {
             builder,
-            (SUI_FRAMEWORK_OBJECT_ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
+            (SuiFramework::ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
         };
         builder.upgrade(current_package_id, upgrade_ticket, vec![], modules);
         (builder.finish(), digest)
@@ -296,11 +296,11 @@ async fn test_upgrade_package_compatibility_too_permissive() {
         let digest_arg = builder.pure(digest).unwrap();
         move_call! {
             builder,
-            (SUI_FRAMEWORK_OBJECT_ID)::package::only_dep_upgrades(Argument::Input(0))
+            (SuiFramework::ID)::package::only_dep_upgrades(Argument::Input(0))
         };
         let upgrade_ticket = move_call! {
             builder,
-            (SUI_FRAMEWORK_OBJECT_ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
+            (SuiFramework::ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
         };
         builder.upgrade(current_package_id, upgrade_ticket, vec![], modules);
         builder.finish()
@@ -333,7 +333,7 @@ async fn test_upgrade_package_unsupported_compatibility() {
         let digest_arg = builder.pure(digest).unwrap();
         let upgrade_ticket = move_call! {
             builder,
-            (SUI_FRAMEWORK_OBJECT_ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
+            (SuiFramework::ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
         };
         builder.upgrade(current_package_id, upgrade_ticket, vec![], modules);
         builder.finish()
@@ -366,7 +366,7 @@ async fn test_upgrade_package_invalid_compatibility() {
         let digest_arg = builder.pure(digest).unwrap();
         let upgrade_ticket = move_call! {
             builder,
-            (SUI_FRAMEWORK_OBJECT_ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
+            (SuiFramework::ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
         };
         builder.upgrade(current_package_id, upgrade_ticket, vec![], modules);
         builder.finish()
@@ -423,9 +423,9 @@ async fn test_upgrade_ticket_doesnt_match() {
         let digest_arg = builder.pure(digest).unwrap();
         let upgrade_ticket = move_call! {
             builder,
-            (SUI_FRAMEWORK_OBJECT_ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
+            (SuiFramework::ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
         };
-        builder.upgrade(MOVE_STDLIB_OBJECT_ID, upgrade_ticket, vec![], modules);
+        builder.upgrade(MoveStdlib::ID, upgrade_ticket, vec![], modules);
         builder.finish()
     };
     let TransactionEffects::V1(effects) = runner.run(pt).await;
@@ -475,12 +475,12 @@ async fn test_multiple_upgrades(use_empty_deps: bool) -> TransactionEffects {
         let digest_arg = builder.pure(digest).unwrap();
         let upgrade_ticket = move_call! {
             builder,
-            (SUI_FRAMEWORK_OBJECT_ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
+            (SuiFramework::ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
         };
         let upgrade_receipt = builder.upgrade(current_package_id, upgrade_ticket, vec![], modules);
         move_call! {
             builder,
-            (SUI_FRAMEWORK_OBJECT_ID)::package::commit_upgrade(Argument::Input(0), upgrade_receipt)
+            (SuiFramework::ID)::package::commit_upgrade(Argument::Input(0), upgrade_receipt)
         };
 
         builder.finish()
@@ -516,17 +516,17 @@ async fn test_multiple_upgrades(use_empty_deps: bool) -> TransactionEffects {
         let digest_arg = builder.pure(digest).unwrap();
         let upgrade_ticket = move_call! {
             builder,
-            (SUI_FRAMEWORK_OBJECT_ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
+            (SuiFramework::ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
         };
         let deps = if use_empty_deps {
             vec![]
         } else {
-            vec![MOVE_STDLIB_OBJECT_ID, SUI_FRAMEWORK_OBJECT_ID]
+            system_package_ids()
         };
         let upgrade_receipt = builder.upgrade(current_package_id, upgrade_ticket, deps, modules);
         move_call! {
             builder,
-            (SUI_FRAMEWORK_OBJECT_ID)::package::commit_upgrade(Argument::Input(0), upgrade_receipt)
+            (SuiFramework::ID)::package::commit_upgrade(Argument::Input(0), upgrade_receipt)
         };
 
         builder.finish()
@@ -563,12 +563,12 @@ async fn test_interleaved_upgrades() {
         let digest_arg = builder.pure(digest).unwrap();
         let upgrade_ticket = move_call! {
             builder,
-            (SUI_FRAMEWORK_OBJECT_ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
+            (SuiFramework::ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
         };
         let upgrade_receipt = builder.upgrade(current_package_id, upgrade_ticket, vec![], modules);
         move_call! {
             builder,
-            (SUI_FRAMEWORK_OBJECT_ID)::package::commit_upgrade(Argument::Input(0), upgrade_receipt)
+            (SuiFramework::ID)::package::commit_upgrade(Argument::Input(0), upgrade_receipt)
         };
 
         builder.finish()
@@ -603,12 +603,12 @@ async fn test_interleaved_upgrades() {
         let digest_arg = builder.pure(digest).unwrap();
         let upgrade_ticket = move_call! {
             builder,
-            (SUI_FRAMEWORK_OBJECT_ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
+            (SuiFramework::ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
         };
         let upgrade_receipt = builder.upgrade(current_package_id, upgrade_ticket, dep_ids, modules);
         move_call! {
             builder,
-            (SUI_FRAMEWORK_OBJECT_ID)::package::commit_upgrade(Argument::Input(0), upgrade_receipt)
+            (SuiFramework::ID)::package::commit_upgrade(Argument::Input(0), upgrade_receipt)
         };
 
         builder.finish()
@@ -647,12 +647,12 @@ async fn test_publish_override_happy_path() {
         let digest_arg = builder.pure(digest).unwrap();
         let upgrade_ticket = move_call! {
             builder,
-            (SUI_FRAMEWORK_OBJECT_ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
+            (SuiFramework::ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
         };
         let upgrade_receipt = builder.upgrade(current_package_id, upgrade_ticket, vec![], modules);
         move_call! {
             builder,
-            (SUI_FRAMEWORK_OBJECT_ID)::package::commit_upgrade(Argument::Input(0), upgrade_receipt)
+            (SuiFramework::ID)::package::commit_upgrade(Argument::Input(0), upgrade_receipt)
         };
 
         builder.finish()

--- a/crates/sui-framework/src/lib.rs
+++ b/crates/sui-framework/src/lib.rs
@@ -12,115 +12,93 @@ use sui_types::{
     error::SuiResult,
     move_package::MovePackage,
     object::{Object, OBJECT_START_VERSION},
-    MOVE_STDLIB_OBJECT_ID,
+    MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS,
 };
 
 pub mod natives;
 
-static SUI_FRAMEWORK_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/sui-framework"));
-static SUI_FRAMEWORK: Lazy<Vec<CompiledModule>> = Lazy::new(|| {
-    get_sui_framework_bytes()
-        .into_iter()
-        .map(|module| CompiledModule::deserialize(&module).unwrap())
-        .collect()
-});
+macro_rules! system_package {
+    ($address:expr, $Package:ident, $path:literal, [$($Dep:ident),* $(,)?]) => {
+        pub struct $Package;
 
-static SUI_FRAMEWORK_TEST: Lazy<Vec<CompiledModule>> = Lazy::new(|| {
-    const SUI_FRAMEWORK_TEST_BYTES: &[u8] =
-        include_bytes!(concat!(env!("OUT_DIR"), "/sui-framework-test"));
+        impl SystemPackage for $Package {
+            const ID: ObjectID = ObjectID::from_address($address);
+            const BCS_BYTES: &'static [u8] = include_bytes!(concat!(env!("OUT_DIR"), "/", $path));
 
-    let serialized_modules: Vec<Vec<u8>> = bcs::from_bytes(SUI_FRAMEWORK_TEST_BYTES).unwrap();
+            fn transitive_dependencies() -> Vec<ObjectID> {
+                vec![$($Dep::ID,)*]
+            }
 
-    serialized_modules
-        .into_iter()
-        .map(|module| CompiledModule::deserialize(&module).unwrap())
-        .collect()
-});
+            fn as_bytes() -> Vec<Vec<u8>> {
+                bcs::from_bytes($Package::BCS_BYTES).unwrap()
+            }
 
-static MOVE_STDLIB_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/move-stdlib"));
-static MOVE_STDLIB: Lazy<Vec<CompiledModule>> = Lazy::new(|| {
-    get_move_stdlib_bytes()
-        .into_iter()
-        .map(|module| CompiledModule::deserialize(&module).unwrap())
-        .collect()
-});
+            fn as_modules() -> Vec<CompiledModule> {
+                static MODULES: Lazy<Vec<CompiledModule>> = Lazy::new(|| {
+                    $Package::as_bytes().into_iter().map(|m| CompiledModule::deserialize(&m).unwrap()).collect()
+                });
+                Lazy::force(&MODULES).to_owned()
+            }
 
-static MOVE_STDLIB_TEST: Lazy<Vec<CompiledModule>> = Lazy::new(|| {
-    const MOVE_STDLIB_TEST_BYTES: &[u8] =
-        include_bytes!(concat!(env!("OUT_DIR"), "/move-stdlib-test"));
+            fn as_package() -> MovePackage {
+                MovePackage::new_system(
+                    OBJECT_START_VERSION,
+                    $Package::as_modules(),
+                    $Package::transitive_dependencies(),
+                )
+            }
 
-    let serialized_modules: Vec<Vec<u8>> = bcs::from_bytes(MOVE_STDLIB_TEST_BYTES).unwrap();
-
-    serialized_modules
-        .into_iter()
-        .map(|module| CompiledModule::deserialize(&module).unwrap())
-        .collect()
-});
-
-pub fn get_sui_framework() -> Vec<CompiledModule> {
-    Lazy::force(&SUI_FRAMEWORK).to_owned()
+            fn as_object() -> Object {
+                Object::new_system_package(
+                    $Package::as_modules(),
+                    OBJECT_START_VERSION,
+                    $Package::transitive_dependencies(),
+                    TransactionDigest::genesis(),
+                )
+            }
+        }
+    };
 }
 
-pub fn get_sui_framework_bytes() -> Vec<Vec<u8>> {
-    bcs::from_bytes(SUI_FRAMEWORK_BYTES).unwrap()
+system_package!(MOVE_STDLIB_ADDRESS, MoveStdlib, "move-stdlib", []);
+system_package!(MOVE_STDLIB_ADDRESS, MoveStdlibTest, "move-stdlib-test", []);
+
+system_package!(
+    SUI_FRAMEWORK_ADDRESS,
+    SuiFramework,
+    "sui-framework",
+    [MoveStdlib]
+);
+
+system_package!(
+    SUI_FRAMEWORK_ADDRESS,
+    SuiFrameworkTest,
+    "sui-framework-test",
+    [MoveStdlib]
+);
+
+/// Trait exposing all the various properties of a system package in a variety of different forms,
+/// of increasing levels of abstraction
+pub trait SystemPackage {
+    const ID: ObjectID;
+    const BCS_BYTES: &'static [u8];
+    fn transitive_dependencies() -> Vec<ObjectID>;
+    fn as_bytes() -> Vec<Vec<u8>>;
+    fn as_modules() -> Vec<CompiledModule>;
+    fn as_package() -> MovePackage;
+    fn as_object() -> Object;
 }
 
-pub fn get_sui_framework_transitive_dependencies() -> Vec<ObjectID> {
-    vec![MOVE_STDLIB_OBJECT_ID]
+pub fn make_system_modules() -> Vec<Vec<CompiledModule>> {
+    vec![MoveStdlib::as_modules(), SuiFramework::as_modules()]
 }
 
-pub fn get_sui_framework_package() -> MovePackage {
-    MovePackage::new_system(
-        OBJECT_START_VERSION,
-        get_sui_framework(),
-        get_sui_framework_transitive_dependencies(),
-    )
+pub fn make_system_packages() -> Vec<MovePackage> {
+    vec![MoveStdlib::as_package(), SuiFramework::as_package()]
 }
 
-pub fn get_sui_framework_object() -> Object {
-    Object::new_system_package(
-        get_sui_framework(),
-        OBJECT_START_VERSION,
-        get_sui_framework_transitive_dependencies(),
-        TransactionDigest::genesis(),
-    )
-}
-
-pub fn get_sui_framework_test() -> Vec<CompiledModule> {
-    Lazy::force(&SUI_FRAMEWORK_TEST).to_owned()
-}
-
-pub fn get_move_stdlib() -> Vec<CompiledModule> {
-    Lazy::force(&MOVE_STDLIB).to_owned()
-}
-
-pub fn get_move_stdlib_bytes() -> Vec<Vec<u8>> {
-    bcs::from_bytes(MOVE_STDLIB_BYTES).unwrap()
-}
-
-pub fn get_move_stdlib_transitive_dependencies() -> Vec<ObjectID> {
-    vec![]
-}
-
-pub fn get_move_stdlib_package() -> MovePackage {
-    MovePackage::new_system(
-        OBJECT_START_VERSION,
-        get_move_stdlib(),
-        get_move_stdlib_transitive_dependencies(),
-    )
-}
-
-pub fn get_move_stdlib_object() -> Object {
-    Object::new_system_package(
-        get_move_stdlib(),
-        OBJECT_START_VERSION,
-        get_move_stdlib_transitive_dependencies(),
-        TransactionDigest::genesis(),
-    )
-}
-
-pub fn get_move_stdlib_test() -> Vec<CompiledModule> {
-    Lazy::force(&MOVE_STDLIB_TEST).to_owned()
+pub fn make_system_objects() -> Vec<Object> {
+    vec![MoveStdlib::as_object(), SuiFramework::as_object()]
 }
 
 pub const DEFAULT_FRAMEWORK_PATH: &str = env!("CARGO_MANIFEST_DIR");
@@ -157,16 +135,4 @@ pub fn build_move_package(path: &Path, config: BuildConfig) -> SuiResult<Compile
         pkg.verify_framework_version(get_sui_framework(), get_move_stdlib())?;
     }*/
     Ok(pkg)
-}
-
-pub fn make_system_modules() -> Vec<Vec<CompiledModule>> {
-    vec![get_move_stdlib(), get_sui_framework()]
-}
-
-pub fn make_system_packages() -> Vec<MovePackage> {
-    vec![get_move_stdlib_package(), get_sui_framework_package()]
-}
-
-pub fn make_system_objects() -> Vec<Object> {
-    vec![get_move_stdlib_object(), get_sui_framework_object()]
 }

--- a/crates/sui-proc-macros/src/lib.rs
+++ b/crates/sui-proc-macros/src/lib.rs
@@ -27,9 +27,10 @@ pub fn init_static_initializers(_args: TokenStream, item: TokenStream) -> TokenS
             // be very important for being able to reproduce a failure that occurs in the Nth
             // iteration of a multi-iteration test run.
             std::thread::spawn(|| {
+                use sui_simulator::sui_framework::SystemPackage;
                 ::sui_simulator::telemetry_subscribers::init_for_testing();
-                ::sui_simulator::sui_framework::get_move_stdlib();
-                ::sui_simulator::sui_framework::get_sui_framework();
+                ::sui_simulator::sui_framework::MoveStdlib::as_modules();
+                ::sui_simulator::sui_framework::SuiFramework::as_modules();
                 ::sui_simulator::sui_types::gas::SuiGasStatus::new_unmetered();
 
                 // For reasons I can't understand, LruCache causes divergent behavior the second

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -37,7 +37,9 @@ use std::{
 use sui_adapter::execution_engine;
 use sui_adapter::{adapter::new_move_vm, execution_mode};
 use sui_core::transaction_input_checker::check_objects;
-use sui_framework::{make_system_modules, make_system_objects, DEFAULT_FRAMEWORK_PATH};
+use sui_framework::{
+    make_system_modules, make_system_objects, system_package_ids, DEFAULT_FRAMEWORK_PATH,
+};
 use sui_protocol_config::ProtocolConfig;
 use sui_types::clock::Clock;
 use sui_types::gas::{GasCostSummary, SuiCostTable};
@@ -56,8 +58,8 @@ use sui_types::{
     },
     object::{self, Object, ObjectFormatOptions},
     object::{MoveObject, Owner},
-    MOVE_STDLIB_ADDRESS, MOVE_STDLIB_OBJECT_ID, SUI_CLOCK_OBJECT_ID,
-    SUI_CLOCK_OBJECT_SHARED_VERSION, SUI_FRAMEWORK_ADDRESS, SUI_FRAMEWORK_OBJECT_ID,
+    MOVE_STDLIB_ADDRESS, SUI_CLOCK_OBJECT_ID, SUI_CLOCK_OBJECT_SHARED_VERSION,
+    SUI_FRAMEWORK_ADDRESS,
 };
 use sui_types::{epoch_data::EpochData, messages::Command};
 use sui_types::{gas::SuiGasStatus, temporary_store::TemporaryStore};
@@ -306,10 +308,9 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                 Ok(id)
             })
             .collect::<Result<_, _>>()?;
-        // we are assuming that all packages depend on Sui framework and (transitively) on Move
-        // stdlib so these don't have to be provided explicitly as parameters
-        dependencies.push(MOVE_STDLIB_OBJECT_ID);
-        dependencies.push(SUI_FRAMEWORK_OBJECT_ID);
+        // we are assuming that all packages depend on the system packages, so these don't have to
+        // be provided explicitly as parameters
+        dependencies.extend(system_package_ids());
         let data = |sender, gas| {
             let mut builder = ProgrammableTransactionBuilder::new();
             if upgradeable {

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -845,6 +845,11 @@ impl ObjectID {
         Self(AccountAddress::new(obj_id))
     }
 
+    /// Const fn variant of <ObjectID as From<AccountAddress>>::from
+    pub const fn from_address(addr: AccountAddress) -> Self {
+        Self(addr)
+    }
+
     /// Random ObjectID
     pub fn random() -> Self {
         Self::from(AccountAddress::random())

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -63,12 +63,12 @@ pub mod utils;
 /// 0x1-- account address where Move stdlib modules are stored
 /// Same as the ObjectID
 pub const MOVE_STDLIB_ADDRESS: AccountAddress = AccountAddress::ONE;
-pub const MOVE_STDLIB_OBJECT_ID: ObjectID = ObjectID::from_single_byte(1);
+pub const MOVE_STDLIB_OBJECT_ID: ObjectID = ObjectID::from_address(MOVE_STDLIB_ADDRESS);
 
 /// 0x2-- account address where sui framework modules are stored
 /// Same as the ObjectID
 pub const SUI_FRAMEWORK_ADDRESS: AccountAddress = get_hex_address_two();
-pub const SUI_FRAMEWORK_OBJECT_ID: ObjectID = ObjectID::from_single_byte(2);
+pub const SUI_FRAMEWORK_OBJECT_ID: ObjectID = ObjectID::from_address(SUI_FRAMEWORK_ADDRESS);
 
 /// 0x5: hardcoded object ID for the singleton sui system state object.
 pub const SUI_SYSTEM_STATE_OBJECT_ID: ObjectID = ObjectID::from_single_byte(5);

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -21,6 +21,7 @@ use crate::crypto::{default_hash, deterministic_random_account_key};
 use crate::error::{ExecutionError, ExecutionErrorKind, UserInputError, UserInputResult};
 use crate::error::{SuiError, SuiResult};
 use crate::gas_coin::TOTAL_SUPPLY_MIST;
+use crate::is_system_package;
 use crate::move_package::MovePackage;
 use crate::{
     base_types::{
@@ -28,7 +29,6 @@ use crate::{
     },
     gas_coin::GasCoin,
 };
-use crate::{MOVE_STDLIB_OBJECT_ID, SUI_FRAMEWORK_OBJECT_ID};
 use sui_protocol_config::ProtocolConfig;
 
 pub const GAS_VALUE_FOR_TESTING: u64 = 2_000_000_u64;
@@ -536,8 +536,7 @@ impl Object {
 
     /// Returns true if the object is a system package.
     pub fn is_system_package(&self) -> bool {
-        let id = self.id();
-        self.is_package() && (id == SUI_FRAMEWORK_OBJECT_ID || id == MOVE_STDLIB_OBJECT_ID)
+        self.is_package() && is_system_package(self.id())
     }
 
     /// Create a system package which is not subject to size limits. Panics if the object ID is not

--- a/crates/sui/src/fire_drill.rs
+++ b/crates/sui/src/fire_drill.rs
@@ -19,6 +19,7 @@ use std::path::{Path, PathBuf};
 use sui_config::node::KeyPairWithPath;
 use sui_config::utils;
 use sui_config::{node::AuthorityKeyPairWithPath, Config, NodeConfig, PersistedConfig};
+use sui_framework::{SuiFramework, SystemPackage};
 use sui_json_rpc_types::{SuiExecutionStatus, SuiTransactionResponseOptions};
 use sui_sdk::{rpc_types::SuiTransactionEffectsAPI, SuiClient, SuiClientBuilder};
 use sui_types::base_types::{ObjectRef, SuiAddress};
@@ -27,9 +28,7 @@ use sui_types::messages::{CallArg, ObjectArg, TransactionData};
 use sui_types::multiaddr::{Multiaddr, Protocol};
 use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{committee::EpochId, crypto::get_authority_key_pair};
-use sui_types::{
-    SUI_FRAMEWORK_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
-};
+use sui_types::{SUI_SYSTEM_STATE_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION};
 use tracing::info;
 
 #[derive(Parser)]
@@ -316,7 +315,7 @@ async fn update_metadata_on_chain(
     args.extend(call_args);
     let tx_data = TransactionData::new_move_call(
         config.sui_address(),
-        SUI_FRAMEWORK_OBJECT_ID,
+        SuiFramework::ID,
         ident_str!("sui_system").to_owned(),
         ident_str!(function).to_owned(),
         vec![],

--- a/crates/sui/src/validator_commands.rs
+++ b/crates/sui/src/validator_commands.rs
@@ -8,6 +8,7 @@ use std::{
     path::PathBuf,
 };
 use sui_config::genesis::GenesisValidatorInfo;
+use sui_framework::{SuiFramework, SystemPackage};
 use sui_types::multiaddr::Multiaddr;
 
 use crate::client_commands::{write_transaction_response, WalletContext};
@@ -35,7 +36,7 @@ use sui_types::messages::Transaction;
 use sui_types::messages::{CallArg, TransactionData};
 use sui_types::{
     crypto::{AuthorityKeyPair, NetworkKeyPair, SignatureScheme, SuiKeyPair},
-    SUI_FRAMEWORK_OBJECT_ID, SUI_SYSTEM_OBJ_CALL_ARG,
+    SUI_SYSTEM_OBJ_CALL_ARG,
 };
 use tracing::info;
 
@@ -297,7 +298,7 @@ async fn call_0x5(
     let gas_obj_ref = get_gas_obj_ref(sender, sui_client, minimal_gas_budget).await?;
     let tx_data = TransactionData::new_move_call(
         sender,
-        SUI_FRAMEWORK_OBJECT_ID,
+        SuiFramework::ID,
         ident_str!("sui_system").to_owned(),
         ident_str!(function).to_owned(),
         vec![],

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -402,7 +402,7 @@ async fn test_full_node_indexes() -> Result<(), anyhow::Error> {
         .state()
         .query_events(
             EventQuery::MoveModule {
-                package: SUI_FRAMEWORK_OBJECT_ID,
+                package: SuiFramework::ID,
                 module: "unused_input_object".to_string(),
             },
             None,

--- a/crates/sui/tests/protocol_version_tests.rs
+++ b/crates/sui/tests/protocol_version_tests.rs
@@ -61,7 +61,7 @@ mod sim_only_tests {
     use std::path::PathBuf;
     use std::sync::Arc;
     use sui_core::authority::sui_framework_injection;
-    use sui_framework::{MoveStdlib, SystemPackage};
+    use sui_framework::{MoveStdlib, SuiFramework, SystemPackage};
     use sui_framework_build::compiled_package::BuildConfig;
     use sui_json_rpc::api::WriteApiClient;
     use sui_macros::*;
@@ -73,7 +73,6 @@ mod sim_only_tests {
         object::{Object, OBJECT_START_VERSION},
         programmable_transaction_builder::ProgrammableTransactionBuilder,
         storage::ObjectStore,
-        SUI_FRAMEWORK_OBJECT_ID,
     };
     use test_utils::network::{TestCluster, TestClusterBuilder};
     use tokio::time::{sleep, timeout, Duration};
@@ -124,7 +123,7 @@ mod sim_only_tests {
             .sui_node
             .subscribe_to_epoch_change();
 
-        timeout(Duration::from_secs(60), async move {
+        timeout(Duration::from_secs(90), async move {
             while let Ok((committee, protocol_version)) = epoch_rx.recv().await {
                 info!(
                     "received epoch {} {:?}",
@@ -389,7 +388,7 @@ mod sim_only_tests {
             let mut builder = ProgrammableTransactionBuilder::new();
             builder
                 .move_call(
-                    SUI_FRAMEWORK_OBJECT_ID,
+                    SuiFramework::ID,
                     ident_str!("msim_extra_1").to_owned(),
                     ident_str!("canary").to_owned(),
                     vec![],
@@ -438,7 +437,7 @@ mod sim_only_tests {
         let effects = node_handle
             .with_async(|node| async {
                 let db = node.state().db();
-                let framework = db.get_object(&SUI_FRAMEWORK_OBJECT_ID);
+                let framework = db.get_object(&SuiFramework::ID);
                 let digest = framework.unwrap().unwrap().previous_transaction;
                 let effects = db.get_executed_effects(&digest);
                 effects.unwrap().unwrap()
@@ -448,12 +447,12 @@ mod sim_only_tests {
         let modified_at = effects
             .modified_at_versions()
             .iter()
-            .find_map(|(id, v)| (id == &SUI_FRAMEWORK_OBJECT_ID).then_some(*v));
+            .find_map(|(id, v)| (id == &SuiFramework::ID).then_some(*v));
 
         let mutated_to = effects
             .mutated()
             .iter()
-            .find_map(|((id, v, _), _)| (id == &SUI_FRAMEWORK_OBJECT_ID).then_some(*v));
+            .find_map(|((id, v, _), _)| (id == &SuiFramework::ID).then_some(*v));
 
         (modified_at, mutated_to)
     }

--- a/crates/sui/tests/protocol_version_tests.rs
+++ b/crates/sui/tests/protocol_version_tests.rs
@@ -61,7 +61,7 @@ mod sim_only_tests {
     use std::path::PathBuf;
     use std::sync::Arc;
     use sui_core::authority::sui_framework_injection;
-    use sui_framework::get_move_stdlib_package;
+    use sui_framework::{MoveStdlib, SystemPackage};
     use sui_framework_build::compiled_package::BuildConfig;
     use sui_json_rpc::api::WriteApiClient;
     use sui_macros::*;
@@ -601,7 +601,7 @@ mod sim_only_tests {
             OBJECT_START_VERSION,
             TransactionDigest::genesis(),
             u64::MAX,
-            &[get_move_stdlib_package()],
+            &[MoveStdlib::as_package()],
         )
         .unwrap()
     }

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -15,6 +15,7 @@ use sui_core::authority_aggregator::{AuthAggMetrics, AuthorityAggregator};
 use sui_core::consensus_adapter::position_submit_certificate;
 use sui_core::safe_client::SafeClientMetricsBase;
 use sui_core::test_utils::make_transfer_sui_transaction;
+use sui_framework::{SuiFramework, SystemPackage};
 use sui_macros::sim_test;
 use sui_node::SuiNodeHandle;
 use sui_types::base_types::{ObjectRef, SuiAddress};
@@ -32,9 +33,7 @@ use sui_types::messages::{
 use sui_types::object::{generate_test_gas_objects_with_owner, Object};
 use sui_types::sui_system_state::{get_validator_from_table, SuiSystemStateTrait};
 use sui_types::utils::to_sender_signed_transaction;
-use sui_types::{
-    SUI_FRAMEWORK_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
-};
+use sui_types::{SUI_SYSTEM_STATE_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION};
 use test_utils::authority::start_node;
 use test_utils::{
     authority::{
@@ -486,7 +485,7 @@ async fn test_inactive_validator_pool_read() {
 
     let tx_data = TransactionData::new_move_call_with_dummy_gas_price(
         address,
-        SUI_FRAMEWORK_OBJECT_ID,
+        SuiFramework::ID,
         ident_str!("sui_system").to_owned(),
         ident_str!("request_remove_validator").to_owned(),
         vec![],
@@ -947,7 +946,7 @@ async fn execute_join_committee_txes(
     // Step 1: Add the new node as a validator candidate.
     let candidate_tx_data = TransactionData::new_move_call_with_dummy_gas_price(
         sender,
-        SUI_FRAMEWORK_OBJECT_ID,
+        SuiFramework::ID,
         ident_str!("sui_system").to_owned(),
         ident_str!("request_add_validator_candidate").to_owned(),
         vec![],
@@ -986,7 +985,7 @@ async fn execute_join_committee_txes(
     // Step 2: Give the candidate enough stake.
     let stake_tx_data = TransactionData::new_move_call_with_dummy_gas_price(
         sender,
-        SUI_FRAMEWORK_OBJECT_ID,
+        SuiFramework::ID,
         ident_str!("sui_system").to_owned(),
         ident_str!("request_add_stake").to_owned(),
         vec![],
@@ -1012,7 +1011,7 @@ async fn execute_join_committee_txes(
     // Step 3: Convert the candidate to an active valdiator.
     let activation_tx_data = TransactionData::new_move_call_with_dummy_gas_price(
         sender,
-        SUI_FRAMEWORK_OBJECT_ID,
+        SuiFramework::ID,
         ident_str!("sui_system").to_owned(),
         ident_str!("request_add_validator").to_owned(),
         vec![],
@@ -1041,7 +1040,7 @@ async fn execute_leave_committee_txes(
 ) -> CertifiedTransactionEffects {
     let tx_data = TransactionData::new_move_call_with_dummy_gas_price(
         node_config.sui_address(),
-        SUI_FRAMEWORK_OBJECT_ID,
+        SuiFramework::ID,
         ident_str!("sui_system").to_owned(),
         ident_str!("request_remove_validator").to_owned(),
         vec![],

--- a/crates/test-utils/tests/network_tests.rs
+++ b/crates/test-utils/tests/network_tests.rs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::access::ModuleAccess;
-use sui_framework::get_move_stdlib_package;
+use sui_framework::{MoveStdlib, SuiFramework, SystemPackage};
 use sui_json_rpc::api::ReadApiClient;
 use sui_json_rpc_types::SuiObjectResponse;
 use sui_types::{
-    base_types::ObjectID, digests::TransactionDigest, object::Object, SUI_FRAMEWORK_OBJECT_ID,
+    base_types::ObjectID, digests::TransactionDigest, object::Object, SUI_FRAMEWORK_ADDRESS,
 };
 use test_utils::network::TestClusterBuilder;
 
@@ -30,12 +30,14 @@ async fn test_additional_objects() {
 #[sim_test]
 async fn test_package_override() {
     // `with_objects` can be used to override existing packages.
-    let id = SUI_FRAMEWORK_OBJECT_ID;
-
     let framework_ref = {
         let default_cluster = TestClusterBuilder::new().build().await.unwrap();
         let client = default_cluster.rpc_client();
-        let SuiObjectResponse::Exists(obj) = client.get_object_with_options(id, None).await.unwrap() else {
+        let SuiObjectResponse::Exists(obj) = client
+            .get_object_with_options(SuiFramework::ID, None)
+            .await
+            .unwrap()
+        else {
             panic!("Original framework package should exist");
         };
 
@@ -43,12 +45,12 @@ async fn test_package_override() {
     };
 
     let modified_ref = {
-        let mut framework_modules = sui_framework::get_sui_framework();
+        let mut framework_modules = SuiFramework::as_modules();
 
         // Create an empty module that is pretending to be part of the sui framework.
         let mut test_module = move_binary_format::file_format::empty_module();
         let address_idx = test_module.self_handle().address.0 as usize;
-        test_module.address_identifiers[address_idx] = id.into();
+        test_module.address_identifiers[address_idx] = SUI_FRAMEWORK_ADDRESS;
 
         // Add the dummy module to the rest of the sui-frameworks.  We can't replace the framework
         // entirely because we will call into it for genesis.
@@ -57,7 +59,7 @@ async fn test_package_override() {
         let package_override = Object::new_package_for_testing(
             framework_modules,
             TransactionDigest::genesis(),
-            &[get_move_stdlib_package()],
+            &[MoveStdlib::as_package()],
         )
         .unwrap();
 
@@ -68,7 +70,11 @@ async fn test_package_override() {
             .unwrap();
 
         let client = modified_cluster.rpc_client();
-        let SuiObjectResponse::Exists(obj) = client.get_object_with_options(id, None).await.unwrap() else {
+        let SuiObjectResponse::Exists(obj) = client
+            .get_object_with_options(SuiFramework::ID, None)
+            .await
+            .unwrap()
+        else {
             panic!("Modified framework package should exist");
         };
 


### PR DESCRIPTION
## Description

Add an abstraction (trait and macro) over system packages.  Now there are a number of methods that need to be added for each one, to get:

- Framework ID
- module BCS bytes
- CompiledModule
- MovePackage
- Object

To avoid us forgetting one, and to simplify adding new ones in future.

## Test Plan

```
$ cargo simtest
$ env SUI_SKIP_SIMTESTS=1 cargo nextest run
```
