### PR TITLE
[chore] Remove implicit VM Error conversion

### DIFF
--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -9,11 +9,8 @@ use crate::{
     object::Owner,
 };
 use fastcrypto::error::FastCryptoError;
-use move_binary_format::access::ModuleAccess;
-use move_binary_format::{
-    errors::{Location, PartialVMError, VMError},
-    file_format::FunctionDefinitionIndex,
-};
+use move_binary_format::{access::ModuleAccess, errors::VMError};
+use move_binary_format::{errors::Location, file_format::FunctionDefinitionIndex};
 use move_core_types::{
     resolver::{ModuleResolver, ResourceResolver},
     vm_status::{StatusCode, StatusType},
@@ -468,26 +465,9 @@ impl From<sui_protocol_config::Error> for SuiError {
     }
 }
 
-// TODO these are both horribly wrong, categorization needs to be considered
-impl From<PartialVMError> for SuiError {
-    fn from(error: PartialVMError) -> Self {
-        SuiError::ModuleVerificationFailure {
-            error: error.to_string(),
-        }
-    }
-}
-
 impl From<ExecutionError> for SuiError {
     fn from(error: ExecutionError) -> Self {
         SuiError::ExecutionError(error.to_string())
-    }
-}
-
-impl From<VMError> for SuiError {
-    fn from(error: VMError) -> Self {
-        SuiError::ModuleVerificationFailure {
-            error: error.to_string(),
-        }
     }
 }
 


### PR DESCRIPTION
## Description 

- Remove automatic conversion for SuiError from PartialVMError and VMError

## Test Plan 

- compiles

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
