### PR TITLE
[bugfix] - print warn to stderr to prevent interfering with the `sui client` json result

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1133,10 +1133,9 @@ impl WalletContext {
                 .get_active_env()?
                 .create_rpc_client(self.request_timeout)
                 .await?;
-
             if let Err(e) = client.check_api_version() {
                 warn!("{e}");
-                println!("{}", format!("[warn] {e}").yellow().bold());
+                eprintln!("{}", format!("[warn] {e}").yellow().bold());
             }
             self.client.write().await.insert(client).clone()
         })


### PR DESCRIPTION
## Description 

Print warn to stderr to prevent interfering with the `sui client` json result. 

The warning message was causing problem when piping the sui client result to another command.

## Test Plan 

Tested manually 
<img width="1137" alt="image" src="https://user-images.githubusercontent.com/1888654/225985863-6dfd0aad-dfc0-4820-b974-871fc64cb567.png">
