### PR TITLE
Add sui system state upgrade test

### DIFF
--- a/crates/sui-types/src/sui_system_state/simtest_sui_system_state_inner.rs
+++ b/crates/sui-types/src/sui_system_state/simtest_sui_system_state_inner.rs
@@ -278,3 +278,147 @@ impl SuiSystemStateTrait for SimTestSuiSystemStateInnerV1 {
         }
     }
 }
+
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
+pub struct SimTestSuiSystemStateInnerV2 {
+    pub new_dummy_field: u64,
+    pub epoch: u64,
+    pub protocol_version: u64,
+    pub system_state_version: u64,
+    pub validators: SimTestValidatorSetV1,
+    pub storage_fund: Balance,
+    pub parameters: SimTestSystemParametersV1,
+    pub reference_gas_price: u64,
+    pub safe_mode: bool,
+    pub epoch_start_timestamp_ms: u64,
+    pub extra_fields: Bag,
+}
+
+impl SuiSystemStateTrait for SimTestSuiSystemStateInnerV2 {
+    fn epoch(&self) -> u64 {
+        self.epoch
+    }
+
+    fn reference_gas_price(&self) -> u64 {
+        self.reference_gas_price
+    }
+
+    fn protocol_version(&self) -> u64 {
+        self.protocol_version
+    }
+
+    fn system_state_version(&self) -> u64 {
+        self.system_state_version
+    }
+
+    fn epoch_start_timestamp_ms(&self) -> u64 {
+        self.epoch_start_timestamp_ms
+    }
+
+    fn epoch_duration_ms(&self) -> u64 {
+        self.parameters.epoch_duration_ms
+    }
+
+    fn safe_mode(&self) -> bool {
+        self.safe_mode
+    }
+
+    fn get_current_epoch_committee(&self) -> CommitteeWithNetworkMetadata {
+        let mut voting_rights = BTreeMap::new();
+        let mut network_metadata = BTreeMap::new();
+        for validator in &self.validators.active_validators {
+            let verified_metadata = validator.verified_metadata();
+            let name = verified_metadata.sui_pubkey_bytes();
+            voting_rights.insert(name, validator.voting_power);
+            network_metadata.insert(
+                name,
+                NetworkMetadata {
+                    network_address: verified_metadata.net_address.clone(),
+                    narwhal_primary_address: verified_metadata.primary_address.clone(),
+                },
+            );
+        }
+        CommitteeWithNetworkMetadata {
+            committee: Committee::new(self.epoch, voting_rights),
+            network_metadata,
+        }
+    }
+
+    fn into_epoch_start_state(self) -> EpochStartSystemState {
+        EpochStartSystemState::new_v1(
+            self.epoch,
+            self.protocol_version,
+            self.reference_gas_price,
+            self.safe_mode,
+            self.epoch_start_timestamp_ms,
+            self.parameters.epoch_duration_ms,
+            self.validators
+                .active_validators
+                .iter()
+                .map(|validator| {
+                    let metadata = validator.verified_metadata();
+                    EpochStartValidatorInfoV1 {
+                        sui_address: metadata.sui_address,
+                        protocol_pubkey: metadata.protocol_pubkey.clone(),
+                        narwhal_network_pubkey: metadata.network_pubkey.clone(),
+                        narwhal_worker_pubkey: metadata.worker_pubkey.clone(),
+                        sui_net_address: metadata.net_address.clone(),
+                        p2p_address: metadata.p2p_address.clone(),
+                        narwhal_primary_address: metadata.primary_address.clone(),
+                        narwhal_worker_address: metadata.worker_address.clone(),
+                        voting_power: validator.voting_power,
+                    }
+                })
+                .collect(),
+        )
+    }
+
+    fn into_sui_system_state_summary(self) -> SuiSystemStateSummary {
+        // If you are making any changes to SuiSystemStateV1 or any of its dependent types before
+        // mainnet, please also update SuiSystemStateSummary and its corresponding TS type.
+        // Post-mainnet, we will need to introduce a new version.
+        let Self {
+            new_dummy_field: _,
+            epoch,
+            protocol_version,
+            system_state_version,
+            validators:
+                SimTestValidatorSetV1 {
+                    active_validators,
+                    inactive_validators:
+                        Table {
+                            id: inactive_pools_id,
+                            size: inactive_pools_size,
+                        },
+                    extra_fields: _,
+                },
+            storage_fund,
+            parameters:
+                SimTestSystemParametersV1 {
+                    epoch_duration_ms,
+                    extra_fields: _,
+                },
+            reference_gas_price,
+            safe_mode,
+            epoch_start_timestamp_ms,
+            extra_fields: _,
+        } = self;
+        SuiSystemStateSummary {
+            epoch,
+            protocol_version,
+            system_state_version,
+            storage_fund: storage_fund.value(),
+            reference_gas_price,
+            safe_mode,
+            epoch_start_timestamp_ms,
+            epoch_duration_ms,
+            active_validators: active_validators
+                .into_iter()
+                .map(|v| v.into_sui_validator_summary())
+                .collect(),
+            inactive_pools_id,
+            inactive_pools_size,
+            ..Default::default()
+        }
+    }
+}

