### PR TITLE
[programmable transactions] Switch to VM types for Objects

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/programmable/coin_operations_non_coins.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/coin_operations_non_coins.exp
@@ -9,15 +9,15 @@ written: object(104)
 
 task 2 'programmable'. lines 29-33:
 Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: Some("Expected a coin but got an object of type test::m1::Coin<sui::sui::SUI>"), command: Some(1) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: Some("Expected a coin but got an non coin object"), command: Some(1) } }
 
 task 3 'programmable'. lines 34-38:
 Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: Some("Expected a coin but got an object of type test::m1::Coin<sui::sui::SUI>"), command: Some(1) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: Some("Expected a coin but got an non coin object"), command: Some(1) } }
 
 task 4 'programmable'. lines 39-41:
 Error: Transaction Effects Status: Invalid command argument at 1. The type of the value does not match the expected type
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: TypeMismatch }, source: Some("Expected a coin of type sui::coin::Coin<sui::sui::SUI> but got an object of type test::m1::Coin<sui::sui::SUI>"), command: Some(1) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: TypeMismatch }, source: Some("Coins do not have the same type"), command: Some(1) } }
 
 task 5 'programmable'. lines 43-44:
 Error: Transaction Effects Status: Invalid command argument at 1. The type of the value does not match the expected type

--- a/crates/sui-adapter-transactional-tests/tests/programmable/merge_coin_mismatched_coin.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/merge_coin_mismatched_coin.exp
@@ -18,16 +18,16 @@ Contents: sui::coin::Coin<test::fake::FAKE> {id: sui::object::UID {id: sui::obje
 
 task 4 'programmable'. lines 31-33:
 Error: Transaction Effects Status: Invalid command argument at 1. The type of the value does not match the expected type
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: TypeMismatch }, source: Some("Expected a coin of type sui::coin::Coin<sui::sui::SUI> but got an object of type sui::coin::Coin<test::fake::FAKE>"), command: Some(1) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: TypeMismatch }, source: Some("Coins do not have the same type"), command: Some(1) } }
 
 task 5 'programmable'. lines 35-36:
 Error: Transaction Effects Status: Invalid command argument at 1. The type of the value does not match the expected type
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: TypeMismatch }, source: Some("Expected a coin of type sui::coin::Coin<sui::sui::SUI> but got an object of type sui::coin::Coin<test::fake::FAKE>"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: TypeMismatch }, source: Some("Coins do not have the same type"), command: Some(0) } }
 
 task 6 'programmable'. lines 38-40:
 Error: Transaction Effects Status: Invalid command argument at 2. The type of the value does not match the expected type
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 2, kind: TypeMismatch }, source: Some("Expected a coin of type sui::coin::Coin<test::fake::FAKE> but got an object of type sui::coin::Coin<sui::sui::SUI>"), command: Some(1) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 2, kind: TypeMismatch }, source: Some("Coins do not have the same type"), command: Some(1) } }
 
 task 7 'programmable'. lines 42-45:
 Error: Transaction Effects Status: Invalid command argument at 1. The type of the value does not match the expected type
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: TypeMismatch }, source: Some("Expected a coin of type sui::coin::Coin<sui::sui::SUI> but got an object of type sui::coin::Coin<test::fake::FAKE>"), command: Some(2) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: TypeMismatch }, source: Some("Coins do not have the same type"), command: Some(2) } }

