### PR TITLE
[bugfix] - remove unused fuzzy Move type checks

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2186,7 +2186,7 @@ impl AuthorityState {
         let object_ids = self
             .get_owner_objects_iterator(owner, None, None, None)?
             .filter(|o| match &o.type_ {
-                ObjectType::Struct(s) => type_.matches_type_fuzzy_generics(s),
+                ObjectType::Struct(s) => &type_ == s,
                 ObjectType::Package => false,
             })
             .map(|info| info.object_id);

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -251,15 +251,6 @@ impl MoveObjectType {
             MoveObjectType::Other(o) => s == o,
         }
     }
-
-    pub fn matches_type_fuzzy_generics(&self, other_type: &Self) -> bool {
-        self.address() == other_type.address()
-            && self.module() == other_type.module()
-            && self.name() == other_type.name()
-            // MUSTFIX: is_empty() looks like a bug here. I think the intention is to support "fuzzy matching" where `get_move_objects`
-            // leaves type_params unspecified, but I don't actually see any call sites taking advantage of this
-            && (self.type_params().is_empty() || self.type_params() == other_type.type_params())
-    }
 }
 
 impl From<StructTag> for MoveObjectType {


### PR DESCRIPTION
## Description 

remove unused fuzzy Move type checks, the method `matches_type_fuzzy_generics` is no longer needed and it is incorrect to ignore type when getting move objects


