### PR TITLE
[Narwhal] update batches resend logic; add more metrics to proposer

### DIFF
--- a/narwhal/primary/src/metrics.rs
+++ b/narwhal/primary/src/metrics.rs
@@ -308,8 +308,7 @@ pub struct PrimaryMetrics {
     pub proposer_batch_latency: Histogram,
     /// The number of headers being resent because they will not get committed.
     pub proposer_resend_headers: IntCounter,
-    /// The latency of a batch between the time it has been
-    /// created and until it has been included to a header proposal.
+    /// The number of batches being resent because they will not get committed.
     pub proposer_resend_batches: IntCounter,
     /// Time it takes for a header to be materialised to a certificate
     pub header_to_certificate_latency: Histogram,

--- a/narwhal/primary/src/metrics.rs
+++ b/narwhal/primary/src/metrics.rs
@@ -306,8 +306,7 @@ pub struct PrimaryMetrics {
     /// The latency of a batch between the time it has been
     /// created and until it has been included to a header proposal.
     pub proposer_batch_latency: Histogram,
-    /// The latency of a batch between the time it has been
-    /// created and until it has been included to a header proposal.
+    /// The number of headers being resent because they will not get committed.
     pub proposer_resend_headers: IntCounter,
     /// The latency of a batch between the time it has been
     /// created and until it has been included to a header proposal.

--- a/narwhal/primary/src/metrics.rs
+++ b/narwhal/primary/src/metrics.rs
@@ -306,6 +306,12 @@ pub struct PrimaryMetrics {
     /// The latency of a batch between the time it has been
     /// created and until it has been included to a header proposal.
     pub proposer_batch_latency: Histogram,
+    /// The latency of a batch between the time it has been
+    /// created and until it has been included to a header proposal.
+    pub proposer_resend_headers: IntCounter,
+    /// The latency of a batch between the time it has been
+    /// created and until it has been included to a header proposal.
+    pub proposer_resend_batches: IntCounter,
     /// Time it takes for a header to be materialised to a certificate
     pub header_to_certificate_latency: Histogram,
 }
@@ -446,6 +452,16 @@ impl PrimaryMetrics {
                 "proposer_batch_latency",
                 "The latency of a batch between the time it has been created and until it has been included to a header proposal.",
                 LATENCY_SEC_BUCKETS.to_vec(),
+                registry
+            ).unwrap(),
+            proposer_resend_headers: register_int_counter_with_registry!(
+                "proposer_resend_headers",
+                "The number of headers being resent because they will not get committed.",
+                registry
+            ).unwrap(),
+            proposer_resend_batches: register_int_counter_with_registry!(
+                "proposer_resend_batches",
+                "The number of batches being resent because they will not get committed.",
                 registry
             ).unwrap(),
             header_to_certificate_latency: register_histogram_with_registry!(

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -1147,7 +1147,7 @@ impl WorkerToPrimary for WorkerReceiverHandler {
                 digest: message.digest,
                 worker_id: message.worker_id,
                 timestamp: message.metadata.created_at,
-                ack_channel: tx_ack,
+                ack_channel: Some(tx_ack),
             })
             .await
             .map(|_| anemo::Response::new(()))

--- a/narwhal/primary/src/proposer.rs
+++ b/narwhal/primary/src/proposer.rs
@@ -6,7 +6,7 @@ use config::{Committee, Epoch, WorkerId};
 use crypto::PublicKey;
 use fastcrypto::hash::Hash as _;
 use mysten_metrics::spawn_logged_monitored_task;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 use std::{cmp::Ordering, sync::Arc};
 use storage::ProposerStore;
 use tokio::time::{sleep_until, Instant};
@@ -30,7 +30,7 @@ pub struct OurDigestMessage {
     pub worker_id: WorkerId,
     pub timestamp: TimestampMs,
     /// A channel to send an () as an ack after this digest is processed by the primary.
-    pub ack_channel: oneshot::Sender<()>,
+    pub ack_channel: Option<oneshot::Sender<()>>,
 }
 
 #[cfg(test)]
@@ -83,11 +83,12 @@ pub struct Proposer {
     /// Holds the certificate of the last leader (if any).
     last_leader: Option<Certificate>,
     /// Holds the batches' digests waiting to be included in the next header.
-    digests: Vec<(BatchDigest, WorkerId, TimestampMs)>,
+    /// Digests are popped in LIFO order from the front.
+    digests: VecDeque<OurDigestMessage>,
 
-    /// Holds the map of proposed previous round headers, used to ensure that
+    /// Holds the map of proposed previous round headers and their digest messages, to ensure that
     /// all batches' digest included will eventually be re-sent.
-    proposed_headers: BTreeMap<Round, Header>,
+    proposed_headers: BTreeMap<Round, (Header, Vec<OurDigestMessage>)>,
     /// Committed headers channel on which we get updates on which of
     /// our own headers have been committed.
     rx_committed_own_headers: Receiver<(Round, Vec<Round>)>,
@@ -138,7 +139,7 @@ impl Proposer {
                     round: 0,
                     last_parents: genesis,
                     last_leader: None,
-                    digests: Vec::with_capacity(2 * max_header_num_of_batches),
+                    digests: VecDeque::with_capacity(2 * max_header_num_of_batches),
                     proposed_headers: BTreeMap::new(),
                     rx_committed_own_headers,
                     metrics,
@@ -196,7 +197,7 @@ impl Proposer {
 
         // Make a new header.
         let num_of_digests = self.digests.len().min(self.max_header_num_of_batches);
-        let digests: Vec<_> = self.digests.drain(..num_of_digests).collect();
+        let header_digests: Vec<_> = self.digests.drain(..num_of_digests).collect();
         let parents: Vec<_> = self.last_parents.drain(..).collect();
 
         // Here we check that the timestamp we will include in the header is consistent with the
@@ -219,9 +220,9 @@ impl Proposer {
             self.name.clone(),
             this_round,
             this_epoch,
-            digests
+            header_digests
                 .iter()
-                .map(|(digest, worker_id, created_at)| (*digest, (*worker_id, *created_at)))
+                .map(|m| (m.digest, (m.worker_id, m.timestamp)))
                 .collect(),
             parents.iter().map(|x| x.digest()).collect(),
         )
@@ -256,15 +257,11 @@ impl Proposer {
             debug!(msg);
         }
 
-        // Register the header by the current round, to remember that we need to commit
-        // it, or re-include the batch digests that it contains.
-        self.proposed_headers.insert(this_round, header.clone());
-
         // Update metrics related to latency
         let mut total_inclusion_secs = 0.0;
-        for (_digest, _worker_id, created_at_timestamp) in digests.clone() {
+        for digest in &header_digests {
             let batch_inclusion_secs =
-                Duration::from_millis(header.created_at - created_at_timestamp).as_secs_f64();
+                Duration::from_millis(header.created_at - digest.timestamp).as_secs_f64();
             total_inclusion_secs += batch_inclusion_secs;
 
             #[cfg(feature = "benchmark")]
@@ -272,8 +269,8 @@ impl Proposer {
                 // NOTE: This log entry is used to compute performance.
                 tracing::info!(
                     "Batch {:?} from worker {} took {} seconds from creation to be included in a proposed header",
-                    _digest,
-                    _worker_id,
+                    digest.digest,
+                    digest.worker_id,
                     batch_inclusion_secs
                 );
             }
@@ -284,21 +281,27 @@ impl Proposer {
         }
 
         // NOTE: This log entry is used to compute performance.
-        let (header_creation_secs, avg_inclusion_secs) = if let Some(digest) = digests.first() {
-            (
-                Duration::from_millis(header.created_at - digest.2).as_secs_f64(),
-                total_inclusion_secs / digests.len() as f64,
-            )
-        } else {
-            (self.max_header_delay.as_secs_f64(), 0.0)
-        };
+        let (header_creation_secs, avg_inclusion_secs) =
+            if let Some(digest) = header_digests.first() {
+                (
+                    Duration::from_millis(header.created_at - digest.timestamp).as_secs_f64(),
+                    total_inclusion_secs / header_digests.len() as f64,
+                )
+            } else {
+                (self.max_header_delay.as_secs_f64(), 0.0)
+            };
         debug!(
             "Header {:?} was created in {} seconds. Contains {} batches, with average delay {} seconds.",
             header.digest(),
             header_creation_secs,
-            digests.len(),
+            header_digests.len(),
             avg_inclusion_secs,
         );
+
+        // Register the header by the current round, to remember that we need to commit
+        // it, or re-include the batch digests that it contains.
+        self.proposed_headers
+            .insert(this_round, (header.clone(), header_digests));
 
         Ok(header)
     }
@@ -512,33 +515,37 @@ impl Proposer {
 
                 Some((commit_round, commit_headers)) = self.rx_committed_own_headers.recv() => {
                     // Remove committed headers from the list of pending
-                    for round in &commit_headers {
-                        self.proposed_headers.remove(round);
+                    let mut max_committed_round = 0;
+                    for round in commit_headers {
+                        max_committed_round = max_committed_round.max(round);
+                        let Some(_) = self.proposed_headers.remove(&round) else {
+                            info!("Own committed header not found at round {round}, probably because of restarts.");
+                            continue;
+                        };
                     }
 
-                    // Now for any round much below the current commit round we re-insert
+                    // Now for any round below the current commit round we re-insert
                     // the batches into the digests we need to send, effectively re-sending
-                    // them
+                    // them in FIFO order.
                     let mut digests_to_resend = Vec::new();
                     let mut retransmit_rounds = Vec::new();
 
                     // Iterate in order of rounds of our own headers.
-                    for (round_header, header) in &mut self.proposed_headers {
-                        // If we are within 2 rounds of the commit we break
-                        if round_header + 2 >= commit_round {
+                    for (header_round, (_header, included_digests)) in &mut self.proposed_headers {
+                        // Stop once we have processed headers at and below last committed round.
+                        if *header_round > max_committed_round {
                             break;
                         }
-
-                        digests_to_resend.extend(
-                            header.payload.iter().map(|(digest, (worker, created_at))| (*digest, *worker, *created_at))
-                        );
-                        retransmit_rounds.push(*round_header);
+                        // Add payloads from oldest to newest.
+                        digests_to_resend.append(included_digests);
+                        retransmit_rounds.push(*header_round);
                     }
 
                     if !retransmit_rounds.is_empty() {
                         // Add the digests to retransmit to the digests for the next header
-                        digests_to_resend.extend(&self.digests);
-                        self.digests = digests_to_resend;
+                        for digest in digests_to_resend.into_iter().rev() {
+                            self.digests.push_front(digest);
+                        }
 
                         // Now delete the headers with batches we re-transmit
                         for round in &retransmit_rounds {
@@ -621,21 +628,15 @@ impl Proposer {
                 }
 
                 // Receive digests from our workers.
-                Some(OurDigestMessage {
-                    digest,
-                    worker_id,
-                    timestamp,
-                    ack_channel,
-                }) = self.rx_our_digests.recv() => {
-                    let digest_record = (digest, worker_id, timestamp, );
-                    self.digests.push(digest_record);
+                Some(mut message) = self.rx_our_digests.recv() => {
                     // Signal back to the worker that the batch is recorded on the
                     // primary, and will be tracked until inclusion. This means that
                     // if the primary does not fail it will attempt to send the digest
                     // (and re-send if necessary) until it is sequenced, or the end of
                     // the epoch is reached. For the moment this does not persist primary
                     // crashes and re-starts.
-                    let _ = ack_channel.send(());
+                    let _ = message.ack_channel.take().unwrap().send(());
+                    self.digests.push_back(message);
                 }
 
                 // Check whether any timer expired.

--- a/narwhal/primary/src/proposer.rs
+++ b/narwhal/primary/src/proposer.rs
@@ -543,6 +543,7 @@ impl Proposer {
 
                     if !retransmit_rounds.is_empty() {
                         // Add the digests to retransmit to the digests for the next header
+                        let num_to_resend = digests_to_resend.len();
                         for digest in digests_to_resend.into_iter().rev() {
                             self.digests.push_front(digest);
                         }
@@ -554,11 +555,14 @@ impl Proposer {
 
                         debug!(
                             "Retransmit {} batches in undelivered headers {:?} at commit round {:?}, remaining headers {}",
-                            self.digests.len(),
+                            num_to_resend,
                             retransmit_rounds,
                             commit_round,
                             self.proposed_headers.len()
                         );
+
+                        self.metrics.proposer_resend_headers.inc_by(retransmit_rounds.len() as u64);
+                        self.metrics.proposer_resend_batches.inc_by(num_to_resend as u64);
                     }
                 },
 

--- a/narwhal/primary/src/state_handler.rs
+++ b/narwhal/primary/src/state_handler.rs
@@ -20,7 +20,7 @@ pub struct StateHandler {
     /// Channel to signal committee changes.
     rx_shutdown: ConditionalBroadcastReceiver,
     /// A channel to update the committed rounds
-    tx_commited_own_headers: Option<Sender<(Round, Vec<Round>)>>,
+    tx_committed_own_headers: Option<Sender<(Round, Vec<Round>)>>,
 
     network: anemo::Network,
 }
@@ -31,7 +31,7 @@ impl StateHandler {
         name: PublicKey,
         rx_committed_certificates: Receiver<(Round, Vec<Certificate>)>,
         rx_shutdown: ConditionalBroadcastReceiver,
-        tx_commited_own_headers: Option<Sender<(Round, Vec<Round>)>>,
+        tx_committed_own_headers: Option<Sender<(Round, Vec<Round>)>>,
         network: anemo::Network,
     ) -> JoinHandle<()> {
         spawn_logged_monitored_task!(
@@ -40,7 +40,7 @@ impl StateHandler {
                     name,
                     rx_committed_certificates,
                     rx_shutdown,
-                    tx_commited_own_headers,
+                    tx_committed_own_headers,
                     network,
                 }
                 .run()
@@ -69,7 +69,7 @@ impl StateHandler {
 
         // If a reporting channel is available send the committed own
         // headers to it.
-        if let Some(sender) = &self.tx_commited_own_headers {
+        if let Some(sender) = &self.tx_committed_own_headers {
             let _ = sender.send((commit_round, own_rounds_committed)).await;
         }
     }

--- a/narwhal/primary/src/tests/proposer_tests.rs
+++ b/narwhal/primary/src/tests/proposer_tests.rs
@@ -107,7 +107,7 @@ async fn propose_payload_and_repropose_after_n_seconds() {
             digest,
             worker_id,
             timestamp: created_at_ts,
-            ack_channel: tx_ack,
+            ack_channel: Some(tx_ack),
         })
         .await
         .unwrap();
@@ -133,7 +133,7 @@ async fn propose_payload_and_repropose_after_n_seconds() {
                 digest: batch_id,
                 worker_id,
                 timestamp: created_at,
-                ack_channel: tx_ack,
+                ack_channel: Some(tx_ack),
             })
             .await
             .unwrap();
@@ -228,7 +228,7 @@ async fn equivocation_protection() {
             digest,
             worker_id,
             timestamp: created_at_ts,
-            ack_channel: tx_ack,
+            ack_channel: Some(tx_ack),
         })
         .await
         .unwrap();
@@ -298,7 +298,7 @@ async fn equivocation_protection() {
             digest,
             worker_id,
             timestamp: 0,
-            ack_channel: tx_ack,
+            ack_channel: Some(tx_ack),
         })
         .await
         .unwrap();


### PR DESCRIPTION
## Description 

This PR contains a fix and a few cleanups:
1. Resending batches in headers whenever commit round is more than 2 above uncommitted header round seems not very accurate, and can introduce unnecessary resends in some cases. Instead, only batches from uncommitted headers below the highest committed header round should get resent.
2. Add metrics for number of headers and digests that are resent.
3. Use OurDigestMessage to keep track of digest metadata, instead of a tuple.
4. Clarify FIFO ordering of sending digests from Proposer.

## Test Plan 

Not adding a new unit test for resending header and digest, because we will update this logic later.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
