### PR TITLE
[hardening] disable conservation checks in dev inspect mode

### DIFF
--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -226,8 +226,12 @@ fn execute_transaction<
     if !is_system {
         #[cfg(debug_assertions)]
         {
-            // ensure that this transaction did not create or destroy SUI
-            temporary_store.check_sui_conserved().unwrap();
+            if !Mode::allow_arbitrary_values() {
+                // ensure that this transaction did not create or destroy SUI
+                temporary_store.check_sui_conserved().unwrap();
+            }
+            // else, we're in dev-inspect mode, which lets you turn bytes into arbitrary
+            // objects (including coins). this can violate conservation, but it's expected
         }
     }
     let cost_summary = gas_status.summary();


### PR DESCRIPTION
Dev inspect mode can violate SUI conservation by turning bytes into coins. This is expected and ok because this is a test-only mode, not code that can ever run on a validator. Skip these checks in dev-inspect mode so we don't fail unexpectedly during dev inspect calls.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration