### PR TITLE
[wallet-kit-site] Rework build to use path aliases

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "explorer": "pnpm --filter ./apps/explorer",
     "wallet": "pnpm --filter ./apps/wallet",
     "wallet-adapter": "pnpm --filter ./sdk/wallet-adapter",
+    "wallet-kit-site": "pnpm --filter wallet-kit-site",
     "sdk": "pnpm --filter ./sdk/typescript",
     "bcs": "pnpm --filter ./sdk/bcs",
     "changeset-version": "pnpm changeset version && pnpm sdk codegen:version"

--- a/sdk/wallet-adapter/site/README.md
+++ b/sdk/wallet-adapter/site/README.md
@@ -1,9 +1,1 @@
-# Nextra Docs Template
-
-## Developing
-
-Building the demo on the site requires all of the dependencies to be built. You can start the dev process using the following command:
-
-```bash
-pnpm turbo --filter wallet-kit-site... dev
-```
+# Wallet Kit Site

--- a/sdk/wallet-adapter/site/next.config.js
+++ b/sdk/wallet-adapter/site/next.config.js
@@ -6,4 +6,8 @@ const withNextra = require("nextra")({
   themeConfig: "./theme.config.tsx",
 });
 
-module.exports = withNextra({});
+module.exports = withNextra({
+  experimental: {
+    externalDir: true,
+  },
+});

--- a/sdk/wallet-adapter/site/tsconfig.json
+++ b/sdk/wallet-adapter/site/tsconfig.json
@@ -13,7 +13,20 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "rootDir": ".",
+    "paths": {
+      "@mysten/wallet-standard": ["../wallet-standard/src"],
+      "@mysten/wallet-adapter-base": ["../adapters/base-adapter/src"],
+      "@mysten/wallet-adapter-unsafe-burner": ["../adapters/unsafe-burner/src"],
+      "@mysten/wallet-adapter-wallet-standard": [
+        "../adapters/wallet-standard-adapter/src"
+      ],
+      "@mysten/wallet-kit": ["../wallet-kit/src"],
+      "@mysten/wallet-kit-core": ["../wallet-kit-core/src"],
+      "@mysten/sui.js": ["../../typescript/src"],
+      "@mysten/bcs": ["../../bcs/src"]
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Description 

Small tweak to how the wallet kit site is built, so that it uses path aliases and doesn't depend on artifacts existing. I dislike path aliases and liked our other approach with using import conditions, but that seems impossible to get working with Next for some reason, so this will have to do.

## Test Plan 

Ran site locally on clean checkout.