### PR TITLE
use base64 for pub keys

### DIFF
--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -6471,7 +6471,7 @@
             "type": "string"
           },
           "networkPubkeyBytes": {
-            "$ref": "#/components/schemas/Base58"
+            "$ref": "#/components/schemas/Base64"
           },
           "nextEpochCommissionRate": {
             "type": "integer",
@@ -6493,7 +6493,7 @@
             "default": null,
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Base58"
+                "$ref": "#/components/schemas/Base64"
               },
               {
                 "type": "null"
@@ -6516,7 +6516,7 @@
             "default": null,
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Base58"
+                "$ref": "#/components/schemas/Base64"
               },
               {
                 "type": "null"
@@ -6527,7 +6527,7 @@
             "default": null,
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Base58"
+                "$ref": "#/components/schemas/Base64"
               },
               {
                 "type": "null"
@@ -6549,7 +6549,7 @@
             "default": null,
             "anyOf": [
               {
-                "$ref": "#/components/schemas/Base58"
+                "$ref": "#/components/schemas/Base64"
               },
               {
                 "type": "null"
@@ -6593,10 +6593,10 @@
             "type": "string"
           },
           "proofOfPossessionBytes": {
-            "$ref": "#/components/schemas/Base58"
+            "$ref": "#/components/schemas/Base64"
           },
           "protocolPubkeyBytes": {
-            "$ref": "#/components/schemas/Base58"
+            "$ref": "#/components/schemas/Base64"
           },
           "rewardsPool": {
             "description": "The epoch stake rewards will be added here at the end of each epoch.",
@@ -6648,7 +6648,7 @@
             "type": "string"
           },
           "workerPubkeyBytes": {
-            "$ref": "#/components/schemas/Base58"
+            "$ref": "#/components/schemas/Base64"
           }
         }
       },

--- a/crates/sui-types/src/sui_system_state/sui_system_state_summary.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_summary.rs
@@ -4,7 +4,7 @@
 use crate::base_types::{AuthorityName, ObjectID, SuiAddress};
 use crate::committee::{Committee, CommitteeWithNetworkMetadata, NetworkMetadata};
 use crate::multiaddr::Multiaddr;
-use fastcrypto::encoding::Base58;
+use fastcrypto::encoding::Base64;
 use fastcrypto::traits::ToFromBytes;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -114,17 +114,17 @@ impl SuiSystemStateSummary {
 pub struct SuiValidatorSummary {
     // Metadata
     pub sui_address: SuiAddress,
-    #[schemars(with = "Base58")]
-    #[serde_as(as = "Base58")]
+    #[schemars(with = "Base64")]
+    #[serde_as(as = "Base64")]
     pub protocol_pubkey_bytes: Vec<u8>,
-    #[schemars(with = "Base58")]
-    #[serde_as(as = "Base58")]
+    #[schemars(with = "Base64")]
+    #[serde_as(as = "Base64")]
     pub network_pubkey_bytes: Vec<u8>,
-    #[schemars(with = "Base58")]
-    #[serde_as(as = "Base58")]
+    #[schemars(with = "Base64")]
+    #[serde_as(as = "Base64")]
     pub worker_pubkey_bytes: Vec<u8>,
-    #[schemars(with = "Base58")]
-    #[serde_as(as = "Base58")]
+    #[schemars(with = "Base64")]
+    #[serde_as(as = "Base64")]
     pub proof_of_possession_bytes: Vec<u8>,
     pub name: String,
     pub description: String,
@@ -134,17 +134,17 @@ pub struct SuiValidatorSummary {
     pub p2p_address: String,
     pub primary_address: String,
     pub worker_address: String,
-    #[schemars(with = "Option<Base58>")]
-    #[serde_as(as = "Option<Base58>")]
+    #[schemars(with = "Option<Base64>")]
+    #[serde_as(as = "Option<Base64>")]
     pub next_epoch_protocol_pubkey_bytes: Option<Vec<u8>>,
-    #[schemars(with = "Option<Base58>")]
-    #[serde_as(as = "Option<Base58>")]
+    #[schemars(with = "Option<Base64>")]
+    #[serde_as(as = "Option<Base64>")]
     pub next_epoch_proof_of_possession: Option<Vec<u8>>,
-    #[schemars(with = "Option<Base58>")]
-    #[serde_as(as = "Option<Base58>")]
+    #[schemars(with = "Option<Base64>")]
+    #[serde_as(as = "Option<Base64>")]
     pub next_epoch_network_pubkey_bytes: Option<Vec<u8>>,
-    #[schemars(with = "Option<Base58>")]
-    #[serde_as(as = "Option<Base58>")]
+    #[schemars(with = "Option<Base64>")]
+    #[serde_as(as = "Option<Base64>")]
     pub next_epoch_worker_pubkey_bytes: Option<Vec<u8>>,
     pub next_epoch_net_address: Option<String>,
     pub next_epoch_p2p_address: Option<String>,


### PR DESCRIPTION
## Description 

base64 is canonical to encode key materials.

## Test Plan 

existing tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Use base64 for pub key in validator summary.
