### PR TITLE
Do not use specific system state version for benchmarking

### DIFF
--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -21,7 +21,7 @@ use sui_types::error::UserInputError;
 use sui_types::fp_ensure;
 use sui_types::message_envelope::Message;
 use sui_types::object::Object;
-use sui_types::sui_system_state::{SuiSystemStateInnerBenchmark, SuiSystemStateTrait};
+use sui_types::sui_system_state::{SuiSystemState, SuiSystemStateTrait};
 use sui_types::{
     base_types::*,
     committee::{Committee, ProtocolVersion},
@@ -926,10 +926,10 @@ where
     /// It should only be used for testing or benchmarking.
     pub async fn get_latest_system_state_object_for_testing(
         &self,
-    ) -> anyhow::Result<SuiSystemStateInnerBenchmark> {
+    ) -> anyhow::Result<SuiSystemState> {
         #[derive(Debug, Default)]
         struct State {
-            latest_system_state: Option<SuiSystemStateInnerBenchmark>,
+            latest_system_state: Option<SuiSystemState>,
             total_weight: StakeUnit,
         }
         let initial_state = State::default();

--- a/crates/sui-core/src/authority_client.rs
+++ b/crates/sui-core/src/authority_client.rs
@@ -12,7 +12,7 @@ use sui_types::base_types::AuthorityName;
 use sui_types::committee::CommitteeWithNetworkMetadata;
 use sui_types::messages_checkpoint::{CheckpointRequest, CheckpointResponse};
 use sui_types::multiaddr::Multiaddr;
-use sui_types::sui_system_state::SuiSystemStateInnerBenchmark;
+use sui_types::sui_system_state::SuiSystemState;
 use sui_types::{error::SuiError, messages::*};
 
 use sui_network::tonic::transport::Channel;
@@ -53,7 +53,7 @@ pub trait AuthorityAPI {
     async fn handle_system_state_object(
         &self,
         request: SystemStateRequest,
-    ) -> Result<SuiSystemStateInnerBenchmark, SuiError>;
+    ) -> Result<SuiSystemState, SuiError>;
 }
 
 #[derive(Clone)]
@@ -150,7 +150,7 @@ impl AuthorityAPI for NetworkAuthorityClient {
     async fn handle_system_state_object(
         &self,
         request: SystemStateRequest,
-    ) -> Result<SuiSystemStateInnerBenchmark, SuiError> {
+    ) -> Result<SuiSystemState, SuiError> {
         self.client()
             .get_system_state_object(request)
             .await

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -16,7 +16,8 @@ use sui_network::{
     tonic,
 };
 use sui_types::multiaddr::Multiaddr;
-use sui_types::{error::*, messages::*, sui_system_state::SuiSystemStateInnerBenchmark};
+use sui_types::sui_system_state::SuiSystemState;
+use sui_types::{error::*, messages::*};
 use sui_types::{
     fp_ensure,
     messages_checkpoint::{CheckpointRequest, CheckpointResponse},
@@ -487,12 +488,8 @@ impl Validator for ValidatorService {
     async fn get_system_state_object(
         &self,
         _request: tonic::Request<SystemStateRequest>,
-    ) -> Result<tonic::Response<SuiSystemStateInnerBenchmark>, tonic::Status> {
-        let response = self
-            .state
-            .database
-            .get_sui_system_state_object()?
-            .into_benchmark_version();
+    ) -> Result<tonic::Response<SuiSystemState>, tonic::Status> {
+        let response = self.state.database.get_sui_system_state_object()?;
 
         return Ok(tonic::Response::new(response));
     }

--- a/crates/sui-core/src/safe_client.rs
+++ b/crates/sui-core/src/safe_client.rs
@@ -12,7 +12,7 @@ use sui_types::crypto::AuthorityPublicKeyBytes;
 use sui_types::messages_checkpoint::{
     CertifiedCheckpointSummary, CheckpointRequest, CheckpointResponse, CheckpointSequenceNumber,
 };
-use sui_types::sui_system_state::SuiSystemStateInnerBenchmark;
+use sui_types::sui_system_state::SuiSystemState;
 use sui_types::{base_types::*, committee::*, fp_ensure};
 use sui_types::{
     error::{SuiError, SuiResult},
@@ -466,9 +466,7 @@ where
         Ok(resp)
     }
 
-    pub async fn handle_system_state_object(
-        &self,
-    ) -> Result<SuiSystemStateInnerBenchmark, SuiError> {
+    pub async fn handle_system_state_object(&self) -> Result<SuiSystemState, SuiError> {
         self.authority_client
             .handle_system_state_object(SystemStateRequest { _unused: false })
             .await

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -11,6 +11,8 @@ use crate::{authority::AuthorityState, authority_client::AuthorityAPI};
 use async_trait::async_trait;
 use mysten_metrics::spawn_monitored_task;
 use sui_config::genesis::Genesis;
+use sui_types::messages::TransactionEvents;
+use sui_types::sui_system_state::SuiSystemState;
 use sui_types::{
     committee::Committee,
     crypto::AuthorityKeyPair,
@@ -23,7 +25,6 @@ use sui_types::{
     messages_checkpoint::{CheckpointRequest, CheckpointResponse},
 };
 use sui_types::{error::SuiResult, messages::HandleCertificateResponse};
-use sui_types::{messages::TransactionEvents, sui_system_state::SuiSystemStateInnerBenchmark};
 
 #[derive(Clone, Copy, Default)]
 pub struct LocalAuthorityClientFaultConfig {
@@ -106,12 +107,8 @@ impl AuthorityAPI for LocalAuthorityClient {
     async fn handle_system_state_object(
         &self,
         _request: SystemStateRequest,
-    ) -> Result<SuiSystemStateInnerBenchmark, SuiError> {
-        Ok(self
-            .state
-            .database
-            .get_sui_system_state_object()?
-            .into_benchmark_version())
+    ) -> Result<SuiSystemState, SuiError> {
+        Ok(self.state.database.get_sui_system_state_object()?)
     }
 }
 
@@ -251,7 +248,7 @@ impl AuthorityAPI for MockAuthorityApi {
     async fn handle_system_state_object(
         &self,
         _request: SystemStateRequest,
-    ) -> Result<SuiSystemStateInnerBenchmark, SuiError> {
+    ) -> Result<SuiSystemState, SuiError> {
         unimplemented!();
     }
 }
@@ -301,7 +298,7 @@ impl AuthorityAPI for HandleTransactionTestAuthorityClient {
     async fn handle_system_state_object(
         &self,
         _request: SystemStateRequest,
-    ) -> Result<SuiSystemStateInnerBenchmark, SuiError> {
+    ) -> Result<SuiSystemState, SuiError> {
         unimplemented!()
     }
 }

--- a/crates/sui-network/build.rs
+++ b/crates/sui-network/build.rs
@@ -72,7 +72,7 @@ fn main() -> Result<()> {
                 .name("get_system_state_object")
                 .route_name("GetSystemStateObject")
                 .input_type("sui_types::messages::SystemStateRequest")
-                .output_type("sui_types::sui_system_state::SuiSystemStateInnerBenchmark")
+                .output_type("sui_types::sui_system_state::SuiSystemState")
                 .codec_path(codec_path)
                 .build(),
         )

--- a/crates/sui-types/src/sui_system_state/mod.rs
+++ b/crates/sui-types/src/sui_system_state/mod.rs
@@ -84,9 +84,6 @@ pub enum SuiSystemState {
 /// This is the fixed type used by genesis.
 pub type SuiSystemStateInnerGenesis = SuiSystemStateInnerV1;
 
-/// This is the fixed type used by benchmarking.
-pub type SuiSystemStateInnerBenchmark = SuiSystemStateInnerV1;
-
 impl SuiSystemState {
     pub fn new_genesis(inner: SuiSystemStateInnerGenesis) -> Self {
         Self::V1(inner)
@@ -98,16 +95,6 @@ impl SuiSystemState {
         match self {
             SuiSystemState::V1(inner) => inner,
         }
-    }
-
-    pub fn into_benchmark_version(self) -> SuiSystemStateInnerBenchmark {
-        match self {
-            SuiSystemState::V1(inner) => inner,
-        }
-    }
-
-    pub fn new_for_benchmarking(inner: SuiSystemStateInnerBenchmark) -> Self {
-        Self::V1(inner)
     }
 
     pub fn new_for_testing(epoch: EpochId) -> Self {


### PR DESCRIPTION
Support arbitrary versions of system state object for benchmarking/stress, instead of a fixed version. This allows stress to work when we upgrade system state type.