### PR TITLE
[transactional tests] Exclude system objects from fake ID enumeration

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/checkpoint/clock.exp
+++ b/crates/sui-adapter-transactional-tests/tests/checkpoint/clock.exp
@@ -1,17 +1,17 @@
 processed 5 tasks
 
 task 1 'consensus-commit-prologue'. lines 6-6:
-written: object(102)
+written: 0x6
 
 task 2 'view-object'. lines 8-8:
 Owner: Shared
 Version: 2
-Contents: sui::clock::Clock {id: sui::object::UID {id: sui::object::ID {bytes: fake(102)}}, timestamp_ms: 43u64}
+Contents: sui::clock::Clock {id: sui::object::UID {id: sui::object::ID {bytes: 0x6}}, timestamp_ms: 43u64}
 
 task 3 'consensus-commit-prologue'. lines 10-10:
-written: object(102)
+written: 0x6
 
 task 4 'view-object'. lines 12-12:
 Owner: Shared
 Version: 3
-Contents: sui::clock::Clock {id: sui::object::UID {id: sui::object::ID {bytes: fake(102)}}, timestamp_ms: 45u64}
+Contents: sui::clock::Clock {id: sui::object::UID {id: sui::object::ID {bytes: 0x6}}, timestamp_ms: 45u64}

--- a/crates/sui-adapter-transactional-tests/tests/checkpoint/clock.move
+++ b/crates/sui-adapter-transactional-tests/tests/checkpoint/clock.move
@@ -5,8 +5,8 @@
 
 //# consensus-commit-prologue --timestamp-ms 43
 
-//# view-object 102
+//# view-object 6
 
 //# consensus-commit-prologue --timestamp-ms 45
 
-//# view-object 102
+//# view-object 6

--- a/crates/sui-adapter-transactional-tests/tests/child_count/count_decremented.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/count_decremented.exp
@@ -1,7 +1,7 @@
 processed 17 tasks
 
 init:
-A: object(100), B: object(101)
+A: object(103), B: object(104)
 
 task 1 'publish'. lines 9-52:
 created: object(106)

--- a/crates/sui-adapter-transactional-tests/tests/child_count/delete_by_wrap.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/delete_by_wrap.exp
@@ -1,7 +1,7 @@
 processed 6 tasks
 
 init:
-A: object(100), B: object(101)
+A: object(103), B: object(104)
 
 task 1 'publish'. lines 9-38:
 created: object(106)

--- a/crates/sui-adapter-transactional-tests/tests/child_count/delete_by_wrap_one_txn.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/delete_by_wrap_one_txn.exp
@@ -1,7 +1,7 @@
 processed 3 tasks
 
 init:
-A: object(100), B: object(101)
+A: object(103), B: object(104)
 
 task 1 'publish'. lines 9-32:
 created: object(106)

--- a/crates/sui-adapter-transactional-tests/tests/child_count/delete_parent_invalid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/delete_parent_invalid.exp
@@ -1,7 +1,7 @@
 processed 6 tasks
 
 init:
-A: object(100), B: object(101)
+A: object(103), B: object(104)
 
 task 1 'publish'. lines 9-33:
 created: object(106)

--- a/crates/sui-adapter-transactional-tests/tests/child_count/delete_parent_valid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/delete_parent_valid.exp
@@ -1,7 +1,7 @@
 processed 7 tasks
 
 init:
-A: object(100), B: object(101)
+A: object(103), B: object(104)
 
 task 1 'publish'. lines 9-58:
 created: object(106)

--- a/crates/sui-adapter-transactional-tests/tests/child_count/delete_parent_valid_one_txn.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/delete_parent_valid_one_txn.exp
@@ -1,7 +1,7 @@
 processed 6 tasks
 
 init:
-A: object(100), B: object(101)
+A: object(103), B: object(104)
 
 task 1 'publish'. lines 10-70:
 created: object(106)

--- a/crates/sui-adapter-transactional-tests/tests/child_count/freeze_parent_invalid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/freeze_parent_invalid.exp
@@ -1,7 +1,7 @@
 processed 6 tasks
 
 init:
-A: object(100), B: object(101)
+A: object(103), B: object(104)
 
 task 1 'publish'. lines 9-62:
 created: object(106)

--- a/crates/sui-adapter-transactional-tests/tests/child_count/freeze_parent_valid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/freeze_parent_valid.exp
@@ -1,7 +1,7 @@
 processed 7 tasks
 
 init:
