### PR TITLE
crypto: audit SuiAddress and ObjectID

### DIFF
--- a/crates/sui-config/Cargo.toml
+++ b/crates/sui-config/Cargo.toml
@@ -40,3 +40,4 @@ sui-simulator = { path = "../sui-simulator" }
 [dev-dependencies]
 insta = { version = "1.21.1", features = ["redactions", "yaml"] }
 tempfile = "3.3.0"
+sui-types = { path = "../sui-types", features = ["test-utils"] }

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -8,6 +8,7 @@ use fastcrypto::encoding::{Base64, Encoding, Hex};
 use fastcrypto::hash::HashFunction;
 use fastcrypto::traits::KeyPair;
 use move_binary_format::CompiledModule;
+use move_core_types::account_address::AccountAddress;
 use move_core_types::ident_str;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_with::serde_as;
@@ -1511,7 +1512,7 @@ fn process_package(
                 .iter()
                 .zip(dependency_objects.iter())
                 .all(|(dependency, obj_opt)| obj_opt.is_some()
-                    || to_be_published_addresses.contains(dependency))
+                    || to_be_published_addresses.contains(&AccountAddress::from(*dependency)))
         );
     }
     let loaded_dependencies: Vec<_> = dependencies

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -86,6 +86,7 @@ serde_yaml = "0.8.26"
 pretty_assertions = "1.2.1"
 narwhal-test-utils = { path = "../../narwhal/test-utils" }
 sui-verifier = { path = "../sui-verifier" }
+sui-types = { path = "../sui-types", features = ["test-utils"] }
 
 [target.'cfg(not(target_env = "msvc"))'.dev-dependencies]
 pprof = { version = "0.11.0", features = ["cpp", "frame-pointer"] }
@@ -108,3 +109,6 @@ harness = false
 [[bench]]
 name = "batch_verification_bench"
 harness = false
+
+[features]
+test-utils = []

--- a/crates/sui-core/src/generate_format.rs
+++ b/crates/sui-core/src/generate_format.rs
@@ -59,8 +59,7 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_value(&mut samples, &sig)?;
 
     // ObjectID and SuiAddress are the same length
-    let addr_bytes: [u8; ObjectID::LENGTH] = addr.as_ref().try_into().unwrap();
-    let oid = ObjectID::from(addr_bytes);
+    let oid: ObjectID = addr.into();
     tracer.trace_value(&mut samples, &oid)?;
 
     // ObjectDigest and Transaction digest use the `serde_as`speedup for ser/de => trace them

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -27,6 +27,7 @@ mod stake_aggregator;
 pub mod state_accumulator;
 pub mod storage;
 pub mod streamer;