--- a/crates/sui/tests/framework_upgrades/mock_sui_systems/upgrade/Move.toml
+++ b/crates/sui/tests/framework_upgrades/mock_sui_systems/upgrade/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "SuiSystemUpgrade"
+version = "0.0.1"
+
+[dependencies]
+Sui = { local = "../../../../../sui-framework/packages/sui-framework" }
+MoveStdlib = { local = "../../../../../sui-framework/packages/move-stdlib" }
+
+[addresses]
+sui_system = "0x3"

--- a/crates/sui/tests/framework_upgrades/mock_sui_systems/upgrade/sources/genesis.move
+++ b/crates/sui/tests/framework_upgrades/mock_sui_systems/upgrade/sources/genesis.move
@@ -1,0 +1,126 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui_system::genesis {
+    use std::vector;
+    use sui::balance::{Self, Balance};
+    use sui::object::UID;
+    use sui::sui::SUI;
+    use sui::tx_context::{Self, TxContext};
+    use std::option::Option;
+
+    use sui_system::sui_system;
+    use sui_system::validator;
+
+    struct GenesisValidatorMetadata has drop, copy {
+        name: vector<u8>,
+        description: vector<u8>,
+        image_url: vector<u8>,
+        project_url: vector<u8>,
+
+        sui_address: address,
+
+        gas_price: u64,
+        commission_rate: u64,
+
+        protocol_public_key: vector<u8>,
+        proof_of_possession: vector<u8>,
+
+        network_public_key: vector<u8>,
+        worker_public_key: vector<u8>,
+
+        network_address: vector<u8>,
+        p2p_address: vector<u8>,
+        primary_address: vector<u8>,
+        worker_address: vector<u8>,
+    }
+
+    struct GenesisChainParameters has drop, copy {
+        protocol_version: u64,
+        chain_start_timestamp_ms: u64,
+        epoch_duration_ms: u64,
+
+        stake_subsidy_start_epoch: u64,
+        stake_subsidy_initial_distribution_amount: u64,
+        stake_subsidy_period_length: u64,
+        stake_subsidy_decrease_rate: u16,
+
+        max_validator_count: u64,
+        min_validator_joining_stake: u64,
+        validator_low_stake_threshold: u64,
+        validator_very_low_stake_threshold: u64,
+        validator_low_stake_grace_period: u64,
+    }
+
+    struct TokenDistributionSchedule has drop {
+        stake_subsidy_fund_mist: u64,
+        allocations: vector<TokenAllocation>,
+    }
+
+    struct TokenAllocation has drop {
+        recipient_address: address,
+        amount_mist: u64,
+        staked_with_validator: Option<address>,
+    }
+
+    fun create(
+        sui_system_state_id: UID,
+        sui_supply: Balance<SUI>,
+        genesis_chain_parameters: GenesisChainParameters,
+        genesis_validators: vector<GenesisValidatorMetadata>,
+        _token_distribution_schedule: TokenDistributionSchedule,
+        ctx: &mut TxContext,
+    ) {
+        assert!(tx_context::epoch(ctx) == 0, 0);
+
+        let validators = vector::empty();
+        let count = vector::length(&genesis_validators);
+        let i = 0;
+        while (i < count) {
+            let GenesisValidatorMetadata {
+                name: _,
+                description: _,
+                image_url: _,
+                project_url: _,
+                sui_address,
+                gas_price: _,
+                commission_rate: _,
+                protocol_public_key,
+                proof_of_possession: _,
+                network_public_key,
+                worker_public_key,
+                network_address,
+                p2p_address,
+                primary_address,
+                worker_address,
+            } = *vector::borrow(&genesis_validators, i);
+
+            let validator = validator::new(
+                sui_address,
+                protocol_public_key,
+                network_public_key,
+                worker_public_key,
+                network_address,
+                p2p_address,
+                primary_address,
+                worker_address,
+                balance::split(&mut sui_supply, 10000),
+                ctx
+            );
+
+            vector::push_back(&mut validators, validator);
+
+            i = i + 1;
+        };
+
+        sui_system::create(
+            sui_system_state_id,
+            validators,
+            sui_supply,     // storage_fund
+            genesis_chain_parameters.protocol_version,
+            genesis_chain_parameters.chain_start_timestamp_ms,
+            genesis_chain_parameters.epoch_duration_ms,
+            ctx,
+        );
+    }
+}

