### PR TITLE
wallet-ext: test site-cs messaging

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -65,20 +65,19 @@ jobs:
           path: apps/explorer/playwright-report/
           retention-days: 30
 
-      # Disable wallet devenet test
-      # - name: Build Wallet
-      #   # need to run Wallet e2e when its upstream(TS SDK and Rust) or itself is changed
-      #   if: ${{ needs.diff.outputs.isWallet == 'true' || needs.diff.outputs.isRust == 'true' || needs.diff.outputs.isTypescriptSDK == 'true'}}
-      #   run: pnpm wallet build
-      # - name: Run Wallet e2e tests
-      #   if: ${{ needs.diff.outputs.isWallet == 'true' || needs.diff.outputs.isRust == 'true' || needs.diff.outputs.isTypescriptSDK == 'true'}}
-      #   run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- pnpm wallet playwright test
-      # - uses: actions/upload-artifact@v3
-      #   if: always()
-      #   with:
-      #     name: playwright-report-wallet
-      #     path: apps/wallet/playwright-report/
-      #     retention-days: 30
+      - name: Build Wallet
+        # need to run Wallet e2e when its upstream(TS SDK and Rust) or itself is changed
+        if: ${{ needs.diff.outputs.isWallet == 'true' || needs.diff.outputs.isRust == 'true' || needs.diff.outputs.isTypescriptSDK == 'true'}}
+        run: pnpm wallet build
+      - name: Run Wallet e2e tests
+        if: ${{ needs.diff.outputs.isWallet == 'true' || needs.diff.outputs.isRust == 'true' || needs.diff.outputs.isTypescriptSDK == 'true'}}
+        run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- pnpm wallet playwright test
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report-wallet
+          path: apps/wallet/playwright-report/
+          retention-days: 30
 
   # Run e2e test against localnet built on the devnet branch for backward compatibility check
   local_devnet_branch:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -65,10 +65,12 @@ jobs:
           path: apps/explorer/playwright-report/
           retention-days: 30
 
+      - name: Set Wallet env
+        run: echo "API_ENV=local" > "$PWD/apps/wallet/configs/environment/.env"
       - name: Build Wallet
         # need to run Wallet e2e when its upstream(TS SDK and Rust) or itself is changed
         if: ${{ needs.diff.outputs.isWallet == 'true' || needs.diff.outputs.isRust == 'true' || needs.diff.outputs.isTypescriptSDK == 'true'}}
-        run: pnpm wallet build
+        run: pnpm wallet build:dev
       - name: Run Wallet e2e tests
         if: ${{ needs.diff.outputs.isWallet == 'true' || needs.diff.outputs.isRust == 'true' || needs.diff.outputs.isTypescriptSDK == 'true'}}
         run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- pnpm wallet playwright test

--- a/apps/wallet/package.json
+++ b/apps/wallet/package.json
@@ -25,7 +25,8 @@
         "pack:zip": "web-ext build --source-dir ./dist --overwrite-dest",
         "storybook": "storybook dev -p 6007",
         "build-storybook": "storybook build",
-        "preview-storybook": "pnpm dlx serve ./storybook-static -l 6007"
+        "preview-storybook": "pnpm dlx serve ./storybook-static -l 6007",
+        "demoApp:dev": "pnpm vite -c ./tests/demo-app/vite.config.ts ./tests/demo-app/"
     },
     "repository": {
         "type": "git",

--- a/apps/wallet/package.json
+++ b/apps/wallet/package.json
@@ -70,6 +70,7 @@
         "@types/zxcvbn": "^4.4.1",
         "@typescript-eslint/eslint-plugin": "^5.58.0",
         "@typescript-eslint/parser": "^5.58.0",
+        "@vitejs/plugin-react": "^3.1.0",
         "concurrently": "^8.0.1",
         "copy-webpack-plugin": "^11.0.0",
         "cross-env": "^7.0.3",

--- a/apps/wallet/package.json
+++ b/apps/wallet/package.json
@@ -26,7 +26,7 @@
         "storybook": "storybook dev -p 6007",
         "build-storybook": "storybook build",
         "preview-storybook": "pnpm dlx serve ./storybook-static -l 6007",
-        "demoApp:dev": "pnpm vite -c ./tests/demo-app/vite.config.ts ./tests/demo-app/"
+        "demoApp:dev": "pnpm vite -c ./tests/demo-app/vite.config.ts ./tests/demo-app/ --port 5181"
     },
     "repository": {
         "type": "git",

--- a/apps/wallet/playwright.config.ts
+++ b/apps/wallet/playwright.config.ts
@@ -50,7 +50,7 @@ const config: PlaywrightTestConfig = {
         },
     ],
     webServer: {
-        command: 'pnpm vite ./tests/demo-app/ --port 5181',
+        command: 'pnpm demoApp:dev --port 5181',
         port: 5181,
         timeout: 30 * 1000,
         reuseExistingServer: !process.env.CI,

--- a/apps/wallet/playwright.config.ts
+++ b/apps/wallet/playwright.config.ts
@@ -39,7 +39,6 @@ const config: PlaywrightTestConfig = {
         /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
         trace: 'on-first-retry',
     },
-
     /* Configure projects for major browsers */
     projects: [
         {
@@ -50,6 +49,12 @@ const config: PlaywrightTestConfig = {
             },
         },
     ],
+    webServer: {
+        command: 'pnpm vite ./tests/demo-app/ --port 5181',
+        port: 5181,
+        timeout: 30 * 1000,
+        reuseExistingServer: !process.env.CI,
+    },
 };
 
 export default config;

