### PR TITLE
Remove unused method and define default test committee size in test-utils

### DIFF
--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -546,13 +546,7 @@ where
     get_key_pair_from_rng(&mut OsRng)
 }
 
-pub const TEST_COMMITTEE_SIZE: usize = 4;
-
-pub fn random_committee_key_pairs() -> Vec<AuthorityKeyPair> {
-    random_committee_key_pairs_of_size(TEST_COMMITTEE_SIZE)
-}
-
-/// Generate a random committee key pairs with size of TEST_COMMITTEE_SIZE.
+/// Generate a random committee key pairs with a given committee size
 pub fn random_committee_key_pairs_of_size(size: usize) -> Vec<AuthorityKeyPair> {
     let mut rng = StdRng::from_seed([0; 32]);
     (0..size)

--- a/crates/test-utils/src/authority.rs
+++ b/crates/test-utils/src/authority.rs
@@ -11,13 +11,15 @@ use sui_core::authority_client::AuthorityAPI;
 use sui_core::authority_client::NetworkAuthorityClient;
 pub use sui_node::{SuiNode, SuiNodeHandle};
 use sui_types::base_types::ObjectID;
-use sui_types::crypto::TEST_COMMITTEE_SIZE;
 use sui_types::messages::ObjectInfoRequest;
 use sui_types::multiaddr::Multiaddr;
 use sui_types::object::Object;
 
 /// The default network buffer size of a test authority.
 pub const NETWORK_BUFFER_SIZE: usize = 65_000;
+
+/// Default committee size for tests
+pub const TEST_COMMITTEE_SIZE: usize = 4;
 
 /// Make an authority config for each of the `TEST_COMMITTEE_SIZE` authorities in the test committee.
 pub fn test_authority_configs() -> NetworkConfig {


### PR DESCRIPTION
## Description 

Clean up crypto.rs by removing an unused method and define default test committee size in test-utils instead.

## Test Plan 

Unit tests.