### PR TITLE
Use a local connection between ConsensusAdapter and Narwhal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5867,6 +5867,7 @@ dependencies = [
  "tap",
  "telemetry-subscribers",
  "tempfile",
+ "thiserror",
  "tokio",
  "tonic",
  "tower",

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -411,6 +411,8 @@ pub enum SuiError {
     FullNodeInvalidTxRangeQuery { error: String },
 
     // Errors related to the authority-consensus interface.
+    #[error("Failed to submit transaction to consensus: {0}")]
+    FailedToSubmitToConsensus(String),
     #[error("Failed to connect with consensus node: {0}")]
     ConsensusConnectionBroken(String),
     #[error("Failed to hear back from consensus: {0}")]

--- a/narwhal/worker/Cargo.toml
+++ b/narwhal/worker/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
+arc-swap = "1.5.1"
 async-trait = "0.1.61"
 byteorder = "1.4.3"
 bytes = "1.3.0"
@@ -14,6 +15,7 @@ futures = "0.3.24"
 governor = "0.5.1"
 rand = { version = "0.8.5", features = ["small_rng"] }
 tap = "1.0.1"
+thiserror = "1.0.35"
 tokio = { workspace = true, features = ["sync", "rt", "macros"] }
 tonic = "0.8.2"
 tower = "0.4.13"
@@ -27,7 +29,6 @@ types = { path = "../types", package = "narwhal-types" }
 prometheus = "0.13.3"
 store = { path = "../../crates/typed-store", package = "typed-store" }
 mysten-network = { path = "../../crates/mysten-network"}
-
 mysten-metrics = { path = "../../crates/mysten-metrics" }
 
 anemo.workspace = true

--- a/narwhal/worker/src/client.rs
+++ b/narwhal/worker/src/client.rs
@@ -1,0 +1,106 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::{btree_map::Entry, BTreeMap},
+    net::Ipv4Addr,
+    sync::{Arc, Mutex},
+};
+
+use arc_swap::ArcSwap;
+use mysten_network::{multiaddr::Protocol, Multiaddr};
+use thiserror::Error;
+use types::{metered_channel::Sender, Transaction, TxResponse};
+
+/// Uses a map to allow running multiple Narwhal instances in the same process.
+/// TODO: after Rust 1.66, use BTreeMap::new() instead of wrapping it in an Option.
+static LOCAL_NARWHAL_CLIENTS: Mutex<Option<BTreeMap<Multiaddr, Arc<ArcSwap<LocalNarwhalClient>>>>> =
+    Mutex::new(None);
+
+/// The maximum allowed size of transactions into Narwhal.
+/// TODO: maybe move to TxValidator?
+pub const MAX_ALLOWED_TRANSACTION_SIZE: usize = 6 * 1024 * 1024;
+
+/// Errors returned to clients submitting transactions to Narwhal.
+#[derive(Clone, Debug, Error)]
+pub enum NarwhalError {
+    #[error("Failed to include transaction in a header!")]
+    TransactionNotIncludedInHeader,
+
+    #[error("Narwhal is shutting down!")]
+    ShuttingDown,
+
+    #[error("Transaction is too large: size={0} limit={1}")]
+    TransactionTooLarge(usize, usize),
+}
+
+/// TODO: add NarwhalClient trait and implement RemoteNarwhalClient with grpc.
+
+/// A client that connects to Narwhal locally.
+#[derive(Clone)]
+pub struct LocalNarwhalClient {
+    /// TODO: maybe use tx_batch_maker for load schedding.
+    tx_batch_maker: Sender<(Transaction, TxResponse)>,
+}
+
+impl LocalNarwhalClient {
+    pub fn new(tx_batch_maker: Sender<(Transaction, TxResponse)>) -> Arc<Self> {
+        Arc::new(Self { tx_batch_maker })
+    }
+
+    /// Sets the instance of LocalNarwhalClient for the local address.
+    /// Address is only used as the key.
+    pub fn set_global(addr: Multiaddr, instance: Arc<Self>) {
+        let addr = Self::canonicalize_address_key(addr);
+        let mut clients = LOCAL_NARWHAL_CLIENTS.lock().unwrap();
+        if clients.is_none() {
+            *clients = Some(BTreeMap::new());
+        }
+        match clients.as_mut().unwrap().entry(addr) {
+            Entry::Vacant(entry) => {
+                entry.insert(Arc::new(ArcSwap::from(instance)));
+            }
+            Entry::Occupied(mut entry) => {
+                entry.get_mut().store(instance);
+            }
+        };
+    }
+
+    /// Gets the instance of LocalNarwhalClient for the local address.
+    /// Address is only used as the key.
+    pub fn get_global(addr: &Multiaddr) -> Option<Arc<ArcSwap<Self>>> {
+        let addr = Self::canonicalize_address_key(addr.clone());
+        let clients = LOCAL_NARWHAL_CLIENTS.lock().unwrap();
+        clients.as_ref()?.get(&addr).cloned()
+    }
+
+    /// Submits a transaction to the local Narwhal worker.
+    pub async fn submit_transaction(&self, transaction: Transaction) -> Result<(), NarwhalError> {
+        if transaction.len() > MAX_ALLOWED_TRANSACTION_SIZE {
+            return Err(NarwhalError::TransactionTooLarge(
+                transaction.len(),
+                MAX_ALLOWED_TRANSACTION_SIZE,
+            ));
+        }
+        // Send the transaction to the batch maker.
+        let (notifier, when_done) = tokio::sync::oneshot::channel();
+        self.tx_batch_maker
+            .send((transaction, notifier))
+            .await
+            .map_err(|_| NarwhalError::ShuttingDown)?;
+
+        let _digest = when_done
+            .await
+            .map_err(|_| NarwhalError::TransactionNotIncludedInHeader)?;
+
+        Ok(())
+    }
+
+    /// Ensures getter and setter use the same key for the same network address.
+    /// This is needed because TxServer serves from 0.0.0.0.
+    fn canonicalize_address_key(address: Multiaddr) -> Multiaddr {
+        address
+            .replace(0, |_protocol| Some(Protocol::Ip4(Ipv4Addr::UNSPECIFIED)))
+            .unwrap()
+    }
+}

--- a/narwhal/worker/src/lib.rs
+++ b/narwhal/worker/src/lib.rs
@@ -9,14 +9,17 @@
 )]
 
 mod batch_maker;
