### PR TITLE
Rename a few functions in protocol config

### DIFF
--- a/crates/sui-benchmark/src/bin/stress.rs
+++ b/crates/sui-benchmark/src/bin/stress.rs
@@ -60,13 +60,13 @@ async fn main() -> Result<()> {
     };
 
     let max_num_new_move_object_ids = protocol_config.max_num_new_move_object_ids();
-    let max_num_transfered_move_object_ids = protocol_config.max_num_transfered_move_object_ids();
+    let max_num_transferred_move_object_ids = protocol_config.max_num_transferred_move_object_ids();
 
     if (opts.gas_request_chunk_size > max_num_new_move_object_ids)
-        || (opts.gas_request_chunk_size > max_num_transfered_move_object_ids)
+        || (opts.gas_request_chunk_size > max_num_transferred_move_object_ids)
     {
         eprintln!(
-            "`gas-request-chunk-size` must be less than the maximum number of new IDs {max_num_new_move_object_ids} and the maximum number of transferred IDs {max_num_transfered_move_object_ids}",
+            "`gas-request-chunk-size` must be less than the maximum number of new IDs {max_num_new_move_object_ids} and the maximum number of transferred IDs {max_num_transferred_move_object_ids}",
         );
     }
 

--- a/crates/sui-framework/src/natives/object_runtime/mod.rs
+++ b/crates/sui-framework/src/natives/object_runtime/mod.rs
@@ -81,8 +81,8 @@ pub(crate) struct LocalProtocolConfig {
     pub(crate) max_num_event_emit: u64,
     pub(crate) max_num_new_move_object_ids: u64,
     pub(crate) max_num_new_move_object_ids_system_tx: u64,
-    pub(crate) max_num_transfered_move_object_ids: u64,
-    pub(crate) max_num_transfered_move_object_ids_system_tx: u64,
+    pub(crate) max_num_transferred_move_object_ids: u64,
+    pub(crate) max_num_transferred_move_object_ids_system_tx: u64,
     pub(crate) max_event_emit_size: u64,
     pub(crate) object_runtime_max_num_cached_objects: u64,
     pub(crate) object_runtime_max_num_cached_objects_system_tx: u64,
@@ -96,14 +96,14 @@ impl LocalProtocolConfig {
             max_num_deleted_move_object_ids: constants.max_num_deleted_move_object_ids(),
             max_num_event_emit: constants.max_num_event_emit(),
             max_num_new_move_object_ids: constants.max_num_new_move_object_ids(),
-            max_num_transfered_move_object_ids: constants.max_num_transfered_move_object_ids(),
+            max_num_transferred_move_object_ids: constants.max_num_transferred_move_object_ids(),
             max_event_emit_size: constants.max_event_emit_size(),
             max_num_deleted_move_object_ids_system_tx: constants
                 .max_num_deleted_move_object_ids_system_tx(),
             max_num_new_move_object_ids_system_tx: constants
                 .max_num_new_move_object_ids_system_tx(),
-            max_num_transfered_move_object_ids_system_tx: constants
-                .max_num_transfered_move_object_ids_system_tx(),
+            max_num_transferred_move_object_ids_system_tx: constants
+                .max_num_transferred_move_object_ids_system_tx(),
 
             object_runtime_max_num_cached_objects: constants
                 .object_runtime_max_num_cached_objects(),
@@ -260,17 +260,17 @@ impl<'a> ObjectRuntime<'a> {
         // Metered transactions don't have limits for now
 
         match check_limit_by_meter!(
-            // TODO: is this not redundant? Metered TX implies framework obj cannot be transfered
+            // TODO: is this not redundant? Metered TX implies framework obj cannot be transferred
             self.is_metered && !is_framework_obj, // We have higher limits for unmetered transactions and framework obj
             self.state.transfers.len(),
-            self.constants.max_num_transfered_move_object_ids,
-            self.constants.max_num_transfered_move_object_ids_system_tx
+            self.constants.max_num_transferred_move_object_ids,
+            self.constants.max_num_transferred_move_object_ids_system_tx
         ) {
             LimitThresholdCrossed::None => (),
             LimitThresholdCrossed::Soft(_, _) => (), /* TODO: add alerting */
             LimitThresholdCrossed::Hard(_, lim) => {
                 return Err(PartialVMError::new(StatusCode::MEMORY_LIMIT_EXCEEDED)
-                    .with_message(format!("Transfering more than {} IDs is not allowed", lim))
+                    .with_message(format!("Transferring more than {} IDs is not allowed", lim))
                     .with_sub_status(
                         VMMemoryLimitExceededSubStatusCode::TRANSFER_ID_COUNT_LIMIT_EXCEEDED as u64,
                     ))

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -155,7 +155,7 @@ pub struct ProtocolConfig {
     /// Maximum size of serialized transaction effects for system transactions.
     max_serialized_tx_effects_size_bytes_system_tx: Option<u64>,
 
-    /// Maximum number of gas payment objets for a transaction.
+    /// Maximum number of gas payment objects for a transaction.
     max_gas_payment_objects: Option<u32>,
 
     /// Maximum number of modules in a Publish transaction.
@@ -240,10 +240,10 @@ pub struct ProtocolConfig {
     max_num_deleted_move_object_ids_system_tx: Option<u64>,
 
     /// Maximum number of IDs that a single transaction can transfer. Enforced by the VM during execution.
-    max_num_transfered_move_object_ids: Option<u64>,
+    max_num_transferred_move_object_ids: Option<u64>,
 
     /// Maximum number of IDs that a single system transaction can transfer. Enforced by the VM during execution.
-    max_num_transfered_move_object_ids_system_tx: Option<u64>,
+    max_num_transferred_move_object_ids_system_tx: Option<u64>,
 
     /// Maximum size of a Move user event. Enforced by the VM during execution.
     max_event_emit_size: Option<u64>,
@@ -496,12 +496,12 @@ impl ProtocolConfig {
         self.max_num_deleted_move_object_ids_system_tx
             .expect(CONSTANT_ERR_MSG)
     }
-    pub fn max_num_transfered_move_object_ids(&self) -> u64 {
-        self.max_num_transfered_move_object_ids
+    pub fn max_num_transferred_move_object_ids(&self) -> u64 {
+        self.max_num_transferred_move_object_ids
             .expect(CONSTANT_ERR_MSG)
     }
-    pub fn max_num_transfered_move_object_ids_system_tx(&self) -> u64 {
-        self.max_num_transfered_move_object_ids_system_tx
+    pub fn max_num_transferred_move_object_ids_system_tx(&self) -> u64 {
+        self.max_num_transferred_move_object_ids_system_tx
             .expect(CONSTANT_ERR_MSG)
     }
     pub fn max_event_emit_size(&self) -> u64 {
@@ -717,7 +717,7 @@ impl ProtocolConfig {
         // To change the values here you must create a new protocol version with the new values!
         match version.0 {
             1 => Self {
-                // will be overwitten before being returned
+                // will be overwritten before being returned
                 version,
 
                 // All flags are disabled in V1
@@ -755,8 +755,8 @@ impl ProtocolConfig {
                 max_num_new_move_object_ids_system_tx: Some(2048 * 16),
                 max_num_deleted_move_object_ids: Some(2048),
                 max_num_deleted_move_object_ids_system_tx: Some(2048 * 16),
-                max_num_transfered_move_object_ids: Some(2048),
-                max_num_transfered_move_object_ids_system_tx: Some(2048 * 16),
+                max_num_transferred_move_object_ids: Some(2048),
+                max_num_transferred_move_object_ids_system_tx: Some(2048 * 16),
                 max_event_emit_size: Some(250 * 1024),
                 max_move_vector_len: Some(256 * 1024),
                 object_runtime_max_num_cached_objects: Some(1000),

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_1.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_1.snap
@@ -36,8 +36,8 @@ max_num_new_move_object_ids: 2048
 max_num_new_move_object_ids_system_tx: 32768
 max_num_deleted_move_object_ids: 2048
 max_num_deleted_move_object_ids_system_tx: 32768
-max_num_transfered_move_object_ids: 2048
-max_num_transfered_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
 max_event_emit_size: 256000
 max_move_vector_len: 262144
 object_runtime_max_num_cached_objects: 1000


### PR DESCRIPTION
typo keeps rename them for me.