### PR TITLE
[bugfix] - fix CallArg <-> SuiJson conversion logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8954,6 +8954,7 @@ dependencies = [
  "jsonrpsee-proc-macros",
  "linked-hash-map",
  "move-binary-format",
+ "move-bytecode-utils",
  "move-core-types",
  "move-package",
  "mysten-metrics",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9272,6 +9272,7 @@ dependencies = [
  "fastcrypto",
  "futures",
  "hyper",
+ "move-bytecode-utils",
  "move-core-types",
  "mysten-metrics",
  "once_cell",

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -1424,6 +1424,7 @@ pub struct SuiPureValue {
 #[serde(tag = "objectType", rename_all = "camelCase")]
 pub enum SuiObjectArg {
     // A Move object, either immutable, or owned mutable.
+    #[serde(rename_all = "camelCase")]
     ImmOrOwnedObject {
         object_id: ObjectID,
         version: SequenceNumber,
@@ -1431,6 +1432,7 @@ pub enum SuiObjectArg {
     },
     // A Move object that's shared.
     // SharedObject::mutable controls whether caller asks for a mutable reference to shared object.
+    #[serde(rename_all = "camelCase")]
     SharedObject {
         object_id: ObjectID,
         initial_shared_version: SequenceNumber,

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -5,13 +5,18 @@ use std::fmt::{self, Display, Formatter, Write};
 
 use enum_dispatch::enum_dispatch;
 use fastcrypto::encoding::Base64;
+use move_binary_format::access::ModuleAccess;
+use move_binary_format::binary_views::BinaryIndexedView;
+use move_binary_format::CompiledModule;
 use move_bytecode_utils::module_cache::GetModule;
-use move_core_types::language_storage::TypeTag;
+use move_core_types::identifier::IdentStr;
+use move_core_types::language_storage::{ModuleId, TypeTag};
+use move_core_types::value::MoveTypeLayout;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 
-use sui_json::SuiJsonValue;
+use sui_json::{primitive_type, SuiJsonCallArg, SuiJsonValue};
 use sui_types::base_types::{
     EpochId, ObjectID, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest,
 };
@@ -19,7 +24,7 @@ use sui_types::digests::TransactionEventsDigest;
 use sui_types::error::{ExecutionError, SuiError};
 use sui_types::gas::GasCostSummary;
 use sui_types::messages::{
-    Argument, Command, ExecuteTransactionRequestType, ExecutionStatus, GenesisObject,
+    Argument, CallArg, Command, ExecuteTransactionRequestType, ExecutionStatus, GenesisObject,
     InputObjectKind, ProgrammableMoveCall, ProgrammableTransaction, SenderSignedData,
     TransactionData, TransactionDataAPI, TransactionEffects, TransactionEffectsAPI,
     TransactionEvents, TransactionKind, VersionedProtocolMessage,
@@ -288,10 +293,8 @@ impl Display for SuiTransactionKind {
     }
 }
 
-impl TryFrom<TransactionKind> for SuiTransactionKind {
-    type Error = anyhow::Error;
-
-    fn try_from(tx: TransactionKind) -> Result<Self, Self::Error> {
+impl SuiTransactionKind {
+    fn try_from(tx: TransactionKind, module_cache: &impl GetModule) -> Result<Self, anyhow::Error> {
         Ok(match tx {
             TransactionKind::ChangeEpoch(e) => Self::ChangeEpoch(SuiChangeEpoch {
                 epoch: e.epoch,
@@ -310,9 +313,9 @@ impl TryFrom<TransactionKind> for SuiTransactionKind {
                     commit_timestamp_ms: p.commit_timestamp_ms,
                 })
             }
-            TransactionKind::ProgrammableTransaction(p) => {
-                Self::ProgrammableTransaction(p.try_into()?)
-            }
+            TransactionKind::ProgrammableTransaction(p) => Self::ProgrammableTransaction(
+                SuiProgrammableTransaction::try_from(p, module_cache)?,
+            ),
         })
     }
 }
@@ -826,10 +829,11 @@ impl Display for SuiTransactionData {
     }
 }
 
-impl TryFrom<TransactionData> for SuiTransactionData {
-    type Error = anyhow::Error;
-
-    fn try_from(data: TransactionData) -> Result<Self, Self::Error> {
+impl SuiTransactionData {
+    pub fn try_from(
+        data: TransactionData,
+        module_cache: &impl GetModule,
+    ) -> Result<Self, anyhow::Error> {
         let message_version = data
             .message_version()
             .expect("TransactionData defines message_version()");
@@ -844,7 +848,7 @@ impl TryFrom<TransactionData> for SuiTransactionData {
             price: data.gas_price(),
             budget: data.gas_budget(),
         };
-        let transaction = data.into_kind().try_into()?;
+        let transaction = SuiTransactionKind::try_from(data.into_kind(), module_cache)?;
         match message_version {
             1 => Ok(SuiTransactionData::V1(SuiTransactionDataV1 {
                 transaction,
@@ -866,12 +870,13 @@ pub struct SuiTransaction {
     pub tx_signatures: Vec<GenericSignature>,
 }
 
-impl TryFrom<SenderSignedData> for SuiTransaction {
-    type Error = anyhow::Error;
-
-    fn try_from(data: SenderSignedData) -> Result<Self, Self::Error> {
+impl SuiTransaction {
+    pub fn try_from(
+        data: SenderSignedData,
+        module_cache: &impl GetModule,
+    ) -> Result<Self, anyhow::Error> {
         Ok(Self {
-            data: data.intent_message().value.clone().try_into()?,
+            data: SuiTransactionData::try_from(data.intent_message().value.clone(), module_cache)?,
             tx_signatures: data.tx_signatures().to_vec(),
         })
     }
@@ -933,7 +938,7 @@ pub enum SuiInputObjectKind {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct SuiProgrammableTransaction {
     /// Input objects or primitive values
-    pub inputs: Vec<SuiJsonValue>,
+    pub inputs: Vec<SuiJsonCallArg>,
     /// The commands to be executed sequentially. A failure in any command will
     /// result in the failure of the entire transaction.
     pub commands: Vec<SuiCommand>,
@@ -951,18 +956,78 @@ impl Display for SuiProgrammableTransaction {
     }
 }
 
-impl TryFrom<ProgrammableTransaction> for SuiProgrammableTransaction {
-    type Error = anyhow::Error;
-
-    fn try_from(value: ProgrammableTransaction) -> Result<Self, Self::Error> {
+impl SuiProgrammableTransaction {
+    fn try_from(
+        value: ProgrammableTransaction,
+        module_cache: &impl GetModule,
+    ) -> Result<Self, anyhow::Error> {
         let ProgrammableTransaction { inputs, commands } = value;
+        let input_types = Self::resolve_input_type(&inputs, &commands, module_cache);
         Ok(SuiProgrammableTransaction {
             inputs: inputs
                 .into_iter()
-                .map(|arg| arg.try_into())
+                .zip(input_types)
+                .map(|(arg, layout)| SuiJsonCallArg::try_from(arg, layout.as_ref()))
                 .collect::<Result<_, _>>()?,
             commands: commands.into_iter().map(SuiCommand::from).collect(),
         })
+    }
+
+    fn resolve_input_type(
+        inputs: &Vec<CallArg>,
+        commands: &[Command],
+        module_cache: &impl GetModule,
+    ) -> Vec<Option<MoveTypeLayout>> {
+        let mut result_types = vec![None; inputs.len()];
+        for command in commands.iter() {
+            match command {
+                Command::MoveCall(c) => {
+                    let id = ModuleId::new(c.package.into(), c.module.clone());
+                    let Some(types) = get_signature_types(id, c.function.as_ident_str(), module_cache) else {
+                        return result_types;
+                    };
+                    for (arg, type_) in c.arguments.iter().zip(types) {
+                        if let &Argument::Input(i) = arg {
+                            result_types[i as usize] = type_;
+                        }
+                    }
+                }
+                Command::SplitCoin(_, Argument::Input(i)) => {
+                    result_types[(*i) as usize] = Some(MoveTypeLayout::U64);
+                }
+                Command::TransferObjects(_, Argument::Input(i)) => {
+                    result_types[(*i) as usize] = Some(MoveTypeLayout::Address);
+                }
+                _ => {}
+            }
+        }
+        result_types
+    }
+}
+
+fn get_signature_types(
+    id: ModuleId,
+    function: &IdentStr,
+    module_cache: &impl GetModule,
+) -> Option<Vec<Option<MoveTypeLayout>>> {
+    use std::borrow::Borrow;
+    if let Ok(Some(module)) = module_cache.get_module_by_id(&id) {
+        let module: &CompiledModule = module.borrow();
+        let view = BinaryIndexedView::Module(module);
+        let func = module
+            .function_handles
+            .iter()
+            .find(|f| module.identifier_at(f.name) == function)?;
+        Some(
+            module
+                .signature_at(func.parameters)
+                .0
+                .iter()
+                .map(|s| primitive_type(&view, &[], s).1)
+                .collect(),
+        )
+    } else {
+        None
     }
 }
 

--- a/crates/sui-json-rpc/Cargo.toml
+++ b/crates/sui-json-rpc/Cargo.toml
@@ -18,6 +18,7 @@ tower-http = { version = "0.3.4", features = ["full"] }
 move-binary-format.workspace = true
 move-core-types.workspace = true
 move-package.workspace = true
+move-bytecode-utils.workspace = true
 prometheus = "0.13.3"
 anyhow = "1.0.64"
 tracing = "0.1.36"

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -26,8 +26,8 @@ use sui_json_rpc_types::{
     BalanceChange, Checkpoint, CheckpointId, CheckpointPage, DynamicFieldPage, MoveFunctionArgType,
     ObjectChange, ObjectValueKind, ObjectsPage, Page, SuiGetPastObjectRequest,
     SuiMoveNormalizedFunction, SuiMoveNormalizedModule, SuiMoveNormalizedStruct, SuiMoveStruct,
-    SuiMoveValue,SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery, SuiPastObjectResponse,
-    SuiTransaction, SuiTransactionEvents, SuiTransactionResponse,
+    SuiMoveValue, SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery,
+    SuiPastObjectResponse, SuiTransaction, SuiTransactionEvents, SuiTransactionResponse,
     SuiTransactionResponseOptions, SuiTransactionResponseQuery, TransactionsPage,
 };
 use sui_open_rpc::Module;

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -13,6 +13,7 @@ use jsonrpsee::core::RpcResult;
 use jsonrpsee::RpcModule;
 use linked_hash_map::LinkedHashMap;
 use move_binary_format::normalized::{Module as NormalizedModule, Type};
+use move_bytecode_utils::module_cache::GetModule;
 use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::StructTag;
 use move_core_types::value::{MoveStruct, MoveStructLayout, MoveValue};
@@ -437,8 +438,12 @@ impl ReadApiServer for ReadApi {
                 temp_response.object_changes = Some(object_changes);
             }
         }
-
-        Ok(convert_to_response(temp_response, &opts))
+        let epoch_store = self.state.load_epoch_store_one_call_per_task();
+        Ok(convert_to_response(
+            temp_response,
+            &opts,
+            epoch_store.module_cache(),
+        ))
     }
 
     async fn multi_get_transactions_with_options(
@@ -651,9 +656,10 @@ impl ReadApiServer for ReadApi {
             }
         }
 
+        let epoch_store = self.state.load_epoch_store_one_call_per_task();
         Ok(temp_response
             .into_iter()
-            .map(|c| convert_to_response(c.1, &opts))
+            .map(|c| convert_to_response(c.1, &opts, epoch_store.module_cache()))
             .collect::<Vec<_>>())
     }
 
@@ -1131,6 +1137,7 @@ fn get_value_from_move_struct(move_struct: &SuiMoveStruct, var_name: &str) -> Rp
 fn convert_to_response(
     cache: IntermediateTransactionResponse,
     opts: &SuiTransactionResponseOptions,
+    module_cache: &impl GetModule,
 ) -> SuiTransactionResponse {
     let mut response = SuiTransactionResponse::new(cache.digest);
     response.errors = cache.errors;
@@ -1144,7 +1151,7 @@ fn convert_to_response(
     }
 
     if opts.show_input && cache.transaction.is_some() {
-        match cache.transaction.unwrap().into_message().try_into() {
+        match SuiTransaction::try_from(cache.transaction.unwrap().into_message(), module_cache) {
             Ok(t) => {
                 response.transaction = Some(t);
             }

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -26,8 +26,8 @@ use sui_json_rpc_types::{
     BalanceChange, Checkpoint, CheckpointId, CheckpointPage, DynamicFieldPage, MoveFunctionArgType,
     ObjectChange, ObjectValueKind, ObjectsPage, Page, SuiGetPastObjectRequest,
     SuiMoveNormalizedFunction, SuiMoveNormalizedModule, SuiMoveNormalizedStruct, SuiMoveStruct,
-    SuiMoveValue, SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery,
-    SuiPastObjectResponse, SuiTransactionEvents, SuiTransactionResponse,
+    SuiMoveValue,SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery, SuiPastObjectResponse,
+    SuiTransaction, SuiTransactionEvents, SuiTransactionResponse,
     SuiTransactionResponseOptions, SuiTransactionResponseQuery, TransactionsPage,
 };
 use sui_open_rpc::Module;

--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -16,8 +16,8 @@ use sui_core::authority::AuthorityState;
 use sui_core::authority_client::NetworkAuthorityClient;
 use sui_core::transaction_orchestrator::TransactiondOrchestrator;
 use sui_json_rpc_types::{
-    DevInspectResults, DryRunTransactionResponse, SuiTransactionEvents, SuiTransactionResponse,
-    SuiTransactionResponseOptions,
+    DevInspectResults, DryRunTransactionResponse, SuiTransaction, SuiTransactionEvents,
+    SuiTransactionResponse, SuiTransactionResponseOptions,
 };
 use sui_open_rpc::Module;
 use sui_types::base_types::{EpochId, SuiAddress};
@@ -75,9 +75,9 @@ impl TransactionExecutionApi {
         for sig in signatures {
             sigs.push(GenericSignature::from_bytes(&sig.to_vec()?)?);
         }
-
+        let epoch_store = self.state.load_epoch_store_one_call_per_task();
         let txn = Transaction::from_generic_sig_data(tx_data, Intent::default(), sigs);
-        let tx = txn.data().clone().try_into()?;
+        let tx = SuiTransaction::try_from(txn.data().clone(), epoch_store.module_cache())?;
         let raw_transaction = if opts.show_raw_input {
             bcs::to_bytes(txn.data())?
         } else {

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -5,9 +5,13 @@ use std::path::Path;
 #[cfg(not(msim))]
 use std::str::FromStr;
 
+use crate::api::{
+    CoinReadApiClient, GovernanceReadApiClient, ReadApiClient, TransactionBuilderClient,
+    WriteApiClient,
+};
 use sui_config::SUI_KEYSTORE_FILENAME;
 use sui_framework_build::compiled_package::BuildConfig;
-use sui_json::SuiJsonValue;
+use sui_json::{call_args, type_args};
 use sui_json_rpc_types::ObjectChange;
 use sui_json_rpc_types::ObjectsPage;
 use sui_json_rpc_types::{
@@ -23,13 +27,8 @@ use sui_types::coin::{TreasuryCap, COIN_MODULE_NAME, LOCKED_COIN_MODULE_NAME};
 use sui_types::gas_coin::GAS;
 use sui_types::messages::ExecuteTransactionRequestType;
 use sui_types::utils::to_sender_signed_transaction;
-use sui_types::{parse_sui_struct_tag, parse_sui_type_tag, SUI_FRAMEWORK_ADDRESS};
+use sui_types::{parse_sui_struct_tag, SUI_FRAMEWORK_ADDRESS};
 use test_utils::network::TestClusterBuilder;
-
-use crate::api::{
-    CoinReadApiClient, GovernanceReadApiClient, ReadApiClient, TransactionBuilderClient,
-    WriteApiClient,
-};
 
 #[sim_test]
 async fn test_get_objects() -> Result<(), anyhow::Error> {
@@ -203,19 +202,14 @@ async fn test_move_call() -> Result<(), anyhow::Error> {
     let module = "pay".to_string();
     let function = "split".to_string();
 
-    let json_args = vec![
-        SuiJsonValue::from_object_id(coin.object_id),
-        SuiJsonValue::from_str("\"10\"")?,
-    ];
-
     let transaction_bytes: TransactionBytes = http_client
         .move_call(
             *address,
             package_id,
             module,
             function,
-            vec![GAS::type_tag().into()],
-            json_args,
+            type_args![GAS::type_tag()]?,
+            call_args!(coin.object_id, 10)?,
             Some(gas.object_id),
             10_000,
             None,
@@ -488,7 +482,6 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
         .unwrap();
 
     let coin_name = format!("{package_id}::trusted_coin::TRUSTED_COIN");
-    let coin_type = parse_sui_type_tag(&coin_name).unwrap();
     let result: Supply = http_client.get_total_supply(coin_name.clone()).await?;
 
     assert_eq!(0, result.value);
@@ -522,12 +515,8 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
             SUI_FRAMEWORK_ADDRESS.into(),
             COIN_MODULE_NAME.to_string(),
             "mint_and_transfer".into(),
-            vec![coin_type.into()],
-            vec![
-                SuiJsonValue::from_str(&treasury_cap.to_string()).unwrap(),
-                SuiJsonValue::from_str("\"100000\"").unwrap(),
-                SuiJsonValue::from_str(&address.to_string()).unwrap(),
-            ],
+            type_args![coin_name]?,
+            call_args![treasury_cap, 100000, address]?,
             Some(gas.object_id),
             10_000,
             None,
@@ -600,12 +589,8 @@ async fn test_locked_sui() -> Result<(), anyhow::Error> {
             SUI_FRAMEWORK_ADDRESS.into(),
             LOCKED_COIN_MODULE_NAME.to_string(),
             "lock_coin".to_string(),
-            vec![parse_sui_type_tag("0x2::sui::SUI")?.into()],
-            vec![
-                SuiJsonValue::from_str(&coins.data[0].coin_object_id.to_string())?,
-                SuiJsonValue::from_str(&format!("{address}"))?,
-                SuiJsonValue::from_bcs_bytes(&bcs::to_bytes(&"20")?)?,
-            ],
+            type_args!("0x2::sui::SUI")?,
+            call_args![coins.data[0].coin_object_id, address, 20]?,
             None,
             2000,
             None,

--- a/crates/sui-json/src/lib.rs
+++ b/crates/sui-json/src/lib.rs
@@ -22,7 +22,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Number, Value as JsonValue, Value};
 
 use sui_types::base_types::{ObjectID, SuiAddress};
-use sui_types::messages::{CallArg, ObjectArg};
 use sui_types::move_package::MovePackage;
 use sui_verifier::entry_points_verifier::{
     is_tx_context, TxContextKind, RESOLVED_ASCII_STR, RESOLVED_STD_OPTION, RESOLVED_SUI_ID,
@@ -75,49 +74,12 @@ impl fmt::Display for SuiJsonValueError {
     }
 }
 
-#[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize, JsonSchema)]
-pub enum SuiJsonCallArg {
-    // Needs to become an Object Ref or Object ID, depending on object type
-    Object(ObjectID),
-    // pure value, bcs encoded
-    Pure(SuiJsonValue),
-    // a vector of objects
-    ObjVec(Vec<ObjectID>),
-}
-
 // Intermediate type to hold resolved args
 #[derive(Eq, PartialEq, Debug)]
 pub enum ResolvedCallArg {
     Object(ObjectID),
     Pure(Vec<u8>),
     ObjVec(Vec<ObjectID>),
-}
-
-impl SuiJsonCallArg {
-    pub fn try_from(
-        value: CallArg,
-        layout: Option<&MoveTypeLayout>,
-    ) -> Result<Self, anyhow::Error> {
-        Ok(match value {
-            CallArg::Pure(p) => SuiJsonCallArg::Pure(SuiJsonValue::from_bcs_bytes(layout, &p)?),
-            CallArg::Object(ObjectArg::ImmOrOwnedObject((id, _, _)))
-            | CallArg::Object(ObjectArg::SharedObject { id, .. }) => SuiJsonCallArg::Object(id),
-        })
-    }
-
-    pub fn pure(&self) -> Option<&SuiJsonValue> {
-        match self {
-            SuiJsonCallArg::Pure(v) => Some(v),
-            _ => None,
-        }
-    }
-
-    pub fn object(&self) -> Option<&ObjectID> {
-        match self {
-            SuiJsonCallArg::Object(o) => Some(o),
-            _ => None,
-        }
-    }
 }
 
 #[derive(Eq, PartialEq, Clone, Deserialize, Serialize, JsonSchema)]

--- a/crates/sui-json/src/tests.rs
+++ b/crates/sui-json/src/tests.rs
@@ -14,11 +14,12 @@ use sui_framework::make_system_packages;
 use sui_framework_build::compiled_package::BuildConfig;
 use test_fuzz::runtime::num_traits::ToPrimitive;
 
+use crate::ResolvedCallArg;
 use sui_types::base_types::{ObjectID, SuiAddress, TransactionDigest};
 use sui_types::object::Object;
 
 use super::{check_valid_homogeneous, HEX_PREFIX};
-use super::{resolve_move_function_args, SuiJsonCallArg, SuiJsonValue};
+use super::{resolve_move_function_args, SuiJsonValue};
 
 // Negative test cases
 #[test]
@@ -482,23 +483,25 @@ fn test_basic_args_linter_top_level() {
 
     assert_eq!(
         json_args[1].0,
-        SuiJsonCallArg::Pure(bcs::to_bytes(&monster_name_raw.as_bytes().to_vec()).unwrap())
+        ResolvedCallArg::Pure(bcs::to_bytes(&monster_name_raw.as_bytes().to_vec()).unwrap())
     );
     assert_eq!(
         json_args[2].0,
-        SuiJsonCallArg::Pure(bcs::to_bytes(&(monster_img_id_raw.parse::<u64>().unwrap())).unwrap()),
+        ResolvedCallArg::Pure(
+            bcs::to_bytes(&(monster_img_id_raw.parse::<u64>().unwrap())).unwrap()
+        ),
     );
     assert_eq!(
         json_args[3].0,
-        SuiJsonCallArg::Pure(bcs::to_bytes(&(breed_raw as u8)).unwrap())
+        ResolvedCallArg::Pure(bcs::to_bytes(&(breed_raw as u8)).unwrap())
     );
     assert_eq!(
         json_args[4].0,
-        SuiJsonCallArg::Pure(bcs::to_bytes(&(monster_affinity_raw as u8)).unwrap()),
+        ResolvedCallArg::Pure(bcs::to_bytes(&(monster_affinity_raw as u8)).unwrap()),
     );
     assert_eq!(
         json_args[5].0,
-        SuiJsonCallArg::Pure(bcs::to_bytes(&monster_description_raw.as_bytes().to_vec()).unwrap()),
+        ResolvedCallArg::Pure(bcs::to_bytes(&monster_description_raw.as_bytes().to_vec()).unwrap()),
     );
 
     // Breed is u8 so too large
@@ -570,14 +573,14 @@ fn test_basic_args_linter_top_level() {
 
     assert_eq!(
         args[0].0,
-        SuiJsonCallArg::Pure(bcs::to_bytes(&(value_raw.parse::<u64>().unwrap())).unwrap())
+        ResolvedCallArg::Pure(bcs::to_bytes(&(value_raw.parse::<u64>().unwrap())).unwrap())
     );
 
     // Need to verify this specially
     // BCS serialzes addresses like vectors so there's a length prefix, which makes the vec longer by 1
     assert_eq!(
         args[1].0,
-        SuiJsonCallArg::Pure(bcs::to_bytes(&AccountAddress::from(address)).unwrap()),
+        ResolvedCallArg::Pure(bcs::to_bytes(&AccountAddress::from(address)).unwrap()),
     );
 
     // Test with object args
@@ -614,7 +617,7 @@ fn test_basic_args_linter_top_level() {
 
     assert_eq!(
         args[0].0,
-        SuiJsonCallArg::Object(
+        ResolvedCallArg::Object(
             ObjectID::from_hex_literal(&format!("0x{:02x}", object_id_raw)).unwrap()
         )
     );
@@ -623,7 +626,7 @@ fn test_basic_args_linter_top_level() {
     // BCS serialzes addresses like vectors so there's a length prefix, which makes the vec longer by 1
     assert_eq!(
         args[1].0,
-        SuiJsonCallArg::Pure(bcs::to_bytes(&AccountAddress::from(address)).unwrap())
+        ResolvedCallArg::Pure(bcs::to_bytes(&AccountAddress::from(address)).unwrap())
     );
 
     // Test with object vector  args
@@ -665,9 +668,9 @@ fn test_basic_args_linter_top_level() {
     )
     .unwrap();
 
-    assert!(matches!(args[0].0, SuiJsonCallArg::ObjVec { .. }));
+    assert!(matches!(args[0].0, ResolvedCallArg::ObjVec { .. }));
 
-    if let SuiJsonCallArg::ObjVec(vec) = &args[0].0 {
+    if let ResolvedCallArg::ObjVec(vec) = &args[0].0 {
         assert_eq!(vec.len(), 2);
         assert_eq!(
             vec[0],
@@ -687,7 +690,7 @@ fn test_convert_address_from_bcs() {
         245, 70, 122, 191, 100, 24, 123, 62, 239, 165, 85,
     ];
 
-    let value = SuiJsonValue::from_bcs_bytes(&bcs_bytes).unwrap();
+    let value = SuiJsonValue::from_bcs_bytes(Some(&MoveTypeLayout::Signer), &bcs_bytes).unwrap();
 
     assert_eq!(
         "0x32866f0109fa1ba911392dcd2d4260f1d824313316f5467abf64187b3eefa555",
@@ -698,7 +701,7 @@ fn test_convert_address_from_bcs() {
 #[test]
 fn test_convert_number_from_bcs() {
     let bcs_bytes = [160u8, 134, 1, 0];
-    let value = SuiJsonValue::from_bcs_bytes(&bcs_bytes).unwrap();
+    let value = SuiJsonValue::from_bcs_bytes(Some(&MoveTypeLayout::U32), &bcs_bytes).unwrap();
     assert_eq!(100000, value.0.as_u64().unwrap());
 }
 
@@ -711,7 +714,7 @@ fn test_no_address_zero_trimming() {
         .unwrap(),
     )
     .unwrap();
-    let value = SuiJsonValue::from_bcs_bytes(&bcs_bytes).unwrap();
+    let value = SuiJsonValue::from_bcs_bytes(Some(&MoveTypeLayout::Address), &bcs_bytes).unwrap();
     assert_eq!(
         "0x0000000000000000000000000000011111111111111111111111111111111111",
         value.0.as_str().unwrap()
@@ -724,7 +727,11 @@ fn test_convert_number_array_from_bcs() {
         5, 80, 195, 0, 0, 80, 195, 0, 0, 80, 195, 0, 0, 80, 195, 0, 0, 80, 195, 0, 0,
     ];
 
-    let value = SuiJsonValue::from_bcs_bytes(&bcs_bytes).unwrap();
+    let value = SuiJsonValue::from_bcs_bytes(
+        Some(&MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U32))),
+        &bcs_bytes,
+    )
+    .unwrap();
 
     for value in value.0.as_array().unwrap() {
         assert_eq!(50000, value.as_u64().unwrap())

--- a/crates/sui-json/src/tests.rs
+++ b/crates/sui-json/src/tests.rs
@@ -848,7 +848,7 @@ fn test_sui_call_arg_option_type() {
         }],
     });
 
-    let v = SuiJsonValue::from_bcs_bytes(Some(option_layout.clone()).as_ref(), &arg1).unwrap();
+    let v = SuiJsonValue::from_bcs_bytes(Some(option_layout).as_ref(), &arg1).unwrap();
 
     let bytes = v
         .to_bcs_bytes(&MoveTypeLayout::Vector(Box::new(string_layout)))

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -181,8 +181,12 @@
                   "transaction": {
                     "kind": "ProgrammableTransaction",
                     "inputs": [
-                      "0x7ba91ddc7e717cf708c937060f04048736ec33fb1746d999a5e58cd5c677ed80",
-                      "4f82f1c8587b98d64c00bfb46c3843bd8bf6ccfa7c65a86138698cd1fdcac3dc"
+                      {
+                        "Pure": "0x7ba91ddc7e717cf708c937060f04048736ec33fb1746d999a5e58cd5c677ed80"
+                      },
+                      {
+                        "Object": "0x4f82f1c8587b98d64c00bfb46c3843bd8bf6ccfa7c65a86138698cd1fdcac3dc"
+                      }
                     ],
                     "commands": [
                       {
@@ -1368,8 +1372,12 @@
                   "transaction": {
                     "kind": "ProgrammableTransaction",
                     "inputs": [
-                      "0x8196d048b7a6d04c8edc89579d86fd3fc90c52f9a14c6b812b94fe613c5bcebb",
-                      "5eeb1d449e2516166d57d71fdeb154d0dc9ecdb7b30057d0a932684cac352cdc"
+                      {
+                        "Pure": "0x8196d048b7a6d04c8edc89579d86fd3fc90c52f9a14c6b812b94fe613c5bcebb"
+                      },
+                      {
+                        "Object": "0x5eeb1d449e2516166d57d71fdeb154d0dc9ecdb7b30057d0a932684cac352cdc"
+                      }
                     ],
                     "commands": [
                       {
@@ -5434,6 +5442,49 @@
           }
         }
       },
+      "SuiJsonCallArg": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "Object"
+            ],
+            "properties": {
+              "Object": {
+                "$ref": "#/components/schemas/ObjectID"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "Pure"
+            ],
+            "properties": {
+              "Pure": {
+                "$ref": "#/components/schemas/SuiJsonValue"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "ObjVec"
+            ],
+            "properties": {
+              "ObjVec": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ObjectID"
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
       "SuiJsonValue": {},
       "SuiMoveAbility": {
         "type": "string",
@@ -6749,7 +6800,7 @@
                 "description": "Input objects or primitive values",
                 "type": "array",
                 "items": {
-                  "$ref": "#/components/schemas/SuiJsonValue"
+                  "$ref": "#/components/schemas/SuiJsonCallArg"
                 }
               },
               "kind": {

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -182,10 +182,16 @@
                     "kind": "ProgrammableTransaction",
                     "inputs": [
                       {
-                        "Pure": "0x7ba91ddc7e717cf708c937060f04048736ec33fb1746d999a5e58cd5c677ed80"
+                        "type": "pure",
+                        "valueType": "address",
+                        "value": "0x7ba91ddc7e717cf708c937060f04048736ec33fb1746d999a5e58cd5c677ed80"
                       },
                       {
-                        "Object": "0x4f82f1c8587b98d64c00bfb46c3843bd8bf6ccfa7c65a86138698cd1fdcac3dc"
+                        "type": "object",
+                        "objectType": "immOrOwnedObject",
+                        "objectId": "0x4f82f1c8587b98d64c00bfb46c3843bd8bf6ccfa7c65a86138698cd1fdcac3dc",
+                        "version": 2,
+                        "digest": "Cv7n2YaM7Am1ssZGu4khsFkcKHnpgVhwFCSs4kLjrtLW"
                       }
                     ],
                     "commands": [
@@ -1373,10 +1379,16 @@
                     "kind": "ProgrammableTransaction",
                     "inputs": [
                       {
-                        "Pure": "0x8196d048b7a6d04c8edc89579d86fd3fc90c52f9a14c6b812b94fe613c5bcebb"
+                        "type": "pure",
+                        "valueType": "address",
+                        "value": "0x8196d048b7a6d04c8edc89579d86fd3fc90c52f9a14c6b812b94fe613c5bcebb"
                       },
                       {
-                        "Object": "0x5eeb1d449e2516166d57d71fdeb154d0dc9ecdb7b30057d0a932684cac352cdc"
+                        "type": "object",
+                        "objectType": "immOrOwnedObject",
+                        "objectId": "0x5eeb1d449e2516166d57d71fdeb154d0dc9ecdb7b30057d0a932684cac352cdc",
+                        "version": 2,
+                        "digest": "GK4NxEKSrK88XkPNeuBqtJYPmU9yMTWMD7K9TdU4ybKN"
                       }
                     ],
                     "commands": [
@@ -5163,6 +5175,103 @@
           }
         ]
       },
+      "SuiCallArg": {
+        "oneOf": [
+          {
+            "type": "object",
+            "oneOf": [
+              {
+                "type": "object",
+                "required": [
+                  "digest",
+                  "objectId",
+                  "objectType",
+                  "version"
+                ],
+                "properties": {
+                  "digest": {
+                    "$ref": "#/components/schemas/ObjectDigest"
+                  },
+                  "objectId": {
+                    "$ref": "#/components/schemas/ObjectID"
+                  },
+                  "objectType": {
+                    "type": "string",
+                    "enum": [
+                      "immOrOwnedObject"
+                    ]
+                  },
+                  "version": {
+                    "$ref": "#/components/schemas/SequenceNumber"
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "required": [
+                  "initialSharedVersion",
+                  "mutable",
+                  "objectId",
+                  "objectType"
+                ],
+                "properties": {
+                  "initialSharedVersion": {
+                    "$ref": "#/components/schemas/SequenceNumber"
+                  },
+                  "mutable": {
+                    "type": "boolean"
+                  },
+                  "objectId": {
+                    "$ref": "#/components/schemas/ObjectID"
+                  },
+                  "objectType": {
+                    "type": "string",
+                    "enum": [
+                      "sharedObject"
+                    ]
+                  }
+                }
+              }
+            ],
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "object"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "pure"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/SuiJsonValue"
+              },
+              "valueType": {
+                "default": null,
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        ]
+      },
       "SuiCoinMetadata": {
         "type": "object",
         "required": [
@@ -5441,49 +5550,6 @@
             }
           }
         }
-      },
-      "SuiJsonCallArg": {
-        "oneOf": [
-          {
-            "type": "object",
-            "required": [
-              "Object"
-            ],
-            "properties": {
-              "Object": {
-                "$ref": "#/components/schemas/ObjectID"
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Pure"
-            ],
-            "properties": {
-              "Pure": {
-                "$ref": "#/components/schemas/SuiJsonValue"
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "ObjVec"
-            ],
-            "properties": {
-              "ObjVec": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/ObjectID"
-                }
-              }
-            },
-            "additionalProperties": false
-          }
-        ]
       },
       "SuiJsonValue": {},
       "SuiMoveAbility": {
@@ -6800,7 +6866,7 @@
                 "description": "Input objects or primitive values",
                 "type": "array",
                 "items": {
-                  "$ref": "#/components/schemas/SuiJsonCallArg"
+                  "$ref": "#/components/schemas/SuiCallArg"
                 }
               },
               "kind": {

--- a/crates/sui-rosetta/Cargo.toml
+++ b/crates/sui-rosetta/Cargo.toml
@@ -41,6 +41,7 @@ chrono = "0.4.23"
 shared-crypto = { path = "../shared-crypto" }
 
 move-core-types.workspace = true
+move-bytecode-utils.workspace = true
 
 telemetry-subscribers.workspace = true
 workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/crates/sui-rosetta/src/operations.rs
+++ b/crates/sui-rosetta/src/operations.rs
@@ -8,8 +8,8 @@ use std::vec;
 
 use anyhow::anyhow;
 use move_core_types::ident_str;
-use move_core_types::language_storage::StructTag;
-use move_core_types::value::MoveTypeLayout;
+use move_core_types::language_storage::{ModuleId, StructTag};
+use move_core_types::resolver::ModuleResolver;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -17,7 +17,7 @@ use sui_json_rpc_types::SuiCommand;
 use sui_json_rpc_types::SuiProgrammableMoveCall;
 use sui_json_rpc_types::SuiProgrammableTransaction;
 use sui_json_rpc_types::{BalanceChange, SuiArgument};
-use sui_sdk::json::SuiJsonValue;
+use sui_sdk::json::SuiJsonCallArg;
 use sui_sdk::rpc_types::{
     SuiTransactionData, SuiTransactionDataAPI, SuiTransactionEffectsAPI, SuiTransactionKind,
     SuiTransactionResponse,
@@ -241,19 +241,10 @@ impl Operations {
                 .get(i as usize)
                 .and_then(|inner| inner.get(j as usize))
         }
-        fn split_coin(inputs: &[SuiJsonValue], amount: SuiArgument) -> Option<Vec<KnownValue>> {
+        fn split_coin(inputs: &[SuiJsonCallArg], amount: SuiArgument) -> Option<Vec<KnownValue>> {
             let amount: u64 = match amount {
                 SuiArgument::Input(i) => {
-                    let input = inputs[i as usize]
-                        .to_bcs_bytes(&MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U8)))
-                        .ok()?;
-                    let input = if input.len() == 8 {
-                        input
-                    } else {
-                        bcs::from_bytes::<Vec<u8>>(&input).ok()?
-                    };
-                    // convert to u64
-                    bcs::from_bytes(&input).ok()?
+                    u64::from_str(inputs[i as usize].pure()?.to_json_value().as_str()?).ok()?
                 }
                 SuiArgument::GasCoin | SuiArgument::Result(_) | SuiArgument::NestedResult(_, _) => {
                     return None
@@ -263,13 +254,13 @@ impl Operations {
         }
         fn transfer_object(
             aggregated_recipients: &mut HashMap<SuiAddress, u64>,
-            inputs: &[SuiJsonValue],
+            inputs: &[SuiJsonCallArg],
             known_results: &[Vec<KnownValue>],
             objs: &[SuiArgument],
             recipient: SuiArgument,
         ) -> Option<Vec<KnownValue>> {
             let addr = match recipient {
-                SuiArgument::Input(i) => inputs[i as usize].to_sui_address().ok()?,
+                SuiArgument::Input(i) => inputs[i as usize].pure()?.to_sui_address().ok()?,
                 SuiArgument::GasCoin | SuiArgument::Result(_) | SuiArgument::NestedResult(_, _) => {
                     return None
                 }
@@ -292,7 +283,7 @@ impl Operations {
             Some(vec![])
         }
         fn stake_call(
-            inputs: &[SuiJsonValue],
+            inputs: &[SuiJsonCallArg],
             known_results: &[Vec<KnownValue>],
             call: &SuiProgrammableMoveCall,
         ) -> Result<Option<(Option<u64>, SuiAddress)>, Error> {
@@ -311,20 +302,18 @@ impl Operations {
                         // We use the position of the validator arg as a indicator of if the rosetta stake
                         // transaction is staking the whole wallet or not, if staking whole wallet, 
                         // we have to omit the amount value in the final operation output.
-                        SuiArgument::Input(i) => (*i==1, inputs[*i as usize].to_sui_address()),
+                        SuiArgument::Input(i) => (*i==1, inputs[*i as usize].pure().map(|v|v.to_sui_address()).transpose()),
                         _=> return Ok(None),
                     };
                     (some_amount.then_some(*amount), validator)
                 },
                 _ => Err(anyhow!("Error encountered when extracting arguments from move call, expecting 3 elements, got {}", arguments.len()))?,
             };
-            let validator =
-                validator.map_err(|_| anyhow!("Error parsing Validator address from call arg."))?;
-            Ok(Some((amount, validator)))
+            Ok(validator.map(|v| v.map(|v| (amount, v)))?)
         }
 
         fn unstake_call(
-            inputs: &[SuiJsonValue],
+            inputs: &[SuiJsonCallArg],
             call: &SuiProgrammableMoveCall,
         ) -> Result<Option<ObjectID>, Error> {
             let SuiProgrammableMoveCall { arguments, .. } = call;
@@ -332,8 +321,7 @@ impl Operations {
                 [_, stake_id] => {
                     match stake_id {
                         SuiArgument::Input(i) => {
-                            let id = inputs[*i as usize].to_json_value().as_str().ok_or_else(|| anyhow!("Cannot fin stake id from input args."))?.to_string();
-                            let id = ObjectID::from_str(&id).map_err(|e| anyhow!("Error parsing stake object id from call arg: {e}"))?;
+                            let id = inputs[*i as usize].object().ok_or_else(|| anyhow!("Cannot find stake id from input args."))?;
                             // [WORKAROUND] - this is a hack to work out if the withdraw stake ops is for a selected stake or None (all stakes).
                             // this hack is similar to the one in stake_call.
                             let some_id = i % 2 == 1;
@@ -344,7 +332,7 @@ impl Operations {
                 },
                 _ => Err(anyhow!("Error encountered when extracting arguments from move call, expecting 3 elements, got {}", arguments.len()))?,
             };
-            Ok(id)
+            Ok(id.cloned())
         }
         let SuiProgrammableTransaction { inputs, commands } = &pt;
         let mut known_results: Vec<Vec<KnownValue>> = vec![];
@@ -586,7 +574,15 @@ fn is_unstake_event(tag: &StructTag) -> bool {
 impl TryFrom<TransactionData> for Operations {
     type Error = Error;
     fn try_from(data: TransactionData) -> Result<Self, Self::Error> {
-        SuiTransactionData::try_from(data)?.try_into()
+        struct NoOpsModuleResolver;
+        impl ModuleResolver for NoOpsModuleResolver {
+            type Error = Error;
+            fn get_module(&self, _id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
+                Ok(None)
+            }
+        }
+        // Rosetta don't need the call args to be parsed into readable format
+        SuiTransactionData::try_from(data, &&mut NoOpsModuleResolver)?.try_into()
     }
 }
 

--- a/crates/sui-rosetta/src/operations.rs
+++ b/crates/sui-rosetta/src/operations.rs
@@ -13,11 +13,10 @@ use move_core_types::resolver::ModuleResolver;
 use serde::Deserialize;
 use serde::Serialize;
 
-use sui_json_rpc_types::SuiCommand;
 use sui_json_rpc_types::SuiProgrammableMoveCall;
 use sui_json_rpc_types::SuiProgrammableTransaction;
 use sui_json_rpc_types::{BalanceChange, SuiArgument};
-use sui_sdk::json::SuiJsonCallArg;
+use sui_json_rpc_types::{SuiCallArg, SuiCommand};
 use sui_sdk::rpc_types::{
     SuiTransactionData, SuiTransactionDataAPI, SuiTransactionEffectsAPI, SuiTransactionKind,
     SuiTransactionResponse,
@@ -241,7 +240,7 @@ impl Operations {
                 .get(i as usize)
                 .and_then(|inner| inner.get(j as usize))
         }
-        fn split_coin(inputs: &[SuiJsonCallArg], amount: SuiArgument) -> Option<Vec<KnownValue>> {
+        fn split_coin(inputs: &[SuiCallArg], amount: SuiArgument) -> Option<Vec<KnownValue>> {
             let amount: u64 = match amount {
                 SuiArgument::Input(i) => {
                     u64::from_str(inputs[i as usize].pure()?.to_json_value().as_str()?).ok()?
@@ -254,7 +253,7 @@ impl Operations {
         }
         fn transfer_object(
             aggregated_recipients: &mut HashMap<SuiAddress, u64>,
-            inputs: &[SuiJsonCallArg],
+            inputs: &[SuiCallArg],
             known_results: &[Vec<KnownValue>],
             objs: &[SuiArgument],
             recipient: SuiArgument,
@@ -283,7 +282,7 @@ impl Operations {
             Some(vec![])
         }
         fn stake_call(
-            inputs: &[SuiJsonCallArg],
+            inputs: &[SuiCallArg],
             known_results: &[Vec<KnownValue>],
             call: &SuiProgrammableMoveCall,
         ) -> Result<Option<(Option<u64>, SuiAddress)>, Error> {
@@ -313,7 +312,7 @@ impl Operations {
         }
 
         fn unstake_call(
-            inputs: &[SuiJsonCallArg],
+            inputs: &[SuiCallArg],
             call: &SuiProgrammableMoveCall,
         ) -> Result<Option<ObjectID>, Error> {
             let SuiProgrammableMoveCall { arguments, .. } = call;

--- a/crates/sui-rosetta/src/unit_tests/operations_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/operations_tests.rs
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use fastcrypto::encoding::{Encoding, Hex};
+use move_core_types::value::MoveTypeLayout;
 
 use shared_crypto::intent::IntentMessage;
+use sui_sdk::json::SuiJsonCallArg;
 use sui_types::base_types::{ObjectDigest, ObjectID, SequenceNumber, SuiAddress};
-use sui_types::messages::TransactionData;
+use sui_types::messages::{CallArg, TransactionData};
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 
 use crate::operations::Operations;
@@ -53,4 +55,13 @@ async fn test_shorter_bytearray_bug() {
 
     let op = Operations::try_from(data.value).unwrap();
     assert_eq!(OperationType::PaySui, op.type_().unwrap());
+}
+
+#[tokio::test]
+async fn test_sui_json() {
+    let arg1 = CallArg::Pure(bcs::to_bytes(&1000000u64).unwrap());
+    let arg2 = CallArg::Pure(bcs::to_bytes(&30215u64).unwrap());
+    let json1 = SuiJsonCallArg::try_from(arg1, Some(&MoveTypeLayout::U64)).unwrap();
+    let json2 = SuiJsonCallArg::try_from(arg2, Some(&MoveTypeLayout::U64)).unwrap();
+    println!("{:?}, {:?}", json1, json2);
 }

--- a/crates/sui-rosetta/src/unit_tests/operations_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/operations_tests.rs
@@ -5,7 +5,7 @@ use fastcrypto::encoding::{Encoding, Hex};
 use move_core_types::value::MoveTypeLayout;
 
 use shared_crypto::intent::IntentMessage;
-use sui_sdk::json::SuiJsonCallArg;
+use sui_json_rpc_types::SuiCallArg;
 use sui_types::base_types::{ObjectDigest, ObjectID, SequenceNumber, SuiAddress};
 use sui_types::messages::{CallArg, TransactionData};
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
@@ -61,7 +61,7 @@ async fn test_shorter_bytearray_bug() {
 async fn test_sui_json() {
     let arg1 = CallArg::Pure(bcs::to_bytes(&1000000u64).unwrap());
     let arg2 = CallArg::Pure(bcs::to_bytes(&30215u64).unwrap());
-    let json1 = SuiJsonCallArg::try_from(arg1, Some(&MoveTypeLayout::U64)).unwrap();
-    let json2 = SuiJsonCallArg::try_from(arg2, Some(&MoveTypeLayout::U64)).unwrap();
+    let json1 = SuiCallArg::try_from(arg1, Some(&MoveTypeLayout::U64)).unwrap();
+    let json2 = SuiCallArg::try_from(arg2, Some(&MoveTypeLayout::U64)).unwrap();
     println!("{:?}, {:?}", json1, json2);
 }

--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -16,7 +16,7 @@ use move_core_types::language_storage::TypeTag;
 use std::result::Result;
 use sui_adapter::adapter::{resolve_and_type_check, CheckCallArg};
 use sui_adapter::execution_mode::ExecutionMode;
-use sui_json::{resolve_move_function_args, SuiJsonCallArg, SuiJsonValue};
+use sui_json::{resolve_move_function_args, ResolvedCallArg, SuiJsonValue};
 use sui_json_rpc_types::{
     CheckpointId, ObjectsPage, RPCTransactionRequestParams, SuiData, SuiObjectDataOptions,
     SuiObjectResponse, SuiObjectResponseQuery, SuiRawData, SuiTypeTag,
@@ -420,11 +420,11 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
         let mut objects = BTreeMap::new();
         for (arg, expected_type) in json_args_and_tokens {
             check_args.push(match arg {
-                SuiJsonCallArg::Object(id) => CheckCallArg::Object(
+                ResolvedCallArg::Object(id) => CheckCallArg::Object(
                     self.get_object_arg(id, &mut objects, expected_type).await?,
                 ),
-                SuiJsonCallArg::Pure(p) => CheckCallArg::Pure(p),
-                SuiJsonCallArg::ObjVec(v) => {
+                ResolvedCallArg::Pure(p) => CheckCallArg::Pure(p),
+                ResolvedCallArg::ObjVec(v) => {
                     let mut object_ids = vec![];
                     for id in v {
                         object_ids.push(

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -9,10 +9,8 @@
 
 use base_types::SequenceNumber;
 use messages::{CallArg, ObjectArg};
-use move_core_types::{
-    account_address::AccountAddress,
-    language_storage::{StructTag, TypeTag},
-};
+pub use move_core_types::language_storage::TypeTag;
+use move_core_types::{account_address::AccountAddress, language_storage::StructTag};
 use object::OBJECT_START_VERSION;
 
 use base_types::ObjectID;

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -92,15 +92,15 @@ export const SuiCallArg = union([
   object({
     type: literal('object'),
     objectType: literal('immOrOwnedObject'),
-    object_id: ObjectId,
+    objectId: ObjectId,
     version: SequenceNumber,
     digest: ObjectDigest,
   }),
   object({
     type: literal('object'),
     objectType: literal('sharedObject'),
-    object_id: ObjectId,
-    initial_shared_version: SequenceNumber,
+    objectId: ObjectId,
+    initialSharedVersion: SequenceNumber,
     mutable: boolean(),
   }),
 ]);

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -83,9 +83,32 @@ export const SuiCommand = union([
   object({ MakeMoveVec: tuple([nullable(string()), array(SuiArgument)]) }),
 ]);
 
+export const SuiCallArg = union([
+  object({
+    type: literal('pure'),
+    valueType: optional(string()),
+    value: SuiJsonValue,
+  }),
+  object({
+    type: literal('object'),
+    objectType: literal('immOrOwnedObject'),
+    object_id: ObjectId,
+    version: SequenceNumber,
+    digest: ObjectDigest,
+  }),
+  object({
+    type: literal('object'),
+    objectType: literal('sharedObject'),
+    object_id: ObjectId,
+    initial_shared_version: SequenceNumber,
+    mutable: boolean(),
+  }),
+]);
+export type SuiCallArg = Infer<typeof SuiCallArg>;
+
 export const ProgrammableTransaction = object({
   commands: array(),
-  inputs: array(SuiJsonValue),
+  inputs: array(SuiCallArg),
 });
 export type ProgrammableTransaction = Infer<typeof ProgrammableTransaction>;
 


### PR DESCRIPTION
## Description 

This PR fixes a move value to SuiJson bug, SuiJson was mainly used for displaying human readable json back in the day, the move object to json conversion was "best effort" and occasionally converting number into ascii strings. This PR changes the conversion and now uses the function signature to determine the correct type before doing the conversion.

This RP also changes the input parameter of SuiProgrammableTransaction to SuiCallArg instead of using SuiJsonValue directly.

## Test Plan 

SuiJson conversion logic are covered by unit tests 
Also did some manual test locally.

Example PT response:
```
{
    "jsonrpc": "2.0",
    "result": {
        "digest": "3FuXQ4UHg7jUCWGrTvmagDYmq2wXggRU5S8Gx7YKQSkz",
        "transaction": {
            "data": {
                "messageVersion": "v1",
                "transaction": {
                    "kind": "ProgrammableTransaction",
                    "inputs": [
                        {
                            "type": "object",
                            "objectType": "sharedObject",
                            "object_id": "0x0000000000000000000000000000000000000000000000000000000000000005",
                            "initial_shared_version": 1,
                            "mutable": true
                        },
                        {
                            "type": "object",
                            "objectType": "immOrOwnedObject",
                            "object_id": "0xf2e2c3cf773758027959170d2d7369a08c3be9d455a35b3d316feaa1950fa453",
                            "version": 1,
                            "digest": "6aQw2cGxuSmf6SuLd8C7t2LnStM293GSi5D1kVwKPYsD"
                        },
                        {
                            "type": "pure",
                            "valueType": "address",
                            "value": "0xc64291042b33e860faa3f733953676cd7bc24462bf8fc79bc1d3ac2ac214ebc2"
                        }
                    ],
                    "commands": [
                        {
                            "MoveCall": {
                                "package": "0x0000000000000000000000000000000000000000000000000000000000000002",
                                "module": "sui_system",
                                "function": "request_add_stake",
                                "arguments": [
                                    {
                                        "Input": 0
                                    },
                                    {
                                        "Input": 1
                                    },
                                    {
                                        "Input": 2
                                    }
                                ]
                            }
                        }
                    ]
                },
                "sender": "0xce1bf7db5ad6b04bfc305c049f08b80d5ccdc5d6d65d2ded13e95516d1e9fa22",
                "gasData": {
                    "payment": [
                        {
                            "objectId": "0x3121afc2890c0eb0cad14d495b4682618c12a1ac73577e7f9a45b04619c755d9",
                            "version": 3,
                            "digest": "DWnuhB7WGepk4bHysVs4jvpDA1bMcWdEqgzoX6zkRHeq"
                        }
                    ],
                    "owner": "0xce1bf7db5ad6b04bfc305c049f08b80d5ccdc5d6d65d2ded13e95516d1e9fa22",
                    "price": 1,
                    "budget": 100000
                }
            },
            "txSignatures": [
                "AFCWZe8Gy8m/enRPZEygzUq23H3O8IANSYnP4jHc5i8pSJdt0f8ZBrUH+0vwnlxyos9A0CzPcoCKSWm66ZbMJgvMmmv2BbuYf+KmNsqJ2ti6sOAiFwS/SbKh1OCWydu6vg=="
            ]
        },
        "timestampMs": 1679239266370,
        "checkpoint": 1160
    },
    "id": 1
}
```
