### PR TITLE
Record consensus message processed for CapabilityNotification

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1611,6 +1611,7 @@ impl AuthorityPerEpochStore {
                         authority.concise()
                     );
                 }
+                self.record_consensus_transaction_processed(&transaction, consensus_index)?;
                 Ok(None)
             }
             SequencedConsensusTransactionKind::System(system_transaction) => {

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -17,7 +17,7 @@ use anyhow::Result;
 use arc_swap::ArcSwap;
 use futures::TryFutureExt;
 use prometheus::Registry;
-use sui_core::consensus_adapter::{LazyNarwhalClient, SubmitToConsensus};
+use sui_core::consensus_adapter::LazyNarwhalClient;
 use sui_types::sui_system_state::SuiSystemState;
 use tap::tap::TapFallible;
 use tokio::sync::broadcast;
@@ -877,18 +877,9 @@ impl SuiNode {
                             .await,
                     ));
                 info!(?transaction, "submitting capabilities to consensus");
-                if let Err(e) = components
+                components
                     .consensus_adapter
-                    .submit_to_consensus(&transaction, &cur_epoch_store)
-                    .await
-                {
-                    warn!(
-                        ?transaction,
-                        "failed to submit capabilities to consensus {e}"
-                    );
-                    tokio::time::sleep(Duration::from_secs(1)).await;
-                    continue;
-                };
+                    .submit(transaction, None, &cur_epoch_store)?;
             }
 
             checkpoint_executor.run_epoch(cur_epoch_store.clone()).await;


### PR DESCRIPTION
## Description 

It seems the proper fix for CapabilityNotification waiting indefinitely in ConsensusAdapter, is to just make sure the waiter gets notified when the message comes out of consensus. [#9735](https://github.com/MystenLabs/sui/pull/9735) is mostly reverted.

Submitting directly to Narwhal seems suitable, but retries have to be managed outside of ConsensusAdapter.

I believe it is ok to not use an atomic write for capability update and recording consensus message processed.

## Test Plan 

existing tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
