### PR TITLE
Add `non_refundable_storage_fee ` to `GasCostSummary`

### DIFF
--- a/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot.snap
+++ b/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot.snap
@@ -6,46 +6,55 @@ expression: common_costs_actual
   "MergeCoin": {
     "computationCost": 1000,
     "storageCost": 26,
-    "storageRebate": 0
+    "storageRebate": 0,
+    "nonRefundableStorageFee": 0
   },
   "Publish": {
     "computationCost": 1000,
     "storageCost": 176,
-    "storageRebate": 0
+    "storageRebate": 0,
+    "nonRefundableStorageFee": 0
   },
   "SharedCounterAssertValue": {
     "computationCost": 1000,
     "storageCost": 34,
-    "storageRebate": 21
+    "storageRebate": 21,
+    "nonRefundableStorageFee": 0
   },
   "SharedCounterCreate": {
     "computationCost": 1000,
     "storageCost": 34,
-    "storageRebate": 0
+    "storageRebate": 0,
+    "nonRefundableStorageFee": 0
   },
   "SharedCounterIncrement": {
     "computationCost": 1000,
     "storageCost": 34,
-    "storageRebate": 21
+    "storageRebate": 21,
+    "nonRefundableStorageFee": 0
   },
   "SplitCoin": {
     "computationCost": 1000,
     "storageCost": 65,
-    "storageRebate": 0
+    "storageRebate": 0,
+    "nonRefundableStorageFee": 0
   },
   "TransferPortionSuiCoin": {
     "computationCost": 1000,
     "storageCost": 26,
-    "storageRebate": 0
+    "storageRebate": 0,
+    "nonRefundableStorageFee": 0
   },
   "TransferWholeCoin": {
     "computationCost": 1000,
     "storageCost": 26,
-    "storageRebate": 0
+    "storageRebate": 0,
+    "nonRefundableStorageFee": 0
   },
   "TransferWholeSuiCoin": {
     "computationCost": 1000,
     "storageCost": 13,
-    "storageRebate": 0
+    "storageRebate": 0,
+    "nonRefundableStorageFee": 0
   }
 }

--- a/crates/sui-indexer/src/models/checkpoints.rs
+++ b/crates/sui-indexer/src/models/checkpoints.rs
@@ -97,6 +97,7 @@ impl TryFrom<Checkpoint> for RpcCheckpoint {
                 computation_cost: checkpoint.total_computation_cost as u64,
                 storage_cost: checkpoint.total_storage_cost as u64,
                 storage_rebate: checkpoint.total_storage_rebate as u64,
+                non_refundable_storage_fee: 0,
             },
             network_total_transactions: checkpoint.total_transactions_from_genesis as u64,
             timestamp_ms: checkpoint.timestamp_ms as u64,

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -810,6 +810,7 @@ pub struct SuiGasCostSummary {
     pub computation_cost: u64,
     pub storage_cost: u64,
     pub storage_rebate: u64,
+    pub non_refundable_storage_fee: u64,
 }
 
 impl From<GasCostSummary> for SuiGasCostSummary {
@@ -818,6 +819,7 @@ impl From<GasCostSummary> for SuiGasCostSummary {
             computation_cost: s.computation_cost,
             storage_cost: s.storage_cost,
             storage_rebate: s.storage_rebate,
+            non_refundable_storage_fee: s.non_refundable_storage_fee,
         }
     }
 }