-A: object(100), B: object(101)
+A: object(103), B: object(104)
 
 task 1 'publish'. lines 9-62:
 created: object(106)

--- a/crates/sui-adapter-transactional-tests/tests/child_count/freeze_parent_valid_one_txn.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/freeze_parent_valid_one_txn.exp
@@ -1,7 +1,7 @@
 processed 6 tasks
 
 init:
-A: object(100), B: object(101)
+A: object(103), B: object(104)
 
 task 1 'publish'. lines 10-65:
 created: object(106)

--- a/crates/sui-adapter-transactional-tests/tests/child_count/non_zero_child_count_valid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/non_zero_child_count_valid.exp
@@ -1,7 +1,7 @@
 processed 10 tasks
 
 init:
-A: object(100), B: object(101)
+A: object(103), B: object(104)
 
 task 1 'publish'. lines 9-46:
 created: object(106)

--- a/crates/sui-adapter-transactional-tests/tests/child_count/non_zero_child_count_valid_one_txn.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/non_zero_child_count_valid_one_txn.exp
@@ -1,7 +1,7 @@
 processed 4 tasks
 
 init:
-A: object(100), B: object(101)
+A: object(103), B: object(104)
 
 task 1 'publish'. lines 10-36:
 created: object(106)

--- a/crates/sui-adapter-transactional-tests/tests/child_count/temp_parent_invalid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/temp_parent_invalid.exp
@@ -1,7 +1,7 @@
 processed 3 tasks
 
 init:
-A: object(100), B: object(101)
+A: object(103), B: object(104)
 
 task 1 'publish'. lines 9-24:
 created: object(106)

--- a/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_never_stored.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_never_stored.exp
@@ -1,7 +1,7 @@
 processed 4 tasks
 
 init:
-A: object(100), B: object(101)
+A: object(103), B: object(104)
 
 task 1 'publish'. lines 9-39:
 created: object(106)

--- a/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_never_stored_transfer.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_never_stored_transfer.exp
@@ -1,7 +1,7 @@
 processed 4 tasks
 
 init:
-A: object(100), B: object(101)
+A: object(103), B: object(104)
 
 task 1 'publish'. lines 9-38:
 created: object(106)

--- a/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_then_delete_invalid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_then_delete_invalid.exp
@@ -1,7 +1,7 @@
 processed 5 tasks
 
 init:
-A: object(100), B: object(101)
+A: object(103), B: object(104)
 
 task 1 'publish'. lines 9-45:
 created: object(106)

--- a/crates/sui-adapter-transactional-tests/tests/children/child_of_shared_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/children/child_of_shared_object.exp
@@ -1,7 +1,7 @@
 processed 8 tasks
 
 init:
-A: object(100)
+A: object(103)
 
 task 1 'publish'. lines 6-21:
 created: object(105)

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/add_duplicate.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/add_duplicate.exp
@@ -1,7 +1,7 @@
 processed 4 tasks
 
 init:
-A: object(100)
+A: object(103)
 
 task 1 'publish'. lines 9-30:
 created: object(105)

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/add_duplicate_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/add_duplicate_object.exp
@@ -1,7 +1,7 @@
 processed 4 tasks
 
 init:
-A: object(100)
+A: object(103)
 
 task 1 'publish'. lines 10-31:
 created: object(105)

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/borrow_wrong_type.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/borrow_wrong_type.exp
@@ -1,7 +1,7 @@
 processed 5 tasks
 
 init:
-A: object(100)
+A: object(103)
 
 task 1 'publish'. lines 9-34:
 created: object(105)

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/borrow_wrong_type_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/borrow_wrong_type_object.exp
@@ -1,7 +1,7 @@
 processed 5 tasks
 
 init:
-A: object(100)
+A: object(103)
 
 task 1 'publish'. lines 10-39:
 created: object(105)

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/exhaustive.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/exhaustive.exp
@@ -1,7 +1,7 @@
 processed 11 tasks
 
 init:
-A: object(100)
+A: object(103)
 
 task 1 'publish'. lines 9-79:
 created: object(105)

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/exhaustive_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/exhaustive_object.exp
@@ -1,7 +1,7 @@
 processed 11 tasks
 
 init:
-A: object(100)
+A: object(103)
 
 task 1 'publish'. lines 10-104:
 created: object(105)

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/read_field_from_immutable.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/read_field_from_immutable.exp
@@ -1,7 +1,7 @@
 processed 4 tasks
 
 init:
