### PR TITLE
wallet-ext: BackgroundServiceSigner sign data signature

### DIFF
--- a/apps/wallet/src/background/keyring/AccountKeypair.test.ts
+++ b/apps/wallet/src/background/keyring/AccountKeypair.test.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+    Ed25519Keypair,
+    RawSigner,
+    JsonRpcProvider,
+    Secp256k1Keypair,
+} from '@mysten/sui.js';
+import { describe, expect, it } from 'vitest';
+
+import { AccountKeypair } from './AccountKeypair';
+
+describe('AccountKeypair', () => {
+    describe('signData produces same signature with RawSigner', () => {
+        it.each([
+            { label: 'Ed25519Keypair', keypair: new Ed25519Keypair() },
+            { label: 'Secp256k1Keypair', keypair: new Secp256k1Keypair() },
+        ])('for $label', async ({ label, keypair }) => {
+            const signData = new TextEncoder().encode('hello world');
+            const account = new AccountKeypair(keypair);
+            const accountKeypairSignature = await account.sign(signData);
+            const rawSigner = new RawSigner(keypair, new JsonRpcProvider());
+            const rawSignerSignature = await rawSigner.signData(signData);
+            expect(accountKeypairSignature).toBe(rawSignerSignature);
+        });
+    });
+});

--- a/apps/wallet/src/background/keyring/AccountKeypair.ts
+++ b/apps/wallet/src/background/keyring/AccountKeypair.ts
@@ -6,6 +6,7 @@ import {
     type SerializedSignature,
     type Keypair,
 } from '@mysten/sui.js';
+import { blake2b } from '@noble/hashes/blake2b';
 
 export class AccountKeypair {
     #keypair: Keypair;
@@ -15,9 +16,10 @@ export class AccountKeypair {
     }
 
     async sign(data: Uint8Array): Promise<SerializedSignature> {
+        const digest = blake2b(data, { dkLen: 32 });
         const pubkey = this.#keypair.getPublicKey();
         // This is fine to hardcode useRecoverable = false because wallet does not support Secp256k1. Ed25519 does not use this parameter.
-        const signature = this.#keypair.signData(data, false);
+        const signature = this.#keypair.signData(digest, false);
         const signatureScheme = this.#keypair.getKeyScheme();
         return toSerializedSignature({
             signature,


### PR DESCRIPTION
## Description 
* update BackgroundServiceSigner to create a signature by signing the data digest instead the data itself
* make sure BackgroundServiceSigner produces the same signature as RawSigner

## Test Plan 
pnpm test
also try sending sui from wallet

fixes executing transactions from wallet (due to wrong signature) [after changing the way signature is created](https://github.com/MystenLabs/sui/pull/9561) 