### PR TITLE
Added information about TS-SDK

### DIFF
--- a/doc/src/build/sui-local-network.md
+++ b/doc/src/build/sui-local-network.md
@@ -162,3 +162,7 @@ pnpm sdk test:e2e
 ```
 
 For more details, refer to [https://github.com/MystenLabs/sui/tree/main/sdk/typescript#testing](https://github.com/MystenLabs/sui/tree/main/sdk/typescript#testing).
+
+## Testing with the Sui TypeScript SDK
+
+The published Sui TypeScript SDK version might be behind the local network version. To make sure you're using the latest version of the SDK, use the `experimental`-tagged version (e.g., `0.0.0-experimental-20230317184920` ) in the [Current Tags section](https://www.npmjs.com/package/@mysten/sui.js/v/0.0.0-experimental-20230127130009?activeTab=versions) of the Sui NPM registry.

--- a/doc/src/build/sui-local-network.md
+++ b/doc/src/build/sui-local-network.md
@@ -165,4 +165,4 @@ For more details, refer to [https://github.com/MystenLabs/sui/tree/main/sdk/type
 
 ## Testing with the Sui TypeScript SDK
 
-The published Sui TypeScript SDK version might be behind the local network version. To make sure you're using the latest version of the SDK, use the `experimental`-tagged version (e.g., `0.0.0-experimental-20230317184920` ) in the [Current Tags section](https://www.npmjs.com/package/@mysten/sui.js/v/0.0.0-experimental-20230127130009?activeTab=versions) of the Sui NPM registry.
+The published Sui TypeScript SDK version might be behind the local network version. To make sure you're using the latest version of the SDK, use the `experimental`-tagged version (for example, `0.0.0-experimental-20230317184920`) in the [Current Tags](https://www.npmjs.com/package/@mysten/sui.js/v/0.0.0-experimental-20230127130009?activeTab=versions) section of the Sui NPM registry.


### PR DESCRIPTION
## Description 

Added section about using latest TS-SDK for testing. 

## Test Plan 

Local

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
