### PR TITLE
crypto: update doc and test vectors for prehash

### DIFF
--- a/.changeset/ten-planes-admire.md
+++ b/.changeset/ten-planes-admire.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+[testing only] an intent scope can be passed in to verifyMessage

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -4,6 +4,7 @@ use anyhow::anyhow;
 use bip32::DerivationPath;
 use clap::*;
 use fastcrypto::encoding::{decode_bytes_hex, Base64, Encoding};
+use fastcrypto::hash::HashFunction;
 use fastcrypto::traits::KeyPair;
 use shared_crypto::intent::{Intent, IntentMessage};
 use std::fs;
@@ -13,15 +14,14 @@ use sui_keys::keypair_file::{
     read_authority_keypair_from_file, read_keypair_from_file, write_authority_keypair_to_file,
     write_keypair_to_file,
 };
-use sui_types::crypto::{PublicKey, Signature};
+use sui_keys::keystore::{AccountKeystore, Keystore};
+use sui_types::base_types::SuiAddress;
+use sui_types::crypto::{get_authority_key_pair, EncodeDecodeBase64, SignatureScheme, SuiKeyPair};
+use sui_types::crypto::{DefaultHash, PublicKey, Signature};
 use sui_types::messages::TransactionData;
 use sui_types::multisig::{MultiSig, MultiSigPublicKey, ThresholdUnit, WeightUnit};
 use sui_types::signature::GenericSignature;
 use tracing::info;
-
-use sui_keys::keystore::{AccountKeystore, Keystore};
-use sui_types::base_types::SuiAddress;
-use sui_types::crypto::{get_authority_key_pair, EncodeDecodeBase64, SignatureScheme, SuiKeyPair};
 #[cfg(test)]
 #[path = "unit_tests/keytool_tests.rs"]
 mod keytool_tests;
@@ -188,10 +188,13 @@ impl KeyToolCommand {
                     })?)?;
                 let intent_msg = IntentMessage::new(intent, msg);
                 println!(
-                    "Intent message to sign: {:?}",
+                    "Raw intent message: {:?}",
                     Base64::encode(bcs::to_bytes(&intent_msg)?)
                 );
