### PR TITLE
publish: e2e test for transitive deps happy path

### DIFF
--- a/crates/sui-core/src/unit_tests/data/transitive_dependencies/package_A_depends_on_B/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/transitive_dependencies/package_A_depends_on_B/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "PackageADependsOnB"
+version = "0.0.1"
+
+[dependencies]
+PackageBDependsOnC = { local = "../package_B_depends_on_C" }

--- a/crates/sui-core/src/unit_tests/data/transitive_dependencies/package_A_depends_on_B/sources/a.move
+++ b/crates/sui-core/src/unit_tests/data/transitive_dependencies/package_A_depends_on_B/sources/a.move
@@ -1,0 +1,8 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module a::a {
+    public fun a(): u64 {
+        b::b::b()
+    }
+}

--- a/crates/sui-core/src/unit_tests/data/transitive_dependencies/package_B_depends_on_C/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/transitive_dependencies/package_B_depends_on_C/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "PackageBDependsOnC"
+version = "0.0.1"
+
+[dependencies]
+PackageC = { local = "../package_C" }

--- a/crates/sui-core/src/unit_tests/data/transitive_dependencies/package_B_depends_on_C/sources/b.move
+++ b/crates/sui-core/src/unit_tests/data/transitive_dependencies/package_B_depends_on_C/sources/b.move
@@ -1,0 +1,8 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module b::b {
+    public fun b(): u64 {
+        c::c::c()
+    }
+}

--- a/crates/sui-core/src/unit_tests/data/transitive_dependencies/package_C/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/transitive_dependencies/package_C/Move.toml
@@ -1,0 +1,4 @@
+[package]
+name = "PackageC"
+version = "0.0.1"
+

--- a/crates/sui-core/src/unit_tests/data/transitive_dependencies/package_C/sources/c.move
+++ b/crates/sui-core/src/unit_tests/data/transitive_dependencies/package_C/sources/c.move
@@ -1,0 +1,12 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module c::c {
+    struct C {
+        x: u64
+    }
+
+    public fun c(): u64 {
+        42
+    }
+}

--- a/crates/sui-core/src/unit_tests/data/transitive_dependencies/package_root_depends_on_A/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/transitive_dependencies/package_root_depends_on_A/Move.toml
@@ -1,0 +1,7 @@
+[package]
+name = "Examples"
+version = "0.0.1"
+
+[dependencies]
+Sui = { local = "../../../../../../sui-framework" }
+PackageADependsOnB = { local = "../Package_A_Depends_On_B" }

--- a/crates/sui-core/src/unit_tests/data/transitive_dependencies/package_root_depends_on_A/sources/trusted_coin.move
+++ b/crates/sui-core/src/unit_tests/data/transitive_dependencies/package_root_depends_on_A/sources/trusted_coin.move
@@ -1,0 +1,39 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Example coin with a trusted owner responsible for minting/burning (e.g., a stablecoin)
+module examples::trusted_coin {
+    use std::option;
+    use sui::coin::{Self, TreasuryCap};
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+
+    /// Name of the coin
+    struct TRUSTED_COIN has drop {}
+
+    /// Register the trusted currency to acquire its `TreasuryCap`. Because
+    /// this is a module initializer, it ensures the currency only gets
+    /// registered once.
+    fun init(witness: TRUSTED_COIN, ctx: &mut TxContext) {
+        // Get a treasury cap for the coin and give it to the transaction
+        // sender
+        let (treasury_cap, metadata) = coin::create_currency<TRUSTED_COIN>(witness, 2, b"TRUSTED", b"", b"", option::none(), ctx);
+        transfer::freeze_object(metadata);
+        transfer::transfer(treasury_cap, tx_context::sender(ctx))
+    }
+
+    public entry fun mint(treasury_cap: &mut TreasuryCap<TRUSTED_COIN>, amount: u64, ctx: &mut TxContext) {
+        let coin = coin::mint<TRUSTED_COIN>(treasury_cap, amount, ctx);
+        transfer::transfer(coin, tx_context::sender(ctx));
+    }
+
+    public entry fun transfer(treasury_cap: TreasuryCap<TRUSTED_COIN>, recipient: address) {
+        transfer::transfer(treasury_cap, recipient);
+    }
+
+    #[test_only]
+    /// Wrapper of module initializer for testing
+    public fun test_init(ctx: &mut TxContext) {
+        init(TRUSTED_COIN {}, ctx)
+    }
+}


### PR DESCRIPTION
## Description

Tests that we successfully publish the following package dependency graph.

```
package root -> package A -> package B -> package C
            `-> sui-framework -> move-stdlib
```

The test needed quite a bit of setup (eased by `named_addresses` pointed out by Ashok!) but is otherwise mechanical (read: a bit of copy-pasta). We publish packages and set IDs, working backward from `package C` and expect each step to succeed.