--- a/apps/wallet/playwright.config.ts
+++ b/apps/wallet/playwright.config.ts
@@ -51,8 +51,8 @@ const config: PlaywrightTestConfig = {
     ],
     webServer: [
         {
-            command: 'pnpm demoApp:dev --port 5181',
-            port: 5181,
+            command: 'pnpm demoApp:dev',
+            port: 5174,
             timeout: 30 * 1000,
             reuseExistingServer: !process.env.CI,
         },

--- a/apps/wallet/playwright.config.ts
+++ b/apps/wallet/playwright.config.ts
@@ -49,12 +49,22 @@ const config: PlaywrightTestConfig = {
             },
         },
     ],
-    webServer: {
-        command: 'pnpm demoApp:dev --port 5181',
-        port: 5181,
-        timeout: 30 * 1000,
-        reuseExistingServer: !process.env.CI,
-    },
+    webServer: [
+        {
+            command: 'pnpm demoApp:dev --port 5181',
+            port: 5181,
+            timeout: 30 * 1000,
+            reuseExistingServer: !process.env.CI,
+        },
+        {
+            command:
+                process.env.E2E_RUN_LOCAL_NET_CMD ??
+                'RUST_LOG="consensus=off" cargo run --bin sui-test-validator',
+            port: 9123,
+            timeout: 120 * 1000,
+            reuseExistingServer: !process.env.CI,
+        },
+    ],
 };
 
 export default config;

