### PR TITLE
[tests][programmable transactions] Added move call tests

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/entry_points/generic_by_ref.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/generic_by_ref.exp
@@ -1,0 +1,8 @@
+processed 2 tasks
+
+init:
+A: object(103)
+
+task 1 'publish'. lines 6-14:
+created: object(105)
+written: object(104)

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/generic_by_ref.move
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/generic_by_ref.move
@@ -1,0 +1,14 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+module test::m1 {
+    public fun t1_1<T>(_: &T) {}
+    public fun t1_2<T>(_: &mut T) {}
+    public fun t2_1<T: copy + drop + store>(_: &T) {}
+    public fun t2_2<T: copy + drop + store>(_: &mut T) {}
+    public fun t3_1<T: key>(_: &T) {}
+    public fun t3_2<T: key>(_: &mut T) {}
+}

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/generic_by_ref_invalid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/generic_by_ref_invalid.exp
@@ -1,0 +1,20 @@
+processed 5 tasks
+
+init:
+A: object(103)
+
+task 1 'publish'. lines 8-11:
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Invalid entry point parameter type. Expected primitive or object type. Got: &T0"), command: Some(0) } }
+
+task 2 'publish'. lines 13-16:
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Invalid entry point parameter type. Expected primitive or object type. Got: &mut T0"), command: Some(0) } }
+
+task 3 'publish'. lines 18-21:
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Invalid entry point parameter type. Expected primitive or object type. Got: &T0"), command: Some(0) } }
+
+task 4 'publish'. lines 23-26:
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Invalid entry point parameter type. Expected primitive or object type. Got: &mut T0"), command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/generic_by_ref_invalid.move
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/generic_by_ref_invalid.move
@@ -1,0 +1,26 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// entry functions cannot take primitives by ref, so the generic must be an object
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+module test::m1 {
+    public entry fun no<T>(_: &T) {}
+}
+
+//# publish
+module test::m1 {
+    public entry fun no<T>(_: &mut T) {}
+}
+
+//# publish
+module test::m1 {
+    public entry fun no<T: copy + drop + store>(_: &T) {}
+}
+
+//# publish
+module test::m1 {
+    public entry fun no<T: copy + drop + store>(_: &mut T) {}
+}

--- a/crates/sui-adapter-transactional-tests/tests/programmable/cannot_call_emit.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/cannot_call_emit.exp
@@ -1,0 +1,20 @@
+processed 5 tasks
+
+init:
+A: object(103)
+
+task 1 'publish'. lines 8-12:
+created: object(105)
+written: object(104)
+
+task 2 'programmable'. lines 14-16:
+Error: Transaction Effects Status: Non Entry Function Invoked. Move Call must start with an entry function
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: NonEntryFunctionInvoked, source: Some("Cannot directly call functions in sui::event"), command: Some(1) } }
+
+task 3 'programmable'. lines 18-21:
+Error: Transaction Effects Status: Non Entry Function Invoked. Move Call must start with an entry function
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: NonEntryFunctionInvoked, source: Some("Cannot directly call functions in sui::event"), command: Some(1) } }
+
+task 4 'programmable'. lines 23-26:
+Error: Transaction Effects Status: Function Not Found.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: FunctionNotFound, source: Some("Could not resolve function 'does_not_exist' in module sui::event"), command: Some(1) } }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/cannot_call_emit.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/cannot_call_emit.move
@@ -1,0 +1,26 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests cannot call init with programmable transactions
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+module test::m1 {
+    struct A has copy, drop, store {}
+    public fun a(): A { A {} }
+}
+
+//# programmable
+//> 0: test::m1::a();
+//> sui::event::emit<test::m1::A>(Result(0));
+
+//# programmable
+//> 0: test::m1::a();
+// wrong type annotation doesn't matter
+//> sui::event::emit<bool>(Result(0));
+
+//# programmable
+//> 0: test::m1::a();
+// function doesn't exist
+//> sui::event::does_not_exist<test::m1::A>(Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/programmable/cannot_call_init.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/cannot_call_init.exp
@@ -1,0 +1,12 @@
+processed 3 tasks
+
+init:
+A: object(103)
+
+task 1 'publish'. lines 8-11:
+created: object(105)
+written: object(104)
+
+task 2 'programmable'. lines 13-14:
+Error: Transaction Effects Status: Non Entry Function Invoked. Move Call must start with an entry function
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: NonEntryFunctionInvoked, source: Some("Can only call `entry` or `public` functions"), command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/cannot_call_init.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/cannot_call_init.move
@@ -1,0 +1,14 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests cannot call init with programmable transactions
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+module test::m1 {
+    fun init(_: &mut sui::tx_context::TxContext) {}
+}
+
+//# programmable
+//> 0: test::m1::init();

