### PR TITLE
[Narwhal] reduce timestamp drift tolerance to 1s

### DIFF
--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -826,7 +826,7 @@ impl PrimaryReceiverHandler {
 
         // Check that the time of the header is smaller than the current time. If not but the difference is
         // small, just wait. Otherwise reject with an error.
-        const TOLERANCE: u64 = 15 * 1000; // 15 sec in milliseconds
+        const TOLERANCE: u64 = 1 * 1000; // 1 sec in milliseconds
         let current_time = now();
         if current_time < header.created_at {
             if header.created_at - current_time < TOLERANCE {

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -826,10 +826,10 @@ impl PrimaryReceiverHandler {
 
         // Check that the time of the header is smaller than the current time. If not but the difference is
         // small, just wait. Otherwise reject with an error.
-        const TOLERANCE: u64 = 1 * 1000; // 1 sec in milliseconds
+        const TOLERANCE_MS: u64 = 1_000;
         let current_time = now();
         if current_time < header.created_at {
-            if header.created_at - current_time < TOLERANCE {
+            if header.created_at - current_time < TOLERANCE_MS {
                 // for a small difference we simply wait
                 tokio::time::sleep(Duration::from_millis(header.created_at - current_time)).await;
             } else {


### PR DESCRIPTION
## Description 

Narwhal headers are produced at 0.5s ~ 1s intervals. Using a larger clock drift tolerance would just suspend the header until it gets cancelled, making it harder to debug. So using a smaller drift which should be more obvious to discover.

In future, we can implement a Narwhal clock that removes the need for operators to detect and fix the issue on their own.

## Test Plan 

Verify in a geo distributed network.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
