### PR TITLE
Reconfig channel return system state

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -20,7 +20,6 @@ mod test {
     use sui_core::authority::authority_store_tables::AuthorityPerpetualTables;
     use sui_core::checkpoints::CheckpointStore;
     use sui_macros::{register_fail_points, sim_test};
-    use sui_protocol_config::ProtocolConfig;
     use sui_simulator::{configs::*, SimConfig};
     use sui_types::messages_checkpoint::VerifiedCheckpoint;
     use test_utils::messages::get_sui_gas_object_with_wallet_context;

--- a/crates/sui-core/src/quorum_driver/reconfig_observer.rs
+++ b/crates/sui-core/src/quorum_driver/reconfig_observer.rs
@@ -3,8 +3,7 @@
 
 use async_trait::async_trait;
 use std::sync::Arc;
-use sui_protocol_config::ProtocolVersion;
-use sui_types::committee::Committee;
+use sui_types::sui_system_state::{SuiSystemState, SuiSystemStateTrait};
 use tokio::sync::broadcast::error::RecvError;
 use tracing::{info, warn};
 
@@ -27,7 +26,7 @@ pub trait ReconfigObserver<A> {
 /// A ReconfigObserver that subscribes to a reconfig channel of new committee.
 /// This is used in TransactionOrchestrator.
 pub struct OnsiteReconfigObserver {
-    reconfig_rx: tokio::sync::broadcast::Receiver<(Committee, ProtocolVersion)>,
+    reconfig_rx: tokio::sync::broadcast::Receiver<SuiSystemState>,
     authority_store: Arc<AuthorityStore>,
     committee_store: Arc<CommitteeStore>,
     safe_client_metrics_base: SafeClientMetricsBase,
@@ -36,7 +35,7 @@ pub struct OnsiteReconfigObserver {
 
 impl OnsiteReconfigObserver {
     pub fn new(
-        reconfig_rx: tokio::sync::broadcast::Receiver<(Committee, ProtocolVersion)>,
+        reconfig_rx: tokio::sync::broadcast::Receiver<SuiSystemState>,
         authority_store: Arc<AuthorityStore>,
         committee_store: Arc<CommitteeStore>,
         safe_client_metrics_base: SafeClientMetricsBase,
@@ -95,8 +94,12 @@ impl ReconfigObserver<NetworkAuthorityClient> for OnsiteReconfigObserver {
         }
         loop {
             match self.reconfig_rx.recv().await {
-                Ok((committee, _protocol_version)) => {
-                    info!("Got reconfig message: {}", committee);
+                Ok(system_state) => {
+                    let committee = system_state.get_current_epoch_committee();
+                    info!(
+                        "Got reconfig message. New committee: {}",
+                        committee.committee
+                    );
                     if committee.epoch() > quorum_driver.current_epoch() {
                         let authority_agg =
                             self.create_authority_aggregator_from_system_state().await;

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -23,10 +23,8 @@ use prometheus::{
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
-use sui_protocol_config::ProtocolVersion;
 use sui_storage::write_path_pending_tx_log::WritePathPendingTransactionLog;
 use sui_types::base_types::TransactionDigest;
-use sui_types::committee::Committee;
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::messages::{
     ExecuteTransactionRequest, ExecuteTransactionRequestType, ExecuteTransactionResponse,
@@ -36,6 +34,7 @@ use sui_types::messages::{
 use sui_types::quorum_driver_types::{
     QuorumDriverEffectsQueueResult, QuorumDriverError, QuorumDriverResult,
 };
+use sui_types::sui_system_state::SuiSystemState;
 use tokio::sync::broadcast::error::RecvError;
 use tokio::sync::broadcast::Receiver;
 use tokio::task::JoinHandle;
@@ -62,7 +61,7 @@ pub struct TransactiondOrchestrator<A> {
 impl TransactiondOrchestrator<NetworkAuthorityClient> {
     pub async fn new_with_network_clients(
         validator_state: Arc<AuthorityState>,
-        reconfig_channel: Receiver<(Committee, ProtocolVersion)>,
+        reconfig_channel: Receiver<SuiSystemState>,
         parent_path: &Path,
         prometheus_registry: &Registry,
     ) -> anyhow::Result<Self> {


### PR DESCRIPTION
Make reconfig channel return system state so that we could inspect more things at epoch change.
Also simplified a bunch of callsites.