### PR TITLE
[indexer] Integrate indexer into sui-test-validator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8616,6 +8616,7 @@ dependencies = [
  "sui-core",
  "sui-faucet",
  "sui-framework-build",
+ "sui-indexer",
  "sui-json",
  "sui-json-rpc-types",
  "sui-keys",
@@ -8911,7 +8912,9 @@ dependencies = [
  "test-utils",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tracing",
+ "url",
  "workspace-hack",
 ]
 

--- a/crates/sui-cluster-test/Cargo.toml
+++ b/crates/sui-cluster-test/Cargo.toml
@@ -24,6 +24,7 @@ prometheus = "0.13.3"
 fastcrypto = { workspace = true }
 shared-crypto = { path = "../shared-crypto" }
 
+sui-indexer = { path = "../sui-indexer" }
 sui-faucet = { path = "../sui-faucet" }
 sui-swarm = { path = "../sui-swarm" }
 sui = { path = "../sui" }

--- a/crates/sui-cluster-test/src/config.rs
+++ b/crates/sui-cluster-test/src/config.rs
@@ -24,6 +24,12 @@ pub struct ClusterTestOpt {
     pub fullnode_address: Option<String>,
     #[clap(long)]
     pub epoch_duration_ms: Option<u64>,
+    /// URL for the indexer RPC server
+    #[clap(long)]
+    pub indexer_address: Option<String>,
+    /// URL for the Indexer Postgres DB
+    #[clap(long)]
+    pub pg_address: Option<String>,
 }
 
 impl ClusterTestOpt {
@@ -33,6 +39,8 @@ impl ClusterTestOpt {
             faucet_address: None,
             fullnode_address: None,
             epoch_duration_ms: None,
+            indexer_address: None,
+            pg_address: None,
         }
     }
 }

--- a/crates/sui-indexer/Cargo.toml
+++ b/crates/sui-indexer/Cargo.toml
@@ -24,6 +24,8 @@ serde_json = "1.0.83"
 thiserror = "1.0.34"
 tracing = "0.1.36"
 tokio = { workspace = true, features = ["full"] }
+tokio-stream = { version = "0.1.8", features = ["sync", "net"] }
+url = "2.3.1"
 
 fastcrypto = { workspace = true, features = ["copy_key"] }
 mysten-metrics = { path = "../mysten-metrics" }
@@ -43,11 +45,12 @@ telemetry-subscribers.workspace = true
 move-core-types.workspace = true
 move-bytecode-utils.workspace = true
 
+diesel_migrations = { version = "2.0.0" }
+
 [features]
 pg_integration = []
 
 [dev-dependencies]
-diesel_migrations = "2.0.0"
 sui-framework-build = { path = "../sui-framework-build" }
 sui-keys = { path = "../sui-keys" }
 test-utils = { path = "../test-utils" }

--- a/crates/sui-indexer/README.md
+++ b/crates/sui-indexer/README.md
@@ -6,7 +6,7 @@ Sui indexer is an off-fullnode service to serve data from Sui protocol, includin
 
 ## Steps to run locally
 ### Prerequisites