--- a/apps/wallet/playwright.config.ts
+++ b/apps/wallet/playwright.config.ts
@@ -52,7 +52,7 @@ const config: PlaywrightTestConfig = {
     webServer: [
         {
             command: 'pnpm demoApp:dev',
-            port: 5174,
+            port: 5181,
             timeout: 30 * 1000,
             reuseExistingServer: !process.env.CI,
         },

--- a/apps/wallet/src/background/connections/ContentScriptConnection.ts
+++ b/apps/wallet/src/background/connections/ContentScriptConnection.ts
@@ -168,6 +168,10 @@ export class ContentScriptConnection extends Connection {
                         msg.id
                     )
                 );
+            } else {
+                throw new Error(
+                    `Unknown message, ${JSON.stringify(msg.payload)}`
+                );
             }
         } catch (e) {
             this.sendError(

--- a/apps/wallet/tests/demo-app/index.html
+++ b/apps/wallet/tests/demo-app/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1, maximum-scale=1"
+        />
+        <title>Demo Test App</title>
+    </head>
+    <body>
+        <noscript>You need to enable JavaScript to run this app.</noscript>
+        <div id="root"></div>
+        <script type="module" src="/src/index.tsx"></script>
+    </body>
+</html>

--- a/apps/wallet/tests/demo-app/src/index.tsx
+++ b/apps/wallet/tests/demo-app/src/index.tsx
@@ -1,0 +1,202 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { TransactionBlock } from '@mysten/sui.js';
+import {
+    type ReadonlyWalletAccount,
+    WalletAccount,
+    getWallets,
+} from '@mysten/wallet-standard';
+import { useEffect, useState } from 'react';
+import ReactDOM from 'react-dom/client';
+
+import { type SuiWallet } from '_src/dapp-interface/WalletStandardInterface';
+
+function App() {
+    const [suiWallet, setSuiWallet] = useState<SuiWallet | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const [accounts, setAccounts] = useState<ReadonlyWalletAccount[]>([]);
+
+    useEffect(() => {
+        const walletsApi = getWallets();
+        function updateWallets() {
+            const updatedWallets = walletsApi.get();
+            setSuiWallet(
+                (updatedWallets.find((aWallet) =>
+                    aWallet.name.includes('Sui Wallet')
+                ) || null) as SuiWallet | null
+            );
+        }
+        updateWallets();
+        const unregister1 = walletsApi.on('register', updateWallets);
+        const unregister2 = walletsApi.on('unregister', updateWallets);
+        return () => {
+            unregister1();
+            unregister2();
+        };
+    }, []);
+    useEffect(() => {
+        if (suiWallet) {
+            setAccounts(suiWallet.accounts);
+            return suiWallet.features['standard:events'].on(
+                'change',
+                ({ accounts }) => {
+                    if (accounts) {
+                        setAccounts(suiWallet.accounts);
+                    }
+                }
+            );
+        }
+    }, [suiWallet]);
+    if (!suiWallet) {
+        return <h1>Sui Wallet not found</h1>;
+    }
+    return (
+        <>
+            <h1>Sui Wallet is installed. ({suiWallet.name})</h1>
+            {accounts.length ? (
+                <ul>
+                    {accounts.map((anAccount) => (
+                        <li key={anAccount.address}>{anAccount.address}</li>
+                    ))}
+                </ul>
+            ) : (
+                <button
+                    onClick={async () =>
+                        suiWallet.features['standard:connect'].connect()
+                    }
+                >
+                    Connect
+                </button>
+            )}
+            <button
+                onClick={async () => {
+                    setError(null);
+                    const txb = new TransactionBlock();
+                    try {
+                        await suiWallet.features[
+                            'sui:signAndExecuteTransactionBlock'
+                        ].signAndExecuteTransactionBlock({
+                            transactionBlock: txb,
+                            account: {} as ReadonlyWalletAccount,
+                            chain: 'sui:unknown',
+                        });
+                    } catch (e) {
+                        setError((e as Error).message);
+                    }
+                }}
+            >
+                Sent transaction no account
+            </button>
+            <button
+                onClick={async () => {
+                    setError(null);
+                    const txb = new TransactionBlock();
+                    try {
+                        await suiWallet.features[
+                            'sui:signAndExecuteTransactionBlock'
+                        ].signAndExecuteTransactionBlock({
+                            transactionBlock: txb,
+                            account: {
+                                address: '12345',
+                            } as ReadonlyWalletAccount,
+                            chain: 'sui:unknown',
+                        });
+                    } catch (e) {
+                        setError((e as Error).message);
+                    }
+                }}
+            >
+                Sent transaction
+            </button>
+            <button
+                onClick={async () => {
+                    setError(null);
+                    const txb = new TransactionBlock();
+                    try {
+                        await suiWallet.features[
+                            'sui:signTransactionBlock'
+                        ].signTransactionBlock({
+                            transactionBlock: txb,
+                            account: {} as ReadonlyWalletAccount,
+                            chain: 'sui:unknown',
+                        });
+                    } catch (e) {
+                        setError((e as Error).message);
+                    }
+                }}
+            >
+                Sign transaction no account
+            </button>
+            <button
+                onClick={async () => {
+                    setError(null);
+                    const txb = new TransactionBlock();
+                    try {
+                        await suiWallet.features[
+                            'sui:signTransactionBlock'
+                        ].signTransactionBlock({
+                            transactionBlock: txb,
+                            account: {
+                                address: '12345',
+                            } as ReadonlyWalletAccount,
+                            chain: 'sui:unknown',
+                        });
+                    } catch (e) {
+                        setError((e as Error).message);
+                    }
+                }}
+            >
+                Sign transaction
+            </button>
+            <button
+                onClick={async () => {
+                    setError(null);
+                    try {
+                        await suiWallet.features['sui:signMessage'].signMessage(
+                            {
+                                account: {} as ReadonlyWalletAccount,
+                                message: new TextEncoder().encode(
+                                    'Test message'
+                                ),
+                            }
+                        );
+                    } catch (e) {
+                        setError((e as Error).message);
+                    }
+                }}
+            >
+                Sign message no account
+            </button>
+            <button
+                onClick={async () => {
+                    setError(null);
+                    try {
+                        await suiWallet.features['sui:signMessage'].signMessage(
+                            {
+                                account: {
+                                    address: '12345',
+                                } as ReadonlyWalletAccount,
+                                message: new TextEncoder().encode(
+                                    'Test message'
+                                ),
+                            }
+                        );
+                    } catch (e) {
+                        setError((e as Error).message);
+                    }
+                }}
+            >
+                Sign message
+            </button>
+            {error ? (
+                <div>
+                    <h6>Error</h6>
+                    <div>{error}</div>
+                </div>
+            ) : null}
+        </>
+    );
+}
+
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);

--- a/apps/wallet/tests/demo-app/vite.config.ts
+++ b/apps/wallet/tests/demo-app/vite.config.ts
@@ -7,4 +7,7 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
     plugins: [react(), tsconfigPaths({ root: '../../' })],
+    resolve: {
+        conditions: ['source'],
+    },
 });

