### PR TITLE
[sui-indexer] - getEpochs - add flag to return results in descending order

### DIFF
--- a/crates/sui-indexer/src/apis/extended_api.rs
+++ b/crates/sui-indexer/src/apis/extended_api.rs
@@ -84,7 +84,7 @@ impl<S: IndexerStore + Sync + Send + 'static> ExtendedApiServer for ExtendedApi<
         &self,
         cursor: Option<EpochId>,
         limit: Option<usize>,
-        descending_order: Option<bool>
+        descending_order: Option<bool>,
     ) -> RpcResult<EpochPage> {
         let limit = validate_limit(limit, QUERY_MAX_RESULT_LIMIT_CHECKPOINTS)?;
         let mut epochs = self.state.get_epochs(cursor, limit + 1, descending_order)?;

--- a/crates/sui-indexer/src/apis/extended_api.rs
+++ b/crates/sui-indexer/src/apis/extended_api.rs
@@ -84,9 +84,10 @@ impl<S: IndexerStore + Sync + Send + 'static> ExtendedApiServer for ExtendedApi<
         &self,
         cursor: Option<EpochId>,
         limit: Option<usize>,
+        descending_order: Option<bool>
     ) -> RpcResult<EpochPage> {
         let limit = validate_limit(limit, QUERY_MAX_RESULT_LIMIT_CHECKPOINTS)?;
-        let mut epochs = self.state.get_epochs(cursor, limit + 1)?;
+        let mut epochs = self.state.get_epochs(cursor, limit + 1, descending_order)?;
 
         let has_next_page = epochs.len() > limit;
         epochs.truncate(limit);
@@ -96,7 +97,7 @@ impl<S: IndexerStore + Sync + Send + 'static> ExtendedApiServer for ExtendedApi<
         Ok(Page {
             data: epochs,
             next_cursor,
-            has_next_page: false,
+            has_next_page,
         })
     }
 