--- a/crates/sui/tests/framework_upgrades/mock_sui_systems/upgrade/sources/sui_system.move
+++ b/crates/sui/tests/framework_upgrades/mock_sui_systems/upgrade/sources/sui_system.move
@@ -1,0 +1,117 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui_system::sui_system {
+    use sui::balance::Balance;
+    use sui::object::UID;
+    use sui::sui::SUI;
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+    use sui::dynamic_field;
+
+    use sui_system::validator::Validator;
+    use sui_system::sui_system_state_inner::{Self, SuiSystemStateInner, SuiSystemStateInnerV2};
+
+    friend sui_system::genesis;
+
+    struct SuiSystemState has key {
+        id: UID,
+        version: u64,
+    }
+
+    public(friend) fun create(
+        id: UID,
+        validators: vector<Validator>,
+        storage_fund: Balance<SUI>,
+        protocol_version: u64,
+        epoch_start_timestamp_ms: u64,
+        epoch_duration_ms: u64,
+        ctx: &mut TxContext,
+    ) {
+        let system_state = sui_system_state_inner::create(
+            validators,
+            storage_fund,
+            protocol_version,
+            epoch_start_timestamp_ms,
+            epoch_duration_ms,
+            ctx,
+        );
+        let version = sui_system_state_inner::genesis_system_state_version();
+        let self = SuiSystemState {
+            id,
+            version,
+        };
+        dynamic_field::add(&mut self.id, version, system_state);
+        transfer::share_object(self);
+    }
+
+    fun advance_epoch(
+        storage_reward: Balance<SUI>,
+        computation_reward: Balance<SUI>,
+        wrapper: &mut SuiSystemState,
+        new_epoch: u64,
+        next_protocol_version: u64,
+        storage_rebate: u64,
+        _storage_fund_reinvest_rate: u64, // share of storage fund's rewards that's reinvested
+                                         // into storage fund, in basis point.
+        _reward_slashing_rate: u64, // how much rewards are slashed to punish a validator, in bps.
+        epoch_start_timestamp_ms: u64, // Timestamp of the epoch start
+        ctx: &mut TxContext,
+    ) : Balance<SUI> {
+        let self = load_system_state_mut(wrapper);
+        assert!(tx_context::sender(ctx) == @0x0, 0);
+        let storage_rebate = sui_system_state_inner::advance_epoch(
+            self,
+            new_epoch,
+            next_protocol_version,
+            storage_reward,
+            computation_reward,
+            storage_rebate,
+            epoch_start_timestamp_ms,
+        );
+
+        storage_rebate
+    }
+
+    fun advance_epoch_safe_mode(
+        storage_reward: Balance<SUI>,
+        computation_reward: Balance<SUI>,
+        wrapper: &mut SuiSystemState,
+        new_epoch: u64,
+        next_protocol_version: u64,
+        storage_rebate: u64,
+        ctx: &mut TxContext,
+    ) {
+        let self = load_system_state_mut(wrapper);
+        // Validator will make a special system call with sender set as 0x0.
+        assert!(tx_context::sender(ctx) == @0x0, 0);
+        sui_system_state_inner::advance_epoch_safe_mode(
+            self,
+            new_epoch,
+            next_protocol_version,
+            storage_reward,
+            computation_reward,
+            storage_rebate,
+            ctx
+        )
+    }
+
+    fun load_system_state_mut(self: &mut SuiSystemState): &mut SuiSystemStateInnerV2 {
+        load_inner_maybe_upgrade(self)
+    }
+
+    fun load_inner_maybe_upgrade(self: &mut SuiSystemState): &mut SuiSystemStateInnerV2 {
+        let version = self.version;
+        if (version == sui_system_state_inner::genesis_system_state_version()) {
+            let inner: SuiSystemStateInner = dynamic_field::remove(&mut self.id, version);
+            let new_inner = sui_system_state_inner::v1_to_v2(inner);
+            version = sui_system_state_inner::system_state_version(&new_inner);
+            dynamic_field::add(&mut self.id, version, new_inner);
+            self.version = version;
+        };
+
+        let inner: &mut SuiSystemStateInnerV2 = dynamic_field::borrow_mut(&mut self.id, version);
+        assert!(sui_system_state_inner::system_state_version(inner) == version, 0);
+        inner
+    }
+}

