### PR TITLE
Use constant total voting power for Committee

### DIFF
--- a/crates/sui-benchmark/src/fullnode_reconfig_observer.rs
+++ b/crates/sui-benchmark/src/fullnode_reconfig_observer.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
-use std::collections::BTreeMap;
 use std::sync::Arc;
 use sui_core::{
     authority_aggregator::{AuthAggMetrics, AuthorityAggregator},
@@ -12,7 +11,6 @@ use sui_core::{
     safe_client::SafeClientMetricsBase,
 };
 use sui_sdk::{SuiClient, SuiClientBuilder};
-use sui_types::committee::Committee;
 use tracing::{debug, error, trace};
 
 /// A ReconfigObserver that polls FullNode periodically
@@ -71,27 +69,9 @@ impl ReconfigObserver<NetworkAuthorityClient> for FullNodeReconfigObserver {
                     let epoch_id = sui_system_state.epoch;
                     if epoch_id > quorum_driver.current_epoch() {
                         debug!(epoch_id, "Got SuiSystemState in newer epoch");
-                        let new_committee = match self
-                            .fullnode_client
-                            .read_api()
-                            .get_committee_info(Some(epoch_id))
-                            .await
-                        {
-                            Ok(committee) => {
-                                // Safe to unwrap, checked above
-                                Committee::new(
-                                    committee.epoch,
-                                    BTreeMap::from_iter(committee.validators.into_iter()),
-                                )
-                            }
-                            other => {
-                                error!(
-                                    "Can't get CommitteeInfo {} from Full Node: {:?}",
-                                    epoch_id, other
-                                );
-                                continue;
-                            }
-                        };
+                        let new_committee = sui_system_state
+                            .get_sui_committee_for_benchmarking()
+                            .committee;
                         let _ = self.committee_store.insert_new_committee(&new_committee);
                         match AuthorityAggregator::new_from_committee(
                             sui_system_state.get_sui_committee_for_benchmarking(),

--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -537,7 +537,8 @@ impl FullNodeProxy {
         let committee_vec = resp.validators;
         let committee_map =
             BTreeMap::from_iter(committee_vec.into_iter().map(|(name, stake)| (name, stake)));
-        let committee = Committee::new(epoch, committee_map);
+        let committee =
+            Committee::new_for_testing_with_normalized_voting_power(epoch, committee_map);
 
         Ok(Self {
             sui_client,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -3133,7 +3133,7 @@ impl AuthorityState {
 
                 let total_votes = stake_aggregator.total_votes();
                 let quorum_threshold = committee.quorum_threshold();
-                let f = committee.total_votes - committee.quorum_threshold();
+                let f = committee.total_votes() - committee.quorum_threshold();
 
                 // multiple by buffer_stake_bps / 10000, rounded up.
                 let buffer_stake = (f * buffer_stake_bps + 9999) / 10000;

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -371,7 +371,6 @@ impl AuthorityPerEpochStore {
         metrics
             .current_voting_right
             .set(committee.weight(&name) as i64);
-        metrics.epoch_total_votes.set(committee.total_votes as i64);
         let protocol_version = epoch_start_configuration
             .epoch_start_state()
             .protocol_version();

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -1361,7 +1361,7 @@ where
     }
 
     fn get_retryable_stake(&self, state: &ProcessTransactionState) -> StakeUnit {
-        self.committee.total_votes
+        self.committee.total_votes()
             - state.conflicting_tx_digests_total_stake()
             - state.non_retryable_stake
             - state.effects_map.total_votes()

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -970,7 +970,10 @@ mod adapter_tests {
                 )
             })
             .collect::<Vec<_>>();
-        let committee = Committee::new(0, authorities.iter().cloned().collect());
+        let committee = Committee::new_for_testing_with_normalized_voting_power(
+            0,
+            authorities.iter().cloned().collect(),
+        );
 
         // generate random transaction digests, and account for validator selection
         const NUM_TEST_TRANSACTIONS: usize = 1000;

--- a/crates/sui-core/src/epoch/epoch_metrics.rs
+++ b/crates/sui-core/src/epoch/epoch_metrics.rs
@@ -24,9 +24,6 @@ pub struct EpochMetrics {
     /// Total amount of gas rewards (i.e. computation gas cost) in the epoch.
     pub epoch_total_gas_reward: IntGauge,
 
-    /// Total amount of stakes in the epoch.
-    pub epoch_total_votes: IntGauge,
-
     // An active validator reconfigures through the following steps:
     // 1. Halt validator (a.k.a. close epoch) and stop accepting user transaction certs.
     // 2. Finishes processing all pending certificates and then send EndOfPublish message.
@@ -114,11 +111,6 @@ impl EpochMetrics {
             epoch_total_gas_reward: register_int_gauge_with_registry!(
                 "epoch_total_gas_reward",
                 "Total amount of gas rewards (i.e. computation gas cost) in the epoch",
-                registry
-            ).unwrap(),
-            epoch_total_votes: register_int_gauge_with_registry!(
-                "epoch_total_votes",
-                "Total amount of votes among validators in the epoch.",
                 registry
             ).unwrap(),
             epoch_pending_certs_processed_time_since_epoch_close_ms: register_int_gauge_with_registry!(

--- a/crates/sui-network/src/state_sync/test_utils.rs
+++ b/crates/sui-network/src/state_sync/test_utils.rs
@@ -32,7 +32,7 @@ impl CommitteeFixture {
             .map(|keypair| (keypair.public().into(), (keypair, 1)))
             .collect::<HashMap<_, _>>();
 
-        let committee = Committee::new(
+        let committee = Committee::new_for_testing_with_normalized_voting_power(
             epoch,
             validators
                 .iter()

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -43,7 +43,7 @@ fn test_signed_values() {
         /* address */ AuthorityPublicKeyBytes::from(sec2.public()),
         /* voting right */ 0,
     );
-    let committee = Committee::new(0, authorities);
+    let committee = Committee::new_for_testing_with_normalized_voting_power(0, authorities);
 
     let transaction = Transaction::from_data_and_signer(
         TransactionData::new_transfer_with_dummy_gas_price(
@@ -120,7 +120,7 @@ fn test_certificates() {
         /* address */ AuthorityPublicKeyBytes::from(sec2.public()),
         /* voting right */ 1,
     );
-    let committee = Committee::new(0, authorities);
+    let committee = Committee::new_for_testing_with_normalized_voting_power(0, authorities);
 
     let transaction = Transaction::from_data_and_signer(
         TransactionData::new_transfer_with_dummy_gas_price(
@@ -193,7 +193,7 @@ fn test_new_with_signatures() {
     let (_, sec): (_, AuthorityKeyPair) = get_key_pair();
     authorities.insert(AuthorityPublicKeyBytes::from(sec.public()), 1);
 
-    let committee = Committee::new(0, authorities.clone());
+    let committee = Committee::new_for_testing_with_normalized_voting_power(0, authorities.clone());
     let quorum =
         AuthorityStrongQuorumSignInfo::new_from_auth_sign_infos(signatures.clone(), &committee)
             .unwrap();
@@ -240,7 +240,7 @@ fn test_handle_reject_malicious_signature() {
         };
     }
 
-    let committee = Committee::new(0, authorities.clone());
+    let committee = Committee::new_for_testing_with_normalized_voting_power(0, authorities.clone());
     let mut quorum =
         AuthorityStrongQuorumSignInfo::new_from_auth_sign_infos(signatures, &committee).unwrap();
     {
@@ -321,7 +321,7 @@ fn test_bitmap_out_of_range() {
         ));
     }
 
-    let committee = Committee::new(0, authorities.clone());
+    let committee = Committee::new_for_testing_with_normalized_voting_power(0, authorities.clone());
     let mut quorum =
         AuthorityStrongQuorumSignInfo::new_from_auth_sign_infos(signatures, &committee).unwrap();
 
@@ -362,7 +362,7 @@ fn test_reject_extra_public_key() {
         signatures[3].clone(),
     ];
 
-    let committee = Committee::new(0, authorities.clone());
+    let committee = Committee::new_for_testing_with_normalized_voting_power(0, authorities.clone());
     let mut quorum =
         AuthorityStrongQuorumSignInfo::new_from_auth_sign_infos(used_signatures, &committee)
             .unwrap();
@@ -400,7 +400,7 @@ fn test_reject_reuse_signatures() {
         signatures[2].clone(),
     ];
 
-    let committee = Committee::new(0, authorities.clone());
+    let committee = Committee::new_for_testing_with_normalized_voting_power(0, authorities.clone());
     let quorum =
         AuthorityStrongQuorumSignInfo::new_from_auth_sign_infos(used_signatures, &committee)
             .unwrap();
@@ -429,7 +429,7 @@ fn test_empty_bitmap() {
         ));
     }
 
-    let committee = Committee::new(0, authorities.clone());
+    let committee = Committee::new_for_testing_with_normalized_voting_power(0, authorities.clone());
     let mut quorum =
         AuthorityStrongQuorumSignInfo::new_from_auth_sign_infos(signatures, &committee).unwrap();
     quorum.signers_map = RoaringBitmap::new();
@@ -453,7 +453,7 @@ fn test_digest_caching() {
     authorities.insert(sec1.public().into(), 1);
     authorities.insert(sec2.public().into(), 0);
 
-    let committee = Committee::new(0, authorities);
+    let committee = Committee::new_for_testing_with_normalized_voting_power(0, authorities);
 
     let transaction = Transaction::from_data_and_signer(
         TransactionData::new_transfer_with_dummy_gas_price(
@@ -620,7 +620,7 @@ fn test_user_signature_committed_in_signed_transactions() {
     // Ensure that signed tx verifies against the transaction with a correct user signature.
     let mut authorities: BTreeMap<AuthorityPublicKeyBytes, u64> = BTreeMap::new();
     authorities.insert(AuthorityPublicKeyBytes::from(sec1.public()), 1);
-    let committee = Committee::new(0, authorities.clone());
+    let committee = Committee::new_for_testing_with_normalized_voting_power(0, authorities.clone());
     assert!(signed_tx_a
         .auth_sig()
         .verify_secure(
@@ -883,7 +883,7 @@ fn verify_sender_signature_correctly_with_flag() {
     let (_, sec2): (_, AuthorityKeyPair) = get_key_pair();
     authorities.insert(sec1.public().into(), 1);
     authorities.insert(sec2.public().into(), 0);
-    let committee = Committee::new(0, authorities);
+    let committee = Committee::new_for_testing_with_normalized_voting_power(0, authorities);
 
     // create a receiver keypair with Secp256k1
     let receiver_kp = SuiKeyPair::Secp256k1(get_key_pair().1);

--- a/crates/sui-types/src/unit_tests/utils.rs
+++ b/crates/sui-types/src/unit_tests/utils.rs
@@ -44,7 +44,7 @@ where
         keys.push(inner_authority_key);
     }
 
-    let committee = Committee::new(0, authorities);
+    let committee = Committee::new_for_testing_with_normalized_voting_power(0, authorities);
     (keys, committee)
 }
 

--- a/crates/sui/tests/framework_upgrades/mock_sui_systems/base/sources/genesis.move
+++ b/crates/sui/tests/framework_upgrades/mock_sui_systems/base/sources/genesis.move
@@ -104,7 +104,7 @@ module sui_system::genesis {
                 p2p_address,
                 primary_address,
                 worker_address,
-                balance::split(&mut sui_supply, 10000),
+                balance::split(&mut sui_supply, 2500),
                 ctx
             );
 

--- a/crates/sui/tests/framework_upgrades/mock_sui_systems/upgrade/sources/genesis.move
+++ b/crates/sui/tests/framework_upgrades/mock_sui_systems/upgrade/sources/genesis.move
@@ -104,7 +104,7 @@ module sui_system::genesis {
                 p2p_address,
                 primary_address,
                 worker_address,
-                balance::split(&mut sui_supply, 10000),
+                balance::split(&mut sui_supply, 2500),
                 ctx
             );
 

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -306,9 +306,9 @@ async fn test_create_advance_epoch_tx_race() {
     };
 
     // Set up wait points.
-    let (change_epoch_delay_tx, _) = broadcast::channel(1);
+    let (change_epoch_delay_tx, _change_epoch_delay_rx) = broadcast::channel(1);
     let change_epoch_delay_tx = Arc::new(change_epoch_delay_tx);
-    let (reconfig_delay_tx, _) = broadcast::channel(1);
+    let (reconfig_delay_tx, _reconfig_delay_rx) = broadcast::channel(1);
     let reconfig_delay_tx = Arc::new(reconfig_delay_tx);
 
     // Test code runs in node 1 - node 2 is always a validator.


### PR DESCRIPTION
This is a simplified version of #8987.
The goal is to get the committee schema change before Friday's cut because it's going to be really difficult to change it latter. The rest of the refactoring can be done afterwards and there is no rush.
This PR replaces total voting power with constant, along with quorum threshold and validity threshold.
Introduces a test constructor for Committee to deal with tests.