### PR TITLE
[ConsensusAdapter] make max pending transactions configurable

### DIFF
--- a/crates/sui-config/src/builder.rs
+++ b/crates/sui-config/src/builder.rs
@@ -412,7 +412,7 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                     address: consensus_address,
                     db_path: consensus_db_path,
                     internal_worker_address,
-                    timeout_secs: Some(60),
+                    max_pending_transactions: None,
                     narwhal_config: ConsensusParameters {
                         network_admin_server: match self.validator_ip_sel {
                             ValidatorIpSelection::Simulator => NetworkAdminServerParameters {

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -219,9 +219,11 @@ pub struct ConsensusConfig {
     // For example, this could be used to connect to co-located workers over a private LAN address.
     pub internal_worker_address: Option<Multiaddr>,
 
-    // Timeout to retry sending transaction to consensus internally.
-    // Default to 60s.
-    pub timeout_secs: Option<u64>,
+    // Maximum number of pending transactions to submit to consensus, including those
+    // in submission wait.
+    // Assuming 10_000 txn tps * 10 sec consensus latency = 100_000 inflight consensus txns,
+    // Default to 100_000.
+    pub max_pending_transactions: Option<usize>,
 
     pub narwhal_config: ConsensusParameters,
 }
@@ -233,6 +235,10 @@ impl ConsensusConfig {
 
     pub fn db_path(&self) -> &Path {
         &self.db_path
+    }
+
+    pub fn max_pending_transactions(&self) -> usize {
+        self.max_pending_transactions.unwrap_or(100_000)
     }
 
     pub fn narwhal_config(&self) -> &ConsensusParameters {

--- a/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -20,7 +20,7 @@ validator_configs:
       address: ""
       db-path: /tmp/foo/
       internal-worker-address: ""
-      timeout-secs: 60
+      max-pending-transactions: ~
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
@@ -91,7 +91,7 @@ validator_configs:
       address: ""
       db-path: /tmp/foo/
       internal-worker-address: ""
-      timeout-secs: 60
+      max-pending-transactions: ~
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
@@ -162,7 +162,7 @@ validator_configs:
       address: ""
       db-path: /tmp/foo/
       internal-worker-address: ""
-      timeout-secs: 60
+      max-pending-transactions: ~
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
@@ -233,7 +233,7 @@ validator_configs:
       address: ""
       db-path: /tmp/foo/
       internal-worker-address: ""
-      timeout-secs: 60
+      max-pending-transactions: ~
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
@@ -304,7 +304,7 @@ validator_configs:
       address: ""
       db-path: /tmp/foo/
       internal-worker-address: ""
-      timeout-secs: 60
+      max-pending-transactions: ~
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
@@ -375,7 +375,7 @@ validator_configs:
       address: ""
       db-path: /tmp/foo/
       internal-worker-address: ""
-      timeout-secs: 60
+      max-pending-transactions: ~
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
@@ -446,7 +446,7 @@ validator_configs:
       address: ""
       db-path: /tmp/foo/
       internal-worker-address: ""
-      timeout-secs: 60
+      max-pending-transactions: ~
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -88,6 +88,8 @@ impl AuthorityServer {
             consensus_client,
             state.name,
             Box::new(Arc::new(ConnectionMonitorStatusForTests {})),
+            100_000,
+            100_000,
             ConsensusAdapterMetrics::new_test(),
         ));
 

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -126,6 +126,8 @@ async fn submit_transaction_to_consensus_adapter() {
         Box::new(SubmitDirectly(state.clone())),
         state.name,
         Box::new(Arc::new(ConnectionMonitorStatusForTests {})),
+        100_000,
+        100_000,
         metrics,
     ));
 

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -557,6 +557,7 @@ impl SuiNode {
             .ok_or_else(|| anyhow!("Validator is missing consensus config"))?;
 
         let consensus_adapter = Arc::new(Self::construct_consensus_adapter(
+            &committee,
             consensus_config,
             state.name,
             connection_monitor_status,
@@ -746,6 +747,7 @@ impl SuiNode {
     }
 
     fn construct_consensus_adapter(
+        committee: &Committee,
         consensus_config: &ConsensusConfig,
         authority: AuthorityName,
         connection_monitor_status: Arc<ConnectionMonitorStatus>,
@@ -774,6 +776,8 @@ impl SuiNode {
             Box::new(consensus_client),
             authority,
             Box::new(connection_monitor_status),
+            consensus_config.max_pending_transactions(),
+            consensus_config.max_pending_transactions() * 2 / committee.num_members(),
             ca_metrics,
         )
     }

--- a/nre/config/validator.yaml
+++ b/nre/config/validator.yaml
@@ -16,7 +16,6 @@ consensus-config:
   address: /ip4/127.0.0.1/tcp/8083/http
   db-path: /opt/sui/db/consensus_db
   internal-worker-address: null
-  timeout-secs: 60
   narwhal-config:
     header_num_of_batches_threshold: 32
     max_header_num_of_batches: 1000


### PR DESCRIPTION
## Description 

This will allow different parameters to be configured on different environments.

Also the limit is raised from 40k to 100k, but I can also keep the original limit and only raise it for private testnet. Max pending local submissions are changed to scale with number of validators.

## Test Plan 

Existing unit tests. Later deploy to an environment.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
