### PR TITLE
Rewrite documentation for splitCoins

### DIFF
--- a/doc/src/doc-updates/sui-migration-guide.md
+++ b/doc/src/doc-updates/sui-migration-guide.md
@@ -11,32 +11,32 @@ The steps in this section provide guidance on making updates related to the chan
 ### Erecover and verify
 
 In this release, `ecdsa_k1::ecrecover` and `ecdsa_k1::secp256k1_verify` now require you to input the raw message instead of a hashed message.
-    
+
  * `ecdsa_k1::ecrecover(sig, hashed_msg, hash_function)` is updated to `ecdsa_k1::secp256k1_ecrecover(sig, msg, hash_function)`
 
  * `ecdsa_k1::secp256k1_verify(sig, pk, hashed_msg)` is updated to `ecdsa_k1::secp256k1_verify(sig, pk, msg, hash_function)`
-    
+
 When you call these APIs, you must provide the raw message instead of the hashed message for verification or EC recover. You must also provide the hash_function name represented by u8. See the source code for more information:
  * [ecdsa_k1.md](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/ecdsa_k1.md)
  * [ecdsa_r1.md](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/ecdsa_r1.md)
 
 ### ID Leak
 
-`UID`s must now be statically deemed “fresh” when you construct an object. This means that the `UID` must come from `object::new` (or `test_scenario::new_object` during tests). To migrate an existing project, any function that previously took a `UID` as an argument to construct an object now requires the `TxContext` to generate new IDs. 
+`UID`s must now be statically deemed “fresh” when you construct an object. This means that the `UID` must come from `object::new` (or `test_scenario::new_object` during tests). To migrate an existing project, any function that previously took a `UID` as an argument to construct an object now requires the `TxContext` to generate new IDs.
 
 For example, prior to release .28, to construct an object:
 
 ```rust
-fun new(id: UID): Counter { 
-    Counter { id, count: 0 } 
+fun new(id: UID): Counter {
+    Counter { id, count: 0 }
 }
 ```
 
 With release .28, to construct an object:
 
 ```rust
-fun new(ctx: &mut TxContext): Counter { 
-    Counter { id: object::new(ctx), count: 0 } 
+fun new(ctx: &mut TxContext): Counter {
+    Counter { id: object::new(ctx), count: 0 }
 }
 ```
 
