### PR TITLE
[move publish/upgrade] Fix tests in typescript and plumb through dependencies

### DIFF
--- a/.changeset/sixty-phones-divide.md
+++ b/.changeset/sixty-phones-divide.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Added dependencies to publish command, dependencies now also returned from the sui move CLI with the `--dump-bytecode-as-base64` flag

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -2399,7 +2399,7 @@ async fn test_custom_property_check_unpublished_dependencies() {
         .expect("Could not build resolution graph.");
 
     let SuiError::ModulePublishFailure { error } =
-        check_unpublished_dependencies(gather_dependencies(&resolution_graph).unpublished)
+        check_unpublished_dependencies(&gather_dependencies(&resolution_graph).unpublished)
             .err()
             .unwrap()
      else {

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -190,60 +190,60 @@ ExecutionFailureStatus:
     9:
       PublishErrorNonZeroAddress: UNIT
     10:
-      PublishUpgradeMissingDependency: UNIT
-    11:
-      PublishUpgradeDependencyDowngrade: UNIT
-    12:
       SuiMoveVerificationError: UNIT
-    13:
+    11:
       MovePrimitiveRuntimeError:
         NEWTYPE:
           TYPENAME: MoveLocationOpt
-    14:
+    12:
       MoveAbort:
         TUPLE:
           - TYPENAME: MoveLocation
           - U64
-    15:
+    13:
       VMVerificationOrDeserializationError: UNIT
-    16:
+    14:
       VMInvariantViolation: UNIT
-    17:
+    15:
       FunctionNotFound: UNIT
-    18:
+    16:
       ArityMismatch: UNIT
-    19:
+    17:
       TypeArityMismatch: UNIT
-    20:
+    18:
       NonEntryFunctionInvoked: UNIT
-    21:
+    19:
       CommandArgumentError:
         STRUCT:
           - arg_idx: U16
           - kind:
               TYPENAME: CommandArgumentError
-    22:
+    20:
       TypeArgumentError:
         STRUCT:
           - argument_idx: U16
           - kind:
               TYPENAME: TypeArgumentError
-    23:
+    21:
       UnusedValueWithoutDrop:
         STRUCT:
           - result_idx: U16
           - secondary_idx: U16
-    24:
+    22:
       InvalidPublicFunctionReturnType:
         STRUCT:
           - idx: U16
-    25:
+    23:
       InvalidTransferObject: UNIT
-    26:
+    24:
       EffectsTooLarge:
         STRUCT:
           - current_size: U64
           - max_size: U64
+    25:
+      PublishUpgradeMissingDependency: UNIT
+    26:
+      PublishUpgradeDependencyDowngrade: UNIT
 ExecutionStatus:
   ENUM:
     0:

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -2170,20 +2170,6 @@ pub enum ExecutionFailureStatus {
         The modules in the package must have their self-addresses set to zero."
     )]
     PublishErrorNonZeroAddress,
-    #[error(
-        "Publish/Upgrade Error, Missing dependency. \
-         A dependency of a published or upgraded package has not been assigned an on-chain \
-         address."
-    )]
-    PublishUpgradeMissingDependency,
-
-    #[error(
-        "Publish/Upgrade Error, Dependency downgrade. \
-         Indirect (transitive) dependency of published or upgraded package has been assigned an \
-         on-chain version that is less than the version required by one of the package's \
-         transitive dependencies."
-    )]
-    PublishUpgradeDependencyDowngrade,
 
     #[error(
         "Sui Move Bytecode Verification Error. \
@@ -2259,6 +2245,21 @@ pub enum ExecutionFailureStatus {
     Limit is {max_size} bytes"
     )]
     EffectsTooLarge { current_size: u64, max_size: u64 },
