### PR TITLE
More detailed error message for dyanmic field read error

### DIFF
--- a/crates/sui-types/src/sui_system_state/mod.rs
+++ b/crates/sui-types/src/sui_system_state/mod.rs
@@ -14,6 +14,7 @@ use enum_dispatch::enum_dispatch;
 use move_core_types::{ident_str, identifier::IdentStr, language_storage::StructTag};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 use self::sui_system_state_inner_v1::{SuiSystemStateInnerV1, ValidatorV1};
 use self::sui_system_state_summary::{SuiSystemStateSummary, SuiValidatorSummary};
@@ -141,8 +142,16 @@ where
     let wrapper = get_sui_system_state_wrapper(object_store)?;
     match wrapper.version {
         1 => {
+            let id = wrapper.id.id.bytes;
             let result: SuiSystemStateInnerV1 =
-                get_dynamic_field_from_store(object_store, wrapper.id.id.bytes, &wrapper.version)?;
+                get_dynamic_field_from_store(object_store, id, &wrapper.version).map_err(
+                    |err| {
+                        SuiError::DynamicFieldReadError(format!(
+                            "Failed to load sui system state inner object with ID {:?} and version {:?}: {:?}",
+                            id, wrapper.version, err
+                        ))
+                    },
+                )?;
             Ok(SuiSystemState::V1(result))
         }
         // The following case is for sim_test only to support authority_tests::test_sui_system_state_nop_upgrade.
@@ -164,29 +173,38 @@ where
 /// the Validator type. This is assuming that the validator is stored in the table as
 /// ValidatorWrapper type.
 pub fn get_validator_from_table<S, K>(
-    system_state_version: u64,
     object_store: &S,
     table_id: ObjectID,
     key: &K,
 ) -> Result<SuiValidatorSummary, SuiError>
 where
     S: ObjectStore,
-    K: MoveTypeTagTrait + Serialize + DeserializeOwned,
+    K: MoveTypeTagTrait + Serialize + DeserializeOwned + fmt::Debug,
 {
-    let field: ValidatorWrapper = get_dynamic_field_from_store(object_store, table_id, key)?;
+    let field: ValidatorWrapper = get_dynamic_field_from_store(object_store, table_id, key)
+        .map_err(|err| {
+            SuiError::SuiSystemStateReadError(format!(
+                "Failed to load validator wrapper from table: {:?}",
+                err
+            ))
+        })?;
     let versioned = field.inner;
-    match system_state_version {
+    let version = versioned.version;
+    match version {
         1 => {
-            let validator: ValidatorV1 = get_dynamic_field_from_store(
-                object_store,
-                versioned.id.id.bytes,
-                &system_state_version,
-            )?;
+            let validator: ValidatorV1 =
+                get_dynamic_field_from_store(object_store, versioned.id.id.bytes, &version)
+                    .map_err(|err| {
+                        SuiError::SuiSystemStateReadError(format!(
+                            "Failed to load inner validator from the wrapper: {:?}",
+                            err
+                        ))
+                    })?;
             Ok(validator.into_sui_validator_summary())
         }
         _ => Err(SuiError::SuiSystemStateReadError(format!(
-            "Unsupported SuiSystemState version: {}",
-            system_state_version
+            "Unsupported Validator version: {}",
+            version
         ))),
     }
 }

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -515,12 +515,10 @@ async fn test_inactive_validator_pool_read() {
             .state()
             .get_sui_system_state_object_for_testing()
             .unwrap();
-        let version = system_state.version();
         let inactive_pool_id = system_state
             .into_sui_system_state_summary()
             .inactive_pools_id;
         let validator = get_validator_from_table(
-            version,
             node.state().db().as_ref(),
             inactive_pool_id,
             &ID::new(staking_pool_id),


### PR DESCRIPTION
This PR makes the error message more informative when we fail to load a dynamic field in the governance api.
Also made a change to validator versioning so that it doesn't depend on system state version but the internal version in the Versioned object.