### PR TITLE
More logging/metrics around advance epoch tx

### DIFF
--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -290,28 +290,31 @@ fn advance_epoch<S: BackingPackageStore + ParentSync + ChildObjectResolver>(
     });
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
+        let call_args = vec![
+            system_object_arg.clone(),
+            CallArg::Pure(bcs::to_bytes(&change_epoch.epoch).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&change_epoch.protocol_version.as_u64()).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&change_epoch.storage_charge).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&change_epoch.computation_charge).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&change_epoch.storage_rebate).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&protocol_config.storage_fund_reinvest_rate()).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&protocol_config.reward_slashing_rate()).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&change_epoch.epoch_start_timestamp_ms).unwrap()),
+            CallArg::Pure(
+                bcs::to_bytes(&get_sui_system_state_version(change_epoch.protocol_version))
+                    .unwrap(),
+            ),
+        ];
+        debug!(
+            "Call arguments to advance_epoch transaction: {:?}",
+            call_args
+        );
         let res = builder.move_call(
             (*module_id.address()).into(),
             module_id.name().to_owned(),
             function,
             vec![],
-            vec![
-                system_object_arg.clone(),
-                CallArg::Pure(bcs::to_bytes(&change_epoch.epoch).unwrap()),
-                CallArg::Pure(bcs::to_bytes(&change_epoch.protocol_version.as_u64()).unwrap()),
-                CallArg::Pure(bcs::to_bytes(&change_epoch.storage_charge).unwrap()),
-                CallArg::Pure(bcs::to_bytes(&change_epoch.computation_charge).unwrap()),
-                CallArg::Pure(bcs::to_bytes(&change_epoch.storage_rebate).unwrap()),
-                CallArg::Pure(
-                    bcs::to_bytes(&protocol_config.storage_fund_reinvest_rate()).unwrap(),
-                ),
-                CallArg::Pure(bcs::to_bytes(&protocol_config.reward_slashing_rate()).unwrap()),
-                CallArg::Pure(bcs::to_bytes(&change_epoch.epoch_start_timestamp_ms).unwrap()),
-                CallArg::Pure(
-                    bcs::to_bytes(&get_sui_system_state_version(change_epoch.protocol_version))
-                        .unwrap(),
-                ),
-            ],
+            call_args,
         );
         assert_invariant!(res.is_ok(), "Unable to generate advance_epoch transaction!");
         builder.finish()
@@ -328,9 +331,9 @@ fn advance_epoch<S: BackingPackageStore + ParentSync + ChildObjectResolver>(
 
     if result.is_err() {
         tracing::error!(
-            "Failed to execute advance epoch transaction. Switching to safe mode. Error: {:?}. System state object: {:?}. Tx data: {:?}",
+            "Failed to execute advance epoch transaction. Switching to safe mode. Error: {:?}. Input objects: {:?}. Tx data: {:?}",
             result.as_ref().err(),
-            temporary_store.read_object(&SUI_SYSTEM_STATE_OBJECT_ID),
+            temporary_store.objects(),
             change_epoch,
         );
         temporary_store.drop_writes();
@@ -374,7 +377,7 @@ fn advance_epoch<S: BackingPackageStore + ParentSync + ChildObjectResolver>(
         let mut new_package = Object::new_system_package(modules, version, tx_ctx.digest())?;
 
         info!(
-            "upgraded system object {:?}",
+            "upgraded system package {:?}",
             new_package.compute_object_reference()
         );
 

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -3254,7 +3254,7 @@ impl AuthorityState {
             "Effects summary of the change epoch transaction: {:?}",
             effects.summary_for_debug()
         );
-        epoch_store.record_is_safe_mode_metric(system_obj.safe_mode());
+        epoch_store.record_checkpoint_builder_is_safe_mode_metric(system_obj.safe_mode());
         // The change epoch transaction cannot fail to execute.
         assert!(effects.status().is_ok());
         Ok((system_obj, effects))

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1876,12 +1876,18 @@ impl AuthorityPerEpochStore {
             .set(self.epoch_open_time.elapsed().as_millis() as i64);
     }
 
-    pub(crate) fn record_is_safe_mode_metric(&self, safe_mode: bool) {
+    pub fn record_is_safe_mode_metric(&self, safe_mode: bool) {
+        self.metrics.is_safe_mode.set(safe_mode as i64);
+    }
+
+    pub fn record_checkpoint_builder_is_safe_mode_metric(&self, safe_mode: bool) {
         if safe_mode {
             // allow tests to inject a panic here.
-            fail_point!("record_is_safe_mode_metric");
+            fail_point!("record_checkpoint_builder_is_safe_mode_metric");
         }
-        self.metrics.is_safe_mode.set(safe_mode as i64);
+        self.metrics
+            .checkpoint_builder_advance_epoch_is_safe_mode
+            .set(safe_mode as i64)
     }
 
     fn record_epoch_total_duration_metric(&self) {

--- a/crates/sui-core/src/epoch/epoch_metrics.rs
+++ b/crates/sui-core/src/epoch/epoch_metrics.rs
@@ -71,6 +71,11 @@ pub struct EpochMetrics {
 
     /// Whether we are running in safe mode where reward distribution and tokenomics are disabled.
     pub is_safe_mode: IntGauge,
+
+    /// When building the last checkpoint of the epoch, we execute advance epoch transaction once
+    /// without committing results to the store. It's useful to know whether this execution leads
+    /// to safe_mode, since in theory the result could be different from checkpoint executor.
+    pub checkpoint_builder_advance_epoch_is_safe_mode: IntGauge,
 }
 
 impl EpochMetrics {
@@ -146,6 +151,11 @@ impl EpochMetrics {
             is_safe_mode: register_int_gauge_with_registry!(
                 "is_safe_mode",
                 "Whether we are running in safe mode",
+                registry,
+            ).unwrap(),
+            checkpoint_builder_advance_epoch_is_safe_mode: register_int_gauge_with_registry!(
+                "checkpoint_builder_advance_epoch_is_safe_mode",
+                "Whether the advance epoch execution leads to safe mode while building the last checkpoint",
                 registry,
             ).unwrap(),
         };

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -867,11 +867,12 @@ impl SuiNode {
             }
 
             checkpoint_executor.run_epoch(cur_epoch_store.clone()).await;
-            let new_epoch_start_state = self
+            let latest_system_state = self
                 .state
                 .get_sui_system_state_object_during_reconfig()
-                .expect("Read Sui System State object cannot fail")
-                .into_epoch_start_state();
+                .expect("Read Sui System State object cannot fail");
+            cur_epoch_store.record_is_safe_mode_metric(latest_system_state.safe_mode());
+            let new_epoch_start_state = latest_system_state.into_epoch_start_state();
             let next_epoch_committee = new_epoch_start_state.get_sui_committee();
             let next_epoch = next_epoch_committee.epoch();
             assert_eq!(cur_epoch_store.epoch() + 1, next_epoch);

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -290,7 +290,7 @@ async fn test_create_advance_epoch_tx_race() {
 
     // panic if we enter safe mode. If you remove the check for `is_tx_already_executed` in
     // AuthorityState::create_and_execute_advance_epoch_tx, this test should fail.
-    register_fail_point("record_is_safe_mode_metric", || {
+    register_fail_point("record_checkpoint_builder_is_safe_mode_metric", || {
         panic!("safe mode recorded");
     });
 


### PR DESCRIPTION
This PR adds more logging around advance epoch tx, also introduce two safe_mode metrics to distinguish the two different cases.