### PR TITLE
[transaction-block-rename][1/n] rename transaction methods

### DIFF
--- a/crates/sui-benchmark/src/bank.rs
+++ b/crates/sui-benchmark/src/bank.rs
@@ -135,7 +135,10 @@ impl BenchmarkBank {
         // transferring it to recipients
         let verified_tx =
             self.make_split_coin_tx(split_amounts.clone(), Some(gas_price), &self.primary_gas.2)?;
-        let effects = self.proxy.execute_transaction(verified_tx.into()).await?;
+        let effects = self
+            .proxy
+            .execute_transaction_block(verified_tx.into())
+            .await?;
         let updated_gas = effects
             .mutated()
             .into_iter()
@@ -160,7 +163,10 @@ impl BenchmarkBank {
             &self.primary_gas.2,
             Some(gas_price),
         )?;
-        let effects = self.proxy.execute_transaction(verified_tx.into()).await?;
+        let effects = self
+            .proxy
+            .execute_transaction_block(verified_tx.into())
+            .await?;
         let address_map: HashMap<SuiAddress, Arc<AccountKeyPair>> = coin_configs
             .iter()
             .map(|c| (c.address, c.keypair.clone()))

--- a/crates/sui-benchmark/src/drivers/bench_driver.rs
+++ b/crates/sui-benchmark/src/drivers/bench_driver.rs
@@ -377,7 +377,7 @@ impl Driver<(BenchmarkStats, StressStats)> for BenchDriver {
                                 let committee_cloned = Arc::new(worker.proxy.clone_committee());
                                 let start = Arc::new(Instant::now());
                                 let res = worker.proxy
-                                    .execute_transaction(b.0.clone().into())
+                                    .execute_transaction_block(b.0.clone().into())
                                     .then(|res| async move  {
                                         match res {
                                             Ok(effects) => {
@@ -429,7 +429,7 @@ impl Driver<(BenchmarkStats, StressStats)> for BenchDriver {
                                 // TODO: clone committee for each request is not ideal.
                                 let committee_cloned = Arc::new(worker.proxy.clone_committee());
                                 let res = worker.proxy
-                                    .execute_transaction(tx.clone().into())
+                                    .execute_transaction_block(tx.clone().into())
                                 .then(|res| async move {
                                     match res {
                                         Ok(effects) => {

--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -160,7 +160,7 @@ pub trait ValidatorProxy {
 
     async fn get_latest_system_state_object(&self) -> Result<SuiSystemStateSummary, anyhow::Error>;
 
-    async fn execute_transaction(&self, tx: Transaction) -> anyhow::Result<ExecutionEffects>;
+    async fn execute_transaction_block(&self, tx: Transaction) -> anyhow::Result<ExecutionEffects>;
 
     /// This function is similar to `execute_transaction` but does not check any validator's
     /// signature. It should only be used for benchmarks.
@@ -284,7 +284,7 @@ impl ValidatorProxy for LocalValidatorAggregatorProxy {
             .into_sui_system_state_summary())
     }
 
-    async fn execute_transaction(&self, tx: Transaction) -> anyhow::Result<ExecutionEffects> {
+    async fn execute_transaction_block(&self, tx: Transaction) -> anyhow::Result<ExecutionEffects> {
         if std::env::var("BENCH_MODE").is_ok() {
             return self.execute_bench_transaction(tx).await;
         }
@@ -573,7 +573,7 @@ impl ValidatorProxy for FullNodeProxy {
             .await?)
     }
 
-    async fn execute_transaction(&self, tx: Transaction) -> anyhow::Result<ExecutionEffects> {
+    async fn execute_transaction_block(&self, tx: Transaction) -> anyhow::Result<ExecutionEffects> {
         let tx_digest = *tx.digest();
         let tx = tx.verify()?;
         let mut retry_cnt = 0;
@@ -583,7 +583,7 @@ impl ValidatorProxy for FullNodeProxy {
             match self
                 .sui_client
                 .quorum_driver()
-                .execute_transaction(
+                .execute_transaction_block(
                     tx.clone(),
                     SuiTransactionResponseOptions::new().with_effects(),
                     None,
@@ -609,7 +609,7 @@ impl ValidatorProxy for FullNodeProxy {
     }
 
     async fn execute_bench_transaction(&self, tx: Transaction) -> anyhow::Result<ExecutionEffects> {
-        self.execute_transaction(tx).await
+        self.execute_transaction_block(tx).await
     }
 
     fn clone_committee(&self) -> Committee {

--- a/crates/sui-benchmark/src/util.rs
+++ b/crates/sui-benchmark/src/util.rs
@@ -66,6 +66,9 @@ pub async fn publish_basics_package(
     path.push("../../sui_programmability/examples/basics");
     let transaction =
         create_publish_move_package_transaction(gas, path, sender, keypair, Some(gas_price));
-    let effects = proxy.execute_transaction(transaction.into()).await.unwrap();
+    let effects = proxy
+        .execute_transaction_block(transaction.into())
+        .await
+        .unwrap();
     parse_package_ref(&effects.created()).unwrap()
 }

--- a/crates/sui-benchmark/src/workloads/adversarial.rs
+++ b/crates/sui-benchmark/src/workloads/adversarial.rs
@@ -298,7 +298,10 @@ impl Workload<dyn Payload> for AdversarialWorkload {
             Some(reference_gas_price),
             gas_budget,
         );
-        let effects = proxy.execute_transaction(transaction.into()).await.unwrap();
+        let effects = proxy
+            .execute_transaction_block(transaction.into())
+            .await
+            .unwrap();
         let created = effects.created();
 
         // should only create the package object, upgrade cap, dynamic field top level obj, and NUM_DYNAMIC_FIELDS df objects. otherwise, there are some object initializers running and we will need to disambiguate

--- a/crates/sui-benchmark/src/workloads/shared_counter.rs
+++ b/crates/sui-benchmark/src/workloads/shared_counter.rs
@@ -200,7 +200,10 @@ impl Workload<dyn Payload> for SharedCounterWorkload {
             );
             let proxy_ref = proxy.clone();
             futures.push(async move {
-                if let Ok(effects) = proxy_ref.execute_transaction(transaction.into()).await {
+                if let Ok(effects) = proxy_ref
+                    .execute_transaction_block(transaction.into())
+                    .await
+                {
                     effects.created()[0].0
                 } else {
                     panic!("Failed to create shared counter!");

--- a/crates/sui-cluster-test/src/lib.rs
+++ b/crates/sui-cluster-test/src/lib.rs
@@ -134,7 +134,7 @@ impl TestContext {
         let resp = self
             .get_fullnode_client()
             .quorum_driver()
-            .execute_transaction(
+            .execute_transaction_block(
                 Transaction::from_data(txn_data, Intent::default(), vec![signature])
                     .verify()
                     .unwrap(),

--- a/crates/sui-cluster-test/src/test_case/fullnode_execute_transaction_test.rs
+++ b/crates/sui-cluster-test/src/test_case/fullnode_execute_transaction_test.rs
@@ -57,7 +57,7 @@ impl TestCaseImpl for FullNodeExecuteTransactionTest {
 
         let response = fullnode
             .quorum_driver()
-            .execute_transaction(
+            .execute_transaction_block(
                 txn,
                 SuiTransactionResponseOptions::new().with_effects(),
                 Some(ExecuteTransactionRequestType::WaitForEffectsCert),
@@ -84,7 +84,7 @@ impl TestCaseImpl for FullNodeExecuteTransactionTest {
 
         let response = fullnode
             .quorum_driver()
-            .execute_transaction(
+            .execute_transaction_block(
                 txn,
                 SuiTransactionResponseOptions::new().with_effects(),
                 Some(ExecuteTransactionRequestType::WaitForLocalExecution),

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1122,7 +1122,7 @@ impl AuthorityState {
     }
 
     /// The object ID for gas can be any object ID, even for an uncreated object
-    pub async fn dev_inspect_transaction(
+    pub async fn dev_inspect_transaction_block(
         &self,
         sender: SuiAddress,
         transaction_kind: TransactionKind,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2229,7 +2229,7 @@ impl AuthorityState {
         }
     }
 
-    pub fn get_total_transaction_number(&self) -> Result<u64, anyhow::Error> {
+    pub fn get_total_transaction_blocks(&self) -> Result<u64, anyhow::Error> {
         Ok(self.get_indexes()?.next_sequence_number())
     }
 

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2265,7 +2265,7 @@ impl AuthorityState {
         &self,
         digests: &[TransactionDigest],
     ) -> Result<Vec<Option<VerifiedTransaction>>, anyhow::Error> {
-        Ok(self.database.multi_get_transactions(digests)?)
+        Ok(self.database.multi_get_transaction_blocks(digests)?)
     }
 
     pub async fn multi_get_executed_effects(

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2237,7 +2237,7 @@ impl AuthorityState {
         &self,
         digest: TransactionDigest,
     ) -> Result<(VerifiedTransaction, TransactionEffects), anyhow::Error> {
-        let transaction = self.database.get_transaction(&digest)?;
+        let transaction = self.database.get_transaction_block(&digest)?;
         let effects = self.database.get_executed_effects(&digest)?;
         match (transaction, effects) {
             (Some(transaction), Some(effects)) => Ok((transaction, effects)),
@@ -2249,7 +2249,7 @@ impl AuthorityState {
         &self,
         digest: TransactionDigest,
     ) -> Result<VerifiedTransaction, anyhow::Error> {
-        let transaction = self.database.get_transaction(&digest)?;
+        let transaction = self.database.get_transaction_block(&digest)?;
         transaction.ok_or_else(|| anyhow!(SuiError::TransactionNotFound { digest }))
     }
 
@@ -2582,7 +2582,7 @@ impl AuthorityState {
         let Some(cert_sig) = epoch_store.get_transaction_cert_sig(tx_digest)? else {
             return Ok(None);
         };
-        let Some(transaction) = self.database.get_transaction(tx_digest)? else {
+        let Some(transaction) = self.database.get_transaction_block(tx_digest)? else {
             return Ok(None);
         };
 
@@ -2604,7 +2604,7 @@ impl AuthorityState {
         if let Some(effects) =
             self.get_signed_effects_and_maybe_resign(transaction_digest, epoch_store)?
         {
-            if let Some(transaction) = self.database.get_transaction(transaction_digest)? {
+            if let Some(transaction) = self.database.get_transaction_block(transaction_digest)? {
                 let cert_sig = epoch_store.get_transaction_cert_sig(transaction_digest)?;
                 let events = if let Some(digest) = effects.events_digest() {
                     self.get_transaction_events(digest)?

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1329,7 +1329,7 @@ impl AuthorityStore {
             .map(|v| v.into_iter().map(|v| v.map(|v| v.into())).collect())?)
     }
 
-    pub fn get_transaction(
+    pub fn get_transaction_block(
         &self,
         tx_digest: &TransactionDigest,
     ) -> Result<Option<VerifiedTransaction>, TypedStoreError> {

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1318,7 +1318,7 @@ impl AuthorityStore {
         Ok(())
     }
 
-    pub fn multi_get_transactions(
+    pub fn multi_get_transaction_blocks(
         &self,
         tx_digests: &[TransactionDigest],
     ) -> Result<Vec<Option<VerifiedTransaction>>, SuiError> {

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -1581,7 +1581,7 @@ where
         }
     }
 
-    pub async fn execute_transaction(
+    pub async fn execute_transaction_block(
         &self,
         transaction: &VerifiedTransaction,
     ) -> Result<VerifiedCertifiedTransactionEffects, anyhow::Error> {

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -642,7 +642,7 @@ fn get_unexecuted_transactions(
 
     // read remaining unexecuted transactions from store
     let executable_txns: Vec<_> = authority_store
-        .multi_get_transactions(&unexecuted_txns)
+        .multi_get_transaction_blocks(&unexecuted_txns)
         .expect("Failed to get checkpoint txes from store")
         .into_iter()
         .enumerate()

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -551,7 +551,7 @@ fn extract_end_of_epoch_tx(
         .expect("Final checkpoint must have at least one transaction");
 
     let change_epoch_tx = authority_store
-        .get_transaction(&digests.transaction)
+        .get_transaction_block(&digests.transaction)
         .expect("read cannot fail");
 
     let change_epoch_tx = VerifiedExecutableTransaction::new_from_checkpoint(
@@ -606,7 +606,7 @@ fn get_unexecuted_transactions(
             .transaction;
 
         let change_epoch_tx = authority_store
-            .get_transaction(&change_epoch_tx_digest)
+            .get_transaction_block(&change_epoch_tx_digest)
             .expect("read cannot fail")
             .unwrap_or_else(||
                 panic!(
@@ -746,7 +746,7 @@ async fn execute_transactions(
                 let pending_digest = missing_digests.first().unwrap();
                 let missing_input = transaction_manager.get_missing_input(pending_digest);
                 let pending_transaction = authority_store
-                    .get_transaction(pending_digest)?
+                    .get_transaction_block(pending_digest)?
                     .expect("state-sync should have ensured that the transaction exists");
 
                 warn!(

--- a/crates/sui-core/src/quorum_driver/mod.rs
+++ b/crates/sui-core/src/quorum_driver/mod.rs
@@ -501,7 +501,7 @@ where
         let result = self
             .validators
             .load()
-            .execute_transaction(&verified_transaction)
+            .execute_transaction_block(&verified_transaction)
             .await
             .tap_ok(|_resp| {
                 debug!(

--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -96,11 +96,11 @@ impl ReadStore for RocksDbStore {
         Ok(self.committee_store.get_committee(&epoch).unwrap())
     }
 
-    fn get_transaction(
+    fn get_transaction_block(
         &self,
         digest: &TransactionDigest,
     ) -> Result<Option<VerifiedTransaction>, Self::Error> {
-        self.authority_store.get_transaction(digest)
+        self.authority_store.get_transaction_block(digest)
     }
 
     fn get_transaction_effects(

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -171,7 +171,7 @@ where
         tx_type = ?request.transaction_type(),
     ),
     err)]
-    pub async fn execute_transaction(
+    pub async fn execute_transaction_block(
         &self,
         request: ExecuteTransactionRequest,
     ) -> Result<ExecuteTransactionResponse, QuorumDriverError> {

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -3266,7 +3266,7 @@ async fn test_store_revert_transfer_sui() {
     );
     // Transaction should not be deleted on revert in case it's needed
     // to execute a future state sync checkpoint.
-    assert!(db.get_transaction(&tx_digest).unwrap().is_some());
+    assert!(db.get_transaction_block(&tx_digest).unwrap().is_some());
     assert!(!db.as_ref().is_tx_already_executed(&tx_digest).unwrap());
 }
 

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -211,7 +211,7 @@ async fn construct_shared_object_transaction_with_sequence_number(
 }
 
 #[tokio::test]
-async fn test_dry_run_transaction() {
+async fn test_dry_run_transaction_block() {
     let (validator, fullnode, transaction, gas_object_id, shared_object_id) =
         construct_shared_object_transaction_with_sequence_number(None).await;
     let initial_shared_object_version = validator
@@ -577,7 +577,7 @@ async fn test_dev_inspect_dynamic_field() {
     };
     let kind = TransactionKind::programmable(pt);
     let DevInspectResults { error, .. } = fullnode
-        .dev_inspect_transaction(sender, kind, Some(1))
+        .dev_inspect_transaction_block(sender, kind, Some(1))
         .await
         .unwrap();
     // produces an error
@@ -819,7 +819,7 @@ async fn test_dev_inspect_gas_coin_argument() {
     };
     let kind = TransactionKind::programmable(pt);
     let results = fullnode
-        .dev_inspect_transaction(sender, kind, Some(1))
+        .dev_inspect_transaction_block(sender, kind, Some(1))
         .await
         .unwrap()
         .results
@@ -881,7 +881,7 @@ async fn test_dev_inspect_uses_unbound_object() {
     let kind = TransactionKind::programmable(pt);
 
     let result = fullnode
-        .dev_inspect_transaction(sender, kind, Some(1))
+        .dev_inspect_transaction_block(sender, kind, Some(1))
         .await;
     let Err(err) = result else { panic!() };
     assert!(err.to_string().contains("ObjectNotFound"));
@@ -4569,7 +4569,7 @@ pub async fn call_dev_inspect(
     ));
     let kind = TransactionKind::programmable(builder.finish());
     authority
-        .dev_inspect_transaction(*sender, kind, Some(1))
+        .dev_inspect_transaction_block(*sender, kind, Some(1))
         .await
 }
 
@@ -5129,7 +5129,7 @@ async fn test_for_inc_201_dev_inspect() {
     builder.command(Command::Publish(modules, system_package_ids()));
     let kind = TransactionKind::programmable(builder.finish());
     let DevInspectResults { events, .. } = fullnode
-        .dev_inspect_transaction(sender, kind, Some(1))
+        .dev_inspect_transaction_block(sender, kind, Some(1))
         .await
         .unwrap();
 

--- a/crates/sui-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/sui-core/src/unit_tests/execution_driver_tests.rs
@@ -95,7 +95,7 @@ async fn pending_exec_notify_ready_certificates() {
         let mut certs = Vec::new();
         while let Some(t) = transactions.pop() {
             let (_cert, effects) = sender_aggregator
-                .execute_transaction(&t)
+                .execute_transaction_block(&t)
                 .await
                 .expect("All ok.");
 
@@ -185,7 +185,7 @@ async fn pending_exec_full() {
         let mut certs = Vec::new();
         while let Some(t) = transactions.pop() {
             let (_cert, effects) = sender_aggregator
-                .execute_transaction(&t)
+                .execute_transaction_block(&t)
                 .await
                 .expect("All ok.");
 

--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -410,7 +410,7 @@ impl SimpleFaucet {
         let client = self.wallet.get_client().await?;
         Ok(client
             .quorum_driver()
-            .execute_transaction(
+            .execute_transaction_block(
                 tx.clone(),
                 SuiTransactionResponseOptions::new().with_effects(),
                 Some(ExecuteTransactionRequestType::WaitForLocalExecution),

--- a/crates/sui-indexer/src/apis/indexer_api.rs
+++ b/crates/sui-indexer/src/apis/indexer_api.rs
@@ -283,7 +283,7 @@ where
         })
     }
 
-    async fn query_transactions(
+    async fn query_transaction_blocks(
         &self,
         query: SuiTransactionResponseQuery,
         cursor: Option<TransactionDigest>,
@@ -296,7 +296,7 @@ where
         {
             return self
                 .fullnode
-                .query_transactions(query, cursor, limit, descending_order)
+                .query_transaction_blocks(query, cursor, limit, descending_order)
                 .await;
         }
         Ok(self.query_transactions_internal(query, cursor, limit, descending_order)?)

--- a/crates/sui-indexer/src/apis/read_api.rs
+++ b/crates/sui-indexer/src/apis/read_api.rs
@@ -156,7 +156,7 @@ where
         Ok(self.get_total_transaction_number_internal()?.into())
     }
 
-    async fn get_transaction(
+    async fn get_transaction_block(
         &self,
         digest: TransactionDigest,
         options: Option<SuiTransactionResponseOptions>,
@@ -165,7 +165,7 @@ where
             .migrated_methods
             .contains(&"get_transaction".to_string())
         {
-            return self.fullnode.get_transaction(digest, options).await;
+            return self.fullnode.get_transaction_block(digest, options).await;
         }
         Ok(self
             .get_transaction_with_options_internal(&digest, options)

--- a/crates/sui-indexer/src/apis/read_api.rs
+++ b/crates/sui-indexer/src/apis/read_api.rs
@@ -172,7 +172,7 @@ where
             .await?)
     }
 
-    async fn multi_get_transactions(
+    async fn multi_get_transaction_blocks(
         &self,
         digests: Vec<TransactionDigest>,
         options: Option<SuiTransactionResponseOptions>,
@@ -181,7 +181,10 @@ where
             .migrated_methods
             .contains(&"multi_get_transactions_with_options".to_string())
         {
-            return self.fullnode.multi_get_transactions(digests, options).await;
+            return self
+                .fullnode
+                .multi_get_transaction_blocks(digests, options)
+                .await;
         }
         Ok(self
             .multi_get_transactions_with_options_internal(&digests, options)

--- a/crates/sui-indexer/src/apis/read_api.rs
+++ b/crates/sui-indexer/src/apis/read_api.rs
@@ -146,12 +146,12 @@ where
         return self.fullnode.multi_get_objects(object_ids, options).await;
     }
 
-    async fn get_total_transaction_number(&self) -> RpcResult<BigInt> {
+    async fn get_total_transaction_blocks(&self) -> RpcResult<BigInt> {
         if !self
             .migrated_methods
             .contains(&"get_total_transaction_number".to_string())
         {
-            return self.fullnode.get_total_transaction_number().await;
+            return self.fullnode.get_total_transaction_blocks().await;
         }
         Ok(self.get_total_transaction_number_internal()?.into())
     }

--- a/crates/sui-indexer/src/apis/write_api.rs
+++ b/crates/sui-indexer/src/apis/write_api.rs
@@ -30,7 +30,7 @@ impl WriteApi {
 
 #[async_trait]
 impl WriteApiServer for WriteApi {
-    async fn execute_transaction(
+    async fn execute_transaction_block(
         &self,
         tx_bytes: Base64,
         signatures: Vec<Base64>,
@@ -38,11 +38,11 @@ impl WriteApiServer for WriteApi {
         request_type: Option<ExecuteTransactionRequestType>,
     ) -> RpcResult<SuiTransactionResponse> {
         self.fullnode
-            .execute_transaction(tx_bytes, signatures, options, request_type)
+            .execute_transaction_block(tx_bytes, signatures, options, request_type)
             .await
     }
 
-    async fn dev_inspect_transaction(
+    async fn dev_inspect_transaction_block(
         &self,
         sender_address: SuiAddress,
         tx_bytes: Base64,
@@ -50,12 +50,15 @@ impl WriteApiServer for WriteApi {
         epoch: Option<EpochId>,
     ) -> RpcResult<DevInspectResults> {
         self.fullnode
-            .dev_inspect_transaction(sender_address, tx_bytes, gas_price, epoch)
+            .dev_inspect_transaction_block(sender_address, tx_bytes, gas_price, epoch)
             .await
     }
 
-    async fn dry_run_transaction(&self, tx_bytes: Base64) -> RpcResult<DryRunTransactionResponse> {
-        self.fullnode.dry_run_transaction(tx_bytes).await
+    async fn dry_run_transaction_block(
+        &self,
+        tx_bytes: Base64,
+    ) -> RpcResult<DryRunTransactionResponse> {
+        self.fullnode.dry_run_transaction_block(tx_bytes).await
     }
 }
 

--- a/crates/sui-indexer/tests/integration_tests.rs
+++ b/crates/sui-indexer/tests/integration_tests.rs
@@ -248,7 +248,7 @@ pub mod pg_integration_test {
         // At least 1 transaction + 1 genesis, others are like Consensus Commit Prologue
         assert!(tx_count >= 2);
         let rpc_tx_count = indexer_rpc_client
-            .get_total_transaction_number()
+            .get_total_transaction_blocks()
             .await
             .unwrap();
         assert!(<u64>::from(rpc_tx_count) >= 2);

--- a/crates/sui-indexer/tests/integration_tests.rs
+++ b/crates/sui-indexer/tests/integration_tests.rs
@@ -80,7 +80,7 @@ pub mod pg_integration_test {
         Ok(gas_objects)
     }
 
-    async fn sign_and_execute_transaction(
+    async fn sign_and_execute_transaction_block(
         test_cluster: &TestCluster,
         indexer_rpc_client: &HttpClient,
         transaction_bytes: TransactionBytes,
@@ -92,7 +92,7 @@ pub mod pg_integration_test {
             to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(sender)?);
         let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
         let tx_response = indexer_rpc_client
-            .execute_transaction(
+            .execute_transaction_block(
                 tx_bytes,
                 signatures,
                 Some(SuiTransactionResponseOptions::full_content()),
@@ -114,7 +114,7 @@ pub mod pg_integration_test {
         let transaction_bytes: TransactionBytes = indexer_rpc_client
             .transfer_object(*sender, object_id, gas, 2000, *recipient)
             .await?;
-        let tx_response = sign_and_execute_transaction(
+        let tx_response = sign_and_execute_transaction_block(
             test_cluster,
             indexer_rpc_client,
             transaction_bytes,
@@ -713,7 +713,7 @@ pub mod pg_integration_test {
                 2000,
             )
             .await?;
-        let tx_response = sign_and_execute_transaction(
+        let tx_response = sign_and_execute_transaction_block(
             &test_cluster,
             &indexer_rpc_client,
             transaction_bytes,

--- a/crates/sui-indexer/tests/integration_tests.rs
+++ b/crates/sui-indexer/tests/integration_tests.rs
@@ -413,7 +413,7 @@ pub mod pg_integration_test {
         wait_until_transaction_synced(&store, nft_digest.base58_encode().as_str()).await;
 
         let tx_multi_read_tx_response_1 = indexer_rpc_client
-            .multi_get_transactions(
+            .multi_get_transaction_blocks(
                 vec![tx_response.digest, nft_digest],
                 Some(SuiTransactionResponseOptions::full_content()),
             )
@@ -423,7 +423,7 @@ pub mod pg_integration_test {
         assert_eq!(tx_multi_read_tx_response_1[1].digest, nft_digest);
 
         let tx_multi_read_tx_response_2 = indexer_rpc_client
-            .multi_get_transactions(
+            .multi_get_transaction_blocks(
                 vec![nft_digest, tx_response.digest],
                 Some(SuiTransactionResponseOptions::full_content()),
             )

--- a/crates/sui-indexer/tests/integration_tests.rs
+++ b/crates/sui-indexer/tests/integration_tests.rs
@@ -280,7 +280,7 @@ pub mod pg_integration_test {
         let checkpoint_seq_query =
             SuiTransactionResponseQuery::new_with_filter(TransactionFilter::Checkpoint(2u64));
         let mut checkpoint_query_tx_digest_vec = indexer_rpc_client
-            .query_transactions(checkpoint_seq_query, None, None, None)
+            .query_transaction_blocks(checkpoint_seq_query, None, None, None)
             .await
             .unwrap()
             .data
@@ -317,7 +317,7 @@ pub mod pg_integration_test {
         let from_query =
             SuiTransactionResponseQuery::new_with_filter(TransactionFilter::FromAddress(sender));
         let tx_from_query_response = indexer_rpc_client
-            .query_transactions(from_query, None, None, None)
+            .query_transaction_blocks(from_query, None, None, None)
             .await?;
         assert!(!tx_from_query_response.has_next_page);
         assert_eq!(tx_from_query_response.data.len(), 3);
@@ -326,7 +326,7 @@ pub mod pg_integration_test {
             TransactionFilter::TransactionKind("ProgrammableTransaction".to_string()),
         );
         let tx_kind_query_response = indexer_rpc_client
-            .query_transactions(tx_kind_query, None, None, None)
+            .query_transaction_blocks(tx_kind_query, None, None, None)
             .await?;
         assert!(!tx_kind_query_response.has_next_page);
         assert_eq!(tx_kind_query_response.data.len(), 3);
@@ -335,7 +335,7 @@ pub mod pg_integration_test {
         let to_query =
             SuiTransactionResponseQuery::new_with_filter(TransactionFilter::ToAddress(recipient));
         let tx_to_query_response = indexer_rpc_client
-            .query_transactions(to_query, None, None, None)
+            .query_transaction_blocks(to_query, None, None, None)
             .await?;
         // the address has received 2 transactions, one is genesis
         assert!(!tx_to_query_response.has_next_page);
@@ -348,7 +348,7 @@ pub mod pg_integration_test {
                 to: recipient,
             });
         let tx_from_to_query_response = indexer_rpc_client
-            .query_transactions(from_to_query, None, None, None)
+            .query_transaction_blocks(from_to_query, None, None, None)
             .await?;
         assert!(!tx_from_to_query_response.has_next_page);
         assert_eq!(tx_from_to_query_response.data.len(), 1);
@@ -362,7 +362,7 @@ pub mod pg_integration_test {
             TransactionFilter::ChangedObject(*gas_objects.first().unwrap()),
         );
         let tx_mutation_query_response = indexer_rpc_client
-            .query_transactions(mutation_query, None, None, None)
+            .query_transaction_blocks(mutation_query, None, None, None)
             .await?;
         // the coin is first created by genesis tx, then transferred by the above tx
         assert!(!tx_mutation_query_response.has_next_page);
@@ -373,7 +373,7 @@ pub mod pg_integration_test {
             TransactionFilter::InputObject(*gas_objects.first().unwrap()),
         );
         let tx_input_query_response = indexer_rpc_client
-            .query_transactions(input_query, None, None, None)
+            .query_transaction_blocks(input_query, None, None, None)
             .await?;
         assert_eq!(tx_input_query_response.data.len(), 2);
 
@@ -385,7 +385,7 @@ pub mod pg_integration_test {
                 function: None,
             });
         let tx_move_call_query_response = indexer_rpc_client
-            .query_transactions(move_call_query, None, None, None)
+            .query_transaction_blocks(move_call_query, None, None, None)
             .await?;
         assert_eq!(tx_move_call_query_response.data.len(), 1);
         assert_eq!(

--- a/crates/sui-indexer/tests/integration_tests.rs
+++ b/crates/sui-indexer/tests/integration_tests.rs
@@ -187,11 +187,11 @@ pub mod pg_integration_test {
             assert!(transaction.is_ok());
             let _fullnode_rpc_tx = test_cluster
                 .rpc_client()
-                .get_transaction(tx_digest, Some(SuiTransactionResponseOptions::new()))
+                .get_transaction_block(tx_digest, Some(SuiTransactionResponseOptions::new()))
                 .await
                 .unwrap();
             let _indexer_rpc_tx = indexer_rpc_client
-                .get_transaction(tx_digest, Some(SuiTransactionResponseOptions::new()))
+                .get_transaction_block(tx_digest, Some(SuiTransactionResponseOptions::new()))
                 .await
                 .unwrap();
 
@@ -297,7 +297,7 @@ pub mod pg_integration_test {
         assert_eq!(checkpoint_query_tx_digest_vec, checkpoint_tx_digest_vec);
 
         let tx_read_response = indexer_rpc_client
-            .get_transaction(
+            .get_transaction_block(
                 tx_response.digest,
                 Some(SuiTransactionResponseOptions::full_content()),
             )
@@ -1084,7 +1084,7 @@ pub mod pg_integration_test {
             execute_simple_transfer(&mut test_cluster, &indexer_rpc_client).await?;
         wait_until_transaction_synced(&store, tx_response.digest.base58_encode().as_str()).await;
         let full_transaction_response = indexer_rpc_client
-            .get_transaction(
+            .get_transaction_block(
                 tx_response.digest,
                 Some(SuiTransactionResponseOptions::full_content()),
             )
@@ -1103,7 +1103,9 @@ pub mod pg_integration_test {
         ];
         let futures = sui_transaction_response_options
             .into_iter()
-            .map(|option| indexer_rpc_client.get_transaction(tx_response.digest, Some(option)))
+            .map(|option| {
+                indexer_rpc_client.get_transaction_block(tx_response.digest, Some(option))
+            })
             .collect::<Vec<_>>();
 
         let received_transaction_results: Vec<SuiTransactionResponse> = join_all(futures)
@@ -1173,7 +1175,7 @@ pub mod pg_integration_test {
         wait_until_transaction_synced(&store, tx_response.digest.base58_encode().as_str()).await;
         // We do this as checkpoint field is only returned in the read api
         let tx_response = indexer_rpc_client
-            .get_transaction(
+            .get_transaction_block(
                 tx_response.digest,
                 Some(SuiTransactionResponseOptions::full_content()),
             )

--- a/crates/sui-json-rpc/src/api/indexer.rs
+++ b/crates/sui-json-rpc/src/api/indexer.rs
@@ -33,7 +33,7 @@ pub trait IndexerApi {
 
     /// Return list of transactions for a specified query criteria.
     #[method(name = "queryTransactions")]
-    async fn query_transactions(
+    async fn query_transaction_blocks(
         &self,
         /// the transaction query criteria.
         query: SuiTransactionResponseQuery,

--- a/crates/sui-json-rpc/src/api/read.rs
+++ b/crates/sui-json-rpc/src/api/read.rs
@@ -29,7 +29,7 @@ pub trait ReadApi {
     /// The method will throw an error if the input contains any duplicate or
     /// the input size exceeds QUERY_MAX_RESULT_LIMIT
     #[method(name = "multiGetTransactions")]
-    async fn multi_get_transactions(
+    async fn multi_get_transaction_blocks(
         &self,
         /// A list of transaction digests.
         digests: Vec<TransactionDigest>,

--- a/crates/sui-json-rpc/src/api/read.rs
+++ b/crates/sui-json-rpc/src/api/read.rs
@@ -115,7 +115,7 @@ pub trait ReadApi {
 
     /// Return the total number of transactions known to the server.
     #[method(name = "getTotalTransactionNumber")]
-    async fn get_total_transaction_number(&self) -> RpcResult<BigInt>;
+    async fn get_total_transaction_blocks(&self) -> RpcResult<BigInt>;
 
     /// Return the sequence number of the latest checkpoint that has been executed
     #[method(name = "getLatestCheckpointSequenceNumber")]

--- a/crates/sui-json-rpc/src/api/read.rs
+++ b/crates/sui-json-rpc/src/api/read.rs
@@ -17,7 +17,7 @@ use sui_types::base_types::{ObjectID, SequenceNumber, TransactionDigest};
 pub trait ReadApi {
     /// Return the transaction response object.
     #[method(name = "getTransaction")]
-    async fn get_transaction(
+    async fn get_transaction_block(
         &self,
         /// the digest of the queried transaction
         digest: TransactionDigest,

--- a/crates/sui-json-rpc/src/api/write.rs
+++ b/crates/sui-json-rpc/src/api/write.rs
@@ -27,7 +27,7 @@ pub trait WriteApi {
     ///     a bool type in the response is set to false to indicated the case.
     /// request_type is default to be `WaitForEffectsCert` unless options.show_events or options.show_effects is true
     #[method(name = "executeTransaction", deprecated)]
-    async fn execute_transaction(
+    async fn execute_transaction_block(
         &self,
         /// BCS serialized transaction data bytes without its type tag, as base-64 encoded string.
         tx_bytes: Base64,
@@ -43,7 +43,7 @@ pub trait WriteApi {
     /// transaction (or Move call) with any arguments. Detailed results are
     /// provided, including both the transaction effects and any return values.
     #[method(name = "devInspectTransaction")]
-    async fn dev_inspect_transaction(
+    async fn dev_inspect_transaction_block(
         &self,
         sender_address: SuiAddress,
         /// BCS encoded TransactionKind(as opposed to TransactionData, which include gasBudget and gasPrice)
@@ -57,5 +57,8 @@ pub trait WriteApi {
     /// Return transaction execution effects including the gas cost summary,
     /// while the effects are not committed to the chain.
     #[method(name = "dryRunTransaction")]
-    async fn dry_run_transaction(&self, tx_bytes: Base64) -> RpcResult<DryRunTransactionResponse>;
+    async fn dry_run_transaction_block(
+        &self,
+        tx_bytes: Base64,
+    ) -> RpcResult<DryRunTransactionResponse>;
 }

--- a/crates/sui-json-rpc/src/indexer_api.rs
+++ b/crates/sui-json-rpc/src/indexer_api.rs
@@ -124,7 +124,7 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
         })
     }
 
-    async fn query_transactions(
+    async fn query_transaction_blocks(
         &self,
         query: SuiTransactionResponseQuery,
         // If `Some`, the query will start from the next item after the specified cursor

--- a/crates/sui-json-rpc/src/indexer_api.rs
+++ b/crates/sui-json-rpc/src/indexer_api.rs
@@ -153,7 +153,7 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
                 .collect()
         } else {
             self.read_api
-                .multi_get_transactions(digests, Some(opts))
+                .multi_get_transaction_blocks(digests, Some(opts))
                 .await?
         };
 

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -356,7 +356,7 @@ impl ReadApiServer for ReadApi {
         ))
     }
 
-    async fn multi_get_transactions(
+    async fn multi_get_transaction_blocks(
         &self,
         digests: Vec<TransactionDigest>,
         opts: Option<SuiTransactionResponseOptions>,

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -257,8 +257,8 @@ impl ReadApiServer for ReadApi {
         }
     }
 
-    async fn get_total_transaction_number(&self) -> RpcResult<BigInt> {
-        Ok(self.state.get_total_transaction_number()?.into())
+    async fn get_total_transaction_blocks(&self) -> RpcResult<BigInt> {
+        Ok(self.state.get_total_transaction_blocks()?.into())
     }
 
     async fn get_transaction_block(

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -261,7 +261,7 @@ impl ReadApiServer for ReadApi {
         Ok(self.state.get_total_transaction_number()?.into())
     }
 
-    async fn get_transaction(
+    async fn get_transaction_block(
         &self,
         digest: TransactionDigest,
         opts: Option<SuiTransactionResponseOptions>,

--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -52,7 +52,7 @@ impl TransactionExecutionApi {
         }
     }
 
-    async fn execute_transaction(
+    async fn execute_transaction_block(
         &self,
         tx_bytes: Base64,
         signatures: Vec<Base64>,
@@ -89,7 +89,7 @@ impl TransactionExecutionApi {
         let digest = *txn.digest();
 
         let transaction_orchestrator = self.transaction_orchestrator.clone();
-        let response = spawn_monitored_task!(transaction_orchestrator.execute_transaction(
+        let response = spawn_monitored_task!(transaction_orchestrator.execute_transaction_block(
             ExecuteTransactionRequest {
                 transaction: txn,
                 request_type,
@@ -153,7 +153,7 @@ impl TransactionExecutionApi {
         }
     }
 
-    async fn dry_run_transaction(
+    async fn dry_run_transaction_block(
         &self,
         tx_bytes: Base64,
     ) -> Result<DryRunTransactionResponse, Error> {
@@ -185,7 +185,7 @@ impl TransactionExecutionApi {
 
 #[async_trait]
 impl WriteApiServer for TransactionExecutionApi {
-    async fn execute_transaction(
+    async fn execute_transaction_block(
         &self,
         tx_bytes: Base64,
         signatures: Vec<Base64>,
@@ -193,11 +193,11 @@ impl WriteApiServer for TransactionExecutionApi {
         request_type: Option<ExecuteTransactionRequestType>,
     ) -> RpcResult<SuiTransactionResponse> {
         Ok(self
-            .execute_transaction(tx_bytes, signatures, opts, request_type)
+            .execute_transaction_block(tx_bytes, signatures, opts, request_type)
             .await?)
     }
 
-    async fn dev_inspect_transaction(
+    async fn dev_inspect_transaction_block(
         &self,
         sender_address: SuiAddress,
         tx_bytes: Base64,
@@ -208,12 +208,15 @@ impl WriteApiServer for TransactionExecutionApi {
             bcs::from_bytes(&tx_bytes.to_vec().map_err(|e| anyhow!(e))?).map_err(|e| anyhow!(e))?;
         Ok(self
             .state
-            .dev_inspect_transaction(sender_address, tx_kind, gas_price.map(<u64>::from))
+            .dev_inspect_transaction_block(sender_address, tx_kind, gas_price.map(<u64>::from))
             .await?)
     }
 
-    async fn dry_run_transaction(&self, tx_bytes: Base64) -> RpcResult<DryRunTransactionResponse> {
-        Ok(self.dry_run_transaction(tx_bytes).await?)
+    async fn dry_run_transaction_block(
+        &self,
+        tx_bytes: Base64,
+    ) -> RpcResult<DryRunTransactionResponse> {
+        Ok(self.dry_run_transaction_block(tx_bytes).await?)
     }
 }
 

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -113,10 +113,10 @@ async fn test_public_transfer_object() -> Result<(), anyhow::Error> {
     let tx = to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
     let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
     let tx_bytes1 = tx_bytes.clone();
-    let dryrun_response = http_client.dry_run_transaction(tx_bytes).await?;
+    let dryrun_response = http_client.dry_run_transaction_block(tx_bytes).await?;
 
     let tx_response: SuiTransactionResponse = http_client
-        .execute_transaction(
+        .execute_transaction_block(
             tx_bytes1,
             signatures,
             Some(
@@ -184,7 +184,7 @@ async fn test_publish() -> Result<(), anyhow::Error> {
     let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     let tx_response = http_client
-        .execute_transaction(
+        .execute_transaction_block(
             tx_bytes,
             signatures,
             Some(SuiTransactionResponseOptions::new().with_effects()),
@@ -245,7 +245,7 @@ async fn test_move_call() -> Result<(), anyhow::Error> {
     let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     let tx_response = http_client
-        .execute_transaction(
+        .execute_transaction_block(
             tx_bytes,
             signatures,
             Some(SuiTransactionResponseOptions::new().with_effects()),
@@ -432,7 +432,7 @@ async fn test_get_metadata() -> Result<(), anyhow::Error> {
     let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     let tx_response = http_client
-        .execute_transaction(
+        .execute_transaction_block(
             tx_bytes,
             signatures,
             Some(
@@ -514,7 +514,7 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
     let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     let tx_response: SuiTransactionResponse = http_client
-        .execute_transaction(
+        .execute_transaction_block(
             tx_bytes,
             signatures,
             Some(
@@ -586,7 +586,7 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
     let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     let tx_response = http_client
-        .execute_transaction(
+        .execute_transaction_block(
             tx_bytes,
             signatures,
             Some(SuiTransactionResponseOptions::new().with_effects()),
@@ -648,7 +648,7 @@ async fn test_staking() -> Result<(), anyhow::Error> {
     let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     http_client
-        .execute_transaction(
+        .execute_transaction_block(
             tx_bytes,
             signatures,
             Some(SuiTransactionResponseOptions::new()),
@@ -717,7 +717,7 @@ async fn test_unstaking() -> Result<(), anyhow::Error> {
         let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
         http_client
-            .execute_transaction(
+            .execute_transaction_block(
                 tx_bytes,
                 signatures,
                 Some(SuiTransactionResponseOptions::new()),
@@ -774,7 +774,7 @@ async fn test_unstaking() -> Result<(), anyhow::Error> {
     let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     http_client
-        .execute_transaction(
+        .execute_transaction_block(
             tx_bytes,
             signatures,
             Some(SuiTransactionResponseOptions::new()),
@@ -853,10 +853,12 @@ async fn test_staking_multiple_coins() -> Result<(), anyhow::Error> {
 
     let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
-    let dryrun_response = http_client.dry_run_transaction(tx_bytes.clone()).await?;
+    let dryrun_response = http_client
+        .dry_run_transaction_block(tx_bytes.clone())
+        .await?;
 
     let executed_response = http_client
-        .execute_transaction(
+        .execute_transaction_block(
             tx_bytes,
             signatures,
             Some(SuiTransactionResponseOptions::new().with_balance_changes()),

--- a/crates/sui-json-rpc/src/unit_tests/transaction_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/transaction_tests.rs
@@ -53,7 +53,7 @@ async fn test_get_transaction_block() -> Result<(), anyhow::Error> {
         let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
         let response = http_client
-            .execute_transaction(
+            .execute_transaction_block(
                 tx_bytes,
                 signatures,
                 Some(SuiTransactionResponseOptions::new()),
@@ -128,7 +128,7 @@ async fn test_get_raw_transaction() -> Result<(), anyhow::Error> {
     let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     let response = http_client
-        .execute_transaction(
+        .execute_transaction_block(
             tx_bytes,
             signatures,
             Some(SuiTransactionResponseOptions::new().with_raw_input()),
@@ -186,7 +186,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
 
             let response = client
                 .quorum_driver()
-                .execute_transaction(
+                .execute_transaction_block(
                     tx,
                     SuiTransactionResponseOptions::new(),
                     Some(ExecuteTransactionRequestType::WaitForLocalExecution),

--- a/crates/sui-json-rpc/src/unit_tests/transaction_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/transaction_tests.rs
@@ -65,10 +65,9 @@ async fn test_get_transaction() -> Result<(), anyhow::Error> {
     }
 
     // TODO(chris): re-enable after rewriting get_transactions_in_range_deprecated with query_transactions
-
-    // // test get_transaction_batch
+    // test get_transaction_batch
     // let batch_responses: Vec<SuiTransactionResponse> = http_client
-    //     .multi_get_transactions(tx, Some(SuiTransactionResponseOptions::new()))
+    //     .multi_get_transaction_blocks(tx, Some(SuiTransactionResponseOptions::new()))
     //     .await?;
 
     // assert_eq!(5, batch_responses.len());

--- a/crates/sui-json-rpc/src/unit_tests/transaction_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/transaction_tests.rs
@@ -201,7 +201,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
     // test get_recent_transactions with smaller range
     let tx = client
         .read_api()
-        .query_transactions(SuiTransactionResponseQuery::default(), None, Some(3), true)
+        .query_transaction_blocks(SuiTransactionResponseQuery::default(), None, Some(3), true)
         .await
         .unwrap();
     assert_eq!(3, tx.data.len());
@@ -210,7 +210,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
     // test get all transactions paged
     let first_page = client
         .read_api()
-        .query_transactions(SuiTransactionResponseQuery::default(), None, Some(5), false)
+        .query_transaction_blocks(SuiTransactionResponseQuery::default(), None, Some(5), false)
         .await
         .unwrap();
     assert_eq!(5, first_page.data.len());
@@ -218,7 +218,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
 
     let second_page = client
         .read_api()
-        .query_transactions(
+        .query_transaction_blocks(
             SuiTransactionResponseQuery::default(),
             first_page.next_cursor,
             None,
@@ -236,7 +236,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
     // test get 10 latest transactions paged
     let latest = client
         .read_api()
-        .query_transactions(SuiTransactionResponseQuery::default(), None, Some(10), true)
+        .query_transaction_blocks(SuiTransactionResponseQuery::default(), None, Some(10), true)
         .await
         .unwrap();
     assert_eq!(10, latest.data.len());
@@ -247,7 +247,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
     // test get from address txs in ascending order
     let address_txs_asc = client
         .read_api()
-        .query_transactions(
+        .query_transaction_blocks(
             SuiTransactionResponseQuery::new_with_filter(TransactionFilter::FromAddress(
                 cluster.accounts[0],
             )),
@@ -262,7 +262,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
     // test get from address txs in descending order
     let address_txs_desc = client
         .read_api()
-        .query_transactions(
+        .query_transaction_blocks(
             SuiTransactionResponseQuery::new_with_filter(TransactionFilter::FromAddress(
                 cluster.accounts[0],
             )),
@@ -282,7 +282,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
     // test get_recent_transactions
     let tx = client
         .read_api()
-        .query_transactions(SuiTransactionResponseQuery::default(), None, Some(20), true)
+        .query_transaction_blocks(SuiTransactionResponseQuery::default(), None, Some(20), true)
         .await
         .unwrap();
     assert_eq!(20, tx.data.len());

--- a/crates/sui-json-rpc/src/unit_tests/transaction_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/transaction_tests.rs
@@ -17,7 +17,7 @@ use test_utils::network::TestClusterBuilder;
 use crate::api::{IndexerApiClient, TransactionBuilderClient, WriteApiClient};
 
 #[sim_test]
-async fn test_get_transaction() -> Result<(), anyhow::Error> {
+async fn test_get_transaction_block() -> Result<(), anyhow::Error> {
     let cluster = TestClusterBuilder::new().build().await?;
     let http_client = cluster.rpc_client();
     let address = cluster.accounts.first().unwrap();
@@ -81,7 +81,7 @@ async fn test_get_transaction() -> Result<(), anyhow::Error> {
     // // test get_transaction
     // for tx_digest in tx {
     //     let response: SuiTransactionResponse = http_client
-    //         .get_transaction(
+    //         .get_transaction_block(
     //             tx_digest,
     //             Some(SuiTransactionResponseOptions::new().with_raw_input()),
     //         )

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -81,7 +81,7 @@ impl RpcExampleProvider {
             self.get_past_object_example(),
             self.get_owned_objects(),
             self.get_total_transaction_number(),
-            self.get_transaction(),
+            self.get_transaction_block(),
             self.query_transactions(),
             self.get_events(),
             self.execute_transaction_example(),
@@ -363,7 +363,7 @@ impl RpcExampleProvider {
         )
     }
 
-    fn get_transaction(&mut self) -> Examples {
+    fn get_transaction_block(&mut self) -> Examples {
         let (_, _, _, _, result) = self.get_transfer_data_response();
         Examples::new(
             "sui_getTransaction",

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -82,7 +82,7 @@ impl RpcExampleProvider {
             self.get_owned_objects(),
             self.get_total_transaction_blocks(),
             self.get_transaction_block(),
-            self.query_transactions(),
+            self.query_transaction_blocks(),
             self.get_events(),
             self.execute_transaction_example(),
             self.get_checkpoint_example(),
@@ -384,7 +384,7 @@ impl RpcExampleProvider {
         )
     }
 
-    fn query_transactions(&mut self) -> Examples {
+    fn query_transaction_blocks(&mut self) -> Examples {
         let mut data = self.get_transaction_digests(5..9);
         let has_next_page = data.len() > (9 - 5);
         data.truncate(9 - 5);

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -80,7 +80,7 @@ impl RpcExampleProvider {
             self.get_object_example(),
             self.get_past_object_example(),
             self.get_owned_objects(),
-            self.get_total_transaction_number(),
+            self.get_total_transaction_blocks(),
             self.get_transaction_block(),
             self.query_transactions(),
             self.get_events(),
@@ -352,7 +352,7 @@ impl RpcExampleProvider {
         )
     }
 
-    fn get_total_transaction_number(&mut self) -> Examples {
+    fn get_total_transaction_blocks(&mut self) -> Examples {
         Examples::new(
             "sui_getTotalTransactionNumber",
             vec![ExamplePairing::new(

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -134,7 +134,7 @@ pub async fn submit(
     let response = context
         .client
         .quorum_driver()
-        .execute_transaction(
+        .execute_transaction_block(
             signed_tx,
             SuiTransactionResponseOptions::new()
                 .with_input()
@@ -307,7 +307,11 @@ pub async fn metadata(
             budget: budget * gas_price,
         })?;
 
-    let dry_run = context.client.read_api().dry_run_transaction(data).await?;
+    let dry_run = context
+        .client
+        .read_api()
+        .dry_run_transaction_block(data)
+        .await?;
     let effects = dry_run.effects;
 
     if let SuiExecutionStatus::Failure { error } = effects.status() {

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -610,7 +610,7 @@ async fn test_transaction(
 
     let response = client
         .quorum_driver()
-        .execute_transaction(
+        .execute_transaction_block(
             Transaction::from_data(data.clone(), Intent::default(), vec![signature])
                 .verify()
                 .unwrap(),

--- a/crates/sui-rosetta/tests/end_to_end_tests.rs
+++ b/crates/sui-rosetta/tests/end_to_end_tests.rs
@@ -102,7 +102,7 @@ async fn test_get_staked_sui() {
     let tx = to_sender_signed_transaction(delegation_tx, keystore.get_key(&address).unwrap());
     client
         .quorum_driver()
-        .execute_transaction(
+        .execute_transaction_block(
             tx,
             SuiTransactionResponseOptions::new(),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),

--- a/crates/sui-rpc-loadgen/src/main.rs
+++ b/crates/sui-rpc-loadgen/src/main.rs
@@ -165,7 +165,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             from_address,
             to_address,
         } => (
-            Command::new_query_transactions(from_address, to_address),
+            Command::new_query_transaction_blocks(from_address, to_address),
             common,
             false,
         ),

--- a/crates/sui-rpc-loadgen/src/payload/mod.rs
+++ b/crates/sui-rpc-loadgen/src/payload/mod.rs
@@ -87,7 +87,7 @@ impl Command {
         }
     }
 
-    pub fn new_query_transactions(
+    pub fn new_query_transaction_blocks(
         from_address: Option<String>,
         to_address: Option<String>,
     ) -> Self {

--- a/crates/sui-rpc-loadgen/src/payload/query_transactions.rs
+++ b/crates/sui-rpc-loadgen/src/payload/query_transactions.rs
@@ -64,7 +64,7 @@ impl<'a> ProcessPayload<'a, &'a QueryTransactions> for RpcCommandProcessor {
                 let with_query = query.clone();
                 async move {
                     let start_time = Instant::now();
-                    let transactions = query_transactions(client, with_query, cursor, None)
+                    let transactions = query_transaction_blocks(client, with_query, cursor, None)
                         .await
                         .unwrap();
                     let elapsed_time = start_time.elapsed();
@@ -88,7 +88,7 @@ impl<'a> ProcessPayload<'a, &'a QueryTransactions> for RpcCommandProcessor {
     }
 }
 
-async fn query_transactions(
+async fn query_transaction_blocks(
     client: &SuiClient,
     query: SuiTransactionResponseQuery,
     cursor: Option<TransactionDigest>,
@@ -96,7 +96,7 @@ async fn query_transactions(
 ) -> Result<Page<SuiTransactionResponse, TransactionDigest>> {
     let transactions = client
         .read_api()
-        .query_transactions(query, cursor, limit, true)
+        .query_transaction_blocks(query, cursor, limit, true)
         .await
         .unwrap();
     Ok(transactions)

--- a/crates/sui-rpc-loadgen/src/payload/rpc_command_processor.rs
+++ b/crates/sui-rpc-loadgen/src/payload/rpc_command_processor.rs
@@ -481,7 +481,7 @@ pub(crate) async fn sign_and_execute(
 
     let transaction_response = match client
         .quorum_driver()
-        .execute_transaction(
+        .execute_transaction_block(
             Transaction::from_data(txn_data, Intent::default(), vec![signature])
                 .verify()
                 .expect("signature error"),

--- a/crates/sui-sdk/examples/tic_tac_toe.rs
+++ b/crates/sui-sdk/examples/tic_tac_toe.rs
@@ -102,7 +102,7 @@ impl TicTacToe {
         let response = self
             .client
             .quorum_driver()
-            .execute_transaction(
+            .execute_transaction_block(
                 Transaction::from_data(create_game_call, Intent::default(), vec![signature])
                     .verify()?,
                 SuiTransactionResponseOptions::full_content(),
@@ -201,7 +201,7 @@ impl TicTacToe {
             let response = self
                 .client
                 .quorum_driver()
-                .execute_transaction(
+                .execute_transaction_block(
                     Transaction::from_data(place_mark_call, Intent::default(), vec![signature])
                         .verify()?,
                     SuiTransactionResponseOptions::new().with_effects(),

--- a/crates/sui-sdk/examples/transfer_coins.rs
+++ b/crates/sui-sdk/examples/transfer_coins.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<(), anyhow::Error> {
     // Execute the transaction
     let transaction_response = sui
         .quorum_driver()
-        .execute_transaction(
+        .execute_transaction_block(
             Transaction::from_data(transfer_tx, Intent::default(), vec![signature]).verify()?,
             SuiTransactionResponseOptions::full_content(),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -125,7 +125,11 @@ impl ReadApi {
         digest: TransactionDigest,
         options: SuiTransactionResponseOptions,
     ) -> SuiRpcResult<SuiTransactionResponse> {
-        Ok(self.api.http.get_transaction(digest, Some(options)).await?)
+        Ok(self
+            .api
+            .http
+            .get_transaction_block(digest, Some(options))
+            .await?)
     }
 
     pub async fn multi_get_transactions_with_options(
@@ -478,7 +482,7 @@ impl QuorumDriver {
     ) -> SuiRpcResult<()> {
         let start = Instant::now();
         loop {
-            let resp = ReadApiClient::get_transaction(
+            let resp = ReadApiClient::get_transaction_block(
                 &c.http,
                 tx_digest,
                 Some(SuiTransactionResponseOptions::new()),

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -227,14 +227,14 @@ impl ReadApi {
         Ok(self.api.http.get_reference_gas_price().await?.into())
     }
 
-    pub async fn dry_run_transaction(
+    pub async fn dry_run_transaction_block(
         &self,
         tx: TransactionData,
     ) -> SuiRpcResult<DryRunTransactionResponse> {
         Ok(self
             .api
             .http
-            .dry_run_transaction(Base64::from_bytes(&bcs::to_bytes(&tx)?))
+            .dry_run_transaction_block(Base64::from_bytes(&bcs::to_bytes(&tx)?))
             .await?)
     }
 }
@@ -438,7 +438,7 @@ impl QuorumDriver {
     /// the fullnode until the fullnode recognizes this transaction, or
     /// until times out (see WAIT_FOR_TX_TIMEOUT_SEC). If it times out, an
     /// error is returned from this call.
-    pub async fn execute_transaction(
+    pub async fn execute_transaction_block(
         &self,
         tx: VerifiedTransaction,
         options: SuiTransactionResponseOptions,
@@ -449,7 +449,7 @@ impl QuorumDriver {
         let mut response: SuiTransactionResponse = self
             .api
             .http
-            .execute_transaction(
+            .execute_transaction_block(
                 tx_bytes,
                 signatures,
                 Some(options),

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -116,8 +116,8 @@ impl ReadApi {
             .await?)
     }
 
-    pub async fn get_total_transaction_number(&self) -> SuiRpcResult<u64> {
-        Ok(self.api.http.get_total_transaction_number().await?.into())
+    pub async fn get_total_transaction_blocks(&self) -> SuiRpcResult<u64> {
+        Ok(self.api.http.get_total_transaction_blocks().await?.into())
     }
 
     pub async fn get_transaction_with_options(

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -148,7 +148,7 @@ impl ReadApi {
         Ok(self.api.http.get_committee_info(epoch).await?)
     }
 
-    pub async fn query_transactions(
+    pub async fn query_transaction_blocks(
         &self,
         query: SuiTransactionResponseQuery,
         cursor: Option<TransactionDigest>,
@@ -158,7 +158,7 @@ impl ReadApi {
         Ok(self
             .api
             .http
-            .query_transactions(query, cursor, limit, Some(descending_order))
+            .query_transaction_blocks(query, cursor, limit, Some(descending_order))
             .await?)
     }
 
@@ -192,7 +192,12 @@ impl ReadApi {
                     Some((item, (data, cursor, false, query)))
                 } else if (cursor.is_none() && first) || cursor.is_some() {
                     let page = self
-                        .query_transactions(query.clone(), cursor, Some(100), descending_order)
+                        .query_transaction_blocks(
+                            query.clone(),
+                            cursor,
+                            Some(100),
+                            descending_order,
+                        )
                         .await
                         .ok()?;
                     let mut data = page.data;

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -136,7 +136,7 @@ impl ReadApi {
         Ok(self
             .api
             .http
-            .multi_get_transactions(digests, Some(options))
+            .multi_get_transaction_blocks(digests, Some(options))
             .await?)
     }
 

--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -3,8 +3,8 @@
 
 use crate::{
     db_tool::{execute_db_tool_command, print_db_all_tables, DbToolCommand},
-    get_object, get_transaction, make_clients, restore_from_db_checkpoint, ConciseObjectOutput,
-    GroupedObjectOutput, VerboseObjectOutput,
+    get_object, get_transaction_block, make_clients, restore_from_db_checkpoint,
+    ConciseObjectOutput, GroupedObjectOutput, VerboseObjectOutput,
 };
 use anyhow::Result;
 use std::path::PathBuf;
@@ -225,7 +225,7 @@ impl ToolCommand {
                 }
             }
             ToolCommand::FetchTransaction { genesis, digest } => {
-                print!("{}", get_transaction(digest, genesis).await?);
+                print!("{}", get_transaction_block(digest, genesis).await?);
             }
             ToolCommand::DbTool { db_path, cmd } => {
                 let path = PathBuf::from(db_path);

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -300,7 +300,10 @@ pub async fn get_object(
     })
 }
 
-pub async fn get_transaction(tx_digest: TransactionDigest, genesis: PathBuf) -> Result<String> {
+pub async fn get_transaction_block(
+    tx_digest: TransactionDigest,
+    genesis: PathBuf,
+) -> Result<String> {
     let clients = make_clients(genesis)?;
     let timer = Instant::now();
     let responses = join_all(clients.iter().map(|(name, (address, client))| async {

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -410,7 +410,7 @@ impl FullCheckpointContents {
         let mut transactions = Vec::with_capacity(contents.size());
         for tx in contents.iter() {
             if let (Some(t), Some(e)) = (
-                store.get_transaction(&tx.transaction)?,
+                store.get_transaction_block(&tx.transaction)?,
                 store.get_transaction_effects(&tx.effects)?,
             ) {
                 transactions.push(ExecutionData::new(t.into_inner(), e))

--- a/crates/sui-types/src/storage.rs
+++ b/crates/sui-types/src/storage.rs
@@ -235,7 +235,7 @@ pub trait ReadStore {
 
     fn get_committee(&self, epoch: EpochId) -> Result<Option<Arc<Committee>>, Self::Error>;
 
-    fn get_transaction(
+    fn get_transaction_block(
         &self,
         digest: &TransactionDigest,
     ) -> Result<Option<VerifiedTransaction>, Self::Error>;
@@ -287,11 +287,11 @@ impl<T: ReadStore> ReadStore for &T {
         ReadStore::get_committee(*self, epoch)
     }
 
-    fn get_transaction(
+    fn get_transaction_block(
         &self,
         digest: &TransactionDigest,
     ) -> Result<Option<VerifiedTransaction>, Self::Error> {
-        ReadStore::get_transaction(*self, digest)
+        ReadStore::get_transaction_block(*self, digest)
     }
 
     fn get_transaction_effects(
@@ -482,7 +482,10 @@ impl InMemoryStore {
         }
     }
 
-    pub fn get_transaction(&self, digest: &TransactionDigest) -> Option<&VerifiedTransaction> {
+    pub fn get_transaction_block(
+        &self,
+        digest: &TransactionDigest,
+    ) -> Option<&VerifiedTransaction> {
         self.transactions.get(digest)
     }
 
@@ -574,11 +577,11 @@ impl ReadStore for SharedInMemoryStore {
             .pipe(Ok)
     }
 
-    fn get_transaction(
+    fn get_transaction_block(
         &self,
         digest: &TransactionDigest,
     ) -> Result<Option<VerifiedTransaction>, Self::Error> {
-        self.inner().get_transaction(digest).cloned().pipe(Ok)
+        self.inner().get_transaction_block(digest).cloned().pipe(Ok)
     }
 
     fn get_transaction_effects(

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -544,7 +544,7 @@ impl SuiClientCommands {
                         .keystore
                         .sign_secure(&sender, &data, Intent::default())?;
                 let response = context
-                    .execute_transaction(
+                    .execute_transaction_block(
                         Transaction::from_data(data, Intent::default(), vec![signature])
                             .verify()?,
                     )
@@ -596,7 +596,7 @@ impl SuiClientCommands {
                         .keystore
                         .sign_secure(&sender, &data, Intent::default())?;
                 let response = context
-                    .execute_transaction(
+                    .execute_transaction_block(
                         Transaction::from_data(data, Intent::default(), vec![signature])
                             .verify()?,
                     )
@@ -668,7 +668,7 @@ impl SuiClientCommands {
                         .keystore
                         .sign_secure(&from, &data, Intent::default())?;
                 let response = context
-                    .execute_transaction(
+                    .execute_transaction_block(
                         Transaction::from_data(data, Intent::default(), vec![signature])
                             .verify()?,
                     )
@@ -705,7 +705,7 @@ impl SuiClientCommands {
                         .keystore
                         .sign_secure(&from, &data, Intent::default())?;
                 let response = context
-                    .execute_transaction(
+                    .execute_transaction_block(
                         Transaction::from_data(data, Intent::default(), vec![signature])
                             .verify()?,
                     )
@@ -754,7 +754,7 @@ impl SuiClientCommands {
                         .keystore
                         .sign_secure(&from, &data, Intent::default())?;
                 let response = context
-                    .execute_transaction(
+                    .execute_transaction_block(
                         Transaction::from_data(data, Intent::default(), vec![signature])
                             .verify()?,
                     )
@@ -805,7 +805,7 @@ impl SuiClientCommands {
                         .keystore
                         .sign_secure(&signer, &data, Intent::default())?;
                 let response = context
-                    .execute_transaction(
+                    .execute_transaction_block(
                         Transaction::from_data(data, Intent::default(), vec![signature])
                             .verify()?,
                     )
@@ -844,7 +844,7 @@ impl SuiClientCommands {
                         .keystore
                         .sign_secure(&signer, &data, Intent::default())?;
                 let response = context
-                    .execute_transaction(
+                    .execute_transaction_block(
                         Transaction::from_data(data, Intent::default(), vec![signature])
                             .verify()?,
                     )
@@ -939,7 +939,7 @@ impl SuiClientCommands {
                         .keystore
                         .sign_secure(&signer, &data, Intent::default())?;
                 let response = context
-                    .execute_transaction(
+                    .execute_transaction_block(
                         Transaction::from_data(data, Intent::default(), vec![signature])
                             .verify()?,
                     )
@@ -964,7 +964,7 @@ impl SuiClientCommands {
                         .keystore
                         .sign_secure(&signer, &data, Intent::default())?;
                 let response = context
-                    .execute_transaction(
+                    .execute_transaction_block(
                         Transaction::from_data(data, Intent::default(), vec![signature])
                             .verify()?,
                     )
@@ -1035,7 +1035,7 @@ impl SuiClientCommands {
                 let verified =
                     Transaction::from_generic_sig_data(data, Intent::default(), sigs).verify()?;
 
-                let response = context.execute_transaction(verified).await?;
+                let response = context.execute_transaction_block(verified).await?;
                 SuiClientCommandResult::ExecuteSignedTx(response)
             }
             SuiClientCommands::NewEnv { alias, rpc, ws } => {
@@ -1342,14 +1342,14 @@ impl WalletContext {
         ))
     }
 
-    pub async fn execute_transaction(
+    pub async fn execute_transaction_block(
         &self,
         tx: VerifiedTransaction,
     ) -> anyhow::Result<SuiTransactionResponse> {
         let client = self.get_client().await?;
         Ok(client
             .quorum_driver()
-            .execute_transaction(
+            .execute_transaction_block(
                 tx,
                 SuiTransactionResponseOptions::new()
                     .with_effects()
@@ -1597,7 +1597,7 @@ pub async fn call_move(
         .sign_secure(&sender, &data, Intent::default())?;
     let transaction = Transaction::from_data(data, Intent::default(), vec![signature]).verify()?;
 
-    let response = context.execute_transaction(transaction).await?;
+    let response = context.execute_transaction_block(transaction).await?;
     let effects = response
         .effects
         .as_ref()

--- a/crates/sui/src/fire_drill.rs
+++ b/crates/sui/src/fire_drill.rs
@@ -341,7 +341,7 @@ async fn execute_tx(
     let tx_digest = *tx.digest();
     let resp = sui_client
         .quorum_driver()
-        .execute_transaction(
+        .execute_transaction_block(
             tx,
             SuiTransactionResponseOptions::full_content(),
             Some(sui_types::messages::ExecuteTransactionRequestType::WaitForLocalExecution),

--- a/crates/sui/src/validator_commands.rs
+++ b/crates/sui/src/validator_commands.rs
@@ -552,7 +552,7 @@ async fn call_0x5(
         Transaction::from_data(tx_data, Intent::default(), vec![signature]).verify()?;
     sui_client
         .quorum_driver()
-        .execute_transaction(
+        .execute_transaction_block(
             transaction,
             SuiTransactionResponseOptions::full_content(),
             Some(sui_types::messages::ExecuteTransactionRequestType::WaitForLocalExecution),

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -146,7 +146,7 @@ async fn test_sponsored_transaction() -> Result<(), anyhow::Error> {
         ],
     );
 
-    context.execute_transaction(tx).await.unwrap();
+    context.execute_transaction_block(tx).await.unwrap();
 
     assert_eq!(sponsor, context.get_object_owner(&sent_coin).await.unwrap(),);
     Ok(())
@@ -726,7 +726,7 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
     let txn = txns.swap_remove(0);
     let digest = *txn.digest();
     let res = transaction_orchestrator
-        .execute_transaction(ExecuteTransactionRequest {
+        .execute_transaction_block(ExecuteTransactionRequest {
             transaction: txn.into(),
             request_type: ExecuteTransactionRequestType::WaitForLocalExecution,
         })
@@ -754,7 +754,7 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
     let txn = txns.swap_remove(0);
     let digest = *txn.digest();
     let res = transaction_orchestrator
-        .execute_transaction(ExecuteTransactionRequest {
+        .execute_transaction_block(ExecuteTransactionRequest {
             transaction: txn.into(),
             request_type: ExecuteTransactionRequestType::WaitForEffectsCert,
         })
@@ -963,7 +963,10 @@ async fn test_get_objects_read() -> Result<(), anyhow::Error> {
         sender,
         recipient,
     );
-    context.execute_transaction(nft_transfer_tx).await.unwrap();
+    context
+        .execute_transaction_block(nft_transfer_tx)
+        .await
+        .unwrap();
     sleep(Duration::from_secs(1)).await;
 
     let (object_ref_v2, object_v2, _) = get_obj_read_from_node(&node, object_id).await?;

--- a/crates/sui/tests/protocol_version_tests.rs
+++ b/crates/sui/tests/protocol_version_tests.rs
@@ -391,7 +391,7 @@ mod sim_only_tests {
         let txn = TransactionKind::programmable(pt);
 
         let response = client
-            .dev_inspect_transaction(
+            .dev_inspect_transaction_block(
                 sender,
                 Base64::from_bytes(&bcs::to_bytes(&txn).unwrap()),
                 /* gas_price */ None,

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -572,7 +572,7 @@ async fn test_inactive_validator_pool_read() {
     )
     .unwrap();
     let transaction = to_sender_signed_transaction(tx_data, &leaving_validator_account_key);
-    let effects = execute_transaction(&authorities, transaction)
+    let effects = execute_transaction_block(&authorities, transaction)
         .await
         .unwrap();
     assert!(effects.status().is_ok());
@@ -1050,7 +1050,9 @@ async fn execute_add_validator_candidate_tx(
     .unwrap();
     let transaction =
         to_sender_signed_transaction(candidate_tx_data, node_config.account_key_pair());
-    let effects = execute_transaction(authorities, transaction).await.unwrap();
+    let effects = execute_transaction_block(authorities, transaction)
+        .await
+        .unwrap();
     assert!(effects.status().is_ok());
     effects
 }
@@ -1093,7 +1095,9 @@ async fn execute_join_committee_txes(
     )
     .unwrap();
     let transaction = to_sender_signed_transaction(stake_tx_data, node_config.account_key_pair());
-    let effects = execute_transaction(authorities, transaction).await.unwrap();
+    let effects = execute_transaction_block(authorities, transaction)
+        .await
+        .unwrap();
     assert!(effects.status().is_ok());
 
     effects_ret.push(effects);
@@ -1116,7 +1120,9 @@ async fn execute_join_committee_txes(
     .unwrap();
     let transaction =
         to_sender_signed_transaction(activation_tx_data, node_config.account_key_pair());
-    let effects = execute_transaction(authorities, transaction).await.unwrap();
+    let effects = execute_transaction_block(authorities, transaction)
+        .await
+        .unwrap();
     assert!(effects.status().is_ok());
     effects_ret.push(effects);
 
@@ -1145,7 +1151,9 @@ async fn execute_leave_committee_tx(
     .unwrap();
 
     let transaction = to_sender_signed_transaction(tx_data, node_config.account_key_pair());
-    let effects = execute_transaction(authorities, transaction).await.unwrap();
+    let effects = execute_transaction_block(authorities, transaction)
+        .await
+        .unwrap();
     assert!(effects.status().is_ok());
     effects
 }
@@ -1198,7 +1206,7 @@ async fn trigger_reconfiguration(authorities: &[SuiNodeHandle]) {
     info!("reconfiguration complete after {:?}", start.elapsed());
 }
 
-async fn execute_transaction(
+async fn execute_transaction_block(
     authorities: &[SuiNodeHandle],
     transaction: VerifiedTransaction,
 ) -> anyhow::Result<CertifiedTransactionEffects> {
@@ -1210,7 +1218,7 @@ async fn execute_transaction(
         AuthAggMetrics::new(&registry),
     )
     .unwrap();
-    net.execute_transaction(&transaction)
+    net.execute_transaction_block(&transaction)
         .await
         .map(|e| e.into_inner())
 }

--- a/crates/sui/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui/tests/transaction_orchestrator_tests.rs
@@ -247,7 +247,7 @@ async fn test_tx_across_epoch_boundaries() {
             let tx = tx.into_inner();
             tokio::task::spawn(async move {
                 match to
-                    .execute_transaction(ExecuteTransactionRequest {
+                    .execute_transaction_block(ExecuteTransactionRequest {
                         transaction: tx.clone(),
                         request_type: ExecuteTransactionRequestType::WaitForEffectsCert,
                     })
@@ -297,7 +297,7 @@ async fn execute_with_orchestrator(
     request_type: ExecuteTransactionRequestType,
 ) -> Result<ExecuteTransactionResponse, QuorumDriverError> {
     orchestrator
-        .execute_transaction(ExecuteTransactionRequest {
+        .execute_transaction_block(ExecuteTransactionRequest {
             transaction: txn.into(),
             request_type,
         })

--- a/crates/test-utils/src/transaction.rs
+++ b/crates/test-utils/src/transaction.rs
@@ -137,7 +137,7 @@ pub async fn publish_package_with_wallet(
 
     let resp = client
         .quorum_driver()
-        .execute_transaction(
+        .execute_transaction_block(
             transaction,
             SuiTransactionResponseOptions::new().with_effects(),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
@@ -200,7 +200,7 @@ pub async fn submit_move_transaction(
 
     let resp = client
         .quorum_driver()
-        .execute_transaction(
+        .execute_transaction_block(
             tx,
             SuiTransactionResponseOptions::full_content(),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
@@ -472,7 +472,7 @@ pub async fn delete_devnet_nft(
     let client = context.get_client().await.unwrap();
     let resp = client
         .quorum_driver()
-        .execute_transaction(
+        .execute_transaction_block(
             tx,
             SuiTransactionResponseOptions::full_content(),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),

--- a/doc/src/build/rust-sdk.md
+++ b/doc/src/build/rust-sdk.md
@@ -94,11 +94,11 @@ async fn main() -> Result<(), anyhow::Error> {
     // Sign transaction
     let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
     let signature = keystore.sign_secure(&my_address, &transfer_tx, Intent::default())?;
-    
+
     // Execute the transaction
     let transaction_response = sui
         .quorum_driver()
-        .execute_transaction(Transaction::from_data(transfer_tx, Intent::default(), signature))
+        .execute_transaction_block(Transaction::from_data(transfer_tx, Intent::default(), signature))
 
     println!("{:?}", transaction_response);
 
@@ -128,4 +128,3 @@ async fn main() -> Result<(), anyhow::Error> {
 ```
 
 **Note:** The Event subscription service requires a running Sui Full node. To learn more, see [Full node setup](fullnode.md#fullnode-setup).
-


### PR DESCRIPTION
## Description 
renamed the following methods
// reading
get_transaction → get_transaction_block
multi_get_transactions → multi_get_transaction_blocks
get_total_transaction_number → get_total_transaction_blocks
query_transactions → query_transaction_blocks

// writing
execute_transaction → execute_transaction_block
dev_inspect_transaction → dev_inspect_transaction_block
dry_run_transaction → dry_run_transaction_block

## Next PRs
1. rename data structure names
2. rename RPC endpoint names (and TS usage)

## Test Plan 

CI build

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
