### PR TITLE
[sui framework] ID and address cleanup

### DIFF
--- a/crates/sui-framework/docs/borrow.md
+++ b/crates/sui-framework/docs/borrow.md
@@ -44,7 +44,7 @@ An object wrapping a <code>T</code> and providing the borrow API.
 
 <dl>
 <dt>
-<code>id: <a href="object.md#0x2_object_ID">object::ID</a></code>
+<code>id: <b>address</b></code>
 </dt>
 <dd>
 
@@ -78,7 +78,7 @@ A hot potato making sure the object is put back once borrowed.
 
 <dl>
 <dt>
-<code>ref: <a href="object.md#0x2_object_ID">object::ID</a></code>
+<code>ref: <b>address</b></code>
 </dt>
 <dd>
 
@@ -137,7 +137,7 @@ Create a new <code><a href="borrow.md#0x2_borrow_Referent">Referent</a></code> s
 
 <pre><code><b>public</b> <b>fun</b> <a href="borrow.md#0x2_borrow_new">new</a>&lt;T: key + store&gt;(value: T, ctx: &<b>mut</b> TxContext): <a href="borrow.md#0x2_borrow_Referent">Referent</a>&lt;T&gt; {
     <a href="borrow.md#0x2_borrow_Referent">Referent</a> {
-        id: <a href="object.md#0x2_object_new_id">object::new_id</a>(ctx),
+        id: <a href="tx_context.md#0x2_tx_context_fresh_object_address">tx_context::fresh_object_address</a>(ctx),
         value: <a href="_some">option::some</a>(value)
     }
 }

