### PR TITLE
[wallet-ext] fix the @mysten/ledgerjs-hw-app-sui alias so we can build wallet releases

### DIFF
--- a/apps/wallet/configs/ts/tsconfig.common.json
+++ b/apps/wallet/configs/ts/tsconfig.common.json
@@ -46,7 +46,7 @@
             "_font-icons/*": ["./font-icons/*"],
             "@mysten/sui.js": ["../../sdk/typescript/src/"],
             "@mysten/bcs": ["../../sdk/bcs/src/"],
-            "@mysten/ledgerjs-hw-app-sui": ["../../sdk/ledgerjs-hw-app-sui"],
+            "@mysten/ledgerjs-hw-app-sui": ["../../sdk/ledgerjs-hw-app-sui/src/Sui.ts"],
             "@mysten/wallet-standard": [
                 "../../sdk/wallet-adapter/wallet-standard/src/"
             ]


### PR DESCRIPTION
## Description 

I misconfigured the TypeScript alias for the `@mysten/ledgerjs-hw-app-sui` library, it should point to the entry point which is `/src/Sui.ts` and not the root of the library folder

## Test Plan 
- `pnpm wallet build:prod` works from the root of the Sui repo

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
N/A
