### PR TITLE
[ts-sdk] Remove import assertions in script

### DIFF
--- a/sdk/typescript/genversion.mjs
+++ b/sdk/typescript/genversion.mjs
@@ -1,13 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { writeFile } from 'fs/promises';
+import { readFile, writeFile } from 'fs/promises';
+
 const LICENSE =
   '// Copyright (c) Mysten Labs, Inc.\n// SPDX-License-Identifier: Apache-2.0\n\n';
 
-import pkg from './package.json' assert { type: 'json' };
-
 async function main() {
+  const pkg = JSON.parse(await readFile('./package.json', 'utf8'));
   await writeFile(
     'src/pkg-version.ts',
     LICENSE + `export const pkgVersion = '${pkg.version}';\n`,


### PR DESCRIPTION
## Description 

Import assertions were demoted to stage 2, and will change, so going to avoid using them for now. Using a fs read file instead.

## Test Plan 

Re-generated file without issues.
