### PR TITLE
wallet-ext: import mnemonic inputs copy paste improvement

### DIFF
--- a/apps/wallet/src/ui/app/pages/initialize/import/steps/StepOne.tsx
+++ b/apps/wallet/src/ui/app/pages/initialize/import/steps/StepOne.tsx
@@ -86,7 +86,7 @@ export default function StepOne({ next, data, mode }: StepProps) {
                                                     );
                                                 const words = inputText
                                                     .trim()
-                                                    .split(' ')
+                                                    .split(/\W/)
                                                     .map((aWord) =>
                                                         aWord.trim()
                                                     )


### PR DESCRIPTION
## Description 

* when pasting the mnemonic split it by any non word character `\W` to avoid cases when words are split by any other characters that space
* fixes the case when copy-pasting the mnemonic from backup page