+#[cfg(feature = "test-utils")]
 pub mod test_utils;
 pub mod transaction_input_checker;
 mod transaction_manager;

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -1063,7 +1063,7 @@ async fn test_handle_shared_object_with_max_sequence_number() {
 
 #[tokio::test]
 async fn test_handle_transfer_transaction_unknown_sender() {
-    let sender = get_new_address::<AccountKeyPair>();
+    let sender = dbg_addr(1);
     let (unknown_address, unknown_key) = get_key_pair();
     let object_id: ObjectID = ObjectID::random();
     let gas_object_id = ObjectID::random();

--- a/crates/sui-indexer/tests/integration_tests.rs
+++ b/crates/sui-indexer/tests/integration_tests.rs
@@ -750,7 +750,7 @@ pub mod pg_integration_test {
         }
 
         // Not exists
-        let obj_id = ObjectID::from([42; 32]);
+        let obj_id = ObjectID::new([42; 32]);
         let resp = indexer_rpc_client
             .get_object(obj_id, Some(show_all_content.clone()))
             .await

--- a/crates/sui-json/Cargo.toml
+++ b/crates/sui-json/Cargo.toml
@@ -27,6 +27,7 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 [dev-dependencies]
 test-fuzz = "3.0.4"
 workspace-hack.workspace = true
+sui-types = { path = "../sui-types", features = ["test-utils"] }
 
 sui-adapter = { path = "../sui-adapter" }
 sui-framework-build = { path = "../sui-framework-build" }

--- a/crates/sui-json/src/tests.rs
+++ b/crates/sui-json/src/tests.rs
@@ -447,7 +447,7 @@ fn test_basic_args_linter_top_level() {
     let monster_description_raw = "MonsterDescription";
     let display_raw = "DisplayUrl";
 
-    let player_id = json!(format!("0x{:02x}", ObjectID::random()));
+    let player_id = json!(format!("0x{}", ObjectID::random()));
     // This is okay since not starting with 0x
     let monster_name = json!(monster_name_raw);
     // Well within U64 bounds
@@ -559,7 +559,7 @@ fn test_basic_args_linter_top_level() {
 
     let value = json!(value_raw);
     // Encode as hex string
-    let addr = json!(format!("0x{:02x}", address));
+    let addr = json!(format!("{address}"));
 
     // They have to be ordered
     let args = vec![value, addr]
@@ -601,9 +601,9 @@ fn test_basic_args_linter_top_level() {
     let object_id_raw = ObjectID::random();
     let address = SuiAddress::random_for_testing_only();
 
-    let object_id = json!(format!("0x{:02x}", object_id_raw));
+    let object_id = json!(format!("{object_id_raw}"));
     // Encode as hex string
-    let addr = json!(format!("0x{:02x}", address));
+    let addr = json!(format!("{address}"));
 
     // They have to be ordered
     let args = vec![object_id, addr]
@@ -624,7 +624,7 @@ fn test_basic_args_linter_top_level() {
     assert_eq!(
         args[0].0,
         ResolvedCallArg::Object(
-            ObjectID::from_hex_literal(&format!("0x{:02x}", object_id_raw)).unwrap()
+            ObjectID::from_hex_literal(&format!("0x{}", object_id_raw)).unwrap()
         )
     );
 
@@ -659,8 +659,8 @@ fn test_basic_args_linter_top_level() {
      */
     let object_id_raw1 = ObjectID::random();
     let object_id_raw2 = ObjectID::random();
-    let object_id1 = json!(format!("0x{:02x}", object_id_raw1));
-    let object_id2 = json!(format!("0x{:02x}", object_id_raw2));
+    let object_id1 = json!(format!("0x{}", object_id_raw1));
+    let object_id2 = json!(format!("0x{}", object_id_raw2));
 
     let args = vec![SuiJsonValue::new(Value::Array(vec![object_id1, object_id2])).unwrap()];
 
@@ -680,11 +680,11 @@ fn test_basic_args_linter_top_level() {
         assert_eq!(vec.len(), 2);
         assert_eq!(
             vec[0],
-            ObjectID::from_hex_literal(&format!("0x{:02x}", object_id_raw1)).unwrap()
+            ObjectID::from_hex_literal(&format!("0x{}", object_id_raw1)).unwrap()
         );
         assert_eq!(
             vec[1],
-            ObjectID::from_hex_literal(&format!("0x{:02x}", object_id_raw2)).unwrap()
+            ObjectID::from_hex_literal(&format!("0x{}", object_id_raw2)).unwrap()
         );
     }
 }

--- a/crates/sui-proxy/Cargo.toml
+++ b/crates/sui-proxy/Cargo.toml
@@ -47,6 +47,7 @@ mime = "0.3"
 serde_json = "1.0"
 tower = { version = "0.4", features = ["util"] }
 axum-server = { version = "0.4.4", default-features = false, features = ["tls-rustls"] }
+sui-types = { path = "../sui-types", features = ["test-utils"] }
 
 [build-dependencies]
 prost-build = "0.11.8"

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -64,3 +64,6 @@ proptest = "1.0.0"
 [[bench]]
 name = "accumulator_bench"
 harness = false
+
+[features]
+test-utils = []

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -8,8 +8,7 @@ use crate::coin::COIN_MODULE_NAME;
 use crate::coin::COIN_STRUCT_NAME;
 pub use crate::committee::EpochId;
 use crate::crypto::{
-    AuthorityPublicKeyBytes, DefaultHash, KeypairTraits, PublicKey, SignatureScheme, SuiPublicKey,
-    SuiSignature,
+    AuthorityPublicKeyBytes, DefaultHash, PublicKey, SignatureScheme, SuiPublicKey, SuiSignature,
 };
 pub use crate::digests::{ObjectDigest, TransactionDigest, TransactionEffectsDigest};
 use crate::dynamic_field::DynamicFieldInfo;
@@ -39,6 +38,7 @@ use anyhow::anyhow;
 use fastcrypto::encoding::decode_bytes_hex;
 use fastcrypto::encoding::{Encoding, Hex};
 use fastcrypto::hash::HashFunction;
+use fastcrypto::traits::AllowedRng;
 use move_core_types::account_address::AccountAddress;
 use move_core_types::ident_str;
 use move_core_types::identifier::IdentStr;
@@ -388,16 +388,18 @@ pub struct SuiAddress(
 impl SuiAddress {
     pub const ZERO: Self = Self([0u8; SUI_ADDRESS_LENGTH]);
 
+    /// Convert the address to a byte buffer.
     pub fn to_vec(&self) -> Vec<u8> {
         self.0.to_vec()
     }
 
-    // for testing
+    #[cfg(feature = "test-utils")]
+    /// Return a random SuiAddress.
     pub fn random_for_testing_only() -> Self {
-        let random_bytes = rand::thread_rng().gen::<[u8; SUI_ADDRESS_LENGTH]>();
-        Self(random_bytes)
+        AccountAddress::random().into()
     }
 
+    /// Serialize an Option<SuiAddress> in Hex.
     pub fn optional_address_as_hex<S>(
         key: &Option<SuiAddress>,
         serializer: S,
@@ -408,6 +410,7 @@ impl SuiAddress {
         serializer.serialize_str(&key.map(Hex::encode).unwrap_or_default())
     }
 
+    /// Deserialize into an Option<SuiAddress>.
     pub fn optional_address_from_hex<'de, D>(
         deserializer: D,
     ) -> Result<Option<SuiAddress>, D::Error>
@@ -419,8 +422,16 @@ impl SuiAddress {
         Ok(Some(value))
     }
 
+    /// Return the underlying byte array of a SuiAddress.
     pub fn to_inner(self) -> [u8; SUI_ADDRESS_LENGTH] {
         self.0
+    }
+
+    /// Parse a SuiAddress from a byte array or buffer.
+    pub fn from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self, SuiError> {
+        <[u8; SUI_ADDRESS_LENGTH]>::try_from(bytes.as_ref())
+            .map_err(|_| SuiError::InvalidAddress)
+            .map(SuiAddress)
     }
 }
 
@@ -436,13 +447,34 @@ impl From<AccountAddress> for SuiAddress {
     }
 }
 
+impl TryFrom<&[u8]> for SuiAddress {
+    type Error = SuiError;
+
+    /// Tries to convert the provided byte array into a SuiAddress.
+    fn try_from(bytes: &[u8]) -> Result<Self, SuiError> {
+        Self::from_bytes(bytes)
+    }
+}
+
 impl TryFrom<Vec<u8>> for SuiAddress {
     type Error = SuiError;
 
+    /// Tries to convert the provided byte buffer into a SuiAddress.
     fn try_from(bytes: Vec<u8>) -> Result<Self, SuiError> {
-        let arr: [u8; SUI_ADDRESS_LENGTH] =
-            bytes.try_into().map_err(|_| SuiError::InvalidAddress)?;
-        Ok(Self(arr))
+        Self::from_bytes(bytes)
+    }
+}
+
+impl AsRef<[u8]> for SuiAddress {
+    fn as_ref(&self) -> &[u8] {
+        &self.0[..]
+    }
+}
+
+impl FromStr for SuiAddress {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        decode_bytes_hex(s).map_err(|e| anyhow!(e))
     }
 }
 
@@ -466,10 +498,12 @@ impl From<&PublicKey> for SuiAddress {
     }
 }
 
-/// A MultiSig address is the first 20 bytes of the hash of
-/// `flag_MultiSig || threshold || flag_1 || pk_1 || weight_1 || ... || flag_n || pk_n || weight_n`
-/// of all participating public keys and its weight.
 impl From<MultiSigPublicKey> for SuiAddress {
+    /// Derive a SuiAddress from [struct MultiSigPublicKey]. A MultiSig address
+    /// is defined as the 32-byte Blake2b hash of serializing the flag, the
+    /// threshold, concatenation of each participating flag, public keys and
+    /// its weight. `flag_MultiSig || threshold || flag_1 || pk_1 || weight_1
+    /// || ... || flag_n || pk_n || weight_n`.
     fn from(multisig_pk: MultiSigPublicKey) -> Self {
         let mut hasher = DefaultHash::default();
         hasher.update([SignatureScheme::MultiSig.flag()]);
@@ -479,13 +513,13 @@ impl From<MultiSigPublicKey> for SuiAddress {
             hasher.update(pk.as_ref());
             hasher.update(w.to_le_bytes());
         });
-        let g_arr = hasher.finalize();
-        SuiAddress(g_arr.digest)
+        SuiAddress(hasher.finalize().digest)
     }
 }
 
 impl TryFrom<&GenericSignature> for SuiAddress {
     type Error = SuiError;
+    /// Derive a SuiAddress from a serialized signature in Sui [GenericSignature].
     fn try_from(sig: &GenericSignature) -> SuiResult<Self> {
         Ok(match sig {
             GenericSignature::Signature(sig) => {
@@ -503,20 +537,23 @@ impl TryFrom<&GenericSignature> for SuiAddress {
     }
 }
 
-impl TryFrom<&[u8]> for SuiAddress {
-    type Error = SuiError;
-
-    fn try_from(bytes: &[u8]) -> Result<Self, SuiError> {
-        let arr: [u8; SUI_ADDRESS_LENGTH] =
-            bytes.try_into().map_err(|_| SuiError::InvalidAddress)?;
-        Ok(Self(arr))
+impl fmt::Display for SuiAddress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "0x{}", Hex::encode(self.0))
     }
 }
 
-impl AsRef<[u8]> for SuiAddress {
-    fn as_ref(&self) -> &[u8] {
-        &self.0[..]
+impl fmt::Debug for SuiAddress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "0x{}", Hex::encode(self.0))
     }
+}
+
+#[cfg(feature = "test-utils")]
+/// Generate a fake SuiAddress with repeated one byte.
+pub fn dbg_addr(name: u8) -> SuiAddress {
+    let addr = [name; SUI_ADDRESS_LENGTH];
+    SuiAddress(addr)
 }
 
 #[derive(
@@ -677,7 +714,8 @@ impl TxContext {
         Ok(())
     }
 
-    // for testing
+    #[cfg(feature = "test-utils")]
+    // Generate a random TxContext for testing.
     pub fn random_for_testing_only() -> Self {
         Self::new(
             &SuiAddress::random_for_testing_only(),
@@ -686,74 +724,11 @@ impl TxContext {
         )
     }
 
-    // for testing
+    #[cfg(feature = "test-utils")]
+    /// Generate a TxContext for testing with a specific sender.
     pub fn with_sender_for_testing_only(sender: &SuiAddress) -> Self {
         Self::new(sender, &TransactionDigest::random(), &EpochData::new_test())
     }
-}
-
-pub fn get_new_address<K: KeypairTraits>() -> SuiAddress
-where
-    <K as KeypairTraits>::PubKey: SuiPublicKey,
-{
-    crate::crypto::get_key_pair::<K>().0
-}
-
-pub fn bytes_as_hex<B, S>(bytes: B, serializer: S) -> Result<S::Ok, S::Error>
-where
-    B: AsRef<[u8]>,
-    S: serde::ser::Serializer,
-{
-    serializer.serialize_str(&Hex::encode(bytes))
-}
-
-pub fn bytes_from_hex<'de, T, D>(deserializer: D) -> Result<T, D::Error>
-where
-    T: for<'a> TryFrom<&'a [u8]>,
-    D: serde::de::Deserializer<'de>,
-{
-    let s = String::deserialize(deserializer)?;
-    let value = decode_bytes_hex(&s).map_err(serde::de::Error::custom)?;
-    Ok(value)
-}
-
-impl fmt::Display for SuiAddress {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:#x}", self)
-    }
-}
-
-impl fmt::Debug for SuiAddress {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:#x}", self)
-    }
-}
-
-impl fmt::LowerHex for SuiAddress {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if f.alternate() {
-            write!(f, "0x")?;
-        }
-        write!(f, "{}", Hex::encode(self))
-    }
-}
-
-impl fmt::UpperHex for SuiAddress {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if f.alternate() {
-            write!(f, "0x")?;
-        }
-        write!(f, "{}", Hex::encode(self).to_uppercase())
-    }
-}
-
-pub fn dbg_addr(name: u8) -> SuiAddress {
-    let addr = [name; SUI_ADDRESS_LENGTH];
-    SuiAddress(addr)
-}
-
-pub fn dbg_object_id(name: u8) -> ObjectID {
-    ObjectID::from_bytes([name; ObjectID::LENGTH]).unwrap()
 }
 
 // TODO: rename to version
@@ -833,7 +808,7 @@ impl ObjectID {
     /// Hex address: 0x0
     pub const ZERO: Self = Self::new([0u8; Self::LENGTH]);
     pub const MAX: Self = Self::new([0xff; Self::LENGTH]);
-    /// Creates a new ObjectID
+    /// Create a new ObjectID
     pub const fn new(obj_id: [u8; Self::LENGTH]) -> Self {
         Self(AccountAddress::new(obj_id))
     }
@@ -843,28 +818,46 @@ impl ObjectID {
         Self(addr)
     }
 
-    /// Random ObjectID
+    /// Return a random ObjectID.
     pub fn random() -> Self {
         Self::from(AccountAddress::random())
     }
 
-    // Random for testing
+    /// Return a random ObjectID from a given RNG.
     pub fn random_from_rng<R>(rng: &mut R) -> Self
     where
-        R: rand::CryptoRng + rand::RngCore,
+        R: AllowedRng,
     {
         let buf: [u8; Self::LENGTH] = rng.gen();
         ObjectID::new(buf)
     }
 
+    /// Return the underlying bytes buffer of the ObjectID.
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.0.to_vec()
+    }
+
+    /// Parse the ObjectID from byte array or buffer.
+    pub fn from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self, ObjectIDParseError> {
+        <[u8; Self::LENGTH]>::try_from(bytes.as_ref())
+            .map_err(|_| ObjectIDParseError::TryFromSliceError)
+            .map(ObjectID::new)
+    }
+
+    /// Return the underlying bytes array of the ObjectID.
+    pub fn into_bytes(self) -> [u8; Self::LENGTH] {
+        self.0.into_bytes()
+    }
+
+    /// Make an ObjectID with padding 0s before the single byte.
     pub const fn from_single_byte(byte: u8) -> ObjectID {
         let mut bytes = [0u8; Self::LENGTH];
         bytes[Self::LENGTH - 1] = byte;
         ObjectID::new(bytes)
     }
 
-    /// Converts from hex string to ObjectID where the string is prefixed with 0x
-    /// Its okay if the strings are less than expected
+    /// Convert from hex string to ObjectID where the string is prefixed with 0x
+    /// Padding 0s if the string is too short.
     pub fn from_hex_literal(literal: &str) -> Result<Self, ObjectIDParseError> {
         if !literal.starts_with("0x") {
             return Err(ObjectIDParseError::HexLiteralPrefixMissing);
@@ -899,15 +892,9 @@ impl ObjectID {
         ObjectID::try_from(&hash.as_ref()[0..ObjectID::LENGTH]).unwrap()
     }
 
-    pub fn from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self, ObjectIDParseError> {
-        <[u8; Self::LENGTH]>::try_from(bytes.as_ref())
-            .map_err(|_| ObjectIDParseError::TryFromSliceError)
-            .map(ObjectID::from)
-    }
-
     /// Incremenent the ObjectID by usize IDs, assuming the ObjectID hex is a number represented as an array of bytes
     pub fn advance(&self, step: usize) -> Result<ObjectID, anyhow::Error> {
-        let mut curr_vec = self.as_slice().to_vec();
+        let mut curr_vec = self.to_vec();
         let mut step_copy = step;
 
         let mut carry = 0;
@@ -928,12 +915,12 @@ impl ObjectID {
         if carry > 0 {
             return Err(anyhow!("Increment will cause overflow"));
         }
-        ObjectID::from_bytes(curr_vec).map_err(|w| w.into())
+        ObjectID::try_from(curr_vec).map_err(|w| w.into())
     }
 
-    /// Incremenent the ObjectID by one, assuming the ObjectID hex is a number represented as an array of bytes
+    /// Increment the ObjectID by one, assuming the ObjectID hex is a number represented as an array of bytes
     pub fn next_increment(&self) -> Result<ObjectID, anyhow::Error> {
-        let mut prev_val = self.as_slice().to_vec();
+        let mut prev_val = self.to_vec();
         let mx = [0xFF; Self::LENGTH];
 
         if prev_val == mx {
@@ -949,7 +936,7 @@ impl ObjectID {
                 break;
             };
         }
-        ObjectID::from_bytes(prev_val.clone()).map_err(|w| w.into())
+        ObjectID::try_from(prev_val.clone()).map_err(|w| w.into())
     }
 
     /// Create `count` object IDs starting with one at `offset`
@@ -965,34 +952,10 @@ impl ObjectID {
         Ok(ret)
     }
 
-    /// Returns the full hex string with 0x prefix without removing trailing 0s. Prefer this
+    /// Return the full hex string with 0x prefix without removing trailing 0s. Prefer this
     /// over [fn to_hex_literal] if the string needs to be fully preserved.
     pub fn to_hex_uncompressed(&self) -> String {
-        format!("0x{:x}", self)
-    }
-}
-
-#[derive(PartialEq, Eq, Clone, Debug, thiserror::Error)]
-pub enum ObjectIDParseError {
-    #[error("ObjectID hex literal must start with 0x")]
-    HexLiteralPrefixMissing,
-
-    #[error("ObjectID hex string should only contain 0-9, A-F, a-f")]
-    InvalidHexCharacter,
-
-    #[error("hex string must be even-numbered. Two chars maps to one byte.")]
-    OddLength,
-
-    #[error("ObjectID must be {} bytes long.", ObjectID::LENGTH)]
-    InvalidLength,
-
-    #[error("Could not convert from bytes slice")]
-    TryFromSliceError,
-}
-
-impl From<[u8; ObjectID::LENGTH]> for ObjectID {
-    fn from(bytes: [u8; ObjectID::LENGTH]) -> Self {
-        Self::new(bytes)
+        format!("{self}")
     }
 }
 
@@ -1003,75 +966,21 @@ impl From<SuiAddress> for ObjectID {
     }
 }
 
-impl std::ops::Deref for ObjectID {
-    type Target = AccountAddress;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
 impl From<AccountAddress> for ObjectID {
     fn from(address: AccountAddress) -> Self {
         Self(address)
     }
 }
 
-impl From<ObjectID> for AccountAddress {
-    fn from(obj_id: ObjectID) -> Self {
-        obj_id.0
-    }
-}
-
-impl From<SuiAddress> for AccountAddress {
-    fn from(address: SuiAddress) -> Self {
-        Self::new(address.0)
-    }
-}
-
 impl fmt::Display for ObjectID {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:#x}", self)
-    }
-}
-
-impl fmt::Display for MoveObjectType {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
-        let s: StructTag = self.clone().into();
-        write!(f, "{}", s)
-    }
-}
-
-impl fmt::Display for ObjectType {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ObjectType::Package => write!(f, "{}", PACKAGE),
-            ObjectType::Struct(t) => write!(f, "{}", t),
-        }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "0x{}", Hex::encode(self.0))
     }
 }
 
 impl fmt::Debug for ObjectID {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:#x}", self)
-    }
-}
-
-impl fmt::LowerHex for ObjectID {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if f.alternate() {
-            write!(f, "0x")?;
-        }
-        write!(f, "{}", Hex::encode(self))
-    }
-}
-
-impl fmt::UpperHex for ObjectID {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if f.alternate() {
-            write!(f, "0x")?;
-        }
-        write!(f, "{}", Hex::encode(self).to_uppercase())
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "0x{}", Hex::encode(self.0))
     }
 }
 
