### PR TITLE
allow to suppress api mismatch warning

### DIFF
--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -98,6 +98,9 @@ pub enum SuiCommand {
         json: bool,
         #[clap(short = 'y', long = "yes")]
         accept_defaults: bool,
+        /// Do not print api version mismatch warning. Useful together with json == true.
+        #[clap(default_value = "false", long = "suppress-api-version-warning")]
+        suppress_api_version_warning: bool,
     },
     /// A tool for validators and validator candidates.
     #[clap(name = "validator")]
@@ -249,10 +252,14 @@ impl SuiCommand {
                 cmd,
                 json,
                 accept_defaults,
+                suppress_api_version_warning,
             } => {
                 let config_path = config.unwrap_or(sui_config_dir()?.join(SUI_CLIENT_CONFIG));
                 prompt_if_no_config(&config_path, accept_defaults).await?;
                 let mut context = WalletContext::new(&config_path, None).await?;
+                if suppress_api_version_warning {
+                    context.suppress_api_version_warning();
+                }
                 if let Some(cmd) = cmd {
                     cmd.execute(&mut context).await?.print(!json);
                 } else {


### PR DESCRIPTION
## Description 

With the warning, `--json` arg fails to work.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Allow to suppress api mismatch warning in sui client cli with `suppress-api-version-warning`
