### PR TITLE
Cache verified transactions

### DIFF
--- a/crates/sui-core/benches/batch_verification_bench.rs
+++ b/crates/sui-core/benches/batch_verification_bench.rs
@@ -14,7 +14,7 @@ use sui_types::committee::Committee;
 use sui_types::crypto::{get_key_pair, AccountKeyPair, AuthorityKeyPair};
 use sui_types::messages::CertifiedTransaction;
 
-use sui_core::batch_bls_verifier::*;
+use sui_core::signature_verifier::*;
 
 fn gen_certs(
     committee: &Committee,
@@ -55,7 +55,7 @@ fn async_verifier_bench(c: &mut Criterion) {
     group.sample_size(10);
 
     let registry = Registry::new();
-    let metrics = BatchCertificateVerifierMetrics::new(&registry);
+    let metrics = VerifiedDigestCacheMetrics::new(&registry);
 
     let num_cpus = num_cpus::get() as u64;
     for num_threads in [1, num_cpus / 2, num_cpus] {
@@ -72,7 +72,7 @@ fn async_verifier_bench(c: &mut Criterion) {
                         .enable_time()
                         .build()
                         .unwrap();
-                    let batch_verifier = Arc::new(BatchCertificateVerifier::new_with_batch_size(
+                    let batch_verifier = Arc::new(SignatureVerifier::new_with_batch_size(
                         committee.clone(),
                         batch_size,
                         metrics.clone(),

--- a/crates/sui-core/benches/verified_cert_cache_bench.rs
+++ b/crates/sui-core/benches/verified_cert_cache_bench.rs
@@ -3,7 +3,7 @@
 
 use criterion::*;
 
-use sui_core::batch_bls_verifier::{BatchCertificateVerifierMetrics, VerifiedCertificateCache};
+use sui_core::signature_verifier::{VerifiedCertificateCache, VerifiedDigestCacheMetrics};
 use sui_types::digests::CertificateDigest;
 
 use criterion::Criterion;
@@ -25,7 +25,7 @@ fn verified_cert_cache_bench(c: &mut Criterion) {
     assert_eq!(chunks.len(), cpus);
 
     let registry = prometheus::Registry::new();
-    let metrics = BatchCertificateVerifierMetrics::new(&registry);
+    let metrics = VerifiedDigestCacheMetrics::new(&registry);
     let cache = VerifiedCertificateCache::new(metrics);
 
     let mut group = c.benchmark_group("digest-caching");

--- a/crates/sui-core/benches/verified_cert_cache_bench.rs
+++ b/crates/sui-core/benches/verified_cert_cache_bench.rs
@@ -3,7 +3,7 @@
 
 use criterion::*;
 
-use sui_core::signature_verifier::{VerifiedCertificateCache, VerifiedDigestCacheMetrics};
+use sui_core::signature_verifier::{VerifiedDigestCache, VerifiedDigestCacheMetrics};
 use sui_types::digests::CertificateDigest;
 
 use criterion::Criterion;
@@ -26,7 +26,10 @@ fn verified_cert_cache_bench(c: &mut Criterion) {
 
     let registry = prometheus::Registry::new();
     let metrics = VerifiedDigestCacheMetrics::new(&registry);
-    let cache = VerifiedCertificateCache::new(metrics);
+    let cache = VerifiedDigestCache::<CertificateDigest>::new(
+        metrics.certificate_signatures_cache_hits.clone(),
+        metrics.certificate_signatures_cache_evictions.clone(),
+    );
 
     let mut group = c.benchmark_group("digest-caching");
     group.throughput(Throughput::Elements(chunk_size as u64));

--- a/crates/sui-core/benches/verified_cert_cache_bench.rs
+++ b/crates/sui-core/benches/verified_cert_cache_bench.rs
@@ -40,10 +40,10 @@ fn verified_cert_cache_bench(c: &mut Criterion) {
                 let threads = chunks.iter().map(|chunk| {
                     s.spawn(|| {
                         for digest in &**chunk {
-                            if cache.is_cert_verified(digest) {
+                            if cache.is_cached(digest) {
                                 continue;
                             } else {
-                                cache.cache_cert_verified(*digest);
+                                cache.cache_digest(*digest);
                             }
                         }
                     })

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1731,7 +1731,7 @@ impl AuthorityState {
         );
         let registry = Registry::new();
         let cache_metrics = Arc::new(ResolverMetrics::new(&registry));
-        let batch_verifier_metrics = VerifiedDigestCacheMetrics::new(&registry);
+        let signature_verifier_metrics = VerifiedDigestCacheMetrics::new(&registry);
         let epoch_store = AuthorityPerEpochStore::new(
             name,
             Arc::new(genesis_committee.clone()),
@@ -1741,7 +1741,7 @@ impl AuthorityState {
             EpochStartConfiguration::new_for_testing(),
             store.clone(),
             cache_metrics,
-            batch_verifier_metrics,
+            signature_verifier_metrics,
         );
 
         let epochs = Arc::new(CommitteeStore::new(

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -97,13 +97,13 @@ use crate::authority::authority_store::{ExecutionLockReadGuard, InputKey, Object
 use crate::authority::authority_store_pruner::AuthorityStorePruner;
 use crate::authority::epoch_start_configuration::EpochStartConfigTrait;
 use crate::authority::epoch_start_configuration::EpochStartConfiguration;
-use crate::batch_bls_verifier::BatchCertificateVerifierMetrics;
 use crate::checkpoints::CheckpointStore;
 use crate::epoch::committee_store::CommitteeStore;
 use crate::epoch::epoch_metrics::EpochMetrics;
 use crate::event_handler::EventHandler;
 use crate::execution_driver::{execution_process, EXECUTION_MAX_ATTEMPTS};
 use crate::module_cache_metrics::ResolverMetrics;
+use crate::signature_verifier::VerifiedDigestCacheMetrics;
 use crate::stake_aggregator::StakeAggregator;
 use crate::{transaction_input_checker, transaction_manager::TransactionManager};
 
@@ -1731,7 +1731,7 @@ impl AuthorityState {
         );
         let registry = Registry::new();
         let cache_metrics = Arc::new(ResolverMetrics::new(&registry));
-        let batch_verifier_metrics = BatchCertificateVerifierMetrics::new(&registry);
+        let batch_verifier_metrics = VerifiedDigestCacheMetrics::new(&registry);
         let epoch_store = AuthorityPerEpochStore::new(
             name,
             Arc::new(genesis_committee.clone()),

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -35,7 +35,6 @@ use typed_store::traits::{TableSummary, TypedStoreDebug};
 
 use crate::authority::epoch_start_configuration::EpochStartConfiguration;
 use crate::authority::{AuthorityStore, CertTxGuard, ResolverWrapper};
-use crate::batch_bls_verifier::*;
 use crate::checkpoints::{
     CheckpointCommitHeight, CheckpointServiceNotify, EpochStats, PendingCheckpoint,
     PendingCheckpointInfo,
@@ -47,6 +46,7 @@ use crate::consensus_handler::{
 use crate::epoch::epoch_metrics::EpochMetrics;
 use crate::epoch::reconfiguration::ReconfigState;
 use crate::module_cache_metrics::ResolverMetrics;
+use crate::signature_verifier::*;
 use crate::stake_aggregator::StakeAggregator;
 use move_bytecode_utils::module_cache::SyncModuleCache;
 use move_vm_runtime::move_vm::MoveVM;
@@ -116,10 +116,10 @@ pub struct AuthorityPerEpochStore {
     reconfig_state_mem: RwLock<ReconfigState>,
     consensus_notify_read: NotifyRead<SequencedConsensusTransactionKey, ()>,
 
-    /// Batch verifier for certificates - also caches certificates that are known to have
+    /// Batch verifier for certificates - also caches certificates and tx sigs that are known to have
     /// valid signatures. Lives in per-epoch store because the caching/batching is only valid
     /// within for certs within the current epoch.
-    pub(crate) batch_verifier: BatchCertificateVerifier,
+    pub(crate) signature_verifier: SignatureVerifier,
 
     pub(crate) checkpoint_state_notify_read: NotifyRead<CheckpointSequenceNumber, Accumulator>,
 
@@ -332,7 +332,7 @@ impl AuthorityPerEpochStore {
         epoch_start_configuration: EpochStartConfiguration,
         store: Arc<AuthorityStore>,
         cache_metrics: Arc<ResolverMetrics>,
-        batch_verifier_metrics: Arc<BatchCertificateVerifierMetrics>,
+        batch_verifier_metrics: Arc<VerifiedDigestCacheMetrics>,
     ) -> Arc<Self> {
         let current_time = Instant::now();
         let epoch_id = committee.epoch;
@@ -371,8 +371,7 @@ impl AuthorityPerEpochStore {
             .protocol_version();
         let protocol_config = ProtocolConfig::get_for_version(protocol_version);
         let execution_component = ExecutionComponents::new(&protocol_config, store, cache_metrics);
-        let batch_verifier =
-            BatchCertificateVerifier::new(committee.clone(), batch_verifier_metrics);
+        let signature_verifier = SignatureVerifier::new(committee.clone(), batch_verifier_metrics);
         Arc::new(Self {
             committee,
             protocol_config,
@@ -383,7 +382,7 @@ impl AuthorityPerEpochStore {
             epoch_alive_notify,
             epoch_alive: tokio::sync::RwLock::new(true),
             consensus_notify_read: NotifyRead::new(),
-            batch_verifier,
+            signature_verifier,
             checkpoint_state_notify_read: NotifyRead::new(),
             end_of_publish: Mutex::new(end_of_publish),
             pending_consensus_certificates: Mutex::new(pending_consensus_certificates),
@@ -429,7 +428,7 @@ impl AuthorityPerEpochStore {
             epoch_start_configuration,
             store,
             self.execution_component.metrics(),
-            self.batch_verifier.metrics.clone(),
+            self.signature_verifier.metrics.clone(),
         )
     }
 

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -332,7 +332,7 @@ impl AuthorityPerEpochStore {
         epoch_start_configuration: EpochStartConfiguration,
         store: Arc<AuthorityStore>,
         cache_metrics: Arc<ResolverMetrics>,
-        batch_verifier_metrics: Arc<VerifiedDigestCacheMetrics>,
+        signature_verifier_metrics: Arc<VerifiedDigestCacheMetrics>,
     ) -> Arc<Self> {
         let current_time = Instant::now();
         let epoch_id = committee.epoch;
@@ -371,7 +371,8 @@ impl AuthorityPerEpochStore {
             .protocol_version();
         let protocol_config = ProtocolConfig::get_for_version(protocol_version);
         let execution_component = ExecutionComponents::new(&protocol_config, store, cache_metrics);
-        let signature_verifier = SignatureVerifier::new(committee.clone(), batch_verifier_metrics);
+        let signature_verifier =
+            SignatureVerifier::new(committee.clone(), signature_verifier_metrics);
         Arc::new(Self {
             committee,
             protocol_config,

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -362,7 +362,10 @@ impl ValidatorService {
         let certificate = {
             let certificate = {
                 let _timer = metrics.cert_verification_latency.start_timer();
-                epoch_store.batch_verifier.verify_cert(certificate).await?
+                epoch_store
+                    .signature_verifier
+                    .verify_cert(certificate)
+                    .await?
             };
 
             let reconfiguration_lock = epoch_store.get_reconfig_state_read_lock_guard();

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -263,9 +263,14 @@ impl ValidatorService {
         let _metrics_guard = metrics.handle_transaction_latency.start_timer();
         let tx_verif_metrics_guard = metrics.tx_verification_latency.start_timer();
 
-        let transaction = transaction.verify().tap_err(|_| {
-            metrics.signature_errors.inc();
-        })?;
+        epoch_store
+            .signature_verifier
+            .verify_tx(transaction.data())
+            .tap_err(|_| {
+                metrics.signature_errors.inc();
+            })?;
+        let transaction = VerifiedTransaction::new_from_verified(transaction);
+
         tx_verif_metrics_guard.stop_and_record();
 
         let tx_digest = transaction.digest();

--- a/crates/sui-core/src/consensus_validator.rs
+++ b/crates/sui-core/src/consensus_validator.rs
@@ -91,7 +91,7 @@ impl TransactionValidator for SuiTxValidator {
         Handle::current()
             .spawn_blocking(move || {
                 epoch_store
-                    .batch_verifier
+                    .signature_verifier
                     .verify_certs_and_checkpoints(cert_batch, ckpt_batch)
                     .tap_err(|e| warn!("batch verification error: {}", e))
                     .wrap_err("Malformed batch (failed to verify)")

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -43,6 +43,6 @@ mod move_package_upgrade_tests;
 mod pay_sui_tests;
 pub mod test_authority_clients;
 
-pub mod batch_bls_verifier;
+pub mod signature_verifier;
 
 pub const SUI_CORE_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/sui-core/src/signature_verifier.rs
+++ b/crates/sui-core/src/signature_verifier.rs
@@ -271,10 +271,10 @@ impl SignatureVerifier {
 }
 
 pub struct VerifiedDigestCacheMetrics {
-    certificate_signatures_cache_hits: IntCounter,
-    certificate_signatures_cache_evictions: IntCounter,
-    signed_data_cache_hits: IntCounter,
-    signed_data_cache_evictions: IntCounter,
+    pub certificate_signatures_cache_hits: IntCounter,
+    pub certificate_signatures_cache_evictions: IntCounter,
+    pub signed_data_cache_hits: IntCounter,
+    pub signed_data_cache_evictions: IntCounter,
     timeouts: IntCounter,
     full_batches: IntCounter,
     partial_batches: IntCounter,

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2907,7 +2907,7 @@ async fn test_authority_persist() {
         fs::create_dir(&epoch_store_path).unwrap();
         let registry = Registry::new();
         let cache_metrics = Arc::new(ResolverMetrics::new(&registry));
-        let async_batch_verifier_metrics = BatchCertificateVerifierMetrics::new(&registry);
+        let async_batch_verifier_metrics = VerifiedDigestCacheMetrics::new(&registry);
 
         let epoch_store = AuthorityPerEpochStore::new(
             name,

--- a/crates/sui-core/src/unit_tests/batch_verification_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_verification_tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::batch_bls_verifier::*;
+use crate::signature_verifier::*;
 use crate::test_utils::{make_cert_with_large_committee, make_dummy_tx};
 use fastcrypto::traits::KeyPair;
 use futures::future::join_all;
@@ -112,8 +112,8 @@ async fn test_async_verifier() {
     let key_pairs = Arc::new(key_pairs);
 
     let registry = Registry::new();
-    let metrics = BatchCertificateVerifierMetrics::new(&registry);
-    let verifier = Arc::new(BatchCertificateVerifier::new(committee.clone(), metrics));
+    let metrics = VerifiedDigestCacheMetrics::new(&registry);
+    let verifier = Arc::new(SignatureVerifier::new(committee.clone(), metrics));
 
     let tasks: Vec<_> = (0..32)
         .into_iter()

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -39,7 +39,6 @@ use sui_core::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use sui_core::authority::epoch_start_configuration::EpochStartConfiguration;
 use sui_core::authority_aggregator::AuthorityAggregator;
 use sui_core::authority_server::ValidatorService;
-use sui_core::batch_bls_verifier::BatchCertificateVerifierMetrics;
 use sui_core::checkpoints::checkpoint_executor;
 use sui_core::checkpoints::{
     CheckpointMetrics, CheckpointService, CheckpointStore, SendCheckpointToStateSync,
@@ -57,6 +56,7 @@ use sui_core::epoch::epoch_metrics::EpochMetrics;
 use sui_core::epoch::reconfiguration::ReconfigurationInitiator;
 use sui_core::module_cache_metrics::ResolverMetrics;
 use sui_core::narwhal_manager::{NarwhalConfiguration, NarwhalManager, NarwhalManagerMetrics};
+use sui_core::signature_verifier::VerifiedDigestCacheMetrics;
 use sui_core::state_accumulator::StateAccumulator;
 use sui_core::storage::RocksDbStore;
 use sui_core::transaction_orchestrator::TransactiondOrchestrator;
@@ -196,7 +196,7 @@ impl SuiNode {
             .get_epoch_start_configuration()?
             .expect("EpochStartConfiguration of the current epoch must exist");
         let cache_metrics = Arc::new(ResolverMetrics::new(&prometheus_registry));
-        let batch_verifier_metrics = BatchCertificateVerifierMetrics::new(&prometheus_registry);
+        let batch_verifier_metrics = VerifiedDigestCacheMetrics::new(&prometheus_registry);
 
         let epoch_store = AuthorityPerEpochStore::new(
             config.protocol_public_key(),

--- a/crates/sui-types/src/digests.rs
+++ b/crates/sui-types/src/digests.rs
@@ -280,7 +280,7 @@ impl fmt::UpperHex for CheckpointContentsDigest {
     }
 }
 
-/// A digest of a cerificate, which commits to the signatures as well as the tx.
+/// A digest of a certificate, which commits to the signatures as well as the tx.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CertificateDigest(Digest);
 
@@ -297,6 +297,24 @@ impl CertificateDigest {
 impl fmt::Debug for CertificateDigest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("CertificateDigest").field(&self.0).finish()
+    }
+}
+
+/// A digest of a SenderSignedData, which commits to the signatures as well as the tx.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SenderSignedDataDigest(Digest);
+
+impl SenderSignedDataDigest {
+    pub const fn new(digest: [u8; 32]) -> Self {
+        Self(Digest::new(digest))
+    }
+}
+
+impl fmt::Debug for SenderSignedDataDigest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("SenderSignedDataDigest")
+            .field(&self.0)
+            .finish()
     }
 }
 

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -10,7 +10,7 @@ use crate::crypto::{
     DefaultHash, Ed25519SuiSignature, EmptySignInfo, Signature, Signer, SuiSignatureInner,
     ToFromBytes,
 };
-use crate::digests::{CertificateDigest, TransactionEventsDigest};
+use crate::digests::{CertificateDigest, SenderSignedDataDigest, TransactionEventsDigest};
 use crate::gas::GasCostSummary;
 use crate::message_envelope::{Envelope, Message, TrustedEnvelope, VerifiedEnvelope};
 use crate::messages_checkpoint::{
@@ -1648,6 +1648,13 @@ impl SenderSignedData {
     pub fn tx_signatures_mut_for_testing(&mut self) -> &mut Vec<GenericSignature> {
         &mut self.inner_mut().tx_signatures
     }
+
+    pub fn full_message_digest(&self) -> SenderSignedDataDigest {
+        let mut digest = DefaultHash::default();
+        bcs::serialize_into(&mut digest, self).expect("serialization should not fail");
+        let hash = digest.finalize();
+        SenderSignedDataDigest::new(hash.into())
+    }
 }
 
 impl VersionedProtocolMessage for SenderSignedData {
@@ -1899,10 +1906,6 @@ impl CertifiedTransaction {
         bcs::serialize_into(&mut digest, self).expect("serialization should not fail");
         let hash = digest.finalize();
         CertificateDigest::new(hash.into())
-    }
-
-    pub fn verify_sender_signatures(&self) -> SuiResult {
-        self.data().verify(None)
     }
 }
 


### PR DESCRIPTION
## Description 
Cache verified transactions similarly to what we have for BLS signatures.
Currently we verify each signature at least 2 times (`handle_transaction`, `handle_certificate`, etc). This PR will cache the verified tx digests (within an epoch, which should be enough for the happy flow).

## Test Plan 
All tests pass.

### Release notes
Cache verified transactions similarly to what we have for BLS signatures. No impact on external APIs.