### PR TITLE
crypto: verify aggregated sig with fallback

### DIFF
--- a/narwhal/primary/src/certifier.rs
+++ b/narwhal/primary/src/certifier.rs
@@ -225,7 +225,21 @@ impl Certifier {
                 received: vote.round
             }
         );
-        vote.verify(&committee)?;
+
+        // Ensure the header is from the correct epoch.
+        ensure!(
+            vote.epoch == committee.epoch(),
+            DagError::InvalidEpoch {
+                expected: committee.epoch(),
+                received: vote.epoch
+            }
+        );
+
+        // Ensure the authority has voting rights.
+        ensure!(
+            committee.stake_by_id(vote.author) > 0,
+            DagError::UnknownAuthority(vote.author.to_string())
+        );
 
         Ok(vote)
     }

--- a/narwhal/primary/src/tests/certificate_tests.rs
+++ b/narwhal/primary/src/tests/certificate_tests.rs
@@ -21,7 +21,7 @@ fn test_empty_certificate_verification() {
     let committee = fixture.committee();
     let header = fixture.header();
     // You should not be allowed to create a certificate that does not satisfying quorum requirements
-    assert!(Certificate::new(&committee, header.clone(), Vec::new()).is_err());
+    assert!(Certificate::new_unverified(&committee, header.clone(), Vec::new()).is_err());
 
     let certificate = Certificate::new_unsigned(&committee, header, Vec::new()).unwrap();
     assert!(certificate
@@ -43,7 +43,7 @@ fn test_valid_certificate_verification() {
         signatures.push((vote.author, vote.signature.clone()));
     }
 
-    let certificate = Certificate::new(&committee, header, signatures).unwrap();
+    let certificate = Certificate::new_unverified(&committee, header, signatures).unwrap();
 
     assert!(certificate
         .verify(&committee, &fixture.worker_cache())
@@ -64,7 +64,7 @@ fn test_certificate_insufficient_signatures() {
         signatures.push((vote.author, vote.signature.clone()));
     }
 
-    assert!(Certificate::new(&committee, header.clone(), signatures.clone()).is_err());
+    assert!(Certificate::new_unverified(&committee, header.clone(), signatures.clone()).is_err());
 
     let certificate = Certificate::new_unsigned(&committee, header, signatures).unwrap();
 
@@ -89,7 +89,7 @@ fn test_certificate_validly_repeated_public_keys() {
         signatures.push((vote.author, vote.signature.clone()));
     }
 
-    let certificate_res = Certificate::new(&committee, header, signatures);
+    let certificate_res = Certificate::new_unverified(&committee, header, signatures);
     assert!(certificate_res.is_ok());
     let certificate = certificate_res.unwrap();
 
@@ -118,7 +118,7 @@ fn test_unknown_signature_in_certificate() {
     let vote = Vote::new_with_signer(&header, &malicious_id, &malicious_key);
     signatures.push((vote.author, vote.signature));
 
-    assert!(Certificate::new(&committee, header, signatures).is_err());
+    assert!(Certificate::new_unverified(&committee, header, signatures).is_err());
 }
 
 proptest::proptest! {
@@ -141,7 +141,7 @@ proptest::proptest! {
             signatures.push((vote.author, vote.signature.clone()));
         }
 
-        let certificate = Certificate::new(&committee, header, signatures).unwrap();
+        let certificate = Certificate::new_unverified(&committee, header, signatures).unwrap();
 
         assert!(certificate
             .verify(&committee, &fixture.worker_cache())

--- a/narwhal/primary/src/tests/certifier_tests.rs
+++ b/narwhal/primary/src/tests/certifier_tests.rs
@@ -6,9 +6,12 @@ use crate::common::create_db_stores;
 
 use crate::primary;
 use consensus::consensus::ConsensusRound;
+use crypto::KeyPair as DefinedKeyPair;
 use fastcrypto::traits::KeyPair;
 use primary::NUM_SHUTDOWN_RECEIVERS;
 use prometheus::Registry;
+use rand::{rngs::StdRng, SeedableRng};
+use std::num::NonZeroUsize;
 use test_utils::CommitteeFixture;
 use tokio::sync::watch;
 use tokio::time::Duration;
@@ -230,6 +233,144 @@ async fn propose_header_failure() {
     }
 }
 
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn propose_header_scenario_with_bad_sigs() {
+    telemetry_subscribers::init_for_testing();
+    // expect cert if less than 2 byzantines, otherwise no cert
+    run_vote_aggregator_with_param(6, 0, true).await;
+    run_vote_aggregator_with_param(6, 1, true).await;
+    run_vote_aggregator_with_param(6, 2, false).await;
+
+    // expect cert if less than 2 byzantines, otherwise no cert
+    run_vote_aggregator_with_param(4, 0, true).await;
+    run_vote_aggregator_with_param(4, 1, true).await;
+    run_vote_aggregator_with_param(4, 2, false).await;
+}
+
+async fn run_vote_aggregator_with_param(
+    committee_size: usize,
+    num_byzantine: usize,
+    expect_cert: bool,
+) {
+    let fixture = CommitteeFixture::builder()
+        .committee_size(NonZeroUsize::new(committee_size).unwrap())
+        .randomize_ports(true)
+        .build();
+
+    let committee = fixture.committee();
+    let worker_cache = fixture.worker_cache();
+    let primary = fixture.authorities().last().unwrap();
+    let network_key = primary.network_keypair().copy().private().0.to_bytes();
+    let id: AuthorityIdentifier = primary.id();
+    let signature_service = SignatureService::new(primary.keypair().copy());
+    let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
+    let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
+    let (tx_certificate_fetcher, _rx_certificate_fetcher) = test_utils::test_channel!(1);
+    let (tx_headers, rx_headers) = test_utils::test_channel!(1);
+    let (tx_new_certificates, mut rx_new_certificates) = test_utils::test_channel!(3);
+    let (tx_parents, _rx_parents) = test_utils::test_channel!(1);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) =
+        watch::channel(ConsensusRound::new(0, 0));
+    let (_tx_synchronizer_network, rx_synchronizer_network) = oneshot::channel();
+    let (header_store, certificate_store, payload_store) = create_db_stores();
+
+    // Create a fake header.
+    let proposed_header = primary.header(&committee);
+
+    // Set up network.
+    let own_address = committee
+        .primary_by_id(&id)
+        .unwrap()
+        .to_anemo_address()
+        .unwrap();
+    let network = anemo::Network::bind(own_address)
+        .server_name("narwhal")
+        .private_key(network_key)
+        .start(anemo::Router::new())
+        .unwrap();
+
+    // Set up remote primaries responding with votes.
+    let mut primary_networks = Vec::new();
+    for (i, primary) in fixture.authorities().filter(|a| a.id() != id).enumerate() {
+        let address = committee.primary(&primary.public_key()).unwrap();
+        let name = primary.id();
+        // Create bad signature for a number of byzantines.
+        let vote = if i < num_byzantine {
+            let bad_key: DefinedKeyPair = DefinedKeyPair::generate(&mut StdRng::from_seed([0; 32]));
+            Vote::new_with_signer(&proposed_header, &name, &bad_key)
+        } else {
+            Vote::new_with_signer(&proposed_header, &name, primary.keypair())
+        };
+        let mut mock_server = MockPrimaryToPrimary::new();
+        let mut mock_seq = mockall::Sequence::new();
+        mock_server
+            .expect_request_vote()
+            .times(1)
+            .in_sequence(&mut mock_seq)
+            .return_once(move |_request| {
+                Ok(anemo::Response::new(RequestVoteResponse {
+                    vote: Some(vote),
+                    missing: Vec::new(),
+                }))
+            });
+        let routes = anemo::Router::new().add_rpc_service(PrimaryToPrimaryServer::new(mock_server));
+        primary_networks.push(primary.new_network(routes));
+        println!("New primary added: {:?}", address);
+
+        let address = address.to_anemo_address().unwrap();
+        let peer_id = anemo::PeerId(primary.network_keypair().public().0.to_bytes());
+        network
+            .connect_with_peer_id(address, peer_id)
+            .await
+            .unwrap();
+    }
+
+    // Spawn the core.
+    let synchronizer = Arc::new(Synchronizer::new(
+        id,
+        fixture.committee(),
+        worker_cache.clone(),
+        /* gc_depth */ 50,
+        certificate_store.clone(),
+        payload_store.clone(),
+        tx_certificate_fetcher,
+        tx_new_certificates.clone(),
+        tx_parents.clone(),
+        rx_consensus_round_updates.clone(),
+        rx_synchronizer_network,
+        None,
+        metrics.clone(),
+    ));
+    let _handle = Certifier::spawn(
+        id,
+        committee.clone(),
+        header_store.clone(),
+        certificate_store.clone(),
+        synchronizer,
+        signature_service,
+        tx_shutdown.subscribe(),
+        rx_headers,
+        metrics.clone(),
+        network,
+    );
+
+    // Send a proposed header.
+    let proposed_digest = proposed_header.digest();
+    tx_headers.send(proposed_header).await.unwrap();
+
+    if expect_cert {
+        // A cert is expected, checks that the header digest matches.
+        let certificate = rx_new_certificates.recv().await.unwrap();
+        assert_eq!(certificate.header.digest(), proposed_digest);
+    } else {
+        // A cert is not expected, checks that it times out without forming the cert.
+        assert!(
+            tokio::time::timeout(Duration::from_secs(5), rx_new_certificates.recv())
+                .await
+                .is_err()
+        );
+    }
+}
 #[tokio::test]
 async fn shutdown_core() {
     let fixture = CommitteeFixture::builder().build();

--- a/narwhal/test-utils/src/lib.rs
+++ b/narwhal/test-utils/src/lib.rs
@@ -641,7 +641,7 @@ pub fn mock_signed_certificate(
         let sig = Signature::new_secure(&to_intent_message(cert.header.digest()), signer);
         votes.push((*name, sig))
     }
-    let cert = Certificate::new(committee, header, votes).unwrap();
+    let cert = Certificate::new_unverified(committee, header, votes).unwrap();
     (cert.digest(), cert)
 }
 
@@ -848,7 +848,7 @@ impl CommitteeFixture {
             .into_iter()
             .map(|x| (x.author, x.signature))
             .collect();
-        Certificate::new(&committee, header.clone(), votes).unwrap()
+        Certificate::new_unverified(&committee, header.clone(), votes).unwrap()
     }
 }
 


### PR DESCRIPTION
## Description 
currently:
1. a narwhal certificate is formed if the vote_aggregator accumulated enought votes (each vote is individually verified), we actually dont verify the aggregated sig at all. 
2. only when a node receives a certificate from another peer, its aggregated sig is verified, and if its invalid, discard the cert. 

this change optimizes (1) to remove individual vote verify and replace it with only verify if the quorum threshold is reached. in the happy path, it is done. otherwise, if there are bad sig found, remove from weights and votes list, then continue to find new vote. (2) is unchanged. 


## Test Plan 

WIP

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
