### PR TITLE
indexer: DB commit optimization via unnest

### DIFF
--- a/crates/sui-indexer/migrations/2022-12-01-034426_objects/up.sql
+++ b/crates/sui-indexer/migrations/2022-12-01-034426_objects/up.sql
@@ -19,7 +19,7 @@ CREATE TABLE objects
 (
     epoch                  BIGINT        NOT NULL,
     checkpoint             BIGINT        NOT NULL,
-    object_id              address PRIMARY KEY,
+    object_id              address       PRIMARY KEY,
     version                BIGINT        NOT NULL,
     object_digest          base58digest  NOT NULL,
     -- owner related

--- a/crates/sui-indexer/src/models/owners.rs
+++ b/crates/sui-indexer/src/models/owners.rs
@@ -4,6 +4,7 @@
 use crate::models::objects::ObjectStatus;
 use diesel::prelude::*;
 use diesel_derive_enum::DbEnum;
+use serde::{Deserialize, Serialize};
 
 #[derive(Queryable, Debug, Clone)]
 #[diesel(table_name = owner)]
@@ -18,8 +19,9 @@ pub struct ObjectOwner {
     pub object_status: ObjectStatus,
 }
 
-#[derive(DbEnum, Debug, Clone)]
+#[derive(DbEnum, Debug, Clone, Deserialize, Serialize)]
 #[ExistingTypePath = "crate::schema::sql_types::OwnerType"]
+#[serde(rename_all = "snake_case")]
 pub enum OwnerType {
     AddressOwner,
     ObjectOwner,


### PR DESCRIPTION
## Description 

PG has a size limit of 65535 around insert via values, to get around it, we need unnest and build the query ourselves.

Follow-ups: perf testing & experiment

## Test Plan 

- Added CI tests to bulk insert then update 10k objects

