### PR TITLE
Add sponsored transaction demo

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -13,6 +13,7 @@
     "sui-explorer",
     "@mysten/core",
     "sui-wallet-adapter-demo",
-    "wallet-kit-site"
+    "wallet-kit-site",
+    "sponsored-transactions"
   ]
 }

--- a/apps/wallet/src/ui/app/hooks/useTransactionData.ts
+++ b/apps/wallet/src/ui/app/hooks/useTransactionData.ts
@@ -16,7 +16,7 @@ export function useTransactionData(transaction?: Transaction | null) {
 
         const tx = new Transaction(transaction);
         if (address) {
-            tx.setSender(address);
+            tx.setSenderIfNotSet(address);
         }
         return tx;
     }, [transaction, address]);

--- a/dapps/sponsored-transactions/.gitignore
+++ b/dapps/sponsored-transactions/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/dapps/sponsored-transactions/index.html
+++ b/dapps/sponsored-transactions/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sponsored Transaction Demo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/dapps/sponsored-transactions/package.json
+++ b/dapps/sponsored-transactions/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "sponsored-transactions",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@mysten/sui.js": "workspace:*",
+    "@mysten/wallet-kit": "workspace:*",
+    "@types/react": "^18.0.28",
+    "@types/react-dom": "^18.0.11",
+    "@vitejs/plugin-react": "^3.1.0",
+    "autoprefixer": "^10.4.13",
+    "postcss": "^8.4.19",
+    "tailwindcss": "^3.2.4",
+    "typescript": "^4.9.3",
+    "vite": "^4.2.0"
+  }
+}

--- a/dapps/sponsored-transactions/postcss.config.cjs
+++ b/dapps/sponsored-transactions/postcss.config.cjs
@@ -1,0 +1,9 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/dapps/sponsored-transactions/src/App.tsx
+++ b/dapps/sponsored-transactions/src/App.tsx
@@ -1,0 +1,148 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  SignedTransaction,
+  SuiTransactionResponse,
+  Transaction,
+} from "@mysten/sui.js";
+import { ConnectButton, useWalletKit } from "@mysten/wallet-kit";
+import { ComponentProps, ReactNode, useEffect, useState } from "react";
+import { provider } from "./utils/rpc";
+import { sponsorTransaction } from "./utils/sponsorTransaction";
+
+const tx = new Transaction();
+tx.moveCall({
+  target: "0x2::devnet_nft::mint",
+  arguments: [tx.pure("foo"), tx.pure("bar"), tx.pure("baz")],
+});
+
+const Button = (props: ComponentProps<"button">) => (
+  <button
+    className="bg-indigo-600 text-sm font-medium text-white rounded-lg px-4 py-3 disabled:cursor-not-allowed disabled:opacity-60"
+    {...props}
+  />
+);
+
+const CodePanel = ({
+  title,
+  json,
+  action,
+}: {
+  title: string;
+  json: object | null;
+  action: ReactNode;
+}) => (
+  <div>
+    <div className="text-lg font-bold mb-2">{title}</div>
+    <div className="mb-4">{action}</div>
+    <code className="block bg-gray-200 p-2 text-gray-800 rounded text-sm break-all whitespace-pre-wrap">
+      {JSON.stringify(json, null, 2)}
+    </code>
+  </div>
+);
+
+export function App() {
+  const { currentAccount, signTransaction } = useWalletKit();
+  const [loading, setLoading] = useState(false);
+  const [sponsoredTx, setSponsoredTx] = useState<SignedTransaction | null>(
+    null
+  );
+  const [signedTx, setSignedTx] = useState<SignedTransaction | null>(null);
+  const [executedTx, setExecutedTx] = useState<SuiTransactionResponse | null>(
+    null
+  );
+
+  return (
+    <div className="p-8">
+      <div className="grid grid-cols-4 gap-8">
+        <CodePanel
+          title="Transaction details"
+          json={tx.transactionData}
+          action={<ConnectButton className="!bg-indigo-600 !text-white" />}
+        />
+
+        <CodePanel
+          title="Sponsored Transaction"
+          json={sponsoredTx}
+          action={
+            <Button
+              disabled={!currentAccount || loading}
+              onClick={async () => {
+                setLoading(true);
+                try {
+                  const bytes = await tx.build({
+                    provider,
+                    onlyTransactionKind: true,
+                  });
+                  const sponsoredBytes = await sponsorTransaction(
+                    currentAccount!.address,
+                    bytes
+                  );
+                  setSponsoredTx(sponsoredBytes);
+                } finally {
+                  setLoading(false);
+                }
+              }}
+            >
+              Sponsor Transaction
+            </Button>
+          }
+        />
+
+        <CodePanel
+          title="Signed Transaction"
+          json={signedTx}
+          action={
+            <Button
+              disabled={!sponsoredTx || loading}
+              onClick={async () => {
+                setLoading(true);
+                try {
+                  const signed = await signTransaction({
+                    transaction: Transaction.from(
+                      sponsoredTx!.transactionBytes
+                    ),
+                  });
+                  setSignedTx(signed);
+                } finally {
+                  setLoading(false);
+                }
+              }}
+            >
+              Sign Transaction
+            </Button>
+          }
+        />
+        <CodePanel
+          title="Executed Transaction"
+          json={executedTx}
+          action={
+            <Button
+              disabled={!signedTx || loading}
+              onClick={async () => {
+                setLoading(true);
+                try {
+                  const executed = await provider.executeTransaction({
+                    transaction: signedTx!.transactionBytes,
+                    signature: [signedTx!.signature, sponsoredTx!.signature],
+                    options: {
+                      showEffects: true,
+                      showEvents: true,
+                      showObjectChanges: true,
+                    },
+                  });
+                  setExecutedTx(executed);
+                } finally {
+                  setLoading(false);
+                }
+              }}
+            >
+              Execute Transaction
+            </Button>
+          }
+        />
+      </div>
+    </div>
+  );
+}

