### PR TITLE
Bump checkpoint transaction count limit to 10,000.

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1289,7 +1289,7 @@ impl ProtocolConfig {
                 storage_fund_reinvest_rate: Some(500),
                 reward_slashing_rate: Some(5000),
                 storage_gas_price: Some(1),
-                max_transactions_per_checkpoint: Some(1000),
+                max_transactions_per_checkpoint: Some(10_000),
                 max_checkpoint_size_bytes: Some(30 * 1024 * 1024),
 
                 // For now, perform upgrades with a bare quorum of validators.

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_1.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_1.snap
@@ -62,7 +62,7 @@ storage_rebate_rate: 9900
 storage_fund_reinvest_rate: 500
 reward_slashing_rate: 5000
 storage_gas_price: 1
-max_transactions_per_checkpoint: 1000
+max_transactions_per_checkpoint: 10000
 max_checkpoint_size_bytes: 31457280
 buffer_stake_for_protocol_upgrade_bps: 0
 address_from_bytes_cost_base: 52


### PR DESCRIPTION
With size limit also in place, we don't need to have count limit quite as low.