### PR TITLE
[ts-sdk] Rename provider methods to reference blocks

### DIFF
--- a/apps/explorer/src/components/module/module-functions-interaction/ModuleFunction.tsx
+++ b/apps/explorer/src/components/module/module-functions-interaction/ModuleFunction.tsx
@@ -47,7 +47,7 @@ export function ModuleFunction({
     functionName,
     functionDetails,
 }: ModuleFunctionProps) {
-    const { isConnected, signAndExecuteTransaction } = useWalletKit();
+    const { isConnected, signAndExecuteTransactionBlock } = useWalletKit();
     const { handleSubmit, formState, register, control } = useZodForm({
         schema: argsSchema,
     });
@@ -85,7 +85,7 @@ export function ModuleFunction({
                             : tx.object(param)
                     ) ?? [],
             });
-            const result = await signAndExecuteTransaction({
+            const result = await signAndExecuteTransactionBlock({
                 transactionBlock: tx,
                 options: {
                     showEffects: true,

--- a/apps/explorer/src/components/transactions/TransactionsForAddress.tsx
+++ b/apps/explorer/src/components/transactions/TransactionsForAddress.tsx
@@ -28,7 +28,7 @@ export function TransactionsForAddress({ address, type }: Props) {
 
             const results = await Promise.all(
                 filters.map((filter) =>
-                    rpc.queryTransactions({
+                    rpc.queryTransactionBlocks({
                         filter,
                         order: 'descending',
                         limit: 100,

--- a/apps/explorer/src/components/transactions/TxCardUtils.tsx
+++ b/apps/explorer/src/components/transactions/TxCardUtils.tsx
@@ -151,7 +151,7 @@ export const getDataOnTxDigests = (
     transactions: string[]
 ) =>
     rpc
-        .multiGetTransactions({
+        .multiGetTransactionBlocks({
             digests: dedupe(transactions),
             options: {
                 showInput: true,

--- a/apps/explorer/src/components/transactions/index.tsx
+++ b/apps/explorer/src/components/transactions/index.tsx
@@ -29,7 +29,7 @@ export function Transactions({
     const rpc = useRpcClient();
 
     const countQuery = useQuery(['transactions', 'count'], () =>
-        rpc.getTotalTransactionNumber()
+        rpc.getTotalTransactionBlocks()
     );
 
     const pagination = usePaginationStack();
@@ -37,7 +37,7 @@ export function Transactions({
     const transactionQuery = useQuery(
         ['transactions', { limit, cursor: pagination.cursor }],
         async () =>
-            rpc.queryTransactions({
+            rpc.queryTransactionBlocks({
                 order: 'descending',
                 cursor: pagination.cursor,
                 limit,

--- a/apps/explorer/src/hooks/useGetTransaction.ts
+++ b/apps/explorer/src/hooks/useGetTransaction.ts
@@ -9,7 +9,7 @@ export function useGetTransaction(transactionId: string) {
     return useQuery(
         ['transactions-by-id', transactionId],
         async () =>
-            rpc.getTransaction({
+            rpc.getTransactionBlock({
                 digest: transactionId,
                 options: {
                     showInput: true,

--- a/apps/explorer/src/hooks/useSearch.ts
+++ b/apps/explorer/src/hooks/useSearch.ts
@@ -31,7 +31,7 @@ const getResultsForTransaction = async (
 ) => {
     if (!isValidTransactionDigest(query)) return null;
 
-    const txdata = await rpc.getTransaction({ digest: query });
+    const txdata = await rpc.getTransactionBlock({ digest: query });
     return {
         label: 'transaction',
         results: [
@@ -89,11 +89,14 @@ const getResultsForAddress = async (rpc: JsonRpcProvider, query: string) => {
         return null;
 
     const [from, to] = await Promise.all([
-        rpc.queryTransactions({
+        rpc.queryTransactionBlocks({
             filter: { FromAddress: normalized },
             limit: 1,
         }),
-        rpc.queryTransactions({ filter: { ToAddress: normalized }, limit: 1 }),
+        rpc.queryTransactionBlocks({
+            filter: { ToAddress: normalized },
+            limit: 1,
+        }),
     ]);
 
     if (from.data?.length || to.data?.length) {

--- a/apps/explorer/tests/utils/localnet.ts
+++ b/apps/explorer/tests/utils/localnet.ts
@@ -35,7 +35,7 @@ export async function split_coin(address: string) {
         arguments: [tx.object(coin_id), tx.pure(10)],
     });
 
-    const result = await signer.signAndExecuteTransaction({
+    const result = await signer.signAndExecuteTransactionBlock({
         transactionBlock: tx,
         options: {
             showInput: true,

--- a/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
+++ b/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
@@ -9,14 +9,14 @@ import {
     SUI_TESTNET_CHAIN,
     SUI_LOCALNET_CHAIN,
     type SuiFeatures,
-    type SuiSignAndExecuteTransactionMethod,
+    type SuiSignAndExecuteTransactionBlockMethod,
     type StandardConnectFeature,
     type StandardConnectMethod,
     type Wallet,
     type StandardEventsFeature,
     type StandardEventsOnMethod,
     type StandardEventsListeners,
-    type SuiSignTransactionMethod,
+    type SuiSignTransactionBlockMethod,
     type SuiSignMessageMethod,
 } from '@mysten/wallet-standard';
 import mitt, { type Emitter } from 'mitt';
@@ -113,13 +113,14 @@ export class SuiWallet implements Wallet {
                 version: '1.0.0',
                 on: this.#on,
             },
-            'sui:signTransaction': {
-                version: '2.0.0',
-                signTransaction: this.#signTransaction,
+            'sui:signTransactionBlock': {
+                version: '1.0.0',
+                signTransactionBlock: this.#signTransactionBlock,
             },
-            'sui:signAndExecuteTransaction': {
-                version: '2.0.0',
-                signAndExecuteTransaction: this.#signAndExecuteTransaction,
+            'sui:signAndExecuteTransactionBlock': {
+                version: '1.0.0',
+                signAndExecuteTransactionBlock:
+                    this.#signAndExecuteTransactionBlock,
             },
             'suiWallet:stake': {
                 version: '0.0.1',
@@ -224,7 +225,7 @@ export class SuiWallet implements Wallet {
         return { accounts: this.accounts };
     };
 
-    #signTransaction: SuiSignTransactionMethod = async (input) => {
+    #signTransactionBlock: SuiSignTransactionBlockMethod = async (input) => {
         if (!TransactionBlock.is(input.transactionBlock)) {
             throw new Error(
                 'Unexpect transaction format found. Ensure that you are using the `Transaction` class.'
@@ -249,33 +250,35 @@ export class SuiWallet implements Wallet {
         );
     };
 
-    #signAndExecuteTransaction: SuiSignAndExecuteTransactionMethod = async (
-        input
-    ) => {
-        if (!TransactionBlock.is(input.transactionBlock)) {
-            throw new Error(
-                'Unexpect transaction format found. Ensure that you are using the `Transaction` class.'
-            );
-        }
+    #signAndExecuteTransactionBlock: SuiSignAndExecuteTransactionBlockMethod =
+        async (input) => {
+            if (!TransactionBlock.is(input.transactionBlock)) {
+                throw new Error(
+                    'Unexpect transaction format found. Ensure that you are using the `Transaction` class.'
+                );
+            }
 
-        return mapToPromise(
-            this.#send<ExecuteTransactionRequest, ExecuteTransactionResponse>({
-                type: 'execute-transaction-request',
-                transaction: {
-                    type: 'transaction',
-                    data: input.transactionBlock.serialize(),
-                    options: input.options,
-                    // account might be undefined if previous version of adapters is used
-                    // in that case use the first account address
-                    account:
-                        input.account?.address ||
-                        this.#accounts[0]?.address ||
-                        '',
-                },
-            }),
-            (response) => response.result
-        );
-    };
+            return mapToPromise(
+                this.#send<
+                    ExecuteTransactionRequest,
+                    ExecuteTransactionResponse
+                >({
+                    type: 'execute-transaction-request',
+                    transaction: {
+                        type: 'transaction',
+                        data: input.transactionBlock.serialize(),
+                        options: input.options,
+                        // account might be undefined if previous version of adapters is used
+                        // in that case use the first account address
+                        account:
+                            input.account?.address ||
+                            this.#accounts[0]?.address ||
+                            '',
+                    },
+                }),
+                (response) => response.result
+            );
+        };
 
     #stake = async (input: StakeInput) => {
         this.#send<StakeRequest, void>({

--- a/apps/wallet/src/shared/messaging/messages/payloads/transactions/ApprovalRequest.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/transactions/ApprovalRequest.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
-    type SuiSignAndExecuteTransactionInput,
+    type SuiSignAndExecuteTransactionBlockInput,
     type SuiSignMessageOutput,
 } from '@mysten/wallet-standard';
 
@@ -17,8 +17,8 @@ export type TransactionDataType = {
     data: string;
     account: SuiAddress;
     justSign?: boolean;
-    requestType?: SuiSignAndExecuteTransactionInput['requestType'];
-    options?: SuiSignAndExecuteTransactionInput['options'];
+    requestType?: SuiSignAndExecuteTransactionBlockInput['requestType'];
+    options?: SuiSignAndExecuteTransactionBlockInput['options'];
 };
 
 export type SignMessageDataType = {

--- a/apps/wallet/src/shared/messaging/messages/payloads/transactions/ExecuteTransactionRequest.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/transactions/ExecuteTransactionRequest.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { type SuiSignTransactionInput } from '@mysten/wallet-standard';
+import { type SuiSignTransactionBlockInput } from '@mysten/wallet-standard';
 
 import { type TransactionDataType } from './ApprovalRequest';
 import { isBasePayload } from '_payloads';
@@ -23,7 +23,7 @@ export function isExecuteTransactionRequest(
 }
 
 export type SuiSignTransactionSerialized = Omit<
-    SuiSignTransactionInput,
+    SuiSignTransactionBlockInput,
     'transaction' | 'account'
 > & {
     transaction: string;

--- a/apps/wallet/src/shared/messaging/messages/payloads/transactions/ExecuteTransactionResponse.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/transactions/ExecuteTransactionResponse.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { type SuiSignTransactionOutput } from '@mysten/wallet-standard';
+import { type SuiSignTransactionBlockOutput } from '@mysten/wallet-standard';
 
 import { isBasePayload } from '_payloads';
 
@@ -24,7 +24,7 @@ export function isExecuteTransactionResponse(
 
 export interface SignTransactionResponse extends BasePayload {
     type: 'sign-transaction-response';
-    result: SuiSignTransactionOutput;
+    result: SuiSignTransactionBlockOutput;
 }
 
 export function isSignTransactionResponse(

--- a/apps/wallet/src/ui/app/hooks/useQueryTransactionsByAddress.ts
+++ b/apps/wallet/src/ui/app/hooks/useQueryTransactionsByAddress.ts
@@ -15,12 +15,12 @@ export function useQueryTransactionsByAddress(address: SuiAddress | null) {
         async () => {
             // combine from and to transactions
             const [txnIds, fromTxnIds] = await Promise.all([
-                rpc.queryTransactions({
+                rpc.queryTransactionBlocks({
                     filter: {
                         ToAddress: address!,
                     },
                 }),
-                rpc.queryTransactions({
+                rpc.queryTransactionBlocks({
                     filter: {
                         FromAddress: address!,
                     },
@@ -28,7 +28,7 @@ export function useQueryTransactionsByAddress(address: SuiAddress | null) {
             ]);
             // TODO: replace this with queryTransactions
             // It seems to be expensive to fetch all transaction data at once though
-            const resp = await rpc.multiGetTransactions({
+            const resp = await rpc.multiGetTransactionBlocks({
                 digests: dedupe(
                     [...txnIds.data, ...fromTxnIds.data].map((x) => x.digest)
                 ),

--- a/apps/wallet/src/ui/app/hooks/useTransactionDryRun.ts
+++ b/apps/wallet/src/ui/app/hooks/useTransactionDryRun.ts
@@ -14,7 +14,7 @@ export function useTransactionDryRun(
     const response = useQuery({
         queryKey: ['dryRunTransaction', transactionBlock.serialize()],
         queryFn: () => {
-            return signer.dryRunTransaction({ transactionBlock });
+            return signer.dryRunTransactionBlock({ transactionBlock });
         },
     });
     return response;

--- a/apps/wallet/src/ui/app/pages/home/nft-transfer/TransferNFTForm.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nft-transfer/TransferNFTForm.tsx
@@ -37,7 +37,7 @@ export function TransferNFTForm({ objectId }: { objectId: string }) {
             const tx = new TransactionBlock();
             tx.transferObjects([tx.object(objectId)], tx.pure(to));
 
-            return signer.signAndExecuteTransaction({
+            return signer.signAndExecuteTransactionBlock({
                 transactionBlock: tx,
                 options: {
                     showInput: true,

--- a/apps/wallet/src/ui/app/pages/home/receipt/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/receipt/index.tsx
@@ -27,7 +27,7 @@ function ReceiptPage() {
     const { data, isLoading, isError } = useQuery(
         ['transactions-by-id', transactionId],
         async () => {
-            return rpc.getTransaction({
+            return rpc.getTransactionBlock({
                 digest: transactionId!,
                 options: {
                     showObjectChanges: true,

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/index.tsx
@@ -63,7 +63,7 @@ function TransferCoinPage() {
                     props: { coinType: coinType! },
                 });
 
-                return signer.signAndExecuteTransaction({
+                return signer.signAndExecuteTransactionBlock({
                     transactionBlock: transaction,
                     options: {
                         showInput: true,

--- a/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
@@ -67,11 +67,11 @@ export const respondToTransactionRequest = createAsyncThunk<
                     const tx = TransactionBlock.from(txRequest.tx.data);
                     if (txRequest.tx.justSign) {
                         // Just a signing request, do not submit
-                        txSigned = await signer.signTransaction({
+                        txSigned = await signer.signTransactionBlock({
                             transactionBlock: tx,
                         });
                     } else {
-                        txResult = await signer.signAndExecuteTransaction({
+                        txResult = await signer.signAndExecuteTransactionBlock({
                             transactionBlock: tx,
                             options: txRequest.tx.options,
                             requestType: txRequest.tx.requestType,

--- a/apps/wallet/src/ui/app/staking/stake/StakingCard.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/StakingCard.tsx
@@ -135,7 +135,7 @@ function StakingCard() {
                     amount,
                     validatorAddress
                 );
-                return await signer.signAndExecuteTransaction({
+                return await signer.signAndExecuteTransactionBlock({
                     transactionBlock,
                     options: {
                         showInput: true,
@@ -162,7 +162,7 @@ function StakingCard() {
             });
             try {
                 const transactionBlock = createUnstakeTransaction(stakedSuiId);
-                return await signer.signAndExecuteTransaction({
+                return await signer.signAndExecuteTransactionBlock({
                     transactionBlock,
                     options: {
                         showInput: true,

--- a/dapps/frenemies/src/components/Validators/actions/AddDelegation.tsx
+++ b/dapps/frenemies/src/components/Validators/actions/AddDelegation.tsx
@@ -34,7 +34,7 @@ function toMist(sui: string) {
  */
 export function AddDelegation({ validator, amount }: Props) {
   const manageCoins = useManageCoin();
-  const { signAndExecuteTransaction } = useWalletKit();
+  const { signAndExecuteTransactionBlock } = useWalletKit();
   const getLatestCoins = useGetLatestCoins();
 
   const stake = useMutation(["stake-for-validator"], async () => {
@@ -65,7 +65,7 @@ export function AddDelegation({ validator, amount }: Props) {
 
     const stakeCoin = await manageCoins(coins, mistAmount, gasRequired);
 
-    await signAndExecuteTransaction({
+    await signAndExecuteTransactionBlock({
       transaction: {
         kind: "moveCall",
         data: {

--- a/dapps/frenemies/src/components/Validators/actions/CancelDelegation.tsx
+++ b/dapps/frenemies/src/components/Validators/actions/CancelDelegation.tsx
@@ -20,10 +20,10 @@ const GAS_BUDGET = 100000n;
  * Can only be called if the Delegation and StakedSui objects are present.
  */
 export function CancelDelegation({ stake }: Props) {
-  const { signAndExecuteTransaction } = useWalletKit();
+  const { signAndExecuteTransactionBlock } = useWalletKit();
 
   const withdrawDelegation = useMutation(["unstake-validator"], async () => {
-    await signAndExecuteTransaction({
+    await signAndExecuteTransactionBlock({
       transaction: {
         kind: "moveCall",
         data: {

--- a/dapps/frenemies/src/network/queries/scorecard-history.ts
+++ b/dapps/frenemies/src/network/queries/scorecard-history.ts
@@ -27,7 +27,7 @@ export function useScorecardHistory(scorecardId?: string | null) {
       const txIds = await provider.queryTransactionsForObjectDeprecated(
         scorecardId
       );
-      const txs = await provider.multiGetTransactions({
+      const txs = await provider.multiGetTransactionBlocks({
         digests: Array.from(new Set(txIds)),
       });
 

--- a/doc/src/doc-updates/sui-migration-guide.md
+++ b/doc/src/doc-updates/sui-migration-guide.md
@@ -54,8 +54,8 @@ example = "0x42"
 
 If your Sui Move code uses a module in the `governance` folder:
 
-`genesis.move`, `sui_system.move`, `validator_cap.move`, `voting_power.move`, 
-`stake_subsidy.move`, `sui_system_state_inner.move`, `validator_set.move`, 
+`genesis.move`, `sui_system.move`, `validator_cap.move`, `voting_power.move`,
+`stake_subsidy.move`, `sui_system_state_inner.move`, `validator_set.move`,
 `staking_pool.move`, `validator.move`, or `validator_wrapper.move`
 
 The modules are now in the `sui-system` package. You must list `SuiSystem` as a dependency, and access these modules via `0x3` or the `sui_system` named address.
@@ -265,13 +265,13 @@ The `sui_getTransaction`and `sui_multiGetTransaction` functions now take an add
 
     // Updated for release .28
     const provider = new JsonRpcProvider();
-    const txn = await provider.getTransaction({
+    const txn = await provider.getTransactionBlock({
       digest: '6mn5W1CczLwitHCO9OIUbqirNrQ0cuKdyxaNe16SAME=',
       // only fetch the effects field
       options: { showEffects: true },
     });
     // You can also fetch multiple transactions in one batch request
-    const txns = await provider.multiGetTransactions({
+    const txns = await provider.multiGetTransactionBlocks({
       digests: [
         '6mn5W1CczLwitHCO9OIUbqirNrQ0cuKdyxaNe16SAME=',
         '7mn5W1CczLwitHCO9OIUbqirNrQ0cuKdyxaNe16SAME=',

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -143,7 +143,7 @@ tx.transferObjects(
   [tx.object('0x5015b016ab570df14c87649eda918e09e5cc61e0')],
   tx.pure('0xd84058cb73bdeabe123b56632713dcd65e1a6c92'),
 );
-const result = await signer.signAndExecuteTransaction({ transactionBlock: tx });
+const result = await signer.signAndExecuteTransactionBlock({ transactionBlock: tx });
 console.log({ result });
 ```
 
@@ -165,7 +165,7 @@ const signer = new RawSigner(keypair, provider);
 const tx = new TransactionBlock();
 const [coin] = tx.splitCoins(tx.gas, tx.pure(1000));
 tx.transferObjects([coin], tx.pure(keypair.getPublicKey().toSuiAddress()));
-const result = await signer.signAndExecuteTransaction({ transactionBlock: tx });
+const result = await signer.signAndExecuteTransactionBlock({ transactionBlock: tx });
 console.log({ result });
 ```
 
@@ -186,7 +186,7 @@ const tx = new TransactionBlock();
 tx.mergeCoin(tx.object('0x5015b016ab570df14c87649eda918e09e5cc61e0'), [
   tx.object('0xcc460051569bfb888dedaf5182e76f473ee351af'),
 ]);
-const result = await signer.signAndExecuteTransaction({ transactionBlock: tx });
+const result = await signer.signAndExecuteTransactionBlock({ transactionBlock: tx });
 console.log({ result });
 ```
 
@@ -209,7 +209,7 @@ tx.moveCall({
   target: `${packageObjectId}::nft::mint`,
   arguments: [tx.pure('Example NFT')],
 });
-const result = await signer.signAndExecuteTransaction({ transactionBlock: tx });
+const result = await signer.signAndExecuteTransactionBlock({ transactionBlock: tx });
 console.log({ result });
 ```
 
@@ -243,7 +243,7 @@ tx.publish(
     normalizeSuiObjectId(addr),
   ),
 );
-const result = await signer.signAndExecuteTransaction({ transactionBlock: tx });
+const result = await signer.signAndExecuteTransactionBlock({ transactionBlock: tx });
 console.log({ result });
 ```
 
@@ -291,13 +291,13 @@ Fetch transaction details from transaction digests:
 ```typescript
 import { JsonRpcProvider } from '@mysten/sui.js';
 const provider = new JsonRpcProvider();
-const txn = await provider.getTransaction({
+const txn = await provider.getTransactionBlock({
   digest: '6mn5W1CczLwitHCO9OIUbqirNrQ0cuKdyxaNe16SAME=',
   // only fetch the effects field
   options: { showEffects: true },
 });
 // You can also fetch multiple transactions in one batch request
-const txns = await provider.multiGetTransactions({
+const txns = await provider.multiGetTransactionBlocks({
   digests: [
     '6mn5W1CczLwitHCO9OIUbqirNrQ0cuKdyxaNe16SAME=',
     '7mn5W1CczLwitHCO9OIUbqirNrQ0cuKdyxaNe16SAME=',

--- a/sdk/typescript/src/builder/TransactionBlock.ts
+++ b/sdk/typescript/src/builder/TransactionBlock.ts
@@ -626,7 +626,9 @@ export class TransactionBlock {
       }
 
       if (!this.blockData.gasConfig.budget) {
-        const dryRunResult = await expectProvider(provider).dryRunTransaction({
+        const dryRunResult = await expectProvider(
+          provider,
+        ).dryRunTransactionBlock({
           transactionBlock: this.#blockData.build({
             overrides: { gasConfig: { budget: String(MAX_GAS), payment: [] } },
           }),

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -452,9 +452,9 @@ export class JsonRpcProvider {
   }
 
   /**
-   * Get transactions for a given query criteria
+   * Get transaction blocks for a given query criteria
    */
-  async queryTransactions(
+  async queryTransactionBlocks(
     input: SuiTransactionResponseQuery & PaginationArguments & OrderArguments,
   ): Promise<PaginatedTransactionResponse> {
     return await this.client.requestWithType(
@@ -473,7 +473,7 @@ export class JsonRpcProvider {
     );
   }
 
-  async getTransaction(input: {
+  async getTransactionBlock(input: {
     digest: TransactionDigest;
     options?: SuiTransactionResponseOptions;
   }): Promise<SuiTransactionResponse> {
@@ -488,7 +488,7 @@ export class JsonRpcProvider {
     );
   }
 
-  async multiGetTransactions(input: {
+  async multiGetTransactionBlocks(input: {
     digests: TransactionDigest[];
     options?: SuiTransactionResponseOptions;
   }): Promise<SuiTransactionResponse[]> {
@@ -511,7 +511,7 @@ export class JsonRpcProvider {
     );
   }
 
-  async executeTransaction(input: {
+  async executeTransactionBlock(input: {
     transactionBlock: Uint8Array | string;
     signature: SerializedSignature | SerializedSignature[];
     options?: SuiTransactionResponseOptions;
@@ -536,7 +536,7 @@ export class JsonRpcProvider {
    * Get total number of transactions
    */
 
-  async getTotalTransactionNumber(): Promise<bigint> {
+  async getTotalTransactionBlocks(): Promise<bigint> {
     const resp = await this.client.requestWithType(
       'sui_getTotalTransactionNumber',
       [],
@@ -651,11 +651,11 @@ export class JsonRpcProvider {
   }
 
   /**
-   * Runs the transaction in dev-inpsect mode. Which allows for nearly any
+   * Runs the transaction block in dev-inpsect mode. Which allows for nearly any
    * transaction (or Move call) with any arguments. Detailed results are
    * provided, including both the transaction effects and any return values.
    */
-  async devInspectTransaction(input: {
+  async devInspectTransactionBlock(input: {
     transactionBlock: TransactionBlock | string | Uint8Array;
     sender: SuiAddress;
     /** Default to use the network reference gas price stored in the Sui System State object */
@@ -689,9 +689,9 @@ export class JsonRpcProvider {
   }
 
   /**
-   * Dry run a transaction and return the result.
+   * Dry run a transaction block and return the result.
    */
-  async dryRunTransaction(input: {
+  async dryRunTransactionBlock(input: {
     transactionBlock: Uint8Array | string;
   }): Promise<DryRunTransactionResponse> {
     return await this.client.requestWithType(

--- a/sdk/typescript/test/e2e/dev-inspect.test.ts
+++ b/sdk/typescript/test/e2e/dev-inspect.test.ts
@@ -56,6 +56,6 @@ async function validateDevInspectTransaction(
   transactionBlock: TransactionBlock,
   status: 'success' | 'failure',
 ) {
-  const result = await signer.devInspectTransaction({ transactionBlock });
+  const result = await signer.devInspectTransactionBlock({ transactionBlock });
   expect(result.effects.status.status).toEqual(status);
 }

--- a/sdk/typescript/test/e2e/entry-point-string.test.ts
+++ b/sdk/typescript/test/e2e/entry-point-string.test.ts
@@ -19,7 +19,7 @@ describe('Test Move call with strings', () => {
       target: `${packageId}::entry_point_types::${funcName}`,
       arguments: [tx.pure(str), tx.pure(len)],
     });
-    const result = await toolbox.signer.signAndExecuteTransaction({
+    const result = await toolbox.signer.signAndExecuteTransactionBlock({
       transactionBlock: tx,
       options: {
         showEffects: true,

--- a/sdk/typescript/test/e2e/governance.test.ts
+++ b/sdk/typescript/test/e2e/governance.test.ts
@@ -68,7 +68,7 @@ async function addStake(signer: RawSigner) {
     validators[0].suiAddress,
   );
 
-  return await signer.signAndExecuteTransaction({
+  return await signer.signAndExecuteTransactionBlock({
     transactionBlock: tx,
     options: {
       showEffects: true,

--- a/sdk/typescript/test/e2e/id-entry-args.test.ts
+++ b/sdk/typescript/test/e2e/id-entry-args.test.ts
@@ -25,7 +25,7 @@ describe('Test ID as args to entry functions', () => {
         ),
       ],
     });
-    const result = await toolbox.signer.signAndExecuteTransaction({
+    const result = await toolbox.signer.signAndExecuteTransactionBlock({
       transactionBlock: tx,
       options: {
         showEffects: true,
@@ -44,7 +44,7 @@ describe('Test ID as args to entry functions', () => {
         ),
       ],
     });
-    const result = await toolbox.signer.signAndExecuteTransaction({
+    const result = await toolbox.signer.signAndExecuteTransactionBlock({
       transactionBlock: tx,
       options: {
         showEffects: true,

--- a/sdk/typescript/test/e2e/invalid-ids.test.ts
+++ b/sdk/typescript/test/e2e/invalid-ids.test.ts
@@ -43,13 +43,13 @@ describe('Object id/Address/Transaction digest validation', () => {
   it('Test all functions with invalid Transaction Digest', async () => {
     //empty digest
     expect(
-      toolbox.provider.getTransaction({ digest: '' }),
+      toolbox.provider.getTransactionBlock({ digest: '' }),
     ).rejects.toThrowError(/Invalid Transaction digest/);
 
     //wrong batch request
     let digests = ['AQ7FA8JTGs368CvMkXj2iFz2WUWwzP6AAWgsLpPLxUmr', 'wrong'];
     expect(
-      toolbox.provider.multiGetTransactions({ digests }),
+      toolbox.provider.multiGetTransactionBlocks({ digests }),
     ).rejects.toThrowError(/Invalid Transaction digest wrong/);
   });
 });

--- a/sdk/typescript/test/e2e/object-vector.test.ts
+++ b/sdk/typescript/test/e2e/object-vector.test.ts
@@ -23,7 +23,7 @@ describe('Test Move call with a vector of objects as input', () => {
       target: `${packageId}::entry_point_vector::mint`,
       arguments: [tx.pure(String(val))],
     });
-    const result = await toolbox.signer.signAndExecuteTransaction({
+    const result = await toolbox.signer.signAndExecuteTransactionBlock({
       transactionBlock: tx,
       options: {
         showEffects: true,
@@ -40,7 +40,7 @@ describe('Test Move call with a vector of objects as input', () => {
       target: `${packageId}::entry_point_vector::two_obj_vec_destroy`,
       arguments: [vec],
     });
-    const result = await toolbox.signer.signAndExecuteTransaction({
+    const result = await toolbox.signer.signAndExecuteTransactionBlock({
       transactionBlock: tx,
       options: {
         showEffects: true,
@@ -75,7 +75,7 @@ describe('Test Move call with a vector of objects as input', () => {
       arguments: [tx.object(coinIDs[0]), vec],
     });
     tx.setGasPayment([coin]);
-    const result = await toolbox.signer.signAndExecuteTransaction({
+    const result = await toolbox.signer.signAndExecuteTransactionBlock({
       transactionBlock: tx,
       options: {
         showEffects: true,

--- a/sdk/typescript/test/e2e/read-transactions.test.ts
+++ b/sdk/typescript/test/e2e/read-transactions.test.ts
@@ -20,19 +20,19 @@ describe('Transaction Reading API', () => {
   });
 
   it('Get Total Transactions', async () => {
-    const numTransactions = await toolbox.provider.getTotalTransactionNumber();
+    const numTransactions = await toolbox.provider.getTotalTransactionBlocks();
     expect(numTransactions).toBeGreaterThan(0);
   });
 
   it('Get Transaction', async () => {
     const digest = transactions[0].digest;
-    const txn = await toolbox.provider.getTransaction({ digest });
+    const txn = await toolbox.provider.getTransactionBlock({ digest });
     expect(getTransactionDigest(txn)).toEqual(digest);
   });
 
   it('Multi Get Pay Transactions', async () => {
     const digests = transactions.map((t) => t.digest);
-    const txns = await toolbox.provider.multiGetTransactions({
+    const txns = await toolbox.provider.multiGetTransactionBlocks({
       digests,
       options: { showBalanceChanges: true },
     });
@@ -44,12 +44,12 @@ describe('Transaction Reading API', () => {
 
   it('Query Transactions with opts', async () => {
     const options = { showEvents: true, showEffects: true };
-    const resp = await toolbox.provider.queryTransactions({
+    const resp = await toolbox.provider.queryTransactionBlocks({
       options,
       limit: 1,
     });
     const digest = resp.data[0].digest;
-    const response2 = await toolbox.provider.getTransaction({
+    const response2 = await toolbox.provider.getTransactionBlock({
       digest,
       options,
     });
@@ -57,18 +57,18 @@ describe('Transaction Reading API', () => {
   });
 
   it('Get Transactions', async () => {
-    const allTransactions = await toolbox.provider.queryTransactions({
+    const allTransactions = await toolbox.provider.queryTransactionBlocks({
       limit: 10,
     });
     expect(allTransactions.data.length).to.greaterThan(0);
   });
 
   it('Genesis exists', async () => {
-    const allTransactions = await toolbox.provider.queryTransactions({
+    const allTransactions = await toolbox.provider.queryTransactionBlocks({
       limit: 1,
       order: 'ascending',
     });
-    const resp = await toolbox.provider.getTransaction({
+    const resp = await toolbox.provider.getTransactionBlock({
       digest: allTransactions.data[0].digest,
       options: { showInput: true },
     });

--- a/sdk/typescript/test/e2e/txn-builder.test.ts
+++ b/sdk/typescript/test/e2e/txn-builder.test.ts
@@ -145,8 +145,8 @@ describe('Transaction Builders', () => {
 });
 
 async function validateTransaction(signer: RawSigner, tx: TransactionBlock) {
-  const localDigest = await signer.getTransactionDigest(tx);
-  const result = await signer.signAndExecuteTransaction({
+  const localDigest = await signer.getTransactionBlockDigest(tx);
+  const result = await signer.signAndExecuteTransactionBlock({
     transactionBlock: tx,
     options: {
       showEffects: true,

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -134,7 +134,7 @@ export async function publishPackage(
   // Transfer the upgrade capability to the sender so they can upgrade the package later if they want.
   tx.transferObjects([cap], tx.pure(await toolbox.signer.getAddress()));
 
-  const publishTxn = await toolbox.signer.signAndExecuteTransaction({
+  const publishTxn = await toolbox.signer.signAndExecuteTransactionBlock({
     transactionBlock: tx,
     options: {
       showEffects: true,
@@ -197,7 +197,7 @@ export async function paySui(
     tx.transferObjects([coin], tx.pure(recipient));
   });
 
-  const txn = await signer.signAndExecuteTransaction({
+  const txn = await signer.signAndExecuteTransactionBlock({
     transactionBlock: tx,
     options: {
       showEffects: true,

--- a/sdk/wallet-adapter/adapters/base-adapter/src/index.ts
+++ b/sdk/wallet-adapter/adapters/base-adapter/src/index.ts
@@ -7,8 +7,8 @@ import {
   SignedMessage,
 } from "@mysten/sui.js";
 import {
-  SuiSignTransactionInput,
-  SuiSignAndExecuteTransactionInput,
+  SuiSignTransactionBlockInput,
+  SuiSignAndExecuteTransactionBlockInput,
   WalletAccount,
   SuiSignMessageInput,
 } from "@mysten/wallet-standard";
@@ -35,14 +35,14 @@ export interface WalletAdapter {
     callback: WalletAdapterEvents[E]
   ) => () => void;
   signMessage(messageInput: SuiSignMessageInput): Promise<SignedMessage>;
-  signTransaction(
-    transactionInput: SuiSignTransactionInput
+  signTransactionBlock(
+    transactionInput: SuiSignTransactionBlockInput
   ): Promise<SignedTransaction>;
   /**
    * Suggest a transaction for the user to sign. Supports all valid transaction types.
    */
-  signAndExecuteTransaction(
-    transactionInput: SuiSignAndExecuteTransactionInput
+  signAndExecuteTransactionBlock(
+    transactionInput: SuiSignAndExecuteTransactionBlockInput
   ): Promise<SuiTransactionResponse>;
 
   getAccounts: () => Promise<readonly WalletAccount[]>;

--- a/sdk/wallet-adapter/adapters/unsafe-burner/src/index.ts
+++ b/sdk/wallet-adapter/adapters/unsafe-burner/src/index.ts
@@ -33,7 +33,10 @@ export class UnsafeBurnerWalletAdapter implements WalletAdapter {
     this.#account = new ReadonlyWalletAccount({
       address: this.#keypair.getPublicKey().toSuiAddress(),
       chains: ["sui:unknown"],
-      features: ["sui:signAndExecuteTransaction", "sui:signTransaction"],
+      features: [
+        "sui:signAndExecuteTransactionBlock",
+        "sui:signTransactionBlock",
+      ],
       publicKey: this.#keypair.getPublicKey().toBytes(),
     });
     this.#signer = new RawSigner(this.#keypair, this.#provider);
@@ -53,17 +56,17 @@ export class UnsafeBurnerWalletAdapter implements WalletAdapter {
     return this.#signer.signMessage({ message: messageInput.message });
   };
 
-  signTransaction: WalletAdapter["signTransaction"] = async (
+  signTransactionBlock: WalletAdapter["signTransactionBlock"] = async (
     transactionInput
   ) => {
-    return this.#signer.signTransaction({
+    return this.#signer.signTransactionBlock({
       transactionBlock: transactionInput.transactionBlock,
     });
   };
 
-  signAndExecuteTransaction: WalletAdapter["signAndExecuteTransaction"] =
+  signAndExecuteTransactionBlock: WalletAdapter["signAndExecuteTransactionBlock"] =
     async (transactionInput) => {
-      return await this.#signer.signAndExecuteTransaction({
+      return await this.#signer.signAndExecuteTransactionBlock({
         transactionBlock: transactionInput.transactionBlock,
         options: transactionInput.options,
         requestType: transactionInput.requestType,

--- a/sdk/wallet-adapter/adapters/wallet-standard-adapter/src/StandardWalletAdapter.ts
+++ b/sdk/wallet-adapter/adapters/wallet-standard-adapter/src/StandardWalletAdapter.ts
@@ -7,8 +7,8 @@ import {
 } from "@mysten/wallet-adapter-base";
 import {
   StandardWalletAdapterWallet,
-  SuiSignAndExecuteTransactionVersion,
-  SuiSignTransactionVersion,
+  SuiSignAndExecuteTransactionBlockVersion,
+  SuiSignTransactionBlockVersion,
 } from "@mysten/wallet-standard";
 import mitt from "mitt";
 
@@ -20,9 +20,10 @@ type WalletAdapterEventsMap = {
   [E in keyof WalletAdapterEvents]: Parameters<WalletAdapterEvents[E]>[0];
 };
 
-const suiSignTransactionLatestVersion: SuiSignTransactionVersion = "2.0.0";
-const suiSignAndExecuteTransactionLatestVersion: SuiSignAndExecuteTransactionVersion =
-  "2.0.0";
+const suiSignTransactionBlockLatestVersion: SuiSignTransactionBlockVersion =
+  "1.0.0";
+const suiSignAndExecuteTransactionBlockLatestVersion: SuiSignAndExecuteTransactionBlockVersion =
+  "1.0.0";
 
 function isFeatureCompatible(featureVersion: string, adapterVersion: string) {
   const [featureMajor] = featureVersion.split(".");
@@ -103,34 +104,38 @@ export class StandardWalletAdapter implements WalletAdapter {
     return this.#wallet.features["sui:signMessage"].signMessage(messageInput);
   };
 
-  signTransaction: WalletAdapter["signTransaction"] = (transactionInput) => {
-    const version = this.#wallet.features["sui:signTransaction"].version;
-    if (!isFeatureCompatible(version, suiSignTransactionLatestVersion)) {
-      throw new Error(
-        `Version mismatch, signTransaction feature version ${version} is not compatible with version ${suiSignTransactionLatestVersion}`
-      );
-    }
-    return this.#wallet.features["sui:signTransaction"].signTransaction(
-      transactionInput
-    );
-  };
-
-  signAndExecuteTransaction: WalletAdapter["signAndExecuteTransaction"] = (
+  signTransactionBlock: WalletAdapter["signTransactionBlock"] = (
     transactionInput
   ) => {
-    const version =
-      this.#wallet.features["sui:signAndExecuteTransaction"].version;
-    if (
-      !isFeatureCompatible(version, suiSignAndExecuteTransactionLatestVersion)
-    ) {
+    const version = this.#wallet.features["sui:signTransactionBlock"].version;
+    if (!isFeatureCompatible(version, suiSignTransactionBlockLatestVersion)) {
       throw new Error(
-        `Version mismatch, signAndExecuteTransaction feature version ${version} is not compatible with version ${suiSignAndExecuteTransactionLatestVersion}`
+        `Version mismatch, signTransaction feature version ${version} is not compatible with version ${suiSignTransactionBlockLatestVersion}`
       );
     }
     return this.#wallet.features[
-      "sui:signAndExecuteTransaction"
-    ].signAndExecuteTransaction(transactionInput);
+      "sui:signTransactionBlock"
+    ].signTransactionBlock(transactionInput);
   };
+
+  signAndExecuteTransactionBlock: WalletAdapter["signAndExecuteTransactionBlock"] =
+    (transactionInput) => {
+      const version =
+        this.#wallet.features["sui:signAndExecuteTransactionBlock"].version;
+      if (
+        !isFeatureCompatible(
+          version,
+          suiSignAndExecuteTransactionBlockLatestVersion
+        )
+      ) {
+        throw new Error(
+          `Version mismatch, signAndExecuteTransactionBlock feature version ${version} is not compatible with version ${suiSignAndExecuteTransactionBlockLatestVersion}`
+        );
+      }
+      return this.#wallet.features[
+        "sui:signAndExecuteTransactionBlock"
+      ].signAndExecuteTransactionBlock(transactionInput);
+    };
 
   on: <E extends keyof WalletAdapterEvents>(
     event: E,

--- a/sdk/wallet-adapter/adapters/wallet-standard-adapter/src/index.ts
+++ b/sdk/wallet-adapter/adapters/wallet-standard-adapter/src/index.ts
@@ -19,7 +19,7 @@ export { StandardWalletAdapter };
 
 // These are the default features that the adapter will check for:
 export const DEFAULT_FEATURES: (keyof StandardWalletAdapterWallet["features"])[] =
-  ["sui:signAndExecuteTransaction"];
+  ["sui:signAndExecuteTransactionBlock"];
 
 export class WalletStandardAdapterProvider implements WalletAdapterProvider {
   #wallets: Wallets;

--- a/sdk/wallet-adapter/example/src/App.tsx
+++ b/sdk/wallet-adapter/example/src/App.tsx
@@ -6,21 +6,21 @@ import { ConnectButton, useWalletKit } from "@mysten/wallet-kit";
 import { TransactionBlock } from "@mysten/sui.js";
 import { useEffect } from "react";
 
-const transaction = new TransactionBlock();
-transaction.moveCall({
+const transactionBlock = new TransactionBlock();
+transactionBlock.moveCall({
   target: `0x2::devnet_nft::mint`,
   arguments: [
-    transaction.pure("foo"),
-    transaction.pure("bar"),
-    transaction.pure("baz"),
+    transactionBlock.pure("foo"),
+    transactionBlock.pure("bar"),
+    transactionBlock.pure("baz"),
   ],
 });
 
 function App() {
   const {
     currentWallet,
-    signTransaction,
-    signAndExecuteTransaction,
+    signTransactionBlock,
+    signAndExecuteTransactionBlock,
     signMessage,
   } = useWalletKit();
 
@@ -34,7 +34,7 @@ function App() {
       <div>
         <button
           onClick={async () => {
-            console.log(await signTransaction({ transaction }));
+            console.log(await signTransactionBlock({ transactionBlock }));
           }}
         >
           Sign Transaction
@@ -44,8 +44,8 @@ function App() {
         <button
           onClick={async () => {
             console.log(
-              await signAndExecuteTransaction({
-                transaction,
+              await signAndExecuteTransactionBlock({
+                transactionBlock,
                 options: { showEffects: true },
               })
             );

--- a/sdk/wallet-adapter/example/src/index.tsx
+++ b/sdk/wallet-adapter/example/src/index.tsx
@@ -12,7 +12,7 @@ export const root = ReactDOM.createRoot(
 );
 root.render(
   <React.StrictMode>
-    <WalletKitProvider features={["sui:signTransaction"]} enableUnsafeBurner>
+    <WalletKitProvider features={["sui:signTransactionBlock"]} enableUnsafeBurner>
       <App />
     </WalletKitProvider>
   </React.StrictMode>

--- a/sdk/wallet-adapter/site/pages/advanced/wallet-standard.mdx
+++ b/sdk/wallet-adapter/site/pages/advanced/wallet-standard.mdx
@@ -6,26 +6,26 @@ If you are building a wallet, we publish a helper library `@mysten/wallet-standa
 
 ### Creating a wallet interface
 
-You need to create a class that represents your wallet. You can use the `Wallet` interface from `@mysten/wallet-standard` to help ensure your class adheres to the standard.
+You need to create a class that represents your wallet. You can use the `Wallet` interface from `@mysten/wallet-standard` to help ensure your class adheres to the standard.
 
 ```tsx
-import { Wallet, SUI_DEVNET_CHAIN } from "@mysten/wallet-standard";
+import { Wallet, SUI_DEVNET_CHAIN } from '@mysten/wallet-standard';
 
 class YourWallet implements Wallet {
-  get version() {
-    // Return the version of the Wallet Standard this implements (in this case, 1.0.0).
-    return "1.0.0";
-  }
-  get name() {
-    return "Wallet Name";
-  }
-  get icon() {
-    return "some-icon-data-url";
-  }
-  // Return the Sui chains that your wallet supports.
-  get chains() {
-    return [SUI_DEVNET_CHAIN];
-  }
+    get version() {
+        // Return the version of the Wallet Standard this implements (in this case, 1.0.0).
+        return '1.0.0';
+    }
+    get name() {
+        return 'Wallet Name';
+    }
+    get icon() {
+        return 'some-icon-data-url';
+    }
+    // Return the Sui chains that your wallet supports.
+    get chains() {
+        return [SUI_DEVNET_CHAIN];
+    }
 }
 ```
 
@@ -33,13 +33,13 @@ class YourWallet implements Wallet {
 
 Features are standard methods consumers can use to interact with a wallet. To be listed in the Sui wallet adapter, you must implement the following features in your wallet:
 
-- `standard:connect` - Used to initiate a connection to the wallet.
-- `standard:events` - Used to listen for changes that happen within the wallet, such as accounts being added or removed.
-- `sui:signMessage` - Used to prompt the user to sign a personal message, and return the message signature back to the dapp. This can be used to verify the user’s public key.
-- `sui:signTransaction` - Used to prompt the user to sign a transaction, and return the serialized transaction and transaction signature back to the dapp. This method does not submit the transaction for execution.
-- `sui:signAndExecuteTransaction` - Used to prompt the user to sign a transaction, then submit it for execution to the blockchain.
+-   `standard:connect` - Used to initiate a connection to the wallet.
+-   `standard:events` - Used to listen for changes that happen within the wallet, such as accounts being added or removed.
+-   `sui:signMessage` - Used to prompt the user to sign a personal message, and return the message signature back to the dapp. This can be used to verify the user’s public key.
+-   `sui:signTransactionBlock` - Used to prompt the user to sign a transaction block, and return the serialized transaction block and signature back to the dapp. This method does not submit the transaction block for execution.
+-   `sui:signAndExecuteTransactionBlock` - Used to prompt the user to sign a transaction, then submit it for execution to the blockchain.
 
-You can implement these features in your wallet class under the `features` property:
+You can implement these features in your wallet class under the `features` property:
 
 ```tsx
 import {
@@ -49,8 +49,8 @@ import {
   EventsOnMethod,
   SuiFeatures,
   SuiSignMessageMethod,
-  SuiSignTransactionMethod,
-  SuiSignAndExecuteTransactionMethod
+  SuiSignTransactionBlockMethod,
+  SuiSignAndExecuteTransactionBlockMethod
 } from "@mysten/wallet-standard";
 
 class YourWallet implements Wallet {
@@ -70,13 +70,13 @@ class YourWallet implements Wallet {
         version: "1.0.0",
 				signMessage: this.#signMessage,
 			},
-      "sui:signTransaction": {
-        version: "2.0.0",
-        signTransaction: this.#signTransaction,
+      "sui:signTransactionBlock": {
+        version: "1.0.0",
+        signTransactionBlock: this.#signTransactionBlock,
       },
-      "sui:signAndExecuteTransaction": {
-        version: "2.0.0",
-        signAndExecuteTransaction: this.#signAndExecuteTransaction,
+      "sui:signAndExecuteTransactionBlock": {
+        version: "1.0.0",
+        signAndExecuteTransactionBlock: this.#signAndExecuteTransactionBlock,
       },
     };
   },
@@ -93,11 +93,11 @@ class YourWallet implements Wallet {
     // Your wallet's signTransaction implementation
   };
 
-  #signTransaction: SuiSignTransactionMethod = () => {
+  #signTransactionBlock: SuiSignTransactionBlockMethod = () => {
     // Your wallet's signTransaction implementation
   };
 
-  #signAndExecuteTransaction: SuiSignAndExecuteTransactionMethod = () => {
+  #signAndExecuteTransactionBlock: SuiSignAndExecuteTransactionBlockMethod = () => {
     // Your wallet's signAndExecuteTransaction implementation
   };
 }
@@ -105,43 +105,43 @@ class YourWallet implements Wallet {
 
 ### Exposing accounts
 
-The last requirement of the wallet interface is to expose an `acccounts` interface. This should expose all of the accounts that a connected dApp has access to. It can be empty prior to initiating a connection through the `standard:connect` feature.
+The last requirement of the wallet interface is to expose an `acccounts` interface. This should expose all of the accounts that a connected dApp has access to. It can be empty prior to initiating a connection through the `standard:connect` feature.
 
-The accounts can use the `ReadonlyWalletAccount` class to easily construct an account matching the required interface.
+The accounts can use the `ReadonlyWalletAccount` class to easily construct an account matching the required interface.
 
 ```tsx
-import { ReadonlyWalletAccount } from "@mysten/wallet-standard";
+import { ReadonlyWalletAccount } from '@mysten/wallet-standard';
 
 class YourWallet implements Wallet {
-  get accounts() {
-    // Assuming we already have some internal representation of accounts:
-    return someWalletAccounts.map(
-      (walletAccount) =>
-        // Return
-        new ReadonlyWalletAccount({
-          address: walletAccount.suiAddress,
-          publicKey: walletAccount.pubkey,
-          // The Sui chains that your wallet supports.
-          chains: [SUI_DEVNET_CHAIN],
-          // The features that this account supports. This can be a subset of the wallet's supported features.
-          // These features must exist on the wallet as well.
-          features: [
-            "sui:signMessage",
-            "sui:signTransaction",
-            "sui:signAndExecuteTransaction",
-          ],
-        })
-    );
-  }
+    get accounts() {
+        // Assuming we already have some internal representation of accounts:
+        return someWalletAccounts.map(
+            (walletAccount) =>
+                // Return
+                new ReadonlyWalletAccount({
+                    address: walletAccount.suiAddress,
+                    publicKey: walletAccount.pubkey,
+                    // The Sui chains that your wallet supports.
+                    chains: [SUI_DEVNET_CHAIN],
+                    // The features that this account supports. This can be a subset of the wallet's supported features.
+                    // These features must exist on the wallet as well.
+                    features: [
+                        'sui:signMessage',
+                        'sui:signTransactionBlock',
+                        'sui:signAndExecuteTransactionBlock',
+                    ],
+                })
+        );
+    }
 }
 ```
 
 ### Registering in the window
 
-Once you have a compatible interface for your wallet, you register it using the `registerWallet` function.
+Once you have a compatible interface for your wallet, you register it using the `registerWallet` function.
 
 ```tsx
-import { registerWallet } from "@mysten/wallet-standard";
+import { registerWallet } from '@mysten/wallet-standard';
 
 registerWallet(new YourWallet());
 ```

--- a/sdk/wallet-adapter/site/pages/docs/use-wallet-kit.mdx
+++ b/sdk/wallet-adapter/site/pages/docs/use-wallet-kit.mdx
@@ -38,5 +38,5 @@ In addition to the hook return’s properties, there are also functions that can
 - `connect(walletName: string)` - Connect to a given wallet name.
 - `disconnect()` - Disconnect from the currently connected wallet
 - `signMessage(messageInput)` - Sign a message using the current account and wallet.
-- `signTransaction(signTransactionInput)` - Sign a transaction using the current account and wallet.
-- `signAndExecuteTransaction(signAndExecuteTransactionInput)` - Sign a transaction using the current account and wallet, and submit it to the chain for execution.
+- `signTransactionBlock(signTransactionInput)` - Sign a transaction block using the current account and wallet.
+- `signAndExecuteTransactionBlock(signAndExecuteTransactionInput)` - Sign a transaction block using the current account and wallet, and submit it to the chain for execution.

--- a/sdk/wallet-adapter/wallet-kit-core/src/index.ts
+++ b/sdk/wallet-adapter/wallet-kit-core/src/index.ts
@@ -9,9 +9,9 @@ import {
 } from "@mysten/wallet-adapter-base";
 import { localStorageAdapter, StorageAdapter } from "./storage";
 import {
-  SuiSignAndExecuteTransactionInput,
+  SuiSignAndExecuteTransactionBlockInput,
   SuiSignMessageInput,
-  SuiSignTransactionInput,
+  SuiSignTransactionBlockInput,
   WalletAccount,
 } from "@mysten/wallet-standard";
 
@@ -61,18 +61,18 @@ export interface WalletKitCore {
   signMessage(
     messageInput: OptionalProperties<SuiSignMessageInput, "account">
   ): ReturnType<WalletAdapter["signMessage"]>;
-  signTransaction: (
+  signTransactionBlock: (
     transactionInput: OptionalProperties<
-      SuiSignTransactionInput,
+      SuiSignTransactionBlockInput,
       "chain" | "account"
     >
-  ) => ReturnType<WalletAdapter["signTransaction"]>;
-  signAndExecuteTransaction: (
+  ) => ReturnType<WalletAdapter["signTransactionBlock"]>;
+  signAndExecuteTransactionBlock: (
     transactionInput: OptionalProperties<
-      SuiSignAndExecuteTransactionInput,
+      SuiSignAndExecuteTransactionBlockInput,
       "chain" | "account"
     >
-  ) => ReturnType<WalletAdapter["signAndExecuteTransaction"]>;
+  ) => ReturnType<WalletAdapter["signAndExecuteTransactionBlock"]>;
 }
 
 export type SubscribeHandler = (state: WalletKitCoreState) => void;
@@ -271,7 +271,7 @@ export function createWalletKitCore({
       });
     },
 
-    async signTransaction(transactionInput) {
+    async signTransactionBlock(transactionInput) {
       if (!internalState.currentWallet || !internalState.currentAccount) {
         throw new Error(
           "No wallet is currently connected, cannot call `signTransaction`."
@@ -284,17 +284,17 @@ export function createWalletKitCore({
       if (!chain) {
         throw new Error("Missing chain");
       }
-      return internalState.currentWallet.signTransaction({
+      return internalState.currentWallet.signTransactionBlock({
         ...transactionInput,
         account,
         chain,
       });
     },
 
-    async signAndExecuteTransaction(transactionInput) {
+    async signAndExecuteTransactionBlock(transactionInput) {
       if (!internalState.currentWallet || !internalState.currentAccount) {
         throw new Error(
-          "No wallet is currently connected, cannot call `signAndExecuteTransaction`."
+          "No wallet is currently connected, cannot call `signAndExecuteTransactionBlock`."
         );
       }
       const {
@@ -304,7 +304,7 @@ export function createWalletKitCore({
       if (!chain) {
         throw new Error("Missing chain");
       }
-      return internalState.currentWallet.signAndExecuteTransaction({
+      return internalState.currentWallet.signAndExecuteTransactionBlock({
         ...transactionInput,
         account,
         chain,

--- a/sdk/wallet-adapter/wallet-kit/README.md
+++ b/sdk/wallet-adapter/wallet-kit/README.md
@@ -48,7 +48,7 @@ import { TransactionBlock } from "@mysten/sui.js";
 import { useWalletKit } from "@mysten/wallet-kit";
 
 export function SendTransaction() {
-  const { signAndExecuteTransaction } = useWalletKit();
+  const { signAndExecuteTransactionBlock } = useWalletKit();
 
   const handleClick = async () => {
     const tx = new TransactionBlock();
@@ -62,7 +62,7 @@ export function SendTransaction() {
         ),
       ],
     });
-    await signAndExecuteTransaction({ transactionBlock: tx });
+    await signAndExecuteTransactionBlock({ transactionBlock: tx });
   };
 
   return (

--- a/sdk/wallet-adapter/wallet-kit/src/WalletKitContext.tsx
+++ b/sdk/wallet-adapter/wallet-kit/src/WalletKitContext.tsx
@@ -85,8 +85,8 @@ type UseWalletKit = WalletKitCoreState &
     | "connect"
     | "disconnect"
     | "signMessage"
-    | "signTransaction"
-    | "signAndExecuteTransaction"
+    | "signTransactionBlock"
+    | "signAndExecuteTransactionBlock"
   >;
 
 export function useWalletKit(): UseWalletKit {
@@ -109,8 +109,8 @@ export function useWalletKit(): UseWalletKit {
       connect: walletKit.connect,
       disconnect: walletKit.disconnect,
       signMessage: walletKit.signMessage,
-      signTransaction: walletKit.signTransaction,
-      signAndExecuteTransaction: walletKit.signAndExecuteTransaction,
+      signTransactionBlock: walletKit.signTransactionBlock,
+      signAndExecuteTransactionBlock: walletKit.signAndExecuteTransactionBlock,
       ...state,
     }),
     [walletKit, state]

--- a/sdk/wallet-adapter/wallet-standard/README.md
+++ b/sdk/wallet-adapter/wallet-standard/README.md
@@ -36,8 +36,8 @@ Features are standard methods consumers can use to interact with a wallet. To be
 
 - `standard:connect` - Used to initiate a connection to the wallet.
 - `standard:events` - Used to listen for changes that happen within the wallet, such as accounts being added or removed.
-- `sui:signTransaction` - Used to prompt the user to sign a transaction, and return the serializated transaction and transaction signature back to the user. This method does not submit the transaction for execution.
-- `sui:signAndExecuteTransaction` - Used to prompt the user to sign a transaction, then submit it for execution to the blockchain.
+- `sui:signTransactionBlock` - Used to prompt the user to sign a transaction block, and return the serializated transaction block and signature back to the user. This method does not submit the transaction block for execution.
+- `sui:signAndExecuteTransactionBlock` - Used to prompt the user to sign a transaction block, then submit it for execution to the blockchain.
 
 You can implement these features in your wallet class under the `features` property:
 
@@ -48,8 +48,8 @@ import {
   StandardEventsFeature,
   StandardEventsOnMethod,
   SuiFeatures,
-  SuiTransactionMethod,
-  SuiSignAndExecuteTransactionMethod
+  SuiSignTransactionBlockMethod,
+  SuiSignAndExecuteTransactionBlockMethod
 } from "@mysten/wallet-standard";
 
 class YourWallet implements Wallet {
@@ -63,31 +63,31 @@ class YourWallet implements Wallet {
         version: "1.0.0",
         on: this.#on,
       },
-      "sui:signTransaction": {
+      "sui:signTransactionBlock": {
         version: "1.0.0",
-        signTransaction: this.#signTransaction,
+        signTransactionBlock: this.#signTransactionBlock,
       },
-      "sui:signAndExecuteTransaction": {
+      "sui:signAndExecuteTransactionBlock": {
         version: "1.1.0",
-        signAndExecuteTransaction: this.#signAndExecuteTransaction,
+        signAndExecuteTransactionBlock: this.#signAndExecuteTransaction,
       },
     };
   },
 
   #on: StandardEventsOnMethod = () => {
-    // Your wallet's events on implementation.
+    // Your wallet's on implementation.
   };
 
   #connect: StandardConnectMethod = () => {
-    // Your wallet's connect implementation
+    // Your wallet's implementation
   };
 
-  #signTransaction: SuiTransactionMethod = () => {
-    // Your wallet's signTransaction implementation
+  #signTransactionBlock: SuiSignTransactionBlockMethod = () => {
+    // Your wallet's implementation
   };
 
-  #signAndExecuteTransaction: SuiSignAndExecuteTransactionMethod = () => {
-    // Your wallet's signAndExecuteTransaction implementation
+  #signAndExecuteTransactionBlock: SuiSignAndExecuteTransactionBlockMethod = () => {
+    // Your wallet's implementation
   };
 }
 ```
@@ -114,7 +114,7 @@ class YourWallet implements Wallet {
           chains: [SUI_DEVNET_CHAIN],
           // The features that this account supports. This can be a subset of the wallet's supported features.
           // These features must exist on the wallet as well.
-          features: ["sui:signAndExecuteTransaction"],
+          features: ["sui:signAndExecuteTransactionBlock"],
         })
     );
   }

--- a/sdk/wallet-adapter/wallet-standard/src/features/index.ts
+++ b/sdk/wallet-adapter/wallet-standard/src/features/index.ts
@@ -2,19 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { WalletWithFeatures } from "@wallet-standard/core";
-import type { SuiSignTransactionFeature } from "./suiSignTransaction";
-import type { SuiSignAndExecuteTransactionFeature } from "./suiSignAndExecuteTransaction";
+import type { SuiSignTransactionBlockFeature } from "./suiSignTransactionBlock";
+import type { SuiSignAndExecuteTransactionBlockFeature } from "./suiSignAndExecuteTransactionBlock";
 import { SuiSignMessageFeature } from "./suiSignMessage";
 
 /**
  * Wallet Standard features that are unique to Sui, and that all Sui wallets are expected to implement.
  */
-export type SuiFeatures = SuiSignTransactionFeature &
-  SuiSignAndExecuteTransactionFeature &
+export type SuiFeatures = SuiSignTransactionBlockFeature &
+  SuiSignAndExecuteTransactionBlockFeature &
   SuiSignMessageFeature;
 
 export type WalletWithSuiFeatures = WalletWithFeatures<SuiFeatures>;
 
 export * from "./suiSignMessage";
-export * from "./suiSignTransaction";
-export * from "./suiSignAndExecuteTransaction";
+export * from "./suiSignTransactionBlock";
+export * from "./suiSignAndExecuteTransactionBlock";

--- a/sdk/wallet-adapter/wallet-standard/src/features/suiSignAndExecuteTransactionBlock.ts
+++ b/sdk/wallet-adapter/wallet-standard/src/features/suiSignAndExecuteTransactionBlock.ts
@@ -6,32 +6,32 @@ import type {
   SuiTransactionResponse,
   SuiTransactionResponseOptions,
 } from "@mysten/sui.js";
-import type { SuiSignTransactionInput } from "./suiSignTransaction";
+import type { SuiSignTransactionBlockInput } from "./suiSignTransactionBlock";
 
-/** The latest API version of the signAndExecuteTransaction API. */
-export type SuiSignAndExecuteTransactionVersion = "2.0.0";
+/** The latest API version of the signAndExecuteTransactionBlock API. */
+export type SuiSignAndExecuteTransactionBlockVersion = "1.0.0";
 
 /**
  * A Wallet Standard feature for signing a transaction, and submitting it to the
  * network. The wallet is expected to submit the transaction to the network via RPC,
  * and return the transaction response.
  */
-export type SuiSignAndExecuteTransactionFeature = {
+export type SuiSignAndExecuteTransactionBlockFeature = {
   /** Namespace for the feature. */
-  "sui:signAndExecuteTransaction": {
+  "sui:signAndExecuteTransactionBlock": {
     /** Version of the feature API. */
-    version: SuiSignAndExecuteTransactionVersion;
-    signAndExecuteTransaction: SuiSignAndExecuteTransactionMethod;
+    version: SuiSignAndExecuteTransactionBlockVersion;
+    signAndExecuteTransactionBlock: SuiSignAndExecuteTransactionBlockMethod;
   };
 };
 
-export type SuiSignAndExecuteTransactionMethod = (
-  input: SuiSignAndExecuteTransactionInput
-) => Promise<SuiSignAndExecuteTransactionOutput>;
+export type SuiSignAndExecuteTransactionBlockMethod = (
+  input: SuiSignAndExecuteTransactionBlockInput
+) => Promise<SuiSignAndExecuteTransactionBlockOutput>;
 
 /** Input for signing and sending transactions. */
-export interface SuiSignAndExecuteTransactionInput
-  extends SuiSignTransactionInput {
+export interface SuiSignAndExecuteTransactionBlockInput
+  extends SuiSignTransactionBlockInput {
   /**
    * `WaitForEffectsCert` or `WaitForLocalExecution`, see details in `ExecuteTransactionRequestType`.
    * Defaults to `WaitForLocalExecution` if options.showEffects or options.showEvents is true
@@ -42,5 +42,5 @@ export interface SuiSignAndExecuteTransactionInput
 }
 
 /** Output of signing and sending transactions. */
-export interface SuiSignAndExecuteTransactionOutput
+export interface SuiSignAndExecuteTransactionBlockOutput
   extends SuiTransactionResponse {}

--- a/sdk/wallet-adapter/wallet-standard/src/features/suiSignTransactionBlock.ts
+++ b/sdk/wallet-adapter/wallet-standard/src/features/suiSignTransactionBlock.ts
@@ -4,32 +4,32 @@
 import type { SignedTransaction, TransactionBlock } from "@mysten/sui.js";
 import type { IdentifierString, WalletAccount } from "@wallet-standard/core";
 
-/** The latest API version of the signTransaction API. */
-export type SuiSignTransactionVersion = "2.0.0";
+/** The latest API version of the signTransactionBlock API. */
+export type SuiSignTransactionBlockVersion = "1.0.0";
 
 /**
  * A Wallet Standard feature for signing a transaction, and returning the
  * serialized transaction and transaction signature.
  */
-export type SuiSignTransactionFeature = {
+export type SuiSignTransactionBlockFeature = {
   /** Namespace for the feature. */
-  "sui:signTransaction": {
+  "sui:signTransactionBlock": {
     /** Version of the feature API. */
-    version: SuiSignTransactionVersion;
-    signTransaction: SuiSignTransactionMethod;
+    version: SuiSignTransactionBlockVersion;
+    signTransactionBlock: SuiSignTransactionBlockMethod;
   };
 };
 
-export type SuiSignTransactionMethod = (
-  input: SuiSignTransactionInput
-) => Promise<SuiSignTransactionOutput>;
+export type SuiSignTransactionBlockMethod = (
+  input: SuiSignTransactionBlockInput
+) => Promise<SuiSignTransactionBlockOutput>;
 
 /** Input for signing transactions. */
-export interface SuiSignTransactionInput {
+export interface SuiSignTransactionBlockInput {
   transactionBlock: TransactionBlock;
   account: WalletAccount;
   chain: IdentifierString;
 }
 
 /** Output of signing transactions. */
-export interface SuiSignTransactionOutput extends SignedTransaction {}
+export interface SuiSignTransactionBlockOutput extends SignedTransaction {}


### PR DESCRIPTION
## Description 

This is a follow-up for #9941, renaming provider methods and wallet adapter methods.

## Test Plan 

Tests should still pass.