-A: object(100)
+A: object(103)
 
 task 1 'publish'. lines 9-30:
 created: object(105)

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/remove_wrong_type.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/remove_wrong_type.exp
@@ -1,7 +1,7 @@
 processed 4 tasks
 
 init:
-A: object(100)
+A: object(103)
 
 task 1 'publish'. lines 9-31:
 created: object(105)

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/remove_wrong_type_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/remove_wrong_type_object.exp
@@ -1,7 +1,7 @@
 processed 4 tasks
 
 init:
-A: object(100)
+A: object(103)
 
 task 1 'publish'. lines 10-36:
 created: object(105)

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/transfer_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/transfer_object.exp
@@ -1,7 +1,7 @@
 processed 11 tasks
 
 init:
-A: object(100)
+A: object(103)
 
 task 1 'publish'. lines 10-67:
 created: object(105)

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/unwrap_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/unwrap_object.exp
@@ -1,7 +1,7 @@
 processed 10 tasks
 
 init:
-A: object(100)
+A: object(103)
 
 task 1 'publish'. lines 8-41:
 created: object(105)

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/wrap_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/wrap_object.exp
@@ -1,7 +1,7 @@
 processed 12 tasks
 
 init:
-A: object(100)
+A: object(103)
 
 task 1 'publish'. lines 8-41:
 created: object(105)

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/wrapped_uid_after_delete.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/wrapped_uid_after_delete.exp
@@ -1,7 +1,7 @@
 processed 10 tasks
 
 init:
-A: object(100)
+A: object(103)
 
 task 1 'publish'. lines 10-84:
 created: object(105)

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/ascii.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/ascii.exp
@@ -1,7 +1,7 @@
 processed 6 tasks
 
 init:
-A: object(100)
+A: object(103)
 
 task 1 'publish'. lines 6-28:
 created: object(105)

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/imm_txn_context.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/imm_txn_context.exp
@@ -1,7 +1,7 @@
 processed 5 tasks
 
 init:
-A: object(100)
+A: object(103)
 
 task 1 'publish'. lines 6-28:
 created: object(105)

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/missing_type.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/missing_type.exp
@@ -1,7 +1,7 @@
 processed 7 tasks
 
 init:
-A: object(100)
+A: object(103)
 
 task 1 'publish'. lines 8-15:
 created: object(105)

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/no_txn_context.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/no_txn_context.exp
@@ -1,7 +1,7 @@
 processed 4 tasks
 
 init:
-A: object(100)
+A: object(103)
 
 task 1 'publish'. lines 6-24:
 created: object(105)

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector.exp
@@ -1,7 +1,7 @@
 processed 19 tasks
 
 init:
-A: object(100)
+A: object(103)
 
 task 1 'publish'. lines 8-116:
 created: object(105)

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic.exp
@@ -1,7 +1,7 @@
 processed 18 tasks
 
 init:
-A: object(100)
+A: object(103)
 
 task 1 'publish'. lines 8-115:
 created: object(105)

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/utf8.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/utf8.exp
@@ -1,7 +1,7 @@
 processed 8 tasks
 
 init:
-A: object(100)
+A: object(103)
 
 task 1 'publish'. lines 6-27:
 created: object(105)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/invalid_option.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/invalid_option.exp
@@ -1,7 +1,7 @@
 processed 20 tasks
 
 init:
-A: object(100)
+A: object(103)
 
 task 1 'publish'. lines 8-17:
 created: object(105)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/make_vec_objects.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/make_vec_objects.exp
@@ -1,7 +1,7 @@
 processed 8 tasks
 
 init:
-A: object(100), B: object(101)
+A: object(103), B: object(104)
 
 task 1 'publish'. lines 8-47:
 created: object(106)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/make_vec_special_validation_invalid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/make_vec_special_validation_invalid.exp
@@ -1,7 +1,7 @@
 processed 4 tasks
 
 init:
-A: object(100)
+A: object(103)
 
 task 1 'publish'. lines 8-31:
 created: object(105)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/split_coins.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/split_coins.exp
@@ -1,7 +1,7 @@
 processed 19 tasks
 
 init:
-A: object(100), B: object(101)
+A: object(103), B: object(104)
 
 task 1 'publish'. lines 9-29:
 created: object(106)
@@ -9,7 +9,7 @@ written: object(105)
 
 task 2 'run'. lines 30-30:
 created: object(108)