@@ -1099,26 +1008,62 @@ impl TryFrom<Vec<u8>> for ObjectID {
     }
 }
 
-impl TryFrom<String> for ObjectID {
-    type Error = ObjectIDParseError;
-
-    fn try_from(s: String) -> Result<ObjectID, ObjectIDParseError> {
-        Self::from_str(&s).or_else(|_| Self::from_hex_literal(&s))
-    }
-}
-
-impl FromStr for SuiAddress {
-    type Err = anyhow::Error;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        decode_bytes_hex(s).map_err(|e| anyhow!(e))
-    }
-}
-
 impl FromStr for ObjectID {
     type Err = ObjectIDParseError;
 
+    /// Parse ObjectID from hex string with or without 0x prefix, pad with 0s if needed.
     fn from_str(s: &str) -> Result<Self, ObjectIDParseError> {
-        // Try to match both the literal (0xABC..) and the normal (ABC)
         decode_bytes_hex(s).or_else(|_| Self::from_hex_literal(s))
+    }
+}
+
+impl std::ops::Deref for ObjectID {
+    type Target = AccountAddress;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[cfg(feature = "test-utils")]
+/// Generate a fake ObjectID with repeated one byte.
+pub fn dbg_object_id(name: u8) -> ObjectID {
+    ObjectID::new([name; ObjectID::LENGTH])
+}
+
+#[derive(PartialEq, Eq, Clone, Debug, thiserror::Error)]
+pub enum ObjectIDParseError {
+    #[error("ObjectID hex literal must start with 0x")]
+    HexLiteralPrefixMissing,
+
+    #[error("Could not convert from bytes slice")]
+    TryFromSliceError,
+}
+
+impl From<ObjectID> for AccountAddress {
+    fn from(obj_id: ObjectID) -> Self {
+        obj_id.0
+    }
+}
+
+impl From<SuiAddress> for AccountAddress {
+    fn from(address: SuiAddress) -> Self {
+        Self::new(address.0)
+    }
+}
+
+impl fmt::Display for MoveObjectType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        let s: StructTag = self.clone().into();
+        write!(f, "{}", s)
+    }
+}
+
+impl fmt::Display for ObjectType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ObjectType::Package => write!(f, "{}", PACKAGE),
+            ObjectType::Struct(t) => write!(f, "{}", t),
+        }
     }
 }

