### PR TITLE
remove parent_sync table

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -767,24 +767,6 @@ impl AuthorityPerEpochStore {
                 .map(SharedInputObject::into_id_and_version)
                 .collect();
 
-            let mut versions_to_write = Vec::new();
-            for id in &uninitialized_objects {
-                // Note: we don't actually need to read from the transaction here, as no writer
-                // can update parent_sync_store until after get_or_init_next_object_versions
-                // completes.
-                versions_to_write.push(
-                    match parent_sync_store.get_latest_parent_entry_ref(*id)? {
-                        Some(objref) => (*id, objref.1),
-                        None => (
-                            *id,
-                            *initial_versions
-                                .get(id)
-                                .expect("object cannot be missing from shared_input_objects"),
-                        ),
-                    },
-                );
-            }
-
             let versions_to_write = uninitialized_objects.iter().map(|id| {
                 // Note: we don't actually need to read from the transaction here, as no writer
                 // can update parent_sync_store until after get_or_init_next_object_versions

--- a/crates/sui-core/src/authority/authority_store_types.rs
+++ b/crates/sui-core/src/authority/authority_store_types.rs
@@ -81,10 +81,17 @@ impl From<StoreObject> for StoreObjectWrapper {
     }
 }
 
+#[derive(Eq, PartialEq, Debug, Clone, Deserialize, Serialize, Hash)]
+pub enum StoreObjectV1 {
+    Value(StoreObjectValue),
+    Deleted,
+    Wrapped,
+}
+
 /// Forked version of [`sui_types::object::Object`]
 /// Used for efficient storing of move objects in the database
 #[derive(Eq, PartialEq, Debug, Clone, Deserialize, Serialize, Hash)]
-pub struct StoreObjectV1 {
+pub struct StoreObjectValue {
     pub data: StoreData,
     pub owner: Owner,
     pub previous_transaction: TransactionDigest,
@@ -213,16 +220,19 @@ pub(crate) fn get_store_object_pair(
             }
         }
     };
-    let store_object = StoreObject {
+    let store_object = StoreObjectValue {
         data,
         owner: object.owner,
         previous_transaction: object.previous_transaction,
         storage_rebate: object.storage_rebate,
     };
-    StoreObjectPair(store_object.into(), indirect_object.map(|i| i.into()))
+    StoreObjectPair(
+        StoreObject::Value(store_object).into(),
+        indirect_object.map(|i| i.into()),
+    )
 }
 
-pub struct MigratedStoreObjectPair(pub StoreObject, pub Option<StoreMoveObject>);
+pub struct MigratedStoreObjectPair(pub StoreObjectValue, pub Option<StoreMoveObject>);
 impl TryFrom<MigratedStoreObjectPair> for Object {
     type Error = SuiError;
 

--- a/crates/sui-tool/src/db_tool/db_dump.rs
+++ b/crates/sui-tool/src/db_tool/db_dump.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use strum_macros::EnumString;
 use sui_core::authority::authority_per_epoch_store::AuthorityEpochTables;
 use sui_core::authority::authority_store_tables::AuthorityPerpetualTables;
-use sui_core::authority::authority_store_types::StoreData;
+use sui_core::authority::authority_store_types::{StoreData, StoreObject};
 use sui_core::epoch::committee_store::CommitteeStoreTables;
 use sui_storage::write_ahead_log::DBWriteAheadLogTables;
 use sui_storage::IndexStoreTables;
@@ -98,20 +98,20 @@ pub fn duplicate_objects_summary(db_path: PathBuf) -> (usize, usize, usize, usiz
     let mut data: HashMap<Vec<u8>, usize> = HashMap::new();
 
     for (key, value) in iter {
-        let value = value.migrate().into_inner();
-
-        if let StoreData::Move(object) = value.data {
-            if object_id != key.0 {
-                for (k, cnt) in data.iter() {
-                    total_bytes += k.len() * cnt;
-                    duplicated_bytes += k.len() * (cnt - 1);
-                    total_count += cnt;
-                    duplicate_count += cnt - 1;
+        if let StoreObject::Value(store_object) = value.migrate().into_inner() {
+            if let StoreData::Move(object) = store_object.data {
+                if object_id != key.0 {
+                    for (k, cnt) in data.iter() {
+                        total_bytes += k.len() * cnt;
+                        duplicated_bytes += k.len() * (cnt - 1);
+                        total_count += cnt;
+                        duplicate_count += cnt - 1;
+                    }
+                    object_id = key.0;
+                    data.clear();
                 }
-                object_id = key.0;
-                data.clear();
+                *data.entry(object.contents().to_vec()).or_default() += 1;
             }
-            *data.entry(object.contents().to_vec()).or_default() += 1;
         }
     }
     (total_count, duplicate_count, total_bytes, duplicated_bytes)


### PR DESCRIPTION
removes `parent_sync` table and its usage
instead whenever object gets deleted/wrapped a separate tombstone entry is added to the objects table
 