### PR TITLE
[package-upgrades] Added test for the case of downgraded dependency

### DIFF
--- a/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -711,6 +711,8 @@ async fn test_publish_dependent_downgrade() {
     );
 
     runner.publish(root_modules, root_dep_ids).await;
-    // TODO: get the actual error code for comparison once this test is enabled
-    effects.status.unwrap_err();
+    assert_eq!(
+        effects.status.unwrap_err().0,
+        ExecutionFailureStatus::PublishUpgradeDependencyDowngrade
+    );
 }


### PR DESCRIPTION
## Description 

This tests the case when a dependent package has a transitive dependency on a higher version of the "base" package than the the version specified by the root package.