--- a/crates/sui/tests/framework_upgrades/mock_sui_systems/upgrade/sources/sui_system_state_inner.move
+++ b/crates/sui/tests/framework_upgrades/mock_sui_systems/upgrade/sources/sui_system_state_inner.move
@@ -1,0 +1,164 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui_system::sui_system_state_inner {
+    use sui::balance::{Self, Balance};
+    use sui::sui::SUI;
+    use sui::tx_context::TxContext;
+    use sui::bag::{Self, Bag};
+    use sui::table::{Self, Table};
+    use sui::object::ID;
+
+    use sui_system::validator::Validator;
+    use sui_system::validator_wrapper::ValidatorWrapper;
+
+    friend sui_system::sui_system;
+
+    const SYSTEM_STATE_VERSION_V1: u64 = 18446744073709551605;  // u64::MAX - 10
+    const SYSTEM_STATE_VERSION_V2: u64 = 18446744073709551606;  // u64::MAX - 9
+
+    struct SystemParameters has store {
+        epoch_duration_ms: u64,
+        extra_fields: Bag,
+    }
+
+    struct ValidatorSet has store {
+        active_validators: vector<Validator>,
+        inactive_validators: Table<ID, ValidatorWrapper>,
+        extra_fields: Bag,
+    }
+
+    struct SuiSystemStateInner has store {
+        epoch: u64,
+        protocol_version: u64,
+        system_state_version: u64,
+        validators: ValidatorSet,
+        storage_fund: Balance<SUI>,
+        parameters: SystemParameters,
+        reference_gas_price: u64,
+        safe_mode: bool,
+        epoch_start_timestamp_ms: u64,
+        extra_fields: Bag,
+    }
+
+    struct SuiSystemStateInnerV2 has store {
+        new_dummy_field: u64,
+        epoch: u64,
+        protocol_version: u64,
+        system_state_version: u64,
+        validators: ValidatorSet,
+        storage_fund: Balance<SUI>,
+        parameters: SystemParameters,
+        reference_gas_price: u64,
+        safe_mode: bool,
+        epoch_start_timestamp_ms: u64,
+        extra_fields: Bag,
+    }
+
+    public(friend) fun create(
+        validators: vector<Validator>,
+        storage_fund: Balance<SUI>,
+        protocol_version: u64,
+        epoch_start_timestamp_ms: u64,
+        epoch_duration_ms: u64,
+        ctx: &mut TxContext,
+    ): SuiSystemStateInner {
+        let validators = new_validator_set(validators, ctx);
+        let system_state = SuiSystemStateInner {
+            epoch: 0,
+            protocol_version,
+            system_state_version: genesis_system_state_version(),
+            validators,
+            storage_fund,
+            parameters: SystemParameters {
+                epoch_duration_ms,
+                extra_fields: bag::new(ctx),
+            },
+            reference_gas_price: 1,
+            safe_mode: false,
+            epoch_start_timestamp_ms,
+            extra_fields: bag::new(ctx),
+        };
+        system_state
+    }
+
+    public(friend) fun advance_epoch(
+        self: &mut SuiSystemStateInnerV2,
+        new_epoch: u64,
+        next_protocol_version: u64,
+        storage_reward: Balance<SUI>,
+        computation_reward: Balance<SUI>,
+        storage_rebate_amount: u64,
+        epoch_start_timestamp_ms: u64,
+    ) : Balance<SUI> {
+        self.epoch_start_timestamp_ms = epoch_start_timestamp_ms;
+        self.epoch = self.epoch + 1;
+        assert!(new_epoch == self.epoch, 0);
+        self.safe_mode = false;
+        self.protocol_version = next_protocol_version;
+
+        balance::join(&mut self.storage_fund, computation_reward);
+        balance::join(&mut self.storage_fund, storage_reward);
+        let storage_rebate = balance::split(&mut self.storage_fund, storage_rebate_amount);
+        storage_rebate
+    }
+
+    public(friend) fun advance_epoch_safe_mode(
+        self: &mut SuiSystemStateInnerV2,
+        new_epoch: u64,
+        next_protocol_version: u64,
+        storage_reward: Balance<SUI>,
+        computation_reward: Balance<SUI>,
+        _storage_rebate: u64,
+        _ctx: &mut TxContext,
+    ) {
+        self.epoch = new_epoch;
+        self.protocol_version = next_protocol_version;
+        self.safe_mode = true;
+        balance::join(&mut self.storage_fund, computation_reward);
+        balance::join(&mut self.storage_fund, storage_reward);
+    }
+
+    public(friend) fun protocol_version(self: &SuiSystemStateInnerV2): u64 { self.protocol_version }
+    public(friend) fun system_state_version(self: &SuiSystemStateInnerV2): u64 { self.system_state_version }
+    public(friend) fun genesis_system_state_version(): u64 {
+        SYSTEM_STATE_VERSION_V1
+    }
+
+    fun new_validator_set(init_active_validators: vector<Validator>, ctx: &mut TxContext): ValidatorSet {
+        ValidatorSet {
+            active_validators: init_active_validators,
+            inactive_validators: table::new(ctx),
+            extra_fields: bag::new(ctx),
+        }
+    }
+
+    public(friend) fun v1_to_v2(v1: SuiSystemStateInner): SuiSystemStateInnerV2 {
+        let SuiSystemStateInner {
+            epoch,
+            protocol_version,
+            system_state_version: old_system_state_version,
+            validators,
+            storage_fund,
+            parameters,
+            reference_gas_price,
+            safe_mode,
+            epoch_start_timestamp_ms,
+            extra_fields,
+        } = v1;
+        assert!(old_system_state_version == SYSTEM_STATE_VERSION_V1, 0);
+        SuiSystemStateInnerV2 {
+            new_dummy_field: 100,
+            epoch,
+            protocol_version,
+            system_state_version: SYSTEM_STATE_VERSION_V2,
+            validators,
+            storage_fund,
+            parameters,
+            reference_gas_price,
+            safe_mode,
+            epoch_start_timestamp_ms,
+            extra_fields,
+        }
+    }
+}

