### PR TITLE
[rpc] Return balances for multiGetTransactions (#9513)

### DIFF
--- a/crates/sui-json-rpc-types/src/balance_changes.rs
+++ b/crates/sui-json-rpc-types/src/balance_changes.rs
@@ -19,5 +19,7 @@ pub struct BalanceChange {
     pub coin_type: TypeTag,
     /// The amount indicate the balance value changes,
     /// negative amount means spending coin value and positive means receiving coin value.
+    #[schemars(with = "String")]
+    #[serde_as(as = "DisplayFromStr")]
     pub amount: i128,
 }

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -162,6 +162,10 @@ impl SuiTransactionResponseOptions {
         self.show_balance_changes || self.show_object_changes
     }
 
+    pub fn require_input(&self) -> bool {
+        self.show_input || self.show_object_changes
+    }
+
     pub fn require_effects(&self) -> bool {
         self.show_effects
             || self.show_events

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -2743,8 +2743,7 @@
         "properties": {
           "amount": {
             "description": "The amount indicate the balance value changes, negative amount means spending coin value and positive means receiving coin value.",
-            "type": "integer",
-            "format": "int128"
+            "type": "string"
           },
           "coinType": {
             "type": "string"

--- a/sdk/typescript/src/types/coin.ts
+++ b/sdk/typescript/src/types/coin.ts
@@ -17,6 +17,7 @@ import { ObjectId, TransactionDigest } from './common';
 
 export const CoinStruct = object({
   coinType: string(),
+  // TODO(chris): rename this to objectId
   coinObjectId: ObjectId,
   version: number(),
   digest: TransactionDigest,

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -349,6 +349,13 @@ export const SuiObjectChange = union([
 ]);
 export type SuiObjectChange = Infer<typeof SuiObjectChange>;
 
+export const BalanceChange = object({
+  owner: ObjectOwner,
+  coinType: string(),
+  /* Coin balance change(positive means receive, negative means send) */
+  amount: string(),
+});
+
 export const SuiTransactionResponse = object({
   digest: TransactionDigest,
   transaction: optional(SuiTransaction),
@@ -358,6 +365,7 @@ export const SuiTransactionResponse = object({
   checkpoint: optional(number()),
   confirmedLocalExecution: optional(boolean()),
   objectChanges: optional(array(SuiObjectChange)),
+  balanceChanges: optional(array(BalanceChange)),
   /* Errors that occurred in fetching/serializing the transaction. */
   errors: optional(array(string())),
 });
@@ -370,9 +378,10 @@ export const SuiTransactionResponseOptions = object({
   showEffects: optional(boolean()),
   /* Whether to show transaction events. Default to be false. */
   showEvents: optional(boolean()),
-  /* Whether to show transaction events. Default to be false. */
+  /* Whether to show object changes. Default to be false. */
   showObjectChanges: optional(boolean()),
-  // MUSTFIX(chris): add showBalanceChanges
+  /* Whether to show coin balance changes. Default to be false. */
+  showBalanceChanges: optional(boolean()),
 });
 
 export type SuiTransactionResponseOptions = Infer<


### PR DESCRIPTION
## Description 

Return balances for multiGetTransactions

## Test Plan 

Add ts e2e tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
