### PR TITLE
[actions] point cargo-deny action at our fork to mitigate tar failure

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -254,7 +254,7 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v3
-      - uses: EmbarkStudios/cargo-deny-action@v1
+      - uses: mystenlabs/cargo-deny-action@main
 
   move-prover:
     name: move-prover


### PR DESCRIPTION
## Description 

Attempt to fix the error seen in https://github.com/MystenLabs/sui/actions/runs/4515249036/jobs/7952315116?pr=9814 by using our [forked version](https://github.com/MystenLabs/cargo-deny-action/commit/ca3520a3cd273d6b935d125b7111cf988f59887b) of the cargo-deny action with the fix.

I also submitted a [PR in the original repo](https://github.com/EmbarkStudios/cargo-deny-action/pull/62) so we can go back to using it after the fix is in place.

## Test Plan 

Ran successful cargo-deny with our fork in https://github.com/MystenLabs/sui/actions/runs/4515503791/jobs/7953092763

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
