### PR TITLE
Make fake gas coin for dry-run an amount big enough to cover for many scenarios

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1016,11 +1016,13 @@ impl AuthorityState {
         let mut gas_object_refs = transaction.gas().to_vec();
         let (gas_status, input_objects) = if transaction.gas().is_empty() {
             let sender = transaction.sender();
-            let protocol_config = epoch_store.protocol_config();
-            let max_tx_gas = protocol_config.max_tx_gas();
+            // use a 100M sui coin
+            const MIST_TO_SUI: u64 = 1_000_000_000;
+            const DRY_RUN_SUI: u64 = 100_000_000;
+            let max_coin_value = MIST_TO_SUI * DRY_RUN_SUI;
             let gas_object_id = ObjectID::random();
             let gas_object = Object::new_move(
-                MoveObject::new_gas_coin(OBJECT_START_VERSION, gas_object_id, max_tx_gas),
+                MoveObject::new_gas_coin(OBJECT_START_VERSION, gas_object_id, max_coin_value),
                 Owner::AddressOwner(sender),
                 TransactionDigest::genesis(),
             );


### PR DESCRIPTION
## Description 

Dry-run was using max gas budget as a "fake" coin when no gas was provided, however with programmable transaction that may be a too small value that would stop some scenarios.
Making that 100M SUI which should allow for every scenario to work

## Test Plan 

Bad repro from @Jordan-Mysten, 
added unit test

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