--- a/crates/sui/tests/framework_upgrades/mock_sui_systems/upgrade/sources/validator.move
+++ b/crates/sui/tests/framework_upgrades/mock_sui_systems/upgrade/sources/validator.move
@@ -1,0 +1,67 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui_system::validator {
+    use std::ascii;
+
+    use sui::tx_context::TxContext;
+    use std::string::{Self, String};
+    use sui::bag::{Self, Bag};
+    use sui::balance::{Self, Balance};
+    use sui::sui::SUI;
+
+    friend sui_system::genesis;
+    friend sui_system::sui_system_state_inner;
+    friend sui_system::validator_wrapper;
+
+    struct ValidatorMetadata has store {
+        sui_address: address,
+        protocol_pubkey_bytes: vector<u8>,
+        network_pubkey_bytes: vector<u8>,
+        worker_pubkey_bytes: vector<u8>,
+        net_address: String,
+        p2p_address: String,
+        primary_address: String,
+        worker_address: String,
+        extra_fields: Bag,
+    }
+
+    struct Validator has store {
+        metadata: ValidatorMetadata,
+        voting_power: u64,
+        stake: Balance<SUI>,
+        extra_fields: Bag,
+    }
+
+    public(friend) fun new(
+        sui_address: address,
+        protocol_pubkey_bytes: vector<u8>,
+        network_pubkey_bytes: vector<u8>,
+        worker_pubkey_bytes: vector<u8>,
+        net_address: vector<u8>,
+        p2p_address: vector<u8>,
+        primary_address: vector<u8>,
+        worker_address: vector<u8>,
+        init_stake: Balance<SUI>,
+        ctx: &mut TxContext
+    ): Validator {
+        let metadata = ValidatorMetadata {
+            sui_address,
+            protocol_pubkey_bytes,
+            network_pubkey_bytes,
+            worker_pubkey_bytes,
+            net_address: string::from_ascii(ascii::string(net_address)),
+            p2p_address: string::from_ascii(ascii::string(p2p_address)),
+            primary_address: string::from_ascii(ascii::string(primary_address)),
+            worker_address: string::from_ascii(ascii::string(worker_address)),
+            extra_fields: bag::new(ctx),
+        };
+
+        Validator {
+            metadata,
+            voting_power: balance::value(&init_stake),
+            stake: init_stake,
+            extra_fields: bag::new(ctx),
+        }
+    }
+}

