### PR TITLE
[benchmarking] add commands per second metric

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -300,7 +300,7 @@ mod test {
             .unwrap();
 
         // TODO: make this stricter (== 0) when we have reliable error retrying on the client.
-        assert!(benchmark_stats.num_error < 30);
+        assert!(benchmark_stats.num_error_txes < 30);
 
         tracing::info!("end of test {:?}", benchmark_stats);
     }


### PR DESCRIPTION
## Description

Add logic to compute the number of commands per successfully executed transaction and report commands per second (CPS) as part of the final results. Needed to show how much computation we can do per tx now that we have programmable txes.
 

Describe the changes or additions included in this PR.

## Test Plan 

`cargo run --package sui-benchmark --bin stress --  --num-client-threads 1 --num-server-threads 6 bench --target-qps 10 --in-flight-ratio 1 --transfer-object 0 --batch-payment 1 --batch-payment-size 15 --run-duration 10s`

```
+-------------+-----+-----+--------+---------------+---------------+---------------+
| duration(s) | tps | cps | error% | latency (min) | latency (p50) | latency (p99) |
+==================================================================================+
| 10          | 11  | 330 | 0      | 105           | 192           | 263           |
+-------------+-----+-----+--------+---------------+---------------+---------------+
```

Note: CPS is 330 because a batch payment to N recipients currently has N * 2 commands (11 TPS * 30 commands/tx = 330). This is because we encode paying N parties as `SplitCoin; Pay` N times. @tnowacki would it be possible to encode paying N parties with N+1 commands by adding a command (SplitCoinN?) or tweaking the existing encoding of `pay_sui`?

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
