### PR TITLE
[rust sdk] adding show.content options in get_owned_objects (#9565)

### DIFF
--- a/crates/sui-json-rpc-types/src/sui_object.rs
+++ b/crates/sui-json-rpc-types/src/sui_object.rs
@@ -270,6 +270,10 @@ impl SuiObjectDataOptions {
         self.show_previous_transaction = true;
         self
     }
+
+    pub fn is_not_in_object_info(&self) -> bool {
+        self.show_bcs || self.show_content || self.show_display || self.show_storage_rebate
+    }
 }
 
 impl TryFrom<(ObjectRead, SuiObjectDataOptions)> for SuiObjectResponse {

--- a/crates/sui-json-rpc/src/api/mod.rs
+++ b/crates/sui-json-rpc/src/api/mod.rs
@@ -29,7 +29,6 @@ pub use read::ReadApiClient;
 pub use read::ReadApiOpenRpc;
 pub use read::ReadApiServer;
 
-// use anyhow::anyhow;
 pub use transaction_builder::TransactionBuilderClient;
 pub use transaction_builder::TransactionBuilderOpenRpc;
 pub use transaction_builder::TransactionBuilderServer;
@@ -50,16 +49,6 @@ pub fn cap_page_limit(limit: Option<usize>) -> usize {
         QUERY_MAX_RESULT_LIMIT
     } else {
         limit
-    }
-}
-
-pub fn cap_page_objects_limit(limit: Option<usize>) -> Result<usize, anyhow::Error> {
-    let limit = limit.unwrap_or(MAX_GET_OWNED_OBJECT_LIMIT);
-    if limit > MAX_GET_OWNED_OBJECT_LIMIT || limit == 0 {
-        Ok(MAX_GET_OWNED_OBJECT_LIMIT)
-        // MUSTFIXD(jian): implement this error: Err(anyhow!("limit is greater than max get owned object size"))
-    } else {
-        Ok(limit)
     }
 }
 

--- a/crates/sui-json-rpc/src/transaction_builder_api.rs
+++ b/crates/sui-json-rpc/src/transaction_builder_api.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::api::TransactionBuilderServer;
+use crate::api::{validate_limit, TransactionBuilderServer};
 use crate::SuiRpcModule;
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
@@ -22,7 +22,7 @@ use fastcrypto::encoding::Base64;
 use jsonrpsee::RpcModule;
 use sui_adapter::execution_mode::{DevInspect, Normal};
 
-use crate::api::cap_page_objects_limit;
+use crate::api::MAX_GET_OWNED_OBJECT_LIMIT;
 use crate::error::Error;
 use anyhow::anyhow;
 use sui_json::SuiJsonValue;
@@ -65,7 +65,7 @@ impl DataReader for AuthorityStateDataReader {
             return Err(anyhow!("at_checkpoint param currently not supported"));
         }
 
-        let limit = cap_page_objects_limit(limit)?;
+        let limit = validate_limit(limit, MAX_GET_OWNED_OBJECT_LIMIT)?;
         let SuiObjectResponseQuery { filter, options } = query.unwrap_or_default();
 
         let options = options.unwrap_or_default();

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -269,6 +269,39 @@ async fn test_get_object_info() -> Result<(), anyhow::Error> {
 }
 
 #[sim_test]
+async fn test_get_object_data_with_content() -> Result<(), anyhow::Error> {
+    let cluster = TestClusterBuilder::new().build().await?;
+    let http_client = cluster.rpc_client();
+    let address = cluster.accounts.first().unwrap();
+    let objects = http_client
+        .get_owned_objects(
+            *address,
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new().with_content().with_owner(),
+            )),
+            None,
+            None,
+            None,
+        )
+        .await?
+        .data;
+
+    for obj in objects {
+        let oref = obj.into_object().unwrap();
+        let result = http_client
+            .get_object_with_options(
+                oref.object_id,
+                Some(SuiObjectDataOptions::new().with_content().with_owner()),
+            )
+            .await?;
+        assert!(
+            matches!(result, SuiObjectResponse::Exists(object) if oref.object_id == object.object_id && &object.owner.unwrap().get_owner_address()? == address)
+        );
+    }
+    Ok(())
+}
+
+#[sim_test]
 async fn test_get_coins() -> Result<(), anyhow::Error> {
     let cluster = TestClusterBuilder::new().build().await?;
     let http_client = cluster.rpc_client();

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -811,7 +811,6 @@ impl SuiClientCommands {
                 let client = context.get_client().await?;
                 let address_object = client
                     .read_api()
-                    // TODO: (jian) fill in later
                     .get_owned_objects(
                         address,
                         Some(SuiObjectResponseQuery::new_with_options(
@@ -1350,7 +1349,6 @@ impl Display for SuiClientCommandResult {
                 )?;
                 writeln!(writer, "{}", ["-"; 165].join(""))?;
                 for oref in object_refs {
-                    // TODO (jian): fix unwrap and clone later
                     let obj = oref.clone().into_object().unwrap();
 
                     let owner_type = match obj.owner {

--- a/crates/sui/src/console.rs
+++ b/crates/sui/src/console.rs
@@ -137,7 +137,6 @@ async fn handle_command(
             SuiClientCommandResult::Objects(ref objects) => {
                 let objects = objects
                     .iter()
-                    // TODO (jian): fix unwrap and clone later
                     .map(|oref| format!("{}", oref.clone().into_object().unwrap().object_id))
                     .collect::<Vec<_>>();
                 cache.insert(CacheKey::new("object", "--id"), objects.clone());

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -1014,10 +1014,7 @@ async fn test_switch_command() -> Result<(), anyhow::Error> {
         .get_owned_objects(
             addr1,
             Some(SuiObjectResponseQuery::new_with_options(
-                SuiObjectDataOptions::new()
-                    .with_type()
-                    .with_owner()
-                    .with_previous_transaction(),
+                SuiObjectDataOptions::full_content(),
             )),
             None,
             None,

--- a/crates/test-utils/src/messages.rs
+++ b/crates/test-utils/src/messages.rs
@@ -75,7 +75,6 @@ pub async fn get_gas_object_with_wallet_context(
     if res.is_empty() {
         None
     } else {
-        // TODO (jian): handle unwrap error
         Some(res.swap_remove(0).into_object().unwrap().object_ref())
     }
 }

--- a/doc/src/build/rust-sdk.md
+++ b/doc/src/build/rust-sdk.md
@@ -41,7 +41,6 @@ use std::str::FromStr;
 use sui_sdk::types::base_types::SuiAddress;
 use sui_sdk::{SuiClient, SuiClientBuilder};
 
-// TODO: (jian) update example after pagination changes
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     let sui = SuiClientBuilder::default().build(
@@ -49,7 +48,7 @@ async fn main() -> Result<(), anyhow::Error> {
     ).await.unwrap();
     let address = SuiAddress::from_str("0xbcab7526033aa0e014f634bf51316715dda0907a7fab5a8d7e3bd44e634a4d44")?;
     let objects = sui.read_api().get_owned_objects(address).await?;
-    println!("{:?}", objects);
+    println!("{:?}", objects.data);
     Ok(())
 }
 ```


### PR DESCRIPTION
## Description 

Added display content option call in get_owned_objects api

## Test Plan 

CI

Content display proof.

![image](https://user-images.githubusercontent.com/123408603/226234049-dfa0bdeb-aca2-429b-8cd4-74ec4360e71b.png)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