--- a/crates/sui/tests/framework_upgrades/mock_sui_systems/upgrade/sources/validator_wrapper.move
+++ b/crates/sui/tests/framework_upgrades/mock_sui_systems/upgrade/sources/validator_wrapper.move
@@ -1,0 +1,54 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui_system::validator_wrapper {
+    use sui::versioned::Versioned;
+    use sui::versioned;
+    use sui::tx_context::TxContext;
+    use sui_system::validator::Validator;
+
+    friend sui_system::sui_system_state_inner;
+
+    const EInvalidVersion: u64 = 0;
+
+    struct ValidatorWrapper has store {
+        inner: Versioned
+    }
+
+    // Validator corresponds to version 1.
+    public(friend) fun create_v1(validator: Validator, ctx: &mut TxContext): ValidatorWrapper {
+        ValidatorWrapper {
+            inner: versioned::create(1, validator, ctx)
+        }
+    }
+
+    /// This function should always return the latest supported version.
+    /// If the inner version is old, we upgrade it lazily in-place.
+    public(friend) fun load_validator_maybe_upgrade(self: &mut ValidatorWrapper): &mut Validator {
+        upgrade_to_latest(self);
+        versioned::load_value_mut<Validator>(&mut self.inner)
+    }
+
+    /// Destroy the wrapper and retrieve the inner validator object.
+    public(friend) fun destroy(self: ValidatorWrapper): Validator {
+        upgrade_to_latest(&mut self);
+        let ValidatorWrapper { inner } = self;
+        versioned::destroy<Validator>(inner)
+    }
+
+    #[test_only]
+    /// Load the inner validator with assumed type. This should be used for testing only.
+    public(friend) fun get_inner_validator_ref(self: &ValidatorWrapper): &Validator {
+        versioned::load_value<Validator>(&self.inner)
+    }
+
+    fun upgrade_to_latest(self: &mut ValidatorWrapper) {
+        let version = version(self);
+        // TODO: When new versions are added, we need to explicitly upgrade here.
+        assert!(version == 1, EInvalidVersion);
+    }
+
+    fun version(self: &ValidatorWrapper): u64 {
+        versioned::version(&self.inner)
+    }
+}

