### PR TITLE
[Metric] fix ms to sec conversion

### DIFF
--- a/narwhal/primary/src/proposer.rs
+++ b/narwhal/primary/src/proposer.rs
@@ -477,7 +477,7 @@ impl Proposer {
                     self.metrics
                         .proposal_latency
                         .with_label_values(&[reason])
-                        .observe(((current_timestamp - t) / 1000) as f64);
+                        .observe(Duration::from_millis(current_timestamp - t).as_secs_f64());
                 }
                 self.last_round_timestamp = Some(current_timestamp);
                 debug!("Dag moved to round {}", self.round);


### PR DESCRIPTION
## Description 

When the sampled time is on the scale of 0 ~ 2 sec, dividing u64 millisec by 1000 could be too inaccurate. Using `Duration` to convert time instead.

## Test Plan 

n/a

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
