### PR TITLE
Add `queryTransactions` to loadgen

### DIFF
--- a/crates/sui-rpc-loadgen/README.md
+++ b/crates/sui-rpc-loadgen/README.md
@@ -22,7 +22,7 @@ To try this locally, refer to [sef](../sui-test-validator/README.md). Recommend 
 
 The following command initiates a single thread (num-threads == 1) to retrieve all checkpoints from the beginning (sequence 0) to the latest, executing the operation exactly once (repeat == 0):
 ```bash
-cargo run --bin sui-rpc-loadgen -- --urls "http://127.0.0.1:9000" "http://127.0.0.1:9124" --num-threads 1 get-checkpoints --start 0 --repeat 0 --interval_in_ms 0 --verify-transactions true
+cargo run --bin sui-rpc-loadgen -- --urls "http://127.0.0.1:9000" "http://127.0.0.1:9124" --num-threads 1 get-checkpoints --start 0 --repeat 0 --interval-in-ms 0 --verify-transactions true
 ```
 This command is equivalent to the simplified version below:
 ```bash

--- a/crates/sui-rpc-loadgen/src/main.rs
+++ b/crates/sui-rpc-loadgen/src/main.rs
@@ -79,6 +79,17 @@ pub enum ClapCommand {
         #[clap(flatten)]
         common: CommonOptions,
     },
+    #[clap(name = "query-transactions")]
+    QueryTransactions {
+        #[clap(short, long)]
+        from_address: Option<String>,
+
+        #[clap(short, long)]
+        to_address: Option<String>,
+
+        #[clap(flatten)]
+        common: CommonOptions,
+    },
 }
 
 fn get_keypair() -> Result<SignerInfo> {
@@ -142,6 +153,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
             verify_objects,
         } => (
             Command::new_get_checkpoints(start, end, verify_transactions, verify_objects),
+            common,
+            false,
+        ),
+        ClapCommand::QueryTransactions {
+            common,
+            from_address,
+            to_address,
+        } => (
+            Command::new_query_transactions(from_address, to_address),
             common,
             false,
         ),

--- a/crates/sui-rpc-loadgen/src/payload/mod.rs
+++ b/crates/sui-rpc-loadgen/src/payload/mod.rs
@@ -6,6 +6,7 @@ mod rpc_command_processor;
 use anyhow::Result;
 use async_trait::async_trait;
 use core::default::Default;
+use std::str::FromStr;
 use std::time::Duration;
 
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
@@ -85,6 +86,20 @@ impl Command {
         }
     }
 
+    pub fn new_query_transactions(
+        from_address: Option<String>,
+        to_address: Option<String>,
+    ) -> Self {
+        let query_transactions = QueryTransactions {
+            from_address: from_address.map(|addr| SuiAddress::from_str(&addr).unwrap()),
+            to_address: to_address.map(|addr| SuiAddress::from_str(&addr).unwrap()),
+        };
+        Self {
+            data: CommandData::QueryTransactions(query_transactions),
+            ..Default::default()
+        }
+    }
+
     pub fn with_repeat_n_times(mut self, num: usize) -> Self {
         self.repeat_n_times = num;
         self
@@ -102,6 +117,7 @@ pub enum CommandData {
     DryRun(DryRun),
     GetCheckpoints(GetCheckpoints),
     PaySui(PaySui),
+    QueryTransactions(QueryTransactions),
 }
 
 impl Default for CommandData {
@@ -125,6 +141,12 @@ pub struct GetCheckpoints {
 
 #[derive(Clone)]
 pub struct PaySui {}
+
+#[derive(Clone, Default)]
+pub struct QueryTransactions {
+    pub from_address: Option<SuiAddress>,
+    pub to_address: Option<SuiAddress>,
+}
 
 #[async_trait]
 pub trait Processor {

--- a/crates/sui-rpc-loadgen/src/payload/rpc_command_processor.rs
+++ b/crates/sui-rpc-loadgen/src/payload/rpc_command_processor.rs
@@ -1,16 +1,18 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use futures::future::join_all;
 use shared_crypto::intent::{Intent, IntentMessage};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use sui_json_rpc_types::{
-    BigInt, CheckpointId, ObjectChange, SuiObjectDataOptions, SuiTransactionResponseOptions,
+    BigInt, CheckpointId, ObjectChange, Page, SuiObjectDataOptions, SuiTransactionResponse,
+    SuiTransactionResponseOptions, SuiTransactionResponseQuery, TransactionsPage,
 };
 use sui_types::digests::TransactionDigest;
+use sui_types::query::TransactionFilter;
 use tokio::sync::RwLock;
 use tokio::time::sleep;
 use tracing::log::warn;
@@ -26,7 +28,7 @@ use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 
 use crate::payload::{
     Command, CommandData, DryRun, GetCheckpoints, PaySui, Payload, ProcessPayload, Processor,
-    SignerInfo,
+    QueryTransactions, SignerInfo,
 };
 
 const DEFAULT_GAS_BUDGET: u64 = 100_000;
@@ -62,6 +64,7 @@ impl RpcCommandProcessor {
             CommandData::DryRun(ref v) => self.process(v, signer_info).await,
             CommandData::GetCheckpoints(ref v) => self.process(v, signer_info).await,
             CommandData::PaySui(ref v) => self.process(v, signer_info).await,
+            CommandData::QueryTransactions(ref v) => self.process(v, signer_info).await,
         }
     }
 
@@ -441,6 +444,20 @@ async fn get_coin_ids(
     results
 }
 
+async fn query_transactions(
+    client: &SuiClient,
+    query: SuiTransactionResponseQuery,
+    cursor: Option<TransactionDigest>,
+    limit: Option<usize>, // TODO: we should probably set a limit and paginate
+) -> Result<Page<SuiTransactionResponse, TransactionDigest>> {
+    let transactions = client
+        .read_api()
+        .query_transactions(query, cursor, limit, true)
+        .await
+        .unwrap();
+    Ok(transactions)
+}
+
 // todo: this and check_transactions can be generic
 pub async fn check_objects(
     clients: &Arc<RwLock<Vec<SuiClient>>>,
@@ -524,6 +541,86 @@ fn cross_validate_entities<T, U>(
                 entity_name, i, key_name, keys[i], a, b
             );
         }
+    }
+}
+
+#[async_trait]
+impl<'a> ProcessPayload<'a, &'a QueryTransactions> for RpcCommandProcessor {
+    async fn process(
+        &'a self,
+        op: &'a QueryTransactions,
+        _signer_info: &Option<SignerInfo>,
+    ) -> Result<()> {
+        let clients = self.get_clients().await?;
+        let filter = match (op.from_address, op.to_address) {
+            (Some(_), Some(_)) => {
+                return Err(anyhow!("Cannot specify both from_address and to_address"));
+            }
+            (Some(address), None) => Some(TransactionFilter::FromAddress(address)),
+            (None, Some(address)) => Some(TransactionFilter::ToAddress(address)),
+            (None, None) => None,
+        };
+        let query = SuiTransactionResponseQuery {
+            filter,
+            options: None, // not supported on indexer
+        };
+
+        let results: Vec<TransactionsPage> = Vec::new();
+
+        // Paginate results, if any
+        while results.is_empty() || results.iter().any(|r| r.has_next_page) {
+            let cursor = if results.is_empty() {
+                None
+            } else {
+                match (
+                    results.get(0).unwrap().next_cursor,
+                    results.get(1).unwrap().next_cursor,
+                ) {
+                    (Some(first_cursor), Some(second_cursor)) => {
+                        if first_cursor != second_cursor {
+                            warn!("Cursors are not the same, received {} vs {}. Selecting the first cursor to continue", first_cursor, second_cursor);
+                        }
+                        Some(first_cursor)
+                    }
+                    (Some(cursor), None) | (None, Some(cursor)) => Some(cursor),
+                    (None, None) => None,
+                }
+            };
+
+            let results = join_all(clients.iter().enumerate().map(|(i, client)| {
+                let with_query = query.clone();
+                async move {
+                    let start_time = Instant::now();
+                    let transactions = query_transactions(client, with_query, cursor, None)
+                        .await
+                        .unwrap();
+                    let elapsed_time = start_time.elapsed();
+                    debug!(
+                        "QueryTransactions Request latency {:.4} for rpc at url {i}",
+                        elapsed_time.as_secs_f64()
+                    );
+                    transactions
+                }
+            }))
+            .await;
+
+            // compare results
+            let digests = results[0]
+                .data
+                .iter()
+                .map(|transaction| transaction.digest)
+                .collect::<Vec<TransactionDigest>>();
+
+            cross_validate_entities(
+                &digests,
+                &results[0].data,
+                &results[1].data,
+                "TransactionDigest",
+                "Transaction",
+            );
+        }
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Description 

Add `queryTransactions`, supports filters `all`, `fromAddress`, `toAddress`

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