--- a/dapps/sponsored-transactions/src/index.css
+++ b/dapps/sponsored-transactions/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/dapps/sponsored-transactions/src/main.tsx
+++ b/dapps/sponsored-transactions/src/main.tsx
@@ -1,0 +1,16 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { WalletKitProvider } from "@mysten/wallet-kit";
+import { App } from "./App";
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <WalletKitProvider enableUnsafeBurner>
+      <App />
+    </WalletKitProvider>
+  </React.StrictMode>
+);

--- a/dapps/sponsored-transactions/src/utils/rpc.ts
+++ b/dapps/sponsored-transactions/src/utils/rpc.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { JsonRpcProvider, localnetConnection } from '@mysten/sui.js';
+
+export const provider = new JsonRpcProvider(localnetConnection);

--- a/dapps/sponsored-transactions/src/utils/sponsorTransaction.ts
+++ b/dapps/sponsored-transactions/src/utils/sponsorTransaction.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Ed25519Keypair, RawSigner, Transaction } from "@mysten/sui.js";
+import { provider } from "./rpc";
+
+// This simulates what a server would do to sponsor a transaction
+export async function sponsorTransaction(
+  sender: string,
+  transactionKindBytes: Uint8Array
+) {
+  // Rather than do gas pool management, we just spin out a new keypair to sponsor the transaction with:
+  const keypair = new Ed25519Keypair();
+  const signer = new RawSigner(keypair, provider);
+  const address = keypair.getPublicKey().toSuiAddress();
+  await signer.requestSuiFromFaucet();
+  console.log(`Sponsor address: ${address}`);
+
+  const tx = Transaction.fromKind(transactionKindBytes);
+  tx.setSender(sender);
+  tx.setGasOwner(address);
+  return await signer.signTransaction({ transaction: tx });
+}

--- a/dapps/sponsored-transactions/src/vite-env.d.ts
+++ b/dapps/sponsored-transactions/src/vite-env.d.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// <reference types="vite/client" />

--- a/dapps/sponsored-transactions/tailwind.config.cjs
+++ b/dapps/sponsored-transactions/tailwind.config.cjs
@@ -1,0 +1,11 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/dapps/sponsored-transactions/tsconfig.json
+++ b/dapps/sponsored-transactions/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "./tsconfig.node.json" },
+    { "path": "../../sdk/typescript" },
+    { "path": "../../sdk/wallet-adapter/wallet-kit" }
+  ]
+}

--- a/dapps/sponsored-transactions/tsconfig.node.json
+++ b/dapps/sponsored-transactions/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/dapps/sponsored-transactions/vite.config.ts
+++ b/dapps/sponsored-transactions/vite.config.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    conditions: ['source']
+  }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -460,6 +460,35 @@ importers:
       webpack-cli: 5.0.1_webpack@5.76.2
       webpack-merge: 5.8.0
 
