### PR TITLE
Ts-sdk: change functions in transactions.ts to return bigint instead of number

### DIFF
--- a/.changeset/clever-dodos-buy.md
+++ b/.changeset/clever-dodos-buy.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Change functions in transactions.ts of ts-sdk such that: `getTotalGasUsed` and `getTotalGasUsedUpperBound` of ts-sdk return a `bigint`,fields of `gasCostSummary` are defined as `string`, `epochId` is defined as `string`. In `sui-json-rpc` the corresponding types are defined as `BigInt`. Introduce `SuiEpochId` type to `sui-json-rpc` types that is a `BigInt`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,9 +914,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.7"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb79c228270dcf2426e74864cabc94babb5dbab01a4314e702d2f16540e1591"
+checksum = "4e246206a63c9830e118d12c894f56a82033da1a2361f5544deeee3df85c99d9"
 dependencies = [
  "async-trait",
  "axum-core",

--- a/apps/explorer/src/pages/transaction-result/TransactionView.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionView.tsx
@@ -356,21 +356,25 @@ export function TransactionView({
                                         </DescriptionItem>
                                         <DescriptionItem title="Computation Fee">
                                             <GasAmount
-                                                amount={
+                                                amount={Number(
                                                     gasUsed?.computationCost
-                                                }
+                                                )}
                                             />
                                         </DescriptionItem>
 
                                         <DescriptionItem title="Storage Fee">
                                             <GasAmount
-                                                amount={gasUsed?.storageCost}
+                                                amount={Number(
+                                                    gasUsed?.storageCost
+                                                )}
                                             />
                                         </DescriptionItem>
 
                                         <DescriptionItem title="Storage Rebate">
                                             <GasAmount
-                                                amount={gasUsed?.storageRebate}
+                                                amount={Number(
+                                                    gasUsed?.storageRebate
+                                                )}
                                             />
                                         </DescriptionItem>
 

--- a/apps/wallet/src/ui/app/components/receipt-card/index.tsx
+++ b/apps/wallet/src/ui/app/components/receipt-card/index.tsx
@@ -72,7 +72,7 @@ function ReceiptCard({ txn, activeAddress }: ReceiptCardProps) {
     const transactionSender = getTransactionSender(txn);
     const isSender = activeAddress === transactionSender;
     const isSponsoredTransaction = transactionSender !== owner;
-    const gasTotal = getTotalGasUsed(txn);
+    const gasTotal = Number(getTotalGasUsed(txn));
 
     const showGasSummary = isSuccessful && isSender && gasTotal;
     const showSponsorInfo = !isSuccessful && isSender && isSponsoredTransaction;

--- a/apps/wallet/src/ui/app/staking/home/StakedCard.tsx
+++ b/apps/wallet/src/ui/app/staking/home/StakedCard.tsx
@@ -134,7 +134,7 @@ export function StakeCard({
     // For cool down epoch, show Available to withdraw add rewards to principal
     // Reward earning epoch is 2 epochs after stake request epoch
     const earningRewardsEpoch = stakeRequestEpoch + NUM_OF_EPOCH_BEFORE_EARNING;
-    const isEarnedRewards = currentEpoch >= earningRewardsEpoch;
+    const isEarnedRewards = currentEpoch >= Number(earningRewardsEpoch);
     const delegationState = inactiveValidator
         ? StakeState.IN_ACTIVE
         : isEarnedRewards
@@ -173,7 +173,7 @@ export function StakeCard({
                 statusLabel={STATUS_COPY[delegationState]}
                 statusText={statusText[delegationState]}
                 earnColor={isEarning}
-                earningRewardEpoch={epochBeforeRewards}
+                earningRewardEpoch={Number(epochBeforeRewards)}
             >
                 <div className="flex justify-between items-start mb-1 ">
                     <ValidatorLogo

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -325,7 +325,7 @@ async fn test_dev_inspect_object_by_bytes() {
     // random gas is mutated
     assert_eq!(effects.mutated().len(), 1);
     assert!(effects.deleted().is_empty());
-    assert!(effects.gas_cost_summary().computation_cost > 0);
+    assert!(<u64>::from(effects.gas_cost_summary().computation_cost) > 0);
     let mut results = results.unwrap();
     assert_eq!(results.len(), 1);
     let exec_results = results.pop().unwrap();
@@ -394,7 +394,7 @@ async fn test_dev_inspect_object_by_bytes() {
     // but random gas is mutated
     assert_eq!(effects.mutated().len(), 1);
     assert!(effects.deleted().is_empty());
-    assert!(effects.gas_cost_summary().computation_cost > 0);
+    assert!(<u64>::from(effects.gas_cost_summary().computation_cost) > 0);
 
     let mut results = results.unwrap();
     assert_eq!(results.len(), 1);
@@ -498,7 +498,7 @@ async fn test_dev_inspect_unowned_object() {
     // random gas and input object are mutated
     assert_eq!(effects.mutated().len(), 2);
     assert!(effects.deleted().is_empty());
-    assert!(effects.gas_cost_summary().computation_cost > 0);
+    assert!(<u64>::from(effects.gas_cost_summary().computation_cost) > 0);
 
     let mut results = results.unwrap();
     assert_eq!(results.len(), 1);
@@ -611,7 +611,7 @@ async fn test_dev_inspect_dynamic_field() {
     assert_eq!(effects.mutated().len(), 1);
     // nothing is deleted
     assert!(effects.deleted().is_empty());
-    assert!(effects.gas_cost_summary().computation_cost > 0);
+    assert!(<u64>::from(effects.gas_cost_summary().computation_cost) > 0);
     assert_eq!(results.len(), 1);
     let exec_results = results.pop().unwrap();
     let SuiExecutionResult {

--- a/crates/sui-indexer/src/models/transactions.rs
+++ b/crates/sui-indexer/src/models/transactions.rs
@@ -157,9 +157,9 @@ impl TryFrom<SuiTransactionFullResponse> for Transaction {
         let gas_object_digest = gas_object_ref.digest.base58_encode();
 
         let gas_summary = effects.gas_cost_summary();
-        let computation_cost = gas_summary.computation_cost;
-        let storage_cost = gas_summary.storage_cost;
-        let storage_rebate = gas_summary.storage_rebate;
+        let computation_cost = <u64>::from(gas_summary.computation_cost);
+        let storage_cost = <u64>::from(gas_summary.storage_cost);
+        let storage_rebate = <u64>::from(gas_summary.storage_rebate);
 
         Ok(Transaction {
             id: None,

--- a/crates/sui-json-rpc-types/src/sui_governance.rs
+++ b/crates/sui-json-rpc-types/src/sui_governance.rs
@@ -7,6 +7,8 @@ use serde::{Deserialize, Serialize};
 use sui_types::base_types::{AuthorityName, EpochId, ObjectID, SuiAddress};
 use sui_types::committee::{Committee, StakeUnit};
 
+use crate::SuiEpochId;
+
 /// RPC representation of the [Committee] type.
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 #[serde(rename = "CommitteeInfo")]
@@ -49,8 +51,8 @@ pub enum StakeStatus {
 pub struct Stake {
     /// ID of the StakedSui receipt object.
     pub staked_sui_id: ObjectID,
-    pub stake_request_epoch: EpochId,
-    pub stake_active_epoch: EpochId,
+    pub stake_request_epoch: SuiEpochId,
+    pub stake_active_epoch: SuiEpochId,
     pub principal: u64,
     #[serde(flatten)]
     pub status: StakeStatus,

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -17,9 +17,7 @@ use enum_dispatch::enum_dispatch;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use sui_json::{primitive_type, SuiJsonValue};
-use sui_types::base_types::{
-    EpochId, ObjectID, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest,
-};
+use sui_types::base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest};
 use sui_types::digests::{ObjectDigest, TransactionEventsDigest};
 use sui_types::error::{ExecutionError, SuiError};
 use sui_types::gas::GasCostSummary;

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -480,7 +480,7 @@ impl SuiTransactionEffectsAPI for SuiTransactionEffectsV1 {
     }
 
     fn executed_epoch(&self) -> SuiEpochId {
-        self.executed_epoch.into()
+        self.executed_epoch
     }
 
     fn transaction_digest(&self) -> &TransactionDigest {

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -812,7 +812,7 @@ pub struct SuiGasCostSummary {
     pub computation_cost: BigInt,
     pub storage_cost: BigInt,
     pub storage_rebate: BigInt,
-    pub non_refundable_storage_fee: u64,
+    pub non_refundable_storage_fee: BigInt,
 }
 
 impl From<GasCostSummary> for SuiGasCostSummary {
@@ -821,7 +821,7 @@ impl From<GasCostSummary> for SuiGasCostSummary {
             computation_cost: s.computation_cost.into(),
             storage_cost: s.storage_cost.into(),
             storage_rebate: s.storage_rebate.into(),
-            non_refundable_storage_fee: s.non_refundable_storage_fee,
+            non_refundable_storage_fee: s.non_refundable_storage_fee.into(),
         }
     }
 }
@@ -832,7 +832,7 @@ impl From<SuiGasCostSummary> for GasCostSummary {
             computation_cost: s.computation_cost.into(),
             storage_cost: s.storage_cost.into(),
             storage_rebate: s.storage_rebate.into(),
-            non_refundable_storage_fee: s.non_refundable_storage_fee,
+            non_refundable_storage_fee: s.non_refundable_storage_fee.into(),
         }
     }
 }

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -807,18 +807,18 @@ fn to_owned_ref(owned_refs: Vec<(ObjectRef, Owner)>) -> Vec<OwnedObjectRef> {
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(rename = "GasCostSummary", rename_all = "camelCase")]
 pub struct SuiGasCostSummary {
-    pub computation_cost: u64,
-    pub storage_cost: u64,
-    pub storage_rebate: u64,
+    pub computation_cost: BigInt,
+    pub storage_cost: BigInt,
+    pub storage_rebate: BigInt,
     pub non_refundable_storage_fee: u64,
 }
 
 impl From<GasCostSummary> for SuiGasCostSummary {
     fn from(s: GasCostSummary) -> Self {
         Self {
-            computation_cost: s.computation_cost,
-            storage_cost: s.storage_cost,
-            storage_rebate: s.storage_rebate,
+            computation_cost: s.computation_cost.into(),
+            storage_cost: s.storage_cost.into(),
+            storage_rebate: s.storage_rebate.into(),
             non_refundable_storage_fee: s.non_refundable_storage_fee,
         }
     }
@@ -827,9 +827,9 @@ impl From<GasCostSummary> for SuiGasCostSummary {
 impl From<SuiGasCostSummary> for GasCostSummary {
     fn from(s: SuiGasCostSummary) -> Self {
         Self {
-            computation_cost: s.computation_cost,
-            storage_cost: s.storage_cost,
-            storage_rebate: s.storage_rebate,
+            computation_cost: s.computation_cost.into(),
+            storage_cost: s.storage_cost.into(),
+            storage_rebate: s.storage_rebate.into(),
             non_refundable_storage_fee: s.non_refundable_storage_fee,
         }
     }

--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -123,8 +123,8 @@ impl GovernanceReadApi {
                 delegations.push(Stake {
                     staked_sui_id: stake.id(),
                     // TODO: this might change when we implement warm up period.
-                    stake_request_epoch: stake.activation_epoch() - 1,
-                    stake_active_epoch: stake.activation_epoch(),
+                    stake_request_epoch: (stake.activation_epoch() - 1).into(),
+                    stake_active_epoch: stake.activation_epoch().into(),
                     principal: stake.principal(),
                     status,
                 })

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -233,9 +233,9 @@
                 },
                 "executedEpoch": 0,
                 "gasUsed": {
-                  "computationCost": 100,
-                  "storageCost": 100,
-                  "storageRebate": 10,
+                  "computationCost": "100",
+                  "storageCost": "100",
+                  "storageRebate": "10",
                   "nonRefundableStorageFee": 0
                 },
                 "transactionDigest": "8UExPV121BEfWkbymSPDYhh23rVNh3MSWtC5juJ9JGMJ",
@@ -445,9 +445,7 @@
                 "nonRefundableStorageFee": 0
               },
               "timestampMs": 1676911928,
-              "transactions": [
-                "3bpzHaSLTQ6p4trLDk2euZxzQ6XqLeWDmUNTAdEXXL2c"
-              ],
+              "transactions": ["3bpzHaSLTQ6p4trLDk2euZxzQ6XqLeWDmUNTAdEXXL2c"],
               "checkpointCommitments": []
             }
           }
@@ -1423,9 +1421,9 @@
                 },
                 "executedEpoch": 0,
                 "gasUsed": {
-                  "computationCost": 100,
-                  "storageCost": 100,
-                  "storageRebate": 10,
+                  "computationCost": "100",
+                  "storageCost": "100",
+                  "storageRebate": "10",
                   "nonRefundableStorageFee": 0
                 },
                 "transactionDigest": "6AyFnAuKAKCqm1cD94EyGzBqJCDDJ716ojjmsKF2rqoi",
@@ -2967,11 +2965,7 @@
       },
       "BalanceChange": {
         "type": "object",
-        "required": [
-          "amount",
-          "coinType",
-          "owner"
-        ],
+        "required": ["amount", "coinType", "owner"],
         "properties": {
           "amount": {
             "description": "The amount indicate the balance value changes, negative amount means spending coin value and positive means receiving coin value.",
@@ -3098,9 +3092,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "ECMHLiveObjectSetDigest"
-            ],
+            "required": ["ECMHLiveObjectSetDigest"],
             "properties": {
               "ECMHLiveObjectSetDigest": {
                 "$ref": "#/components/schemas/ECMHLiveObjectSetDigest"
@@ -3154,10 +3146,7 @@
             "$ref": "#/components/schemas/ObjectDigest"
           },
           "lockedUntilEpoch": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "format": "uint64",
             "minimum": 0.0
           },
@@ -3172,10 +3161,7 @@
       "CommitteeInfo": {
         "description": "RPC representation of the [Committee] type.",
         "type": "object",
-        "required": [
-          "epoch",
-          "validators"
-        ],
+        "required": ["epoch", "validators"],
         "properties": {
           "epoch": {
             "type": "integer",
@@ -3207,9 +3193,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "Ed25519"
-            ],
+            "required": ["Ed25519"],
             "properties": {
               "Ed25519": {
                 "$ref": "#/components/schemas/Base64"
@@ -3219,9 +3203,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "Secp256k1"
-            ],
+            "required": ["Secp256k1"],
             "properties": {
               "Secp256k1": {
                 "$ref": "#/components/schemas/Base64"
@@ -3231,9 +3213,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "Secp256r1"
-            ],
+            "required": ["Secp256r1"],
             "properties": {
               "Secp256r1": {
                 "$ref": "#/components/schemas/Base64"
@@ -3247,18 +3227,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "dataType",
-              "fields",
-              "hasPublicTransfer",
-              "type"
-            ],
+            "required": ["dataType", "fields", "hasPublicTransfer", "type"],
             "properties": {
               "dataType": {
                 "type": "string",
-                "enum": [
-                  "moveObject"
-                ]
+                "enum": ["moveObject"]
               },
               "fields": {
                 "$ref": "#/components/schemas/MoveStruct"
@@ -3273,16 +3246,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "dataType",
-              "disassembled"
-            ],
+            "required": ["dataType", "disassembled"],
             "properties": {
               "dataType": {
                 "type": "string",
-                "enum": [
-                  "package"
-                ]
+                "enum": ["package"]
               },
               "disassembled": {
                 "type": "object",
@@ -3294,11 +3262,7 @@
       },
       "DelegatedStake": {
         "type": "object",
-        "required": [
-          "stakes",
-          "stakingPool",
-          "validatorAddress"
-        ],
+        "required": ["stakes", "stakingPool", "validatorAddress"],
         "properties": {
           "stakes": {
             "type": "array",
@@ -3327,10 +3291,7 @@
       "DevInspectResults": {
         "description": "The response from processing a dev inspect transaction",
         "type": "object",
-        "required": [
-          "effects",
-          "events"
-        ],
+        "required": ["effects", "events"],
         "properties": {
           "effects": {
             "description": "Summary of effects that likely would be generated if the transaction is actually run. Note however, that not all dev-inspect transactions are actually usable as transactions so it might not be possible actually generate these effects from a normal transaction.",
@@ -3342,10 +3303,7 @@
           },
           "error": {
             "description": "Execution error from executing the transaction commands",
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "events": {
             "description": "Events that likely would be generated if the transaction is actually run.",
@@ -3356,10 +3314,7 @@
           },
           "results": {
             "description": "Execution results (including return values) from executing the transaction commands",
-            "type": [
-              "array",
-              "null"
-            ],
+            "type": ["array", "null"],
             "items": {
               "$ref": "#/components/schemas/SuiExecutionResult"
             }
@@ -3376,10 +3331,7 @@
       },
       "DryRunTransactionResponse": {
         "type": "object",
-        "required": [
-          "effects",
-          "events"
-        ],
+        "required": ["effects", "events"],
         "properties": {
           "effects": {
             "$ref": "#/components/schemas/TransactionEffects"
@@ -3429,10 +3381,7 @@
       },
       "DynamicFieldName": {
         "type": "object",
-        "required": [
-          "type",
-          "value"
-        ],
+        "required": ["type", "value"],
         "properties": {
           "type": {
             "type": "string"
@@ -3442,17 +3391,12 @@
       },
       "DynamicFieldType": {
         "type": "string",
-        "enum": [
-          "DynamicField",
-          "DynamicObject"
-        ]
+        "enum": ["DynamicField", "DynamicObject"]
       },
       "ECMHLiveObjectSetDigest": {
         "description": "The Sha256 digest of an EllipticCurveMultisetHash committing to the live object set.",
         "type": "object",
-        "required": [
-          "digest"
-        ],
+        "required": ["digest"],
         "properties": {
           "digest": {
             "type": "array",
@@ -3700,10 +3644,7 @@
           },
           "timestampMs": {
             "description": "UTC timestamp in milliseconds since epoch (1/1/1970)",
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "format": "uint64",
             "minimum": 0.0
           },
@@ -3722,9 +3663,7 @@
           {
             "description": "Query by sender address.",
             "type": "object",
-            "required": [
-              "Sender"
-            ],
+            "required": ["Sender"],
             "properties": {
               "Sender": {
                 "$ref": "#/components/schemas/SuiAddress"
@@ -3735,9 +3674,7 @@
           {
             "description": "Return events emitted by the given transaction.",
             "type": "object",
-            "required": [
-              "Transaction"
-            ],
+            "required": ["Transaction"],
             "properties": {
               "Transaction": {
                 "$ref": "#/components/schemas/TransactionDigest"
@@ -3748,9 +3685,7 @@
           {
             "description": "Return events emitted in a specified Package.",
             "type": "object",
-            "required": [
-              "Package"
-            ],
+            "required": ["Package"],
             "properties": {
               "Package": {
                 "$ref": "#/components/schemas/ObjectID"
@@ -3761,16 +3696,11 @@
           {
             "description": "Return events emitted in a specified Move module.",
             "type": "object",
-            "required": [
-              "MoveModule"
-            ],
+            "required": ["MoveModule"],
             "properties": {
               "MoveModule": {
                 "type": "object",
-                "required": [
-                  "module",
-                  "package"
-                ],
+                "required": ["module", "package"],
                 "properties": {
                   "module": {
                     "description": "the module name",
@@ -3792,9 +3722,7 @@
           {
             "description": "Return events with the given move event struct name",
             "type": "object",
-            "required": [
-              "MoveEventType"
-            ],
+            "required": ["MoveEventType"],
             "properties": {
               "MoveEventType": {
                 "type": "string"
@@ -3804,16 +3732,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "MoveEventField"
-            ],
+            "required": ["MoveEventField"],
             "properties": {
               "MoveEventField": {
                 "type": "object",
-                "required": [
-                  "path",
-                  "value"
-                ],
+                "required": ["path", "value"],
                 "properties": {
                   "path": {
                     "type": "string"
@@ -3827,16 +3750,11 @@
           {
             "description": "Return events emitted in [start_time, end_time] interval",
             "type": "object",
-            "required": [
-              "TimeRange"
-            ],
+            "required": ["TimeRange"],
             "properties": {
               "TimeRange": {
                 "type": "object",
-                "required": [
-                  "endTime",
-                  "startTime"
-                ],
+                "required": ["endTime", "startTime"],
                 "properties": {
                   "endTime": {
                     "description": "right endpoint of time interval, milliseconds since epoch, exclusive",
@@ -3857,9 +3775,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "All"
-            ],
+            "required": ["All"],
             "properties": {
               "All": {
                 "type": "array",
@@ -3872,9 +3788,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "Any"
-            ],
+            "required": ["Any"],
             "properties": {
               "Any": {
                 "type": "array",
@@ -3887,9 +3801,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "And"
-            ],
+            "required": ["And"],
             "properties": {
               "And": {
                 "type": "array",
@@ -3909,9 +3821,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "Or"
-            ],
+            "required": ["Or"],
             "properties": {
               "Or": {
                 "type": "array",
@@ -3934,10 +3844,7 @@
       "EventID": {
         "description": "Unique ID of a Sui Event, the ID is a combination of tx seq number and event seq number, the ID is local to this particular fullnode and will be different from other fullnode.",
         "type": "object",
-        "required": [
-          "eventSeq",
-          "txDigest"
-        ],
+        "required": ["eventSeq", "txDigest"],
         "properties": {
           "eventSeq": {
             "type": "integer",
@@ -3951,42 +3858,30 @@
       },
       "ExecuteTransactionRequestType": {
         "type": "string",
-        "enum": [
-          "WaitForEffectsCert",
-          "WaitForLocalExecution"
-        ]
+        "enum": ["WaitForEffectsCert", "WaitForLocalExecution"]
       },
       "ExecutionStatus": {
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "status"
-            ],
+            "required": ["status"],
             "properties": {
               "status": {
                 "type": "string",
-                "enum": [
-                  "success"
-                ]
+                "enum": ["success"]
               }
             }
           },
           {
             "type": "object",
-            "required": [
-              "error",
-              "status"
-            ],
+            "required": ["error", "status"],
             "properties": {
               "error": {
                 "type": "string"
               },
               "status": {
                 "type": "string",
-                "enum": [
-                  "failure"
-                ]
+                "enum": ["failure"]
               }
             }
           }
@@ -4012,25 +3907,16 @@
             "minimum": 0.0
           },
           "storageCost": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+            "$ref": "#/components/schemas/BigInt"
           },
           "storageRebate": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+            "$ref": "#/components/schemas/BigInt"
           }
         }
       },
       "GasData": {
         "type": "object",
-        "required": [
-          "budget",
-          "owner",
-          "payment",
-          "price"
-        ],
+        "required": ["budget", "owner", "payment", "price"],
         "properties": {
           "budget": {
             "type": "integer",
@@ -4058,9 +3944,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "MultiSig"
-            ],
+            "required": ["MultiSig"],
             "properties": {
               "MultiSig": {
                 "$ref": "#/components/schemas/MultiSig"
@@ -4070,9 +3954,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "Signature"
-            ],
+            "required": ["Signature"],
             "properties": {
               "Signature": {
                 "$ref": "#/components/schemas/Signature"
@@ -4084,10 +3966,7 @@
       },
       "GetPastObjectRequest": {
         "type": "object",
-        "required": [
-          "objectId",
-          "version"
-        ],
+        "required": ["objectId", "version"],
         "properties": {
           "objectId": {
             "description": "the ID of the queried object",
@@ -4115,9 +3994,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "MovePackage"
-            ],
+            "required": ["MovePackage"],
             "properties": {
               "MovePackage": {
                 "$ref": "#/components/schemas/ObjectID"
@@ -4127,9 +4004,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "ImmOrOwnedMoveObject"
-            ],
+            "required": ["ImmOrOwnedMoveObject"],
             "properties": {
               "ImmOrOwnedMoveObject": {
                 "$ref": "#/components/schemas/ObjectRef"
@@ -4139,16 +4014,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "SharedMoveObject"
-            ],
+            "required": ["SharedMoveObject"],
             "properties": {
               "SharedMoveObject": {
                 "type": "object",
-                "required": [
-                  "id",
-                  "initial_shared_version"
-                ],
+                "required": ["id", "initial_shared_version"],
                 "properties": {
                   "id": {
                     "$ref": "#/components/schemas/ObjectID"
@@ -4169,12 +4039,7 @@
       },
       "MoveCallParams": {
         "type": "object",
-        "required": [
-          "arguments",
-          "function",
-          "module",
-          "packageObjectId"
-        ],
+        "required": ["arguments", "function", "module", "packageObjectId"],
         "properties": {
           "arguments": {
             "type": "array",
@@ -4204,15 +4069,11 @@
         "oneOf": [
           {
             "type": "string",
-            "enum": [
-              "Pure"
-            ]
+            "enum": ["Pure"]
           },
           {
             "type": "object",
-            "required": [
-              "Object"
-            ],
+            "required": ["Object"],
             "properties": {
               "Object": {
                 "$ref": "#/components/schemas/ObjectValueKind"
@@ -4224,9 +4085,7 @@
       },
       "MovePackage": {
         "type": "object",
-        "required": [
-          "disassembled"
-        ],
+        "required": ["disassembled"],
         "properties": {
           "disassembled": {
             "type": "object",
@@ -4244,10 +4103,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "fields",
-              "type"
-            ],
+            "required": ["fields", "type"],
             "properties": {
               "fields": {
                 "type": "object",
@@ -4292,9 +4148,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "id"
-            ],
+            "required": ["id"],
             "properties": {
               "id": {
                 "$ref": "#/components/schemas/ObjectID"
@@ -4319,11 +4173,7 @@
       "MultiSig": {
         "description": "The struct that contains signatures and public keys necessary for authenticating a MultiSig.",
         "type": "object",
-        "required": [
-          "bitmap",
-          "multisig_pk",
-          "sigs"
-        ],
+        "required": ["bitmap", "multisig_pk", "sigs"],
         "properties": {
           "bitmap": {
             "description": "A bitmap that indicates the position of which public key the signature should be authenticated with.",
@@ -4353,10 +4203,7 @@
       "MultiSigPublicKey": {
         "description": "The struct that contains the public key used for authenticating a MultiSig.",
         "type": "object",
-        "required": [
-          "pk_map",
-          "threshold"
-        ],
+        "required": ["pk_map", "threshold"],
         "properties": {
           "pk_map": {
             "description": "A list of public key and its corresponding weight.",
@@ -4391,13 +4238,7 @@
           {
             "description": "Module published",
             "type": "object",
-            "required": [
-              "digest",
-              "modules",
-              "packageId",
-              "type",
-              "version"
-            ],
+            "required": ["digest", "modules", "packageId", "type", "version"],
             "properties": {
               "digest": {
                 "$ref": "#/components/schemas/ObjectDigest"
@@ -4413,9 +4254,7 @@
               },
               "type": {
                 "type": "string",
-                "enum": [
-                  "published"
-                ]
+                "enum": ["published"]
               },
               "version": {
                 "$ref": "#/components/schemas/SequenceNumber"
@@ -4452,9 +4291,7 @@
               },
               "type": {
                 "type": "string",
-                "enum": [
-                  "transferred"
-                ]
+                "enum": ["transferred"]
               },
               "version": {
                 "$ref": "#/components/schemas/SequenceNumber"
@@ -4495,9 +4332,7 @@
               },
               "type": {
                 "type": "string",
-                "enum": [
-                  "mutated"
-                ]
+                "enum": ["mutated"]
               },
               "version": {
                 "$ref": "#/components/schemas/SequenceNumber"
@@ -4507,13 +4342,7 @@
           {
             "description": "Delete object",
             "type": "object",
-            "required": [
-              "objectId",
-              "objectType",
-              "sender",
-              "type",
-              "version"
-            ],
+            "required": ["objectId", "objectType", "sender", "type", "version"],
             "properties": {
               "objectId": {
                 "$ref": "#/components/schemas/ObjectID"
@@ -4526,9 +4355,7 @@
               },
               "type": {
                 "type": "string",
-                "enum": [
-                  "deleted"
-                ]
+                "enum": ["deleted"]
               },
               "version": {
                 "$ref": "#/components/schemas/SequenceNumber"
@@ -4538,13 +4365,7 @@
           {
             "description": "Wrapped object",
             "type": "object",
-            "required": [
-              "objectId",
-              "objectType",
-              "sender",
-              "type",
-              "version"
-            ],
+            "required": ["objectId", "objectType", "sender", "type", "version"],
             "properties": {
               "objectId": {
                 "$ref": "#/components/schemas/ObjectID"
@@ -4557,9 +4378,7 @@
               },
               "type": {
                 "type": "string",
-                "enum": [
-                  "wrapped"
-                ]
+                "enum": ["wrapped"]
               },
               "version": {
                 "$ref": "#/components/schemas/SequenceNumber"
@@ -4596,9 +4415,7 @@
               },
               "type": {
                 "type": "string",
-                "enum": [
-                  "created"
-                ]
+                "enum": ["created"]
               },
               "version": {
                 "$ref": "#/components/schemas/SequenceNumber"
@@ -4609,11 +4426,7 @@
       },
       "ObjectData": {
         "type": "object",
-        "required": [
-          "digest",
-          "objectId",
-          "version"
-        ],
+        "required": ["digest", "objectId", "version"],
         "properties": {
           "bcs": {
             "description": "Move object content or package content in BCS, default to be None unless SuiObjectDataOptions.showBcs is set to true",
@@ -4647,10 +4460,7 @@
           },
           "display": {
             "description": "The Display metadata for frontend UI rendering, default to be None unless SuiObjectDataOptions.showContent is set to true This can also be None if the struct type does not have Display defined See more details in <https://forums.sui.io/t/nft-object-display-proposal/4872>",
-            "type": [
-              "object",
-              "null"
-            ],
+            "type": ["object", "null"],
             "additionalProperties": {
               "type": "string"
             }
@@ -4682,19 +4492,13 @@
           },
           "storageRebate": {
             "description": "The amount of SUI we would rebate if this object gets deleted. This number is re-calculated each time the object is mutated based on the present storage gas price.",
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "format": "uint64",
             "minimum": 0.0
           },
           "type": {
             "description": "The type of the object. Default to be None unless SuiObjectDataOptions.showType is set to true",
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "version": {
             "description": "Object version.",
@@ -4757,67 +4561,49 @@
           {
             "description": "The object exists and is found with this version",
             "type": "object",
-            "required": [
-              "details",
-              "status"
-            ],
+            "required": ["details", "status"],
             "properties": {
               "details": {
                 "$ref": "#/components/schemas/ObjectData"
               },
               "status": {
                 "type": "string",
-                "enum": [
-                  "VersionFound"
-                ]
+                "enum": ["VersionFound"]
               }
             }
           },
           {
             "description": "The object does not exist",
             "type": "object",
-            "required": [
-              "details",
-              "status"
-            ],
+            "required": ["details", "status"],
             "properties": {
               "details": {
                 "$ref": "#/components/schemas/ObjectID"
               },
               "status": {
                 "type": "string",
-                "enum": [
-                  "ObjectNotExists"
-                ]
+                "enum": ["ObjectNotExists"]
               }
             }
           },
           {
             "description": "The object is found to be deleted with this version",
             "type": "object",
-            "required": [
-              "details",
-              "status"
-            ],
+            "required": ["details", "status"],
             "properties": {
               "details": {
                 "$ref": "#/components/schemas/ObjectRef"
               },
               "status": {
                 "type": "string",
-                "enum": [
-                  "ObjectDeleted"
-                ]
+                "enum": ["ObjectDeleted"]
               }
             }
           },
           {
             "description": "The object exists but not found with this version",
             "type": "object",
-            "required": [
-              "details",
-              "status"
-            ],
+            "required": ["details", "status"],
             "properties": {
               "details": {
                 "type": "array",
@@ -4834,27 +4620,18 @@
               },
               "status": {
                 "type": "string",
-                "enum": [
-                  "VersionNotFound"
-                ]
+                "enum": ["VersionNotFound"]
               }
             }
           },
           {
             "description": "The asked object version is higher than the latest",
             "type": "object",
-            "required": [
-              "details",
-              "status"
-            ],
+            "required": ["details", "status"],
             "properties": {
               "details": {
                 "type": "object",
-                "required": [
-                  "asked_version",
-                  "latest_version",
-                  "object_id"
-                ],
+                "required": ["asked_version", "latest_version", "object_id"],
                 "properties": {
                   "asked_version": {
                     "$ref": "#/components/schemas/SequenceNumber"
@@ -4869,9 +4646,7 @@
               },
               "status": {
                 "type": "string",
-                "enum": [
-                  "VersionTooHigh"
-                ]
+                "enum": ["VersionTooHigh"]
               }
             }
           }
@@ -4879,11 +4654,7 @@
       },
       "ObjectRef": {
         "type": "object",
-        "required": [
-          "digest",
-          "objectId",
-          "version"
-        ],
+        "required": ["digest", "objectId", "version"],
         "properties": {
           "digest": {
             "description": "Base64 string representing the object digest",
@@ -4915,16 +4686,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "code",
-              "object_id"
-            ],
+            "required": ["code", "object_id"],
             "properties": {
               "code": {
                 "type": "string",
-                "enum": [
-                  "notExists"
-                ]
+                "enum": ["notExists"]
               },
               "object_id": {
                 "$ref": "#/components/schemas/ObjectID"
@@ -4933,18 +4699,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "code",
-              "digest",
-              "object_id",
-              "version"
-            ],
+            "required": ["code", "digest", "object_id", "version"],
             "properties": {
               "code": {
                 "type": "string",
-                "enum": [
-                  "deleted"
-                ]
+                "enum": ["deleted"]
               },
               "digest": {
                 "description": "Base64 string representing the object digest",
@@ -4969,15 +4728,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "code"
-            ],
+            "required": ["code"],
             "properties": {
               "code": {
                 "type": "string",
-                "enum": [
-                  "unknown"
-                ]
+                "enum": ["unknown"]
               }
             }
           }
@@ -5014,18 +4769,11 @@
       },
       "ObjectValueKind": {
         "type": "string",
-        "enum": [
-          "ByImmutableReference",
-          "ByMutableReference",
-          "ByValue"
-        ]
+        "enum": ["ByImmutableReference", "ByMutableReference", "ByValue"]
       },
       "OwnedObjectRef": {
         "type": "object",
-        "required": [
-          "owner",
-          "reference"
-        ],
+        "required": ["owner", "reference"],
         "properties": {
           "owner": {
             "$ref": "#/components/schemas/Owner"
@@ -5040,9 +4788,7 @@
           {
             "description": "Object is exclusively owned by a single address, and is mutable.",
             "type": "object",
-            "required": [
-              "AddressOwner"
-            ],
+            "required": ["AddressOwner"],
             "properties": {
               "AddressOwner": {
                 "$ref": "#/components/schemas/SuiAddress"
@@ -5053,9 +4799,7 @@
           {
             "description": "Object is exclusively owned by a single object, and is mutable. The object ID is converted to SuiAddress as SuiAddress is universal.",
             "type": "object",
-            "required": [
-              "ObjectOwner"
-            ],
+            "required": ["ObjectOwner"],
             "properties": {
               "ObjectOwner": {
                 "$ref": "#/components/schemas/SuiAddress"
@@ -5066,15 +4810,11 @@
           {
             "description": "Object is shared, can be used by any address, and is mutable.",
             "type": "object",
-            "required": [
-              "Shared"
-            ],
+            "required": ["Shared"],
             "properties": {
               "Shared": {
                 "type": "object",
-                "required": [
-                  "initial_shared_version"
-                ],
+                "required": ["initial_shared_version"],
                 "properties": {
                   "initial_shared_version": {
                     "description": "The version at which the object became shared",
@@ -5092,19 +4832,14 @@
           {
             "description": "Object is immutable, and hence ownership doesn't matter.",
             "type": "string",
-            "enum": [
-              "Immutable"
-            ]
+            "enum": ["Immutable"]
           }
         ]
       },
       "Page_for_Checkpoint_and_BigInt": {
         "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
-        "required": [
-          "data",
-          "hasNextPage"
-        ],
+        "required": ["data", "hasNextPage"],
         "properties": {
           "data": {
             "type": "array",
@@ -5130,10 +4865,7 @@
       "Page_for_Coin_and_ObjectID": {
         "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
-        "required": [
-          "data",
-          "hasNextPage"
-        ],
+        "required": ["data", "hasNextPage"],
         "properties": {
           "data": {
             "type": "array",
@@ -5159,10 +4891,7 @@
       "Page_for_DynamicFieldInfo_and_ObjectID": {
         "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
-        "required": [
-          "data",
-          "hasNextPage"
-        ],
+        "required": ["data", "hasNextPage"],
         "properties": {
           "data": {
             "type": "array",
@@ -5188,10 +4917,7 @@
       "Page_for_EpochInfo_and_uint64": {
         "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
-        "required": [
-          "data",
-          "hasNextPage"
-        ],
+        "required": ["data", "hasNextPage"],
         "properties": {
           "data": {
             "type": "array",
@@ -5203,10 +4929,7 @@
             "type": "boolean"
           },
           "nextCursor": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "format": "uint64",
             "minimum": 0.0
           }
@@ -5215,10 +4938,7 @@
       "Page_for_Event_and_EventID": {
         "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
-        "required": [
-          "data",
-          "hasNextPage"
-        ],
+        "required": ["data", "hasNextPage"],
         "properties": {
           "data": {
             "type": "array",
@@ -5244,10 +4964,7 @@
       "Page_for_SuiObjectResponse_and_ObjectID": {
         "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
-        "required": [
-          "data",
-          "hasNextPage"
-        ],
+        "required": ["data", "hasNextPage"],
         "properties": {
           "data": {
             "type": "array",
@@ -5273,10 +4990,7 @@
       "Page_for_TransactionResponse_and_TransactionDigest": {
         "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
-        "required": [
-          "data",
-          "hasNextPage"
-        ],
+        "required": ["data", "hasNextPage"],
         "properties": {
           "data": {
             "type": "array",
@@ -5308,9 +5022,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "Ed25519"
-            ],
+            "required": ["Ed25519"],
             "properties": {
               "Ed25519": {
                 "$ref": "#/components/schemas/Base64"
@@ -5320,9 +5032,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "Secp256k1"
-            ],
+            "required": ["Secp256k1"],
             "properties": {
               "Secp256k1": {
                 "$ref": "#/components/schemas/Base64"
@@ -5332,9 +5042,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "Secp256r1"
-            ],
+            "required": ["Secp256r1"],
             "properties": {
               "Secp256r1": {
                 "$ref": "#/components/schemas/Base64"
@@ -5348,9 +5056,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "transferObjectRequestParams"
-            ],
+            "required": ["transferObjectRequestParams"],
             "properties": {
               "transferObjectRequestParams": {
                 "$ref": "#/components/schemas/TransferObjectParams"
@@ -5360,9 +5066,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "moveCallRequestParams"
-            ],
+            "required": ["moveCallRequestParams"],
             "properties": {
               "moveCallRequestParams": {
                 "$ref": "#/components/schemas/MoveCallParams"
@@ -5389,9 +5093,7 @@
               },
               "dataType": {
                 "type": "string",
-                "enum": [
-                  "moveObject"
-                ]
+                "enum": ["moveObject"]
               },
               "hasPublicTransfer": {
                 "type": "boolean"
@@ -5417,9 +5119,7 @@
             "properties": {
               "dataType": {
                 "type": "string",
-                "enum": [
-                  "package"
-                ]
+                "enum": ["package"]
               },
               "id": {
                 "$ref": "#/components/schemas/ObjectID"
@@ -5464,9 +5164,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "Ed25519SuiSignature"
-            ],
+            "required": ["Ed25519SuiSignature"],
             "properties": {
               "Ed25519SuiSignature": {
                 "$ref": "#/components/schemas/Ed25519SuiSignature"
@@ -5476,9 +5174,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "Secp256k1SuiSignature"
-            ],
+            "required": ["Secp256k1SuiSignature"],
             "properties": {
               "Secp256k1SuiSignature": {
                 "$ref": "#/components/schemas/Secp256k1SuiSignature"
@@ -5488,9 +5184,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "Secp256r1SuiSignature"
-            ],
+            "required": ["Secp256r1SuiSignature"],
             "properties": {
               "Secp256r1SuiSignature": {
                 "$ref": "#/components/schemas/Secp256r1SuiSignature"
@@ -5505,24 +5199,17 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "status"
-            ],
+            "required": ["status"],
             "properties": {
               "status": {
                 "type": "string",
-                "enum": [
-                  "Pending"
-                ]
+                "enum": ["Pending"]
               }
             }
           },
           {
             "type": "object",
-            "required": [
-              "estimatedReward",
-              "status"
-            ],
+            "required": ["estimatedReward", "status"],
             "properties": {
               "estimatedReward": {
                 "type": "integer",
@@ -5531,9 +5218,7 @@
               },
               "status": {
                 "type": "string",
-                "enum": [
-                  "Active"
-                ]
+                "enum": ["Active"]
               }
             }
           }
@@ -5579,16 +5264,12 @@
           {
             "description": "The gas coin. The gas coin can only be used by-ref, except for with `TransferObjects`, which can use it by-value.",
             "type": "string",
-            "enum": [
-              "GasCoin"
-            ]
+            "enum": ["GasCoin"]
           },
           {
             "description": "One of the input objects or primitive values (from `ProgrammableTransaction` inputs)",
             "type": "object",
-            "required": [
-              "Input"
-            ],
+            "required": ["Input"],
             "properties": {
               "Input": {
                 "type": "integer",
@@ -5601,9 +5282,7 @@
           {
             "description": "The result of another command (from `ProgrammableTransaction` commands)",
             "type": "object",
-            "required": [
-              "Result"
-            ],
+            "required": ["Result"],
             "properties": {
               "Result": {
                 "type": "integer",
@@ -5616,9 +5295,7 @@
           {
             "description": "Like a `Result` but it accesses a nested result. Currently, the only usage of this is to access a value from a Move call with multiple return values.",
             "type": "object",
-            "required": [
-              "NestedResult"
-            ],
+            "required": ["NestedResult"],
             "properties": {
               "NestedResult": {
                 "type": "array",
@@ -5649,12 +5326,7 @@
             "oneOf": [
               {
                 "type": "object",
-                "required": [
-                  "digest",
-                  "objectId",
-                  "objectType",
-                  "version"
-                ],
+                "required": ["digest", "objectId", "objectType", "version"],
                 "properties": {
                   "digest": {
                     "$ref": "#/components/schemas/ObjectDigest"
@@ -5664,9 +5336,7 @@
                   },
                   "objectType": {
                     "type": "string",
-                    "enum": [
-                      "immOrOwnedObject"
-                    ]
+                    "enum": ["immOrOwnedObject"]
                   },
                   "version": {
                     "$ref": "#/components/schemas/SequenceNumber"
@@ -5693,47 +5363,33 @@
                   },
                   "objectType": {
                     "type": "string",
-                    "enum": [
-                      "sharedObject"
-                    ]
+                    "enum": ["sharedObject"]
                   }
                 }
               }
             ],
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "object"
-                ]
+                "enum": ["object"]
               }
             }
           },
           {
             "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
+            "required": ["type", "value"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "pure"
-                ]
+                "enum": ["pure"]
               },
               "value": {
                 "$ref": "#/components/schemas/SuiJsonValue"
               },
               "valueType": {
                 "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             }
           }
@@ -5741,12 +5397,7 @@
       },
       "SuiCoinMetadata": {
         "type": "object",
-        "required": [
-          "decimals",
-          "description",
-          "name",
-          "symbol"
-        ],
+        "required": ["decimals", "description", "name", "symbol"],
         "properties": {
           "decimals": {
             "description": "Number of decimal places the coin uses.",
@@ -5760,10 +5411,7 @@
           },
           "iconUrl": {
             "description": "URL for the token logo",
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "id": {
             "description": "Object id for the CoinMetadata object",
@@ -5792,9 +5440,7 @@
           {
             "description": "A call to either an entry or a public Move function",
             "type": "object",
-            "required": [
-              "MoveCall"
-            ],
+            "required": ["MoveCall"],
             "properties": {
               "MoveCall": {
                 "$ref": "#/components/schemas/SuiProgrammableMoveCall"
@@ -5805,9 +5451,7 @@
           {
             "description": "`(Vec<forall T:key+store. T>, address)` It sends n-objects to the specified address. These objects must have store (public transfer) and either the previous owner must be an address or the object must be newly created.",
             "type": "object",
-            "required": [
-              "TransferObjects"
-            ],
+            "required": ["TransferObjects"],
             "properties": {
               "TransferObjects": {
                 "type": "array",
@@ -5831,9 +5475,7 @@
           {
             "description": "`(&mut Coin<T>, Vec<u64>)` -> `Vec<Coin<T>>` It splits off some amounts into a new coins with those amounts",
             "type": "object",
-            "required": [
-              "SplitCoins"
-            ],
+            "required": ["SplitCoins"],
             "properties": {
               "SplitCoins": {
                 "type": "array",
@@ -5857,9 +5499,7 @@
           {
             "description": "`(&mut Coin<T>, Vec<Coin<T>>)` It merges n-coins into the first coin",
             "type": "object",
-            "required": [
-              "MergeCoins"
-            ],
+            "required": ["MergeCoins"],
             "properties": {
               "MergeCoins": {
                 "type": "array",
@@ -5883,9 +5523,7 @@
           {
             "description": "Publishes a Move package. It takes the package bytes and a list of the package's transitive dependencies to link against on-chain.",
             "type": "object",
-            "required": [
-              "Publish"
-            ],
+            "required": ["Publish"],
             "properties": {
               "Publish": {
                 "type": "array",
@@ -5909,9 +5547,7 @@
           {
             "description": "Upgrades a Move package",
             "type": "object",
-            "required": [
-              "Upgrade"
-            ],
+            "required": ["Upgrade"],
             "properties": {
               "Upgrade": {
                 "type": "array",
@@ -5941,18 +5577,13 @@
           {
             "description": "`forall T: Vec<T> -> vector<T>` Given n-values of the same type, it constructs a vector. For non objects or an empty vector, the type tag must be specified.",
             "type": "object",
-            "required": [
-              "MakeMoveVec"
-            ],
+            "required": ["MakeMoveVec"],
             "properties": {
               "MakeMoveVec": {
                 "type": "array",
                 "items": [
                   {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
+                    "type": ["string", "null"]
                   },
                   {
                     "type": "array",
@@ -6024,18 +5655,11 @@
       "SuiJsonValue": {},
       "SuiMoveAbility": {
         "type": "string",
-        "enum": [
-          "Copy",
-          "Drop",
-          "Store",
-          "Key"
-        ]
+        "enum": ["Copy", "Drop", "Store", "Key"]
       },
       "SuiMoveAbilitySet": {
         "type": "object",
-        "required": [
-          "abilities"
-        ],
+        "required": ["abilities"],
         "properties": {
           "abilities": {
             "type": "array",
@@ -6047,10 +5671,7 @@
       },
       "SuiMoveModuleId": {
         "type": "object",
-        "required": [
-          "address",
-          "name"
-        ],
+        "required": ["address", "name"],
         "properties": {
           "address": {
             "type": "string"
@@ -6062,10 +5683,7 @@
       },
       "SuiMoveNormalizedField": {
         "type": "object",
-        "required": [
-          "name",
-          "type"
-        ],
+        "required": ["name", "type"],
         "properties": {
           "name": {
             "type": "string"
@@ -6155,11 +5773,7 @@
       },
       "SuiMoveNormalizedStruct": {
         "type": "object",
-        "required": [
-          "abilities",
-          "fields",
-          "typeParameters"
-        ],
+        "required": ["abilities", "fields", "typeParameters"],
         "properties": {
           "abilities": {
             "$ref": "#/components/schemas/SuiMoveAbilitySet"
@@ -6196,18 +5810,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "Struct"
-            ],
+            "required": ["Struct"],
             "properties": {
               "Struct": {
                 "type": "object",
-                "required": [
-                  "address",
-                  "module",
-                  "name",
-                  "typeArguments"
-                ],
+                "required": ["address", "module", "name", "typeArguments"],
                 "properties": {
                   "address": {
                     "type": "string"
@@ -6231,9 +5838,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "Vector"
-            ],
+            "required": ["Vector"],
             "properties": {
               "Vector": {
                 "$ref": "#/components/schemas/SuiMoveNormalizedType"
@@ -6243,9 +5848,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "TypeParameter"
-            ],
+            "required": ["TypeParameter"],
             "properties": {
               "TypeParameter": {
                 "type": "integer",
@@ -6257,9 +5860,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "Reference"
-            ],
+            "required": ["Reference"],
             "properties": {
               "Reference": {
                 "$ref": "#/components/schemas/SuiMoveNormalizedType"
@@ -6269,9 +5870,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "MutableReference"
-            ],
+            "required": ["MutableReference"],
             "properties": {
               "MutableReference": {
                 "$ref": "#/components/schemas/SuiMoveNormalizedType"
@@ -6283,10 +5882,7 @@
       },
       "SuiMoveStructTypeParameter": {
         "type": "object",
-        "required": [
-          "constraints",
-          "isPhantom"
-        ],
+        "required": ["constraints", "isPhantom"],
         "properties": {
           "constraints": {
             "$ref": "#/components/schemas/SuiMoveAbilitySet"
@@ -6298,19 +5894,13 @@
       },
       "SuiMoveVisibility": {
         "type": "string",
-        "enum": [
-          "Private",
-          "Public",
-          "Friend"
-        ]
+        "enum": ["Private", "Public", "Friend"]
       },
       "SuiObjectDataFilter": {
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "MatchAll"
-            ],
+            "required": ["MatchAll"],
             "properties": {
               "MatchAll": {
                 "type": "array",
@@ -6323,9 +5913,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "MatchAny"
-            ],
+            "required": ["MatchAny"],
             "properties": {
               "MatchAny": {
                 "type": "array",
@@ -6339,9 +5927,7 @@
           {
             "description": "Query by type a specified Package.",
             "type": "object",
-            "required": [
-              "Package"
-            ],
+            "required": ["Package"],
             "properties": {
               "Package": {
                 "$ref": "#/components/schemas/ObjectID"
@@ -6352,16 +5938,11 @@
           {
             "description": "Query by type a specified Move module.",
             "type": "object",
-            "required": [
-              "MoveModule"
-            ],
+            "required": ["MoveModule"],
             "properties": {
               "MoveModule": {
                 "type": "object",
-                "required": [
-                  "module",
-                  "package"
-                ],
+                "required": ["module", "package"],
                 "properties": {
                   "module": {
                     "description": "the module name",
@@ -6383,9 +5964,7 @@
           {
             "description": "Query by type",
             "type": "object",
-            "required": [
-              "StructType"
-            ],
+            "required": ["StructType"],
             "properties": {
               "StructType": {
                 "type": "string"
@@ -6395,9 +5974,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "AddressOwner"
-            ],
+            "required": ["AddressOwner"],
             "properties": {
               "AddressOwner": {
                 "$ref": "#/components/schemas/SuiAddress"
@@ -6407,9 +5984,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "ObjectOwner"
-            ],
+            "required": ["ObjectOwner"],
             "properties": {
               "ObjectOwner": {
                 "$ref": "#/components/schemas/ObjectID"
@@ -6419,9 +5994,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "ObjectId"
-            ],
+            "required": ["ObjectId"],
             "properties": {
               "ObjectId": {
                 "$ref": "#/components/schemas/ObjectID"
@@ -6431,9 +6004,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "ObjectIds"
-            ],
+            "required": ["ObjectIds"],
             "properties": {
               "ObjectIds": {
                 "type": "array",
@@ -6446,9 +6017,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "Version"
-            ],
+            "required": ["Version"],
             "properties": {
               "Version": {
                 "type": "integer",
@@ -6488,11 +6057,7 @@
       "SuiProgrammableMoveCall": {
         "description": "The command for calling a Move function, either an entry function or a public function (which cannot return references).",
         "type": "object",
-        "required": [
-          "function",
-          "module",
-          "package"
-        ],
+        "required": ["function", "module", "package"],
         "properties": {
           "arguments": {
             "description": "The arguments to the function.",
@@ -6821,16 +6386,12 @@
           {
             "description": "Regular Sui Transactions that are committed on chain",
             "type": "string",
-            "enum": [
-              "Commit"
-            ]
+            "enum": ["Commit"]
           },
           {
             "description": "Simulated transaction that allows calling any Move function with arbitrary values.",
             "type": "string",
-            "enum": [
-              "DevInspect"
-            ]
+            "enum": ["DevInspect"]
           }
         ]
       },
@@ -6919,10 +6480,7 @@
             "minimum": 0.0
           },
           "nextEpochNetAddress": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "nextEpochNetworkPubkeyBytes": {
             "default": null,
@@ -6936,16 +6494,10 @@
             ]
           },
           "nextEpochP2pAddress": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "nextEpochPrimaryAddress": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "nextEpochProofOfPossession": {
             "default": null,
@@ -6975,10 +6527,7 @@
             "minimum": 0.0
           },
           "nextEpochWorkerAddress": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "nextEpochWorkerPubkeyBytes": {
             "default": null,
@@ -7041,19 +6590,13 @@
           },
           "stakingPoolActivationEpoch": {
             "description": "The epoch at which this pool became active.",
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "format": "uint64",
             "minimum": 0.0
           },
           "stakingPoolDeactivationEpoch": {
             "description": "The epoch at which this staking pool ceased to be active. `None` = {pre-active, active},",
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "format": "uint64",
             "minimum": 0.0
           },
@@ -7089,9 +6632,7 @@
       },
       "Supply": {
         "type": "object",
-        "required": [
-          "value"
-        ],
+        "required": ["value"],
         "properties": {
           "value": {
             "type": "integer",
@@ -7102,10 +6643,7 @@
       },
       "Transaction": {
         "type": "object",
-        "required": [
-          "data",
-          "txSignatures"
-        ],
+        "required": ["data", "txSignatures"],
         "properties": {
           "data": {
             "$ref": "#/components/schemas/TransactionData"
@@ -7120,11 +6658,7 @@
       },
       "TransactionBytes": {
         "type": "object",
-        "required": [
-          "gas",
-          "inputObjects",
-          "txBytes"
-        ],
+        "required": ["gas", "inputObjects", "txBytes"],
         "properties": {
           "gas": {
             "description": "the gas objects to be used",
@@ -7154,21 +6688,14 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "gasData",
-              "messageVersion",
-              "sender",
-              "transaction"
-            ],
+            "required": ["gasData", "messageVersion", "sender", "transaction"],
             "properties": {
               "gasData": {
                 "$ref": "#/components/schemas/GasData"
               },
               "messageVersion": {
                 "type": "string",
-                "enum": [
-                  "v1"
-                ]
+                "enum": ["v1"]
               },
               "sender": {
                 "$ref": "#/components/schemas/SuiAddress"
@@ -7253,9 +6780,7 @@
               },
               "messageVersion": {
                 "type": "string",
-                "enum": [
-                  "v1"
-                ]
+                "enum": ["v1"]
               },
               "modifiedAtVersions": {
                 "description": "The version that every modified (mutated or deleted) object had before it was modified by this transaction.",
@@ -7321,10 +6846,7 @@
       },
       "TransactionEffectsModifiedAtVersions": {
         "type": "object",
-        "required": [
-          "objectId",
-          "sequenceNumber"
-        ],
+        "required": ["objectId", "sequenceNumber"],
         "properties": {
           "objectId": {
             "$ref": "#/components/schemas/ObjectID"
@@ -7342,27 +6864,17 @@
           {
             "description": "Query by move function.",
             "type": "object",
-            "required": [
-              "MoveFunction"
-            ],
+            "required": ["MoveFunction"],
             "properties": {
               "MoveFunction": {
                 "type": "object",
-                "required": [
-                  "package"
-                ],
+                "required": ["package"],
                 "properties": {
                   "function": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
+                    "type": ["string", "null"]
                   },
                   "module": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
+                    "type": ["string", "null"]
                   },
                   "package": {
                     "$ref": "#/components/schemas/ObjectID"
@@ -7375,9 +6887,7 @@
           {
             "description": "Query by input object.",
             "type": "object",
-            "required": [
-              "InputObject"
-            ],
+            "required": ["InputObject"],
             "properties": {
               "InputObject": {
                 "$ref": "#/components/schemas/ObjectID"
@@ -7388,9 +6898,7 @@
           {
             "description": "Query by changed object, including created, mutated and unwrapped objects.",
             "type": "object",
-            "required": [
-              "ChangedObject"
-            ],
+            "required": ["ChangedObject"],
             "properties": {
               "ChangedObject": {
                 "$ref": "#/components/schemas/ObjectID"
@@ -7401,9 +6909,7 @@
           {
             "description": "Query by sender address.",
             "type": "object",
-            "required": [
-              "FromAddress"
-            ],
+            "required": ["FromAddress"],
             "properties": {
               "FromAddress": {
                 "$ref": "#/components/schemas/SuiAddress"
@@ -7414,9 +6920,7 @@
           {
             "description": "Query by recipient address.",
             "type": "object",
-            "required": [
-              "ToAddress"
-            ],
+            "required": ["ToAddress"],
             "properties": {
               "ToAddress": {
                 "$ref": "#/components/schemas/SuiAddress"
@@ -7457,9 +6961,7 @@
               },
               "kind": {
                 "type": "string",
-                "enum": [
-                  "ChangeEpoch"
-                ]
+                "enum": ["ChangeEpoch"]
               },
               "storage_charge": {
                 "type": "integer",
@@ -7476,16 +6978,11 @@
           {
             "description": "A system transaction used for initializing the initial state of the chain.",
             "type": "object",
-            "required": [
-              "kind",
-              "objects"
-            ],
+            "required": ["kind", "objects"],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "Genesis"
-                ]
+                "enum": ["Genesis"]
               },
               "objects": {
                 "type": "array",
@@ -7498,12 +6995,7 @@
           {
             "description": "A system transaction marking the start of a series of transactions scheduled as part of a checkpoint",
             "type": "object",
-            "required": [
-              "commit_timestamp_ms",
-              "epoch",
-              "kind",
-              "round"
-            ],
+            "required": ["commit_timestamp_ms", "epoch", "kind", "round"],
             "properties": {
               "commit_timestamp_ms": {
                 "type": "integer",
@@ -7517,9 +7009,7 @@
               },
               "kind": {
                 "type": "string",
-                "enum": [
-                  "ConsensusCommitPrologue"
-                ]
+                "enum": ["ConsensusCommitPrologue"]
               },
               "round": {
                 "type": "integer",
@@ -7531,11 +7021,7 @@
           {
             "description": "A series of commands where the results of one command can be used in future commands",
             "type": "object",
-            "required": [
-              "commands",
-              "inputs",
-              "kind"
-            ],
+            "required": ["commands", "inputs", "kind"],
             "properties": {
               "commands": {
                 "description": "The commands to be executed sequentially. A failure in any command will result in the failure of the entire transaction.",
@@ -7553,9 +7039,7 @@
               },
               "kind": {
                 "type": "string",
-                "enum": [
-                  "ProgrammableTransaction"
-                ]
+                "enum": ["ProgrammableTransaction"]
               }
             }
           }
@@ -7563,33 +7047,22 @@
       },
       "TransactionResponse": {
         "type": "object",
-        "required": [
-          "digest"
-        ],
+        "required": ["digest"],
         "properties": {
           "balanceChanges": {
-            "type": [
-              "array",
-              "null"
-            ],
+            "type": ["array", "null"],
             "items": {
               "$ref": "#/components/schemas/BalanceChange"
             }
           },
           "checkpoint": {
             "description": "The checkpoint number when this transaction was included and hence finalized. This is only returned in the read api, not in the transaction execution api.",
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "format": "uint64",
             "minimum": 0.0
           },
           "confirmedLocalExecution": {
-            "type": [
-              "boolean",
-              "null"
-            ]
+            "type": ["boolean", "null"]
           },
           "digest": {
             "$ref": "#/components/schemas/TransactionDigest"
@@ -7611,19 +7084,13 @@
             }
           },
           "events": {
-            "type": [
-              "array",
-              "null"
-            ],
+            "type": ["array", "null"],
             "items": {
               "$ref": "#/components/schemas/Event"
             }
           },
           "objectChanges": {
-            "type": [
-              "array",
-              "null"
-            ],
+            "type": ["array", "null"],
             "items": {
               "$ref": "#/components/schemas/ObjectChange"
             }
@@ -7637,10 +7104,7 @@
             ]
           },
           "timestampMs": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "format": "uint64",
             "minimum": 0.0
           },
@@ -7723,10 +7187,7 @@
       },
       "TransferObjectParams": {
         "type": "object",
-        "required": [
-          "objectId",
-          "recipient"
-        ],
+        "required": ["objectId", "recipient"],
         "properties": {
           "objectId": {
             "$ref": "#/components/schemas/ObjectID"
@@ -7739,11 +7200,7 @@
       "TypeOrigin": {
         "description": "Identifies a struct and the module it was defined in",
         "type": "object",
-        "required": [
-          "module_name",
-          "package",
-          "struct_name"
-        ],
+        "required": ["module_name", "package", "struct_name"],
         "properties": {
           "module_name": {
             "type": "string"
@@ -7762,10 +7219,7 @@
       "UpgradeInfo": {
         "description": "Upgraded package info for the linkage table",
         "type": "object",
-        "required": [
-          "upgraded_id",
-          "upgraded_version"
-        ],
+        "required": ["upgraded_id", "upgraded_version"],
         "properties": {
           "upgraded_id": {
             "description": "ID of the upgraded packages",

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -236,7 +236,7 @@
                   "computationCost": "100",
                   "storageCost": "100",
                   "storageRebate": "10",
-                  "nonRefundableStorageFee": 0
+                  "nonRefundableStorageFee": "0"
                 },
                 "transactionDigest": "8UExPV121BEfWkbymSPDYhh23rVNh3MSWtC5juJ9JGMJ",
                 "mutated": [
@@ -445,7 +445,9 @@
                 "nonRefundableStorageFee": 0
               },
               "timestampMs": 1676911928,
-              "transactions": ["3bpzHaSLTQ6p4trLDk2euZxzQ6XqLeWDmUNTAdEXXL2c"],
+              "transactions": [
+                "3bpzHaSLTQ6p4trLDk2euZxzQ6XqLeWDmUNTAdEXXL2c"
+              ],
               "checkpointCommitments": []
             }
           }
@@ -1424,7 +1426,7 @@
                   "computationCost": "100",
                   "storageCost": "100",
                   "storageRebate": "10",
-                  "nonRefundableStorageFee": 0
+                  "nonRefundableStorageFee": "0"
                 },
                 "transactionDigest": "6AyFnAuKAKCqm1cD94EyGzBqJCDDJ716ojjmsKF2rqoi",
                 "mutated": [
@@ -2965,7 +2967,11 @@
       },
       "BalanceChange": {
         "type": "object",
-        "required": ["amount", "coinType", "owner"],
+        "required": [
+          "amount",
+          "coinType",
+          "owner"
+        ],
         "properties": {
           "amount": {
             "description": "The amount indicate the balance value changes, negative amount means spending coin value and positive means receiving coin value.",
@@ -3092,7 +3098,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["ECMHLiveObjectSetDigest"],
+            "required": [
+              "ECMHLiveObjectSetDigest"
+            ],
             "properties": {
               "ECMHLiveObjectSetDigest": {
                 "$ref": "#/components/schemas/ECMHLiveObjectSetDigest"
@@ -3146,7 +3154,10 @@
             "$ref": "#/components/schemas/ObjectDigest"
           },
           "lockedUntilEpoch": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "format": "uint64",
             "minimum": 0.0
           },
@@ -3161,7 +3172,10 @@
       "CommitteeInfo": {
         "description": "RPC representation of the [Committee] type.",
         "type": "object",
-        "required": ["epoch", "validators"],
+        "required": [
+          "epoch",
+          "validators"
+        ],
         "properties": {
           "epoch": {
             "type": "integer",
@@ -3193,7 +3207,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["Ed25519"],
+            "required": [
+              "Ed25519"
+            ],
             "properties": {
               "Ed25519": {
                 "$ref": "#/components/schemas/Base64"
@@ -3203,7 +3219,9 @@
           },
           {
             "type": "object",
-            "required": ["Secp256k1"],
+            "required": [
+              "Secp256k1"
+            ],
             "properties": {
               "Secp256k1": {
                 "$ref": "#/components/schemas/Base64"
@@ -3213,7 +3231,9 @@
           },
           {
             "type": "object",
-            "required": ["Secp256r1"],
+            "required": [
+              "Secp256r1"
+            ],
             "properties": {
               "Secp256r1": {
                 "$ref": "#/components/schemas/Base64"
@@ -3227,11 +3247,18 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["dataType", "fields", "hasPublicTransfer", "type"],
+            "required": [
+              "dataType",
+              "fields",
+              "hasPublicTransfer",
+              "type"
+            ],
             "properties": {
               "dataType": {
                 "type": "string",
-                "enum": ["moveObject"]
+                "enum": [
+                  "moveObject"
+                ]
               },
               "fields": {
                 "$ref": "#/components/schemas/MoveStruct"
@@ -3246,11 +3273,16 @@
           },
           {
             "type": "object",
-            "required": ["dataType", "disassembled"],
+            "required": [
+              "dataType",
+              "disassembled"
+            ],
             "properties": {
               "dataType": {
                 "type": "string",
-                "enum": ["package"]
+                "enum": [
+                  "package"
+                ]
               },
               "disassembled": {
                 "type": "object",
@@ -3262,7 +3294,11 @@
       },
       "DelegatedStake": {
         "type": "object",
-        "required": ["stakes", "stakingPool", "validatorAddress"],
+        "required": [
+          "stakes",
+          "stakingPool",
+          "validatorAddress"
+        ],
         "properties": {
           "stakes": {
             "type": "array",
@@ -3291,7 +3327,10 @@
       "DevInspectResults": {
         "description": "The response from processing a dev inspect transaction",
         "type": "object",
-        "required": ["effects", "events"],
+        "required": [
+          "effects",
+          "events"
+        ],
         "properties": {
           "effects": {
             "description": "Summary of effects that likely would be generated if the transaction is actually run. Note however, that not all dev-inspect transactions are actually usable as transactions so it might not be possible actually generate these effects from a normal transaction.",
@@ -3303,7 +3342,10 @@
           },
           "error": {
             "description": "Execution error from executing the transaction commands",
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "events": {
             "description": "Events that likely would be generated if the transaction is actually run.",
@@ -3314,7 +3356,10 @@
           },
           "results": {
             "description": "Execution results (including return values) from executing the transaction commands",
-            "type": ["array", "null"],
+            "type": [
+              "array",
+              "null"
+            ],
             "items": {
               "$ref": "#/components/schemas/SuiExecutionResult"
             }
@@ -3331,7 +3376,10 @@
       },
       "DryRunTransactionResponse": {
         "type": "object",
-        "required": ["effects", "events"],
+        "required": [
+          "effects",
+          "events"
+        ],
         "properties": {
           "effects": {
             "$ref": "#/components/schemas/TransactionEffects"
@@ -3381,7 +3429,10 @@
       },
       "DynamicFieldName": {
         "type": "object",
-        "required": ["type", "value"],
+        "required": [
+          "type",
+          "value"
+        ],
         "properties": {
           "type": {
             "type": "string"
@@ -3391,12 +3442,17 @@
       },
       "DynamicFieldType": {
         "type": "string",
-        "enum": ["DynamicField", "DynamicObject"]
+        "enum": [
+          "DynamicField",
+          "DynamicObject"
+        ]
       },
       "ECMHLiveObjectSetDigest": {
         "description": "The Sha256 digest of an EllipticCurveMultisetHash committing to the live object set.",
         "type": "object",
-        "required": ["digest"],
+        "required": [
+          "digest"
+        ],
         "properties": {
           "digest": {
             "type": "array",
@@ -3644,7 +3700,10 @@
           },
           "timestampMs": {
             "description": "UTC timestamp in milliseconds since epoch (1/1/1970)",
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "format": "uint64",
             "minimum": 0.0
           },
@@ -3663,7 +3722,9 @@
           {
             "description": "Query by sender address.",
             "type": "object",
-            "required": ["Sender"],
+            "required": [
+              "Sender"
+            ],
             "properties": {
               "Sender": {
                 "$ref": "#/components/schemas/SuiAddress"
@@ -3674,7 +3735,9 @@
           {
             "description": "Return events emitted by the given transaction.",
             "type": "object",
-            "required": ["Transaction"],
+            "required": [
+              "Transaction"
+            ],
             "properties": {
               "Transaction": {
                 "$ref": "#/components/schemas/TransactionDigest"
@@ -3685,7 +3748,9 @@
           {
             "description": "Return events emitted in a specified Package.",
             "type": "object",
-            "required": ["Package"],
+            "required": [
+              "Package"
+            ],
             "properties": {
               "Package": {
                 "$ref": "#/components/schemas/ObjectID"
@@ -3696,11 +3761,16 @@
           {
             "description": "Return events emitted in a specified Move module.",
             "type": "object",
-            "required": ["MoveModule"],
+            "required": [
+              "MoveModule"
+            ],
             "properties": {
               "MoveModule": {
                 "type": "object",
-                "required": ["module", "package"],
+                "required": [
+                  "module",
+                  "package"
+                ],
                 "properties": {
                   "module": {
                     "description": "the module name",
@@ -3722,7 +3792,9 @@
           {
             "description": "Return events with the given move event struct name",
             "type": "object",
-            "required": ["MoveEventType"],
+            "required": [
+              "MoveEventType"
+            ],
             "properties": {
               "MoveEventType": {
                 "type": "string"
@@ -3732,11 +3804,16 @@
           },
           {
             "type": "object",
-            "required": ["MoveEventField"],
+            "required": [
+              "MoveEventField"
+            ],
             "properties": {
               "MoveEventField": {
                 "type": "object",
-                "required": ["path", "value"],
+                "required": [
+                  "path",
+                  "value"
+                ],
                 "properties": {
                   "path": {
                     "type": "string"
@@ -3750,11 +3827,16 @@
           {
             "description": "Return events emitted in [start_time, end_time] interval",
             "type": "object",
-            "required": ["TimeRange"],
+            "required": [
+              "TimeRange"
+            ],
             "properties": {
               "TimeRange": {
                 "type": "object",
-                "required": ["endTime", "startTime"],
+                "required": [
+                  "endTime",
+                  "startTime"
+                ],
                 "properties": {
                   "endTime": {
                     "description": "right endpoint of time interval, milliseconds since epoch, exclusive",
@@ -3775,7 +3857,9 @@
           },
           {
             "type": "object",
-            "required": ["All"],
+            "required": [
+              "All"
+            ],
             "properties": {
               "All": {
                 "type": "array",
@@ -3788,7 +3872,9 @@
           },
           {
             "type": "object",
-            "required": ["Any"],
+            "required": [
+              "Any"
+            ],
             "properties": {
               "Any": {
                 "type": "array",
@@ -3801,7 +3887,9 @@
           },
           {
             "type": "object",
-            "required": ["And"],
+            "required": [
+              "And"
+            ],
             "properties": {
               "And": {
                 "type": "array",
@@ -3821,7 +3909,9 @@
           },
           {
             "type": "object",
-            "required": ["Or"],
+            "required": [
+              "Or"
+            ],
             "properties": {
               "Or": {
                 "type": "array",
@@ -3844,7 +3934,10 @@
       "EventID": {
         "description": "Unique ID of a Sui Event, the ID is a combination of tx seq number and event seq number, the ID is local to this particular fullnode and will be different from other fullnode.",
         "type": "object",
-        "required": ["eventSeq", "txDigest"],
+        "required": [
+          "eventSeq",
+          "txDigest"
+        ],
         "properties": {
           "eventSeq": {
             "type": "integer",
@@ -3858,30 +3951,42 @@
       },
       "ExecuteTransactionRequestType": {
         "type": "string",
-        "enum": ["WaitForEffectsCert", "WaitForLocalExecution"]
+        "enum": [
+          "WaitForEffectsCert",
+          "WaitForLocalExecution"
+        ]
       },
       "ExecutionStatus": {
         "oneOf": [
           {
             "type": "object",
-            "required": ["status"],
+            "required": [
+              "status"
+            ],
             "properties": {
               "status": {
                 "type": "string",
-                "enum": ["success"]
+                "enum": [
+                  "success"
+                ]
               }
             }
           },
           {
             "type": "object",
-            "required": ["error", "status"],
+            "required": [
+              "error",
+              "status"
+            ],
             "properties": {
               "error": {
                 "type": "string"
               },
               "status": {
                 "type": "string",
-                "enum": ["failure"]
+                "enum": [
+                  "failure"
+                ]
               }
             }
           }
@@ -3897,14 +4002,10 @@
         ],
         "properties": {
           "computationCost": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+            "$ref": "#/components/schemas/BigInt"
           },
           "nonRefundableStorageFee": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+            "$ref": "#/components/schemas/BigInt"
           },
           "storageCost": {
             "$ref": "#/components/schemas/BigInt"
@@ -3916,7 +4017,12 @@
       },
       "GasData": {
         "type": "object",
-        "required": ["budget", "owner", "payment", "price"],
+        "required": [
+          "budget",
+          "owner",
+          "payment",
+          "price"
+        ],
         "properties": {
           "budget": {
             "type": "integer",
@@ -3944,7 +4050,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["MultiSig"],
+            "required": [
+              "MultiSig"
+            ],
             "properties": {
               "MultiSig": {
                 "$ref": "#/components/schemas/MultiSig"
@@ -3954,7 +4062,9 @@
           },
           {
             "type": "object",
-            "required": ["Signature"],
+            "required": [
+              "Signature"
+            ],
             "properties": {
               "Signature": {
                 "$ref": "#/components/schemas/Signature"
@@ -3966,7 +4076,10 @@
       },
       "GetPastObjectRequest": {
         "type": "object",
-        "required": ["objectId", "version"],
+        "required": [
+          "objectId",
+          "version"
+        ],
         "properties": {
           "objectId": {
             "description": "the ID of the queried object",
@@ -3994,7 +4107,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["MovePackage"],
+            "required": [
+              "MovePackage"
+            ],
             "properties": {
               "MovePackage": {
                 "$ref": "#/components/schemas/ObjectID"
@@ -4004,7 +4119,9 @@
           },
           {
             "type": "object",
-            "required": ["ImmOrOwnedMoveObject"],
+            "required": [
+              "ImmOrOwnedMoveObject"
+            ],
             "properties": {
               "ImmOrOwnedMoveObject": {
                 "$ref": "#/components/schemas/ObjectRef"
@@ -4014,11 +4131,16 @@
           },
           {
             "type": "object",
-            "required": ["SharedMoveObject"],
+            "required": [
+              "SharedMoveObject"
+            ],
             "properties": {
               "SharedMoveObject": {
                 "type": "object",
-                "required": ["id", "initial_shared_version"],
+                "required": [
+                  "id",
+                  "initial_shared_version"
+                ],
                 "properties": {
                   "id": {
                     "$ref": "#/components/schemas/ObjectID"
@@ -4039,7 +4161,12 @@
       },
       "MoveCallParams": {
         "type": "object",
-        "required": ["arguments", "function", "module", "packageObjectId"],
+        "required": [
+          "arguments",
+          "function",
+          "module",
+          "packageObjectId"
+        ],
         "properties": {
           "arguments": {
             "type": "array",
@@ -4069,11 +4196,15 @@
         "oneOf": [
           {
             "type": "string",
-            "enum": ["Pure"]
+            "enum": [
+              "Pure"
+            ]
           },
           {
             "type": "object",
-            "required": ["Object"],
+            "required": [
+              "Object"
+            ],
             "properties": {
               "Object": {
                 "$ref": "#/components/schemas/ObjectValueKind"
@@ -4085,7 +4216,9 @@
       },
       "MovePackage": {
         "type": "object",
-        "required": ["disassembled"],
+        "required": [
+          "disassembled"
+        ],
         "properties": {
           "disassembled": {
             "type": "object",
@@ -4103,7 +4236,10 @@
           },
           {
             "type": "object",
-            "required": ["fields", "type"],
+            "required": [
+              "fields",
+              "type"
+            ],
             "properties": {
               "fields": {
                 "type": "object",
@@ -4148,7 +4284,9 @@
           },
           {
             "type": "object",
-            "required": ["id"],
+            "required": [
+              "id"
+            ],
             "properties": {
               "id": {
                 "$ref": "#/components/schemas/ObjectID"
@@ -4173,7 +4311,11 @@
       "MultiSig": {
         "description": "The struct that contains signatures and public keys necessary for authenticating a MultiSig.",
         "type": "object",
-        "required": ["bitmap", "multisig_pk", "sigs"],
+        "required": [
+          "bitmap",
+          "multisig_pk",
+          "sigs"
+        ],
         "properties": {
           "bitmap": {
             "description": "A bitmap that indicates the position of which public key the signature should be authenticated with.",
@@ -4203,7 +4345,10 @@
       "MultiSigPublicKey": {
         "description": "The struct that contains the public key used for authenticating a MultiSig.",
         "type": "object",
-        "required": ["pk_map", "threshold"],
+        "required": [
+          "pk_map",
+          "threshold"
+        ],
         "properties": {
           "pk_map": {
             "description": "A list of public key and its corresponding weight.",
@@ -4238,7 +4383,13 @@
           {
             "description": "Module published",
             "type": "object",
-            "required": ["digest", "modules", "packageId", "type", "version"],
+            "required": [
+              "digest",
+              "modules",
+              "packageId",
+              "type",
+              "version"
+            ],
             "properties": {
               "digest": {
                 "$ref": "#/components/schemas/ObjectDigest"
@@ -4254,7 +4405,9 @@
               },
               "type": {
                 "type": "string",
-                "enum": ["published"]
+                "enum": [
+                  "published"
+                ]
               },
               "version": {
                 "$ref": "#/components/schemas/SequenceNumber"
@@ -4291,7 +4444,9 @@
               },
               "type": {
                 "type": "string",
-                "enum": ["transferred"]
+                "enum": [
+                  "transferred"
+                ]
               },
               "version": {
                 "$ref": "#/components/schemas/SequenceNumber"
@@ -4332,7 +4487,9 @@
               },
               "type": {
                 "type": "string",
-                "enum": ["mutated"]
+                "enum": [
+                  "mutated"
+                ]
               },
               "version": {
                 "$ref": "#/components/schemas/SequenceNumber"
@@ -4342,7 +4499,13 @@
           {
             "description": "Delete object",
             "type": "object",
-            "required": ["objectId", "objectType", "sender", "type", "version"],
+            "required": [
+              "objectId",
+              "objectType",
+              "sender",
+              "type",
+              "version"
+            ],
             "properties": {
               "objectId": {
                 "$ref": "#/components/schemas/ObjectID"
@@ -4355,7 +4518,9 @@
               },
               "type": {
                 "type": "string",
-                "enum": ["deleted"]
+                "enum": [
+                  "deleted"
+                ]
               },
               "version": {
                 "$ref": "#/components/schemas/SequenceNumber"
@@ -4365,7 +4530,13 @@
           {
             "description": "Wrapped object",
             "type": "object",
-            "required": ["objectId", "objectType", "sender", "type", "version"],
+            "required": [
+              "objectId",
+              "objectType",
+              "sender",
+              "type",
+              "version"
+            ],
             "properties": {
               "objectId": {
                 "$ref": "#/components/schemas/ObjectID"
@@ -4378,7 +4549,9 @@
               },
               "type": {
                 "type": "string",
-                "enum": ["wrapped"]
+                "enum": [
+                  "wrapped"
+                ]
               },
               "version": {
                 "$ref": "#/components/schemas/SequenceNumber"
@@ -4415,7 +4588,9 @@
               },
               "type": {
                 "type": "string",
-                "enum": ["created"]
+                "enum": [
+                  "created"
+                ]
               },
               "version": {
                 "$ref": "#/components/schemas/SequenceNumber"
@@ -4426,7 +4601,11 @@
       },
       "ObjectData": {
         "type": "object",
-        "required": ["digest", "objectId", "version"],
+        "required": [
+          "digest",
+          "objectId",
+          "version"
+        ],
         "properties": {
           "bcs": {
             "description": "Move object content or package content in BCS, default to be None unless SuiObjectDataOptions.showBcs is set to true",
@@ -4460,7 +4639,10 @@
           },
           "display": {
             "description": "The Display metadata for frontend UI rendering, default to be None unless SuiObjectDataOptions.showContent is set to true This can also be None if the struct type does not have Display defined See more details in <https://forums.sui.io/t/nft-object-display-proposal/4872>",
-            "type": ["object", "null"],
+            "type": [
+              "object",
+              "null"
+            ],
             "additionalProperties": {
               "type": "string"
             }
@@ -4492,13 +4674,19 @@
           },
           "storageRebate": {
             "description": "The amount of SUI we would rebate if this object gets deleted. This number is re-calculated each time the object is mutated based on the present storage gas price.",
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "format": "uint64",
             "minimum": 0.0
           },
           "type": {
             "description": "The type of the object. Default to be None unless SuiObjectDataOptions.showType is set to true",
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "version": {
             "description": "Object version.",
@@ -4561,49 +4749,67 @@
           {
             "description": "The object exists and is found with this version",
             "type": "object",
-            "required": ["details", "status"],
+            "required": [
+              "details",
+              "status"
+            ],
             "properties": {
               "details": {
                 "$ref": "#/components/schemas/ObjectData"
               },
               "status": {
                 "type": "string",
-                "enum": ["VersionFound"]
+                "enum": [
+                  "VersionFound"
+                ]
               }
             }
           },
           {
             "description": "The object does not exist",
             "type": "object",
-            "required": ["details", "status"],
+            "required": [
+              "details",
+              "status"
+            ],
             "properties": {
               "details": {
                 "$ref": "#/components/schemas/ObjectID"
               },
               "status": {
                 "type": "string",
-                "enum": ["ObjectNotExists"]
+                "enum": [
+                  "ObjectNotExists"
+                ]
               }
             }
           },
           {
             "description": "The object is found to be deleted with this version",
             "type": "object",
-            "required": ["details", "status"],
+            "required": [
+              "details",
+              "status"
+            ],
             "properties": {
               "details": {
                 "$ref": "#/components/schemas/ObjectRef"
               },
               "status": {
                 "type": "string",
-                "enum": ["ObjectDeleted"]
+                "enum": [
+                  "ObjectDeleted"
+                ]
               }
             }
           },
           {
             "description": "The object exists but not found with this version",
             "type": "object",
-            "required": ["details", "status"],
+            "required": [
+              "details",
+              "status"
+            ],
             "properties": {
               "details": {
                 "type": "array",
@@ -4620,18 +4826,27 @@
               },
               "status": {
                 "type": "string",
-                "enum": ["VersionNotFound"]
+                "enum": [
+                  "VersionNotFound"
+                ]
               }
             }
           },
           {
             "description": "The asked object version is higher than the latest",
             "type": "object",
-            "required": ["details", "status"],
+            "required": [
+              "details",
+              "status"
+            ],
             "properties": {
               "details": {
                 "type": "object",
-                "required": ["asked_version", "latest_version", "object_id"],
+                "required": [
+                  "asked_version",
+                  "latest_version",
+                  "object_id"
+                ],
                 "properties": {
                   "asked_version": {
                     "$ref": "#/components/schemas/SequenceNumber"
@@ -4646,7 +4861,9 @@
               },
               "status": {
                 "type": "string",
-                "enum": ["VersionTooHigh"]
+                "enum": [
+                  "VersionTooHigh"
+                ]
               }
             }
           }
@@ -4654,7 +4871,11 @@
       },
       "ObjectRef": {
         "type": "object",
-        "required": ["digest", "objectId", "version"],
+        "required": [
+          "digest",
+          "objectId",
+          "version"
+        ],
         "properties": {
           "digest": {
             "description": "Base64 string representing the object digest",
@@ -4686,11 +4907,16 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["code", "object_id"],
+            "required": [
+              "code",
+              "object_id"
+            ],
             "properties": {
               "code": {
                 "type": "string",
-                "enum": ["notExists"]
+                "enum": [
+                  "notExists"
+                ]
               },
               "object_id": {
                 "$ref": "#/components/schemas/ObjectID"
@@ -4699,11 +4925,18 @@
           },
           {
             "type": "object",
-            "required": ["code", "digest", "object_id", "version"],
+            "required": [
+              "code",
+              "digest",
+              "object_id",
+              "version"
+            ],
             "properties": {
               "code": {
                 "type": "string",
-                "enum": ["deleted"]
+                "enum": [
+                  "deleted"
+                ]
               },
               "digest": {
                 "description": "Base64 string representing the object digest",
@@ -4728,11 +4961,15 @@
           },
           {
             "type": "object",
-            "required": ["code"],
+            "required": [
+              "code"
+            ],
             "properties": {
               "code": {
                 "type": "string",
-                "enum": ["unknown"]
+                "enum": [
+                  "unknown"
+                ]
               }
             }
           }
@@ -4769,11 +5006,18 @@
       },
       "ObjectValueKind": {
         "type": "string",
-        "enum": ["ByImmutableReference", "ByMutableReference", "ByValue"]
+        "enum": [
+          "ByImmutableReference",
+          "ByMutableReference",
+          "ByValue"
+        ]
       },
       "OwnedObjectRef": {
         "type": "object",
-        "required": ["owner", "reference"],
+        "required": [
+          "owner",
+          "reference"
+        ],
         "properties": {
           "owner": {
             "$ref": "#/components/schemas/Owner"
@@ -4788,7 +5032,9 @@
           {
             "description": "Object is exclusively owned by a single address, and is mutable.",
             "type": "object",
-            "required": ["AddressOwner"],
+            "required": [
+              "AddressOwner"
+            ],
             "properties": {
               "AddressOwner": {
                 "$ref": "#/components/schemas/SuiAddress"
@@ -4799,7 +5045,9 @@
           {
             "description": "Object is exclusively owned by a single object, and is mutable. The object ID is converted to SuiAddress as SuiAddress is universal.",
             "type": "object",
-            "required": ["ObjectOwner"],
+            "required": [
+              "ObjectOwner"
+            ],
             "properties": {
               "ObjectOwner": {
                 "$ref": "#/components/schemas/SuiAddress"
@@ -4810,11 +5058,15 @@
           {
             "description": "Object is shared, can be used by any address, and is mutable.",
             "type": "object",
-            "required": ["Shared"],
+            "required": [
+              "Shared"
+            ],
             "properties": {
               "Shared": {
                 "type": "object",
-                "required": ["initial_shared_version"],
+                "required": [
+                  "initial_shared_version"
+                ],
                 "properties": {
                   "initial_shared_version": {
                     "description": "The version at which the object became shared",
@@ -4832,14 +5084,19 @@
           {
             "description": "Object is immutable, and hence ownership doesn't matter.",
             "type": "string",
-            "enum": ["Immutable"]
+            "enum": [
+              "Immutable"
+            ]
           }
         ]
       },
       "Page_for_Checkpoint_and_BigInt": {
         "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
-        "required": ["data", "hasNextPage"],
+        "required": [
+          "data",
+          "hasNextPage"
+        ],
         "properties": {
           "data": {
             "type": "array",
@@ -4865,7 +5122,10 @@
       "Page_for_Coin_and_ObjectID": {
         "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
-        "required": ["data", "hasNextPage"],
+        "required": [
+          "data",
+          "hasNextPage"
+        ],
         "properties": {
           "data": {
             "type": "array",
@@ -4891,7 +5151,10 @@
       "Page_for_DynamicFieldInfo_and_ObjectID": {
         "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
-        "required": ["data", "hasNextPage"],
+        "required": [
+          "data",
+          "hasNextPage"
+        ],
         "properties": {
           "data": {
             "type": "array",
@@ -4917,7 +5180,10 @@
       "Page_for_EpochInfo_and_uint64": {
         "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
-        "required": ["data", "hasNextPage"],
+        "required": [
+          "data",
+          "hasNextPage"
+        ],
         "properties": {
           "data": {
             "type": "array",
@@ -4929,7 +5195,10 @@
             "type": "boolean"
           },
           "nextCursor": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "format": "uint64",
             "minimum": 0.0
           }
@@ -4938,7 +5207,10 @@
       "Page_for_Event_and_EventID": {
         "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
-        "required": ["data", "hasNextPage"],
+        "required": [
+          "data",
+          "hasNextPage"
+        ],
         "properties": {
           "data": {
             "type": "array",
@@ -4964,7 +5236,10 @@
       "Page_for_SuiObjectResponse_and_ObjectID": {
         "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
-        "required": ["data", "hasNextPage"],
+        "required": [
+          "data",
+          "hasNextPage"
+        ],
         "properties": {
           "data": {
             "type": "array",
@@ -4990,7 +5265,10 @@
       "Page_for_TransactionResponse_and_TransactionDigest": {
         "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
-        "required": ["data", "hasNextPage"],
+        "required": [
+          "data",
+          "hasNextPage"
+        ],
         "properties": {
           "data": {
             "type": "array",
@@ -5022,7 +5300,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["Ed25519"],
+            "required": [
+              "Ed25519"
+            ],
             "properties": {
               "Ed25519": {
                 "$ref": "#/components/schemas/Base64"
@@ -5032,7 +5312,9 @@
           },
           {
             "type": "object",
-            "required": ["Secp256k1"],
+            "required": [
+              "Secp256k1"
+            ],
             "properties": {
               "Secp256k1": {
                 "$ref": "#/components/schemas/Base64"
@@ -5042,7 +5324,9 @@
           },
           {
             "type": "object",
-            "required": ["Secp256r1"],
+            "required": [
+              "Secp256r1"
+            ],
             "properties": {
               "Secp256r1": {
                 "$ref": "#/components/schemas/Base64"
@@ -5056,7 +5340,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["transferObjectRequestParams"],
+            "required": [
+              "transferObjectRequestParams"
+            ],
             "properties": {
               "transferObjectRequestParams": {
                 "$ref": "#/components/schemas/TransferObjectParams"
@@ -5066,7 +5352,9 @@
           },
           {
             "type": "object",
-            "required": ["moveCallRequestParams"],
+            "required": [
+              "moveCallRequestParams"
+            ],
             "properties": {
               "moveCallRequestParams": {
                 "$ref": "#/components/schemas/MoveCallParams"
@@ -5093,7 +5381,9 @@
               },
               "dataType": {
                 "type": "string",
-                "enum": ["moveObject"]
+                "enum": [
+                  "moveObject"
+                ]
               },
               "hasPublicTransfer": {
                 "type": "boolean"
@@ -5119,7 +5409,9 @@
             "properties": {
               "dataType": {
                 "type": "string",
-                "enum": ["package"]
+                "enum": [
+                  "package"
+                ]
               },
               "id": {
                 "$ref": "#/components/schemas/ObjectID"
@@ -5164,7 +5456,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["Ed25519SuiSignature"],
+            "required": [
+              "Ed25519SuiSignature"
+            ],
             "properties": {
               "Ed25519SuiSignature": {
                 "$ref": "#/components/schemas/Ed25519SuiSignature"
@@ -5174,7 +5468,9 @@
           },
           {
             "type": "object",
-            "required": ["Secp256k1SuiSignature"],
+            "required": [
+              "Secp256k1SuiSignature"
+            ],
             "properties": {
               "Secp256k1SuiSignature": {
                 "$ref": "#/components/schemas/Secp256k1SuiSignature"
@@ -5184,7 +5480,9 @@
           },
           {
             "type": "object",
-            "required": ["Secp256r1SuiSignature"],
+            "required": [
+              "Secp256r1SuiSignature"
+            ],
             "properties": {
               "Secp256r1SuiSignature": {
                 "$ref": "#/components/schemas/Secp256r1SuiSignature"
@@ -5199,17 +5497,24 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["status"],
+            "required": [
+              "status"
+            ],
             "properties": {
               "status": {
                 "type": "string",
-                "enum": ["Pending"]
+                "enum": [
+                  "Pending"
+                ]
               }
             }
           },
           {
             "type": "object",
-            "required": ["estimatedReward", "status"],
+            "required": [
+              "estimatedReward",
+              "status"
+            ],
             "properties": {
               "estimatedReward": {
                 "type": "integer",
@@ -5218,7 +5523,9 @@
               },
               "status": {
                 "type": "string",
-                "enum": ["Active"]
+                "enum": [
+                  "Active"
+                ]
               }
             }
           }
@@ -5260,12 +5567,16 @@
           {
             "description": "The gas coin. The gas coin can only be used by-ref, except for with `TransferObjects`, which can use it by-value.",
             "type": "string",
-            "enum": ["GasCoin"]
+            "enum": [
+              "GasCoin"
+            ]
           },
           {
             "description": "One of the input objects or primitive values (from `ProgrammableTransaction` inputs)",
             "type": "object",
-            "required": ["Input"],
+            "required": [
+              "Input"
+            ],
             "properties": {
               "Input": {
                 "type": "integer",
@@ -5278,7 +5589,9 @@
           {
             "description": "The result of another command (from `ProgrammableTransaction` commands)",
             "type": "object",
-            "required": ["Result"],
+            "required": [
+              "Result"
+            ],
             "properties": {
               "Result": {
                 "type": "integer",
@@ -5291,7 +5604,9 @@
           {
             "description": "Like a `Result` but it accesses a nested result. Currently, the only usage of this is to access a value from a Move call with multiple return values.",
             "type": "object",
-            "required": ["NestedResult"],
+            "required": [
+              "NestedResult"
+            ],
             "properties": {
               "NestedResult": {
                 "type": "array",
@@ -5322,7 +5637,12 @@
             "oneOf": [
               {
                 "type": "object",
-                "required": ["digest", "objectId", "objectType", "version"],
+                "required": [
+                  "digest",
+                  "objectId",
+                  "objectType",
+                  "version"
+                ],
                 "properties": {
                   "digest": {
                     "$ref": "#/components/schemas/ObjectDigest"
@@ -5332,7 +5652,9 @@
                   },
                   "objectType": {
                     "type": "string",
-                    "enum": ["immOrOwnedObject"]
+                    "enum": [
+                      "immOrOwnedObject"
+                    ]
                   },
                   "version": {
                     "$ref": "#/components/schemas/SequenceNumber"
@@ -5359,33 +5681,47 @@
                   },
                   "objectType": {
                     "type": "string",
-                    "enum": ["sharedObject"]
+                    "enum": [
+                      "sharedObject"
+                    ]
                   }
                 }
               }
             ],
-            "required": ["type"],
+            "required": [
+              "type"
+            ],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["object"]
+                "enum": [
+                  "object"
+                ]
               }
             }
           },
           {
             "type": "object",
-            "required": ["type", "value"],
+            "required": [
+              "type",
+              "value"
+            ],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["pure"]
+                "enum": [
+                  "pure"
+                ]
               },
               "value": {
                 "$ref": "#/components/schemas/SuiJsonValue"
               },
               "valueType": {
                 "default": null,
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
           }
@@ -5393,7 +5729,12 @@
       },
       "SuiCoinMetadata": {
         "type": "object",
-        "required": ["decimals", "description", "name", "symbol"],
+        "required": [
+          "decimals",
+          "description",
+          "name",
+          "symbol"
+        ],
         "properties": {
           "decimals": {
             "description": "Number of decimal places the coin uses.",
@@ -5407,7 +5748,10 @@
           },
           "iconUrl": {
             "description": "URL for the token logo",
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "id": {
             "description": "Object id for the CoinMetadata object",
@@ -5436,7 +5780,9 @@
           {
             "description": "A call to either an entry or a public Move function",
             "type": "object",
-            "required": ["MoveCall"],
+            "required": [
+              "MoveCall"
+            ],
             "properties": {
               "MoveCall": {
                 "$ref": "#/components/schemas/SuiProgrammableMoveCall"
@@ -5447,7 +5793,9 @@
           {
             "description": "`(Vec<forall T:key+store. T>, address)` It sends n-objects to the specified address. These objects must have store (public transfer) and either the previous owner must be an address or the object must be newly created.",
             "type": "object",
-            "required": ["TransferObjects"],
+            "required": [
+              "TransferObjects"
+            ],
             "properties": {
               "TransferObjects": {
                 "type": "array",
@@ -5471,7 +5819,9 @@
           {
             "description": "`(&mut Coin<T>, Vec<u64>)` -> `Vec<Coin<T>>` It splits off some amounts into a new coins with those amounts",
             "type": "object",
-            "required": ["SplitCoins"],
+            "required": [
+              "SplitCoins"
+            ],
             "properties": {
               "SplitCoins": {
                 "type": "array",
@@ -5495,7 +5845,9 @@
           {
             "description": "`(&mut Coin<T>, Vec<Coin<T>>)` It merges n-coins into the first coin",
             "type": "object",
-            "required": ["MergeCoins"],
+            "required": [
+              "MergeCoins"
+            ],
             "properties": {
               "MergeCoins": {
                 "type": "array",
@@ -5519,7 +5871,9 @@
           {
             "description": "Publishes a Move package. It takes the package bytes and a list of the package's transitive dependencies to link against on-chain.",
             "type": "object",
-            "required": ["Publish"],
+            "required": [
+              "Publish"
+            ],
             "properties": {
               "Publish": {
                 "type": "array",
@@ -5543,7 +5897,9 @@
           {
             "description": "Upgrades a Move package",
             "type": "object",
-            "required": ["Upgrade"],
+            "required": [
+              "Upgrade"
+            ],
             "properties": {
               "Upgrade": {
                 "type": "array",
@@ -5573,13 +5929,18 @@
           {
             "description": "`forall T: Vec<T> -> vector<T>` Given n-values of the same type, it constructs a vector. For non objects or an empty vector, the type tag must be specified.",
             "type": "object",
-            "required": ["MakeMoveVec"],
+            "required": [
+              "MakeMoveVec"
+            ],
             "properties": {
               "MakeMoveVec": {
                 "type": "array",
                 "items": [
                   {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   {
                     "type": "array",
@@ -5651,11 +6012,18 @@
       "SuiJsonValue": {},
       "SuiMoveAbility": {
         "type": "string",
-        "enum": ["Copy", "Drop", "Store", "Key"]
+        "enum": [
+          "Copy",
+          "Drop",
+          "Store",
+          "Key"
+        ]
       },
       "SuiMoveAbilitySet": {
         "type": "object",
-        "required": ["abilities"],
+        "required": [
+          "abilities"
+        ],
         "properties": {
           "abilities": {
             "type": "array",
@@ -5667,7 +6035,10 @@
       },
       "SuiMoveModuleId": {
         "type": "object",
-        "required": ["address", "name"],
+        "required": [
+          "address",
+          "name"
+        ],
         "properties": {
           "address": {
             "type": "string"
@@ -5679,7 +6050,10 @@
       },
       "SuiMoveNormalizedField": {
         "type": "object",
-        "required": ["name", "type"],
+        "required": [
+          "name",
+          "type"
+        ],
         "properties": {
           "name": {
             "type": "string"
@@ -5769,7 +6143,11 @@
       },
       "SuiMoveNormalizedStruct": {
         "type": "object",
-        "required": ["abilities", "fields", "typeParameters"],
+        "required": [
+          "abilities",
+          "fields",
+          "typeParameters"
+        ],
         "properties": {
           "abilities": {
             "$ref": "#/components/schemas/SuiMoveAbilitySet"
@@ -5806,11 +6184,18 @@
           },
           {
             "type": "object",
-            "required": ["Struct"],
+            "required": [
+              "Struct"
+            ],
             "properties": {
               "Struct": {
                 "type": "object",
-                "required": ["address", "module", "name", "typeArguments"],
+                "required": [
+                  "address",
+                  "module",
+                  "name",
+                  "typeArguments"
+                ],
                 "properties": {
                   "address": {
                     "type": "string"
@@ -5834,7 +6219,9 @@
           },
           {
             "type": "object",
-            "required": ["Vector"],
+            "required": [
+              "Vector"
+            ],
             "properties": {
               "Vector": {
                 "$ref": "#/components/schemas/SuiMoveNormalizedType"
@@ -5844,7 +6231,9 @@
           },
           {
             "type": "object",
-            "required": ["TypeParameter"],
+            "required": [
+              "TypeParameter"
+            ],
             "properties": {
               "TypeParameter": {
                 "type": "integer",
@@ -5856,7 +6245,9 @@
           },
           {
             "type": "object",
-            "required": ["Reference"],
+            "required": [
+              "Reference"
+            ],
             "properties": {
               "Reference": {
                 "$ref": "#/components/schemas/SuiMoveNormalizedType"
@@ -5866,7 +6257,9 @@
           },
           {
             "type": "object",
-            "required": ["MutableReference"],
+            "required": [
+              "MutableReference"
+            ],
             "properties": {
               "MutableReference": {
                 "$ref": "#/components/schemas/SuiMoveNormalizedType"
@@ -5878,7 +6271,10 @@
       },
       "SuiMoveStructTypeParameter": {
         "type": "object",
-        "required": ["constraints", "isPhantom"],
+        "required": [
+          "constraints",
+          "isPhantom"
+        ],
         "properties": {
           "constraints": {
             "$ref": "#/components/schemas/SuiMoveAbilitySet"
@@ -5890,13 +6286,19 @@
       },
       "SuiMoveVisibility": {
         "type": "string",
-        "enum": ["Private", "Public", "Friend"]
+        "enum": [
+          "Private",
+          "Public",
+          "Friend"
+        ]
       },
       "SuiObjectDataFilter": {
         "oneOf": [
           {
             "type": "object",
-            "required": ["MatchAll"],
+            "required": [
+              "MatchAll"
+            ],
             "properties": {
               "MatchAll": {
                 "type": "array",
@@ -5909,7 +6311,9 @@
           },
           {
             "type": "object",
-            "required": ["MatchAny"],
+            "required": [
+              "MatchAny"
+            ],
             "properties": {
               "MatchAny": {
                 "type": "array",
@@ -5923,7 +6327,9 @@
           {
             "description": "Query by type a specified Package.",
             "type": "object",
-            "required": ["Package"],
+            "required": [
+              "Package"
+            ],
             "properties": {
               "Package": {
                 "$ref": "#/components/schemas/ObjectID"
@@ -5934,11 +6340,16 @@
           {
             "description": "Query by type a specified Move module.",
             "type": "object",
-            "required": ["MoveModule"],
+            "required": [
+              "MoveModule"
+            ],
             "properties": {
               "MoveModule": {
                 "type": "object",
-                "required": ["module", "package"],
+                "required": [
+                  "module",
+                  "package"
+                ],
                 "properties": {
                   "module": {
                     "description": "the module name",
@@ -5960,7 +6371,9 @@
           {
             "description": "Query by type",
             "type": "object",
-            "required": ["StructType"],
+            "required": [
+              "StructType"
+            ],
             "properties": {
               "StructType": {
                 "type": "string"
@@ -5970,7 +6383,9 @@
           },
           {
             "type": "object",
-            "required": ["AddressOwner"],
+            "required": [
+              "AddressOwner"
+            ],
             "properties": {
               "AddressOwner": {
                 "$ref": "#/components/schemas/SuiAddress"
@@ -5980,7 +6395,9 @@
           },
           {
             "type": "object",
-            "required": ["ObjectOwner"],
+            "required": [
+              "ObjectOwner"
+            ],
             "properties": {
               "ObjectOwner": {
                 "$ref": "#/components/schemas/ObjectID"
@@ -5990,7 +6407,9 @@
           },
           {
             "type": "object",
-            "required": ["ObjectId"],
+            "required": [
+              "ObjectId"
+            ],
             "properties": {
               "ObjectId": {
                 "$ref": "#/components/schemas/ObjectID"
@@ -6000,7 +6419,9 @@
           },
           {
             "type": "object",
-            "required": ["ObjectIds"],
+            "required": [
+              "ObjectIds"
+            ],
             "properties": {
               "ObjectIds": {
                 "type": "array",
@@ -6013,7 +6434,9 @@
           },
           {
             "type": "object",
-            "required": ["Version"],
+            "required": [
+              "Version"
+            ],
             "properties": {
               "Version": {
                 "type": "integer",
@@ -6053,7 +6476,11 @@
       "SuiProgrammableMoveCall": {
         "description": "The command for calling a Move function, either an entry function or a public function (which cannot return references).",
         "type": "object",
-        "required": ["function", "module", "package"],
+        "required": [
+          "function",
+          "module",
+          "package"
+        ],
         "properties": {
           "arguments": {
             "description": "The arguments to the function.",
@@ -6382,12 +6809,16 @@
           {
             "description": "Regular Sui Transactions that are committed on chain",
             "type": "string",
-            "enum": ["Commit"]
+            "enum": [
+              "Commit"
+            ]
           },
           {
             "description": "Simulated transaction that allows calling any Move function with arbitrary values.",
             "type": "string",
-            "enum": ["DevInspect"]
+            "enum": [
+              "DevInspect"
+            ]
           }
         ]
       },
@@ -6476,7 +6907,10 @@
             "minimum": 0.0
           },
           "nextEpochNetAddress": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "nextEpochNetworkPubkeyBytes": {
             "default": null,
@@ -6490,10 +6924,16 @@
             ]
           },
           "nextEpochP2pAddress": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "nextEpochPrimaryAddress": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "nextEpochProofOfPossession": {
             "default": null,
@@ -6523,7 +6963,10 @@
             "minimum": 0.0
           },
           "nextEpochWorkerAddress": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "nextEpochWorkerPubkeyBytes": {
             "default": null,
@@ -6586,13 +7029,19 @@
           },
           "stakingPoolActivationEpoch": {
             "description": "The epoch at which this pool became active.",
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "format": "uint64",
             "minimum": 0.0
           },
           "stakingPoolDeactivationEpoch": {
             "description": "The epoch at which this staking pool ceased to be active. `None` = {pre-active, active},",
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "format": "uint64",
             "minimum": 0.0
           },
@@ -6628,7 +7077,9 @@
       },
       "Supply": {
         "type": "object",
-        "required": ["value"],
+        "required": [
+          "value"
+        ],
         "properties": {
           "value": {
             "type": "integer",
@@ -6639,7 +7090,10 @@
       },
       "Transaction": {
         "type": "object",
-        "required": ["data", "txSignatures"],
+        "required": [
+          "data",
+          "txSignatures"
+        ],
         "properties": {
           "data": {
             "$ref": "#/components/schemas/TransactionData"
@@ -6654,7 +7108,11 @@
       },
       "TransactionBytes": {
         "type": "object",
-        "required": ["gas", "inputObjects", "txBytes"],
+        "required": [
+          "gas",
+          "inputObjects",
+          "txBytes"
+        ],
         "properties": {
           "gas": {
             "description": "the gas objects to be used",
@@ -6684,14 +7142,21 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["gasData", "messageVersion", "sender", "transaction"],
+            "required": [
+              "gasData",
+              "messageVersion",
+              "sender",
+              "transaction"
+            ],
             "properties": {
               "gasData": {
                 "$ref": "#/components/schemas/GasData"
               },
               "messageVersion": {
                 "type": "string",
-                "enum": ["v1"]
+                "enum": [
+                  "v1"
+                ]
               },
               "sender": {
                 "$ref": "#/components/schemas/SuiAddress"
@@ -6778,7 +7243,9 @@
               },
               "messageVersion": {
                 "type": "string",
-                "enum": ["v1"]
+                "enum": [
+                  "v1"
+                ]
               },
               "modifiedAtVersions": {
                 "description": "The version that every modified (mutated or deleted) object had before it was modified by this transaction.",
@@ -6844,7 +7311,10 @@
       },
       "TransactionEffectsModifiedAtVersions": {
         "type": "object",
-        "required": ["objectId", "sequenceNumber"],
+        "required": [
+          "objectId",
+          "sequenceNumber"
+        ],
         "properties": {
           "objectId": {
             "$ref": "#/components/schemas/ObjectID"
@@ -6862,17 +7332,27 @@
           {
             "description": "Query by move function.",
             "type": "object",
-            "required": ["MoveFunction"],
+            "required": [
+              "MoveFunction"
+            ],
             "properties": {
               "MoveFunction": {
                 "type": "object",
-                "required": ["package"],
+                "required": [
+                  "package"
+                ],
                 "properties": {
                   "function": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "module": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "package": {
                     "$ref": "#/components/schemas/ObjectID"
@@ -6885,7 +7365,9 @@
           {
             "description": "Query by input object.",
             "type": "object",
-            "required": ["InputObject"],
+            "required": [
+              "InputObject"
+            ],
             "properties": {
               "InputObject": {
                 "$ref": "#/components/schemas/ObjectID"
@@ -6896,7 +7378,9 @@
           {
             "description": "Query by changed object, including created, mutated and unwrapped objects.",
             "type": "object",
-            "required": ["ChangedObject"],
+            "required": [
+              "ChangedObject"
+            ],
             "properties": {
               "ChangedObject": {
                 "$ref": "#/components/schemas/ObjectID"
@@ -6907,7 +7391,9 @@
           {
             "description": "Query by sender address.",
             "type": "object",
-            "required": ["FromAddress"],
+            "required": [
+              "FromAddress"
+            ],
             "properties": {
               "FromAddress": {
                 "$ref": "#/components/schemas/SuiAddress"
@@ -6918,7 +7404,9 @@
           {
             "description": "Query by recipient address.",
             "type": "object",
-            "required": ["ToAddress"],
+            "required": [
+              "ToAddress"
+            ],
             "properties": {
               "ToAddress": {
                 "$ref": "#/components/schemas/SuiAddress"
@@ -6957,7 +7445,9 @@
               },
               "kind": {
                 "type": "string",
-                "enum": ["ChangeEpoch"]
+                "enum": [
+                  "ChangeEpoch"
+                ]
               },
               "storage_charge": {
                 "type": "integer",
@@ -6974,11 +7464,16 @@
           {
             "description": "A system transaction used for initializing the initial state of the chain.",
             "type": "object",
-            "required": ["kind", "objects"],
+            "required": [
+              "kind",
+              "objects"
+            ],
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["Genesis"]
+                "enum": [
+                  "Genesis"
+                ]
               },
               "objects": {
                 "type": "array",
@@ -6991,7 +7486,12 @@
           {
             "description": "A system transaction marking the start of a series of transactions scheduled as part of a checkpoint",
             "type": "object",
-            "required": ["commit_timestamp_ms", "epoch", "kind", "round"],
+            "required": [
+              "commit_timestamp_ms",
+              "epoch",
+              "kind",
+              "round"
+            ],
             "properties": {
               "commit_timestamp_ms": {
                 "type": "integer",
@@ -7005,7 +7505,9 @@
               },
               "kind": {
                 "type": "string",
-                "enum": ["ConsensusCommitPrologue"]
+                "enum": [
+                  "ConsensusCommitPrologue"
+                ]
               },
               "round": {
                 "type": "integer",
@@ -7017,7 +7519,11 @@
           {
             "description": "A series of commands where the results of one command can be used in future commands",
             "type": "object",
-            "required": ["commands", "inputs", "kind"],
+            "required": [
+              "commands",
+              "inputs",
+              "kind"
+            ],
             "properties": {
               "commands": {
                 "description": "The commands to be executed sequentially. A failure in any command will result in the failure of the entire transaction.",
@@ -7035,7 +7541,9 @@
               },
               "kind": {
                 "type": "string",
-                "enum": ["ProgrammableTransaction"]
+                "enum": [
+                  "ProgrammableTransaction"
+                ]
               }
             }
           }
@@ -7043,22 +7551,33 @@
       },
       "TransactionResponse": {
         "type": "object",
-        "required": ["digest"],
+        "required": [
+          "digest"
+        ],
         "properties": {
           "balanceChanges": {
-            "type": ["array", "null"],
+            "type": [
+              "array",
+              "null"
+            ],
             "items": {
               "$ref": "#/components/schemas/BalanceChange"
             }
           },
           "checkpoint": {
             "description": "The checkpoint number when this transaction was included and hence finalized. This is only returned in the read api, not in the transaction execution api.",
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "format": "uint64",
             "minimum": 0.0
           },
           "confirmedLocalExecution": {
-            "type": ["boolean", "null"]
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "digest": {
             "$ref": "#/components/schemas/TransactionDigest"
@@ -7080,13 +7599,19 @@
             }
           },
           "events": {
-            "type": ["array", "null"],
+            "type": [
+              "array",
+              "null"
+            ],
             "items": {
               "$ref": "#/components/schemas/Event"
             }
           },
           "objectChanges": {
-            "type": ["array", "null"],
+            "type": [
+              "array",
+              "null"
+            ],
             "items": {
               "$ref": "#/components/schemas/ObjectChange"
             }
@@ -7100,7 +7625,10 @@
             ]
           },
           "timestampMs": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "format": "uint64",
             "minimum": 0.0
           },
@@ -7183,7 +7711,10 @@
       },
       "TransferObjectParams": {
         "type": "object",
-        "required": ["objectId", "recipient"],
+        "required": [
+          "objectId",
+          "recipient"
+        ],
         "properties": {
           "objectId": {
             "$ref": "#/components/schemas/ObjectID"
@@ -7196,7 +7727,11 @@
       "TypeOrigin": {
         "description": "Identifies a struct and the module it was defined in",
         "type": "object",
-        "required": ["module_name", "package", "struct_name"],
+        "required": [
+          "module_name",
+          "package",
+          "struct_name"
+        ],
         "properties": {
           "module_name": {
             "type": "string"
@@ -7215,7 +7750,10 @@
       "UpgradeInfo": {
         "description": "Upgraded package info for the linkage table",
         "type": "object",
-        "required": ["upgraded_id", "upgraded_version"],
+        "required": [
+          "upgraded_id",
+          "upgraded_version"
+        ],
         "properties": {
           "upgraded_id": {
             "description": "ID of the upgraded packages",

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -231,7 +231,7 @@
                 "status": {
                   "status": "success"
                 },
-                "executedEpoch": 0,
+                "executedEpoch": "0",
                 "gasUsed": {
                   "computationCost": "100",
                   "storageCost": "100",
@@ -1419,7 +1419,7 @@
                 "status": {
                   "status": "success"
                 },
-                "executedEpoch": 0,
+                "executedEpoch": "0",
                 "gasUsed": {
                   "computationCost": "100",
                   "storageCost": "100",
@@ -5236,14 +5236,10 @@
             "minimum": 0.0
           },
           "stakeActiveEpoch": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+            "$ref": "#/components/schemas/BigInt"
           },
           "stakeRequestEpoch": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
+            "$ref": "#/components/schemas/BigInt"
           },
           "stakedSuiId": {
             "description": "ID of the StakedSui receipt object.",
@@ -6763,9 +6759,11 @@
               },
               "executedEpoch": {
                 "description": "The epoch when this transaction was executed.",
-                "type": "integer",
-                "format": "uint64",
-                "minimum": 0.0
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BigInt"
+                  }
+                ]
               },
               "gasObject": {
                 "description": "The updated gas object reference. Have a dedicated field for convenient access. It's also included in mutated.",
@@ -6950,9 +6948,7 @@
                 "minimum": 0.0
               },
               "epoch": {
-                "type": "integer",
-                "format": "uint64",
-                "minimum": 0.0
+                "$ref": "#/components/schemas/BigInt"
               },
               "epoch_start_timestamp_ms": {
                 "type": "integer",

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -483,9 +483,9 @@ impl RpcExampleProvider {
                 executed_epoch: 0,
                 modified_at_versions: vec![],
                 gas_used: SuiGasCostSummary {
-                    computation_cost: 100,
-                    storage_cost: 100,
-                    storage_rebate: 10,
+                    computation_cost: 100.into(),
+                    storage_cost: 100.into(),
+                    storage_rebate: 10.into(),
                     non_refundable_storage_fee: 0,
                 },
                 shared_objects: vec![],

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -486,7 +486,7 @@ impl RpcExampleProvider {
                     computation_cost: 100.into(),
                     storage_cost: 100.into(),
                     storage_rebate: 10.into(),
-                    non_refundable_storage_fee: 0,
+                    non_refundable_storage_fee: 0.into(),
                 },
                 shared_objects: vec![],
                 transaction_digest: TransactionDigest::new(self.rng.gen()),

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -480,7 +480,7 @@ impl RpcExampleProvider {
             digest: *tx_digest,
             effects: Some(SuiTransactionEffects::V1(SuiTransactionEffectsV1 {
                 status: SuiExecutionStatus::Success,
-                executed_epoch: 0,
+                executed_epoch: 0.into(),
                 modified_at_versions: vec![],
                 gas_used: SuiGasCostSummary {
                     computation_cost: 100.into(),

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -314,8 +314,8 @@ pub async fn metadata(
         return Err(Error::TransactionDryRunError(error.to_string()));
     }
 
-    let budget =
-        effects.gas_cost_summary().computation_cost + effects.gas_cost_summary().storage_cost;
+    let budget = <u64>::from(effects.gas_cost_summary().computation_cost)
+        + <u64>::from(effects.gas_cost_summary().storage_cost);
 
     Ok(ConstructionMetadataResponse {
         metadata: ConstructionMetadata {

--- a/crates/sui-rosetta/src/operations.rs
+++ b/crates/sui-rosetta/src/operations.rs
@@ -511,9 +511,9 @@ impl TryFrom<SuiTransactionResponse> for Operations {
             .ok_or_else(|| anyhow!("Response effects should not be empty"))?;
         let gas_owner = effect.gas_object().owner.get_owner_address()?;
         let gas_summary = effect.gas_cost_summary();
-        let gas_used = gas_summary.storage_rebate as i128
-            - gas_summary.storage_cost as i128
-            - gas_summary.computation_cost as i128;
+        let gas_used = <u64>::from(gas_summary.storage_rebate) as i128
+            - <u64>::from(gas_summary.storage_cost) as i128
+            - <u64>::from(gas_summary.computation_cost) as i128;
 
         let status = Some(effect.into_status().into());
         let ops: Operations = tx.data.try_into()?;

--- a/crates/test-utils/src/transaction.rs
+++ b/crates/test-utils/src/transaction.rs
@@ -371,7 +371,8 @@ pub async fn transfer_coin(
                 .gas_data()
                 .payment
                 .clone(),
-            gas_used.computation_cost + gas_used.storage_cost - gas_used.storage_rebate,
+            <u64>::from(gas_used.computation_cost) + <u64>::from(gas_used.storage_cost)
+                - <u64>::from(gas_used.storage_rebate),
         )
     } else {
         panic!("transfer command did not return WalletCommandResult::Transfer");

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -34,8 +34,7 @@ import {
   SuiObjectRef,
 } from './objects';
 
-// TODO: support u64
-export const EpochId = number();
+export const EpochId = string();
 
 export const SuiChangeEpoch = object({
   epoch: EpochId,

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -174,9 +174,9 @@ export const AuthorityQuorumSignInfo = object({
 export type AuthorityQuorumSignInfo = Infer<typeof AuthorityQuorumSignInfo>;
 
 export const GasCostSummary = object({
-  computationCost: number(),
-  storageCost: number(),
-  storageRebate: number(),
+  computationCost: string(),
+  storageCost: string(),
+  storageRebate: string(),
   nonRefundableStorageFee: number(),
 });
 export type GasCostSummary = Infer<typeof GasCostSummary>;
@@ -535,21 +535,21 @@ export function getExecutionStatusGasSummary(
 
 export function getTotalGasUsed(
   data: SuiTransactionResponse | TransactionEffects,
-): number | undefined {
+): bigint | undefined {
   const gasSummary = getExecutionStatusGasSummary(data);
   return gasSummary
-    ? gasSummary.computationCost +
-        gasSummary.storageCost -
-        gasSummary.storageRebate
+    ? BigInt(gasSummary.computationCost) +
+        BigInt(gasSummary.storageCost) -
+        BigInt(gasSummary.storageRebate)
     : undefined;
 }
 
 export function getTotalGasUsedUpperBound(
   data: SuiTransactionResponse | TransactionEffects,
-): number | undefined {
+): bigint | undefined {
   const gasSummary = getExecutionStatusGasSummary(data);
   return gasSummary
-    ? gasSummary.computationCost + gasSummary.storageCost
+    ? BigInt(gasSummary.computationCost) + BigInt(gasSummary.storageCost)
     : undefined;
 }
 

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -176,7 +176,7 @@ export const GasCostSummary = object({
   computationCost: string(),
   storageCost: string(),
   storageRebate: string(),
-  nonRefundableStorageFee: number(),
+  nonRefundableStorageFee: string(),
 });
 export type GasCostSummary = Infer<typeof GasCostSummary>;
 


### PR DESCRIPTION
## Description 

Change functions in transaction.ts of ts-sdk to return `bigint` instead of number. Define associated types as `string`. In more detail:

- `getTotalGasUsed` and `getTotalGasUsedUpperBound` of ts-sdk return a `bigint`
-  fileds of `GasCostSummary` are defined as `string()`
- In sui-json-rpc the corresponding types are defined as `BigInt`.

- `EpochId` of ts-sdk is defined as a `string()`
- Introduce `SuiEpochId` type in sui-json-rpc-types that is a `BigInt`

Related PR: #9412 

## Test Plan 

Manually test explorer and wallet.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
