### PR TITLE
feat: adding fullnode x docker compose example

### DIFF
--- a/docker/fullnode-x/README.md
+++ b/docker/fullnode-x/README.md
@@ -1,0 +1,17 @@
+
+
+1. bring up postgres first so you can create the DB with the `diesel` commands:
+
+- `docker compose up postgres -d`
+- psql -U postgres -p 5432 -h localhost -c 'create database sui_indexer_testnet'
+- run this in sui.git/crates/sui-indexer:
+  * diesel setup --database-url=postgres://postgres:admin@localhost:5432/sui_indexer_testnet
+  * diesel migration run  --database-url=postgres://postgres:admin@localhost:5432/sui_indexer_testnet
+
+
+2. for whichever network you want to use, get the fullnode.yaml config and the genesis.blob files and place them in fullnode/config/
+
+3. `docker compose up fullnode -d`
+   - verify it's working by watching the logs with `docker compose logs fullnode -f`
+
+4. Once the fullnode is working, then start indexer with:  `docker compose up indexer -d`

--- a/docker/fullnode-x/docker-compose.yaml
+++ b/docker/fullnode-x/docker-compose.yaml
@@ -1,0 +1,61 @@
+version: "3.9"
+
+services:
+
+  fullnode:
+    build:
+      context: ../..
+      dockerfile: ./docker/sui-node/Dockerfile
+      args:
+        # update with git sha of whichever branch you're building on.
+        GIT_REVISION: db24658bc9
+        BUILD_DATE: today
+
+    environment:
+      - LD_PRELOAD
+      - RUST_JSON_LOG="true"
+      - RUST_LOG="debug"
+#      - RUST_LOG="sui_core=debug,narwhal=info,info"
+    image: sui-node:latest
+    command: /opt/sui/entry.sh
+    # populate your local ./fullnode/config/ directory with fullnode.yaml and genesis.blob for the network you want to use.
+    volumes:
+      - ./fullnode:/opt/sui
+    ports:
+      - 9000
+      - 9184
+      - target: 8084
+        published: 8084
+        protocol: udp
+
+  indexer:
+    build:
+      context: ../..
+      dockerfile: ./docker/sui-indexer/Dockerfile
+    image: sui-indexer:latest
+    command: /opt/sui/indexer.sh
+    volumes:
+      - ./indexer:/opt/sui
+    environment:
+      - RUST_LOG="sui_core=debug,narwhal=info,info"
+      - RUST_JSON_LOG="true"
+      - DATABASE_URL=postgres://postgres:admin@postgres:5432/sui_indexer_testnet
+      - RPC_CLIENT_URL=http://fullnode:9000
+    ports:
+      - target: 3030
+        published: 3030
+        protocol: tcp
+      - 9184
+
+  postgres:
+    image: postgres:15
+    environment:
+      - POSTGRES_PASSWORD=admin
+    ports:
+      - target: 5432
+        published: 5432
+    volumes:
+      - db-data:/var/lib/postgres/data
+
+volumes:
+  db-data:

--- a/docker/fullnode-x/fullnode/entry.sh
+++ b/docker/fullnode-x/fullnode/entry.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+unset LD_PRELOAD
+
+/usr/local/bin/sui-node --config-path /opt/sui/config/fullnode.yaml
+

--- a/docker/fullnode-x/indexer/indexer.sh
+++ b/docker/fullnode-x/indexer/indexer.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+
+/usr/local/bin/sui-indexer --db-url ${DATABASE_URL} --rpc-client-url ${RPC_CLIENT_URL}


### PR DESCRIPTION
## Description 

This is a docker compose configuration and some instructions for running the fullnode+indexer+Pg locally on a desktop/laptop.

## Test Plan 

Just verified it starts up and catches up with the network epoch.

