### PR TITLE
[rust/ts sdk] adding response error field

### DIFF
--- a/.changeset/nice-meals-float.md
+++ b/.changeset/nice-meals-float.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Changing the SuiObjectResponse struct to use data/error fields instead of details/status

--- a/apps/explorer/src/components/ownedobjects/OwnedObjects.tsx
+++ b/apps/explorer/src/components/ownedobjects/OwnedObjects.tsx
@@ -65,13 +65,13 @@ function OwnedObject({ id, byAddress }: { id: string; byAddress: boolean }) {
                 .then((results) => {
                     setResults(
                         results
-                            .filter(({ status }) => status === 'Exists')
+                            .filter(({ data }) => data !== undefined)
                             .map(
                                 (resp) => {
                                     const displayMeta =
-                                        typeof resp.details === 'object' &&
-                                        'display' in resp.details
-                                            ? resp.details.display
+                                        typeof resp.data === 'object' &&
+                                        'display' in resp.data
+                                            ? resp.data.display
                                             : undefined;
                                     const url = parseImageURL(displayMeta);
                                     return {

--- a/apps/explorer/src/hooks/useSearch.ts
+++ b/apps/explorer/src/hooks/useSearch.ts
@@ -48,14 +48,14 @@ const getResultsForObject = async (rpc: JsonRpcProvider, query: string) => {
     const normalized = normalizeSuiObjectId(query);
     if (!isValidSuiObjectId(normalized)) return null;
 
-    const { details, status } = await rpc.getObject({ id: normalized });
-    if (is(details, SuiObjectData) && status === 'Exists') {
+    const { data, error } = await rpc.getObject({ id: normalized });
+    if (is(data, SuiObjectData) && !error) {
         return {
             label: 'object',
             results: [
                 {
-                    id: details.objectId,
-                    label: details.objectId,
+                    id: data.objectId,
+                    label: data.objectId,
                     type: 'object',
                 },
             ],

--- a/apps/explorer/src/pages/object-result/ObjectResult.tsx
+++ b/apps/explorer/src/pages/object-result/ObjectResult.tsx
@@ -37,7 +37,7 @@ export function ObjectResult() {
     }
 
     // TODO: Handle status better NotExists, Deleted, Other
-    if (data?.status !== 'Exists') {
+    if (data.error) {
         return <Fail objID={objID} />;
     }
 

--- a/apps/explorer/src/pages/object-result/ObjectResultType.tsx
+++ b/apps/explorer/src/pages/object-result/ObjectResultType.tsx
@@ -46,38 +46,23 @@ export function instanceOfDataType(object: any): object is DataType {
  * to make this more extensible and customizable for different Move types
  */
 export function translate(o: SuiObjectResponse): DataType {
-    switch (o.status) {
-        case 'Exists': {
-            return {
-                id: getObjectId(o),
-                version: getObjectVersion(o)!.toString(),
-                objType: parseObjectType(o),
-                owner: getObjectOwner(o)!,
-                data: {
-                    contents: getObjectFields(o) ?? getMovePackageContent(o)!,
-                    tx_digest: getObjectPreviousTransactionDigest(o),
-                },
-                display:
-                    (typeof o.details === 'object' &&
-                        'display' in o.details &&
-                        o.details.display) ||
-                    undefined,
-            };
-        }
-        case 'NotExists': {
-            // TODO: implement this
-            throw new Error(
-                `Implement me: Object ${getObjectId(o)} does not exist`
-            );
-        }
-        case 'Deleted': {
-            // TODO: implement this
-            throw new Error(
-                `Implement me: Object ${getObjectId(o)} has been deleted`
-            );
-        }
-        default: {
-            throw new Error(`Unexpected status ${o.status} for object ${o}`);
-        }
+    if (o.data) {
+        return {
+            id: getObjectId(o),
+            version: getObjectVersion(o)!.toString(),
+            objType: parseObjectType(o),
+            owner: getObjectOwner(o)!,
+            data: {
+                contents: getObjectFields(o) ?? getMovePackageContent(o)!,
+                tx_digest: getObjectPreviousTransactionDigest(o),
+            },
+            display:
+                (typeof o.data === 'object' &&
+                    'display' in o.data &&
+                    o.data.display) ||
+                undefined,
+        };
+    } else {
+        throw new Error(`${o.error}`);
     }
 }

--- a/apps/wallet/src/ui/app/helpers/NftClient.ts
+++ b/apps/wallet/src/ui/app/helpers/NftClient.ts
@@ -96,10 +96,10 @@ const DisplayDomainRegex =
 export const NftParser: SuiObjectParser<NftRpcResponse, NftRaw> = {
     parser: (data, suiData, rpcResponse) => {
         if (
-            typeof rpcResponse.details === 'object' &&
-            'owner' in rpcResponse.details
+            typeof rpcResponse.data === 'object' &&
+            'owner' in rpcResponse.data
         ) {
-            const { owner } = rpcResponse.details;
+            const { owner } = rpcResponse.data;
 
             const matches = (suiData.content as SuiMoveObject).type.match(
                 NftRegex
@@ -114,7 +114,7 @@ export const NftParser: SuiObjectParser<NftRpcResponse, NftRaw> = {
             return {
                 owner,
                 type: suiData.content?.dataType,
-                id: rpcResponse.details.objectId,
+                id: rpcResponse.data.objectId,
                 packageObjectId,
                 packageModule,
                 packageModuleClassName,
@@ -128,12 +128,12 @@ export const NftParser: SuiObjectParser<NftRpcResponse, NftRaw> = {
     regex: NftRegex,
 };
 
-const isObjectExists = (o: SuiObjectResponse) => o.status === 'Exists';
+const isObjectExists = (o: SuiObjectResponse) => o.data;
 
 const isTypeMatchRegex = (d: SuiObjectResponse, regex: RegExp) => {
-    const { details } = d;
-    if (is(details, SuiObjectData)) {
-        const { content } = details;
+    const { data } = d;
+    if (is(data, SuiObjectData)) {
+        const { content } = data;
         if (content && 'type' in content) {
             return content.type.match(regex);
         }

--- a/apps/wallet/src/ui/app/hooks/useGetNFTMeta.ts
+++ b/apps/wallet/src/ui/app/hooks/useGetNFTMeta.ts
@@ -13,14 +13,14 @@ export type NFTMetadata = {
 };
 
 export function useGetNFTMeta(objectID: string) {
-    const data = useGetObject(objectID);
+    const resp = useGetObject(objectID);
 
     const nftMeta = useMemo(() => {
-        if (!data.data) return null;
+        if (!resp.data) return null;
 
-        const { details } = data.data || {};
-        if (!is(details, SuiObjectData) || !data) return null;
-        const fields = getObjectFields(data.data);
+        const { data } = resp.data || {};
+        if (!is(data, SuiObjectData) || !resp) return null;
+        const fields = getObjectFields(resp.data);
         if (!fields?.url) return null;
         return {
             description:
@@ -30,10 +30,10 @@ export function useGetNFTMeta(objectID: string) {
             name: typeof fields.name === 'string' ? fields.name : null,
             url: fields.url,
         };
-    }, [data]);
+    }, [resp]);
 
     return {
-        ...data,
+        ...resp,
         data: nftMeta,
     };
 }

--- a/apps/wallet/src/ui/app/hooks/useOwnedNFT.ts
+++ b/apps/wallet/src/ui/app/hooks/useOwnedNFT.ts
@@ -18,14 +18,14 @@ export function useOwnedNFT(
     const data = useGetObject(nftObjectId!);
     const { data: objectData } = data;
     const objectDetails = useMemo(() => {
-        if (!objectData || !is(objectData.details, SuiObjectData) || !address)
+        if (!objectData || !is(objectData.data, SuiObjectData) || !address)
             return null;
         const objectOwner = getObjectOwner(objectData);
         return objectOwner &&
             objectOwner !== 'Immutable' &&
             'AddressOwner' in objectOwner &&
             objectOwner.AddressOwner === address
-            ? objectData.details
+            ? objectData.data
             : null;
     }, [address, objectData]);
     return { ...data, data: objectDetails };

--- a/apps/wallet/src/ui/app/pages/home/nfts/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nfts/index.tsx
@@ -25,7 +25,7 @@ function NftsPage() {
         (obj) => !Coin.isCoin(obj)
     );
     const nfts = nft_objects?.map((nft) => {
-        const nft_details = nft.details as SuiObjectData;
+        const nft_details = nft.data as SuiObjectData;
         return nft_details;
     });
 

--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -15,7 +15,7 @@ use std::path::Path;
 use shared_crypto::intent::Intent;
 use sui::client_commands::WalletContext;
 use sui_json_rpc_types::{
-    SuiObjectDataOptions, SuiObjectResponse, SuiTransactionEffectsAPI, SuiTransactionResponse,
+    SuiObjectDataOptions, SuiTransactionEffectsAPI, SuiTransactionResponse,
     SuiTransactionResponseOptions,
 };
 use sui_keys::keystore::AccountKeystore;
@@ -200,12 +200,12 @@ impl SimpleFaucet {
                     .with_content(),
             )
             .await?;
-        Ok(match gas_obj {
-            SuiObjectResponse::NotExists(_) | SuiObjectResponse::Deleted(_) => None,
-            SuiObjectResponse::Exists(obj) => {
-                GasCoin::try_from(&obj).ok().map(|coin| (obj.owner, coin))
-            }
-        })
+        let o = gas_obj.data;
+        if let Some(o) = o {
+            Ok(GasCoin::try_from(&o).ok().map(|coin| (o.owner, coin)))
+        } else {
+            Ok(None)
+        }
     }
 
     /// Similar to get_coin but checks that the owner is the active

--- a/crates/sui-indexer/tests/integration_tests.rs
+++ b/crates/sui-indexer/tests/integration_tests.rs
@@ -63,9 +63,12 @@ pub mod pg_integration_test {
             .await?
             .data
             .into_iter()
-            .filter_map(|object_resp| match object_resp {
-                SuiObjectResponse::Exists(obj_data) => Some(obj_data.object_id),
-                _ => None,
+            .filter_map(|object_resp| {
+                if let Some(data) = object_resp.data {
+                    Some(data.object_id)
+                } else {
+                    None
+                }
             })
             .collect();
 
@@ -143,9 +146,12 @@ pub mod pg_integration_test {
             .await?
             .data
             .into_iter()
-            .filter_map(|object_resp| match object_resp {
-                SuiObjectResponse::Exists(obj_data) => Some(obj_data.object_id),
-                _ => None,
+            .filter_map(|object_resp| {
+                if let Some(data) = object_resp.data {
+                    Some(data.object_id)
+                } else {
+                    None
+                }
             })
             .collect();
 
@@ -472,9 +478,12 @@ pub mod pg_integration_test {
             .await?
             .data
             .into_iter()
-            .filter_map(|object_resp| match object_resp {
-                SuiObjectResponse::Exists(obj_data) => Some(obj_data),
-                _ => None,
+            .filter_map(|object_resp| {
+                if let Some(data) = object_resp.data {
+                    Some(data.object_id)
+                } else {
+                    None
+                }
             })
             .any(|obj| obj.object_id == transferred_object);
         assert!(object_correctly_transferred);

--- a/crates/sui-indexer/tests/integration_tests.rs
+++ b/crates/sui-indexer/tests/integration_tests.rs
@@ -35,6 +35,7 @@ pub mod pg_integration_test {
     use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
     use sui_types::base_types::{ObjectID, SuiAddress};
     use sui_types::digests::TransactionDigest;
+    use sui_types::error::SuiObjectResponseError;
     use sui_types::gas_coin::GasCoin;
     use sui_types::messages::ExecuteTransactionRequestType;
     use sui_types::object::ObjectFormatOptions;
@@ -485,7 +486,7 @@ pub mod pg_integration_test {
                     None
                 }
             })
-            .any(|obj| obj.object_id == transferred_object);
+            .any(|obj| obj == transferred_object);
         assert!(object_correctly_transferred);
 
         Ok(())
@@ -721,26 +722,43 @@ pub mod pg_integration_test {
             .await
             .unwrap();
 
-        match resp {
-            SuiObjectResponse::Deleted(obj) => {
-                assert_eq!(obj.object_id, post_transfer_full_obj_data.object_id);
-                assert_eq!(obj.digest, post_transfer_full_obj_data.digest);
-                assert_eq!(obj.version.value(), 3);
+        match (&resp.data, &resp.error) {
+            (
+                None,
+                Some(SuiObjectResponseError::Deleted {
+                    object_id,
+                    version,
+                    digest,
+                }),
+            ) => {
+                assert_eq!(object_id, &post_transfer_full_obj_data.object_id);
+                assert_eq!(digest, &post_transfer_full_obj_data.digest);
+                assert_eq!(version.value(), 3);
             }
             _ => {
-                panic!("Expected SuiObjectResponse::Deleted, but got {:?}", resp);
+                panic!(
+                    "Expected SuiObjectResponse::Deleted, but got {:?}",
+                    resp.error
+                );
             }
         }
 
         // Not exists
-        let object_id = ObjectID::from([42; 32]);
+        let obj_id = ObjectID::from([42; 32]);
         let resp = indexer_rpc_client
-            .get_object_with_options(object_id, Some(show_all_content.clone()))
+            .get_object_with_options(obj_id, Some(show_all_content.clone()))
             .await
             .unwrap();
 
-        assert!(matches!(resp, SuiObjectResponse::NotExists(obj_id) if obj_id == object_id));
-        matches!(resp, SuiObjectResponse::NotExists(_));
+        if let Some(SuiObjectResponseError::NotExists { object_id }) = resp.error {
+            assert_eq!(object_id, obj_id)
+        } else {
+            panic!(
+                "Expected SuiObjectResponse::NotExists, but got {:?}",
+                resp.error
+            );
+        }
+
         Ok(())
     }
 

--- a/crates/sui-json-rpc/src/error.rs
+++ b/crates/sui-json-rpc/src/error.rs
@@ -5,7 +5,7 @@ use fastcrypto::error::FastCryptoError;
 use hyper::header::InvalidHeaderValue;
 use jsonrpsee::core::Error as RpcError;
 use jsonrpsee::types::error::CallError;
-use sui_types::error::{SuiError, UserInputError};
+use sui_types::error::{SuiError, SuiObjectResponseError, UserInputError};
 use sui_types::quorum_driver_types::QuorumDriverError;
 use thiserror::Error;
 use tokio::task::JoinError;
@@ -44,6 +44,9 @@ pub enum Error {
 
     #[error(transparent)]
     FastCryptoError(#[from] FastCryptoError),
+
+    #[error(transparent)]
+    SuiObjectResponseError(#[from] SuiObjectResponseError),
 }
 
 impl From<Error> for RpcError {

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -282,7 +282,7 @@ async fn test_get_object_info() -> Result<(), anyhow::Error> {
             )
             .await?;
         assert!(
-            matches!(result, SuiObjectResponse::Exists(object) if oref.object_id == object.object_id && &object.owner.unwrap().get_owner_address()? == address)
+            matches!(result, SuiObjectResponse { data: Some(object), .. } if oref.object_id == object.object_id && &object.owner.unwrap().get_owner_address()? == address)
         );
     }
     Ok(())
@@ -315,7 +315,7 @@ async fn test_get_object_data_with_content() -> Result<(), anyhow::Error> {
             )
             .await?;
         assert!(
-            matches!(result, SuiObjectResponse::Exists(object) if oref.object_id == object.object_id && &object.owner.unwrap().get_owner_address()? == address)
+            matches!(result, SuiObjectResponse { data: Some(object), .. } if oref.object_id == object.object_id && &object.owner.unwrap().get_owner_address()? == address)
         );
     }
     Ok(())

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -630,7 +630,7 @@
         "name": "SuiObjectResponse",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/ObjectRead"
+          "$ref": "#/components/schemas/SuiObjectResponse"
         }
       }
     },
@@ -987,7 +987,7 @@
         "name": "SuiObjectResponse",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/ObjectRead"
+          "$ref": "#/components/schemas/SuiObjectResponse"
         }
       },
       "examples": [
@@ -1014,8 +1014,7 @@
           "result": {
             "name": "Result",
             "value": {
-              "status": "Exists",
-              "details": {
+              "data": {
                 "objectId": "0x53e4567ccafa5f36ce84c80aa8bc9be64e0d5ae796884274aef3005ae6733809",
                 "version": 1,
                 "digest": "33K5ZXJ3RyubvYaHuEnQ1QXmmbhgtrFwp199dnEbL4n7",
@@ -1094,7 +1093,7 @@
         "name": "ObjectsPage",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/Page_for_ObjectRead_and_ObjectID"
+          "$ref": "#/components/schemas/Page_for_SuiObjectResponse_and_ObjectID"
         }
       },
       "examples": [
@@ -1565,7 +1564,7 @@
         "schema": {
           "type": "array",
           "items": {
-            "$ref": "#/components/schemas/ObjectRead"
+            "$ref": "#/components/schemas/SuiObjectResponse"
           }
         }
       }
@@ -4708,6 +4707,7 @@
       "ObjectRead": {
         "oneOf": [
           {
+            "description": "The object exists and is found with this version",
             "type": "object",
             "required": [
               "details",
@@ -4720,12 +4720,13 @@
               "status": {
                 "type": "string",
                 "enum": [
-                  "Exists"
+                  "VersionFound"
                 ]
               }
             }
           },
           {
+            "description": "The object does not exist",
             "type": "object",
             "required": [
               "details",
@@ -4738,12 +4739,13 @@
               "status": {
                 "type": "string",
                 "enum": [
-                  "NotExists"
+                  "ObjectNotExists"
                 ]
               }
             }
           },
           {
+            "description": "The object is found to be deleted with this version",
             "type": "object",
             "required": [
               "details",
@@ -4756,7 +4758,71 @@
               "status": {
                 "type": "string",
                 "enum": [
-                  "Deleted"
+                  "ObjectDeleted"
+                ]
+              }
+            }
+          },
+          {
+            "description": "The object exists but not found with this version",
+            "type": "object",
+            "required": [
+              "details",
+              "status"
+            ],
+            "properties": {
+              "details": {
+                "type": "array",
+                "items": [
+                  {
+                    "$ref": "#/components/schemas/ObjectID"
+                  },
+                  {
+                    "$ref": "#/components/schemas/SequenceNumber"
+                  }
+                ],
+                "maxItems": 2,
+                "minItems": 2
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "VersionNotFound"
+                ]
+              }
+            }
+          },
+          {
+            "description": "The asked object version is higher than the latest",
+            "type": "object",
+            "required": [
+              "details",
+              "status"
+            ],
+            "properties": {
+              "details": {
+                "type": "object",
+                "required": [
+                  "asked_version",
+                  "latest_version",
+                  "object_id"
+                ],
+                "properties": {
+                  "asked_version": {
+                    "$ref": "#/components/schemas/SequenceNumber"
+                  },
+                  "latest_version": {
+                    "$ref": "#/components/schemas/SequenceNumber"
+                  },
+                  "object_id": {
+                    "$ref": "#/components/schemas/ObjectID"
+                  }
+                }
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "VersionTooHigh"
                 ]
               }
             }
@@ -4796,6 +4862,78 @@
             ]
           }
         }
+      },
+      "ObjectResponseError": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "code",
+              "object_id"
+            ],
+            "properties": {
+              "code": {
+                "type": "string",
+                "enum": [
+                  "notExists"
+                ]
+              },
+              "object_id": {
+                "$ref": "#/components/schemas/ObjectID"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "code",
+              "digest",
+              "object_id",
+              "version"
+            ],
+            "properties": {
+              "code": {
+                "type": "string",
+                "enum": [
+                  "deleted"
+                ]
+              },
+              "digest": {
+                "description": "Base64 string representing the object digest",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ObjectDigest"
+                  }
+                ]
+              },
+              "object_id": {
+                "$ref": "#/components/schemas/ObjectID"
+              },
+              "version": {
+                "description": "Object version.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SequenceNumber"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "code"
+            ],
+            "properties": {
+              "code": {
+                "type": "string",
+                "enum": [
+                  "unknown"
+                ]
+              }
+            }
+          }
+        ]
       },
       "ObjectResponseQuery": {
         "type": "object",
@@ -5053,7 +5191,7 @@
           }
         }
       },
-      "Page_for_ObjectRead_and_ObjectID": {
+      "Page_for_SuiObjectResponse_and_ObjectID": {
         "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
         "required": [
@@ -5064,7 +5202,7 @@
           "data": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ObjectRead"
+              "$ref": "#/components/schemas/SuiObjectResponse"
             }
           },
           "hasNextPage": {
@@ -6176,6 +6314,31 @@
             "additionalProperties": false
           }
         ]
+      },
+      "SuiObjectResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ObjectData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ObjectResponseError"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
       },
       "SuiProgrammableMoveCall": {
         "description": "The command for calling a Move function, either an entry function or a public function (which cannot return references).",

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -208,7 +208,7 @@ impl RpcExampleProvider {
 
         let coin = GasCoin::new(object_id, 10000);
 
-        let result = SuiObjectResponse::Exists(SuiObjectData {
+        let result = SuiObjectResponse::new_with_data(SuiObjectData {
             content: Some(
                 SuiParsedData::try_from_object(
                     coin.to_object(SequenceNumber::from_u64(1)),

--- a/crates/sui-source-validation/src/lib.rs
+++ b/crates/sui-source-validation/src/lib.rs
@@ -6,7 +6,7 @@ use futures::future;
 use move_binary_format::access::ModuleAccess;
 use move_binary_format::CompiledModule;
 use std::{collections::HashMap, fmt::Debug};
-use sui_types::error::UserInputError;
+use sui_types::error::SuiObjectResponseError;
 use thiserror::Error;
 
 use move_compiler::compiled_unit::{CompiledUnitEnum, NamedCompiledModule};
@@ -28,7 +28,7 @@ pub enum SourceVerificationError {
     DependencyObjectReadFailure(Error),
 
     #[error("Dependency object does not exist or was deleted: {0:?}")]
-    SuiObjectRefFailure(UserInputError),
+    SuiObjectRefFailure(SuiObjectResponseError),
 
     #[error("Dependency ID contains a Sui object, not a Move package: {0}")]
     ObjectFoundWhenPackageExpected(ObjectID, SuiRawMoveObject),

--- a/crates/sui-source-validation/src/tests.rs
+++ b/crates/sui-source-validation/src/tests.rs
@@ -300,7 +300,8 @@ async fn package_not_found() -> anyhow::Result<()> {
         panic!("Expected verification to fail");
     };
 
-    let expected = expect!["Dependency object does not exist or was deleted: ObjectNotFound { object_id: 0x<id>, version: None }"];
+    let expected =
+        expect!["Dependency object does not exist or was deleted: NotExists { object_id: 0x<id> }"];
     expected.assert_eq(&sanitize_id(err.to_string(), &stable_addrs));
 
     let package_root = AccountAddress::random();
@@ -314,7 +315,8 @@ async fn package_not_found() -> anyhow::Result<()> {
 
     // <id> below may refer to either the package_root or dependent package `b`
     // (the check reports the first missing object nondeterministically)
-    let expected = expect!["Dependency object does not exist or was deleted: ObjectNotFound { object_id: 0x<id>, version: None }"];
+    let expected =
+        expect!["Dependency object does not exist or was deleted: NotExists { object_id: 0x<id> }"];
     expected.assert_eq(&sanitize_id(err.to_string(), &stable_addrs));
 
     let package_root = AccountAddress::random();
@@ -326,7 +328,8 @@ async fn package_not_found() -> anyhow::Result<()> {
 	panic!("Expected verification to fail");
     };
 
-    let expected = expect!["Dependency object does not exist or was deleted: ObjectNotFound { object_id: 0x<id>, version: None }"];
+    let expected =
+        expect!["Dependency object does not exist or was deleted: NotExists { object_id: 0x<id> }"];
     expected.assert_eq(&sanitize_id(err.to_string(), &stable_addrs));
 
     Ok(())

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -18,7 +18,6 @@ use move_core_types::{
 pub use move_vm_runtime::move_vm::MoveVM;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::fmt;
 use std::{collections::BTreeMap, fmt::Debug};
 use strum_macros::{AsRefStr, IntoStaticStr};
 use thiserror::Error;
@@ -199,10 +198,16 @@ pub enum UserInputError {
     JsonSchema,
     Error,
 )]
+#[serde(tag = "code", rename = "ObjectResponseError", rename_all = "camelCase")]
 pub enum SuiObjectResponseError {
-    NotExists {
-        object_id: ObjectID,
-    },
+    #[error("Object {:?} does not exist.", object_id)]
+    NotExists { object_id: ObjectID },
+    #[error(
+        "Object has been deleted object_id: {:?} at version: {:?} in digest {:?}",
+        object_id,
+        version,
+        digest
+    )]
     Deleted {
         object_id: ObjectID,
         /// Object version.
@@ -210,29 +215,9 @@ pub enum SuiObjectResponseError {
         /// Base64 string representing the object digest
         digest: ObjectDigest,
     },
-    Unknown, // TODO: also integrate SuiPastObjectResponse (VersionNotFound,  VersionTooHigh)
-}
-
-impl fmt::Display for SuiObjectResponseError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            SuiObjectResponseError::NotExists { object_id } => {
-                write!(f, "Object not exists: {}", object_id)
-            }
-            SuiObjectResponseError::Deleted {
-                object_id,
-                version,
-                digest,
-            } => {
-                write!(
-                    f,
-                    "Object deleted: {}, version: {}, digest: {}",
-                    object_id, version, digest
-                )
-            }
-            SuiObjectResponseError::Unknown => write!(f, "Unknown error"),
-        }
-    }
+    #[error("Unknown Error.")]
+    Unknown,
+    // TODO: also integrate SuiPastObjectResponse (VersionNotFound,  VersionTooHigh)
 }
 
 /// Custom error type for Sui.

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1343,15 +1343,13 @@ impl WalletContext {
             .await?;
 
         for object in responses {
-            match object {
-                SuiObjectResponse::Exists(o) => {
-                    if matches!( &o.type_, Some(type_)  if type_.is_gas_coin()) {
-                        // Okay to unwrap() since we already checked type
-                        let gas_coin = GasCoin::try_from(&o)?;
-                        values_objects.push((gas_coin.value(), o.clone()));
-                    }
+            let o = object.data;
+            if let Some(o) = o {
+                if matches!( &o.type_, Some(type_)  if type_.is_gas_coin()) {
+                    // Okay to unwrap() since we already checked type
+                    let gas_coin = GasCoin::try_from(&o)?;
+                    values_objects.push((gas_coin.value(), o.clone()));
                 }
-                _ => continue,
             }
         }
 

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -521,14 +521,19 @@ impl SuiClientCommands {
                     )
                     .await?;
 
-                let SuiObjectResponse::Exists(data) = context
+                let resp = context
                     .get_client()
                     .await?
                     .read_api()
-                    .get_object_with_options(upgrade_capability, SuiObjectDataOptions::default().with_bcs().with_owner())
-                    .await? else {
-                        return Err(anyhow!("Could not find upgrade capability at {upgrade_capability}"))
-                    };
+                    .get_object_with_options(
+                        upgrade_capability,
+                        SuiObjectDataOptions::default().with_bcs().with_owner(),
+                    )
+                    .await?;
+
+                let Some(data) = resp.data else {
+                    return Err(anyhow!("Could not find upgrade capability at {upgrade_capability}"))
+                };
 
                 let upgrade_cap: UpgradeCap = data
                     .bcs

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -37,6 +37,7 @@ use sui_types::base_types::{ObjectType, SuiAddress};
 use sui_types::crypto::{
     Ed25519SuiSignature, Secp256k1SuiSignature, SignatureScheme, SuiKeyPair, SuiSignatureInner,
 };
+use sui_types::error::SuiObjectResponseError;
 use sui_types::{base_types::ObjectID, crypto::get_key_pair, gas_coin::GasCoin};
 use sui_types::{sui_framework_address_concat_string, SUI_FRAMEWORK_ADDRESS};
 use test_utils::messages::make_transactions_with_wallet_context;
@@ -285,16 +286,23 @@ async fn test_create_example_nft_command() {
     .unwrap();
 
     match result {
-        SuiClientCommandResult::CreateExampleNFT(SuiObjectResponse::Exists(obj)) => {
-            assert_eq!(obj.owner.unwrap().get_owner_address().unwrap(), address);
-            assert_eq!(
-                obj.type_.clone().unwrap(),
-                ObjectType::from_str(&sui_framework_address_concat_string(
-                    "::devnet_nft::DevNetNFT"
-                ))
-                .unwrap()
-            );
-            Ok(obj)
+        SuiClientCommandResult::CreateExampleNFT(response) => {
+            if let Some(obj) = response.data {
+                assert_eq!(obj.owner.unwrap().get_owner_address().unwrap(), address);
+                assert_eq!(
+                    obj.type_.clone().unwrap(),
+                    ObjectType::from_str(&sui_framework_address_concat_string(
+                        "::devnet_nft::DevNetNFT"
+                    ))
+                    .unwrap()
+                );
+                Ok(obj)
+            } else {
+                match response.error {
+                    Some(error) => Err(anyhow!("Error: {}", error)),
+                    None => Err(anyhow!("No data or error found in the response")),
+                }
+            }
         }
         _ => Err(anyhow!(
             "WalletCommands::CreateExampleNFT returns wrong type"
@@ -1133,22 +1141,30 @@ async fn test_native_transfer() -> Result<(), anyhow::Error> {
     }
     .execute(context)
     .await?;
-    let mut_obj1 = if let SuiClientCommandResult::Object(SuiObjectResponse::Exists(object)) = resp {
-        object
+    let mut_obj1 = if let SuiClientCommandResult::Object(resp) = resp {
+        if let Some(obj) = resp.data {
+            obj
+        } else {
+            panic!()
+        }
     } else {
-        panic!()
+        panic!();
     };
 
-    let resp = SuiClientCommands::Object {
+    let resp2 = SuiClientCommands::Object {
         id: mut_obj2,
         bcs: false,
     }
     .execute(context)
     .await?;
-    let mut_obj2 = if let SuiClientCommandResult::Object(SuiObjectResponse::Exists(object)) = resp {
-        object
+    let mut_obj2 = if let SuiClientCommandResult::Object(resp2) = resp2 {
+        if let Some(obj) = resp2.data {
+            obj
+        } else {
+            panic!()
+        }
     } else {
-        panic!()
+        panic!();
     };
 
     let (gas, obj) = if mut_obj1.owner.unwrap().get_owner_address().unwrap() == address {
@@ -1223,7 +1239,11 @@ async fn test_native_transfer() -> Result<(), anyhow::Error> {
 #[test]
 // Test for issue https://github.com/MystenLabs/sui/issues/1078
 fn test_bug_1078() {
-    let read = SuiClientCommandResult::Object(SuiObjectResponse::NotExists(ObjectID::random()));
+    let read = SuiClientCommandResult::Object(SuiObjectResponse::new_with_error(
+        SuiObjectResponseError::NotExists {
+            object_id: ObjectID::random(),
+        },
+    ));
     let mut writer = String::new();
     // fmt ObjectRead should not fail.
     write!(writer, "{}", read).unwrap();
@@ -1417,7 +1437,7 @@ async fn get_object(id: ObjectID, context: &WalletContext) -> Option<SuiObjectDa
         .get_object_with_options(id, SuiObjectDataOptions::full_content())
         .await
         .unwrap();
-    if let SuiObjectResponse::Exists(o) = response {
+    if let Some(o) = response.data {
         Some(o)
     } else {
         None

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -1437,11 +1437,7 @@ async fn get_object(id: ObjectID, context: &WalletContext) -> Option<SuiObjectDa
         .get_object_with_options(id, SuiObjectDataOptions::full_content())
         .await
         .unwrap();
-    if let Some(o) = response.data {
-        Some(o)
-    } else {
-        None
-    }
+    response.data
 }
 
 async fn get_parsed_object_assert_existence(

--- a/crates/sui/src/validator_commands.rs
+++ b/crates/sui/src/validator_commands.rs
@@ -727,7 +727,8 @@ async fn get_pending_candidate_summary(
         )
         .await?;
     for resp in resps {
-        let object_id = resp.object_id();
+        // We always expect an objectId from the response as one of data/error should be included.
+        let object_id = resp.object_id()?;
         let bcs = resp.move_object_bcs().ok_or_else(|| {
             anyhow::anyhow!(
                 "Object {} does not exist or does not return bcs bytes",

--- a/crates/test-utils/src/messages.rs
+++ b/crates/test-utils/src/messages.rs
@@ -106,13 +106,8 @@ pub async fn get_gas_objects_with_wallet_context(
         .await
         .unwrap()
         .into_iter()
-        .map(|(_val, object_data)| SuiObjectResponse::Exists(object_data))
+        .map(|(_val, object_data)| SuiObjectResponse::new_with_data(object_data))
         .collect()
-    // .try_fold(vec![], |mut acc, (_val, object_data)| {
-    //     let obj_resp = SuiObjectResponse::Exists(object_data);
-    //     acc.push(obj_resp);
-    //     Ok::<Vec<SuiObjectResponse>, Error>(acc)
-    // })?
 }
 
 /// A helper function to get all accounts and their owned gas objects

--- a/crates/test-utils/src/transaction.rs
+++ b/crates/test-utils/src/transaction.rs
@@ -13,8 +13,8 @@ use sui::client_commands::{SuiClientCommandResult, SuiClientCommands};
 use sui_core::authority_client::AuthorityAPI;
 pub use sui_core::test_utils::{compile_basics_package, wait_for_all_txes, wait_for_tx};
 use sui_json_rpc_types::{
-    SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery, SuiTransactionDataAPI,
-    SuiTransactionEffectsAPI, SuiTransactionResponse, SuiTransactionResponseOptions,
+    SuiObjectDataOptions, SuiObjectResponseQuery, SuiTransactionDataAPI, SuiTransactionEffectsAPI,
+    SuiTransactionResponse, SuiTransactionResponseOptions,
 };
 use sui_keys::keystore::AccountKeystore;
 use sui_sdk::json::SuiJsonValue;
@@ -254,17 +254,21 @@ pub async fn create_devnet_nft(
     .execute(context)
     .await?;
 
-    let (object_id, digest) = if let SuiClientCommandResult::CreateExampleNFT(
-        SuiObjectResponse::Exists(obj),
-    ) = res
-    {
-        (
-            obj.object_id,
-            obj.previous_transaction
-                .expect("previous_transaction should not be None"),
-        )
+    let (object_id, digest) = if let SuiClientCommandResult::CreateExampleNFT(ref response) = res {
+        if let Some(obj) = &response.data {
+            (
+                obj.object_id,
+                obj.previous_transaction
+                    .expect("previous_transaction should not be None"),
+            )
+        } else {
+            panic!(
+                "CreateExampleNFT command did not return data, got {:?}",
+                res
+            );
+        }
     } else {
-        panic!("CreateExampleNFT command did not return WalletCommandResult::CreateExampleNFT(SuiObjectResponse::Exists, got {:?}", res);
+        panic!("CreateExampleNFT command did not return WalletCommandResult::CreateExampleNFT, got {:?}", res);
     };
 
     Ok((sender, object_id, digest))

--- a/crates/test-utils/tests/network_tests.rs
+++ b/crates/test-utils/tests/network_tests.rs
@@ -24,7 +24,7 @@ async fn test_additional_objects() {
 
     let client = cluster.rpc_client();
     let resp = client.get_object_with_options(id, None).await.unwrap();
-    assert!(matches!(resp, SuiObjectResponse::Exists(_)));
+    assert!(matches!(resp, SuiObjectResponse { data: Some(_), .. }));
 }
 
 #[sim_test]
@@ -36,12 +36,13 @@ async fn test_package_override() {
         let SuiObjectResponse::Exists(obj) = client
             .get_object_with_options(SuiSystem::ID, None)
             .await
-            .unwrap()
-        else {
-            panic!("Original framework package should exist");
-        };
+            .unwrap();
 
-        obj.object_ref()
+        if let Some(obj) = obj.data {
+            obj.object_ref()
+        } else {
+            panic!("Original framework package should exist");
+        }
     };
 
     let modified_ref = {
@@ -73,12 +74,13 @@ async fn test_package_override() {
         let SuiObjectResponse::Exists(obj) = client
             .get_object_with_options(SuiSystem::ID, None)
             .await
-            .unwrap()
-        else {
-            panic!("Modified framework package should exist");
-        };
+            .unwrap();
 
-        obj.object_ref()
+        if let Some(obj) = obj.data {
+            obj.object_ref()
+        } else {
+            panic!("Original framework package should exist");
+        }
     };
 
     assert_ne!(framework_ref, modified_ref);

--- a/crates/test-utils/tests/network_tests.rs
+++ b/crates/test-utils/tests/network_tests.rs
@@ -33,7 +33,7 @@ async fn test_package_override() {
     let framework_ref = {
         let default_cluster = TestClusterBuilder::new().build().await.unwrap();
         let client = default_cluster.rpc_client();
-        let SuiObjectResponse::Exists(obj) = client
+        let obj = client
             .get_object_with_options(SuiSystem::ID, None)
             .await
             .unwrap();
@@ -71,7 +71,7 @@ async fn test_package_override() {
             .unwrap();
 
         let client = modified_cluster.rpc_client();
-        let SuiObjectResponse::Exists(obj) = client
+        let obj = client
             .get_object_with_options(SuiSystem::ID, None)
             .await
             .unwrap();

--- a/dapps/frenemies/src/network/rawObject.ts
+++ b/dapps/frenemies/src/network/rawObject.ts
@@ -4,22 +4,27 @@
 // This file implements `sui_getRawObject` RPC call to
 // speed up data processing and lessen network load by using BCS
 
-import { ObjectOwner, ObjectStatus, Provider, SuiObjectRef } from "@mysten/sui.js";
+import {
+  ObjectOwner,
+  ObjectStatus,
+  Provider,
+  SuiObjectRef,
+} from "@mysten/sui.js";
 import { bcs } from "./bcs";
 
 /**
  * Filling in the missing piece in TS SDK.
  */
 export type RawObjectResponse = {
-    status: ObjectStatus;
-    details: {
-        reference: SuiObjectRef;
-        owner: ObjectOwner;
-        data: {
-            /* ... some other fields */
-            bcs_bytes: string
-        },
-    }
+  status: ObjectStatus;
+  details: {
+    reference: SuiObjectRef;
+    owner: ObjectOwner;
+    data: {
+      /* ... some other fields */
+      bcs_bytes: string;
+    };
+  };
 };
 
 /**
@@ -27,30 +32,37 @@ export type RawObjectResponse = {
  * Contains both the reference to use in txs and the data.
  */
 export type ObjectData<T> = {
-    reference: SuiObjectRef;
-    data: T;
+  reference: SuiObjectRef;
+  data: T;
 };
 
 /**
  * Wraps the `sui_getRawObject` method.
  */
-export function getRawObject(provider: Provider, objectId: string): Promise<RawObjectResponse> {
-    return provider.call('sui_getRawObject', [ objectId ]);
+export function getRawObject(
+  provider: Provider,
+  objectId: string
+): Promise<RawObjectResponse> {
+  return provider.call("sui_getRawObject", [objectId]);
 }
 
 /**
  * Wrapper for the `getRawObject` which adds bcs deserialization call on the response.
  */
-export async function getRawObjectParsedUnsafe<T>(provider: Provider, objectId: string, bcsType: string): Promise<ObjectData<T>> {
-    const objectData = await getRawObject(provider, objectId);
+export async function getRawObjectParsedUnsafe<T>(
+  provider: Provider,
+  objectId: string,
+  bcsType: string
+): Promise<ObjectData<T>> {
+  const objectData = await getRawObject(provider, objectId);
 
-    const {
-      reference,
-      data: { bcs_bytes },
-    } = objectData.details;
+  const {
+    reference,
+    data: { bcs_bytes },
+  } = objectData.details;
 
-    return {
-      reference,
-      data: bcs.de(bcsType, bcs_bytes, "base64"),
-    };
+  return {
+    reference,
+    data: bcs.de(bcsType, bcs_bytes, "base64"),
+  };
 }

--- a/sdk/typescript/src/builder/Transaction.ts
+++ b/sdk/typescript/src/builder/Transaction.ts
@@ -580,7 +580,7 @@ export class Transaction {
       );
 
       const invalidObjects = Array.from(objectsById)
-        .filter(([_, obj]) => obj.status !== 'Exists')
+        .filter(([_, obj]) => obj.error)
         .map(([id, _]) => id);
       if (invalidObjects.length) {
         throw new Error(

--- a/sdk/typescript/src/framework/framework.ts
+++ b/sdk/typescript/src/framework/framework.ts
@@ -36,6 +36,12 @@ export const COIN_TYPE_ARG_REGEX = /^0x2::coin::Coin<(.+)>$/;
 type ObjectData = ObjectDataFull | SuiObjectInfo;
 type ObjectDataFull = SuiObjectResponse | SuiMoveObject;
 
+export function isObjectDataFull(
+  resp: ObjectData | ObjectDataFull,
+): resp is SuiObjectResponse {
+  return !!(resp as SuiObjectResponse).data || !!(resp as SuiMoveObject).type;
+}
+
 export const CoinMetadataStruct = object({
   decimals: number(),
   name: string(),
@@ -124,7 +130,7 @@ export class Coin {
   }
 
   private static getType(data: ObjectData): string | undefined {
-    if ('status' in data) {
+    if (isObjectDataFull(data)) {
       return getObjectType(data);
     }
     return data.type;

--- a/sdk/typescript/test/e2e/dev-inspect.test.ts
+++ b/sdk/typescript/test/e2e/dev-inspect.test.ts
@@ -26,7 +26,7 @@ describe('Test dev inspect', () => {
     const coins = await toolbox.getGasObjectsOwnedByAddress();
 
     const tx = new Transaction();
-    const coin_0 = coins[0].details as SuiObjectData;
+    const coin_0 = coins[0].data as SuiObjectData;
     const obj = tx.moveCall({
       target: `${packageId}::serializer_tests::return_struct`,
       typeArguments: ['0x2::coin::Coin<0x2::sui::SUI>'],

--- a/sdk/typescript/test/e2e/dynamic-fields.test.ts
+++ b/sdk/typescript/test/e2e/dynamic-fields.test.ts
@@ -22,7 +22,7 @@ describe('Dynamic Fields Reading API', () => {
         filter: { StructType: `${packageId}::dynamic_fields_test::Test` },
       })
       .then(function (objects) {
-        const data = objects.data[0].details as SuiObjectData;
+        const data = objects.data[0].data as SuiObjectData;
         parentObjectId = data.objectId;
       });
   });
@@ -64,6 +64,7 @@ describe('Dynamic Fields Reading API', () => {
       parentId: parentObjectId,
       name: objDofName,
     });
-    expect(dynamicObjectField.status).toEqual('Exists');
+
+    expect(dynamicObjectField).not.toEqual({});
   });
 });

--- a/sdk/typescript/test/e2e/object-display-standard.test.ts
+++ b/sdk/typescript/test/e2e/object-display-standard.test.ts
@@ -23,7 +23,7 @@ describe('Test Object Display Standard', () => {
         filter: { StructType: `${packageId}::boars::Boar` },
       })
     ).data;
-    const data = resp[0].details as SuiObjectData;
+    const data = resp[0].data as SuiObjectData;
     const boarId = data.objectId;
     const display = getObjectDisplay(
       await toolbox.provider.getObject({
@@ -47,7 +47,7 @@ describe('Test Object Display Standard', () => {
 
   it('Test getting Display fields for object that has no display object', async () => {
     const coin = (await toolbox.getGasObjectsOwnedByAddress())[0]
-      .details as SuiObjectData;
+      .data as SuiObjectData;
     const coinId = coin.objectId;
     const display = getObjectDisplay(
       await toolbox.provider.getObject({

--- a/sdk/typescript/test/e2e/object-vector.test.ts
+++ b/sdk/typescript/test/e2e/object-vector.test.ts
@@ -63,7 +63,7 @@ describe('Test Move call with a vector of objects as input', () => {
 
   it('Test regular arg mixed with object vector arg', async () => {
     const coins = await toolbox.getGasObjectsOwnedByAddress();
-    const coin = coins[3].details as SuiObjectData;
+    const coin = coins[3].data as SuiObjectData;
     const coinIDs = coins.map((coin) => Coin.getID(coin));
     const tx = new Transaction();
     const vec = tx.makeMoveVec({

--- a/sdk/typescript/test/e2e/objects.test.ts
+++ b/sdk/typescript/test/e2e/objects.test.ts
@@ -24,7 +24,7 @@ describe('Object Reading API', () => {
     expect(gasObjects.length).to.greaterThan(0);
     const objectInfos = await Promise.all(
       gasObjects.map((gasObject) => {
-        const details = gasObject.details as SuiObjectData;
+        const details = gasObject.data as SuiObjectData;
         return toolbox.provider.getObject({
           id: details.objectId,
           options: { showType: true },
@@ -42,7 +42,7 @@ describe('Object Reading API', () => {
     const gasObjects = await toolbox.getGasObjectsOwnedByAddress();
     expect(gasObjects.length).to.greaterThan(0);
     const gasObjectIds = gasObjects.map((gasObject) => {
-      const details = gasObject.details as SuiObjectData;
+      const details = gasObject.data as SuiObjectData;
       return details.objectId;
     });
     const objectInfos = await toolbox.provider.multiGetObjects({

--- a/sdk/typescript/test/e2e/txn-builder.test.ts
+++ b/sdk/typescript/test/e2e/txn-builder.test.ts
@@ -46,7 +46,7 @@ describe('Transaction Builders', () => {
   it('SplitCoins + TransferObjects', async () => {
     const coins = await toolbox.getGasObjectsOwnedByAddress();
     const tx = new Transaction();
-    const coin_0 = coins[0].details as SuiObjectData;
+    const coin_0 = coins[0].data as SuiObjectData;
 
     const coin = tx.splitCoins(tx.object(coin_0.objectId), [
       tx.pure(DEFAULT_GAS_BUDGET * 2),
@@ -57,8 +57,8 @@ describe('Transaction Builders', () => {
 
   it('MergeCoins', async () => {
     const coins = await toolbox.getGasObjectsOwnedByAddress();
-    const coin_0 = coins[0].details as SuiObjectData;
-    const coin_1 = coins[1].details as SuiObjectData;
+    const coin_0 = coins[0].data as SuiObjectData;
+    const coin_1 = coins[1].data as SuiObjectData;
     const tx = new Transaction();
     tx.mergeCoins(tx.object(coin_0.objectId), [tx.object(coin_1.objectId)]);
     await validateTransaction(toolbox.signer, tx);
@@ -81,7 +81,7 @@ describe('Transaction Builders', () => {
 
   it('MoveCall Shared Object', async () => {
     const coins = await toolbox.getGasObjectsOwnedByAddress();
-    const coin_2 = coins[2].details as SuiObjectData;
+    const coin_2 = coins[2].data as SuiObjectData;
 
     const [{ suiAddress: validatorAddress }] =
       await toolbox.getActiveValidators();
@@ -115,7 +115,7 @@ describe('Transaction Builders', () => {
   it('TransferObject', async () => {
     const coins = await toolbox.getGasObjectsOwnedByAddress();
     const tx = new Transaction();
-    const coin_0 = coins[2].details as SuiObjectData;
+    const coin_0 = coins[2].data as SuiObjectData;
 
     tx.transferObjects(
       [tx.object(coin_0.objectId)],

--- a/sdk/typescript/test/e2e/txn-serializer.test.ts
+++ b/sdk/typescript/test/e2e/txn-serializer.test.ts
@@ -54,7 +54,7 @@ describe('Transaction Serialization and deserialization', () => {
       await toolbox.getActiveValidators();
 
     const tx = new Transaction();
-    const coin = coins[2].details as SuiObjectData;
+    const coin = coins[2].data as SuiObjectData;
     tx.moveCall({
       target: '0x3::sui_system::request_add_stake',
       arguments: [


### PR DESCRIPTION
## Description 

Redefining the error / data fields in `SuiObjectResponse`.
## Test Plan 

CI / unit testing / running tests on wallet / explorer side.

Explorer main: 

<img width="915" alt="image" src="https://user-images.githubusercontent.com/123408603/227034929-398d9998-1637-4c49-9f9f-5a304831f342.png">
owned objects on address:
<img width="941" alt="image" src="https://user-images.githubusercontent.com/123408603/227035036-e44e469f-5555-446e-b5a3-330e04691530.png">



testing wallet:
![image](https://user-images.githubusercontent.com/123408603/226954047-2401c0ea-20db-4d03-a6d4-3c039e8d85d0.png)


---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [x] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
