### PR TITLE
[ts-sdk] Tweak logic for txcontext detection

### DIFF
--- a/sdk/typescript/src/builder/serializer.ts
+++ b/sdk/typescript/src/builder/serializer.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
-  extractMutableReference,
   extractStructTag,
   ID_STRUCT_NAME,
   isValidSuiAddress,
@@ -50,7 +49,6 @@ const isSameStruct = (a: any, b: any) =>
 export function isTxContext(param: SuiMoveNormalizedType): boolean {
   const struct = extractStructTag(param)?.Struct;
   return (
-    extractMutableReference(param) != null &&
     struct?.address === '0x2' &&
     struct?.module === 'tx_context' &&
     struct?.name === 'TxContext'

--- a/sdk/typescript/test/e2e/data/id_entry_args/sources/id_entry_args.move
+++ b/sdk/typescript/test/e2e/data/id_entry_args/sources/id_entry_args.move
@@ -8,4 +8,8 @@ module id_entry_args::test {
     public entry fun test_id(id: ID, _ctx: &mut TxContext) {
         assert!(object::id_to_address(&id) == @0xc2b5625c221264078310a084df0a3137956d20ee, 0);
     }
+
+    public entry fun test_id_non_mut(id: ID, _ctx: &TxContext) {
+        assert!(object::id_to_address(&id) == @0xc2b5625c221264078310a084df0a3137956d20ee, 0);
+    }
 }

--- a/sdk/typescript/test/e2e/id-entry-args.test.ts
+++ b/sdk/typescript/test/e2e/id-entry-args.test.ts
@@ -33,4 +33,23 @@ describe('Test ID as args to entry functions', () => {
     });
     expect(getExecutionStatusType(result)).toEqual('success');
   });
+
+  it('Test ID as arg to entry functions', async () => {
+    const tx = new Transaction();
+    tx.moveCall({
+      target: `${packageId}::test::test_id_non_mut`,
+      arguments: [
+        tx.pure(
+          '0x000000000000000000000000c2b5625c221264078310a084df0a3137956d20ee',
+        ),
+      ],
+    });
+    const result = await toolbox.signer.signAndExecuteTransaction({
+      transaction: tx,
+      options: {
+        showEffects: true,
+      },
+    });
+    expect(getExecutionStatusType(result)).toEqual('success');
+  });
 });


### PR DESCRIPTION
## Description 

Fixed [9581](https://github.com/MystenLabs/sui/issues/9581). Previously we only determined txcontext if it was passed `mut`, now we just check the struct itself.

## Test Plan 

Added new testcase.
