### PR TITLE
[bugfix] - handle pending validator in get_stakes and fix wrong activation epoch

### DIFF
--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -1,18 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use jsonrpsee::core::RpcResult;
 use std::collections::BTreeMap;
 use std::sync::Arc;
-use sui_json_rpc_types::SuiCommittee;
-use sui_types::sui_system_state::sui_system_state_summary::SuiSystemStateSummary;
 
-use crate::api::GovernanceReadApiServer;
-use crate::error::Error;
-use crate::SuiRpcModule;
 use async_trait::async_trait;
+use jsonrpsee::core::RpcResult;
 use jsonrpsee::RpcModule;
+
 use sui_core::authority::AuthorityState;
+use sui_json_rpc_types::SuiCommittee;
 use sui_json_rpc_types::{DelegatedStake, Stake, StakeStatus};
 use sui_open_rpc::Module;
 use sui_types::base_types::{MoveObjectType, ObjectID, SuiAddress};
@@ -20,9 +17,14 @@ use sui_types::committee::EpochId;
 use sui_types::dynamic_field::get_dynamic_field_from_store;
 use sui_types::governance::StakedSui;
 use sui_types::id::ID;
+use sui_types::sui_system_state::sui_system_state_summary::SuiSystemStateSummary;
 use sui_types::sui_system_state::PoolTokenExchangeRate;
 use sui_types::sui_system_state::SuiSystemStateTrait;
 use sui_types::sui_system_state::{get_validator_from_table, SuiSystemState};
+
+use crate::api::GovernanceReadApiServer;
+use crate::error::Error;
+use crate::SuiRpcModule;
 
 pub struct GovernanceReadApi {
     state: Arc<AuthorityState>,
@@ -84,33 +86,49 @@ impl GovernanceReadApi {
             self.get_system_state()?.into_sui_system_state_summary();
         let mut delegated_stakes = vec![];
         for ((pool_id, validator_address), stakes) in pools {
+            // Rate table and rate can be null when the pool is not active
             let rate_table = self
                 .get_exchange_rate_table(&system_state, &pool_id)
-                .await?;
-
-            let current_rate = self
-                .get_exchange_rate(rate_table, system_state.epoch)
-                .await?;
+                .await
+                .ok();
+            let current_rate = if let Some(rate_table) = rate_table {
+                self.get_exchange_rate(rate_table, system_state.epoch)
+                    .await
+                    .ok()
+            } else {
+                None
+            };
 
             let mut delegations = vec![];
             for stake in stakes {
                 // delegation will be active in next epoch
-                let status = if system_state.epoch >= stake.request_epoch() {
-                    let stake_rate = self
-                        .get_exchange_rate(rate_table, stake.request_epoch())
-                        .await?;
-                    let estimated_reward = (((stake_rate.rate() / current_rate.rate()) - 1.0)
-                        * stake.principal() as f64)
-                        .round() as u64;
+                let status = if system_state.epoch >= stake.activation_epoch() {
+                    let estimated_reward = if let (Some(rate_table), Some(current_rate)) =
+                        (&rate_table, &current_rate)
+                    {
+                        let stake_rate = self
+                            .get_exchange_rate(*rate_table, stake.activation_epoch())
+                            .await
+                            .unwrap_or_default();
+                        let estimated_reward = ((stake_rate.rate() / current_rate.rate()) - 1.0)
+                            * stake.principal() as f64;
+                        if estimated_reward < 0.0 {
+                            0
+                        } else {
+                            estimated_reward.round() as u64
+                        }
+                    } else {
+                        0
+                    };
                     StakeStatus::Active { estimated_reward }
                 } else {
                     StakeStatus::Pending
                 };
                 delegations.push(Stake {
                     staked_sui_id: stake.id(),
-                    stake_request_epoch: stake.request_epoch(),
                     // TODO: this might change when we implement warm up period.
-                    stake_active_epoch: stake.request_epoch() + 1,
+                    stake_request_epoch: stake.activation_epoch() - 1,
+                    stake_active_epoch: stake.activation_epoch(),
                     principal: stake.principal(),
                     status,
                 })

--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::cmp::max;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
@@ -101,7 +102,6 @@ impl GovernanceReadApi {
 
             let mut delegations = vec![];
             for stake in stakes {
-                // delegation will be active in next epoch
                 let status = if system_state.epoch >= stake.activation_epoch() {
                     let estimated_reward = if let (Some(rate_table), Some(current_rate)) =
                         (&rate_table, &current_rate)
@@ -112,11 +112,7 @@ impl GovernanceReadApi {
                             .unwrap_or_default();
                         let estimated_reward = ((stake_rate.rate() / current_rate.rate()) - 1.0)
                             * stake.principal() as f64;
-                        if estimated_reward < 0.0 {
-                            0
-                        } else {
-                            estimated_reward.round() as u64
-                        }
+                        max(0, estimated_reward.round() as u64)
                     } else {
                         0
                     };

--- a/crates/sui-types/src/governance.rs
+++ b/crates/sui-types/src/governance.rs
@@ -59,7 +59,7 @@ impl StakedSui {
         self.pool_id.bytes
     }
 
-    pub fn request_epoch(&self) -> EpochId {
+    pub fn activation_epoch(&self) -> EpochId {
         self.stake_activation_epoch
     }
 

--- a/crates/sui-types/src/sui_system_state/mod.rs
+++ b/crates/sui-types/src/sui_system_state/mod.rs
@@ -205,7 +205,7 @@ impl PoolTokenExchangeRate {
     /// Rate of the staking pool, pool token amount : Sui amount
     pub fn rate(&self) -> f64 {
         if self.sui_amount == 0 {
-            1 as f64
+            1_f64
         } else {
             self.pool_token_amount as f64 / self.sui_amount as f64
         }

--- a/crates/sui-types/src/sui_system_state/mod.rs
+++ b/crates/sui-types/src/sui_system_state/mod.rs
@@ -195,7 +195,7 @@ pub fn get_sui_system_state_version(_protocol_version: ProtocolVersion) -> u64 {
     INIT_SYSTEM_STATE_VERSION
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, Default)]
 pub struct PoolTokenExchangeRate {
     sui_amount: u64,
     pool_token_amount: u64,
@@ -205,7 +205,7 @@ impl PoolTokenExchangeRate {
     /// Rate of the staking pool, pool token amount : Sui amount
     pub fn rate(&self) -> f64 {
         if self.sui_amount == 0 {
-            0 as f64
+            1 as f64
         } else {
             self.pool_token_amount as f64 / self.sui_amount as f64
         }


### PR DESCRIPTION
## Description 

Pending validator will not have rate table and will not have historic rate when it's not active, add extra checks to make sure get_stakes won't fail when this is the case.

also fixed a data misalignment in the StakedSui object, in move requested_epoch has been changed to activation_epoch, but the same change hasn't happen in the RPC layer. 

## Test Plan 

Manually tested locally