### PR TITLE
[rosetta] - change the format of sub account

### DIFF
--- a/crates/sui-rosetta/src/types.rs
+++ b/crates/sui-rosetta/src/types.rs
@@ -143,8 +143,15 @@ pub struct Amount {
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct AmountMetadata {
+    pub sub_balances: Vec<SubBalance>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct SubBalance {
     pub stake_id: ObjectID,
     pub validator: SuiAddress,
+    #[serde(with = "str_format")]
+    pub value: i128,
 }
 
 impl Amount {
@@ -155,14 +162,13 @@ impl Amount {
             metadata: None,
         }
     }
-    pub fn new_stake(value: i128, stake_id: ObjectID, validator: SuiAddress) -> Self {
+    pub fn new_from_sub_balances(sub_balances: Vec<SubBalance>) -> Self {
+        let value = sub_balances.iter().map(|b| b.value).sum();
+
         Self {
             value,
             currency: SUI.clone(),
-            metadata: Some(AmountMetadata {
-                stake_id,
-                validator,
-            }),
+            metadata: Some(AmountMetadata { sub_balances }),
         }
     }
 }


### PR DESCRIPTION
## Description 
 
Changing the sub account result format , requested by CB team, we need to group all stakes into metadata because CB can only support 1 currency type in a balance response.

## Test Plan 
Tested locally
response payload:
```
{
    "block_identifier": {
        "index": 369734,
        "hash": "CgjcAdsFv3nRGrNi2UrCSNBLjpg9L25vpDJbhZ8f7LJu"
    },
    "balances": [
        {
            "value": "99964336104",
            "currency": {
                "symbol": "SUI",
                "decimals": 9
            },
            "metadata": {
                "sub_balances": [
                    {
                        "stake_id": "0x45f335e3b4ea908b79d4df5380d29e49b08ba93205dcc3d5a15eb512f0ed0532",
                        "validator": "0xbff0c15fa28f7706e43f6aee9fd0113db13f7119931a90244dfe8c76b9ebd9ae",
                        "value": "99964336104"
                    }
                ]
            }
        }
    ]
}
```
