### PR TITLE
[sui verifier] Allow droppable return values from entry functions

### DIFF
--- a/crates/sui-adapter/src/programmable_transactions/execution.rs
+++ b/crates/sui-adapter/src/programmable_transactions/execution.rs
@@ -908,14 +908,14 @@ fn check_visibility_and_signature<E: fmt::Debug, S: StorageView<E>, Mode: Execut
         .map_err(|e| context.convert_vm_error(e))?;
     let signature = subst_signature(signature).map_err(|e| context.convert_vm_error(e))?;
     let return_value_kinds = match function_kind {
-        FunctionKind::PrivateEntry | FunctionKind::PublicEntry | FunctionKind::Init => {
+        FunctionKind::Init => {
             assert_invariant!(
                 signature.return_.is_empty(),
-                "entry functions must have no return values"
+                "init functions must have no return values"
             );
             vec![]
         }
-        FunctionKind::NonEntry => {
+        FunctionKind::PrivateEntry | FunctionKind::PublicEntry | FunctionKind::NonEntry => {
             check_non_entry_signature::<_, _, Mode>(context, module_id, function, &signature)?
         }
     };

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/return_values.exp
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/return_values.exp
@@ -1,17 +1,21 @@
-processed 4 tasks
+processed 5 tasks
 
-task 0 'publish'. lines 4-11:
-Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Entry function foo cannot have return values"), command: Some(0) } }
+task 0 'publish'. lines 6-13:
+created: object(104)
+written: object(103)
 
-task 1 'publish'. lines 13-20:
-Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Entry function foo cannot have return values"), command: Some(0) } }
+task 1 'publish'. lines 15-22:
+created: object(106)
+written: object(105)
 
-task 2 'publish'. lines 22-29:
-Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Entry function foo cannot have return values"), command: Some(0) } }
+task 2 'publish'. lines 24-31:
+created: object(108)
+written: object(107)
 
-task 3 'publish'. lines 32-39:
-Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Entry function foo cannot have return values"), command: Some(0) } }
+task 3 'publish'. lines 33-41:
+created: object(110)
+written: object(109)
+
+task 4 'publish'. lines 43-51:
+created: object(112)
+written: object(111)

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/return_values.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/return_values.mvir
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+// return values from entry functions must have drop
+
 //# publish
 module 0x0.m {
     import 0x2.tx_context;
@@ -28,11 +30,21 @@ module 0x0.m {
     }
 }
 
+//# publish
+module 0x0.m {
+    import 0x2.tx_context;
+    struct Droppable has drop { flag: bool }
+    public entry foo(ctx: &mut tx_context.TxContext): Self.Droppable {
+        label l0:
+        abort 0;
+    }
+}
 
 //# publish
 module 0x0.m {
     import 0x2.tx_context;
-    public entry foo(ctx: &mut tx_context.TxContext): &u8 {
+    struct Droppable has drop { flag: bool }
+    public entry foo(ctx: &mut tx_context.TxContext): vector<Self.Droppable> * u64 {
         label l0:
         abort 0;
     }

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/return_values_invalid.exp
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/return_values_invalid.exp
@@ -1,0 +1,25 @@
+processed 6 tasks
+
+task 0 'publish'. lines 6-13:
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Invalid entry point return type. Expected a non reference type."), command: Some(0) } }
+
+task 1 'publish'. lines 15-22:
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Invalid entry point return type. Expected a non reference type."), command: Some(0) } }
+
+task 2 'publish'. lines 24-31:
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Invalid entry point return type. Expected a non reference type."), command: Some(0) } }
+
+task 3 'publish'. lines 33-41:
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Invalid entry point return type. The specified return type does not have the 'drop' ability: _::m::Copyable"), command: Some(0) } }
+
+task 4 'publish'. lines 43-52:
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Invalid entry point return type. The specified return type does not have the 'drop' ability: _::m::Obj"), command: Some(0) } }
+
+task 5 'publish'. lines 54-63:
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Invalid entry point return type. The specified return type does not have the 'drop' ability: vector<_::m::Obj>"), command: Some(0) } }

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/return_values_invalid.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/return_values_invalid.mvir
@@ -1,0 +1,63 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// return values from entry functions must have drop
+
+//# publish
+module 0x0.m {
+    import 0x2.tx_context;
+    public entry foo(ctx: &mut tx_context.TxContext): &u8 {
+        label l0:
+        abort 0;
+    }
+}
+
+//# publish
+module 0x0.m {
+    import 0x2.tx_context;
+    public entry foo(ctx: &mut tx_context.TxContext): &mut u8 {
+        label l0:
+        abort 0;
+    }
+}
+
+//# publish
+module 0x0.m {
+    import 0x2.tx_context;
+    public entry foo(ctx: &mut tx_context.TxContext): u64 * &u8 * u8 {
+        label l0:
+        abort 0;
+    }
+}
+
+//# publish
+module 0x0.m {
+    import 0x2.tx_context;
+    struct Copyable has copy { flag: bool }
+    public entry foo(ctx: &mut tx_context.TxContext): Self.Copyable {
+        label l0:
+        abort 0;
+    }
+}
+
+//# publish
+module 0x0.m {
+    import 0x2.tx_context;
+    import 0x2.object;
+    struct Obj has key, store { id: object.UID }
+    public entry foo(ctx: &mut tx_context.TxContext): Self.Obj {
+        label l0:
+        abort 0;
+    }
+}
+
+//# publish
+module 0x0.m {
+    import 0x2.tx_context;
+    import 0x2.object;
+    struct Obj has key, store { id: object.UID }
+    public entry foo(ctx: &mut tx_context.TxContext): vector<Self.Obj> {
+        label l0:
+        abort 0;
+    }
+}


### PR DESCRIPTION
## Description 

- Originally, we did not allow return values from entry functions because there was little to no use.
- Now the values can be used, and this should help reduce the number of other wrappers needed for entry functions.

## Test Plan 

- New tests
- Updated tests 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
