### PR TITLE
Serialize aggregate signatures as uncompressed

### DIFF
--- a/narwhal/node/tests/staged/narwhal.yaml
+++ b/narwhal/node/tests/staged/narwhal.yaml
@@ -15,10 +15,7 @@ Certificate:
   STRUCT:
     - header:
         TYPENAME: Header
-    - aggregated_signature:
-        TUPLEARRAY:
-          CONTENT: U8
-          SIZE: 48
+    - aggregated_signature: BYTES
     - signed_authorities: BYTES
     - metadata:
         TYPENAME: Metadata

--- a/narwhal/types/src/primary.rs
+++ b/narwhal/types/src/primary.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
     error::{DagError, DagResult},
-    serde::NarwhalBitmap,
+    serde::{NarwhalBitmap, UncompressedAggregateSignature},
     CertificateDigestProto,
 };
 use bytes::Bytes;
@@ -499,6 +499,7 @@ impl PartialEq for Vote {
 #[derive(Clone, Serialize, Deserialize, Default, MallocSizeOf)]
 pub struct Certificate {
     pub header: Header,
+    #[serde_as(as = "UncompressedAggregateSignature")]
     aggregated_signature: AggregateSignature,
     #[serde_as(as = "NarwhalBitmap")]
     signed_authorities: roaring::RoaringBitmap,

--- a/narwhal/types/src/serde.rs
+++ b/narwhal/types/src/serde.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crypto::AggregateSignature;
+use fastcrypto::traits::ToFromBytes;
 use serde::{
     de::{Deserializer, Error},
     ser::{Error as SerError, Serializer},
@@ -51,5 +53,26 @@ impl<'de> DeserializeAs<'de, roaring::RoaringBitmap> for NarwhalBitmap {
     {
         let bytes: Vec<u8> = Bytes::deserialize_as(deserializer)?;
         roaring::RoaringBitmap::deserialize_from(&bytes[..]).map_err(to_custom_error::<'de, D, _>)
+    }
+}
+
+pub struct UncompressedAggregateSignature;
+
+impl SerializeAs<AggregateSignature> for UncompressedAggregateSignature {
+    fn serialize_as<S>(source: &AggregateSignature, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        Bytes::serialize_as(&source.sig.serialize(), serializer)
+    }
+}
+
+impl<'de> DeserializeAs<'de, AggregateSignature> for UncompressedAggregateSignature {
+    fn deserialize_as<D>(deserializer: D) -> Result<AggregateSignature, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let bytes: Vec<u8> = Bytes::deserialize_as(deserializer)?;
+        AggregateSignature::from_bytes(&bytes).map_err(to_custom_error::<'de, D, _>)
     }
 }


### PR DESCRIPTION
## Description 

Deserializing the aggregate signature in a narwhal `Certificate` when this is read from disk accounts for up to 2% of cpu time spent by validators because these signatures are stored in compressed form. This PR changes this such that signatures are stored in uncompressed form. This makes them 96 bytes long compared to 48 bytes, but with significantly faster deserialisation.

Closing #8982 

## Test Plan 

Unit tests.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [x] necessitate either a data wipe or data migration

### Release notes