--- a/crates/sui/tests/protocol_version_tests.rs
+++ b/crates/sui/tests/protocol_version_tests.rs
@@ -66,7 +66,10 @@ mod sim_only_tests {
     use sui_json_rpc::api::WriteApiClient;
     use sui_macros::*;
     use sui_protocol_config::SupportedProtocolVersions;
-    use sui_types::sui_system_state::SuiSystemStateTrait;
+    use sui_types::sui_system_state::{
+        SuiSystemState, SuiSystemStateTrait, SUI_SYSTEM_STATE_SIM_TEST_V1,
+        SUI_SYSTEM_STATE_SIM_TEST_V2,
+    };
     use sui_types::{
         base_types::SequenceNumber,
         digests::TransactionDigest,
@@ -556,6 +559,38 @@ mod sim_only_tests {
             .unwrap();
         // Make sure we can survive at least one epoch.
         test_cluster.wait_for_epoch(None).await;
+    }
+
+    #[sim_test]
+    async fn sui_system_state_upgrade_test() {
+        let test_cluster = TestClusterBuilder::new()
+            .with_epoch_duration_ms(20000)
+            .with_supported_protocol_versions(SupportedProtocolVersions::new_for_testing(
+                START, FINISH,
+            ))
+            .with_objects([sui_system_package_object("mock_sui_systems/base")])
+            .build()
+            .await
+            .unwrap();
+        sui_system_injection::set_override(sui_system_modules("mock_sui_systems/upgrade"));
+        // Wait for the upgrade to finish. After the upgrade, the new framework will be installed,
+        // but the system state object hasn't been upgraded yet.
+        let system_state = test_cluster.wait_for_epoch(Some(1)).await;
+        assert_eq!(system_state.protocol_version(), FINISH);
+        assert_eq!(
+            system_state.system_state_version(),
+            SUI_SYSTEM_STATE_SIM_TEST_V1
+        );
+        assert!(matches!(system_state, SuiSystemState::SimTestV1(_)));
+
+        // The system state object will be upgraded next time we execute advance_epoch transaction
+        // at epoch boundary.
+        let system_state = test_cluster.wait_for_epoch(Some(2)).await;
+        assert_eq!(
+            system_state.system_state_version(),
+            SUI_SYSTEM_STATE_SIM_TEST_V2
+        );
+        assert!(matches!(system_state, SuiSystemState::SimTestV2(_)));
     }
 
     async fn monitor_version_change(test_cluster: &TestCluster, final_version: u64) {


### PR DESCRIPTION
Adds a simtest to exercise sui system state upgrade.
This only covers the basic upgrade so far, where we add a new field in the top level type.
Will look at adding more complex upgrade test latter, and also we need to have a way to inspect the sui system state after the upgrade.