### PR TITLE
[ts-sdk] Rework wallet adapter signAndExecuteTransaction

### DIFF
--- a/.changeset/thin-points-ring.md
+++ b/.changeset/thin-points-ring.md
@@ -1,0 +1,6 @@
+---
+"@mysten/wallet-adapter-unsafe-burner": minor
+"@mysten/wallet-standard": minor
+---
+
+Changed where the options and requestType for signAndExecuteTransaction are.

--- a/apps/explorer/src/components/module/module-functions-interaction/ModuleFunction.tsx
+++ b/apps/explorer/src/components/module/module-functions-interaction/ModuleFunction.tsx
@@ -88,11 +88,9 @@ export function ModuleFunction({
             const result = await signAndExecuteTransaction({
                 transaction: tx,
                 options: {
-                    contentOptions: {
-                        showEffects: true,
-                        showEvents: true,
-                        showInput: true,
-                    },
+                    showEffects: true,
+                    showEvents: true,
+                    showInput: true,
                 },
             });
             if (getExecutionStatusType(result) === 'failure') {

--- a/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
+++ b/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
@@ -10,12 +10,12 @@ import {
     SUI_LOCALNET_CHAIN,
     type SuiFeatures,
     type SuiSignAndExecuteTransactionMethod,
-    type ConnectFeature,
-    type ConnectMethod,
+    type StandardConnectFeature,
+    type StandardConnectMethod,
     type Wallet,
-    type EventsFeature,
-    type EventsOnMethod,
-    type EventsListeners,
+    type StandardEventsFeature,
+    type StandardEventsOnMethod,
+    type StandardEventsListeners,
     type SuiSignTransactionMethod,
     type SuiSignMessageMethod,
 } from '@mysten/wallet-standard';
@@ -50,7 +50,9 @@ import type {
 import type { NetworkEnvType } from '_src/background/NetworkEnv';
 
 type WalletEventsMap = {
-    [E in keyof EventsListeners]: Parameters<EventsListeners[E]>[0];
+    [E in keyof StandardEventsListeners]: Parameters<
+        StandardEventsListeners[E]
+    >[0];
 };
 
 // NOTE: Because this runs in a content script, we can't fetch the manifest.
@@ -98,8 +100,8 @@ export class SuiWallet implements Wallet {
         return SUI_CHAINS;
     }
 
-    get features(): ConnectFeature &
-        EventsFeature &
+    get features(): StandardConnectFeature &
+        StandardEventsFeature &
         SuiFeatures &
         SuiWalletStakeFeature {
         return {
@@ -186,7 +188,7 @@ export class SuiWallet implements Wallet {
         this.#connected();
     }
 
-    #on: EventsOnMethod = (event, listener) => {
+    #on: StandardEventsOnMethod = (event, listener) => {
         this.#events.on(event, listener);
         return () => this.#events.off(event, listener);
     };
@@ -203,7 +205,7 @@ export class SuiWallet implements Wallet {
         }
     };
 
-    #connect: ConnectMethod = async (input) => {
+    #connect: StandardConnectMethod = async (input) => {
         if (!input?.silent) {
             await mapToPromise(
                 this.#send<
@@ -282,18 +284,13 @@ export class SuiWallet implements Wallet {
         });
     };
 
-    #signMessage: SuiSignMessageMethod = async ({
-        message,
-        account,
-        options,
-    }) => {
+    #signMessage: SuiSignMessageMethod = async ({ message, account }) => {
         return mapToPromise(
             this.#send<SignMessageRequest, SignMessageRequest>({
                 type: 'sign-message-request',
                 args: {
                     message: toB64(message),
                     accountAddress: account.address,
-                    options,
                 },
             }),
             (response) => {

--- a/apps/wallet/src/shared/messaging/messages/payloads/transactions/ApprovalRequest.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/transactions/ApprovalRequest.ts
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+    type SuiSignAndExecuteTransactionInput,
     type SuiSignMessageOutput,
-    type SuiSignMessageOptions,
-    type SuiSignAndExecuteTransactionOptions,
 } from '@mysten/wallet-standard';
 
 import type {
@@ -18,14 +17,14 @@ export type TransactionDataType = {
     data: string;
     account: SuiAddress;
     justSign?: boolean;
-    options?: SuiSignAndExecuteTransactionOptions;
+    requestType?: SuiSignAndExecuteTransactionInput['requestType'];
+    options?: SuiSignAndExecuteTransactionInput['options'];
 };
 
 export type SignMessageDataType = {
     type: 'sign-message';
     message: string;
     accountAddress: SuiAddress;
-    options?: SuiSignMessageOptions;
 };
 
 export type ApprovalRequest = {

--- a/apps/wallet/src/shared/messaging/messages/payloads/transactions/SignMessage.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/transactions/SignMessage.ts
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { type SuiAddress } from '@mysten/sui.js';
-import {
-    type SuiSignMessageOptions,
-    type SuiSignMessageOutput,
-} from '@mysten/wallet-standard';
+import { type SuiSignMessageOutput } from '@mysten/wallet-standard';
 
 import { type BasePayload, isBasePayload } from '../BasePayload';
 import { type Payload } from '../Payload';
@@ -14,7 +11,6 @@ export interface SignMessageRequest extends BasePayload {
     type: 'sign-message-request';
     args?: {
         message: string; // base64
-        options?: SuiSignMessageOptions;
         accountAddress: SuiAddress;
     };
     return?: SuiSignMessageOutput;

--- a/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
@@ -97,8 +97,8 @@ export const respondToTransactionRequest = createAsyncThunk<
                     } else {
                         txResult = await signer.signAndExecuteTransaction({
                             transaction: tx,
-                            options: txRequest.tx.options?.contentOptions,
-                            requestType: txRequest.tx.options?.requestType,
+                            options: txRequest.tx.options,
+                            requestType: txRequest.tx.requestType,
                         });
                     }
                 } else {

--- a/sdk/wallet-adapter/adapters/unsafe-burner/src/index.ts
+++ b/sdk/wallet-adapter/adapters/unsafe-burner/src/index.ts
@@ -65,8 +65,8 @@ export class UnsafeBurnerWalletAdapter implements WalletAdapter {
     async (transactionInput) => {
       return await this.#signer.signAndExecuteTransaction({
         transaction: transactionInput.transaction,
-        options: transactionInput.options?.contentOptions,
-        requestType: transactionInput.options?.requestType,
+        options: transactionInput.options,
+        requestType: transactionInput.requestType,
       });
     };
 

--- a/sdk/wallet-adapter/example/src/App.tsx
+++ b/sdk/wallet-adapter/example/src/App.tsx
@@ -46,7 +46,7 @@ function App() {
             console.log(
               await signAndExecuteTransaction({
                 transaction,
-                options: { contentOptions: { showEffects: true } },
+                options: { showEffects: true },
               })
             );
           }}

--- a/sdk/wallet-adapter/wallet-standard/README.md
+++ b/sdk/wallet-adapter/wallet-standard/README.md
@@ -43,17 +43,17 @@ You can implement these features in your wallet class under the `features` prope
 
 ```typescript
 import {
-  ConnectFeature,
-  ConnectMethod,
-  EventsFeature,
-  EventsOnMethod,
+  StandardConnectFeature,
+  StandardConnectMethod,
+  StandardEventsFeature,
+  StandardEventsOnMethod,
   SuiFeatures,
   SuiTransactionMethod,
   SuiSignAndExecuteTransactionMethod
 } from "@mysten/wallet-standard";
 
 class YourWallet implements Wallet {
-  get features(): ConnectFeature & EventsFeature & SuiFeatures {
+  get features(): StandardConnectFeature & StandardEventsFeature & SuiFeatures {
     return {
       "standard:connect": {
         version: "1.0.0",
@@ -74,11 +74,11 @@ class YourWallet implements Wallet {
     };
   },
 
-  #on: EventsOnMethod = () => {
+  #on: StandardEventsOnMethod = () => {
     // Your wallet's events on implementation.
   };
 
-  #connect: ConnectMethod = () => {
+  #connect: StandardConnectMethod = () => {
     // Your wallet's connect implementation
   };
 

--- a/sdk/wallet-adapter/wallet-standard/src/detect.ts
+++ b/sdk/wallet-adapter/wallet-standard/src/detect.ts
@@ -2,20 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
-  ConnectFeature,
-  DisconnectFeature,
-  EventsFeature,
+  StandardConnectFeature,
+  StandardDisconnectFeature,
+  StandardEventsFeature,
   Wallet,
   WalletWithFeatures,
 } from "@wallet-standard/core";
 import { SuiFeatures } from "./features";
 
 export type StandardWalletAdapterWallet = WalletWithFeatures<
-  ConnectFeature &
-    EventsFeature &
+  StandardConnectFeature &
+    StandardEventsFeature &
     SuiFeatures &
     // Disconnect is an optional feature:
-    Partial<DisconnectFeature>
+    Partial<StandardDisconnectFeature>
 >;
 
 // These features are absolutely required for wallets to function in the Sui ecosystem.

--- a/sdk/wallet-adapter/wallet-standard/src/features/suiSignAndExecuteTransaction.ts
+++ b/sdk/wallet-adapter/wallet-standard/src/features/suiSignAndExecuteTransaction.ts
@@ -32,15 +32,15 @@ export type SuiSignAndExecuteTransactionMethod = (
 /** Input for signing and sending transactions. */
 export interface SuiSignAndExecuteTransactionInput
   extends SuiSignTransactionInput {
-  options?: SuiSignAndExecuteTransactionOptions;
+  /**
+   * `WaitForEffectsCert` or `WaitForLocalExecution`, see details in `ExecuteTransactionRequestType`.
+   * Defaults to `WaitForLocalExecution` if options.showEffects or options.showEvents is true
+   */
+  requestType?: ExecuteTransactionRequestType;
+  /** specify which fields to return (e.g., transaction, effects, events, etc). By default, only the transaction digest will be returned. */
+  options?: SuiTransactionResponseOptions;
 }
 
 /** Output of signing and sending transactions. */
 export interface SuiSignAndExecuteTransactionOutput
   extends SuiTransactionResponse {}
-
-/** Options for signing and sending transactions. */
-export interface SuiSignAndExecuteTransactionOptions {
-  requestType?: ExecuteTransactionRequestType;
-  contentOptions?: SuiTransactionResponseOptions;
-}

--- a/sdk/wallet-adapter/wallet-standard/src/features/suiSignMessage.ts
+++ b/sdk/wallet-adapter/wallet-standard/src/features/suiSignMessage.ts
@@ -27,12 +27,8 @@ export type SuiSignMessageMethod = (
 /** Input for signing messages. */
 export interface SuiSignMessageInput {
   message: Uint8Array;
-  options?: SuiSignMessageOptions;
   account: WalletAccount;
 }
 
 /** Output of signing messages. */
 export interface SuiSignMessageOutput extends SignedMessage {}
-
-/** Options for signing messages. */
-export interface SuiSignMessageOptions {}

--- a/sdk/wallet-adapter/wallet-standard/src/features/suiSignTransaction.ts
+++ b/sdk/wallet-adapter/wallet-standard/src/features/suiSignTransaction.ts
@@ -1,10 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type {
-  SignedTransaction,
-  Transaction,
-} from "@mysten/sui.js";
+import type { SignedTransaction, Transaction } from "@mysten/sui.js";
 import type { IdentifierString, WalletAccount } from "@wallet-standard/core";
 
 /** The latest API version of the signTransaction API. */
@@ -30,13 +27,9 @@ export type SuiSignTransactionMethod = (
 /** Input for signing transactions. */
 export interface SuiSignTransactionInput {
   transaction: Transaction;
-  options?: SuiSignTransactionOptions;
   account: WalletAccount;
   chain: IdentifierString;
 }
 
 /** Output of signing transactions. */
 export interface SuiSignTransactionOutput extends SignedTransaction {}
-
-/** Options for signing transactions. */
-export interface SuiSignTransactionOptions {}


### PR DESCRIPTION
## Description 

We got feedback from partners that the different API signatures for `signAndExecuteTransaction` that exist between the provider and the wallet standard are confusing, so unifying those signatures.

## Test Plan 

Tests should still pass.