### PR TITLE
inactive validators

### DIFF
--- a/apps/wallet/src/ui/app/hooks/index.ts
+++ b/apps/wallet/src/ui/app/hooks/index.ts
@@ -23,6 +23,7 @@ export { useGetAllBalances } from './useGetAllBalances';
 export { useObjectsOwnedByAddress } from './useObjectsOwnedByAddress';
 export { useOwnedNFT } from './useOwnedNFT';
 export { useGetCoins } from './useGetCoins';
+export { useGetInactiveValidators } from './useGetInactiveValidators';
 export * from './useSigner';
 export * from './useOriginbyteNft';
 export * from './useTransactionData';

--- a/apps/wallet/src/ui/app/hooks/useGetInactiveValidators.ts
+++ b/apps/wallet/src/ui/app/hooks/useGetInactiveValidators.ts
@@ -1,0 +1,27 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useRpcClient } from '@mysten/core';
+import { type ObjectId } from '@mysten/sui.js';
+import { useQuery } from '@tanstack/react-query';
+
+import { notEmpty } from '_helpers';
+
+// Get invalid validators by inactivePoolsIds
+// get system state summary
+export function useGetInactiveValidators(inactivePoolsId?: ObjectId) {
+    const rpc = useRpcClient();
+    const data = useQuery(
+        ['inactive-pool-id', inactivePoolsId],
+        () => rpc.getDynamicFields({ parentId: inactivePoolsId! }),
+        { enabled: !!inactivePoolsId }
+    );
+    // return validator stakePoolId
+    return {
+        ...data,
+        data:
+            data.data?.data
+                .map((validator) => validator.name?.value || null)
+                .filter(notEmpty) || [],
+    };
+}

--- a/apps/wallet/src/ui/app/staking/delegation-detail/DelegationDetailCard.tsx
+++ b/apps/wallet/src/ui/app/staking/delegation-detail/DelegationDetailCard.tsx
@@ -20,6 +20,7 @@ import { IconTooltip } from '_app/shared/tooltip';
 import Alert from '_components/alert';
 import Icon, { SuiIcons } from '_components/icon';
 import LoadingIndicator from '_components/loading/LoadingIndicator';
