### PR TITLE
[wallet-ext] re-factor LedgerSigner to handle lazily connecting to Ledger and do some other clean-up type work

### DIFF
--- a/apps/wallet/src/ui/app/LedgerSigner.ts
+++ b/apps/wallet/src/ui/app/LedgerSigner.ts
@@ -11,7 +11,7 @@ import {
     type JsonRpcProvider,
 } from '@mysten/sui.js';
 
-import SuiLedgerClient from '@mysten/ledgerjs-hw-app-sui';
+import type SuiLedgerClient from '@mysten/ledgerjs-hw-app-sui';
 
 export class LedgerSigner extends SignerWithProvider {
     #suiLedgerClient: SuiLedgerClient | null;

--- a/apps/wallet/src/ui/app/LedgerSigner.ts
+++ b/apps/wallet/src/ui/app/LedgerSigner.ts
@@ -11,25 +11,35 @@ import {
     type JsonRpcProvider,
 } from '@mysten/sui.js';
 
-import type SuiLedgerClient from '@mysten/ledgerjs-hw-app-sui';
+import SuiLedgerClient from '@mysten/ledgerjs-hw-app-sui';
 
 export class LedgerSigner extends SignerWithProvider {
-    readonly #suiLedgerClient: SuiLedgerClient;
+    #suiLedgerClient: SuiLedgerClient | null;
+    readonly #connectToLedger: () => Promise<SuiLedgerClient>;
     readonly #derivationPath: string;
     readonly #signatureScheme: SignatureScheme = 'ED25519';
 
     constructor(
-        suiLedgerClient: SuiLedgerClient,
+        connectToLedger: () => Promise<SuiLedgerClient>,
         derivationPath: string,
         provider: JsonRpcProvider
     ) {
         super(provider);
-        this.#suiLedgerClient = suiLedgerClient;
+        this.#connectToLedger = connectToLedger;
+        this.#suiLedgerClient = null;
         this.#derivationPath = derivationPath;
     }
 
+    async #initializeSuiLedgerClient() {
+        if (!this.#suiLedgerClient) {
+            this.#suiLedgerClient = await this.#connectToLedger();
+        }
+        return this.#suiLedgerClient;
+    }
+
     async getAddress(): Promise<SuiAddress> {
-        const publicKeyResult = await this.#suiLedgerClient.getPublicKey(
+        const ledgerClient = await this.#initializeSuiLedgerClient();
+        const publicKeyResult = await ledgerClient.getPublicKey(
             this.#derivationPath
         );
         const publicKey = new Ed25519PublicKey(publicKeyResult.publicKey);
@@ -37,14 +47,16 @@ export class LedgerSigner extends SignerWithProvider {
     }
 
     async getPublicKey(): Promise<Ed25519PublicKey> {
-        const { publicKey } = await this.#suiLedgerClient.getPublicKey(
+        const ledgerClient = await this.#initializeSuiLedgerClient();
+        const { publicKey } = await ledgerClient.getPublicKey(
             this.#derivationPath
         );
         return new Ed25519PublicKey(publicKey);
     }
 
     async signData(data: Uint8Array): Promise<SerializedSignature> {
-        const { signature } = await this.#suiLedgerClient.signTransaction(
+        const ledgerClient = await this.#initializeSuiLedgerClient();
+        const { signature } = await ledgerClient.signTransaction(
             this.#derivationPath,
             data
         );
@@ -58,7 +70,7 @@ export class LedgerSigner extends SignerWithProvider {
 
     connect(provider: JsonRpcProvider): SignerWithProvider {
         return new LedgerSigner(
-            this.#suiLedgerClient,
+            this.#connectToLedger,
             this.#derivationPath,
             provider
         );

--- a/apps/wallet/src/ui/app/components/ledger/LedgerExceptions.ts
+++ b/apps/wallet/src/ui/app/components/ledger/LedgerExceptions.ts
@@ -14,10 +14,3 @@ export class LedgerNoTransportMechanismError extends Error {
         Object.setPrototypeOf(this, LedgerNoTransportMechanismError.prototype);
     }
 }
-
-export class LedgerDeviceNotFoundError extends Error {
-    constructor(message: string) {
-        super(message);
-        Object.setPrototypeOf(this, LedgerDeviceNotFoundError.prototype);
-    }
-}

--- a/apps/wallet/src/ui/app/components/ledger/SuiLedgerClientProvider.tsx
+++ b/apps/wallet/src/ui/app/components/ledger/SuiLedgerClientProvider.tsx
@@ -13,8 +13,6 @@ import {
     useState,
 } from 'react';
 
-import { LedgerSigner } from '../../LedgerSigner';
-import { api } from '../../redux/store/thunk-extras';
 import {
     LedgerConnectionFailedError,
     LedgerDeviceNotFoundError,
@@ -28,9 +26,6 @@ type SuiLedgerClientProviderProps = {
 type SuiLedgerClientContextValue = {
     suiLedgerClient: SuiLedgerClient | undefined;
     connectToLedger: () => Promise<SuiLedgerClient>;
-    initializeLedgerSignerInstance: (
-        derivationPath: string
-    ) => Promise<LedgerSigner>;
 };
 
 const SuiLedgerClientContext = createContext<
@@ -51,33 +46,6 @@ export function SuiLedgerClientProvider({
         return () => suiLedgerClient?.transport.off('disconnect', onDisconnect);
     }, [suiLedgerClient?.transport]);
 
-    const initializeLedgerSignerInstance = useCallback(
-        async (derivationPath: string) => {
-            if (!suiLedgerClient) {
-                try {
-                    const transport = await forceConnectionToLedger();
-                    const newClient = new SuiLedgerClient(transport);
-                    setSuiLedgerClient(newClient);
-
-                    return new LedgerSigner(
-                        newClient,
-                        derivationPath,
-                        api.instance.fullNode
-                    );
-                } catch (error) {
-                    throw new Error('Failed to connect');
-                }
-            }
-
-            return new LedgerSigner(
-                suiLedgerClient,
-                derivationPath,
-                api.instance.fullNode
-            );
-        },
-        [suiLedgerClient]
-    );
-
     const connectToLedger = useCallback(async () => {
         if (suiLedgerClient?.transport) {
             // If we've already connected to a Ledger device, we need
@@ -95,9 +63,8 @@ export function SuiLedgerClientProvider({
         return {
             suiLedgerClient,
             connectToLedger,
-            initializeLedgerSignerInstance,
         };
-    }, [connectToLedger, suiLedgerClient, initializeLedgerSignerInstance]);
+    }, [connectToLedger, suiLedgerClient]);
 
     return (
         <SuiLedgerClientContext.Provider value={contextValue}>

--- a/apps/wallet/src/ui/app/components/ledger/SuiLedgerClientProvider.tsx
+++ b/apps/wallet/src/ui/app/components/ledger/SuiLedgerClientProvider.tsx
@@ -15,7 +15,6 @@ import {
 
 import {
     LedgerConnectionFailedError,
-    LedgerDeviceNotFoundError,
     LedgerNoTransportMechanismError,
 } from './LedgerExceptions';
 
@@ -98,26 +97,4 @@ async function requestConnectionToLedger() {
     throw new LedgerNoTransportMechanismError(
         "There are no supported transport mechanisms to connect to the user's Ledger device"
     );
-}
-
-async function forceConnectionToLedger() {
-    let transport: TransportWebHID | TransportWebUSB | null | undefined;
-    try {
-        if (await TransportWebHID.isSupported()) {
-            transport = await TransportWebHID.openConnected();
-        } else if (await TransportWebUSB.isSupported()) {
-            transport = await TransportWebUSB.openConnected();
-        }
-    } catch (error) {
-        throw new LedgerConnectionFailedError(
-            "Unable to connect to the user's Ledger device"
-        );
-    }
-
-    if (!transport) {
-        throw new LedgerDeviceNotFoundError(
-            'Connected Ledger device not found'
-        );
-    }
-    return transport;
 }

--- a/apps/wallet/src/ui/app/hooks/useSigner.ts
+++ b/apps/wallet/src/ui/app/hooks/useSigner.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { LedgerSigner } from '../LedgerSigner';
 import { useSuiLedgerClient } from '../components/ledger/SuiLedgerClientProvider';
 import { useAccounts } from './useAccounts';
 import { useActiveAccount } from './useActiveAccount';
@@ -8,7 +9,6 @@ import { thunkExtras } from '_redux/store/thunk-extras';
 import { AccountType } from '_src/background/keyring/Account';
 
 import type { SuiAddress } from '@mysten/sui.js';
-import { LedgerSigner } from '../LedgerSigner';
 
 export function useSigner(address?: SuiAddress) {
     const activeAccount = useActiveAccount();

--- a/apps/wallet/src/ui/app/hooks/useTransactionDryRun.ts
+++ b/apps/wallet/src/ui/app/hooks/useTransactionDryRun.ts
@@ -13,11 +13,9 @@ export function useTransactionDryRun(
     const signer = useSigner(sender);
     const response = useQuery({
         queryKey: ['dryRunTransaction', transaction.serialize()],
-        queryFn: async () => {
-            const initializedSigner = await signer();
-            return initializedSigner.dryRunTransaction({ transaction });
+        queryFn:  () => {
+            return signer.dryRunTransaction({ transaction });
         },
-        enabled: !!signer,
     });
     return response;
 }

--- a/apps/wallet/src/ui/app/hooks/useTransactionDryRun.ts
+++ b/apps/wallet/src/ui/app/hooks/useTransactionDryRun.ts
@@ -13,7 +13,7 @@ export function useTransactionDryRun(
     const signer = useSigner(sender);
     const response = useQuery({
         queryKey: ['dryRunTransaction', transaction.serialize()],
-        queryFn:  () => {
+        queryFn: () => {
             return signer.dryRunTransaction({ transaction });
         },
     });

--- a/apps/wallet/src/ui/app/pages/approval-request/SignMessageRequest.tsx
+++ b/apps/wallet/src/ui/app/pages/approval-request/SignMessageRequest.tsx
@@ -3,12 +3,9 @@
 
 import { fromB64 } from '@mysten/sui.js';
 import { useMemo } from 'react';
-import toast from 'react-hot-toast';
 
-import { useSuiLedgerClient } from '../../components/ledger/SuiLedgerClientProvider';
 import { UserApproveContainer } from '../../components/user-approve-container';
 import { useAppDispatch, useSigner } from '../../hooks';
-import { useAccounts } from '../../hooks/useAccounts';
 import { respondToTransactionRequest } from '../../redux/slices/transaction-requests';
 import { Heading } from '../../shared/heading';
 import { PageMainLayoutTitle } from '../../shared/page-main-layout/PageMainLayoutTitle';

--- a/apps/wallet/src/ui/app/pages/approval-request/SignMessageRequest.tsx
+++ b/apps/wallet/src/ui/app/pages/approval-request/SignMessageRequest.tsx
@@ -7,7 +7,7 @@ import toast from 'react-hot-toast';
 
 import { useSuiLedgerClient } from '../../components/ledger/SuiLedgerClientProvider';
 import { UserApproveContainer } from '../../components/user-approve-container';
-import { useAppDispatch } from '../../hooks';
+import { useAppDispatch, useSigner } from '../../hooks';
 import { useAccounts } from '../../hooks/useAccounts';
 import { respondToTransactionRequest } from '../../redux/slices/transaction-requests';
 import { Heading } from '../../shared/heading';
@@ -38,12 +38,8 @@ export function SignMessageRequest({ request }: SignMessageRequestProps) {
         };
     }, [request.tx.message]);
 
-    const accounts = useAccounts();
-    const accountForTransaction = accounts.find(
-        (account) => account.address === request.tx.accountAddress
-    );
+    const signer = useSigner(request.tx.accountAddress);
     const dispatch = useAppDispatch();
-    const { initializeLedgerSignerInstance } = useSuiLedgerClient();
 
     return (
         <UserApproveContainer
@@ -52,20 +48,13 @@ export function SignMessageRequest({ request }: SignMessageRequestProps) {
             approveTitle="Sign"
             rejectTitle="Reject"
             onSubmit={(approved) => {
-                if (accountForTransaction) {
-                    dispatch(
-                        respondToTransactionRequest({
-                            txRequestID: request.id,
-                            approved,
-                            accountForTransaction,
-                            initializeLedgerSignerInstance,
-                        })
-                    );
-                } else {
-                    toast.error(
-                        `Account for address ${request.tx.accountAddress} not found`
-                    );
-                }
+                dispatch(
+                    respondToTransactionRequest({
+                        txRequestID: request.id,
+                        approved,
+                        signer,
+                    })
+                );
             }}
             address={request.tx.accountAddress}
             scrollable

--- a/apps/wallet/src/ui/app/pages/approval-request/transaction-request/index.tsx
+++ b/apps/wallet/src/ui/app/pages/approval-request/transaction-request/index.tsx
@@ -20,16 +20,17 @@ export type TransactionRequestProps = {
 };
 
 export function TransactionRequest({ txRequest }: TransactionRequestProps) {
-    const signer = useSigner(txRequest.tx.account);
+    const addressForTransaction = txRequest.tx.account;
+    const signer = useSigner(addressForTransaction);
     const dispatch = useAppDispatch();
     const transaction = useMemo(() => {
         const tx = Transaction.from(txRequest.tx.data);
-        if (accountForTransaction) {
-            tx.setSenderIfNotSet(accountForTransaction.address);
+        if (addressForTransaction) {
+            tx.setSenderIfNotSet(addressForTransaction);
         }
         return tx;
-    }, [txRequest.tx.data, accountForTransaction]);
-    const addressForTransaction = txRequest.tx.account;
+    }, [txRequest.tx.data, addressForTransaction]);
+
     const handleOnSubmit = useCallback(
         (approved: boolean) => {
             dispatch(
@@ -60,11 +61,11 @@ export function TransactionRequest({ txRequest }: TransactionRequestProps) {
                     address={addressForTransaction}
                 /> */}
                 <GasFees
-                    sender={accountForTransaction?.address}
+                    sender={addressForTransaction}
                     transaction={transaction}
                 />
                 <TransactionDetails
-                    sender={accountForTransaction?.address}
+                    sender={addressForTransaction}
                     transaction={transaction}
                 />
             </section>

--- a/apps/wallet/src/ui/app/pages/approval-request/transaction-request/index.tsx
+++ b/apps/wallet/src/ui/app/pages/approval-request/transaction-request/index.tsx
@@ -4,7 +4,6 @@
 // import { Transaction } from '@mysten/sui.js';
 import { Transaction } from '@mysten/sui.js';
 import { useCallback, useMemo } from 'react';
-import toast from 'react-hot-toast';
 
 import { GasFees } from './GasFees';
 import { TransactionDetails } from './TransactionDetails';
@@ -12,8 +11,6 @@ import { UserApproveContainer } from '_components/user-approve-container';
 import { useAppDispatch, useSigner } from '_hooks';
 import { type TransactionApprovalRequest } from '_payloads/transactions/ApprovalRequest';
 import { respondToTransactionRequest } from '_redux/slices/transaction-requests';
-import { useSuiLedgerClient } from '_src/ui/app/components/ledger/SuiLedgerClientProvider';
-import { useAccounts } from '_src/ui/app/hooks/useAccounts';
 import { PageMainLayoutTitle } from '_src/ui/app/shared/page-main-layout/PageMainLayoutTitle';
 
 import st from './TransactionRequest.module.scss';
@@ -43,7 +40,7 @@ export function TransactionRequest({ txRequest }: TransactionRequestProps) {
                 })
             );
         },
-        [dispatch, txRequest.id, txRequest.tx.account]
+        [dispatch, txRequest.id, signer]
     );
 
     return (

--- a/apps/wallet/src/ui/app/pages/home/nft-transfer/TransferNFTForm.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nft-transfer/TransferNFTForm.tsx
@@ -36,8 +36,7 @@ export function TransferNFTForm({ objectId }: { objectId: string }) {
             const tx = new Transaction();
             tx.transferObjects([tx.object(objectId)], tx.pure(to));
 
-            const initializedSigner = await signer();
-            return initializedSigner.signAndExecuteTransaction({
+            return signer.signAndExecuteTransaction({
                 transaction: tx,
                 options: {
                     showInput: true,

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/index.tsx
@@ -20,11 +20,11 @@ import BottomMenuLayout, {
 } from '_app/shared/bottom-menu-layout';
 import { ActiveCoinsCard } from '_components/active-coins-card';
 import Overlay from '_components/overlay';
-import { useSigner } from '_hooks';
 import { trackEvent } from '_src/shared/plausible';
 import { useActiveAddress } from '_src/ui/app/hooks/useActiveAddress';
 
 import type { SubmitProps } from './SendTokenForm';
+import { useSigner } from '_src/ui/app/hooks';
 
 function TransferCoinPage() {
     const [searchParams] = useSearchParams();
@@ -62,8 +62,7 @@ function TransferCoinPage() {
                     props: { coinType: coinType! },
                 });
 
-                const initializedSigner = await signer();
-                return initializedSigner.signAndExecuteTransaction({
+                return signer.signAndExecuteTransaction({
                     transaction,
                     options: {
                         showInput: true,

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/index.tsx
@@ -21,10 +21,10 @@ import BottomMenuLayout, {
 import { ActiveCoinsCard } from '_components/active-coins-card';
 import Overlay from '_components/overlay';
 import { trackEvent } from '_src/shared/plausible';
+import { useSigner } from '_src/ui/app/hooks';
 import { useActiveAddress } from '_src/ui/app/hooks/useActiveAddress';
 
 import type { SubmitProps } from './SendTokenForm';
-import { useSigner } from '_src/ui/app/hooks';
 
 function TransferCoinPage() {
     const [searchParams] = useSearchParams();

--- a/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
@@ -14,12 +14,6 @@ import {
     createSlice,
 } from '@reduxjs/toolkit';
 
-import {
-    AccountType,
-    type SerializedAccount,
-} from '_src/background/keyring/Account';
-import { type LedgerSigner } from '_src/ui/app/LedgerSigner';
-
 import type { SuiTransactionResponse } from '@mysten/sui.js';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import type { ApprovalRequest } from '_payloads/transactions/ApprovalRequest';
@@ -49,12 +43,8 @@ export const respondToTransactionRequest = createAsyncThunk<
 >(
     'respond-to-transaction-request',
     async (
-        {
-            txRequestID,
-            approved,
-            signer,
-        },
-        { extra: { background, }, getState }
+        { txRequestID, approved, signer },
+        { extra: { background }, getState }
     ) => {
         const state = getState();
         const txRequest = txRequestsSelectors.selectById(state, txRequestID);

--- a/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
@@ -43,10 +43,7 @@ export const respondToTransactionRequest = createAsyncThunk<
     {
         txRequestID: string;
         approved: boolean;
-        accountForTransaction: SerializedAccount;
-        initializeLedgerSignerInstance: (
-            derivationPath: string
-        ) => Promise<LedgerSigner>;
+        signer: SignerWithProvider;
     },
     AppThunkConfig
 >(
@@ -55,10 +52,9 @@ export const respondToTransactionRequest = createAsyncThunk<
         {
             txRequestID,
             approved,
-            accountForTransaction,
-            initializeLedgerSignerInstance,
+            signer,
         },
-        { extra: { background, api }, getState }
+        { extra: { background, }, getState }
     ) => {
         const state = getState();
         const txRequest = txRequestsSelectors.selectById(state, txRequestID);
@@ -70,18 +66,6 @@ export const respondToTransactionRequest = createAsyncThunk<
             undefined;
         let txResultError: string | undefined;
         if (approved) {
-            let signer: SignerWithProvider | undefined;
-            if (accountForTransaction.type === AccountType.LEDGER) {
-                signer = await initializeLedgerSignerInstance(
-                    accountForTransaction.derivationPath
-                );
-            } else {
-                signer = api.getSignerInstance(
-                    accountForTransaction,
-                    background
-                );
-            }
-
             try {
                 if (txRequest.tx.type === 'sign-message') {
                     txResult = await signer.signMessage({

--- a/apps/wallet/src/ui/app/staking/stake/StakingCard.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/StakingCard.tsx
@@ -135,8 +135,7 @@ function StakingCard() {
                     amount,
                     validatorAddress
                 );
-                const initializedSigner = await signer();
-                return await initializedSigner.signAndExecuteTransaction({
+                return await signer.signAndExecuteTransaction({
                     transaction,
                     options: {
                         showInput: true,
@@ -163,8 +162,7 @@ function StakingCard() {
             });
             try {
                 const transaction = createUnstakeTransaction(stakedSuiId);
-                const initializedSigner = await signer();
-                return await initializedSigner.signAndExecuteTransaction({
+                return await signer.signAndExecuteTransaction({
                     transaction,
                     options: {
                         showInput: true,


### PR DESCRIPTION
## Description 
This PR refactors the Ledger signing flow so that `useSigner` doesn't return an `async` function. As I was prepping this for multi-Ledger support, I also figured that it would be better to always prompt the user to select what Ledger device they'd like to sign transactions with instead of just connecting to the first connected device. 

## Test Plan 
- Manual testing (signed/staked/approved transaction requests with and without a Ledger account)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
N/A
