### PR TITLE
[Shapshots] feature flag for root state digest commitment

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -63,8 +63,8 @@ use sui_types::event::{Event, EventID};
 use sui_types::gas::{GasCostSummary, GasPrice, SuiCostTable, SuiGasStatus};
 use sui_types::message_envelope::Message;
 use sui_types::messages_checkpoint::{
-    CheckpointContents, CheckpointContentsDigest, CheckpointDigest, CheckpointSequenceNumber,
-    CheckpointSummary, CheckpointTimestamp, VerifiedCheckpoint,
+    CheckpointCommitment, CheckpointContents, CheckpointContentsDigest, CheckpointDigest,
+    CheckpointSequenceNumber, CheckpointSummary, CheckpointTimestamp, VerifiedCheckpoint,
 };
 use sui_types::messages_checkpoint::{CheckpointRequest, CheckpointResponse};
 use sui_types::object::{MoveObject, Owner, PastObjectRead, OBJECT_START_VERSION};
@@ -509,6 +509,24 @@ impl AuthorityState {
 
     pub fn clone_committee_store(&self) -> Arc<CommitteeStore> {
         self.committee_store.clone()
+    }
+
+    pub fn get_epoch_state_commitments(
+        &self,
+        epoch: EpochId,
+    ) -> SuiResult<Option<Vec<CheckpointCommitment>>> {
+        let commitments =
+            self.checkpoint_store
+                .get_epoch_last_checkpoint(epoch)?
+                .map(|checkpoint| {
+                    checkpoint
+                        .end_of_epoch_data
+                        .as_ref()
+                        .expect("Last checkpoint of epoch expected to have EndOfEpochData")
+                        .epoch_commitments
+                        .clone()
+                });
+        Ok(commitments)
     }
 
     /// This is a private method and should be kept that way. It doesn't check whether

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -737,17 +737,22 @@ impl CheckpointBuilder {
                 self.metrics.highest_accumulated_epoch.set(epoch as i64);
                 info!("Epoch {epoch} root state hash digest: {root_state_digest:?}");
 
+                let epoch_commitments = if self
+                    .epoch_store
+                    .protocol_config()
+                    .check_commit_root_state_digest_supported()
+                {
+                    vec![root_state_digest.into()]
+                } else {
+                    vec![]
+                };
+
                 Some(EndOfEpochData {
                     next_epoch_committee: committee.voting_rights,
                     next_epoch_protocol_version: ProtocolVersion::new(
                         system_state_obj.protocol_version(),
                     ),
-                    // MUSTFIX: This should become
-                    //
-                    //   epoch_commitments: vec![root_state_digest.into()]
-                    //
-                    // When the accumulator is deemed stable.
-                    epoch_commitments: vec![],
+                    epoch_commitments,
                 })
             } else {
                 self.accumulator.accumulate_checkpoint(

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -114,6 +114,9 @@ struct FeatureFlags {
     // Add feature flags here, e.g.:
     // new_protocol_feature: bool,
     package_upgrades: bool,
+    // If true, validators will commit to the root state digest
+    // in end of epoch checkpoint proposals
+    commit_root_state_digest: bool,
 }
 
 /// Constants that change the behavior of the protocol.
@@ -540,6 +543,10 @@ impl ProtocolConfig {
                 self.version
             )))
         }
+    }
+
+    pub fn check_commit_root_state_digest_supported(&self) -> bool {
+        self.feature_flags.package_upgrades
     }
 }
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_1.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_1.snap
@@ -5,6 +5,7 @@ expression: "ProtocolConfig::get_for_version(cur)"
 version: 1
 feature_flags:
   package_upgrades: false
+  commit_root_state_digest: false
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_serialized_tx_effects_size_bytes: 524288

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -264,6 +264,22 @@ async fn test_passive_reconfig() {
         .unwrap_or(4);
 
     test_cluster.wait_for_epoch(Some(target_epoch)).await;
+
+    test_cluster
+        .swarm
+        .validators()
+        .next()
+        .unwrap()
+        .get_node_handle()
+        .unwrap()
+        .with(|node| {
+            let commitments = node
+                .state()
+                .get_epoch_state_commitments(0)
+                .unwrap()
+                .unwrap();
+            assert_eq!(commitments.len(), 0);
+        });
 }
 
 // This test just starts up a cluster that reconfigures itself under 0 load.


### PR DESCRIPTION
## Description 

Introduce a feature flag for enabling commitment of root state hash to checkpoint proposals by validators at some future protocol version.

## Test Plan 

`cargo simtest test_passive_reconfig`

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
