### PR TITLE
[Narwhal] use mysten histogram for committed_certificates metric

### DIFF
--- a/narwhal/consensus/src/bullshark.rs
+++ b/narwhal/consensus/src/bullshark.rs
@@ -233,7 +233,7 @@ impl ConsensusProtocol for Bullshark {
 
         self.metrics
             .committed_certificates
-            .observe(total_committed_certificates as f64);
+            .report(total_committed_certificates as u64);
 
         Ok((Outcome::Commit, committed_sub_dags))
     }

--- a/narwhal/consensus/src/dag.rs
+++ b/narwhal/consensus/src/dag.rs
@@ -32,8 +32,6 @@ pub mod dag_tests;
 /// consensus running on top of it. This is a [`fastcrypto::traits::VerifyingKey`], [`Certificate`] and [`Round`]-aware
 ///  variant of the Dag, with a secondary index to link a (pubkey, round) pair to the possible
 /// certified collection by that authority at that round.
-///
-#[derive(Debug)]
 struct InnerDag {
     /// Receives new certificates from the primary. The primary should send us new certificates only
     /// if it already sent us its whole history.

--- a/narwhal/consensus/src/metrics.rs
+++ b/narwhal/consensus/src/metrics.rs
@@ -1,10 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use prometheus::{
-    default_registry, register_histogram_with_registry, register_int_counter_vec_with_registry,
-    register_int_counter_with_registry, register_int_gauge_vec_with_registry,
-    register_int_gauge_with_registry, Histogram, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
-    Registry,
+    default_registry, linear_buckets, register_histogram_with_registry,
+    register_int_counter_vec_with_registry, register_int_counter_with_registry,
+    register_int_gauge_vec_with_registry, register_int_gauge_with_registry, Histogram, IntCounter,
+    IntCounterVec, IntGauge, IntGaugeVec, Registry,
 };
 
 const LATENCY_SEC_BUCKETS: &[f64] = &[
@@ -92,11 +92,14 @@ impl ConsensusMetrics {
             committed_certificates: register_histogram_with_registry!(
                 "committed_certificates",
                 "The number of certificates committed on a commit round",
-                // buckets in number of certificates
-                vec![
-                    0.0, 5.0, 10.0, 20.0, 30.0, 40.0, 50.0, 100.0, 150.0,
-                    200.0, 300.0, 400.0, 500.0, 1_000.0, 2_000.0, 5_000.0
-                ],
+                // total 64 buckets in number of certificates, up to 950.
+                [
+                    linear_buckets(1.0, 1.0, 9).unwrap(), 
+                    linear_buckets(10.0, 2.0, 15).unwrap(),
+                    linear_buckets(40.0, 5.0, 10).unwrap(), 
+                    linear_buckets(100.0, 10.0, 15).unwrap(),
+                    linear_buckets(250.0, 50.0, 15).unwrap(),
+                ].concat(),
                 registry
             ).unwrap(),
             certificate_commit_latency: register_histogram_with_registry!(


### PR DESCRIPTION
## Description 

Otherwise width of 50 is too coarse grained for the range we are interested in.

## Test Plan 

n/a

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
