### PR TITLE
remove sui_getTransactionsInRangeDeprecated

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2233,22 +2233,6 @@ impl AuthorityState {
         Ok(self.get_indexes()?.next_sequence_number())
     }
 
-    pub fn get_transactions_in_range_deprecated(
-        &self,
-        start: TxSequenceNumber,
-        end: TxSequenceNumber,
-    ) -> Result<Vec<(TxSequenceNumber, TransactionDigest)>, anyhow::Error> {
-        self.get_indexes()?
-            .get_transactions_in_range_deprecated(start, end)
-    }
-
-    pub fn get_recent_transactions(
-        &self,
-        count: u64,
-    ) -> Result<Vec<(TxSequenceNumber, TransactionDigest)>, anyhow::Error> {
-        self.get_indexes()?.get_recent_transactions(count)
-    }
-
     pub async fn get_executed_transaction_and_effects(
         &self,
         digest: TransactionDigest,

--- a/crates/sui-indexer/src/apis/read_api.rs
+++ b/crates/sui-indexer/src/apis/read_api.rs
@@ -15,7 +15,7 @@ use sui_json_rpc_types::{
     SuiTransactionResponse, SuiTransactionResponseOptions,
 };
 use sui_open_rpc::Module;
-use sui_types::base_types::{ObjectID, SequenceNumber, TxSequenceNumber};
+use sui_types::base_types::{ObjectID, SequenceNumber};
 use sui_types::digests::TransactionDigest;
 
 use crate::errors::IndexerError;
@@ -154,16 +154,6 @@ where
             return self.fullnode.get_total_transaction_number().await;
         }
         Ok(self.get_total_transaction_number_internal()?.into())
-    }
-
-    async fn get_transactions_in_range_deprecated(
-        &self,
-        start: TxSequenceNumber,
-        end: TxSequenceNumber,
-    ) -> RpcResult<Vec<TransactionDigest>> {
-        self.fullnode
-            .get_transactions_in_range_deprecated(start, end)
-            .await
     }
 
     async fn get_transaction(

--- a/crates/sui-json-rpc/src/api/read.rs
+++ b/crates/sui-json-rpc/src/api/read.rs
@@ -10,22 +10,11 @@ use sui_json_rpc_types::{
     SuiTransactionResponse, SuiTransactionResponseOptions,
 };
 use sui_open_rpc_macros::open_rpc;
-use sui_types::base_types::{ObjectID, SequenceNumber, TransactionDigest, TxSequenceNumber};
+use sui_types::base_types::{ObjectID, SequenceNumber, TransactionDigest};
 
 #[open_rpc(namespace = "sui", tag = "Read API")]
 #[rpc(server, client, namespace = "sui")]
 pub trait ReadApi {
-    /// Return list of transaction digests within the queried range.
-    /// This method will be removed before April 2023, please use `queryTransactions` instead
-    #[method(name = "getTransactionsInRangeDeprecated", deprecated)]
-    async fn get_transactions_in_range_deprecated(
-        &self,
-        /// the matching transactions' sequence number will be greater than or equals to the starting sequence number
-        start: TxSequenceNumber,
-        /// the matching transactions' sequence number will be less than the ending sequence number
-        end: TxSequenceNumber,
-    ) -> RpcResult<Vec<TransactionDigest>>;
-
     /// Return the transaction response object.
     #[method(name = "getTransaction")]
     async fn get_transaction(

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -28,7 +28,7 @@ use sui_json_rpc_types::{
     SuiTransactionEvents, SuiTransactionResponse, SuiTransactionResponseOptions,
 };
 use sui_open_rpc::Module;
-use sui_types::base_types::{ObjectID, SequenceNumber, TransactionDigest, TxSequenceNumber};
+use sui_types::base_types::{ObjectID, SequenceNumber, TransactionDigest};
 use sui_types::collection_types::VecMap;
 use sui_types::crypto::default_hash;
 use sui_types::digests::TransactionEventsDigest;
@@ -259,19 +259,6 @@ impl ReadApiServer for ReadApi {
 
     async fn get_total_transaction_number(&self) -> RpcResult<BigInt> {
         Ok(self.state.get_total_transaction_number()?.into())
-    }
-
-    async fn get_transactions_in_range_deprecated(
-        &self,
-        start: TxSequenceNumber,
-        end: TxSequenceNumber,
-    ) -> RpcResult<Vec<TransactionDigest>> {
-        Ok(self
-            .state
-            .get_transactions_in_range_deprecated(start, end)?
-            .into_iter()
-            .map(|(_, digest)| digest)
-            .collect())
     }
 
     async fn get_transaction(

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -940,48 +940,6 @@
       ]
     },
     {
-      "name": "sui_getTransactionsInRangeDeprecated",
-      "tags": [
-        {
-          "name": "Read API"
-        }
-      ],
-      "description": "Return list of transaction digests within the queried range. This method will be removed before April 2023, please use `queryTransactions` instead",
-      "params": [
-        {
-          "name": "start",
-          "description": "the matching transactions' sequence number will be greater than or equals to the starting sequence number",
-          "required": true,
-          "schema": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
-          }
-        },
-        {
-          "name": "end",
-          "description": "the matching transactions' sequence number will be less than the ending sequence number",
-          "required": true,
-          "schema": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
-          }
-        }
-      ],
-      "result": {
-        "name": "Vec<TransactionDigest>",
-        "required": true,
-        "schema": {
-          "type": "array",
-          "items": {
-            "$ref": "#/components/schemas/TransactionDigest"
-          }
-        }
-      },
-      "deprecated": true
-    },
-    {
       "name": "sui_multiGetObjects",
       "tags": [
         {

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -23,9 +23,7 @@ use sui_json_rpc_types::{
     SuiTransactionResponseQuery, TransactionsPage,
 };
 use sui_types::balance::Supply;
-use sui_types::base_types::{
-    ObjectID, SequenceNumber, SuiAddress, TransactionDigest, TxSequenceNumber,
-};
+use sui_types::base_types::{ObjectID, SequenceNumber, SuiAddress, TransactionDigest};
 use sui_types::committee::EpochId;
 use sui_types::error::TRANSACTION_NOT_FOUND_MSG_PREFIX;
 use sui_types::event::EventID;
@@ -120,18 +118,6 @@ impl ReadApi {
 
     pub async fn get_total_transaction_number(&self) -> SuiRpcResult<u64> {
         Ok(self.api.http.get_total_transaction_number().await?.into())
-    }
-
-    pub async fn get_transactions_in_range_deprecated(
-        &self,
-        start: TxSequenceNumber,
-        end: TxSequenceNumber,
-    ) -> SuiRpcResult<Vec<TransactionDigest>> {
-        Ok(self
-            .api
-            .http
-            .get_transactions_in_range_deprecated(start, end)
-            .await?)
     }
 
     pub async fn get_transaction_with_options(


### PR DESCRIPTION
## Description 

Remove sui_getTransactionsInRangeDeprecated since it's no longer used in the repo

## Test Plan 

CI test

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [x] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes