### PR TITLE
[tests][programmable transactions] More coin tests

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/programmable/coin_negative.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/coin_negative.exp
@@ -1,0 +1,20 @@
+processed 5 tasks
+
+init:
+A: object(103)
+
+task 1 'publish'. lines 8-23:
+created: object(105), object(106), object(107)
+written: object(104)
+
+task 2 'programmable'. lines 25-27:
+created: object(109)
+written: object(107), object(108)
+
+task 3 'programmable'. lines 29-30:
+Error: Transaction Effects Status: Insufficient coin balance for operation.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientCoinBalance, source: Some("balance: 1 required: 2"), command: Some(0) } }
+
+task 4 'programmable'. lines 32-33:
+Error: Transaction Effects Status: Insufficient coin balance for operation.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientCoinBalance, source: Some("balance: 2990000 required: 18446744073709551615"), command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/coin_negative.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/coin_negative.move
@@ -1,0 +1,33 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests coin balance going negative on split
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish --sender A
+module test::fake {
+    use std::option;
+    use sui::coin;
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+
+    struct FAKE has drop {}
+
+    fun init(witness: FAKE, ctx: &mut TxContext) {
+        let (treasury_cap, metadata) = coin::create_currency(witness, 2, b"FAKE", b"", b"", option::none(), ctx);
+        transfer::public_freeze_object(metadata);
+        transfer::public_transfer(treasury_cap, tx_context::sender(ctx));
+    }
+
+}
+
+//# programmable --sender A --inputs object(107) 1 @A
+//> 0: sui::coin::mint<test::fake::FAKE>(Input(0), Input(1));
+//> TransferObjects([Result(0)], Input(2))
+
+//# programmable --sender A --inputs object(109) 2
+//> SplitCoins(Input(0), [Input(1)]);
+
+//# programmable --sender A --inputs 18446744073709551615
+//> SplitCoins(Gas, [Input(0)])

--- a/crates/sui-adapter-transactional-tests/tests/programmable/coin_operations_custom_coin.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/coin_operations_custom_coin.exp
@@ -1,0 +1,22 @@
+processed 5 tasks
+
+init:
+A: object(103)
+
+task 1 'publish'. lines 8-23:
+created: object(105), object(106), object(107)
+written: object(104)
+
+task 2 'programmable'. lines 25-27:
+created: object(109)
+written: object(107), object(108)
+
+task 3 'view-object'. lines 29-29:
+Owner: Account Address ( A )
+Version: 3
+Contents: sui::coin::Coin<test::fake::FAKE> {id: sui::object::UID {id: sui::object::ID {bytes: fake(109)}}, balance: sui::balance::Balance<test::fake::FAKE> {value: 100u64}}
+
+task 4 'programmable'. lines 31-37:
+created: object(111)
+written: object(107), object(110)
+deleted: object(109)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/coin_operations_custom_coin.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/coin_operations_custom_coin.move
@@ -1,0 +1,37 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests coin operations with custom coins
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish --sender A
+module test::fake {
+    use std::option;
+    use sui::coin;
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+
+    struct FAKE has drop {}
+
+    fun init(witness: FAKE, ctx: &mut TxContext) {
+        let (treasury_cap, metadata) = coin::create_currency(witness, 2, b"FAKE", b"", b"", option::none(), ctx);
+        transfer::public_freeze_object(metadata);
+        transfer::public_transfer(treasury_cap, tx_context::sender(ctx));
+    }
+
+}
+
+//# programmable --sender A --inputs object(107) 100 @A
+//> 0: sui::coin::mint<test::fake::FAKE>(Input(0), Input(1));
+//> TransferObjects([Result(0)], Input(2))
+
+//# view-object 109
+
+//# programmable --sender A --inputs object(107) 100 object(109) 1 @A
+//> 0: sui::coin::mint<test::fake::FAKE>(Input(0), Input(1));
+//> 1: sui::coin::mint<test::fake::FAKE>(Input(0), Input(1));
+//> 2: SplitCoins(Result(0), [Input(3)]);
+//> 3: SplitCoins(Input(2), [Input(3)]);
+//> MergeCoins(Result(1), [Result(0), Input(2), Result(2), Result(3)]);
+//> TransferObjects([Result(1)], Input(4))

--- a/crates/sui-adapter-transactional-tests/tests/programmable/coin_operations_non_coins.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/coin_operations_non_coins.exp
@@ -1,0 +1,28 @@
+processed 7 tasks
+
+init:
+A: object(103)
+
+task 1 'publish'. lines 8-28:
+created: object(105)
+written: object(104)
+
+task 2 'programmable'. lines 29-33:
+Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: Some("Expected a coin but got an object of type test::m1::Coin<sui::sui::SUI>"), command: Some(1) } }
+
+task 3 'programmable'. lines 34-38:
+Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: Some("Expected a coin but got an object of type test::m1::Coin<sui::sui::SUI>"), command: Some(1) } }
+
+task 4 'programmable'. lines 39-41:
+Error: Transaction Effects Status: Invalid command argument at 1. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: TypeMismatch }, source: Some("Expected a coin of type sui::coin::Coin<sui::sui::SUI> but got an object of type test::m1::Coin<sui::sui::SUI>"), command: Some(1) } }
+
+task 5 'programmable'. lines 43-44:
+Error: Transaction Effects Status: Invalid command argument at 1. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: TypeMismatch }, source: None, command: Some(0) } }
+
+task 6 'programmable'. lines 46-47:
+Error: Transaction Effects Status: Invalid command argument at 1. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: TypeMismatch }, source: None, command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/coin_operations_non_coins.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/coin_operations_non_coins.move
@@ -1,0 +1,47 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// test invalid usages of coin commands
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+module test::m1 {
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+
+    // not a native coin, but same type structure and BCS layout
+    struct Coin<phantom T> has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    public fun mint<T>(ctx: &mut TxContext): Coin<T> {
+        Coin {
+            id: object::new(ctx),
+            value: 1000000,
+        }
+    }
+
+}
+
+// split non-coin
+//# programmable --sender A --inputs 0
+//> 0: test::m1::mint<sui::sui::SUI>();
+//> SplitCoins(Result(0), [Input(0)])
+
+// merge into non-coin
+//# programmable --sender A --inputs 0
+//> 0: test::m1::mint<sui::sui::SUI>();
+//> MergeCoins(Result(0), [Gas])
+
+// merge non-coin into gas
+//# programmable --sender A --inputs 0
+//> 0: test::m1::mint<sui::sui::SUI>();
+//> MergeCoins(Gas, [Result(0)])
+
+//# programmable --sender A --inputs 10000u64
+//> MergeCoins(Gas, [Input(0)])
+
+//# programmable --sender A --inputs 10000u64
+//> MergeCoins(Gas, [Input(0)])

--- a/crates/sui-adapter-transactional-tests/tests/programmable/coin_overflow.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/coin_overflow.exp
@@ -1,0 +1,20 @@
+processed 5 tasks
+
+init:
+A: object(103)
+
+task 1 'publish'. lines 8-23:
+created: object(105), object(106), object(107)
+written: object(104)
+
+task 2 'programmable'. lines 25-27:
+created: object(109)
+written: object(107), object(108)
+
+task 3 'programmable'. lines 29-31:
+Error: Transaction Effects Status: Move Runtime Abort. Location: sui::balance::increase_supply (function index 3) at offset 12, Abort Code: 1
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("balance") }, function: 3, instruction: 12, function_name: Some("increase_supply") }, 1), source: Some(VMError { major_status: ABORTED, sub_status: Some(1), message: Some("sui::balance::increase_supply at offset 12"), exec_state: Some(ExecutionState { stack_trace: [(Some(ModuleId { address: sui, name: Identifier("coin") }), FunctionDefinitionIndex(17), 5)] }), location: Module(ModuleId { address: sui, name: Identifier("balance") }), indices: [], offsets: [(FunctionDefinitionIndex(3), 12)] }), command: Some(0) } }
+
+task 4 'programmable'. lines 33-34:
+Error: Transaction Effects Status: Invalid command argument at 1. Invalid usage of value. Mutably borrowed values require unique usage. Immutably borrowed values cannot be taken or borrowed mutably. Taken values cannot be used again.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: InvalidValueUsage }, source: None, command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/coin_overflow.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/coin_overflow.move
@@ -1,0 +1,34 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests coin overflow... which isn't actually possible without directly editing the coin bytes
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish --sender A
+module test::fake {
+    use std::option;
+    use sui::coin;
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+
+    struct FAKE has drop {}
+
+    fun init(witness: FAKE, ctx: &mut TxContext) {
+        let (treasury_cap, metadata) = coin::create_currency(witness, 2, b"FAKE", b"", b"", option::none(), ctx);
+        transfer::public_freeze_object(metadata);
+        transfer::public_transfer(treasury_cap, tx_context::sender(ctx));
+    }
+
+}
+
+//# programmable --sender A --inputs object(107) 18446744073709551614 @A
+//> 0: sui::coin::mint<test::fake::FAKE>(Input(0), Input(1));
+//> TransferObjects([Result(0)], Input(2))
+
+//# programmable --sender A --inputs object(107) 1 @A
+//> 0: sui::coin::mint<test::fake::FAKE>(Input(0), Input(1));
+//> TransferObjects([Result(0)], Input(2))
+
+//# programmable --sender A --inputs object(109)
+//> MergeCoins(Input(0), [Input(0)]);

