### PR TITLE
Update disclosureBox to include outline variant, subtitle, footer

### DIFF
--- a/apps/core/tailwind.config.ts
+++ b/apps/core/tailwind.config.ts
@@ -170,6 +170,9 @@ export default {
             rotate: {
                 135: '135deg',
             },
+            borderRadius: {
+                '2lg': '0.625rem',
+            },
         },
     },
     corePlugins: {

--- a/apps/explorer/src/ui/DisclosureBox.tsx
+++ b/apps/explorer/src/ui/DisclosureBox.tsx
@@ -25,18 +25,16 @@ export interface DisclosureBoxProps
     extends VariantProps<typeof disclosureBoxStyles> {
     defaultOpen?: boolean;
     title: ReactNode;
-    subTitle?: ReactNode;
+    preview?: ReactNode;
     children: ReactNode;
-    footer?: ReactNode;
 }
 
 export function DisclosureBox({
     defaultOpen,
     title,
     children,
-    subTitle,
+    preview,
     variant,
-    footer,
 }: DisclosureBoxProps) {
     return (
         <div className={disclosureBoxStyles({ variant })}>
@@ -49,7 +47,7 @@ export function DisclosureBox({
                         >
                             <div className="flex flex-1 text-body font-semibold text-gray-90">
                                 {title}
-                                {subTitle && !open ? subTitle : null}
+                                {preview && !open ? preview : null}
                             </div>
 
                             <ChevronRight12 className="text-caption text-steel ui-open:rotate-90" />
@@ -57,12 +55,6 @@ export function DisclosureBox({
                         <Disclosure.Panel className="px-5 pb-3.75">
                             {children}
                         </Disclosure.Panel>
-
-                        {footer && open ? (
-                            <Disclosure.Panel className="mx-5 border-t border-gray-45 py-3.75">
-                                {footer}
-                            </Disclosure.Panel>
-                        ) : null}
                     </>
                 )}
             </Disclosure>

--- a/apps/explorer/src/ui/DisclosureBox.tsx
+++ b/apps/explorer/src/ui/DisclosureBox.tsx
@@ -20,7 +20,6 @@ const disclosureBoxStyles = cva('', {
     },
 });
 
-// adding a sub title to the disclosure box for disappearing preview
 export interface DisclosureBoxProps
     extends VariantProps<typeof disclosureBoxStyles> {
     defaultOpen?: boolean;
@@ -45,9 +44,9 @@ export function DisclosureBox({
                             as="div"
                             className="flex cursor-pointer flex-nowrap items-center px-5 py-3.75"
                         >
-                            <div className="flex flex-1 text-body font-semibold text-gray-90">
+                            <div className="flex flex-1 gap-1 text-body font-semibold text-gray-90">
                                 {title}
-                                {preview && !open ? preview : null}
+                                {preview && !open ? <div>{preview}</div> : null}
                             </div>
 
                             <ChevronRight12 className="text-caption text-steel ui-open:rotate-90" />

--- a/apps/explorer/src/ui/DisclosureBox.tsx
+++ b/apps/explorer/src/ui/DisclosureBox.tsx
@@ -2,37 +2,69 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Disclosure } from '@headlessui/react';
-
-import { ReactComponent as ChevronDownIcon } from './icons/chevron_down.svg';
+import { ChevronRight12 } from '@mysten/icons';
+import { cva, type VariantProps } from 'class-variance-authority';
 
 import type { ReactNode } from 'react';
 
-export type DisclosureBoxProps = {
+const disclosureBoxStyles = cva('', {
+    variants: {
+        variant: {
+            primary: 'bg-gray-40 rounded-lg',
+            outline:
+                'bg-transparent border border-gray-45 hover:bg-gray-40 hover:border-transparent rounded-2lg',
+        },
+    },
+    defaultVariants: {
+        variant: 'primary',
+    },
+});
+
+// adding a sub title to the disclosure box for disappearing preview
+export interface DisclosureBoxProps
+    extends VariantProps<typeof disclosureBoxStyles> {
     defaultOpen?: boolean;
     title: ReactNode;
+    subTitle?: ReactNode;
     children: ReactNode;
-};
+    footer?: ReactNode;
+}
 
 export function DisclosureBox({
     defaultOpen,
     title,
     children,
+    subTitle,
+    variant,
+    footer,
 }: DisclosureBoxProps) {
     return (
-        <div className="rounded-lg bg-gray-40">
+        <div className={disclosureBoxStyles({ variant })}>
             <Disclosure defaultOpen={defaultOpen}>
-                <Disclosure.Button
-                    as="div"
-                    className="flex cursor-pointer flex-nowrap items-center px-5 py-3.75"
-                >
-                    <div className="flex-1 text-body font-semibold text-gray-90">
-                        {title}
-                    </div>
-                    <ChevronDownIcon className="-rotate-90 text-gray-75 ui-open:rotate-0" />
-                </Disclosure.Button>
-                <Disclosure.Panel className="px-5 pb-5">
-                    {children}
-                </Disclosure.Panel>
+                {({ open }) => (
+                    <>
+                        <Disclosure.Button
+                            as="div"
+                            className="flex cursor-pointer flex-nowrap items-center px-5 py-3.75"
+                        >
+                            <div className="flex flex-1 text-body font-semibold text-gray-90">
+                                {title}
+                                {subTitle && !open ? subTitle : null}
+                            </div>
+
+                            <ChevronRight12 className="text-caption text-steel ui-open:rotate-90" />
+                        </Disclosure.Button>
+                        <Disclosure.Panel className="px-5 pb-3.75">
+                            {children}
+                        </Disclosure.Panel>
+
+                        {footer && open ? (
+                            <Disclosure.Panel className="mx-5 border-t border-gray-45 py-3.75">
+                                {footer}
+                            </Disclosure.Panel>
+                        ) : null}
+                    </>
+                )}
             </Disclosure>
         </div>
     );

--- a/apps/explorer/src/ui/stories/DisclosureBox.stories.tsx
+++ b/apps/explorer/src/ui/stories/DisclosureBox.stories.tsx
@@ -22,3 +22,12 @@ export const DisclosureBoxClosed: StoryObj<DisclosureBoxProps> = {
         preview: 'Preview content',
     },
 };
+
+export const DisclosureBoxOutline: StoryObj<DisclosureBoxProps> = {
+    ...DisclosureBoxDefault,
+    args: {
+        title: 'Outline disclosure box',
+        preview: 'Preview content',
+        variant: 'outline',
+    },
+};

--- a/apps/explorer/src/ui/stories/DisclosureBox.stories.tsx
+++ b/apps/explorer/src/ui/stories/DisclosureBox.stories.tsx
@@ -19,7 +19,6 @@ export const DisclosureBoxClosed: StoryObj<DisclosureBoxProps> = {
     args: {
         title: 'Expanded disclosure box',
         defaultOpen: true,
-        subTitle: 'Sub title',
-        footer: 'Footer',
+        preview: 'Preview content',
     },
 };

--- a/apps/explorer/src/ui/stories/DisclosureBox.stories.tsx
+++ b/apps/explorer/src/ui/stories/DisclosureBox.stories.tsx
@@ -16,5 +16,5 @@ export const DisclosureBoxDefault: StoryObj<DisclosureBoxProps> = {
 
 export const DisclosureBoxClosed: StoryObj<DisclosureBoxProps> = {
     ...DisclosureBoxDefault,
-    args: { title: 'Expanded disclosure box', defaultOpen: true },
+    args: { title: 'Expanded disclosure box ', defaultOpen: true, subTitle: 'Sub title', footer: 'Footer' },
 };

--- a/apps/explorer/src/ui/stories/DisclosureBox.stories.tsx
+++ b/apps/explorer/src/ui/stories/DisclosureBox.stories.tsx
@@ -16,5 +16,5 @@ export const DisclosureBoxDefault: StoryObj<DisclosureBoxProps> = {
 
 export const DisclosureBoxClosed: StoryObj<DisclosureBoxProps> = {
     ...DisclosureBoxDefault,
-    args: { title: 'Expanded disclosure box ', defaultOpen: true, subTitle: 'Sub title', footer: 'Footer' },
+    args: { title: 'Expanded disclosure box', defaultOpen: true, subTitle: 'Sub title', footer: 'Footer' },
 };

--- a/apps/explorer/src/ui/stories/DisclosureBox.stories.tsx
+++ b/apps/explorer/src/ui/stories/DisclosureBox.stories.tsx
@@ -16,5 +16,10 @@ export const DisclosureBoxDefault: StoryObj<DisclosureBoxProps> = {
 
 export const DisclosureBoxClosed: StoryObj<DisclosureBoxProps> = {
     ...DisclosureBoxDefault,
-    args: { title: 'Expanded disclosure box', defaultOpen: true, subTitle: 'Sub title', footer: 'Footer' },
+    args: {
+        title: 'Expanded disclosure box',
+        defaultOpen: true,
+        subTitle: 'Sub title',
+        footer: 'Footer',
+    },
 };


### PR DESCRIPTION
## Description 

Describe the changes or additions included in this PR.

This PR adds an outline variant, a subtitle, and footer props to DisclosureBox. Added `2lg` border-radius 

## Test Plan 
<img width="977" alt="Screenshot 2023-03-23 at 4 38 30 PM" src="https://user-images.githubusercontent.com/126525197/227356483-6da3299d-2a52-4c1e-bc59-f7bde7485075.png">

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
