### PR TITLE
[faucet] Increase local faucet amount to 1000 SUI per request

### DIFF
--- a/crates/sui-cluster-test/src/faucet.rs
+++ b/crates/sui-cluster-test/src/faucet.rs
@@ -114,7 +114,7 @@ impl FaucetClient for LocalFaucetClient {
     async fn request_sui_coins(&self, request_address: SuiAddress) -> FaucetResponse {
         let receipt = self
             .simple_faucet
-            .send(Uuid::new_v4(), request_address, &[200000000; 5])
+            .send(Uuid::new_v4(), request_address, &[200_000_000_000; 5])
             .await
             .unwrap_or_else(|err| panic!("Failed to get gas tokens with error: {}", err));
 


### PR DESCRIPTION
## Description 

We have received feedback from the community that increasing the faucet amount makes testing large amounts of transactions easier

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
