### PR TITLE
remove validator address from StakedSui

### DIFF
--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -821,12 +821,18 @@ impl Builder {
             self.validators.len(),
             system_state.validators.active_validators.len()
         );
+        let mut address_to_pool_id = BTreeMap::new();
         for (validator, onchain_validator) in self
             .validators
             .values()
             .zip(system_state.validators.active_validators.iter())
         {
             let metadata = onchain_validator.verified_metadata();
+
+            // Validators should not have duplicate addresses so the result of insertion should be None.
+            assert!(address_to_pool_id
+                .insert(metadata.sui_address, onchain_validator.staking_pool.id)
+                .is_none());
             assert_eq!(validator.info.sui_address(), metadata.sui_address);
             assert_eq!(validator.info.protocol_key(), metadata.sui_pubkey_bytes());
             assert_eq!(validator.info.network_key, metadata.network_pubkey);
@@ -938,6 +944,9 @@ impl Builder {
 
         for allocation in token_distribution_schedule.allocations {
             if let Some(staked_with_validator) = allocation.staked_with_validator {
+                let staking_pool_id = *address_to_pool_id
+                    .get(&staked_with_validator)
+                    .expect("staking pool should exist");
                 let staked_sui_object_id = staked_sui_objects
                     .iter()
                     .find(|(_k, (o, s))| {
@@ -946,7 +955,7 @@ impl Builder {
                     };
                         *owner == allocation.recipient_address
                             && s.principal() == allocation.amount_mist
-                            && s.validator_address() == staked_with_validator
+                            && s.pool_id() == staking_pool_id
                     })
                     .map(|(k, _)| *k)
                     .expect("all allocations should be present");
@@ -956,10 +965,8 @@ impl Builder {
                     Owner::AddressOwner(allocation.recipient_address)
                 );
                 assert_eq!(staked_sui_object.1.principal(), allocation.amount_mist);
-                assert_eq!(
-                    staked_sui_object.1.validator_address(),
-                    staked_with_validator
-                );
+                assert_eq!(staked_sui_object.1.pool_id(), staking_pool_id);
+                assert_eq!(staked_sui_object.1.activation_epoch(), 0);
             } else {
                 let gas_object_id = gas_objects
                     .iter()

--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0xfa12ec912e3ceb10e8d748ee46f6a4fefa811813d6fb8fb0c0a35bd243e53908"
+            id: "0x6536ea65f42ac01132c0e7640cd4606388b602a1e0c49724e077a4cd3796f058"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0x039baa23e3c867eae2ea441ada6113c8bab0ce8346bbd6c9e0f6f0297de39ce2"
+      operation_cap_id: "0x3bf8bd448b159e517a8dcdf4af164024f6560494e171630e5b44358a9a9706a1"
       gas_price: 1
       staking_pool:
-        id: "0xd142943967843a3c02f772e47598ad3745e23bec3315592d85c70d6a185881e9"
+        id: "0x015365c41502836163356579e04d437b8ba0ce7c6212c97cdb85261b9bc58517"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0x03cc47cf86fccef8650b5c3b243e4d0f64152eb22cd1bbff688cf5f084e089ef"
+          id: "0xab6dbe939bc6916cc7d563c4a08d23376af492949bbc34b572036d1a52ae7a01"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0x7ef979cef27198930bfe2ff537458f0d1ebc3a7209f5f1ee339d343ce8ca6ce1"
+            id: "0xb467ab60353e24a53900a683300c7578be7839be5b8344227babf7d64bafd211"
           size: 0
       commission_rate: 0
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 0
       extra_fields:
         id:
-          id: "0x25ca26b872e696cacb5bc0575605fbcde60be912fb6e0944960987292ce3b92a"
+          id: "0xa72f3c9064a83267f86920dff30e6cd8bf75f1ddff84fe1f602badcb0417918c"
         size: 0
   pending_active_validators:
     contents:
-      id: "0xb5b58b5ce8573474ab66bad8d46e5df1d9a0e7bfb21ca1e1ec36ba6b6cff9788"
+      id: "0x349174fd8e139d10f9f8d867ae6cbcb79bde101e63206cd998a376852bd8b6e0"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0xce9355c61eb3d06b968b7efd0ce52181e37aa1e33b4db7be5b209c00d9895023"
+    id: "0x8a8c0705c9869a26c07f5f440df27fc7c047b3bffa8588a709c4894a7bc45db5"
     size: 1
   inactive_validators:
-    id: "0x6565047d0f07429b882cb793cb569b69a48177d7b9b631445878d7954989e2ca"
+    id: "0xefb7ea0a9353c4518568a83285588e354139c1aa26b967622dd9c3dfb29128e8"
     size: 0
   validator_candidates:
-    id: "0x1446d5334572f05990312a81193e973028df2d945ab175e3cb3bb75e85f0c7c2"
+    id: "0x45707e50a1ba334f16a71a9513e3bb75de0a85478fbcbcf4da6cfb22cf26f85a"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0x9ab6f17f8d033294c01f821acf1d0d756f47cf9a03d818979b67e492d099498d"
+      id: "0x16457372993ed926c6ec8957446f935d6212dcd79479b3f2e2f9c68800bce458"
     size: 0
 storage_fund:
   value: 0
@@ -303,7 +303,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0xbc09357edc91308772e2673c5493c6896c0a05e51f15ddc4054a6e42d3982472"
+      id: "0x1709abe23d2803776e2d117ffb1f6b54c85171d8a07c278f3ba36daba3167c7f"
     size: 0
 reference_gas_price: 1
 validator_report_records:
@@ -317,7 +317,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 10000
   extra_fields:
     id:
-      id: "0xfa75f15e2b69ac3b1ea6aa2680c0f1a880e85ae0145b404aedf43cdb2527443e"
+      id: "0x0002e1e85b0d12fb53b74bc6d88fa1a8ef1606877cb3fe50287930c28483ef8f"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -328,6 +328,6 @@ safe_mode_storage_rebates: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0xd5f70cbdfccd5422b8dbee2f8aadc34105a3d0728ce928941f7c41b297f0bd75"
+    id: "0x8951f41a036ad75e4a0df29ae575944c28551544a95e35ab185fe7f0fddc31e9"
   size: 0
 

--- a/crates/sui-framework/docs/staking_pool.md
+++ b/crates/sui-framework/docs/staking_pool.md
@@ -214,12 +214,6 @@ A self-custodial object holding the staked SUI tokens.
  ID of the staking pool we are staking with.
 </dd>
 <dt>
-<code>validator_address: <b>address</b></code>
-</dt>
-<dd>
-
-</dd>
-<dt>
 <code>stake_activation_epoch: u64</code>
 </dt>
 <dd>
@@ -448,7 +442,7 @@ Create a new, empty staking pool.
 Request to stake to a staking pool. The stake starts counting at the beginning of the next epoch,
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x3_staking_pool_request_add_stake">request_add_stake</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x3_staking_pool_StakingPool">staking_pool::StakingPool</a>, stake: <a href="_Balance">balance::Balance</a>&lt;<a href="_SUI">sui::SUI</a>&gt;, validator_address: <b>address</b>, staker: <b>address</b>, stake_activation_epoch: u64, ctx: &<b>mut</b> <a href="_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x3_staking_pool_request_add_stake">request_add_stake</a>(pool: &<b>mut</b> <a href="staking_pool.md#0x3_staking_pool_StakingPool">staking_pool::StakingPool</a>, stake: <a href="_Balance">balance::Balance</a>&lt;<a href="_SUI">sui::SUI</a>&gt;, staker: <b>address</b>, stake_activation_epoch: u64, ctx: &<b>mut</b> <a href="_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -460,7 +454,6 @@ Request to stake to a staking pool. The stake starts counting at the beginning o
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="staking_pool.md#0x3_staking_pool_request_add_stake">request_add_stake</a>(
     pool: &<b>mut</b> <a href="staking_pool.md#0x3_staking_pool_StakingPool">StakingPool</a>,
     stake: Balance&lt;SUI&gt;,
-    validator_address: <b>address</b>,
     staker: <b>address</b>,
     stake_activation_epoch: u64,
     ctx: &<b>mut</b> TxContext
@@ -471,7 +464,6 @@ Request to stake to a staking pool. The stake starts counting at the beginning o
     <b>let</b> staked_sui = <a href="staking_pool.md#0x3_staking_pool_StakedSui">StakedSui</a> {
         id: <a href="_new">object::new</a>(ctx),
         pool_id: <a href="_id">object::id</a>(pool),
-        validator_address,
         stake_activation_epoch,
         principal: stake,
     };
@@ -594,7 +586,6 @@ Returns values are amount of pool tokens withdrawn and withdrawn principal porti
     <b>let</b> <a href="staking_pool.md#0x3_staking_pool_StakedSui">StakedSui</a> {
         id,
         pool_id: _,
-        validator_address: _,
         stake_activation_epoch: _,
         principal,
     } = staked_sui;
@@ -1040,7 +1031,6 @@ All the other parameters of the StakedSui like <code>stake_activation_epoch</cod
     <a href="staking_pool.md#0x3_staking_pool_StakedSui">StakedSui</a> {
         id: <a href="_new">object::new</a>(ctx),
         pool_id: self.pool_id,
-        validator_address: self.validator_address,
         stake_activation_epoch: self.stake_activation_epoch,
         principal: <a href="_split">balance::split</a>(&<b>mut</b> self.principal, split_amount),
     }
@@ -1099,7 +1089,6 @@ Aborts if some of the staking parameters are incompatible (pool id, stake activa
     <b>let</b> <a href="staking_pool.md#0x3_staking_pool_StakedSui">StakedSui</a> {
         id,
         pool_id: _,
-        validator_address: _,
         stake_activation_epoch: _,
         principal,
     } = other;
@@ -1131,7 +1120,6 @@ Returns true if all the staking parameters of the staked sui except the principa
 
 <pre><code><b>public</b> <b>fun</b> <a href="staking_pool.md#0x3_staking_pool_is_equal_staking_metadata">is_equal_staking_metadata</a>(self: &<a href="staking_pool.md#0x3_staking_pool_StakedSui">StakedSui</a>, other: &<a href="staking_pool.md#0x3_staking_pool_StakedSui">StakedSui</a>): bool {
     (self.pool_id == other.pool_id) &&
-    (self.validator_address == other.validator_address) &&
     (self.stake_activation_epoch == other.stake_activation_epoch)
 }
 </code></pre>

--- a/crates/sui-framework/docs/validator.md
+++ b/crates/sui-framework/docs/validator.md
@@ -834,7 +834,7 @@ Request to add stake to the validator's staking pool, processed at the end of th
     <b>assert</b>!(stake_amount &gt; 0, 0);
     <b>let</b> stake_epoch = <a href="_epoch">tx_context::epoch</a>(ctx) + 1;
     <a href="staking_pool.md#0x3_staking_pool_request_add_stake">staking_pool::request_add_stake</a>(
-        &<b>mut</b> self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>, stake, self.metadata.sui_address, staker_address, stake_epoch, ctx
+        &<b>mut</b> self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>, stake, staker_address, stake_epoch, ctx
     );
     // Process stake right away <b>if</b> staking pool is preactive.
     <b>if</b> (<a href="staking_pool.md#0x3_staking_pool_is_preactive">staking_pool::is_preactive</a>(&self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>)) {
@@ -886,7 +886,6 @@ Request to add stake to the validator's staking pool at genesis
     <a href="staking_pool.md#0x3_staking_pool_request_add_stake">staking_pool::request_add_stake</a>(
         &<b>mut</b> self.<a href="staking_pool.md#0x3_staking_pool">staking_pool</a>,
         stake,
-        self.metadata.sui_address,
         staker_address,
         0, // epoch 0 -- <a href="genesis.md#0x3_genesis">genesis</a>
         ctx

--- a/crates/sui-framework/packages/sui-system/sources/staking_pool.move
+++ b/crates/sui-framework/packages/sui-system/sources/staking_pool.move
@@ -78,8 +78,6 @@ module sui_system::staking_pool {
         id: UID,
         /// ID of the staking pool we are staking with.
         pool_id: ID,
-        // TODO: keeping this field here because the apps depend on it. consider removing it.
-        validator_address: address,
         /// The epoch at which the stake becomes active.
         stake_activation_epoch: u64,
         /// The staked SUI tokens.
@@ -112,7 +110,6 @@ module sui_system::staking_pool {
     public(friend) fun request_add_stake(
         pool: &mut StakingPool,
         stake: Balance<SUI>,
-        validator_address: address,
         staker: address,
         stake_activation_epoch: u64,
         ctx: &mut TxContext
@@ -123,7 +120,6 @@ module sui_system::staking_pool {
         let staked_sui = StakedSui {
             id: object::new(ctx),
             pool_id: object::id(pool),
-            validator_address,
             stake_activation_epoch,
             principal: stake,
         };
@@ -186,7 +182,6 @@ module sui_system::staking_pool {
         let StakedSui {
             id,
             pool_id: _,
-            validator_address: _,
             stake_activation_epoch: _,
             principal,
         } = staked_sui;
@@ -340,7 +335,6 @@ module sui_system::staking_pool {
         StakedSui {
             id: object::new(ctx),
             pool_id: self.pool_id,
-            validator_address: self.validator_address,
             stake_activation_epoch: self.stake_activation_epoch,
             principal: balance::split(&mut self.principal, split_amount),
         }
@@ -359,7 +353,6 @@ module sui_system::staking_pool {
         let StakedSui {
             id,
             pool_id: _,
-            validator_address: _,
             stake_activation_epoch: _,
             principal,
         } = other;
@@ -371,7 +364,6 @@ module sui_system::staking_pool {
     /// Returns true if all the staking parameters of the staked sui except the principal are identical
     public fun is_equal_staking_metadata(self: &StakedSui, other: &StakedSui): bool {
         (self.pool_id == other.pool_id) &&
-        (self.validator_address == other.validator_address) &&
         (self.stake_activation_epoch == other.stake_activation_epoch)
     }
 

--- a/crates/sui-framework/packages/sui-system/sources/validator.move
+++ b/crates/sui-framework/packages/sui-system/sources/validator.move
@@ -284,7 +284,7 @@ module sui_system::validator {
         assert!(stake_amount > 0, 0);
         let stake_epoch = tx_context::epoch(ctx) + 1;
         staking_pool::request_add_stake(
-            &mut self.staking_pool, stake, self.metadata.sui_address, staker_address, stake_epoch, ctx
+            &mut self.staking_pool, stake, staker_address, stake_epoch, ctx
         );
         // Process stake right away if staking pool is preactive.
         if (staking_pool::is_preactive(&self.staking_pool)) {
@@ -316,7 +316,6 @@ module sui_system::validator {
         staking_pool::request_add_stake(
             &mut self.staking_pool,
             stake,
-            self.metadata.sui_address,
             staker_address,
             0, // epoch 0 -- genesis
             ctx
@@ -570,8 +569,8 @@ module sui_system::validator {
             || self.metadata.protocol_pubkey_bytes == other.metadata.protocol_pubkey_bytes
             || self.metadata.network_pubkey_bytes == other.metadata.network_pubkey_bytes
             || self.metadata.network_pubkey_bytes == other.metadata.worker_pubkey_bytes
-            || self.metadata.worker_pubkey_bytes == other.metadata.worker_pubkey_bytes            
-            || self.metadata.worker_pubkey_bytes == other.metadata.network_pubkey_bytes            
+            || self.metadata.worker_pubkey_bytes == other.metadata.worker_pubkey_bytes
+            || self.metadata.worker_pubkey_bytes == other.metadata.network_pubkey_bytes
             // All next epoch parameters.
             || is_equal_some(&self.metadata.next_epoch_net_address, &other.metadata.next_epoch_net_address)
             || is_equal_some(&self.metadata.next_epoch_p2p_address, &other.metadata.next_epoch_p2p_address)

--- a/crates/sui-types/src/governance.rs
+++ b/crates/sui-types/src/governance.rs
@@ -6,7 +6,7 @@ use move_core_types::identifier::IdentStr;
 use move_core_types::language_storage::StructTag;
 
 use crate::balance::Balance;
-use crate::base_types::{ObjectID, SuiAddress};
+use crate::base_types::ObjectID;
 use crate::committee::EpochId;
 use crate::error::SuiError;
 use crate::gas_coin::MIST_PER_SUI;
@@ -53,7 +53,6 @@ pub const WITHDRAW_STAKE_FUN_NAME: &IdentStr = ident_str!("request_withdraw_stak
 pub struct StakedSui {
     id: UID,
     pool_id: ID,
-    validator_address: SuiAddress,
     stake_activation_epoch: u64,
     principal: Balance,
 }
@@ -89,10 +88,6 @@ impl StakedSui {
 
     pub fn principal(&self) -> u64 {
         self.principal.value()
-    }
-
-    pub fn validator_address(&self) -> SuiAddress {
-        self.validator_address
     }
 }
 

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -7,7 +7,7 @@
     rust_2021_compatibility
 )]
 
-use base_types::SequenceNumber;
+use base_types::{SequenceNumber, SuiAddress};
 use messages::{CallArg, ObjectArg};
 pub use move_core_types::language_storage::TypeTag;
 use move_core_types::{account_address::AccountAddress, language_storage::StructTag};
@@ -132,5 +132,17 @@ pub trait MoveTypeTagTrait {
 impl MoveTypeTagTrait for u64 {
     fn get_type_tag() -> TypeTag {
         TypeTag::U64
+    }
+}
+
+impl MoveTypeTagTrait for ObjectID {
+    fn get_type_tag() -> TypeTag {
+        TypeTag::Address
+    }
+}
+
+impl MoveTypeTagTrait for SuiAddress {
+    fn get_type_tag() -> TypeTag {
+        TypeTag::Address
     }
 }


### PR DESCRIPTION
## Description 

This PR removes `validator_address` field from `StakedSui` object. Some dependencies are removed by adding an API that looks up a validator by its pool id, whether it's candidate, active or inactive.

## Test Plan 

Added a test.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [x] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
