### PR TITLE
[rpc-loadgen] use burner address for paysui

### DIFF
--- a/crates/sui-rpc-loadgen/src/main.rs
+++ b/crates/sui-rpc-loadgen/src/main.rs
@@ -100,7 +100,7 @@ fn get_keypair() -> Result<SignerInfo> {
     let active_address = keystore.addresses().pop().unwrap();
     let keypair: &SuiKeyPair = keystore.get_key(&active_address)?;
     println!("using address {active_address} for signing");
-    Ok(SignerInfo::new(keypair.encode_base64(), active_address))
+    Ok(SignerInfo::new(keypair.encode_base64()))
 }
 
 fn get_sui_config_directory() -> PathBuf {

--- a/crates/sui-rpc-loadgen/src/payload/mod.rs
+++ b/crates/sui-rpc-loadgen/src/payload/mod.rs
@@ -22,18 +22,15 @@ use sui_types::base_types::{ObjectID, SuiAddress};
 #[derive(Default, Clone)]
 pub struct SignerInfo {
     pub encoded_keypair: String,
-    // TODO(chris): we should be able to derive this from the keypair?
-    pub signer_address: SuiAddress,
     /// Different thread should use different gas_payment to avoid equivocation
     pub gas_payment: Option<ObjectID>,
     pub gas_budget: Option<u64>,
 }
 
 impl SignerInfo {
-    pub fn new(encoded_keypair: String, signer_address: SuiAddress) -> Self {
+    pub fn new(encoded_keypair: String) -> Self {
         Self {
             encoded_keypair,
-            signer_address,
             gas_payment: None,
             gas_budget: None,
         }

--- a/crates/sui-rpc-loadgen/src/payload/pay_sui.rs
+++ b/crates/sui-rpc-loadgen/src/payload/pay_sui.rs
@@ -21,16 +21,16 @@ impl<'a> ProcessPayload<'a, &'a PaySui> for RpcCommandProcessor {
         let clients = self.get_clients().await?;
         let SignerInfo {
             encoded_keypair,
-            signer_address,
             gas_budget,
             gas_payment,
         } = signer_info.clone().unwrap();
         let recipient = SuiAddress::random_for_testing_only();
-        let amount = 11;
+        let amount = 1;
         let gas_budget = gas_budget.unwrap_or(DEFAULT_GAS_BUDGET);
 
         let keypair =
             SuiKeyPair::decode_base64(&encoded_keypair).expect("Decoding keypair should not fail");
+        let signer_address = SuiAddress::from(&keypair.public());
 
         debug!("Pay Sui to {recipient} with {amount} MIST with {gas_payment:?}");
         for client in clients.iter() {
@@ -49,7 +49,6 @@ impl<'a> ProcessPayload<'a, &'a PaySui> for RpcCommandProcessor {
                 &IntentMessage::new(Intent::default(), &transfer_tx),
                 &keypair,
             );
-            debug!("signature {:?}", signature);
 
             let transaction_response = client
                 .quorum_driver()

--- a/crates/sui-rpc-loadgen/src/payload/rpc_command_processor.rs
+++ b/crates/sui-rpc-loadgen/src/payload/rpc_command_processor.rs
@@ -4,20 +4,23 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use futures::future::join_all;
+
 use shared_crypto::intent::{Intent, IntentMessage};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use sui_json_rpc_types::SuiTransactionResponseOptions;
+use sui_json_rpc_types::{
+    SuiExecutionStatus, SuiTransactionEffectsAPI, SuiTransactionResponse,
+    SuiTransactionResponseOptions,
+};
 use tokio::sync::RwLock;
 use tokio::time::sleep;
 use tracing::debug;
 
 use crate::load_test::LoadTestConfig;
-use sui_json_rpc_types::SuiTransactionEffectsAPI;
 use sui_sdk::{SuiClient, SuiClientBuilder};
-use sui_types::base_types::ObjectID;
-use sui_types::crypto::{EncodeDecodeBase64, Signature, SuiKeyPair};
-use sui_types::messages::{ExecuteTransactionRequestType, Transaction};
+use sui_types::base_types::{ObjectID, SuiAddress};
+use sui_types::crypto::{get_key_pair, AccountKeyPair, EncodeDecodeBase64, Signature, SuiKeyPair};
+use sui_types::messages::{ExecuteTransactionRequestType, Transaction, TransactionData};
 
 use crate::payload::{
     Command, CommandData, DryRun, GetCheckpoints, Payload, ProcessPayload, Processor, SignerInfo,
@@ -102,16 +105,17 @@ impl Processor for RpcCommandProcessor {
             _ => vec![config.command.clone(); config.num_threads],
         };
 
-        let mut signer_infos = vec![config.signer_info.clone(); config.num_threads];
-
-        if let Some(info) = &config.signer_info {
-            let coins = get_coin_ids(clients.first().unwrap(), info, config.num_threads).await;
-            signer_infos
-                .iter_mut()
-                .zip(coins.into_iter())
-                .for_each(|(info, coin)| {
-                    info.as_mut().unwrap().gas_payment = Some(coin);
-                });
+        let coins_and_keys = if config.signer_info.is_some() {
+            Some(
+                prepare_new_signer_and_coins(
+                    clients.first().unwrap(),
+                    config.signer_info.as_ref().unwrap(),
+                    config.num_threads,
+                )
+                .await,
+            )
+        } else {
+            None
         };
 
         Ok(command_payloads
@@ -119,7 +123,13 @@ impl Processor for RpcCommandProcessor {
             .enumerate()
             .map(|(i, command)| Payload {
                 commands: vec![command], // note commands is also a vector
-                signer_info: signer_infos[i].clone(),
+                signer_info: coins_and_keys
+                    .as_ref()
+                    .map(|(coins, encoded_keypair)| SignerInfo {
+                        encoded_keypair: encoded_keypair.clone(),
+                        gas_payment: Some(coins[i]),
+                        gas_budget: None,
+                    }),
             })
             .collect())
     }
@@ -172,69 +182,125 @@ async fn divide_checkpoint_tasks(
         .collect()
 }
 
-async fn get_coin_ids(
+async fn prepare_new_signer_and_coins(
     client: &SuiClient,
     signer_info: &SignerInfo,
     num_coins: usize,
-) -> Vec<ObjectID> {
-    let sender = signer_info.signer_address;
-    let coin_page = client
-        .coin_read_api()
-        .get_coins(sender, None, None, None)
-        .await
-        .expect("Did you give gas coins to this address?");
-    let coin_object_id = coin_page
-        .data
-        .first()
-        .expect("Did you give gas coins to this address?")
-        .coin_object_id;
+) -> (Vec<ObjectID>, String) {
+    let primary_keypair = SuiKeyPair::decode_base64(&signer_info.encoded_keypair)
+        .expect("Decoding keypair should not fail");
+    let sender = SuiAddress::from(&primary_keypair.public());
+    let coins = get_sui_coin_ids(client, sender).await;
+    // one coin for splitting, the other coins for gas payment
+    let coin_to_split: ObjectID = coins[0];
+    let coin_for_split_gas: ObjectID = coins[1];
 
+    // We don't want to split coins in our primary address because we want to avoid having
+    // a million coin objects in our address. We can also fetch directly from the faucet, but in
+    // some environment that might not be possible when faucet resource is scarce
+    let (burner_address, burner_keypair): (_, AccountKeyPair) = get_key_pair();
+    let burner_keypair = SuiKeyPair::Ed25519(burner_keypair);
+    transfer_coin(client, &primary_keypair, coin_to_split, burner_address).await;
+    transfer_coin(client, &primary_keypair, coin_for_split_gas, burner_address).await;
+
+    let mut results: Vec<ObjectID> =
+        split_coins(client, &burner_keypair, coin_to_split, num_coins as u64).await;
+    results.push(coin_to_split);
+    debug!("Split {coin_to_split} into {results:?} for gas payment");
+    assert_eq!(results.len(), num_coins);
+    (results, burner_keypair.encode_base64())
+}
+
+// TODO: move this to the Rust SDK
+async fn get_sui_coin_ids(client: &SuiClient, address: SuiAddress) -> Vec<ObjectID> {
+    match client
+        .coin_read_api()
+        .get_coins(address, None, None, None)
+        .await
+    {
+        Ok(page) => page
+            .data
+            .into_iter()
+            .map(|c| c.coin_object_id)
+            .collect::<Vec<_>>(),
+        Err(e) => {
+            panic!("get_sui_coin_ids error for address {address} {e}")
+        }
+    }
+    // TODO: implement iteration over next page
+}
+
+async fn transfer_coin(
+    client: &SuiClient,
+    keypair: &SuiKeyPair,
+    coin_id: ObjectID,
+    recipient: SuiAddress,
+) -> SuiTransactionResponse {
+    let sender = SuiAddress::from(&keypair.public());
+    let txn = client
+        .transaction_builder()
+        .transfer_object(sender, coin_id, None, DEFAULT_GAS_BUDGET, recipient)
+        .await
+        .expect("Failed to construct transfer coin transaction");
+    sign_and_execute(client, keypair, txn).await
+}
+
+async fn split_coins(
+    client: &SuiClient,
+    keypair: &SuiKeyPair,
+    coin_to_split: ObjectID,
+    num_coins: u64,
+) -> Vec<ObjectID> {
+    let sender = SuiAddress::from(&keypair.public());
     let split_coin_tx = client
         .transaction_builder()
-        .split_coin_equal(
-            sender,
-            coin_object_id,
-            num_coins as u64,
-            None,
-            signer_info.gas_budget.unwrap_or(DEFAULT_GAS_BUDGET),
-        )
+        .split_coin_equal(sender, coin_to_split, num_coins, None, DEFAULT_GAS_BUDGET)
         .await
         .expect("Failed to construct split coin transaction");
-    debug!("split_coin_tx {:?}", split_coin_tx);
-    let keypair = SuiKeyPair::decode_base64(&signer_info.encoded_keypair)
-        .expect("Decoding keypair should not fail");
-    let signature = Signature::new_secure(
-        &IntentMessage::new(Intent::default(), &split_coin_tx),
-        &keypair,
-    );
-    debug!("signature {:?}", signature);
+    sign_and_execute(client, keypair, split_coin_tx)
+        .await
+        .effects
+        .unwrap()
+        .created()
+        .iter()
+        .map(|owned_object_ref| owned_object_ref.reference.object_id)
+        .collect::<Vec<_>>()
+}
+
+async fn sign_and_execute(
+    client: &SuiClient,
+    keypair: &SuiKeyPair,
+    txn_data: TransactionData,
+) -> SuiTransactionResponse {
+    let signature =
+        Signature::new_secure(&IntentMessage::new(Intent::default(), &txn_data), keypair);
 
     let transaction_response = client
         .quorum_driver()
         .execute_transaction(
-            Transaction::from_data(split_coin_tx, Intent::default(), vec![signature])
+            Transaction::from_data(txn_data, Intent::default(), vec![signature])
                 .verify()
                 .expect("signature error"),
             SuiTransactionResponseOptions::full_content(),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await
-        .expect("Splitcoin transaction failed");
-    debug!("split coin transaction response {transaction_response:?}");
-    let mut results: Vec<ObjectID> = transaction_response
-        .effects
-        .unwrap_or_else(|| {
+        .unwrap_or_else(|_| panic!("Execute Transaction Failed"));
+    match &transaction_response.effects {
+        Some(effects) => {
+            if let SuiExecutionStatus::Failure { error } = effects.status() {
+                panic!(
+                    "Transaction {} failed with error: {}. Transaction Response: {:?}",
+                    transaction_response.digest, error, &transaction_response
+                );
+            }
+        }
+        None => {
             panic!(
-                "split coin transaction should have effects {}",
-                transaction_response.digest
-            )
-        })
-        .created()
-        .iter()
-        .map(|owned_object_ref| owned_object_ref.reference.object_id)
-        .collect();
-    results.push(coin_object_id);
-    debug!("Split {coin_object_id} into {results:?} for gas payment");
-    assert_eq!(results.len(), num_coins);
-    results
+                "Transaction {} has no effects. Response {:?}",
+                transaction_response.digest, &transaction_response
+            );
+        }
+    };
+    transaction_response
 }


### PR DESCRIPTION
Previously, the PaySui logic is as following
1.  get the last address in the keystore(assume it has sufficient coins)
2. split the first coin into `num_threads` coins and assign one dedicated coin to each thread
3. That thread will use the assigned coin for all transactions

The problem is that after the second step, the address ends up with a lot of coins with small balances that make it hard to select coins to split if we need to run the script again. This PR adds an additional step between 1 and 2 to send coins to a burner address and uses the burner address for step 2 and 3.

We are able to get around ~60 write tps with this approach on local Mac book. The next PR will try to improve this number by further splitting the coins on each thread and each thread will run multiple paysui transactions concurrently. Another lever we have is to use `ExecuteTransactionRequestType::WaitForEffectsCert` instead of the current `ExecuteTransactionRequestType::WaitForLocalExecution`