### PR TITLE
[Narwhal] rename Core to Certifier

### DIFF
--- a/narwhal/consensus/src/dag.rs
+++ b/narwhal/consensus/src/dag.rs
@@ -134,7 +134,7 @@ impl InnerDag {
         loop {
             tokio::select! {
                  Some(certificate) = self.rx_primary.recv() => {
-                    // The Core (process_certificate) guarantees the certificate
+                    // The Synchronizer (process_certificate) guarantees the certificate
                     // has gone through causal completion => this is ready to be inserted
                     let _ = self.insert(certificate);
                 }

--- a/narwhal/consensus/src/metrics.rs
+++ b/narwhal/consensus/src/metrics.rs
@@ -132,9 +132,9 @@ pub struct ChannelMetrics {
     /// occupancy of the channel from the `Consensus` to `SubscriberHandler`.
     /// See also:
     /// * tx_committed_certificates in primary, where the committed certificates
-    /// from `Consensus` are sent to `primary::Core`
-    /// * tx_new_certificates where the newly created certificates are sent
-    /// from `primary::Core` to `Consensus`
+    /// from `Consensus` are sent to `primary::StateHandler`
+    /// * tx_new_certificates where the newly accepted certificates are sent
+    /// from `primary::Synchronizer` to `Consensus`
     pub tx_sequence: IntGauge,
 }
 

--- a/narwhal/executor/src/lib.rs
+++ b/narwhal/executor/src/lib.rs
@@ -67,7 +67,7 @@ impl Executor {
     {
         let metrics = ExecutorMetrics::new(registry);
 
-        // We expect this will ultimately be needed in the `Core` as well as the `Subscriber`.
+        // This will be needed in the `Subscriber`.
         let arc_metrics = Arc::new(metrics);
 
         // Spawn the subscriber.

--- a/narwhal/executor/src/subscriber.rs
+++ b/narwhal/executor/src/subscriber.rs
@@ -31,7 +31,7 @@ use types::{
 
 /// The `Subscriber` receives certificates sequenced by the consensus and waits until the
 /// downloaded all the transactions references by the certificates; it then
-/// forward the certificates to the Executor Core.
+/// forward the certificates to the Executor.
 pub struct Subscriber<Network> {
     /// Receiver for shutdown
     rx_shutdown: ConditionalBroadcastReceiver,

--- a/narwhal/primary/src/certifier.rs
+++ b/narwhal/primary/src/certifier.rs
@@ -32,7 +32,7 @@ pub mod certifier_tests;
 
 /// This component is responisble for proposing headers to peers, collecting votes on headers,
 /// and certifying headers into certificates.
-/// 
+///
 /// It receives headers to propose from Proposer via `rx_headers`, and sends out certificates to be
 /// broadcasted by calling `Synchronizer::accept_own_certificate()`.
 pub struct Certifier {

--- a/narwhal/primary/src/certifier.rs
+++ b/narwhal/primary/src/certifier.rs
@@ -27,10 +27,15 @@ use types::{
 };
 
 #[cfg(test)]
-#[path = "tests/core_tests.rs"]
-pub mod core_tests;
+#[path = "tests/certifier_tests.rs"]
+pub mod certifier_tests;
 
-pub struct Core {
+/// This component is responisble for proposing headers to peers, collecting votes on headers,
+/// and certifying headers into certificates.
+/// 
+/// It receives headers to propose from Proposer via `rx_headers`, and sends out certificates to be
+/// broadcasted by calling `Synchronizer::accept_own_certificate()`.
+pub struct Certifier {
     /// The public key of this primary.
     name: PublicKey,
     /// The committee information.
@@ -61,7 +66,7 @@ pub struct Core {
     metrics: Arc<PrimaryMetrics>,
 }
 
-impl Core {
+impl Certifier {
     #[allow(clippy::too_many_arguments)]
     #[must_use]
     pub fn spawn(
@@ -95,7 +100,7 @@ impl Core {
                 .run_inner()
                 .await
             },
-            "CoreTask"
+            "CertifierTask"
         )
     }
 
@@ -239,7 +244,7 @@ impl Core {
     ) -> DagResult<Certificate> {
         if header.epoch != committee.epoch() {
             debug!(
-                "Core received mismatched header proposal for epoch {}, currently at epoch {}",
+                "Certifier received mismatched header proposal for epoch {}, currently at epoch {}",
                 header.epoch,
                 committee.epoch()
             );
@@ -328,7 +333,7 @@ impl Core {
         Ok(certificate)
     }
 
-    // Logs Core errors as appropriate.
+    // Logs Certifier errors as appropriate.
     fn process_result(result: &DagResult<()>) {
         match result {
             Ok(()) => (),
@@ -347,7 +352,7 @@ impl Core {
 
     // Main loop listening to incoming messages.
     pub async fn run(mut self) -> DagResult<Self> {
-        info!("Core on node {} has started successfully.", self.name);
+        info!("Certifier on node {} has started successfully.", self.name);
         loop {
             let result = tokio::select! {
                 // We also receive here our new headers created by the `Proposer`.

--- a/narwhal/primary/src/lib.rs
+++ b/narwhal/primary/src/lib.rs
@@ -13,7 +13,7 @@ mod block_remover;
 pub mod block_synchronizer;
 mod block_waiter;
 mod certificate_fetcher;
-mod core;
+mod certifier;
 mod grpc_server;
 mod primary;
 mod proposer;

--- a/narwhal/primary/src/metrics.rs
+++ b/narwhal/primary/src/metrics.rs
@@ -64,17 +64,17 @@ pub struct PrimaryChannelMetrics {
     pub tx_others_digests: IntGauge,
     /// occupancy of the channel from the `primary::WorkerReceiverHandler` to the `primary::Proposer`
     pub tx_our_digests: IntGauge,
-    /// occupancy of the channel from the `primary::Core` to the `primary::Proposer`
+    /// occupancy of the channel from the `primary::Synchronizer` to the `primary::Proposer`
     pub tx_parents: IntGauge,
-    /// occupancy of the channel from the `primary::Proposer` to the `primary::Core`
+    /// occupancy of the channel from the `primary::Proposer` to the `primary::Certifier`
     pub tx_headers: IntGauge,
     /// occupancy of the channel from the `primary::Synchronizer` to the `primary::CertificaterWaiter`
     pub tx_certificate_fetcher: IntGauge,
     /// occupancy of the channel from the `primary::BlockSynchronizerHandler` to the `primary::BlockSynchronizer`
     pub tx_block_synchronizer_commands: IntGauge,
-    /// occupancy of the channel from the `Consensus` to the `primary::Core`
+    /// occupancy of the channel from the `Consensus` to the `primary::StateHandler`
     pub tx_committed_certificates: IntGauge,
-    /// occupancy of the channel from the `primary::Core` to the `Consensus`
+    /// occupancy of the channel from the `primary::Synchronizer` to the `Consensus`
     pub tx_new_certificates: IntGauge,
     /// occupancy of the channel signaling own committed headers
     pub tx_commited_own_headers: IntGauge,
@@ -84,9 +84,9 @@ pub struct PrimaryChannelMetrics {
     pub tx_others_digests_total: IntCounter,
     /// total received on channel from the `primary::WorkerReceiverHandler` to the `primary::Proposer`
     pub tx_our_digests_total: IntCounter,
-    /// total received on channel from the `primary::Core` to the `primary::Proposer`
+    /// total received on channel from the `primary::Synchronizer` to the `primary::Proposer`
     pub tx_parents_total: IntCounter,
-    /// total received on channel from the `primary::Proposer` to the `primary::Core`
+    /// total received on channel from the `primary::Proposer` to the `primary::Certifier`
     pub tx_headers_total: IntCounter,
     /// total received on channel from the `primary::Synchronizer` to the `primary::CertificaterWaiter`
     pub tx_certificate_fetcher_total: IntCounter,
@@ -94,9 +94,9 @@ pub struct PrimaryChannelMetrics {
     pub tx_block_synchronizer_commands_total: IntCounter,
     /// total received on channel from the `primary::WorkerReceiverHandler` to the `primary::StateHandler`
     pub tx_state_handler_total: IntCounter,
-    /// total received on channel from the `Consensus` to the `primary::Core`
+    /// total received on channel from the `Consensus` to the `primary::StateHandler`
     pub tx_committed_certificates_total: IntCounter,
-    /// total received on channel from the `primary::Core` to the `Consensus`
+    /// total received on channel from the `primary::Synchronizer` to the `Consensus`
     pub tx_new_certificates_total: IntCounter,
     /// total received on the channel signaling own committed headers
     pub tx_commited_own_headers_total: IntCounter,
@@ -107,23 +107,23 @@ impl PrimaryChannelMetrics {
     // load-bearing, see `replace_registered_committed_certificates_metric`.
     pub const NAME_COMMITTED_CERTS: &'static str = "tx_committed_certificates";
     pub const DESC_COMMITTED_CERTS: &'static str =
-        "occupancy of the channel from the `Consensus` to the `primary::Core`";
+        "occupancy of the channel from the `Consensus` to the `primary::StateHandler`";
     // The consistent use of this constant in the below, as well as in `node::spawn_primary` is
     // load-bearing, see `replace_registered_new_certificates_metric`.
     pub const NAME_NEW_CERTS: &'static str = "tx_new_certificates";
     pub const DESC_NEW_CERTS: &'static str =
-        "occupancy of the channel from the `primary::Core` to the `Consensus`";
+        "occupancy of the channel from the `primary::Synchronizer` to the `Consensus`";
 
     // The consistent use of this constant in the below, as well as in `node::spawn_primary` is
     // load-bearing, see `replace_registered_committed_certificates_metric`.
     pub const NAME_COMMITTED_CERTS_TOTAL: &'static str = "tx_committed_certificates_total";
     pub const DESC_COMMITTED_CERTS_TOTAL: &'static str =
-        "total received on channel from the `Consensus` to the `primary::Core`";
+        "total received on channel from the `Consensus` to the `primary::StateHandler`";
     // The consistent use of this constant in the below, as well as in `node::spawn_primary` is
     // load-bearing, see `replace_registered_new_certificates_metric`.
     pub const NAME_NEW_CERTS_TOTAL: &'static str = "tx_new_certificates_total";
     pub const DESC_NEW_CERTS_TOTAL: &'static str =
-        "total received on channel from the `primary::Core` to the `Consensus`";
+        "total received on channel from the `primary::Synchronizer` to the `Consensus`";
 
     pub fn new(registry: &Registry) -> Self {
         Self {
@@ -139,12 +139,12 @@ impl PrimaryChannelMetrics {
             ).unwrap(),
             tx_parents: register_int_gauge_with_registry!(
                 "tx_parents",
-                "occupancy of the channel from the `primary::Core` to the `primary::Proposer`",
+                "occupancy of the channel from the `primary::Synchronizer` to the `primary::Proposer`",
                 registry
             ).unwrap(),
             tx_headers: register_int_gauge_with_registry!(
                 "tx_headers",
-                "occupancy of the channel from the `primary::Proposer` to the `primary::Core`",
+                "occupancy of the channel from the `primary::Proposer` to the `primary::Certifier`",
                 registry
             ).unwrap(),
             tx_certificate_fetcher: register_int_gauge_with_registry!(
@@ -186,12 +186,12 @@ impl PrimaryChannelMetrics {
             ).unwrap(),
             tx_parents_total: register_int_counter_with_registry!(
                 "tx_parents_total",
-                "total received on channel from the `primary::Core` to the `primary::Proposer`",
+                "total received on channel from the `primary::Synchronizer` to the `primary::Proposer`",
                 registry
             ).unwrap(),
             tx_headers_total: register_int_counter_with_registry!(
                 "tx_headers_total",
-                "total received on channel from the `primary::Proposer` to the `primary::Core`",
+                "total received on channel from the `primary::Proposer` to the `primary::Certifier`",
                 registry
             ).unwrap(),
             tx_certificate_fetcher_total: register_int_counter_with_registry!(

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -5,7 +5,7 @@ use crate::{
     block_synchronizer::{handler::BlockSynchronizerHandler, BlockSynchronizer},
     block_waiter::BlockWaiter,
     certificate_fetcher::CertificateFetcher,
-    core::Core,
+    certifier::Certifier,
     grpc_server::ConsensusAPIGrpc,
     metrics::{initialise_metrics, PrimaryMetrics},
     proposer::{OurDigestMessage, Proposer},
@@ -461,7 +461,7 @@ impl Primary {
             }
         }
 
-        let core_handle = Core::spawn(
+        let core_handle = Certifier::spawn(
             name.clone(),
             committee.clone(),
             header_store.clone(),

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -475,7 +475,7 @@ impl Primary {
         );
 
         // The `CertificateFetcher` waits to receive all the ancestors of a certificate before looping it back to the
-        // `Core` for further processing.
+        // `Synchronizer` for further processing.
         let certificate_fetcher_handle = CertificateFetcher::spawn(
             name.clone(),
             committee.clone(),
@@ -488,8 +488,8 @@ impl Primary {
             node_metrics.clone(),
         );
 
-        // When the `Core` collects enough parent certificates, the `Proposer` generates a new header with new batch
-        // digests from our workers and sends it back to the `Core`.
+        // When the `Synchronizer` collects enough parent certificates, the `Proposer` generates
+        // a new header with new batch digests from our workers and sends it to the `Certifier`.
         let proposer_handle = Proposer::spawn(
             name.clone(),
             committee.clone(),

--- a/narwhal/primary/src/proposer.rs
+++ b/narwhal/primary/src/proposer.rs
@@ -69,7 +69,7 @@ pub struct Proposer {
     rx_parents: Receiver<(Vec<Certificate>, Round, Epoch)>,
     /// Receives the batches' digests from our workers.
     rx_our_digests: Receiver<OurDigestMessage>,
-    /// Sends newly created headers to the `Core`.
+    /// Sends newly created headers to the `Certifier`.
     tx_headers: Sender<Header>,
 
     /// The proposer store for persisting the last header.
@@ -169,7 +169,7 @@ impl Proposer {
 
         let num_of_included_digests = header.payload.len();
 
-        // Send the new header to the `Core` that will broadcast and process it.
+        // Send the new header to the `Certifier` that will broadcast and certify it.
         self.tx_headers
             .send(header.clone())
             .await

--- a/narwhal/primary/src/tests/certifier_tests.rs
+++ b/narwhal/primary/src/tests/certifier_tests.rs
@@ -109,7 +109,7 @@ async fn propose_header() {
         None,
         metrics.clone(),
     ));
-    let _core_handle = Core::spawn(
+    let _handle = Certifier::spawn(
         name,
         committee.clone(),
         header_store.clone(),
@@ -206,7 +206,7 @@ async fn propose_header_failure() {
         None,
         metrics.clone(),
     ));
-    let _core_handle = Core::spawn(
+    let _handle = Certifier::spawn(
         name,
         committee.clone(),
         header_store.clone(),
@@ -282,7 +282,7 @@ async fn shutdown_core() {
         .unwrap();
 
     // Spawn the core.
-    let handle = Core::spawn(
+    let handle = Certifier::spawn(
         name.clone(),
         committee.clone(),
         header_store.clone(),


### PR DESCRIPTION
## Description 

The functionality of `Core` is more restricted now, only covering the `Header` to `Certificate` logic. So renaming `Core` to `Certifier` to better represent its purpose.

## Test Plan 

Existing unit tests.

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