@@ -48,9 +48,9 @@ This is not a breaking change, but `Publisher` is an important addition that can
 module example::dummy {
     use sui::package;
     use sui::tx_context::TxContext;
-    
+
     struct DUMMY has drop {}
-    
+
     fun init(otw: DUMMY, ctx: &mut TxContext) {
     	// creates a Publisher object and sends to the `sender`
     	package::claim_and_keep(otw, ctx)
@@ -63,11 +63,11 @@ To learn more about `Publisher`, see [Publisher](http://examples.sui.io/basics/p
 ### Sui Object Display Standard
 
 This release includes the Sui Object Display standard, a new way to describe objects of a single type using a set of named templates to standardize their display off-chain. The Sui API also supports the new standard.
-    
+
 To read a detailed description and the motivation behind the standard, see the [Sui Object Display proposal](https://forums.sui.io/t/nft-object-display-proposal/4872).
-    
+
 In Sui Move, to claim a `Display` object, call `display::new<T>(&Publisher)`. As stated in the signature, it requires the `Publisher` object. Once acquired, `Display` can be modified by adding new fields (templates) to it, and when it’s ready to be published, a `display::update_version(&mut Display)` call is required to publish and make it available. All further additions / edits in the `Display` should also be applied by calling `update_version` again.
-    
+
 Fields that we suggest to use in `Display` are:
  * **name:** a displayable name
  * **link:** a link to an object in an application / external link
@@ -75,7 +75,7 @@ Fields that we suggest to use in `Display` are:
  * **image_url:** an URL or a blob with an image
  * **project_url:** a link to a website
  * **creator:** mentions the creator in any way (text, link, address etc)
-    
+
 See additional information and examples in [Display](http://examples.sui.io/basics/display.html).
 
 ## API and SDK changes
@@ -83,16 +83,16 @@ See additional information and examples in [Display](http://examples.sui.io/basi
 The steps in this section provide guidance on making updates related to the changes to Sui APIs and SDKs.
 
 ### Reading objects
-    
+
 The `sui_getObject` endpoint now takes an additional configuration parameter of type `SuiObjectDataOptions` to control which fields the endpoint retrieves. By default, the endpoint retrieves only object references unless the client request  explicitly specifies other data, such as `type`, `owner`, or `bcs`.
-    
+
 #### TypeScript Migration
-    
+
 ```tsx
-    
+
 import { JsonRpcProvider } from '@mysten/sui.js';
 const provider = new JsonRpcProvider();
-    
+
     // Prior to release .28
     const txn = await provider.getObject(
       '0xcff6ccc8707aa517b4f1b95750a2a8c666012df3',
@@ -101,12 +101,12 @@ const provider = new JsonRpcProvider();
       '0xcff6ccc8707aa517b4f1b95750a2a8c666012df3',
       '0xdff6ccc8707aa517b4f1b95750a2a8c666012df3',
     ]);
-    
+
     // Updated for release .28
     const txn = await provider.getObject({
       id: '0xcff6ccc8707aa517b4f1b95750a2a8c666012df3',
       // fetch the object content field and display
-      options: { 
+      options: {
     		showContent: true,
     		showDisplay: true
     	},
@@ -120,9 +120,9 @@ const provider = new JsonRpcProvider();
       options: { showType: true },
     });
 ```
-    
+
 #### JSON RPC Migration
-    
+
 ```bash
     # Prior to release .28
     curl --location --request POST 'https://fullnode.devnet.sui.io:443' \
@@ -135,7 +135,7 @@ const provider = new JsonRpcProvider();
             "object_id": "0x08240661f5504c9bb4a487d9a28e7e9d6822abf692801f2a750d67a44d0b2340",
         }
     }'
-    
+
     # Updated for release .28
 
     curl --location --request POST 'https://fullnode.devnet.sui.io:443' \
@@ -152,7 +152,7 @@ const provider = new JsonRpcProvider();
             }
         }
     }'
-    
+
     # If you use sui_getRawObject, enable the showBcs option to retrieve it
     curl --location --request POST 'https://fullnode.devnet.sui.io:443' \
     --header 'Content-Type: application/json' \
@@ -172,13 +172,13 @@ const provider = new JsonRpcProvider();
 ### Display
 
 To get a `Display` for an object, pass an additional flag to the `sui_getObject` call.
-    
+
 ```jsx
 { showDisplay: true }
 ```
-    
+
 The returned value is the processed template for a type. For example, for Sui Capys it could be:
-    
+
 ```json
     {
         "name": "Capy - one of many",
@@ -191,14 +191,14 @@ The returned value is the processed template for a type. For example, for Sui Ca
 ```
 
 ### Reading transactions
-    
+
 The `sui_getTransaction`and `sui_multiGetTransaction` functions now take an additional optional parameter called `options`. Use `options` to specify which fields to retrieve, such as transaction, effects, or events. By default, it returns only the transaction digest.
-    
+
 ```tsx
-    
+
     import { JsonRpcProvider } from '@mysten/sui.js';
     const provider = new JsonRpcProvider();
-    
+
     // Prior to release .28
     const provider = new JsonRpcProvider();
     const txn = await provider.getTransactionWithEffects(
@@ -209,7 +209,7 @@ The `sui_getTransaction`and `sui_multiGetTransaction` functions now take an add
       '6mn5W1CczLwitHCO9OIUbqirNrQ0cuKdyxaNe16SAME=',
       '7mn5W1CczLwitHCO9OIUbqirNrQ0cuKdyxaNe16SAME=',
     ]);
-    
+
     // Updated for release .28
     const provider = new JsonRpcProvider();
     const txn = await provider.getTransaction({
@@ -234,26 +234,26 @@ This release makes the following changes related to reading events:
 
  * Removes System events such as `Publish`, `TransferObject`, `NewObject` and keeps only `MoveEvents`.
  * Adds an `object_changes` and `balance_changes` field in `SuiTransactionResponse`
-    
+
 ```tsx
     import { JsonRpcProvider } from '@mysten/sui.js';
     const provider = new JsonRpcProvider();
-    
+
     // Prior to release .28
     provider.getEvents(
     	{ Sender: toolbox.address() },
       null,
       2,
     );
-    
+
     // Updated for release .28
     const events = provider.queryEvents({
       query: { Sender: toolbox.address() },
       limit: 2,
     });
-    
+
     // Subscribe events
-    
+
     // Prior to release .28
     const subscriptionId = await provider.subscribeEvent(
       { SenderAddress: '0xbff6ccc8707aa517b4f1b95750a2a8c666012df3' },
@@ -261,11 +261,11 @@ This release makes the following changes related to reading events:
         // handle subscription notification message here. This function is called once per subscription message.
       },
     );
-    
+
     // later, to unsubscribe
     // calls RPC method 'sui_unsubscribeEvent' with params: [ subscriptionId ]
     const subFoundAndRemoved = await provider.unsubscribeEvent(subscriptionId);
-    
+
     // Updated for release .28
     // calls RPC method 'sui_subscribeEvent' with params:
     // [ { Sender: '0xbff6ccc8707aa517b4f1b95750a2a8c666012df3' } ]
@@ -275,30 +275,30 @@ This release makes the following changes related to reading events:
         // handle subscription notification message here. This function is called once per subscription message.
       },
     });
-    
+
     // later, to unsubscribe
     // calls RPC method 'sui_unsubscribeEvent' with params: [ subscriptionId ]
     const subFoundAndRemoved = await provider.unsubscribeEvent({
       id: subscriptionId,
     });
-    
+
 ```
 
 ### Pagination
-    
-This release changes the `Page` definition. 
+
+This release changes the `Page` definition.
 
 **Prior to release .28**
 ```rust
-    
+
     pub struct Page<T, C> {
         pub data: Vec<T>,
         pub next_cursor: Option<C>,
     }
 ```
-    
+
 **Updated for release .28**
-    
+
 ```rust
     pub struct Page<T, C> {
         pub data: Vec<T>,
@@ -314,35 +314,35 @@ Additionally:
 If you use `Page` to read pages one by one, now you do not have to manually handle the returned `None` value of `next_cursor` when the reading process hits the latest page, instead you can always use the returned `next_cursor` as the input argument of next read. Before this release, the reading process will start from genesis when it hits latest and the `None` value is not properly handled.
 
 ### Building and executing transaction
-    
+
 The previous transaction builder methods on the `Signer`, and the `SignableTransaction` interface have been removed, and replaced with a new `Transaction` builder class. This new transaction builder takes full advantage of Programmable Transactions.
-    
+
 ```tsx
     // Construct a new transaction:
     const tx = new Transaction();
-    
+
     // Example replacement for a SUI token transfer:
-    const coin = tx.splitCoin(tx.gas, tx.pure(1000));
+    const [coin] = tx.splitCoins(tx.gas, [tx.pure(1000)]);
     tx.transferObjects([coin], tx.pure(keypair.getPublicKey().toSuiAddress()));
-    
+
     // Merge a list of coins into a primary coin:
     tx.mergeCoin(tx.object('0xcoinA'), [
       tx.object('0xcoinB'),
       tx.object('0xcoinC'),
     ]);
-    
+
     // Make a move call:
     tx.moveCall({
       target: `${packageObjectId}::nft::mint`,
       arguments: [tx.pure('Example NFT')],
     });
-    
+
     // Execute a transaction:
     const result = await signer.signAndExecuteTransaction({ transaction: tx });
 ```
-    
+
 Transaction now support providing a list of gas coins as payment for a transaction. By default, the transaction builder automatically determines the gas budget and coins to use as payment for a transaction. You can also set these values, for example to  set your own budget, change the gas price, or do your own gas selection:
-    
+
 ```tsx
     // Set an explicit gas price. By default, uses the current reference gas price:
     tx.setGasPrice(100);
@@ -357,13 +357,13 @@ Transaction now support providing a list of gas coins as payment for a transacti
 The steps in this section provide guidance on making updates related to the changes to Sui staking.
 
 ### Locked coin staking removed
-    
+
 Previously users could stake either their `Coin<SUI>` or their `LockedCoin<SUI>` with a validator. This release removes support for staking locked coins so stake functions can now take only `Coin<SUI>`.
 
 ### StakedSui object layout changed
-    
+
 Prior to this release, StakedSui struct had the following definition:
-    
+
 ```rust
     struct StakedSui has key {
         id: UID,
@@ -380,9 +380,9 @@ Prior to this release, StakedSui struct had the following definition:
         sui_token_lock: Option<EpochTimeLock>,
     }
 ```
-    
+
 With the removal of locked coin staking and changes to the Sui staking flow, the new struct definition is:
-    
+
 ```rust
     struct StakedSui has key {
         id: UID,
@@ -401,10 +401,10 @@ With the removal of locked coin staking and changes to the Sui staking flow, the
 
 This release includes the following changes related to stake deposit and withdrawal requests:
  * Removes the `request_switch_delegation` function
- * Renames all delegation functions to use staking instead of delegation. 
+ * Renames all delegation functions to use staking instead of delegation.
 
 Prior to release .28, the function names were:
-    
+
 ```rust
     /// Add delegated stake to a validator's staking pool using multiple coins and amount.
     #[method(name = "requestAddDelegation")]
@@ -423,7 +423,7 @@ Prior to release .28, the function names were:
         /// the gas budget, the transaction will fail if the gas cost exceed the budget
         gas_budget: u64,
     ) -> RpcResult<TransactionBytes>;
-    
+
     /// Withdraw a delegation from a validator's staking pool.
     #[method(name = "requestWithdrawDelegation")]
     async fn request_withdraw_delegation(
@@ -439,7 +439,7 @@ Prior to release .28, the function names were:
         /// the gas budget, the transaction will fail if the gas cost exceed the budget
         gas_budget: u64,
     ) -> RpcResult<TransactionBytes>;
-    
+
     /// Switch delegation from the current validator to a new one.
     #[method(name = "requestSwitchDelegation")]
     async fn request_switch_delegation(
@@ -458,9 +458,9 @@ Prior to release .28, the function names were:
          gas_budget: u64,
     ) -> RpcResult<TransactionBytes>;
 ```
-    
+
 Effective with release .28, the function names are:
-    
+
 ```rust
     /// Add stake to a validator's staking pool using multiple coins and amount.
     #[method(name = "requestAddStake")]
@@ -479,7 +479,7 @@ Effective with release .28, the function names are:
         /// the gas budget, the transaction will fail if the gas cost exceed the budget
         gas_budget: u64,
     ) -> RpcResult<TransactionBytes>;
-    
+
     /// Withdraw stake from a validator's staking pool.
     #[method(name = "requestWithdrawStake")]
     async fn request_withdraw_stake(
@@ -498,9 +498,9 @@ Effective with release .28, the function names are:
 ```
 
 ### Changes to getDelegatedStakes
-    
+
 The `getDelegatedStakes` function has been renamed to `getStakes`. The `getStakes` function returns all of the stakes for an address grouped by validator staking pools, as well as the estimated staking rewards earned so far:
-    
+
 ```rust
     {
         "jsonrpc": "2.0",
@@ -550,7 +550,7 @@ The `getDelegatedStakes` function has been renamed to `getStakes`. The `getStake
 With the new `getStakesByIds` it's possible to query the delegated stakes using a vector of staked SUI IDs. The function returns all of the stakes queried, grouped by validator staking pools, as well as the estimated staking rewards earned so far.
 
 ### Secp256k1 derive keypair
-    
+
 Match `Secp256k1.deriveKeypair` with Ed25519 on a function signature takes in a mnemonics string and an optional path string instead of a required path string and a mnemonics string. See [PR 8542](https://github.com/MystenLabs/sui/pull/8542/files#diff-66c975e3c863646441ca600b074edb151f357e471bab6a34166caaecd5f546e1L151) for details.
 
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -149,7 +149,7 @@ console.log({ result });
 
 ### Transfer Sui
 
-To transfer `1000` SUI to another address:
+To transfer `1000` MIST to another address:
 
 ```typescript
 import {
@@ -163,7 +163,7 @@ const keypair = new Ed25519Keypair();
 const provider = new JsonRpcProvider();
 const signer = new RawSigner(keypair, provider);
 const tx = new Transaction();
-const coin = tx.splitCoin(tx.gas, tx.pure(1000));
+const [coin] = tx.splitCoins(tx.gas, tx.pure(1000));
 tx.transferObjects([coin], tx.pure(keypair.getPublicKey().toSuiAddress()));
 const result = await signer.signAndExecuteTransaction({ transaction: tx });
 console.log({ result });


### PR DESCRIPTION
## Description 

This updates the documentation for `splitCoins`, as it previously referenced `splitCoin`.

## Test Plan 

N/A