### PR TITLE
[rpc-loadgen][9/n] support ExecutionRequestType::WaitForEffectsCert

### DIFF
--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -1479,6 +1479,9 @@ impl OwnedObjectRef {
     pub fn object_id(&self) -> ObjectID {
         self.reference.object_id
     }
+    pub fn version(&self) -> SequenceNumber {
+        self.reference.version
+    }
 }
 
 #[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/crates/sui-rpc-loadgen/src/payload/pay_sui.rs
+++ b/crates/sui-rpc-loadgen/src/payload/pay_sui.rs
@@ -1,14 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::payload::rpc_command_processor::{sign_and_execute, DEFAULT_GAS_BUDGET};
+use crate::payload::rpc_command_processor::DEFAULT_GAS_BUDGET;
 use crate::payload::{PaySui, ProcessPayload, RpcCommandProcessor, SignerInfo};
 use async_trait::async_trait;
 use futures::future::join_all;
-use sui_json_rpc_types::SuiTransactionResponse;
-use sui_sdk::SuiClient;
-use sui_types::base_types::{ObjectID, SuiAddress};
+use sui_types::base_types::SuiAddress;
 use sui_types::crypto::{EncodeDecodeBase64, SuiKeyPair};
+use sui_types::messages::{ExecuteTransactionRequestType, TransactionData};
 use tracing::debug;
 
 #[async_trait]
@@ -36,30 +35,34 @@ impl<'a> ProcessPayload<'a, &'a PaySui> for RpcCommandProcessor {
             "Transfer Sui {} time to {recipient} with {amount} MIST with {gas_payments:?}",
             gas_payments.len()
         );
+
+        let sender = SuiAddress::from(&keypair.public());
         for client in clients.iter() {
+            let gas_price = client
+                .governance_api()
+                .get_reference_gas_price()
+                .await
+                .expect("Unable to fetch gas price");
             join_all(gas_payments.iter().map(|gas| async {
-                transfer_sui(client, &keypair, *gas, gas_budget, recipient, amount).await;
+                let tx = TransactionData::new_transfer_sui(
+                    recipient,
+                    sender,
+                    Some(amount),
+                    self.get_object_ref(client, gas).await,
+                    gas_budget,
+                    gas_price,
+                );
+                self.sign_and_execute(
+                    client,
+                    &keypair,
+                    tx,
+                    ExecuteTransactionRequestType::WaitForEffectsCert,
+                )
+                .await
             }))
             .await;
         }
 
         Ok(())
     }
-}
-
-async fn transfer_sui(
-    client: &SuiClient,
-    keypair: &SuiKeyPair,
-    gas_payment: ObjectID,
-    gas_budget: u64,
-    recipient: SuiAddress,
-    amount: u64,
-) -> SuiTransactionResponse {
-    let sender = SuiAddress::from(&keypair.public());
-    let tx = client
-        .transaction_builder()
-        .transfer_sui(sender, gas_payment, gas_budget, recipient, Some(amount))
-        .await
-        .expect("Failed to construct transfer coin transaction");
-    sign_and_execute(client, keypair, tx).await
 }


### PR DESCRIPTION
## Description 

Follow up to https://github.com/MystenLabs/sui/pull/9899. Change execution mode to ExecutionRequestType::WaitForEffectsCert to improve TPS by reducing response latency.

## Test Plan 

Tested against CI fullnode and was able to reach ~1200TPS.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
