### PR TITLE
[explorer] - use `atRiskValidators` field for displaying at-risk validators

### DIFF
--- a/apps/explorer/src/pages/epochs/EpochDetail.tsx
+++ b/apps/explorer/src/pages/epochs/EpochDetail.tsx
@@ -48,11 +48,7 @@ function EpochDetail() {
     if (isLoading || validatorsEventsLoading) return <LoadingSpinner />;
     if (!data || !validatorEvents) return null;
 
-    const validatorsTable = validatorsTableData(
-        data.activeValidators,
-        data.epoch,
-        validatorEvents?.data
-    );
+    const validatorsTable = validatorsTableData(data, validatorEvents.data);
 
     return (
         <div className="flex flex-col space-y-16">

--- a/apps/explorer/src/pages/validators/Validators.tsx
+++ b/apps/explorer/src/pages/validators/Validators.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { calculateAPY, roundFloat } from '@mysten/core';
-import { type SuiValidatorSummary, type SuiEvent } from '@mysten/sui.js';
+import { type SuiSystemStateSummary, type SuiEvent } from '@mysten/sui.js';
 import { lazy, Suspense, useMemo } from 'react';
 
 import { ErrorBoundary } from '~/components/error-boundary/ErrorBoundary';
@@ -24,24 +24,20 @@ import { getValidatorMoveEvent } from '~/utils/getValidatorMoveEvent';
 
 const APY_DECIMALS = 3;
 
-// This constant needs to match the constant in the on-chain smart contract sui_system::VALIDATOR_LOW_STAKE_THRESHOLD.
-const VALIDATOR_LOW_STAKE_THRESHOLD = 25_000_000_000_000_000;
-
 const NodeMap = lazy(() => import('../../components/node-map'));
 
 export function validatorsTableData(
-    validators: SuiValidatorSummary[],
-    epoch: number,
-    validatorsEvents: SuiEvent[]
+    systemState: SuiSystemStateSummary,
+    validatorEvents: SuiEvent[]
 ) {
     return {
-        data: validators.map((validator) => {
+        data: systemState.activeValidators.map((validator) => {
             const validatorName = validator.name;
             const totalStake = validator.stakingPoolSuiBalance;
             const img = validator.imageUrl;
 
             const event = getValidatorMoveEvent(
-                validatorsEvents,
+                validatorEvents,
                 validator.suiAddress
             );
             return {
@@ -50,13 +46,15 @@ export function validatorsTableData(
                     logo: validator.imageUrl,
                 },
                 stake: totalStake,
-                apy: calculateAPY(validator, epoch),
+                apy: calculateAPY(validator, systemState.epoch),
                 nextEpochGasPrice: validator.nextEpochGasPrice,
                 commission: +validator.commissionRate / 100,
                 img: img,
                 address: validator.suiAddress,
                 lastReward: event?.stake_rewards || 0,
-                atRisk: totalStake < VALIDATOR_LOW_STAKE_THRESHOLD,
+                atRisk: systemState.atRiskValidators.some(
+                    ([address]) => address === validator.suiAddress
+                ),
             };
         }),
         columns: [
@@ -233,14 +231,7 @@ function ValidatorPageResult() {
 
     const validatorsTable = useMemo(() => {
         if (!data || !validatorEvents) return null;
-
-        const validators = data.activeValidators;
-
-        return validatorsTableData(
-            validators,
-            +data.epoch,
-            validatorEvents.data
-        );
+        return validatorsTableData(data, validatorEvents.data);
     }, [validatorEvents, data]);
 
     const defaultSorting = [{ id: 'stake', desc: false }];


### PR DESCRIPTION
## Description 

Updates Validators table to use `atRiskValidators` field for displaying validators that are at-risk, instead of computing value based on stake.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