-written: object(100), object(107)
+written: object(103), object(107)
 
 task 3 'view-object'. lines 32-34:
 Owner: Account Address ( A )

--- a/crates/sui-adapter-transactional-tests/tests/programmable/split_coins.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/split_coins.move
@@ -27,7 +27,7 @@ module test::m1 {
 
 
 // let's get ourselves a coin worth 1000
-//# run sui::pay::split_and_transfer --type-args sui::sui::SUI --args object(100) 1000 @A --sender A
+//# run sui::pay::split_and_transfer --type-args sui::sui::SUI --args object(103) 1000 @A --sender A
 
 //# view-object 108
 

--- a/crates/sui-adapter-transactional-tests/tests/programmable/split_coins_invalid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/split_coins_invalid.exp
@@ -1,7 +1,7 @@
 processed 11 tasks
 
 init:
-A: object(100), B: object(101), C: object(102)
+A: object(103), B: object(104), C: object(105)
 
 task 1 'publish'. lines 9-28:
 created: object(107)
@@ -9,7 +9,7 @@ written: object(106)
 
 task 2 'run'. lines 29-29:
 created: object(109)
-written: object(100), object(108)
+written: object(103), object(108)
 
 task 3 'view-object'. lines 31-33:
 Owner: Account Address ( A )

--- a/crates/sui-adapter-transactional-tests/tests/programmable/split_coins_invalid.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/split_coins_invalid.move
@@ -26,7 +26,7 @@ module test::m1 {
 }
 
 // let's get ourselves a coin worth 1000
-//# run sui::pay::split_and_transfer --type-args sui::sui::SUI --args object(100) 1000 @A --sender A
+//# run sui::pay::split_and_transfer --type-args sui::sui::SUI --args object(103) 1000 @A --sender A
 
 //# view-object 109
 

--- a/crates/sui-adapter-transactional-tests/tests/programmable/transfer_objects.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/transfer_objects.exp
@@ -1,7 +1,7 @@
 processed 12 tasks
 
 init:
-A: object(100), B: object(101)
+A: object(103), B: object(104)
 
 task 1 'publish'. lines 8-35:
 created: object(106)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/transfer_objects_invalid_address.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/transfer_objects_invalid_address.exp
@@ -1,7 +1,7 @@
 processed 5 tasks
 
 init:
-A: object(100), B: object(101)
+A: object(103), B: object(104)
 
 task 1 'publish'. lines 8-31:
 created: object(106)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/transfer_objects_invalid_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/transfer_objects_invalid_object.exp
@@ -1,7 +1,7 @@
 processed 7 tasks
 
 init:
-A: object(100), B: object(101)
+A: object(103), B: object(104)
 
 task 1 'publish'. lines 8-38:
 created: object(106)

--- a/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/coin_limit.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/coin_limit.exp
@@ -1,7 +1,7 @@
 processed 11 tasks
 
 init:
-A: object(100)
+A: object(103)
 
 task 1 'publish'. lines 6-28:
 created: object(105)

--- a/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/make_vec.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/make_vec.exp
@@ -1,7 +1,7 @@
 processed 7 tasks
 
 init:
-A: object(100)
+A: object(103)
 
 task 1 'publish'. lines 6-53:
 created: object(105)

--- a/crates/sui-adapter-transactional-tests/tests/shared/upgrade.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/upgrade.exp
@@ -1,7 +1,7 @@
 processed 7 tasks
 
 init:
-A: object(100)
+A: object(103)
 
 task 1 'publish'. lines 8-40:
 created: object(105)

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/move_object_size_limit.exp
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/move_object_size_limit.exp
@@ -1,7 +1,7 @@
 processed 9 tasks
 
 init:
-A: object(100)
+A: object(103)
 
 task 1 'publish'. lines 8-79:
 created: object(105)

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/object_runtime_limits.exp
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/object_runtime_limits.exp
@@ -1,7 +1,7 @@
 processed 5 tasks
 
 init:
-A: object(100)
+A: object(103)
 
 task 1 'publish'. lines 9-30:
 created: object(105)

--- a/crates/sui-adapter-transactional-tests/tests/sui/coin_transfer.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/coin_transfer.exp
@@ -1,21 +1,21 @@
 processed 7 tasks
 
 init:
-A: object(100), B: object(101), C: object(102)
+A: object(103), B: object(104), C: object(105)
 
 task 1 'view-object'. lines 8-8:
 Owner: Account Address ( B )
 Version: 1
-Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(101)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 2000000u64}}
+Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(104)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 2000000u64}}
 
 task 2 'run'. lines 10-10:
 created: object(107)
