### PR TITLE
[fire-drill-2.2.1] Incompatible framework upgrade

### DIFF
--- a/crates/sui-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -5,7 +5,7 @@ expression: genesis_config
 validator_config_info: ~
 parameters:
   timestamp_ms: 0
-  protocol_version: 2
+  protocol_version: 3
   allow_insertion_of_extra_objects: true
   initial_sui_custody_account_address: "0x0000000000000000000000000000000000000000000000000000000000000000"
   initial_validator_stake_mist: 25000000000000000
@@ -80,3 +80,4 @@ accounts:
       - object_id: "0x58fe0e977d9cebceef216ee0abca798d7295d37117a9709d29d445f969384de1"
         gas_value: 100000000000000
     gas_object_ranges: []
+

--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-3.snap
@@ -3,7 +3,7 @@ source: crates/sui-config/tests/snapshot_tests.rs
 expression: genesis.sui_system_object()
 ---
 epoch: 0
-protocol_version: 2
+protocol_version: 3
 system_state_version: 1
 validators:
   total_stake: 25000000000000000
@@ -290,3 +290,4 @@ stake_subsidy:
   current_epoch_amount: 1000000000000000
 safe_mode: false
 epoch_start_timestamp_ms: 10
+

--- a/crates/sui-framework/docs/package.md
+++ b/crates/sui-framework/docs/package.md
@@ -721,7 +721,7 @@ the parent package must be compatible with the policy in the ticket
 for the upgrade to succeed.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="package.md#0x2_package_authorize_upgrade">authorize_upgrade</a>(cap: &<b>mut</b> <a href="package.md#0x2_package_UpgradeCap">package::UpgradeCap</a>, policy: u8, <a href="digest.md#0x2_digest">digest</a>: <a href="">vector</a>&lt;u8&gt;): <a href="package.md#0x2_package_UpgradeTicket">package::UpgradeTicket</a>
+<pre><code><b>public</b> <b>fun</b> <a href="package.md#0x2_package_authorize_upgrade">authorize_upgrade</a>(cap: &<b>mut</b> <a href="package.md#0x2_package_UpgradeCap">package::UpgradeCap</a>, policy: u8, <a href="digest.md#0x2_digest">digest</a>: <a href="">vector</a>&lt;u8&gt;, _dummy_parameter: bool): <a href="package.md#0x2_package_UpgradeTicket">package::UpgradeTicket</a>
 </code></pre>
 
 