--- a/crates/sui-adapter-transactional-tests/tests/programmable/cannot_call_private.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/cannot_call_private.exp
@@ -1,0 +1,12 @@
+processed 3 tasks
+
+init:
+A: object(103)
+
+task 1 'publish'. lines 8-11:
+created: object(105)
+written: object(104)
+
+task 2 'programmable'. lines 13-14:
+Error: Transaction Effects Status: Non Entry Function Invoked. Move Call must start with an entry function
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: NonEntryFunctionInvoked, source: Some("Can only call `entry` or `public` functions"), command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/cannot_call_private.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/cannot_call_private.move
@@ -1,0 +1,14 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests cannot call private with programmable transactions
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+module test::m1 {
+    fun priv(_: &mut sui::tx_context::TxContext) {}
+}
+
+//# programmable
+//> 0: test::m1::priv();

--- a/crates/sui-adapter-transactional-tests/tests/programmable/generics_substitution.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/generics_substitution.exp
@@ -1,0 +1,15 @@
+processed 4 tasks
+
+init:
+A: object(103)
+
+task 1 'publish'. lines 8-26:
+created: object(105)
+written: object(104)
+
+task 2 'programmable'. lines 27-36:
+written: object(106)
+
+task 3 'programmable'. lines 37-44:
+Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(5) } }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/generics_substitution.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/generics_substitution.move
@@ -1,0 +1,44 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests correct generic substitution in Move call
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+module test::m1 {
+    struct A has copy, drop { value: u64 }
+    struct B has copy, drop { value: u256 }
+
+    public fun a(): A { A { value: 0 } }
+    public fun b(): B { B { value: 0 } }
+
+    public fun swap<T1: copy, T2: copy>(
+        v1: &vector<T1>,
+        v2: &mut vector<T2>,
+    ): (vector<vector<T2>>, vector<vector<T1>>) {
+        (vector[*v2], vector[*v1])
+    }
+
+    public fun eat(_: &vector<vector<A>>, _: &mut vector<vector<B>>, _: vector<vector<A>>) {}
+}
+
+// valid
+//# programmable
+//> 0: test::m1::a();
+//> 1: test::m1::b();
+//> 2: MakeMoveVec<test::m1::A>([Result(0)]);
+//> 3: MakeMoveVec<test::m1::B>([Result(1)]);
+//> 4: test::m1::swap<test::m1::A, test::m1::B>(Result(2), Result(3));
+//  correct usage A                  B                  A
+//> test::m1::eat(NestedResult(4,1), NestedResult(4,0), NestedResult(4,1));
+
+// invalid
+//# programmable
+//> 0: test::m1::a();
+//> 1: test::m1::b();
+//> 2: MakeMoveVec<test::m1::A>([Result(0)]);
+//> 3: MakeMoveVec<test::m1::B>([Result(1)]);
+//> 4: test::m1::swap<test::m1::A, test::m1::B>(Result(2), Result(3));
+//  incorrect usage B                B                  A
+//> test::m1::eat(NestedResult(4,0), NestedResult(4,0), NestedResult(4,1));

--- a/crates/sui-adapter-transactional-tests/tests/programmable/invalid_option.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/invalid_option.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// tessts various invalid vector instantions for types
+// tests various invalid vector instantions for types
 
 //# init --addresses test=0x0 --accounts A
 

--- a/crates/sui-adapter-transactional-tests/tests/programmable/invalid_public_function_return.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/invalid_public_function_return.exp
@@ -1,0 +1,20 @@
+processed 5 tasks
+
+init:
+A: object(103)
+
+task 1 'publish'. lines 8-16:
+created: object(105)
+written: object(104)
+
+task 2 'programmable'. lines 18-19:
+Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidPublicFunctionReturnType { idx: 0 }, source: None, command: Some(0) } }
+
+task 3 'programmable'. lines 21-22:
+Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidPublicFunctionReturnType { idx: 0 }, source: None, command: Some(0) } }
+
+task 4 'programmable'. lines 24-25:
+Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 1
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidPublicFunctionReturnType { idx: 1 }, source: None, command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/invalid_public_function_return.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/invalid_public_function_return.move
@@ -1,0 +1,25 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests invalid return values from public functions
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+module test::m1 {
+    struct A has copy, drop { value: u64 }
+    struct B has copy, drop { value: u256 }
+
+    public fun t1(_: &mut u64): &mut u64 { abort 0}
+    public fun t2(_: &mut u64): &u64 { abort 0}
+    public fun t3(_: &mut u64): (u64, &u64) { abort 0}
+}
+
+//# programmable
+//> 0: test::m1::t1();
+
+//# programmable
+//> 0: test::m1::t2();
+
+//# programmable
+//> 0: test::m1::t3();

