### PR TITLE
[wallet-ext] do some design polish for the Ledger integration

### DIFF
--- a/apps/wallet/src/ui/app/components/ledger/ConnectLedgerModal.tsx
+++ b/apps/wallet/src/ui/app/components/ledger/ConnectLedgerModal.tsx
@@ -3,7 +3,7 @@
 
 import { useState } from 'react';
 
-import ExternalLink from '_components/external-link';
+import { Link } from '../../shared/Link';
 import { useSuiLedgerClient } from '_src/ui/app/components/ledger/SuiLedgerClientProvider';
 import { Button } from '_src/ui/app/shared/ButtonUI';
 import { ModalDialog } from '_src/ui/app/shared/ModalDialog';
@@ -52,31 +52,38 @@ export function ConnectLedgerModal({
                             Connect your ledger to your computer, unlock it, and
                             launch the Sui app. Click Continue when done.
                         </Text>
-                        <div className="mt-2">
+                        <div className="flex items-center justify-center mt-2">
                             <Text
                                 variant="p2"
                                 color="steel-dark"
                                 weight="normal"
                             >
-                                <span>Need more help?</span>{' '}
-                                {/* TODO: Replace this link with the correct URL once the tutorial is ready */}
-                                <ExternalLink
-                                    href="https://mystenlabs.com"
-                                    className="text-hero-dark"
-                                    showIcon={false}
-                                >
-                                    View tutorial.
-                                </ExternalLink>
+                                Need more help?&nbsp;
                             </Text>
+                            {/* TODO: Replace this link with the correct URL once the tutorial is ready */}
+                            <span>
+                                <Link
+                                    underline="hover"
+                                    href="https://mystenlabs.com"
+                                    text="View tutorial."
+                                    color="heroDark"
+                                />
+                            </span>
                         </div>
                     </div>
                 </div>
             }
             footer={
                 <div className="w-full flex flex-row self-center gap-3">
-                    <Button variant="outline" text="Cancel" onClick={onClose} />
                     <Button
                         variant="outline"
+                        size="tall"
+                        text="Cancel"
+                        onClick={onClose}
+                    />
+                    <Button
+                        variant="outline"
+                        size="tall"
                         text="Continue"
                         onClick={onContinueClick}
                         loading={isConnectingToLedger}

--- a/apps/wallet/src/ui/app/components/ledger/ImportLedgerAccounts.tsx
+++ b/apps/wallet/src/ui/app/components/ledger/ImportLedgerAccounts.tsx
@@ -96,7 +96,7 @@ export function ImportLedgerAccounts() {
     let summaryCardBody: JSX.Element | null = null;
     if (areLedgerAccountsLoading) {
         summaryCardBody = (
-            <div className="w-full h-full flex flex-col justify-center items-center gap-3">
+            <div className="w-full h-full flex flex-col justify-center items-center gap-2">
                 <SpinnerIcon className="animate-spin text-steel w-4 h-4" />
                 <Text variant="p2" color="steel-darker">
                     Looking for accounts
@@ -158,18 +158,21 @@ export function ImportLedgerAccounts() {
                         </div>
                     </div>
                 </div>
-                <Button
-                    variant="primary"
-                    before={<UnlockedLockIcon />}
-                    text="Unlock"
-                    loading={importLedgerAccountsMutation.isLoading}
-                    onClick={() =>
-                        importLedgerAccountsMutation.mutate(
-                            selectedLedgerAccounts
-                        )
-                    }
-                    disabled={areNoAccountsSelected}
-                />
+                <div>
+                    <Button
+                        variant="primary"
+                        size="tall"
+                        before={<UnlockedLockIcon />}
+                        text="Unlock"
+                        loading={importLedgerAccountsMutation.isLoading}
+                        onClick={() =>
+                            importLedgerAccountsMutation.mutate(
+                                selectedLedgerAccounts
+                            )
+                        }
+                        disabled={areNoAccountsSelected}
+                    />
+                </div>
             </div>
         </Overlay>
     );

--- a/apps/wallet/src/ui/app/components/menu/content/Account.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/Account.tsx
@@ -50,7 +50,7 @@ export function Account({ address, accountType }: AccountProps) {
                         </div>
                         <Copy16
                             onClick={copyCallback}
-                            className="transition text-base leading-none text-gray-60 active:text-gray-60 hover:text-hero-darkest cursor-pointer p1"
+                            className="transition text-base leading-none text-gray-60 active:text-gray-60 group-hover:text-hero-darkest cursor-pointer p1"
                         />
                         <ChevronDown16 className="transition text-base leading-none text-gray-60 ui-open:rotate-180 ui-open:text-hero-darkest group-hover:text-hero-darkest" />
                     </Disclosure.Button>

--- a/apps/wallet/src/ui/app/components/menu/content/AccountActions.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/AccountActions.tsx
@@ -34,7 +34,7 @@ export function AccountActions({
                     />
                 </div>
             ) : (
-                <Text variant="bodySmall" weight="medium" color="steel-dark">
+                <Text variant="bodySmall" weight="medium" color="steel">
                     No actions available
                 </Text>
             )}

--- a/apps/wallet/src/ui/app/shared/Link.tsx
+++ b/apps/wallet/src/ui/app/shared/Link.tsx
@@ -9,13 +9,17 @@ import { ButtonOrLink, type ButtonOrLinkProps } from './utils/ButtonOrLink';
 const styles = cva(
     [
         'transition flex flex-nowrap items-center justify-center outline-none gap-1 w-full',
-        'no-underline bg-transparent p-0 border-none',
+        'bg-transparent p-0 border-none',
         'active:opacity-70',
         'disabled:opacity-40',
         'cursor-pointer group',
     ],
     {
         variants: {
+            underline: {
+                none: 'no-underline',
+                hover: 'no-underline hover:underline',
+            },
             color: {
                 steelDark: [
                     'text-steel-dark hover:text-steel-darker focus:text-steel-darker disabled:text-steel-dark',
@@ -72,12 +76,13 @@ export const Link = forwardRef(
             color,
             weight,
             size = 'bodySmall',
+            underline = 'none',
             ...otherProps
         }: LinkProps,
         ref: Ref<HTMLAnchorElement | HTMLButtonElement>
     ) => (
         <ButtonOrLink
-            className={styles({ color, weight, size })}
+            className={styles({ color, weight, size, underline })}
             {...otherProps}
             ref={ref}
         >


### PR DESCRIPTION
## Description 
Just some design polish at the request of @mystie711:
  - Fixed the spacing between the loading icon <> copy text in the import flow
  - Added a new link `underline` prop so the link in the Ledger modal is only underlined on hover
  - Fixed the height of the buttons used in the Ledger modal and import flow
  - Updated the hover state in the account disclosure so that the `Copy` icon is highlighted
  - Updated the color of the `No actions available` text from `steel-dark` -> `steel`

https://capture.dropbox.com/LxttUF2zT2nKmuIr

## Test Plan 
- Manual testing (👁️)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
N/A