### PR TITLE
[snapshots] Fixes to wrapped object handling

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -9,12 +9,13 @@ use std::path::Path;
 use std::sync::Arc;
 
 use either::Either;
-use fastcrypto::hash::{Digest, MultisetHash};
+use fastcrypto::hash::MultisetHash;
 use move_bytecode_utils::module_cache::GetModule;
 use move_core_types::resolver::ModuleResolver;
 use once_cell::sync::OnceCell;
 use rocksdb::Options;
 use serde::{Deserialize, Serialize};
+use sui_types::messages_checkpoint::ECMHLiveObjectSetDigest;
 use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use tracing::{debug, info, trace};
 
@@ -186,13 +187,13 @@ impl AuthorityStore {
         Ok(store)
     }
 
-    pub fn get_root_state_hash(&self, epoch: EpochId) -> SuiResult<Digest<32>> {
+    pub fn get_root_state_hash(&self, epoch: EpochId) -> SuiResult<ECMHLiveObjectSetDigest> {
         let acc = self
             .perpetual_tables
             .root_state_hash_by_epoch
             .get(&epoch)?
             .expect("Root state hash for this epoch does not exist");
-        Ok(acc.1.digest())
+        Ok(acc.1.digest().into())
     }
 
     pub fn get_recovery_epoch_at_restart(&self) -> SuiResult<EpochId> {

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -282,13 +282,13 @@ impl Iterator for LiveSetIter<'_> {
                 self.prev = Some(next);
 
                 match prev {
-                    Some(prev) if prev.0 != next.0 && prev.2.is_alive() => return Some(prev),
+                    Some(prev) if prev.0 != next.0 && !prev.2.is_deleted() => return Some(prev),
                     _ => continue,
                 }
             }
 
             return match self.prev {
-                Some(prev) if prev.2.is_alive() => {
+                Some(prev) if !prev.2.is_deleted() => {
                     self.prev = None;
                     Some(prev)
                 }

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1008,23 +1008,11 @@ impl SuiNode {
                     )
                 } else {
                     // was a fullnode, still a fullnode
-                    let live_object_set = self
-                        .state
-                        .database
-                        .iter_live_object_set()
-                        .map(|oref| oref.2);
-                    let mut acc = sui_types::accumulator::Accumulator::default();
-                    fastcrypto::hash::MultisetHash::insert_all(&mut acc, live_object_set);
-
-                    let live_object_set_hash = fastcrypto::hash::MultisetHash::digest(&acc);
-
-                    let root_state_hash = self
-                        .state
-                        .database
-                        .get_root_state_hash(cur_epoch_store.epoch())
-                        .expect("Retrieving root state hash cannot fail");
-
-                    let is_inconsistent = root_state_hash != live_object_set_hash;
+                    let is_inconsistent = self.check_is_consistent_state(
+                        self.accumulator.clone(),
+                        cur_epoch_store.epoch(),
+                        false,
+                    );
                     checkpoint_executor.set_inconsistent_state(is_inconsistent);
 
                     None
@@ -1033,6 +1021,31 @@ impl SuiNode {
             *self.validator_components.lock().await = new_validator_components;
             info!("Reconfiguration finished");
         }
+    }
+
+    fn check_is_consistent_state(
+        &self,
+        accumulator: Arc<StateAccumulator>,
+        epoch: EpochId,
+        panic: bool,
+    ) -> bool {
+        let live_object_set_hash = accumulator.digest_live_object_set();
+
+        let root_state_hash = self
+            .state
+            .database
+            .get_root_state_hash(epoch)
+            .expect("Retrieving root state hash cannot fail");
+
+        let is_inconsistent = root_state_hash != live_object_set_hash;
+        if is_inconsistent && panic {
+            panic!(
+                "Inconsistent state detected: root state hash: {:?}, live object set hash: {:?}",
+                root_state_hash, live_object_set_hash
+            );
+        }
+
+        is_inconsistent
     }
 
     async fn reconfigure_state(

--- a/crates/sui-types/src/digests.rs
+++ b/crates/sui-types/src/digests.rs
@@ -561,6 +561,10 @@ impl ObjectDigest {
         *self != Self::OBJECT_DIGEST_DELETED && *self != Self::OBJECT_DIGEST_WRAPPED
     }
 
+    pub fn is_deleted(&self) -> bool {
+        *self == Self::OBJECT_DIGEST_DELETED
+    }
+
     pub fn base58_encode(&self) -> String {
         Base58::encode(self.0)
     }


### PR DESCRIPTION
## Description 

A couple fixes for how we handle wrapped objects.
1. Do not delete objects in `wrapped` effects in accumulator, as these reference the child object, which is now tombstoned
2. Aforementioned tombstone needs to be inserted into accumulator (using newly introduced struct to differentiate tombstoned objects from one another - note that we use this rather than the `ObjectRef` as it is easier to serialize for `Accumulator`) as otherwise we will fork between nodes running from genesis and nodes restoring from snapshot (in the latter case, wrapped objects would not be accounted for)
3. Fixes `LiveObjectIter` to include wrapped object tombstones
4. Adds helpers for digesting the live object set, such as is needed for inconsistency verification by fullnodes as well as new nodes restoring from snapshot

## Test Plan 

Let tests run


### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