-- install local [Postgres server](https://www.postgresql.org/download/). You can also `brew install postgres@version` and then add the following to your `~/.zshrc` `~/.zprofile` etc: 
+- install local [Postgres server](https://www.postgresql.org/download/). You can also `brew install postgres@version` and then add the following to your `~/.zshrc` or `~/.zprofile`, etc: 
 ```sh
 export LDFLAGS="-L/opt/homebrew/opt/postgresql@15/lib"
 export CPPFLAGS="-I/opt/homebrew/opt/postgresql@15/include"
@@ -14,10 +14,16 @@ export PATH="/opt/homebrew/opt/postgresql@15/bin:$PATH"
 ```
 - make sure you have libpq installed: `brew install libpq`, and in your profile, add `export PATH="/opt/homebrew/opt/libpq/bin:$PATH"`. If this doesn't work, try `brew link --force libpq`.
 
-- install Diesel CLI, you can follow the [Diesel Getting Started guide](https://diesel.rs/guides/getting-started) up to the *Write Rust* section
+- install Diesel CLI with `cargo install diesel_cli --no-default-features --features postgres`, refer to [Diesel Getting Started guide](https://diesel.rs/guides/getting-started) for more details
 - [optional but handy] Postgres client like [Postico](https://eggerapps.at/postico2/), for local check, query execution etc.
 
-### Steps
+
+### Local Development(Recommended)
+
+Use [sui-test-validator](../../crates/sui-test-validator/README.md)
+
+
+### Running standalone indexer
 1. DB setup, under `sui/crates/sui-indexer` run:
 ```sh
 # an example DATABASE_URL is "postgres://postgres:postgres@localhost/gegao"
@@ -26,7 +32,9 @@ diesel migration run --database-url="<DATABASE_URL>"
 ```
 Note that you'll need an existing database for the above to work. Replace `gegao` with the name of the database created.
 
-2. Checkout devnet
+2. Checkout to your target branch
+
+For example, if you want to be on the DevNet branch
 ```sh
 git fetch upstream devnet && git reset --hard upstream/devnet
 ```
@@ -57,4 +65,4 @@ And to execute a single test such as just `test_event_query_e2e`, you can do
 POSTGRES_PORT=5432 cargo test test_event_query_e2e --package sui-indexer --test integration_tests --features pg_integration -- --test-threads=1
 ```
 
-Note: all existing data will be wiped during the test.
+**Note** all existing data will be wiped during the test.

--- a/crates/sui-indexer/migrations/2022-11-18-195259_transactions/up.sql
+++ b/crates/sui-indexer/migrations/2022-11-18-195259_transactions/up.sql
@@ -1,7 +1,15 @@
+DO $$
+BEGIN
 -- SuiAddress and ObjectId type, 0x + 64 chars hex string
 CREATE DOMAIN address VARCHAR(66);
 -- Max char length for base58 encoded digest
 CREATE DOMAIN base58digest VARCHAR(44);
+EXCEPTION
+    WHEN duplicate_object THEN
+        -- Domain already exists, do nothing
+        NULL;
+END $$;
+
 
 CREATE TABLE transactions (
     id                          BIGSERIAL PRIMARY KEY,

--- a/crates/sui-indexer/migrations/2022-12-01-034426_objects/up.sql
+++ b/crates/sui-indexer/migrations/2022-12-01-034426_objects/up.sql
@@ -1,10 +1,17 @@
+DO $$
+BEGIN
 CREATE TYPE owner_type AS ENUM ('address_owner', 'object_owner', 'shared', 'immutable');
 CREATE TYPE object_status AS ENUM ('created', 'mutated', 'deleted', 'wrapped', 'unwrapped', 'unwrapped_then_deleted');
 CREATE TYPE bcs_bytes AS
-(
+    (
     name TEXT,
     data bytea
-);
+    );
+EXCEPTION
+    WHEN duplicate_object THEN
+        -- Type already exists, do nothing
+        NULL;
+END $$;
 
 CREATE TABLE objects
 (

--- a/crates/sui-indexer/src/indexer_test_utils.rs
+++ b/crates/sui-indexer/src/indexer_test_utils.rs
@@ -1,0 +1,83 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::errors::IndexerError;
+use crate::store::PgIndexerStore;
+use crate::{new_pg_connection_pool, Indexer, IndexerConfig, PgPoolConnection};
+use anyhow::anyhow;
+use diesel::migration::MigrationSource;
+use diesel::{PgConnection, RunQueryDsl};
+use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
+use prometheus::Registry;
+use tokio::task::JoinHandle;
+
+const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations");
+
+/// Resets the database by reverting all migrations and reapplying them.
+///
+/// If `drop_all` is set to `true`, the function will drop all tables in the database before
+/// resetting the migrations. This option is destructive and will result in the loss of all
+/// data in the tables. Use with caution, especially in production environments.
+pub fn reset_database(conn: &mut PgPoolConnection, drop_all: bool) -> Result<(), anyhow::Error> {
+    if drop_all {
+        drop_all_tables(conn)
+            .map_err(|e| anyhow!("Encountering error when dropping all tables {e}"))?;
+    } else {
+        conn.revert_all_migrations(MIGRATIONS)
+            .map_err(|e| anyhow!("Error reverting all migrations {e}"))?;
+    }
+
+    conn.run_migrations(&MIGRATIONS.migrations().unwrap())
+        .map_err(|e| anyhow!("Failed to run migrations {e}"))?;
+    Ok(())
+}
+
+pub fn drop_all_tables(conn: &mut PgConnection) -> Result<(), diesel::result::Error> {
+    let table_names: Vec<String> = diesel::dsl::sql::<diesel::sql_types::Text>(
+        "
+        SELECT tablename FROM pg_tables WHERE schemaname = 'public'
+    ",
+    )
+    .load(conn)?;
+
+    for table_name in table_names {
+        let drop_table_query = format!("DROP TABLE IF EXISTS {} CASCADE", table_name);
+        diesel::sql_query(drop_table_query).execute(conn)?;
+    }
+
+    // Recreate the __diesel_schema_migrations table
+    diesel::sql_query(
+        "
+        CREATE TABLE __diesel_schema_migrations (
+            version VARCHAR(50) PRIMARY KEY,
+            run_on TIMESTAMP NOT NULL DEFAULT NOW()
+        )
+    ",
+    )
+    .execute(conn)?;
+    Ok(())
+}
+
+/// Spawns an indexer thread with provided Postgres DB url
+pub async fn start_test_indexer(
+    config: IndexerConfig,
+    reset: bool,
+) -> Result<(PgIndexerStore, JoinHandle<Result<(), IndexerError>>), anyhow::Error> {
+    let pg_connection_pool = new_pg_connection_pool(&config.base_connection_url())
+        .await
+        .map_err(|e| anyhow!("unable to connect to Postgres, is it running? {e}"))?;
+    if reset {
+        reset_database(
+            &mut pg_connection_pool
+                .get()
+                .map_err(|e| anyhow!("Fail to get pg_connection_pool {e}"))?,
+            true,
+        )?;
+    }
+    let store = PgIndexerStore::new(pg_connection_pool);
+
+    let registry = Registry::default();
+    let store_clone = store.clone();
+    let handle = tokio::spawn(async move { Indexer::start(&config, &registry, store_clone).await });
+    Ok((store, handle))
+}

--- a/crates/sui-test-validator/README.md
+++ b/crates/sui-test-validator/README.md
@@ -1,0 +1,15 @@
+The sui-test-validator starts a local network that includes a Sui Full node, a Sui validator, a Sui faucet and (optionally)
+an indexer.
+
+## Guide
+
+Refer to [sui-local-network.md](../../doc/src/build/sui-local-network.md)
+
+## Experimental Feature - Running with Indexer
+
+**Note** Similar to the fullnode db, all state will be wiped upon restart
+
+1. Follow the [Prerequisites section](../../crates/sui-indexer/README.md#prerequisites) in the `sui-indexer` README to set up the postgresdb on your local machine
+2. Make sure the `Posgresdb` starts on your local machine
+3. run `RUST_LOG="consensus=off" ./target/debug/sui-test-validator --with-indexer`
+4. To check your local db, if you use the default db url `postgres://postgres:postgres@localhost:5432/sui_indexer`, you can login to the `postgres` database and run `\dt` to show all tables.

--- a/crates/sui-test-validator/src/main.rs
+++ b/crates/sui-test-validator/src/main.rs
@@ -35,9 +35,26 @@ struct Args {
     #[clap(long, default_value = "9123")]
     faucet_port: u16,
 
+    /// Port to start the Indexer RPC server on
+    #[clap(long, default_value = "9124")]
+    indexer_rpc_port: u16,
+
+    /// Port for the Indexer Postgres DB
+    /// 5432 is the default port for postgres on Mac
+    #[clap(long, default_value = "5432")]
+    pg_port: u16,
+
+    /// Hostname for the Indexer Postgres DB
+    #[clap(long, default_value = "localhost")]
+    pg_host: String,
+
     /// The duration for epochs (defaults to one minute)
     #[clap(long, default_value = "60000")]
     epoch_duration_ms: u64,
+
+    /// if we should run indexer
+    #[clap(long, takes_value = false)]
+    pub with_indexer: bool,
 }
 
 #[tokio::main]
@@ -47,18 +64,38 @@ async fn main() -> Result<()> {
         .init();
 
     let args = Args::parse();
+    let Args {
+        fullnode_rpc_port,
+        indexer_rpc_port,
+        pg_port,
+        pg_host,
+        epoch_duration_ms,
+        faucet_port,
+        with_indexer,
+    } = args;
 
     let cluster = LocalNewCluster::start(&ClusterTestOpt {
         env: Env::NewLocal,
-        fullnode_address: Some(format!("127.0.0.1:{}", args.fullnode_rpc_port)),
+        fullnode_address: Some(format!("127.0.0.1:{}", fullnode_rpc_port)),
+        indexer_address: with_indexer.then_some(format!("127.0.0.1:{}", indexer_rpc_port)),
+        pg_address: with_indexer.then_some(format!(
+            "postgres://postgres@{pg_host}:{pg_port}/sui_indexer"
+        )),
         faucet_address: None,
-        epoch_duration_ms: Some(args.epoch_duration_ms),
+        epoch_duration_ms: Some(epoch_duration_ms),
     })
     .await?;
 
     println!("Fullnode RPC URL: {}", cluster.fullnode_url());
 
-    start_faucet(&cluster, args.faucet_port).await?;
+    if with_indexer {
+        println!(
+            "Indexer RPC URL: {}",
+            cluster.indexer_url().clone().unwrap_or_default()
+        );
+    }
+
+    start_faucet(&cluster, faucet_port).await?;
 
     Ok(())
 }


### PR DESCRIPTION
## Description 

[sui-test-validator](https://docs.sui.io/build/sui-local-network) starts a local network that includes a Sui Full node, a Sui validator, and a Sui faucet. With this PR, it now starts an indexer as well. This assumes that Postgres is running locally. This allows app builders to test out their applications against indexer locally in a single step.

By default, the indexer will not run unless `--with-indexer true` is specified. Like fullnode, the postgres db will be reset upon restart.

## Follow up
- config which route uses the indexer db
- handle errors when postgres is not running. Right now it will panic with the error message `thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: PgConnectionPoolInitError("Failed to initialize connection pool with error: Error(Some(\"connection to server at \\\"localhost\\\" (::1), port 5432 failed`
- Figure out data persistence upon restart
- Update docs once enough people dogfood it


## Test Plan 

0. Make sure postgres db is running
1. start `sui-test-validator`
```
RUST_LOG="consensus=off" ./target/debug/sui-test-validator --with-indexer true
Fullnode RPC URL: http://127.0.0.1:9000
Indexer RPC URL: 127.0.0.1:9124
Faucet URL: http://127.0.0.1:9123
```
2. send a request to indexer rpc

```
curl --location --request POST 'http://127.0.0.1:9124' \
--header 'Content-Type: application/json' \
--data-raw '{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "sui_getTotalTransactionNumber",
  "params": []
}'

{"jsonrpc":"2.0","result":663,"id":1}%  
```