### PR TITLE
some log reductions

### DIFF
--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -14,7 +14,7 @@ use sui_types::balance::{
 use sui_types::base_types::ObjectID;
 use sui_types::gas_coin::GAS;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
-use tracing::{debug, info, instrument, warn};
+use tracing::{info, instrument, trace, warn};
 
 use crate::programmable_transactions;
 use sui_protocol_config::{
@@ -101,7 +101,7 @@ pub fn execute_transaction_to_effects<
             (ExecutionStatus::new_failure(status, command), Err(error))
         }
     };
-    debug!(
+    trace!(
         computation_gas_cost = gas_cost_summary.computation_cost,
         storage_gas_cost = gas_cost_summary.storage_cost,
         storage_gas_rebate = gas_cost_summary.storage_rebate,
@@ -372,7 +372,7 @@ pub fn construct_advance_epoch_pt(
 
     arguments.append(&mut call_arg_arguments.unwrap());
 
-    debug!(
+    info!(
         "Call arguments to advance_epoch transaction: {:?}",
         arguments
     );
@@ -427,7 +427,7 @@ pub fn construct_advance_epoch_safe_mode_pt(
 
     arguments.append(&mut call_arg_arguments.unwrap());
 
-    debug!(
+    info!(
         "Call arguments to advance_epoch transaction: {:?}",
         arguments
     );

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -580,10 +580,7 @@ impl AuthorityState {
         );
 
         let tx_digest = *transaction.digest();
-        debug!(
-            "handle_transaction with transaction data: {:?}",
-            &transaction.data().intent_message().value
-        );
+        debug!("handle_transaction");
 
         // Ensure an idempotent answer. This is checked before the system_tx check so that
         // a validator is able to return the signed system tx if it was already signed locally.
@@ -751,7 +748,7 @@ impl AuthorityState {
 
         self.process_certificate(tx_guard, certificate, epoch_store)
             .await
-            .tap_err(|e| debug!(?tx_digest, "process_certificate failed: {e}"))
+            .tap_err(|e| info!(?tx_digest, "process_certificate failed: {e}"))
     }
 
     /// Test only wrapper for `try_execute_immediately()` above, useful for checking errors if the
@@ -821,7 +818,7 @@ impl AuthorityState {
         // possible that reconfiguration has happened and they no longer match.
         if *execution_guard != epoch_store.epoch() {
             tx_guard.release();
-            debug!("The epoch of the execution_guard doesn't match the epoch store");
+            info!("The epoch of the execution_guard doesn't match the epoch store");
             return Err(SuiError::WrongEpoch {
                 expected_epoch: epoch_store.epoch(),
                 actual_epoch: *execution_guard,
@@ -837,7 +834,7 @@ impl AuthorityState {
             .await
         {
             Err(e) => {
-                debug!(name = ?self.name, ?digest, "Error preparing transaction: {e}");
+                info!(name = ?self.name, ?digest, "Error preparing transaction: {e}");
                 tx_guard.release();
                 return Err(e);
             }
@@ -2755,7 +2752,7 @@ impl AuthorityState {
             )
             .await
             .tap_ok(|_| {
-                debug!(?tx_digest, "commit_certificate finished");
+                debug!("commit_certificate finished");
             })?;
 
         // todo - ideally move this metric in NotifyRead once we have metrics in AuthorityStore
@@ -3272,7 +3269,7 @@ impl AuthorityState {
                 err
             })?;
 
-        debug!(
+        info!(
             "Effects summary of the change epoch transaction: {:?}",
             effects.summary_for_debug()
         );
@@ -3302,7 +3299,7 @@ impl AuthorityState {
             // lock is dropped here
         }
         let pending_certificates = epoch_store.pending_consensus_certificates();
-        debug!(
+        info!(
             "Reverting {} locally executed transactions that was not included in the epoch",
             pending_certificates.len()
         );
@@ -3311,13 +3308,13 @@ impl AuthorityState {
                 .database
                 .is_transaction_executed_in_checkpoint(&digest)?
             {
-                debug!("Not reverting pending consensus transaction {:?} - it was included in checkpoint", digest);
+                info!("Not reverting pending consensus transaction {:?} - it was included in checkpoint", digest);
                 continue;
             }
-            debug!("Reverting {:?} at the end of epoch", digest);
+            info!("Reverting {:?} at the end of epoch", digest);
             self.database.revert_state_update(&digest).await?;
         }
-        debug!("All uncommitted local transactions reverted");
+        info!("All uncommitted local transactions reverted");
         Ok(())
     }
 

--- a/crates/sui-core/src/authority/authority_notify_read.rs
+++ b/crates/sui-core/src/authority/authority_notify_read.rs
@@ -12,7 +12,7 @@ use std::time::Instant;
 use sui_types::base_types::TransactionDigest;
 use sui_types::error::SuiResult;
 use sui_types::messages::{TransactionEffects, TransactionEffectsAPI};
-use tracing::debug;
+use tracing::trace;
 
 #[async_trait]
 pub trait EffectsNotifyRead: Send + Sync + 'static {
@@ -66,7 +66,7 @@ impl EffectsNotifyRead for Arc<AuthorityStore> {
         }
         if needs_wait {
             // Only log the duration if we ended up waiting.
-            debug!(duration=?timer.elapsed(), ?last_finished, "Finished notify_read_effects");
+            trace!(duration=?timer.elapsed(), ?last_finished, "Finished notify_read_effects");
         }
         // Map from digests to ensures returned order is the same as order of digests
         Ok(digests

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -807,7 +807,7 @@ impl AuthorityPerEpochStore {
         Ok(next_versions)
     }
 
-    pub async fn set_assigned_shared_object_versions(
+    async fn set_assigned_shared_object_versions(
         &self,
         certificate: &VerifiedExecutableTransaction,
         assigned_versions: &Vec<(ObjectID, SequenceNumber)>,
@@ -1200,7 +1200,7 @@ impl AuthorityPerEpochStore {
         )
     }
 
-    pub fn finish_assign_shared_object_versions(
+    fn finish_assign_shared_object_versions(
         &self,
         key: SequencedConsensusTransactionKey,
         certificate: &VerifiedExecutableTransaction,

--- a/crates/sui-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_output.rs
@@ -15,7 +15,7 @@ use sui_types::messages_checkpoint::{
     CertifiedCheckpointSummary, CheckpointContents, CheckpointSignatureMessage, CheckpointSummary,
     SignedCheckpointSummary, VerifiedCheckpoint,
 };
-use tracing::{debug, info};
+use tracing::{debug, info, trace};
 
 use super::CheckpointMetrics;
 

--- a/crates/sui-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_output.rs
@@ -107,9 +107,10 @@ impl CheckpointOutput for LogCheckpointOutput {
         contents: &CheckpointContents,
         _epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult {
-        debug!(
+        trace!(
             "Including following transactions in checkpoint {}: {:?}",
-            summary.sequence_number, contents
+            summary.sequence_number,
+            contents
         );
         info!(
             "Creating checkpoint {:?} at epoch {}, sequence {}, previous digest {:?}, transactions count {}, content digest {:?}, end_of_epoch_data {:?}",

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -50,7 +50,7 @@ use tokio::{
     sync::{watch, Notify},
     time::timeout,
 };
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, trace, warn};
 use typed_store::rocks::{DBMap, MetricConf, TypedStoreError};
 use typed_store::traits::{TableSummary, TypedStoreDebug};
 use typed_store::Map;

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -652,11 +652,8 @@ impl CheckpointBuilder {
         }
 
         debug!(
-            "Waiting for checkpoint user signatures for certificates {:?} to appear in consensus",
-            all_effects_and_transaction_sizes
-                .iter()
-                .map(|(effects, _)| effects)
-                .collect::<Vec<_>>()
+            "Waiting for checkpoint user signatures for {:?} certificates to appear in consensus",
+            all_effects_and_transaction_sizes.len()
         );
         let signatures = {
             let _guard = monitored_scope("CheckpointBuilder::wait_user_signatures");
@@ -1227,6 +1224,11 @@ impl CheckpointServiceNotify for CheckpointService {
             return Ok(());
         }
         debug!(
+            "Pending checkpoint at height {} has {} roots",
+            checkpoint.height(),
+            checkpoint.roots.len(),
+        );
+        trace!(
             "Transaction roots for pending checkpoint at height {}: {:?}",
             checkpoint.height(),
             checkpoint.roots

--- a/crates/sui-core/src/execution_driver.rs
+++ b/crates/sui-core/src/execution_driver.rs
@@ -12,7 +12,7 @@ use tokio::{
     sync::{mpsc::UnboundedReceiver, oneshot, Semaphore},
     time::sleep,
 };
-use tracing::{debug, error, error_span, info, Instrument};
+use tracing::{error, error_span, info, trace, Instrument};
 
 use crate::authority::AuthorityState;
 
@@ -71,7 +71,7 @@ pub async fn execution_process(
         let epoch_store = authority.load_epoch_store_one_call_per_task();
 
         let digest = *certificate.digest();
-        debug!(?digest, "Pending certificate execution activated.");
+        trace!(?digest, "Pending certificate execution activated.");
 
         let limit = limit.clone();
         // hold semaphore permit until task completes. unwrap ok because we never close

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -329,13 +329,15 @@ impl TransactionManager {
                 assert!(pending_cert.missing.remove(&input_key));
                 // When a certificate has no missing input, it is ready to execute.
                 if pending_cert.missing.is_empty() {
-                    debug!(tx_digest = ?digest, "certificate ready");
+                    trace!(tx_digest = ?digest, "certificate ready");
                     let pending_cert = inner.pending_certificates.remove(&digest).unwrap();
                     assert!(inner.executing_certificates.insert(digest));
                     ready_digests.push(digest);
                     self.certificate_ready(pending_cert.certificate);
                 } else {
-                    debug!(tx_digest = ?digest, missing = ?pending_cert.missing, "Certificate waiting on missing inputs");
+                    // TODO: we should start logging this at a higher level after some period of
+                    // time has elapsed.
+                    trace!(missing = ?pending_cert.missing, "Certificate waiting on missing inputs");
                 }
             }
         }

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -337,7 +337,7 @@ impl TransactionManager {
                 } else {
                     // TODO: we should start logging this at a higher level after some period of
                     // time has elapsed.
-                    trace!(missing = ?pending_cert.missing, "Certificate waiting on missing inputs");
+                    debug!(missing = ?pending_cert.missing, "Certificate waiting on missing inputs");
                 }
             }
         }

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -15,7 +15,7 @@ use sui_types::{
 };
 use sui_types::{base_types::TransactionDigest, error::SuiResult};
 use tokio::sync::mpsc::UnboundedSender;
-use tracing::{debug, error, warn};
+use tracing::{debug, error, trace, warn};
 
 use crate::authority::{
     authority_per_epoch_store::AuthorityPerEpochStore, authority_store::InputKey,

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -48,7 +48,7 @@ use strum::IntoStaticStr;
 use sui_protocol_config::{ProtocolConfig, SupportedProtocolVersions};
 use tap::Pipe;
 use thiserror::Error;
-use tracing::debug;
+use tracing::trace;
 
 pub const DUMMY_GAS_PRICE: u64 = 1;
 
@@ -3077,7 +3077,7 @@ impl InputObjects {
             })
             .collect();
 
-        debug!(
+        trace!(
             num_mutable_objects = owned_objects.len(),
             "Checked locks and found mutable objects"
         );


### PR DESCRIPTION
This does two things:

- moves some debug logs to trace if they haven't been useful (at least in my personal experience)
- moves some debug logs to info so that we lose less if people run at INFO level.