### PR TITLE
[hardening] make get_total_sui look inside vectors

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/sui/coin_in_vec.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/coin_in_vec.exp
@@ -1,0 +1,15 @@
+processed 4 tasks
+
+init:
+A: object(103)
+
+task 1 'publish'. lines 6-32:
+created: object(105), object(106)
+written: object(104)
+
+task 2 'run'. lines 34-34:
+written: object(105), object(107)
+deleted: object(104)
+
+task 3 'run'. lines 36-36:
+written: object(104), object(105), object(108)

--- a/crates/sui-adapter-transactional-tests/tests/sui/coin_in_vec.move
+++ b/crates/sui-adapter-transactional-tests/tests/sui/coin_in_vec.move
@@ -1,0 +1,36 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish --sender A
+
+module test::coin_in_vec {
+    use std::vector;
+    use sui::coin::Coin;
+    use sui::object::{Self, UID};
+    use sui::sui::SUI;
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+
+    struct Wrapper has key {
+        id: UID,
+        coins: vector<Coin<SUI>>,
+    }
+
+    fun init(ctx: &mut TxContext) {
+        transfer::transfer(Wrapper { id: object::new(ctx), coins: vector[] }, tx_context::sender(ctx));
+    }
+
+    public fun deposit(wrapper: &mut Wrapper, c: Coin<SUI>) {
+        vector::push_back(&mut wrapper.coins, c)
+    }
+
+    public fun withdraw(wrapper: &mut Wrapper, ctx: &mut TxContext) {
+        transfer::public_transfer(vector::pop_back(&mut wrapper.coins), tx_context::sender(ctx))
+    }
+}
+
+//# run test::coin_in_vec::deposit --args --args object(105) object(104) --sender A
+
+//# run test::coin_in_vec::withdraw --args object(105) --sender A


### PR DESCRIPTION
## Description 

Fixing a silly bug that makes the conservation checks fail if a coin flows into or out of a vector

## Test Plan 

New test using coins in a vector that failed before, passes now
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration