### PR TITLE
[explorer]: update Signature page with clickable links for address and signature

### DIFF
--- a/apps/explorer/src/pages/transaction-result/Signatures.tsx
+++ b/apps/explorer/src/pages/transaction-result/Signatures.tsx
@@ -14,6 +14,7 @@ import {
 } from '@mysten/sui.js';
 
 import { DescriptionItem, DescriptionList } from '~/ui/DescriptionList';
+import { AddressLink } from '~/ui/InternalLink';
 import { Tab, TabGroup, TabList } from '~/ui/Tabs';
 import { Text } from '~/ui/Text';
 
@@ -36,9 +37,12 @@ function SignaturePanel({
                     </Text>
                 </DescriptionItem>
                 <DescriptionItem title="Address">
-                    <Text variant="p1/medium" color="steel-darker">
-                        {signature.pubKey.toSuiAddress()}
-                    </Text>
+                    <AddressLink
+                        noTruncate
+                        address={normalizeSuiAddress(
+                            signature.pubKey.toSuiAddress()
+                        )}
+                    />
                 </DescriptionItem>
                 <DescriptionItem title="Signature">
                     <Text variant="p1/medium" color="steel-darker">

--- a/apps/explorer/src/pages/transaction-result/TransactionView.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionView.tsx
@@ -33,7 +33,7 @@ import { ProgrammableTransactionView } from '~/pages/transaction-result/programm
 import { Banner } from '~/ui/Banner';
 import { DateCard } from '~/ui/DateCard';
 import { DescriptionItem, DescriptionList } from '~/ui/DescriptionList';
-import { ObjectLink } from '~/ui/InternalLink';
+import { CheckpointSequenceLink, ObjectLink } from '~/ui/InternalLink';
 import { PageHeader } from '~/ui/PageHeader';
 import { StatAmount } from '~/ui/StatAmount';
 import { TableHeader } from '~/ui/TableHeader';
@@ -308,6 +308,22 @@ export function TransactionView({
                                         .transaction as ProgrammableTransaction
                                 }
                             />
+                        )}
+
+                        {transaction.checkpoint && (
+                            <section className="py-12">
+                                <TableHeader>Checkpoint Detail</TableHeader>
+                                <div className="pt-4">
+                                    <DescriptionItem title="Checkpoint Seq. Number">
+                                        <CheckpointSequenceLink
+                                            noTruncate
+                                            sequence={String(
+                                                transaction.checkpoint
+                                            )}
+                                        />
+                                    </DescriptionItem>
+                                </div>
+                            </section>
                         )}
 
                         <div data-testid="gas-breakdown" className="mt-8">

--- a/apps/explorer/src/ui/InternalLink.tsx
+++ b/apps/explorer/src/ui/InternalLink.tsx
@@ -31,6 +31,11 @@ function createInternalLink<T extends string>(
 }
 
 export const CheckpointLink = createInternalLink('checkpoint', 'digest');
+export const CheckpointSequenceLink = createInternalLink(
+    'checkpoint',
+    'sequence',
+    (address: string) => address
+);
 export const AddressLink = createInternalLink('address', 'address');
 export const ObjectLink = createInternalLink('object', 'objectId');
 export const TransactionLink = createInternalLink(


### PR DESCRIPTION
## Description 

Update signature page with linkable links
https://mysten.atlassian.net/browse/APPS-656

<img width="1461" alt="Screenshot 2023-03-22 at 11 48 18 AM" src="https://user-images.githubusercontent.com/127577476/227006920-1612f3ea-6cd6-48e9-b82d-170a1ff0946f.png">


<img width="625" alt="Screenshot 2023-03-22 at 7 19 26 PM" src="https://user-images.githubusercontent.com/127577476/227083295-127d6373-4250-4b61-9090-f174359901a2.png">


## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
