### PR TITLE
[hardening] dynamic checks for ensuring all objects read by a tx have…

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/read_field_from_immutable.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/read_field_from_immutable.exp
@@ -1,0 +1,15 @@
+processed 4 tasks
+
+init:
+A: object(100)
+
+task 1 'publish'. lines 9-30:
+created: object(105)
+written: object(104)
+
+task 2 'run'. lines 32-32:
+created: object(107), object(108)
+written: object(106)
+
+task 3 'run'. lines 34-34:
+written: object(109)

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/read_field_from_immutable.move
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/read_field_from_immutable.move
@@ -1,0 +1,34 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// similar to dynamic_field_tests but over multiple transactions, as this uses a different code path
+// test duplicate add
+
+//# init --addresses a=0x0 --accounts A
+
+//# publish
+module a::m {
+
+use sui::dynamic_field::{add, borrow};
+use sui::object;
+use sui::tx_context::TxContext;
+
+struct Obj has key {
+    id: object::UID,
+}
+
+entry fun add_then_freeze(ctx: &mut TxContext) {
+    let id = object::new(ctx);
+    add<u64, u64>(&mut id, 0, 0);
+    sui::transfer::freeze_object(Obj { id })
+}
+
+entry fun read_from_frozen(obj: &Obj) {
+    let _ = borrow<u64, u64>(&obj.id, 0);
+}
+
+}
+
+//# run a::m::add_then_freeze --sender A
+
+//# run a::m::read_from_frozen --sender A --args object(107)

--- a/crates/sui-adapter-transactional-tests/tests/sui/unwrap_then_freeze.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/unwrap_then_freeze.exp
@@ -1,0 +1,31 @@
+processed 7 tasks
+
+init:
+A: object(100)
+
+task 1 'publish'. lines 9-42:
+created: object(105)
+written: object(104)
+
+task 2 'run'. lines 44-44:
+created: object(107)
+written: object(106)
+
+task 3 'view-object'. lines 46-46:
+Owner: Account Address ( A )
+Version: 2
+Contents: test::object_basics::Object {id: sui::object::UID {id: sui::object::ID {bytes: fake(107)}}, value: 10u64}
+
+task 4 'run'. lines 48-48:
+created: object(109)
+written: object(108)
+deleted: object(107)
+
+task 5 'run'. lines 50-50:
+written: object(107), object(110)
+deleted: object(109)
+
+task 6 'view-object'. lines 52-52:
+Owner: Immutable
+Version: 4
+Contents: test::object_basics::Object {id: sui::object::UID {id: sui::object::ID {bytes: fake(107)}}, value: 10u64}

--- a/crates/sui-adapter-transactional-tests/tests/sui/unwrap_then_freeze.move
+++ b/crates/sui-adapter-transactional-tests/tests/sui/unwrap_then_freeze.move
@@ -1,0 +1,52 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Exercise test functions that wrap and object and subsequently unwrap it
+// Ensure that the object's version is consistent
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+
+module test::object_basics {
+    use sui::object::{Self, UID};
+    use sui::tx_context::{Self, TxContext};
+    use sui::transfer;
+
+    struct Object has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    struct Wrapper has key {
+        id: UID,
+        o: Object
+    }
+
+    public entry fun create(value: u64, recipient: address, ctx: &mut TxContext) {
+        transfer::transfer(
+            Object { id: object::new(ctx), value },
+            recipient
+        )
+    }
+
+    public entry fun wrap(o: Object, ctx: &mut TxContext) {
+        transfer::transfer(Wrapper { id: object::new(ctx), o }, tx_context::sender(ctx))
+    }
+
+    public entry fun unwrap_and_freeze(w: Wrapper) {
+        let Wrapper { id, o } = w;
+        object::delete(id);
+        transfer::freeze_object(o)
+    }
+}
+
+//# run test::object_basics::create --args 10 @A
+
+//# view-object 107
+
+//# run test::object_basics::wrap --args object(107) --sender A
+
+//# run test::object_basics::unwrap_and_freeze --args object(109) --sender A
+
+//# view-object 107

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -82,6 +82,12 @@ pub const SUI_SYSTEM_OBJ_CALL_ARG: CallArg = CallArg::Object(ObjectArg::SharedOb
 pub const SUI_CLOCK_OBJECT_ID: ObjectID = ObjectID::from_single_byte(6);
 pub const SUI_CLOCK_OBJECT_SHARED_VERSION: SequenceNumber = OBJECT_START_VERSION;
 
+/// Return `true` if `id` is a special system package that can be upgraded at epoch boundaries
+/// All new system package ID's must be added here
+pub fn is_system_package(id: ObjectID) -> bool {
+    matches!(id, MOVE_STDLIB_OBJECT_ID | SUI_FRAMEWORK_OBJECT_ID)
+}
+
 const fn get_hex_address_two() -> AccountAddress {
     let mut addr = [0u8; AccountAddress::LENGTH];
     addr[AccountAddress::LENGTH - 1] = 2u8;
@@ -100,10 +106,6 @@ pub fn parse_sui_struct_tag(s: &str) -> anyhow::Result<StructTag> {
 pub fn parse_sui_type_tag(s: &str) -> anyhow::Result<TypeTag> {
     use move_command_line_common::types::ParsedType;
     ParsedType::parse(s)?.into_type_tag(&resolve_address)
-}
-
-pub fn is_system_package(id: ObjectID) -> bool {
-    matches!(id, MOVE_STDLIB_OBJECT_ID | SUI_FRAMEWORK_OBJECT_ID)
 }
 
 fn resolve_address(addr: &str) -> Option<AccountAddress> {


### PR DESCRIPTION
… been authenticated

## Description 

One of the key security properties of a Sui transaction is that it should only read objects that have been authenticated: e.g., the object is owned directly by the sender, is shared or immutable, or is indirectly owned by the sender or an input object.

This adds a dynamic check at the end of tx execution to ensure that every object accessed can be authenticated w.r.t one of the roots. For now, we gate this to run in debug mode only.

## Test Plan 

All of the existing tests pass with the addition of this check, which is good! 

There was a dev inspect test using unowned objects that broke until I special-cased dev-inspect, which is a good sign for the positive case.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
