### PR TITLE
[sui-proxy/ add initial metric for metrics]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9505,6 +9505,7 @@ dependencies = [
  "itertools",
  "mime",
  "multiaddr",
+ "mysten-metrics",
  "prometheus",
  "prost",
  "prost-build",

--- a/crates/sui-proxy/Cargo.toml
+++ b/crates/sui-proxy/Cargo.toml
@@ -31,6 +31,7 @@ reqwest = { version = "0.11.4", default-features = false, features = ["rustls-tl
 hyper = { version = "0.14", features = ["full"] }
 sui-tls = { path = "../sui-tls" }
 sui-types = { path = "../sui-types" }
+mysten-metrics = { path = "../mysten-metrics" }
 multiaddr = "0.17.0"
 prometheus = "0.13.3"
 snap = "1.1.0"

--- a/crates/sui-proxy/src/config.rs
+++ b/crates/sui-proxy/src/config.rs
@@ -15,6 +15,7 @@ pub struct ProxyConfig {
     pub listen_address: SocketAddr,
     pub remote_write: RemoteWriteConfig,
     pub json_rpc: PeerValidationConfig,
+    pub metrics_address: SocketAddr,
 }
 
 #[serde_as]

--- a/crates/sui-proxy/src/data/config.yaml
+++ b/crates/sui-proxy/src/data/config.yaml
@@ -9,3 +9,4 @@ json-rpc:
   interval: 30
   certificate-file: /opt/joeman/fullchain.pem
   private-key: /opt/joeman/privkey.pem
+metrics-address: 192.168.0.2:9184

--- a/crates/sui-proxy/src/lib.rs
+++ b/crates/sui-proxy/src/lib.rs
@@ -4,6 +4,7 @@ pub mod admin;
 pub mod config;
 pub mod consumer;
 pub mod handlers;
+pub mod metrics;
 pub mod middleware;
 pub mod peers;
 pub mod prom_to_mimir;

--- a/crates/sui-proxy/src/metrics.rs
+++ b/crates/sui-proxy/src/metrics.rs
@@ -1,0 +1,41 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use axum::{extract::Extension, http::StatusCode, routing::get, Router};
+use mysten_metrics::RegistryService;
+use prometheus::{Registry, TextEncoder};
+use std::net::SocketAddr;
+
+const METRICS_ROUTE: &str = "/metrics";
+
+// Creates a new http server that has as a sole purpose to expose
+// and endpoint that prometheus agent can use to poll for the metrics.
+// A RegistryService is returned that can be used to get access in prometheus Registries.
+pub fn start_prometheus_server(addr: SocketAddr) -> RegistryService {
+    let registry = Registry::new();
+
+    let registry_service = RegistryService::new(registry);
+
+    let app = Router::new()
+        .route(METRICS_ROUTE, get(metrics))
+        .layer(Extension(registry_service.clone()));
+
+    tokio::spawn(async move {
+        axum::Server::bind(&addr)
+            .serve(app.into_make_service())
+            .await
+            .unwrap();
+    });
+
+    registry_service
+}
+
+async fn metrics(Extension(registry_service): Extension<RegistryService>) -> (StatusCode, String) {
+    let metrics_families = registry_service.gather_all();
+    match TextEncoder.encode_to_string(&metrics_families) {
+        Ok(metrics) => (StatusCode::OK, metrics),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("unable to encode metrics: {error}"),
+        ),
+    }
+}


### PR DESCRIPTION
Summary:

* lets serve our version metric

Test Plan:

```
curl -v --get http://192.168.0.184:9184/metrics
*   Trying 192.168.0.184:9184...
* Connected to 192.168.0.184 (192.168.0.184) port 9184 (#0)
> GET /metrics HTTP/1.1
> Host: 192.168.0.184:9184
> User-Agent: curl/7.84.0
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< content-type: text/plain; charset=utf-8
< content-length: 107
< date: Fri, 17 Mar 2023 21:15:59 GMT
<
# HELP uptime uptime of the node service in seconds
# TYPE uptime counter
uptime{version="0.0.1-DIRTY"} 57
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
