### PR TITLE
[programmable-transactions] No more generic Error parameter

### DIFF
--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -297,7 +297,7 @@ fn execution_loop<
             Ok(Mode::empty_results())
         }
         TransactionKind::ProgrammableTransaction(pt) => {
-            programmable_transactions::execution::execute::<_, _, Mode>(
+            programmable_transactions::execution::execute::<_, Mode>(
                 protocol_config,
                 move_vm,
                 temporary_store,
@@ -471,7 +471,7 @@ fn advance_epoch<S: BackingPackageStore + ParentSync + ChildObjectResolver>(
         epoch_start_timestamp_ms: change_epoch.epoch_start_timestamp_ms,
     };
     let advance_epoch_pt = construct_advance_epoch_pt(&params)?;
-    let result = programmable_transactions::execution::execute::<_, _, execution_mode::System>(
+    let result = programmable_transactions::execution::execute::<_, execution_mode::System>(
         protocol_config,
         move_vm,
         temporary_store,
@@ -490,7 +490,7 @@ fn advance_epoch<S: BackingPackageStore + ParentSync + ChildObjectResolver>(
         );
         temporary_store.drop_writes();
         let advance_epoch_safe_mode_pt = construct_advance_epoch_safe_mode_pt(&params)?;
-        programmable_transactions::execution::execute::<_, _, execution_mode::System>(
+        programmable_transactions::execution::execute::<_, execution_mode::System>(
             protocol_config,
             move_vm,
             temporary_store,
@@ -569,7 +569,7 @@ fn setup_consensus_commit<S: BackingPackageStore + ParentSync + ChildObjectResol
         );
         builder.finish()
     };
-    programmable_transactions::execution::execute::<_, _, execution_mode::System>(
+    programmable_transactions::execution::execute::<_, execution_mode::System>(
         protocol_config,
         move_vm,
         temporary_store,

--- a/crates/sui-adapter/src/execution_mode.rs
+++ b/crates/sui-adapter/src/execution_mode.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use move_core_types::language_storage::TypeTag;
-use std::fmt;
 use sui_types::{error::ExecutionError, messages::Argument};
 
 use crate::programmable_transactions::{
@@ -33,15 +32,15 @@ pub trait ExecutionMode {
 
     fn empty_results() -> Self::ExecutionResults;
 
-    fn add_argument_update<E: fmt::Debug, S: StorageView<E>>(
-        context: &mut ExecutionContext<E, S>,
+    fn add_argument_update<S: StorageView>(
+        context: &mut ExecutionContext<S>,
         acc: &mut Self::ArgumentUpdates,
         arg: Argument,
         _new_value: &Value,
     ) -> Result<(), ExecutionError>;
 
-    fn finish_command<E: fmt::Debug, S: StorageView<E>>(
-        context: &mut ExecutionContext<E, S>,
+    fn finish_command<S: StorageView>(
+        context: &mut ExecutionContext<S>,
         acc: &mut Self::ExecutionResults,
         argument_updates: Self::ArgumentUpdates,
         command_result: &[Value],
@@ -71,8 +70,8 @@ impl ExecutionMode for Normal {
 
     fn empty_results() -> Self::ExecutionResults {}
 
-    fn add_argument_update<E: fmt::Debug, S: StorageView<E>>(
-        _context: &mut ExecutionContext<E, S>,
+    fn add_argument_update<S: StorageView>(
+        _context: &mut ExecutionContext<S>,
         _acc: &mut Self::ArgumentUpdates,
         _arg: Argument,
         _new_value: &Value,
@@ -80,8 +79,8 @@ impl ExecutionMode for Normal {
         Ok(())
     }
 
-    fn finish_command<E: fmt::Debug, S: StorageView<E>>(
-        _context: &mut ExecutionContext<E, S>,
+    fn finish_command<S: StorageView>(
+        _context: &mut ExecutionContext<S>,
         _acc: &mut Self::ExecutionResults,
         _argument_updates: Self::ArgumentUpdates,
         _command_result: &[Value],
@@ -113,8 +112,8 @@ impl ExecutionMode for Genesis {
 
     fn empty_results() -> Self::ExecutionResults {}
 
-    fn add_argument_update<E: fmt::Debug, S: StorageView<E>>(
-        _context: &mut ExecutionContext<E, S>,
+    fn add_argument_update<S: StorageView>(
+        _context: &mut ExecutionContext<S>,
         _acc: &mut Self::ArgumentUpdates,
         _arg: Argument,
         _new_value: &Value,
@@ -122,8 +121,8 @@ impl ExecutionMode for Genesis {
         Ok(())
     }
 
-    fn finish_command<E: fmt::Debug, S: StorageView<E>>(
-        _context: &mut ExecutionContext<E, S>,
+    fn finish_command<S: StorageView>(
+        _context: &mut ExecutionContext<S>,
         _acc: &mut Self::ExecutionResults,
         _argument_updates: Self::ArgumentUpdates,
         _command_result: &[Value],
@@ -158,8 +157,8 @@ impl ExecutionMode for System {
 
     fn empty_results() -> Self::ExecutionResults {}
 
-    fn add_argument_update<E: fmt::Debug, S: StorageView<E>>(
-        _context: &mut ExecutionContext<E, S>,
+    fn add_argument_update<S: StorageView>(
+        _context: &mut ExecutionContext<S>,
         _acc: &mut Self::ArgumentUpdates,
         _arg: Argument,
         _new_value: &Value,
@@ -167,8 +166,8 @@ impl ExecutionMode for System {
         Ok(())
     }
 
-    fn finish_command<E: fmt::Debug, S: StorageView<E>>(
-        _context: &mut ExecutionContext<E, S>,
+    fn finish_command<S: StorageView>(
+        _context: &mut ExecutionContext<S>,
         _acc: &mut Self::ExecutionResults,
         _argument_updates: Self::ArgumentUpdates,
         _command_result: &[Value],
@@ -211,8 +210,8 @@ impl ExecutionMode for DevInspect {
         vec![]
     }
 
-    fn add_argument_update<E: fmt::Debug, S: StorageView<E>>(
-        context: &mut ExecutionContext<E, S>,
+    fn add_argument_update<S: StorageView>(
+        context: &mut ExecutionContext<S>,
         acc: &mut Self::ArgumentUpdates,
         arg: Argument,
         new_value: &Value,
@@ -222,8 +221,8 @@ impl ExecutionMode for DevInspect {
         Ok(())
     }
 
-    fn finish_command<E: fmt::Debug, S: StorageView<E>>(
-        context: &mut ExecutionContext<E, S>,
+    fn finish_command<S: StorageView>(
+        context: &mut ExecutionContext<S>,
         acc: &mut Self::ExecutionResults,
         argument_updates: Self::ArgumentUpdates,
         command_result: &[Value],
@@ -237,8 +236,8 @@ impl ExecutionMode for DevInspect {
     }
 }
 
-fn value_to_bytes_and_tag<E: fmt::Debug, S: StorageView<E>>(
-    context: &mut ExecutionContext<E, S>,
+fn value_to_bytes_and_tag<S: StorageView>(
+    context: &mut ExecutionContext<S>,
     value: &Value,
 ) -> Result<(Vec<u8>, TypeTag), ExecutionError> {
     let (type_tag, bytes) = match value {

--- a/crates/sui-adapter/src/programmable_transactions/context.rs
+++ b/crates/sui-adapter/src/programmable_transactions/context.rs
@@ -1,11 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
-    fmt,
-    marker::PhantomData,
-};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use move_binary_format::{
     errors::{Location, VMError},
@@ -36,7 +32,7 @@ use crate::{
 use super::types::*;
 
 /// Maintains all runtime state specific to programmable transactions
-pub struct ExecutionContext<'vm, 'state, 'a, 'b, E: fmt::Debug, S: StorageView<E>> {
+pub struct ExecutionContext<'vm, 'state, 'a, 'b, S: StorageView> {
     /// The protocol config
     pub protocol_config: &'a ProtocolConfig,
     /// The MoveVM
@@ -68,7 +64,6 @@ pub struct ExecutionContext<'vm, 'state, 'a, 'b, E: fmt::Debug, S: StorageView<E
     /// Map of arguments that are currently borrowed in this command, true if the borrow is mutable
     /// This gets cleared out when new results are pushed, i.e. the end of a command
     borrowed: HashMap<Argument, /* mut */ bool>,
-    _e: PhantomData<E>,
 }
 
 /// A write for an object that was generated outside of the Move ObjectRuntime
@@ -83,11 +78,7 @@ struct AdditionalWrite {
     bytes: Vec<u8>,
 }
 
-impl<'vm, 'state, 'a, 'b, E, S> ExecutionContext<'vm, 'state, 'a, 'b, E, S>
-where
-    E: fmt::Debug,
-    S: StorageView<E>,
-{
+impl<'vm, 'state, 'a, 'b, S: StorageView> ExecutionContext<'vm, 'state, 'a, 'b, S> {
     pub fn new(
         protocol_config: &'a ProtocolConfig,
         vm: &'vm MoveVM,
@@ -183,7 +174,6 @@ where
             new_packages: vec![],
             user_events: vec![],
             borrowed: HashMap::new(),
-            _e: PhantomData,
         })
     }
 
@@ -787,7 +777,7 @@ where
 }
 
 /// Load an input object from the state_view
-fn load_object<E: fmt::Debug, S: StorageView<E>>(
+fn load_object<S: StorageView>(
     vm: &MoveVM,
     state_view: &S,
     session: &Session<S>,
@@ -827,7 +817,7 @@ fn load_object<E: fmt::Debug, S: StorageView<E>>(
 }
 
 /// Load an a CallArg, either an object or a raw set of BCS bytes
-fn load_call_arg<E: fmt::Debug, S: StorageView<E>>(
+fn load_call_arg<S: StorageView>(
     vm: &MoveVM,
     state_view: &S,
     session: &Session<S>,
@@ -843,7 +833,7 @@ fn load_call_arg<E: fmt::Debug, S: StorageView<E>>(
 }
 
 /// Load an ObjectArg from state view, marking if it can be treated as mutable or not
-fn load_object_arg<E: fmt::Debug, S: StorageView<E>>(
+fn load_object_arg<S: StorageView>(
     vm: &MoveVM,
     state_view: &S,
     session: &Session<S>,
@@ -928,7 +918,7 @@ fn refund_max_gas_budget(
 ///
 /// This function assumes proper generation of has_public_transfer, either from the abilities of
 /// the StructTag, or from the runtime correctly propagating from the inputs
-unsafe fn create_written_object<E: fmt::Debug, S: StorageView<E>>(
+unsafe fn create_written_object<S: StorageView>(
     vm: &MoveVM,
     state_view: &S,
     session: &Session<S>,

--- a/crates/sui-adapter/src/programmable_transactions/execution.rs
+++ b/crates/sui-adapter/src/programmable_transactions/execution.rs
@@ -61,7 +61,7 @@ use crate::{
 
 use super::{context::*, types::*};
 
-pub fn execute<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
+pub fn execute<S: StorageView, Mode: ExecutionMode>(
     protocol_config: &ProtocolConfig,
     vm: &MoveVM,
     state_view: &mut S,
@@ -83,7 +83,7 @@ pub fn execute<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
     // execute commands
     let mut mode_results = Mode::empty_results();
     for (idx, command) in commands.into_iter().enumerate() {
-        execute_command::<_, _, Mode>(&mut context, &mut mode_results, command)
+        execute_command::<_, Mode>(&mut context, &mut mode_results, command)
             .map_err(|e| e.with_command_index(idx))?
     }
     // apply changes
@@ -105,8 +105,8 @@ pub fn execute<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
 }
 
 /// Execute a single command
-fn execute_command<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
-    context: &mut ExecutionContext<E, S>,
+fn execute_command<S: StorageView, Mode: ExecutionMode>(
+    context: &mut ExecutionContext<S>,
     mode_results: &mut Mode::ExecutionResults,
     command: Command,
 ) -> Result<(), ExecutionError> {
@@ -162,7 +162,7 @@ fn execute_command<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
             };
             for (idx, arg) in arg_iter {
                 let value: Value = context.by_value_arg(CommandKind::MakeMoveVec, idx, arg)?;
-                check_param_type::<_, _, Mode>(context, idx, &value, &elem_ty)?;
+                check_param_type::<_, Mode>(context, idx, &value, &elem_ty)?;
                 used_in_non_entry_move_call =
                     used_in_non_entry_move_call || value.was_used_in_non_entry_move_call();
                 value.write_bcs_bytes(&mut res);
@@ -271,7 +271,7 @@ fn execute_command<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
                 arguments,
             } = *move_call;
             let module_id = ModuleId::new(package.into(), module);
-            execute_move_call::<_, _, Mode>(
+            execute_move_call::<_, Mode>(
                 context,
                 &mut argument_updates,
                 &module_id,
@@ -282,10 +282,10 @@ fn execute_command<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
             )?
         }
         Command::Publish(modules, dep_ids) => {
-            execute_move_publish::<_, _, Mode>(context, &mut argument_updates, modules, dep_ids)?
+            execute_move_publish::<_, Mode>(context, &mut argument_updates, modules, dep_ids)?
         }
         Command::Upgrade(modules, dep_ids, current_package_id, upgrade_ticket) => {
-            execute_move_upgrade::<_, _, Mode>(
+            execute_move_upgrade::<_, Mode>(
                 context,
                 modules,
                 dep_ids,
@@ -301,8 +301,8 @@ fn execute_command<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
 }
 
 /// Execute a single Move call
-fn execute_move_call<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
-    context: &mut ExecutionContext<E, S>,
+fn execute_move_call<S: StorageView, Mode: ExecutionMode>(
+    context: &mut ExecutionContext<S>,
     argument_updates: &mut Mode::ArgumentUpdates,
     module_id: &ModuleId,
     function: &IdentStr,
@@ -317,7 +317,7 @@ fn execute_move_call<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
         return_value_kinds,
         index,
         last_instr,
-    } = check_visibility_and_signature::<_, _, Mode>(
+    } = check_visibility_and_signature::<_, Mode>(
         context,
         module_id,
         function,
@@ -326,7 +326,7 @@ fn execute_move_call<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
     )?;
     // build the arguments, storing meta data about by-mut-ref args
     let (tx_context_kind, by_mut_ref, serialized_arguments) =
-        build_move_args::<_, _, Mode>(context, module_id, function, kind, &signature, &arguments)?;
+        build_move_args::<_, Mode>(context, module_id, function, kind, &signature, &arguments)?;
     // invoke the VM
     let SerializedReturnValues {
         mutable_reference_outputs,
@@ -372,8 +372,8 @@ fn execute_move_call<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
         .collect()
 }
 
-fn make_value<E: fmt::Debug, S: StorageView<E>>(
-    context: &ExecutionContext<E, S>,
+fn make_value<S: StorageView>(
+    context: &ExecutionContext<S>,
     value_info: ValueKind,
     bytes: Vec<u8>,
     used_in_non_entry_move_call: bool,
@@ -404,8 +404,8 @@ fn make_value<E: fmt::Debug, S: StorageView<E>>(
 
 /// Publish Move modules and call the init functions.  Returns an `UpgradeCap` for the newly
 /// published package on success.
-fn execute_move_publish<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
-    context: &mut ExecutionContext<E, S>,
+fn execute_move_publish<S: StorageView, Mode: ExecutionMode>(
+    context: &mut ExecutionContext<S>,
     argument_updates: &mut Mode::ArgumentUpdates,
     module_bytes: Vec<Vec<u8>>,
     dep_ids: Vec<ObjectID>,
@@ -417,7 +417,7 @@ fn execute_move_publish<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
     context
         .gas_status
         .charge_publish_package(module_bytes.iter().map(|v| v.len()).sum())?;
-    let modules = publish_and_verify_new_modules::<_, _, Mode>(context, &module_bytes)?;
+    let modules = publish_and_verify_new_modules::<_, Mode>(context, &module_bytes)?;
     let modules_to_init = modules
         .iter()
         .filter_map(|module| {
@@ -437,7 +437,7 @@ fn execute_move_publish<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
     // new_package also initializes type origin table in the package object
     let package_id = context.new_package(modules, &dependencies, None)?;
     for module_id in &modules_to_init {
-        let return_values = execute_move_call::<_, _, Mode>(
+        let return_values = execute_move_call::<_, Mode>(
             context,
             argument_updates,
             module_id,
@@ -471,8 +471,8 @@ fn execute_move_publish<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
 }
 
 /// Upgrade a Move package.  Returns an `UpgradeReceipt` for the upgraded package on success.
-fn execute_move_upgrade<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
-    context: &mut ExecutionContext<E, S>,
+fn execute_move_upgrade<S: StorageView, Mode: ExecutionMode>(
+    context: &mut ExecutionContext<S>,
     module_bytes: Vec<Vec<u8>>,
     dep_ids: Vec<ObjectID>,
     current_package_id: ObjectID,
@@ -497,7 +497,7 @@ fn execute_move_upgrade<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
             .session
             .load_type(&TypeTag::Struct(Box::new(UpgradeTicket::type_())))
             .map_err(|e| context.convert_vm_error(e))?;
-        check_param_type::<_, _, Mode>(context, 0, &ticket_val, &ticket_type)?;
+        check_param_type::<_, Mode>(context, 0, &ticket_val, &ticket_type)?;
         ticket_val.write_bcs_bytes(&mut ticket_bytes);
         bcs::from_bytes(&ticket_bytes).map_err(|_| {
             ExecutionError::from_kind(ExecutionErrorKind::CommandArgumentError {
@@ -537,7 +537,7 @@ fn execute_move_upgrade<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
 
     // Run the move + sui verifier on the modules and publish them into the cache.
     // NB: this will substitute in the original package id for the `self` address in all of these modules.
-    let upgraded_package_modules = publish_and_verify_upgraded_modules::<_, _, Mode>(
+    let upgraded_package_modules = publish_and_verify_upgraded_modules::<_, Mode>(
         context,
         &module_bytes,
         current_package.original_package_id(),
@@ -575,8 +575,8 @@ fn execute_move_upgrade<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
     )])
 }
 
-fn check_compatibility<'a, E: fmt::Debug, S: StorageView<E>>(
-    context: &ExecutionContext<E, S>,
+fn check_compatibility<'a, S: StorageView>(
+    context: &ExecutionContext<S>,
     existing_package: &MovePackage,
     upgrading_modules: impl IntoIterator<Item = &'a CompiledModule>,
     policy: u8,
@@ -637,8 +637,8 @@ fn check_compatibility<'a, E: fmt::Debug, S: StorageView<E>>(
     Ok(())
 }
 
-fn fetch_package<'a, E: fmt::Debug, S: StorageView<E>>(
-    context: &'a ExecutionContext<E, S>,
+fn fetch_package<'a, S: StorageView>(
+    context: &'a ExecutionContext<S>,
     package_id: &ObjectID,
 ) -> Result<MovePackage, ExecutionError> {
     let mut fetched_packages = fetch_packages(context, vec![package_id])?;
@@ -654,8 +654,8 @@ fn fetch_package<'a, E: fmt::Debug, S: StorageView<E>>(
     }
 }
 
-fn fetch_packages<'a, E: fmt::Debug, S: StorageView<E>>(
-    context: &'a ExecutionContext<E, S>,
+fn fetch_packages<'a, S: StorageView>(
+    context: &'a ExecutionContext<S>,
     package_ids: impl IntoIterator<Item = &'a ObjectID>,
 ) -> Result<Vec<MovePackage>, ExecutionError> {
     let package_ids: BTreeSet<_> = package_ids.into_iter().collect();
@@ -686,8 +686,8 @@ fn fetch_packages<'a, E: fmt::Debug, S: StorageView<E>>(
  * Move execution
  **************************************************************************************************/
 
-fn vm_move_call<E: fmt::Debug, S: StorageView<E>>(
-    context: &mut ExecutionContext<E, S>,
+fn vm_move_call<S: StorageView>(
+    context: &mut ExecutionContext<S>,
     module_id: &ModuleId,
     function: &IdentStr,
     type_arguments: Vec<TypeTag>,
@@ -727,8 +727,8 @@ fn vm_move_call<E: fmt::Debug, S: StorageView<E>>(
     Ok(result)
 }
 
-fn deserialize_modules<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
-    context: &mut ExecutionContext<E, S>,
+fn deserialize_modules<S: StorageView, Mode: ExecutionMode>(
+    context: &mut ExecutionContext<S>,
     module_bytes: &[Vec<u8>],
 ) -> Result<Vec<CompiledModule>, ExecutionError> {
     let modules = module_bytes
@@ -753,11 +753,11 @@ fn deserialize_modules<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
 /// - Deserializes the modules
 /// - Publishes them into the VM, which invokes the Move verifier
 /// - Run the Sui Verifier
-fn publish_and_verify_new_modules<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
-    context: &mut ExecutionContext<E, S>,
+fn publish_and_verify_new_modules<S: StorageView, Mode: ExecutionMode>(
+    context: &mut ExecutionContext<S>,
     module_bytes: &[Vec<u8>],
 ) -> Result<Vec<CompiledModule>, ExecutionError> {
-    let mut modules = deserialize_modules::<_, _, Mode>(context, module_bytes)?;
+    let mut modules = deserialize_modules::<_, Mode>(context, module_bytes)?;
 
     // It should be fine that this does not go through ExecutionContext::fresh_id since the Move
     // runtime does not to know about new packages created, since Move objects and Move packages
@@ -771,18 +771,18 @@ fn publish_and_verify_new_modules<E: fmt::Debug, S: StorageView<E>, Mode: Execut
     publish_and_verify_modules(context, package_id, modules)
 }
 
-fn publish_and_verify_upgraded_modules<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
-    context: &mut ExecutionContext<E, S>,
+fn publish_and_verify_upgraded_modules<S: StorageView, Mode: ExecutionMode>(
+    context: &mut ExecutionContext<S>,
     module_bytes: &[Vec<u8>],
     package_id: ObjectID,
 ) -> Result<Vec<CompiledModule>, ExecutionError> {
-    let mut modules = deserialize_modules::<_, _, Mode>(context, module_bytes)?;
+    let mut modules = deserialize_modules::<_, Mode>(context, module_bytes)?;
     substitute_package_id(&mut modules, package_id)?;
     publish_and_verify_modules(context, package_id, modules)
 }
 
-fn publish_and_verify_modules<E: fmt::Debug, S: StorageView<E>>(
-    context: &mut ExecutionContext<E, S>,
+fn publish_and_verify_modules<S: StorageView>(
+    context: &mut ExecutionContext<S>,
     package_id: ObjectID,
     modules: Vec<CompiledModule>,
 ) -> Result<Vec<CompiledModule>, ExecutionError> {
@@ -855,8 +855,8 @@ struct LoadedFunctionInfo {
 /// - an entry function
 /// - a public function that does not return references
 /// - module init (only internal usage)
-fn check_visibility_and_signature<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
-    context: &mut ExecutionContext<E, S>,
+fn check_visibility_and_signature<S: StorageView, Mode: ExecutionMode>(
+    context: &mut ExecutionContext<S>,
     module_id: &ModuleId,
     function: &IdentStr,
     type_arguments: &[TypeTag],
@@ -938,7 +938,7 @@ fn check_visibility_and_signature<E: fmt::Debug, S: StorageView<E>, Mode: Execut
             vec![]
         }
         FunctionKind::PrivateEntry | FunctionKind::PublicEntry | FunctionKind::NonEntry => {
-            check_non_entry_signature::<_, _, Mode>(context, module_id, function, &signature)?
+            check_non_entry_signature::<_, Mode>(context, module_id, function, &signature)?
         }
     };
     check_private_generics(context, module_id, function, &signature.type_arguments)?;
@@ -979,8 +979,8 @@ fn subst_signature(
 
 /// Checks that the non-entry function does not return references. And marks the return values
 /// as object or non-object return values
-fn check_non_entry_signature<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
-    context: &mut ExecutionContext<E, S>,
+fn check_non_entry_signature<S: StorageView, Mode: ExecutionMode>(
+    context: &mut ExecutionContext<S>,
     _module_id: &ModuleId,
     _function: &IdentStr,
     signature: &LoadedFunctionInstantiation,
@@ -1041,8 +1041,8 @@ fn check_non_entry_signature<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMo
         .collect()
 }
 
-fn check_private_generics<E: fmt::Debug, S: StorageView<E>>(
-    _context: &mut ExecutionContext<E, S>,
+fn check_private_generics<S: StorageView>(
+    _context: &mut ExecutionContext<S>,
     module_id: &ModuleId,
     function: &IdentStr,
     _type_arguments: &[Type],
@@ -1082,8 +1082,8 @@ type ArgInfo = (
 
 /// Serializes the arguments into BCS values for Move. Performs the necessary type checking for
 /// each value
-fn build_move_args<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
-    context: &mut ExecutionContext<E, S>,
+fn build_move_args<S: StorageView, Mode: ExecutionMode>(
+    context: &mut ExecutionContext<S>,
     module_id: &ModuleId,
     function: &IdentStr,
     function_kind: FunctionKind,
@@ -1179,7 +1179,7 @@ fn build_move_args<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
                 idx,
             ));
         }
-        check_param_type::<_, _, Mode>(context, idx, &value, non_ref_param_ty)?;
+        check_param_type::<_, Mode>(context, idx, &value, non_ref_param_ty)?;
         let bytes = {
             let mut v = vec![];
             value.write_bcs_bytes(&mut v);
@@ -1191,8 +1191,8 @@ fn build_move_args<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
 }
 
 /// checks that the value is compatible with the specified type
-fn check_param_type<E: fmt::Debug, S: StorageView<E>, Mode: ExecutionMode>(
-    context: &mut ExecutionContext<E, S>,
+fn check_param_type<S: StorageView, Mode: ExecutionMode>(
+    context: &mut ExecutionContext<S>,
     idx: usize,
     value: &Value,
     param_ty: &Type,
@@ -1254,8 +1254,8 @@ fn get_struct_ident(s: &StructType) -> (&AccountAddress, &IdentStr, &IdentStr) {
 // Returns Some(kind) if the type is a reference to the TxnContext. kind being Mutable with
 // a MutableReference, and Immutable otherwise.
 // Returns None for all other types
-pub fn is_tx_context<E: fmt::Debug, S: StorageView<E>>(
-    context: &mut ExecutionContext<E, S>,
+pub fn is_tx_context<S: StorageView>(
+    context: &mut ExecutionContext<S>,
     t: &Type,
 ) -> Result<TxContextKind, ExecutionError> {
     let (is_mut, inner) = match t {
@@ -1283,8 +1283,8 @@ pub fn is_tx_context<E: fmt::Debug, S: StorageView<E>>(
 }
 
 /// Returns Some(layout) iff it is a primitive, an ID, a String, or an option/vector of a valid type
-fn primitive_serialization_layout<E: fmt::Debug, S: StorageView<E>>(
-    context: &mut ExecutionContext<E, S>,
+fn primitive_serialization_layout<S: StorageView>(
+    context: &mut ExecutionContext<S>,
     param_ty: &Type,
 ) -> Result<Option<PrimitiveArgumentLayout>, ExecutionError> {
     Ok(match param_ty {

--- a/crates/sui-adapter/src/programmable_transactions/types.rs
+++ b/crates/sui-adapter/src/programmable_transactions/types.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeMap, fmt};
+use std::collections::BTreeMap;
 
 use move_binary_format::file_format::AbilitySet;
 use move_core_types::{
@@ -15,33 +15,33 @@ use serde::Deserialize;
 use sui_types::{
     base_types::{MoveObjectType, ObjectID, SequenceNumber, SuiAddress},
     coin::Coin,
-    error::{convert_vm_error, ExecutionError, ExecutionErrorKind},
+    error::{convert_vm_error, ExecutionError, ExecutionErrorKind, SuiError},
     messages::CommandArgumentError,
     object::{Data, MoveObject, Object, Owner},
     storage::{BackingPackageStore, ChildObjectResolver, ObjectChange, ParentSync, Storage},
     TypeTag,
 };
 
-pub trait StorageView<E: std::fmt::Debug>:
-    ResourceResolver<Error = E>
-    + ModuleResolver<Error = E>
-    + LinkageResolver<Error = E>
+pub trait StorageView:
+    ResourceResolver<Error = SuiError>
+    + ModuleResolver<Error = SuiError>
+    + LinkageResolver<Error = SuiError>
     + BackingPackageStore
     + Storage
     + ParentSync
     + ChildObjectResolver
 {
 }
+
 impl<
-        E: std::fmt::Debug,
-        T: ResourceResolver<Error = E>
-            + ModuleResolver<Error = E>
-            + LinkageResolver<Error = E>
+        T: ResourceResolver<Error = SuiError>
+            + ModuleResolver<Error = SuiError>
+            + LinkageResolver<Error = SuiError>
             + BackingPackageStore
             + Storage
             + ParentSync
             + ChildObjectResolver,
-    > StorageView<E> for T
+    > StorageView for T
 {
 }
 
@@ -188,7 +188,7 @@ impl Value {
 }
 
 impl ObjectValue {
-    pub fn new<E: fmt::Debug, S: StorageView<E>>(
+    pub fn new<S: StorageView>(
         vm: &MoveVM,
         state_view: &S,
         session: &Session<S>,
@@ -217,7 +217,7 @@ impl ObjectValue {
         })
     }
 
-    pub fn from_object<E: fmt::Debug, S: StorageView<E>>(
+    pub fn from_object<S: StorageView>(
         vm: &MoveVM,
         state_view: &S,
         session: &Session<S>,
@@ -230,7 +230,7 @@ impl ObjectValue {
         }
     }
 
-    pub fn from_move_object<E: fmt::Debug, S: StorageView<E>>(
+    pub fn from_move_object<S: StorageView>(
         vm: &MoveVM,
         state_view: &S,
         session: &Session<S>,

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -1546,7 +1546,7 @@ fn process_package(
         builder.command(Command::Publish(module_bytes, dependencies));
         builder.finish()
     };
-    programmable_transactions::execution::execute::<_, _, execution_mode::Genesis>(
+    programmable_transactions::execution::execute::<_, execution_mode::Genesis>(
         protocol_config,
         vm,
         &mut temporary_store,
@@ -1635,7 +1635,7 @@ pub fn generate_genesis_system_object(
         );
         builder.finish()
     };
-    programmable_transactions::execution::execute::<_, _, execution_mode::Genesis>(
+    programmable_transactions::execution::execute::<_, execution_mode::Genesis>(
         &protocol_config,
         move_vm,
         &mut temporary_store,


### PR DESCRIPTION
## Description

`StorageView` (and by extension `ExecutionContext`) had an error parameter, but it was always supplied with `SuiError`, and introduces a bunch of line noise passing the generic parameter around.

Avoid that, by just requiring that implementations of `StorageView` communicate errors through `SuiError`.  Main motivation was to avoid propagating this parameter further when introducing the wrapping type that implements `LinkageResolver`.

## Test Plan:

```
$ cargo simtest
$ env SUI_SKIP_SIMTESTS=1 cargo nextest run
```