### PR TITLE
Make change in signing a versioned operation

### DIFF
--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -209,6 +209,7 @@ async fn check_gas(
             gas_price,
             more_gas_objects,
             &cost_table,
+            protocol_config,
         )?;
 
         gas::start_gas_metering(

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -865,6 +865,10 @@ impl ProtocolConfig {
     pub fn set_buffer_stake_for_protocol_upgrade_bps_for_testing(&mut self, b: u64) {
         self.buffer_stake_for_protocol_upgrade_bps = Some(b)
     }
+
+    pub fn set_gas_checks_v2(&mut self, b: bool) {
+        self.feature_flags.gas_buckets_sub_and_storage_computation = b;
+    }
 }
 
 type OverrideFn = dyn Fn(ProtocolVersion, ProtocolConfig) -> ProtocolConfig + Send;


### PR DESCRIPTION
## Description 

Protect the fix for signing with a version check.
The worry here is that while the system is upgrading a version unprotected behavior may lead to different results in signing. If that should not cause forking it may create equivocation and objects locked for an epoch

## Test Plan 

Existing tests and writing few specific ones

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
