### PR TITLE
Add serialized tx cli flag to publish move modules

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -614,25 +614,25 @@ impl SuiClientCommands {
                         gas_budget,
                     )
                     .await?;
-                if serialize_output == false {
-                    let signature =
-                        context
-                            .config
-                            .keystore
-                            .sign_secure(&sender, &data, Intent::default())?;
-                    let response = context
-                        .execute_transaction(
-                            Transaction::from_data(data, Intent::default(), vec![signature])
-                                .verify()?,
-                        )
-                        .await?;
-
-                    SuiClientCommandResult::Publish(response)
-                } else {
-                    SuiClientCommandResult::SerializePublish(Base64::encode(
+                if serialize_output {
+                    return Ok(SuiClientCommandResult::SerializePublish(Base64::encode(
                         bcs::to_bytes(&data).unwrap(),
-                    ))
+                    )));
                 }
+
+                let signature =
+                    context
+                        .config
+                        .keystore
+                        .sign_secure(&sender, &data, Intent::default())?;
+                let response = context
+                    .execute_transaction(
+                        Transaction::from_data(data, Intent::default(), vec![signature])
+                            .verify()?,
+                    )
+                    .await?;
+
+                SuiClientCommandResult::Publish(response)
             }
 
             SuiClientCommands::Object { id, bcs } => {

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -484,6 +484,7 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
         gas_budget: 20_000,
         skip_dependency_verification: false,
         with_unpublished_dependencies: false,
+        serialize_output: false,
     }
     .execute(context)
     .await?;
@@ -690,6 +691,7 @@ async fn test_package_publish_command() -> Result<(), anyhow::Error> {
         gas_budget: 20_000,
         skip_dependency_verification: false,
         with_unpublished_dependencies: false,
+        serialize_output: false,
     }
     .execute(context)
     .await?;
@@ -825,6 +827,7 @@ async fn test_package_publish_command_with_unpublished_dependency_fails(
         gas_budget: 20_000,
         skip_dependency_verification: false,
         with_unpublished_dependencies,
+        serialize_output: false,
     }
     .execute(context)
     .await;
@@ -868,6 +871,7 @@ async fn test_package_publish_command_non_zero_unpublished_dep_fails() -> Result
         gas_budget: 20_000,
         skip_dependency_verification: false,
         with_unpublished_dependencies,
+        serialize_output: false,
     }
     .execute(context)
     .await;
@@ -921,6 +925,7 @@ async fn test_package_publish_command_failure_invalid() -> Result<(), anyhow::Er
         gas_budget: 20_000,
         skip_dependency_verification: false,
         with_unpublished_dependencies,
+        serialize_output: false,
     }
     .execute(context)
     .await;
@@ -961,6 +966,7 @@ async fn test_package_publish_nonexistent_dependency() -> Result<(), anyhow::Err
         gas_budget: 20_000,
         skip_dependency_verification: false,
         with_unpublished_dependencies: false,
+        serialize_output: false,
     }
     .execute(context)
     .await;
@@ -1014,6 +1020,7 @@ async fn test_package_upgrade_command() -> Result<(), anyhow::Error> {
         gas_budget: 20_000,
         skip_dependency_verification: false,
         with_unpublished_dependencies: false,
+        serialize_output: false,
     }
     .execute(context)
     .await?;

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -757,6 +757,7 @@ async fn test_package_publish_command_with_unpublished_dependency_succeeds(
         gas_budget: 20_000,
         skip_dependency_verification: false,
         with_unpublished_dependencies,
+        serialize_output: false,
     }
     .execute(context)
     .await?;


### PR DESCRIPTION
## Description 

- generate a transaction object for publishing move modules `sui client publish --serialize-output`

Similar to `SerializeTransfer`, this feature enables serializing transactions to publish move modules.

This serialized transaction can be used by users who want to publish packages with offline signers or multisig accounts.

## Test Plan 


