### PR TITLE
[upgrades] adapter sets link context and table

### DIFF
--- a/.config/hakari.toml
+++ b/.config/hakari.toml
@@ -31,9 +31,9 @@ workspace-members = [ "sui-move" ]
 third-party = [
     ## Exclude the 'move-unit-test' crate in order to ensure that the 'testing'
     # feature isn't enabled in the workspace-hack
-    { name = "move-unit-test", git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" },
-    { name = "move-cli", git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" },
-    { name = "move-transactional-test-runner", git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" },
+    { name = "move-unit-test", git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" },
+    { name = "move-cli", git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" },
+    { name = "move-transactional-test-runner", git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" },
     { name = "object_store" },
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1377,7 +1377,7 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -4631,7 +4631,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4648,7 +4648,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -4661,12 +4661,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4681,7 +4681,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4693,7 +4693,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "anyhow",
  "fail 0.4.0",
@@ -4706,7 +4706,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -4723,7 +4723,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4769,7 +4769,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "anyhow",
  "difference",
@@ -4786,7 +4786,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4815,7 +4815,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4834,7 +4834,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4854,7 +4854,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -4872,7 +4872,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "anyhow",
  "codespan",
@@ -4890,7 +4890,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4904,7 +4904,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4923,7 +4923,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -4942,7 +4942,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "anyhow",
  "hex",
@@ -4955,7 +4955,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "anyhow",
  "hex",
@@ -4969,7 +4969,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "anyhow",
  "codespan",
@@ -4995,7 +4995,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5031,7 +5031,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5068,7 +5068,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5096,7 +5096,7 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5107,7 +5107,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5122,7 +5122,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -5149,7 +5149,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
@@ -5167,7 +5167,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "anyhow",
  "hex",
@@ -5190,7 +5190,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "once_cell",
  "serde 1.0.152",
@@ -5199,7 +5199,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5216,7 +5216,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -5248,7 +5248,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "anyhow",
  "better_any",
@@ -5279,7 +5279,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "better_any",
  "fail 0.4.0",
@@ -5297,7 +5297,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5310,7 +5310,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -7360,7 +7360,7 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7375,7 +7375,7 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46#dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -8800,6 +8800,7 @@ dependencies = [
  "move-bytecode-utils",
  "move-core-types",
  "move-package",
+ "move-symbol-pool",
  "move-vm-runtime",
  "mysten-common",
  "mysten-metrics",
@@ -9722,6 +9723,7 @@ dependencies = [
  "move-compiler",
  "move-core-types",
  "move-stdlib",
+ "move-symbol-pool",
  "move-transactional-test-runner",
  "move-vm-runtime",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,26 +116,26 @@ opt-level = 1
 tokio = "1.24.1"
 
 # Move dependencies
-move-binary-format = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-cli = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-compiler = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", features = ["address32"] }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-package = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-prover = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-cli = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-compiler = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", features = ["address32"] }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-package = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-prover = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
 
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "c2f79b1807bff7d09517b631191b61f2614c641c" }
 fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "c2f79b1807bff7d09517b631191b61f2614c641c", package = "fastcrypto-zkp" }

--- a/crates/sui-adapter-transactional-tests/tests/sui/move_call_incorrect_function.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/move_call_incorrect_function.exp
@@ -6,7 +6,7 @@ mutated: object(103)
 
 task 2 'run'. lines 16-18:
 Error: Transaction Effects Status: Move Bytecode Verification Error. Please run the Bytecode Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VMVerificationOrDeserializationError, source: Some(VMError { major_status: LINKER_ERROR, sub_status: None, message: Some("Cannot find ModuleId { address: _, name: Identifier(\"M\") } in data cache"), exec_state: None, location: Undefined, indices: [], offsets: [] }), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VMVerificationOrDeserializationError, source: Some(VMError { major_status: LINKER_ERROR, sub_status: None, message: Some("Cannot find link context _ in store"), exec_state: None, location: Undefined, indices: [], offsets: [] }), command: Some(0) } }
 
 task 3 'run'. lines 19-19:
 Error: Transaction Effects Status: Function Not Found.

--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -563,7 +563,7 @@ fn advance_epoch<S: BackingPackageStore + ParentSync + ChildObjectResolver>(
             .collect();
 
         let mut new_package =
-            Object::new_system_package(modules, version, dependencies, tx_ctx.digest());
+            Object::new_system_package(&modules, version, dependencies, tx_ctx.digest());
 
         info!(
             "upgraded system package {:?}",

--- a/crates/sui-adapter/src/lib.rs
+++ b/crates/sui-adapter/src/lib.rs
@@ -6,7 +6,7 @@ macro_rules! invariant_violation {
         if cfg!(debug_assertions) {
             panic!("{}", $msg)
         }
-        return Err(sui_types::error::ExecutionError::invariant_violation($msg));
+        return Err(sui_types::error::ExecutionError::invariant_violation($msg).into());
     }};
 }
 

--- a/crates/sui-adapter/src/programmable_transactions/context.rs
+++ b/crates/sui-adapter/src/programmable_transactions/context.rs
@@ -11,7 +11,6 @@ use move_binary_format::{
 use move_core_types::{
     account_address::AccountAddress,
     language_storage::{ModuleId, StructTag, TypeTag},
-    resolver::LinkageResolver,
 };
 use move_vm_runtime::{move_vm::MoveVM, session::Session};
 use move_vm_types::loaded_data::runtime_types::Type;
@@ -216,7 +215,7 @@ impl<'vm, 'state, 'a, 'b, S: StorageView> ExecutionContext<'vm, 'state, 'a, 'b, 
         package_id: ObjectID,
     ) -> Result<AccountAddress, ExecutionError> {
         let resolver = self.session.get_resolver();
-        if resolver.link_context() == *package_id {
+        if resolver.has_linkage(package_id) {
             // Setting same context again, can skip.
             return Ok(resolver.original_package_id());
         }

--- a/crates/sui-adapter/src/programmable_transactions/context.rs
+++ b/crates/sui-adapter/src/programmable_transactions/context.rs
@@ -4,10 +4,15 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use move_binary_format::{
-    errors::{Location, VMError},
+    errors::{Location, VMError, VMResult},
     file_format::{CodeOffset, FunctionDefinitionIndex, TypeParameterIndex},
+    CompiledModule,
 };
-use move_core_types::language_storage::{ModuleId, StructTag, TypeTag};
+use move_core_types::{
+    account_address::AccountAddress,
+    language_storage::{ModuleId, StructTag, TypeTag},
+    resolver::LinkageResolver,
+};
 use move_vm_runtime::{move_vm::MoveVM, session::Session};
 use move_vm_types::loaded_data::runtime_types::Type;
 use sui_framework::natives::object_runtime::{max_event_error, ObjectRuntime, RuntimeResults};
@@ -20,15 +25,16 @@ use sui_types::{
     gas::{SuiGasStatus, SuiGasStatusAPI},
     messages::{Argument, CallArg, CommandArgumentError, ObjectArg},
     move_package::MovePackage,
-    object::{MoveObject, Object, Owner, OBJECT_START_VERSION},
+    object::{MoveObject, Object, Owner},
     storage::{ObjectChange, WriteKind},
 };
 
 use crate::{
-    adapter::{missing_unwrapped_msg, new_session},
+    adapter::{missing_unwrapped_msg, new_native_extensions},
     execution_mode::ExecutionMode,
 };
 
+use super::linkage_view::{LinkageInfo, LinkageView, SavedLinkage};
 use super::types::*;
 
 sui_macros::checked_arithmetic! {
@@ -47,7 +53,7 @@ pub struct ExecutionContext<'vm, 'state, 'a, 'b, S: StorageView> {
     /// The gas status used for metering
     pub gas_status: &'a mut SuiGasStatus<'b>,
     /// The session used for interacting with Move types and calls
-    pub session: Session<'state, 'vm, S>,
+    pub session: Session<'state, 'vm, LinkageView<'state, S>>,
     /// Additional transfers not from the Move runtime
     additional_transfers: Vec<(/* new owner */ SuiAddress, ObjectValue)>,
     /// Newly published packages
@@ -90,11 +96,17 @@ impl<'vm, 'state, 'a, 'b, S: StorageView> ExecutionContext<'vm, 'state, 'a, 'b, 
         gas_coin_opt: Option<ObjectID>,
         inputs: Vec<CallArg>,
     ) -> Result<Self, ExecutionError> {
+        let init_linkage = if protocol_config.package_upgrades_supported() {
+            LinkageInfo::Unset
+        } else {
+            LinkageInfo::Universal
+        };
+
         // we need a new session just for loading types, which is sad
         // TODO remove this
-        let tmp_session = new_session(
+        let mut tmp_session = new_session(
             vm,
-            state_view,
+            LinkageView::new(state_view, init_linkage),
             BTreeMap::new(),
             !gas_status.is_unmetered(),
             protocol_config,
@@ -106,7 +118,7 @@ impl<'vm, 'state, 'a, 'b, S: StorageView> ExecutionContext<'vm, 'state, 'a, 'b, 
                 load_call_arg(
                     vm,
                     state_view,
-                    &tmp_session,
+                    &mut tmp_session,
                     &mut object_owner_map,
                     call_arg,
                 )
@@ -116,7 +128,7 @@ impl<'vm, 'state, 'a, 'b, S: StorageView> ExecutionContext<'vm, 'state, 'a, 'b, 
             let mut gas = load_object(
                 vm,
                 state_view,
-                &tmp_session,
+                &mut tmp_session,
                 &mut object_owner_map,
                 /* imm override */ false,
                 gas_coin,
@@ -149,15 +161,15 @@ impl<'vm, 'state, 'a, 'b, S: StorageView> ExecutionContext<'vm, 'state, 'a, 'b, 
         };
         // the session was just used for ability and layout metadata fetching, no changes should
         // exist. Plus, Sui Move does not use these changes or events
-        let (change_set, move_events) = tmp_session
-            .finish()
-            .map_err(|e| sui_types::error::convert_vm_error(e, vm, state_view))?;
+        let (res, linkage) = tmp_session.finish();
+        let (change_set, move_events) =
+            res.map_err(|e| sui_types::error::convert_vm_error(e, vm, &linkage))?;
         assert_invariant!(change_set.accounts().is_empty(), "Change set must be empty");
         assert_invariant!(move_events.is_empty(), "Events must be empty");
         // make the real session
         let session = new_session(
             vm,
-            state_view,
+            linkage,
             object_owner_map,
             !gas_status.is_unmetered(),
             protocol_config,
@@ -197,6 +209,51 @@ impl<'vm, 'state, 'a, 'b, S: StorageView> ExecutionContext<'vm, 'state, 'a, 'b, 
             .map_err(|e| self.convert_vm_error(e.finish(Location::Undefined)))
     }
 
+    /// Set the link context for the session from the linkage information in the MovePackage found
+    /// at `package_id`.  Returns the runtime ID of the link context package on success.
+    pub fn set_link_context(
+        &mut self,
+        package_id: ObjectID,
+    ) -> Result<AccountAddress, ExecutionError> {
+        let resolver = self.session.get_resolver();
+        if resolver.link_context() == *package_id {
+            // Setting same context again, can skip.
+            return Ok(resolver.original_package_id());
+        }
+
+        let package =
+            package_for_linkage(&self.session, package_id).map_err(|e| self.convert_vm_error(e))?;
+
+        set_linkage(&mut self.session, &package)
+    }
+
+    /// Set the link context for the session from the linkage information in the `package`.  Returns
+    /// the runtime ID of the link context package on success.
+    pub fn set_linkage(&mut self, package: &MovePackage) -> Result<AccountAddress, ExecutionError> {
+        set_linkage(&mut self.session, package)
+    }
+
+    /// Turn off linkage information, so that the next use of the session will need to set linkage
+    /// information to succeed.
+    pub fn reset_linkage(&mut self) {
+        reset_linkage(&mut self.session);
+    }
+
+    /// Reset the linkage context, and save it (if one exists)
+    pub fn steal_linkage(&mut self) -> Option<SavedLinkage> {
+        steal_linkage(&mut self.session)
+    }
+
+    /// Restore a previously stolen/saved link context.
+    pub fn restore_linkage(&mut self, saved: Option<SavedLinkage>) -> Result<(), ExecutionError> {
+        restore_linkage(&mut self.session, saved)
+    }
+
+    /// Load a type using the context's current session.
+    pub fn load_type(&mut self, type_tag: &TypeTag) -> VMResult<Type> {
+        load_type(&mut self.session, type_tag)
+    }
+
     /// Takes the user events from the runtime and tags them with the Move module of the function
     /// that was invoked for the command
     pub fn take_user_events(
@@ -217,10 +274,8 @@ impl<'vm, 'state, 'a, 'b, S: StorageView> ExecutionContext<'vm, 'state, 'a, 'b, 
         }
         let new_events = events
             .into_iter()
-            .map(|(tag, value)| {
-                let layout = self
-                    .session
-                    .get_type_layout(&TypeTag::Struct(Box::new(tag.clone())))?;
+            .map(|(ty, tag, value)| {
+                let layout = self.session.type_to_type_layout(&ty)?;
                 let bytes = value.simple_serialize(&layout).unwrap();
                 Ok((module_id.clone(), tag, bytes))
             })
@@ -393,43 +448,41 @@ impl<'vm, 'state, 'a, 'b, S: StorageView> ExecutionContext<'vm, 'state, 'a, 'b, 
 
     /// Create a new package
     pub fn new_package<'p>(
-        &mut self,
-        modules: Vec<move_binary_format::CompiledModule>,
+        &self,
+        modules: &[CompiledModule],
         dependencies: impl IntoIterator<Item = &'p MovePackage>,
-        version: Option<SequenceNumber>,
-    ) -> Result<ObjectID, ExecutionError> {
-        // wrap the modules in an object, write it to the store
-        let object = Object::new_package(
+    ) -> Result<Object, ExecutionError> {
+        Object::new_package(
             modules,
-            version.unwrap_or(OBJECT_START_VERSION),
             self.tx_context.digest(),
             self.protocol_config.max_move_package_size(),
             dependencies,
-        )?;
-        let object_id = object.id();
-        self.new_packages.push(object);
-        Ok(object_id)
+        )
     }
 
     /// Create a package upgrade from `previous_package` with `new_modules` and `dependencies`
     pub fn upgrade_package<'p>(
-        &mut self,
+        &self,
+        storage_id: ObjectID,
         previous_package: &MovePackage,
-        new_modules: Vec<move_binary_format::CompiledModule>,
+        new_modules: &[CompiledModule],
         dependencies: impl IntoIterator<Item = &'p MovePackage>,
-    ) -> Result<ObjectID, ExecutionError> {
-        let new_package_object_id = self.tx_context.fresh_id();
-        let object = Object::new_upgraded_package(
+    ) -> Result<Object, ExecutionError> {
+        Object::new_upgraded_package(
             previous_package,
-            new_package_object_id,
+            storage_id,
             new_modules,
             self.tx_context.digest(),
             self.protocol_config.max_move_package_size(),
             dependencies,
-        )?;
-        let object_id = object.id();
-        self.new_packages.push(object);
-        Ok(object_id)
+        )
+    }
+
+    /// Add a newly created package to write as an effect of the transaction
+    pub fn write_package(&mut self, package: Object) -> Result<(), ExecutionError> {
+        assert_invariant!(package.is_package(), "Must be a package");
+        self.new_packages.push(package);
+        Ok(())
     }
 
     /// Finish a command: clearing the borrows and adding the results to the result vector
@@ -552,9 +605,9 @@ impl<'vm, 'state, 'a, 'b, S: StorageView> ExecutionContext<'vm, 'state, 'a, 'b, 
             refund_max_gas_budget(&mut additional_writes, gas_status, gas_id)?;
         }
 
-        let (change_set, events, mut native_context_extensions) = session
-            .finish_with_extensions()
-            .map_err(|e| convert_vm_error(e, vm, state_view))?;
+        let (res, linkage) = session.finish_with_extensions();
+        let (change_set, events, mut native_context_extensions) =
+            res.map_err(|e| convert_vm_error(e, vm, &linkage))?;
         // Sui Move programs should never touch global state, so resources should be empty
         assert_invariant!(
             change_set.resources().next().is_none(),
@@ -586,7 +639,7 @@ impl<'vm, 'state, 'a, 'b, S: StorageView> ExecutionContext<'vm, 'state, 'a, 'b, 
         // TODO remove this
         let tmp_session = new_session(
             vm,
-            state_view,
+            linkage,
             BTreeMap::new(),
             !gas_status.is_unmetered(),
             protocol_config,
@@ -615,7 +668,6 @@ impl<'vm, 'state, 'a, 'b, S: StorageView> ExecutionContext<'vm, 'state, 'a, 'b, 
             let move_object = unsafe {
                 create_written_object(
                     vm,
-                    state_view,
                     &tmp_session,
                     protocol_config,
                     &input_object_metadata,
@@ -632,20 +684,19 @@ impl<'vm, 'state, 'a, 'b, S: StorageView> ExecutionContext<'vm, 'state, 'a, 'b, 
             object_changes.insert(id, change);
         }
 
-        for (id, (write_kind, recipient, ty, move_type, value)) in writes {
+        for (id, (write_kind, recipient, ty, value)) in writes {
             let abilities = tmp_session
                 .get_type_abilities(&ty)
-                .map_err(|e| convert_vm_error(e, vm, state_view))?;
+                .map_err(|e| convert_vm_error(e, vm, tmp_session.get_resolver()))?;
             let has_public_transfer = abilities.has_store();
             let layout = tmp_session
-                .get_type_layout(&move_type.clone().into())
-                .map_err(|e| convert_vm_error(e, vm, state_view))?;
+                .type_to_type_layout(&ty)
+                .map_err(|e| convert_vm_error(e, vm, tmp_session.get_resolver()))?;
             let bytes = value.simple_serialize(&layout).unwrap();
             // safe because has_public_transfer has been determined by the abilities
             let move_object = unsafe {
                 create_written_object(
                     vm,
-                    state_view,
                     &tmp_session,
                     protocol_config,
                     &input_object_metadata,
@@ -674,9 +725,10 @@ impl<'vm, 'state, 'a, 'b, S: StorageView> ExecutionContext<'vm, 'state, 'a, 'b, 
             };
             object_changes.insert(id, ObjectChange::Delete(version, delete_kind));
         }
-        let (change_set, move_events) = tmp_session
-            .finish()
-            .map_err(|e| convert_vm_error(e, vm, state_view))?;
+
+        let (res, linkage) = tmp_session.finish();
+        let (change_set, move_events) = res.map_err(|e| convert_vm_error(e, vm, &linkage))?;
+
         // the session was just used for ability and layout metadata fetching, no changes should
         // exist. Plus, Sui Move does not use these changes or events
         assert_invariant!(change_set.accounts().is_empty(), "Change set must be empty");
@@ -690,7 +742,7 @@ impl<'vm, 'state, 'a, 'b, S: StorageView> ExecutionContext<'vm, 'state, 'a, 'b, 
 
     /// Convert a VM Error to an execution one
     pub fn convert_vm_error(&self, error: VMError) -> ExecutionError {
-        sui_types::error::convert_vm_error(error, self.vm, self.state_view)
+        sui_types::error::convert_vm_error(error, self.vm, self.session.get_resolver())
     }
 
     /// Special case errors for type arguments to Move functions
@@ -778,11 +830,153 @@ impl<'vm, 'state, 'a, 'b, S: StorageView> ExecutionContext<'vm, 'state, 'a, 'b, 
     }
 }
 
+fn new_session<'state, 'vm, S: StorageView>(
+    vm: &'vm MoveVM,
+    linkage: LinkageView<'state, S>,
+    input_objects: BTreeMap<ObjectID, Owner>,
+    is_metered: bool,
+    protocol_config: &ProtocolConfig,
+) -> Session<'state, 'vm, LinkageView<'state, S>> {
+    let store = linkage.storage();
+    vm.new_session_with_extensions(
+        linkage,
+        new_native_extensions(store, input_objects, is_metered, protocol_config),
+    )
+}
+
+/// Set the link context for the session from the linkage information in the `package`.
+pub fn set_linkage<S: StorageView>(
+    session: &mut Session<LinkageView<S>>,
+    linkage: &MovePackage,
+) -> Result<AccountAddress, ExecutionError> {
+    session.get_resolver_mut().set_linkage(linkage)
+}
+
+/// Turn off linkage information, so that the next use of the session will need to set linkage
+/// information to succeed.
+pub fn reset_linkage<S: StorageView>(session: &mut Session<LinkageView<S>>) {
+    session.get_resolver_mut().reset_linkage();
+}
+
+pub fn steal_linkage<S: StorageView>(
+    session: &mut Session<LinkageView<S>>,
+) -> Option<SavedLinkage> {
+    session.get_resolver_mut().steal_linkage()
+}
+
+pub fn restore_linkage<S: StorageView>(
+    session: &mut Session<LinkageView<S>>,
+    saved: Option<SavedLinkage>,
+) -> Result<(), ExecutionError> {
+    session.get_resolver_mut().restore_linkage(saved)
+}
+
+/// Fetch the package at `package_id` with a view to using it as a link context.  Produces an error
+/// if the object at that ID does not exist, or is not a package.
+fn package_for_linkage<S: StorageView>(
+    session: &Session<LinkageView<S>>,
+    package_id: ObjectID,
+) -> VMResult<MovePackage> {
+    use move_binary_format::errors::PartialVMError;
+    use move_core_types::vm_status::StatusCode;
+
+    let storage = session.get_resolver().storage();
+    match storage.get_package(&package_id) {
+        Ok(Some(package)) => Ok(package),
+        Ok(None) => Err(PartialVMError::new(StatusCode::LINKER_ERROR)
+            .with_message(format!("Cannot find link context {package_id} in store"))
+            .finish(Location::Undefined)),
+        Err(err) => Err(PartialVMError::new(StatusCode::LINKER_ERROR)
+            .with_message(format!(
+                "Error loading link context {package_id} from store: {err}"
+            ))
+            .finish(Location::Undefined)),
+    }
+}
+
+/// Load `type_tag` to get a `Type` in the provided `session`.  `session`'s linkage context may be
+/// reset after this operation, because during the operation, it may change when loading a struct.
+pub fn load_type<'vm, 'state, S: StorageView>(
+    session: &mut Session<'state, 'vm, LinkageView<'state, S>>,
+    type_tag: &TypeTag,
+) -> VMResult<Type> {
+    use move_binary_format::errors::PartialVMError;
+    use move_core_types::vm_status::StatusCode;
+
+    fn verification_error<T>(code: StatusCode) -> VMResult<T> {
+        Err(PartialVMError::new(code).finish(Location::Undefined))
+    }
+
+    Ok(match type_tag {
+        TypeTag::Bool => Type::Bool,
+        TypeTag::U8 => Type::U8,
+        TypeTag::U16 => Type::U16,
+        TypeTag::U32 => Type::U32,
+        TypeTag::U64 => Type::U64,
+        TypeTag::U128 => Type::U128,
+        TypeTag::U256 => Type::U256,
+        TypeTag::Address => Type::Address,
+        TypeTag::Signer => Type::Signer,
+
+        TypeTag::Vector(inner) => Type::Vector(Box::new(load_type(session, inner)?)),
+        TypeTag::Struct(struct_tag) => {
+            let StructTag {
+                address,
+                module,
+                name,
+                type_params,
+            } = struct_tag.as_ref();
+
+            // Load the package that the struct is defined in, in storage
+            let defining_id = ObjectID::from_address(*address);
+            let package = package_for_linkage(session, defining_id)?;
+
+            // Set the defining package as the link context on the session while loading the
+            // struct
+            let original_address = set_linkage(session, &package).map_err(|e| {
+                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                    .with_message(e.to_string())
+                    .finish(Location::Undefined)
+            })?;
+
+            let runtime_id = ModuleId::new(original_address, module.clone());
+            let res = session.load_struct(&runtime_id, name);
+            reset_linkage(session);
+            let (idx, struct_type) = res?;
+
+            // Recursively load type parameters, if necessary
+            let type_param_constraints = struct_type.type_param_constraints();
+            if type_param_constraints.len() != type_params.len() {
+                return verification_error(StatusCode::NUMBER_OF_TYPE_ARGUMENTS_MISMATCH);
+            }
+
+            if type_params.is_empty() {
+                Type::Struct(idx)
+            } else {
+                let loaded_type_params = type_params
+                    .iter()
+                    .map(|type_param| load_type(session, type_param))
+                    .collect::<VMResult<Vec<_>>>()?;
+
+                // Verify that the type parameter constraints on the struct are met
+                for (constraint, param) in type_param_constraints.zip(&loaded_type_params) {
+                    let abilities = session.get_type_abilities(param)?;
+                    if !constraint.is_subset(abilities) {
+                        return verification_error(StatusCode::CONSTRAINT_NOT_SATISFIED);
+                    }
+                }
+
+                Type::StructInstantiation(idx, loaded_type_params)
+            }
+        }
+    })
+}
+
 /// Load an input object from the state_view
-fn load_object<S: StorageView>(
-    vm: &MoveVM,
-    state_view: &S,
-    session: &Session<S>,
+fn load_object<'vm, 'state, S: StorageView>(
+    vm: &'vm MoveVM,
+    state_view: &'state S,
+    session: &mut Session<'state, 'vm, LinkageView<'state, S>>,
     object_owner_map: &mut BTreeMap<ObjectID, Owner>,
     override_as_immutable: bool,
     id: ObjectID,
@@ -814,15 +1008,15 @@ fn load_object<S: StorageView>(
     let prev = object_owner_map.insert(id, obj.owner);
     // protected by transaction input checker
     assert_invariant!(prev.is_none(), format!("Duplicate input object {}", id));
-    let obj_value = ObjectValue::from_object(vm, state_view, session, obj)?;
+    let obj_value = ObjectValue::from_object(vm, session, obj)?;
     Ok(InputValue::new_object(object_metadata, obj_value))
 }
 
 /// Load an a CallArg, either an object or a raw set of BCS bytes
-fn load_call_arg<S: StorageView>(
-    vm: &MoveVM,
-    state_view: &S,
-    session: &Session<S>,
+fn load_call_arg<'vm, 'state, S: StorageView>(
+    vm: &'vm MoveVM,
+    state_view: &'state S,
+    session: &mut Session<'state, 'vm, LinkageView<'state, S>>,
     object_owner_map: &mut BTreeMap<ObjectID, Owner>,
     call_arg: CallArg,
 ) -> Result<InputValue, ExecutionError> {
@@ -835,10 +1029,10 @@ fn load_call_arg<S: StorageView>(
 }
 
 /// Load an ObjectArg from state view, marking if it can be treated as mutable or not
-fn load_object_arg<S: StorageView>(
-    vm: &MoveVM,
-    state_view: &S,
-    session: &Session<S>,
+fn load_object_arg<'vm, 'state, S: StorageView>(
+    vm: &'vm MoveVM,
+    state_view: &'state S,
+    session: &mut Session<'state, 'vm, LinkageView<'state, S>>,
     object_owner_map: &mut BTreeMap<ObjectID, Owner>,
     obj_arg: ObjectArg,
 ) -> Result<InputValue, ExecutionError> {
@@ -922,8 +1116,7 @@ fn refund_max_gas_budget(
 /// the StructTag, or from the runtime correctly propagating from the inputs
 unsafe fn create_written_object<S: StorageView>(
     vm: &MoveVM,
-    state_view: &S,
-    session: &Session<S>,
+    session: &Session<LinkageView<S>>,
     protocol_config: &ProtocolConfig,
     input_object_metadata: &BTreeMap<ObjectID, InputObjectMetadata>,
     loaded_child_objects: &BTreeMap<ObjectID, SequenceNumber>,
@@ -955,7 +1148,7 @@ unsafe fn create_written_object<S: StorageView>(
 
     let type_tag = session
         .get_type_tag(&type_)
-        .map_err(|e| sui_types::error::convert_vm_error(e, vm, state_view))?;
+        .map_err(|e| sui_types::error::convert_vm_error(e, vm, session.get_resolver()))?;
 
     let struct_tag = match type_tag {
         TypeTag::Struct(inner) => *inner,

--- a/crates/sui-adapter/src/programmable_transactions/linkage_view.rs
+++ b/crates/sui-adapter/src/programmable_transactions/linkage_view.rs
@@ -1,0 +1,352 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    cell::RefCell,
+    collections::{hash_map::Entry, BTreeMap, HashMap, HashSet},
+    str::FromStr,
+};
+
+use move_core_types::{
+    account_address::AccountAddress,
+    identifier::{IdentStr, Identifier},
+    language_storage::{ModuleId, StructTag},
+    resolver::{LinkageResolver, ModuleResolver, ResourceResolver},
+};
+use sui_types::{
+    base_types::ObjectID,
+    error::{ExecutionError, SuiError},
+    move_package::{MovePackage, TypeOrigin, UpgradeInfo},
+};
+
+use super::types::StorageView;
+
+/// Exposes module and linkage resolution to the Move runtime.  The first by delegating to
+/// `StorageView` and the second via linkage information that is loaded from a move package.
+pub struct LinkageView<'state, S: StorageView> {
+    /// Immutable access to the store for the transaction.
+    state_view: &'state S,
+    /// Information used to change module and type identities during linkage.
+    linkage_info: LinkageInfo,
+    /// Cache containing the type origin information from every package that has been set as the
+    /// link context, and every other type that has been requested by the loader in this session.
+    /// It's okay to retain entries in this cache between different link contexts because a type's
+    /// Runtime ID and Defining ID are invariant between across link contexts.
+    ///
+    /// Cache is keyed first by the Runtime ID of the type's module, and then the type's identifier.
+    /// The value is the ObjectID/Address of the package that introduced the type.
+    type_origin_cache: RefCell<HashMap<ModuleId, HashMap<Identifier, AccountAddress>>>,
+    /// Cache of past package addresses that have been the link context -- if a package is in this
+    /// set, then we will not try to load its type origin table when setting it as a context (again).
+    past_contexts: RefCell<HashSet<ObjectID>>,
+}
+
+#[derive(Debug)]
+pub enum LinkageInfo {
+    /// No linkage information -- requests to relink will fail with an invariant violation.
+    Unset,
+    /// Linkage information cannot be altered, and does not affect type or module identity.
+    Universal,
+    /// Linkage provided by the package found at `storage_id` whose module self-addresses are
+    /// `runtime_id`.
+    /// Linkage information derived from a specific
+    Set(PackageLinkage),
+}
+
+#[derive(Debug)]
+pub struct PackageLinkage {
+    storage_id: AccountAddress,
+    runtime_id: AccountAddress,
+    link_table: BTreeMap<ObjectID, UpgradeInfo>,
+}
+
+pub struct SavedLinkage(PackageLinkage);
+
+impl<'state, S: StorageView> LinkageView<'state, S> {
+    pub fn new(state_view: &'state S, linkage_info: LinkageInfo) -> Self {
+        Self {
+            state_view,
+            linkage_info,
+            type_origin_cache: RefCell::new(HashMap::new()),
+            past_contexts: RefCell::new(HashSet::new()),
+        }
+    }
+
+    pub fn reset_linkage(&mut self) {
+        if let LinkageInfo::Set(_) = &self.linkage_info {
+            // Resetting does not affect "universal" linkage.
+            self.linkage_info = LinkageInfo::Unset;
+        }
+    }
+
+    /// Reset the linkage, but save the context that existed before, if there was one.
+    pub fn steal_linkage(&mut self) -> Option<SavedLinkage> {
+        if let LinkageInfo::Universal = &self.linkage_info {
+            return None;
+        }
+
+        match std::mem::replace(&mut self.linkage_info, LinkageInfo::Unset) {
+            LinkageInfo::Set(linkage) => Some(SavedLinkage(linkage)),
+            LinkageInfo::Unset => None,
+            LinkageInfo::Universal => unreachable!(),
+        }
+    }
+
+    /// Restore a previously saved linkage context.  Fails if there is already a context set.
+    pub fn restore_linkage(&mut self, saved: Option<SavedLinkage>) -> Result<(), ExecutionError> {
+        let Some(SavedLinkage(saved)) = saved else {
+            return Ok(());
+        };
+
+        match &self.linkage_info {
+            LinkageInfo::Unset => (),
+            LinkageInfo::Universal => (),
+            LinkageInfo::Set(existing) => {
+                return Err(ExecutionError::invariant_violation(format!(
+                    "Attempt to overwrite linkage by restoring: {saved:#?} \
+                     Existing linkage: {existing:#?}",
+                )))
+            }
+        }
+
+        // No need to populate type origin cache, because a saved context must have been set as a
+        // linkage before, and the cache would have been populated at that time.
+        self.linkage_info = LinkageInfo::Set(saved);
+        Ok(())
+    }
+
+    /// Set the linkage context to the information based on the linkage and type origin tables from
+    /// the `context` package.  Returns the original package ID (aka the runtime ID) of the context
+    /// package on success.
+    pub fn set_linkage(&mut self, context: &MovePackage) -> Result<AccountAddress, ExecutionError> {
+        match &self.linkage_info {
+            LinkageInfo::Unset => (),
+            LinkageInfo::Universal => return Ok(*context.id()),
+
+            LinkageInfo::Set(existing) => {
+                return Err(ExecutionError::invariant_violation(format!(
+                    "Attempt to overwrite linkage info with context from {}. \
+                     Existing linkage: {existing:#?}",
+                    context.id(),
+                )))
+            }
+        }
+
+        let linkage = PackageLinkage::from(context);
+        let storage_id = context.id();
+        let runtime_id = linkage.runtime_id;
+        self.linkage_info = LinkageInfo::Set(linkage);
+
+        if !self.past_contexts.borrow_mut().insert(storage_id) {
+            return Ok(runtime_id);
+        }
+
+        // Pre-populate the type origin cache with entries from the current package -- this is
+        // necessary to serve "defining module" requests for unpublished packages, but will also
+        // speed up other requests.
+        for TypeOrigin {
+            module_name,
+            struct_name,
+            package: defining_id,
+        } in context.type_origin_table()
+        {
+            let Ok(module_name) = Identifier::from_str(module_name) else {
+                return Err(ExecutionError::invariant_violation(format!(
+                    "Module name isn't an identifier: {module_name}"
+                )));
+            };
+
+            let Ok(struct_name) = Identifier::from_str(struct_name) else {
+                return Err(ExecutionError::invariant_violation(format!(
+                    "Struct name isn't an identifier: {struct_name}"
+                )));
+            };
+
+            let runtime_id = ModuleId::new(runtime_id, module_name);
+            self.add_type_origin(runtime_id, struct_name, *defining_id)?;
+        }
+
+        Ok(runtime_id)
+    }
+
+    pub fn storage(&self) -> &'state S {
+        self.state_view
+    }
+
+    pub fn original_package_id(&self) -> AccountAddress {
+        if let LinkageInfo::Set(linkage) = &self.linkage_info {
+            linkage.runtime_id
+        } else {
+            AccountAddress::ZERO
+        }
+    }
+
+    fn get_cached_type_origin(
+        &self,
+        runtime_id: &ModuleId,
+        struct_: &IdentStr,
+    ) -> Option<AccountAddress> {
+        self.type_origin_cache
+            .borrow()
+            .get(runtime_id)?
+            .get(struct_)
+            .cloned()
+    }
+
+    fn add_type_origin(
+        &self,
+        runtime_id: ModuleId,
+        struct_: Identifier,
+        defining_id: ObjectID,
+    ) -> Result<(), ExecutionError> {
+        let mut cache = self.type_origin_cache.borrow_mut();
+        let module_cache = cache.entry(runtime_id.clone()).or_default();
+
+        match module_cache.entry(struct_) {
+            Entry::Vacant(entry) => {
+                entry.insert(*defining_id);
+            }
+
+            Entry::Occupied(entry) => {
+                if entry.get() != &*defining_id {
+                    return Err(ExecutionError::invariant_violation(format!(
+                        "Conflicting defining ID for {}::{}: {} and {}",
+                        runtime_id,
+                        entry.key(),
+                        defining_id,
+                        entry.get(),
+                    )));
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl From<&MovePackage> for PackageLinkage {
+    fn from(package: &MovePackage) -> Self {
+        Self {
+            storage_id: package.id().into(),
+            runtime_id: package.original_package_id().into(),
+            link_table: package.linkage_table().clone(),
+        }
+    }
+}
+
+impl<'state, S: StorageView> LinkageResolver for LinkageView<'state, S> {
+    type Error = SuiError;
+
+    fn link_context(&self) -> AccountAddress {
+        if let LinkageInfo::Set(linkage) = &self.linkage_info {
+            linkage.storage_id
+        } else {
+            AccountAddress::ZERO
+        }
+    }
+
+    fn relocate(&self, module_id: &ModuleId) -> Result<ModuleId, Self::Error> {
+        let linkage = match &self.linkage_info {
+            LinkageInfo::Set(linkage) => linkage,
+            LinkageInfo::Universal => return Ok(module_id.clone()),
+
+            LinkageInfo::Unset => {
+                return Err(ExecutionError::invariant_violation(format!(
+                    "No linkage context set while relocating {module_id}."
+                ))
+                .into())
+            }
+        };
+
+        // The request is to relocate a module in the package that the link context is from.  This
+        // entry will not be stored in the linkage table, so must be handled specially.
+        if module_id.address() == &linkage.runtime_id {
+            return Ok(ModuleId::new(
+                linkage.storage_id,
+                module_id.name().to_owned(),
+            ));
+        }
+
+        let runtime_id = ObjectID::from_address(*module_id.address());
+        let Some(upgrade) = linkage.link_table.get(&runtime_id) else {
+            return Err(ExecutionError::invariant_violation(format!(
+                "Missing linkage for {runtime_id} in context {}",
+                linkage.storage_id,
+            )).into());
+        };
+
+        Ok(ModuleId::new(
+            upgrade.upgraded_id.into(),
+            module_id.name().to_owned(),
+        ))
+    }
+
+    fn defining_module(
+        &self,
+        runtime_id: &ModuleId,
+        struct_: &IdentStr,
+    ) -> Result<ModuleId, Self::Error> {
+        match &self.linkage_info {
+            LinkageInfo::Set(_) => (),
+            LinkageInfo::Universal => return Ok(runtime_id.clone()),
+
+            LinkageInfo::Unset => {
+                return Err(ExecutionError::invariant_violation(format!(
+                    "No linkage context set for defining module query on {runtime_id}::{struct_}."
+                ))
+                .into())
+            }
+        };
+
+        if let Some(cached) = self.get_cached_type_origin(runtime_id, struct_) {
+            return Ok(ModuleId::new(cached, runtime_id.name().to_owned()));
+        }
+
+        let storage_id = ObjectID::from(*self.relocate(runtime_id)?.address());
+        let Some(package) = self.state_view.get_package(&storage_id)? else {
+            return Err(ExecutionError::invariant_violation(format!(
+                "Missing dependent package in store: {storage_id}",
+            )).into())
+        };
+
+        for TypeOrigin {
+            module_name,
+            struct_name,
+            package,
+        } in package.type_origin_table()
+        {
+            if module_name == runtime_id.name().as_str() && struct_name == struct_.as_str() {
+                self.add_type_origin(runtime_id.clone(), struct_.to_owned(), *package)?;
+                return Ok(ModuleId::new(**package, runtime_id.name().to_owned()));
+            }
+        }
+
+        Err(ExecutionError::invariant_violation(format!(
+            "{runtime_id}::{struct_} not found in type origin table in {storage_id} (v{})",
+            package.version(),
+        ))
+        .into())
+    }
+}
+
+/** Remaining implementations delegated to StorageView ************************/
+
+impl<'state, S: StorageView> ResourceResolver for LinkageView<'state, S> {
+    type Error = <S as ResourceResolver>::Error;
+
+    fn get_resource(
+        &self,
+        address: &AccountAddress,
+        typ: &StructTag,
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        self.state_view.get_resource(address, typ)
+    }
+}
+
+impl<'state, S: StorageView> ModuleResolver for LinkageView<'state, S> {
+    type Error = <S as ModuleResolver>::Error;
+
+    fn get_module(&self, id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
+        self.state_view.get_module(id)
+    }
+}

--- a/crates/sui-adapter/src/programmable_transactions/mod.rs
+++ b/crates/sui-adapter/src/programmable_transactions/mod.rs
@@ -3,4 +3,5 @@
 
 pub mod context;
 pub mod execution;
+pub mod linkage_view;
 pub mod types;

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -1441,7 +1441,7 @@ fn create_genesis_transaction(
 
 fn create_genesis_objects(
     genesis_ctx: &mut TxContext,
-    modules: &[(Vec<CompiledModule>, Vec<ObjectID>)],
+    modules: &[(&[CompiledModule], Vec<ObjectID>)],
     input_objects: &[Object],
     validators: &[GenesisValidatorMetadata],
     parameters: &GenesisChainParameters,
@@ -1460,7 +1460,7 @@ fn create_genesis_objects(
             &mut store,
             &move_vm,
             genesis_ctx,
-            modules.to_owned(),
+            modules,
             dependencies.to_owned(),
             &protocol_config,
         )
@@ -1488,7 +1488,7 @@ fn process_package(
     store: &mut InMemoryStorage,
     vm: &MoveVM,
     ctx: &mut TxContext,
-    modules: Vec<CompiledModule>,
+    modules: &[CompiledModule],
     dependencies: Vec<ObjectID>,
     protocol_config: &ProtocolConfig,
 ) -> Result<()> {
@@ -1532,7 +1532,7 @@ fn process_package(
     );
     let mut gas_status = SuiGasStatus::new_unmetered(protocol_config);
     let module_bytes = modules
-        .into_iter()
+        .iter()
         .map(|m| {
             let mut buf = vec![];
             m.serialize(&mut buf).unwrap();

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -78,6 +78,7 @@ sui-macros = { path = "../sui-macros" }
 shared-crypto = { path = "../shared-crypto" }
 
 [dev-dependencies]
+move-symbol-pool.workspace = true
 clap = { version = "3.2.17", features = ["derive"] }
 criterion = { version = "0.4.0" }
 fs_extra = "1.2.0"

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -25,7 +25,6 @@ use sui_types::crypto::{AuthorityKeyPair, Signer};
 use sui_types::messages::{
     SignedTransaction, TransactionData, VerifiedTransaction, DUMMY_GAS_PRICE,
 };
-use sui_types::object::OBJECT_START_VERSION;
 use sui_types::utils::create_fake_transaction;
 use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{
@@ -155,14 +154,9 @@ async fn init_genesis(
     ObjectID,
 ) {
     // add object_basics package object to genesis
-    let modules = compile_basics_package()
-        .get_modules()
-        .into_iter()
-        .cloned()
-        .collect();
+    let modules: Vec<_> = compile_basics_package().get_modules().cloned().collect();
     let pkg = Object::new_package(
-        modules,
-        OBJECT_START_VERSION,
+        &modules,
         TransactionDigest::genesis(),
         ProtocolConfig::get_for_max_version().max_move_package_size(),
         &sui_framework::make_system_packages(),

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -324,14 +324,13 @@ async fn test_quorum_map_and_reduce_timeout() {
     let build_config = BuildConfig::new_for_testing();
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push("src/unit_tests/data/object_basics");
-    let modules = sui_framework::build_move_package(&path, build_config)
+    let modules: Vec<_> = sui_framework::build_move_package(&path, build_config)
         .unwrap()
         .get_modules()
-        .into_iter()
         .cloned()
         .collect();
     let pkg = Object::new_package_for_testing(
-        modules,
+        &modules,
         TransactionDigest::genesis(),
         &make_system_packages(),
     )

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -539,6 +539,7 @@ async fn test_dev_inspect_dynamic_field() {
                 )
                 .await
                 .unwrap();
+                assert!(effects.status().is_ok(), "{:#?}", effects.status());
                 let created_object_id = effects.created()[0].0 .0;
                 let created_object = validator
                     .get_object(&created_object_id)
@@ -1290,39 +1291,6 @@ async fn test_handle_transfer_transaction_unknown_sender() {
         .await
         .unwrap()
         .is_none());
-}
-
-#[tokio::test]
-async fn test_upgrade_module_is_feature_gated() {
-    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
-    let gas_object_id = ObjectID::random();
-    let gas_object = Object::with_id_owner_for_testing(gas_object_id, sender);
-    let authority_state = init_state().await;
-    authority_state.insert_genesis_object(gas_object).await;
-
-    let pt = {
-        let mut builder = ProgrammableTransactionBuilder::new();
-        // Data doesn't matter here. We hit the feature flag before checking it.
-        let arg = builder.pure(1).unwrap();
-        let stdlib_pkg_id = ObjectID::from_hex_literal("0x1").unwrap();
-        builder.upgrade(stdlib_pkg_id, arg, vec![], vec![vec![]]);
-        builder.finish()
-    };
-
-    let TransactionEffects::V1(effects) = execute_programmable_transaction(
-        &authority_state,
-        &gas_object_id,
-        &sender,
-        &sender_key,
-        pt,
-    )
-    .await
-    .unwrap();
-    let (failure_status, _) = effects.status.unwrap_err();
-    assert_eq!(
-        failure_status,
-        ExecutionFailureStatus::FeatureNotYetSupported
-    );
 }
 
 /* FIXME: This tests the submission of out of transaction certs, but modifies object sequence numbers manually

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -4265,11 +4265,10 @@ async fn publish_object_basics(state: Arc<AuthorityState>) -> (Arc<AuthorityStat
         .build(path)
         .unwrap()
         .get_modules()
-        .into_iter()
         .cloned()
         .collect();
     let digest = TransactionDigest::genesis();
-    let pkg = Object::new_package_for_testing(modules, digest, &make_system_packages()).unwrap();
+    let pkg = Object::new_package_for_testing(&modules, digest, &make_system_packages()).unwrap();
     let pkg_ref = pkg.compute_object_reference();
     state.insert_genesis_object(pkg).await;
     (state, pkg_ref)
@@ -4297,11 +4296,10 @@ pub async fn init_state_with_ids_and_object_basics_with_fullnode<
         .build(path)
         .unwrap()
         .get_modules()
-        .into_iter()
         .cloned()
         .collect();
     let digest = TransactionDigest::genesis();
-    let pkg = Object::new_package_for_testing(modules, digest, &make_system_packages()).unwrap();
+    let pkg = Object::new_package_for_testing(&modules, digest, &make_system_packages()).unwrap();
     let pkg_ref = pkg.compute_object_reference();
     validator.insert_genesis_object(pkg.clone()).await;
     fullnode.insert_genesis_object(pkg).await;

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/additive_upgrade/sources/base.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/additive_upgrade/sources/base.move
@@ -19,11 +19,13 @@ module base_addr::base {
     // new function is fine
     public fun return_1(): u64 { 1 }
 
-    public fun return_0(): u64 { 0 }
+    public fun return_0(): u64 { abort 42 }
 
     public fun plus_1(x: u64): u64 { x + 1 }
 
     public(friend) fun friend_fun(x: u64): u64 { x }
 
     fun non_public_fun(y: bool): u64 { if (y) 0 else 1 }
+
+    entry fun entry_fun() { }
 }

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/additive_upgrade_invalid/sources/base.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/additive_upgrade_invalid/sources/base.move
@@ -27,4 +27,6 @@ module base_addr::base {
 
     // This is invalid since I just changed the code
     fun non_public_fun(y: bool): u64 { if (y) 0 else 2 }
+
+    entry fun entry_fun() { }
 }

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/compatibility_invalid/sources/base.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/compatibility_invalid/sources/base.move
@@ -17,4 +17,6 @@ module base_addr::base {
     public(friend) fun friend_fun(x: u64): u64 { x }
 
     fun non_public_fun(y: bool): u64 { if (y) 0 else 1 }
+
+    entry fun entry_fun() { }
 }

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/dep_only_upgrade/sources/base.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/dep_only_upgrade/sources/base.move
@@ -10,11 +10,13 @@ module base_addr::base {
 
     friend base_addr::friend_module;
 
-    public fun return_0(): u64 { 0 }
+    public fun return_0(): u64 { abort 42 }
 
     public fun plus_1(x: u64): u64 { x + 1 }
 
     public(friend) fun friend_fun(x: u64): u64 { x }
 
     fun non_public_fun(y: bool): u64 { if (y) 0 else 1 }
+
+    entry fun entry_fun() { }
 }

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/makes_new_object/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/makes_new_object/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "makes_new_object"
+version = "0.0.1"
+
+[dependencies]
+Sui = { local = "../../../../../../sui-framework/packages/sui-framework" }
+
+[addresses]
+base_addr =  "0x0"

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/makes_new_object/sources/base.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/makes_new_object/sources/base.move
@@ -1,0 +1,40 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module base_addr::base {
+    use sui::object::{Self, UID};
+    use sui::tx_context::{Self, TxContext};
+    use sui::transfer;
+
+    struct A<T> {
+        f1: bool,
+        f2: T
+    }
+
+    struct B has key {
+        id: UID,
+        x: u64,
+    }
+
+    friend base_addr::friend_module;
+
+    public fun return_0(): u64 { abort 42 }
+
+    public fun plus_1(x: u64): u64 { x + 1 }
+
+    public(friend) fun friend_fun(x: u64): u64 { x }
+
+    fun non_public_fun(y: bool): u64 { if (y) 0 else 1 }
+
+    entry fun makes_b(ctx: &mut TxContext) {
+        transfer::transfer(
+            B { id: object::new(ctx), x: 42 },
+            tx_context::sender(ctx),
+        )
+    }
+
+    entry fun destroys_b(b: B) {
+        let B { id, x: _ }  = b;
+        object::delete(id);
+    }
+}

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/makes_new_object/sources/friend_module.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/makes_new_object/sources/friend_module.move
@@ -1,22 +1,18 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-module base_addr::base {
+module base_addr::friend_module {
 
     struct A<T> {
-        f1: bool,
-        f2: T
+        field1: u64,
+        field2: T
     }
 
-    friend base_addr::friend_module;
+    public fun friend_call(): u64 { base_addr::base::friend_fun(1) }
 
     public fun return_0(): u64 { 0 }
 
     public fun plus_1(x: u64): u64 { x + 1 }
 
-    public(friend) fun friend_fun(x: u64): u64 { x }
-
     fun non_public_fun(y: bool): u64 { if (y) 0 else 1 }
-
-    entry fun entry_fun() { }
 }

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/new_object/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/new_object/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "new_object"
+version = "0.0.1"
+
+[dependencies]
+Sui = { local = "../../../../../../sui-framework/packages/sui-framework" }
+
+[addresses]
+base_addr =  "0x0"

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/new_object/sources/base.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/new_object/sources/base.move
@@ -2,13 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module base_addr::base {
+    use sui::object::UID;
 
     struct A<T> {
         f1: bool,
         f2: T
     }
 
+    struct B has key {
+        id: UID,
+        x: u64,
+    }
+
     friend base_addr::friend_module;
+
 
     public fun return_0(): u64 { abort 42 }
 
@@ -17,6 +24,4 @@ module base_addr::base {
     public(friend) fun friend_fun(x: u64): u64 { x }
 
     fun non_public_fun(y: bool): u64 { if (y) 0 else 1 }
-
-    entry fun entry_fun() { }
 }

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/new_object/sources/friend_module.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/new_object/sources/friend_module.move
@@ -1,22 +1,18 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-module base_addr::base {
+module base_addr::friend_module {
 
     struct A<T> {
-        f1: bool,
-        f2: T
+        field1: u64,
+        field2: T
     }
 
-    friend base_addr::friend_module;
+    public fun friend_call(): u64 { base_addr::base::friend_fun(1) }
 
     public fun return_0(): u64 { 0 }
 
     public fun plus_1(x: u64): u64 { x + 1 }
 
-    public(friend) fun friend_fun(x: u64): u64 { x }
-
     fun non_public_fun(y: bool): u64 { if (y) 0 else 1 }
-
-    entry fun entry_fun() { }
 }

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/stage1_basic_compatibility_valid/sources/base.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/stage1_basic_compatibility_valid/sources/base.move
@@ -25,4 +25,7 @@ module base_addr::base {
 
     // Change this private function
     fun non_public_fun(y: bool, g: u64): u64 { if (y) 0 else g }
+
+    // Note that this is fine since the entry function is private
+    entry fun entry_fun(x: u64): u64 { x }
 }

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/stage2_basic_compatibility_valid/sources/base.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/stage2_basic_compatibility_valid/sources/base.move
@@ -25,4 +25,6 @@ module base_addr::base {
 
     // Change this private function
     fun non_public_fun(y: bool, g: u64): u64 { if (y) 0 else g }
+
+    entry fun entry_fun() { }
 }

--- a/crates/sui-core/src/unit_tests/move_package_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_tests.rs
@@ -47,30 +47,13 @@ macro_rules! linkage_table {
 #[test]
 fn test_new_initial() {
     let c_id1 = ObjectID::from_single_byte(0xc1);
-    let c_pkg = MovePackage::new_initial(
-        OBJECT_START_VERSION,
-        build_test_modules("Cv1"),
-        u64::MAX,
-        [],
-    )
-    .unwrap();
+    let c_pkg = MovePackage::new_initial(&build_test_modules("Cv1"), u64::MAX, []).unwrap();
 
     let b_id1 = ObjectID::from_single_byte(0xb1);
-    let b_pkg = MovePackage::new_initial(
-        OBJECT_START_VERSION,
-        build_test_modules("B"),
-        u64::MAX,
-        [&c_pkg],
-    )
-    .unwrap();
+    let b_pkg = MovePackage::new_initial(&build_test_modules("B"), u64::MAX, [&c_pkg]).unwrap();
 
-    let a_pkg = MovePackage::new_initial(
-        OBJECT_START_VERSION,
-        build_test_modules("A"),
-        u64::MAX,
-        [&b_pkg, &c_pkg],
-    )
-    .unwrap();
+    let a_pkg =
+        MovePackage::new_initial(&build_test_modules("A"), u64::MAX, [&b_pkg, &c_pkg]).unwrap();
 
     assert_eq!(
         a_pkg.linkage_table(),
@@ -115,17 +98,11 @@ fn test_new_initial() {
 #[test]
 fn test_upgraded() {
     let c_id1 = ObjectID::from_single_byte(0xc1);
-    let c_pkg = MovePackage::new_initial(
-        OBJECT_START_VERSION,
-        build_test_modules("Cv1"),
-        u64::MAX,
-        [],
-    )
-    .unwrap();
+    let c_pkg = MovePackage::new_initial(&build_test_modules("Cv1"), u64::MAX, []).unwrap();
 
     let c_id2 = ObjectID::from_single_byte(0xc2);
     let c_new = c_pkg
-        .new_upgraded(c_id2, build_test_modules("Cv2"), u64::MAX, [])
+        .new_upgraded(c_id2, &build_test_modules("Cv2"), u64::MAX, [])
         .unwrap();
 
     let mut expected_version = OBJECT_START_VERSION;
@@ -144,26 +121,14 @@ fn test_upgraded() {
 #[test]
 fn test_depending_on_upgrade() {
     let c_id1 = ObjectID::from_single_byte(0xc1);
-    let c_pkg = MovePackage::new_initial(
-        OBJECT_START_VERSION,
-        build_test_modules("Cv1"),
-        u64::MAX,
-        [],
-    )
-    .unwrap();
+    let c_pkg = MovePackage::new_initial(&build_test_modules("Cv1"), u64::MAX, []).unwrap();
 
     let c_id2 = ObjectID::from_single_byte(0xc2);
     let c_new = c_pkg
-        .new_upgraded(c_id2, build_test_modules("Cv2"), u64::MAX, [])
+        .new_upgraded(c_id2, &build_test_modules("Cv2"), u64::MAX, [])
         .unwrap();
 
-    let b_pkg = MovePackage::new_initial(
-        OBJECT_START_VERSION,
-        build_test_modules("B"),
-        u64::MAX,
-        [&c_new],
-    )
-    .unwrap();
+    let b_pkg = MovePackage::new_initial(&build_test_modules("B"), u64::MAX, [&c_new]).unwrap();
 
     assert_eq!(
         b_pkg.linkage_table(),
@@ -176,30 +141,18 @@ fn test_depending_on_upgrade() {
 #[test]
 fn test_upgrade_upgrades_linkage() {
     let c_id1 = ObjectID::from_single_byte(0xc1);
-    let c_pkg = MovePackage::new_initial(
-        OBJECT_START_VERSION,
-        build_test_modules("Cv1"),
-        u64::MAX,
-        [],
-    )
-    .unwrap();
+    let c_pkg = MovePackage::new_initial(&build_test_modules("Cv1"), u64::MAX, []).unwrap();
 
     let c_id2 = ObjectID::from_single_byte(0xc2);
     let c_new = c_pkg
-        .new_upgraded(c_id2, build_test_modules("Cv2"), u64::MAX, [])
+        .new_upgraded(c_id2, &build_test_modules("Cv2"), u64::MAX, [])
         .unwrap();
 
-    let b_pkg = MovePackage::new_initial(
-        OBJECT_START_VERSION,
-        build_test_modules("B"),
-        u64::MAX,
-        [&c_pkg],
-    )
-    .unwrap();
+    let b_pkg = MovePackage::new_initial(&build_test_modules("B"), u64::MAX, [&c_pkg]).unwrap();
 
     let b_id2 = ObjectID::from_single_byte(0xb2);
     let b_new = b_pkg
-        .new_upgraded(b_id2, build_test_modules("B"), u64::MAX, [&c_new])
+        .new_upgraded(b_id2, &build_test_modules("B"), u64::MAX, [&c_new])
         .unwrap();
 
     assert_eq!(
@@ -220,30 +173,18 @@ fn test_upgrade_upgrades_linkage() {
 #[test]
 fn test_upgrade_linkage_digest_to_new_dep() {
     let c_id1 = ObjectID::from_single_byte(0xc1);
-    let c_pkg = MovePackage::new_initial(
-        OBJECT_START_VERSION,
-        build_test_modules("Cv1"),
-        u64::MAX,
-        [],
-    )
-    .unwrap();
+    let c_pkg = MovePackage::new_initial(&build_test_modules("Cv1"), u64::MAX, []).unwrap();
 
     let c_id2 = ObjectID::from_single_byte(0xc2);
     let c_new = c_pkg
-        .new_upgraded(c_id2, build_test_modules("Cv2"), u64::MAX, [])
+        .new_upgraded(c_id2, &build_test_modules("Cv2"), u64::MAX, [])
         .unwrap();
 
-    let b_pkg = MovePackage::new_initial(
-        OBJECT_START_VERSION,
-        build_test_modules("B"),
-        u64::MAX,
-        [&c_pkg],
-    )
-    .unwrap();
+    let b_pkg = MovePackage::new_initial(&build_test_modules("B"), u64::MAX, [&c_pkg]).unwrap();
 
     let b_id2 = ObjectID::from_single_byte(0xb2);
     let b_new = b_pkg
-        .new_upgraded(b_id2, build_test_modules("B"), u64::MAX, [&c_new])
+        .new_upgraded(b_id2, &build_test_modules("B"), u64::MAX, [&c_new])
         .unwrap();
 
     assert_eq!(
@@ -274,30 +215,18 @@ fn test_upgrade_linkage_digest_to_new_dep() {
 #[test]
 fn test_upgrade_downngrades_linkage() {
     let c_id1 = ObjectID::from_single_byte(0xc1);
-    let c_pkg = MovePackage::new_initial(
-        OBJECT_START_VERSION,
-        build_test_modules("Cv1"),
-        u64::MAX,
-        [],
-    )
-    .unwrap();
+    let c_pkg = MovePackage::new_initial(&build_test_modules("Cv1"), u64::MAX, []).unwrap();
 
     let c_id2 = ObjectID::from_single_byte(0xc2);
     let c_new = c_pkg
-        .new_upgraded(c_id2, build_test_modules("Cv2"), u64::MAX, [])
+        .new_upgraded(c_id2, &build_test_modules("Cv2"), u64::MAX, [])
         .unwrap();
 
-    let b_pkg = MovePackage::new_initial(
-        OBJECT_START_VERSION,
-        build_test_modules("B"),
-        u64::MAX,
-        [&c_new],
-    )
-    .unwrap();
+    let b_pkg = MovePackage::new_initial(&build_test_modules("B"), u64::MAX, [&c_new]).unwrap();
 
     let b_id2 = ObjectID::from_single_byte(0xb2);
     let b_new = b_pkg
-        .new_upgraded(b_id2, build_test_modules("B"), u64::MAX, [&c_pkg])
+        .new_upgraded(b_id2, &build_test_modules("B"), u64::MAX, [&c_pkg])
         .unwrap();
 
     assert_eq!(
@@ -318,35 +247,18 @@ fn test_upgrade_downngrades_linkage() {
 #[test]
 fn test_transitively_depending_on_upgrade() {
     let c_id1 = ObjectID::from_single_byte(0xc1);
-    let c_pkg = MovePackage::new_initial(
-        OBJECT_START_VERSION,
-        build_test_modules("Cv1"),
-        u64::MAX,
-        [],
-    )
-    .unwrap();
+    let c_pkg = MovePackage::new_initial(&build_test_modules("Cv1"), u64::MAX, []).unwrap();
 
     let c_id2 = ObjectID::from_single_byte(0xc2);
     let c_new = c_pkg
-        .new_upgraded(c_id2, build_test_modules("Cv2"), u64::MAX, [])
+        .new_upgraded(c_id2, &build_test_modules("Cv2"), u64::MAX, [])
         .unwrap();
 
     let b_id1 = ObjectID::from_single_byte(0xb1);
-    let b_pkg = MovePackage::new_initial(
-        OBJECT_START_VERSION,
-        build_test_modules("B"),
-        u64::MAX,
-        [&c_pkg],
-    )
-    .unwrap();
+    let b_pkg = MovePackage::new_initial(&build_test_modules("B"), u64::MAX, [&c_pkg]).unwrap();
 
-    let a_pkg = MovePackage::new_initial(
-        OBJECT_START_VERSION,
-        build_test_modules("A"),
-        u64::MAX,
-        [&b_pkg, &c_new],
-    )
-    .unwrap();
+    let a_pkg =
+        MovePackage::new_initial(&build_test_modules("A"), u64::MAX, [&b_pkg, &c_new]).unwrap();
 
     assert_eq!(
         a_pkg.linkage_table(),
@@ -359,34 +271,16 @@ fn test_transitively_depending_on_upgrade() {
 
 #[test]
 fn package_digest_changes_with_dep_upgrades_and_in_sync_with_move_package_digest() {
-    let c_v1 = MovePackage::new_initial(
-        OBJECT_START_VERSION,
-        build_test_modules("Cv1"),
-        u64::MAX,
-        [],
-    )
-    .unwrap();
+    let c_v1 = MovePackage::new_initial(&build_test_modules("Cv1"), u64::MAX, []).unwrap();
 
     let c_id2 = ObjectID::from_single_byte(0xc2);
     let c_v2 = c_v1
-        .new_upgraded(c_id2, build_test_modules("Cv2"), u64::MAX, [])
+        .new_upgraded(c_id2, &build_test_modules("Cv2"), u64::MAX, [])
         .unwrap();
 
-    let b_pkg = MovePackage::new_initial(
-        OBJECT_START_VERSION,
-        build_test_modules("B"),
-        u64::MAX,
-        [&c_v1],
-    )
-    .unwrap();
+    let b_pkg = MovePackage::new_initial(&build_test_modules("B"), u64::MAX, [&c_v1]).unwrap();
 
-    let b_v2 = MovePackage::new_initial(
-        OBJECT_START_VERSION,
-        build_test_modules("Bv2"),
-        u64::MAX,
-        [&c_v2],
-    )
-    .unwrap();
+    let b_v2 = MovePackage::new_initial(&build_test_modules("Bv2"), u64::MAX, [&c_v2]).unwrap();
 
     let local_v1 = build_test_package("B").get_package_digest(false);
     let local_v2 = build_test_package("Bv2").get_package_digest(false);
@@ -400,13 +294,12 @@ fn package_digest_changes_with_dep_upgrades_and_in_sync_with_move_package_digest
 #[test]
 #[should_panic]
 fn test_panic_on_empty_package() {
-    let _ = MovePackage::new_initial(OBJECT_START_VERSION, vec![], u64::MAX, []);
+    let _ = MovePackage::new_initial(&[], u64::MAX, []);
 }
 
 #[test]
 fn test_fail_on_missing_dep() {
-    let err = MovePackage::new_initial(OBJECT_START_VERSION, build_test_modules("B"), u64::MAX, [])
-        .unwrap_err();
+    let err = MovePackage::new_initial(&build_test_modules("B"), u64::MAX, []).unwrap_err();
 
     assert_eq!(
         err.kind(),
@@ -416,29 +309,11 @@ fn test_fail_on_missing_dep() {
 
 #[test]
 fn test_fail_on_missing_transitive_dep() {
-    let c_pkg = MovePackage::new_initial(
-        OBJECT_START_VERSION,
-        build_test_modules("Cv1"),
-        u64::MAX,
-        [],
-    )
-    .unwrap();
+    let c_pkg = MovePackage::new_initial(&build_test_modules("Cv1"), u64::MAX, []).unwrap();
 
-    let b_pkg = MovePackage::new_initial(
-        OBJECT_START_VERSION,
-        build_test_modules("B"),
-        u64::MAX,
-        [&c_pkg],
-    )
-    .unwrap();
+    let b_pkg = MovePackage::new_initial(&build_test_modules("B"), u64::MAX, [&c_pkg]).unwrap();
 
-    let err = MovePackage::new_initial(
-        OBJECT_START_VERSION,
-        build_test_modules("A"),
-        u64::MAX,
-        [&b_pkg],
-    )
-    .unwrap_err();
+    let err = MovePackage::new_initial(&build_test_modules("A"), u64::MAX, [&b_pkg]).unwrap_err();
 
     assert_eq!(
         err.kind(),
@@ -448,34 +323,17 @@ fn test_fail_on_missing_transitive_dep() {
 
 #[test]
 fn test_fail_on_transitive_dependency_downgrade() {
-    let c_pkg = MovePackage::new_initial(
-        OBJECT_START_VERSION,
-        build_test_modules("Cv1"),
-        u64::MAX,
-        [],
-    )
-    .unwrap();
+    let c_pkg = MovePackage::new_initial(&build_test_modules("Cv1"), u64::MAX, []).unwrap();
 
     let c_id2 = ObjectID::from_single_byte(0xc2);
     let c_new = c_pkg
-        .new_upgraded(c_id2, build_test_modules("Cv2"), u64::MAX, [])
+        .new_upgraded(c_id2, &build_test_modules("Cv2"), u64::MAX, [])
         .unwrap();
 
-    let b_pkg = MovePackage::new_initial(
-        OBJECT_START_VERSION,
-        build_test_modules("B"),
-        u64::MAX,
-        [&c_new],
-    )
-    .unwrap();
+    let b_pkg = MovePackage::new_initial(&build_test_modules("B"), u64::MAX, [&c_new]).unwrap();
 
-    let err = MovePackage::new_initial(
-        OBJECT_START_VERSION,
-        build_test_modules("A"),
-        u64::MAX,
-        [&b_pkg, &c_pkg],
-    )
-    .unwrap_err();
+    let err =
+        MovePackage::new_initial(&build_test_modules("A"), u64::MAX, [&b_pkg, &c_pkg]).unwrap_err();
 
     assert_eq!(
         err.kind(),
@@ -485,17 +343,11 @@ fn test_fail_on_transitive_dependency_downgrade() {
 
 #[test]
 fn test_fail_on_upgrade_missing_type() {
-    let c_pkg = MovePackage::new_initial(
-        OBJECT_START_VERSION,
-        build_test_modules("Cv2"),
-        u64::MAX,
-        [],
-    )
-    .unwrap();
+    let c_pkg = MovePackage::new_initial(&build_test_modules("Cv2"), u64::MAX, []).unwrap();
 
     let c_id2 = ObjectID::from_single_byte(0xc2);
     let err = c_pkg
-        .new_upgraded(c_id2, build_test_modules("Cv1"), u64::MAX, [])
+        .new_upgraded(c_id2, &build_test_modules("Cv1"), u64::MAX, [])
         .unwrap_err();
 
     assert_eq!(err.kind(), &ExecutionErrorKind::InvariantViolation);

--- a/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -1,7 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use move_core_types::{account_address::AccountAddress, ident_str};
+use move_core_types::{account_address::AccountAddress, ident_str, language_storage::StructTag};
+use move_symbol_pool::Symbol;
 use sui_framework::{MoveStdlib, SuiFramework, SystemPackage};
 use sui_framework_build::compiled_package::BuildConfig;
 use sui_protocol_config::ProtocolConfig;
@@ -10,7 +11,7 @@ use sui_types::{
     crypto::{get_key_pair, AccountKeyPair},
     messages::{
         Argument, CommandArgumentError, ExecutionFailureStatus, ObjectArg, PackageUpgradeError,
-        ProgrammableTransaction, TransactionEffects,
+        ProgrammableTransaction, TransactionEffects, TransactionEffectsV1,
     },
     move_package::UpgradePolicy,
     object::{Object, Owner},
@@ -18,7 +19,11 @@ use sui_types::{
     storage::BackingPackageStore,
 };
 
-use std::{collections::BTreeSet, path::PathBuf, sync::Arc};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::PathBuf,
+    sync::Arc,
+};
 
 use crate::authority::{
     authority_tests::{execute_programmable_transaction, init_state},
@@ -52,10 +57,11 @@ pub fn build_upgrade_test_modules(test_dir: &str) -> (Vec<u8>, Vec<Vec<u8>>) {
 
 pub fn build_upgrade_test_modules_with_dep_addr(
     test_dir: &str,
+    dep_original_addresses: impl IntoIterator<Item = (&'static str, ObjectID)>,
     dep_ids: impl IntoIterator<Item = (&'static str, ObjectID)>,
 ) -> (Vec<u8>, Vec<Vec<u8>>, Vec<ObjectID>) {
     let mut build_config = BuildConfig::new_for_testing();
-    for (addr_name, obj_id) in dep_ids.into_iter() {
+    for (addr_name, obj_id) in dep_original_addresses {
         build_config
             .config
             .additional_named_addresses
@@ -64,11 +70,34 @@ pub fn build_upgrade_test_modules_with_dep_addr(
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.extend(["src", "unit_tests", "data", "move_upgrade", test_dir]);
     let with_unpublished_deps = false;
-    let package = sui_framework::build_move_package(&path, build_config).unwrap();
+    let mut package = sui_framework::build_move_package(&path, build_config).unwrap();
+
+    let dep_id_mapping: BTreeMap<_, _> = dep_ids
+        .into_iter()
+        .map(|(dep_name, obj_id)| (Symbol::from(dep_name), obj_id))
+        .collect();
+
+    assert_eq!(
+        dep_id_mapping.len(),
+        package.dependency_ids.unpublished.len()
+    );
+    for unpublished_dep in &package.dependency_ids.unpublished {
+        let published_id = dep_id_mapping.get(unpublished_dep).unwrap();
+        // Make sure we aren't overriding a package
+        assert!(package
+            .dependency_ids
+            .published
+            .insert(*unpublished_dep, *published_id)
+            .is_none())
+    }
+
+    // No unpublished deps
+    package.dependency_ids.unpublished = BTreeSet::new();
+
     (
         package.get_package_digest(with_unpublished_deps).to_vec(),
         package.get_package_bytes(with_unpublished_deps),
-        package.get_dependency_original_package_ids(),
+        package.dependency_ids.published.values().cloned().collect(),
     )
 }
 
@@ -114,7 +143,7 @@ impl UpgradeStateRunner {
     }
 
     pub async fn publish(
-        &self,
+        &mut self,
         modules: Vec<Vec<u8>>,
         dep_ids: Vec<ObjectID>,
     ) -> (ObjectRef, ObjectRef) {
@@ -125,7 +154,7 @@ impl UpgradeStateRunner {
             builder.finish()
         };
         let TransactionEffects::V1(effects) = self.run(pt).await;
-        assert!(effects.status.is_ok());
+        assert!(effects.status.is_ok(), "{:#?}", effects.status);
 
         let package = effects
             .created
@@ -142,8 +171,47 @@ impl UpgradeStateRunner {
         (package.0, cap.0)
     }
 
-    pub async fn run(&self, pt: ProgrammableTransaction) -> TransactionEffects {
-        execute_programmable_transaction(
+    pub async fn upgrade(
+        &mut self,
+        policy: u8,
+        digest: Vec<u8>,
+        modules: Vec<Vec<u8>>,
+        dep_ids: Vec<ObjectID>,
+    ) -> TransactionEffectsV1 {
+        let pt = {
+            let package_id = self.package.0;
+            let mut builder = ProgrammableTransactionBuilder::new();
+
+            let cap = builder
+                .obj(ObjectArg::ImmOrOwnedObject(self.upgrade_cap))
+                .unwrap();
+            let policy = builder.pure(policy).unwrap();
+            let digest = builder.pure(digest).unwrap();
+            let ticket = move_call! {
+                builder,
+                (SuiFramework::ID)::package::authorize_upgrade(cap, policy, digest)
+            };
+
+            let receipt = builder.upgrade(package_id, ticket, dep_ids, modules);
+            move_call! { builder, (SuiFramework::ID)::package::commit_upgrade(cap, receipt) };
+
+            builder.finish()
+        };
+
+        let TransactionEffects::V1(effects) = self.run(pt).await;
+        if effects.status.is_ok() {
+            self.package = *effects
+                .created
+                .iter()
+                .find_map(|(pkg, owner)| matches!(owner, Owner::Immutable).then_some(pkg))
+                .unwrap();
+        }
+
+        effects
+    }
+
+    pub async fn run(&mut self, pt: ProgrammableTransaction) -> TransactionEffects {
+        let effects = execute_programmable_transaction(
             &self.authority_state,
             &self.gas_object_id,
             &self.sender,
@@ -151,50 +219,52 @@ impl UpgradeStateRunner {
             pt,
         )
         .await
-        .unwrap()
+        .unwrap();
+
+        let TransactionEffects::V1(fx) = &effects;
+
+        if let Some(updated_cap) = fx
+            .mutated
+            .iter()
+            .find_map(|(cap, _)| (cap.0 == self.upgrade_cap.0).then_some(cap))
+        {
+            self.upgrade_cap = *updated_cap;
+        }
+
+        effects
     }
 }
 
 #[tokio::test]
 async fn test_upgrade_package_happy_path() {
-    let runner = UpgradeStateRunner::new("move_upgrade/base").await;
-    let pt = {
-        let mut builder = ProgrammableTransactionBuilder::new();
-        let current_package_id = runner.package.0;
-        let (digest, modules) = build_upgrade_test_modules("stage1_basic_compatibility_valid");
+    let mut runner = UpgradeStateRunner::new("move_upgrade/base").await;
 
-        // We take as input the upgrade cap
-        builder
-            .obj(ObjectArg::ImmOrOwnedObject(runner.upgrade_cap))
-            .unwrap();
+    let TransactionEffects::V1(effects) = runner
+        .run({
+            let mut builder = ProgrammableTransactionBuilder::new();
+            move_call! {
+                builder,
+                (runner.package.0)::base::return_0()
+            };
 
-        // Create the upgrade ticket
-        let upgrade_arg = builder.pure(UpgradePolicy::COMPATIBLE).unwrap();
-        let digest_arg = builder.pure(digest).unwrap();
-        let upgrade_ticket = move_call! {
-            builder,
-            (SuiFramework::ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
-        };
-        let upgrade_receipt = builder.upgrade(current_package_id, upgrade_ticket, vec![], modules);
-        move_call! {
-            builder,
-            (SuiFramework::ID)::package::commit_upgrade(Argument::Input(0), upgrade_receipt)
-        };
+            builder.finish()
+        })
+        .await;
 
-        builder.finish()
+    match effects.status.unwrap_err().0 {
+        ExecutionFailureStatus::MoveAbort(_, 42) => { /* nop */ }
+        err => panic!("Unexpected error: {:#?}", err),
     };
-    let TransactionEffects::V1(effects) = runner.run(pt).await;
 
-    assert!(effects.status.is_ok());
-    let new_package = effects
-        .created
-        .iter()
-        .find(|(_, owner)| matches!(owner, Owner::Immutable))
-        .unwrap();
+    let (digest, modules) = build_upgrade_test_modules("stage1_basic_compatibility_valid");
+    runner
+        .upgrade(UpgradePolicy::COMPATIBLE, digest, modules, vec![])
+        .await;
+
     let package = runner
         .authority_state
         .database
-        .get_package(&new_package.0 .0)
+        .get_package(&runner.package.0)
         .unwrap()
         .unwrap();
     let normalized_modules = package
@@ -202,113 +272,164 @@ async fn test_upgrade_package_happy_path() {
         .unwrap();
     assert!(normalized_modules.contains_key("new_module"));
     assert!(normalized_modules["new_module"]
-        .exposed_functions
+        .functions
         .contains_key(ident_str!("this_is_a_new_module")));
     assert!(normalized_modules["new_module"]
-        .exposed_functions
+        .functions
         .contains_key(ident_str!(
             "i_can_call_funs_in_other_modules_that_already_existed"
         )));
+
+    // Call into the upgraded module
+    let TransactionEffects::V1(effects) = runner
+        .run({
+            let mut builder = ProgrammableTransactionBuilder::new();
+            move_call! {
+                builder,
+                (runner.package.0)::base::return_0()
+            };
+
+            builder.finish()
+        })
+        .await;
+    assert!(effects.status.is_ok(), "{:#?}", effects.status);
 }
 
-// TODO(tzakian): turn this test on once the Move loader changes.
 #[tokio::test]
-#[ignore]
+async fn test_upgrade_introduces_type_then_uses_it() {
+    let mut runner = UpgradeStateRunner::new("move_upgrade/base").await;
+
+    // First upgrade introduces a new type, B.
+    let (digest, modules) = build_upgrade_test_modules("new_object");
+    let effects = runner
+        .upgrade(
+            UpgradePolicy::COMPATIBLE,
+            digest,
+            modules,
+            vec![SuiFramework::ID, MoveStdlib::ID],
+        )
+        .await;
+
+    assert!(effects.status.is_ok(), "{:#?}", effects.status);
+    let package_v2 = runner.package.0;
+
+    // Second upgrade introduces an entry function that creates `B`s.
+    let (digest, modules) = build_upgrade_test_modules("makes_new_object");
+    let effects = runner
+        .upgrade(
+            UpgradePolicy::COMPATIBLE,
+            digest,
+            modules,
+            vec![SuiFramework::ID, MoveStdlib::ID],
+        )
+        .await;
+
+    assert!(effects.status.is_ok(), "{:#?}", effects.status);
+    let package_v3 = runner.package.0;
+
+    // Create an instance of the type introduced at version 2, with the function introduced at
+    // version 3.
+    let TransactionEffects::V1(effects) = runner
+        .run({
+            let mut builder = ProgrammableTransactionBuilder::new();
+            move_call! { builder, (package_v3)::base::makes_b() };
+            builder.finish()
+        })
+        .await;
+
+    assert!(effects.status.is_ok(), "{:#?}", effects.status);
+    let created = effects
+        .created
+        .iter()
+        .find_map(|(b, owner)| matches!(owner, Owner::AddressOwner(_)).then_some(b))
+        .unwrap();
+
+    let b = runner
+        .authority_state
+        .database
+        .get_object_by_key(&created.0, created.1)
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(
+        b.data.struct_tag().unwrap(),
+        StructTag {
+            address: *package_v2,
+            module: ident_str!("base").to_owned(),
+            name: ident_str!("B").to_owned(),
+            type_params: vec![],
+        },
+    );
+
+    // Delete the instance we just created
+    let TransactionEffects::V1(effects) = runner
+        .run({
+            let mut builder = ProgrammableTransactionBuilder::new();
+            let b = builder.obj(ObjectArg::ImmOrOwnedObject(*created)).unwrap();
+            move_call! { builder, (package_v3)::base::destroys_b(b) };
+            builder.finish()
+        })
+        .await;
+
+    assert!(effects.status.is_ok(), "{:#?}", effects.status);
+}
+
+#[tokio::test]
 async fn test_upgrade_incompatible() {
-    let runner = UpgradeStateRunner::new("move_upgrade/base").await;
-    let pt = {
-        let mut builder = ProgrammableTransactionBuilder::new();
-        let current_package_id = runner.package.0;
-        let (digest, modules) = build_upgrade_test_modules("compatibility_invalid");
+    let mut runner = UpgradeStateRunner::new("move_upgrade/base").await;
 
-        // We take as input the upgrade cap
-        builder
-            .obj(ObjectArg::ImmOrOwnedObject(runner.upgrade_cap))
-            .unwrap();
-
-        // Create the upgrade ticket
-        let upgrade_arg = builder.pure(UpgradePolicy::COMPATIBLE).unwrap();
-        let digest_arg = builder.pure(digest).unwrap();
-        let upgrade_ticket = move_call! {
-            builder,
-            (SuiFramework::ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
-        };
-        let upgrade_receipt = builder.upgrade(current_package_id, upgrade_ticket, vec![], modules);
-        move_call! {
-            builder,
-            (SuiFramework::ID)::package::commit_upgrade(Argument::Input(0), upgrade_receipt)
-        };
-
-        builder.finish()
-    };
-    let TransactionEffects::V1(effects) = runner.run(pt).await;
-
-    assert!(effects.status.is_ok());
-}
-
-#[tokio::test]
-async fn test_upgrade_package_incorrect_digest() {
-    let runner = UpgradeStateRunner::new("move_upgrade/base").await;
-    let (pt, actual_digest) = {
-        let mut builder = ProgrammableTransactionBuilder::new();
-        let current_package_id = runner.package.0;
-        let (digest, modules) = build_upgrade_test_modules("stage1_basic_compatibility_valid");
-        let bad_digest: Vec<u8> = digest.iter().map(|_| 0).collect();
-
-        builder
-            .obj(ObjectArg::ImmOrOwnedObject(runner.upgrade_cap))
-            .unwrap();
-        let upgrade_arg = builder.pure(UpgradePolicy::COMPATIBLE).unwrap();
-        let digest_arg = builder.pure(bad_digest).unwrap();
-        let upgrade_ticket = move_call! {
-            builder,
-            (SuiFramework::ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
-        };
-        builder.upgrade(current_package_id, upgrade_ticket, vec![], modules);
-        (builder.finish(), digest)
-    };
-
-    let TransactionEffects::V1(effects) = runner.run(pt).await;
+    let (digest, modules) = build_upgrade_test_modules("compatibility_invalid");
+    let effects = runner
+        .upgrade(UpgradePolicy::COMPATIBLE, digest, modules, vec![])
+        .await;
 
     assert_eq!(
         effects.status.unwrap_err().0,
         ExecutionFailureStatus::PackageUpgradeError {
-            upgrade_error: PackageUpgradeError::DigestDoesNotMatch {
-                digest: actual_digest
-            }
+            upgrade_error: PackageUpgradeError::IncompatibleUpgrade,
+        },
+    )
+}
+
+#[tokio::test]
+async fn test_upgrade_package_incorrect_digest() {
+    let mut runner = UpgradeStateRunner::new("move_upgrade/base").await;
+    let (digest, modules) = build_upgrade_test_modules("stage1_basic_compatibility_valid");
+    let bad_digest = vec![0; digest.len()];
+
+    let effects = runner
+        .upgrade(UpgradePolicy::COMPATIBLE, bad_digest, modules, vec![])
+        .await;
+
+    assert_eq!(
+        effects.status.unwrap_err().0,
+        ExecutionFailureStatus::PackageUpgradeError {
+            upgrade_error: PackageUpgradeError::DigestDoesNotMatch { digest }
         }
     );
 }
 
 #[tokio::test]
 async fn test_upgrade_package_compatibility_too_permissive() {
-    let runner = UpgradeStateRunner::new("move_upgrade/base").await;
-    let pt = {
-        let mut builder = ProgrammableTransactionBuilder::new();
-        let current_package_id = runner.package.0;
-        let (digest, modules) = build_upgrade_test_modules("stage1_basic_compatibility_valid");
+    let mut runner = UpgradeStateRunner::new("move_upgrade/base").await;
 
-        // We take as input the upgrade runner.upgrade_cap
-        builder
-            .obj(ObjectArg::ImmOrOwnedObject(runner.upgrade_cap))
-            .unwrap();
+    let TransactionEffects::V1(effects) = runner
+        .run({
+            let mut builder = ProgrammableTransactionBuilder::new();
+            let cap = builder
+                .obj(ObjectArg::ImmOrOwnedObject(runner.upgrade_cap))
+                .unwrap();
+            move_call! { builder, (SuiFramework::ID)::package::only_dep_upgrades(cap) };
+            builder.finish()
+        })
+        .await;
 
-        // Create the upgrade ticket
-        let upgrade_arg = builder.pure(UpgradePolicy::COMPATIBLE).unwrap();
-        let digest_arg = builder.pure(digest).unwrap();
-        move_call! {
-            builder,
-            (SuiFramework::ID)::package::only_dep_upgrades(Argument::Input(0))
-        };
-        let upgrade_ticket = move_call! {
-            builder,
-            (SuiFramework::ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
-        };
-        builder.upgrade(current_package_id, upgrade_ticket, vec![], modules);
-        builder.finish()
-    };
+    assert!(effects.status.is_ok(), "{:#?}", effects.status);
 
-    let TransactionEffects::V1(effects) = runner.run(pt).await;
+    let (digest, modules) = build_upgrade_test_modules("stage1_basic_compatibility_valid");
+    let effects = runner
+        .upgrade(UpgradePolicy::COMPATIBLE, digest, modules, vec![])
+        .await;
 
     // ETooPermissive abort when we try to authorize the upgrade.
     assert!(matches!(
@@ -319,29 +440,12 @@ async fn test_upgrade_package_compatibility_too_permissive() {
 
 #[tokio::test]
 async fn test_upgrade_package_compatible_in_dep_only_mode() {
-    let runner = UpgradeStateRunner::new("move_upgrade/base").await;
-    let pt = {
-        let mut builder = ProgrammableTransactionBuilder::new();
-        let current_package_id = runner.package.0;
-        let (digest, modules) = build_upgrade_test_modules("stage1_basic_compatibility_valid");
+    let mut runner = UpgradeStateRunner::new("move_upgrade/base").await;
 
-        // We take as input the upgrade runner.upgrade_cap
-        builder
-            .obj(ObjectArg::ImmOrOwnedObject(runner.upgrade_cap))
-            .unwrap();
-
-        // Create the upgrade ticket
-        let upgrade_arg = builder.pure(UpgradePolicy::DEP_ONLY).unwrap();
-        let digest_arg = builder.pure(digest).unwrap();
-        let upgrade_ticket = move_call! {
-            builder,
-            (SuiFramework::ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
-        };
-        builder.upgrade(current_package_id, upgrade_ticket, vec![], modules);
-        builder.finish()
-    };
-
-    let TransactionEffects::V1(effects) = runner.run(pt).await;
+    let (digest, modules) = build_upgrade_test_modules("stage1_basic_compatibility_valid");
+    let effects = runner
+        .upgrade(UpgradePolicy::DEP_ONLY, digest, modules, vec![])
+        .await;
 
     assert_eq!(
         effects.status.unwrap_err().0,
@@ -353,29 +457,12 @@ async fn test_upgrade_package_compatible_in_dep_only_mode() {
 
 #[tokio::test]
 async fn test_upgrade_package_compatible_in_additive_mode() {
-    let runner = UpgradeStateRunner::new("move_upgrade/base").await;
-    let pt = {
-        let mut builder = ProgrammableTransactionBuilder::new();
-        let current_package_id = runner.package.0;
-        let (digest, modules) = build_upgrade_test_modules("stage1_basic_compatibility_valid");
+    let mut runner = UpgradeStateRunner::new("move_upgrade/base").await;
 
-        // We take as input the upgrade runner.upgrade_cap
-        builder
-            .obj(ObjectArg::ImmOrOwnedObject(runner.upgrade_cap))
-            .unwrap();
-
-        // Create the upgrade ticket
-        let upgrade_arg = builder.pure(UpgradePolicy::ADDITIVE).unwrap();
-        let digest_arg = builder.pure(digest).unwrap();
-        let upgrade_ticket = move_call! {
-            builder,
-            (SuiFramework::ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
-        };
-        builder.upgrade(current_package_id, upgrade_ticket, vec![], modules);
-        builder.finish()
-    };
-
-    let TransactionEffects::V1(effects) = runner.run(pt).await;
+    let (digest, modules) = build_upgrade_test_modules("stage1_basic_compatibility_valid");
+    let effects = runner
+        .upgrade(UpgradePolicy::ADDITIVE, digest, modules, vec![])
+        .await;
 
     assert_eq!(
         effects.status.unwrap_err().0,
@@ -387,29 +474,10 @@ async fn test_upgrade_package_compatible_in_additive_mode() {
 
 #[tokio::test]
 async fn test_upgrade_package_invalid_compatibility() {
-    let runner = UpgradeStateRunner::new("move_upgrade/base").await;
-    let pt = {
-        let mut builder = ProgrammableTransactionBuilder::new();
-        let current_package_id = runner.package.0;
-        let (digest, modules) = build_upgrade_test_modules("stage1_basic_compatibility_valid");
+    let mut runner = UpgradeStateRunner::new("move_upgrade/base").await;
 
-        // We take as input the upgrade runner.upgrade_cap
-        builder
-            .obj(ObjectArg::ImmOrOwnedObject(runner.upgrade_cap))
-            .unwrap();
-
-        // Create the upgrade ticket -- but it has an invalid compatibility policy.
-        let upgrade_arg = builder.pure(255u8).unwrap();
-        let digest_arg = builder.pure(digest).unwrap();
-        let upgrade_ticket = move_call! {
-            builder,
-            (SuiFramework::ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
-        };
-        builder.upgrade(current_package_id, upgrade_ticket, vec![], modules);
-        builder.finish()
-    };
-
-    let TransactionEffects::V1(effects) = runner.run(pt).await;
+    let (digest, modules) = build_upgrade_test_modules("stage1_basic_compatibility_valid");
+    let effects = runner.upgrade(255u8, digest, modules, vec![]).await;
 
     assert!(matches!(
         effects.status.unwrap_err().0,
@@ -421,62 +489,24 @@ async fn test_upgrade_package_invalid_compatibility() {
 
 #[tokio::test]
 async fn test_upgrade_package_additive_mode() {
-    let runner = UpgradeStateRunner::new("move_upgrade/base").await;
-    let pt = {
-        let mut builder = ProgrammableTransactionBuilder::new();
-        let current_package_id = runner.package.0;
-        let (digest, modules) = build_upgrade_test_modules("additive_upgrade");
+    let mut runner = UpgradeStateRunner::new("move_upgrade/base").await;
 
-        // We take as input the upgrade runner.upgrade_cap
-        builder
-            .obj(ObjectArg::ImmOrOwnedObject(runner.upgrade_cap))
-            .unwrap();
+    let (digest, modules) = build_upgrade_test_modules("additive_upgrade");
+    let effects = runner
+        .upgrade(UpgradePolicy::ADDITIVE, digest, modules, vec![])
+        .await;
 
-        // Create the upgrade ticket
-        let upgrade_arg = builder.pure(UpgradePolicy::ADDITIVE).unwrap();
-        let digest_arg = builder.pure(digest).unwrap();
-        let upgrade_ticket = move_call! {
-            builder,
-            (SuiFramework::ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
-        };
-        let upgrade_receipt = builder.upgrade(current_package_id, upgrade_ticket, vec![], modules);
-        move_call! {
-            builder,
-            (SuiFramework::ID)::package::commit_upgrade(Argument::Input(0), upgrade_receipt)
-        };
-        builder.finish()
-    };
-
-    let TransactionEffects::V1(effects) = runner.run(pt).await;
-
-    assert!(effects.status.is_ok());
+    assert!(effects.status.is_ok(), "{:#?}", effects.status);
 }
 
 #[tokio::test]
 async fn test_upgrade_package_invalid_additive_mode() {
-    let runner = UpgradeStateRunner::new("move_upgrade/base").await;
-    let pt = {
-        let mut builder = ProgrammableTransactionBuilder::new();
-        let current_package_id = runner.package.0;
-        let (digest, modules) = build_upgrade_test_modules("additive_upgrade_invalid");
+    let mut runner = UpgradeStateRunner::new("move_upgrade/base").await;
 
-        // We take as input the upgrade runner.upgrade_cap
-        builder
-            .obj(ObjectArg::ImmOrOwnedObject(runner.upgrade_cap))
-            .unwrap();
-
-        // Create the upgrade ticket
-        let upgrade_arg = builder.pure(UpgradePolicy::ADDITIVE).unwrap();
-        let digest_arg = builder.pure(digest).unwrap();
-        let upgrade_ticket = move_call! {
-            builder,
-            (SuiFramework::ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
-        };
-        builder.upgrade(current_package_id, upgrade_ticket, vec![], modules);
-        builder.finish()
-    };
-
-    let TransactionEffects::V1(effects) = runner.run(pt).await;
+    let (digest, modules) = build_upgrade_test_modules("additive_upgrade_invalid");
+    let effects = runner
+        .upgrade(UpgradePolicy::ADDITIVE, digest, modules, vec![])
+        .await;
 
     assert_eq!(
         effects.status.unwrap_err().0,
@@ -488,29 +518,12 @@ async fn test_upgrade_package_invalid_additive_mode() {
 
 #[tokio::test]
 async fn test_upgrade_package_additive_dep_only_mode() {
-    let runner = UpgradeStateRunner::new("move_upgrade/base").await;
-    let pt = {
-        let mut builder = ProgrammableTransactionBuilder::new();
-        let current_package_id = runner.package.0;
-        let (digest, modules) = build_upgrade_test_modules("additive_upgrade");
+    let mut runner = UpgradeStateRunner::new("move_upgrade/base").await;
 
-        // We take as input the upgrade runner.upgrade_cap
-        builder
-            .obj(ObjectArg::ImmOrOwnedObject(runner.upgrade_cap))
-            .unwrap();
-
-        // Create the upgrade ticket
-        let upgrade_arg = builder.pure(UpgradePolicy::DEP_ONLY).unwrap();
-        let digest_arg = builder.pure(digest).unwrap();
-        let upgrade_ticket = move_call! {
-            builder,
-            (SuiFramework::ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
-        };
-        builder.upgrade(current_package_id, upgrade_ticket, vec![], modules);
-        builder.finish()
-    };
-
-    let TransactionEffects::V1(effects) = runner.run(pt).await;
+    let (digest, modules) = build_upgrade_test_modules("additive_upgrade");
+    let effects = runner
+        .upgrade(UpgradePolicy::DEP_ONLY, digest, modules, vec![])
+        .await;
 
     assert_eq!(
         effects.status.unwrap_err().0,
@@ -522,55 +535,34 @@ async fn test_upgrade_package_additive_dep_only_mode() {
 
 #[tokio::test]
 async fn test_upgrade_package_dep_only_mode() {
-    let runner = UpgradeStateRunner::new("move_upgrade/base").await;
-    let pt = {
-        let mut builder = ProgrammableTransactionBuilder::new();
-        let current_package_id = runner.package.0;
-        let (digest, modules) = build_upgrade_test_modules("dep_only_upgrade");
+    let mut runner = UpgradeStateRunner::new("move_upgrade/base").await;
 
-        // We take as input the upgrade runner.upgrade_cap
-        builder
-            .obj(ObjectArg::ImmOrOwnedObject(runner.upgrade_cap))
-            .unwrap();
-
-        // Create the upgrade ticket
-        let upgrade_arg = builder.pure(UpgradePolicy::DEP_ONLY).unwrap();
-        let digest_arg = builder.pure(digest).unwrap();
-        let upgrade_ticket = move_call! {
-            builder,
-            (SuiFramework::ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
-        };
-        let upgrade_receipt = builder.upgrade(
-            current_package_id,
-            upgrade_ticket,
-            vec![SuiFramework::ID, MoveStdlib::ID],
+    let (digest, modules) = build_upgrade_test_modules("dep_only_upgrade");
+    let effects = runner
+        .upgrade(
+            UpgradePolicy::DEP_ONLY,
+            digest,
             modules,
-        );
-        move_call! {
-            builder,
-            (SuiFramework::ID)::package::commit_upgrade(Argument::Input(0), upgrade_receipt)
-        };
-        builder.finish()
-    };
+            vec![SuiFramework::ID, MoveStdlib::ID],
+        )
+        .await;
 
-    let TransactionEffects::V1(effects) = runner.run(pt).await;
-
-    assert!(effects.status.is_ok());
+    assert!(effects.status.is_ok(), "{:#?}", effects.status);
 }
 
 #[tokio::test]
 async fn test_upgrade_package_not_a_ticket() {
-    let runner = UpgradeStateRunner::new("move_upgrade/base").await;
+    let mut runner = UpgradeStateRunner::new("move_upgrade/base").await;
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
         let current_package_id = runner.package.0;
         let (_, modules) = build_upgrade_test_modules("stage1_basic_compatibility_valid");
 
         // We take as input the upgrade runner.upgrade_cap
-        builder
+        let cap = builder
             .obj(ObjectArg::ImmOrOwnedObject(runner.upgrade_cap))
             .unwrap();
-        builder.upgrade(current_package_id, Argument::Input(0), vec![], modules);
+        builder.upgrade(current_package_id, cap, vec![], modules);
         builder.finish()
     };
     let TransactionEffects::V1(effects) = runner.run(pt).await;
@@ -586,7 +578,7 @@ async fn test_upgrade_package_not_a_ticket() {
 
 #[tokio::test]
 async fn test_upgrade_ticket_doesnt_match() {
-    let runner = UpgradeStateRunner::new("move_upgrade/base").await;
+    let mut runner = UpgradeStateRunner::new("move_upgrade/base").await;
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
         let (digest, modules) = build_upgrade_test_modules("stage1_basic_compatibility_valid");
@@ -619,7 +611,7 @@ async fn test_upgrade_ticket_doesnt_match() {
 
 #[tokio::test]
 async fn upgrade_missing_deps() {
-    let TransactionEffects::V1(effects) = test_multiple_upgrades(true).await;
+    let effects = test_multiple_upgrades(true).await;
     assert!(matches!(
         effects.status.unwrap_err().0,
         ExecutionFailureStatus::PackageUpgradeError {
@@ -630,96 +622,45 @@ async fn upgrade_missing_deps() {
 
 #[tokio::test]
 async fn test_multiple_upgrades_valid() {
-    let TransactionEffects::V1(effects) = test_multiple_upgrades(false).await;
-    assert!(effects.status.is_ok());
+    let effects = test_multiple_upgrades(false).await;
+    assert!(effects.status.is_ok(), "{:#?}", effects.status);
 }
 
-async fn test_multiple_upgrades(use_empty_deps: bool) -> TransactionEffects {
-    let runner = UpgradeStateRunner::new("move_upgrade/base").await;
-    let pt1 = {
-        let mut builder = ProgrammableTransactionBuilder::new();
-        let current_package_id = runner.package.0;
-        let (digest, modules) = build_upgrade_test_modules("stage1_basic_compatibility_valid");
+async fn test_multiple_upgrades(use_empty_deps: bool) -> TransactionEffectsV1 {
+    let mut runner = UpgradeStateRunner::new("move_upgrade/base").await;
 
-        // We take as input the upgrade cap
-        builder
-            .obj(ObjectArg::ImmOrOwnedObject(runner.upgrade_cap))
-            .unwrap();
+    let (digest, modules) = build_upgrade_test_modules("stage1_basic_compatibility_valid");
+    let effects = runner
+        .upgrade(UpgradePolicy::COMPATIBLE, digest, modules, vec![])
+        .await;
 
-        // Create the upgrade ticket
-        let upgrade_arg = builder.pure(UpgradePolicy::COMPATIBLE).unwrap();
-        let digest_arg = builder.pure(digest).unwrap();
-        let upgrade_ticket = move_call! {
-            builder,
-            (SuiFramework::ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
-        };
-        let upgrade_receipt = builder.upgrade(current_package_id, upgrade_ticket, vec![], modules);
-        move_call! {
-            builder,
-            (SuiFramework::ID)::package::commit_upgrade(Argument::Input(0), upgrade_receipt)
-        };
+    assert!(effects.status.is_ok(), "{:#?}", effects.status);
 
-        builder.finish()
-    };
-    let TransactionEffects::V1(effects) = runner.run(pt1).await;
-    assert!(effects.status.is_ok());
-
-    let new_package = effects
-        .created
-        .iter()
-        .find(|(_, owner)| matches!(owner, Owner::Immutable))
-        .unwrap();
-
-    let new_upgrade_cap = effects
-        .mutated
-        .iter()
-        .find(|(obj, _)| obj.0 == runner.upgrade_cap.0)
-        .unwrap();
-
-    // Second upgrade: Also adds a dep on the sui framework and stdlib.
-    let pt2 = {
-        let mut builder = ProgrammableTransactionBuilder::new();
-        let current_package_id = new_package.0 .0;
-        let (digest, modules) = build_upgrade_test_modules("stage2_basic_compatibility_valid");
-
-        // We take as input the upgrade cap
-        builder
-            .obj(ObjectArg::ImmOrOwnedObject(new_upgrade_cap.0))
-            .unwrap();
-
-        // Create the upgrade ticket
-        let upgrade_arg = builder.pure(UpgradePolicy::COMPATIBLE).unwrap();
-        let digest_arg = builder.pure(digest).unwrap();
-        let upgrade_ticket = move_call! {
-            builder,
-            (SuiFramework::ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
-        };
-        let deps = if use_empty_deps {
-            vec![]
-        } else {
-            vec![SuiFramework::ID, MoveStdlib::ID]
-        };
-        let upgrade_receipt = builder.upgrade(current_package_id, upgrade_ticket, deps, modules);
-        move_call! {
-            builder,
-            (SuiFramework::ID)::package::commit_upgrade(Argument::Input(0), upgrade_receipt)
-        };
-
-        builder.finish()
-    };
-    runner.run(pt2).await
+    // Second upgrade: May also adds a dep on the sui framework and stdlib.
+    let (digest, modules) = build_upgrade_test_modules("stage2_basic_compatibility_valid");
+    runner
+        .upgrade(
+            UpgradePolicy::COMPATIBLE,
+            digest,
+            modules,
+            if use_empty_deps {
+                vec![]
+            } else {
+                vec![SuiFramework::ID, MoveStdlib::ID]
+            },
+        )
+        .await
 }
 
-// TODO(tzakian): turn this test on once the Move loader changes.
 #[tokio::test]
-#[ignore]
 async fn test_interleaved_upgrades() {
-    let runner = UpgradeStateRunner::new("move_upgrade/base").await;
+    let mut runner = UpgradeStateRunner::new("move_upgrade/base").await;
 
     // Base has been published. Publish a package now that depends on the base package.
     let (_, module_bytes, dep_ids) = build_upgrade_test_modules_with_dep_addr(
         "dep_on_upgrading_package",
         [("base_addr", runner.package.0)],
+        [("package_upgrade_base", runner.package.0)],
     );
     let (depender_package, depender_cap) = runner.publish(module_bytes, dep_ids).await;
 
@@ -750,7 +691,7 @@ async fn test_interleaved_upgrades() {
         builder.finish()
     };
     let TransactionEffects::V1(effects) = runner.run(pt1).await;
-    assert!(effects.status.is_ok());
+    assert!(effects.status.is_ok(), "{:#?}", effects.status);
 
     let dep_v2_package = effects
         .created
@@ -766,7 +707,8 @@ async fn test_interleaved_upgrades() {
         // Currently doesn't work -- need to wait for linkage table to be added to the loader.
         let (digest, modules, dep_ids) = build_upgrade_test_modules_with_dep_addr(
             "dep_on_upgrading_package",
-            [("base_addr", dep_v2_package.0)],
+            [("base_addr", runner.package.0)],
+            [("package_upgrade_base", dep_v2_package.0)],
         );
 
         // We take as input the upgrade cap
@@ -790,17 +732,18 @@ async fn test_interleaved_upgrades() {
         builder.finish()
     };
     let TransactionEffects::V1(effects) = runner.run(pt2).await;
-    assert!(effects.status.is_ok());
+    assert!(effects.status.is_ok(), "{:#?}", effects.status);
 }
 
 #[tokio::test]
 async fn test_publish_override_happy_path() {
-    let runner = UpgradeStateRunner::new("move_upgrade/base").await;
+    let mut runner = UpgradeStateRunner::new("move_upgrade/base").await;
 
     // Base has been published already. Publish a package now that depends on the base package.
     let (_, module_bytes, dep_ids) = build_upgrade_test_modules_with_dep_addr(
         "dep_on_upgrading_package",
         [("base_addr", runner.package.0)],
+        [("package_upgrade_base", runner.package.0)],
     );
     // Dependency graph: base <-- dep_on_upgrading_package
     let (depender_package, _) = runner.publish(module_bytes, dep_ids).await;
@@ -834,7 +777,7 @@ async fn test_publish_override_happy_path() {
         builder.finish()
     };
     let TransactionEffects::V1(effects) = runner.run(pt1).await;
-    assert!(effects.status.is_ok());
+    assert!(effects.status.is_ok(), "{:#?}", effects.status);
 
     let dep_v2_package = effects
         .created
@@ -851,6 +794,10 @@ async fn test_publish_override_happy_path() {
         "dep_on_dep",
         [
             ("base_addr", dep_v2_package.0),
+            ("dep_on_upgrading_package", depender_package.0),
+        ],
+        [
+            ("package_upgrade_base", dep_v2_package.0),
             ("dep_on_upgrading_package", depender_package.0),
         ],
     );

--- a/crates/sui-framework-build/src/compiled_package.rs
+++ b/crates/sui-framework-build/src/compiled_package.rs
@@ -474,7 +474,7 @@ impl CompiledPackage {
                 });
             }
             // 2. generate struct layouts for all parameters of `entry` funs
-            for (_name, f) in normalized_m.exposed_functions {
+            for (_name, f) in normalized_m.functions {
                 if f.is_entry {
                     for t in f.parameters {
                         let tag_opt = match t.clone() {

--- a/crates/sui-framework/src/lib.rs
+++ b/crates/sui-framework/src/lib.rs
@@ -43,19 +43,19 @@ macro_rules! define_system_package {
                 bcs::from_bytes($Package::BCS_BYTES).unwrap()
             }
 
-            fn as_modules() -> Vec<CompiledModule> {
+            fn as_modules() -> &'static [CompiledModule] {
                 static MODULES: Lazy<Vec<CompiledModule>> = Lazy::new(|| {
                     // deserialization here uses overall max version of supported Move bytecode
                     // rather than the max supported by the framework but it's OK
                     $Package::as_bytes().into_iter().map(|m| CompiledModule::deserialize(&m).unwrap()).collect()
                 });
-                Lazy::force(&MODULES).to_owned()
+                &Lazy::force(&MODULES)
             }
 
             fn as_package() -> MovePackage {
                 MovePackage::new_system(
                     OBJECT_START_VERSION,
-                    $Package::as_modules(),
+                    &$Package::as_modules(),
                     $Package::transitive_dependencies(),
                 )
             }
@@ -110,7 +110,7 @@ pub trait SystemPackage {
     const BCS_BYTES: &'static [u8];
     fn transitive_dependencies() -> Vec<ObjectID>;
     fn as_bytes() -> Vec<Vec<u8>>;
-    fn as_modules() -> Vec<CompiledModule>;
+    fn as_modules() -> &'static [CompiledModule];
     fn as_package() -> MovePackage;
     fn as_object() -> Object;
 }
@@ -121,9 +121,9 @@ pub fn system_package_ids() -> Vec<ObjectID> {
 
 pub fn make_system_modules() -> Vec<Vec<CompiledModule>> {
     vec![
-        MoveStdlib::as_modules(),
-        SuiFramework::as_modules(),
-        SuiSystem::as_modules(),
+        MoveStdlib::as_modules().to_owned(),
+        SuiFramework::as_modules().to_owned(),
+        SuiSystem::as_modules().to_owned(),
     ]
 }
 

--- a/crates/sui-framework/src/natives/event.rs
+++ b/crates/sui-framework/src/natives/event.rs
@@ -95,6 +95,6 @@ pub fn emit(
 
     let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
 
-    obj_runtime.emit_event(*tag, event_value)?;
+    obj_runtime.emit_event(ty, *tag, event_value)?;
     Ok(NativeResult::ok(context.gas_used(), smallvec![]))
 }

--- a/crates/sui-framework/src/natives/object_runtime/object_store.rs
+++ b/crates/sui-framework/src/natives/object_runtime/object_store.rs
@@ -29,7 +29,6 @@ pub(crate) struct ChildObjectEffect {
     // none if it was an input object
     pub(super) loaded_version: Option<SequenceNumber>,
     pub(super) ty: Type,
-    pub(super) move_type: MoveObjectType,
     pub(super) effect: Op<Value>,
 }
 
@@ -375,7 +374,7 @@ impl<'a> ObjectStore<'a> {
                 let ChildObject {
                     owner,
                     ty,
-                    move_type,
+                    move_type: _,
                     value,
                 } = child_object;
                 let loaded_version = loaded_versions.get(&id).copied();
@@ -384,7 +383,6 @@ impl<'a> ObjectStore<'a> {
                     owner,
                     loaded_version,
                     ty,
-                    move_type,
                     effect,
                 };
                 Some((id, child_effect))

--- a/crates/sui-framework/src/natives/test_scenario.rs
+++ b/crates/sui-framework/src/natives/test_scenario.rs
@@ -124,7 +124,7 @@ pub fn end_transaction(
     // handle transfers, inserting transferred/written objects into their respective inventory
     let mut created = vec![];
     let mut written = vec![];
-    for (id, (kind, owner, ty, _tag, value)) in writes {
+    for (id, (kind, owner, ty, value)) in writes {
         new_object_values.insert(id, (ty.clone(), value.copy_value().unwrap()));
         transferred.push((id, owner));
         incorrect_shared_or_imm_handling = incorrect_shared_or_imm_handling

--- a/crates/sui-framework/src/natives/transfer.rs
+++ b/crates/sui-framework/src/natives/transfer.rs
@@ -14,10 +14,7 @@ use move_vm_types::{
 };
 use smallvec::smallvec;
 use std::collections::VecDeque;
-use sui_types::{
-    base_types::{MoveObjectType, SequenceNumber},
-    object::Owner,
-};
+use sui_types::{base_types::SequenceNumber, object::Owner};
 
 const E_SHARED_NON_NEW_OBJECT: u64 = 0;
 
@@ -150,15 +147,13 @@ fn object_runtime_transfer(
     ty: Type,
     obj: Value,
 ) -> PartialVMResult<TransferResult> {
-    let tag = match context.type_to_type_tag(&ty)? {
-        TypeTag::Struct(s) => *s,
-        _ => {
-            return Err(
-                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                    .with_message("Sui verifier guarantees this is a struct".to_string()),
-            )
-        }
-    };
+    if !matches!(context.type_to_type_tag(&ty)?, TypeTag::Struct(_)) {
+        return Err(
+            PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                .with_message("Sui verifier guarantees this is a struct".to_string()),
+        );
+    }
+
     let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
-    obj_runtime.transfer(owner, ty, MoveObjectType::from(tag), obj)
+    obj_runtime.transfer(owner, ty, obj)
 }

--- a/crates/sui-json-rpc-types/src/sui_move.rs
+++ b/crates/sui-json-rpc-types/src/sui_move.rs
@@ -139,10 +139,12 @@ impl From<NormalizedModule> for SuiMoveNormalizedModule {
                 .map(|(name, struct_)| (name.to_string(), SuiMoveNormalizedStruct::from(struct_)))
                 .collect::<BTreeMap<String, SuiMoveNormalizedStruct>>(),
             exposed_functions: module
-                .exposed_functions
+                .functions
                 .into_iter()
-                .map(|(name, function)| {
-                    (name.to_string(), SuiMoveNormalizedFunction::from(function))
+                .filter_map(|(name, function)| {
+                    // TODO: Do we want to expose the private functions as well?
+                    (function.is_entry || function.visibility != Visibility::Private)
+                        .then(|| (name.to_string(), SuiMoveNormalizedFunction::from(function)))
                 })
                 .collect::<BTreeMap<String, SuiMoveNormalizedFunction>>(),
         }

--- a/crates/sui-json-rpc/src/move_utils.rs
+++ b/crates/sui-json-rpc/src/move_utils.rs
@@ -90,7 +90,7 @@ impl MoveUtilsServer for MoveUtils {
         function_name: String,
     ) -> RpcResult<SuiMoveNormalizedFunction> {
         let module = get_move_module(&self.state, package, module_name).await?;
-        let functions = module.exposed_functions;
+        let functions = module.functions;
         let identifier = Identifier::new(function_name.as_str()).map_err(|e| anyhow!("{e}"))?;
         Ok(match functions.get(&identifier) {
             Some(function) => Ok(function.clone().into()),
@@ -130,11 +130,9 @@ impl MoveUtilsServer for MoveUtils {
         }?;
 
         let identifier = Identifier::new(function.as_str()).map_err(|e| anyhow!("{e}"))?;
-        let parameters = normalized.get(&module).and_then(|m| {
-            m.exposed_functions
-                .get(&identifier)
-                .map(|f| f.parameters.clone())
-        });
+        let parameters = normalized
+            .get(&module)
+            .and_then(|m| m.functions.get(&identifier).map(|f| f.parameters.clone()));
 
         Ok(match parameters {
             Some(parameters) => Ok(parameters

--- a/crates/sui-json/src/tests.rs
+++ b/crates/sui-json/src/tests.rs
@@ -414,7 +414,7 @@ fn test_basic_args_linter_top_level() {
         .unwrap()
         .into_modules();
     let example_package = Object::new_package_for_testing(
-        compiled_modules,
+        &compiled_modules,
         TransactionDigest::genesis(),
         &make_system_packages(),
     )
@@ -540,7 +540,7 @@ fn test_basic_args_linter_top_level() {
         .unwrap()
         .into_modules();
     let example_package = Object::new_package_for_testing(
-        compiled_modules,
+        &compiled_modules,
         TransactionDigest::genesis(),
         &make_system_packages(),
     )
@@ -643,7 +643,7 @@ fn test_basic_args_linter_top_level() {
         .unwrap()
         .into_modules();
     let example_package = Object::new_package_for_testing(
-        compiled_modules,
+        &compiled_modules,
         TransactionDigest::genesis(),
         &make_system_packages(),
     )

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -17,7 +17,7 @@ const MAX_PROTOCOL_VERSION: u64 = 3;
 // Version 1: Original version.
 // Version 2: Framework changes, including advancing epoch_start_time in safemode.
 // Version 3: gas model v2, including all sui conservation fixes. Fix for loaded child object
-//            changes.
+//            changes, enable package upgrades.
 
 #[derive(
     Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, JsonSchema,
@@ -565,6 +565,10 @@ impl ProtocolConfig {
                 self.version
             )))
         }
+    }
+
+    pub fn package_upgrades_supported(&self) -> bool {
+        self.feature_flags.package_upgrades
     }
 
     pub fn check_commit_root_state_digest_supported(&self) -> bool {
@@ -1511,6 +1515,7 @@ impl ProtocolConfig {
                 // storage gas price multiplier
                 cfg.storage_gas_price = Some(76);
                 cfg.feature_flags.loaded_child_objects_fixed = true;
+                cfg.feature_flags.package_upgrades = true;
                 cfg
             }
             // Use this template when making changes:

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_3.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_3.snap
@@ -4,6 +4,7 @@ expression: "ProtocolConfig::get_for_version(cur)"
 ---
 version: 3
 feature_flags:
+  package_upgrades: true
   advance_epoch_start_time_in_safe_mode: true
   loaded_child_objects_fixed: true
 max_tx_size_bytes: 131072

--- a/crates/sui-transactional-test-runner/Cargo.toml
+++ b/crates/sui-transactional-test-runner/Cargo.toml
@@ -21,6 +21,7 @@ move-command-line-common.workspace = true
 move-compiler.workspace = true
 move-core-types.workspace = true
 move-stdlib.workspace = true
+move-symbol-pool.workspace = true
 move-transactional-test-runner.workspace = true
 move-vm-runtime.workspace = true
 

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -12,7 +12,7 @@ use fastcrypto::error::FastCryptoError;
 use move_binary_format::{access::ModuleAccess, errors::VMError};
 use move_binary_format::{errors::Location, file_format::FunctionDefinitionIndex};
 use move_core_types::{
-    resolver::{LinkageResolver, ModuleResolver, ResourceResolver},
+    resolver::MoveResolver,
     vm_status::{StatusCode, StatusType},
 };
 pub use move_vm_runtime::move_vm::MoveVM;
@@ -754,14 +754,10 @@ impl From<ExecutionErrorKind> for ExecutionError {
     }
 }
 
-pub fn convert_vm_error<
-    'r,
-    E: Debug,
-    S: ResourceResolver<Error = E> + ModuleResolver<Error = E> + LinkageResolver<Error = E>,
->(
+pub fn convert_vm_error<S: MoveResolver<Err = SuiError>>(
     error: VMError,
-    vm: &'r MoveVM,
-    state_view: &'r S,
+    vm: &MoveVM,
+    state_view: &S,
 ) -> ExecutionError {
     let kind = match (error.major_status(), error.sub_status(), error.location()) {
         (StatusCode::EXECUTED, _, _) => {

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -552,7 +552,7 @@ impl Object {
     /// Create a system package which is not subject to size limits. Panics if the object ID is not
     /// a known system package.
     pub fn new_system_package(
-        modules: Vec<CompiledModule>,
+        modules: &[CompiledModule],
         version: SequenceNumber,
         dependencies: Vec<ObjectID>,
         previous_transaction: TransactionDigest,
@@ -577,15 +577,13 @@ impl Object {
 
     // Note: this will panic if `modules` is empty
     pub fn new_package<'p>(
-        modules: Vec<CompiledModule>,
-        version: SequenceNumber,
+        modules: &[CompiledModule],
         previous_transaction: TransactionDigest,
         max_move_package_size: u64,
         dependencies: impl IntoIterator<Item = &'p MovePackage>,
     ) -> Result<Self, ExecutionError> {
         Ok(Self::new_package_from_data(
             Data::Package(MovePackage::new_initial(
-                version,
                 modules,
                 max_move_package_size,
                 dependencies,
@@ -594,13 +592,13 @@ impl Object {
         ))
     }
 
-    pub fn new_upgraded_package<'a>(
+    pub fn new_upgraded_package<'p>(
         previous_package: &MovePackage,
         new_package_id: ObjectID,
-        modules: Vec<CompiledModule>,
+        modules: &[CompiledModule],
         previous_transaction: TransactionDigest,
         max_move_package_size: u64,
-        dependencies: impl IntoIterator<Item = &'a MovePackage>,
+        dependencies: impl IntoIterator<Item = &'p MovePackage>,
     ) -> Result<Self, ExecutionError> {
         Ok(Self::new_package_from_data(
             Data::Package(previous_package.new_upgraded(
@@ -614,13 +612,12 @@ impl Object {
     }
 
     pub fn new_package_for_testing<'p>(
-        modules: Vec<CompiledModule>,
+        modules: &[CompiledModule],
         previous_transaction: TransactionDigest,
         dependencies: impl IntoIterator<Item = &'p MovePackage>,
     ) -> Result<Self, ExecutionError> {
         Self::new_package(
             modules,
-            OBJECT_START_VERSION,
             previous_transaction,
             ProtocolConfig::get_for_max_version().max_move_package_size(),
             dependencies,

--- a/crates/sui-types/src/unit_tests/base_types_tests.rs
+++ b/crates/sui-types/src/unit_tests/base_types_tests.rs
@@ -16,7 +16,6 @@ use crate::crypto::{
     Signature, SuiAuthoritySignature, SuiSignature,
 };
 use crate::id::{ID, UID};
-use crate::OBJECT_START_VERSION;
 use crate::{gas_coin::GasCoin, object::Object, SUI_FRAMEWORK_ADDRESS};
 use shared_crypto::intent::{Intent, IntentMessage, IntentScope};
 use sui_protocol_config::ProtocolConfig;
@@ -359,8 +358,7 @@ fn test_move_object_size_for_gas_metering() {
 fn test_move_package_size_for_gas_metering() {
     let module = file_format::empty_module();
     let package = Object::new_package(
-        vec![module],
-        OBJECT_START_VERSION,
+        &[module],
         TransactionDigest::genesis(),
         ProtocolConfig::get_for_max_version().max_move_package_size(),
         &[], // empty dependencies for empty package (no modules)

--- a/crates/sui-verifier-transactional-tests/tests/one_time_witness/other_mod_def.move
+++ b/crates/sui-verifier-transactional-tests/tests/one_time_witness/other_mod_def.move
@@ -11,7 +11,7 @@ module test1::m {
     struct M has drop { }
 }
 
-//# publish
+//# publish --dependencies test1
 module test2::n {
 
     fun init(_: test1::m::M, _ctx: &mut sui::tx_context::TxContext) {

--- a/crates/sui-verifier-transactional-tests/tests/private_generics/no_public_transfer.move
+++ b/crates/sui-verifier-transactional-tests/tests/private_generics/no_public_transfer.move
@@ -10,21 +10,21 @@ module a::m {
     struct S has key { id: sui::object::UID }
 }
 
-//# publish
+//# publish --dependencies a
 module test::m {
     fun t(s: a::m::S) {
         sui::transfer::transfer(s, @100)
     }
 }
 
-//# publish
+//# publish --dependencies a
 module test::m {
     fun t(s: a::m::S) {
         sui::transfer::freeze_object(s)
     }
 }
 
-//# publish
+//# publish --dependencies a
 module test::m {
     fun t(s: a::m::S) {
         sui::transfer::share_object(s)

--- a/crates/sui-verifier-transactional-tests/tests/private_generics/no_public_transfer_store.move
+++ b/crates/sui-verifier-transactional-tests/tests/private_generics/no_public_transfer_store.move
@@ -10,21 +10,21 @@ module a::m {
     struct S has key, store { id: sui::object::UID }
 }
 
-//# publish
+//# publish --dependencies a
 module test::m {
     fun t(s: a::m::S) {
         sui::transfer::transfer(s, @100)
     }
 }
 
-//# publish
+//# publish --dependencies a
 module test::m {
     fun t(s: a::m::S) {
         sui::transfer::freeze_object(s)
     }
 }
 
-//# publish
+//# publish --dependencies a
 module test::m {
     fun t(s: a::m::S) {
         sui::transfer::share_object(s)

--- a/crates/sui-verifier-transactional-tests/tests/private_generics/private_event_emit.move
+++ b/crates/sui-verifier-transactional-tests/tests/private_generics/private_event_emit.move
@@ -10,7 +10,7 @@ module a::m {
     struct S has copy, drop {}
 }
 
-//# publish
+//# publish --dependencies a
 module test::m {
     fun t(s: a::m::S) {
         sui::event::emit(s)

--- a/crates/sui/tests/protocol_version_tests.rs
+++ b/crates/sui/tests/protocol_version_tests.rs
@@ -81,7 +81,7 @@ mod sim_only_tests {
         base_types::SequenceNumber,
         digests::TransactionDigest,
         messages::{TransactionEffectsAPI, TransactionKind},
-        object::{Object, OBJECT_START_VERSION},
+        object::Object,
         programmable_transaction_builder::ProgrammableTransactionBuilder,
         storage::ObjectStore,
     };
@@ -745,8 +745,7 @@ mod sim_only_tests {
     /// Like `sui_framework`, but package the modules in an `Object`.
     fn sui_system_package_object(fixture: &str) -> Object {
         Object::new_package(
-            sui_system_modules(fixture),
-            OBJECT_START_VERSION,
+            &sui_system_modules(fixture),
             TransactionDigest::genesis(),
             u64::MAX,
             &[MoveStdlib::as_package(), SuiFramework::as_package()],

--- a/crates/test-utils/tests/network_tests.rs
+++ b/crates/test-utils/tests/network_tests.rs
@@ -6,7 +6,7 @@ use sui_framework::{MoveStdlib, SuiFramework, SuiSystem, SystemPackage};
 use sui_json_rpc::api::ReadApiClient;
 use sui_json_rpc_types::SuiObjectResponse;
 use sui_types::{
-    base_types::ObjectID, digests::TransactionDigest, object::Object, SUI_FRAMEWORK_ADDRESS,
+    base_types::ObjectID, digests::TransactionDigest, object::Object, SUI_SYSTEM_ADDRESS,
 };
 use test_utils::network::TestClusterBuilder;
 
@@ -43,19 +43,19 @@ async fn test_package_override() {
     };
 
     let modified_ref = {
-        let mut framework_modules = SuiSystem::as_modules();
+        let mut framework_modules = SuiSystem::as_modules().to_owned();
 
         // Create an empty module that is pretending to be part of the sui framework.
         let mut test_module = move_binary_format::file_format::empty_module();
         let address_idx = test_module.self_handle().address.0 as usize;
-        test_module.address_identifiers[address_idx] = SUI_FRAMEWORK_ADDRESS;
+        test_module.address_identifiers[address_idx] = SUI_SYSTEM_ADDRESS;
 
         // Add the dummy module to the rest of the sui-frameworks.  We can't replace the framework
         // entirely because we will call into it for genesis.
         framework_modules.push(test_module);
 
         let package_override = Object::new_package_for_testing(
-            framework_modules,
+            &framework_modules,
             TransactionDigest::genesis(),
             &[MoveStdlib::as_package(), SuiFramework::as_package()],
         )

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -316,33 +316,33 @@ miniz_oxide = { version = "0.6", default-features = false, features = ["with-all
 mio = { version = "0.8", features = ["net", "os-ext"] }
 mockall = { version = "0.11", default-features = false }
 more-asserts = { version = "0.3", default-features = false }
-move-abigen = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-borrow-graph = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-compiler = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-core-types = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", features = ["address32"] }
-move-coverage = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-docgen = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-errmapgen = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-model = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-package = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-prover = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", features = ["tiered-gas"] }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", default-features = false }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-borrow-graph = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", default-features = false }
+move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", default-features = false }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", default-features = false }
+move-compiler = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", default-features = false }
+move-core-types = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", features = ["address32"] }
+move-coverage = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-docgen = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", default-features = false }
+move-errmapgen = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", default-features = false }
+move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", default-features = false }
+move-model = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", default-features = false }
+move-package = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", default-features = false }
+move-prover = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", default-features = false }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", default-features = false }
+move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", default-features = false }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", default-features = false }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", default-features = false }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", features = ["tiered-gas"] }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
 multiaddr = { version = "0.17" }
 multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }
@@ -978,33 +978,33 @@ mio = { version = "0.8", features = ["net", "os-ext"] }
 mockall = { version = "0.11", default-features = false }
 mockall_derive = { version = "0.11", default-features = false }
 more-asserts = { version = "0.3", default-features = false }
-move-abigen = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-borrow-graph = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-compiler = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-core-types = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", features = ["address32"] }
-move-coverage = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-docgen = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-errmapgen = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-model = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-package = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-prover = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", features = ["tiered-gas"] }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", default-features = false }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-borrow-graph = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", default-features = false }
+move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", default-features = false }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", default-features = false }
+move-compiler = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", default-features = false }
+move-core-types = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", features = ["address32"] }
+move-coverage = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-docgen = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", default-features = false }
+move-errmapgen = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", default-features = false }
+move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", default-features = false }
+move-model = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", default-features = false }
+move-package = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", default-features = false }
+move-prover = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", default-features = false }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", default-features = false }
+move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", default-features = false }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", default-features = false }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", default-features = false }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46", features = ["tiered-gas"] }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
 multiaddr = { version = "0.17" }
 multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }


### PR DESCRIPTION
## Description 

Connect up the `linkage_table` in `MovePackage` to the `LinkageResolver` trait in the Move Runtime and Loader to enable a package to override a transitive dependency.  Requires the following structural changes:

- Re-implement `load_type` in the adapter, to set the correct `link_context` for the type (type parameters, and inputs to a programmable transaction may not show up in the linkage tables of any function being called in the transaction, or if they do, they might show up at conflicting versions, so they need to be loaded in their own contexts).
- Build the `MovePackage` for publishes and upgrades before calling into the runtime to publish and verify them (because this operation now requires a link context to be set).
  - Note that to maintain backwards compatibility on errors, we need to maintain a version of this code that calls `verify_and_publish_modules` first, if upgrades are not enabled, to maintain the behaviour that a package that has forgotten dependencies and also has verifier errors in its own module will fail with the verification error first.

## Test Plan 

```
$ cargo simtest
$ env SUI_SKIP_SIMTESTS=1 cargo nextest run --no-fail-fast
```