--- a/crates/sui-framework/docs/object.md
+++ b/crates/sui-framework/docs/object.md
@@ -11,7 +11,6 @@ Sui object identifiers
 -  [Resource `Ownership`](#0x2_object_Ownership)
 -  [Resource `DynamicFields`](#0x2_object_DynamicFields)
 -  [Constants](#@Constants_0)
--  [Function `fresh_id`](#0x2_object_fresh_id)
 -  [Function `id_to_bytes`](#0x2_object_id_to_bytes)
 -  [Function `id_to_address`](#0x2_object_id_to_address)
 -  [Function `id_from_bytes`](#0x2_object_id_from_bytes)
@@ -204,32 +203,6 @@ The hardcoded ID for the singleton Sui System State Object.
 </code></pre>
 
 
-
-<a name="0x2_object_fresh_id"></a>
-
-## Function `fresh_id`
-
-Create an <code><a href="object.md#0x2_object_ID">ID</a></code> from an unused object address. Not to be mistaken for <code><a href="object.md#0x2_object_new">object::new</a></code> which
-generates a new UID.
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_fresh_id">fresh_id</a>(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="object.md#0x2_object_ID">object::ID</a>
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_fresh_id">fresh_id</a>(ctx: &<b>mut</b> TxContext): <a href="object.md#0x2_object_ID">ID</a> {
-    <a href="object.md#0x2_object_ID">ID</a> { bytes: <a href="tx_context.md#0x2_tx_context_fresh_object_address">tx_context::fresh_object_address</a>(ctx) }
-}
-</code></pre>
-
-
-
-</details>
 
 <a name="0x2_object_id_to_bytes"></a>
 

--- a/crates/sui-framework/docs/object.md
+++ b/crates/sui-framework/docs/object.md
@@ -11,7 +11,7 @@ Sui object identifiers
 -  [Resource `Ownership`](#0x2_object_Ownership)
 -  [Resource `DynamicFields`](#0x2_object_DynamicFields)
 -  [Constants](#@Constants_0)
--  [Function `new_id`](#0x2_object_new_id)
+-  [Function `fresh_id`](#0x2_object_fresh_id)
 -  [Function `id_to_bytes`](#0x2_object_id_to_bytes)
 -  [Function `id_to_address`](#0x2_object_id_to_address)
 -  [Function `id_from_bytes`](#0x2_object_id_from_bytes)
@@ -205,15 +205,15 @@ The hardcoded ID for the singleton Sui System State Object.
 
 
 
-<a name="0x2_object_new_id"></a>
+<a name="0x2_object_fresh_id"></a>
 
-## Function `new_id`
+## Function `fresh_id`
 
-Create an <code><a href="object.md#0x2_object_ID">ID</a></code>. Not to be mistaken for <code><a href="object.md#0x2_object_new">object::new</a></code> which
+Create an <code><a href="object.md#0x2_object_ID">ID</a></code> from an unused object address. Not to be mistaken for <code><a href="object.md#0x2_object_new">object::new</a></code> which
 generates a new UID.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_new_id">new_id</a>(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="object.md#0x2_object_ID">object::ID</a>
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_fresh_id">fresh_id</a>(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="object.md#0x2_object_ID">object::ID</a>
 </code></pre>
 
 
@@ -222,8 +222,8 @@ generates a new UID.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_new_id">new_id</a>(ctx: &<b>mut</b> TxContext): <a href="object.md#0x2_object_ID">ID</a> {
-    <a href="object.md#0x2_object_ID">ID</a> { bytes: <a href="tx_context.md#0x2_tx_context_new_object">tx_context::new_object</a>(ctx) }
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_fresh_id">fresh_id</a>(ctx: &<b>mut</b> TxContext): <a href="object.md#0x2_object_ID">ID</a> {
+    <a href="object.md#0x2_object_ID">ID</a> { bytes: <a href="tx_context.md#0x2_tx_context_fresh_object_address">tx_context::fresh_object_address</a>(ctx) }
 }
 </code></pre>
 
@@ -507,7 +507,7 @@ This is the only way to create <code><a href="object.md#0x2_object_UID">UID</a><
 
 <pre><code><b>public</b> <b>fun</b> <a href="object.md#0x2_object_new">new</a>(ctx: &<b>mut</b> TxContext): <a href="object.md#0x2_object_UID">UID</a> {
     <a href="object.md#0x2_object_UID">UID</a> {
-        id: <a href="object.md#0x2_object_ID">ID</a> { bytes: <a href="tx_context.md#0x2_tx_context_new_object">tx_context::new_object</a>(ctx) },
+        id: <a href="object.md#0x2_object_ID">ID</a> { bytes: <a href="tx_context.md#0x2_tx_context_fresh_object_address">tx_context::fresh_object_address</a>(ctx) },
     }
 }
 </code></pre>

--- a/crates/sui-framework/docs/transfer.md
+++ b/crates/sui-framework/docs/transfer.md
@@ -42,9 +42,9 @@ be constructed in the transaction they are created.
 ## Function `transfer`
 
 Transfer ownership of <code>obj</code> to <code>recipient</code>. <code>obj</code> must have the <code>key</code> attribute,
-which (in turn) ensures that <code>obj</code> has a globally unique ID. Note that while while the
-recipient <code><b>address</b></code> might represent an object ID, the mechanism for the object to actually
-use or claim objects sent to it is not yet implemented.
+which (in turn) ensures that <code>obj</code> has a globally unique ID. Note that if the recipient
+address represents an object ID, the <code>obj</code> sent will be inaccessible after the transfer
+(though they will be retrievable at a future date once new features are added).
 This function has custom rules performed by the Sui Move bytecode verifier that ensures
 that <code>T</code> is an object defined in the module where <code><a href="transfer.md#0x2_transfer">transfer</a></code> is invoked. Use
 <code>public_transfer</code> to transfer an object with <code>store</code> outside of its module.
@@ -73,9 +73,9 @@ that <code>T</code> is an object defined in the module where <code><a href="tran
 ## Function `public_transfer`
 
 Transfer ownership of <code>obj</code> to <code>recipient</code>. <code>obj</code> must have the <code>key</code> attribute,
-which (in turn) ensures that <code>obj</code> has a globally unique ID. Note that while while the
-recipient <code><b>address</b></code> might represent an object ID, the mechanism for the object to actually
-use or claim objects sent to it is not yet implemented.
+which (in turn) ensures that <code>obj</code> has a globally unique ID. Note that if the recipient
+address represents an object ID, the <code>obj</code> sent will be inaccessible after the transfer
+(though they will be retrievable at a future date once new features are added).
 The object must have <code>store</code> to be transferred outside of its module.
 
 

--- a/crates/sui-framework/docs/transfer.md
+++ b/crates/sui-framework/docs/transfer.md
@@ -42,7 +42,9 @@ be constructed in the transaction they are created.
 ## Function `transfer`
 
 Transfer ownership of <code>obj</code> to <code>recipient</code>. <code>obj</code> must have the <code>key</code> attribute,
-which (in turn) ensures that <code>obj</code> has a globally unique ID.
+which (in turn) ensures that <code>obj</code> has a globally unique ID. Note that while while the
+recipient <code><b>address</b></code> might represent an object ID, the mechanism for the object to actually
+use or claim objects sent to it is not yet implemented.
 This function has custom rules performed by the Sui Move bytecode verifier that ensures
 that <code>T</code> is an object defined in the module where <code><a href="transfer.md#0x2_transfer">transfer</a></code> is invoked. Use
 <code>public_transfer</code> to transfer an object with <code>store</code> outside of its module.
@@ -71,7 +73,9 @@ that <code>T</code> is an object defined in the module where <code><a href="tran
 ## Function `public_transfer`
 
 Transfer ownership of <code>obj</code> to <code>recipient</code>. <code>obj</code> must have the <code>key</code> attribute,
-which (in turn) ensures that <code>obj</code> has a globally unique ID.
+which (in turn) ensures that <code>obj</code> has a globally unique ID. Note that while while the
+recipient <code><b>address</b></code> might represent an object ID, the mechanism for the object to actually
+use or claim objects sent to it is not yet implemented.
 The object must have <code>store</code> to be transferred outside of its module.
 
 

--- a/crates/sui-framework/docs/tx_context.md
+++ b/crates/sui-framework/docs/tx_context.md
@@ -10,7 +10,7 @@
 -  [Function `sender`](#0x2_tx_context_sender)
 -  [Function `epoch`](#0x2_tx_context_epoch)
 -  [Function `epoch_timestamp_ms`](#0x2_tx_context_epoch_timestamp_ms)
--  [Function `new_object`](#0x2_tx_context_new_object)
+-  [Function `fresh_object_address`](#0x2_tx_context_fresh_object_address)
 -  [Function `ids_created`](#0x2_tx_context_ids_created)
 -  [Function `derive_id`](#0x2_tx_context_derive_id)
 
@@ -175,14 +175,16 @@ Return the epoch start time as a unix timestamp in milliseconds.
 
 </details>
 
-<a name="0x2_tx_context_new_object"></a>
+<a name="0x2_tx_context_fresh_object_address"></a>
 
-## Function `new_object`
+## Function `fresh_object_address`
 
-Generate a new, globally unique object ID with version 0
+Create an <code><b>address</b></code> that has not been used. As it is an object address, it should never
+occurr as the address for a user.
+In other words, the generated address is a globally unique object ID.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="tx_context.md#0x2_tx_context_new_object">new_object</a>(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <b>address</b>
+<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context_fresh_object_address">fresh_object_address</a>(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <b>address</b>
 </code></pre>
 
 
@@ -191,7 +193,7 @@ Generate a new, globally unique object ID with version 0
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="tx_context.md#0x2_tx_context_new_object">new_object</a>(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a>): <b>address</b> {
+<pre><code><b>public</b> <b>fun</b> <a href="tx_context.md#0x2_tx_context_fresh_object_address">fresh_object_address</a>(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">TxContext</a>): <b>address</b> {
     <b>let</b> ids_created = ctx.ids_created;
     <b>let</b> id = <a href="tx_context.md#0x2_tx_context_derive_id">derive_id</a>(*&ctx.tx_hash, ids_created);
     ctx.ids_created = ids_created + 1;

--- a/crates/sui-framework/docs/tx_context.md
+++ b/crates/sui-framework/docs/tx_context.md
@@ -179,8 +179,8 @@ Return the epoch start time as a unix timestamp in milliseconds.
 
 ## Function `fresh_object_address`
 
-Create an <code><b>address</b></code> that has not been used. As it is an object address, it should never
-occurr as the address for a user.
+Create an <code><b>address</b></code> that has not been used. As it is an object address, it will never
+occur as the address for a user.
 In other words, the generated address is a globally unique object ID.
 
 

--- a/crates/sui-framework/sources/borrow.move
+++ b/crates/sui-framework/sources/borrow.move
@@ -9,7 +9,7 @@
 module sui::borrow {
     use sui::object::{Self, ID};
     use std::option::{Self, Option};
-    use sui::tx_context::TxContext;
+    use sui::tx_context::{Self, TxContext};
 
     /// The `Borrow` does not match the `Referent`.
     const EWrongBorrow: u64 = 0;
@@ -18,17 +18,17 @@ module sui::borrow {
 
     /// An object wrapping a `T` and providing the borrow API.
     struct Referent<T: key + store> has store {
-        id: ID,
+        id: address,
         value: Option<T>
     }
 
     /// A hot potato making sure the object is put back once borrowed.
-    struct Borrow { ref: ID, obj: ID }
+    struct Borrow { ref: address, obj: ID }
 
     /// Create a new `Referent` struct
     public fun new<T: key + store>(value: T, ctx: &mut TxContext): Referent<T> {
         Referent {
-            id: object::new_id(ctx),
+            id: tx_context::fresh_object_address(ctx),
             value: option::some(value)
         }
     }

--- a/crates/sui-framework/sources/collectible/transfer_policy.move
+++ b/crates/sui-framework/sources/collectible/transfer_policy.move
@@ -350,8 +350,8 @@ module sui::malicious_policy {
 #[test_only]
 module sui::transfer_policy_test {
     use sui::transfer_policy::{Self as policy, TransferPolicy, TransferPolicyCap};
-    use sui::tx_context::{TxContext, dummy as ctx};
-    use sui::object::{Self, UID};
+    use sui::tx_context::{Self, TxContext, dummy as ctx};
+    use sui::object::{Self, ID, UID};
     use sui::dummy_policy;
     use sui::malicious_policy;
     use sui::package;
@@ -367,7 +367,7 @@ module sui::transfer_policy_test {
         let (policy, cap) = prepare(ctx);
 
         // time to make a new transfer request
-        let request = policy::new_request(10_000, object::fresh_id(ctx), ctx);
+        let request = policy::new_request(10_000, fresh_id(ctx), ctx);
         policy::confirm_request(&policy, request);
 
         wrapup(policy, cap, ctx);
@@ -382,7 +382,7 @@ module sui::transfer_policy_test {
         // now require everyone to pay any amount
         dummy_policy::set(&mut policy, &cap);
 
-        let request = policy::new_request(10_000, object::fresh_id(ctx), ctx);
+        let request = policy::new_request(10_000, fresh_id(ctx), ctx);
 
         dummy_policy::pay(&mut policy, &mut request, coin::mint_for_testing(10_000, ctx));
         policy::confirm_request(&policy, request);
@@ -402,7 +402,7 @@ module sui::transfer_policy_test {
         // now require everyone to pay any amount
         dummy_policy::set(&mut policy, &cap);
 
-        let request = policy::new_request(10_000, object::fresh_id(ctx), ctx);
+        let request = policy::new_request(10_000, fresh_id(ctx), ctx);
         policy::confirm_request(&policy, request);
 
         wrapup(policy, cap, ctx);
@@ -419,7 +419,7 @@ module sui::transfer_policy_test {
         dummy_policy::set(&mut policy, &cap);
         dummy_policy::set(&mut policy, &cap);
 
-        let request = policy::new_request(10_000, object::fresh_id(ctx), ctx);
+        let request = policy::new_request(10_000, fresh_id(ctx), ctx);
         policy::confirm_request(&policy, request);
 
         wrapup(policy, cap, ctx);
@@ -434,7 +434,7 @@ module sui::transfer_policy_test {
 
         // now require everyone to pay any amount
         dummy_policy::set(&mut policy, &cap);
-        let request = policy::new_request(10_000, object::fresh_id(ctx), ctx);
+        let request = policy::new_request(10_000, fresh_id(ctx), ctx);
 
         // try to add receipt from another rule
         malicious_policy::cheat(&mut request);
@@ -453,5 +453,9 @@ module sui::transfer_policy_test {
     fun wrapup(policy: TransferPolicy<Asset>, cap: TransferPolicyCap<Asset>, ctx: &mut TxContext): u64 {
         let profits = policy::destroy_and_withdraw(policy, cap, ctx);
         coin::burn_for_testing(profits)
+    }
+
+    fun fresh_id(ctx: &mut TxContext): ID {
+        object::id_from_address(tx_context::fresh_object_address(ctx))
     }
 }

--- a/crates/sui-framework/sources/collectible/transfer_policy.move
+++ b/crates/sui-framework/sources/collectible/transfer_policy.move
@@ -367,7 +367,7 @@ module sui::transfer_policy_test {
         let (policy, cap) = prepare(ctx);
 
         // time to make a new transfer request
-        let request = policy::new_request(10_000, object::new_id(ctx), ctx);
+        let request = policy::new_request(10_000, object::fresh_id(ctx), ctx);
         policy::confirm_request(&policy, request);
 
         wrapup(policy, cap, ctx);
@@ -382,7 +382,7 @@ module sui::transfer_policy_test {
         // now require everyone to pay any amount
         dummy_policy::set(&mut policy, &cap);
 
-        let request = policy::new_request(10_000, object::new_id(ctx), ctx);
+        let request = policy::new_request(10_000, object::fresh_id(ctx), ctx);
 
         dummy_policy::pay(&mut policy, &mut request, coin::mint_for_testing(10_000, ctx));
         policy::confirm_request(&policy, request);
@@ -402,7 +402,7 @@ module sui::transfer_policy_test {
         // now require everyone to pay any amount
         dummy_policy::set(&mut policy, &cap);
 
-        let request = policy::new_request(10_000, object::new_id(ctx), ctx);
+        let request = policy::new_request(10_000, object::fresh_id(ctx), ctx);
         policy::confirm_request(&policy, request);
 
         wrapup(policy, cap, ctx);
@@ -419,7 +419,7 @@ module sui::transfer_policy_test {
         dummy_policy::set(&mut policy, &cap);
         dummy_policy::set(&mut policy, &cap);
 
-        let request = policy::new_request(10_000, object::new_id(ctx), ctx);
+        let request = policy::new_request(10_000, object::fresh_id(ctx), ctx);
         policy::confirm_request(&policy, request);
 
         wrapup(policy, cap, ctx);
@@ -434,7 +434,7 @@ module sui::transfer_policy_test {
 
         // now require everyone to pay any amount
         dummy_policy::set(&mut policy, &cap);
-        let request = policy::new_request(10_000, object::new_id(ctx), ctx);
+        let request = policy::new_request(10_000, object::fresh_id(ctx), ctx);
 
         // try to add receipt from another rule
         malicious_policy::cheat(&mut request);

--- a/crates/sui-framework/sources/object.move
+++ b/crates/sui-framework/sources/object.move
@@ -50,10 +50,10 @@ module sui::object {
 
     // === id ===
 
-    /// Create an `ID`. Not to be mistaken for `object::new` which
+    /// Create an `ID` from an unused object address. Not to be mistaken for `object::new` which
     /// generates a new UID.
-    public fun new_id(ctx: &mut TxContext): ID {
-        ID { bytes: tx_context::new_object(ctx) }
+    public fun fresh_id(ctx: &mut TxContext): ID {
+        ID { bytes: tx_context::fresh_object_address(ctx) }
     }
 
     /// Get the raw bytes of a `ID`
@@ -121,7 +121,7 @@ module sui::object {
     /// This is the only way to create `UID`s.
     public fun new(ctx: &mut TxContext): UID {
         UID {
-            id: ID { bytes: tx_context::new_object(ctx) },
+            id: ID { bytes: tx_context::fresh_object_address(ctx) },
         }
     }
 

--- a/crates/sui-framework/sources/object.move
+++ b/crates/sui-framework/sources/object.move
@@ -50,12 +50,6 @@ module sui::object {
 
     // === id ===
 
-    /// Create an `ID` from an unused object address. Not to be mistaken for `object::new` which
-    /// generates a new UID.
-    public fun fresh_id(ctx: &mut TxContext): ID {
-        ID { bytes: tx_context::fresh_object_address(ctx) }
-    }
-
     /// Get the raw bytes of a `ID`
     public fun id_to_bytes(id: &ID): vector<u8> {
         bcs::to_bytes(&id.bytes)

--- a/crates/sui-framework/sources/transfer.move
+++ b/crates/sui-framework/sources/transfer.move
@@ -15,7 +15,9 @@ module sui::transfer {
     const ESharedNonNewObject: u64 = 0;
 
     /// Transfer ownership of `obj` to `recipient`. `obj` must have the `key` attribute,
-    /// which (in turn) ensures that `obj` has a globally unique ID.
+    /// which (in turn) ensures that `obj` has a globally unique ID. Note that while while the
+    /// recipient `address` might represent an object ID, the mechanism for the object to actually
+    /// use or claim objects sent to it is not yet implemented.
     /// This function has custom rules performed by the Sui Move bytecode verifier that ensures
     /// that `T` is an object defined in the module where `transfer` is invoked. Use
     /// `public_transfer` to transfer an object with `store` outside of its module.
@@ -24,7 +26,9 @@ module sui::transfer {
     }
 
     /// Transfer ownership of `obj` to `recipient`. `obj` must have the `key` attribute,
-    /// which (in turn) ensures that `obj` has a globally unique ID.
+    /// which (in turn) ensures that `obj` has a globally unique ID. Note that while while the
+    /// recipient `address` might represent an object ID, the mechanism for the object to actually
+    /// use or claim objects sent to it is not yet implemented.
     /// The object must have `store` to be transferred outside of its module.
     public fun public_transfer<T: key + store>(obj: T, recipient: address) {
         transfer_impl(obj, recipient)

--- a/crates/sui-framework/sources/transfer.move
+++ b/crates/sui-framework/sources/transfer.move
@@ -15,9 +15,9 @@ module sui::transfer {
     const ESharedNonNewObject: u64 = 0;
 
     /// Transfer ownership of `obj` to `recipient`. `obj` must have the `key` attribute,
-    /// which (in turn) ensures that `obj` has a globally unique ID. Note that while while the
-    /// recipient `address` might represent an object ID, the mechanism for the object to actually
-    /// use or claim objects sent to it is not yet implemented.
+    /// which (in turn) ensures that `obj` has a globally unique ID. Note that if the recipient
+    /// address represents an object ID, the `obj` sent will be inaccessible after the transfer
+    /// (though they will be retrievable at a future date once new features are added).
     /// This function has custom rules performed by the Sui Move bytecode verifier that ensures
     /// that `T` is an object defined in the module where `transfer` is invoked. Use
     /// `public_transfer` to transfer an object with `store` outside of its module.
@@ -26,9 +26,9 @@ module sui::transfer {
     }
 
     /// Transfer ownership of `obj` to `recipient`. `obj` must have the `key` attribute,
-    /// which (in turn) ensures that `obj` has a globally unique ID. Note that while while the
-    /// recipient `address` might represent an object ID, the mechanism for the object to actually
-    /// use or claim objects sent to it is not yet implemented.
+    /// which (in turn) ensures that `obj` has a globally unique ID. Note that if the recipient
+    /// address represents an object ID, the `obj` sent will be inaccessible after the transfer
+    /// (though they will be retrievable at a future date once new features are added).
     /// The object must have `store` to be transferred outside of its module.
     public fun public_transfer<T: key + store>(obj: T, recipient: address) {
         transfer_impl(obj, recipient)

--- a/crates/sui-framework/sources/tx_context.move
+++ b/crates/sui-framework/sources/tx_context.move
@@ -49,8 +49,8 @@ module sui::tx_context {
        self.epoch_timestamp_ms
     }
 
-    /// Create an `address` that has not been used. As it is an object address, it should never
-    /// occurr as the address for a user.
+    /// Create an `address` that has not been used. As it is an object address, it will never
+    /// occur as the address for a user.
     /// In other words, the generated address is a globally unique object ID.
     public fun fresh_object_address(ctx: &mut TxContext): address {
         let ids_created = ctx.ids_created;

--- a/crates/sui-framework/sources/tx_context.move
+++ b/crates/sui-framework/sources/tx_context.move
@@ -3,8 +3,6 @@
 
 module sui::tx_context {
 
-    friend sui::object;
-
     #[test_only]
     use std::vector;
 
@@ -51,8 +49,10 @@ module sui::tx_context {
        self.epoch_timestamp_ms
     }
 
-    /// Generate a new, globally unique object ID with version 0
-    public(friend) fun new_object(ctx: &mut TxContext): address {
+    /// Create an `address` that has not been used. As it is an object address, it should never
+    /// occurr as the address for a user.
+    /// In other words, the generated address is a globally unique object ID.
+    public fun fresh_object_address(ctx: &mut TxContext): address {
         let ids_created = ctx.ids_created;
         let id = derive_id(*&ctx.tx_hash, ids_created);
         ctx.ids_created = ids_created + 1;


### PR DESCRIPTION
## Description 

- Removed sui::object as a friend of sui::tx_context
- Made object generation public
- Renamed sui::object::new
- Clarified transfer::transfer

## Test Plan 

- Updated tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
