### PR TITLE
Update faucet.md

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,4 @@
+[default]
+extend-ignore-re = [
+  "[a-zA-Z0-9]{44}"
+]

--- a/doc/src/build/faucet.md
+++ b/doc/src/build/faucet.md
@@ -43,9 +43,9 @@ Replace `'https://faucet.devnet.sui.io/gas'` with `http://127.0.0.1:5003/gas` wh
 You can also access the faucet through the TS-SDK.
 
 ```
-import { JsonRpcProvider, Network } from '@mysten/sui.js';
+import { JsonRpcProvider, devnetConnection } from '@mysten/sui.js';
 // connect to Devnet
-const provider = new JsonRpcProvider(Network.DEVNET);
+const provider = new JsonRpcProvider(devnetConnection);
 // get tokens from the Devnet faucet server
 await provider.requestSuiFromFaucet(
   '<YOUR SUI ADDRESS>'


### PR DESCRIPTION
Modified based on [this](https://github.com/MystenLabs/sui/tree/main/sdk/typescript) document.

This error is located at [this](https://docs.sui.io/build/faucet) link.

The previous code will produce the error "The requested module '@mysten/sui.js' does not provide an export named 'Network'".