@@ -828,6 +830,7 @@ impl From<SuiGasCostSummary> for GasCostSummary {
             computation_cost: s.computation_cost,
             storage_cost: s.storage_cost,
             storage_rebate: s.storage_rebate,
+            non_refundable_storage_fee: s.non_refundable_storage_fee,
         }
     }
 }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -237,7 +237,8 @@
                 "gasUsed": {
                   "computationCost": 100,
                   "storageCost": 100,
-                  "storageRebate": 10
+                  "storageRebate": 10,
+                  "nonRefundableStorageFee": 0
                 },
                 "transactionDigest": "8UExPV121BEfWkbymSPDYhh23rVNh3MSWtC5juJ9JGMJ",
                 "mutated": [
@@ -442,7 +443,8 @@
               "epochRollingGasCostSummary": {
                 "computationCost": 0,
                 "storageCost": 0,
-                "storageRebate": 0
+                "storageRebate": 0,
+                "nonRefundableStorageFee": 0
               },
               "timestampMs": 1676911928,
               "transactions": [
@@ -1434,7 +1436,8 @@
                 "gasUsed": {
                   "computationCost": 100,
                   "storageCost": 100,
-                  "storageRebate": 10
+                  "storageRebate": 10,
+                  "nonRefundableStorageFee": 0
                 },
                 "transactionDigest": "6AyFnAuKAKCqm1cD94EyGzBqJCDDJ716ojjmsKF2rqoi",
                 "mutated": [
@@ -3955,11 +3958,17 @@
         "type": "object",
         "required": [
           "computationCost",
+          "nonRefundableStorageFee",
           "storageCost",
           "storageRebate"
         ],
         "properties": {
           "computationCost": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "nonRefundableStorageFee": {
             "type": "integer",
             "format": "uint64",
             "minimum": 0.0

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -486,6 +486,7 @@ impl RpcExampleProvider {
                     computation_cost: 100,
                     storage_cost: 100,
                     storage_rebate: 10,
+                    non_refundable_storage_fee: 0,
                 },
                 shared_objects: vec![],
                 transaction_digest: TransactionDigest::new(self.rng.gen()),

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -63,7 +63,7 @@ pub const APPROX_SIZE_OF_EXECUTION_STATUS: usize = 120;
 // Approximate size of `EpochId` type in bytes
 pub const APPROX_SIZE_OF_EPOCH_ID: usize = 10;
 // Approximate size of `GasCostSummary` type in bytes
-pub const APPROX_SIZE_OF_GAS_COST_SUMMARY: usize = 30;
+pub const APPROX_SIZE_OF_GAS_COST_SUMMARY: usize = 40;
 // Approximate size of `Option<TransactionEventsDigest>` type in bytes
 pub const APPROX_SIZE_OF_OPT_TX_EVENTS_DIGEST: usize = 40;
 // Approximate size of `TransactionDigest` type in bytes
@@ -2947,6 +2947,7 @@ impl Default for TransactionEffectsV1 {
                 computation_cost: 0,
                 storage_cost: 0,
                 storage_rebate: 0,
+                non_refundable_storage_fee: 0,
             },
             modified_at_versions: Vec::new(),
             shared_objects: Vec::new(),

--- a/sdk/typescript/src/types/checkpoints.ts
+++ b/sdk/typescript/src/types/checkpoints.ts
@@ -21,6 +21,7 @@ export const GasCostSummary = object({
   computationCost: number(),
   storageCost: number(),
   storageRebate: number(),
+  nonRefundableStorageFee: number(),
 });
 export type GasCostSummary = Infer<typeof GasCostSummary>;
 

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -177,6 +177,7 @@ export const GasCostSummary = object({
   computationCost: number(),
   storageCost: number(),
   storageRebate: number(),
+  nonRefundableStorageFee: number(),
 });
 export type GasCostSummary = Infer<typeof GasCostSummary>;
 


### PR DESCRIPTION
## Description 

Add the non refundable portion of storage rebate to the transaction effects.
IIRC the idea is to have `storage_rebate` be the value "send back" to the user and `non_refundable_storage_fee` being the portion of the rebate that is "charged". 
@sblackshear @emmazzz @lxfind @bmwill @tzakian please confirm my understanding and make suggestions.
This simply add the new field and it initializes to 0. 
Given this is a breaking change we are separating this change from the usage and try to get this in asap.

## Test Plan 

Existing tests as there is nothing to test for now

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
