### PR TITLE
Set genesis system state version in Move

### DIFF
--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -44,8 +44,8 @@ use sui_types::multiaddr::Multiaddr;
 use sui_types::object::Owner;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::sui_system_state::{
-    get_sui_system_state, get_sui_system_state_version, get_sui_system_state_wrapper,
-    SuiSystemStateInnerGenesis, SuiSystemStateTrait, SuiSystemStateWrapper, SuiValidatorGenesis,
+    get_sui_system_state, get_sui_system_state_wrapper, SuiSystemStateInnerGenesis,
+    SuiSystemStateTrait, SuiSystemStateWrapper, SuiValidatorGenesis,
 };
 use sui_types::temporary_store::{InnerTemporaryStore, TemporaryStore};
 use sui_types::{
@@ -395,7 +395,6 @@ pub struct GenesisValidatorMetadata {
 #[serde(rename_all = "kebab-case")]
 pub struct GenesisChainParameters {
     pub protocol_version: u64,
-    pub system_state_version: u64,
     pub governance_start_epoch: u64,
     pub chain_start_timestamp_ms: u64,
     pub epoch_duration_ms: u64,
@@ -495,7 +494,6 @@ impl GenesisCeremonyParameters {
     fn to_genesis_chain_parameters(&self) -> GenesisChainParameters {
         GenesisChainParameters {
             protocol_version: self.protocol_version.as_u64(),
-            system_state_version: get_sui_system_state_version(self.protocol_version),
             governance_start_epoch: self.governance_start_epoch,
             chain_start_timestamp_ms: self.timestamp_ms,
             epoch_duration_ms: self.epoch_duration_ms,

--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0x03838f7b4ae40ab0b2291040509974ee2c8264adce8c08748fcc663491d2cd6d"
+            id: "0x8cf561b852af748ae645cf6b56922070f356c4c98ad90c800adafd4070e04f75"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0xe880b8b1085e5cf3fde5ba88684311ac8b8ea43f6a99feb0a52c206d0c720d62"
+      operation_cap_id: "0x89c5ecc9df40a511dd4ff82049feb852751e3628374173208e3f247183beb851"
       gas_price: 1
       staking_pool:
-        id: "0x21710d064e393974914a2b0dcc572d8d96c55bc3b4da9c3a80b0dc37c47516f8"
+        id: "0xe725ecdc6f6fee60ef34ede1f226b2ac39b0a41d7a24121ee4186d22c9cedbed"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 25000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 25000000000000000
         exchange_rates:
-          id: "0x91d84ed6dc0105a32ea1ea5806b2454fdaa784e8eea5aaa62ab29d4932870b0d"
+          id: "0x1c4e64de66a7fd8e0552604e8660c1da7b9678f9ad19e0d20d7e3e5875557683"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0x75824803e2a4c17ee0b3712f88693ac9fbce096eca6f1fc2b70d8f8426ea2af6"
+            id: "0xe6bf5e2f55e75829af031a26741eae73531659ae29a61e02c53f50dec96e19f4"
           size: 0
       commission_rate: 0
       next_epoch_stake: 25000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 0
       extra_fields:
         id:
-          id: "0x7365155b04cefa5b2941dfc20fb1c2ae86888a0679a64ff25bac3d20b01e4026"
+          id: "0x6a93c619a28419a20400421e89740d3a225a645073d8cace3fef1cecc42d1a60"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x56053be2d34ea8e9f8763f90df844ede5d0a8f1d1dc65d81457b43416a1a8899"
+      id: "0x1ff3d87cbe54983e7d2ce97434f5a88d9d83be46e28158a63751f68c063436f7"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0x22b9215b1c6804e1796c90df7ac728a3f2ba53ed711e63e88d7516fc846c92f5"
+    id: "0xc60e69a3fe96f59392bf8e6983c6afb3bc552ccd9d1542739eaa0ab0d1a8ad3e"
     size: 1
   inactive_validators:
-    id: "0x68e07ec6a578e119f45c182fc5a4817138a3644420d0747cd04bd75de6248b0e"
+    id: "0x22b60aeeec06e8379b5d129a79ebe9c6c4588747884486330642e6e853549531"
     size: 0
   validator_candidates:
-    id: "0x50f83cf7c9541d9a1268ed2f1be646b3c83e9c6ee6dbd28c254667fe87b2911d"
+    id: "0x2750820e430d3e34edc9bdd7eced3847764e33a1c2821e46a17c8bc1e6f4c443"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0xbffb7fb481053445f00c0d104f86ff6a02b96a5e3b22f2e4129093a17914320c"
+      id: "0xfaa658dd0607e603c6a48aa372a0ca7d970446c2053b1c4d0d4b2a1f8649368f"
     size: 0
 storage_fund:
   value: 0
@@ -298,7 +298,7 @@ parameters:
   epoch_duration_ms: 86400000
   extra_fields:
     id:
-      id: "0x1a349a6f387c0ff82d7ac3080c2e3db3c658cd1fda602e59e5593fe0043d1061"
+      id: "0xda60991929142bd57983c4ff8497509b0b17d0a2c23904a424641ba630a4690e"
     size: 0
 reference_gas_price: 1
 validator_report_records:
@@ -312,12 +312,12 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 10000
   extra_fields:
     id:
-      id: "0xdf827f61fb4c1a584e14428b796468b0d2c04a132b6713f83db4c9ca691ac0fa"
+      id: "0x3e1d4fcae7fe59c703555c7158ddaac55c4caf521ab4fc0cda898e5eefd42799"
     size: 0
 safe_mode: false
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0xc8e8268db32f8fbaf610b8241a63ca23807b3d295a683a74406a868da62cdb7a"
+    id: "0x579950615c4daf66dd661dc4cd3626cfbb2243d6cfbb691c263b10f8a56c784f"
   size: 0
 

--- a/crates/sui-framework/docs/genesis.md
+++ b/crates/sui-framework/docs/genesis.md
@@ -163,12 +163,6 @@
 
 </dd>
 <dt>
-<code>system_state_version: u64</code>
-</dt>
-<dd>
-
-</dd>
-<dt>
 <code>governance_start_epoch: u64</code>
 </dt>
 <dd>
@@ -406,7 +400,6 @@ all the information we need in the system.
         subsidy_fund,
         storage_fund,
         genesis_chain_parameters.protocol_version,
-        genesis_chain_parameters.system_state_version,
         genesis_chain_parameters.governance_start_epoch,
         genesis_chain_parameters.chain_start_timestamp_ms,
         genesis_chain_parameters.epoch_duration_ms,

--- a/crates/sui-framework/docs/sui_system.md
+++ b/crates/sui-framework/docs/sui_system.md
@@ -110,7 +110,7 @@ Create a new SuiSystemState object and make it shared.
 This function will be called only once in genesis.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system.md#0x3_sui_system_create">create</a>(id: <a href="_UID">object::UID</a>, validators: <a href="">vector</a>&lt;<a href="validator.md#0x3_validator_Validator">validator::Validator</a>&gt;, stake_subsidy_fund: <a href="_Balance">balance::Balance</a>&lt;<a href="_SUI">sui::SUI</a>&gt;, storage_fund: <a href="_Balance">balance::Balance</a>&lt;<a href="_SUI">sui::SUI</a>&gt;, protocol_version: u64, system_state_version: u64, governance_start_epoch: u64, epoch_start_timestamp_ms: u64, epoch_duration_ms: u64, initial_stake_subsidy_distribution_amount: u64, stake_subsidy_period_length: u64, stake_subsidy_decrease_rate: u16, ctx: &<b>mut</b> <a href="_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system.md#0x3_sui_system_create">create</a>(id: <a href="_UID">object::UID</a>, validators: <a href="">vector</a>&lt;<a href="validator.md#0x3_validator_Validator">validator::Validator</a>&gt;, stake_subsidy_fund: <a href="_Balance">balance::Balance</a>&lt;<a href="_SUI">sui::SUI</a>&gt;, storage_fund: <a href="_Balance">balance::Balance</a>&lt;<a href="_SUI">sui::SUI</a>&gt;, protocol_version: u64, governance_start_epoch: u64, epoch_start_timestamp_ms: u64, epoch_duration_ms: u64, initial_stake_subsidy_distribution_amount: u64, stake_subsidy_period_length: u64, stake_subsidy_decrease_rate: u16, ctx: &<b>mut</b> <a href="_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -125,7 +125,6 @@ This function will be called only once in genesis.
     stake_subsidy_fund: Balance&lt;SUI&gt;,
     storage_fund: Balance&lt;SUI&gt;,
     protocol_version: u64,
-    system_state_version: u64,
     governance_start_epoch: u64,
     epoch_start_timestamp_ms: u64,
     epoch_duration_ms: u64,
@@ -139,7 +138,6 @@ This function will be called only once in genesis.
         stake_subsidy_fund,
         storage_fund,
         protocol_version,
-        system_state_version,
         governance_start_epoch,
         epoch_start_timestamp_ms,
         epoch_duration_ms,
@@ -148,11 +146,12 @@ This function will be called only once in genesis.
         stake_subsidy_decrease_rate,
         ctx,
     );
+    <b>let</b> version = <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_system_state_version">sui_system_state_inner::system_state_version</a>(&system_state);
     <b>let</b> self = <a href="sui_system.md#0x3_sui_system_SuiSystemState">SuiSystemState</a> {
         id,
-        version: system_state_version,
+        version,
     };
-    <a href="_add">dynamic_field::add</a>(&<b>mut</b> self.id, system_state_version, system_state);
+    <a href="_add">dynamic_field::add</a>(&<b>mut</b> self.id, version, system_state);
     <a href="_share_object">transfer::share_object</a>(self);
 }
 </code></pre>

--- a/crates/sui-framework/docs/sui_system_state_inner.md
+++ b/crates/sui-framework/docs/sui_system_state_inner.md
@@ -451,6 +451,15 @@ Lower-bound on the amount of stake required to become a validator.
 
 
 
+<a name="0x3_sui_system_state_inner_SYSTEM_STATE_VERSION_V1"></a>
+
+
+
+<pre><code><b>const</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SYSTEM_STATE_VERSION_V1">SYSTEM_STATE_VERSION_V1</a>: u64 = 1;
+</code></pre>
+
+
+
 <a name="0x3_sui_system_state_inner_VALIDATOR_LOW_STAKE_GRACE_PERIOD"></a>
 
 
@@ -491,7 +500,7 @@ Create a new SuiSystemState object and make it shared.
 This function will be called only once in genesis.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_create">create</a>(validators: <a href="">vector</a>&lt;<a href="validator.md#0x3_validator_Validator">validator::Validator</a>&gt;, stake_subsidy_fund: <a href="_Balance">balance::Balance</a>&lt;<a href="_SUI">sui::SUI</a>&gt;, storage_fund: <a href="_Balance">balance::Balance</a>&lt;<a href="_SUI">sui::SUI</a>&gt;, protocol_version: u64, system_state_version: u64, governance_start_epoch: u64, epoch_start_timestamp_ms: u64, epoch_duration_ms: u64, initial_stake_subsidy_distribution_amount: u64, stake_subsidy_period_length: u64, stake_subsidy_decrease_rate: u16, ctx: &<b>mut</b> <a href="_TxContext">tx_context::TxContext</a>): <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_create">create</a>(validators: <a href="">vector</a>&lt;<a href="validator.md#0x3_validator_Validator">validator::Validator</a>&gt;, stake_subsidy_fund: <a href="_Balance">balance::Balance</a>&lt;<a href="_SUI">sui::SUI</a>&gt;, storage_fund: <a href="_Balance">balance::Balance</a>&lt;<a href="_SUI">sui::SUI</a>&gt;, protocol_version: u64, governance_start_epoch: u64, epoch_start_timestamp_ms: u64, epoch_duration_ms: u64, initial_stake_subsidy_distribution_amount: u64, stake_subsidy_period_length: u64, stake_subsidy_decrease_rate: u16, ctx: &<b>mut</b> <a href="_TxContext">tx_context::TxContext</a>): <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>
 </code></pre>
 
 
@@ -505,7 +514,6 @@ This function will be called only once in genesis.
     stake_subsidy_fund: Balance&lt;SUI&gt;,
     storage_fund: Balance&lt;SUI&gt;,
     protocol_version: u64,
-    system_state_version: u64,
     governance_start_epoch: u64,
     epoch_start_timestamp_ms: u64,
     epoch_duration_ms: u64,
@@ -519,7 +527,7 @@ This function will be called only once in genesis.
     <b>let</b> system_state = <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a> {
         epoch: 0,
         protocol_version,
-        system_state_version,
+        system_state_version: <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SYSTEM_STATE_VERSION_V1">SYSTEM_STATE_VERSION_V1</a>,
         validators,
         storage_fund,
         parameters: <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SystemParameters">SystemParameters</a> {

--- a/crates/sui-framework/packages/sui-system/sources/genesis.move
+++ b/crates/sui-framework/packages/sui-system/sources/genesis.move
@@ -42,7 +42,6 @@ module sui_system::genesis {
 
     struct GenesisChainParameters has drop, copy {
         protocol_version: u64,
-        system_state_version: u64,
         governance_start_epoch: u64,
         chain_start_timestamp_ms: u64,
         epoch_duration_ms: u64,
@@ -159,7 +158,6 @@ module sui_system::genesis {
             subsidy_fund,
             storage_fund,
             genesis_chain_parameters.protocol_version,
-            genesis_chain_parameters.system_state_version,
             genesis_chain_parameters.governance_start_epoch,
             genesis_chain_parameters.chain_start_timestamp_ms,
             genesis_chain_parameters.epoch_duration_ms,

--- a/crates/sui-framework/packages/sui-system/sources/sui_system.move
+++ b/crates/sui-framework/packages/sui-system/sources/sui_system.move
@@ -45,7 +45,6 @@ module sui_system::sui_system {
         stake_subsidy_fund: Balance<SUI>,
         storage_fund: Balance<SUI>,
         protocol_version: u64,
-        system_state_version: u64,
         governance_start_epoch: u64,
         epoch_start_timestamp_ms: u64,
         epoch_duration_ms: u64,
@@ -59,7 +58,6 @@ module sui_system::sui_system {
             stake_subsidy_fund,
             storage_fund,
             protocol_version,
-            system_state_version,
             governance_start_epoch,
             epoch_start_timestamp_ms,
             epoch_duration_ms,
@@ -68,11 +66,12 @@ module sui_system::sui_system {
             stake_subsidy_decrease_rate,
             ctx,
         );
+        let version = sui_system_state_inner::system_state_version(&system_state);
         let self = SuiSystemState {
             id,
-            version: system_state_version,
+            version,
         };
-        dynamic_field::add(&mut self.id, system_state_version, system_state);
+        dynamic_field::add(&mut self.id, version, system_state);
         transfer::share_object(self);
     }
 

--- a/crates/sui-framework/packages/sui-system/sources/sui_system_state_inner.move
+++ b/crates/sui-framework/packages/sui-system/sources/sui_system_state_inner.move
@@ -36,6 +36,8 @@ module sui_system::sui_system_state_inner {
     const ACTIVE_OR_PENDING_VALIDATOR: u8 = 2;
     const ANY_VALIDATOR: u8 = 3;
 
+    const SYSTEM_STATE_VERSION_V1: u64 = 1;
+
     // TODO: To suppress a false positive prover failure, which we should look into.
     spec module { pragma verify = false; }
 
@@ -150,7 +152,6 @@ module sui_system::sui_system_state_inner {
         stake_subsidy_fund: Balance<SUI>,
         storage_fund: Balance<SUI>,
         protocol_version: u64,
-        system_state_version: u64,
         governance_start_epoch: u64,
         epoch_start_timestamp_ms: u64,
         epoch_duration_ms: u64,
@@ -164,7 +165,7 @@ module sui_system::sui_system_state_inner {
         let system_state = SuiSystemStateInner {
             epoch: 0,
             protocol_version,
-            system_state_version,
+            system_state_version: SYSTEM_STATE_VERSION_V1,
             validators,
             storage_fund,
             parameters: SystemParameters {

--- a/crates/sui-framework/packages/sui-system/tests/governance_test_utils.move
+++ b/crates/sui-framework/packages/sui-system/tests/governance_test_utils.move
@@ -65,7 +65,6 @@ module sui_system::governance_test_utils {
             balance::create_for_testing<SUI>(sui_supply_amount), // sui_supply
             balance::create_for_testing<SUI>(storage_fund_amount), // storage_fund
             1,   // protocol version
-            1,   // system state version
             100, // governance_start_epoch, we set this to a big-ish number so that
                  // low stake departure won't start kicking in for testing
             0,   // epoch_start_timestamp_ms

--- a/crates/sui-types/src/sui_system_state/mod.rs
+++ b/crates/sui-types/src/sui_system_state/mod.rs
@@ -85,10 +85,6 @@ pub type SuiSystemStateInnerGenesis = SuiSystemStateInnerV1;
 pub type SuiValidatorGenesis = ValidatorV1;
 
 impl SuiSystemState {
-    pub fn new_genesis(inner: SuiSystemStateInnerGenesis) -> Self {
-        Self::V1(inner)
-    }
-
     /// Always return the version that we will be using for genesis.
     /// Genesis always uses this version regardless of the current version.
     pub fn into_genesis_version(self) -> SuiSystemStateInnerGenesis {


### PR DESCRIPTION
The genesis system state version should be set in Move, because Move is the source of truth of what the initial type version is used. Sending from Rust has problems because Rust could support multiple versions easily. This will also make upgrade testing easier.