### PR TITLE
Updated wallet docs to remove nft create

### DIFF
--- a/doc/src/build/sui-local-network.md
+++ b/doc/src/build/sui-local-network.md
@@ -269,7 +269,9 @@ For more details about Sui Explorer, see the [Explorer README](https://github.co
 
 You can also use a local Sui Wallet to test with your local network. You can then see transactions executed from your local Sui Wallet on your local Sui Explorer.
 
-**Note:** To run the command you have `pnpm` installed. See [Install Sui Wallet and Sui Explorer locally](#install-sui-wallet-and-sui-explorer-locally) for details.
+**Note:** To run the command you must have `pnpm` installed. See [Install Sui Wallet and Sui Explorer locally](#install-sui-wallet-and-sui-explorer-locally) for details.
+
+Before you start the Sui Wallet app, update the environment it points to by default to be your local network. To do so, first make a copy of `sui/apps/wallet/configs/environment/.env.defaults` and rename it to `.env` in the same directory. In your `.env` file, edit the first line to read `API_ENV=local`.
 
 Run the following command from the `sui` root folder to start Sui Wallet on your local network:
 
@@ -277,15 +279,21 @@ Run the following command from the `sui` root folder to start Sui Wallet on your
 pnpm wallet start
 ```
 
-Follow [this guide](https://github.com/MystenLabs/sui/blob/main/apps/wallet/README.md#install-the-extension-to-chrome) to load your locally built wallet to chrome
+### Add local Sui Wallet to Chrome
 
-**Note** You can set the default environment for the wallet to use so that you don't have to switch network manually. For details, see [https://github.com/MystenLabs/sui/tree/main/apps/wallet#environment-variables](https://github.com/MystenLabs/sui/tree/main/apps/wallet#environment-variables). 
+After you build your local version of Sui Wallet, you can add the extension to Chrome. 
+
+1. Open a Chrome browser to `chrome://extensions`.
+1. Click the **Developer mode** toggle to enable, if needed.
+1. Click the **Load unpacked** button and select your `sui/apps/wallet/dist` directory.
+
+Consult the Sui Wallet [Readme](https://github.com/MystenLabs/sui/blob/main/apps/wallet/README.md#install-the-extension-to-chrome) for more information on working with a locally built wallet on Chrome.
 
 ## Generate example data
 
 Use the TypeScript SDK to add example data to your network. 
 
-**Note:** To run the command you must complete the `Pre-requisites for Building Apps locally` section first
+**Note:** To run the command you must complete the `Pre-requisites for Building Apps locally` section first.
 
 Run the following command from the `sui` root folder: 
 

--- a/doc/src/build/sui-local-network.md
+++ b/doc/src/build/sui-local-network.md
@@ -271,7 +271,7 @@ You can also use a local Sui Wallet to test with your local network. You can the
 
 **Note:** To run the command you must have `pnpm` installed. See [Install Sui Wallet and Sui Explorer locally](#install-sui-wallet-and-sui-explorer-locally) for details.
 
-Before you start the Sui Wallet app, update the environment it points to by default to be your local network. To do so, first make a copy of `sui/apps/wallet/configs/environment/.env.defaults` and rename it to `.env` in the same directory. In your `.env` file, edit the first line to read `API_ENV=local`.
+Before you start the Sui Wallet app, update its default environment to point to your local network. To do so, first make a copy of `sui/apps/wallet/configs/environment/.env.defaults` and rename it to `.env` in the same directory. In your `.env` file, edit the first line to read `API_ENV=local` and then save the file.
 
 Run the following command from the `sui` root folder to start Sui Wallet on your local network:
 
@@ -281,10 +281,10 @@ pnpm wallet start
 
 ### Add local Sui Wallet to Chrome
 
-After you build your local version of Sui Wallet, you can add the extension to Chrome. 
+After you build your local version of Sui Wallet, you can add the extension to Chrome: 
 
 1. Open a Chrome browser to `chrome://extensions`.
-1. Click the **Developer mode** toggle to enable, if needed.
+1. Click the **Developer mode** toggle to enable, if it's not already on.
 1. Click the **Load unpacked** button and select your `sui/apps/wallet/dist` directory.
 
 Consult the Sui Wallet [Readme](https://github.com/MystenLabs/sui/blob/main/apps/wallet/README.md#install-the-extension-to-chrome) for more information on working with a locally built wallet on Chrome.

--- a/doc/src/explore/wallet-browser.md
+++ b/doc/src/explore/wallet-browser.md
@@ -202,29 +202,6 @@ To view all of the transactions for your address, click **Apps** and then click 
 
 Sui Explorer opens with the details for your wallet address displayed.
 
-## Mint an example NFT
-
-You can mint an example Sui NFT directly from Sui Wallet.
-
-Click **Apps**, then click **Mint an NFT**. In the current version, you can mint only example NFTs.
-
-## Create a new NFT
-
-The [Sui Wallet demo](https://sui-wallet-demo.sui.io/) site lets you create a new NFT on the Sui network using your own image file. To access the site directly from Sui Wallet, click the **Apps** tab, and then click **Sui NFT Mint**. You must have an active wallet to mint NFTs.
-
-To mint a new NFT using the demo site
-1. Open the [Sui Wallet demo](https://sui-wallet-demo.sui.io/) site.
-1. Click **Connect**.
-1. In your Sui Wallet, click **Connect** to connect your wallet with the demo site.
-   You may need to enter your wallet password.
-1. Enter a **Name** and **Description** for your NFT, and then enter Image URL to the image to use.
-1. Click **Create**.
-1. Click **Approve** in your wallet to allow the site to add the NFT to your wallet and withdraw gas fees from your SUI balance.
-
-After you successfully create a new NFT, you can transfer it to another wallet address. Enter the address to send it to in the **Recipient** field, then click **Transfer**. Click **Approve** in your wallet to allow the transfer.
-
-You can view details for the transactions to create the NFT and then transfer it in [Sui Explorer](https://explorer.sui.io/).
-
 ## View your NFTs
 
 Click the **NFTs** tab to view all of the NFTS that you mint, purchase, or receive in your wallet. This includes any NFTs that you obtain from connected apps.  Click on an NFT to view additional details about it, view a larger NFT image, or send the NFT to another address.


### PR DESCRIPTION
## Description 

Wallet does not create nfts any longer.

## Test Plan 

Locally

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
