### PR TITLE
[wallet] update wallet list select item component styling

### DIFF
--- a/apps/wallet/src/ui/app/components/WalletListSelect.tsx
+++ b/apps/wallet/src/ui/app/components/WalletListSelect.tsx
@@ -9,6 +9,7 @@ import { useDeriveNextAccountMutation } from '../hooks/useDeriveNextAccountMutat
 import { Link } from '../shared/Link';
 import { SummaryCard } from './SummaryCard';
 import {
+    SELECTION_MODE as WALLET_SELECTION_MODE,
     WalletListSelectItem,
     type WalletListSelectItemProps,
 } from './WalletListSelectItem';
@@ -26,7 +27,7 @@ export function WalletListSelect({
     title,
     values,
     visibleValues,
-    mode = 'select',
+    mode = WALLET_SELECTION_MODE.SELECT,
     disabled = false,
     onChange,
 }: WalletListSelectProps) {
@@ -85,7 +86,7 @@ export function WalletListSelect({
                 </ul>
             }
             footer={
-                mode === 'select' ? (
+                mode === WALLET_SELECTION_MODE.SELECT ? (
                     <div className="flex flex-row flex-nowrap self-stretch justify-between">
                         <div>
                             {filteredAccounts.length > 1 ? (

--- a/apps/wallet/src/ui/app/components/WalletListSelect.tsx
+++ b/apps/wallet/src/ui/app/components/WalletListSelect.tsx
@@ -9,7 +9,6 @@ import { useDeriveNextAccountMutation } from '../hooks/useDeriveNextAccountMutat
 import { Link } from '../shared/Link';
 import { SummaryCard } from './SummaryCard';
 import {
-    SELECTION_MODE as WALLET_SELECTION_MODE,
     WalletListSelectItem,
     type WalletListSelectItemProps,
 } from './WalletListSelectItem';
@@ -27,7 +26,7 @@ export function WalletListSelect({
     title,
     values,
     visibleValues,
-    mode = WALLET_SELECTION_MODE.SELECT,
+    mode = 'select',
     disabled = false,
     onChange,
 }: WalletListSelectProps) {
@@ -86,7 +85,7 @@ export function WalletListSelect({
                 </ul>
             }
             footer={
-                mode === WALLET_SELECTION_MODE.SELECT ? (
+                mode === 'select' ? (
                     <div className="flex flex-row flex-nowrap self-stretch justify-between">
                         <div>
                             {filteredAccounts.length > 1 ? (

--- a/apps/wallet/src/ui/app/components/WalletListSelectItem.tsx
+++ b/apps/wallet/src/ui/app/components/WalletListSelectItem.tsx
@@ -89,7 +89,6 @@ export function WalletListSelectItem({
             {mode === 'disconnect' && selected ? (
                 <XFill16 className="text-issue-dark text-base font-bold" />
             ) : null}
-            {/* Secondary/BodySmall-SB */}
             <Text
                 mono
                 variant="body"

--- a/apps/wallet/src/ui/app/components/WalletListSelectItem.tsx
+++ b/apps/wallet/src/ui/app/components/WalletListSelectItem.tsx
@@ -8,11 +8,6 @@ import { useEffect, useRef } from 'react';
 
 import { Text } from '../shared/text';
 
-export enum SELECTION_MODE {
-    DISCONNECT = 'disconnect',
-    SELECT = 'select',
-}
-
 const styles = cva(
     'transition flex flex-row flex-nowrap items-center gap-3 py-2 cursor-pointer',
     {
@@ -36,8 +31,8 @@ const styles = cva(
                 disabled: false,
                 className: 'hover:text-steel-dark',
             },
-            { mode: 'select', selected: true, className: 'text-steel-dark' },
-            { mode: 'select', selected: false, className: 'text-steel' },
+            { mode: 'select', selected: true, className: 'text-steel-darker' },
+            { mode: 'select', selected: false, className: 'text-steel-dark' },
             {
                 mode: 'disconnect',
                 selected: true,
@@ -46,7 +41,7 @@ const styles = cva(
             {
                 mode: 'disconnect',
                 selected: false,
-                className: 'text-steel-dark',
+                className: 'text-steel-darker',
             },
         ],
     }
@@ -82,12 +77,12 @@ export function WalletListSelectItem({
         };
     }, [isNew]);
 
-    const isActiveModeDisconnect = mode === SELECTION_MODE.DISCONNECT;
-    const isActiveModeSelect = mode === SELECTION_MODE.SELECT;
+    const isDisconnect = mode === 'disconnect';
+    const isSelect = mode === 'select';
 
     return (
         <div ref={elementRef} className={styles({ selected, mode, disabled })}>
-            {isActiveModeSelect ? (
+            {isSelect ? (
                 <CheckFill16
                     className={cx(
                         selected ? 'text-success' : 'text-gray-50',
@@ -95,29 +90,20 @@ export function WalletListSelectItem({
                     )}
                 />
             ) : null}
-            {isActiveModeDisconnect && selected ? (
+            {isDisconnect && selected ? (
                 <XFill16 className="text-issue-dark text-base font-bold" />
             ) : null}
-            <Text
-                mono
-                variant="body"
-                weight="semibold"
-                color={
-                    selected && isActiveModeDisconnect
-                        ? 'issue-dark'
-                        : 'steel-darker'
-                }
-            >
+            <Text mono variant="body" weight="semibold">
                 {formatAddress(address)}
             </Text>
-            {isActiveModeDisconnect && !selected ? (
+            {isDisconnect && !selected ? (
                 <div className="flex flex-1 justify-end text-issue-dark">
                     <Text variant="subtitle" weight="normal">
                         Disconnect
                     </Text>
                 </div>
             ) : null}
-            {isActiveModeSelect && isNew ? (
+            {isSelect && isNew ? (
                 <div className="flex-1 flex justify-end">
                     <Text variant="subtitleSmall" color="steel">
                         NEW

--- a/apps/wallet/src/ui/app/components/WalletListSelectItem.tsx
+++ b/apps/wallet/src/ui/app/components/WalletListSelectItem.tsx
@@ -76,9 +76,13 @@ export function WalletListSelectItem({
             clearTimeout(timeout);
         };
     }, [isNew]);
+
+    const disconnectModeActive = mode === 'disconnect';
+    const selectModeActive = mode === 'select';
+
     return (
         <div ref={elementRef} className={styles({ selected, mode, disabled })}>
-            {mode === 'select' ? (
+            {selectModeActive ? (
                 <CheckFill16
                     className={cx(
                         selected ? 'text-success' : 'text-gray-50',
@@ -86,7 +90,7 @@ export function WalletListSelectItem({
                     )}
                 />
             ) : null}
-            {mode === 'disconnect' && selected ? (
+            {disconnectModeActive && selected ? (
                 <XFill16 className="text-issue-dark text-base font-bold" />
             ) : null}
             <Text
@@ -94,21 +98,21 @@ export function WalletListSelectItem({
                 variant="body"
                 weight="semibold"
                 color={
-                    selected && mode === 'disconnect'
+                    selected && disconnectModeActive
                         ? 'issue-dark'
                         : 'steel-darker'
                 }
             >
                 {formatAddress(address)}
             </Text>
-            {mode === 'disconnect' && !selected ? (
+            {disconnectModeActive && !selected ? (
                 <div className="flex flex-1 justify-end text-issue-dark">
                     <Text variant="subtitle" weight="normal">
                         Disconnect
                     </Text>
                 </div>
             ) : null}
-            {mode === 'select' && isNew ? (
+            {selectModeActive && isNew ? (
                 <div className="flex-1 flex justify-end">
                     <Text variant="subtitleSmall" color="steel">
                         NEW

--- a/apps/wallet/src/ui/app/components/WalletListSelectItem.tsx
+++ b/apps/wallet/src/ui/app/components/WalletListSelectItem.tsx
@@ -8,6 +8,11 @@ import { useEffect, useRef } from 'react';
 
 import { Text } from '../shared/text';
 
+export enum SELECTION_MODE {
+    DISCONNECT = 'disconnect',
+    SELECT = 'select',
+}
+
 const styles = cva(
     'transition flex flex-row flex-nowrap items-center gap-3 py-2 cursor-pointer',
     {
@@ -77,12 +82,12 @@ export function WalletListSelectItem({
         };
     }, [isNew]);
 
-    const disconnectModeActive = mode === 'disconnect';
-    const selectModeActive = mode === 'select';
+    const isActiveModeDisconnect = mode === SELECTION_MODE.DISCONNECT;
+    const isActiveModeSelect = mode === SELECTION_MODE.SELECT;
 
     return (
         <div ref={elementRef} className={styles({ selected, mode, disabled })}>
-            {selectModeActive ? (
+            {isActiveModeSelect ? (
                 <CheckFill16
                     className={cx(
                         selected ? 'text-success' : 'text-gray-50',
@@ -90,7 +95,7 @@ export function WalletListSelectItem({
                     )}
                 />
             ) : null}
-            {disconnectModeActive && selected ? (
+            {isActiveModeDisconnect && selected ? (
                 <XFill16 className="text-issue-dark text-base font-bold" />
             ) : null}
             <Text
@@ -98,21 +103,21 @@ export function WalletListSelectItem({
                 variant="body"
                 weight="semibold"
                 color={
-                    selected && disconnectModeActive
+                    selected && isActiveModeDisconnect
                         ? 'issue-dark'
                         : 'steel-darker'
                 }
             >
                 {formatAddress(address)}
             </Text>
-            {disconnectModeActive && !selected ? (
+            {isActiveModeDisconnect && !selected ? (
                 <div className="flex flex-1 justify-end text-issue-dark">
                     <Text variant="subtitle" weight="normal">
                         Disconnect
                     </Text>
                 </div>
             ) : null}
-            {selectModeActive && isNew ? (
+            {isActiveModeSelect && isNew ? (
                 <div className="flex-1 flex justify-end">
                     <Text variant="subtitleSmall" color="steel">
                         NEW

--- a/apps/wallet/src/ui/app/components/WalletListSelectItem.tsx
+++ b/apps/wallet/src/ui/app/components/WalletListSelectItem.tsx
@@ -89,7 +89,17 @@ export function WalletListSelectItem({
             {mode === 'disconnect' && selected ? (
                 <XFill16 className="text-issue-dark text-base font-bold" />
             ) : null}
-            <Text mono variant="body" weight="semibold">
+            {/* Secondary/BodySmall-SB */}
+            <Text
+                mono
+                variant="body"
+                weight="semibold"
+                color={
+                    selected && mode === 'disconnect'
+                        ? 'issue-dark'
+                        : 'steel-darker'
+                }
+            >
                 {formatAddress(address)}
             </Text>
             {mode === 'disconnect' && !selected ? (


### PR DESCRIPTION
## Description 

Updated WalletListSelectItem styling contrasts following [this figma](https://www.figma.com/file/m1wFK3XLrjyfnwtqGXxgJe/01-Components-%3A-Wallet?node-id=306-2034&t=2kWTuANKfmhiosC5-0).

<img width="199" alt="image" src="https://user-images.githubusercontent.com/128089541/227334725-b72cea8c-88e3-47de-85ab-961f9dd563b2.png">
<img width="154" alt="image" src="https://user-images.githubusercontent.com/128089541/227334832-fc211781-5ea0-47f3-b078-e0ab4f8366d4.png">
<img width="184" alt="image" src="https://user-images.githubusercontent.com/128089541/227334898-9a239d5e-7e65-4260-b4c0-9d9344ccef37.png">
<img width="185" alt="image" src="https://user-images.githubusercontent.com/128089541/227335007-b1602440-ca85-41af-beb0-6e907d847ee6.png">

- Also some minor code readability improvements.

## Test Plan 

Locally.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Small contrast improvements for wallet selection.