### PR TITLE
[wallet-ext] open Ledger connection modal in new tab to prevent HID/USB connection issues

### DIFF
--- a/apps/wallet/src/ui/app/components/ledger/ConnectLedgerModal.tsx
+++ b/apps/wallet/src/ui/app/components/ledger/ConnectLedgerModal.tsx
@@ -10,14 +10,12 @@ import { ModalDialog } from '_src/ui/app/shared/ModalDialog';
 import { Text } from '_src/ui/app/shared/text';
 
 type ConnectLedgerModalProps = {
-    isOpen: boolean;
     onClose: () => void;
     onConfirm: () => void;
     onError: (error: unknown) => void;
 };
 
 export function ConnectLedgerModal({
-    isOpen,
     onClose,
     onConfirm,
     onError,
@@ -39,7 +37,7 @@ export function ConnectLedgerModal({
 
     return (
         <ModalDialog
-            isOpen={isOpen}
+            isOpen
             title="Connect Ledger Wallet"
             onClose={onClose}
             body={

--- a/apps/wallet/src/ui/app/components/ledger/ConnectLedgerModalContainer.tsx
+++ b/apps/wallet/src/ui/app/components/ledger/ConnectLedgerModalContainer.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { LockedDeviceError } from '@ledgerhq/errors';
 import toast from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';

--- a/apps/wallet/src/ui/app/components/ledger/ConnectLedgerModalContainer.tsx
+++ b/apps/wallet/src/ui/app/components/ledger/ConnectLedgerModalContainer.tsx
@@ -1,0 +1,45 @@
+import { LockedDeviceError } from '@ledgerhq/errors';
+import toast from 'react-hot-toast';
+import { useNavigate } from 'react-router-dom';
+
+import { useNextMenuUrl } from '../menu/hooks';
+import { ConnectLedgerModal } from './ConnectLedgerModal';
+import {
+    LedgerConnectionFailedError,
+    LedgerNoTransportMechanismError,
+} from './LedgerExceptions';
+
+export function ConnectLedgerModalContainer() {
+    const navigate = useNavigate();
+    const accountsUrl = useNextMenuUrl(true, '/accounts');
+    const importLedgerAccountsUrl = useNextMenuUrl(
+        true,
+        '/import-ledger-accounts'
+    );
+
+    return (
+        <ConnectLedgerModal
+            onClose={() => {
+                navigate(accountsUrl);
+            }}
+            onError={(error) => {
+                navigate(accountsUrl);
+                toast.error(getLedgerErrorMessage(error));
+            }}
+            onConfirm={() => {
+                navigate(importLedgerAccountsUrl);
+            }}
+        />
+    );
+}
+
+function getLedgerErrorMessage(error: unknown) {
+    if (error instanceof LockedDeviceError) {
+        return 'Your device is locked. Un-lock it and try again.';
+    } else if (error instanceof LedgerConnectionFailedError) {
+        return 'Ledger connection failed.';
+    } else if (error instanceof LedgerNoTransportMechanismError) {
+        return "Your machine doesn't support USB or HID.";
+    }
+    return 'Something went wrong. Try again.';
+}

--- a/apps/wallet/src/ui/app/components/menu/content/AccountsSettings.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/AccountsSettings.tsx
@@ -2,21 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useFeature } from '@growthbook/growthbook-react';
-import { LockedDeviceError } from '@ledgerhq/errors';
 import { LockLocked16 as LockedLockIcon } from '@mysten/icons';
-import { useState } from 'react';
-import toast from 'react-hot-toast';
-import { useNavigate } from 'react-router-dom';
+import { Outlet, useNavigate } from 'react-router-dom';
+import Browser from 'webextension-polyfill';
 
-import { ConnectLedgerModal } from '../../ledger/ConnectLedgerModal';
-import {
-    LedgerConnectionFailedError,
-    LedgerNoTransportMechanismError,
-} from '../../ledger/LedgerExceptions';
 import { Account } from './Account';
 import { MenuLayout } from './MenuLayout';
 import { useNextMenuUrl } from '_components/menu/hooks';
+import { AppType } from '_redux/slices/app/AppType';
 import { FEATURES } from '_src/shared/experimentation/features';
+import { useAppSelector } from '_src/ui/app/hooks';
 import { useAccounts } from '_src/ui/app/hooks/useAccounts';
 import { useDeriveNextAccountMutation } from '_src/ui/app/hooks/useDeriveNextAccountMutation';
 import { Button } from '_src/ui/app/shared/ButtonUI';
@@ -25,22 +20,15 @@ export function AccountsSettings() {
     const backUrl = useNextMenuUrl(true, '/');
     const importPrivateKeyUrl = useNextMenuUrl(true, '/import-private-key');
     const accounts = useAccounts();
-    const isMultiAccountsEnabled = useFeature(
-        FEATURES.WALLET_MULTI_ACCOUNTS
-    ).on;
     const createAccountMutation = useDeriveNextAccountMutation();
-
-    const [isConnectLedgerModalOpen, setConnectLedgerModalOpen] =
-        useState(false);
-
     const { on: isLedgerIntegrationEnabled } = useFeature(
         FEATURES.WALLET_LEDGER_INTEGRATION
     );
-
     const navigate = useNavigate();
-    const importLedgerAccountsUrl = useNextMenuUrl(
+    const appType = useAppSelector((state) => state.app.appType);
+    const connectLedgerModalUrl = useNextMenuUrl(
         true,
-        '/import-ledger-accounts'
+        '/accounts/connect-ledger-modal'
     );
 
     return (
@@ -53,58 +41,45 @@ export function AccountsSettings() {
                         accountType={type}
                     />
                 ))}
-                {isMultiAccountsEnabled ? (
-                    <>
-                        <Button
-                            variant="outline"
-                            size="tall"
-                            text="Create New Account"
-                            loading={createAccountMutation.isLoading}
-                            onClick={() => createAccountMutation.mutate()}
-                        />
-                        <Button
-                            variant="outline"
-                            size="tall"
-                            text="Import Private Key"
-                            to={importPrivateKeyUrl}
-                        />
-                    </>
-                ) : null}
+                <Button
+                    variant="outline"
+                    size="tall"
+                    text="Create New Account"
+                    loading={createAccountMutation.isLoading}
+                    onClick={() => createAccountMutation.mutate()}
+                />
+                <Button
+                    variant="outline"
+                    size="tall"
+                    text="Import Private Key"
+                    to={importPrivateKeyUrl}
+                />
                 {isLedgerIntegrationEnabled ? (
-                    <>
-                        <Button
-                            variant="outline"
-                            size="tall"
-                            text="Connect Ledger Wallet"
-                            before={<LockedLockIcon />}
-                            onClick={() => setConnectLedgerModalOpen(true)}
-                        />
-                        <ConnectLedgerModal
-                            isOpen={isConnectLedgerModalOpen}
-                            onClose={() => setConnectLedgerModalOpen(false)}
-                            onError={(error) => {
-                                setConnectLedgerModalOpen(false);
-                                toast.error(getLedgerErrorMessage(error));
-                            }}
-                            onConfirm={() => {
-                                setConnectLedgerModalOpen(false);
-                                navigate(importLedgerAccountsUrl);
-                            }}
-                        />
-                    </>
+                    <Button
+                        variant="outline"
+                        size="tall"
+                        text="Connect Ledger Wallet"
+                        before={<LockedLockIcon />}
+                        onClick={async () => {
+                            if (appType === AppType.popup) {
+                                const absoluteConnectLedgerModalUrl = new URL(
+                                    `${window.location.origin}/${window.location.pathname}`
+                                );
+                                absoluteConnectLedgerModalUrl.hash =
+                                    connectLedgerModalUrl;
+
+                                await Browser.tabs.create({
+                                    url: absoluteConnectLedgerModalUrl.toString(),
+                                });
+                                window.close();
+                            } else {
+                                navigate(connectLedgerModalUrl);
+                            }
+                        }}
+                    />
                 ) : null}
+                <Outlet />
             </div>
         </MenuLayout>
     );
-}
-
-function getLedgerErrorMessage(error: unknown) {
-    if (error instanceof LockedDeviceError) {
-        return 'Your device is locked. Un-lock it and try again.';
-    } else if (error instanceof LedgerConnectionFailedError) {
-        return 'Ledger connection failed.';
-    } else if (error instanceof LedgerNoTransportMechanismError) {
-        return "Your machine doesn't support USB or HID.";
-    }
-    return 'Something went wrong. Try again.';
 }

--- a/apps/wallet/src/ui/app/components/menu/content/AccountsSettings.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/AccountsSettings.tsx
@@ -20,6 +20,9 @@ export function AccountsSettings() {
     const backUrl = useNextMenuUrl(true, '/');
     const importPrivateKeyUrl = useNextMenuUrl(true, '/import-private-key');
     const accounts = useAccounts();
+    const isMultiAccountsEnabled = useFeature(
+        FEATURES.WALLET_MULTI_ACCOUNTS
+    ).on;
     const createAccountMutation = useDeriveNextAccountMutation();
     const { on: isLedgerIntegrationEnabled } = useFeature(
         FEATURES.WALLET_LEDGER_INTEGRATION
@@ -41,19 +44,23 @@ export function AccountsSettings() {
                         accountType={type}
                     />
                 ))}
-                <Button
-                    variant="outline"
-                    size="tall"
-                    text="Create New Account"
-                    loading={createAccountMutation.isLoading}
-                    onClick={() => createAccountMutation.mutate()}
-                />
-                <Button
-                    variant="outline"
-                    size="tall"
-                    text="Import Private Key"
-                    to={importPrivateKeyUrl}
-                />
+                {isMultiAccountsEnabled ? (
+                    <>
+                        <Button
+                            variant="outline"
+                            size="tall"
+                            text="Create New Account"
+                            loading={createAccountMutation.isLoading}
+                            onClick={() => createAccountMutation.mutate()}
+                        />
+                        <Button
+                            variant="outline"
+                            size="tall"
+                            text="Import Private Key"
+                            to={importPrivateKeyUrl}
+                        />
+                    </>
+                ) : null}
                 {isLedgerIntegrationEnabled ? (
                     <Button
                         variant="outline"

--- a/apps/wallet/src/ui/app/components/menu/content/AccountsSettings.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/AccountsSettings.tsx
@@ -69,14 +69,9 @@ export function AccountsSettings() {
                         before={<LockedLockIcon />}
                         onClick={async () => {
                             if (appType === AppType.popup) {
-                                const absoluteConnectLedgerModalUrl = new URL(
-                                    `${window.location.origin}/${window.location.pathname}`
-                                );
-                                absoluteConnectLedgerModalUrl.hash =
-                                    connectLedgerModalUrl;
-
+                                const { origin, pathname } = window.location;
                                 await Browser.tabs.create({
-                                    url: absoluteConnectLedgerModalUrl.toString(),
+                                    url: `${origin}/${pathname}#${connectLedgerModalUrl}`,
                                 });
                                 window.close();
                             } else {

--- a/apps/wallet/src/ui/app/components/menu/content/index.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/index.tsx
@@ -40,7 +40,7 @@ import type { MouseEvent } from 'react';
 const CLOSE_KEY_CODES: string[] = ['Escape'];
 
 function MenuContent() {
-    const backUrl = useNextMenuUrl(true, '/');
+    const accountsUrl = useNextMenuUrl(true, '/accounts');
     const mainLocation = useLocation();
     const isOpen = useMenuIsOpen();
     const menuUrl = useMenuUrl();
@@ -84,10 +84,10 @@ function MenuContent() {
                                 element={
                                     <ConnectLedgerModal
                                         onClose={() => {
-                                            navigate(backUrl);
+                                            navigate(accountsUrl);
                                         }}
                                         onError={(error) => {
-                                            navigate(backUrl);
+                                            navigate(accountsUrl);
                                             toast.error(
                                                 getLedgerErrorMessage(error)
                                             );

--- a/apps/wallet/src/ui/app/components/menu/content/index.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/index.tsx
@@ -93,7 +93,6 @@ function MenuContent() {
                                 />
                             </>
                         ) : null}
-
                         <Route path="/network" element={<NetworkSettings />} />
                         <Route
                             path="/auto-lock"


### PR DESCRIPTION
## Description 
TLDR; Some browser APIs don't work properly when an extension is in popup mode, so we have to re-work some of the Ledger flow UX. The first UX change is that we need to always open the Ledger connection/import flow in a new window, which is what this PR changes. The second UX change (will tackle this in a follow-up) is that we need to stop requesting user connections during the signing flow which is something that I introduced yesterday.

https://capture.dropbox.com/ArbF7mmK4Ws1OkYj

### More information re: the root bug
`@ledger/transport-web-hid` relies on the `HID.requestDevices` API implemented in Chrome, and you can only call this API in the context of a user gesture (mousedown, keydown, etc.). The API uses this logic (https://developer.mozilla.org/en-US/docs/Web/API/UserActivation) to determine whether or not the API call fits in the context of a user gesture, but the logic simply doesn't work as expected when the Chrome extension is in popup mode.

## Test Plan 
- Manual testing
  - Can connect to Ledger successfully 100% of the time now
  - Despite demo'ing this several times, I can't seem to connect to Ledger in popup mode whatsoever now

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
