### PR TITLE
[StateAccumulator] Fix parent sync iteration inefficiency

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -379,6 +379,22 @@ impl AuthorityStore {
             .transpose()
     }
 
+    pub fn multi_get_object_by_key(
+        &self,
+        object_keys: &[ObjectKey],
+    ) -> Result<Vec<Option<Object>>, SuiError> {
+        let wrappers = self.perpetual_tables.objects.multi_get(object_keys)?;
+        let mut ret = vec![];
+
+        for w in wrappers {
+            ret.push(
+                w.map(|object| self.perpetual_tables.object(object))
+                    .transpose()?,
+            );
+        }
+        Ok(ret)
+    }
+
     /// Get many objects
     pub fn get_objects(&self, objects: &[ObjectID]) -> Result<Vec<Option<Object>>, SuiError> {
         let mut result = Vec::new();


### PR DESCRIPTION
## Description 

Fixing an inefficiency in processing `modified_at_versions` effects. Rather than iterate through parent_sync to get the object digests for these effects (note that the effects in this case do not contain the digest), we `multi_get` lookup from the objects table.

## Test Plan 

Let simtests run. Will test further in subsequent debugging

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