-written: object(101), object(106)
+written: object(104), object(106)
 
 task 3 'view-object'. lines 12-12:
 Owner: Account Address ( B )
 Version: 2
-Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(101)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 1999990u64}}
+Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(104)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 1999990u64}}
 
 task 4 'view-object'. lines 14-14:
 Owner: Account Address ( A )
@@ -28,4 +28,4 @@ Error: Transaction was not signed by the correct sender: Object 0xbea8d80a001a7a
 task 6 'view-object'. lines 18-18:
 Owner: Account Address ( B )
 Version: 2
-Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(101)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 1999990u64}}
+Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(104)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 1999990u64}}

--- a/crates/sui-adapter-transactional-tests/tests/sui/coin_transfer.move
+++ b/crates/sui-adapter-transactional-tests/tests/sui/coin_transfer.move
@@ -5,14 +5,14 @@
 
 //# init --accounts A B C
 
-//# view-object 101
+//# view-object 104
 
-//# run sui::pay::split_and_transfer --type-args sui::sui::SUI --args object(101) 10 @A --sender B
+//# run sui::pay::split_and_transfer --type-args sui::sui::SUI --args object(104) 10 @A --sender B
 
-//# view-object 101
+//# view-object 104
 
 //# view-object 107
 
-//# run sui::pay::split_and_transfer --type-args sui::sui::SUI --args object(101) 0 @C --sender A
+//# run sui::pay::split_and_transfer --type-args sui::sui::SUI --args object(104) 0 @C --sender A
 
-//# view-object 101
+//# view-object 104

--- a/crates/sui-adapter-transactional-tests/tests/sui/freeze.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/freeze.exp
@@ -1,7 +1,7 @@
 processed 6 tasks
 
 init:
-A: object(100)
+A: object(103)
 
 task 1 'publish'. lines 8-70:
 created: object(105)

--- a/crates/sui-adapter-transactional-tests/tests/sui/object_basics.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/object_basics.exp
@@ -1,7 +1,7 @@
 processed 9 tasks
 
 init:
-A: object(100), B: object(101)
+A: object(103), B: object(104)
 
 task 1 'publish'. lines 8-70:
 created: object(106)

--- a/crates/sui-adapter-transactional-tests/tests/sui/unwrap.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/unwrap.exp
@@ -1,7 +1,7 @@
 processed 7 tasks
 
 init:
-A: object(100)
+A: object(103)
 
 task 1 'publish'. lines 9-71:
 created: object(105)

--- a/crates/sui-adapter-transactional-tests/tests/sui/unwrap_then_freeze.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/unwrap_then_freeze.exp
@@ -1,7 +1,7 @@
 processed 7 tasks
 
 init:
-A: object(100)
+A: object(103)
 
 task 1 'publish'. lines 9-42:
 created: object(105)

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/does_not_have_store.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/does_not_have_store.exp
@@ -1,7 +1,7 @@
 processed 10 tasks
 
 init:
-A: object(100), B: object(101)
+A: object(103), B: object(104)
 
 task 1 'publish'. lines 8-29:
 created: object(106)

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/has_store.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/has_store.exp
@@ -1,7 +1,7 @@
 processed 10 tasks
 
 init:
-A: object(100), B: object(101)
+A: object(103), B: object(104)
 
 task 1 'publish'. lines 8-29:
 created: object(106)

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/immutable.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/immutable.exp
@@ -1,7 +1,7 @@
 processed 6 tasks
 
 init:
-A: object(100), B: object(101)
+A: object(103), B: object(104)
 
 task 1 'publish'. lines 8-22:
 created: object(106)

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/package.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/package.exp
@@ -1,7 +1,7 @@
 processed 5 tasks
 
 init:
-A: object(100), B: object(101)
+A: object(103), B: object(104)
 
 task 1 'publish'. lines 8-10:
 created: object(106)

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/quasi_shared.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/quasi_shared.exp
@@ -1,7 +1,7 @@
 processed 7 tasks
 
 init:
-A: object(100), B: object(101)
+A: object(103), B: object(104)
 
 task 1 'publish'. lines 8-27:
 created: object(106)

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/shared.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/shared.exp
@@ -1,7 +1,7 @@
 processed 6 tasks
 
 init:
