### PR TITLE
[explorer] - add next epoch gas to validators table

### DIFF
--- a/apps/explorer/src/components/validator/DelegationAmount.tsx
+++ b/apps/explorer/src/components/validator/DelegationAmount.tsx
@@ -16,9 +16,12 @@ export function DelegationAmount({ amount, isStats }: DelegationAmountProps) {
     const [formattedAmount, symbol] = useFormatCoin(amount, SUI_TYPE_ARG);
 
     return isStats ? (
-        <div className="break-all">
-            <Heading as="div" variant="heading2/semibold" color="steel-darker">
+        <div className="flex items-end gap-1.5 break-all">
+            <Heading as="div" variant="heading3/semibold" color="steel-darker">
                 {formattedAmount}
+            </Heading>
+            <Heading variant="heading4/medium" color="steel-darker">
+                {symbol}
             </Heading>
         </div>
     ) : (

--- a/apps/explorer/src/components/validator/ValidatorMeta.tsx
+++ b/apps/explorer/src/components/validator/ValidatorMeta.tsx
@@ -71,7 +71,7 @@ export function ValidatorMeta({ validatorData }: ValidatorMetaProps) {
                         />
                     </DescriptionItem>
                     <DescriptionItem title="Public Key">
-                        <Text variant="p1/medium" color="gray-90">
+                        <Text variant="p1/medium" color="steel-darker">
                             {validatorPublicKey}
                         </Text>
                     </DescriptionItem>

--- a/apps/explorer/src/components/validator/ValidatorStats.tsx
+++ b/apps/explorer/src/components/validator/ValidatorStats.tsx
@@ -161,6 +161,15 @@ export function ValidatorStats({
                                     tooltip="Latest Narwhal round for this epoch."
                                     unavailable
                                 />
+                                <Stats
+                                    label="Next Epoch Gas Price"
+                                    tooltip="This validator's gas price quote for the next epoch."
+                                >
+                                    <DelegationAmount
+                                        amount={validatorData.nextEpochGasPrice}
+                                        isStats
+                                    />
+                                </Stats>
                             </div>
                         </div>
                     </div>

--- a/apps/explorer/src/pages/validators/Validators.tsx
+++ b/apps/explorer/src/pages/validators/Validators.tsx
@@ -44,7 +44,6 @@ export function validatorsTableData(
                 validatorsEvents,
                 validator.suiAddress
             );
-
             return {
                 name: {
                     name: validatorName,
@@ -52,6 +51,7 @@ export function validatorsTableData(
                 },
                 stake: totalStake,
                 apy: calculateAPY(validator, epoch),
+                nextEpochGasPrice: validator.nextEpochGasPrice,
                 commission: +validator.commissionRate / 100,
                 img: img,
                 address: validator.suiAddress,
@@ -112,6 +112,12 @@ export function validatorsTableData(
             {
                 header: 'Stake',
                 accessorKey: 'stake',
+                enableSorting: true,
+                cell: (props: any) => <StakeColumn stake={props.getValue()} />,
+            },
+            {
+                header: 'Next Epoch Gas Price',
+                accessorKey: 'nextEpochGasPrice',
                 enableSorting: true,
                 cell: (props: any) => <StakeColumn stake={props.getValue()} />,
             },
@@ -249,10 +255,6 @@ function ValidatorPageResult() {
 
     return (
         <div>
-            <Heading as="h1" variant="heading2/bold">
-                Validators
-            </Heading>
-
             <div className="mt-8 grid gap-5 md:grid-cols-2">
                 <Card spacing="lg">
                     <div className="flex w-full basis-full flex-col gap-8">


### PR DESCRIPTION
## Description 

Adds `nextEpochGasPrice` to Validators Table / Details and makes a few small style changes to match designs.





## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
