### PR TITLE
[ts-bcs] Use string to represent large integers

### DIFF
--- a/.changeset/violet-cooks-laugh.md
+++ b/.changeset/violet-cooks-laugh.md
@@ -1,0 +1,6 @@
+---
+"@mysten/sui.js": minor
+"@mysten/bcs": minor
+---
+
+When parsing u64, u128, and u256 values with bcs, they are now string encoded.

--- a/sdk/bcs/src/index.ts
+++ b/sdk/bcs/src/index.ts
@@ -132,34 +132,34 @@ export class BcsReader {
    * Read U64 value from the buffer and shift cursor by 8.
    * @returns
    */
-  read64(): bigint {
+  read64(): string {
     let value1 = this.read32();
     let value2 = this.read32();
 
     let result = value2.toString(16) + value1.toString(16).padStart(8, "0");
 
-    return BigInt("0x" + result);
+    return BigInt("0x" + result).toString(10);
   }
   /**
    * Read U128 value from the buffer and shift cursor by 16.
    */
-  read128(): bigint {
-    let value1 = this.read64();
-    let value2 = this.read64();
+  read128(): string {
+    let value1 = BigInt(this.read64());
+    let value2 = BigInt(this.read64());
     let result = value2.toString(16) + value1.toString(16).padStart(8, "0");
 
-    return BigInt("0x" + result);
+    return BigInt("0x" + result).toString(10);
   }
   /**
    * Read U128 value from the buffer and shift cursor by 32.
    * @returns
    */
-  read256(): bigint {
-    let value1 = this.read128();
-    let value2 = this.read128();
+  read256(): string {
+    let value1 = BigInt(this.read128());
+    let value2 = BigInt(this.read128());
     let result = value2.toString(16) + value1.toString(16).padStart(16, "0");
 
-    return BigInt("0x" + result);
+    return BigInt("0x" + result).toString(10);
   }
   /**
    * Read `num` number of bytes from the buffer and shift cursor by `num`.

--- a/sdk/bcs/tests/bcs.test.ts
+++ b/sdk/bcs/tests/bcs.test.ts
@@ -16,11 +16,11 @@ describe("BCS: Primitives", () => {
     const bcs = new BCS(getSuiMoveConfig());
 
     const exp = "AO/Nq3hWNBI=";
-    const num = BigInt("1311768467750121216");
+    const num = "1311768467750121216";
     const set = bcs.ser("u64", num).toString("base64");
 
     expect(set).toEqual(exp);
-    expect(bcs.de("u64", exp, "base64")).toEqual(1311768467750121216n);
+    expect(bcs.de("u64", exp, "base64")).toEqual("1311768467750121216");
   });
 
   it("should ser/de u128", () => {
@@ -47,7 +47,7 @@ describe("BCS: Primitives", () => {
     const rustBcs = "gNGxBWAAAAAOQmlnIFdhbGxldCBHdXkA";
     const expected = {
       owner: "Big Wallet Guy",
-      value: 412412400000n,
+      value: "412412400000",
       is_locked: false,
     };
 
@@ -139,7 +139,7 @@ describe("BCS: Primitives", () => {
     const rustBcs = "gNGxBWAAAAAOQmlnIFdhbGxldCBHdXkA";
     const expected = {
       owner: "Big Wallet Guy",
-      value: 412412400000n,
+      value: "412412400000",
       is_locked: false,
     };
 

--- a/sdk/bcs/tests/inline-definition.test.ts
+++ b/sdk/bcs/tests/inline-definition.test.ts
@@ -9,7 +9,7 @@ describe("BCS: Inline struct definitions", () => {
     const bcs = new BCS(getSuiMoveConfig());
     const value = {
       t1: "Adam",
-      t2: 1000n,
+      t2: "1000",
       t3: ["aabbcc", "00aa00", "00aaffcc"],
     };
 

--- a/sdk/bcs/tests/nested.object.test.ts
+++ b/sdk/bcs/tests/nested.object.test.ts
@@ -7,7 +7,7 @@ import { BCS, getSuiMoveConfig } from "../src/index";
 describe("BCS: Nested temp object", () => {
   it("should support object as a type", () => {
     const bcs = new BCS(getSuiMoveConfig());
-    const value = { name: { boop: "beep", beep: 100n } };
+    const value = { name: { boop: "beep", beep: "100" } };
 
     bcs.registerStructType("Beep", {
       name: {

--- a/sdk/bcs/tests/serde.test.ts
+++ b/sdk/bcs/tests/serde.test.ts
@@ -184,7 +184,7 @@ describe("BCS: Serde", () => {
     const value = {
       objectId:
         "5443700000000000000000000000000000000000000000000000000000000000",
-      version: 9180n,
+      version: "9180",
       digest: "hahahahahaha",
     };
 

--- a/sdk/typescript/src/builder/Inputs.ts
+++ b/sdk/typescript/src/builder/Inputs.ts
@@ -3,7 +3,6 @@
 
 import {
   array,
-  bigint,
   boolean,
   Infer,
   integer,
@@ -19,7 +18,7 @@ const ObjectArg = union([
   object({
     Shared: object({
       objectId: string(),
-      initialSharedVersion: union([bigint(), integer()]),
+      initialSharedVersion: union([integer(), string()]),
       mutable: boolean(),
     }),
   }),

--- a/sdk/typescript/src/builder/__tests__/Transaction.test.ts
+++ b/sdk/typescript/src/builder/__tests__/Transaction.test.ts
@@ -110,10 +110,10 @@ describe('offline build', () => {
   });
 });
 
-function ref(): { objectId: string; version: bigint; digest: string } {
+function ref(): { objectId: string; version: string; digest: string } {
   return {
     objectId: (Math.random() * 100000).toFixed(0).padEnd(64, '0'),
-    version: BigInt((Math.random() * 10000).toFixed(0)),
+    version: String((Math.random() * 10000).toFixed(0)),
     digest: toB58(
       new Uint8Array([
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,

--- a/sdk/typescript/src/builder/__tests__/bcs.test.ts
+++ b/sdk/typescript/src/builder/__tests__/bcs.test.ts
@@ -58,10 +58,10 @@ it('can serialize enum with "kind" property', () => {
   expect(result).toEqual(command);
 });
 
-function ref(): { objectId: string; version: bigint; digest: string } {
+function ref(): { objectId: string; version: string; digest: string } {
   return {
     objectId: (Math.random() * 100000).toFixed(0).padEnd(64, '0'),
-    version: BigInt((Math.random() * 10000).toFixed(0)),
+    version: String((Math.random() * 10000).toFixed(0)),
     digest: toB58(
       new Uint8Array([
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
@@ -79,8 +79,8 @@ it('can serialize transaction data with a programmable transaction', () => {
       gasData: {
         payment: [ref()],
         owner: sui,
-        price: 1n,
-        budget: 1000000n,
+        price: '1',
+        budget: '1000000',
       },
       kind: {
         ProgrammableTransaction: {

--- a/sdk/typescript/src/types/objects.ts
+++ b/sdk/typescript/src/types/objects.ts
@@ -5,7 +5,6 @@ import {
   any,
   array,
   assign,
-  bigint,
   boolean,
   Infer,
   literal,
@@ -34,7 +33,7 @@ export const SuiObjectRef = object({
   /** Hex code as string representing the object id */
   objectId: string(),
   /** Object version */
-  version: union([bigint(), number()]),
+  version: union([number(), string()]),
 });
 export type SuiObjectRef = Infer<typeof SuiObjectRef>;
 
@@ -249,7 +248,7 @@ export function getObjectId(
 
 export function getObjectVersion(
   data: SuiObjectResponse | SuiObjectRef | SuiObjectData,
-): bigint | number | undefined {
+): string | number | undefined {
   if ('version' in data) {
     return data.version;
   }

--- a/sdk/typescript/src/types/sui-bcs.ts
+++ b/sdk/typescript/src/types/sui-bcs.ts
@@ -32,7 +32,7 @@ export type SharedObjectRef = {
   objectId: string;
 
   /** The version the object was shared at */
-  initialSharedVersion: number | bigint;
+  initialSharedVersion: number | string;
 
   /** Whether reference is mutable */
   mutable: boolean;


### PR DESCRIPTION
## Description 

While working with BCS I noticed that its use of bigints is good for precision but leads to a couple odd cases:
- Cannot JSON.stringify values that bcs deserializes. This isn't a _huge_ issue, as we can use BCS encoding in a lot of places, but for the transaction builder this becomes a little problematic.
- Causes mis-alignment with the API, which can be confusing when you get strings out of one API and bigints out of another (potentially viewing the same data!).

## Test Plan 

Updated tests to pass.