### PR TITLE
[StateAccumulator] Exercise transaction edge cases in test

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -381,6 +381,26 @@ impl AuthorityStore {
             .flatten())
     }
 
+    pub fn get_object_prior_to_key(
+        &self,
+        object_id: &ObjectID,
+        version: VersionNumber,
+    ) -> Result<Option<Object>, SuiError> {
+        let Some(prior_version) = version.one_before() else {
+            return Ok(None);
+        };
+        let key = ObjectKey(*object_id, prior_version);
+        let Some(metadata) = self.perpetual_tables
+            .objects
+            .iter()
+            .skip_prior_to(&key)?
+            .next() else {
+                return Ok(None);
+            };
+
+        Ok(Some(self.perpetual_tables.object(metadata.1)?))
+    }
+
     pub fn multi_get_object_by_key(
         &self,
         object_keys: &[ObjectKey],

--- a/crates/sui-core/src/state_accumulator.rs
+++ b/crates/sui-core/src/state_accumulator.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use either::Either;
+use itertools::Itertools;
 use mysten_metrics::monitored_scope;
 use serde::Serialize;
 use sui_types::base_types::{ObjectID, SequenceNumber};
@@ -10,6 +12,7 @@ use sui_types::storage::ObjectKey;
 use tracing::debug;
 use typed_store::Map;
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use fastcrypto::hash::MultisetHash;
@@ -50,7 +53,7 @@ impl StateAccumulator {
         Self { authority_store }
     }
 
-    /// Accumulates the effects of a single checkpoint.
+    /// Accumulates the effects of a single checkpoint and persists the accumulator.
     /// This function is idempotent.
     pub fn accumulate_checkpoint(
         &self,
@@ -63,6 +66,20 @@ impl StateAccumulator {
             return Ok(acc);
         }
 
+        let acc = self.accumulate_effects(effects);
+
+        epoch_store.insert_state_hash_for_checkpoint(&checkpoint_seq_num, &acc)?;
+        debug!("Accumulated checkpoint {}", checkpoint_seq_num);
+
+        epoch_store
+            .checkpoint_state_notify_read
+            .notify(&checkpoint_seq_num, &acc);
+
+        Ok(acc)
+    }
+
+    /// Accumulates given effects and returns the accumulator without side effects.
+    pub fn accumulate_effects(&self, effects: Vec<TransactionEffects>) -> Accumulator {
         let mut acc = Accumulator::default();
 
         // process insertions to the set
@@ -89,6 +106,7 @@ impl StateAccumulator {
                     fx.wrapped()
                         .iter()
                         .map(|oref| {
+                            println!("TESTING -- wrapped: {:?}", oref.1);
                             bcs::to_bytes(&WrappedObject::new(oref.0, oref.1))
                                 .unwrap()
                                 .to_vec()
@@ -98,45 +116,110 @@ impl StateAccumulator {
                 .collect::<Vec<Vec<u8>>>(),
         );
 
-        // get all modified_at_versions for the fx
-        let modified_at_version_keys: Vec<_> = effects
+        let all_unwrapped = effects
             .iter()
             .flat_map(|fx| {
-                fx.modified_at_versions()
+                fx.unwrapped()
                     .iter()
-                    .map(|(id, seq_num)| ObjectKey(*id, *seq_num))
-                    .collect::<Vec<ObjectKey>>()
+                    .map(|(oref, _owner)| (oref.0, oref.1))
+                    .collect::<Vec<(ObjectID, SequenceNumber)>>()
+            })
+            .chain(effects.iter().flat_map(|fx| {
+                fx.unwrapped_then_deleted()
+                    .iter()
+                    .map(|oref| (oref.0, oref.1))
+                    .collect::<Vec<(ObjectID, SequenceNumber)>>()
+            }))
+            .collect::<Vec<(ObjectID, SequenceNumber)>>();
+
+        let unwrapped_ids: HashSet<ObjectID> =
+            all_unwrapped.iter().map(|(id, _)| id).cloned().collect();
+
+        // Collect keys from modified_at_versions to remove from the accumulator.
+        // Filter all unwrapped objects (from unwrapped or unwrapped_then_deleted effects)
+        // as these were inserted into the accumulator as a WrappedObject. Will handle these
+        // separately.
+        let modified_at_version_keys: Vec<ObjectKey> = effects
+            .iter()
+            .flat_map(|fx| fx.modified_at_versions())
+            .filter_map(|(id, seq_num)| {
+                if unwrapped_ids.contains(id) {
+                    None
+                } else {
+                    Some(ObjectKey(*id, *seq_num))
+                }
             })
             .collect();
 
         let modified_at_digests: Vec<_> = self
             .authority_store
-            .multi_get_object_by_key(&modified_at_version_keys)
+            .multi_get_object_by_key(&modified_at_version_keys.clone())
             .expect("Failed to get modified_at_versions object from object table")
             .into_iter()
-            .map(|obj| {
-                obj.expect(
-                    "Object from modified_at_versions effects does not exist in objects table",
-                )
+            .zip(modified_at_version_keys)
+            .map(|(obj, key)| {
+                obj.unwrap_or_else(|| panic!("Object for key {:?} from modified_at_versions effects does not exist in objects table", key))
                 .compute_object_reference()
                 .2
             })
             .collect();
-
         acc.remove_all(modified_at_digests);
 
-        epoch_store.insert_state_hash_for_checkpoint(&checkpoint_seq_num, &acc)?;
-        debug!("Accumulated checkpoint {}", checkpoint_seq_num);
+        // Process unwrapped and unwrapped_then_deleted effects, which need to be
+        // removed as WrappedObject using the last sequence number it was tombstoned
+        // against. Unfortunately since this happened in a past transaction, and the
+        // child object may have been modified since (and hence its sequence number incremented),
+        // we must traverse the objects table until we find the tombstone in order to get the
+        // correct sequence number
+        let wrapped_objects_to_remove: Vec<WrappedObject> = all_unwrapped
+            .iter()
+            .map(|(id, seq_num)| {
+                let (_key, wrapper) = self
+                    .authority_store
+                    .perpetual_tables
+                    .objects
+                    .iter()
+                    .skip_prior_to(&ObjectKey(*id, *seq_num))
+                    .unwrap_or_else(|err| {
+                        panic!("Object with id {} expected to be tombstoned: {}", id, err)
+                    })
+                    .reverse()
+                    .find(|(_key, wrapper)| {
+                        let object = self
+                            .authority_store
+                            .perpetual_tables
+                            .object(wrapper.clone())
+                            .expect("Failed to convert StoreObjectWrapper to Object");
+                        object.id() == *id && object.digest() == ObjectDigest::OBJECT_DIGEST_WRAPPED
+                    })
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "Did not find tombstoned object in objects table for id {}",
+                            id
+                        )
+                    });
+                let object = self
+                    .authority_store
+                    .perpetual_tables
+                    .object(wrapper)
+                    .expect("Failed to convert StoreObjectWrapper to Object");
 
-        epoch_store
-            .checkpoint_state_notify_read
-            .notify(&checkpoint_seq_num, &acc);
+                WrappedObject::new(object.id(), object.version())
+            })
+            .collect();
 
-        Ok(acc)
+        acc.remove_all(
+            wrapped_objects_to_remove
+                .iter()
+                .map(|wrapped| bcs::to_bytes(wrapped).unwrap().to_vec())
+                .collect::<Vec<Vec<u8>>>(),
+        );
+
+        acc
     }
 
     /// Unions all checkpoint accumulators at the end of the epoch to generate the
-    /// root state hash and saves it. This function is idempotent. Can be called on
+    /// root state hash and persists it to db. This function is idempotent. Can be called on
     /// non-consecutive epochs, e.g. to accumulate epoch 3 after having last
     /// accumulated epoch 1.
     pub async fn accumulate_epoch(
@@ -220,6 +303,7 @@ impl StateAccumulator {
         Ok(root_state_hash)
     }
 
+    /// Returns the result of accumulatng the live object set, without side effects
     pub fn accumulate_live_object_set(&self) -> Accumulator {
         let mut acc = Accumulator::default();
         for oref in self.authority_store.iter_live_object_set() {

--- a/crates/sui-core/src/state_accumulator.rs
+++ b/crates/sui-core/src/state_accumulator.rs
@@ -175,12 +175,11 @@ impl StateAccumulator {
             .iter()
             .map(|(id, seq_num)| {
                 dbg!(id, seq_num);
-                let wrapped_tombstone = self
+                let objref = self
                     .authority_store
-                    .get_object_prior_to_key(id, *seq_num)
+                    .get_object_ref_prior_to_key(id, *seq_num)
                     .expect("read cannot fail")
                     .expect("wrapped tombstone must precede unwrapped object");
-                let objref = wrapped_tombstone.compute_object_reference();
 
                 assert!(objref.2.is_wrapped(), "{:?}", objref);
 

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -10,6 +10,7 @@ use std::task::{Context, Poll};
 use std::{convert::TryInto, env};
 
 use bcs;
+use fastcrypto::hash::MultisetHash;
 use futures::{stream::FuturesUnordered, StreamExt};
 use move_binary_format::access::ModuleAccess;
 use move_binary_format::{
@@ -62,6 +63,7 @@ use sui_types::{SUI_CLOCK_OBJECT_ID, SUI_CLOCK_OBJECT_SHARED_VERSION};
 use crate::authority::move_integration_tests::build_and_publish_test_package_with_upgrade_cap;
 use crate::consensus_handler::SequencedConsensusTransaction;
 use crate::epoch::epoch_metrics::EpochMetrics;
+use crate::state_accumulator::StateAccumulator;
 use crate::{
     authority_client::{AuthorityAPI, NetworkAuthorityClient},
     authority_server::AuthorityServer,
@@ -1533,7 +1535,22 @@ pub async fn send_and_confirm_transaction_(
 
     // Submit the confirmation. *Now* execution actually happens, and it should fail when we try to look up our dummy module.
     // we unfortunately don't get a very descriptive error message, but we can at least see that something went wrong inside the VM
+    let state_acc = StateAccumulator::new(authority.database.clone());
+    let mut state = state_acc.accumulate_live_object_set();
+
     let result = authority.try_execute_for_test(&certificate).await?;
+
+    println!("TESTING -- accumulating live object set");
+    let state_after = state_acc.accumulate_live_object_set();
+    println!("TESTING -- finished accumulating live object set");
+
+    println!("TESTING -- accumulating test tx effects");
+    let effects_acc = state_acc.accumulate_effects(vec![result.inner().data().clone()]);
+    println!("TESTING -- finished accumulating test tx effects");
+    state.union(&effects_acc);
+
+    assert_eq!(state_after.digest(), state.digest());
+
     if let Some(fullnode) = fullnode {
         fullnode.try_execute_for_test(&certificate).await?;
     }

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -194,6 +194,7 @@ async fn test_publish_duplicate_modules() {
 #[tokio::test]
 #[cfg_attr(msim, ignore)]
 async fn test_object_wrapping_unwrapping() {
+    telemetry_subscribers::init_for_testing();
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
     let gas = ObjectID::random();
     let authority = init_state_with_ids(vec![(sender, gas)]).await;

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -752,8 +752,6 @@ async fn test_create_then_delete_parent_child_wrap_separate() {
     )
     .await;
 
-    println!("TESTING -- create_parent");
-
     // Create a parent.
     let effects = call_move(
         &authority,
@@ -769,12 +767,8 @@ async fn test_create_then_delete_parent_child_wrap_separate() {
     .await
     .unwrap();
 
-    println!("TESTING -- finished create_parent");
-
     assert!(effects.status().is_ok());
     let parent = effects.created()[0].0;
-
-    println!("TESTING -- create_child");
 
     // Create a child.
     let effects = call_move(
@@ -791,12 +785,8 @@ async fn test_create_then_delete_parent_child_wrap_separate() {
     .await
     .unwrap();
 
-    println!("TESTING -- finished create_child");
-
     assert!(effects.status().is_ok());
     let child = effects.created()[0].0;
-
-    println!("TESTING -- add_child_wrapped");
 
     // Add the child to the parent.
     let effects = call_move(
@@ -813,13 +803,9 @@ async fn test_create_then_delete_parent_child_wrap_separate() {
     .await
     .unwrap();
 
-    println!("TESTING -- finished add_child_wrapped");
-
     assert!(effects.status().is_ok());
     assert_eq!(effects.created().len(), 1);
     assert_eq!(effects.wrapped().len(), 1);
-
-    println!("TESTING -- delete_parent_and_child_wrapped");
 
     // Delete the parent and child altogether.
     let effects = call_move(
@@ -835,8 +821,6 @@ async fn test_create_then_delete_parent_child_wrap_separate() {
     )
     .await
     .unwrap();
-
-    println!("TESTING -- finished delete_parent_and_child_wrapped");
 
     assert!(effects.status().is_ok());
     // Check that parent object was deleted.

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -751,6 +751,8 @@ async fn test_create_then_delete_parent_child_wrap_separate() {
     )
     .await;
 
+    println!("TESTING -- create_parent");
+
     // Create a parent.
     let effects = call_move(
         &authority,
@@ -766,8 +768,12 @@ async fn test_create_then_delete_parent_child_wrap_separate() {
     .await
     .unwrap();
 
+    println!("TESTING -- finished create_parent");
+
     assert!(effects.status().is_ok());
     let parent = effects.created()[0].0;
+
+    println!("TESTING -- create_child");
 
     // Create a child.
     let effects = call_move(
@@ -783,11 +789,15 @@ async fn test_create_then_delete_parent_child_wrap_separate() {
     )
     .await
     .unwrap();
+
+    println!("TESTING -- finished create_child");
+
     assert!(effects.status().is_ok());
     let child = effects.created()[0].0;
 
+    println!("TESTING -- add_child_wrapped");
+
     // Add the child to the parent.
-    println!("add_child_wrapped");
     let effects = call_move(
         &authority,
         &gas,
@@ -802,9 +812,13 @@ async fn test_create_then_delete_parent_child_wrap_separate() {
     .await
     .unwrap();
 
+    println!("TESTING -- finished add_child_wrapped");
+
     assert!(effects.status().is_ok());
     assert_eq!(effects.created().len(), 1);
     assert_eq!(effects.wrapped().len(), 1);
+
+    println!("TESTING -- delete_parent_and_child_wrapped");
 
     // Delete the parent and child altogether.
     let effects = call_move(
@@ -820,6 +834,8 @@ async fn test_create_then_delete_parent_child_wrap_separate() {
     )
     .await
     .unwrap();
+
+    println!("TESTING -- finished delete_parent_and_child_wrapped");
 
     assert!(effects.status().is_ok());
     // Check that parent object was deleted.

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -75,6 +75,16 @@ mod base_types_tests;
 )]
 pub struct SequenceNumber(u64);
 
+impl SequenceNumber {
+    pub fn one_before(&self) -> Option<SequenceNumber> {
+        if self.0 == 0 {
+            None
+        } else {
+            Some(SequenceNumber(self.0 - 1))
+        }
+    }
+}
+
 pub type TxSequenceNumber = u64;
 
 impl fmt::Display for SequenceNumber {

--- a/crates/sui-types/src/digests.rs
+++ b/crates/sui-types/src/digests.rs
@@ -583,6 +583,10 @@ impl ObjectDigest {
         *self == Self::OBJECT_DIGEST_DELETED
     }
 
+    pub fn is_wrapped(&self) -> bool {
+        *self == Self::OBJECT_DIGEST_WRAPPED
+    }
+
     pub fn base58_encode(&self) -> String {
         Base58::encode(self.0)
     }


### PR DESCRIPTION
## Description 

This exercises state accumulation against edge case transactions such as those created from the use of `created_then_wrapped`, `unwrapped_then_deleted`, as well as other combinations of wraps and unwraps, by adding incremental checking of the live object set against the result of accumulating single transaction effects. This path will be exercised by any tests that hit `authority_tests::send_and_confirm_transaction_()`. Notably, this includes all tests in `move_interation_tests.rs`. 

Included also is bug fixes uncovered from the above.

## Test Plan 

```
cargo simtest && cargo nextest run
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