--- a/apps/wallet/tests/demo-app/vite.config.ts
+++ b/apps/wallet/tests/demo-app/vite.config.ts
@@ -6,5 +6,5 @@ import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
-    plugins: [react(), tsconfigPaths()],
+    plugins: [react(), tsconfigPaths({ root: '../../' })],
 });

--- a/apps/wallet/tests/fixtures.ts
+++ b/apps/wallet/tests/fixtures.ts
@@ -15,6 +15,7 @@ const LAUNCH_ARGS = [
 export const test = base.extend<{
     context: BrowserContext;
     extensionUrl: string;
+    demoPageUrl: string;
 }>({
     // eslint-disable-next-line no-empty-pattern
     context: async ({}, use) => {
@@ -34,6 +35,10 @@ export const test = base.extend<{
         const extensionId = background.url().split('/')[2];
         const extensionUrl = `chrome-extension://${extensionId}/ui.html`;
         await use(extensionUrl);
+    },
+    // eslint-disable-next-line no-empty-pattern
+    demoPageUrl: async ({}, use) => {
+        await use('http://localhost:5181');
     },
 });
 

--- a/apps/wallet/tests/fixtures.ts
+++ b/apps/wallet/tests/fixtures.ts
@@ -38,7 +38,7 @@ export const test = base.extend<{
     },
     // eslint-disable-next-line no-empty-pattern
     demoPageUrl: async ({}, use) => {
-        await use('http://localhost:5181');
+        await use('http://localhost:5174');
     },
 });
 

--- a/apps/wallet/tests/fixtures.ts
+++ b/apps/wallet/tests/fixtures.ts
@@ -38,7 +38,7 @@ export const test = base.extend<{
     },
     // eslint-disable-next-line no-empty-pattern
     demoPageUrl: async ({}, use) => {
-        await use('http://localhost:5174');
+        await use('http://localhost:5181');
     },
 });
 

