### PR TITLE
Remove MAX_DELAY_MUL from consensus submissions

### DIFF
--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -8,8 +8,7 @@ use dashmap::DashMap;
 use futures::future::{select, Either};
 use futures::FutureExt;
 use itertools::Itertools;
-use narwhal_types::TransactionProto;
-use narwhal_types::TransactionsClient;
+use narwhal_types::{TransactionProto, TransactionsClient};
 use parking_lot::{Mutex, RwLockReadGuard};
 use prometheus::IntGauge;
 use prometheus::Registry;
@@ -299,9 +298,8 @@ impl ConsensusAdapter {
                     .sequencing_estimated_latency
                     .set(latency.as_millis() as i64);
                 let delay_step = latency * 3 / 2;
-                const MAX_DELAY_MUL: usize = 10;
                 (
-                    delay_step * std::cmp::min(position, MAX_DELAY_MUL) as u32,
+                    delay_step * position as u32,
                     position,
                 )
             }


### PR DESCRIPTION
## Description 

The latency reduction benefit of submitting to additional validators after 9 resubmissions are very small, so avoiding overloading the system by removing `MAX_DELAY_MUL`. 

## Test Plan 

n/a

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