+
+    #[error(
+        "Publish/Upgrade Error, Missing dependency. \
+         A dependency of a published or upgraded package has not been assigned an on-chain \
+         address."
+    )]
+    PublishUpgradeMissingDependency,
+
+    #[error(
+        "Publish/Upgrade Error, Dependency downgrade. \
+         Indirect (transitive) dependency of published or upgraded package has been assigned an \
+         on-chain version that is less than the version required by one of the package's \
+         transitive dependencies."
+    )]
+    PublishUpgradeDependencyDowngrade,
     // NOTE: if you want to add a new enum,
     // please add it at the end for Rust SDK backward compatibility.
 }

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -482,10 +482,10 @@ impl SuiClientCommands {
                 let resolution_graph = config.resolution_graph(&package_path)?;
                 let dependencies = gather_dependencies(&resolution_graph);
 
-                check_invalid_dependencies(dependencies.invalid)?;
+                check_invalid_dependencies(&dependencies.invalid)?;
 
                 if !with_unpublished_dependencies {
-                    check_unpublished_dependencies(dependencies.unpublished)?;
+                    check_unpublished_dependencies(&dependencies.unpublished)?;
                 };
 
                 let compiled_package = build_from_resolution_graph(

--- a/doc/src/build/json-rpc.md
+++ b/doc/src/build/json-rpc.md
@@ -44,7 +44,7 @@ curl --location --request POST $SUI_RPC_HOST \
 The examples in this section demonstrate how to create transfer transactions. To use the example commands, replace the values between double brackets ({{ example_ID }} with actual values.
 
 Objects IDs for `{{coin_object_id}}` and `{{gas_object_id}}` must
-be owned by the address specified for `{{owner_address}}` for the command to succeed. Use [`sui_getOwnedObjects`](#sui_getOwnedObjects) to return object IDs. 
+be owned by the address specified for `{{owner_address}}` for the command to succeed. Use [`sui_getOwnedObjects`](#sui_getOwnedObjects) to return object IDs.
 
 **Important:** As a security best practice, you should serialize data from the JSON-RPC service locally in the same location as the signer. This reduces the risk of trusting data from the service directly.
 
@@ -93,14 +93,14 @@ curl --location --request POST $SUI_RPC_HOST \
   "jsonrpc": "2.0",
   "id": 1,
   "method": "sui_executeTransactionSerializedSig",
-  "params": [ 
+  "params": [
     "{{tx_bytes}}",
     "{{signature}}",
     "{{request_type}}"
   ]
 }' | json_pp
 ```
-`signature` is a Base64 encoded `flag || signature || pubkey`. 
+`signature` is a Base64 encoded `flag || signature || pubkey`.
 
 Native transfer by `sui_transferObject` supports any object that allows for public transfers. Some objects cannot be transferred natively and require a [Move call](#sui_movecall). See [Transactions](../learn/transactions.md#native-transaction) for more information about native transfers.
 
@@ -116,7 +116,7 @@ the [Move](move/index.md) language):
 ```shell
 curl --location --request POST $SUI_RPC_HOST \
 --header 'Content-Type: application/json' \
---data-raw '{ 
+--data-raw '{
   "jsonrpc": "2.0",
   "method": "sui_moveCall",
   "params": [
@@ -129,7 +129,7 @@ curl --location --request POST $SUI_RPC_HOST \
     "{{gas_object_id}}",
      2000
   ],
-  "id": 1 
+  "id": 1
 }' | json_pp
 ```
 
@@ -147,12 +147,13 @@ To learn more about which `args` a Move call accepts, see [SuiJSON](sui-json.md)
 ```shell
 curl --location --request POST $SUI_RPC_HOST \
 --header 'Content-Type: application/json' \
---data-raw '{ 
+--data-raw '{
   "jsonrpc":"2.0",
   "method":"sui_publish",
   "params":[
     "{{owner_address}}",
     ["{{vector_of_compiled_modules}}"],
+    ["{{vector_of_dependency_ids}}"],
     "{{gas_object_id}}",
      10000
    ],
@@ -163,10 +164,10 @@ curl --location --request POST $SUI_RPC_HOST \
 This endpoint performs proper verification and linking to make
 sure the package is valid. If some modules have [initializers](move/debug-publish.md#module-initializers), these initializers execute in Move (which means new Move objects can be created in the process of publishing a Move package). Gas budget is required because of the need to execute module initializers.
 
-To publish a Move module, you also need to include `{{vector_of_compiled_modules}}`. To generate the value of this field, use the `sui move` command. The `sui move` command supports printing the bytecode as base64:
+To publish a Move module, you also need to include `{{vector_of_compiled_modules}}` along with the `{{vector_of_dependency_ids}}`. To generate the values for these fields, use the `sui move` command. The `sui move` command supports printing the bytecode as base64 and dependency object IDs:
 
 ```
-sui move <move-module-path> build --dump-bytecode-as-base64 
+sui move <move-module-path> build --dump-bytecode-as-base64
 ```
 
 Assuming that the location of the package's sources is in the `PATH_TO_PACKAGE` environment variable an example command resembles the following:
@@ -174,11 +175,14 @@ Assuming that the location of the package's sources is in the `PATH_TO_PACKAGE` 
 ```
 sui move $PATH_TO_PACKAGE/my_move_package build --dump-bytecode-as-base64
 
-["oRzrCwUAAAAJAQAIAggUAxw3BFMKBV1yB88BdAjDAigK6wIFDPACQgAAAQEBAgEDAAACAAEEDAEAAQEBDAEAAQMDAgAABQABAAAGAgEAAAcDBAAACAUBAAEFBwEBAAEKCQoBAgMLCwwAAgwNAQEIAQcODwEAAQgQAQEABAYFBgcICAYJBgMHCwEBCAALAgEIAAcIAwABBwgDAwcLAQEIAAMHCAMBCwIBCAADCwEBCAAFBwgDAQgAAgsCAQkABwsBAQkAAQsBAQgAAgkABwgDAQsBAQkAAQYIAwEFAgkABQMDBwsBAQkABwgDAQsCAQkAAgsBAQkABQdNQU5BR0VEBENvaW4IVHJhbnNmZXIJVHhDb250ZXh0C1RyZWFzdXJ5Q2FwBGJ1cm4EaW5pdARtaW50DHRyYW5zZmVyX2NhcAtkdW1teV9maWVsZA9jcmVhdGVfY3VycmVuY3kGc2VuZGVyCHRyYW5zZmVyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgACAQkBAAEAAAEECwELADgAAgEAAAAICwkSAAoAOAEMAQsBCwAuEQY4AgICAQAAAQULAQsACwI4AwIDAQAAAQQLAAsBOAQCAA==", "oRzrCwUAAAALAQAOAg4kAzJZBIsBHAWnAasBB9IC6QEIuwQoBuMECgrtBB0MigWzAQ29BgYAAAABAQIBAwEEAQUBBgAAAgAABwgAAgIMAQABBAQCAAEBAgAGBgIAAxAEAAISDAEAAQAIAAEAAAkCAwAACgQFAAALBgcAAAwEBQAADQQFAAIVCgUBAAIICwMBAAIWDQ4BAAIXERIBAgYYAhMAAhkCDgEABRoVAwEIAhsWAwEAAgsXDgEAAg0YBQEABgkHCQgMCA8JCQsMCw8MFAYPBgwNDA0PDgkPCQMHCAELAgEIAAcIBQILAgEIAwsCAQgEAQcIBQABBggBAQMEBwgBCwIBCAMLAgEIBAcIBQELAgEIAAMLAgEIBAMLAgEIAwEIAAEGCwIBCQACCwIBCQAHCwcBCQABCAMDBwsCAQkAAwcIBQELAgEJAAEIBAELBwEIAAIJAAcIBQELBwEJAAEIBgEIAQEJAAIHCwIBCQALAgEJAAMDBwsHAQkABwgFAQYLBwEJAAZCQVNLRVQHTUFOQUdFRARDb2luAklEA1NVSQhUcmFuc2ZlcglUeENvbnRleHQHUmVzZXJ2ZQRidXJuBGluaXQObWFuYWdlZF9zdXBwbHkEbWludApzdWlfc3VwcGx5DHRvdGFsX3N1cHBseQtkdW1teV9maWVsZAJpZAtWZXJzaW9uZWRJRAx0cmVhc3VyeV9jYXALVHJlYXN1cnlDYXADc3VpB21hbmFnZWQFdmFsdWUId2l0aGRyYXcPY3JlYXRlX2N1cnJlbmN5Bm5ld19pZAR6ZXJvDHNoYXJlX29iamVjdARqb2luAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgMIAAAAAAAAAAAAAgEOAQECBA8IBhELBwEIABMLAgEIAxQLAgEIBAABAAAIFg4BOAAMBAsBCgAPADgBCgAPAQoECgI4AgwFCwAPAgsECwI4AwwDCwULAwIBAAAAEA8JEgAKADgEDAEKABEKCwEKADgFCwA4BhIBOAcCAgEAAAMECwAQAjgIAgMBAAAFHA4BOAkMBAoEDgI4CCEDDgsAAQsDAQcAJwoADwELATgKCgAPAgsCOAsLBAsADwALAzgMAgQBAAADBAsAEAE4CQIFAQAAAwQLABAAOA0CAQEBAgEDAA=="]
+{
+  "modules": "oRzrCwUAAAAJAQAIAggUAxw3BFMKBV1yB88BdAjDAigK6wIFDPACQgAAAQEBAgEDAAACAAEEDAEAAQEBDAEAAQMDAgAABQABAAAGAgEAAAcDBAAACAUBAAEFBwEBAAEKCQoBAgMLCwwAAgwNAQEIAQcODwEAAQgQAQEABAYFBgcICAYJBgMHCwEBCAALAgEIAAcIAwABBwgDAwcLAQEIAAMHCAMBCwIBCAADCwEBCAAFBwgDAQgAAgsCAQkABwsBAQkAAQsBAQgAAgkABwgDAQsBAQkAAQYIAwEFAgkABQMDBwsBAQkABwgDAQsCAQkAAgsBAQkABQdNQU5BR0VEBENvaW4IVHJhbnNmZXIJVHhDb250ZXh0C1RyZWFzdXJ5Q2FwBGJ1cm4EaW5pdARtaW50DHRyYW5zZmVyX2NhcAtkdW1teV9maWVsZA9jcmVhdGVfY3VycmVuY3kGc2VuZGVyCHRyYW5zZmVyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgACAQkBAAEAAAEECwELADgAAgEAAAAICwkSAAoAOAEMAQsBCwAuEQY4AgICAQAAAQULAQsACwI4AwIDAQAAAQQLAAsBOAQCAA==", "oRzrCwUAAAALAQAOAg4kAzJZBIsBHAWnAasBB9IC6QEIuwQoBuMECgrtBB0MigWzAQ29BgYAAAABAQIBAwEEAQUBBgAAAgAABwgAAgIMAQABBAQCAAEBAgAGBgIAAxAEAAISDAEAAQAIAAEAAAkCAwAACgQFAAALBgcAAAwEBQAADQQFAAIVCgUBAAIICwMBAAIWDQ4BAAIXERIBAgYYAhMAAhkCDgEABRoVAwEIAhsWAwEAAgsXDgEAAg0YBQEABgkHCQgMCA8JCQsMCw8MFAYPBgwNDA0PDgkPCQMHCAELAgEIAAcIBQILAgEIAwsCAQgEAQcIBQABBggBAQMEBwgBCwIBCAMLAgEIBAcIBQELAgEIAAMLAgEIBAMLAgEIAwEIAAEGCwIBCQACCwIBCQAHCwcBCQABCAMDBwsCAQkAAwcIBQELAgEJAAEIBAELBwEIAAIJAAcIBQELBwEJAAEIBgEIAQEJAAIHCwIBCQALAgEJAAMDBwsHAQkABwgFAQYLBwEJAAZCQVNLRVQHTUFOQUdFRARDb2luAklEA1NVSQhUcmFuc2ZlcglUeENvbnRleHQHUmVzZXJ2ZQRidXJuBGluaXQObWFuYWdlZF9zdXBwbHkEbWludApzdWlfc3VwcGx5DHRvdGFsX3N1cHBseQtkdW1teV9maWVsZAJpZAtWZXJzaW9uZWRJRAx0cmVhc3VyeV9jYXALVHJlYXN1cnlDYXADc3VpB21hbmFnZWQFdmFsdWUId2l0aGRyYXcPY3JlYXRlX2N1cnJlbmN5Bm5ld19pZAR6ZXJvDHNoYXJlX29iamVjdARqb2luAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgMIAAAAAAAAAAAAAgEOAQECBA8IBhELBwEIABMLAgEIAxQLAgEIBAABAAAIFg4BOAAMBAsBCgAPADgBCgAPAQoECgI4AgwFCwAPAgsECwI4AwwDCwULAwIBAAAAEA8JEgAKADgEDAEKABEKCwEKADgFCwA4BhIBOAcCAgEAAAMECwAQAjgIAgMBAAAFHA4BOAkMBAoEDgI4CCEDDgsAAQsDAQcAJwoADwELATgKCgAPAgsCOAsLBAsADwALAzgMAgQBAAADBAsAEAE4CQIFAQAAAwQLABAAOA0CAQEBAgEDAA==",
+  "dependencies": ["0x0000000000000000000000000000000000000000000000000000000000000001"],
+}
 Build Successful
 ```
 
-Copy the output base64 representation of the compiled Move module into the
+Copy the output base64 representation of the compiled Move module along with the dependency IDs into the
 REST publish endpoint.
 
 The command generates a package object that represents the published Move code. You can use the package ID as an argument for subsequent Move calls to functions defined in this package.

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -369,20 +369,24 @@ import {
   JsonRpcProvider,
   RawSigner,
   Transaction,
+  normalizeSuiObjectId,
 } from '@mysten/sui.js';
 const { execSync } = require('child_process');
 // Generate a new Keypair
 const keypair = new Ed25519Keypair();
 const provider = new JsonRpcProvider();
 const signer = new RawSigner(keypair, provider);
-const compiledModules = JSON.parse(
+const compiledModulesAndDependencies = JSON.parse(
   execSync(
     `${cliPath} move build --dump-bytecode-as-base64 --path ${packagePath}`,
     { encoding: 'utf-8' },
   ),
 );
 const tx = new Transaction();
-tx.publish(compiledModules);
+tx.publish(
+    compiledModulesAndDeps.modules.map((m: any) => Array.from(fromB64(m))),
+    compiledModulesAndDeps.dependencies.map((addr: string) => normalizeSuiObjectId(addr)),
+);
 const result = await signer.signAndExecuteTransaction({ transaction: tx });
 console.log({ result });
 ```

--- a/sdk/typescript/src/builder/Commands.ts
+++ b/sdk/typescript/src/builder/Commands.ts
@@ -17,6 +17,7 @@ import {
   Struct,
   define,
 } from 'superstruct';
+import { ObjectId } from '../types/common';
 import { COMMAND_TYPE, WellKnownEncoding, create } from './utils';
 
 const option = <T extends Struct<any, any>>(some: T) =>
@@ -103,6 +104,7 @@ export type MakeMoveVecCommand = Infer<typeof MakeMoveVecCommand>;
 export const PublishCommand = object({
   kind: literal('Publish'),
   modules: array(array(integer())),
+  dependencies: array(ObjectId),
 });
 export type PublishCommand = Infer<typeof PublishCommand>;
 
@@ -164,8 +166,8 @@ export const Commands = {
       MergeCoinsCommand,
     );
   },
-  Publish(modules: number[][]): PublishCommand {
-    return create({ kind: 'Publish', modules }, PublishCommand);
+  Publish(modules: number[][], dependencies: ObjectId[]): PublishCommand {
+    return create({ kind: 'Publish', modules, dependencies }, PublishCommand);
   },
   MakeMoveVec({
     type,

--- a/sdk/typescript/src/builder/bcs.ts
+++ b/sdk/typescript/src/builder/bcs.ts
@@ -74,7 +74,10 @@ export const builder = new BCS(bcs)
     /**
      * Publish a Move module.
      */
-    Publish: { modules: [VECTOR, [VECTOR, BCS.U8]] },
+    Publish: {
+      modules: [VECTOR, [VECTOR, BCS.U8]],
+      dependencies: [VECTOR, BCS.ADDRESS],
+    },
     /**
      * Build a vector of objects using the input arguments.
      * It is impossible to construct a `vector<T: key>` otherwise,


### PR DESCRIPTION
This fixes the tests on the typescript side, and plumbs through the dependencies in the typescript APIs and publish command.

This also updates the `--dump-bytecode-as-base64` flag to return a json-dict as opposed to just a json array. It now includes:

* The base64 encoded modules bytes in the `modules` field
* The array of hex-encoded object IDs for each dependency of the package.

## Test Plan 

Make sure existing tests pass

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [X] user-visible impact
- [X] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration
