### PR TITLE
Remove Cargo.lock from isMove check in CI

### DIFF
--- a/.github/actions/diffs/action.yml
+++ b/.github/actions/diffs/action.yml
@@ -35,4 +35,3 @@ runs:
           - 'crates/sui-framework/sources/**'
           - 'crates/sui/src/sui_move/**'
           - 'Cargo.toml'
-          - 'Cargo.lock'


### PR DESCRIPTION
## Description 

Move prover is failing on unrelated changes and we don't know how to fix.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