+mod client;
 mod handlers;
-pub mod metrics;
 mod primary_connector;
 mod quorum_waiter;
 mod transactions_server;
 mod tx_validator;
 mod worker;
 
+pub mod metrics;
+
+pub use crate::client::LocalNarwhalClient;
 pub use crate::tx_validator::{TransactionValidator, TrivialTransactionValidator};
 pub use crate::worker::Worker;
 

--- a/narwhal/worker/src/tests/worker_tests.rs
+++ b/narwhal/worker/src/tests/worker_tests.rs
@@ -2,6 +2,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
+use crate::LocalNarwhalClient;
 use crate::{metrics::initialise_metrics, TrivialTransactionValidator};
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -134,8 +135,9 @@ async fn reject_invalid_clients_transactions() {
     assert!(res.is_err());
 }
 
+/// TODO: test both RemoteNarwhalClient and LocalNarwhalClient in the same test case.
 #[tokio::test]
-async fn handle_clients_transactions() {
+async fn handle_remote_clients_transactions() {
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
     let worker_cache = fixture.worker_cache();
@@ -181,6 +183,8 @@ async fn handle_clients_transactions() {
 
     // Spawn a network listener to receive our batch's digest.
     let mut peer_networks = Vec::new();
+
+    // Create batches
     let batch = batch();
     let batch_digest = batch.digest();
 
@@ -233,6 +237,117 @@ async fn handle_clients_transactions() {
             // Calls to submit_transaction are now blocking, so we need to drive them
             // all at the same time, rather than sequentially.
             let mut inner_client = client.clone();
+            fut_list.push_back(async move {
+                inner_client.submit_transaction(txn).await.unwrap();
+            });
+        }
+
+        // Drive all sending in parallel.
+        while fut_list.next().await.is_some() {}
+    });
+
+    // Ensure the primary received the batch's digest (ie. it did not panic).
+    rx_await_batch.recv().await.unwrap();
+
+    // Ensure sending ended.
+    assert!(join_handle.await.is_ok());
+}
+
+/// TODO: test both RemoteNarwhalClient and LocalNarwhalClient in the same test case.
+#[tokio::test]
+async fn handle_local_clients_transactions() {
+    let fixture = CommitteeFixture::builder().randomize_ports(true).build();
+    let committee = fixture.committee();
+    let worker_cache = fixture.worker_cache();
+
+    let worker_id = 0;
+    let my_primary = fixture.authorities().next().unwrap();
+    let myself = my_primary.worker(worker_id);
+    let authority_public_key = my_primary.public_key();
+
+    let parameters = Parameters {
+        batch_size: 200, // Two transactions.
+        ..Parameters::default()
+    };
+
+    // Create a new test store.
+    let batch_store = rocks::DBMap::<BatchDigest, Batch>::open(
+        temp_dir(),
+        MetricConf::default(),
+        None,
+        Some("batches"),
+        &ReadWriteOptions::default(),
+    )
+    .unwrap();
+
+    let registry = Registry::new();
+    let metrics = initialise_metrics(&registry);
+
+    let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
+
+    // Spawn a `Worker` instance.
+    Worker::spawn(
+        my_primary.authority().clone(),
+        myself.keypair(),
+        worker_id,
+        committee.clone(),
+        worker_cache.clone(),
+        parameters,
+        TrivialTransactionValidator::default(),
+        batch_store,
+        metrics,
+        &mut tx_shutdown,
+    );
+
+    // Spawn a network listener to receive our batch's digest.
+    let mut peer_networks = Vec::new();
+
+    // Create batches
+    let batch = batch();
+    let batch_digest = batch.digest();
+
+    let (tx_await_batch, mut rx_await_batch) = test_utils::test_channel!(CHANNEL_CAPACITY);
+    let mut mock_primary_server = MockWorkerToPrimary::new();
+    mock_primary_server
+        .expect_report_our_batch()
+        .withf(move |request| {
+            let message = request.body();
+            message.digest == batch_digest && message.worker_id == worker_id
+        })
+        .times(1)
+        .returning(move |_| {
+            tx_await_batch.try_send(()).unwrap();
+            Ok(anemo::Response::new(()))
+        });
+    let primary_routes =
+        anemo::Router::new().add_rpc_service(WorkerToPrimaryServer::new(mock_primary_server));
+    peer_networks.push(my_primary.new_network(primary_routes));
+
+    // Spawn enough workers' listeners to acknowledge our batches.
+    for worker in fixture.authorities().skip(1).map(|a| a.worker(worker_id)) {
+        let mut mock_server = MockWorkerToWorker::new();
+        mock_server
+            .expect_report_batch()
+            .returning(|_| Ok(anemo::Response::new(())));
+        let routes = anemo::Router::new().add_rpc_service(WorkerToWorkerServer::new(mock_server));
+        peer_networks.push(worker.new_network(routes));
+    }
+
+    // Wait till other services have been able to start up
+    tokio::task::yield_now().await;
+    // Send enough transactions to create a batch.
+    let address = worker_cache
+        .worker(&authority_public_key, &worker_id)
+        .unwrap()
+        .transactions;
+    let client = LocalNarwhalClient::get_global(&address).unwrap().load();
+
+    let join_handle = tokio::task::spawn(async move {
+        let mut fut_list = FuturesOrdered::new();
+        for txn in batch.transactions {
+            // Calls to submit_transaction are now blocking, so we need to drive them
+            // all at the same time, rather than sequentially.
+            let inner_client = client.clone();
             fut_list.push_back(async move {
                 inner_client.submit_transaction(txn).await.unwrap();
             });

--- a/narwhal/worker/src/transactions_server.rs
+++ b/narwhal/worker/src/transactions_server.rs
@@ -1,26 +1,26 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+
+use crate::client::LocalNarwhalClient;
 use crate::metrics::WorkerEndpointMetrics;
 use crate::TransactionValidator;
 use async_trait::async_trait;
+use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use mysten_metrics::spawn_logged_monitored_task;
 use mysten_network::server::Server;
 use mysten_network::Multiaddr;
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::task::JoinHandle;
 use tokio::time::{sleep, timeout};
 use tonic::{Request, Response, Status};
 use tracing::{error, info, warn};
-use types::error::DagError;
 use types::metered_channel::Sender;
 use types::{
     ConditionalBroadcastReceiver, Empty, Transaction, TransactionProto, Transactions,
     TransactionsServer, TxResponse,
 };
-
-/// The maximum allowed size of transactions into Narwhal.
-pub const MAX_ALLOWED_TRANSACTION_SIZE: usize = 6 * 1024 * 1024;
 
 pub struct TxServer<V: TransactionValidator> {
     address: Multiaddr,
@@ -57,13 +57,17 @@ impl<V: TransactionValidator> TxServer<V> {
         const RETRY_BACKOFF: Duration = Duration::from_millis(1_000);
         const GRACEFUL_SHUTDOWN_DURATION: Duration = Duration::from_millis(2_000);
 
+        // create and initialize local Narwhal client
+        let local_client = LocalNarwhalClient::new(self.tx_batch_maker.clone());
+        LocalNarwhalClient::set_global(self.address.clone(), local_client.clone());
+
         // create the handler
         let tx_handler = TxReceiverHandler {
-            tx_batch_maker: self.tx_batch_maker,
+            local_client,
             validator: self.validator,
         };
 
-        //now create the server
+        // now create the server
         let mut retries = MAX_RETRIES;
         let mut server: Server;
 
@@ -127,7 +131,7 @@ impl<V: TransactionValidator> TxServer<V> {
 /// Defines how the network receiver handles incoming transactions.
 #[derive(Clone)]
 pub(crate) struct TxReceiverHandler<V> {
-    pub(crate) tx_batch_maker: Sender<(Transaction, TxResponse)>,
+    pub(crate) local_client: Arc<LocalNarwhalClient>,
     pub(crate) validator: V,
 }
 
@@ -137,29 +141,15 @@ impl<V: TransactionValidator> Transactions for TxReceiverHandler<V> {
         &self,
         request: Request<TransactionProto>,
     ) -> Result<Response<Empty>, Status> {
-        let message = request.into_inner().transaction;
-        if message.len() > MAX_ALLOWED_TRANSACTION_SIZE {
-            return Err(Status::resource_exhausted(format!(
-                "Transaction size is too large: {} > {}",
-                message.len(),
-                MAX_ALLOWED_TRANSACTION_SIZE
-            )));
-        }
-        if self.validator.validate(message.as_ref()).is_err() {
+        let transaction = request.into_inner().transaction;
+        if self.validator.validate(transaction.as_ref()).is_err() {
             return Err(Status::invalid_argument("Invalid transaction"));
         }
-        // Send the transaction to the batch maker.
-        let (notifier, when_done) = tokio::sync::oneshot::channel();
-        self.tx_batch_maker
-            .send((message.to_vec(), notifier))
+        // Send the transaction to Narwhal via the local client.
+        self.local_client
+            .submit_transaction(transaction.to_vec())
             .await
-            .map_err(|_| DagError::ShuttingDown)
-            .map_err(|e| Status::not_found(e.to_string()))?;
-
-        let _digest = when_done
-            .await
-            .map_err(|_| Status::internal("Failed to propagate transaction for proposal"))?;
-
+            .map_err(|e| Status::internal(e.to_string()))?;
         Ok(Response::new(Empty {}))
     }
 
@@ -168,7 +158,7 @@ impl<V: TransactionValidator> Transactions for TxReceiverHandler<V> {
         request: Request<tonic::Streaming<types::TransactionProto>>,
     ) -> Result<Response<types::Empty>, Status> {
         let mut transactions = request.into_inner();
-        let mut responses = Vec::new();
+        let mut reqeusts = FuturesUnordered::new();
 
         while let Some(Ok(txn)) = transactions.next().await {
             if let Err(err) = self.validator.validate(txn.transaction.as_ref()) {
@@ -177,25 +167,21 @@ impl<V: TransactionValidator> Transactions for TxReceiverHandler<V> {
                     "Stream contains an invalid transaction {err}"
                 )));
             }
-            // Send the transaction to the batch maker.
-            let (notifier, when_done) = tokio::sync::oneshot::channel();
-            self.tx_batch_maker
-                .send((txn.transaction.to_vec(), notifier))
-                .await
-                .expect("Failed to send transaction");
-
+            // Send the transaction to Narwhal via the local client.
             // Note that here we do not wait for a response because this would
             // mean that we process only a single message from this stream at a
             // time. Instead we gather them and resolve them once the stream is over.
-            responses.push(when_done);
+            reqeusts.push(
+                self.local_client
+                    .submit_transaction(txn.transaction.to_vec()),
+            );
         }
 
-        // TODO: activate when we provide a meaningful guarantee, and
-        // distingush between a digest being returned vs the channel closing
-        // suggesting an error.
-        // for response in responses {
-        //     let _digest = response.await;
-        // }
+        while let Some(result) = reqeusts.next().await {
+            if let Err(e) = result {
+                return Err(Status::internal(e.to_string()));
+            }
+        }
 
         Ok(Response::new(Empty {}))
     }


### PR DESCRIPTION
## Description 

We are having operational and potentially throughput issues with using gRPC for Sui -> Narwhal submissions. Switching to a local interface should simplify debugging.

## Test Plan 

Existing unit tests. Deploy to private testnet.
This change seems to have speed up reconfig simtests, sometimes cutting the time by half.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