--- a/crates/sui-types/src/collection_types.rs
+++ b/crates/sui-types/src/collection_types.rs
@@ -3,7 +3,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::base_types::{ObjectID, SuiAddress};
+use crate::base_types::ObjectID;
 use crate::id::UID;
 
 /// Rust version of the Move sui::vec_map::VecMap type
@@ -35,7 +35,7 @@ impl Default for TableVec {
     fn default() -> Self {
         TableVec {
             contents: Table {
-                id: ObjectID::from(SuiAddress::ZERO),
+                id: ObjectID::ZERO,
                 size: 0,
             },
         }
@@ -52,7 +52,7 @@ pub struct Table {
 impl Default for Table {
     fn default() -> Self {
         Table {
-            id: ObjectID::from(SuiAddress::ZERO),
+            id: ObjectID::ZERO,
             size: 0,
         }
     }
@@ -70,7 +70,7 @@ pub struct LinkedTable<K> {
 impl<K> Default for LinkedTable<K> {
     fn default() -> Self {
         LinkedTable {
-            id: ObjectID::from(SuiAddress::ZERO),
+            id: ObjectID::ZERO,
             size: 0,
             head: None,
             tail: None,

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -55,6 +55,8 @@ pub mod temporary_store;
 pub mod versioned;
 
 pub mod epoch_data;
+
+#[cfg(feature = "test-utils")]
 #[path = "./unit_tests/utils.rs"]
 pub mod utils;
 

--- a/crates/sui-types/src/unit_tests/base_types_tests.rs
+++ b/crates/sui-types/src/unit_tests/base_types_tests.rs
@@ -124,14 +124,8 @@ fn test_object_id_conversions() {}
 #[test]
 fn test_object_id_display() {
     let hex = SAMPLE_ADDRESS;
-    let upper_hex = SAMPLE_ADDRESS.to_uppercase();
-
     let id = ObjectID::from_str(hex).unwrap();
     assert_eq!(format!("{:?}", id), format!("0x{hex}"));
-    assert_eq!(format!("{:X}", id), upper_hex);
-    assert_eq!(format!("{:x}", id), hex);
-    assert_eq!(format!("{:#x}", id), format!("0x{hex}"));
-    assert_eq!(format!("{:#X}", id), format!("0x{upper_hex}"));
 }
 
 #[test]
@@ -252,14 +246,8 @@ fn test_object_id_zero_padding() {
 #[test]
 fn test_address_display() {
     let hex = SAMPLE_ADDRESS;
-    let upper_hex = SAMPLE_ADDRESS.to_uppercase();
-
     let id = SuiAddress::from_str(hex).unwrap();
     assert_eq!(format!("{:?}", id), format!("0x{hex}"));
-    assert_eq!(format!("{:X}", id), upper_hex);
-    assert_eq!(format!("{:x}", id), hex);
-    assert_eq!(format!("{:#x}", id), format!("0x{hex}"));
-    assert_eq!(format!("{:#X}", id), format!("0x{upper_hex}"));
 }
 
 #[test]
@@ -350,7 +338,6 @@ fn test_authority_signature_serde_human_readable() {
 
 #[test]
 fn test_object_id_from_empty_string() {
-    assert!(ObjectID::try_from("".to_string()).is_err());
     assert!(ObjectID::from_str("").is_err());
 }
 

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -669,7 +669,7 @@ fn test_sponsored_transaction_message() {
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
         builder
-            .transfer_object(get_new_address::<AccountKeyPair>(), random_object_ref())
+            .transfer_object(dbg_addr(1), random_object_ref())
             .unwrap();
         builder.finish()
     };
@@ -785,7 +785,7 @@ fn test_sponsored_transaction_validity_check() {
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
         builder
-            .transfer_object(get_new_address::<AccountKeyPair>(), random_object_ref())
+            .transfer_object(dbg_addr(1), random_object_ref())
             .unwrap();
         builder.finish()
     };

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = "1.0.88"
 rand = "0.8.5"
 sui = { path = "../sui" }
 sui-config = { path = "../sui-config" }
-sui-core = { path = "../sui-core" }
+sui-core = { path = "../sui-core", features = ["test-utils"] }
 sui-framework = { path = "../sui-framework" }
 sui-framework-build = { path = "../sui-framework-build" }
 sui-json-rpc = { path = "../sui-json-rpc" }
@@ -27,7 +27,7 @@ sui-json-rpc-types= { path = "../sui-json-rpc-types" }
 sui-node = { path = "../sui-node" }
 sui-protocol-config = { path = "../sui-protocol-config" }
 sui-swarm = { path = "../sui-swarm" }
-sui-types = { path = "../sui-types" }
+sui-types = { path = "../sui-types", features = ["test-utils"] }
 sui-keys = { path = "../sui-keys" }
 sui-sdk = { path = "../sui-sdk" }
 mysten-metrics = { path = "../mysten-metrics"}


### PR DESCRIPTION
## Description 

Audit all methods for SuiAddress and ObjectID in base_types.rs: added docs, removed unused, clean up test only methods behind feature flag. 
## Test Plan 

Existing tests. 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