+import { useGetInactiveValidators } from '_hooks';
 import { FEATURES } from '_src/shared/experimentation/features';
 
 type DelegationDetailCardProps = {
@@ -75,6 +76,11 @@ export function DelegationDetailCard({
         staked: stakedId,
     }).toString()}`;
 
+    const { data: inActiveValidatorsIds } = useGetInactiveValidators(
+        system?.inactivePoolsId
+    );
+
+    const inActiveValidator = inActiveValidatorsIds.length;
     const commission = validatorData ? +validatorData.commissionRate / 100 : 0;
     const stakingEnabled = useFeature(FEATURES.STAKING_ENABLED).on;
 
@@ -103,6 +109,13 @@ export function DelegationDetailCard({
             <BottomMenuLayout>
                 <Content>
                     <div className="justify-center w-full flex flex-col items-center">
+                        {inActiveValidator ? (
+                            <Alert className="mb-3">
+                                Unstake SUI from this inactive validator and
+                                stake on an active validator to start earning
+                                rewards again.
+                            </Alert>
+                        ) : null}
                         <div className="w-full flex">
                             <Card
                                 header={
@@ -195,19 +208,21 @@ export function DelegationDetailCard({
                             </Card>
                         </div>
                         <div className="flex gap-2.5 w-full my-3.75">
-                            <Button
-                                size="large"
-                                mode="outline"
-                                href={stakeByValidatorAddress}
-                                className="border-bg-steel-dark border-solid w-full hover:border-bg-steel-darker"
-                                disabled={!stakingEnabled}
-                            >
-                                <Icon
-                                    icon={SuiIcons.Add}
-                                    className="font-normal"
-                                />
-                                Stake SUI
-                            </Button>
+                            {!inActiveValidator ? (
+                                <Button
+                                    size="large"
+                                    mode="outline"
+                                    href={stakeByValidatorAddress}
+                                    className="border-bg-steel-dark border-solid w-full hover:border-bg-steel-darker"
+                                    disabled={!stakingEnabled}
+                                >
+                                    <Icon
+                                        icon={SuiIcons.Add}
+                                        className="font-normal"
+                                    />
+                                    Stake SUI
+                                </Button>
+                            ) : null}
                             {Boolean(totalStake) && delegationId && (
                                 <Button
                                     size="large"

--- a/apps/wallet/src/ui/app/staking/home/StakedCard.tsx
+++ b/apps/wallet/src/ui/app/staking/home/StakedCard.tsx
@@ -142,7 +142,12 @@ export function StakeCard({
         : StakeState.WARM_UP;
 
     const rewards = isEarnedRewards && estimatedReward ? estimatedReward : 0;
-    const [principalStaked, symbol] = useFormatCoin(principal, SUI_TYPE_ARG);
+
+    // For inactive validator, show principal + rewards
+    const [principalStaked, symbol] = useFormatCoin(
+        inactiveValidator ? principal + rewards : principal,
+        SUI_TYPE_ARG
+    );
     const [rewardsStaked] = useFormatCoin(rewards, SUI_TYPE_ARG);
     const isEarning = delegationState === StakeState.EARNING && rewards > 0;
 

--- a/apps/wallet/src/ui/app/staking/validators/ValidatorsCard.tsx
+++ b/apps/wallet/src/ui/app/staking/validators/ValidatorsCard.tsx
@@ -20,6 +20,7 @@ import { Text } from '_app/shared/text';
 import Alert from '_components/alert';
 import Icon, { SuiIcons } from '_components/icon';
 import LoadingIndicator from '_components/loading/LoadingIndicator';
+import { useGetInactiveValidators } from '_hooks';
 import { FEATURES } from '_src/shared/experimentation/features';
 
 export function ValidatorsCard() {
@@ -40,14 +41,22 @@ export function ValidatorsCard() {
         return getAllStakeSui(delegatedStake);
     }, [delegatedStake]);
 
+    const { data: inActiveStakingPoolID } = useGetInactiveValidators(
+        system?.inactivePoolsId
+    );
+
     const delegations = useMemo(() => {
         return delegatedStake?.flatMap((delegation) => {
             return delegation.stakes.map((d) => ({
                 ...d,
+                // flag any inactive validator for the stakeSui object
+                inactiveValidator: inActiveStakingPoolID?.includes(
+                    delegation.stakingPool
+                ),
                 validatorAddress: delegation.validatorAddress,
             }));
         });
-    }, [delegatedStake]);
+    }, [delegatedStake, inActiveStakingPoolID]);
 
     // Get total rewards for all delegations
     const totalEarnTokenReward = useMemo(() => {
@@ -92,6 +101,29 @@ export function ValidatorsCard() {
             <BottomMenuLayout>
                 <Content>
                     <div className="mb-4">
+                        {inActiveStakingPoolID?.length ? (
+                            <Alert className="mb-3">
+                                Unstake SUI from the inactive validators and
+                                stake on an active validator to start earning
+                                rewards again.
+                            </Alert>
+                        ) : null}
+                        <div className="grid grid-cols-2 gap-2.5 mb-4">
+                            {system &&
+                                delegations
+                                    ?.filter(
+                                        ({ inactiveValidator }) =>
+                                            inactiveValidator
+                                    )
+                                    .map((delegation) => (
+                                        <StakeCard
+                                            delegationObject={delegation}
+                                            currentEpoch={system.epoch}
+                                            key={delegation.stakedSuiId}
+                                            inactiveValidator
+                                        />
+                                    ))}
+                        </div>
                         <Card
                             padding="none"
                             header={
@@ -128,13 +160,18 @@ export function ValidatorsCard() {
 
                         <div className="grid grid-cols-2 gap-2.5 mt-4">
                             {system &&
-                                delegations?.map((delegation) => (
-                                    <StakeCard
-                                        delegationObject={delegation}
-                                        currentEpoch={+system.epoch}
-                                        key={delegation.stakedSuiId}
-                                    />
-                                ))}
+                                delegations
+                                    ?.filter(
+                                        ({ inactiveValidator }) =>
+                                            !inactiveValidator
+                                    )
+                                    .map((delegation) => (
+                                        <StakeCard
+                                            delegationObject={delegation}
+                                            currentEpoch={system.epoch}
+                                            key={delegation.stakedSuiId}
+                                        />
+                                    ))}
                         </div>
                     </div>
                 </Content>


### PR DESCRIPTION
## Description 

Describe the changes or additions included in this PR.

- Get inactive staking `stakingPoolId` from `inactivePoolsId`
- Added notification whenever a stakeObject is on an inactive validator
- Highlight stakeObject with an inactive validator  



## Test Plan 

How did you test the new or updated feature?

<img width="440" alt="Screenshot 2023-03-22 at 1 49 35 PM" src="https://user-images.githubusercontent.com/126525197/226993797-459ff1a8-1664-4a56-9417-e06bfb493c28.png">

<img width="440" alt="Screenshot 2023-03-22 at 1 49 35 PM" src="https://user-images.githubusercontent.com/126525197/226993824-257aacf4-cda0-4e50-a1d0-6e2147d8eead.png">


---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
