### PR TITLE
End friendships in framework code using programmable txns

### DIFF
--- a/crates/sui-adapter/src/execution_mode.rs
+++ b/crates/sui-adapter/src/execution_mode.rs
@@ -132,6 +132,51 @@ impl ExecutionMode for Genesis {
     }
 }
 
+#[derive(Copy, Clone)]
+pub struct System;
+
+/// Execution mode for executing a system transaction, including the epoch change
+/// transaction and the consensus commit prologue. In this mode, we allow calls to
+/// any function bypassing visibility.
+impl ExecutionMode for System {
+    type ArgumentUpdates = ();
+    type ExecutionResults = ();
+
+    fn allow_arbitrary_function_calls() -> bool {
+        true
+    }
+
+    fn allow_arbitrary_values() -> bool {
+        false
+    }
+
+    fn packages_are_predefined() -> bool {
+        true
+    }
+
+    fn empty_arguments() -> Self::ArgumentUpdates {}
+
+    fn empty_results() -> Self::ExecutionResults {}
+
+    fn add_argument_update<E: fmt::Debug, S: StorageView<E>>(
+        _context: &mut ExecutionContext<E, S>,
+        _acc: &mut Self::ArgumentUpdates,
+        _arg: Argument,
+        _new_value: &Value,
+    ) -> Result<(), ExecutionError> {
+        Ok(())
+    }
+
+    fn finish_command<E: fmt::Debug, S: StorageView<E>>(
+        _context: &mut ExecutionContext<E, S>,
+        _acc: &mut Self::ExecutionResults,
+        _argument_updates: Self::ArgumentUpdates,
+        _command_result: &[Value],
+    ) -> Result<(), ExecutionError> {
+        Ok(())
+    }
+}
+
 /// WARNING! Using this mode will bypass all normal checks around Move entry functions! This
 /// includes the various rules for function arguments, meaning any object can be created just from
 /// BCS bytes!

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -1202,21 +1202,55 @@ pub fn generate_genesis_system_object(
 
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
-        builder
-            .move_call(
-                SUI_FRAMEWORK_ADDRESS.into(),
-                ident_str!("genesis").to_owned(),
-                ident_str!("create").to_owned(),
-                vec![],
-                vec![
-                    CallArg::Pure(bcs::to_bytes(&genesis_chain_parameters).unwrap()),
-                    CallArg::Pure(bcs::to_bytes(&genesis_validators).unwrap()),
-                    CallArg::Pure(bcs::to_bytes(&token_distribution_schedule).unwrap()),
-                    CallArg::Pure(bcs::to_bytes(&parameters.protocol_version.as_u64()).unwrap()),
-                    CallArg::Pure(bcs::to_bytes(&system_state_version).unwrap()),
-                ],
-            )
-            .unwrap();
+        // Step 1: Create the SuiSystemState UID
+        let sui_system_state_uid = builder.programmable_move_call(
+            SUI_FRAMEWORK_ADDRESS.into(),
+            ident_str!("object").to_owned(),
+            ident_str!("sui_system_state").to_owned(),
+            vec![],
+            vec![],
+        );
+
+        // Step 2: Create and share the Clock.
+        builder.move_call(
+            SUI_FRAMEWORK_ADDRESS.into(),
+            ident_str!("clock").to_owned(),
+            ident_str!("create").to_owned(),
+            vec![],
+            vec![],
+        )?;
+
+        // Step 3: Mint the supply of SUI.
+        let sui_supply = builder.programmable_move_call(
+            SUI_FRAMEWORK_ADDRESS.into(),
+            ident_str!("sui").to_owned(),
+            ident_str!("new").to_owned(),
+            vec![],
+            vec![],
+        );
+
+        // Step 4: Run genesis.
+        // The first argument is the system state uid we got from step 1 and the second one is the SUI supply we
+        // got from step 3.
+        let mut arguments = vec![sui_system_state_uid, sui_supply];
+        let mut call_arg_arguments = vec![
+            CallArg::Pure(bcs::to_bytes(&genesis_chain_parameters).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&genesis_validators).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&token_distribution_schedule).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&parameters.protocol_version.as_u64()).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&system_state_version).unwrap()),
+        ]
+        .into_iter()
+        .map(|a| builder.input(a))
+        .collect::<Result<_, _>>()?;
+        arguments.append(&mut call_arg_arguments);
+        builder.programmable_move_call(
+            SUI_FRAMEWORK_ADDRESS.into(),
+            ident_str!("genesis").to_owned(),
+            ident_str!("create").to_owned(),
+            vec![],
+            arguments,
+        );
         builder.finish()
     };
     programmable_transactions::execution::execute::<_, _, execution_mode::Genesis>(

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -3141,6 +3141,7 @@ async fn test_genesis_sui_system_state_object() {
 #[cfg(msim)]
 #[sim_test]
 async fn test_sui_system_state_nop_upgrade() {
+    use sui_adapter::execution_engine::{construct_advance_epoch_pt, AdvanceEpochParams};
     use sui_adapter::programmable_transactions;
     use sui_types::sui_system_state::SUI_SYSTEM_STATE_TESTING_VERSION1;
     use sui_types::{MOVE_STDLIB_ADDRESS, SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION};
@@ -3169,39 +3170,25 @@ async fn test_sui_system_state_nop_upgrade() {
         TransactionDigest::genesis(),
         &protocol_config,
     );
-    let system_object_arg = CallArg::Object(ObjectArg::SharedObject {
-        id: SUI_SYSTEM_STATE_OBJECT_ID,
-        initial_shared_version: SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
-        mutable: true,
-    });
+
     let new_protocol_version = ProtocolVersion::MIN.as_u64() + 1;
     let new_system_state_version = SUI_SYSTEM_STATE_TESTING_VERSION1;
 
-    let pt = {
-        let mut builder = ProgrammableTransactionBuilder::new();
-        builder
-            .move_call(
-                SUI_FRAMEWORK_ADDRESS.into(),
-                ident_str!("sui_system").to_owned(),
-                ident_str!("advance_epoch").to_owned(),
-                vec![],
-                vec![
-                    system_object_arg,
-                    CallArg::Pure(bcs::to_bytes(&1u64).unwrap()),
-                    CallArg::Pure(bcs::to_bytes(&new_protocol_version).unwrap()),
-                    CallArg::Pure(bcs::to_bytes(&0u64).unwrap()),
-                    CallArg::Pure(bcs::to_bytes(&0u64).unwrap()),
-                    CallArg::Pure(bcs::to_bytes(&0u64).unwrap()),
-                    CallArg::Pure(bcs::to_bytes(&0u64).unwrap()),
-                    CallArg::Pure(bcs::to_bytes(&0u64).unwrap()),
-                    CallArg::Pure(bcs::to_bytes(&0u64).unwrap()),
-                    CallArg::Pure(bcs::to_bytes(&new_system_state_version).unwrap()), // Upgrade sui system state, set new version to 1.
-                ],
-            )
-            .unwrap();
-        builder.finish()
-    };
-    programmable_transactions::execution::execute::<_, _, execution_mode::Normal>(
+    // Dummy change epoch with the new protocol version and system state version.
+    let pt = construct_advance_epoch_pt(AdvanceEpochParams {
+        epoch: 1,
+        next_protocol_version: ProtocolVersion::from(new_protocol_version),
+        storage_charge: 0,
+        computation_charge: 0,
+        storage_rebate: 0,
+        storage_fund_reinvest_rate: 0,
+        reward_slashing_rate: 0,
+        epoch_start_timestamp_ms: 0,
+        new_system_state_version,
+    })
+    .unwrap();
+
+    programmable_transactions::execution::execute::<_, _, execution_mode::System>(
         &protocol_config,
         &move_vm,
         &mut temporary_store,

--- a/crates/sui-framework/docs/balance.md
+++ b/crates/sui-framework/docs/balance.md
@@ -25,7 +25,8 @@ custom coins with <code><a href="balance.md#0x2_balance_Supply">Supply</a></code
 -  [Function `destroy_supply`](#0x2_balance_destroy_supply)
 
 
-<pre><code></code></pre>
+<pre><code><b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
+</code></pre>
 
 
 
@@ -90,6 +91,16 @@ Can be used to store coins which don't need the key ability.
 <a name="@Constants_0"></a>
 
 ## Constants
+
+
+<a name="0x2_balance_ENotSystemAddress"></a>
+
+Sender is not @0x0 the system address.
+
+
+<pre><code><b>const</b> <a href="balance.md#0x2_balance_ENotSystemAddress">ENotSystemAddress</a>: u64 = 3;
+</code></pre>
+
 
 
 <a name="0x2_balance_ENonZero"></a>
@@ -414,11 +425,11 @@ Destroy a zero <code><a href="balance.md#0x2_balance_Balance">Balance</a></code>
 ## Function `create_staking_rewards`
 
 CAUTION: this function creates a <code><a href="balance.md#0x2_balance_Balance">Balance</a></code> without increasing the supply.
-It should only be called by <code><a href="sui_system.md#0x2_sui_system_advance_epoch">sui_system::advance_epoch</a></code> to create staking rewards,
+It should only be called by the epoch change system txn to create staking rewards,
 and nowhere else.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="balance.md#0x2_balance_create_staking_rewards">create_staking_rewards</a>&lt;T&gt;(value: u64): <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;
+<pre><code><b>fun</b> <a href="balance.md#0x2_balance_create_staking_rewards">create_staking_rewards</a>&lt;T&gt;(value: u64, ctx: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;
 </code></pre>
 
 
@@ -427,7 +438,8 @@ and nowhere else.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="balance.md#0x2_balance_create_staking_rewards">create_staking_rewards</a>&lt;T&gt;(value: u64): <a href="balance.md#0x2_balance_Balance">Balance</a>&lt;T&gt; {
+<pre><code><b>fun</b> <a href="balance.md#0x2_balance_create_staking_rewards">create_staking_rewards</a>&lt;T&gt;(value: u64, ctx: &TxContext): <a href="balance.md#0x2_balance_Balance">Balance</a>&lt;T&gt; {
+    <b>assert</b>!(<a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx) == @0x0, <a href="balance.md#0x2_balance_ENotSystemAddress">ENotSystemAddress</a>);
     <a href="balance.md#0x2_balance_Balance">Balance</a> { value }
 }
 </code></pre>
@@ -441,11 +453,11 @@ and nowhere else.
 ## Function `destroy_storage_rebates`
 
 CAUTION: this function destroys a <code><a href="balance.md#0x2_balance_Balance">Balance</a></code> without decreasing the supply.
-It should only be called by <code><a href="sui_system.md#0x2_sui_system_advance_epoch">sui_system::advance_epoch</a></code> to destroy storage rebates,
+It should only be called by the epoch change system txn to destroy storage rebates,
 and nowhere else.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="balance.md#0x2_balance_destroy_storage_rebates">destroy_storage_rebates</a>&lt;T&gt;(self: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;)
+<pre><code><b>fun</b> <a href="balance.md#0x2_balance_destroy_storage_rebates">destroy_storage_rebates</a>&lt;T&gt;(self: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;T&gt;, ctx: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -454,7 +466,8 @@ and nowhere else.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="balance.md#0x2_balance_destroy_storage_rebates">destroy_storage_rebates</a>&lt;T&gt;(self: <a href="balance.md#0x2_balance_Balance">Balance</a>&lt;T&gt;) {
+<pre><code><b>fun</b> <a href="balance.md#0x2_balance_destroy_storage_rebates">destroy_storage_rebates</a>&lt;T&gt;(self: <a href="balance.md#0x2_balance_Balance">Balance</a>&lt;T&gt;, ctx: &TxContext) {
+    <b>assert</b>!(<a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx) == @0x0, <a href="balance.md#0x2_balance_ENotSystemAddress">ENotSystemAddress</a>);
     <b>let</b> <a href="balance.md#0x2_balance_Balance">Balance</a> { value: _ } = self;
 }
 </code></pre>

--- a/crates/sui-framework/docs/clock.md
+++ b/crates/sui-framework/docs/clock.md
@@ -8,13 +8,15 @@ shared object that is created at 0x6 during genesis.
 
 
 -  [Resource `Clock`](#0x2_clock_Clock)
+-  [Constants](#@Constants_0)
 -  [Function `timestamp_ms`](#0x2_clock_timestamp_ms)
 -  [Function `create`](#0x2_clock_create)
--  [Function `set_timestamp`](#0x2_clock_set_timestamp)
+-  [Function `consensus_commit_prologue`](#0x2_clock_consensus_commit_prologue)
 
 
 <pre><code><b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
 <b>use</b> <a href="transfer.md#0x2_transfer">0x2::transfer</a>;
+<b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
 </code></pre>
 
 
@@ -63,6 +65,21 @@ input parameter, unless it is passed by immutable reference.
 
 </details>
 
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x2_clock_ENotSystemAddress"></a>
+
+Sender is not @0x0 the system address.
+
+
+<pre><code><b>const</b> <a href="clock.md#0x2_clock_ENotSystemAddress">ENotSystemAddress</a>: u64 = 0;
+</code></pre>
+
+
+
 <a name="0x2_clock_timestamp_ms"></a>
 
 ## Function `timestamp_ms`
@@ -97,7 +114,7 @@ Create and share the singleton Clock -- this function is
 called exactly once, during genesis.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="clock.md#0x2_clock_create">create</a>()
+<pre><code><b>fun</b> <a href="clock.md#0x2_clock_create">create</a>(ctx: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -106,7 +123,9 @@ called exactly once, during genesis.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="clock.md#0x2_clock_create">create</a>() {
+<pre><code><b>fun</b> <a href="clock.md#0x2_clock_create">create</a>(ctx: &TxContext) {
+    <b>assert</b>!(<a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx) == @0x0, <a href="clock.md#0x2_clock_ENotSystemAddress">ENotSystemAddress</a>);
+
     <a href="transfer.md#0x2_transfer_share_object">transfer::share_object</a>(<a href="clock.md#0x2_clock_Clock">Clock</a> {
         id: <a href="object.md#0x2_object_clock">object::clock</a>(),
         // Initialised <b>to</b> zero, but set <b>to</b> a real timestamp by a
@@ -121,15 +140,13 @@ called exactly once, during genesis.
 
 </details>
 
-<a name="0x2_clock_set_timestamp"></a>
+<a name="0x2_clock_consensus_commit_prologue"></a>
 
-## Function `set_timestamp`
-
-Set the Clock's timestamp -- this function should only be called by
-<code>sui::system_state::consensus_commit_prologue</code>.
+## Function `consensus_commit_prologue`
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="clock.md#0x2_clock_set_timestamp">set_timestamp</a>(<a href="clock.md#0x2_clock">clock</a>: &<b>mut</b> <a href="clock.md#0x2_clock_Clock">clock::Clock</a>, timestamp_ms: u64)
+
+<pre><code><b>fun</b> <a href="clock.md#0x2_clock_consensus_commit_prologue">consensus_commit_prologue</a>(<a href="clock.md#0x2_clock">clock</a>: &<b>mut</b> <a href="clock.md#0x2_clock_Clock">clock::Clock</a>, timestamp_ms: u64, ctx: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -138,7 +155,14 @@ Set the Clock's timestamp -- this function should only be called by
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="clock.md#0x2_clock_set_timestamp">set_timestamp</a>(<a href="clock.md#0x2_clock">clock</a>: &<b>mut</b> <a href="clock.md#0x2_clock_Clock">Clock</a>, timestamp_ms: u64) {
+<pre><code><b>fun</b> <a href="clock.md#0x2_clock_consensus_commit_prologue">consensus_commit_prologue</a>(
+    <a href="clock.md#0x2_clock">clock</a>: &<b>mut</b> <a href="clock.md#0x2_clock_Clock">Clock</a>,
+    timestamp_ms: u64,
+    ctx: &TxContext,
+) {
+    // Validator will make a special system call <b>with</b> sender set <b>as</b> 0x0.
+    <b>assert</b>!(<a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx) == @0x0, <a href="clock.md#0x2_clock_ENotSystemAddress">ENotSystemAddress</a>);
+
     <a href="clock.md#0x2_clock">clock</a>.timestamp_ms = timestamp_ms
 }
 </code></pre>

--- a/crates/sui-framework/docs/ed25519.md
+++ b/crates/sui-framework/docs/ed25519.md
@@ -6,11 +6,9 @@
 
 
 -  [Function `ed25519_verify`](#0x2_ed25519_ed25519_verify)
--  [Function `ed25519_verify_with_domain`](#0x2_ed25519_ed25519_verify_with_domain)
 
 
-<pre><code><b>use</b> <a href="">0x1::vector</a>;
-</code></pre>
+<pre><code></code></pre>
 
 
 
@@ -49,38 +47,6 @@ Otherwise, return false.
 
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> [abstract] <b>true</b>;
-</code></pre>
-
-
-
-</details>
-
-<a name="0x2_ed25519_ed25519_verify_with_domain"></a>
-
-## Function `ed25519_verify_with_domain`
-
-@param signature: 32-byte signature that is a point on the Ed25519 elliptic curve.
-@param public_key: 32-byte signature that is a point on the Ed25519 elliptic curve.
-@param msg: The message that we test the signature against.
-@param domain: The domain that the signature is tested again. We essentially prepend this to the message.
-
-If the signature is a valid Ed25519 signature of the message and public key, return true.
-Otherwise, return false.
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="ed25519.md#0x2_ed25519_ed25519_verify_with_domain">ed25519_verify_with_domain</a>(signature: &<a href="">vector</a>&lt;u8&gt;, public_key: &<a href="">vector</a>&lt;u8&gt;, msg: <a href="">vector</a>&lt;u8&gt;, domain: <a href="">vector</a>&lt;u8&gt;): bool
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="ed25519.md#0x2_ed25519_ed25519_verify_with_domain">ed25519_verify_with_domain</a>(signature: &<a href="">vector</a>&lt;u8&gt;, public_key: &<a href="">vector</a>&lt;u8&gt;, msg: <a href="">vector</a>&lt;u8&gt;, domain: <a href="">vector</a>&lt;u8&gt;): bool {
-    std::vector::append(&<b>mut</b> domain, msg);
-    <a href="ed25519.md#0x2_ed25519_ed25519_verify">ed25519_verify</a>(signature, public_key, &domain)
-}
 </code></pre>
 
 

--- a/crates/sui-framework/docs/genesis.md
+++ b/crates/sui-framework/docs/genesis.md
@@ -18,8 +18,8 @@
 <pre><code><b>use</b> <a href="">0x1::option</a>;
 <b>use</b> <a href="">0x1::vector</a>;
 <b>use</b> <a href="balance.md#0x2_balance">0x2::balance</a>;
-<b>use</b> <a href="clock.md#0x2_clock">0x2::clock</a>;
 <b>use</b> <a href="coin.md#0x2_coin">0x2::coin</a>;
+<b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
 <b>use</b> <a href="sui.md#0x2_sui">0x2::sui</a>;
 <b>use</b> <a href="sui_system.md#0x2_sui_system">0x2::sui_system</a>;
 <b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
@@ -275,7 +275,7 @@ It will create a singleton SuiSystemState object, which contains
 all the information we need in the system.
 
 
-<pre><code><b>fun</b> <a href="genesis.md#0x2_genesis_create">create</a>(genesis_chain_parameters: <a href="genesis.md#0x2_genesis_GenesisChainParameters">genesis::GenesisChainParameters</a>, genesis_validators: <a href="">vector</a>&lt;<a href="genesis.md#0x2_genesis_GenesisValidatorMetadata">genesis::GenesisValidatorMetadata</a>&gt;, token_distribution_schedule: <a href="genesis.md#0x2_genesis_TokenDistributionSchedule">genesis::TokenDistributionSchedule</a>, protocol_version: u64, system_state_version: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>fun</b> <a href="genesis.md#0x2_genesis_create">create</a>(sui_system_state_id: <a href="object.md#0x2_object_UID">object::UID</a>, sui_supply: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, genesis_chain_parameters: <a href="genesis.md#0x2_genesis_GenesisChainParameters">genesis::GenesisChainParameters</a>, genesis_validators: <a href="">vector</a>&lt;<a href="genesis.md#0x2_genesis_GenesisValidatorMetadata">genesis::GenesisValidatorMetadata</a>&gt;, token_distribution_schedule: <a href="genesis.md#0x2_genesis_TokenDistributionSchedule">genesis::TokenDistributionSchedule</a>, protocol_version: u64, system_state_version: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -285,6 +285,8 @@ all the information we need in the system.
 
 
 <pre><code><b>fun</b> <a href="genesis.md#0x2_genesis_create">create</a>(
+    sui_system_state_id: UID,
+    sui_supply: Balance&lt;SUI&gt;,
     genesis_chain_parameters: <a href="genesis.md#0x2_genesis_GenesisChainParameters">GenesisChainParameters</a>,
     genesis_validators: <a href="">vector</a>&lt;<a href="genesis.md#0x2_genesis_GenesisValidatorMetadata">GenesisValidatorMetadata</a>&gt;,
     token_distribution_schedule: <a href="genesis.md#0x2_genesis_TokenDistributionSchedule">TokenDistributionSchedule</a>,
@@ -300,7 +302,6 @@ all the information we need in the system.
         allocations,
     } = token_distribution_schedule;
 
-    <b>let</b> sui_supply = <a href="sui.md#0x2_sui_new">sui::new</a>(ctx);
     <b>let</b> subsidy_fund = <a href="balance.md#0x2_balance_split">balance::split</a>(
         &<b>mut</b> sui_supply,
         stake_subsidy_fund_mist,
@@ -372,6 +373,7 @@ all the information we need in the system.
     <a href="genesis.md#0x2_genesis_activate_validators">activate_validators</a>(&<b>mut</b> validators);
 
     <a href="sui_system.md#0x2_sui_system_create">sui_system::create</a>(
+        sui_system_state_id,
         validators,
         subsidy_fund,
         storage_fund,
@@ -383,8 +385,6 @@ all the information we need in the system.
         genesis_chain_parameters.epoch_duration_ms,
         ctx,
     );
-
-    <a href="clock.md#0x2_clock_create">clock::create</a>();
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/object.md
+++ b/crates/sui-framework/docs/object.md
@@ -175,6 +175,16 @@ containing object's address)
 ## Constants
 
 
+<a name="0x2_object_ENotSystemAddress"></a>
+
+Sender is not @0x0 the system address.
+
+
+<pre><code><b>const</b> <a href="object.md#0x2_object_ENotSystemAddress">ENotSystemAddress</a>: u64 = 0;
+</code></pre>
+
+
+
 <a name="0x2_object_SUI_CLOCK_OBJECT_ID"></a>
 
 The hardcoded ID for the singleton Clock Object.
@@ -329,7 +339,7 @@ Create the <code><a href="object.md#0x2_object_UID">UID</a></code> for the singl
 This should only be called once from <code><a href="sui_system.md#0x2_sui_system">sui_system</a></code>.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object.md#0x2_object_sui_system_state">sui_system_state</a>(): <a href="object.md#0x2_object_UID">object::UID</a>
+<pre><code><b>fun</b> <a href="object.md#0x2_object_sui_system_state">sui_system_state</a>(ctx: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="object.md#0x2_object_UID">object::UID</a>
 </code></pre>
 
 
@@ -338,7 +348,8 @@ This should only be called once from <code><a href="sui_system.md#0x2_sui_system
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object.md#0x2_object_sui_system_state">sui_system_state</a>(): <a href="object.md#0x2_object_UID">UID</a> {
+<pre><code><b>fun</b> <a href="object.md#0x2_object_sui_system_state">sui_system_state</a>(ctx: &TxContext): <a href="object.md#0x2_object_UID">UID</a> {
+    <b>assert</b>!(<a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx) == @0x0, <a href="object.md#0x2_object_ENotSystemAddress">ENotSystemAddress</a>);
     <a href="object.md#0x2_object_UID">UID</a> {
         id: <a href="object.md#0x2_object_ID">ID</a> { bytes: <a href="object.md#0x2_object_SUI_SYSTEM_STATE_OBJECT_ID">SUI_SYSTEM_STATE_OBJECT_ID</a> },
     }

--- a/crates/sui-framework/docs/sui.md
+++ b/crates/sui-framework/docs/sui.md
@@ -56,6 +56,16 @@ Name of the coin
 ## Constants
 
 
+<a name="0x2_sui_ENotSystemAddress"></a>
+
+Sender is not @0x0 the system address.
+
+
+<pre><code><b>const</b> <a href="sui.md#0x2_sui_ENotSystemAddress">ENotSystemAddress</a>: u64 = 1;
+</code></pre>
+
+
+
 <a name="0x2_sui_EAlreadyMinted"></a>
 
 
@@ -104,7 +114,7 @@ Register the <code><a href="sui.md#0x2_sui_SUI">SUI</a></code> Coin to acquire i
 This should be called only once during genesis creation.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui.md#0x2_sui_new">new</a>(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;
+<pre><code><b>fun</b> <a href="sui.md#0x2_sui_new">new</a>(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;
 </code></pre>
 
 
@@ -113,7 +123,8 @@ This should be called only once during genesis creation.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui.md#0x2_sui_new">new</a>(ctx: &<b>mut</b> TxContext): Balance&lt;<a href="sui.md#0x2_sui_SUI">SUI</a>&gt; {
+<pre><code><b>fun</b> <a href="sui.md#0x2_sui_new">new</a>(ctx: &<b>mut</b> TxContext): Balance&lt;<a href="sui.md#0x2_sui_SUI">SUI</a>&gt; {
+    <b>assert</b>!(<a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx) == @0x0, <a href="sui.md#0x2_sui_ENotSystemAddress">ENotSystemAddress</a>);
     <b>assert</b>!(<a href="tx_context.md#0x2_tx_context_epoch">tx_context::epoch</a>(ctx) == 0, <a href="sui.md#0x2_sui_EAlreadyMinted">EAlreadyMinted</a>);
 
     <b>let</b> (treasury, metadata) = <a href="coin.md#0x2_coin_create_currency">coin::create_currency</a>(

--- a/crates/sui-framework/docs/sui_system.md
+++ b/crates/sui-framework/docs/sui_system.md
@@ -41,7 +41,6 @@
 -  [Function `update_candidate_validator_network_pubkey`](#0x2_sui_system_update_candidate_validator_network_pubkey)
 -  [Function `advance_epoch`](#0x2_sui_system_advance_epoch)
 -  [Function `advance_epoch_safe_mode`](#0x2_sui_system_advance_epoch_safe_mode)
--  [Function `consensus_commit_prologue`](#0x2_sui_system_consensus_commit_prologue)
 -  [Function `epoch`](#0x2_sui_system_epoch)
 -  [Function `epoch_start_timestamp_ms`](#0x2_sui_system_epoch_start_timestamp_ms)
 -  [Function `validator_stake_amount`](#0x2_sui_system_validator_stake_amount)
@@ -54,7 +53,6 @@
 
 <pre><code><b>use</b> <a href="">0x1::option</a>;
 <b>use</b> <a href="balance.md#0x2_balance">0x2::balance</a>;
-<b>use</b> <a href="clock.md#0x2_clock">0x2::clock</a>;
 <b>use</b> <a href="coin.md#0x2_coin">0x2::coin</a>;
 <b>use</b> <a href="dynamic_field.md#0x2_dynamic_field">0x2::dynamic_field</a>;
 <b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
@@ -112,7 +110,7 @@ Create a new SuiSystemState object and make it shared.
 This function will be called only once in genesis.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system.md#0x2_sui_system_create">create</a>(validators: <a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, stake_subsidy_fund: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, storage_fund: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, governance_start_epoch: u64, initial_stake_subsidy_amount: u64, protocol_version: u64, system_state_version: u64, epoch_start_timestamp_ms: u64, epoch_duration_ms: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system.md#0x2_sui_system_create">create</a>(id: <a href="object.md#0x2_object_UID">object::UID</a>, validators: <a href="">vector</a>&lt;<a href="validator.md#0x2_validator_Validator">validator::Validator</a>&gt;, stake_subsidy_fund: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, storage_fund: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, governance_start_epoch: u64, initial_stake_subsidy_amount: u64, protocol_version: u64, system_state_version: u64, epoch_start_timestamp_ms: u64, epoch_duration_ms: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -122,6 +120,7 @@ This function will be called only once in genesis.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system.md#0x2_sui_system_create">create</a>(
+    id: UID,
     validators: <a href="">vector</a>&lt;Validator&gt;,
     stake_subsidy_fund: Balance&lt;SUI&gt;,
     storage_fund: Balance&lt;SUI&gt;,
@@ -146,8 +145,7 @@ This function will be called only once in genesis.
         ctx,
     );
     <b>let</b> self = <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a> {
-        // Use a hardcoded ID.
-        id: <a href="object.md#0x2_object_sui_system_state">object::sui_system_state</a>(),
+        id,
         version: system_state_version,
     };
     <a href="dynamic_field.md#0x2_dynamic_field_add">dynamic_field::add</a>(&<b>mut</b> self.id, system_state_version, system_state);
@@ -1194,7 +1192,7 @@ gas coins.
 4. Update all validators.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_advance_epoch">advance_epoch</a>(wrapper: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, new_epoch: u64, next_protocol_version: u64, storage_charge: u64, computation_charge: u64, storage_rebate: u64, storage_fund_reinvest_rate: u64, reward_slashing_rate: u64, epoch_start_timestamp_ms: u64, new_system_state_version: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>fun</b> <a href="sui_system.md#0x2_sui_system_advance_epoch">advance_epoch</a>(storage_reward: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, computation_reward: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, wrapper: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, new_epoch: u64, next_protocol_version: u64, storage_rebate: u64, storage_fund_reinvest_rate: u64, reward_slashing_rate: u64, epoch_start_timestamp_ms: u64, new_system_state_version: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;
 </code></pre>
 
 
@@ -1203,12 +1201,12 @@ gas coins.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_advance_epoch">advance_epoch</a>(
+<pre><code><b>fun</b> <a href="sui_system.md#0x2_sui_system_advance_epoch">advance_epoch</a>(
+    storage_reward: Balance&lt;SUI&gt;,
+    computation_reward: Balance&lt;SUI&gt;,
     wrapper: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>,
     new_epoch: u64,
     next_protocol_version: u64,
-    storage_charge: u64,
-    computation_charge: u64,
     storage_rebate: u64,
     storage_fund_reinvest_rate: u64, // share of storage fund's rewards that's reinvested
                                      // into storage fund, in basis point.
@@ -1216,17 +1214,17 @@ gas coins.
     epoch_start_timestamp_ms: u64, // Timestamp of the epoch start
     new_system_state_version: u64,
     ctx: &<b>mut</b> TxContext,
-) {
+) : Balance&lt;SUI&gt; {
     <b>let</b> self = <a href="sui_system.md#0x2_sui_system_load_system_state_mut">load_system_state_mut</a>(wrapper);
     // Validator will make a special system call <b>with</b> sender set <b>as</b> 0x0.
     <b>assert</b>!(<a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx) == @0x0, 0);
     <b>let</b> old_protocol_version = <a href="sui_system_state_inner.md#0x2_sui_system_state_inner_protocol_version">sui_system_state_inner::protocol_version</a>(self);
-    <a href="sui_system_state_inner.md#0x2_sui_system_state_inner_advance_epoch">sui_system_state_inner::advance_epoch</a>(
+    <b>let</b> storage_rebate = <a href="sui_system_state_inner.md#0x2_sui_system_state_inner_advance_epoch">sui_system_state_inner::advance_epoch</a>(
         self,
         new_epoch,
         next_protocol_version,
-        storage_charge,
-        computation_charge,
+        storage_reward,
+        computation_reward,
         storage_rebate,
         storage_fund_reinvest_rate,
         reward_slashing_rate,
@@ -1243,6 +1241,7 @@ gas coins.
         wrapper.version = new_system_state_version;
         <a href="dynamic_field.md#0x2_dynamic_field_add">dynamic_field::add</a>(&<b>mut</b> wrapper.id, wrapper.version, new_state);
     };
+    storage_rebate
 }
 </code></pre>
 
@@ -1262,7 +1261,7 @@ system running and continue making epoch changes.
 version
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_advance_epoch_safe_mode">advance_epoch_safe_mode</a>(wrapper: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, new_epoch: u64, next_protocol_version: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system.md#0x2_sui_system_advance_epoch_safe_mode">advance_epoch_safe_mode</a>(wrapper: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">sui_system::SuiSystemState</a>, new_epoch: u64, next_protocol_version: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -1271,7 +1270,7 @@ version
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_advance_epoch_safe_mode">advance_epoch_safe_mode</a>(
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system.md#0x2_sui_system_advance_epoch_safe_mode">advance_epoch_safe_mode</a>(
     wrapper: &<b>mut</b> <a href="sui_system.md#0x2_sui_system_SuiSystemState">SuiSystemState</a>,
     new_epoch: u64,
     next_protocol_version: u64,
@@ -1281,37 +1280,6 @@ version
     // Validator will make a special system call <b>with</b> sender set <b>as</b> 0x0.
     <b>assert</b>!(<a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx) == @0x0, 0);
     <a href="sui_system_state_inner.md#0x2_sui_system_state_inner_advance_epoch_safe_mode">sui_system_state_inner::advance_epoch_safe_mode</a>(self, new_epoch, next_protocol_version, ctx)
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0x2_sui_system_consensus_commit_prologue"></a>
-
-## Function `consensus_commit_prologue`
-
-
-
-<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_consensus_commit_prologue">consensus_commit_prologue</a>(<a href="clock.md#0x2_clock">clock</a>: &<b>mut</b> <a href="clock.md#0x2_clock_Clock">clock::Clock</a>, timestamp_ms: u64, ctx: &<a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> entry <b>fun</b> <a href="sui_system.md#0x2_sui_system_consensus_commit_prologue">consensus_commit_prologue</a>(
-    <a href="clock.md#0x2_clock">clock</a>: &<b>mut</b> Clock,
-    timestamp_ms: u64,
-    ctx: &TxContext,
-) {
-    // Validator will make a special system call <b>with</b> sender set <b>as</b> 0x0.
-    <b>assert</b>!(<a href="tx_context.md#0x2_tx_context_sender">tx_context::sender</a>(ctx) == @0x0, 0);
-
-    <a href="clock.md#0x2_clock_set_timestamp">clock::set_timestamp</a>(<a href="clock.md#0x2_clock">clock</a>, timestamp_ms);
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui_system_state_inner.md
+++ b/crates/sui-framework/docs/sui_system_state_inner.md
@@ -1683,7 +1683,7 @@ gas coins.
 4. Update all validators.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x2_sui_system_state_inner_advance_epoch">advance_epoch</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x2_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, new_epoch: u64, next_protocol_version: u64, storage_charge: u64, computation_charge: u64, storage_rebate: u64, storage_fund_reinvest_rate: u64, reward_slashing_rate: u64, epoch_start_timestamp_ms: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x2_sui_system_state_inner_advance_epoch">advance_epoch</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x2_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, new_epoch: u64, next_protocol_version: u64, storage_reward: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, computation_reward: <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;, storage_rebate_amount: u64, storage_fund_reinvest_rate: u64, reward_slashing_rate: u64, epoch_start_timestamp_ms: u64, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="sui.md#0x2_sui_SUI">sui::SUI</a>&gt;
 </code></pre>
 
 
@@ -1696,15 +1696,15 @@ gas coins.
     self: &<b>mut</b> <a href="sui_system_state_inner.md#0x2_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
     new_epoch: u64,
     next_protocol_version: u64,
-    storage_charge: u64,
-    computation_charge: u64,
-    storage_rebate: u64,
+    storage_reward: Balance&lt;SUI&gt;,
+    computation_reward: Balance&lt;SUI&gt;,
+    storage_rebate_amount: u64,
     storage_fund_reinvest_rate: u64, // share of storage fund's rewards that's reinvested
                                      // into storage fund, in basis point.
     reward_slashing_rate: u64, // how much rewards are slashed <b>to</b> punish a <a href="validator.md#0x2_validator">validator</a>, in bps.
     epoch_start_timestamp_ms: u64, // Timestamp of the epoch start
     ctx: &<b>mut</b> TxContext,
-) {
+) : Balance&lt;SUI&gt; {
     self.epoch_start_timestamp_ms = epoch_start_timestamp_ms;
 
     <b>let</b> bps_denominator_u64 = (<a href="sui_system_state_inner.md#0x2_sui_system_state_inner_BASIS_POINT_DENOMINATOR">BASIS_POINT_DENOMINATOR</a> <b>as</b> u64);
@@ -1719,8 +1719,8 @@ gas coins.
     <b>let</b> storage_fund_balance = <a href="balance.md#0x2_balance_value">balance::value</a>(&self.storage_fund);
     <b>let</b> total_stake = storage_fund_balance + total_validators_stake;
 
-    <b>let</b> storage_reward = <a href="balance.md#0x2_balance_create_staking_rewards">balance::create_staking_rewards</a>(storage_charge);
-    <b>let</b> computation_reward = <a href="balance.md#0x2_balance_create_staking_rewards">balance::create_staking_rewards</a>(computation_charge);
+    <b>let</b> storage_charge = <a href="balance.md#0x2_balance_value">balance::value</a>(&storage_reward);
+    <b>let</b> computation_charge = <a href="balance.md#0x2_balance_value">balance::value</a>(&computation_reward);
 
     // Include stake subsidy in the rewards given out <b>to</b> validators and stakers.
     // Delay distributing any stake subsidies until after `governance_start_epoch`.
@@ -1785,8 +1785,8 @@ gas coins.
     <a href="balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> self.storage_fund, computation_reward);
 
     // Destroy the storage rebate.
-    <b>assert</b>!(<a href="balance.md#0x2_balance_value">balance::value</a>(&self.storage_fund) &gt;= storage_rebate, 0);
-    <a href="balance.md#0x2_balance_destroy_storage_rebates">balance::destroy_storage_rebates</a>(<a href="balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> self.storage_fund, storage_rebate));
+    <b>assert</b>!(<a href="balance.md#0x2_balance_value">balance::value</a>(&self.storage_fund) &gt;= storage_rebate_amount, 0);
+    <b>let</b> storage_rebate = <a href="balance.md#0x2_balance_split">balance::split</a>(&<b>mut</b> self.storage_fund, storage_rebate_amount);
 
     <b>let</b> new_total_stake = <a href="validator_set.md#0x2_validator_set_total_stake">validator_set::total_stake</a>(&self.validators);
 
@@ -1798,7 +1798,7 @@ gas coins.
             total_stake: new_total_stake,
             storage_charge,
             storage_fund_reinvestment: (storage_fund_reinvestment_amount <b>as</b> u64),
-            storage_rebate,
+            storage_rebate: storage_rebate_amount,
             storage_fund_balance: <a href="balance.md#0x2_balance_value">balance::value</a>(&self.storage_fund),
             stake_subsidy_amount,
             total_gas_fees: computation_charge,
@@ -1807,6 +1807,7 @@ gas coins.
         }
     );
     self.safe_mode = <b>false</b>;
+    storage_rebate
 }
 </code></pre>
 

--- a/crates/sui-framework/sources/clock.move
+++ b/crates/sui-framework/sources/clock.move
@@ -6,9 +6,10 @@
 module sui::clock {
     use sui::object::{Self, UID};
     use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
 
-    friend sui::genesis;
-    friend sui::sui_system;
+    /// Sender is not @0x0 the system address.
+    const ENotSystemAddress: u64 = 0;
 
     /// Singleton shared object that exposes time to Move calls.  This
     /// object is found at address 0x6, and can only be read (accessed
@@ -35,7 +36,9 @@ module sui::clock {
 
     /// Create and share the singleton Clock -- this function is
     /// called exactly once, during genesis.
-    public(friend) fun create() {
+    fun create(ctx: &TxContext) {
+        assert!(tx_context::sender(ctx) == @0x0, ENotSystemAddress);
+
         transfer::share_object(Clock {
             id: object::clock(),
             // Initialised to zero, but set to a real timestamp by a
@@ -45,9 +48,14 @@ module sui::clock {
         })
     }
 
-    /// Set the Clock's timestamp -- this function should only be called by
-    /// `sui::system_state::consensus_commit_prologue`.
-    public(friend) fun set_timestamp(clock: &mut Clock, timestamp_ms: u64) {
+    fun consensus_commit_prologue(
+        clock: &mut Clock,
+        timestamp_ms: u64,
+        ctx: &TxContext,
+    ) {
+        // Validator will make a special system call with sender set as 0x0.
+        assert!(tx_context::sender(ctx) == @0x0, ENotSystemAddress);
+
         clock.timestamp_ms = timestamp_ms
     }
 

--- a/crates/sui-framework/sources/crypto/bls12381.move
+++ b/crates/sui-framework/sources/crypto/bls12381.move
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module sui::bls12381 {
-    friend sui::validator;
 
-    /// @param signature: A 48-bytes signature that is a point on the G1 subgroup. 
+    /// @param signature: A 48-bytes signature that is a point on the G1 subgroup.
     /// @param public_key: A 96-bytes public key that is a point on the G2 subgroup.
     /// @param msg: The message that we test the signature against.
     ///

--- a/crates/sui-framework/sources/crypto/ed25519.move
+++ b/crates/sui-framework/sources/crypto/ed25519.move
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module sui::ed25519 {
-    friend sui::validator;
     /// @param signature: 32-byte signature that is a point on the Ed25519 elliptic curve.
     /// @param public_key: 32-byte signature that is a point on the Ed25519 elliptic curve.
     /// @param msg: The message that we test the signature against.
@@ -10,17 +9,4 @@ module sui::ed25519 {
     /// If the signature is a valid Ed25519 signature of the message and public key, return true.
     /// Otherwise, return false.
     public native fun ed25519_verify(signature: &vector<u8>, public_key: &vector<u8>, msg: &vector<u8>): bool;
-
-    /// @param signature: 32-byte signature that is a point on the Ed25519 elliptic curve.
-    /// @param public_key: 32-byte signature that is a point on the Ed25519 elliptic curve.
-    /// @param msg: The message that we test the signature against.
-    /// @param domain: The domain that the signature is tested again. We essentially prepend this to the message.
-    ///
-    /// If the signature is a valid Ed25519 signature of the message and public key, return true.
-    /// Otherwise, return false.
-    public(friend) fun ed25519_verify_with_domain(signature: &vector<u8>, public_key: &vector<u8>, msg: vector<u8>, domain: vector<u8>): bool {
-        std::vector::append(&mut domain, msg);
-        ed25519_verify(signature, public_key, &domain)
-    }
-
 }

--- a/crates/sui-framework/sources/governance/genesis.move
+++ b/crates/sui-framework/sources/governance/genesis.move
@@ -4,9 +4,9 @@
 module sui::genesis {
     use std::vector;
 
-    use sui::balance::{Balance, Self};
+    use sui::balance::{Self, Balance};
     use sui::coin;
-    use sui::clock;
+    use sui::object::UID;
     use sui::sui::{Self, SUI};
     use sui::sui_system;
     use sui::tx_context::{Self, TxContext};
@@ -63,6 +63,8 @@ module sui::genesis {
     /// It will create a singleton SuiSystemState object, which contains
     /// all the information we need in the system.
     fun create(
+        sui_system_state_id: UID,
+        sui_supply: Balance<SUI>,
         genesis_chain_parameters: GenesisChainParameters,
         genesis_validators: vector<GenesisValidatorMetadata>,
         token_distribution_schedule: TokenDistributionSchedule,
@@ -78,7 +80,6 @@ module sui::genesis {
             allocations,
         } = token_distribution_schedule;
 
-        let sui_supply = sui::new(ctx);
         let subsidy_fund = balance::split(
             &mut sui_supply,
             stake_subsidy_fund_mist,
@@ -150,6 +151,7 @@ module sui::genesis {
         activate_validators(&mut validators);
 
         sui_system::create(
+            sui_system_state_id,
             validators,
             subsidy_fund,
             storage_fund,
@@ -161,8 +163,6 @@ module sui::genesis {
             genesis_chain_parameters.epoch_duration_ms,
             ctx,
         );
-
-        clock::create();
     }
 
     fun allocate_tokens(

--- a/crates/sui-framework/sources/object.move
+++ b/crates/sui-framework/sources/object.move
@@ -10,7 +10,6 @@ module sui::object {
     friend sui::clock;
     friend sui::dynamic_field;
     friend sui::dynamic_object_field;
-    friend sui::sui_system;
     friend sui::transfer;
 
     #[test_only]
@@ -21,6 +20,9 @@ module sui::object {
 
     /// The hardcoded ID for the singleton Clock Object.
     const SUI_CLOCK_OBJECT_ID: address = @0x6;
+
+    /// Sender is not @0x0 the system address.
+    const ENotSystemAddress: u64 = 0;
 
     /// An object ID. This is used to reference Sui Objects.
     /// This is *not* guaranteed to be globally unique--anyone can create an `ID` from a `UID` or
@@ -78,7 +80,8 @@ module sui::object {
 
     /// Create the `UID` for the singleton `SuiSystemState` object.
     /// This should only be called once from `sui_system`.
-    public(friend) fun sui_system_state(): UID {
+    fun sui_system_state(ctx: &TxContext): UID {
+        assert!(tx_context::sender(ctx) == @0x0, ENotSystemAddress);
         UID {
             id: ID { bytes: SUI_SYSTEM_STATE_OBJECT_ID },
         }

--- a/crates/sui-framework/sources/sui.move
+++ b/crates/sui-framework/sources/sui.move
@@ -10,9 +10,9 @@ module sui::sui {
     use sui::transfer;
     use sui::coin;
 
-    friend sui::genesis;
-
     const EAlreadyMinted: u64 = 0;
+    /// Sender is not @0x0 the system address.
+    const ENotSystemAddress: u64 = 1;
 
     /// The amount of Mist per Sui token based on the the fact that mist is
     /// 10^-9 of a Sui token
@@ -29,11 +29,12 @@ module sui::sui {
 
     /// Register the `SUI` Coin to acquire its `Supply`.
     /// This should be called only once during genesis creation.
-    public(friend) fun new(ctx: &mut TxContext): Balance<SUI> {
+    fun new(ctx: &mut TxContext): Balance<SUI> {
+        assert!(tx_context::sender(ctx) == @0x0, ENotSystemAddress);
         assert!(tx_context::epoch(ctx) == 0, EAlreadyMinted);
 
         let (treasury, metadata) = coin::create_currency(
-            SUI {}, 
+            SUI {},
             9,
             b"SUI",
             b"Sui",

--- a/crates/sui-framework/tests/governance_test_utils.move
+++ b/crates/sui-framework/tests/governance_test_utils.move
@@ -5,6 +5,7 @@
 module sui::governance_test_utils {
     use sui::address;
     use sui::balance;
+    use sui::object;
     use sui::sui::SUI;
     use sui::coin::{Self, Coin};
     use sui::staking_pool::{Self, StakedSui, StakingPool};
@@ -59,6 +60,7 @@ module sui::governance_test_utils {
         validators: vector<Validator>, sui_supply_amount: u64, storage_fund_amount: u64, ctx: &mut TxContext
     ) {
         sui_system::create(
+            object::new(ctx), // it doesn't matter what ID sui system state has in tests
             validators,
             balance::create_for_testing<SUI>(sui_supply_amount), // sui_supply
             balance::create_for_testing<SUI>(storage_fund_amount), // storage_fund
@@ -111,7 +113,7 @@ module sui::governance_test_utils {
 
         let ctx = test_scenario::ctx(scenario);
 
-        sui_system::advance_epoch(&mut system_state, new_epoch, 1, storage_charge, computation_charge, 0, 0, 0, 0, 1, ctx);
+        sui_system::advance_epoch_for_testing(&mut system_state, new_epoch, 1, storage_charge, computation_charge, 0, 0, 0, 0, 1, ctx);
         test_scenario::return_shared(system_state);
         test_scenario::next_epoch(scenario, @0x0);
     }
@@ -128,7 +130,7 @@ module sui::governance_test_utils {
 
         let ctx = test_scenario::ctx(scenario);
 
-        sui_system::advance_epoch(
+        sui_system::advance_epoch_for_testing(
             &mut system_state, new_epoch, 1, storage_charge, computation_charge, 0, 0, reward_slashing_rate, 0, 1, ctx
         );
         test_scenario::return_shared(system_state);

--- a/crates/sui-types/src/balance.rs
+++ b/crates/sui-types/src/balance.rs
@@ -12,6 +12,8 @@ use serde::Deserialize;
 use serde::Serialize;
 pub const BALANCE_MODULE_NAME: &IdentStr = ident_str!("balance");
 pub const BALANCE_STRUCT_NAME: &IdentStr = ident_str!("Balance");
+pub const BALANCE_CREATE_REWARDS_FUNCTION_NAME: &IdentStr = ident_str!("create_staking_rewards");
+pub const BALANCE_DESTROY_REBATES_FUNCTION_NAME: &IdentStr = ident_str!("destroy_storage_rebates");
 
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
 pub struct Supply {

--- a/crates/sui-types/src/clock.rs
+++ b/crates/sui-types/src/clock.rs
@@ -8,6 +8,8 @@ use crate::{id::UID, SUI_FRAMEWORK_ADDRESS};
 
 pub const CLOCK_MODULE_NAME: &IdentStr = ident_str!("clock");
 pub const CLOCK_STRUCT_NAME: &IdentStr = ident_str!("Clock");
+pub const CONSENSUS_COMMIT_PROLOGUE_FUNCTION_NAME: &IdentStr =
+    ident_str!("consensus_commit_prologue");
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Clock {

--- a/crates/sui-types/src/sui_system_state/mod.rs
+++ b/crates/sui-types/src/sui_system_state/mod.rs
@@ -27,8 +27,6 @@ const SUI_SYSTEM_STATE_WRAPPER_STRUCT_NAME: &IdentStr = ident_str!("SuiSystemSta
 pub const SUI_SYSTEM_MODULE_NAME: &IdentStr = ident_str!("sui_system");
 pub const ADVANCE_EPOCH_FUNCTION_NAME: &IdentStr = ident_str!("advance_epoch");
 pub const ADVANCE_EPOCH_SAFE_MODE_FUNCTION_NAME: &IdentStr = ident_str!("advance_epoch_safe_mode");
-pub const CONSENSUS_COMMIT_PROLOGUE_FUNCTION_NAME: &IdentStr =
-    ident_str!("consensus_commit_prologue");
 
 pub const INIT_SYSTEM_STATE_VERSION: u64 = 1;
 


### PR DESCRIPTION
## Description 

This PR removes the friendship between modules in `governance` folder and modules that are not. This is preparation for separating `governance` into its own package.

A few things are changed to make this happen:
- Some `public(friend)` functions are made private
- The signatures of genesis and epoch change function are changed
- Genesis and epoch change are now multi-step programmable txns executed in `System` mode


## Test Plan 

Making sure existing tests pass.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
