### PR TITLE
[easy/ rust sdk] Adding comparator on SuiObjectResponse

### DIFF
--- a/crates/sui-json-rpc-types/src/sui_object.rs
+++ b/crates/sui-json-rpc-types/src/sui_object.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::fmt;
 use std::fmt::Write;
@@ -58,6 +59,32 @@ impl SuiObjectResponse {
             data: None,
             error: Some(error),
         }
+    }
+}
+
+impl Ord for SuiObjectResponse {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (&self.data, &other.data) {
+            (Some(data), Some(data_2)) => {
+                if data.object_id.cmp(&data_2.object_id).eq(&Ordering::Greater) {
+                    return Ordering::Greater;
+                } else if data.object_id.cmp(&data_2.object_id).eq(&Ordering::Less) {
+                    return Ordering::Less;
+                }
+                Ordering::Equal
+            }
+            // In this ordering those with data will come before SuiObjectResponses that are errors.
+            (Some(_), None) => Ordering::Less,
+            (None, Some(_)) => Ordering::Greater,
+            // SuiObjectResponses that are errors are just considered equal.
+            _ => Ordering::Equal,
+        }
+    }
+}
+
+impl PartialOrd for SuiObjectResponse {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -1258,7 +1258,7 @@ async fn test_switch_command() -> Result<(), anyhow::Error> {
         .execute(context)
         .await?;
 
-    let cmd_objs = if let SuiClientCommandResult::Objects(v) = os {
+    let mut cmd_objs = if let SuiClientCommandResult::Objects(v) = os {
         v
     } else {
         panic!("Command failed")
@@ -1266,7 +1266,7 @@ async fn test_switch_command() -> Result<(), anyhow::Error> {
 
     // Check that we indeed fetched for addr1
     let client = context.get_client().await?;
-    let actual_objs = client
+    let mut actual_objs = client
         .read_api()
         .get_owned_objects(
             addr1,
@@ -1279,9 +1279,8 @@ async fn test_switch_command() -> Result<(), anyhow::Error> {
         .await
         .unwrap()
         .data;
-    // TODO (jian): impl Ord on SuiObjectResponse
-    // cmd_objs.sort();
-    // actual_objs.sort();
+    cmd_objs.sort();
+    actual_objs.sort();
     assert_eq!(cmd_objs, actual_objs);
 
     // Switch the address

--- a/crates/test-utils/src/messages.rs
+++ b/crates/test-utils/src/messages.rs
@@ -159,8 +159,10 @@ pub async fn make_transactions_with_wallet_context(
                 recipient,
                 *address,
                 Some(2),
-                // TODO (jian)
-                obj.clone().into_object().expect("REASON").object_ref(),
+                obj.clone()
+                    .into_object()
+                    .expect("Gas coin could not be converted to object ref.")
+                    .object_ref(),
                 MAX_GAS,
             );
             let tx = to_sender_signed_transaction(


### PR DESCRIPTION
## Description 

Adding ordering impl on SuiObjectResposne
## Test Plan 

CI
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
