### PR TITLE
[chore] Fix flaky tests due to filesystem races

### DIFF
--- a/crates/sui-framework-build/src/compiled_package.rs
+++ b/crates/sui-framework-build/src/compiled_package.rs
@@ -68,7 +68,10 @@ pub struct BuildConfig {
 impl BuildConfig {
     pub fn new_for_testing() -> Self {
         let mut build_config: Self = Default::default();
-        build_config.config.install_dir = Some(tempfile::TempDir::new().unwrap().into_path());
+        let install_dir = tempfile::tempdir().unwrap().into_path();
+        let lock_file = install_dir.join("Move.lock");
+        build_config.config.install_dir = Some(install_dir);
+        build_config.config.lock_file = Some(lock_file);
         build_config
     }
 

--- a/crates/sui-move/src/build.rs
+++ b/crates/sui-move/src/build.rs
@@ -87,12 +87,13 @@ impl Build {
 
 /// Resolve Move.lock file path in package directory (where Move.toml is).
 pub fn resolve_lock_file_path(
-    build_config: MoveBuildConfig,
+    mut build_config: MoveBuildConfig,
     package_path: Option<PathBuf>,
 ) -> Result<MoveBuildConfig, anyhow::Error> {
-    let package_root = base::reroot_path(package_path)?;
-    let lock_file_path = package_root.join("Move.lock");
-    let mut build_config = build_config;
-    build_config.lock_file = Some(lock_file_path);
+    if build_config.lock_file.is_none() {
+        let package_root = base::reroot_path(package_path)?;
+        let lock_file_path = package_root.join("Move.lock");
+        build_config.lock_file = Some(lock_file_path);
+    }
     Ok(build_config)
 }

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -5,7 +5,6 @@ use std::{fmt::Write, fs::read_dir, path::PathBuf, str, thread, time::Duration};
 
 use anyhow::anyhow;
 use expect_test::expect;
-use move_package::BuildConfig;
 use serde_json::json;
 use sui_types::object::Owner;
 use tokio::time::sleep;
@@ -21,6 +20,7 @@ use sui_config::{
     NetworkConfig, PersistedConfig, SUI_CLIENT_CONFIG, SUI_FULLNODE_CONFIG, SUI_GENESIS_FILENAME,
     SUI_KEYSTORE_FILENAME, SUI_NETWORK_CONFIG,
 };
+use sui_framework_build::compiled_package::BuildConfig;
 use sui_json::SuiJsonValue;
 use sui_json_rpc_types::{
     OwnedObjectRef, SuiObjectData, SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery,
@@ -400,7 +400,7 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
     let gas_obj_id = object_refs.first().unwrap().object().unwrap().object_id;
     let mut package_path = PathBuf::from(TEST_DATA_DIR);
     package_path.push("move_call_args_linter");
-    let build_config = BuildConfig::default();
+    let build_config = BuildConfig::new_for_testing().config;
     let resp = SuiClientCommands::Publish {
         package_path,
         build_config,
@@ -606,7 +606,7 @@ async fn test_package_publish_command() -> Result<(), anyhow::Error> {
     // Provide path to well formed package sources
     let mut package_path = PathBuf::from(TEST_DATA_DIR);
     package_path.push("dummy_modules_publish");
-    let build_config = BuildConfig::default();
+    let build_config = BuildConfig::new_for_testing().config;
     let resp = SuiClientCommands::Publish {
         package_path,
         build_config,
@@ -673,7 +673,7 @@ async fn test_package_publish_command_with_unpublished_dependency_succeeds(
 
     let mut package_path = PathBuf::from(TEST_DATA_DIR);
     package_path.push("module_publish_with_unpublished_dependency");
-    let build_config = BuildConfig::default();
+    let build_config = BuildConfig::new_for_testing().config;
     let resp = SuiClientCommands::Publish {
         package_path,
         build_config,
@@ -740,7 +740,7 @@ async fn test_package_publish_command_with_unpublished_dependency_fails(
 
     let mut package_path = PathBuf::from(TEST_DATA_DIR);
     package_path.push("module_publish_with_unpublished_dependency");
-    let build_config = BuildConfig::default();
+    let build_config = BuildConfig::new_for_testing().config;
     let result = SuiClientCommands::Publish {
         package_path,
         build_config,
@@ -793,7 +793,7 @@ async fn test_package_publish_command_failure_invalid() -> Result<(), anyhow::Er
 
     let mut package_path = PathBuf::from(TEST_DATA_DIR);
     package_path.push("module_publish_failure_invalid");
-    let build_config = BuildConfig::default();
+    let build_config = BuildConfig::new_for_testing().config;
     let result = SuiClientCommands::Publish {
         package_path,
         build_config,


### PR DESCRIPTION
## Description

There were two filesystem races going on:  One for access to `install_dir` (this was an existing problem)  and one for the lock file (new problem).  This PR addresses both, by using `BuildConfig::new_for_testing` in `cli_tests` and ensuring that the lock file gets stored in the temporary directory rather than the package root in tests that use `BuildConfig::new_for_testing`.

## Test Plan

```
$ env RUST_LOG=off MSIM_TEST_NUM=10 cargo simtest
```