### PR TITLE
Gas cleanup again

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1180,13 +1180,12 @@ impl AuthorityState {
             transaction_digest,
             protocol_config,
         );
-        let mut gas_status = SuiGasStatus::new_with_budget(
+        let gas_status = SuiGasStatus::new_with_budget(
             max_tx_gas,
             GasPrice::from(gas_price),
             storage_gas_price.into(),
             SuiCostTable::new(protocol_config),
         );
-        gas_status.charge_min_tx_gas()?;
         let move_vm = Arc::new(
             adapter::new_move_vm(
                 epoch_store.native_functions().clone(),

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -3,7 +3,7 @@
 
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use crate::authority::AuthorityStore;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use sui_adapter::adapter::run_metered_move_bytecode_verifier;
 use sui_protocol_config::ProtocolConfig;
 use sui_types::base_types::ObjectRef;
@@ -23,6 +23,10 @@ use sui_types::{
 use sui_types::{SUI_CLOCK_OBJECT_ID, SUI_CLOCK_OBJECT_SHARED_VERSION};
 use tracing::instrument;
 
+// Entry point for all checks related to gas.
+// Called on both signing and execution.
+// On success the gas part of the transaction (gas data and gas coins)
+// is verified and good to go
 async fn get_gas_status(
     objects: &[Object],
     gas: &[ObjectRef],
@@ -30,8 +34,7 @@ async fn get_gas_status(
     transaction: &TransactionData,
 ) -> SuiResult<SuiGasStatus<'static>> {
     // Get the first coin (possibly the only one) and make it "the gas coin", then
-    // keep track of all others that can contribute to gas (gas smashing and special
-    // pay transactions).
+    // keep track of all others that can contribute to gas (gas smashing).
     let gas_object_ref = gas.get(0).unwrap();
     // all other gas coins
     let more_gas_object_refs = gas[1..].to_vec();
@@ -40,10 +43,10 @@ async fn get_gas_status(
         objects,
         epoch_store,
         gas_object_ref,
+        more_gas_object_refs,
         transaction.gas_budget(),
         transaction.gas_price(),
         transaction.kind(),
-        more_gas_object_refs,
     )
     .await
 }
@@ -155,71 +158,64 @@ pub async fn check_certificate_input(
     Ok((gas_status, input_objects))
 }
 
-/// Checking gas budget by fetching the gas object only from the store,
-/// and check whether the balance and budget satisfies the miminum requirement.
-/// Returns the gas object (to be able to reuse it latter) and a gas status
-/// that will be used in the entire lifecycle of the transaction execution.
+/// Check transaction gas data/info and gas coins consistency.
+/// Return the gas status to be used for the lifecycle of the transaction.
 #[instrument(level = "trace", skip_all)]
 async fn check_gas(
     objects: &[Object],
     epoch_store: &AuthorityPerEpochStore,
     gas_payment: &ObjectRef,
-    gas_budget: u64,
-    computation_gas_price: u64,
-    tx_kind: &TransactionKind,
     more_gas_object_refs: Vec<ObjectRef>,
+    gas_budget: u64,
+    gas_price: u64,
+    tx_kind: &TransactionKind,
 ) -> SuiResult<SuiGasStatus<'static>> {
     if tx_kind.is_system_tx() {
         Ok(SuiGasStatus::new_unmetered())
     } else {
-        let gas_object = objects.iter().find(|o| o.id() == gas_payment.0);
-        let gas_object = gas_object.ok_or(UserInputError::ObjectNotFound {
-            object_id: gas_payment.0,
-            version: Some(gas_payment.1),
-        })?;
-
-        // If the transaction is TransferSui, we ensure that the gas balance is enough to cover
-        // both gas budget and the transfer amount.
+        // gas price must be bigger or equal to reference gas price
         let reference_gas_price = epoch_store.reference_gas_price();
-        if computation_gas_price < reference_gas_price {
+        if gas_price < reference_gas_price {
             return Err(UserInputError::GasPriceUnderRGP {
-                gas_price: computation_gas_price,
+                gas_price,
                 reference_gas_price,
             }
             .into());
         }
-        let protocol_config = epoch_store.protocol_config();
-        let cost_table = SuiCostTable::new(protocol_config);
-        let storage_gas_price = protocol_config.storage_gas_price();
 
-        // MUSTFIX: We should revisit how we compute gas price and compare to gas budget.
-        let gas_price = std::cmp::max(computation_gas_price, storage_gas_price);
+        // load all gas coins
+        let objects: BTreeMap<_, _> = objects.iter().map(|o| (o.id(), o)).collect();
 
+        let gas_object = objects.get(&gas_payment.0);
+        let gas_object = *gas_object.ok_or(UserInputError::ObjectNotFound {
+            object_id: gas_payment.0,
+            version: Some(gas_payment.1),
+        })?;
         let mut more_gas_objects = vec![];
         for obj_ref in more_gas_object_refs.iter() {
-            let obj = objects.iter().find(|o| o.id() == obj_ref.0);
-            let obj = obj.ok_or(UserInputError::ObjectNotFound {
+            let obj = objects.get(&obj_ref.0);
+            let obj = *obj.ok_or(UserInputError::ObjectNotFound {
                 object_id: obj_ref.0,
                 version: Some(obj_ref.1),
             })?;
-            more_gas_objects.push(obj.clone());
+            more_gas_objects.push(obj);
         }
 
+        // check balance and coins consistency
+        let protocol_config = epoch_store.protocol_config();
+        let cost_table = SuiCostTable::new(protocol_config);
         gas::check_gas_balance(
             gas_object,
+            more_gas_objects,
             gas_budget,
             gas_price,
-            more_gas_objects,
             &cost_table,
         )?;
 
-        gas::start_gas_metering(
-            gas_budget,
-            computation_gas_price,
-            storage_gas_price,
-            cost_table,
-        )
-        .map_err(|e| e.into())
+        // make the gas status to be used by execution
+        let storage_gas_price = protocol_config.storage_gas_price();
+        gas::start_gas_metering(gas_budget, gas_price, storage_gas_price, cost_table)
+            .map_err(|e| e.into())
     }
 }
 

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -316,6 +316,11 @@ pub struct ProtocolConfig {
     // entire object, just consulting an ID -> tx digest map
     obj_access_cost_verify_per_byte: Option<u64>,
 
+    /// === Gas version. gas model ===
+
+    /// Gas model version, what code we are using to charge gas
+    gas_model_version: Option<u64>,
+
     /// === Storage gas costs ===
 
     /// Per-byte cost of storing an object in the Sui global object store. Some of this cost may be refundable if the object is later freed
@@ -728,6 +733,9 @@ impl ProtocolConfig {
     pub fn obj_metadata_cost_non_refundable(&self) -> u64 {
         self.obj_metadata_cost_non_refundable
             .expect(CONSTANT_ERR_MSG)
+    }
+    pub fn gas_model_version(&self) -> u64 {
+        self.gas_model_version.expect(CONSTANT_ERR_MSG)
     }
     pub fn storage_rebate_rate(&self) -> u64 {
         self.storage_rebate_rate.expect(CONSTANT_ERR_MSG)
@@ -1293,6 +1301,7 @@ impl ProtocolConfig {
                 obj_access_cost_verify_per_byte: Some(200),
                 obj_data_cost_refundable: Some(100),
                 obj_metadata_cost_non_refundable: Some(50),
+                gas_model_version: Some(1),
                 storage_rebate_rate: Some(9900),
                 storage_fund_reinvest_rate: Some(500),
                 reward_slashing_rate: Some(5000),

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_1.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_1.snap
@@ -57,6 +57,7 @@ obj_access_cost_read_per_byte: 15
 obj_access_cost_mutate_per_byte: 40
 obj_access_cost_delete_per_byte: 40
 obj_access_cost_verify_per_byte: 200
+gas_model_version: 1
 obj_data_cost_refundable: 100
 obj_metadata_cost_non_refundable: 50
 storage_rebate_rate: 9900

--- a/crates/sui-types/src/temporary_store.rs
+++ b/crates/sui-types/src/temporary_store.rs
@@ -701,10 +701,12 @@ impl<S: ObjectStore> TemporaryStore<S> {
         execution_result: &mut Result<T, ExecutionError>,
         gas: &[ObjectRef],
     ) {
-        // at this point, we have done some charging for computation, but have not yet set the storage rebate or storage gas units
+        // at this point, we have done *all* charging for computation,
+        // but have not yet set the storage rebate or storage gas units
         assert!(gas_status.storage_rebate() == 0);
         assert!(gas_status.storage_gas_units() == 0);
 
+        // bucketize computation cost
         if let Err(err) = gas_status.bucketize_computation() {
             if execution_result.is_ok() {
                 *execution_result = Err(err);


### PR DESCRIPTION
## Description 

This is pretty simple and mostly a cleanup.
It also adds a gas model version to the protocol config so we can easily fork the code.
There are pretty much only 2 entry points to protect (`SuiGasStatus` creation and `charge_gas` call) to version gas properly. 
And we know we need to version super soon.
The work I was supposed to land is getting too intrusive and adding the handling of system transaction is way too much for today.
I don't feel comfortable with any work in that space going in today, I'd rather fix things better over the weekend and push the change in an upgrade as soon as we can next week.
@lxfind @bmwill @emmazzz @sblackshear

## Test Plan 

Existing tests at the moment, as this is not a new feature but a core change. More tests would be nice soon

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
