### PR TITLE
[package updgrades] Add support and tests for different upgrade types

### DIFF
--- a/crates/sui-core/src/unit_tests/data/move_upgrade/additive_upgrade/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/additive_upgrade/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "additive_upgrade"
+version = "0.0.1"
+
+[addresses]
+base_addr =  "0x0"

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/additive_upgrade/sources/base.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/additive_upgrade/sources/base.move
@@ -1,0 +1,29 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module base_addr::base {
+
+    struct A<T> {
+        f1: bool,
+        f2: T
+    }
+
+    // new struct is fine
+    struct B<T> {
+        f2: bool,
+        f1: T,
+    }
+
+    friend base_addr::friend_module;
+
+    // new function is fine
+    public fun return_1(): u64 { 1 }
+
+    public fun return_0(): u64 { 0 }
+
+    public fun plus_1(x: u64): u64 { x + 1 }
+
+    public(friend) fun friend_fun(x: u64): u64 { x }
+
+    fun non_public_fun(y: bool): u64 { if (y) 0 else 1 }
+}

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/additive_upgrade/sources/friend_module.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/additive_upgrade/sources/friend_module.move
@@ -1,0 +1,18 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module base_addr::friend_module {
+
+    struct A<T> {
+        field1: u64,
+        field2: T
+    }
+
+    public fun friend_call(): u64 { base_addr::base::friend_fun(1) }
+
+    public fun return_0(): u64 { 0 }
+
+    public fun plus_1(x: u64): u64 { x + 1 }
+
+    fun non_public_fun(y: bool): u64 { if (y) 0 else 1 }
+}

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/additive_upgrade_invalid/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/additive_upgrade_invalid/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "additive_upgrade_invalid"
+version = "0.0.1"
+
+[addresses]
+base_addr =  "0x0"

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/additive_upgrade_invalid/sources/base.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/additive_upgrade_invalid/sources/base.move
@@ -1,0 +1,30 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module base_addr::base {
+
+    struct A<T> {
+        f1: bool,
+        f2: T
+    }
+
+    // new struct is fine
+    struct B<T> {
+        f2: bool,
+        f1: T,
+    }
+
+    friend base_addr::friend_module;
+
+    // new function is fine
+    public fun return_1(): u64 { 1 }
+
+    public fun return_0(): u64 { 0 }
+
+    public fun plus_1(x: u64): u64 { x + 1 }
+
+    public(friend) fun friend_fun(x: u64): u64 { x }
+
+    // This is invalid since I just changed the code
+    fun non_public_fun(y: bool): u64 { if (y) 0 else 2 }
+}

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/additive_upgrade_invalid/sources/friend_module.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/additive_upgrade_invalid/sources/friend_module.move
@@ -1,0 +1,18 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module base_addr::friend_module {
+
+    struct A<T> {
+        field1: u64,
+        field2: T
+    }
+
+    public fun friend_call(): u64 { base_addr::base::friend_fun(1) }
+
+    public fun return_0(): u64 { 0 }
+
+    public fun plus_1(x: u64): u64 { x + 1 }
+
+    fun non_public_fun(y: bool): u64 { if (y) 0 else 1 }
+}

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/dep_only_upgrade/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/dep_only_upgrade/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "package_upgrade_base"
+version = "0.0.1"
+
+[addresses]
+base_addr =  "0x0"
+
+[dependencies]
+Sui = { local = "../../../../../../sui-framework/packages/sui-framework" }

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/dep_only_upgrade/sources/base.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/dep_only_upgrade/sources/base.move
@@ -1,0 +1,20 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module base_addr::base {
+
+    struct A<T> {
+        f1: bool,
+        f2: T
+    }
+
+    friend base_addr::friend_module;
+
+    public fun return_0(): u64 { 0 }
+
+    public fun plus_1(x: u64): u64 { x + 1 }
+
+    public(friend) fun friend_fun(x: u64): u64 { x }
+
+    fun non_public_fun(y: bool): u64 { if (y) 0 else 1 }
+}

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/dep_only_upgrade/sources/friend_module.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/dep_only_upgrade/sources/friend_module.move
@@ -1,0 +1,18 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module base_addr::friend_module {
+
+    struct A<T> {
+        field1: u64,
+        field2: T
+    }
+
+    public fun friend_call(): u64 { base_addr::base::friend_fun(1) }
+
+    public fun return_0(): u64 { 0 }
+
+    public fun plus_1(x: u64): u64 { x + 1 }
+
+    fun non_public_fun(y: bool): u64 { if (y) 0 else 1 }
+}


### PR DESCRIPTION
This adds support for different types of upgrades along with different tests for these upgrades.

Currently this will not build as it depends on https://github.com/move-language/move/pull/1000 once that lands and we bump the Move pointer this will compile and the additional tests will pass.

This also changes the representation of the different compatibility types to be an enum (that cannot be serialized/deserialized) with associated constants. Compatibility checking is then implemented on this enum -- so the upgrade type and checking logic for the upgrades should be self-contained within the `move_package` module and opaque to the rest of the system. 

