### PR TITLE
[genesis] Reduce dependency on inner type

### DIFF
--- a/crates/sui-config/src/swarm.rs
+++ b/crates/sui-config/src/swarm.rs
@@ -25,7 +25,6 @@ use sui_types::crypto::{
     get_key_pair_from_rng, AccountKeyPair, AuthorityKeyPair, NetworkKeyPair, SuiKeyPair,
 };
 use sui_types::multiaddr::Multiaddr;
-use sui_types::sui_system_state::SuiSystemStateInnerGenesis;
 
 /// This is a config that is used for testing or local use as it contains the config and keys for
 /// all validators
@@ -51,10 +50,6 @@ impl NetworkConfig {
             .into_values()
             .map(|n| n.network_address)
             .collect()
-    }
-
-    pub fn genesis_system_state(&self) -> SuiSystemStateInnerGenesis {
-        self.genesis.sui_system_object()
     }
 
     pub fn committee_with_network(&self) -> CommitteeWithNetworkMetadata {

--- a/crates/sui-config/tests/snapshot_tests.rs
+++ b/crates/sui-config/tests/snapshot_tests.rs
@@ -88,7 +88,9 @@ fn populated_genesis_snapshot_matches() {
         .add_validator_signature(&key)
         .build();
     assert_yaml_snapshot!(genesis.sui_system_wrapper_object());
-    assert_yaml_snapshot!(genesis.sui_system_object());
+    assert_yaml_snapshot!(genesis
+        .sui_system_object()
+        .into_genesis_version_for_tooling());
     assert_yaml_snapshot!(genesis.clock());
     // Serialized `genesis` is not static and cannot be snapshot tested.
 }

--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -237,9 +237,9 @@ impl ToolCommand {
             ToolCommand::DumpValidators { genesis, concise } => {
                 let genesis = Genesis::load(genesis).unwrap();
                 if !concise {
-                    println!("{:#?}", genesis.validator_set());
+                    println!("{:#?}", genesis.validator_set_for_tooling());
                 } else {
-                    for (i, val_info) in genesis.validator_set().iter().enumerate() {
+                    for (i, val_info) in genesis.validator_set_for_tooling().iter().enumerate() {
                         let metadata = val_info.verified_metadata();
                         println!(
                             "#{:<2} {:<20} {:?<66} {:?} {}",

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -31,7 +31,7 @@ fn make_clients(
 
     let mut authority_clients = BTreeMap::new();
 
-    for validator in genesis.validator_set() {
+    for validator in genesis.validator_set_for_tooling() {
         let metadata = validator.verified_metadata();
         let channel = net_config
             .connect_lazy(&metadata.net_address)

--- a/crates/sui-types/src/sui_system_state/mod.rs
+++ b/crates/sui-types/src/sui_system_state/mod.rs
@@ -87,7 +87,9 @@ pub type SuiValidatorGenesis = ValidatorV1;
 impl SuiSystemState {
     /// Always return the version that we will be using for genesis.
     /// Genesis always uses this version regardless of the current version.
-    pub fn into_genesis_version(self) -> SuiSystemStateInnerGenesis {
+    /// Note that since it's possible for the actual genesis of the network to diverge from the
+    /// genesis of the latest Rust code, it's important that we only use this for tooling purposes.
+    pub fn into_genesis_version_for_tooling(self) -> SuiSystemStateInnerGenesis {
         match self {
             SuiSystemState::V1(inner) => inner,
         }

--- a/crates/sui/src/genesis_inspector.rs
+++ b/crates/sui/src/genesis_inspector.rs
@@ -27,7 +27,9 @@ const STR_VALIDATORS: &str = "Validators";
 
 #[allow(clippy::or_fun_call)]
 pub(crate) fn examine_genesis_checkpoint(genesis: UnsignedGenesis) {
-    let system_object = genesis.sui_system_object();
+    let system_object = genesis
+        .sui_system_object()
+        .into_genesis_version_for_tooling();
 
     // Prepare Validator info
     let validator_set = &system_object.validators.active_validators;

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -596,7 +596,7 @@ async fn test_reconfig_with_committee_change_basic() {
     // Validator information from genesis contains public network addresses that we need to commit on-chain.
     let new_validator = new_configs
         .genesis
-        .validator_set()
+        .validator_set_for_tooling()
         .into_iter()
         .find(|v| {
             let name: AuthorityName = v.verified_metadata().sui_pubkey_bytes();
@@ -785,13 +785,13 @@ async fn test_reconfig_with_committee_change_stress() {
 
     let initial_pubkeys: Vec<_> = initial_network
         .genesis
-        .validator_set()
+        .validator_set_for_tooling()
         .iter()
         .map(|v| v.verified_metadata().sui_pubkey_bytes())
         .collect();
     let mut standby_nodes: Vec<_> = validator_superset
         .genesis
-        .validator_set()
+        .validator_set_for_tooling()
         .into_iter()
         .map(|val| {
             let node_config = validator_superset


### PR DESCRIPTION
Currently when node starts it reads the genesis system state object to get committee and checkpoint. This process would attempt to convert the state into a specific version. Doing so makes it impossible to test a different genesis system state type because it would always panic during node start.
This PR delays the process of converting the system state to the inner type, and only do so when we need the validator set, which is only needed for tooling.