### PR TITLE
[2/N] Remove validator_set API from genesis

### DIFF
--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -23,11 +23,11 @@ use sui_types::base_types::{ExecutionDigests, TransactionDigest};
 use sui_types::base_types::{ObjectID, SequenceNumber, SuiAddress};
 use sui_types::clock::Clock;
 use sui_types::committee::CommitteeWithNetworkMetadata;
+use sui_types::crypto::DefaultHash;
 use sui_types::crypto::{
     AuthorityKeyPair, AuthorityPublicKeyBytes, AuthoritySignInfo, AuthoritySignature,
     SuiAuthoritySignature, ToFromBytes,
 };
-use sui_types::crypto::{DefaultHash, PublicKey as AccountsPublicKey};
 use sui_types::epoch_data::EpochData;
 use sui_types::gas::SuiGasStatus;
 use sui_types::gas_coin::TOTAL_SUPPLY_MIST;
@@ -43,11 +43,9 @@ use sui_types::messages_checkpoint::{
 use sui_types::multiaddr::Multiaddr;
 use sui_types::object::Owner;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
-use sui_types::sui_system_state::sui_system_state_inner_v1::VerifiedValidatorMetadataV1;
-use sui_types::sui_system_state::sui_system_state_summary::SuiValidatorSummary;
 use sui_types::sui_system_state::{
     get_sui_system_state, get_sui_system_state_version, get_sui_system_state_wrapper,
-    SuiSystemStateInnerGenesis, SuiSystemStateTrait, SuiSystemStateWrapper,
+    SuiSystemStateInnerGenesis, SuiSystemStateTrait, SuiSystemStateWrapper, SuiValidatorGenesis,
 };
 use sui_types::temporary_store::{InnerTemporaryStore, TemporaryStore};
 use sui_types::MOVE_STDLIB_ADDRESS;
@@ -136,44 +134,8 @@ impl Genesis {
         0
     }
 
-    pub fn validator_set(&self) -> Vec<ValidatorInfo> {
-        self.sui_system_object()
-            .validators
-            .active_validators
-            .iter()
-            .map(|validator| {
-                let metadata = validator.verified_metadata();
-                ValidatorInfo {
-                    name: metadata.name.clone(),
-                    account_key: AccountsPublicKey::Ed25519(metadata.network_pubkey.clone()), //TODO this is wrong and we shouldn't have this here
-                    protocol_key: metadata.sui_pubkey_bytes(),
-                    worker_key: metadata.worker_pubkey.clone(),
-                    network_key: metadata.network_pubkey.clone(),
-                    gas_price: validator.gas_price,
-                    commission_rate: validator.commission_rate,
-                    network_address: metadata.net_address.clone(),
-                    p2p_address: metadata.p2p_address.clone(),
-                    narwhal_primary_address: metadata.primary_address.clone(),
-                    narwhal_worker_address: metadata.worker_address.clone(),
-                    description: metadata.description.clone(),
-                    image_url: metadata.image_url.clone(),
-                    project_url: metadata.project_url.clone(),
-                }
-            })
-            .collect()
-    }
-
-    pub fn validator_summary_set(&self) -> Vec<(SuiValidatorSummary, VerifiedValidatorMetadataV1)> {
-        self.sui_system_object()
-            .validators
-            .active_validators
-            .iter()
-            .map(|validator| {
-                let summary = validator.clone().into_sui_validator_summary();
-                let metadata = validator.verified_metadata().clone();
-                (summary, metadata)
-            })
-            .collect()
+    pub fn validator_set(&self) -> Vec<SuiValidatorGenesis> {
+        self.sui_system_object().validators.active_validators
     }
 
     pub fn committee_with_network(&self) -> CommitteeWithNetworkMetadata {
@@ -355,17 +317,8 @@ impl UnsignedGenesis {
         0
     }
 
-    pub fn validator_summary_set(&self) -> Vec<(SuiValidatorSummary, VerifiedValidatorMetadataV1)> {
-        self.sui_system_object()
-            .validators
-            .active_validators
-            .iter()
-            .map(|validator| {
-                let summary = validator.clone().into_sui_validator_summary();
-                let metadata = validator.verified_metadata().clone();
-                (summary, metadata)
-            })
-            .collect()
+    pub fn validator_set(&self) -> Vec<SuiValidatorGenesis> {
+        self.sui_system_object().validators.active_validators
     }
 
     pub fn sui_system_wrapper_object(&self) -> SuiSystemStateWrapper {

--- a/crates/sui-config/src/swarm.rs
+++ b/crates/sui-config/src/swarm.rs
@@ -9,7 +9,7 @@ use crate::node::{
 use crate::p2p::{P2pConfig, SeedPeer};
 use crate::{
     builder::{self, ProtocolVersionsConfig, SupportedProtocolVersionsCallback},
-    genesis, utils, Config, NodeConfig, ValidatorInfo,
+    genesis, utils, Config, NodeConfig,
 };
 use fastcrypto::traits::KeyPair;
 use rand::rngs::OsRng;
@@ -20,10 +20,12 @@ use std::net::{IpAddr, SocketAddr};
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use sui_protocol_config::SupportedProtocolVersions;
-use sui_types::committee::Committee;
+use sui_types::committee::CommitteeWithNetworkMetadata;
 use sui_types::crypto::{
     get_key_pair_from_rng, AccountKeyPair, AuthorityKeyPair, NetworkKeyPair, SuiKeyPair,
 };
+use sui_types::multiaddr::Multiaddr;
+use sui_types::sui_system_state::SuiSystemStateInnerGenesis;
 
 /// This is a config that is used for testing or local use as it contains the config and keys for
 /// all validators
@@ -42,12 +44,21 @@ impl NetworkConfig {
         &self.validator_configs
     }
 
-    pub fn validator_set(&self) -> Vec<ValidatorInfo> {
-        self.genesis.validator_set()
+    pub fn net_addresses(&self) -> Vec<Multiaddr> {
+        self.genesis
+            .committee_with_network()
+            .network_metadata
+            .into_values()
+            .map(|n| n.network_address)
+            .collect()
     }
 
-    pub fn committee(&self) -> Committee {
-        self.genesis.committee().unwrap()
+    pub fn genesis_system_state(&self) -> SuiSystemStateInnerGenesis {
+        self.genesis.sui_system_object()
+    }
+
+    pub fn committee_with_network(&self) -> CommitteeWithNetworkMetadata {
+        self.genesis.committee_with_network()
     }
 
     pub fn into_validator_configs(self) -> Vec<NodeConfig> {

--- a/crates/sui-cost/tests/empirical_transaction_cost.rs
+++ b/crates/sui-cost/tests/empirical_transaction_cost.rs
@@ -197,7 +197,7 @@ async fn create_txes(
     // Using the `counter` example
     //
 
-    let package_id = publish_counter_package(gas_objects.pop().unwrap(), &configs.validator_set())
+    let package_id = publish_counter_package(gas_objects.pop().unwrap(), &configs.net_addresses())
         .await
         .0;
 
@@ -211,7 +211,7 @@ async fn create_txes(
         /* arguments */ Vec::default(),
     );
     let (effects, _) =
-        submit_single_owner_transaction(transaction.clone(), &configs.validator_set()).await;
+        submit_single_owner_transaction(transaction.clone(), &configs.net_addresses()).await;
     assert!(matches!(effects.status(), ExecutionStatus::Success { .. }));
     let ((counter_id, counter_initial_shared_version, _), _) = effects.created()[0];
     let counter_object_arg = ObjectArg::SharedObject {
@@ -272,14 +272,14 @@ async fn run_actual_costs(
     let tx_map = create_txes(sender, &keypair, &gas_objects, &configs).await;
     for (tx_type, tx) in tx_map {
         let gas_used = if tx_type.is_shared_object_tx() {
-            submit_shared_object_transaction(tx, &configs.validator_set())
+            submit_shared_object_transaction(tx, &configs.net_addresses())
                 .await
                 .unwrap()
                 .0
                 .gas_cost_summary()
                 .clone()
         } else {
-            submit_single_owner_transaction(tx, &configs.validator_set())
+            submit_single_owner_transaction(tx, &configs.net_addresses())
                 .await
                 .0
                 .gas_cost_summary()

--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -240,13 +240,14 @@ impl ToolCommand {
                     println!("{:#?}", genesis.validator_set());
                 } else {
                     for (i, val_info) in genesis.validator_set().iter().enumerate() {
+                        let metadata = val_info.verified_metadata();
                         println!(
                             "#{:<2} {:<20} {:?<66} {:?} {}",
                             i,
-                            val_info.name(),
-                            val_info.protocol_key(),
-                            val_info.network_address(),
-                            anemo::PeerId(val_info.network_key().0.to_bytes()),
+                            metadata.name,
+                            metadata.protocol_pubkey,
+                            metadata.net_address,
+                            anemo::PeerId(metadata.network_pubkey.0.to_bytes()),
                         )
                     }
                 }
@@ -261,7 +262,7 @@ impl ToolCommand {
             } => {
                 let clients = make_clients(genesis)?;
 
-                for (name, (_val, client)) in clients {
+                for (name, (_, client)) in clients {
                     let resp = client
                         .handle_checkpoint(CheckpointRequest {
                             sequence_number,

--- a/crates/sui-types/src/committee.rs
+++ b/crates/sui-types/src/committee.rs
@@ -343,6 +343,7 @@ pub fn validity_threshold(total_stake: StakeUnit) -> StakeUnit {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct NetworkMetadata {
     pub network_address: Multiaddr,
+    pub narwhal_primary_address: Multiaddr,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/sui-types/src/sui_system_state/mod.rs
+++ b/crates/sui-types/src/sui_system_state/mod.rs
@@ -81,6 +81,7 @@ pub enum SuiSystemState {
 
 /// This is the fixed type used by genesis.
 pub type SuiSystemStateInnerGenesis = SuiSystemStateInnerV1;
+pub type SuiValidatorGenesis = ValidatorV1;
 
 /// This is the fixed type used by benchmarking.
 pub type SuiSystemStateInnerBenchmark = SuiSystemStateInnerV1;

--- a/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
@@ -490,6 +490,7 @@ impl SuiSystemStateTrait for SuiSystemStateInnerV1 {
                 name,
                 NetworkMetadata {
                     network_address: verified_metadata.net_address.clone(),
+                    narwhal_primary_address: verified_metadata.primary_address.clone(),
                 },
             );
         }

--- a/crates/sui-types/src/sui_system_state/sui_system_state_summary.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_summary.rs
@@ -94,6 +94,8 @@ impl SuiSystemStateSummary {
                 name,
                 NetworkMetadata {
                     network_address: Multiaddr::try_from(validator.net_address.clone()).unwrap(),
+                    narwhal_primary_address: Multiaddr::try_from(validator.primary_address.clone())
+                        .unwrap(),
                 },
             );
         }

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -10,7 +10,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use sui_config::builder::ConfigBuilder;
-use sui_config::{NodeConfig, ValidatorInfo};
+use sui_config::NodeConfig;
 use sui_core::authority_aggregator::{AuthAggMetrics, AuthorityAggregator};
 use sui_core::consensus_adapter::position_submit_certificate;
 use sui_core::safe_client::SafeClientMetricsBase;
@@ -18,7 +18,7 @@ use sui_core::test_utils::make_transfer_sui_transaction;
 use sui_framework::{SuiFramework, SystemPackage};
 use sui_macros::sim_test;
 use sui_node::SuiNodeHandle;
-use sui_types::base_types::{ObjectRef, SuiAddress};
+use sui_types::base_types::{AuthorityName, ObjectRef, SuiAddress};
 use sui_types::crypto::{
     generate_proof_of_possession, get_account_key_pair, get_key_pair_from_rng, AccountKeyPair,
     KeypairTraits, ToFromBytes,
@@ -31,6 +31,7 @@ use sui_types::messages::{
     VerifiedTransaction,
 };
 use sui_types::object::{generate_test_gas_objects_with_owner, Object};
+use sui_types::sui_system_state::sui_system_state_inner_v1::VerifiedValidatorMetadataV1;
 use sui_types::sui_system_state::{get_validator_from_table, SuiSystemStateTrait};
 use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{SUI_SYSTEM_STATE_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION};
@@ -584,23 +585,32 @@ async fn test_reconfig_with_committee_change_basic() {
     // The order of validator_set() and validator_configs() is also different.
     // TODO: We should really fix the above inconveniences.
     let public_keys: HashSet<_> = init_configs
-        .validator_set()
+        .validator_configs
         .iter()
-        .map(|v| v.protocol_key())
+        .map(|config| config.protocol_public_key())
         .collect();
-    let new_validator = new_configs
-        .validator_set()
-        .into_iter()
-        .find(|v| !public_keys.contains(&v.protocol_key()))
-        .unwrap();
+    // Node configs contain things such as private keys, which we need to send transactions.
     let new_node_config = new_configs
-        .validator_configs()
+        .validator_configs
         .iter()
         .find(|v| !public_keys.contains(&v.protocol_public_key()))
         .unwrap();
+    // Validator information from genesis contains public network addresses that we need to commit on-chain.
+    let new_validator = new_configs
+        .genesis
+        .validator_set()
+        .into_iter()
+        .find(|v| {
+            let name: AuthorityName = v.verified_metadata().sui_pubkey_bytes();
+            !public_keys.contains(&name)
+        })
+        .unwrap();
     info!(
         "New validator is: {:?}",
-        new_validator.protocol_key.concise()
+        new_validator
+            .verified_metadata()
+            .sui_pubkey_bytes()
+            .concise()
     );
 
     let mut authorities = spawn_test_authorities(&init_configs).await;
@@ -613,8 +623,8 @@ async fn test_reconfig_with_committee_change_basic() {
             .map(|obj| obj.compute_object_reference())
             .collect::<Vec<_>>(),
         stake.compute_object_reference(),
-        &new_validator,
         new_node_config,
+        new_validator.verified_metadata(),
     )
     .await;
 
@@ -776,11 +786,13 @@ async fn test_reconfig_with_committee_change_stress() {
     tokio::time::sleep(Duration::from_secs(5)).await;
 
     let initial_pubkeys: Vec<_> = initial_network
+        .genesis
         .validator_set()
         .iter()
-        .map(|v| v.protocol_key())
+        .map(|v| v.verified_metadata().sui_pubkey_bytes())
         .collect();
-    let mut standby_nodes: Vec<(ValidatorInfo, &NodeConfig)> = validator_superset
+    let mut standby_nodes: Vec<_> = validator_superset
+        .genesis
         .validator_set()
         .into_iter()
         .map(|val| {
@@ -788,12 +800,14 @@ async fn test_reconfig_with_committee_change_stress() {
                 .validator_configs()
                 .iter()
                 .find(|config| {
-                    config.protocol_public_key().as_bytes() == val.protocol_key().as_bytes()
+                    config.protocol_public_key() == val.verified_metadata().sui_pubkey_bytes()
                 })
                 .unwrap();
             (val, node_config)
         })
-        .filter(|(val, _node)| !initial_pubkeys.contains(&val.protocol_key()))
+        .filter(|(val, _node)| {
+            !initial_pubkeys.contains(&val.verified_metadata().sui_pubkey_bytes())
+        })
         .collect();
     assert_eq!(standby_nodes.len(), 6);
 
@@ -807,15 +821,15 @@ async fn test_reconfig_with_committee_change_stress() {
         assert_eq!(joining_validators.len(), 2);
 
         // request to add new validators
-        for (validator_info, node_config) in joining_validators.clone() {
+        for (validator, node_config) in joining_validators.clone() {
             let sender = node_config.sui_address();
             let (gas_objects, stake) = object_map.get(&sender).unwrap();
             let effects = execute_join_committee_txes(
                 &validator_handles,
                 gas_objects.clone(),
                 *stake,
-                &validator_info,
                 node_config,
+                validator.verified_metadata(),
             )
             .await;
 
@@ -860,7 +874,7 @@ async fn test_reconfig_with_committee_change_stress() {
         // bookkeeping and verification for joined validators
         let joined_auths: Vec<_> = joining_validators
             .iter()
-            .map(|(val, _node)| val.protocol_key())
+            .map(|(val, _node)| val.verified_metadata().sui_pubkey_bytes())
             .collect();
 
         assert_eq!(joined_auths.len(), 2);
@@ -933,15 +947,12 @@ async fn execute_join_committee_txes(
     authorities: &[SuiNodeHandle],
     gas_objects: Vec<ObjectRef>,
     stake: ObjectRef,
-    val: &ValidatorInfo,
     node_config: &NodeConfig,
+    val: &VerifiedValidatorMetadataV1,
 ) -> Vec<CertifiedTransactionEffects> {
+    assert_eq!(node_config.protocol_public_key(), val.sui_pubkey_bytes());
     let mut effects_ret = vec![];
-    let sender = node_config.sui_address();
-    assert_eq!(
-        node_config.protocol_public_key().as_bytes(),
-        val.protocol_key().as_bytes()
-    );
+    let sender = val.sui_address;
     let proof_of_possession = generate_proof_of_possession(node_config.protocol_key_pair(), sender);
 
     // Step 1: Add the new node as a validator candidate.
@@ -958,18 +969,18 @@ async fn execute_join_committee_txes(
                 initial_shared_version: SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
                 mutable: true,
             }),
-            CallArg::Pure(bcs::to_bytes(&val.protocol_key().as_bytes().to_vec()).unwrap()),
-            CallArg::Pure(bcs::to_bytes(val.network_key().as_bytes()).unwrap()),
-            CallArg::Pure(bcs::to_bytes(val.worker_key().as_bytes()).unwrap()),
+            CallArg::Pure(bcs::to_bytes(val.protocol_pubkey.as_bytes()).unwrap()),
+            CallArg::Pure(bcs::to_bytes(val.network_pubkey.as_bytes()).unwrap()),
+            CallArg::Pure(bcs::to_bytes(val.worker_pubkey.as_bytes()).unwrap()),
             CallArg::Pure(bcs::to_bytes(proof_of_possession.as_ref()).unwrap()),
-            CallArg::Pure(bcs::to_bytes(val.name().as_bytes()).unwrap()),
-            CallArg::Pure(bcs::to_bytes("description".as_bytes()).unwrap()),
-            CallArg::Pure(bcs::to_bytes("image_url".as_bytes()).unwrap()),
-            CallArg::Pure(bcs::to_bytes("project_url".as_bytes()).unwrap()),
-            CallArg::Pure(bcs::to_bytes(&val.network_address()).unwrap()),
-            CallArg::Pure(bcs::to_bytes(&val.p2p_address()).unwrap()),
-            CallArg::Pure(bcs::to_bytes(&val.narwhal_primary_address()).unwrap()),
-            CallArg::Pure(bcs::to_bytes(&val.narwhal_worker_address()).unwrap()),
+            CallArg::Pure(bcs::to_bytes(val.name.as_bytes()).unwrap()),
+            CallArg::Pure(bcs::to_bytes(val.description.as_bytes()).unwrap()),
+            CallArg::Pure(bcs::to_bytes(val.image_url.as_bytes()).unwrap()),
+            CallArg::Pure(bcs::to_bytes(val.project_url.as_bytes()).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&val.net_address).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&val.p2p_address).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&val.primary_address).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&val.worker_address).unwrap()),
             CallArg::Pure(bcs::to_bytes(&1u64).unwrap()), // gas_price
             CallArg::Pure(bcs::to_bytes(&0u64).unwrap()), // commission_rate
         ],

--- a/crates/sui/tests/shared_objects_tests.rs
+++ b/crates/sui/tests/shared_objects_tests.rs
@@ -45,7 +45,7 @@ async fn shared_object_transaction() {
 
     // Submit the transaction. Note that this transaction is random and we do not expect
     // it to be successfully executed by the Move execution engine.
-    let _effects = submit_shared_object_transaction(transaction, &configs.validator_set())
+    let _effects = submit_shared_object_transaction(transaction, &configs.net_addresses())
         .await
         .unwrap();
 }
@@ -73,7 +73,7 @@ async fn many_shared_object_transactions() {
 
     // Submit the transaction. Note that this transaction is random and we do not expect
     // it to be successfully executed by the Move execution engine.
-    let _effects = submit_shared_object_transaction(transaction, &configs.validator_set())
+    let _effects = submit_shared_object_transaction(transaction, &configs.net_addresses())
         .await
         .unwrap();
 }
@@ -90,7 +90,7 @@ async fn call_shared_object_contract() {
     let _handles = spawn_test_authorities(&configs).await;
 
     // Publish the move package to all authorities and get its package ID.
-    let package_id = publish_counter_package(gas_objects.pop().unwrap(), &configs.validator_set())
+    let package_id = publish_counter_package(gas_objects.pop().unwrap(), &configs.net_addresses())
         .await
         .0;
 
@@ -102,7 +102,7 @@ async fn call_shared_object_contract() {
         package_id,
         /* arguments */ Vec::default(),
     );
-    let (effects, _) = submit_single_owner_transaction(transaction, &configs.validator_set()).await;
+    let (effects, _) = submit_single_owner_transaction(transaction, &configs.net_addresses()).await;
     assert!(matches!(effects.status(), ExecutionStatus::Success { .. }));
     let counter_creation_transaction = *effects.transaction_digest();
     let ((counter_id, counter_initial_shared_version, _), _) = effects.created()[0];
@@ -130,7 +130,7 @@ async fn call_shared_object_contract() {
                 CallArg::Pure(0u64.to_le_bytes().to_vec()),
             ],
         );
-        let (effects, _) = submit_shared_object_transaction(transaction, &configs.validator_set())
+        let (effects, _) = submit_shared_object_transaction(transaction, &configs.net_addresses())
             .await
             .unwrap();
         assert!(matches!(effects.status(), ExecutionStatus::Success { .. }));
@@ -151,7 +151,7 @@ async fn call_shared_object_contract() {
         package_id,
         vec![CallArg::Object(counter_object_arg)],
     );
-    let (effects, _) = submit_shared_object_transaction(transaction, &configs.validator_set())
+    let (effects, _) = submit_shared_object_transaction(transaction, &configs.net_addresses())
         .await
         .unwrap();
     let increment_transaction = *effects.transaction_digest();
@@ -182,7 +182,7 @@ async fn call_shared_object_contract() {
                 CallArg::Pure(1u64.to_le_bytes().to_vec()),
             ],
         );
-        let (effects, _) = submit_shared_object_transaction(transaction, &configs.validator_set())
+        let (effects, _) = submit_shared_object_transaction(transaction, &configs.net_addresses())
             .await
             .unwrap();
         assert!(matches!(effects.status(), ExecutionStatus::Success { .. }));
@@ -202,7 +202,7 @@ async fn call_shared_object_contract() {
         package_id,
         vec![CallArg::Object(counter_object_arg_imm)],
     );
-    let (effects, _) = submit_shared_object_transaction(transaction, &configs.validator_set())
+    let (effects, _) = submit_shared_object_transaction(transaction, &configs.net_addresses())
         .await
         .unwrap();
     // Transaction fails
@@ -232,7 +232,7 @@ async fn access_clock_object_test() {
     let handles = spawn_test_authorities(&configs).await;
 
     // Publish the move package to all authorities and get its package ID.
-    let package_id = publish_counter_package(gas_objects.pop().unwrap(), &configs.validator_set())
+    let package_id = publish_counter_package(gas_objects.pop().unwrap(), &configs.net_addresses())
         .await
         .0;
 
@@ -253,7 +253,7 @@ async fn access_clock_object_test() {
     let start = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap();
-    let (effects, events) = submit_shared_object_transaction(transaction, &configs.validator_set())
+    let (effects, events) = submit_shared_object_transaction(transaction, &configs.net_addresses())
         .await
         .unwrap();
     let finish = SystemTime::now()
@@ -313,7 +313,7 @@ async fn shared_object_flood() {
     let _handles = spawn_test_authorities(&configs).await;
 
     // Publish the move package to all authorities and get its package ID.
-    let package_id = publish_counter_package(gas_objects.pop().unwrap(), &configs.validator_set())
+    let package_id = publish_counter_package(gas_objects.pop().unwrap(), &configs.net_addresses())
         .await
         .0;
 
@@ -325,7 +325,7 @@ async fn shared_object_flood() {
         package_id,
         /* arguments */ Vec::default(),
     );
-    let (effects, _) = submit_single_owner_transaction(transaction, &configs.validator_set()).await;
+    let (effects, _) = submit_single_owner_transaction(transaction, &configs.net_addresses()).await;
     assert!(matches!(effects.status(), ExecutionStatus::Success { .. }));
     let ((counter_id, counter_initial_shared_version, _), _) = effects.created()[0];
     let counter_object_arg = ObjectArg::SharedObject {
@@ -345,7 +345,7 @@ async fn shared_object_flood() {
             CallArg::Pure(0u64.to_le_bytes().to_vec()),
         ],
     );
-    let (effects, _) = submit_shared_object_transaction(transaction, &configs.validator_set())
+    let (effects, _) = submit_shared_object_transaction(transaction, &configs.net_addresses())
         .await
         .unwrap();
     assert!(matches!(effects.status(), ExecutionStatus::Success { .. }));
@@ -358,7 +358,7 @@ async fn shared_object_flood() {
         package_id,
         vec![CallArg::Object(counter_object_arg)],
     );
-    let (effects, _) = submit_shared_object_transaction(transaction, &configs.validator_set())
+    let (effects, _) = submit_shared_object_transaction(transaction, &configs.net_addresses())
         .await
         .unwrap();
     assert!(matches!(effects.status(), ExecutionStatus::Success { .. }));
@@ -374,7 +374,7 @@ async fn shared_object_flood() {
             CallArg::Pure(1u64.to_le_bytes().to_vec()),
         ],
     );
-    let (effects, _) = submit_shared_object_transaction(transaction, &configs.validator_set())
+    let (effects, _) = submit_shared_object_transaction(transaction, &configs.net_addresses())
         .await
         .unwrap();
     assert!(matches!(effects.status(), ExecutionStatus::Success { .. }));
@@ -391,7 +391,7 @@ async fn shared_object_sync() {
     let _handles = spawn_test_authorities(&configs).await;
 
     // Publish the move package to all authorities and get its package ID.
-    let package_id = publish_counter_package(gas_objects.pop().unwrap(), &configs.validator_set())
+    let package_id = publish_counter_package(gas_objects.pop().unwrap(), &configs.net_addresses())
         .await
         .0;
 
@@ -404,19 +404,24 @@ async fn shared_object_sync() {
         /* arguments */ Vec::default(),
     );
 
-    let (slow_validators, fast_validators): (Vec<_>, Vec<_>) =
-        configs.validator_set().iter().cloned().partition(|info| {
+    let committee = configs.committee_with_network();
+    let (slow_validators, fast_validators): (Vec<_>, Vec<_>) = committee
+        .network_metadata
+        .into_iter()
+        .partition(|(name, _net)| {
             position_submit_certificate(
-                &configs.committee(),
-                &info.protocol_key(),
+                &committee.committee,
+                name,
                 create_counter_transaction.digest(),
             ) > 0
         });
 
     let (effects, _) = submit_single_owner_transaction(
         create_counter_transaction.clone(),
-        //&configs.validator_set()[1..],
-        &slow_validators,
+        &slow_validators
+            .iter()
+            .map(|(_, net)| net.network_address.clone())
+            .collect::<Vec<_>>(),
     )
     .await;
     assert!(matches!(effects.status(), ExecutionStatus::Success { .. }));
@@ -429,9 +434,8 @@ async fn shared_object_sync() {
 
     // Check that the counter object exists in at least one of the validators the transaction was
     // sent to.
-    let validator_set = configs.validator_set();
-    let has_counter = stream::iter(&validator_set[1..]).any(|config| async move {
-        get_client(config)
+    let has_counter = stream::iter(&slow_validators).any(|(_, net)| async move {
+        get_client(&net.network_address)
             .handle_object_info_request(ObjectInfoRequest::latest_object_info_request(
                 counter_id, None,
             ))
@@ -442,7 +446,7 @@ async fn shared_object_sync() {
     assert!(has_counter.await);
 
     // Check that the validator that wasn't sent the transaction is unaware of the counter object
-    assert!(get_client(&fast_validators[0])
+    assert!(get_client(&fast_validators[0].1.network_address)
         .handle_object_info_request(ObjectInfoRequest::latest_object_info_request(
             counter_id, None,
         ))
@@ -461,7 +465,7 @@ async fn shared_object_sync() {
     // Let's submit the transaction to the original set of validators.
     let (effects, _) = submit_shared_object_transaction(
         increment_counter_transaction.clone(),
-        &configs.validator_set()[1..],
+        &configs.net_addresses()[1..],
     )
     .await
     .unwrap();
@@ -471,7 +475,7 @@ async fn shared_object_sync() {
     // It will succeed because we share owned object certificates through narwhal
     let (effects, _) = submit_shared_object_transaction(
         increment_counter_transaction,
-        &configs.validator_set()[0..1],
+        &configs.net_addresses()[0..1],
     )
     .await
     .unwrap();
@@ -489,7 +493,7 @@ async fn replay_shared_object_transaction() {
     let _handles = spawn_test_authorities(&configs).await;
 
     // Publish the move package to all authorities and get its package ID
-    let package_id = publish_counter_package(gas_objects.pop().unwrap(), &configs.validator_set())
+    let package_id = publish_counter_package(gas_objects.pop().unwrap(), &configs.net_addresses())
         .await
         .0;
 
@@ -506,7 +510,7 @@ async fn replay_shared_object_transaction() {
     for _ in 0..2 {
         let (effects, _) = submit_single_owner_transaction(
             create_counter_transaction.clone(),
-            &configs.validator_set(),
+            &configs.net_addresses(),
         )
         .await;
         assert!(matches!(effects.status(), ExecutionStatus::Success { .. }));

--- a/crates/sui/tests/shared_objects_version_tests.rs
+++ b/crates/sui/tests/shared_objects_version_tests.rs
@@ -3,7 +3,7 @@
 
 use std::path::PathBuf;
 use std::time::Duration;
-use sui_config::{NetworkConfig, ValidatorInfo};
+use sui_config::NetworkConfig;
 use sui_macros::*;
 use sui_node::SuiNodeHandle;
 use sui_types::base_types::{ObjectID, ObjectRef, SequenceNumber};
@@ -12,6 +12,7 @@ use sui_types::messages::{
     CallArg, ExecutionFailureStatus, ExecutionStatus, ObjectArg, TransactionEffects,
     TransactionEffectsAPI, TransactionEvents,
 };
+use sui_types::multiaddr::Multiaddr;
 use sui_types::object::{generate_test_gas_objects, Object, Owner, OBJECT_START_VERSION};
 use sui_types::SUI_FRAMEWORK_ADDRESS;
 use test_utils::authority::{spawn_test_authorities, test_authority_configs_with_objects};
@@ -131,7 +132,7 @@ impl TestEnvironment {
         let node_handles = spawn_test_authorities(&configs).await;
 
         let move_package =
-            publish_move_package(gas_objects.pop().unwrap(), &configs.validator_set())
+            publish_move_package(gas_objects.pop().unwrap(), &configs.net_addresses())
                 .await
                 .0;
 
@@ -156,7 +157,7 @@ impl TestEnvironment {
                 self.move_package,
                 arguments,
             ),
-            &self.configs.validator_set(),
+            &self.configs.net_addresses(),
         )
         .await
     }
@@ -174,7 +175,7 @@ impl TestEnvironment {
                 self.move_package,
                 arguments,
             ),
-            &self.configs.validator_set(),
+            &self.configs.net_addresses(),
         )
         .await
     }
@@ -263,8 +264,8 @@ impl TestEnvironment {
     }
 }
 
-async fn publish_move_package(gas: Object, validators: &[ValidatorInfo]) -> ObjectRef {
+async fn publish_move_package(gas: Object, net_addresses: &[Multiaddr]) -> ObjectRef {
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push("tests/move_test_code");
-    publish_package(gas, path, validators).await
+    publish_package(gas, path, net_addresses).await
 }

--- a/crates/test-utils/src/authority.rs
+++ b/crates/test-utils/src/authority.rs
@@ -6,13 +6,14 @@ use prometheus::Registry;
 use rand::{prelude::StdRng, SeedableRng};
 use std::net::IpAddr;
 use std::time::Duration;
-use sui_config::{builder::ConfigBuilder, NetworkConfig, NodeConfig, ValidatorInfo};
+use sui_config::{builder::ConfigBuilder, NetworkConfig, NodeConfig};
 use sui_core::authority_client::AuthorityAPI;
 use sui_core::authority_client::NetworkAuthorityClient;
 pub use sui_node::{SuiNode, SuiNodeHandle};
 use sui_types::base_types::ObjectID;
 use sui_types::crypto::TEST_COMMITTEE_SIZE;
 use sui_types::messages::ObjectInfoRequest;
+use sui_types::multiaddr::Multiaddr;
 use sui_types::object::Object;
 
 /// The default network buffer size of a test authority.
@@ -156,12 +157,12 @@ pub async fn spawn_fullnode(config: &NetworkConfig, rpc_port: Option<u16>) -> Su
 }
 
 /// Get a network client to communicate with the consensus.
-pub fn get_client(config: &ValidatorInfo) -> NetworkAuthorityClient {
-    NetworkAuthorityClient::connect_lazy(config.network_address()).unwrap()
+pub fn get_client(net_address: &Multiaddr) -> NetworkAuthorityClient {
+    NetworkAuthorityClient::connect_lazy(net_address).unwrap()
 }
 
-pub async fn get_object(config: &ValidatorInfo, object_id: ObjectID) -> Object {
-    get_client(config)
+pub async fn get_object(net_address: &Multiaddr, object_id: ObjectID) -> Object {
+    get_client(net_address)
         .handle_object_info_request(ObjectInfoRequest::latest_object_info_request(
             object_id, None,
         ))


### PR DESCRIPTION
`validator_set` API on genesis exposes two things that shouldn't be exposed: ValidatorInfo and the actual validator set implementation (the V1 of Validator type). This is really not necessary and we could obtain such information directly from genesis. This PR removes such API and adjust all callsites.