### PR TITLE
[wallet-ext] fix sponsored transaction badge showing for non-sponsored transactions

### DIFF
--- a/apps/wallet/src/ui/app/pages/approval-request/transaction-request/GasFees.tsx
+++ b/apps/wallet/src/ui/app/pages/approval-request/transaction-request/GasFees.tsx
@@ -23,15 +23,17 @@ export function GasFees({ sender, transaction }: Props) {
 
     const isSponsored =
         transactionData?.gasConfig.owner &&
-        transactionData?.sender !== transactionData?.gasConfig.owner;
+        transactionData.sender !== transactionData.gasConfig.owner;
 
     return (
         <SummaryCard
             header="Estimated Gas Fees"
             badge={
-                <div className="bg-white text-success px-1.5 py-0.5 text-captionSmallExtra rounded-full font-medium uppercase">
-                    Sponsored
-                </div>
+                isSponsored ? (
+                    <div className="bg-white text-success px-1.5 py-0.5 text-captionSmallExtra rounded-full font-medium uppercase">
+                        Sponsored
+                    </div>
+                ) : null
             }
             initialExpanded
         >


### PR DESCRIPTION
## Description 

Before:
<img width="396" alt="image" src="https://user-images.githubusercontent.com/7453188/226796106-f49ac287-a074-43b4-95e0-47fa88acd06e.png">

After:
<img width="388" alt="image" src="https://user-images.githubusercontent.com/7453188/226796018-f86ce587-a480-4d2e-944b-8406ffaeea58.png">


## Test Plan 
Manual testing

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
N/A
