### PR TITLE
[narwhal] Do not reset proposer timer when advancing to the next round

### DIFF
--- a/narwhal/primary/src/proposer.rs
+++ b/narwhal/primary/src/proposer.rs
@@ -608,17 +608,6 @@ impl Proposer {
                             self.round = round;
                             let _ = self.tx_narwhal_round_updates.send(self.round);
                             self.last_parents = parents;
-
-                            // we re-calculate the timeout to give the opportunity to the node
-                            // to propose earlier if it's a leader for the round
-                            // Reschedule the timer.
-                            let timer_start = Instant::now();
-                            max_delay_timer
-                                .as_mut()
-                                .reset(timer_start + self.max_delay());
-                            min_delay_timer
-                                .as_mut()
-                                .reset(timer_start + self.min_delay());
                         },
                         Ordering::Less => {
                             // Ignore parents from older rounds.


### PR DESCRIPTION
Resetting timer might increase the probability for proposal starvation in case the timer is being reset time after time when the proposer is falling behind.

## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
