### PR TITLE
[package upgrades] Add CLI command for package digest + bug fixes

### DIFF
--- a/crates/sui-core/src/unit_tests/data/move_package/Bv2/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_package/Bv2/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "B"
+version = "0.0.1"
+
+[addresses]
+b = "0xb1"
+
+[dependencies]
+C = { local = "../Cv2" }

--- a/crates/sui-core/src/unit_tests/data/move_package/Bv2/sources/b.move
+++ b/crates/sui-core/src/unit_tests/data/move_package/Bv2/sources/b.move
@@ -1,0 +1,8 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module b::b {
+    public fun b(): u64 {
+        c::c::c()
+    }
+}

--- a/crates/sui-core/src/unit_tests/data/move_package/Cv1/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_package/Cv1/Move.toml
@@ -1,6 +1,7 @@
 [package]
 name = "C"
 version = "0.0.1"
+published-at = "0xc1"
 
 [addresses]
 c = "0xc1"

--- a/crates/sui-core/src/unit_tests/data/move_package/Cv2/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_package/Cv2/Move.toml
@@ -1,6 +1,7 @@
 [package]
 name = "C"
 version = "0.0.2"
+published-at = "0xc2"
 
 [addresses]
 c = "0xc1"

--- a/crates/sui-core/src/unit_tests/move_package_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_tests.rs
@@ -3,7 +3,7 @@
 
 use move_binary_format::file_format::CompiledModule;
 