--- a/crates/sui-adapter/src/execution_mode.rs
+++ b/crates/sui-adapter/src/execution_mode.rs
@@ -243,9 +243,13 @@ fn value_to_bytes_and_tag<E: fmt::Debug, S: StorageView<E>>(
 ) -> Result<(Vec<u8>, TypeTag), ExecutionError> {
     let (type_tag, bytes) = match value {
         Value::Object(obj) => {
+            let tag = context
+                .session
+                .get_type_tag(&obj.type_)
+                .map_err(|e| context.convert_vm_error(e))?;
             let mut bytes = vec![];
             obj.write_bcs_bytes(&mut bytes);
-            (obj.type_.clone().into(), bytes)
+            (tag, bytes)
         }
         Value::Raw(RawValueType::Any, bytes) => {
             // this case shouldn't happen

--- a/crates/sui-adapter/src/programmable_transactions/types.rs
+++ b/crates/sui-adapter/src/programmable_transactions/types.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, fmt};
 
 use move_binary_format::file_format::AbilitySet;
 use move_core_types::{
@@ -9,15 +9,17 @@ use move_core_types::{
     language_storage::{ModuleId, StructTag},
     resolver::{LinkageResolver, ModuleResolver, ResourceResolver},
 };
+use move_vm_runtime::{move_vm::MoveVM, session::Session};
 use move_vm_types::loaded_data::runtime_types::Type;
 use serde::Deserialize;
 use sui_types::{
     base_types::{MoveObjectType, ObjectID, SequenceNumber, SuiAddress},
     coin::Coin,
-    error::{ExecutionError, ExecutionErrorKind},
+    error::{convert_vm_error, ExecutionError, ExecutionErrorKind},
     messages::CommandArgumentError,
     object::{Data, MoveObject, Object, Owner},
     storage::{BackingPackageStore, ChildObjectResolver, ObjectChange, ParentSync, Storage},
+    TypeTag,
 };
 
 pub trait StorageView<E: std::fmt::Debug>:
@@ -87,7 +89,7 @@ pub enum Value {
 
 #[derive(Debug, Clone)]
 pub struct ObjectValue {
-    pub type_: MoveObjectType,
+    pub type_: Type,
     pub has_public_transfer: bool,
     // true if it has been used in a public, non-entry Move call
     // In other words, false if all usages have been with non-Move comamnds or
@@ -186,7 +188,10 @@ impl Value {
 }
 
 impl ObjectValue {
-    pub fn new(
+    pub fn new<E: fmt::Debug, S: StorageView<E>>(
+        vm: &MoveVM,
+        state_view: &S,
+        session: &Session<S>,
         type_: MoveObjectType,
         has_public_transfer: bool,
         used_in_non_entry_move_call: bool,
@@ -200,6 +205,10 @@ impl ObjectValue {
         } else {
             ObjectContents::Raw(contents.to_vec())
         };
+        let tag: StructTag = type_.into();
+        let type_ = session
+            .load_type(&TypeTag::Struct(Box::new(tag)))
+            .map_err(|e| convert_vm_error(e, vm, state_view))?;
         Ok(Self {
             type_,
             has_public_transfer,
@@ -208,16 +217,29 @@ impl ObjectValue {
         })
     }
 
-    pub fn from_object(object: &Object) -> Result<Self, ExecutionError> {
+    pub fn from_object<E: fmt::Debug, S: StorageView<E>>(
+        vm: &MoveVM,
+        state_view: &S,
+        session: &Session<S>,
+        object: &Object,
+    ) -> Result<Self, ExecutionError> {
         let Object { data, .. } = object;
         match data {
             Data::Package(_) => invariant_violation!("Expected a Move object"),
-            Data::Move(move_object) => Self::from_move_object(move_object),
+            Data::Move(move_object) => Self::from_move_object(vm, state_view, session, move_object),
         }
     }
 
-    pub fn from_move_object(object: &MoveObject) -> Result<Self, ExecutionError> {
+    pub fn from_move_object<E: fmt::Debug, S: StorageView<E>>(
+        vm: &MoveVM,
+        state_view: &S,
+        session: &Session<S>,
+        object: &MoveObject,
+    ) -> Result<Self, ExecutionError> {
         Self::new(
+            vm,
+            state_view,
+            session,
             object.type_().clone(),
             object.has_public_transfer(),
             false,
@@ -225,14 +247,16 @@ impl ObjectValue {
         )
     }
 
-    pub fn coin(type_: MoveObjectType, coin: Coin) -> Result<Self, ExecutionError> {
-        assert_invariant!(type_.is_coin(), "Cannot make a coin without a coin type");
-        Ok(Self {
+    /// # Safety:
+    /// We must have the Type is the coin type,
+    /// but we are unable to check it at this spot
+    pub unsafe fn coin(type_: Type, coin: Coin) -> Self {
+        Self {
             type_,
             has_public_transfer: true,
             used_in_non_entry_move_call: false,
             contents: ObjectContents::Coin(coin),
-        })
+        }
     }
 
     pub fn ensure_public_transfer_eligible(&self) -> Result<(), ExecutionError> {
@@ -247,10 +271,6 @@ impl ObjectValue {
             ObjectContents::Raw(bytes) => buf.extend(bytes),
             ObjectContents::Coin(coin) => buf.extend(coin.to_bcs_bytes()),
         }
-    }
-
-    pub fn into_type(self) -> MoveObjectType {
-        self.type_
     }
 }
 

--- a/crates/sui-adapter/src/programmable_transactions/types.rs
+++ b/crates/sui-adapter/src/programmable_transactions/types.rs
@@ -247,9 +247,8 @@ impl ObjectValue {
         )
     }
 
-    /// # Safety:
-    /// We must have the Type is the coin type,
-    /// but we are unable to check it at this spot
+    /// # Safety
+    /// We must have the Type is the coin type, but we are unable to check it at this spot
     pub unsafe fn coin(type_: Type, coin: Coin) -> Self {
         Self {
             type_,


### PR DESCRIPTION
## Description 

- To support upgrades, the type of objects in the runtime now are loaded by the VM
- This adds a tiny overhead to the non-Move operations, but there really isn't much of a way around this to support the versioning of the one-time witness type inside of the coin

## Test Plan 

- Internal change, ran existing tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