-A: object(100), B: object(101)
+A: object(103), B: object(104)
 
 task 1 'publish'. lines 8-21:
 created: object(106)

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/transfer_coin.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/transfer_coin.exp
@@ -1,17 +1,17 @@
 processed 4 tasks
 
 init:
-A: object(100), B: object(101)
+A: object(103), B: object(104)
 
 task 1 'view-object'. lines 8-8:
 Owner: Account Address ( A )
 Version: 1
-Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(100)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 2000000u64}}
+Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(103)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 2000000u64}}
 
 task 2 'transfer-object'. lines 10-10:
-written: object(100), object(105)
+written: object(103), object(105)
 
 task 3 'view-object'. lines 12-12:
 Owner: Account Address ( B )
 Version: 2
-Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(100)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 2000000u64}}
+Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(103)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 2000000u64}}

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/transfer_coin.move
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/transfer_coin.move
@@ -5,8 +5,8 @@
 
 //# init --accounts A B
 
-//# view-object 100
+//# view-object 103
 
-//# transfer-object 100 --sender A --recipient B
+//# transfer-object 103 --sender A --recipient B
 
-//# view-object 100
+//# view-object 103

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/wrap_unwrap.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/wrap_unwrap.exp
@@ -1,7 +1,7 @@
 processed 8 tasks
 
 init:
-A: object(100)
+A: object(103)
 
 task 1 'publish'. lines 8-41:
 created: object(105)

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -68,7 +68,7 @@ use sui_types::{in_memory_storage::InMemoryStorage, messages::ProgrammableTransa
 pub(crate) type FakeID = u64;
 
 // initial value for fake object ID mapping
-const INIT_NEXT_FAKE: FakeID = 100;
+const INIT_NEXT_FAKE: FakeID = 103;
 // TODO use the file name as a seed
 const RNG_SEED: [u8; 32] = [
     21, 23, 199, 200, 234, 250, 252, 178, 94, 15, 202, 178, 62, 186, 88, 137, 233, 192, 130, 157,
@@ -795,6 +795,25 @@ impl<'a> SuiTestAdapter<'a> {
     }
 
     fn enumerate_fake(&mut self, id: ObjectID) -> FakeID {
+        let id_addr: SuiAddress = id.into();
+        let id_bytes: [u8; SUI_ADDRESS_LENGTH] = id_addr.to_inner();
+        let high = &id_bytes[0..(SUI_ADDRESS_LENGTH - 8)];
+        let low = [
+            id_bytes[SUI_ADDRESS_LENGTH - 8],
+            id_bytes[SUI_ADDRESS_LENGTH - 7],
+            id_bytes[SUI_ADDRESS_LENGTH - 6],
+            id_bytes[SUI_ADDRESS_LENGTH - 5],
+            id_bytes[SUI_ADDRESS_LENGTH - 4],
+            id_bytes[SUI_ADDRESS_LENGTH - 3],
+            id_bytes[SUI_ADDRESS_LENGTH - 2],
+            id_bytes[SUI_ADDRESS_LENGTH - 1],
+        ];
+        assert!(high.len() + low.len() == SUI_ADDRESS_LENGTH);
+        let id_u64 = u64::from_be_bytes(low);
+        if id_u64 < INIT_NEXT_FAKE && high.iter().copied().all(|u| u == 0) {
+            self.object_enumeration.insert(id, id_u64);
+            return id_u64;
+        }
         if let Some(fake) = self.object_enumeration.get_by_left(&id) {
             return *fake;
         }
@@ -866,6 +885,7 @@ impl<'a> SuiTestAdapter<'a> {
         objs.iter()
             .map(|id| match self.real_to_fake_object_id(id) {
                 None => "object(_)".to_string(),
+                Some(fake) if fake < INIT_NEXT_FAKE => format!("0x{fake:X}"),
                 Some(fake) => format!("object({})", fake),
             })
             .collect::<Vec<_>>()
@@ -930,6 +950,7 @@ impl<'a> SuiTestAdapter<'a> {
         }
         match self.real_to_fake_object_id(&parsed.into()) {
             None => "_".to_string(),
+            Some(fake) if fake < INIT_NEXT_FAKE => format!("0x{fake:X}"),
             Some(fake) => format!("fake({})", fake),
         }
     }


### PR DESCRIPTION
## Description 

- Exclude system objects from fake ID enumeration for easier usability

## Test Plan 

- updated tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
