### PR TITLE
indexer easy: add tx command count for CPS

### DIFF
--- a/crates/sui-indexer/migrations/2022-11-18-195259_transactions/up.sql
+++ b/crates/sui-indexer/migrations/2022-11-18-195259_transactions/up.sql
@@ -19,6 +19,7 @@ CREATE TABLE transactions (
     checkpoint_sequence_number  BIGINT       NOT NULL,
     timestamp_ms                BIGINT       NOT NULL,
     transaction_kind            TEXT         NOT NULL,
+    command_count               BIGINT       NOT NULL,
     -- object related
     created                     TEXT[]       NOT NULL,
     mutated                     TEXT[]       NOT NULL,

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -259,6 +259,7 @@ diesel::table! {
         checkpoint_sequence_number -> Int8,
         timestamp_ms -> Int8,
         transaction_kind -> Text,
+        command_count -> Int8,
         created -> Array<Nullable<Text>>,
         mutated -> Array<Nullable<Text>>,
         deleted -> Array<Nullable<Text>>,

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -323,6 +323,13 @@ impl SuiTransactionKind {
             ),
         })
     }
+
+    pub fn command_count(&self) -> usize {
+        match self {
+            Self::ProgrammableTransaction(p) => p.commands.len(),
+            _ => 1,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]


### PR DESCRIPTION
## Description 

Add command count to tx table on indexer to unblock CPS metric on Explorer.

## Test Plan 

CI