--- a/crates/sui-adapter-transactional-tests/tests/programmable/merge_coin_mismatched_coin.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/merge_coin_mismatched_coin.exp
@@ -1,0 +1,33 @@
+processed 8 tasks
+
+init:
+A: object(103)
+
+task 1 'publish'. lines 8-23:
+created: object(105), object(106), object(107)
+written: object(104)
+
+task 2 'programmable'. lines 25-27:
+created: object(109)
+written: object(107), object(108)
+
+task 3 'view-object'. lines 29-29:
+Owner: Account Address ( A )
+Version: 3
+Contents: sui::coin::Coin<test::fake::FAKE> {id: sui::object::UID {id: sui::object::ID {bytes: fake(109)}}, balance: sui::balance::Balance<test::fake::FAKE> {value: 100u64}}
+
+task 4 'programmable'. lines 31-33:
+Error: Transaction Effects Status: Invalid command argument at 1. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: TypeMismatch }, source: Some("Expected a coin of type sui::coin::Coin<sui::sui::SUI> but got an object of type sui::coin::Coin<test::fake::FAKE>"), command: Some(1) } }
+
+task 5 'programmable'. lines 35-36:
+Error: Transaction Effects Status: Invalid command argument at 1. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: TypeMismatch }, source: Some("Expected a coin of type sui::coin::Coin<sui::sui::SUI> but got an object of type sui::coin::Coin<test::fake::FAKE>"), command: Some(0) } }
+
+task 6 'programmable'. lines 38-40:
+Error: Transaction Effects Status: Invalid command argument at 2. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 2, kind: TypeMismatch }, source: Some("Expected a coin of type sui::coin::Coin<test::fake::FAKE> but got an object of type sui::coin::Coin<sui::sui::SUI>"), command: Some(1) } }
+
+task 7 'programmable'. lines 42-45:
+Error: Transaction Effects Status: Invalid command argument at 1. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: TypeMismatch }, source: Some("Expected a coin of type sui::coin::Coin<sui::sui::SUI> but got an object of type sui::coin::Coin<test::fake::FAKE>"), command: Some(2) } }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/merge_coin_mismatched_coin.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/merge_coin_mismatched_coin.move
@@ -1,0 +1,45 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests various mismatched coin types for merge coins
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish --sender A
+module test::fake {
+    use std::option;
+    use sui::coin;
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+
+    struct FAKE has drop {}
+
+    fun init(witness: FAKE, ctx: &mut TxContext) {
+        let (treasury_cap, metadata) = coin::create_currency(witness, 2, b"FAKE", b"", b"", option::none(), ctx);
+        transfer::public_freeze_object(metadata);
+        transfer::public_transfer(treasury_cap, tx_context::sender(ctx));
+    }
+
+}
+
+//# programmable --sender A --inputs object(107) 100 @A
+//> 0: sui::coin::mint<test::fake::FAKE>(Input(0), Input(1));
+//> TransferObjects([Result(0)], Input(2))
+
+//# view-object 109
+
+//# programmable --sender A --inputs object(107) 100
+//> 0: sui::coin::mint<test::fake::FAKE>(Input(0), Input(1));
+//> MergeCoins(Gas, [Result(0)])
+
+//# programmable --sender A --inputs object(109)
+//> MergeCoins(Gas, [Input(0)])
+
+//# programmable --sender A --inputs object(107) 100 object(109) object(103)
+//> 0: sui::coin::mint<test::fake::FAKE>(Input(0), Input(1));
+//> MergeCoins(Result(0), [Input(2), Input(3)])
+
+//# programmable --sender A --inputs object(107) 100
+//> 0: sui::coin::mint<test::fake::FAKE>(Input(0), Input(1));
+//> 1: SplitCoins(Result(0), [Input(1)]);
+//> MergeCoins(Gas, [Result(1)])

--- a/crates/sui-adapter/src/programmable_transactions/context.rs
+++ b/crates/sui-adapter/src/programmable_transactions/context.rs
@@ -342,7 +342,6 @@ where
         value: Value,
     ) -> Result<(), ExecutionError> {
         Mode::add_argument_update(self, updates, arg, &value)?;
-        Mode::add_argument_update(self, updates, arg, &value)?;
         let was_mut_opt = self.borrowed.remove(&arg);
         assert_invariant!(
             was_mut_opt.is_some() && was_mut_opt.unwrap(),

--- a/crates/sui-adapter/src/programmable_transactions/context.rs
+++ b/crates/sui-adapter/src/programmable_transactions/context.rs
@@ -342,6 +342,7 @@ where
         value: Value,
     ) -> Result<(), ExecutionError> {
         Mode::add_argument_update(self, updates, arg, &value)?;
+        Mode::add_argument_update(self, updates, arg, &value)?;
         let was_mut_opt = self.borrowed.remove(&arg);
         assert_invariant!(
             was_mut_opt.is_some() && was_mut_opt.unwrap(),


### PR DESCRIPTION
## Description 

- Added tests for coin operations

## Test Plan 

- New tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
