### PR TITLE
[ts-sdk] add `getEpochs` and `getCurrentEpoch` endpoints

### DIFF
--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -62,6 +62,7 @@ import { Connection, devnetConnection } from '../rpc/connection';
 import { Transaction } from '../builder';
 import { CheckpointPage } from '../types/checkpoints';
 import { RPCError } from '../utils/errors';
+import { EpochInfo, EpochPage } from '../types/epochs';
 
 export const TARGETED_RPC_VERSION = '0.27.0';
 
@@ -860,6 +861,32 @@ export class JsonRpcProvider {
       'sui_getCommitteeInfo',
       [input?.epoch],
       CommitteeInfo,
+    );
+  }
+  /**
+   * Retrieves a historical list of epochs. Extended API (requires sui-indexer)
+   */
+  async getEpochs(input?: {
+    cursor?: number;
+    limit?: number;
+  }): Promise<EpochPage> {
+    return await this.client.requestWithType(
+      'suix_getEpochs',
+      [input?.cursor, input?.limit],
+      EpochPage,
+      this.options.skipDataValidation,
+    );
+  }
+  /**
+   * Retrieves info about the current epoch. Extended API (requires sui-indexer)
+   * @
+   */
+  async getCurrentEpoch(): Promise<EpochInfo> {
+    return await this.client.requestWithType(
+      'suix_getCurrentEpoch',
+      [],
+      EpochInfo,
+      this.options.skipDataValidation,
     );
   }
 }

--- a/sdk/typescript/src/types/epochs.ts
+++ b/sdk/typescript/src/types/epochs.ts
@@ -1,0 +1,51 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  array,
+  boolean,
+  Infer,
+  literal,
+  nullable,
+  number,
+  object,
+  union,
+} from 'superstruct';
+import { SuiValidatorSummary } from './validator';
+
+export const EndOfEpochInfo = object({
+  lastCheckpointId: number(),
+  epochEndTimestamp: number(),
+  protocolVersion: number(),
+  referenceGasPrice: number(),
+  totalStake: number(),
+  storageFundReinvestment: number(),
+  storageCharge: number(),
+  storageRebate: number(),
+  storageFundBalance: number(),
+  stakeSubsidyAmount: number(),
+  totalGasFees: number(),
+  totalStakeRewardsDistributed: number(),
+  leftoverStorageFundInflow: number(),
+});
+
+export type EndOfEpochInfo = Infer<typeof EndOfEpochInfo>;
+
+export const EpochInfo = object({
+  epoch: number(),
+  validators: array(SuiValidatorSummary),
+  epochTotalTransactions: number(),
+  firstCheckpointId: number(),
+  epochStartTimestamp: number(),
+  endOfEpochInfo: nullable(EndOfEpochInfo),
+});
+
+export type EpochInfo = Infer<typeof EpochInfo>;
+
+export const EpochPage = object({
+  data: array(EpochInfo),
+  nextCursor: union([number(), literal(null)]),
+  hasNextPage: boolean(),
+});
+
+export type EpochPage = Infer<typeof EpochPage>;

--- a/sdk/typescript/src/types/validator.ts
+++ b/sdk/typescript/src/types/validator.ts
@@ -99,10 +99,12 @@ export const DelegationStakingPool = object({
   fields: DelegationStakingPoolFields,
 });
 
+export const Validators = array(tuple([AuthorityName, number()]));
+
 export const CommitteeInfo = object({
   epoch: number(),
   /** Array of (validator public key, stake unit) tuple */
-  validators: optional(array(tuple([AuthorityName, number()]))),
+  validators: Validators,
 });
 
 export const SuiValidatorSummary = object({


### PR DESCRIPTION
## Description 

Adds TS sdk support for the `getEpochs` and `getCurrentEpoch` endpoints

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
