### PR TITLE
Fix port description

### DIFF
--- a/nre/sui_for_node_operators.md
+++ b/nre/sui_for_node_operators.md
@@ -67,7 +67,7 @@ Sui Node uses the following ports by default:
 | ------------- | ---------------- | --------------------------------- |
 | TCP/8080      | inbound          | protocol/transaction interface    |
 | UDP/8081      | inbound/outbound | narwhal primary interface         |
-| UDP/8082      | inbound/outbound | narwhal primary interface         |
+| UDP/8082      | inbound/outbound | narwhal worker interface         |
 | TCP/8083      | localhost        | sui -> narwhal interface          |
 | UDP/8084      | inbound/outbound | peer to peer state sync interface |
 | TCP/8443      | outbound         | metrics pushing                   |


### PR DESCRIPTION
## Description 

8082 is Narwhal worker port for anemo.

## Test Plan 

doc fix

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
