### PR TITLE
[do-not-merge] demo gas error

### DIFF
--- a/sdk/typescript/test/e2e/txn-builder.test.ts
+++ b/sdk/typescript/test/e2e/txn-builder.test.ts
@@ -77,6 +77,7 @@ describe('Transaction Builders', () => {
         ),
       ],
     });
+    tx.setGasBudget(1000);
     await validateTransaction(toolbox.signer, tx);
   });
 


### PR DESCRIPTION
Fullnode report the following error when gas budget is set to too low

## Repro step

Run `pnpm sdk prepare:e2e` in one window and then `pnpm sdk test:e2e` in another and see the following error

```
thread 'thread '2023-03-20T01:35:45.388114Z ERROR execution_driver{tx_digest=TransactionDigest(DNJd84kMH7e7vJqzxcjan4DE3jyH9n4YQsRd8DymPUnb)}: telemetry_subscribers: panicked at 'assertion failed: `(left == right)`
  left: `1000000065`,
 right: `1000000013`', /Users/chrisli/sui/crates/sui-types/src/temporary_store.rs:746:9 panic.file="/Users/chrisli/sui/crates/sui-types/src/temporary_store.rs" panic.line=746 panic.column=9
<unnamed><unnamed>' panicked at '' panicked at 'assertion failed: `(left == right)`
  left: `1000000065`,
 right: `1000000013`2023-03-20T01:35:45.388111Z ERROR execution_driver{tx_digest=TransactionDigest(DNJd84kMH7e7vJqzxcjan4DE3jyH9n4YQsRd8DymPUnb)}: telemetry_subscribers: panicked at 'assertion failed: `(left == right)`
  left: `1000000065`,
 right: `1000000013`', /Users/chrthread 'thread 'isli/sui/crates/sui-types/src/temporary_store.rs:746:9 panic.file="/Users/chrisli/sui/crates/sui-types/src/temporary_store.rs" panic.line=746 panic.column=9
assertion failed: `(left == right)`
  left: `1000000065`,
 right: `1000000013`<unnamed>', ', /Users/chrisli/sui/crates/sui-types/src/temporary_store.rs:746:' panicked at '9<unnamed>
assertion failed: `(left == right)`
  left: `1000000065`,
 right: `1000000013`/Users/chrisli/sui/crates/sui-types/src/temporary_store.rs2023-03-20T01:35:45.388135Z ERROR execution_driver{tx_digest=TransactionDigest(DNJd84kMH7e7vJqzxcjan4DE3jyH9n4YQsRd8DymPUnb)}: telemetry_subscribers: panicked at 'assertion failed: `(left == right)`
  left: `1000000065`,
 right: `1000000013`', /Users/chrisli/sui/crates/sui-types/src/temporary_store.rs:746:9 panic.file="/Users/chrisli/sui/crates/sui-types/src/temporary_store.rs" panic.line=746 panic.column=9
2023-03-20T01:35:45.388197Z ERROR execution_driver{tx_digest=TransactionDigest(DNJd84kMH7e7vJqzxcjan4DE3jyH9n4YQsRd8DymPUnb)}: telemetry_subscribers: panicked at 'assertion failed: `(left == right)`
  left: `1000000065`,
 right: `1000000013`', /Users/chrisli/sui/crates/sui-types/src/temporary_store.rs:746:9 panic.file="/Users/chrisli/sui/crates/sui-types/src/temporary_store.rs" panic.line=746 panic.column=9
' panicked at ':', assertion failed: `(left == right)`
  left: `1000000065`,
 right: `1000000013`746', :/Users/chrisli/sui/crates/sui-types/src/temporary_store.rs/Users/chrisli/sui/crates/sui-types/src/temporary_store.rs9:
:746:746:9
9
2023-03-20T01:35:45.388502Z ERROR execution_driver{tx_digest=TransactionDigest(DNJd84kMH7e7vJqzxcjan4DE3jyH9n4YQsRd8DymPUnb)}: sui_storage::write_ahead_log: DBTxGuard dropped without explicit commit digest=TransactionDigest(DNJd84kMH7e7vJqzxcjan4DE3jyH9n4YQsRd8DymPUnb)
2023-03-20T01:35:45.388501Z ERROR execution_driver{tx_digest=TransactionDigest(DNJd84kMH7e7vJqzxcjan4DE3jyH9n4YQsRd8DymPUnb)}: sui_storage::write_ahead_log: DBTxGuard dropped without explicit commit digest=TransactionDigest(DNJd84kMH7e7vJqzxcjan4DE3jyH9n4YQsRd8DymPUnb)
2023-03-20T01:35:45.388502Z ERROR execution_driver{tx_digest=TransactionDigest(DNJd84kMH7e7vJqzxcjan4DE3jyH9n4YQsRd8DymPUnb)}: sui_storage::write_ahead_log: DBTxGuard dropped without explicit commit digest=TransactionDigest(DNJd84kMH7e7vJqzxcjan4DE3jyH9n4YQsRd8DymPUnb)
2023-03-20T01:35:45.388517Z ERROR execution_driver{tx_digest=TransactionDigest(DNJd84kMH7e7vJqzxcjan4DE3jyH9n4YQsRd8DymPUnb)}: sui_storage::write_ahead_log: DBTxGuard dropped without explicit commit digest=TransactionDigest(DNJd84kMH7e7vJqzxcjan4DE3jyH9n4YQsRd8DymPUnb)
```