### PR TITLE
[rpc-loadgen] support concurrent execution on the same thread

### DIFF
--- a/crates/sui-rpc-loadgen/src/load_test.rs
+++ b/crates/sui-rpc-loadgen/src/load_test.rs
@@ -33,6 +33,8 @@ pub struct LoadTestConfig {
     /// should divide tasks across multiple threads
     pub divide_tasks: bool,
     pub signer_info: Option<SignerInfo>,
+    pub num_chunks_per_thread: usize,
+    pub max_repeat: usize,
 }
 
 pub(crate) struct LoadTest<R: Processor + Send + Sync + Clone> {

--- a/crates/sui-rpc-loadgen/src/main.rs
+++ b/crates/sui-rpc-loadgen/src/main.rs
@@ -45,6 +45,10 @@ pub struct CommonOptions {
 
     #[clap(short, long, default_value_t = 0)]
     pub interval_in_ms: u64,
+
+    /// different chunks will be executed concurrently on the same thread
+    #[clap(long, default_value_t = 1)]
+    num_chunks_per_thread: usize,
 }
 
 #[derive(Parser)]
@@ -183,6 +187,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
             // TODO: pass in from config
             divide_tasks: true,
             signer_info,
+            num_chunks_per_thread: common.num_chunks_per_thread,
+            max_repeat: common.repeat,
         },
     };
     load_test.run().await?;

--- a/crates/sui-rpc-loadgen/src/payload/mod.rs
+++ b/crates/sui-rpc-loadgen/src/payload/mod.rs
@@ -23,7 +23,7 @@ use sui_types::base_types::{ObjectID, SuiAddress};
 pub struct SignerInfo {
     pub encoded_keypair: String,
     /// Different thread should use different gas_payment to avoid equivocation
-    pub gas_payment: Option<ObjectID>,
+    pub gas_payment: Option<Vec<ObjectID>>,
     pub gas_budget: Option<u64>,
 }
 


### PR DESCRIPTION
## Description 

Follow-up to https://github.com/MystenLabs/sui/pull/9899. 

## Test Plan 

Tested against CI fullnode and was able to reach ~300TPS.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
