### PR TITLE
give error details when failing to load client.yaml

### DIFF
--- a/crates/sui-keys/src/keystore.rs
+++ b/crates/sui-keys/src/keystore.rs
@@ -175,8 +175,12 @@ impl AccountKeystore for FileBasedKeystore {
 impl FileBasedKeystore {
     pub fn new(path: &PathBuf) -> Result<Self, anyhow::Error> {
         let keys = if path.exists() {
-            let reader = BufReader::new(File::open(path)?);
-            let kp_strings: Vec<String> = serde_json::from_reader(reader)?;
+            let reader = BufReader::new(
+                File::open(path)
+                    .map_err(|e| anyhow!("Can't open FileBasedKeystore from {:?}: {e}", path))?,
+            );
+            let kp_strings: Vec<String> = serde_json::from_reader(reader)
+                .map_err(|e| anyhow!("Can't deserialize FileBasedKeystore from {:?}: {e}", path))?;
             kp_strings
                 .iter()
                 .map(|kpstr| {

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1113,10 +1113,10 @@ impl WalletContext {
         request_timeout: Option<std::time::Duration>,
     ) -> Result<Self, anyhow::Error> {
         let config: SuiClientConfig = PersistedConfig::read(config_path).map_err(|err| {
-            err.context(format!(
-                "Cannot open wallet config file at {:?}",
+            anyhow!(
+                "Cannot open wallet config file at {:?}. Err: {err}",
                 config_path
-            ))
+            )
         })?;
 
         let config = config.persisted(config_path);


### PR DESCRIPTION
## Description 

At the moment if only says `Cannot open wallet config file at xyz` without giving any details. This PR fixes this, particularly the sui.keystore loading error.

## Test Plan 

tested locally 
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Give detailed error context when failing to load client.yaml