@@ -733,7 +733,8 @@ for the upgrade to succeed.
 <pre><code><b>public</b> <b>fun</b> <a href="package.md#0x2_package_authorize_upgrade">authorize_upgrade</a>(
     cap: &<b>mut</b> <a href="package.md#0x2_package_UpgradeCap">UpgradeCap</a>,
     policy: u8,
-    <a href="digest.md#0x2_digest">digest</a>: <a href="">vector</a>&lt;u8&gt;
+    <a href="digest.md#0x2_digest">digest</a>: <a href="">vector</a>&lt;u8&gt;,
+    _dummy_parameter: bool,
 ): <a href="package.md#0x2_package_UpgradeTicket">UpgradeTicket</a> {
     <b>let</b> id_zero = <a href="object.md#0x2_object_id_from_address">object::id_from_address</a>(@0x0);
     <b>assert</b>!(cap.<a href="package.md#0x2_package">package</a> != id_zero, <a href="package.md#0x2_package_EAlreadyAuthorized">EAlreadyAuthorized</a>);

--- a/crates/sui-framework/sources/package.move
+++ b/crates/sui-framework/sources/package.move
@@ -189,7 +189,8 @@ module sui::package {
     public fun authorize_upgrade(
         cap: &mut UpgradeCap,
         policy: u8,
-        digest: vector<u8>
+        digest: vector<u8>,
+        _dummy_parameter: bool,
     ): UpgradeTicket {
         let id_zero = object::id_from_address(@0x0);
         assert!(cap.package != id_zero, EAlreadyAuthorized);

--- a/crates/sui-framework/tests/package_tests.move
+++ b/crates/sui-framework/tests/package_tests.move
@@ -70,6 +70,7 @@ module sui::package_tests {
             &mut cap,
             package::dep_only_policy(),
             sui::hash::blake2b256(&b"package contents"),
+            false,
         );
 
         let receipt = package::test_upgrade(ticket);
@@ -104,6 +105,7 @@ module sui::package_tests {
             &mut cap,
             package::compatible_policy(),
             sui::hash::blake2b256(&b"package contents"),
+            false,
         );
 
         abort 0
@@ -119,6 +121,7 @@ module sui::package_tests {
             &mut cap,
             package::compatible_policy(),
             sui::hash::blake2b256(&b"package contents 0"),
+            false,
         );
 
         // It's an error to try and issue more than one simultaneous
@@ -127,6 +130,7 @@ module sui::package_tests {
             &mut cap,
             package::compatible_policy(),
             sui::hash::blake2b256(&b"package contents 1"),
+            false,
         );
 
         abort 0
@@ -143,6 +147,7 @@ module sui::package_tests {
             &mut cap1,
             package::dep_only_policy(),
             sui::hash::blake2b256(&b"package contents 1"),
+            false,
         );
 
         let receipt1 = package::test_upgrade(ticket1);

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -10,13 +10,14 @@ use tracing::{info, warn};
 
 /// The minimum and maximum protocol versions supported by this build.
 const MIN_PROTOCOL_VERSION: u64 = 1;
-const MAX_PROTOCOL_VERSION: u64 = 2;
+const MAX_PROTOCOL_VERSION: u64 = 3;
 
 // Record history of protocol version allocations here:
 //
 // Version 1: Original version.
 // Version 2: Add FeatureFlag to change gas buckets computation and remove gas computation for
 //            storage
+// Version 3: Intentionally broken attempt to upgrade the framework with an incompatible change.
 #[derive(
     Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, JsonSchema,
 )]
@@ -816,7 +817,7 @@ impl ProtocolConfig {
                 // When adding a new constant, set it to None in the earliest version, like this:
                 // new_constant: None,
             },
-            2 => {
+            2 | 3 => {
                 let mut cfg = Self::get_for_version_impl(version - 1);
                 cfg.feature_flags.gas_buckets_sub_and_storage_computation = true;
                 cfg

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_3.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_3.snap
@@ -1,0 +1,75 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur)"
+---
+version: 3
+feature_flags:
+  package_upgrades: false
+  gas_buckets_sub_and_storage_computation: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 128
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 6
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_tx_gas: 10000000000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 256
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transfered_move_object_ids: 2048
+max_num_transfered_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_move_vector_len: 262144
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 110000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 5000
+storage_gas_price: 1
+max_transactions_per_checkpoint: 1000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 7500
+copy_bytes_to_address_cost_per_byte: 10
+address_to_vec_cost_per_byte: 10
+address_vec_reverse_cost_per_byte: 10
+copy_convert_to_u256_cost_per_byte: 10
+u256_to_bytes_to_vec_cost_per_byte: 10
+u256_bytes_vec_reverse_cost_per_byte: 10
+copy_convert_to_address_cost_per_byte: 10
+event_value_size_derivation_cost_per_byte: 1000
+event_tag_size_derivation_cost_per_byte: 1000
+event_emit_cost_per_byte: 1000
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_3.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_3.snap
@@ -37,8 +37,8 @@ max_num_new_move_object_ids: 2048
 max_num_new_move_object_ids_system_tx: 32768
 max_num_deleted_move_object_ids: 2048
 max_num_deleted_move_object_ids_system_tx: 32768
-max_num_transfered_move_object_ids: 2048
-max_num_transfered_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
 max_event_emit_size: 256000
 max_move_vector_len: 262144
 object_runtime_max_num_cached_objects: 1000


### PR DESCRIPTION
## Description

This PR introduces an incompatible change to the framework (a new parameter for a public function), to test incompatible upgrades.

It is intended to be used to build binaries that are used temporarily to confirm that a protocol version upgrade involving an incompatible framework upgrade will not go through.

## Test Plan

Fire drills

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
- Adds a new unused parameter to a public function in sui framework, which makes the resulting upgrade incompatible.