### PR TITLE
[wallet] updated account selector styling

### DIFF
--- a/apps/wallet/src/ui/app/shared/ButtonConnectedTo.tsx
+++ b/apps/wallet/src/ui/app/shared/ButtonConnectedTo.tsx
@@ -8,7 +8,7 @@ const styles = cva(
     [
         'cursor-pointer outline-0 flex flex-row items-center py-1 px-2 gap-1 rounded-2xl',
         'transition text-body-small font-medium border border-solid max-w-full min-w-0',
-        'border-transparent bg-transparent group',
+        'border-1 border-gray-45 bg-transparent group',
         'hover:text-hero hover:bg-sui-light hover:border-sui',
         'focus:text-hero focus:bg-sui-light focus:border-sui',
         'active:text-steel active:bg-gray-45 active:border-transparent',


### PR DESCRIPTION
## Description 

old:
<img width="160" alt="image" src="https://user-images.githubusercontent.com/128089541/227356349-1c321bc1-3fc6-4d92-b760-3328879c30d3.png">

new:
<img width="251" alt="image" src="https://user-images.githubusercontent.com/128089541/227356246-739e7a41-84f9-4fbc-b55d-a3cf35ec5657.png">

Updated as per [figma](https://www.figma.com/file/m1wFK3XLrjyfnwtqGXxgJe/01-Components-%3A-Wallet?node-id=1310-5654&t=9TCbrZJQuA4EZZYR-0)

## Test Plan 

Locally.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Updated account selector styling.