### PR TITLE
[wallet-ext] fix bug where you can't sign transactions with Ledger in popup mode

### DIFF
--- a/apps/wallet/src/ui/app/LedgerSigner.ts
+++ b/apps/wallet/src/ui/app/LedgerSigner.ts
@@ -32,6 +32,8 @@ export class LedgerSigner extends SignerWithProvider {
 
     async #initializeSuiLedgerClient() {
         if (!this.#suiLedgerClient) {
+            // We want to make sure that there's only one connection established per Ledger signer
+            // instance since some methods make multiple calls like getAddress and signData
             this.#suiLedgerClient = await this.#connectToLedger();
         }
         return this.#suiLedgerClient;

--- a/apps/wallet/src/ui/app/components/ledger/ConnectLedgerModal.tsx
+++ b/apps/wallet/src/ui/app/components/ledger/ConnectLedgerModal.tsx
@@ -26,7 +26,7 @@ export function ConnectLedgerModal({
     const onContinueClick = async () => {
         try {
             setConnectingToLedger(true);
-            await connectToLedger();
+            await connectToLedger(true);
             onConfirm();
         } catch (error) {
             onError(error);


### PR DESCRIPTION
## Description 

This is the second UX change mentioned in https://github.com/MystenLabs/sui/pull/9768 - in short, we need to use `openConnected` when connecting to Ledger devices during signing flows instead of `request` due to API inconsistencies when the extension is in popup mode. This PR also applies some of the new error-handling utilities I added in https://github.com/MystenLabs/sui/pull/9842 (the changes are kind of intertwined hence them being in this PR).

Proof of successful Ledger txn:
<img width="377" alt="image" src="https://user-images.githubusercontent.com/7453188/227588041-771ea9bf-6a70-4a39-a3b7-20ec72ce5481.png">


## Test Plan 
- Manual testing (signing works in the browser window and popup mode)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
N/A