--- a/crates/sui-adapter-transactional-tests/tests/programmable/make_vec_objects.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/make_vec_objects.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// tessts various vector instantions with objects
+// tests various vector instantions with objects
 
 //# init --addresses test=0x0 --accounts A B
 

--- a/crates/sui-adapter-transactional-tests/tests/programmable/non_primitive_non_object_arguments.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/non_primitive_non_object_arguments.exp
@@ -1,0 +1,11 @@
+processed 3 tasks
+
+init:
+A: object(103)
+
+task 1 'publish'. lines 8-19:
+created: object(105)
+written: object(104)
+
+task 2 'programmable'. lines 21-26:
+written: object(106)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/non_primitive_non_object_arguments.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/non_primitive_non_object_arguments.move
@@ -1,0 +1,26 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests various calls of non-primitive argument usage
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+module test::m1 {
+    struct Potato {}
+
+    public fun potato(): Potato { Potato {} }
+    public fun otatop(tater: Potato) { let Potato {} = tater; }
+
+    public fun pass(tater: Potato): Potato { tater }
+    public fun imm(_: &Potato) {}
+    public fun mut(_: &mut Potato) {}
+
+}
+
+//# programmable
+//> 0: test::m1::potato();
+//> 1: test::m1::pass(Result(0));
+//> test::m1::imm(Result(1));
+//> test::m1::mut(Result(1));
+//> test::m1::otatop(Result(1));

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_by_ref_input_invalid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_by_ref_input_invalid.exp
@@ -1,0 +1,24 @@
+processed 6 tasks
+
+init:
+A: object(103)
+
+task 1 'publish'. lines 9-21:
+created: object(105)
+written: object(104)
+
+task 2 'programmable'. lines 23-28:
+created: object(107)
+written: object(106)
+
+task 3 'programmable'. lines 30-32:
+Error: Transaction Effects Status: Invalid command argument at 0. Invalid argument to private entry function. These functions cannot take arguments from other Move functions
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidArgumentToPrivateEntryFunction }, source: None, command: Some(1) } }
+
+task 4 'programmable'. lines 34-38:
+Error: Transaction Effects Status: Invalid command argument at 0. Invalid argument to private entry function. These functions cannot take arguments from other Move functions
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidArgumentToPrivateEntryFunction }, source: None, command: Some(1) } }
+
+task 5 'programmable'. lines 40-42:
+Error: Transaction Effects Status: Invalid command argument at 0. Invalid argument to private entry function. These functions cannot take arguments from other Move functions
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidArgumentToPrivateEntryFunction }, source: None, command: Some(1) } }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_by_ref_input_invalid.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_by_ref_input_invalid.move
@@ -1,0 +1,42 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests that object values cannot be used private entry functions if they have been
+// dirtied by non-entry functions
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+module test::m1 {
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+
+    struct R has key, store { id: UID }
+    public fun r(ctx: &mut TxContext): R { R { id: object::new(ctx) } }
+
+    public fun id(r: R): R { r }
+    public fun dirty(_: &mut R) {}
+
+    entry fun priv(_: R) { abort 0 }
+}
+
+//# programmable --sender A --inputs @A
+//> 0: test::m1::r();
+//> TransferObjects([Result(0)], Input(0))
+
+
+// cannot use results from other functions
+
+//# programmable
+//> 0: test::m1::r();
+//> test::m1::priv(Result(0));
+
+//# programmable --sender A --inputs object(107)
+//> 0: test::m1::id(Input(0));
+//> test::m1::priv(Result(0));
+
+// cannot use an object once it has been used in a non-entry function
+
+//# programmable --sender A --inputs object(107)
+//> 0: test::m1::dirty(Input(0));
+//> test::m1::priv(Input(0));

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_by_ref_input_valid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_by_ref_input_valid.exp
@@ -1,0 +1,19 @@
+processed 5 tasks
+
+init:
+A: object(103)
+
+task 1 'publish'. lines 9-25:
+created: object(105)
+written: object(104)
+
+task 2 'programmable'. lines 27-29:
+created: object(107)
+written: object(106)
+
+task 3 'programmable'. lines 31-38:
+written: object(107), object(108)
+
+task 4 'programmable'. lines 40-45:
+created: object(110)
+written: object(109)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_by_ref_input_valid.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_by_ref_input_valid.move
@@ -1,0 +1,45 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests that object values can be used private entry functions if they have been used
+// by other entry functions or primitive commands
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+module test::m1 {
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::coin::Coin;
+    use sui::sui::SUI;
+
+    struct R has key, store { id: UID }
+    public fun r(ctx: &mut TxContext): R { R { id: object::new(ctx) } }
+
+    public fun v(): u64 { 100 }
+
+    public entry fun clean(_: &mut R, _extra_arg: u64) {}
+    entry fun priv(_: &mut R) { }
+
+    entry fun coin(_: &mut Coin<SUI>) {}
+}
+
+//# programmable --sender A --inputs @A
+//> 0: test::m1::r();
+//> TransferObjects([Result(0)], Input(0))
+
+//# programmable --sender A --inputs object(107) 200
+//> 0: test::m1::v();
+//> test::m1::clean(Input(0), Result(0));
+//> test::m1::priv(Input(0));
+//> test::m1::clean(Input(0), Input(1));
+//> test::m1::priv(Input(0));
+//> test::m1::priv(Input(0));
+//> test::m1::priv(Input(0));
+
+//# programmable --sender A --inputs @A
+//> 0: test::m1::v();
+//> 1: SplitCoins(Gas, [Result(0)]);
+//> test::m1::coin(Gas);
+//> test::m1::coin(Result(1));
+//> TransferObjects([Result(1)], Input(0))

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_copied_input_valid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_copied_input_valid.exp
@@ -1,0 +1,11 @@
+processed 3 tasks
+
+init:
+A: object(103)
+
+task 1 'publish'. lines 9-13:
+created: object(105)
+written: object(104)
+
+task 2 'programmable'. lines 15-17:
+written: object(106)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_copied_input_valid.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_copied_input_valid.move
@@ -1,0 +1,17 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests that non-input primitive values can be used private entry functions, even if they have
+// been copied to other, non-entry functions
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+module test::m1 {
+    public fun clean(_: u64) {}
+    entry fun priv(_: u64) {}
+}
+
+//# programmable --inputs 0
+//> test::m1::clean(Input(0));
+//> test::m1::priv(Input(0));

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_make_move_vec_invalid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_make_move_vec_invalid.exp
@@ -1,0 +1,20 @@
+processed 5 tasks
+
+init:
+A: object(103)
+
+task 1 'publish'. lines 9-21:
+created: object(105)
+written: object(104)
+
+task 2 'programmable'. lines 23-27:
+created: object(107), object(108), object(109)
+written: object(106)
+
+task 3 'programmable'. lines 29-32:
+Error: Transaction Effects Status: Invalid command argument at 0. Invalid argument to private entry function. These functions cannot take arguments from other Move functions
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidArgumentToPrivateEntryFunction }, source: None, command: Some(2) } }
+
+task 4 'programmable'. lines 34-37:
+Error: Transaction Effects Status: Invalid command argument at 0. Invalid argument to private entry function. These functions cannot take arguments from other Move functions
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidArgumentToPrivateEntryFunction }, source: None, command: Some(2) } }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_make_move_vec_invalid.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_make_move_vec_invalid.move
@@ -1,0 +1,37 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests MakeMoveVec makes a "dirty" value if at least one value has been used in a non-entry
+// function used private entry function
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+module test::m1 {
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+
+    struct R has key, store { id: UID }
+    public fun r(ctx: &mut TxContext): R { R { id: object::new(ctx) } }
+
+    public fun dirty(_: &mut R) {}
+    public fun dirty_u64(_: &mut u64) {}
+    entry fun priv(_: vector<R>) { abort 0 }
+    entry fun priv2(_: vector<u64>) { abort 0 }
+}
+
+//# programmable --sender A --inputs @A
+//> 0: test::m1::r();
+//> 1: test::m1::r();
+//> 2: test::m1::r();
+//> TransferObjects([Result(0), Result(1), Result(2)], Input(0))
+
+//# programmable --sender A --inputs object(107) object(108) object(109)
+//> 0: test::m1::dirty(Input(2));
+//> 1: MakeMoveVec([Input(0), Input(1), Input(2)]);
+//> test::m1::priv(Result(1))
+
+//# programmable --sender A --inputs 0 0 0
+//> 0: test::m1::dirty_u64(Input(1));
+//> 1: MakeMoveVec<u64>([Input(0), Input(1), Input(2)]);
+//> test::m1::priv(Result(1))

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_make_move_vec_valid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_make_move_vec_valid.exp
@@ -1,0 +1,19 @@
+processed 5 tasks
+
+init:
+A: object(103)
+
+task 1 'publish'. lines 9-29:
+created: object(105)
+written: object(104)
+
+task 2 'programmable'. lines 31-35:
+created: object(107), object(108), object(109)
+written: object(106)
+
+task 3 'programmable'. lines 37-41:
+written: object(110)
+deleted: object(107), object(108), object(109)
+
+task 4 'programmable'. lines 43-46:
+written: object(111)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_make_move_vec_valid.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_make_move_vec_valid.move
@@ -1,0 +1,46 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests MakeMoveVec does not "dirty" value if no value has been used in a non-entry
+// function used private entry function
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+module test::m1 {
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use std::vector;
+
+    struct R has key, store { id: UID }
+    public fun r(ctx: &mut TxContext): R { R { id: object::new(ctx) } }
+
+    public entry fun clean(_: &mut R) {}
+    public entry fun clean_u64(_: u64) {}
+    entry fun priv1(_: &mut R) {}
+    entry fun priv2(v: vector<R>) {
+        while (!vector::is_empty(&v)) {
+            let R { id } = vector::pop_back(&mut v);
+            object::delete(id);
+        };
+        vector::destroy_empty(v)
+    }
+    entry fun priv3(_: vector<u64>) {}
+}
+
+//# programmable --sender A --inputs @A
+//> 0: test::m1::r();
+//> 1: test::m1::r();
+//> 2: test::m1::r();
+//> TransferObjects([Result(0), Result(1), Result(2)], Input(0))
+
+//# programmable --sender A --inputs object(107) object(108) object(109)
+//> 0: test::m1::clean(Input(2));
+//> 1: test::m1::priv1(Input(2));
+//> 2: MakeMoveVec([Input(0), Input(1), Input(2)]);
+//> test::m1::priv2(Result(2))
+
+//# programmable --sender A --inputs 0 0 0
+//> 0: test::m1::clean_u64(Input(1));
+//> 1: MakeMoveVec<u64>([Input(0), Input(1), Input(2)]);
+//> test::m1::priv3(Result(1))

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_non_pure_input_invalid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_non_pure_input_invalid.exp
@@ -1,0 +1,20 @@
+processed 5 tasks
+
+init:
+A: object(103)
+
+task 1 'publish'. lines 8-16:
+created: object(105)
+written: object(104)
+
+task 2 'programmable'. lines 17-19:
+Error: Transaction Effects Status: Invalid command argument at 0. Invalid argument to private entry function. These functions cannot take arguments from other Move functions
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidArgumentToPrivateEntryFunction }, source: None, command: Some(1) } }
+
+task 3 'programmable'. lines 21-25:
+Error: Transaction Effects Status: Invalid command argument at 0. Invalid argument to private entry function. These functions cannot take arguments from other Move functions
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidArgumentToPrivateEntryFunction }, source: None, command: Some(1) } }
+
+task 4 'programmable'. lines 26-28:
+Error: Transaction Effects Status: Invalid command argument at 0. Invalid argument to private entry function. These functions cannot take arguments from other Move functions
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidArgumentToPrivateEntryFunction }, source: None, command: Some(1) } }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_non_pure_input_invalid.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_non_pure_input_invalid.move
@@ -1,0 +1,28 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests that non-input primitive values cannot be used private entry functions
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+module test::m1 {
+    public fun v1(): u64 { 0 }
+    entry fun v2(): u64 { 0 }
+    public fun dirty(_: &mut u64) {}
+    entry fun priv(_: u64) { abort 0 }
+}
+
+// cannot use results from other functions
+//# programmable
+//> 0: test::m1::v1();
+//> test::m1::priv(Result(0));
+
+//# programmable
+//> 0: test::m1::v2();
+//> test::m1::priv(Result(0));
+
+// pure value has been "dirtied" and cannot be used
+//# programmable --inputs 0
+//> test::m1::dirty(Input(0));
+//> test::m1::priv(Input(0));

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_per_argument.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_per_argument.exp
@@ -1,0 +1,20 @@
+processed 5 tasks
+
+init:
+A: object(103)
+
+task 1 'publish'. lines 8-18:
+created: object(105)
+written: object(104)
+
+task 2 'programmable'. lines 20-23:
+created: object(107), object(108)
+written: object(106)
+
+task 3 'programmable'. lines 25-27:
+Error: Transaction Effects Status: Invalid command argument at 1. Invalid argument to private entry function. These functions cannot take arguments from other Move functions
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: InvalidArgumentToPrivateEntryFunction }, source: None, command: Some(1) } }
+
+task 4 'programmable'. lines 29-32:
+Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be instantiated from raw bytes
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidUsageOfPureArg }, source: Some("Non-primitive argument at index 0. If it is an object, it must be populated by an object"), command: Some(1) } }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_per_argument.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_per_argument.move
@@ -1,0 +1,32 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests dirty check happens in order of arguments, nto all at once
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+module test::m1 {
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+
+    struct R has key, store { id: UID }
+    public fun r(ctx: &mut TxContext): R { R { id: object::new(ctx) } }
+
+    public fun dirty(_: &mut R) {}
+    entry fun priv(_: &mut R, _: &mut R) {}
+}
+
+//# programmable --sender A --inputs @A
+//> 0: test::m1::r();
+//> 1: test::m1::r();
+//> TransferObjects([Result(0), Result(1)], Input(0))
+
+//# programmable --sender A --inputs object(107) object(108)
+//> test::m1::dirty(Input(1));
+//> test::m1::priv(Input(0), Input(1));
+
+//# programmable --sender A --inputs 0u64 object(108)
+//> test::m1::dirty(Input(1));
+// type error instead of dirty error
+//> test::m1::priv(Input(0), Input(1));

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_type_check.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_type_check.exp
@@ -1,0 +1,20 @@
+processed 5 tasks
+
+init:
+A: object(103)
+
+task 1 'publish'. lines 8-18:
+created: object(105)
+written: object(104)
+
+task 2 'programmable'. lines 20-22:
+created: object(107)
+written: object(106)
+
+task 3 'programmable'. lines 24-26:
+Error: Transaction Effects Status: Invalid command argument at 0. Invalid argument to private entry function. These functions cannot take arguments from other Move functions
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidArgumentToPrivateEntryFunction }, source: None, command: Some(1) } }
+
+task 4 'programmable'. lines 28-29:
+Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_type_check.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_type_check.move
@@ -1,0 +1,29 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests dirty check happens before type checking
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+module test::m1 {
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+
+    struct R has key, store { id: UID }
+    public fun r(ctx: &mut TxContext): R { R { id: object::new(ctx) } }
+
+    public fun dirty(_: &mut R) {}
+    entry fun priv1(_: u64) {}
+}
+
+//# programmable --sender A --inputs @A
+//> 0: test::m1::r();
+//> TransferObjects([Result(0)], Input(0))
+
+//# programmable --sender A --inputs object(107)
+//> 0: test::m1::dirty(Input(0));
+//> test::m1::priv1(Input(0));
+
+//# programmable --sender A --inputs object(107)
+//> test::m1::priv1(Input(0));

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_transfer_invalid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_transfer_invalid.exp
@@ -1,0 +1,44 @@
+processed 11 tasks
+
+init:
+A: object(103)
+
+task 1 'publish'. lines 8-20:
+created: object(105)
+written: object(104)
+
+task 2 'programmable'. lines 22-24:
+Error: Transaction Effects Status: Non Entry Function Invoked. Move Call must start with an entry function
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: NonEntryFunctionInvoked, source: Some("Cannot directly call sui::transfer::transfer. Use the public variant instead, sui::transfer::public_transfer"), command: Some(1) } }
+
+task 3 'programmable'. lines 26-28:
+Error: Transaction Effects Status: Non Entry Function Invoked. Move Call must start with an entry function
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: NonEntryFunctionInvoked, source: Some("Cannot directly call sui::transfer::share_object. Use the public variant instead, sui::transfer::public_share_object"), command: Some(1) } }
+
+task 4 'programmable'. lines 30-35:
+Error: Transaction Effects Status: Non Entry Function Invoked. Move Call must start with an entry function
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: NonEntryFunctionInvoked, source: Some("Cannot directly call sui::transfer::freeze_object. Use the public variant instead, sui::transfer::public_freeze_object"), command: Some(1) } }
+
+task 5 'programmable'. lines 37-39:
+Error: Transaction Effects Status: Non Entry Function Invoked. Move Call must start with an entry function
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: NonEntryFunctionInvoked, source: Some("Cannot directly call sui::transfer::transfer. Use the public variant instead, sui::transfer::public_transfer"), command: Some(1) } }
+
+task 6 'programmable'. lines 41-43:
+Error: Transaction Effects Status: Non Entry Function Invoked. Move Call must start with an entry function
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: NonEntryFunctionInvoked, source: Some("Cannot directly call sui::transfer::share_object. Use the public variant instead, sui::transfer::public_share_object"), command: Some(1) } }
+
+task 7 'programmable'. lines 45-50:
+Error: Transaction Effects Status: Non Entry Function Invoked. Move Call must start with an entry function
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: NonEntryFunctionInvoked, source: Some("Cannot directly call sui::transfer::freeze_object. Use the public variant instead, sui::transfer::public_freeze_object"), command: Some(1) } }
+
+task 8 'programmable'. lines 52-54:
+Error: Transaction Effects Status: Move Bytecode Verification Error. Please run the Bytecode Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VMVerificationOrDeserializationError, source: Some(VMError { major_status: CONSTRAINT_NOT_SATISFIED, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: sui, name: Identifier("transfer") }), indices: [], offsets: [] }), command: Some(1) } }
+
+task 9 'programmable'. lines 56-58:
+Error: Transaction Effects Status: Move Bytecode Verification Error. Please run the Bytecode Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VMVerificationOrDeserializationError, source: Some(VMError { major_status: CONSTRAINT_NOT_SATISFIED, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: sui, name: Identifier("transfer") }), indices: [], offsets: [] }), command: Some(1) } }
+
+task 10 'programmable'. lines 60-62:
+Error: Transaction Effects Status: Move Bytecode Verification Error. Please run the Bytecode Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VMVerificationOrDeserializationError, source: Some(VMError { major_status: CONSTRAINT_NOT_SATISFIED, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: sui, name: Identifier("transfer") }), indices: [], offsets: [] }), command: Some(1) } }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_transfer_invalid.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_transfer_invalid.move
@@ -1,0 +1,62 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests calling public transfer functions
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+module test::m1 {
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+
+    struct Pub has key, store { id: UID }
+    public fun pub(ctx: &mut TxContext): Pub { Pub { id: object::new(ctx) } }
+
+    struct Priv has key { id: UID }
+    public fun priv(ctx: &mut TxContext): Priv { Priv { id: object::new(ctx) } }
+}
+
+// Has store, but cannot be used with internal varaints
+
+//# programmable --sender A --inputs @A
+//> 0: test::m1::pub();
+//> sui::transfer::transfer<test::m1::Pub>(Result(0), Input(0));
+
+//# programmable
+//> 0: test::m1::pub();
+//> sui::transfer::share_object<test::m1::Pub>(Result(0));
+
+//# programmable
+//> 0: test::m1::pub();
+//> sui::transfer::freeze_object<test::m1::Pub>(Result(0));
+
+
+// Does not have store, cannot be used with internal varaints
+
+//# programmable --sender A --inputs @A
+//> 0: test::m1::priv();
+//> sui::transfer::transfer<test::m1::Priv>(Result(0), Input(0));
+
+//# programmable
+//> 0: test::m1::priv();
+//> sui::transfer::share_object<test::m1::Priv>(Result(0));
+
+//# programmable
+//> 0: test::m1::priv();
+//> sui::transfer::freeze_object<test::m1::Priv>(Result(0));
+
+
+// Does not have store, cannot be used with public varaints
+
+//# programmable --sender A --inputs @A
+//> 0: test::m1::priv();
+//> sui::transfer::public_transfer<test::m1::Priv>(Result(0), Input(0));
+
+//# programmable
+//> 0: test::m1::priv();
+//> sui::transfer::public_share_object<test::m1::Priv>(Result(0));
+
+//# programmable
+//> 0: test::m1::priv();
+//> sui::transfer::public_freeze_object<test::m1::Priv>(Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_transfer_valid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_transfer_valid.exp
@@ -1,0 +1,35 @@
+processed 8 tasks
+
+init:
+A: object(103)
+
+task 1 'publish'. lines 8-15:
+created: object(105)
+written: object(104)
+
+task 2 'programmable'. lines 17-19:
+created: object(107)
+written: object(106)
+
+task 3 'view-object'. lines 21-21:
+Owner: Account Address ( A )
+Version: 2
+Contents: test::m1::Pub {id: sui::object::UID {id: sui::object::ID {bytes: fake(107)}}}
+
+task 4 'programmable'. lines 23-25:
+created: object(109)
+written: object(108)
+
+task 5 'view-object'. lines 27-27:
+Owner: Shared
+Version: 2
+Contents: test::m1::Pub {id: sui::object::UID {id: sui::object::ID {bytes: fake(109)}}}
+
+task 6 'programmable'. lines 29-31:
+created: object(111)
+written: object(110)
+
+task 7 'view-object'. lines 33-33:
+Owner: Immutable
+Version: 2
+Contents: test::m1::Pub {id: sui::object::UID {id: sui::object::ID {bytes: fake(111)}}}

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_transfer_valid.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_transfer_valid.move
@@ -1,0 +1,33 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests calling public transfer functions
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+module test::m1 {
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+
+    struct Pub has key, store { id: UID }
+    public fun pub(ctx: &mut TxContext): Pub { Pub { id: object::new(ctx) } }
+}
+
+//# programmable --sender A --inputs @A
+//> 0: test::m1::pub();
+//> sui::transfer::public_transfer<test::m1::Pub>(Result(0), Input(0));
+
+//# view-object 107
+
+//# programmable
+//> 0: test::m1::pub();
+//> sui::transfer::public_share_object<test::m1::Pub>(Result(0));
+
+//# view-object 109
+
+//# programmable
+//> 0: test::m1::pub();
+//> sui::transfer::public_freeze_object<test::m1::Pub>(Result(0));
+
+//# view-object 111

