### PR TITLE
[wallet-ext] add account badge to the account selector dropdown

### DIFF
--- a/apps/wallet/src/ui/app/components/AccountBadge.tsx
+++ b/apps/wallet/src/ui/app/components/AccountBadge.tsx
@@ -1,0 +1,34 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { AccountType } from '_src/background/keyring/Account';
+import { Text } from '_src/ui/app/shared/text';
+
+type AccountBadgeProps = {
+    accountType: AccountType;
+};
+
+export function AccountBadge({ accountType }: AccountBadgeProps) {
+    let badgeText: string | null = null;
+    switch (accountType) {
+        case AccountType.LEDGER:
+            badgeText = 'Ledger';
+            break;
+        case AccountType.IMPORTED:
+            badgeText = 'Imported';
+            break;
+        case AccountType.DERIVED:
+            badgeText = null;
+            break;
+        default:
+            throw new Error(`Encountered unknown account type ${accountType}`);
+    }
+
+    return badgeText ? (
+        <div className="bg-gray-40 rounded-2xl border border-solid border-gray-45 py-1 px-1.5">
+            <Text variant="captionSmallExtra" color="steel-dark">
+                {badgeText}
+            </Text>
+        </div>
+    ) : null;
+}

--- a/apps/wallet/src/ui/app/components/AccountList.tsx
+++ b/apps/wallet/src/ui/app/components/AccountList.tsx
@@ -11,14 +11,14 @@ export type AccountListProps = {
 export function AccountList({ onAccountSelected }: AccountListProps) {
     const allAccounts = useAccounts();
     return (
-        <div className="flex flex-col items-stretch">
-            {allAccounts.map(({ address }) => (
+        <ul className="list-none m-0 px-0 py-1.25 flex flex-col items-stretch">
+            {allAccounts.map((account) => (
                 <AccountListItem
-                    address={address}
-                    key={address}
+                    account={account}
+                    key={account.address}
                     onAccountSelected={onAccountSelected}
                 />
             ))}
-        </div>
+        </ul>
     );
 }

--- a/apps/wallet/src/ui/app/components/AccountListItem.tsx
+++ b/apps/wallet/src/ui/app/components/AccountListItem.tsx
@@ -2,49 +2,53 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Check12, Copy12 } from '@mysten/icons';
-import { formatAddress, type SuiAddress } from '@mysten/sui.js';
+import { formatAddress } from '@mysten/sui.js';
 
-import { useAccounts } from '../hooks/useAccounts';
 import { useActiveAddress } from '../hooks/useActiveAddress';
 import { useCopyToClipboard } from '../hooks/useCopyToClipboard';
 import { Text } from '../shared/text';
+import { AccountBadge } from './AccountBadge';
+import { type SerializedAccount } from '_src/background/keyring/Account';
 
 export type AccountItemProps = {
-    address: SuiAddress;
-    onAccountSelected: (address: SuiAddress) => void;
+    account: SerializedAccount;
+    onAccountSelected: (address: SerializedAccount) => void;
 };
 
 export function AccountListItem({
-    address,
+    account,
     onAccountSelected,
 }: AccountItemProps) {
-    const account = useAccounts([address])[0];
+    const { address, type } = account;
     const activeAddress = useActiveAddress();
     const copy = useCopyToClipboard(address, {
         copySuccessMessage: 'Address Copied',
     });
-    if (!account) {
-        return null;
-    }
+
     return (
-        <div
-            className="flex p-2.5 items-start gap-2.5 rounded-md hover:bg-sui/10 cursor-pointer focus-visible:ring-1 group transition-colors"
-            onClick={() => {
-                onAccountSelected(address);
-            }}
-        >
-            <div className="flex-1">
-                <Text color="steel-darker" variant="bodySmall" mono>
-                    {formatAddress(address)}
-                </Text>
-            </div>
-            {activeAddress === address ? (
-                <Check12 className="text-success" />
-            ) : null}
-            <Copy12
-                className="text-gray-60 group-hover:text-steel transition-colors hover:!text-hero-dark"
-                onClick={copy}
-            />
-        </div>
+        <li>
+            <button
+                className="appearance-none bg-transparent border-0 w-full flex p-2.5 items-center gap-2.5 rounded-md hover:bg-sui/10 cursor-pointer focus-visible:ring-1 group transition-colors"
+                onClick={() => {
+                    onAccountSelected(account);
+                }}
+            >
+                <div className="flex items-center gap-2 flex-1">
+                    <div className="shrink-0">
+                        <Text color="steel-darker" variant="bodySmall" mono>
+                            {formatAddress(address)}
+                        </Text>
+                    </div>
+                    <AccountBadge accountType={type} />
+                </div>
+                {activeAddress === address ? (
+                    <Check12 className="text-success" />
+                ) : null}
+                <Copy12
+                    className="text-gray-60 group-hover:text-steel transition-colors hover:!text-hero-dark"
+                    onClick={copy}
+                />
+            </button>
+        </li>
     );
 }

--- a/apps/wallet/src/ui/app/components/AccountSelector.tsx
+++ b/apps/wallet/src/ui/app/components/AccountSelector.tsx
@@ -59,16 +59,14 @@ export function AccountSelector() {
                         leaveFrom="transform scale-100 opacity-100"
                         leaveTo="transform scale-75 opacity-0"
                     >
-                        <Popover.Panel className="absolute left-1/2 -translate-x-1/2 w-50 drop-shadow-accountModal mt-2 z-0 rounded-md bg-white">
+                        <Popover.Panel className="absolute left-1/2 -translate-x-1/2 w-60 drop-shadow-accountModal mt-2 z-0 rounded-md bg-white">
                             <div className="absolute w-3 h-3 bg-white -top-1 left-1/2 -translate-x-1/2 rotate-45" />
-                            <div className="relative px-1.25 my-1.25 max-h-80 overflow-y-auto max-w-full z-10">
+                            <div className="relative px-1.25 max-h-80 overflow-y-auto max-w-full z-10">
                                 <AccountList
-                                    onAccountSelected={async (
-                                        selectedAddress
-                                    ) => {
-                                        if (selectedAddress !== activeAddress) {
+                                    onAccountSelected={async ({ address }) => {
+                                        if (address !== activeAddress) {
                                             await backgroundClient.selectAccount(
-                                                selectedAddress
+                                                address
                                             );
                                         }
                                         close();

--- a/apps/wallet/src/ui/app/components/menu/content/Account.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/Account.tsx
@@ -6,11 +6,11 @@ import { ChevronDown16, Copy16 } from '@mysten/icons';
 import { formatAddress } from '@mysten/sui.js';
 import { cx } from 'class-variance-authority';
 
+import { AccountBadge } from '../../AccountBadge';
 import { AccountActions } from './AccountActions';
-import { AccountType } from '_src/background/keyring/Account';
+import { type AccountType } from '_src/background/keyring/Account';
 import { useCopyToClipboard } from '_src/ui/app/hooks/useCopyToClipboard';
 import { Heading } from '_src/ui/app/shared/heading';
-import { Text } from '_src/ui/app/shared/text';
 
 export type AccountProps = {
     address: string;
@@ -73,33 +73,4 @@ export function Account({ address, accountType }: AccountProps) {
             )}
         </Disclosure>
     );
-}
-
-type AccountBadgeProps = {
-    accountType: AccountType;
-};
-
-function AccountBadge({ accountType }: AccountBadgeProps) {
-    let badgeText: string | null = null;
-    switch (accountType) {
-        case AccountType.LEDGER:
-            badgeText = 'Ledger';
-            break;
-        case AccountType.IMPORTED:
-            badgeText = 'Imported';
-            break;
-        case AccountType.DERIVED:
-            badgeText = null;
-            break;
-        default:
-            throw new Error(`Encountered unknown account type ${accountType}`);
-    }
-
-    return badgeText ? (
-        <div className="bg-gray-40 rounded-2xl border border-solid border-gray-45 py-1 px-1.5">
-            <Text variant="captionSmallExtra" color="steel-dark">
-                {badgeText}
-            </Text>
-        </div>
-    ) : null;
 }


### PR DESCRIPTION
## Description 
This PR adds a badge to the account selector dropdown so folks can easily identify their accounts. I also made some small accessibility improvements like using an unordered list and using a `button` vs a clickable div.

<img width="307" alt="image" src="https://user-images.githubusercontent.com/7453188/227027566-2e779fc9-eeb2-42b6-97ba-1497de3030bc.png">
 
Focus state:
<img width="305" alt="image" src="https://user-images.githubusercontent.com/7453188/227027678-c0f0242b-f374-4997-9584-92cddb06fdf6.png">

## Test Plan 
- Manual testing (regular/imported/Ledger accounts)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
N/A