+  dapps/sponsored-transactions:
+    specifiers:
+      '@mysten/sui.js': workspace:*
+      '@mysten/wallet-kit': workspace:*
+      '@types/react': ^18.0.28
+      '@types/react-dom': ^18.0.11
+      '@vitejs/plugin-react': ^3.1.0
+      autoprefixer: ^10.4.13
+      postcss: ^8.4.19
+      react: ^18.2.0
+      react-dom: ^18.2.0
+      tailwindcss: ^3.2.4
+      typescript: ^4.9.3
+      vite: ^4.2.0
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    devDependencies:
+      '@mysten/sui.js': link:../../sdk/typescript
+      '@mysten/wallet-kit': link:../../sdk/wallet-adapter/wallet-kit
+      '@types/react': 18.0.28
+      '@types/react-dom': 18.0.11
+      '@vitejs/plugin-react': 3.1.0_vite@4.2.0
+      autoprefixer: 10.4.14_postcss@8.4.21
+      postcss: 8.4.21
+      tailwindcss: 3.2.7_postcss@8.4.21
+      typescript: 4.9.5
+      vite: 4.2.0
+
   sdk/bcs:
     specifiers:
       '@size-limit/preset-small-lib': ^8.2.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - "sdk/**"
   - "apps/**"
+  - "dapps/sponsored-transactions"

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -718,7 +718,7 @@ export class JsonRpcProvider {
   }): Promise<DevInspectResults> {
     let devInspectTxBytes;
     if (Transaction.is(input.transaction)) {
-      input.transaction.setSender(input.sender);
+      input.transaction.setSenderIfNotSet(input.sender);
       devInspectTxBytes = toB64(
         await input.transaction.build({
           provider: this,

--- a/sdk/typescript/src/signers/signer-with-provider.ts
+++ b/sdk/typescript/src/signers/signer-with-provider.ts
@@ -85,7 +85,9 @@ export abstract class SignerWithProvider implements Signer {
     let transactionBytes;
 
     if (Transaction.is(input.transaction)) {
-      input.transaction.setSender(await this.getAddress());
+      // If the sender has not yet been set on the transaction, then set it.
+      // NOTE: This allows for signing transactions with mis-matched senders, which is important for sponsored transactions.
+      input.transaction.setSenderIfNotSet(await this.getAddress());
       transactionBytes = await input.transaction.build({
         provider: this.provider,
       });
@@ -143,7 +145,7 @@ export abstract class SignerWithProvider implements Signer {
    */
   async getTransactionDigest(tx: Uint8Array | Transaction): Promise<string> {
     if (Transaction.is(tx)) {
-      tx.setSender(await this.getAddress());
+      tx.setSenderIfNotSet(await this.getAddress());
       return tx.getDigest({ provider: this.provider });
     } else if (tx instanceof Uint8Array) {
       return TransactionDataBuilder.getDigestFromBytes(tx);
@@ -175,7 +177,7 @@ export abstract class SignerWithProvider implements Signer {
   }): Promise<DryRunTransactionResponse> {
     let dryRunTxBytes: Uint8Array;
     if (Transaction.is(input.transaction)) {
-      input.transaction.setSender(await this.getAddress());
+      input.transaction.setSenderIfNotSet(await this.getAddress());
       dryRunTxBytes = await input.transaction.build({
         provider: this.provider,
       });

--- a/sdk/wallet-adapter/adapters/unsafe-burner/src/index.ts
+++ b/sdk/wallet-adapter/adapters/unsafe-burner/src/index.ts
@@ -6,7 +6,7 @@ import {
   JsonRpcProvider,
   RawSigner,
   Connection,
-  devnetConnection,
+  localnetConnection,
 } from "@mysten/sui.js";
 import {
   WalletAdapter,
@@ -27,7 +27,7 @@ export class UnsafeBurnerWalletAdapter implements WalletAdapter {
   #signer: RawSigner;
   #account: ReadonlyWalletAccount;
 
-  constructor(network: Connection = devnetConnection) {
+  constructor(network: Connection = localnetConnection) {
     this.#keypair = new Ed25519Keypair();
     this.#provider = new JsonRpcProvider(network);
     this.#account = new ReadonlyWalletAccount({


### PR DESCRIPTION
## Description 

We've wanted to be able to easily test sponsored transactions locally, but never had a good demo to do so. This spins up a little mini sponsored transaction dapp, which walks through the flow piece by piece and lets you locally run a sponsored transaction.

## Test Plan 

Tests should still pass.