### PR TITLE
[ts-sdk] Normalize Sui Address in more places

### DIFF
--- a/apps/explorer/src/pages/transaction-result/Signatures.tsx
+++ b/apps/explorer/src/pages/transaction-result/Signatures.tsx
@@ -37,7 +37,6 @@ function SignaturePanel({
                 </DescriptionItem>
                 <DescriptionItem title="Address">
                     <Text variant="p1/medium" color="steel-darker">
-                        0x
                         {signature.pubKey.toSuiAddress()}
                     </Text>
                 </DescriptionItem>
@@ -57,8 +56,7 @@ function getSignatureFromAddress(
 ) {
     return signatures.find(
         (signature) =>
-            normalizeSuiAddress(signature.pubKey.toSuiAddress()) ===
-            normalizeSuiAddress(suiAddress)
+            signature.pubKey.toSuiAddress() === normalizeSuiAddress(suiAddress)
     );
 }
 

--- a/apps/explorer/tests/objects.spec.ts
+++ b/apps/explorer/tests/objects.spec.ts
@@ -21,7 +21,7 @@ test.describe('Owned Objects', () => {
         const tx = await mint(address);
 
         const [nft] = getCreatedObjects(tx)!;
-        await page.goto(`/address/0x${address}`);
+        await page.goto(`/address/${address}`);
 
         // Find a reference to the NFT:
         await page.getByText(nft.reference.objectId.slice(0, 4)).click();
@@ -29,6 +29,6 @@ test.describe('Owned Objects', () => {
 
         // Find a reference to the owning address:
         await page.getByText(address.slice(0, 4)).click();
-        await expect(page).toHaveURL(`/address/0x${address}`);
+        await expect(page).toHaveURL(`/address/${address}`);
     });
 });

--- a/apps/explorer/tests/search.spec.ts
+++ b/apps/explorer/tests/search.spec.ts
@@ -17,7 +17,7 @@ test('can search for an address', async ({ page }) => {
     const address = await faucet();
     await page.goto('/');
     await search(page, address);
-    await expect(page).toHaveURL(`/address/0x${address}`);
+    await expect(page).toHaveURL(`/address/${address}`);
 });
 
 test('can search for objects', async ({ page }) => {

--- a/apps/wallet/src/background/keyring/DerivedAccount.ts
+++ b/apps/wallet/src/background/keyring/DerivedAccount.ts
@@ -1,11 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-    normalizeSuiAddress,
-    type Keypair,
-    type SuiAddress,
-} from '@mysten/sui.js';
+import { type Keypair, type SuiAddress } from '@mysten/sui.js';
 
 import { type Account, AccountType } from './Account';
 import { AccountKeypair } from './AccountKeypair';
@@ -32,9 +28,7 @@ export class DerivedAccount implements Account {
         this.type = AccountType.IMPORTED;
         this.derivationPath = derivationPath;
         this.accountKeypair = new AccountKeypair(keypair);
-        this.address = normalizeSuiAddress(
-            this.accountKeypair.publicKey.toSuiAddress()
-        );
+        this.address = this.accountKeypair.publicKey.toSuiAddress();
     }
 
     toJSON(): SerializedDerivedAccount {

--- a/apps/wallet/src/background/keyring/ImportedAccount.ts
+++ b/apps/wallet/src/background/keyring/ImportedAccount.ts
@@ -1,11 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-    normalizeSuiAddress,
-    type Keypair,
-    type SuiAddress,
-} from '@mysten/sui.js';
+import { type Keypair, type SuiAddress } from '@mysten/sui.js';
 
 import { type Account, AccountType } from './Account';
 import { AccountKeypair } from './AccountKeypair';
@@ -24,9 +20,7 @@ export class ImportedAccount implements Account {
     constructor({ keypair }: { keypair: Keypair }) {
         this.type = AccountType.IMPORTED;
         this.accountKeypair = new AccountKeypair(keypair);
-        this.address = normalizeSuiAddress(
-            this.accountKeypair.publicKey.toSuiAddress()
-        );
+        this.address = this.accountKeypair.publicKey.toSuiAddress();
     }
 
     toJSON(): SerializedImportedAccount {

--- a/apps/wallet/src/background/keyring/VaultStorage.ts
+++ b/apps/wallet/src/background/keyring/VaultStorage.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { fromExportedKeypair, normalizeSuiAddress } from '@mysten/sui.js';
+import { fromExportedKeypair } from '@mysten/sui.js';
 import { randomBytes } from '@noble/hashes/utils';
 
 import {
@@ -146,9 +146,7 @@ class VaultStorageClass {
             throw new Error('Error, vault is locked. Unlock the vault first.');
         }
         const keypairToImport = fromExportedKeypair(keypair);
-        const importedAddress = normalizeSuiAddress(
-            keypairToImport.getPublicKey().toSuiAddress()
-        );
+        const importedAddress = keypairToImport.getPublicKey().toSuiAddress();
         const isDuplicate = existingAccounts.some(
             (anAccount) => anAccount.address === importedAddress
         );

--- a/apps/wallet/src/test-utils/vault.ts
+++ b/apps/wallet/src/test-utils/vault.ts
@@ -24,27 +24,23 @@ export const testEd25519SerializedLegacy = Object.freeze({
 export const testEd25519Legacy = fromExportedKeypair(
     testEd25519SerializedLegacy
 );
-export const testEd25519AddressLegacy = `0x${testEd25519Legacy
+export const testEd25519AddressLegacy = testEd25519Legacy
     .getPublicKey()
-    .toSuiAddress()}`;
+    .toSuiAddress();
 
 export const testEd25519Serialized = Object.freeze({
     schema: 'ED25519',
     privateKey: 'a3R0jvXpEziZLHsbX1DogdyGm8AK87HScEK+JJHwaV8=',
 } as const);
 export const testEd25519 = fromExportedKeypair(testEd25519Serialized);
-export const testEd25519Address = `0x${testEd25519
-    .getPublicKey()
-    .toSuiAddress()}`;
+export const testEd25519Address = testEd25519.getPublicKey().toSuiAddress();
 
 export const testSecp256k1Serialized = Object.freeze({
     schema: 'Secp256k1',
     privateKey: '4DD3CUtZvbc9Ur69tTvKaLeIDptxNa9qZcpkyXWjVGY=',
 } as const);
 export const testSecp256k1 = fromExportedKeypair(testSecp256k1Serialized);
-export const testSecp256k1Address = `0x${testSecp256k1
-    .getPublicKey()
-    .toSuiAddress()}`;
+export const testSecp256k1Address = testSecp256k1.getPublicKey().toSuiAddress();
 type TestDataVault = typeof testDataVault1;
 /**
  * A test vault with 2 keypairs

--- a/apps/wallet/src/ui/app/components/ledger/useDeriveLedgerAccounts.ts
+++ b/apps/wallet/src/ui/app/components/ledger/useDeriveLedgerAccounts.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Ed25519PublicKey, normalizeSuiAddress } from '@mysten/sui.js';
+import { Ed25519PublicKey } from '@mysten/sui.js';
 import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
 
 import { useSuiLedgerClient } from './SuiLedgerClientProvider';
@@ -59,7 +59,7 @@ async function deriveAccountsFromLedger(
             derivationPath
         );
         const publicKey = new Ed25519PublicKey(publicKeyResult.publicKey);
-        const suiAddress = normalizeSuiAddress(publicKey.toSuiAddress());
+        const suiAddress = publicKey.toSuiAddress();
         ledgerAccounts.push({
             type: AccountType.LEDGER,
             address: suiAddress,

--- a/apps/wallet/src/ui/app/pages/approval-request/transaction-request/TransactionDetails/Command.tsx
+++ b/apps/wallet/src/ui/app/pages/approval-request/transaction-request/TransactionDetails/Command.tsx
@@ -6,6 +6,7 @@ import {
     type CommandArgument,
     formatAddress,
     type TransactionCommand,
+    normalizeSuiAddress,
 } from '@mysten/sui.js';
 import { useState } from 'react';
 
@@ -44,7 +45,7 @@ function convertCommandToString({ kind, ...command }: TransactionCommand) {
             if (key === 'target') {
                 const [packageId, moduleName, functionName] = value.split('::');
                 return [
-                    `package: ${formatAddress(packageId)}`,
+                    `package: ${formatAddress(normalizeSuiAddress(packageId))}`,
                     `module: ${moduleName}`,
                     `function: ${functionName}`,
                 ].join(', ');

--- a/apps/wallet/tests/onboarding.spec.ts
+++ b/apps/wallet/tests/onboarding.spec.ts
@@ -24,6 +24,6 @@ test('import wallet', async ({ page, extensionUrl }) => {
     await page.getByRole('button', { name: /Open Sui Wallet/ }).click();
     await expect(page.getByTestId('coin-page')).toBeVisible();
     await expect(
-        page.getByText(keypair.getPublicKey().toSuiAddress().slice(0, 4))
+        page.getByText(keypair.getPublicKey().toSuiAddress().slice(0, 6))
     ).toBeVisible();
 });

--- a/crates/sui-core/src/unit_tests/data/entry_point_types/Move.lock
+++ b/crates/sui-core/src/unit_tests/data/entry_point_types/Move.lock
@@ -9,11 +9,11 @@ dependencies = [
 
 [[move.package]]
 name = "MoveStdlib"
-source = { local = "../../../../../sui-framework/deps/move-stdlib" }
+source = { local = "../../../../../sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 name = "Sui"
-source = { local = "../../../../../sui-framework" }
+source = { local = "../../../../../sui-framework/packages/sui-framework" }
 
 dependencies = [
   { name = "MoveStdlib" },

--- a/crates/sui-core/src/unit_tests/data/entry_point_vector/Move.lock
+++ b/crates/sui-core/src/unit_tests/data/entry_point_vector/Move.lock
@@ -9,11 +9,11 @@ dependencies = [
 
 [[move.package]]
 name = "MoveStdlib"
-source = { local = "../../../../../sui-framework/deps/move-stdlib" }
+source = { local = "../../../../../sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 name = "Sui"
-source = { local = "../../../../../sui-framework" }
+source = { local = "../../../../../sui-framework/packages/sui-framework" }
 
 dependencies = [
   { name = "MoveStdlib" },

--- a/sdk/typescript/src/builder/Inputs.ts
+++ b/sdk/typescript/src/builder/Inputs.ts
@@ -10,7 +10,12 @@ import {
   string,
   union,
 } from 'superstruct';
-import { ObjectId, SharedObjectRef, SuiObjectRef } from '../types';
+import {
+  normalizeSuiAddress,
+  ObjectId,
+  SharedObjectRef,
+  SuiObjectRef,
+} from '../types';
 import { builder } from './bcs';
 
 const ObjectArg = union([
@@ -50,7 +55,7 @@ export const Inputs = {
 
 export function getIdFromCallArg(arg: ObjectId | ObjectCallArg) {
   if (typeof arg === 'string') {
-    return arg;
+    return normalizeSuiAddress(arg);
   }
   if ('ImmOrOwned' in arg.Object) {
     return arg.Object.ImmOrOwned.objectId;
@@ -61,13 +66,13 @@ export function getIdFromCallArg(arg: ObjectId | ObjectCallArg) {
 export function getSharedObjectInput(
   arg: BuilderCallArg,
 ): SharedObjectRef | undefined {
-  return typeof arg == 'object' && 'Object' in arg && 'Shared' in arg.Object
+  return typeof arg === 'object' && 'Object' in arg && 'Shared' in arg.Object
     ? arg.Object.Shared
     : undefined;
 }
 
 export function isSharedObjectInput(arg: BuilderCallArg): boolean {
-  return getSharedObjectInput(arg) !== undefined;
+  return !!getSharedObjectInput(arg);
 }
 
 export function isMutableSharedObjectInput(arg: BuilderCallArg): boolean {

--- a/sdk/typescript/src/cryptography/ed25519-publickey.ts
+++ b/sdk/typescript/src/cryptography/ed25519-publickey.ts
@@ -5,7 +5,7 @@ import { blake2b } from '@noble/hashes/blake2b';
 import { fromB64, toB64 } from '@mysten/bcs';
 import { bytesEqual, PublicKeyInitData } from './publickey';
 import { SIGNATURE_SCHEME_TO_FLAG } from './signature';
-import { SUI_ADDRESS_LENGTH } from '../types';
+import { normalizeSuiAddress, SUI_ADDRESS_LENGTH } from '../types';
 import { bytesToHex } from '@noble/hashes/utils';
 
 const PUBLIC_KEY_SIZE = 32;
@@ -73,9 +73,8 @@ export class Ed25519PublicKey {
     tmp.set([SIGNATURE_SCHEME_TO_FLAG['ED25519']]);
     tmp.set(this.toBytes(), 1);
     // Each hex char represents half a byte, hence hex address doubles the length
-    return bytesToHex(blake2b(tmp, { dkLen: 32 })).slice(
-      0,
-      SUI_ADDRESS_LENGTH * 2,
+    return normalizeSuiAddress(
+      bytesToHex(blake2b(tmp, { dkLen: 32 })).slice(0, SUI_ADDRESS_LENGTH * 2),
     );
   }
 }

--- a/sdk/typescript/src/cryptography/secp256k1-publickey.ts
+++ b/sdk/typescript/src/cryptography/secp256k1-publickey.ts
@@ -4,7 +4,7 @@
 import { fromB64, toB64 } from '@mysten/bcs';
 import { blake2b } from '@noble/hashes/blake2b';
 import { bytesToHex } from '@noble/hashes/utils';
-import { SUI_ADDRESS_LENGTH } from '../types';
+import { normalizeSuiAddress, SUI_ADDRESS_LENGTH } from '../types';
 import { bytesEqual, PublicKey, PublicKeyInitData } from './publickey';
 import { SIGNATURE_SCHEME_TO_FLAG } from './signature';
 
@@ -73,9 +73,8 @@ export class Secp256k1PublicKey implements PublicKey {
     tmp.set([SIGNATURE_SCHEME_TO_FLAG['Secp256k1']]);
     tmp.set(this.toBytes(), 1);
     // Each hex char represents half a byte, hence hex address doubles the length
-    return bytesToHex(blake2b(tmp, { dkLen: 32 })).slice(
-      0,
-      SUI_ADDRESS_LENGTH * 2,
+    return normalizeSuiAddress(
+      bytesToHex(blake2b(tmp, { dkLen: 32 })).slice(0, SUI_ADDRESS_LENGTH * 2),
     );
   }
 }

--- a/sdk/typescript/test/e2e/data/coin_metadata/Move.lock
+++ b/sdk/typescript/test/e2e/data/coin_metadata/Move.lock
@@ -9,11 +9,11 @@ dependencies = [
 
 [[move.package]]
 name = "MoveStdlib"
-source = { local = "../../../../../../crates/sui-framework/deps/move-stdlib" }
+source = { local = "../../../../../../crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 name = "Sui"
-source = { local = "../../../../../../crates/sui-framework" }
+source = { local = "../../../../../../crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { name = "MoveStdlib" },

--- a/sdk/typescript/test/e2e/data/dynamic_fields/Move.lock
+++ b/sdk/typescript/test/e2e/data/dynamic_fields/Move.lock
@@ -9,11 +9,11 @@ dependencies = [
 
 [[move.package]]
 name = "MoveStdlib"
-source = { local = "../../../../../../crates/sui-framework/deps/move-stdlib" }
+source = { local = "../../../../../../crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 name = "Sui"
-source = { local = "../../../../../../crates/sui-framework" }
+source = { local = "../../../../../../crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { name = "MoveStdlib" },

--- a/sdk/typescript/test/e2e/data/id_entry_args/Move.lock
+++ b/sdk/typescript/test/e2e/data/id_entry_args/Move.lock
@@ -9,11 +9,11 @@ dependencies = [
 
 [[move.package]]
 name = "MoveStdlib"
-source = { local = "../../../../../../crates/sui-framework/deps/move-stdlib" }
+source = { local = "../../../../../../crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 name = "Sui"
-source = { local = "../../../../../../crates/sui-framework" }
+source = { local = "../../../../../../crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { name = "MoveStdlib" },

--- a/sdk/typescript/test/e2e/data/serializer/Move.lock
+++ b/sdk/typescript/test/e2e/data/serializer/Move.lock
@@ -9,11 +9,11 @@ dependencies = [
 
 [[move.package]]
 name = "MoveStdlib"
-source = { local = "../../../../../../crates/sui-framework/deps/move-stdlib" }
+source = { local = "../../../../../../crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 name = "Sui"
-source = { local = "../../../../../../crates/sui-framework" }
+source = { local = "../../../../../../crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { name = "MoveStdlib" },

--- a/sdk/typescript/test/e2e/governance.test.ts
+++ b/sdk/typescript/test/e2e/governance.test.ts
@@ -27,6 +27,7 @@ describe('Governance API', () => {
   });
 
   it('test getDelegatedStakes', async () => {
+    await addStake(signer);
     const stakes = await toolbox.provider.getStakes({
       owner: toolbox.address(),
     });

--- a/sdk/typescript/test/e2e/object-display-standard.test.ts
+++ b/sdk/typescript/test/e2e/object-display-standard.test.ts
@@ -33,7 +33,7 @@ describe('Test Object Display Standard', () => {
     );
     expect(display).toEqual({
       age: '10',
-      buyer: `0x${toolbox.address()}`,
+      buyer: toolbox.address(),
       creator: 'Chris',
       description: `Unique Boar from the Boars collection with First Boar and ${boarId}`,
       img_url: 'https://get-a-boar.com/first.png',

--- a/sdk/typescript/test/e2e/raw-signer.test.ts
+++ b/sdk/typescript/test/e2e/raw-signer.test.ts
@@ -32,19 +32,19 @@ const TEST_CASES = [
   [
     'film crazy soon outside stand loop subway crumble thrive popular green nuclear struggle pistol arm wife phrase warfare march wheat nephew ask sunny firm',
     'ImR/7u82MGC9QgWhZxoV8QoSNnZZGLG19jjYLzPPxGk=',
-    'a2d14fad60c56049ecf75246a481934691214ce413e6a8ae2fe6834c173a6133',
+    '0xa2d14fad60c56049ecf75246a481934691214ce413e6a8ae2fe6834c173a6133',
     'NwIObhuKot7QRWJu4wWCC5ttOgEfN7BrrVq1draImpDZqtKEaWjNNRKKfWr1FL4asxkBlQd8IwpxpKSTzcXMAQ==',
   ],
   [
     'require decline left thought grid priority false tiny gasp angle royal system attack beef setup reward aunt skill wasp tray vital bounce inflict level',
     'vG6hEnkYNIpdmWa/WaLivd1FWBkxG+HfhXkyWgs9uP4=',
-    '1ada6e6f3f3e4055096f606c746690f1108fcc2ca479055cc434a3e1d3f758aa',
+    '0x1ada6e6f3f3e4055096f606c746690f1108fcc2ca479055cc434a3e1d3f758aa',
     '8BSMw/VdYSXxbpl5pp8b5ylWLntTWfBG3lSvAHZbsV9uD2/YgsZDbhVba4rIPhGTn3YvDNs3FOX5+EIXMup3Bw==',
   ],
   [
     'organ crash swim stick traffic remember army arctic mesh slice swear summer police vast chaos cradle squirrel hood useless evidence pet hub soap lake',
     'arEzeF7Uu90jP4Sd+Or17c+A9kYviJpCEQAbEt0FHbU=',
-    'e69e896ca10f5a77732769803cc2b5707f0ab9d4407afb5e4b4464b89769af14',
+    '0xe69e896ca10f5a77732769803cc2b5707f0ab9d4407afb5e4b4464b89769af14',
     '/ihBMku1SsqK+yDxNY47N/tAREZ+gWVTvZrUoCHsGGR9CoH6E7SLKDRYY9RnwBw/Bt3wWcdJ0Wc2Q3ioHIlzDA==',
   ],
 ];
@@ -58,19 +58,19 @@ const TEST_CASES_SECP256K1 = [
   [
     'film crazy soon outside stand loop subway crumble thrive popular green nuclear struggle pistol arm wife phrase warfare march wheat nephew ask sunny firm',
     'Ar2Vs2ei2HgaCIvcsAVAZ6bKYXhDfRTlF432p8Wn4lsL',
-    '9e8f732575cc5386f8df3c784cd3ed1b53ce538da79926b2ad54dcc1197d2532',
+    '0x9e8f732575cc5386f8df3c784cd3ed1b53ce538da79926b2ad54dcc1197d2532',
     'y7a8KDd9Py4i5GIka7zAFSHOCOTVLm9ibDx3wPd6WsQa7C1FUdxz32+h5TYmNNWUpTRgWgdBAeG9OgAnDBg0cQ==',
   ],
   [
     'require decline left thought grid priority false tiny gasp angle royal system attack beef setup reward aunt skill wasp tray vital bounce inflict level',
     'A5IcrmWDxl0J/4MNkrtE1AvwiLZiqih9tjttcGlafw+m',
-    '9fd5a804ed6b46d36949ff7434247f0fd594673973ece24aede6b86a7b5dae01',
+    '0x9fd5a804ed6b46d36949ff7434247f0fd594673973ece24aede6b86a7b5dae01',
     'ijfLeBFowLQjuUD9h6/q9cmuZGg1Afo0ZgZJsZrJsIt2FSFddIomOzqnan3v1T9aW14aBMAlymUELgryib4Q/A==',
   ],
   [
     'organ crash swim stick traffic remember army arctic mesh slice swear summer police vast chaos cradle squirrel hood useless evidence pet hub soap lake',
     'AuEiECTZwyHhqStzpO/RNBXO89/Wa8oc4BtoneKnl6h8',
-    '60287d7c38dee783c2ab1077216124011774be6b0764d62bd05f32c88979d5c5',
+    '0x60287d7c38dee783c2ab1077216124011774be6b0764d62bd05f32c88979d5c5',
     'qAZyBPNUOtr2uKNByx9HNpWlDxQrOCjtMajYXGTAtWMnTp1cFYMe6QyT0EsYJ0t5xKtK8xq29yChbpsHWz94qA==',
   ],
 ];

--- a/sdk/typescript/test/unit/cryptography/ed25519-keypair.test.ts
+++ b/sdk/typescript/test/unit/cryptography/ed25519-keypair.test.ts
@@ -13,17 +13,17 @@ const TEST_CASES = [
   [
     'film crazy soon outside stand loop subway crumble thrive popular green nuclear struggle pistol arm wife phrase warfare march wheat nephew ask sunny firm',
     'AN0JMHpDum3BhrVwnkylH0/HGRHBQ/fO/8+MYOawO8j6',
-    'a2d14fad60c56049ecf75246a481934691214ce413e6a8ae2fe6834c173a6133',
+    '0xa2d14fad60c56049ecf75246a481934691214ce413e6a8ae2fe6834c173a6133',
   ],
   [
     'require decline left thought grid priority false tiny gasp angle royal system attack beef setup reward aunt skill wasp tray vital bounce inflict level',
     'AJrA997C1eVz6wYIp7bO8dpITSRBXpvg1m70/P3gusu2',
-    '1ada6e6f3f3e4055096f606c746690f1108fcc2ca479055cc434a3e1d3f758aa',
+    '0x1ada6e6f3f3e4055096f606c746690f1108fcc2ca479055cc434a3e1d3f758aa',
   ],
   [
     'organ crash swim stick traffic remember army arctic mesh slice swear summer police vast chaos cradle squirrel hood useless evidence pet hub soap lake',
     'AAEMSIQeqyz09StSwuOW4MElQcZ+4jHW4/QcWlJEf5Yk',
-    'e69e896ca10f5a77732769803cc2b5707f0ab9d4407afb5e4b4464b89769af14',
+    '0xe69e896ca10f5a77732769803cc2b5707f0ab9d4407afb5e4b4464b89769af14',
   ],
 ];
 

--- a/sdk/typescript/test/unit/cryptography/ed25519-publickey.test.ts
+++ b/sdk/typescript/test/unit/cryptography/ed25519-publickey.test.ts
@@ -11,15 +11,15 @@ import { Ed25519PublicKey } from '../../../src';
 let TEST_CASES = new Map<string, string>([
   [
     'UdGRWooy48vGTs0HBokIis5NK+DUjiWc9ENUlcfCCBE=',
-    'd77a6cd55073e98d4029b1b0b8bd8d88f45f343dad2732fc9a7965094e635c55',
+    '0xd77a6cd55073e98d4029b1b0b8bd8d88f45f343dad2732fc9a7965094e635c55',
   ],
   [
     '0PTAfQmNiabgbak9U/stWZzKc5nsRqokda2qnV2DTfg=',
-    '7e8fd489c3d3cd9cc7cbcc577dc5d6de831e654edd9997d95c412d013e6eea23',
+    '0x7e8fd489c3d3cd9cc7cbcc577dc5d6de831e654edd9997d95c412d013e6eea23',
   ],
   [
     '6L/l0uhGt//9cf6nLQ0+24Uv2qanX/R6tn7lWUJX1Xk=',
-    '3a1b4410ebe9c3386a429c349ba7929aafab739c277f97f32622b971972a14a2',
+    '0x3a1b4410ebe9c3386a429c349ba7929aafab739c277f97f32622b971972a14a2',
   ],
 ]);
 

--- a/sdk/typescript/test/unit/cryptography/secp256k1-keypair.test.ts
+++ b/sdk/typescript/test/unit/cryptography/secp256k1-keypair.test.ts
@@ -38,17 +38,17 @@ const TEST_CASES = [
   [
     'film crazy soon outside stand loop subway crumble thrive popular green nuclear struggle pistol arm wife phrase warfare march wheat nephew ask sunny firm',
     'AQA9EYZoLXirIahsXHQMDfdi5DPQ72wLA79zke4EY6CP',
-    '9e8f732575cc5386f8df3c784cd3ed1b53ce538da79926b2ad54dcc1197d2532',
+    '0x9e8f732575cc5386f8df3c784cd3ed1b53ce538da79926b2ad54dcc1197d2532',
   ],
   [
     'require decline left thought grid priority false tiny gasp angle royal system attack beef setup reward aunt skill wasp tray vital bounce inflict level',
     'Ae+TTptXI6WaJfzplSrphnrbTD5qgftfMX5kTyca7unQ',
-    '9fd5a804ed6b46d36949ff7434247f0fd594673973ece24aede6b86a7b5dae01',
+    '0x9fd5a804ed6b46d36949ff7434247f0fd594673973ece24aede6b86a7b5dae01',
   ],
   [
     'organ crash swim stick traffic remember army arctic mesh slice swear summer police vast chaos cradle squirrel hood useless evidence pet hub soap lake',
     'AY2iJpGSDMhvGILPjjpyeM1bV4Jky979nUenB5kvQeSj',
-    '60287d7c38dee783c2ab1077216124011774be6b0764d62bd05f32c88979d5c5',
+    '0x60287d7c38dee783c2ab1077216124011774be6b0764d62bd05f32c88979d5c5',
   ],
 ];
 

--- a/sdk/typescript/test/unit/cryptography/secp256k1-publickey.test.ts
+++ b/sdk/typescript/test/unit/cryptography/secp256k1-publickey.test.ts
@@ -16,19 +16,19 @@ import {
 let SECP_TEST_CASES = new Map<string, string>([
   [
     'AwTC3jVFRxXc3RJIFgoQcv486QdqwYa8vBp4bgSq0gsI',
-    'cdce00b4326fb908fdac83c35bcfbda323bfcc0618b47c66ccafbdced850efaa',
+    '0xcdce00b4326fb908fdac83c35bcfbda323bfcc0618b47c66ccafbdced850efaa',
   ],
   [
     'A1F2CtldIGolO92Pm9yuxWXs5E07aX+6ZEHAnSuKOhii',
-    'b588e58ed8967b6a6f9dbce76386283d374cf7389fb164189551257e32b023b2',
+    '0xb588e58ed8967b6a6f9dbce76386283d374cf7389fb164189551257e32b023b2',
   ],
   [
     'Ak5rsa5Od4T6YFN/V3VIhZ/azMMYPkUilKQwc+RiaId+',
-    '694dd74af1e82b968822a82fb5e315f6d20e8697d5d03c0b15e0178c1a1fcfa0',
+    '0x694dd74af1e82b968822a82fb5e315f6d20e8697d5d03c0b15e0178c1a1fcfa0',
   ],
   [
     'A4XbJ3fLvV/8ONsnLHAW1nORKsoCYsHaXv9FK1beMtvY',
-    '78acc6ca0003457737d755ade25a6f3a144e5e44ed6f8e6af4982c5cc75e55e7',
+    '0x78acc6ca0003457737d755ade25a6f3a144e5e44ed6f8e6af4982c5cc75e55e7',
   ],
 ]);
 describe('Secp256k1PublicKey', () => {


### PR DESCRIPTION
## Description 

This normalizes Sui address in more cases in the TS SDK, so that they don't require normalization as much externally. Specifically `toSuiAddress()` in public keys, and when taking an object as input in the programmable transaction builder. The effect of this is that `0x` should now consistently be included in address internally.

## Test Plan 

Updated tests to include `0x`.