-
+                let mut hasher = DefaultHash::default();
+                hasher.update(bcs::to_bytes(&intent_msg)?);
+                let digest = hasher.finalize().digest;
+                println!("Digest to sign: {:?}", Base64::encode(digest));
                 let sui_signature =
                     keystore.sign_secure(&address, &intent_msg.value, intent_msg.intent)?;
                 println!(

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -384,8 +384,10 @@ const compiledModulesAndDependencies = JSON.parse(
 );
 const tx = new Transaction();
 tx.publish(
-    compiledModulesAndDeps.modules.map((m: any) => Array.from(fromB64(m))),
-    compiledModulesAndDeps.dependencies.map((addr: string) => normalizeSuiObjectId(addr)),
+  compiledModulesAndDeps.modules.map((m: any) => Array.from(fromB64(m))),
+  compiledModulesAndDeps.dependencies.map((addr: string) =>
+    normalizeSuiObjectId(addr),
+  ),
 );
 const result = await signer.signAndExecuteTransaction({ transaction: tx });
 console.log({ result });

--- a/sdk/typescript/src/utils/verify.ts
+++ b/sdk/typescript/src/utils/verify.ts
@@ -15,14 +15,15 @@ import { blake2b } from '@noble/hashes/blake2b';
 // it could allow the Sui.js to be tree-shaken a little better, possibly allowing keypairs that are
 // not used (and their deps) to be entirely removed from the bundle.
 
-/** Verify data that is signed with `signer.signMessage`. */
+/** Verify data that is signed with the expected scope. */
 export async function verifyMessage(
   message: Uint8Array | string,
   serializedSignature: SerializedSignature,
+  scope: IntentScope,
 ) {
   const signature = fromSerializedSignature(serializedSignature);
   const messageBytes = messageWithIntent(
-    IntentScope.PersonalMessage,
+    scope,
     typeof message === 'string' ? fromB64(message) : message,
   );
   const digest = blake2b(messageBytes, { dkLen: 32 });

--- a/sdk/typescript/test/e2e/raw-signer.test.ts
+++ b/sdk/typescript/test/e2e/raw-signer.test.ts
@@ -1,19 +1,79 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import nacl from 'tweetnacl';
 import { describe, it, expect, beforeAll } from 'vitest';
 import {
   Ed25519Keypair,
+  fromB64,
   fromSerializedSignature,
+  IntentScope,
+  messageWithIntent,
   RawSigner,
   Secp256k1Keypair,
+  toB64,
   verifyMessage,
 } from '../../src';
-import * as secp from '@noble/secp256k1';
-import { Signature } from '@noble/secp256k1';
+
 import { setup, TestToolbox } from './utils/setup';
 import { blake2b } from '@noble/hashes/blake2b';
+
+const TX_BYTES =
+  'AAACAQDMdYtdFSLGe6VbgpuIsMksv9Ypzpvkq2jiYq0hAjUpOQIAAAAAAAAAIHGwPza+lUm6RuJV1vn9pA4y0PwVT7k/KMMbUViQS5ydACAMVn/9+BYsttUa90vgGZRDuS6CPUumztJN5cbEY3l9RgEBAQEAAAEBAHUFfdk1Tg9l6STLBoSBJbbUuehTDUlLH7p81kpqCKsaBCiJ034Ac84f1oqgmpz79O8L/UeLNDUpOUMa+LadeX93AgAAAAAAAAAgs1e67e789jSlrzOJUXq0bb7Bn/hji+3F5UoMAbze595xCSZCVjU1ItUC9G7KQjygNiBbzZe8t7YLPjRAQyGTzAIAAAAAAAAAIAujHFcrkJJhZfCmxmCHsBWxj5xkviUqB479oupdgMZu07b+hkrjyvCcX50dO30v3PszXFj7+lCNTUTuE4UI3eoCAAAAAAAAACBIv39dyVELUFTkNv72mat5R1uHFkQdViikc1lTMiSVlOD+eESUq3neyciBatafk9dHuhhrS37RaSflqKwFlwzPAgAAAAAAAAAg8gqL3hCkAho8bb0PoqshJdqQFoRP8ZmQMZDFvsGBqa11BX3ZNU4PZekkywaEgSW21LnoUw1JSx+6fNZKagirGgEAAAAAAAAAKgQAAAAAAAAA';
+const DIGEST = 'VMVv+/L/EG7/yhEbCQ1qiSt30JXV8yIm+4xO6yTkqeM=';
+const DERIVATION_PATH = `m/44'/784'/0'/0'/0'`;
+const DERIVATION_PATH_SECP256K1 = `m/54'/784'/0'/0/0`;
+
+// Test cases for Ed25519.
+// First element is the mnemonics, second element is the
+// base64 encoded pubkey, derived using DERIVATION_PATH,
+// third element is the hex encoded address, fourth
+// element is the valid signature produced for TX_BYTES.
+const TEST_CASES = [
+  [
+    'film crazy soon outside stand loop subway crumble thrive popular green nuclear struggle pistol arm wife phrase warfare march wheat nephew ask sunny firm',
+    'ImR/7u82MGC9QgWhZxoV8QoSNnZZGLG19jjYLzPPxGk=',
+    'a2d14fad60c56049ecf75246a481934691214ce413e6a8ae2fe6834c173a6133',
+    'NwIObhuKot7QRWJu4wWCC5ttOgEfN7BrrVq1draImpDZqtKEaWjNNRKKfWr1FL4asxkBlQd8IwpxpKSTzcXMAQ==',
+  ],
+  [
+    'require decline left thought grid priority false tiny gasp angle royal system attack beef setup reward aunt skill wasp tray vital bounce inflict level',
+    'vG6hEnkYNIpdmWa/WaLivd1FWBkxG+HfhXkyWgs9uP4=',
+    '1ada6e6f3f3e4055096f606c746690f1108fcc2ca479055cc434a3e1d3f758aa',
+    '8BSMw/VdYSXxbpl5pp8b5ylWLntTWfBG3lSvAHZbsV9uD2/YgsZDbhVba4rIPhGTn3YvDNs3FOX5+EIXMup3Bw==',
+  ],
+  [
+    'organ crash swim stick traffic remember army arctic mesh slice swear summer police vast chaos cradle squirrel hood useless evidence pet hub soap lake',
+    'arEzeF7Uu90jP4Sd+Or17c+A9kYviJpCEQAbEt0FHbU=',
+    'e69e896ca10f5a77732769803cc2b5707f0ab9d4407afb5e4b4464b89769af14',
+    '/ihBMku1SsqK+yDxNY47N/tAREZ+gWVTvZrUoCHsGGR9CoH6E7SLKDRYY9RnwBw/Bt3wWcdJ0Wc2Q3ioHIlzDA==',
+  ],
+];
+
+// Test cases for Secp256k1.
+// First element is the mnemonics, second element is the
+// base64 encoded pubkey, derived using DERIVATION_PATH_SECP256K1,
+// third element is the hex encoded address, fourth
+// element is the valid signature produced for TX_BYTES.
+const TEST_CASES_SECP256K1 = [
+  [
+    'film crazy soon outside stand loop subway crumble thrive popular green nuclear struggle pistol arm wife phrase warfare march wheat nephew ask sunny firm',
+    'Ar2Vs2ei2HgaCIvcsAVAZ6bKYXhDfRTlF432p8Wn4lsL',
+    '9e8f732575cc5386f8df3c784cd3ed1b53ce538da79926b2ad54dcc1197d2532',
+    'y7a8KDd9Py4i5GIka7zAFSHOCOTVLm9ibDx3wPd6WsQa7C1FUdxz32+h5TYmNNWUpTRgWgdBAeG9OgAnDBg0cQ==',
+  ],
+  [
+    'require decline left thought grid priority false tiny gasp angle royal system attack beef setup reward aunt skill wasp tray vital bounce inflict level',
+    'A5IcrmWDxl0J/4MNkrtE1AvwiLZiqih9tjttcGlafw+m',
+    '9fd5a804ed6b46d36949ff7434247f0fd594673973ece24aede6b86a7b5dae01',
+    'ijfLeBFowLQjuUD9h6/q9cmuZGg1Afo0ZgZJsZrJsIt2FSFddIomOzqnan3v1T9aW14aBMAlymUELgryib4Q/A==',
+  ],
+  [
+    'organ crash swim stick traffic remember army arctic mesh slice swear summer police vast chaos cradle squirrel hood useless evidence pet hub soap lake',
+    'AuEiECTZwyHhqStzpO/RNBXO89/Wa8oc4BtoneKnl6h8',
+    '60287d7c38dee783c2ab1077216124011774be6b0764d62bd05f32c88979d5c5',
+    'qAZyBPNUOtr2uKNByx9HNpWlDxQrOCjtMajYXGTAtWMnTp1cFYMe6QyT0EsYJ0t5xKtK8xq29yChbpsHWz94qA==',
+  ],
+];
 
 describe('RawSigner', () => {
   let toolbox: TestToolbox;
@@ -23,18 +83,31 @@ describe('RawSigner', () => {
   });
 
   it('Ed25519 keypair signData', async () => {
-    const keypair = new Ed25519Keypair();
-    const signData = new TextEncoder().encode('hello world');
-    const digest = blake2b(signData, { dkLen: 32 });
-    const signer = new RawSigner(keypair, toolbox.provider);
-    const serializedSignature = await signer.signData(signData);
-    const { signature, pubKey } = fromSerializedSignature(serializedSignature);
-    const isValid = nacl.sign.detached.verify(
-      digest,
-      signature,
-      pubKey.toBytes(),
+    const tx_bytes = fromB64(TX_BYTES);
+    const intentMessage = messageWithIntent(
+      IntentScope.TransactionData,
+      tx_bytes,
     );
-    expect(isValid).toBeTruthy();
+    const digest = blake2b(intentMessage, { dkLen: 32 });
+    expect(toB64(digest)).toEqual(DIGEST);
+
+    for (const t of TEST_CASES) {
+      const keypair = Ed25519Keypair.deriveKeypair(t[0], DERIVATION_PATH);
+      expect(keypair.getPublicKey().toBase64()).toEqual(t[1]);
+      expect(keypair.getPublicKey().toSuiAddress()).toEqual(t[2]);
+
+      const signer = new RawSigner(keypair, toolbox.provider);
+      const serializedSignature = await signer.signData(intentMessage);
+      const { signature } = fromSerializedSignature(serializedSignature);
+      expect(toB64(signature)).toEqual(t[3]);
+
+      const isValid = await verifyMessage(
+        tx_bytes,
+        serializedSignature,
+        IntentScope.TransactionData,
+      );
+      expect(isValid).toBeTruthy();
+    }
   });
 
   it('Ed25519 keypair signMessage', async () => {
@@ -42,7 +115,11 @@ describe('RawSigner', () => {
     const signData = new TextEncoder().encode('hello world');
     const signer = new RawSigner(keypair, toolbox.provider);
     const { signature } = await signer.signMessage({ message: signData });
-    const isValid = await verifyMessage(signData, signature);
+    const isValid = await verifyMessage(
+      signData,
+      signature,
+      IntentScope.PersonalMessage,
+    );
     expect(isValid).toBe(true);
   });
 
@@ -54,22 +131,40 @@ describe('RawSigner', () => {
     const isValid = await verifyMessage(
       new TextEncoder().encode('hello worlds'),
       signature,
+      IntentScope.PersonalMessage,
     );
     expect(isValid).toBe(false);
   });
 
   it('Secp256k1 keypair signData', async () => {
-    const keypair = new Secp256k1Keypair();
-    const signData = new TextEncoder().encode('hello world');
-    const digest = blake2b(signData, { dkLen: 32 });
-    const msgHash = await secp.utils.sha256(digest);
-    const signer = new RawSigner(keypair, toolbox.provider);
-    const serializedSignature = await signer.signData(signData);
-    const { signature, pubKey } = fromSerializedSignature(serializedSignature);
+    const tx_bytes = fromB64(TX_BYTES);
+    const intentMessage = messageWithIntent(
+      IntentScope.TransactionData,
+      tx_bytes,
+    );
+    const digest = blake2b(intentMessage, { dkLen: 32 });
+    expect(toB64(digest)).toEqual(DIGEST);
 
-    expect(
-      secp.verify(Signature.fromCompact(signature), msgHash, pubKey.toBytes()),
-    ).toBeTruthy();
+    for (const t of TEST_CASES_SECP256K1) {
+      const keypair = Secp256k1Keypair.deriveKeypair(
+        t[0],
+        DERIVATION_PATH_SECP256K1,
+      );
+      expect(keypair.getPublicKey().toBase64()).toEqual(t[1]);
+      expect(keypair.getPublicKey().toSuiAddress()).toEqual(t[2]);
+
+      const signer = new RawSigner(keypair, toolbox.provider);
+      const serializedSignature = await signer.signData(intentMessage);
+      const { signature } = fromSerializedSignature(serializedSignature);
+      expect(toB64(signature)).toEqual(t[3]);
+
+      const isValid = await verifyMessage(
+        tx_bytes,
+        serializedSignature,
+        IntentScope.TransactionData,
+      );
+      expect(isValid).toBeTruthy();
+    }
   });
 
   it('Secp256k1 keypair signMessage', async () => {
@@ -78,7 +173,11 @@ describe('RawSigner', () => {
     const signer = new RawSigner(keypair, toolbox.provider);
     const { signature } = await signer.signMessage({ message: signData });
 
-    const isValid = await verifyMessage(signData, signature);
+    const isValid = await verifyMessage(
+      signData,
+      signature,
+      IntentScope.PersonalMessage,
+    );
     expect(isValid).toBe(true);
   });
 });


### PR DESCRIPTION
## Description 
Updating docs and test vectors for https://github.com/MystenLabs/sui/pull/9561
## Test Plan 
unit and e2e tests pass. 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