For a primer on multi-sig (and examples to setup local environment for testing), see:
[multisig.md](https://github.com/MystenLabs/sui/blob/27487bdc4824453883e719c7221c63b75ff6bc25/crates/sui/multisig.md)

For quick testing, setup a 2-of-3 account
```
 musig_addr=$($sui keytool multi-sig-address \
  --pks $PK_1 $PK_2 $PK_3 \
  --weights 1 1 1 \
  --threshold 2 \
  | grep MultiSig \
  | sed 's/.*\://' \
  | xargs)

```

Get some Sui Tokens for your new multisig account:

```
 object_id=$(curl \
  --location \
  --silent \
  --request POST 'http://127.0.0.1:9123/gas' \
  --header 'Content-Type: application/json' \
  --data-raw "{ \"FixedAmountRequest\": {
  \"recipient\": \"$musig_addr\" } }" \
  | jq '.transferredGasObjects[0].id' \
  | cut -d'"' -f 2)
```

Now craft the serialized publish transaction
```
serialized_tx=$($sui client publish "${module_path}" \
  --gas $object_id \
  --gas-budget $gas_budget \
  --serialize-output \
  | grep execute \
  | sed 's/.*\://' \
  | xargs)
```

Sign with two of the three keys and combine signatures

```
sigs_1="$($sui keytool sign \
  --address $addr_1 \
  --data $serialized_tx \
  | grep Serialized \
  | cut -d'"' -f 2)"

sigs_2="$($sui keytool sign \
  --address $addr_2 \
  --data $serialized_tx \
  | grep Serialized \
  | cut -d'"' -f 2)"

serialized_musig="$($sui keytool multi-sig-combine-partial-sig \
  --pks $PK_1 $PK_2 $PK_3 \
  --weights 1 1 1 \
  --threshold 2 \
  --sigs $sigs_1 $sigs_2 \
  | grep serialized \
  | cut -d'"' -f 2)"
```

Now execute the signed publish transaction:

```
$sui client execute-signed-tx \
  --tx-bytes $serialized_tx \
  --signatures $serialized_musig
```

Congrats! You just published a move module with a multi-sig account!

Successful output looks something like this:

```
----- Transaction Digest ----
Fe96qN5qtoCHZDpos1ReyFoQDqmyimoWwzEAqYAwNLJr
----- Transaction Data ----
Transaction Signature: [MultiSig(MultiSig { sigs: [Ed25519(BytesRepresentation([23, 142, 20, 2, 248, 48, 71, 36, 117, 147, 96, 49, 121, 97, 147, 98, 209, 83, 89, 38, 204, 165, 191, 59, 141, 71, 240, 56, 115, 238, 14, 244, 46, 16, 230, 221, 44, 13, 120, 205, 222, 54, 73, 238, 114, 219, 196, 46, 206, 86, 132, 92, 207, 118, 15, 204, 77, 78, 217, 83, 205, 31, 12, 14])), Ed25519(BytesRepresentation([81, 58, 144, 148, 2, 155, 197, 133, 149, 34, 130, 142, 126, 112, 45, 176, 154, 235, 29, 149, 153, 160, 248, 142, 161, 83, 148, 208, 204, 204, 93, 107, 173, 223, 254, 248, 230, 63, 248, 43, 78, 201, 251, 229, 70, 28, 123, 182, 108, 199, 62, 76, 106, 67, 8, 92, 103, 250, 224, 138, 106, 134, 136, 13]))], bitmap: RoaringBitmap<[0, 1]>, multisig_pk: MultiSigPublicKey { pk_map: [("AJQwyQMKQ7gLQw+KVbNh4pbr0473XV7Ec/j/Ljvggj3U", 1), ("AOJbaGb622hGZlwJZ5SAh2rnr1WnR1TkhzIOMnya0QFm", 1), ("AI+TXXrZDfq8vG24cNyayJHaizYN4KxYHxpwiJhYdqxK", 1)], threshold: 2 }, bytes: OnceCell(Uninit) })]
Transaction Kind : Programmable
Inputs: [Pure(SuiPureValue { value_type: Some(Address), value: "0x589e4a5f647f37692669cb9d3764549fe9ad7df001d4941198794b7bbbaa7694" })]
Commands: [
  Publish(_,,0x00000000000000000000000000000000000000000000000000000000000000010x0000000000000000000000000000000000000000000000000000000000000002),
  TransferObjects([Result(0)],Input(0)),
]
Sender: 0x589e4a5f647f37692669cb9d3764549fe9ad7df001d4941198794b7bbbaa7694
Gas Payment: Object ID: 0x144e89a316d394106c5a3d6d92546895c93c3b8b2f8d5e87aa82246b59dfd4d9, version: 0x2, digest: EZRMZKG8suYVXjzbVevXU42pfaP9dwewNZUbv5WBxHpg
Gas Owner: 0x589e4a5f647f37692669cb9d3764549fe9ad7df001d4941198794b7bbbaa7694
Gas Price: 1
Gas Budget: 30000
----- Transaction Effects ----
Status : Success
Created Objects:
  - ID: 0x7024329b6e2da101b2b180eabd0ff08bd9f98f948931ccf6237cdcda55d80614 , Owner: Account Address ( 0x589e4a5f647f37692669cb9d3764549fe9ad7df001d4941198794b7bbbaa7694 )
  - ID: 0xc39380b02475bb16084bb4b2e75f86d7776c027d8c383bca5a09cf324b06d242 , Owner: Account Address ( 0x589e4a5f647f37692669cb9d3764549fe9ad7df001d4941198794b7bbbaa7694 )
  - ID: 0xd714c617da460f7d87c73824e35c2052a9c4d26bd3a9dc7f309b1346109e3562 , Owner: Immutable
Mutated Objects:
  - ID: 0x144e89a316d394106c5a3d6d92546895c93c3b8b2f8d5e87aa82246b59dfd4d9 , Owner: Account Address ( 0x589e4a5f647f37692669cb9d3764549fe9ad7df001d4941198794b7bbbaa7694 )
----- Events ----
Array []
----- Object changes ----
Array [
    Object {
        "type": String("mutated"),
        "sender": String("0x589e4a5f647f37692669cb9d3764549fe9ad7df001d4941198794b7bbbaa7694"),
        "owner": Object {
            "AddressOwner": String("0x589e4a5f647f37692669cb9d3764549fe9ad7df001d4941198794b7bbbaa7694"),
        },
        "objectType": String("0x2::coin::Coin<0x2::sui::SUI>"),
        "objectId": String("0x144e89a316d394106c5a3d6d92546895c93c3b8b2f8d5e87aa82246b59dfd4d9"),
        "version": Number(3),
        "previousVersion": Number(2),
        "digest": String("8vW8ky8Daczh1aszbgLxK2m5WTATvSt8Jfcy8oCcZzMM"),
    },
    Object {
        "type": String("created"),
        "sender": String("0x589e4a5f647f37692669cb9d3764549fe9ad7df001d4941198794b7bbbaa7694"),
        "owner": Object {
            "AddressOwner": String("0x589e4a5f647f37692669cb9d3764549fe9ad7df001d4941198794b7bbbaa7694"),
        },
        "objectType": String("0x2::package::UpgradeCap"),
        "objectId": String("0x7024329b6e2da101b2b180eabd0ff08bd9f98f948931ccf6237cdcda55d80614"),
        "version": Number(3),
        "digest": String("2UrGu8dy7oDaGjhEHbiMtmkUTh98bYeDmLrDFi9MgNG7"),
    },
    Object {
        "type": String("created"),
        "sender": String("0x589e4a5f647f37692669cb9d3764549fe9ad7df001d4941198794b7bbbaa7694"),
        "owner": Object {
            "AddressOwner": String("0x589e4a5f647f37692669cb9d3764549fe9ad7df001d4941198794b7bbbaa7694"),
        },
        "objectType": String("0xd714c617da460f7d87c73824e35c2052a9c4d26bd3a9dc7f309b1346109e3562::my_module::Forge"),
        "objectId": String("0xc39380b02475bb16084bb4b2e75f86d7776c027d8c383bca5a09cf324b06d242"),
        "version": Number(3),
        "digest": String("2dpBN7S4U4aqCXTFbp6SViDpHV3nY838otf1FjbP6CUY"),
    },
    Object {
        "type": String("published"),
        "packageId": String("0xd714c617da460f7d87c73824e35c2052a9c4d26bd3a9dc7f309b1346109e3562"),
        "version": Number(1),
        "digest": String("DZHMiScib9daws9HrujAAEXpiNkBXdA1EemVMtBngnVz"),
        "modules": Array [
            String("my_module"),
        ],
    },
]
----- Balance changes ----
Array [
    Object {
        "owner": Object {
            "AddressOwner": String("0x589e4a5f647f37692669cb9d3764549fe9ad7df001d4941198794b7bbbaa7694"),
        },
        "coinType": String("0x2::sui::SUI"),
        "amount": String("-1121"),
    },
]
```





---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

* Add `--serialize-output` feature to `sui client publish` command--for creating serialized transactions for publishing move modules for offline and multisig account signing