### PR TITLE
[package upgrades] Add fast-path package upgrade CLI command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8467,6 +8467,7 @@ dependencies = [
  "const-str",
  "expect-test",
  "fastcrypto",
+ "fs_extra",
  "futures",
  "git-version",
  "inquire",

--- a/crates/sui-framework-build/src/compiled_package.rs
+++ b/crates/sui-framework-build/src/compiled_package.rs
@@ -618,6 +618,18 @@ pub fn gather_dependencies(resolution_graph: &ResolvedGraph) -> PackageDependenc
     }
 }
 
+pub fn root_published_at(resolution_graph: &ResolvedGraph) -> Option<ObjectID> {
+    let published_at = resolution_graph
+        .package_table
+        .get(&resolution_graph.graph.root_package)
+        .unwrap()
+        .source_package
+        .package
+        .custom_properties
+        .get(&Symbol::from(PUBLISHED_AT_MANIFEST_FIELD))?;
+    ObjectID::from_str(published_at.as_str()).ok()
+}
+
 pub fn check_unpublished_dependencies(unpublished: &BTreeSet<Symbol>) -> Result<(), SuiError> {
     if unpublished.is_empty() {
         return Ok(());

--- a/crates/sui-json-rpc/src/api/transaction_builder.rs
+++ b/crates/sui-json-rpc/src/api/transaction_builder.rs
@@ -138,13 +138,13 @@ pub trait TransactionBuilder {
         execution_mode: Option<SuiTransactionBuilderMode>,
     ) -> RpcResult<TransactionBytes>;
 
-    /// Create an unsigned transaction to publish Move module.
+    /// Create an unsigned transaction to publish a Move package.
     #[method(name = "publish")]
     async fn publish(
         &self,
         /// the transaction signer's Sui address
         sender: SuiAddress,
-        /// the compiled bytes of a move module, the
+        /// the compiled bytes of a Move package
         compiled_modules: Vec<Base64>,
         /// a list of transitive dependency addresses that this set of modules depends on.
         dependencies: Vec<ObjectID>,

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -2399,7 +2399,7 @@
           "name": "Transaction Builder API"
         }
       ],
-      "description": "Create an unsigned transaction to publish Move module.",
+      "description": "Create an unsigned transaction to publish a Move package.",
       "params": [
         {
           "name": "sender",
@@ -2411,7 +2411,7 @@
         },
         {
           "name": "compiled_modules",
-          "description": "the compiled bytes of a move module, the",
+          "description": "the compiled bytes of a Move package",
           "required": true,
           "schema": {
             "type": "array",

--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -480,6 +480,44 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
         ))
     }
 
+    pub async fn upgrade(
+        &self,
+        sender: SuiAddress,
+        package_id: ObjectID,
+        compiled_modules: Vec<Vec<u8>>,
+        dep_ids: Vec<ObjectID>,
+        upgrade_capability: ObjectID,
+        upgrade_policy: u8,
+        digest: Vec<u8>,
+        gas: Option<ObjectID>,
+        gas_budget: u64,
+    ) -> anyhow::Result<TransactionData> {
+        let gas_price = self.0.get_reference_gas_price().await?;
+        let gas = self
+            .select_gas(sender, gas, gas_budget, vec![], gas_price)
+            .await?;
+        let upgrade_cap = self
+            .0
+            .get_object_with_options(upgrade_capability, SuiObjectDataOptions::new().with_owner())
+            .await?
+            .into_object()?;
+        let cap_owner = upgrade_cap
+            .owner
+            .ok_or_else(|| anyhow!("Unable to determine ownership of upgrade capability"))?;
+        TransactionData::new_upgrade(
+            sender,
+            gas,
+            package_id,
+            compiled_modules,
+            dep_ids,
+            (upgrade_cap.object_ref(), cap_owner),
+            upgrade_policy,
+            digest,
+            gas_budget,
+            gas_price,
+        )
+    }
+
     // TODO: consolidate this with Pay transactions
     pub async fn split_coin(
         &self,

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -21,14 +21,15 @@ use crate::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use crate::signature::{AuthenticatorTrait, GenericSignature};
 use crate::storage::{DeleteKind, WriteKind};
 use crate::{
-    SUI_CLOCK_OBJECT_ID, SUI_CLOCK_OBJECT_SHARED_VERSION, SUI_SYSTEM_STATE_OBJECT_ID,
-    SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
+    SUI_CLOCK_OBJECT_ID, SUI_CLOCK_OBJECT_SHARED_VERSION, SUI_FRAMEWORK_OBJECT_ID,
+    SUI_SYSTEM_STATE_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
 };
 use byteorder::{BigEndian, ReadBytesExt};
 use enum_dispatch::enum_dispatch;
 use fastcrypto::{encoding::Base64, hash::HashFunction};
 use itertools::Either;
 use move_binary_format::file_format::{CodeOffset, TypeParameterIndex};
+use move_core_types::ident_str;
 use move_core_types::identifier::IdentStr;
 use move_core_types::language_storage::ModuleId;
 use move_core_types::{identifier::Identifier, language_storage::TypeTag, value::MoveStructLayout};
@@ -1331,6 +1332,71 @@ impl TransactionData {
             builder.finish()
         };
         Self::new_programmable(sender, vec![gas_payment], pt, gas_budget, gas_price)
+    }
+
+    pub fn new_upgrade(
+        sender: SuiAddress,
+        gas_payment: ObjectRef,
+        package_id: ObjectID,
+        modules: Vec<Vec<u8>>,
+        dep_ids: Vec<ObjectID>,
+        (upgrade_capability, capability_owner): (ObjectRef, Owner),
+        upgrade_policy: u8,
+        digest: Vec<u8>,
+        gas_budget: u64,
+        gas_price: u64,
+    ) -> anyhow::Result<Self> {
+        let pt = {
+            let mut builder = ProgrammableTransactionBuilder::new();
+            let capability_arg = match capability_owner {
+                Owner::AddressOwner(_) => ObjectArg::ImmOrOwnedObject(upgrade_capability),
+                Owner::Shared {
+                    initial_shared_version,
+                } => ObjectArg::SharedObject {
+                    id: upgrade_capability.0,
+                    initial_shared_version,
+                    mutable: true,
+                },
+                Owner::Immutable => {
+                    return Err(anyhow::anyhow!(
+                        "Upgrade capability is stored immutably and cannot be used for upgrades"
+                    ))
+                }
+                // If the capability is owned by an object, then the module defining the owning
+                // object gets to decide how the upgrade capability should be used.
+                Owner::ObjectOwner(_) => {
+                    return Err(anyhow::anyhow!("Upgrade capability controlled by object"))
+                }
+            };
+            builder.obj(capability_arg).unwrap();
+            let upgrade_arg = builder.pure(upgrade_policy).unwrap();
+            let digest_arg = builder.pure(digest).unwrap();
+            let upgrade_ticket = builder.programmable_move_call(
+                SUI_FRAMEWORK_OBJECT_ID,
+                ident_str!("package").to_owned(),
+                ident_str!("authorize_upgrade").to_owned(),
+                vec![],
+                vec![Argument::Input(0), upgrade_arg, digest_arg],
+            );
+            let upgrade_receipt = builder.upgrade(package_id, upgrade_ticket, dep_ids, modules);
+
+            builder.programmable_move_call(
+                SUI_FRAMEWORK_OBJECT_ID,
+                ident_str!("package").to_owned(),
+                ident_str!("commit_upgrade").to_owned(),
+                vec![],
+                vec![Argument::Input(0), upgrade_receipt],
+            );
+
+            builder.finish()
+        };
+        Ok(Self::new_programmable(
+            sender,
+            vec![gas_payment],
+            pt,
+            gas_budget,
+            gas_price,
+        ))
     }
 
     pub fn new_programmable_with_dummy_gas_price(

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -65,6 +65,7 @@ jemalloc-ctl = "^0.5"
 tempfile = "3.3.0"
 futures = "0.3.23"
 prometheus = "0.13.3"
+fs_extra = "1.2.0"
 
 jsonrpsee = { version = "0.16.2", features = ["jsonrpsee-core"] }
 

--- a/crates/sui/src/unit_tests/data/dummy_modules_upgrade/Move.toml
+++ b/crates/sui/src/unit_tests/data/dummy_modules_upgrade/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "Examples"
+version = "0.0.1"
+
+[addresses]
+examples = "0x0"

--- a/crates/sui/src/unit_tests/data/dummy_modules_upgrade/sources/trusted_coin.move
+++ b/crates/sui/src/unit_tests/data/dummy_modules_upgrade/sources/trusted_coin.move
@@ -1,0 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module examples::trusted_coin {
+    public fun f() { }
+}


### PR DESCRIPTION
This adds a fast-path upgrade for the Sui CLI I specifically didn't want to add it to the transaction builder/json-rpc API at the moment since we will probably want to to think that API through quite a bit more so we don't have to make too many breaking changes to it (and to allow custom upgrade policies). 

## Test Plan 

Added a new test (there's some nastiness around `published-at` that's needed in there sadly), and exercised the upgrade path locally in the CLI as well. 

