### PR TITLE
[hardening] updating SUI conservation check to account for dynamic fi…

### DIFF
--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -225,7 +225,7 @@ fn execute_transaction<
         #[cfg(debug_assertions)]
         {
             // ensure that this transaction did not create or destroy SUI
-            temporary_store.check_sui_conserved();
+            temporary_store.check_sui_conserved().unwrap();
         }
     }
     let cost_summary = gas_status.summary();

--- a/crates/sui-types/src/temporary_store.rs
+++ b/crates/sui-types/src/temporary_store.rs
@@ -183,33 +183,6 @@ impl<S> TemporaryStore<S> {
         &self.input_objects
     }
 
-    /// Return the dynamic field objects that are written or deleted by this transaction
-    pub fn dynamic_fields_touched_do_not_call_before_fixing(&self) -> Vec<ObjectID> {
-        let mut dynamic_fields = Vec::new();
-        for (id, (_, kind)) in &self.written {
-            match kind {
-                WriteKind::Mutate => {
-                    if !self.input_objects.contains_key(id) {
-                        dynamic_fields.push(*id)
-                    }
-                }
-                WriteKind::Create | WriteKind::Unwrap => (),
-            }
-        }
-        // TODO: The following logic is incorrect.
-        for (id, (_, kind)) in &self.deleted {
-            match kind {
-                DeleteKind::Normal => {
-                    if !self.input_objects.contains_key(id) {
-                        dynamic_fields.push(*id)
-                    }
-                }
-                DeleteKind::UnwrapThenDelete | DeleteKind::Wrap => (),
-            }
-        }
-        dynamic_fields
-    }
-
     /// Break up the structure and return its internal stores (objects, active_inputs, written, deleted)
     pub fn into_inner(self) -> InnerTemporaryStore {
         #[cfg(debug_assertions)]
@@ -291,64 +264,6 @@ impl<S> TemporaryStore<S> {
             // The object must be mutated as it was present in the input objects
             self.write_object(object, WriteKind::Mutate);
         }
-    }
-
-    /// Compute storage gas for each mutable input object (including the gas coin), and each created object.
-    /// Compute storage refunds for each deleted object
-    /// Will *not* charge any computation gas. Returns the total size in bytes of all deleted objects + all mutated objects,
-    /// which the caller can use to charge computation gas
-    fn charge_gas_for_storage_changes(
-        &mut self,
-        gas_status: &mut SuiGasStatus<'_>,
-        gas_object_id: ObjectID,
-    ) -> Result<u64, ExecutionError> {
-        let mut total_bytes_written_deleted = 0;
-
-        // If the gas coin was not yet written, charge gas for mutating the gas object in advance.
-        let gas_object = self
-            .read_object(&gas_object_id)
-            .expect("We constructed the object map so it should always have the gas object id")
-            .clone();
-        self.written
-            .entry(gas_object_id)
-            .or_insert_with(|| (gas_object, WriteKind::Mutate));
-        self.ensure_active_inputs_mutated();
-        let mut objects_to_update = vec![];
-
-        for (object_id, (object, write_kind)) in &mut self.written {
-            let (old_object_size, storage_rebate) = self
-                .input_objects
-                .get(object_id)
-                .map(|old| (old.object_size_for_gas_metering(), old.storage_rebate))
-                .unwrap_or((0, 0));
-
-            let new_object_size = object.object_size_for_gas_metering();
-            let new_storage_rebate =
-                gas_status.charge_storage_mutation(new_object_size, storage_rebate.into())?;
-            object.storage_rebate = new_storage_rebate;
-            if !object.is_immutable() {
-                objects_to_update.push((object.clone(), *write_kind));
-            }
-            total_bytes_written_deleted += old_object_size + new_object_size;
-        }
-
-        for object_id in self.deleted.keys() {
-            // If an object is in `self.deleted`, and also in `self.objects`, we give storage rebate.
-            // Otherwise if an object is in `self.deleted` but not in `self.objects`, it means this
-            // object was unwrapped and then deleted. The rebate would have been provided already when
-            // mutating the object that wrapped this object.
-            if let Some(old_object) = self.input_objects.get(object_id) {
-                gas_status.charge_storage_mutation(0, old_object.storage_rebate.into())?;
-                total_bytes_written_deleted += old_object.object_size_for_gas_metering();
-            }
-        }
-
-        // Write all objects at the end only if all previous gas charges succeeded.
-        // This avoids polluting the temporary store state if this function failed.
-        for (object, write_kind) in objects_to_update {
-            self.write_object(object, write_kind);
-        }
-        Ok(total_bytes_written_deleted as u64)
     }
 
     pub fn to_effects(
@@ -513,70 +428,6 @@ impl<S> TemporaryStore<S> {
         // previous transaction digest, so we ensure it is correct here.
         object.previous_transaction = self.tx_digest;
         self.written.insert(object.id(), (object, kind));
-    }
-
-    /// 1. Compute tx storage gas costs and tx storage rebates, update storage_rebate field of mutated objects
-    /// 2. Deduct computation gas costs and storage costs to `gas_object_id`, credit storage rebates to `gas_object_id`.
-    // The happy path of this function follows (1) + (2) and is fairly simple. Most of the complexity is in the unhappy paths:
-    // - if execution aborted before calling this function, we have to dump all writes + re-smash gas, then charge for storage
-    // - if we run out of gas while charging for storage, we have to dump all writes + re-smash gas, then charge for storage again
-    pub fn charge_gas<T>(
-        &mut self,
-        gas_object_id: ObjectID,
-        gas_status: &mut SuiGasStatus<'_>,
-        execution_result: &mut Result<T, ExecutionError>,
-        gas: &[ObjectRef],
-    ) {
-        // at this point, we have done some charging for computation, but have not yet set the storage rebate or storage gas units
-        assert!(gas_status.storage_rebate() == 0);
-        assert!(gas_status.storage_gas_units() == 0);
-
-        if let Err(err) = gas_status.bucketize_computation() {
-            if execution_result.is_ok() {
-                *execution_result = Err(err);
-            }
-        }
-        if execution_result.is_err() {
-            // Tx execution aborted--need to dump writes, deletes, etc before charging storage gas
-            self.reset(gas, gas_status);
-        }
-
-        if let Err(err) = self.charge_gas_for_storage_changes(gas_status, gas_object_id) {
-            // Ran out of gas while charging for storage changes. reset store, now at state just after gas smashing
-            self.reset(gas, gas_status);
-
-            // charge for storage again. This will now account only for the storage cost of gas coins
-            if self
-                .charge_gas_for_storage_changes(gas_status, gas_object_id)
-                .is_err()
-            {
-                // MUSTFIX: this shouldn't happen, because we should check that the budget is enough to cover the storage costs of gas coins at signing time
-                // perhaps that check isn't there?
-                trace!("out of gas while charging for gas smashing")
-            }
-
-            // if execution succeeded, but we ran out of gas while charging for storage, overwrite the successful execution result
-            // with an out of gas failure
-            if execution_result.is_ok() {
-                *execution_result = Err(err)
-            }
-        }
-        let cost_summary = gas_status.summary();
-        let gas_used = cost_summary.gas_used();
-
-        // Important to fetch the gas object here instead of earlier, as it may have been reset
-        // previously in the case of error.
-        let mut gas_object = self.read_object(&gas_object_id).unwrap().clone();
-        gas::deduct_gas(
-            &mut gas_object,
-            gas_used,
-            // MUSTFIX: This is incorrect. Storage rebate in cost summary need to be consistent with balance change.
-            cost_summary.sender_rebate(self.storage_rebate_rate),
-        );
-        trace!(gas_used, gas_obj_id =? gas_object.id(), gas_obj_ver =? gas_object.version(), "Updated gas object");
-
-        self.write_object(gas_object, WriteKind::Mutate);
-        self.gas_charged = Some((gas_object_id, cost_summary));
     }
 
     pub fn smash_gas(&mut self, gas: &[ObjectRef]) -> Result<ObjectRef, ExecutionError> {
@@ -832,72 +683,294 @@ impl<S: ObjectStore> TemporaryStore<S> {
         }
         Ok(())
     }
+
+    /// 1. Compute tx storage gas costs and tx storage rebates, update storage_rebate field of mutated objects
+    /// 2. Deduct computation gas costs and storage costs to `gas_object_id`, credit storage rebates to `gas_object_id`.
+    // The happy path of this function follows (1) + (2) and is fairly simple. Most of the complexity is in the unhappy paths:
+    // - if execution aborted before calling this function, we have to dump all writes + re-smash gas, then charge for storage
+    // - if we run out of gas while charging for storage, we have to dump all writes + re-smash gas, then charge for storage again
+    pub fn charge_gas<T>(
+        &mut self,
+        gas_object_id: ObjectID,
+        gas_status: &mut SuiGasStatus<'_>,
+        execution_result: &mut Result<T, ExecutionError>,
+        gas: &[ObjectRef],
+    ) {
+        // at this point, we have done some charging for computation, but have not yet set the storage rebate or storage gas units
+        assert!(gas_status.storage_rebate() == 0);
+        assert!(gas_status.storage_gas_units() == 0);
+
+        if let Err(err) = gas_status.bucketize_computation() {
+            if execution_result.is_ok() {
+                *execution_result = Err(err);
+            }
+        }
+        if execution_result.is_err() {
+            // Tx execution aborted--need to dump writes, deletes, etc before charging storage gas
+            self.reset(gas, gas_status);
+        }
+
+        if let Err(err) = self.charge_gas_for_storage_changes(gas_status, gas_object_id) {
+            // Ran out of gas while charging for storage changes. reset store, now at state just after gas smashing
+            self.reset(gas, gas_status);
+
+            // charge for storage again. This will now account only for the storage cost of gas coins
+            if self
+                .charge_gas_for_storage_changes(gas_status, gas_object_id)
+                .is_err()
+            {
+                // MUSTFIX: this shouldn't happen, because we should check that the budget is enough to cover the storage costs of gas coins at signing time
+                // perhaps that check isn't there?
+                trace!("out of gas while charging for gas smashing")
+            }
+
+            // if execution succeeded, but we ran out of gas while charging for storage, overwrite the successful execution result
+            // with an out of gas failure
+            if execution_result.is_ok() {
+                *execution_result = Err(err)
+            }
+        }
+        let cost_summary = gas_status.summary();
+        let gas_used = cost_summary.gas_used();
+
+        // Important to fetch the gas object here instead of earlier, as it may have been reset
+        // previously in the case of error.
+        let mut gas_object = self.read_object(&gas_object_id).unwrap().clone();
+        gas::deduct_gas(
+            &mut gas_object,
+            gas_used,
+            // MUSTFIX: This is incorrect. Storage rebate in cost summary need to be consistent with balance change.
+            cost_summary.sender_rebate(self.storage_rebate_rate),
+        );
+        trace!(gas_used, gas_obj_id =? gas_object.id(), gas_obj_ver =? gas_object.version(), "Updated gas object");
+
+        self.write_object(gas_object, WriteKind::Mutate);
+        self.gas_charged = Some((gas_object_id, cost_summary));
+    }
+
+    /// Return the storage rebate and size of `id` at input
+    fn get_input_storage_rebate_and_size(
+        &self,
+        id: &ObjectID,
+        expected_version: SequenceNumber,
+    ) -> Result<(u64, usize), ExecutionError> {
+        if let Some(old_obj) = self.input_objects.get(id) {
+            Ok((
+                old_obj.storage_rebate,
+                old_obj.object_size_for_gas_metering(),
+            ))
+        } else {
+            // else, this is a dynamic field, not an input object
+            if let Ok(Some(old_obj)) = self.store.get_object(id) {
+                if old_obj.version() != expected_version {
+                    return Err(ExecutionError::invariant_violation(
+                        "Expected to find old object with version {expected_version}",
+                    ));
+                }
+                Ok((
+                    old_obj.storage_rebate,
+                    old_obj.object_size_for_gas_metering(),
+                ))
+            } else {
+                Err(ExecutionError::invariant_violation(
+                    "Looking up storage rebate of mutated object should not fail",
+                ))
+            }
+        }
+    }
+
+    /// Compute storage gas for each mutable input object (including the gas coin), and each created object.
+    /// Compute storage refunds for each deleted object
+    /// Will *not* charge any computation gas. Returns the total size in bytes of all deleted objects + all mutated objects,
+    /// which the caller can use to charge computation gas
+    fn charge_gas_for_storage_changes(
+        &mut self,
+        gas_status: &mut SuiGasStatus<'_>,
+        gas_object_id: ObjectID,
+    ) -> Result<u64, ExecutionError> {
+        let mut total_bytes_written_deleted = 0;
+
+        // If the gas coin was not yet written, charge gas for mutating the gas object in advance.
+        let gas_object = self
+            .read_object(&gas_object_id)
+            .expect("We constructed the object map so it should always have the gas object id")
+            .clone();
+        self.written
+            .entry(gas_object_id)
+            .or_insert_with(|| (gas_object, WriteKind::Mutate));
+        self.ensure_active_inputs_mutated();
+        let mut objects_to_update = vec![];
+
+        for (object_id, (object, write_kind)) in &mut self.written {
+            let (old_storage_rebate, old_object_size) = match write_kind {
+                WriteKind::Create | WriteKind::Unwrap => (0, 0),
+                WriteKind::Mutate => {
+                    if let Some(old_obj) = self.input_objects.get(object_id) {
+                        (
+                            old_obj.storage_rebate,
+                            old_obj.object_size_for_gas_metering(),
+                        )
+                    } else {
+                        // else, this is an input object, not a dynamic field
+                        if let Ok(Some(old_obj)) = self.store.get_object(object_id) {
+                            let expected_version = object.version();
+                            if old_obj.version() != expected_version {
+                                return Err(ExecutionError::invariant_violation(
+                                    "Expected to find old object with version {expected_version}",
+                                ));
+                            }
+                            (
+                                old_obj.storage_rebate,
+                                old_obj.object_size_for_gas_metering(),
+                            )
+                        } else {
+                            return Err(ExecutionError::invariant_violation(
+                                "Looking up storage rebate of mutated object should not fail",
+                            ));
+                        }
+                    }
+                }
+            };
+            let new_object_size = object.object_size_for_gas_metering();
+            let new_storage_rebate =
+                gas_status.charge_storage_mutation(new_object_size, old_storage_rebate.into())?;
+            object.storage_rebate = new_storage_rebate;
+            if !object.is_immutable() {
+                objects_to_update.push((object.clone(), *write_kind));
+            }
+            total_bytes_written_deleted += old_object_size + new_object_size;
+        }
+
+        for (object_id, (version, kind)) in &self.deleted {
+            match kind {
+                DeleteKind::Wrap | DeleteKind::Normal => {
+                    let (storage_rebate, object_size) =
+                        self.get_input_storage_rebate_and_size(object_id, *version)?;
+                    gas_status.charge_storage_mutation(0, storage_rebate.into())?;
+                    total_bytes_written_deleted += object_size;
+                }
+                DeleteKind::UnwrapThenDelete => {
+                    // an unwrapped object does not have a storage rebate, we will charge for storage changes via its wrapper object
+                }
+            }
+        }
+
+        // Write all objects at the end only if all previous gas charges succeeded.
+        // This avoids polluting the temporary store state if this function failed.
+        for (object, write_kind) in objects_to_update {
+            self.write_object(object, write_kind);
+        }
+        Ok(total_bytes_written_deleted as u64)
+    }
 }
 
 impl<S: GetModule + ObjectStore + BackingPackageStore> TemporaryStore<S> {
+    /// Get the total SUI in `obj` at version `v`, which should be the version before the
+    /// tx executed. for internal use only
+    fn get_input_sui(&self, id: &ObjectID, expected_version: SequenceNumber) -> SuiResult<u64> {
+        if let Some(obj) = self.input_objects.get(id) {
+            debug_assert_eq!(obj.version(), expected_version);
+            obj.get_total_sui(&self)
+        } else {
+            // not in input objects, must be a dynamic field
+            let obj = self
+                .store
+                .get_object(id)
+                .unwrap()
+                .expect("Failed to look up input object and identify its total SUI");
+            debug_assert_eq!(obj.version(), expected_version);
+            obj.get_total_sui(&self)
+        }
+    }
+
     /// Check that this transaction neither creates nor destroys SUI. This should hold for all txes except
     /// the epoch change tx, which mints staking rewards equal to the gas fees burned in the previous epoch.
     /// This intended to be called *after* we have charged for gas + applied the storage rebate to the gas object,
     /// but *before* we have updated object versions
-    pub fn check_sui_conserved(&self) {
-        if !self
-            .dynamic_fields_touched_do_not_call_before_fixing()
-            .is_empty()
-        {
-            // TODO: check conservation in the presence of dynamic fields
-            return;
+    pub fn check_sui_conserved(&self) -> SuiResult<()> {
+        // total amount of SUI in input objects, including both coins and storage rebates
+        let mut total_input_sui = 0;
+        // total amount of SUI in output objects, including both coins and storage rebates
+        let mut total_output_sui = 0;
+        // sum of the storage_rebate fields of all objects written by this tx
+        let mut _output_rebate_amount = 0;
+        for (id, (output_obj, kind)) in &self.written {
+            match kind {
+                WriteKind::Mutate => {
+                    // note: output_obj.version has not yet been increased by the tx, so output_obj.version
+                    // is the object version at tx input
+                    let input_version = output_obj.version();
+                    total_input_sui += self.get_input_sui(id, input_version)?;
+                    total_output_sui += output_obj.get_total_sui(&self)?;
+                    _output_rebate_amount += output_obj.storage_rebate;
+                }
+                WriteKind::Create => {
+                    // created objects did not exist at input, and thus contribute 0 to input SUI
+                    total_output_sui += output_obj.get_total_sui(&self)?;
+                    _output_rebate_amount += output_obj.storage_rebate;
+                }
+                WriteKind::Unwrap => {
+                    // an unwrapped object was either:
+                    // 1. wrapped in an input object A,
+                    // 2. wrapped in a dynamic field A, or itself a dynamic field
+                    // in both cases, its contribution to input SUI will be captured by looking at A
+                    total_output_sui += output_obj.get_total_sui(&self)?;
+                    _output_rebate_amount += output_obj.storage_rebate;
+                }
+            }
         }
-        let gas_summary = &self.gas_charged.as_ref().unwrap().1;
+        for (id, (input_version, kind)) in &self.deleted {
+            match kind {
+                DeleteKind::Normal => {
+                    total_input_sui += self.get_input_sui(id, *input_version)?;
+                }
+                DeleteKind::Wrap => {
+                    // wrapped object was a tx input or dynamic field--need to account for it in input SUI
+                    // note: if an object is created by the tx, then wrapped, it will not appear here
+                    total_input_sui += self.get_input_sui(id, *input_version)?;
+                    // else, the wrapped object was either:
+                    // 1. freshly created, which means it has 0 contribution to input SUI
+                    // 2. unwrapped from another object A, which means its contribution to input SUI will be captured by looking at A
+                }
+                DeleteKind::UnwrapThenDelete => {
+                    // an unwrapped option was wrapped in input object or dynamic field A, which means its contribution to input SUI will
+                    // be captured by looking at A
+                }
+            }
+        }
+
+        // we do account for the "storage rebate inflow" (portion of the storage rebate which flows back into the storage fund).
+        let gas_summary = &self
+            .gas_charged
+            .as_ref()
+            .ok_or_else(|| {
+                ExecutionError::invariant_violation(
+                    "Failed unwrapping gas_charged in SUI conservation checking",
+                )
+            })?
+            .1;
         let storage_fund_rebate_inflow =
             gas_summary.storage_fund_rebate_inflow(self.storage_rebate_rate);
-
-        // total SUI in input objects
-        let input_sui = self.mutable_input_refs.iter().fold(0, |acc, o| {
-            acc + self
-                .input_objects
-                .get(&o.0)
-                .unwrap()
-                .get_total_sui(&self)
-                .unwrap()
-        });
-        // if a dynamic field object O is written by this tx, count get_total_sui(pre_tx_value(O)) as part of input_sui
-        let dynamic_field_input_sui = self
-            .dynamic_fields_touched_do_not_call_before_fixing()
-            .iter()
-            .fold(0, |acc, id| {
-                acc + self
-                    .store
-                    .get_object(id)
-                    .unwrap()
-                    .unwrap()
-                    .get_total_sui(&self)
-                    .unwrap()
-            });
-        // sum of the storage rebate fields of all objects written by this tx
-        let mut output_rebate_amount = 0;
-        // total SUI in output objects
-        let output_sui = self.written.values().fold(0, |acc, (o, _)| {
-            output_rebate_amount += o.storage_rebate;
-            acc + o.get_total_sui(&self).unwrap()
-        });
 
         // storage gas cost should be equal to total rebates of mutated objects + storage fund rebate inflow (see below).
         // note: each mutated object O of size N bytes is assessed a storage cost of N * storage_price bytes, but also
         // has O.storage_rebate credited to the tx storage rebate.
-        // TODO: figure out what's wrong with this check. The one below is more important, so going without it for now
+        // TODO: figure out what's wrong with this check. The one below is more important, but this should still hold.
+        // I suspect the problem is rounding error on `storage_rebate_inflow`
         /*assert_eq!(
             gas_summary.storage_cost,
             output_rebate_amount + storage_fund_rebate_inflow
         );*/
 
         // note: storage_cost flows into the storage_rebate field of the output objects, which is why it is not accounted for here.
-        // similarly, storage_rebate flows into the gas coin
-        // we do account for the "storage rebate inflow" (portion of the storage rebate which flows back into the storage fund). like
-        // computation gas fees, this quantity is burned, then re-minted at epoch boundaries.
+        // similarly, all of the storage_rebate *except* the storage_fund_rebate_inflow gets credited to the gas coin
+        // both computation costs and storage rebate inflow are
         assert_eq!(
-            input_sui + dynamic_field_input_sui,
-            output_sui + gas_summary.computation_cost + storage_fund_rebate_inflow
-        )
+            total_input_sui,
+            total_output_sui + gas_summary.computation_cost + storage_fund_rebate_inflow,
+            "SUI conservation violated--this transaction either mints or burns SUI"
+        );
+        Ok(())
     }
 }
 


### PR DESCRIPTION
…elds, fixing two SUI conservation bugs

## Description 

@tnowacki previously pointed out that the logic for identifying dynamic field inputs was incorrect + the right way to do this is to look at `writes` and `deletes` to identify objects that are not inputs. Refactored `check_sui_conserved` to use this approach, and turn off the logic that skips any code with dynamic fields.

After doing this, a lot of tests using dynamic fields started failing conservation checks. I investigated this and discovered/fixed two related conservation bugs in `charge_gas_for_storage_changes`:
1. If a dynamic field with storage rebate `N` gets mutated, we will burn `N` SUI
2. If a dynamic field with storage rebate `N` gets deleted, we will burn `N` SUI

After fixing these bugs, all tests pass the conservation checks. But it would still be good to make sure we have test coverage for all {wrap/unwrap/delete}, {dynamic field/input object} scenarios.

## Test Plan 

All tests now pass with the conservation checks on

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
