### PR TITLE
json rpc: refactor get_object_changes to be used in indexer

### DIFF
--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -356,10 +356,21 @@ pub trait SuiTransactionEffectsAPI {
     fn dependencies(&self) -> &[TransactionDigest];
     fn executed_epoch(&self) -> EpochId;
     fn transaction_digest(&self) -> &TransactionDigest;
+    fn modified_at_versions(&self) -> Vec<(ObjectID, SequenceNumber)>;
     fn gas_used(&self) -> &SuiGasCostSummary;
 
     /// Return an iterator of mutated objects, but excluding the gas object.
     fn mutated_excluding_gas(&self) -> Vec<OwnedObjectRef>;
+}
+
+#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(
+    rename = "TransactionEffectsModifiedAtVersions",
+    rename_all = "camelCase"
+)]
+pub struct SuiTransactionEffectsModifiedAtVersions {
+    object_id: ObjectID,
+    sequence_number: SequenceNumber,
 }
 
 /// The response from processing a transaction or a certified transaction
@@ -371,6 +382,10 @@ pub struct SuiTransactionEffectsV1 {
     /// The epoch when this transaction was executed.
     pub executed_epoch: EpochId,
     pub gas_used: SuiGasCostSummary,
+    /// The version that every modified (mutated or deleted) object had before it was modified by
+    /// this transaction.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub modified_at_versions: Vec<SuiTransactionEffectsModifiedAtVersions>,
     /// The object references of the shared objects used in this transaction. Empty if no shared objects were used.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub shared_objects: Vec<SuiObjectRef>,
@@ -454,6 +469,13 @@ impl SuiTransactionEffectsAPI for SuiTransactionEffectsV1 {
         &self.transaction_digest
     }
 
+    fn modified_at_versions(&self) -> Vec<(ObjectID, SequenceNumber)> {
+        self.modified_at_versions
+            .iter()
+            .map(|v| (v.object_id, v.sequence_number))
+            .collect::<Vec<_>>()
+    }
+
     fn gas_used(&self) -> &SuiGasCostSummary {
         &self.gas_used
     }
@@ -481,6 +503,17 @@ impl TryFrom<TransactionEffects> for SuiTransactionEffects {
             1 => Ok(SuiTransactionEffects::V1(SuiTransactionEffectsV1 {
                 status: effect.status().clone().into(),
                 executed_epoch: effect.executed_epoch(),
+                modified_at_versions: effect
+                    .modified_at_versions()
+                    .iter()
+                    .copied()
+                    .map(
+                        |(object_id, sequence_number)| SuiTransactionEffectsModifiedAtVersions {
+                            object_id,
+                            sequence_number,
+                        },
+                    )
+                    .collect(),
                 gas_used: effect.gas_cost_summary().clone().into(),
                 shared_objects: to_sui_object_ref(effect.shared_objects().to_vec()),
                 transaction_digest: *effect.transaction_digest(),

--- a/crates/sui-json-rpc/src/balance_changes.rs
+++ b/crates/sui-json-rpc/src/balance_changes.rs
@@ -20,7 +20,7 @@ use sui_types::messages::{ExecutionStatus, TransactionEffects};
 use sui_types::object::{Object, Owner};
 use sui_types::storage::WriteKind;
 
-pub async fn get_balance_change_from_effect<P: ObjectProvider<Error = E>, E>(
+pub async fn get_balance_changes_from_effect<P: ObjectProvider<Error = E>, E>(
     object_provider: &P,
     effects: &TransactionEffects,
 ) -> Result<Vec<BalanceChange>, E> {
@@ -41,7 +41,7 @@ pub async fn get_balance_change_from_effect<P: ObjectProvider<Error = E>, E>(
         .map(|((id, version, _), _, _)| (*id, *version))
         .collect::<Vec<_>>();
 
-    get_balance_change(
+    get_balance_changes(
         object_provider,
         effects.modified_at_versions(),
         &all_mutated,
@@ -49,7 +49,7 @@ pub async fn get_balance_change_from_effect<P: ObjectProvider<Error = E>, E>(
     .await
 }
 
-pub async fn get_balance_change<P: ObjectProvider<Error = E>, E>(
+pub async fn get_balance_changes<P: ObjectProvider<Error = E>, E>(
     object_provider: &P,
     modified_at_version: &[(ObjectID, SequenceNumber)],
     all_mutated: &[(ObjectID, SequenceNumber)],

--- a/crates/sui-json-rpc/src/object_changes.rs
+++ b/crates/sui-json-rpc/src/object_changes.rs
@@ -4,29 +4,30 @@
 use std::collections::BTreeMap;
 
 use sui_json_rpc_types::ObjectChange;
-use sui_types::base_types::{MoveObjectType, SuiAddress};
+use sui_types::base_types::{MoveObjectType, ObjectID, ObjectRef, SequenceNumber, SuiAddress};
 use sui_types::coin::Coin;
 use sui_types::gas_coin::GasCoin;
 use sui_types::governance::StakedSui;
-use sui_types::messages::TransactionEffectsAPI;
+use sui_types::object::Owner;
 use sui_types::storage::{DeleteKind, WriteKind};
 
 use crate::ObjectProvider;
 
-pub async fn get_object_change_from_effect<P: ObjectProvider<Error = E>, E>(
+pub async fn get_object_changes<P: ObjectProvider<Error = E>, E>(
     object_provider: &P,
     sender: SuiAddress,
-    effects: &impl TransactionEffectsAPI,
+    modified_at_versions: &[(ObjectID, SequenceNumber)],
+    all_changed_objects: Vec<(&ObjectRef, &Owner, WriteKind)>,
+    all_deleted: Vec<(&ObjectRef, DeleteKind)>,
 ) -> Result<Vec<ObjectChange>, E> {
     let mut object_changes = vec![];
 
-    let modify_at_version = effects
-        .modified_at_versions()
+    let modify_at_version = modified_at_versions
         .iter()
         .cloned()
         .collect::<BTreeMap<_, _>>();
 
-    for ((id, version, digest), owner, kind) in effects.all_changed_objects() {
+    for ((id, version, digest), owner, kind) in all_changed_objects {
         let o = object_provider.get_object(id, version).await?;
         if let Some(type_) = o.type_() {
             let object_type = match type_ {
@@ -69,7 +70,7 @@ pub async fn get_object_change_from_effect<P: ObjectProvider<Error = E>, E>(
         };
     }
 
-    for ((id, version, _), kind) in effects.all_deleted() {
+    for ((id, version, _), kind) in all_deleted {
         let o = object_provider
             .find_object_lt_or_eq_version(id, version)
             .await?;

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -56,8 +56,7 @@ use crate::api::{
 };
 use crate::error::Error;
 use crate::{
-    get_balance_change_from_effect, get_object_change_from_effect, ObjectProviderCache,
-    SuiRpcModule,
+    get_balance_changes_from_effect, get_object_changes, ObjectProviderCache, SuiRpcModule,
 };
 
 const MAX_DISPLAY_NESTED_LEVEL: usize = 10;
@@ -426,7 +425,7 @@ impl ReadApiServer for ReadApi {
         let object_cache = ObjectProviderCache::new(self.state.clone());
         if opts.show_balance_changes {
             if let Some(effects) = &temp_response.effects {
-                let balance_changes = get_balance_change_from_effect(&object_cache, effects)
+                let balance_changes = get_balance_changes_from_effect(&object_cache, effects)
                     .await
                     .map_err(Error::SuiError)?;
                 temp_response.balance_changes = Some(balance_changes);
@@ -438,9 +437,15 @@ impl ReadApiServer for ReadApi {
                 (&temp_response.effects, &temp_response.transaction)
             {
                 let sender = input.data().intent_message().value.sender();
-                let object_changes = get_object_change_from_effect(&object_cache, sender, effects)
-                    .await
-                    .map_err(Error::SuiError)?;
+                let object_changes = get_object_changes(
+                    &object_cache,
+                    sender,
+                    effects.modified_at_versions(),
+                    effects.all_changed_objects(),
+                    effects.all_deleted(),
+                )
+                .await
+                .map_err(Error::SuiError)?;
                 temp_response.object_changes = Some(object_changes);
             }
         }
@@ -612,7 +617,7 @@ impl ReadApiServer for ReadApi {
         if opts.show_balance_changes {
             let mut futures = vec![];
             for resp in temp_response.values() {
-                futures.push(get_balance_change_from_effect(
+                futures.push(get_balance_changes_from_effect(
                     &object_cache,
                     resp.effects.as_ref().ok_or_else(|| {
                         anyhow!("unable to derive balance changes because effect is empty")
@@ -634,7 +639,11 @@ impl ReadApiServer for ReadApi {
         if opts.show_object_changes {
             let mut futures = vec![];
             for resp in temp_response.values() {
-                futures.push(get_object_change_from_effect(
+                let effects = resp.effects.as_ref().ok_or_else(|| {
+                    anyhow!("unable to derive object changes because effect is empty")
+                })?;
+
+                futures.push(get_object_changes(
                     &object_cache,
                     resp.transaction
                         .as_ref()
@@ -645,9 +654,9 @@ impl ReadApiServer for ReadApi {
                         .intent_message()
                         .value
                         .sender(),
-                    resp.effects.as_ref().ok_or_else(|| {
-                        anyhow!("unable to derive object changes because effect is empty")
-                    })?,
+                    effects.modified_at_versions(),
+                    effects.all_changed_objects(),
+                    effects.all_deleted(),
                 ));
             }
             let results = join_all(futures).await;

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -6822,6 +6822,13 @@
                   "v1"
                 ]
               },
+              "modifiedAtVersions": {
+                "description": "The version that every modified (mutated or deleted) object had before it was modified by this transaction.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/TransactionEffectsModifiedAtVersions"
+                }
+              },
               "mutated": {
                 "description": "ObjectRef and owner of mutated objects, including gas object.",
                 "type": "array",
@@ -6876,6 +6883,21 @@
             }
           }
         ]
+      },
+      "TransactionEffectsModifiedAtVersions": {
+        "type": "object",
+        "required": [
+          "objectId",
+          "sequenceNumber"
+        ],
+        "properties": {
+          "objectId": {
+            "$ref": "#/components/schemas/ObjectID"
+          },
+          "sequenceNumber": {
+            "$ref": "#/components/schemas/SequenceNumber"
+          }
+        }
       },
       "TransactionEventsDigest": {
         "$ref": "#/components/schemas/Digest"

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -481,6 +481,7 @@ impl RpcExampleProvider {
             effects: Some(SuiTransactionEffects::V1(SuiTransactionEffectsV1 {
                 status: SuiExecutionStatus::Success,
                 executed_epoch: 0,
+                modified_at_versions: vec![],
                 gas_used: SuiGasCostSummary {
                     computation_cost: 100,
                     storage_cost: 100,

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -193,6 +193,10 @@ export const OwnedObjectRef = object({
   reference: SuiObjectRef,
 });
 export type OwnedObjectRef = Infer<typeof OwnedObjectRef>;
+export const TransactionEffectsModifiedAtVersions = object({
+  object_id: ObjectId,
+  sequence_number: SequenceNumber,
+});
 
 export const TransactionEffects = object({
   // Eventually this will become union(literal('v1'), literal('v2'), ...)
@@ -202,6 +206,8 @@ export const TransactionEffects = object({
   status: ExecutionStatus,
   /** The epoch when this transaction was executed */
   executedEpoch: EpochId,
+  /** The version that every modified (mutated or deleted) object had before it was modified by this transaction. **/
+  modifiedAtVersions: optional(array(TransactionEffectsModifiedAtVersions)),
   gasUsed: GasCostSummary,
   /** The object references of the shared objects used in this transaction. Empty if no shared objects were used. */
   sharedObjects: optional(array(SuiObjectRef)),


### PR DESCRIPTION
## Description 

- add `modified_at_versions` to sui txn effects
- also refactor get_object_changes to be used by indexer

Heard from @patrickkuo that there might be an issue with get_balance_changes, which should use input objects of txn data instead of modified_at_versions, I can quickly add that if we have consensus.

But with or without that, indexer can now use `get_object_changes` and `get_balance_changes` after this PR.

## Test Plan 

CI

