### PR TITLE
[authority aggregator] special casing system overload errors to not retry

### DIFF
--- a/crates/sui-core/src/quorum_driver/mod.rs
+++ b/crates/sui-core/src/quorum_driver/mod.rs
@@ -319,6 +319,17 @@ where
                 }))
             }
 
+            Err(AggregatorProcessTransactionError::SystemOverload {
+                overloaded_stake,
+                errors,
+            }) => {
+                debug!(?tx_digest, ?errors, "System overload");
+                Err(Some(QuorumDriverError::SystemOverload {
+                    overloaded_stake,
+                    errors,
+                }))
+            }
+
             Err(AggregatorProcessTransactionError::RetryableTransaction { errors }) => {
                 debug!(?tx_digest, ?errors, "Retryable transaction error");
                 Err(None)

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -625,6 +625,10 @@ impl SuiError {
                 }
             }
 
+            // Overload errors
+            SuiError::TooManyTransactionsPendingExecution { .. } => (true, true),
+            SuiError::TooManyTransactionsPendingOnObject { .. } => (true, true),
+
             // Non retryable error
             SuiError::ExecutionError(..) => (false, true),
             SuiError::ByzantineAuthoritySuspicion { .. } => (false, true),
@@ -632,9 +636,6 @@ impl SuiError {
                 (false, true)
             }
 
-            // Overload errors
-            SuiError::TooManyTransactionsPendingExecution { .. } => (false, true),
-            SuiError::TooManyTransactionsPendingOnObject { .. } => (false, true),
             _ => (false, false),
         }
     }
@@ -650,6 +651,14 @@ impl SuiError {
             }
             _ => false,
         }
+    }
+
+    pub fn is_overload(&self) -> bool {
+        matches!(
+            self,
+            SuiError::TooManyTransactionsPendingExecution { .. }
+                | SuiError::TooManyTransactionsPendingOnObject { .. }
+        )
     }
 }
 

--- a/crates/sui-types/src/quorum_driver_types.rs
+++ b/crates/sui-types/src/quorum_driver_types.rs
@@ -44,4 +44,9 @@ pub enum QuorumDriverError {
     NonRecoverableTransactionError {
         errors: Vec<(SuiError, Vec<AuthorityName>, StakeUnit)>,
     },
+    #[error("Transaction is not processed because {overloaded_stake} of validators by stake are overloaded with certificates pending execution.")]
+    SystemOverload {
+        overloaded_stake: StakeUnit,
+        errors: Vec<(SuiError, Vec<AuthorityName>, StakeUnit)>,
+    },
 }


### PR DESCRIPTION

## Description 

When the system is overloaded we should return a meaningful error to the user and not retry the transaction at quorum driver.

## Test Plan 

Added a new test.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
