### PR TITLE
fix explorer displaying two addresses owning the same object

### DIFF
--- a/apps/explorer/src/components/ownedobjects/OwnedObjects.tsx
+++ b/apps/explorer/src/components/ownedobjects/OwnedObjects.tsx
@@ -5,6 +5,8 @@ import { useRpcClient } from '@mysten/core';
 import {
     Coin,
     getObjectId,
+    getObjectType,
+    getObjectOwner,
     PaginatedObjectsResponse,
     is,
 } from '@mysten/sui.js';
@@ -65,7 +67,25 @@ function OwnedObject({ id, byAddress }: { id: string; byAddress: boolean }) {
                 .then((results) => {
                     setResults(
                         results
-                            .filter(({ data }) => data !== undefined)
+                            .filter((resp) => {
+                                if (
+                                    byAddress &&
+                                    getObjectType(resp) === 'moveObject'
+                                ) {
+                                    const owner = getObjectOwner(resp);
+                                    const addressOwner =
+                                        owner &&
+                                        owner !== 'Immutable' &&
+                                        'AddressOwner' in owner
+                                            ? owner.AddressOwner
+                                            : null;
+                                    return (
+                                        resp !== undefined &&
+                                        addressOwner === id
+                                    );
+                                }
+                                return resp !== undefined;
+                            })
                             .map(
                                 (resp) => {
                                     const displayMeta =


### PR DESCRIPTION
## Description 

Describe the changes or additions included in this PR.
The PR fixes the explorer display bug showing two addresses owning the same object

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
