### PR TITLE
Safe mode advance epoch must succeed

### DIFF
--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -498,7 +498,8 @@ fn advance_epoch<S: BackingPackageStore + ParentSync + ChildObjectResolver>(
             gas_status,
             None,
             advance_epoch_safe_mode_pt,
-        )?;
+        )
+        .expect("Advance epoch with safe mode must succeed");
     }
 
     for (version, modules, dependencies) in change_epoch.system_packages.into_iter() {


### PR DESCRIPTION
If we cannot execute advance epoch safe mode, we would lose liveness anyway. It's easier to debug if we panic here instead of falling into a strange mode where we fail to execute this transaction.