--- a/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_type_change.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_type_change.exp
@@ -1,0 +1,24 @@
+processed 6 tasks
+
+init:
+A: object(103)
+
+task 1 'publish'. lines 8-27:
+created: object(105)
+written: object(104)
+
+task 2 'programmable'. lines 29-35:
+Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(3) } }
+
+task 3 'programmable'. lines 37-43:
+Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(3) } }
+
+task 4 'programmable'. lines 45-51:
+Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(3) } }
+
+task 5 'programmable'. lines 53-59:
+Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(3) } }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_type_change.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_type_change.move
@@ -1,0 +1,59 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests that pure arguments have their types fixed/changed after being used by a mutable reference
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+module test::m1 {
+    use std::option::Option;
+    use sui::object::ID;
+    use std::string::String;
+    use std::ascii;
+
+    public fun fix<T>(_: &mut T) {}
+
+    public fun addr(_: address) {}
+    public fun id(_: ID) {}
+
+    public fun ascii(_: ascii::String) {}
+    public fun string(_: String) {}
+
+    public fun vec<T: drop>(_: vector<T>) {}
+    public fun opt<T: drop>(_: Option<T>) {}
+
+
+}
+
+//# programmable --inputs "hello"
+
+//> 0: test::m1::ascii(Input(0));
+//> 1: test::m1::string(Input(0));
+//> 2: test::m1::fix<std::ascii::String>(Input(0));
+// now will fail as Input(0) if always a String
+//> 3: test::m1::string(Input(0));
+
+//# programmable --inputs @A
+
+//> 0: test::m1::addr(Input(0));
+//> 1: test::m1::id(Input(0));
+//> 2: test::m1::fix<sui::object::ID>(Input(0));
+// now will fail as Input(0) if always an ID
+//> 3: test::m1::addr(Input(0));
+
+//# programmable --inputs vector[0u64]
+
+//> 0: test::m1::vec<u64>(Input(0));
+//> 1: test::m1::opt<u64>(Input(0));
+//> 2: test::m1::fix<vector<u64>>(Input(0));
+// now will fail as Input(0) if always a vector
+//> 3: test::m1::opt<u64>(Input(0));
+
+//# programmable --inputs vector[]
+
+//> 0: test::m1::vec<u64>(Input(0));
+//> 1: test::m1::opt<u64>(Input(0));
+//> 2: test::m1::fix<std::option::Option<u64>>(Input(0));
+// now will fail as Input(0) if always an Option
+//> 3: test::m1::vec<u64>(Input(0));


### PR DESCRIPTION
## Description 

- Tested move calls
- Extensive tests for private entry rules

## Test Plan 

- It is tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [X] breaking change for FNs (FN binary must upgrade)
- [X] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [X] necessitate either a data wipe or data migration

### Release notes