--- a/crates/sui-indexer/src/lib.rs
+++ b/crates/sui-indexer/src/lib.rs
@@ -72,7 +72,7 @@ pub struct IndexerConfig {
     pub client_metric_port: u16,
     #[clap(long, default_value = "0.0.0.0", global = true)]
     pub rpc_server_url: String,
-    #[clap(long, default_value = "9000", global = true)]
+    #[clap(long, default_value = "3030", global = true)]
     pub rpc_server_port: u16,
     #[clap(long, multiple_occurrences = false, multiple_values = true)]
     pub migrated_methods: Vec<String>,
@@ -109,7 +109,7 @@ impl Default for IndexerConfig {
             client_metric_host: "0.0.0.0".to_string(),
             client_metric_port: 9184,
             rpc_server_url: "0.0.0.0".to_string(),
-            rpc_server_port: 9000,
+            rpc_server_port: 3030,
             migrated_methods: vec![],
             reset_db: false,
         }

--- a/crates/sui-indexer/src/lib.rs
+++ b/crates/sui-indexer/src/lib.rs
@@ -72,7 +72,7 @@ pub struct IndexerConfig {
     pub client_metric_port: u16,
     #[clap(long, default_value = "0.0.0.0", global = true)]
     pub rpc_server_url: String,
-    #[clap(long, default_value = "3030", global = true)]
+    #[clap(long, default_value = "9000", global = true)]
     pub rpc_server_port: u16,
     #[clap(long, multiple_occurrences = false, multiple_values = true)]
     pub migrated_methods: Vec<String>,
@@ -109,7 +109,7 @@ impl Default for IndexerConfig {
             client_metric_host: "0.0.0.0".to_string(),
             client_metric_port: 9184,
             rpc_server_url: "0.0.0.0".to_string(),
-            rpc_server_port: 3030,
+            rpc_server_port: 9000,
             migrated_methods: vec![],
             reset_db: false,
         }

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -176,7 +176,7 @@ pub trait IndexerStore {
         &self,
         cursor: Option<EpochId>,
         limit: usize,
-        descending_order: Option<bool>
+        descending_order: Option<bool>,
     ) -> Result<Vec<EpochInfo>, IndexerError>;
     fn get_current_epoch(&self) -> Result<EpochInfo, IndexerError>;
 

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -176,6 +176,7 @@ pub trait IndexerStore {
         &self,
         cursor: Option<EpochId>,
         limit: usize,
+        descending_order: Option<bool>
     ) -> Result<Vec<EpochInfo>, IndexerError>;
     fn get_current_epoch(&self) -> Result<EpochInfo, IndexerError>;
 

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -1159,16 +1159,22 @@ WHERE e1.epoch = e2.epoch
         &self,
         cursor: Option<EpochId>,
         limit: usize,
+        descending_order: Option<bool>
     ) -> Result<Vec<EpochInfo>, IndexerError> {
-        let id = cursor.map(|id| id as i64).unwrap_or(-1);
+        let is_descending = descending_order.unwrap_or(false);
+        let id = cursor.map(|id| id as i64).unwrap_or(if is_descending { i64::MAX } else { -1 });
         let mut pg_pool_conn = get_pg_pool_connection(&self.cp)?;
+        let mut query = epochs_dsl::epochs.into_boxed();
+        if is_descending {
+            query = query.filter(epochs::epoch.lt(id)).order_by(epochs::epoch.desc());
+        } else {
+            query = query.filter(epochs::epoch.gt(id)).order_by(epochs::epoch.asc());
+        }
+
         let epoch_info :Vec<DBEpochInfo> = pg_pool_conn
             .build_transaction()
             .read_only()
-            .run(|conn| {
-                epochs_dsl::epochs.filter(epochs::epoch.gt(id)).order_by(epochs::epoch.asc())
-                    .limit(limit as i64).load(conn)
-            })
+            .run(|conn| query.limit(limit as i64).load(conn))
             .map_err(|e| {
                 IndexerError::PostgresReadError(format!(
                     "Failed reading latest checkpoint sequence number in PostgresDB with error {:?}",

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -1159,16 +1159,22 @@ WHERE e1.epoch = e2.epoch
         &self,
         cursor: Option<EpochId>,
         limit: usize,
-        descending_order: Option<bool>
+        descending_order: Option<bool>,
     ) -> Result<Vec<EpochInfo>, IndexerError> {
         let is_descending = descending_order.unwrap_or(false);
-        let id = cursor.map(|id| id as i64).unwrap_or(if is_descending { i64::MAX } else { -1 });
+        let id = cursor
+            .map(|id| id as i64)
+            .unwrap_or(if is_descending { i64::MAX } else { -1 });
         let mut pg_pool_conn = get_pg_pool_connection(&self.cp)?;
         let mut query = epochs_dsl::epochs.into_boxed();
         if is_descending {
-            query = query.filter(epochs::epoch.lt(id)).order_by(epochs::epoch.desc());
+            query = query
+                .filter(epochs::epoch.lt(id))
+                .order_by(epochs::epoch.desc());
         } else {
-            query = query.filter(epochs::epoch.gt(id)).order_by(epochs::epoch.asc());
+            query = query
+                .filter(epochs::epoch.gt(id))
+                .order_by(epochs::epoch.asc());
         }
 
         let epoch_info :Vec<DBEpochInfo> = pg_pool_conn

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -1161,7 +1161,7 @@ WHERE e1.epoch = e2.epoch
         limit: usize,
         descending_order: Option<bool>,
     ) -> Result<Vec<EpochInfo>, IndexerError> {
-        let is_descending = descending_order.unwrap_or(false);
+        let is_descending = descending_order.unwrap_or_default();
         let id = cursor
             .map(|id| id as i64)
             .unwrap_or(if is_descending { i64::MAX } else { -1 });

--- a/crates/sui-indexer/tests/integration_tests.rs
+++ b/crates/sui-indexer/tests/integration_tests.rs
@@ -844,14 +844,14 @@ pub mod pg_integration_test {
         wait_until_next_checkpoint(&store).await;
 
         let current_epoch = store.get_current_epoch().unwrap();
-        let epoch_page = store.get_epochs(None, 100).unwrap();
+        let epoch_page = store.get_epochs(None, 100, None).unwrap();
         assert_eq!(0, current_epoch.epoch);
         assert!(current_epoch.end_of_epoch_info.is_none());
         assert_eq!(1, epoch_page.len());
         wait_until_next_epoch(&store).await;
 
         let current_epoch = store.get_current_epoch().unwrap();
-        let epoch_page = store.get_epochs(None, 100).unwrap();
+        let epoch_page = store.get_epochs(None, 100, None).unwrap();
 
         assert_eq!(1, current_epoch.epoch);
         assert!(current_epoch.end_of_epoch_info.is_none());

--- a/crates/sui-json-rpc/src/api/extended.rs
+++ b/crates/sui-json-rpc/src/api/extended.rs
@@ -20,7 +20,7 @@ pub trait ExtendedApi {
         /// maximum number of items per page
         limit: Option<usize>,
         /// flag to return results in descending order
-        descending_order: Option<bool>
+        descending_order: Option<bool>,
     ) -> RpcResult<EpochPage>;
 
     /// Return current epoch info

--- a/crates/sui-json-rpc/src/api/extended.rs
+++ b/crates/sui-json-rpc/src/api/extended.rs
@@ -19,6 +19,8 @@ pub trait ExtendedApi {
         cursor: Option<EpochId>,
         /// maximum number of items per page
         limit: Option<usize>,
+        /// flag to return results in descending order
+        descending_order: Option<bool>
     ) -> RpcResult<EpochPage>;
 
     /// Return current epoch info

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1958,6 +1958,13 @@
             "format": "uint",
             "minimum": 0.0
           }
+        },
+        {
+          "name": "descending_order",
+          "description": "flag to return results in descending order",
+          "schema": {
+            "type": "boolean"
+          }
         }
       ],
       "result": {


### PR DESCRIPTION
## Description 

Adds a flag to the `getEpochs` endpoint to allow returning results in descending order

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
