### PR TITLE
[DOC] - Minor changes to Staking section in Migration-Guide

### DIFF
--- a/doc/src/doc-updates/sui-migration-guide.md
+++ b/doc/src/doc-updates/sui-migration-guide.md
@@ -499,7 +499,7 @@ Effective with release .28, the function names are:
 
 ### Changes to getDelegatedStakes
     
-With the new staking flow introduced in release .28, the `getDelegatedStakes` function returns all of the stakes for an address grouped by validator staking pools, as well as the estimated staking rewards earned so far:
+The `getDelegatedStakes` function has been renamed to `getStakes` and with the new staking flow introduced in release .28, the `getStakes` function returns all of the stakes for an address grouped by validator staking pools, as well as the estimated staking rewards earned so far:
     
 ```rust
     {
@@ -544,6 +544,10 @@ With the new staking flow introduced in release .28, the `getDelegatedStakes` fu
         "id": 1
     }
 ```
+
+### Add getStakesByIds function
+
+With the new `getStakesByIds` it will be possible to query the delegated stakes using a vector of staked sui ids. The function returns all of the stakes queried grouped by validator staking pools, as well as the estimated staking rewards earned so far.
 
 ### Secp256k1 derive keypair
     


### PR DESCRIPTION
## Description 

Add sui_getStakesByIds method with which will be possible to query the delegated stakes using a vector of staked sui ids.
Also mention the renaming of sui_getDelegatedStakes to sui_getStakes in Sui-Migration-Guide

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
