### PR TITLE
[rust/ts SDK] Adding query param onto get_owned_objects (#9399)

### DIFF
--- a/.changeset/wild-points-clean.md
+++ b/.changeset/wild-points-clean.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Switching the response type of the getOwnedObjects api to a paginatedObjects response, and also moving filtering to FN

--- a/apps/explorer/src/components/ownedobjects/OwnedObjects.tsx
+++ b/apps/explorer/src/components/ownedobjects/OwnedObjects.tsx
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useRpcClient } from '@mysten/core';
-import { Coin, getObjectFields, getObjectId } from '@mysten/sui.js';
+import {
+    Coin,
+    getObjectFields,
+    getObjectId,
+    PaginatedObjectsResponse,
+    is,
+} from '@mysten/sui.js';
 import {
     useCallback,
     useEffect,
@@ -63,8 +69,8 @@ function OwnedObject({ id, byAddress }: { id: string; byAddress: boolean }) {
 
         req.then((objects) => {
             let ids: string[];
-            if (objects instanceof Array) {
-                ids = objects.map(({ objectId }) => objectId);
+            if (is(objects, PaginatedObjectsResponse)) {
+                ids = objects.data.map((resp) => getObjectId(resp));
             } else {
                 ids = objects.data.map(({ objectId }) => objectId);
             }

--- a/apps/explorer/src/utils/api/searchUtil.ts
+++ b/apps/explorer/src/utils/api/searchUtil.ts
@@ -36,13 +36,13 @@ export const navigateWithUnknown = async (
         const addrObjPromise = Promise.allSettled([
             rpc(network)
                 .getOwnedObjects({ owner: input })
-                .then((data) => {
-                    if (data.length <= 0)
+                .then((response) => {
+                    if (response.data.length <= 0)
                         throw new Error('No objects for Address');
 
                     return {
                         category: 'address',
-                        data: data,
+                        data: response.data,
                     };
                 }),
             rpc(network)

--- a/apps/wallet/src/ui/app/hooks/useObjectsOwnedByAddress.ts
+++ b/apps/wallet/src/ui/app/hooks/useObjectsOwnedByAddress.ts
@@ -4,13 +4,21 @@
 import { useRpcClient } from '@mysten/core';
 import { useQuery } from '@tanstack/react-query';
 
-import type { SuiAddress } from '@mysten/sui.js';
+import type { SuiAddress, SuiObjectResponseQuery } from '@mysten/sui.js';
 
-export function useObjectsOwnedByAddress(address?: SuiAddress | null) {
+export function useObjectsOwnedByAddress(
+    address?: SuiAddress | null,
+    query?: SuiObjectResponseQuery
+) {
     const rpc = useRpcClient();
     return useQuery(
         ['objects-owned', address],
-        () => rpc.getOwnedObjects({ owner: address! }),
+        () =>
+            rpc.getOwnedObjects({
+                owner: address!,
+                filter: query?.filter,
+                options: query?.options,
+            }),
         {
             enabled: !!address,
         }

--- a/apps/wallet/src/ui/app/pages/home/nfts/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nfts/index.tsx
@@ -12,11 +12,22 @@ import { NFTDisplayCard } from '_components/nft-display';
 import { useObjectsOwnedByAddress } from '_hooks';
 import PageTitle from '_src/ui/app/shared/PageTitle';
 
+import type { SuiObjectResponse, SuiObjectData } from '@mysten/sui.js';
+
 function NftsPage() {
     const accountAddress = useActiveAddress();
-    const { data, isLoading, error, isError } =
-        useObjectsOwnedByAddress(accountAddress);
-    const nfts = data?.filter((obj) => !Coin.isCoin(obj));
+    const { data, isLoading, error, isError } = useObjectsOwnedByAddress(
+        accountAddress,
+        { options: { showType: true } }
+    );
+    const sui_object_responses = data?.data as SuiObjectResponse[];
+    const nft_objects = sui_object_responses?.filter(
+        (obj) => !Coin.isCoin(obj)
+    );
+    const nfts = nft_objects?.map((nft) => {
+        const nft_details = nft.details as SuiObjectData;
+        return nft_details;
+    });
 
     return (
         <div className="flex flex-col flex-nowrap items-center gap-4 flex-1">
@@ -30,7 +41,6 @@ function NftsPage() {
                         <small>{(error as Error).message}</small>
                     </Alert>
                 ) : null}
-
                 {nfts?.length ? (
                     <div className="grid grid-cols-2 gap-x-3.5 gap-y-4 w-full h-full">
                         {nfts.map(({ objectId }) => (

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -44,7 +44,7 @@ use sui_config::genesis::Genesis;
 use sui_config::node::{AuthorityStorePruningConfig, DBCheckpointConfig};
 use sui_json_rpc_types::{
     DevInspectResults, DryRunTransactionResponse, EventFilter, SuiEvent, SuiMoveValue,
-    SuiTransactionEvents,
+    SuiObjectDataFilter, SuiTransactionEvents,
 };
 use sui_macros::{fail_point, nondeterministic};
 use sui_protocol_config::{ProtocolConfig, SupportedProtocolVersions};
@@ -2162,9 +2162,10 @@ impl AuthorityState {
         owner: SuiAddress,
         cursor: Option<ObjectID>,
         limit: usize,
+        filter: Option<SuiObjectDataFilter>,
     ) -> SuiResult<Vec<ObjectInfo>> {
         if let Some(indexes) = &self.indexes {
-            indexes.get_owner_objects(owner, cursor, limit)
+            indexes.get_owner_objects(owner, cursor, limit, filter)
         } else {
             Err(SuiError::IndexStoreNotAvailable)
         }
@@ -2173,9 +2174,15 @@ impl AuthorityState {
     pub fn get_owner_objects_iterator(
         &self,
         owner: SuiAddress,
+        cursor: Option<ObjectID>,
+        limit: Option<usize>,
+        filter: Option<SuiObjectDataFilter>,
     ) -> SuiResult<impl Iterator<Item = ObjectInfo> + '_> {
+        let cursor_u = cursor.unwrap_or(ObjectID::ZERO);
+        let count = limit.unwrap_or(MAX_GET_OWNED_OBJECT_SIZE);
+
         if let Some(indexes) = &self.indexes {
-            indexes.get_owner_objects_iterator(owner, ObjectID::ZERO, MAX_GET_OWNED_OBJECT_SIZE)
+            indexes.get_owner_objects_iterator(owner, cursor_u, count, filter)
         } else {
             Err(SuiError::IndexStoreNotAvailable)
         }
@@ -2190,7 +2197,7 @@ impl AuthorityState {
         T: DeserializeOwned,
     {
         let object_ids = self
-            .get_owner_objects_iterator(owner)?
+            .get_owner_objects_iterator(owner, None, None, None)?
             .filter(|o| match &o.type_ {
                 ObjectType::Struct(s) => Self::matches_type_fuzzy_generics(&type_, s),
                 ObjectType::Package => false,

--- a/crates/sui-indexer/src/apis/read_api.rs
+++ b/crates/sui-indexer/src/apis/read_api.rs
@@ -14,9 +14,9 @@ use sui_json_rpc::SuiRpcModule;
 use sui_json_rpc_types::{
     Checkpoint, CheckpointId, DynamicFieldPage, MoveFunctionArgType, ObjectsPage, Page,
     SuiGetPastObjectRequest, SuiMoveNormalizedFunction, SuiMoveNormalizedModule,
-    SuiMoveNormalizedStruct, SuiObjectDataOptions, SuiObjectResponse, SuiPastObjectResponse,
-    SuiTransactionResponse, SuiTransactionResponseOptions, SuiTransactionResponseQuery,
-    TransactionsPage,
+    SuiMoveNormalizedStruct, SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery,
+    SuiPastObjectResponse, SuiTransactionResponse, SuiTransactionResponseOptions,
+    SuiTransactionResponseQuery, TransactionsPage,
 };
 use sui_open_rpc::Module;
 use sui_types::base_types::{ObjectID, SequenceNumber, SuiAddress, TxSequenceNumber};
@@ -218,13 +218,13 @@ where
     async fn get_owned_objects(
         &self,
         address: SuiAddress,
-        options: Option<SuiObjectDataOptions>,
+        query: Option<SuiObjectResponseQuery>,
         cursor: Option<ObjectID>,
         limit: Option<usize>,
         at_checkpoint: Option<CheckpointId>,
     ) -> RpcResult<ObjectsPage> {
         self.fullnode
-            .get_owned_objects(address, options, cursor, limit, at_checkpoint)
+            .get_owned_objects(address, query, cursor, limit, at_checkpoint)
             .await
     }
 

--- a/crates/sui-indexer/tests/integration_tests.rs
+++ b/crates/sui-indexer/tests/integration_tests.rs
@@ -16,8 +16,9 @@ mod pg_integration {
     use sui_indexer::{new_pg_connection_pool, Indexer, IndexerConfig, PgPoolConnection};
     use sui_json_rpc::api::{ReadApiClient, TransactionBuilderClient, WriteApiClient};
     use sui_json_rpc_types::{
-        SuiMoveObject, SuiObjectDataOptions, SuiObjectResponse, SuiParsedMoveObject,
-        SuiTransactionResponseOptions, SuiTransactionResponseQuery, TransactionBytes,
+        SuiMoveObject, SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery,
+        SuiParsedMoveObject, SuiTransactionResponseOptions, SuiTransactionResponseQuery,
+        TransactionBytes,
     };
     use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
     use sui_types::base_types::ObjectID;
@@ -72,7 +73,9 @@ mod pg_integration {
         let gas_objects: Vec<ObjectID> = indexer_rpc_client
             .get_owned_objects(
                 *address,
-                Some(SuiObjectDataOptions::new().with_type()),
+                Some(SuiObjectResponseQuery::new_with_options(
+                    SuiObjectDataOptions::new().with_type(),
+                )),
                 None,
                 None,
                 None,

--- a/crates/sui-json-rpc-types/src/sui_object.rs
+++ b/crates/sui-json-rpc-types/src/sui_object.rs
@@ -5,6 +5,7 @@ use anyhow::anyhow;
 use colored::Colorize;
 use fastcrypto::encoding::Base64;
 use move_bytecode_utils::module_cache::GetModule;
+use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::StructTag;
 use move_core_types::value::{MoveStruct, MoveStructLayout};
 use schemars::JsonSchema;
@@ -889,4 +890,55 @@ pub struct SuiGetPastObjectRequest {
     pub object_id: ObjectID,
     /// the version of the queried object.
     pub version: SequenceNumber,
+}
+
+#[serde_as]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub enum SuiObjectDataFilter {
+    /// Query by type a specified Package.
+    Package(ObjectID),
+    /// Query by type a specified Move module.
+    MoveModule {
+        /// the Move package ID
+        package: ObjectID,
+        /// the module name
+        #[schemars(with = "String")]
+        #[serde_as(as = "DisplayFromStr")]
+        module: Identifier,
+    },
+    /// Query by type
+    StructType(
+        #[schemars(with = "String")]
+        #[serde_as(as = "DisplayFromStr")]
+        StructTag,
+    ),
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, Default)]
+#[serde(rename_all = "camelCase", rename = "ObjectResponseQuery", default)]
+pub struct SuiObjectResponseQuery {
+    /// If None, no filter will be applied
+    pub filter: Option<SuiObjectDataFilter>,
+    /// config which fields to include in the response, by default only digest is included
+    pub options: Option<SuiObjectDataOptions>,
+}
+
+impl SuiObjectResponseQuery {
+    pub fn new(filter: Option<SuiObjectDataFilter>, options: Option<SuiObjectDataOptions>) -> Self {
+        Self { filter, options }
+    }
+
+    pub fn new_with_filter(filter: SuiObjectDataFilter) -> Self {
+        Self {
+            filter: Some(filter),
+            options: None,
+        }
+    }
+
+    pub fn new_with_options(options: SuiObjectDataOptions) -> Self {
+        Self {
+            filter: None,
+            options: Some(options),
+        }
+    }
 }

--- a/crates/sui-json-rpc/src/api/read.rs
+++ b/crates/sui-json-rpc/src/api/read.rs
@@ -7,9 +7,9 @@ use std::collections::BTreeMap;
 use sui_json_rpc_types::{
     Checkpoint, CheckpointId, DynamicFieldPage, MoveFunctionArgType, ObjectsPage,
     SuiGetPastObjectRequest, SuiMoveNormalizedFunction, SuiMoveNormalizedModule,
-    SuiMoveNormalizedStruct, SuiObjectDataOptions, SuiObjectResponse, SuiPastObjectResponse,
-    SuiTransactionResponse, SuiTransactionResponseOptions, SuiTransactionResponseQuery,
-    TransactionsPage,
+    SuiMoveNormalizedStruct, SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery,
+    SuiPastObjectResponse, SuiTransactionResponse, SuiTransactionResponseOptions,
+    SuiTransactionResponseQuery, TransactionsPage,
 };
 use sui_open_rpc_macros::open_rpc;
 use sui_types::base_types::{
@@ -27,8 +27,8 @@ pub trait ReadApi {
         &self,
         /// the owner's Sui address
         address: SuiAddress,
-        /// options for specifying the content to be returned
-        options: Option<SuiObjectDataOptions>,
+        /// the objects query criteria.
+        query: Option<SuiObjectResponseQuery>,
         /// Optional paging cursor
         cursor: Option<ObjectID>,
         /// Max number of items returned per page, default to [MAX_GET_OWNED_OBJECT_SIZE] if not specified.

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -125,7 +125,7 @@ impl CoinReadApi {
     ) -> Result<impl Iterator<Item = ObjectID> + '_, Error> {
         Ok(self
             .state
-            .get_owner_objects_iterator(owner)?
+            .get_owner_objects_iterator(owner, None, None, None)?
             .filter(move |o| matches!(&o.type_, ObjectType::Struct(type_) if is_coin_type(type_, coin_type)))
             .map(|info|info.object_id))
     }

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -25,9 +25,9 @@ use sui_json_rpc_types::{
     BalanceChange, Checkpoint, CheckpointId, DynamicFieldPage, MoveFunctionArgType, ObjectChange,
     ObjectValueKind, ObjectsPage, Page, SuiGetPastObjectRequest, SuiMoveNormalizedFunction,
     SuiMoveNormalizedModule, SuiMoveNormalizedStruct, SuiMoveStruct, SuiMoveValue,
-    SuiObjectDataOptions, SuiObjectResponse, SuiPastObjectResponse, SuiTransactionEvents,
-    SuiTransactionResponse, SuiTransactionResponseOptions, SuiTransactionResponseQuery,
-    TransactionsPage,
+    SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery, SuiPastObjectResponse,
+    SuiTransactionEvents, SuiTransactionResponse, SuiTransactionResponseOptions,
+    SuiTransactionResponseQuery, TransactionsPage,
 };
 use sui_open_rpc::Module;
 use sui_types::base_types::{
@@ -118,22 +118,27 @@ impl ReadApiServer for ReadApi {
         &self,
         address: SuiAddress,
         // exclusive cursor if `Some`, otherwise start from the beginning
-        options: Option<SuiObjectDataOptions>,
+        query: Option<SuiObjectResponseQuery>,
         cursor: Option<ObjectID>,
         limit: Option<usize>,
         at_checkpoint: Option<CheckpointId>,
     ) -> RpcResult<ObjectsPage> {
         if at_checkpoint.is_some() {
-            return Err(anyhow!("at_checkpoint param currently not supported").into());
+            return Err(anyhow!(UserInputError::Unsupported(
+                "at_checkpoint param currently not supported".to_string()
+            ))
+            .into());
         }
         let limit = cap_page_objects_limit(limit)?;
+        let SuiObjectResponseQuery { filter, options } = query.unwrap_or_default();
         let options = options.unwrap_or_default();
 
-        // MUSTFIXD(jian): multi-get-object for content/storage rebate if opt.show_content is true
         let mut objects = self
             .state
-            .get_owner_objects(address, cursor, limit + 1)
+            .get_owner_objects(address, cursor, limit + 1, filter)
             .map_err(|e| anyhow!("{e}"))?;
+
+        // MUSTFIX(jian): multi-get-object for content/storage rebate if opt.show_content is true
 
         // objects here are of size (limit + 1), where the last one is the cursor for the next page
         let has_next_page = objects.len() > limit;

--- a/crates/sui-json-rpc/src/transaction_builder_api.rs
+++ b/crates/sui-json-rpc/src/transaction_builder_api.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use sui_core::authority::AuthorityState;
 use sui_json_rpc_types::{
     BigInt, CheckpointId, ObjectsPage, Page, SuiObjectDataOptions, SuiObjectResponse,
-    SuiTransactionBuilderMode, SuiTypeTag, TransactionBytes,
+    SuiObjectResponseQuery, SuiTransactionBuilderMode, SuiTypeTag, TransactionBytes,
 };
 use sui_open_rpc::Module;
 use sui_transaction_builder::{DataReader, TransactionBuilder};
@@ -56,7 +56,7 @@ impl DataReader for AuthorityStateDataReader {
     async fn get_owned_objects(
         &self,
         address: SuiAddress,
-        options: Option<SuiObjectDataOptions>,
+        query: Option<SuiObjectResponseQuery>,
         cursor: Option<ObjectID>,
         limit: Option<usize>,
         at_checkpoint: Option<CheckpointId>,
@@ -66,9 +66,13 @@ impl DataReader for AuthorityStateDataReader {
         }
 
         let limit = cap_page_objects_limit(limit)?;
+        let SuiObjectResponseQuery { filter, options } = query.unwrap_or_default();
+
         let options = options.unwrap_or_default();
 
-        let mut objects = self.0.get_owner_objects(address, cursor, limit + 1)?;
+        let mut objects = self
+            .0
+            .get_owner_objects(address, cursor, limit + 1, filter)?;
 
         // objects here are of size (limit + 1), where the last one is the cursor for the next page
         let has_next_page = objects.len() > limit;

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -13,8 +13,8 @@ use sui_json_rpc_types::ObjectsPage;
 use sui_json_rpc_types::SuiTransactionResponseQuery;
 use sui_json_rpc_types::{
     Balance, CoinPage, DelegatedStake, StakeStatus, SuiCoinMetadata, SuiExecutionStatus,
-    SuiObjectDataOptions, SuiObjectResponse, SuiTransactionEffectsAPI, SuiTransactionResponse,
-    SuiTransactionResponseOptions, TransactionBytes,
+    SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery, SuiTransactionEffectsAPI,
+    SuiTransactionResponse, SuiTransactionResponseOptions, TransactionBytes,
 };
 use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use sui_macros::sim_test;
@@ -44,7 +44,9 @@ async fn test_get_objects() -> Result<(), anyhow::Error> {
     let objects = http_client
         .get_owned_objects(
             *address,
-            Some(SuiObjectDataOptions::new()),
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new(),
+            )),
             None,
             None,
             None,
@@ -75,7 +77,12 @@ async fn test_public_transfer_object() -> Result<(), anyhow::Error> {
     let objects = http_client
         .get_owned_objects(
             *address,
-            Some(SuiObjectDataOptions::full_content()),
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
             None,
             None,
             None,
@@ -123,7 +130,12 @@ async fn test_publish() -> Result<(), anyhow::Error> {
     let objects = http_client
         .get_owned_objects(
             *address,
-            Some(SuiObjectDataOptions::full_content()),
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
             None,
             None,
             None,
@@ -165,7 +177,12 @@ async fn test_move_call() -> Result<(), anyhow::Error> {
     let objects = http_client
         .get_owned_objects(
             *address,
-            Some(SuiObjectDataOptions::full_content()),
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
             None,
             None,
             None,
@@ -226,7 +243,12 @@ async fn test_get_object_info() -> Result<(), anyhow::Error> {
     let objects = http_client
         .get_owned_objects(
             *address,
-            Some(SuiObjectDataOptions::full_content()),
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
             None,
             None,
             None,
@@ -315,7 +337,12 @@ async fn test_get_metadata() -> Result<(), anyhow::Error> {
     let objects = http_client
         .get_owned_objects(
             *address,
-            Some(SuiObjectDataOptions::full_content()),
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
             None,
             None,
             None,
@@ -386,7 +413,12 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
     let objects = http_client
         .get_owned_objects(
             *address,
-            Some(SuiObjectDataOptions::full_content()),
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
             None,
             None,
             None,
@@ -514,7 +546,12 @@ async fn test_get_transaction() -> Result<(), anyhow::Error> {
     let objects = http_client
         .get_owned_objects(
             *address,
-            Some(SuiObjectDataOptions::full_content()),
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
             None,
             None,
             None,
@@ -603,7 +640,12 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
             .read_api()
             .get_owned_objects(
                 *address,
-                Some(SuiObjectDataOptions::full_content()),
+                Some(SuiObjectResponseQuery::new_with_options(
+                    SuiObjectDataOptions::new()
+                        .with_type()
+                        .with_owner()
+                        .with_previous_transaction(),
+                )),
                 None,
                 None,
                 None,
@@ -749,7 +791,12 @@ async fn test_locked_sui() -> Result<(), anyhow::Error> {
     let objects = http_client
         .get_owned_objects(
             *address,
-            Some(SuiObjectDataOptions::full_content()),
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
             None,
             None,
             None,
@@ -825,7 +872,12 @@ async fn test_staking() -> Result<(), anyhow::Error> {
     let objects: ObjectsPage = http_client
         .get_owned_objects(
             *address,
-            Some(SuiObjectDataOptions::full_content()),
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
             None,
             None,
             None,

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1005,10 +1005,10 @@
           }
         },
         {
-          "name": "options",
-          "description": "options for specifying the content to be returned",
+          "name": "query",
+          "description": "the objects query criteria.",
           "schema": {
-            "$ref": "#/components/schemas/ObjectDataOptions"
+            "$ref": "#/components/schemas/ObjectResponseQuery"
           }
         },
         {
@@ -1051,15 +1051,20 @@
               "value": "0x4e049913233eb918c11638af89d575beb99003d30a245ac74a02e26e45cb80ee"
             },
             {
-              "name": "options",
+              "name": "query",
               "value": {
-                "showType": true,
-                "showOwner": true,
-                "showPreviousTransaction": true,
-                "showDisplay": false,
-                "showContent": false,
-                "showBcs": false,
-                "showStorageRebate": false
+                "filter": {
+                  "StructType": "0x2::coin::Coin<0x2::sui::SUI>"
+                },
+                "options": {
+                  "showType": true,
+                  "showOwner": true,
+                  "showPreviousTransaction": true,
+                  "showDisplay": false,
+                  "showContent": false,
+                  "showBcs": false,
+                  "showStorageRebate": false
+                }
               }
             },
             {
@@ -4452,6 +4457,35 @@
           }
         }
       },
+      "ObjectResponseQuery": {
+        "type": "object",
+        "properties": {
+          "filter": {
+            "description": "If None, no filter will be applied",
+            "default": null,
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SuiObjectDataFilter"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "options": {
+            "description": "config which fields to include in the response, by default only digest is included",
+            "default": null,
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ObjectDataOptions"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      },
       "ObjectValueKind": {
         "type": "string",
         "enum": [
@@ -5588,6 +5622,67 @@
           "Private",
           "Public",
           "Friend"
+        ]
+      },
+      "SuiObjectDataFilter": {
+        "oneOf": [
+          {
+            "description": "Query by type a specified Package.",
+            "type": "object",
+            "required": [
+              "Package"
+            ],
+            "properties": {
+              "Package": {
+                "$ref": "#/components/schemas/ObjectID"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Query by type a specified Move module.",
+            "type": "object",
+            "required": [
+              "MoveModule"
+            ],
+            "properties": {
+              "MoveModule": {
+                "type": "object",
+                "required": [
+                  "module",
+                  "package"
+                ],
+                "properties": {
+                  "module": {
+                    "description": "the module name",
+                    "type": "string"
+                  },
+                  "package": {
+                    "description": "the Move package ID",
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/ObjectID"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Query by type",
+            "type": "object",
+            "required": [
+              "StructType"
+            ],
+            "properties": {
+              "StructType": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
         ]
       },
       "SuiProgrammableMoveCall": {

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -7,6 +7,7 @@ use std::str::FromStr;
 
 use fastcrypto::traits::EncodeDecodeBase64;
 use move_core_types::identifier::Identifier;
+use move_core_types::language_storage::StructTag;
 use move_core_types::parser::parse_struct_tag;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
@@ -19,10 +20,10 @@ use sui_json::SuiJsonValue;
 use sui_json_rpc_types::{
     Checkpoint, CheckpointId, EventPage, MoveCallParams, ObjectChange, OwnedObjectRef,
     RPCTransactionRequestParams, SuiData, SuiEvent, SuiExecutionStatus, SuiGasCostSummary,
-    SuiObjectData, SuiObjectDataOptions, SuiObjectRef, SuiObjectResponse, SuiParsedData,
-    SuiPastObjectResponse, SuiTransaction, SuiTransactionData, SuiTransactionEffects,
-    SuiTransactionEffectsV1, SuiTransactionResponse, SuiTransactionResponseOptions,
-    TransactionBytes, TransactionsPage, TransferObjectParams,
+    SuiObjectData, SuiObjectDataFilter, SuiObjectDataOptions, SuiObjectRef, SuiObjectResponse,
+    SuiObjectResponseQuery, SuiParsedData, SuiPastObjectResponse, SuiTransaction,
+    SuiTransactionData, SuiTransactionEffects, SuiTransactionEffectsV1, SuiTransactionResponse,
+    SuiTransactionResponseOptions, TransactionBytes, TransactionsPage, TransferObjectParams,
 };
 use sui_open_rpc::ExamplePairing;
 use sui_types::base_types::{
@@ -325,11 +326,18 @@ impl RpcExampleProvider {
                 vec![
                     ("address", json!(owner)),
                     (
-                        "options",
-                        json!(SuiObjectDataOptions::new()
-                            .with_type()
-                            .with_owner()
-                            .with_previous_transaction()),
+                        "query",
+                        json!(SuiObjectResponseQuery {
+                            filter: Some(SuiObjectDataFilter::StructType(
+                                StructTag::from_str("0x2::coin::Coin<0x2::sui::SUI>").unwrap()
+                            )),
+                            options: Some(
+                                SuiObjectDataOptions::new()
+                                    .with_type()
+                                    .with_owner()
+                                    .with_previous_transaction()
+                            )
+                        }),
                     ),
                     ("cursor", json!(ObjectID::new(self.rng.gen()))),
                     ("limit", json!(100)),

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -15,12 +15,13 @@ use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use crate::operations::Operations;
 use shared_crypto::intent::Intent;
 use sui_framework_build::compiled_package::BuildConfig;
-use sui_json_rpc_types::{ObjectChange, SuiObjectRef};
+use sui_json_rpc_types::{
+    ObjectChange, SuiObjectDataOptions, SuiObjectRef, SuiObjectResponseQuery,
+};
 use sui_keys::keystore::AccountKeystore;
 use sui_keys::keystore::Keystore;
 use sui_sdk::rpc_types::{
-    OwnedObjectRef, SuiData, SuiExecutionStatus, SuiObjectDataOptions, SuiTransactionEffectsAPI,
-    SuiTransactionResponse,
+    OwnedObjectRef, SuiData, SuiExecutionStatus, SuiTransactionEffectsAPI, SuiTransactionResponse,
 };
 use sui_sdk::SuiClient;
 use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
@@ -673,7 +674,12 @@ async fn get_random_sui(
         .read_api()
         .get_owned_objects(
             sender,
-            Some(SuiObjectDataOptions::full_content()),
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
             /* cursor */ None,
             /* limit */ None,
             /* at_checkpoint */ None,
@@ -708,7 +714,12 @@ async fn get_balance(client: &SuiClient, address: SuiAddress) -> u64 {
         .read_api()
         .get_owned_objects(
             address,
-            Some(SuiObjectDataOptions::full_content()),
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
             /* cursor */ None,
             /* limit */ None,
             /* at_checkpoint */ None,

--- a/crates/sui-rosetta/tests/rosetta_client.rs
+++ b/crates/sui-rosetta/tests/rosetta_client.rs
@@ -13,7 +13,7 @@ use std::net::SocketAddr;
 use std::path::Path;
 use std::str::FromStr;
 use sui_config::utils;
-use sui_json_rpc_types::SuiObjectDataOptions;
+use sui_json_rpc_types::{SuiObjectDataOptions, SuiObjectResponseQuery};
 use sui_keys::keystore::AccountKeystore;
 use sui_keys::keystore::Keystore;
 use sui_rosetta::operations::Operations;
@@ -187,7 +187,9 @@ pub async fn get_random_sui(
         .read_api()
         .get_owned_objects(
             sender,
-            Some(SuiObjectDataOptions::full_content()),
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::full_content(),
+            )),
             None,
             None,
             None,

--- a/crates/sui-sdk/examples/get_owned_objects.rs
+++ b/crates/sui-sdk/examples/get_owned_objects.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::str::FromStr;
-use sui_json_rpc_types::SuiObjectDataOptions;
+use sui_json_rpc_types::{SuiObjectDataOptions, SuiObjectResponseQuery};
 use sui_sdk::types::base_types::SuiAddress;
 use sui_sdk::SuiClientBuilder;
 
@@ -16,7 +16,9 @@ async fn main() -> Result<(), anyhow::Error> {
         .read_api()
         .get_owned_objects(
             address,
-            Some(SuiObjectDataOptions::default()),
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new(),
+            )),
             None,
             None,
             None,

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -16,8 +16,9 @@ use sui_json_rpc_types::{
     Balance, Checkpoint, CheckpointId, Coin, CoinPage, DelegatedStake, DryRunTransactionResponse,
     DynamicFieldPage, EventFilter, EventPage, ObjectsPage, SuiCoinMetadata, SuiCommittee, SuiEvent,
     SuiGetPastObjectRequest, SuiMoveNormalizedModule, SuiObjectDataOptions, SuiObjectResponse,
-    SuiPastObjectResponse, SuiTransactionEffectsAPI, SuiTransactionResponse,
-    SuiTransactionResponseOptions, SuiTransactionResponseQuery, TransactionsPage,
+    SuiObjectResponseQuery, SuiPastObjectResponse, SuiTransactionEffectsAPI,
+    SuiTransactionResponse, SuiTransactionResponseOptions, SuiTransactionResponseQuery,
+    TransactionsPage,
 };
 use sui_types::balance::Supply;
 use sui_types::base_types::{
@@ -46,7 +47,7 @@ impl ReadApi {
     pub async fn get_owned_objects(
         &self,
         address: SuiAddress,
-        options: Option<SuiObjectDataOptions>,
+        query: Option<SuiObjectResponseQuery>,
         cursor: Option<ObjectID>,
         limit: Option<usize>,
         checkpoint: Option<CheckpointId>,
@@ -54,7 +55,7 @@ impl ReadApi {
         Ok(self
             .api
             .http
-            .get_owned_objects(address, options, cursor, limit, checkpoint)
+            .get_owned_objects(address, query, cursor, limit, checkpoint)
             .await?)
     }
 

--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -22,7 +22,9 @@ use sui_json_rpc::{
     CLIENT_SDK_TYPE_HEADER, CLIENT_SDK_VERSION_HEADER, CLIENT_TARGET_API_VERSION_HEADER,
 };
 pub use sui_json_rpc_types as rpc_types;
-use sui_json_rpc_types::{CheckpointId, ObjectsPage, SuiObjectDataOptions, SuiObjectResponse};
+use sui_json_rpc_types::{
+    CheckpointId, ObjectsPage, SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery,
+};
 use sui_transaction_builder::{DataReader, TransactionBuilder};
 pub use sui_types as types;
 use sui_types::base_types::{ObjectID, SuiAddress};
@@ -250,13 +252,13 @@ impl DataReader for ReadApi {
     async fn get_owned_objects(
         &self,
         address: SuiAddress,
-        options: Option<SuiObjectDataOptions>,
+        query: Option<SuiObjectResponseQuery>,
         cursor: Option<ObjectID>,
         limit: Option<usize>,
         checkpoint: Option<CheckpointId>,
     ) -> Result<ObjectsPage, anyhow::Error> {
         Ok(self
-            .get_owned_objects(address, options, cursor, limit, checkpoint)
+            .get_owned_objects(address, query, cursor, limit, checkpoint)
             .await?)
     }
 

--- a/crates/sui-storage/src/indexes.rs
+++ b/crates/sui-storage/src/indexes.rs
@@ -14,7 +14,10 @@ use move_core_types::language_storage::{ModuleId, StructTag};
 use serde::{de::DeserializeOwned, Serialize};
 use tracing::debug;
 
-use sui_types::base_types::{ObjectID, SuiAddress, TransactionDigest, TxSequenceNumber};
+use sui_json_rpc_types::SuiObjectDataFilter;
+use sui_types::base_types::{
+    ObjectID, ObjectType, SuiAddress, TransactionDigest, TxSequenceNumber,
+};
 use sui_types::base_types::{ObjectInfo, ObjectRef};
 use sui_types::digests::TransactionEventsDigest;
 use sui_types::dynamic_field::{DynamicFieldInfo, DynamicFieldName};
@@ -853,6 +856,7 @@ impl IndexStore {
         owner: SuiAddress,
         cursor: Option<ObjectID>,
         limit: usize,
+        filter: Option<SuiObjectDataFilter>,
     ) -> SuiResult<Vec<ObjectInfo>> {
         let cursor = match cursor {
             Some(cursor) => cursor,
@@ -860,7 +864,7 @@ impl IndexStore {
         };
 
         Ok(self
-            .get_owner_objects_iterator(owner, cursor, limit)?
+            .get_owner_objects_iterator(owner, cursor, limit, filter)?
             .collect())
     }
 
@@ -871,6 +875,7 @@ impl IndexStore {
         owner: SuiAddress,
         starting_object_id: ObjectID,
         count: usize,
+        filter: Option<SuiObjectDataFilter>,
     ) -> SuiResult<impl Iterator<Item = ObjectInfo> + '_> {
         // We use +1 to grab the next cursor
         let count = min(count, MAX_GET_OWNED_OBJECT_SIZE + 1);
@@ -881,7 +886,45 @@ impl IndexStore {
             .iter()
             // The object id 0 is the smallest possible
             .skip_to(&(owner, starting_object_id))?
-            .take_while(move |((object_owner, _), _)| (object_owner == &owner))
+            .filter(move |((object_owner, _), obj_info)| {
+                let to_include: bool = match &filter {
+                    Some(SuiObjectDataFilter::StructType(struct_tag)) => {
+                        let obj_tag: StructTag = match obj_info.type_.clone().try_into() {
+                            Ok(tag) => tag,
+                            Err(_) => {
+                                return false;
+                            }
+                        };
+                        // If people do not provide type_params, we will match all type_params
+                        // e.g. `0x2::coin::Coin` can match `0x2::coin::Coin<0x2::sui::SUI>`
+                        if !struct_tag.type_params.is_empty()
+                            && struct_tag.type_params != obj_tag.type_params
+                        {
+                            return false;
+                        }
+                        return obj_tag.address == struct_tag.address
+                            && obj_tag.module == struct_tag.module
+                            && obj_tag.name == struct_tag.name;
+                    }
+                    Some(SuiObjectDataFilter::MoveModule { package, module }) => {
+                        if let ObjectType::Struct(o) = obj_info.clone().type_ {
+                            o.address().to_string() == package.to_string()
+                                && o.module().to_string() == module.to_string()
+                        } else {
+                            false
+                        }
+                    }
+                    Some(SuiObjectDataFilter::Package(package_id)) => {
+                        if let ObjectType::Struct(o) = obj_info.clone().type_ {
+                            o.address().to_string() == package_id.to_string()
+                        } else {
+                            false
+                        }
+                    }
+                    None => true,
+                };
+                object_owner == &owner && to_include
+            })
             .take(count)
             .map(|(_, object_info)| object_info))
     }

--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -19,7 +19,7 @@ use sui_adapter::execution_mode::ExecutionMode;
 use sui_json::{resolve_move_function_args, SuiJsonCallArg, SuiJsonValue};
 use sui_json_rpc_types::{
     CheckpointId, ObjectsPage, RPCTransactionRequestParams, SuiData, SuiObjectDataOptions,
-    SuiObjectResponse, SuiTypeTag,
+    SuiObjectResponse, SuiObjectResponseQuery, SuiTypeTag,
 };
 use sui_protocol_config::ProtocolConfig;
 use sui_types::base_types::{ObjectID, ObjectRef, ObjectType, SuiAddress};
@@ -43,7 +43,7 @@ pub trait DataReader {
     async fn get_owned_objects(
         &self,
         address: SuiAddress,
-        options: Option<SuiObjectDataOptions>,
+        options: Option<SuiObjectResponseQuery>,
         cursor: Option<ObjectID>,
         limit: Option<usize>,
         checkpoint: Option<CheckpointId>,
@@ -84,7 +84,9 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
                 .0
                 .get_owned_objects(
                     signer,
-                    Some(SuiObjectDataOptions::full_content()),
+                    Some(SuiObjectResponseQuery::new_with_options(
+                        SuiObjectDataOptions::full_content(),
+                    )),
                     None,
                     None,
                     None,

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -302,6 +302,17 @@ impl From<&Object> for ObjectType {
     }
 }
 
+impl TryFrom<ObjectType> for StructTag {
+    type Error = anyhow::Error;
+
+    fn try_from(o: ObjectType) -> Result<Self, anyhow::Error> {
+        match o {
+            ObjectType::Package => Err(anyhow!("Cannot create StructTag from Package")),
+            ObjectType::Struct(move_object_type) => Ok(move_object_type.into()),
+        }
+    }
+}
+
 impl FromStr for ObjectType {
     type Err = anyhow::Error;
 

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -37,8 +37,8 @@ use sui_framework_build::compiled_package::{
 };
 use sui_json::SuiJsonValue;
 use sui_json_rpc_types::{
-    DynamicFieldPage, SuiObjectData, SuiObjectResponse, SuiRawData, SuiTransactionEffectsAPI,
-    SuiTransactionResponse, SuiTransactionResponseOptions,
+    DynamicFieldPage, SuiObjectData, SuiObjectResponse, SuiObjectResponseQuery, SuiRawData,
+    SuiTransactionEffectsAPI, SuiTransactionResponse, SuiTransactionResponseOptions,
 };
 use sui_json_rpc_types::{SuiExecutionStatus, SuiObjectDataOptions};
 use sui_keys::keystore::AccountKeystore;
@@ -814,7 +814,9 @@ impl SuiClientCommands {
                     // TODO: (jian) fill in later
                     .get_owned_objects(
                         address,
-                        Some(SuiObjectDataOptions::full_content()),
+                        Some(SuiObjectResponseQuery::new_with_options(
+                            SuiObjectDataOptions::full_content(),
+                        )),
                         None,
                         None,
                         None,
@@ -1179,12 +1181,13 @@ impl WalletContext {
         let client = self.get_client().await?;
         let objects = client
             .read_api()
-            // TODO: (jian) fill in later
             .get_owned_objects(
                 address,
-                Some(SuiObjectDataOptions::full_content()),
+                Some(SuiObjectResponseQuery::new_with_options(
+                    SuiObjectDataOptions::full_content(),
+                )),
                 None,
-                Some(256),
+                None,
                 None,
             )
             .await?

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -23,7 +23,7 @@ use sui_config::{
 };
 use sui_json::SuiJsonValue;
 use sui_json_rpc_types::{
-    OwnedObjectRef, SuiObjectData, SuiObjectDataOptions, SuiObjectResponse,
+    OwnedObjectRef, SuiObjectData, SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery,
     SuiTransactionEffectsAPI,
 };
 use sui_keys::keystore::AccountKeystore;
@@ -145,7 +145,18 @@ async fn test_objects_command() -> Result<(), anyhow::Error> {
     let client = context.get_client().await?;
     let _object_refs = client
         .read_api()
-        .get_owned_objects(address, Some(SuiObjectDataOptions::new()), None, None, None)
+        .get_owned_objects(
+            address,
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
+            None,
+            None,
+            None,
+        )
         .await?;
 
     Ok(())
@@ -270,7 +281,15 @@ async fn test_object_info_get_command() -> Result<(), anyhow::Error> {
 
     let object_refs = client
         .read_api()
-        .get_owned_objects(address, Some(SuiObjectDataOptions::new()), None, None, None)
+        .get_owned_objects(
+            address,
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new(),
+            )),
+            None,
+            None,
+            None,
+        )
         .await?
         .data;
 
@@ -305,7 +324,15 @@ async fn test_gas_command() -> Result<(), anyhow::Error> {
     let client = context.get_client().await?;
     let object_refs = client
         .read_api()
-        .get_owned_objects(address, Some(SuiObjectDataOptions::new()), None, None, None)
+        .get_owned_objects(
+            address,
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::full_content(),
+            )),
+            None,
+            None,
+            None,
+        )
         .await?;
 
     let object_id = object_refs
@@ -361,7 +388,9 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
         .read_api()
         .get_owned_objects(
             address1,
-            Some(SuiObjectDataOptions::full_content()),
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::full_content(),
+            )),
             None,
             None,
             None,
@@ -415,12 +444,12 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
         .read_api()
         .get_owned_objects(
             address1,
-            Some(
+            Some(SuiObjectResponseQuery::new_with_options(
                 SuiObjectDataOptions::new()
                     .with_type()
                     .with_owner()
                     .with_previous_transaction(),
-            ),
+            )),
             None,
             None,
             None,
@@ -558,7 +587,12 @@ async fn test_package_publish_command() -> Result<(), anyhow::Error> {
         .read_api()
         .get_owned_objects(
             address,
-            Some(SuiObjectDataOptions::full_content()),
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
             None,
             None,
             None,
@@ -622,7 +656,12 @@ async fn test_package_publish_command_with_unpublished_dependency_succeeds(
         .read_api()
         .get_owned_objects(
             address,
-            Some(SuiObjectDataOptions::full_content()),
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
             None,
             None,
             None,
@@ -684,7 +723,12 @@ async fn test_package_publish_command_with_unpublished_dependency_fails(
         .read_api()
         .get_owned_objects(
             address,
-            Some(SuiObjectDataOptions::full_content()),
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
             None,
             None,
             None,
@@ -732,7 +776,12 @@ async fn test_package_publish_command_failure_invalid() -> Result<(), anyhow::Er
         .read_api()
         .get_owned_objects(
             address,
-            Some(SuiObjectDataOptions::full_content()),
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
             None,
             None,
             None,
@@ -779,7 +828,12 @@ async fn test_native_transfer() -> Result<(), anyhow::Error> {
         .read_api()
         .get_owned_objects(
             address,
-            Some(SuiObjectDataOptions::full_content()),
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
             None,
             None,
             None,
@@ -867,7 +921,12 @@ async fn test_native_transfer() -> Result<(), anyhow::Error> {
         .read_api()
         .get_owned_objects(
             address,
-            Some(SuiObjectDataOptions::full_content()),
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
             None,
             None,
             None,
@@ -954,7 +1013,12 @@ async fn test_switch_command() -> Result<(), anyhow::Error> {
         .read_api()
         .get_owned_objects(
             addr1,
-            Some(SuiObjectDataOptions::full_content()),
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
             None,
             None,
             None,
@@ -1139,7 +1203,12 @@ async fn test_merge_coin() -> Result<(), anyhow::Error> {
         .read_api()
         .get_owned_objects(
             address,
-            Some(SuiObjectDataOptions::full_content()),
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
             None,
             None,
             None,
@@ -1190,7 +1259,12 @@ async fn test_merge_coin() -> Result<(), anyhow::Error> {
         .read_api()
         .get_owned_objects(
             address,
-            Some(SuiObjectDataOptions::full_content()),
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
             None,
             None,
             None,
@@ -1248,7 +1322,12 @@ async fn test_split_coin() -> Result<(), anyhow::Error> {
         .read_api()
         .get_owned_objects(
             address,
-            Some(SuiObjectDataOptions::full_content()),
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
             None,
             None,
             None,
@@ -1305,7 +1384,12 @@ async fn test_split_coin() -> Result<(), anyhow::Error> {
         .read_api()
         .get_owned_objects(
             address,
-            Some(SuiObjectDataOptions::full_content()),
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
             None,
             None,
             None,
@@ -1369,7 +1453,12 @@ async fn test_split_coin() -> Result<(), anyhow::Error> {
         .read_api()
         .get_owned_objects(
             address,
-            Some(SuiObjectDataOptions::full_content()),
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
             None,
             None,
             None,
@@ -1475,7 +1564,12 @@ async fn test_serialize_tx() -> Result<(), anyhow::Error> {
         .read_api()
         .get_owned_objects(
             address,
-            Some(SuiObjectDataOptions::full_content()),
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
             None,
             None,
             None,

--- a/crates/test-utils/src/transaction.rs
+++ b/crates/test-utils/src/transaction.rs
@@ -13,8 +13,8 @@ use sui_config::ValidatorInfo;
 use sui_core::authority_client::AuthorityAPI;
 pub use sui_core::test_utils::{compile_basics_package, wait_for_all_txes, wait_for_tx};
 use sui_json_rpc_types::{
-    SuiObjectDataOptions, SuiObjectResponse, SuiTransactionDataAPI, SuiTransactionEffectsAPI,
-    SuiTransactionResponse, SuiTransactionResponseOptions,
+    SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery, SuiTransactionDataAPI,
+    SuiTransactionEffectsAPI, SuiTransactionResponse, SuiTransactionResponseOptions,
 };
 use sui_keys::keystore::AccountKeystore;
 use sui_sdk::json::SuiJsonValue;
@@ -322,7 +322,9 @@ pub async fn transfer_coin(
         .read_api()
         .get_owned_objects(
             sender,
-            Some(SuiObjectDataOptions::full_content()),
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::full_content(),
+            )),
             None,
             None,
             None,

--- a/sdk/typescript/src/types/objects.ts
+++ b/sdk/typescript/src/types/objects.ts
@@ -369,3 +369,14 @@ export const PaginatedObjectsResponse = object({
   hasNextPage: boolean(),
 });
 export type PaginatedObjectsResponse = Infer<typeof PaginatedObjectsResponse>;
+
+// mirrors sui_json_rpc_types:: SuiObjectDataFilter
+export type SuiObjectDataFilter =
+  | { Package: ObjectId }
+  | { MoveModule: { package: ObjectId; module: string } }
+  | { StructType: string };
+
+export type SuiObjectResponseQuery = {
+  filter?: SuiObjectDataFilter;
+  options?: SuiObjectDataOptions;
+};

--- a/sdk/typescript/test/e2e/coin.test.ts
+++ b/sdk/typescript/test/e2e/coin.test.ts
@@ -6,9 +6,9 @@ import {
   Coin,
   normalizeSuiObjectId,
   ObjectId,
-  SuiObjectInfo,
   SUI_TYPE_ARG,
   Transaction,
+  SuiObjectData,
 } from '../../src';
 
 import { setup, TestToolbox } from './utils/setup';
@@ -18,12 +18,13 @@ const SPLIT_AMOUNTS = [BigInt(1), BigInt(2), BigInt(3)];
 describe('Coin related API', () => {
   let toolbox: TestToolbox;
   let coinToSplit: ObjectId;
-  let coinsAfterSplit: SuiObjectInfo[];
+  let coinsAfterSplit: SuiObjectData[];
 
   beforeAll(async () => {
     toolbox = await setup();
     const coins = await toolbox.getGasObjectsOwnedByAddress();
-    coinToSplit = coins[0].objectId;
+    const coin_0 = coins[0].details as SuiObjectData;
+    coinToSplit = coin_0.objectId;
     const tx = new Transaction();
     const recieverInput = tx.pure(toolbox.address());
     SPLIT_AMOUNTS.forEach((amount) => {
@@ -36,7 +37,12 @@ describe('Coin related API', () => {
       transaction: tx,
       requestType: 'WaitForLocalExecution',
     });
-    coinsAfterSplit = await toolbox.getGasObjectsOwnedByAddress();
+    const coins_after_split_response =
+      await toolbox.getGasObjectsOwnedByAddress();
+    coinsAfterSplit = coins_after_split_response.map((coin) => {
+      const coin_details = coin.details as SuiObjectData;
+      return coin_details;
+    });
   });
 
   it('test Coin utility functions', async () => {

--- a/sdk/typescript/test/e2e/dev-inspect.test.ts
+++ b/sdk/typescript/test/e2e/dev-inspect.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, beforeAll } from 'vitest';
-import { RawSigner, Transaction } from '../../src';
+import { RawSigner, SuiObjectData, Transaction } from '../../src';
 import { publishPackage, setup, TestToolbox } from './utils/setup';
 
 describe('Test dev inspect', () => {
@@ -26,10 +26,11 @@ describe('Test dev inspect', () => {
     const coins = await toolbox.getGasObjectsOwnedByAddress();
 
     const tx = new Transaction();
+    const coin_0 = coins[0].details as SuiObjectData;
     const obj = tx.moveCall({
       target: `${packageId}::serializer_tests::return_struct`,
       typeArguments: ['0x2::coin::Coin<0x2::sui::SUI>'],
-      arguments: [tx.pure(coins[0].objectId)],
+      arguments: [tx.pure(coin_0.objectId)],
     });
 
     // TODO: Ideally dev inspect transactions wouldn't need this, but they do for now

--- a/sdk/typescript/test/e2e/dynamic-fields.test.ts
+++ b/sdk/typescript/test/e2e/dynamic-fields.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, it, expect, beforeAll } from 'vitest';
 import { publishPackage, setup, TestToolbox } from './utils/setup';
+import { SuiObjectData } from '../../src';
 
 describe('Dynamic Fields Reading API', () => {
   let toolbox: TestToolbox;
@@ -18,12 +19,12 @@ describe('Dynamic Fields Reading API', () => {
       .getOwnedObjects({
         owner: toolbox.address(),
         options: { showType: true },
+        filter: { StructType: `${packageId}::dynamic_fields_test::Test` },
       })
       .then(function (objects) {
-        const obj = objects.filter(
-          (o) => o.type === `${packageId}::dynamic_fields_test::Test`,
-        );
-        parentObjectId = obj[0].objectId;
+        console.log(objects);
+        const data = objects.data[0].details as SuiObjectData;
+        parentObjectId = data.objectId;
       });
   });
 

--- a/sdk/typescript/test/e2e/object-display-standard.test.ts
+++ b/sdk/typescript/test/e2e/object-display-standard.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, beforeAll } from 'vitest';
-import { ObjectId, getObjectDisplay } from '../../src';
+import { ObjectId, getObjectDisplay, SuiObjectData } from '../../src';
 import { publishPackage, setup, TestToolbox } from './utils/setup';
 
 describe('Test Object Display Standard', () => {
@@ -16,13 +16,15 @@ describe('Test Object Display Standard', () => {
   });
 
   it('Test getting Display fields', async () => {
-    const boarId = (
+    const resp = (
       await toolbox.provider.getOwnedObjects({
         owner: toolbox.address(),
-        typeFilter: `${packageId}::boars::Boar`,
         options: { showDisplay: true, showType: true },
+        filter: { StructType: `${packageId}::boars::Boar` },
       })
-    )[0].objectId;
+    ).data;
+    const data = resp[0].details as SuiObjectData;
+    const boarId = data.objectId;
     const display = getObjectDisplay(
       await toolbox.provider.getObject({
         id: boarId,
@@ -44,7 +46,9 @@ describe('Test Object Display Standard', () => {
   });
 
   it('Test getting Display fields for object that has no display object', async () => {
-    const coinId = (await toolbox.getGasObjectsOwnedByAddress())[0].objectId;
+    const coin = (await toolbox.getGasObjectsOwnedByAddress())[0]
+      .details as SuiObjectData;
+    const coinId = coin.objectId;
     const display = getObjectDisplay(
       await toolbox.provider.getObject({
         id: coinId,

--- a/sdk/typescript/test/e2e/object-vector.test.ts
+++ b/sdk/typescript/test/e2e/object-vector.test.ts
@@ -7,6 +7,7 @@ import {
   getCreatedObjects,
   getExecutionStatusType,
   ObjectId,
+  SuiObjectData,
   SUI_FRAMEWORK_ADDRESS,
   Transaction,
 } from '../../src';
@@ -62,6 +63,7 @@ describe('Test Move call with a vector of objects as input', () => {
 
   it('Test regular arg mixed with object vector arg', async () => {
     const coins = await toolbox.getGasObjectsOwnedByAddress();
+    const coin = coins[3].details as SuiObjectData;
     const coinIDs = coins.map((coin) => Coin.getID(coin));
     const tx = new Transaction();
     const vec = tx.makeMoveVec({
@@ -72,7 +74,7 @@ describe('Test Move call with a vector of objects as input', () => {
       typeArguments: ['0x2::sui::SUI'],
       arguments: [tx.object(coinIDs[0]), vec],
     });
-    tx.setGasPayment([coins[3]]);
+    tx.setGasPayment([coin]);
     const result = await toolbox.signer.signAndExecuteTransaction({
       transaction: tx,
       options: {

--- a/sdk/typescript/test/e2e/objects.test.ts
+++ b/sdk/typescript/test/e2e/objects.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, beforeAll } from 'vitest';
-import { getObjectType } from '../../src';
+import { getObjectType, SuiObjectData } from '../../src';
 import { setup, TestToolbox } from './utils/setup';
 
 describe('Object Reading API', () => {
@@ -16,19 +16,20 @@ describe('Object Reading API', () => {
     const gasObjects = await toolbox.provider.getOwnedObjects({
       owner: toolbox.address(),
     });
-    expect(gasObjects.length).to.greaterThan(0);
+    expect(gasObjects.data.length).to.greaterThan(0);
   });
 
   it('Get Object', async () => {
     const gasObjects = await toolbox.getGasObjectsOwnedByAddress();
     expect(gasObjects.length).to.greaterThan(0);
     const objectInfos = await Promise.all(
-      gasObjects.map((gasObject) =>
-        toolbox.provider.getObject({
-          id: gasObject['objectId'],
+      gasObjects.map((gasObject) => {
+        const details = gasObject.details as SuiObjectData;
+        return toolbox.provider.getObject({
+          id: details.objectId,
           options: { showType: true },
-        }),
-      ),
+        });
+      }),
     );
     objectInfos.forEach((objectInfo) =>
       expect(getObjectType(objectInfo)).to.equal(
@@ -40,7 +41,10 @@ describe('Object Reading API', () => {
   it('Get Objects', async () => {
     const gasObjects = await toolbox.getGasObjectsOwnedByAddress();
     expect(gasObjects.length).to.greaterThan(0);
-    const gasObjectIds = gasObjects.map((gasObject) => gasObject['objectId']);
+    const gasObjectIds = gasObjects.map((gasObject) => {
+      const details = gasObject.details as SuiObjectData;
+      return details.objectId;
+    });
     const objectInfos = await toolbox.provider.multiGetObjects({
       ids: gasObjectIds,
       options: {

--- a/sdk/typescript/test/e2e/rpc-endpoint.test.ts
+++ b/sdk/typescript/test/e2e/rpc-endpoint.test.ts
@@ -18,13 +18,7 @@ describe('Invoke any RPC endpoint', () => {
     const gasObjects = await toolbox.provider.call('sui_getOwnedObjects', [
       toolbox.address(),
     ]);
-    // TODO (jian): fix this test in the upcoming PR because sui_getOwnedObjects returns a paginated response which our API
-    // currently doesn't consume
-    for (let i = 0; i < gasObjectsExpected.length; i++) {
-      expect(gasObjects.data[i].details.objectId).toStrictEqual(
-        gasObjectsExpected[i].objectId,
-      );
-    }
+    expect(gasObjects.data).toStrictEqual(gasObjectsExpected.data);
   });
 
   it('sui_getObjectOwnedByAddress Error', async () => {

--- a/sdk/typescript/test/e2e/txn-builder.test.ts
+++ b/sdk/typescript/test/e2e/txn-builder.test.ts
@@ -12,6 +12,7 @@ import {
   SuiTransactionResponse,
   SUI_SYSTEM_STATE_OBJECT_ID,
   Transaction,
+  SuiObjectData,
   getCreatedObjects,
 } from '../../src';
 import {
@@ -44,8 +45,10 @@ describe('Transaction Builders', () => {
   it('SplitCoin + TransferObjects', async () => {
     const coins = await toolbox.getGasObjectsOwnedByAddress();
     const tx = new Transaction();
+    const coin_0 = coins[0].details as SuiObjectData;
+
     const coin = tx.splitCoin(
-      tx.object(coins[0].objectId),
+      tx.object(coin_0.objectId),
       tx.pure(DEFAULT_GAS_BUDGET * 2),
     );
     tx.transferObjects([coin], tx.pure(toolbox.address()));
@@ -54,8 +57,10 @@ describe('Transaction Builders', () => {
 
   it('MergeCoins', async () => {
     const coins = await toolbox.getGasObjectsOwnedByAddress();
+    const coin_0 = coins[0].details as SuiObjectData;
+    const coin_1 = coins[1].details as SuiObjectData;
     const tx = new Transaction();
-    tx.mergeCoins(tx.object(coins[0].objectId), [tx.object(coins[1].objectId)]);
+    tx.mergeCoins(tx.object(coin_0.objectId), [tx.object(coin_1.objectId)]);
     await validateTransaction(toolbox.signer, tx);
   });
 
@@ -76,6 +81,7 @@ describe('Transaction Builders', () => {
 
   it('MoveCall Shared Object', async () => {
     const coins = await toolbox.getGasObjectsOwnedByAddress();
+    const coin_2 = coins[2].details as SuiObjectData;
 
     const [{ suiAddress: validatorAddress }] =
       await toolbox.getActiveValidators();
@@ -85,7 +91,7 @@ describe('Transaction Builders', () => {
       target: '0x2::sui_system::request_add_stake',
       arguments: [
         tx.object(SUI_SYSTEM_STATE_OBJECT_ID),
-        tx.object(coins[2].objectId),
+        tx.object(coin_2.objectId),
         tx.pure(validatorAddress),
       ],
     });
@@ -109,8 +115,10 @@ describe('Transaction Builders', () => {
   it('TransferObject', async () => {
     const coins = await toolbox.getGasObjectsOwnedByAddress();
     const tx = new Transaction();
+    const coin_0 = coins[2].details as SuiObjectData;
+
     tx.transferObjects(
-      [tx.object(coins[0].objectId)],
+      [tx.object(coin_0.objectId)],
       tx.pure(DEFAULT_RECIPIENT),
     );
     await validateTransaction(toolbox.signer, tx);

--- a/sdk/typescript/test/e2e/txn-serializer.test.ts
+++ b/sdk/typescript/test/e2e/txn-serializer.test.ts
@@ -9,6 +9,7 @@ import {
   isMutableSharedObjectInput,
   isSharedObjectInput,
   ObjectId,
+  SuiObjectData,
   SuiTransactionResponse,
   SUI_SYSTEM_STATE_OBJECT_ID,
   Transaction,
@@ -53,11 +54,12 @@ describe('Transaction Serialization and deserialization', () => {
       await toolbox.getActiveValidators();
 
     const tx = new Transaction();
+    const coin = coins[2].details as SuiObjectData;
     tx.moveCall({
       target: '0x2::sui_system::request_add_stake',
       arguments: [
         tx.object(SUI_SYSTEM_STATE_OBJECT_ID),
-        tx.object(coins[2].objectId),
+        tx.object(coin.objectId),
         tx.pure(validatorAddress),
       ],
     });

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -53,9 +53,13 @@ export class TestToolbox {
   async getGasObjectsOwnedByAddress() {
     const objects = await this.provider.getOwnedObjects({
       owner: this.address(),
-      options: { showType: true, showContent: true, showOwner: true },
+      options: {
+        showType: true,
+        showContent: true,
+        showOwner: true,
+      },
     });
-    return objects.filter((obj) => Coin.isSUI(obj));
+    return objects.data.filter((obj) => Coin.isSUI(obj));
   }
 
   public async getActiveValidators() {


### PR DESCRIPTION
Adding query param onto get_owned_objects

Modified unit tests in e2e to handle `ObjectsPage` response that is returned by the SDK.
Adding query param onto get_owned_objects

How did you test the new or updated feature?
CI / Unit testing

Address page of explorer:

![image](https://user-images.githubusercontent.com/123408603/225946167-70760de1-62a5-4182-a61a-0989c32b3e09.png)

Txn page:

![image](https://user-images.githubusercontent.com/123408603/225946279-b5475f46-f506-4f5a-9421-2777020a434a.png)

Sui wallet:

![image](https://user-images.githubusercontent.com/123408603/225977046-c375b3dd-9a32-4228-acbc-5243b10b0fff.png) NFT on wallet

![image](https://user-images.githubusercontent.com/123408603/225979023-657516e1-c2b6-42b0-936d-b3e515375e4c.png)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

- [ ] user-visible impact
- [ x] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