--- a/apps/wallet/tests/onboarding.spec.ts
+++ b/apps/wallet/tests/onboarding.spec.ts
@@ -21,7 +21,7 @@ test('import wallet', async ({ page, extensionUrl }) => {
     await page.getByLabel('Create Password').fill('mystenlabs');
     await page.getByLabel('Confirm Password').fill('mystenlabs');
     await page.getByRole('button', { name: /Import/ }).click();
-    await page.getByRole('button', { name: /Open Sui Wallet/ }).click();
+    await page.getByRole('link', { name: /Open Sui Wallet/ }).click();
     await expect(page.getByTestId('coin-page')).toBeVisible();
     await expect(
         page.getByText(keypair.getPublicKey().toSuiAddress().slice(0, 6))

--- a/apps/wallet/tests/sites-to-cs-messaging.spec.ts
+++ b/apps/wallet/tests/sites-to-cs-messaging.spec.ts
@@ -38,55 +38,6 @@ test.describe('site to content script messages', () => {
     const allTests = [
         ['get accounts', { type: 'get-account' }, false],
         [
-            'hasPermissions',
-            {
-                type: 'has-permissions-request',
-            },
-            {
-                payload: {
-                    result: false,
-                },
-            },
-        ],
-        [
-            'execute transaction no account',
-            {
-                type: 'execute-transaction-request',
-            },
-            false,
-        ],
-        [
-            'execute transaction',
-            {
-                type: 'execute-transaction-request',
-                transaction: { account: '0x100' },
-            },
-            false,
-        ],
-        [
-            'sign transaction no account',
-            {
-                type: 'sign-transaction-request',
-            },
-            false,
-        ],
-        [
-            'sign transaction',
-            {
-                type: 'sign-transaction-request',
-                transaction: { account: '0x100' },
-            },
-            false,
-        ],
-        [
-            'sign message',
-            {
-                type: 'sign-message-request',
-                args: {},
-            },
-            false,
-        ],
-        [
             'UI get-features',
             {
                 type: 'get-features',

--- a/apps/wallet/tests/sites-to-cs-messaging.spec.ts
+++ b/apps/wallet/tests/sites-to-cs-messaging.spec.ts
@@ -1,0 +1,145 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { type Page } from '@playwright/test';
+
+import { expect, test } from './fixtures';
+import { createWallet } from './utils/auth';
+
+function getInAppMessage(page: Page, id: string) {
+    return page.evaluate(
+        (anId) =>
+            Promise.race([
+                new Promise((r) => setTimeout(() => r(null), 1000)),
+                new Promise((r) => {
+                    const callBackFN = (msg: MessageEvent) => {
+                        if (
+                            msg.data.target === 'sui_in-page' &&
+                            msg.data.payload.id === anId
+                        ) {
+                            window.removeEventListener('message', callBackFN);
+                            r(msg.data.payload);
+                        }
+                    };
+                    window.addEventListener('message', callBackFN);
+                }),
+            ]),
+        id
+    );
+}
+
+const noPermissionError = {
+    payload: {
+        error: true,
+        message:
+            "Operation not allowed, dapp doesn't have the required permissions",
+    },
+};
+
+const noAccountError = {
+    payload: {
+        error: true,
+        message: "Cannot read properties of undefined (reading 'account')",
+    },
+};
+
+test.describe('site to content script messages', () => {
+    test.beforeAll(async ({ page, extensionUrl }) => {
+        await createWallet(page, extensionUrl);
+        await page.close();
+    });
+
+    const allTests = [
+        ['get accounts', { type: 'get-account' }, noPermissionError],
+        [
+            'hasPermissions',
+            {
+                type: 'has-permissions-request',
+            },
+            {
+                payload: {
+                    result: false,
+                },
+            },
+        ],
+        [
+            'execute transaction no account',
+            {
+                type: 'execute-transaction-request',
+            },
+            noAccountError,
+        ],
+        [
+            'execute transaction',
+            {
+                type: 'execute-transaction-request',
+                transaction: { account: '0x100' },
+            },
+            noPermissionError,
+        ],
+        [
+            'sign transaction no account',
+            {
+                type: 'sign-transaction-request',
+            },
+            noAccountError,
+        ],
+        [
+            'sign transaction',
+            {
+                type: 'sign-transaction-request',
+                transaction: { account: '0x100' },
+            },
+            noPermissionError,
+        ],
+        [
+            'sign message',
+            {
+                type: 'sign-message-request',
+                args: {},
+            },
+            noPermissionError,
+        ],
+        [
+            'UI get-features',
+            {
+                type: 'get-features',
+            },
+            null,
+        ],
+        [
+            'UI create wallet',
+            {
+                type: 'keyring',
+                method: 'create',
+                args: {},
+            },
+            null,
+        ],
+    ] as const;
+    for (const [aLabel, aPayload, result] of allTests) {
+        test(aLabel, async ({ context }) => {
+            const page = await context.newPage();
+            await page.goto('https://example.com');
+            const nextMessage = getInAppMessage(page, aLabel);
+            await page.evaluate(
+                ({ aPayload: payload, aLabel: label }) => {
+                    window.postMessage({
+                        target: 'sui_content-script',
+                        payload: {
+                            id: label,
+                            payload,
+                        },
+                    });
+                },
+                { aPayload, aLabel }
+            );
+            if (result) {
+                expect(await nextMessage).toMatchObject(result);
+            } else {
+                // no response
+                expect(await nextMessage).toBeNull();
+            }
+        });
+    }
+});

--- a/apps/wallet/tests/sites-to-cs-messaging.spec.ts
+++ b/apps/wallet/tests/sites-to-cs-messaging.spec.ts
@@ -5,6 +5,7 @@ import { type Page } from '@playwright/test';
 
 import { expect, test } from './fixtures';
 import { createWallet } from './utils/auth';
+import { demoDappConnect } from './utils/dapp-connect';
 
 function getInAppMessage(page: Page, id: string) {
     return page.evaluate(
@@ -29,20 +30,41 @@ function getInAppMessage(page: Page, id: string) {
     );
 }
 
-test.describe('site to content script messages', () => {
-    test.beforeAll(async ({ page, extensionUrl }) => {
-        await createWallet(page, extensionUrl);
-        await page.close();
-    });
+test.beforeEach(async ({ page, extensionUrl }) => {
+    await createWallet(page, extensionUrl);
+    await page.close();
+});
 
+test.describe('site to content script messages', () => {
     const allTests = [
         ['get accounts', { type: 'get-account' }, false],
+        [
+            'execute transaction no account',
+            {
+                type: 'execute-transaction-request',
+            },
+            false,
+        ],
+        [
+            'sign transaction no account',
+            {
+                type: 'sign-transaction-request',
+            },
+            false,
+        ],
+        [
+            'sign message no account',
+            {
+                type: 'sign-message-request',
+            },
+            false,
+        ],
         [
             'UI get-features',
             {
                 type: 'get-features',
             },
-            null,
+            false,
         ],
         [
             'UI create wallet',
@@ -51,13 +73,13 @@ test.describe('site to content script messages', () => {
                 method: 'create',
                 args: {},
             },
-            null,
+            false,
         ],
     ] as const;
     for (const [aLabel, aPayload, result] of allTests) {
-        test(aLabel, async ({ context }) => {
+        test(aLabel, async ({ context, demoPageUrl }) => {
             const page = await context.newPage();
-            await page.goto('https://example.com');
+            await page.goto(demoPageUrl);
             const nextMessage = getInAppMessage(page, aLabel);
             await page.evaluate(
                 ({ aPayload: payload, aLabel: label }) => {
@@ -78,4 +100,81 @@ test.describe('site to content script messages', () => {
             }
         });
     }
+});
+
+test.describe('Wallet interface', () => {
+    let demoPage: Page;
+
+    test.beforeEach(async ({ context, demoPageUrl }) => {
+        demoPage = await context.newPage();
+        await demoPage.goto(demoPageUrl);
+    });
+    test.describe('when not connected', () => {
+        // eslint-disable-next-line no-empty-pattern
+        test('no account is connected', async ({}) => {
+            expect((await demoPage.locator('.account').all()).length).toBe(0);
+            await expect(
+                demoPage.getByRole('button', { name: 'Connect' })
+            ).toBeVisible();
+        });
+        test('executing a transaction fails', async () => {
+            await demoPage
+                .getByRole('button', { name: 'Send transaction' })
+                .click();
+            await expect(demoPage.getByText('Error')).toBeVisible();
+        });
+        test('signing a transaction fails', async () => {
+            await demoPage
+                .getByRole('button', { name: 'Sign transaction' })
+                .click();
+            await expect(demoPage.getByText('Error')).toBeVisible();
+        });
+        test('signing a message', async () => {
+            await demoPage
+                .getByRole('button', { name: 'Sign message' })
+                .click();
+            await expect(demoPage.getByText('Error')).toBeVisible();
+        });
+    });
+    test.describe('when connected', () => {
+        test.beforeEach(async ({ context, demoPageUrl }) => {
+            await demoDappConnect(demoPage, demoPageUrl, context);
+        });
+        test('executing transaction works', async ({ context }) => {
+            const newPage = context.waitForEvent('page');
+            await demoPage.waitForSelector('.account');
+            await demoPage
+                .getByRole('button', { name: 'Send transaction' })
+                .click();
+            const walletPage = await newPage;
+            const approve = await walletPage.getByRole('button', {
+                name: 'Approve',
+            });
+            await expect(approve).toBeVisible();
+            await expect(approve).toBeEnabled();
+        });
+        test.describe('and using wrong account', () => {
+            test.beforeEach(async () => {
+                await demoPage.getByLabel('Use wrong account').check();
+            });
+            test('executing transaction fails', async () => {
+                await demoPage
+                    .getByRole('button', { name: 'Send transaction' })
+                    .click();
+                await expect(demoPage.getByText('Error')).toBeVisible();
+            });
+            test('signing transaction fails', async () => {
+                await demoPage
+                    .getByRole('button', { name: 'Sign transaction' })
+                    .click();
+                await expect(demoPage.getByText('Error')).toBeVisible();
+            });
+            test('signing message fails', async () => {
+                await demoPage
+                    .getByRole('button', { name: 'Sign message' })
+                    .click();
+                await expect(demoPage.getByText('Error')).toBeVisible();
+            });
+        });
+    });
 });

--- a/apps/wallet/tests/sites-to-cs-messaging.spec.ts
+++ b/apps/wallet/tests/sites-to-cs-messaging.spec.ts
@@ -110,8 +110,7 @@ test.describe('Wallet interface', () => {
         await demoPage.goto(demoPageUrl);
     });
     test.describe('when not connected', () => {
-        // eslint-disable-next-line no-empty-pattern
-        test('no account is connected', async ({}) => {
+        test('no account is connected', async () => {
             expect((await demoPage.locator('.account').all()).length).toBe(0);
             await expect(
                 demoPage.getByRole('button', { name: 'Connect' })
@@ -142,7 +141,6 @@ test.describe('Wallet interface', () => {
         });
         test('executing transaction works', async ({ context }) => {
             const newPage = context.waitForEvent('page');
-            await demoPage.waitForSelector('.account');
             await demoPage
                 .getByRole('button', { name: 'Send transaction' })
                 .click();

--- a/apps/wallet/tests/tabs.spec.ts
+++ b/apps/wallet/tests/tabs.spec.ts
@@ -24,7 +24,7 @@ test('Apps tab', async ({ page, extensionUrl }) => {
         .click();
 
     await expect(page.getByRole('main')).toHaveText(
-        /Builders in sui ecosystem/i
+        /Apps below are actively curated but do not indicate any endorsement or relationship with Sui Wallet. Please DYOR./i
     );
 });
 

--- a/apps/wallet/tests/utils/auth.ts
+++ b/apps/wallet/tests/utils/auth.ts
@@ -18,5 +18,5 @@ export async function createWallet(page: Page, extensionUrl: string) {
     await page
         .locator('label', { has: page.locator('input[type=checkbox]') })
         .click();
-    await page.getByRole('button', { name: /Open Sui Wallet/ }).click();
+    await page.getByRole('link', { name: /Open Sui Wallet/ }).click();
 }

--- a/apps/wallet/tests/utils/dapp-connect.ts
+++ b/apps/wallet/tests/utils/dapp-connect.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect } from '../fixtures';
+
+import type { Page, BrowserContext } from '@playwright/test';
+
+export async function demoDappConnect(
+    page: Page,
+    demoPageUrl: string,
+    context: BrowserContext
+) {
+    await page.goto(demoPageUrl);
+    const newWalletPage = context.waitForEvent('page');
+    await page.getByRole('button', { name: 'Connect' }).click();
+    const walletPage = await newWalletPage;
+    await walletPage.waitForLoadState();
+    await walletPage.getByRole('button', { name: 'Continue' }).click();
+    await walletPage.getByRole('button', { name: 'Connect' }).click();
+    await page.waitForSelector('.account');
+    await expect((await page.locator('.account').all()).length).toBe(1);
+}

--- a/apps/wallet/tests/utils/dapp-connect.ts
+++ b/apps/wallet/tests/utils/dapp-connect.ts
@@ -17,6 +17,7 @@ export async function demoDappConnect(
     await walletPage.waitForLoadState();
     await walletPage.getByRole('button', { name: 'Continue' }).click();
     await walletPage.getByRole('button', { name: 'Connect' }).click();
-    await page.waitForSelector('.account');
-    await expect((await page.locator('.account').all()).length).toBe(1);
+    const accountsList = page.getByTestId('accounts-list');
+    const accountListItems = accountsList.getByRole('listitem');
+    await expect(accountListItems).toHaveCount(1);
 }

--- a/apps/wallet/vite.config.ts
+++ b/apps/wallet/vite.config.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({
+    plugins: [react(), tsconfigPaths()],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -567,6 +567,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^5.58.0
         version: 5.58.0(eslint@8.38.0)(typescript@5.0.4)
+      '@vitejs/plugin-react':
+        specifier: ^3.1.0
+        version: 3.1.0(vite@4.2.1)
       concurrently:
         specifier: ^8.0.1
         version: 8.0.1


### PR DESCRIPTION
## Description 

* make sure when a site with no permissions can not access wallet data
* make sure sending messages expected from wallet popup from sites are ignored
* also fixes tests failing on create and import flows
* updated cs connection to throw error when it receives unknown messages
* adds demo dapp to test wallet interface
* enables wallet e2e tests
* updates wallet e2e tests to run against local network instead of the default

closes APPS-603