-use sui_framework_build::compiled_package::BuildConfig;
+use sui_framework_build::compiled_package::{BuildConfig, CompiledPackage};
 use sui_types::{
     base_types::ObjectID,
     digests::TransactionDigest,
@@ -356,6 +356,46 @@ fn test_transitively_depending_on_upgrade() {
 }
 
 #[test]
+fn package_digest_changes_with_dep_upgrades_and_in_sync_with_move_package_digest() {
+    let c_v1 = MovePackage::new_initial(
+        OBJECT_START_VERSION,
+        build_test_modules("Cv1"),
+        u64::MAX,
+        [],
+    )
+    .unwrap();
+
+    let c_id2 = ObjectID::from_single_byte(0xc2);
+    let c_v2 = c_v1
+        .new_upgraded(c_id2, build_test_modules("Cv2"), u64::MAX, [])
+        .unwrap();
+
+    let b_pkg = MovePackage::new_initial(
+        OBJECT_START_VERSION,
+        build_test_modules("B"),
+        u64::MAX,
+        [&c_v1],
+    )
+    .unwrap();
+
+    let b_v2 = MovePackage::new_initial(
+        OBJECT_START_VERSION,
+        build_test_modules("Bv2"),
+        u64::MAX,
+        [&c_v2],
+    )
+    .unwrap();
+
+    let local_v1 = build_test_package("B").get_package_digest(false);
+    let local_v2 = build_test_package("Bv2").get_package_digest(false);
+
+    assert_ne!(b_pkg.digest(), b_v2.digest());
+    assert_eq!(b_pkg.digest(), local_v1);
+    assert_eq!(b_v2.digest(), local_v2);
+    assert_ne!(local_v1, local_v2);
+}
+
+#[test]
 #[should_panic]
 fn test_panic_on_empty_package() {
     let _ = MovePackage::new_initial(OBJECT_START_VERSION, vec![], u64::MAX, []);
@@ -459,12 +499,15 @@ fn test_fail_on_upgrade_missing_type() {
     assert_eq!(err.kind(), &ExecutionErrorKind::InvariantViolation);
 }
 
-pub fn build_test_modules(test_dir: &str) -> Vec<CompiledModule> {
+pub fn build_test_package(test_dir: &str) -> CompiledPackage {
     let build_config = BuildConfig::new_for_testing();
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.extend(["src", "unit_tests", "data", "move_package", test_dir]);
-    sui_framework::build_move_package(&path, build_config)
-        .unwrap()
+    sui_framework::build_move_package(&path, build_config).unwrap()
+}
+
+pub fn build_test_modules(test_dir: &str) -> Vec<CompiledModule> {
+    build_test_package(test_dir)
         .get_modules()
         .cloned()
         .collect()

--- a/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -44,8 +44,8 @@ pub fn build_upgrade_test_modules(test_dir: &str) -> (Vec<u8>, Vec<Vec<u8>>) {
     path.extend(["src", "unit_tests", "data", "move_upgrade", test_dir]);
     let package = sui_framework::build_move_package(&path, build_config).unwrap();
     (
-        package.get_package_digest().to_vec(),
-        package.get_package_bytes(true),
+        package.get_package_digest(false).to_vec(),
+        package.get_package_bytes(false),
     )
 }
 
@@ -64,8 +64,8 @@ pub fn build_upgrade_test_modules_with_dep_addr(
     path.extend(["src", "unit_tests", "data", "move_upgrade", test_dir]);
     let package = sui_framework::build_move_package(&path, build_config).unwrap();
     (
-        package.get_package_digest().to_vec(),
-        package.get_package_bytes(true),
+        package.get_package_digest(false).to_vec(),
+        package.get_package_bytes(false),
         package.get_dependency_original_package_ids(),
     )
 }
@@ -97,7 +97,7 @@ impl UpgradeStateRunner {
             &sender_key,
             &gas_object_id,
             base_package_name,
-            true,
+            false,
         )
         .await;
 

--- a/crates/sui-framework-build/src/compiled_package.rs
+++ b/crates/sui-framework-build/src/compiled_package.rs
@@ -303,10 +303,10 @@ impl CompiledPackage {
         ids.into_iter().collect()
     }
 
-    pub fn get_package_digest(&self) -> [u8; 32] {
+    pub fn get_package_digest(&self, with_unpublished_deps: bool) -> [u8; 32] {
         MovePackage::compute_digest_for_modules_and_deps(
-            &self.get_package_bytes(/* with_unpublished_deps */ true),
-            &self.get_dependency_original_package_ids(),
+            &self.get_package_bytes(with_unpublished_deps),
+            self.dependency_ids.published.values(),
         )
     }
 

--- a/crates/sui-move/src/build.rs
+++ b/crates/sui-move/src/build.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
+use fastcrypto::encoding::{Encoding, Hex};
 use move_cli::base::{self, build};
 use move_package::BuildConfig as MoveBuildConfig;
 use serde_json::json;
@@ -34,6 +35,9 @@ pub struct Build {
     /// and events.
     #[clap(long, global = true)]
     pub generate_struct_layouts: bool,
+    /// Compute and display the package digest in hex.
+    #[clap(long, global = true)]
+    pub dump_package_digest: bool,
 }
 
 impl Build {
@@ -50,6 +54,7 @@ impl Build {
             self.with_unpublished_dependencies,
             self.dump_bytecode_as_base64,
             self.generate_struct_layouts,
+            self.dump_package_digest,
         )
     }
 
@@ -59,6 +64,7 @@ impl Build {
         with_unpublished_deps: bool,
         dump_bytecode_as_base64: bool,
         generate_struct_layouts: bool,
+        dump_package_digest: bool,
     ) -> anyhow::Result<()> {
         let pkg = sui_framework::build_move_package(
             rerooted_path,
@@ -82,6 +88,13 @@ impl Build {
                     "dependencies": json!(package_dependencies),
                 })
             )
+        }
+
+        if dump_package_digest {
+            println!(
+                "{}",
+                Hex::encode(pkg.get_package_digest(with_unpublished_deps))
+            );
         }
 
         if generate_struct_layouts {

--- a/crates/sui-move/src/unit_test.rs
+++ b/crates/sui-move/src/unit_test.rs
@@ -46,6 +46,7 @@ impl Test {
         let with_unpublished_deps = false;
         let dump_bytecode_as_base64 = false;
         let generate_struct_layouts: bool = false;
+        let dump_package_digest = false;
         build::Build::execute_internal(
             &rerooted_path,
             BuildConfig {
@@ -55,6 +56,7 @@ impl Test {
             with_unpublished_deps,
             dump_bytecode_as_base64,
             generate_struct_layouts,
+            dump_package_digest,
         )?;
         run_move_unit_tests(
             &rerooted_path,


### PR DESCRIPTION
## Description 

Adds the `--dump-package-digest` command to the CLI that computes the package digest.

Also fixes a bug where we were using the package dependencies base package IDs as opposed to the current package IDs when computing the digest.

```
$ sui move build --dump-package-digest
b79151ec5d30a80b78789805f293fa4fb8fd1eebc0c9367e7c9106678a893df1
```

## Test Plan 

Make sure existing tests pass. 