### PR TITLE
[tiny] Fix histogram metric, reduce warning volume

### DIFF
--- a/narwhal/primary/src/proposer.rs
+++ b/narwhal/primary/src/proposer.rs
@@ -475,7 +475,7 @@ impl Proposer {
                     self.metrics
                         .proposal_latency
                         .with_label_values(&[reason])
-                        .observe((current_timestamp - t) as f64);
+                        .observe(((current_timestamp - t) / 1000) as f64);
                 }
                 self.last_round_timestamp = Some(current_timestamp);
                 debug!("Dag moved to round {}", self.round);


### PR DESCRIPTION
1. The histogram for calculating round duration didn't convert it from ms to sec
2. We shouldn't generate a warn message for the long standing user cert sequencing, it might creates unhealthy volume of unnecessary logs.

## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
