### PR TITLE
[Step 1] System state upgrade firedrill

### DIFF
--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -3137,6 +3137,7 @@ async fn test_genesis_sui_system_state_object() {
 
 #[cfg(msim)]
 #[sim_test]
+#[ignore]
 async fn test_sui_system_state_nop_upgrade() {
     use sui_adapter::programmable_transactions;
     use sui_types::sui_system_state::SUI_SYSTEM_STATE_TESTING_VERSION1;

--- a/crates/sui-framework/docs/sui_system.md
+++ b/crates/sui-framework/docs/sui_system.md
@@ -7,6 +7,7 @@
 
 -  [Struct `SystemParameters`](#0x2_sui_system_SystemParameters)
 -  [Struct `SuiSystemStateInner`](#0x2_sui_system_SuiSystemStateInner)
+-  [Struct `SuiSystemStateInnerV2`](#0x2_sui_system_SuiSystemStateInnerV2)
 -  [Resource `SuiSystemState`](#0x2_sui_system_SuiSystemState)
 -  [Struct `SystemEpochInfoEvent`](#0x2_sui_system_SystemEpochInfoEvent)
 -  [Constants](#@Constants_0)
@@ -222,6 +223,99 @@ The top-level object containing all information of the Sui system.
 </dt>
 <dd>
  Unix timestamp of the current epoch start
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_sui_system_SuiSystemStateInnerV2"></a>
+
+## Struct `SuiSystemStateInnerV2`
+
+
+
+<pre><code><b>struct</b> <a href="sui_system.md#0x2_sui_system_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a> <b>has</b> store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>new_dummy_field: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>epoch: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>protocol_version: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>system_state_version: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>validators: <a href="validator_set.md#0x2_validator_set_ValidatorSet">validator_set::ValidatorSet</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>storage_fund: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>parameters: <a href="sui_system.md#0x2_sui_system_SystemParameters">sui_system::SystemParameters</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>reference_gas_price: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>validator_report_records: <a href="vec_map.md#0x2_vec_map_VecMap">vec_map::VecMap</a>&lt;<b>address</b>, <a href="vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;<b>address</b>&gt;&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code><a href="stake_subsidy.md#0x2_stake_subsidy">stake_subsidy</a>: <a href="stake_subsidy.md#0x2_stake_subsidy_StakeSubsidy">stake_subsidy::StakeSubsidy</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>safe_mode: bool</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>epoch_start_timestamp_ms: u64</code>
+</dt>
+<dd>
+
 </dd>
 </dl>
 
@@ -1879,8 +1973,7 @@ gas coins.
         // is also upgraded.
         <b>assert</b>!(old_protocol_version != next_protocol_version, 0);
         <b>let</b> cur_state: <a href="sui_system.md#0x2_sui_system_SuiSystemStateInner">SuiSystemStateInner</a> = <a href="dynamic_field.md#0x2_dynamic_field_remove">dynamic_field::remove</a>(&<b>mut</b> wrapper.id, wrapper.version);
-        <b>let</b> new_state = <a href="sui_system.md#0x2_sui_system_upgrade_system_state">upgrade_system_state</a>(cur_state);
-        new_state.system_state_version = new_system_state_version;
+        <b>let</b> new_state = <a href="sui_system.md#0x2_sui_system_upgrade_system_state">upgrade_system_state</a>(cur_state, new_system_state_version);
         wrapper.version = new_system_state_version;
         <a href="dynamic_field.md#0x2_dynamic_field_add">dynamic_field::add</a>(&<b>mut</b> wrapper.id, wrapper.version, new_state);
     };
@@ -2186,7 +2279,7 @@ Returns all the validators who are currently reporting <code>addr</code>
 
 
 
-<pre><code><b>fun</b> <a href="sui_system.md#0x2_sui_system_upgrade_system_state">upgrade_system_state</a>(cur_state: <a href="sui_system.md#0x2_sui_system_SuiSystemStateInner">sui_system::SuiSystemStateInner</a>): <a href="sui_system.md#0x2_sui_system_SuiSystemStateInner">sui_system::SuiSystemStateInner</a>
+<pre><code><b>fun</b> <a href="sui_system.md#0x2_sui_system_upgrade_system_state">upgrade_system_state</a>(self: <a href="sui_system.md#0x2_sui_system_SuiSystemStateInner">sui_system::SuiSystemStateInner</a>, new_system_state_version: u64): <a href="sui_system.md#0x2_sui_system_SuiSystemStateInnerV2">sui_system::SuiSystemStateInnerV2</a>
 </code></pre>
 
 
@@ -2195,11 +2288,37 @@ Returns all the validators who are currently reporting <code>addr</code>
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="sui_system.md#0x2_sui_system_upgrade_system_state">upgrade_system_state</a>(cur_state: <a href="sui_system.md#0x2_sui_system_SuiSystemStateInner">SuiSystemStateInner</a>): <a href="sui_system.md#0x2_sui_system_SuiSystemStateInner">SuiSystemStateInner</a> {
+<pre><code><b>fun</b> <a href="sui_system.md#0x2_sui_system_upgrade_system_state">upgrade_system_state</a>(self: <a href="sui_system.md#0x2_sui_system_SuiSystemStateInner">SuiSystemStateInner</a>, new_system_state_version: u64): <a href="sui_system.md#0x2_sui_system_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a> {
     // Whenever we upgrade the system state version, we will have <b>to</b> first
     // ship a framework upgrade that introduces a new system state type, and make this
     // function generate such type from the <b>old</b> state.
-    cur_state
+    <b>let</b> <a href="sui_system.md#0x2_sui_system_SuiSystemStateInner">SuiSystemStateInner</a> {
+        epoch: u64,
+        protocol_version,
+        system_state_version: _,
+        validators,
+        storage_fund,
+        parameters,
+        reference_gas_price,
+        validator_report_records,
+        <a href="stake_subsidy.md#0x2_stake_subsidy">stake_subsidy</a>,
+        safe_mode,
+        epoch_start_timestamp_ms,
+    } = self;
+    <a href="sui_system.md#0x2_sui_system_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a> {
+        new_dummy_field: 100,
+        epoch: u64,
+        protocol_version,
+        system_state_version: new_system_state_version,
+        validators,
+        storage_fund,
+        parameters,
+        reference_gas_price,
+        validator_report_records,
+        <a href="stake_subsidy.md#0x2_stake_subsidy">stake_subsidy</a>,
+        safe_mode,
+        epoch_start_timestamp_ms,
+    }
 }
 </code></pre>
 


### PR DESCRIPTION
This is the first step of the system state upgrade, which introduces a new type only and modified the advance epoch function to migrate the old type to the new type.
This PR assumes that another change in the stack will also modify the protocol version to trigger the framework upgrade.