### PR TITLE
[linkage] Set linkage table for ExecutionContext

### DIFF
--- a/.config/hakari.toml
+++ b/.config/hakari.toml
@@ -31,9 +31,9 @@ workspace-members = [ "sui-move" ]
 third-party = [
     ## Exclude the 'move-unit-test' crate in order to ensure that the 'testing'
     # feature isn't enabled in the workspace-hack
-    { name = "move-unit-test", git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" },
-    { name = "move-cli", git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" },
-    { name = "move-transactional-test-runner", git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" },
+    { name = "move-unit-test", git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" },
+    { name = "move-cli", git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" },
+    { name = "move-transactional-test-runner", git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" },
     { name = "object_store" },
 ]
 

--- a/.config/hakari.toml
+++ b/.config/hakari.toml
@@ -31,9 +31,9 @@ workspace-members = [ "sui-move" ]
 third-party = [
     ## Exclude the 'move-unit-test' crate in order to ensure that the 'testing'
     # feature isn't enabled in the workspace-hack
-    { name = "move-unit-test", git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" },
-    { name = "move-cli", git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" },
-    { name = "move-transactional-test-runner", git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" },
+    { name = "move-unit-test", git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" },
+    { name = "move-cli", git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" },
+    { name = "move-transactional-test-runner", git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" },
     { name = "object_store" },
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,7 +1370,7 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -4586,7 +4586,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4603,7 +4603,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -4616,12 +4616,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4636,7 +4636,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4648,7 +4648,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "anyhow",
  "fail 0.4.0",
@@ -4661,7 +4661,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -4678,7 +4678,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4724,7 +4724,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "anyhow",
  "difference",
@@ -4741,7 +4741,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4770,7 +4770,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4789,7 +4789,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4809,7 +4809,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -4827,7 +4827,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "anyhow",
  "codespan",
@@ -4845,7 +4845,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4859,7 +4859,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4878,7 +4878,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -4897,7 +4897,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "anyhow",
  "hex",
@@ -4910,7 +4910,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "anyhow",
  "hex",
@@ -4924,7 +4924,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "anyhow",
  "codespan",
@@ -4950,7 +4950,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4986,7 +4986,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5023,7 +5023,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5051,7 +5051,7 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5062,7 +5062,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5077,7 +5077,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -5104,7 +5104,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
@@ -5122,7 +5122,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "anyhow",
  "hex",
@@ -5145,7 +5145,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "once_cell",
  "serde 1.0.152",
@@ -5154,7 +5154,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5171,7 +5171,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -5203,7 +5203,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "anyhow",
  "better_any",
@@ -5234,7 +5234,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "better_any",
  "fail 0.4.0",
@@ -5252,7 +5252,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5265,7 +5265,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -7309,7 +7309,7 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7324,7 +7324,7 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
+source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
 dependencies = [
  "anyhow",
  "move-binary-format",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,7 +1370,7 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -4586,7 +4586,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4603,7 +4603,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -4616,12 +4616,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4636,7 +4636,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4648,7 +4648,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "anyhow",
  "fail 0.4.0",
@@ -4661,7 +4661,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -4678,7 +4678,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4724,7 +4724,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "anyhow",
  "difference",
@@ -4741,7 +4741,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4770,7 +4770,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4789,7 +4789,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4809,7 +4809,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -4827,7 +4827,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "anyhow",
  "codespan",
@@ -4845,7 +4845,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4859,7 +4859,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4878,7 +4878,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -4897,7 +4897,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "anyhow",
  "hex",
@@ -4910,7 +4910,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "anyhow",
  "hex",
@@ -4924,7 +4924,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "anyhow",
  "codespan",
@@ -4950,7 +4950,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4986,7 +4986,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5023,7 +5023,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5051,7 +5051,7 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5062,7 +5062,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5077,7 +5077,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -5104,7 +5104,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
@@ -5122,7 +5122,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "anyhow",
  "hex",
@@ -5145,7 +5145,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "once_cell",
  "serde 1.0.152",
@@ -5154,7 +5154,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5171,7 +5171,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -5203,7 +5203,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "anyhow",
  "better_any",
@@ -5234,7 +5234,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "better_any",
  "fail 0.4.0",
@@ -5252,7 +5252,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5265,7 +5265,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -7309,7 +7309,7 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7324,7 +7324,7 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=5ef16234b9c7367f1e19d1e18d31915c07581ffb#5ef16234b9c7367f1e19d1e18d31915c07581ffb"
 dependencies = [
  "anyhow",
  "move-binary-format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,26 +110,26 @@ opt-level = 1
 tokio = "1.24.1"
 
 # Move dependencies
-move-binary-format = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-cli = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-compiler = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", features = ["address32"] }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-package = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-prover = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-cli = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-compiler = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", features = ["address32"] }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-package = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-prover = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
 
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "c2f79b1807bff7d09517b631191b61f2614c641c" }
 fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "c2f79b1807bff7d09517b631191b61f2614c641c", package = "fastcrypto-zkp" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,26 +110,26 @@ opt-level = 1
 tokio = "1.24.1"
 
 # Move dependencies
-move-binary-format = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-cli = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-compiler = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", features = ["address32"] }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-package = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-prover = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-cli = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-compiler = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", features = ["address32"] }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-package = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-prover = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
 
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "c2f79b1807bff7d09517b631191b61f2614c641c" }
 fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "c2f79b1807bff7d09517b631191b61f2614c641c", package = "fastcrypto-zkp" }

--- a/crates/sui-adapter/src/programmable_transactions/context.rs
+++ b/crates/sui-adapter/src/programmable_transactions/context.rs
@@ -584,6 +584,9 @@ impl<'vm, 'state, 'a, 'b, S: StorageView> ExecutionContext<'vm, 'state, 'a, 'b, 
         }
         // we need a new session just for deserializing and fetching abilities. Which is sad
         // TODO remove this
+        // TODO do we need (some part of) linkage context from the entire transactional execution
+        // here (e.g., type origin info for all objects that have been "touched" by the
+        // transaction)?
         let tmp_session = new_tmp_session(
             vm,
             LinkageView::new(state_view, SUI_FRAMEWORK_OBJECT_ID)?,

--- a/crates/sui-adapter/src/programmable_transactions/execution.rs
+++ b/crates/sui-adapter/src/programmable_transactions/execution.rs
@@ -381,7 +381,6 @@ fn make_value<S: StorageView>(
             has_public_transfer,
         } => Value::Object(ObjectValue::new(
             context.vm,
-            context.state_view,
             &context.session,
             type_,
             has_public_transfer,
@@ -475,7 +474,6 @@ fn execute_move_publish<S: StorageView, Mode: ExecutionMode>(
         let cap = &UpgradeCap::new(context.fresh_id()?, storage_id);
         vec![Value::Object(ObjectValue::new(
             context.vm,
-            context.state_view,
             &context.session,
             UpgradeCap::type_().into(),
             /* has_public_transfer */ true,
@@ -857,7 +855,7 @@ fn check_visibility_and_signature<S: StorageView, Mode: ExecutionMode>(
     }
     let module = context
         .vm
-        .load_module(module_id, context.state_view)
+        .load_module(module_id, context.session.get_resolver())
         .map_err(|e| context.convert_vm_error(e))?;
     let Some((index, fdef)) = module.function_defs.iter().enumerate().find(|(_index, fdef)| {
         module.identifier_at(module.function_handle_at(fdef.function).name) == function

--- a/crates/sui-adapter/src/programmable_transactions/linkage_view.rs
+++ b/crates/sui-adapter/src/programmable_transactions/linkage_view.rs
@@ -1,0 +1,125 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+
+use move_core_types::{
+    account_address::AccountAddress,
+    language_storage::{ModuleId, StructTag},
+    resolver::{LinkageResolver, ModuleResolver, ResourceResolver},
+};
+use sui_types::{
+    base_types::{ObjectID, ObjectRef},
+    error::{SuiError, SuiResult},
+    event::Event,
+    move_package::UpgradeInfo,
+    object::Object,
+    storage::{BackingPackageStore, ChildObjectResolver, ObjectChange, ParentSync, Storage},
+};
+
+use super::types::StorageView;
+
+/// TODO Docs
+#[allow(dead_code)]
+pub struct LinkageView<'state, S: StorageView> {
+    state_view: &'state S,
+    linkage_info: Option<LinkageInfo>,
+}
+
+/// TODO Docs
+#[allow(dead_code)]
+pub struct LinkageInfo {
+    link_context: ObjectID,
+    linkage_table: BTreeMap<ObjectID, UpgradeInfo>,
+}
+
+impl<'state, S: StorageView> LinkageView<'state, S> {
+    pub fn new(state_view: &'state S) -> Self {
+        Self {
+            state_view,
+            linkage_info: None,
+        }
+    }
+
+    pub fn storage(&self) -> &'state S {
+        self.state_view
+    }
+}
+
+impl<'state, S: StorageView> LinkageResolver for LinkageView<'state, S> {
+    type Error = SuiError;
+
+    fn link_context(&self) -> AccountAddress {
+        AccountAddress::ZERO
+    }
+
+    fn relocate(&self, module_id: &ModuleId) -> Result<ModuleId, Self::Error> {
+        Ok(module_id.clone())
+    }
+
+    fn defining_module(
+        &self,
+        module_id: &ModuleId,
+        _struct: &move_core_types::identifier::IdentStr,
+    ) -> Result<ModuleId, Self::Error> {
+        Ok(module_id.clone())
+    }
+}
+
+/** Remaining implementations delegated to StorageView ************************/
+
+impl<'state, S: StorageView> ResourceResolver for LinkageView<'state, S> {
+    type Error = <S as ResourceResolver>::Error;
+
+    fn get_resource(
+        &self,
+        address: &AccountAddress,
+        typ: &StructTag,
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        self.state_view.get_resource(address, typ)
+    }
+}
+
+impl<'state, S: StorageView> ModuleResolver for LinkageView<'state, S> {
+    type Error = <S as ModuleResolver>::Error;
+
+    fn get_module(&self, id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
+        self.state_view.get_module(id)
+    }
+}
+
+impl<'state, S: StorageView> BackingPackageStore for LinkageView<'state, S> {
+    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<Object>> {
+        self.state_view.get_package_object(package_id)
+    }
+}
+
+impl<'state, S: StorageView> Storage for LinkageView<'state, S> {
+    fn read_object(&self, id: &ObjectID) -> Option<&Object> {
+        self.state_view.read_object(id)
+    }
+
+    fn reset(&mut self) {
+        unimplemented!("Read-only storage only.")
+    }
+
+    fn log_event(&mut self, _event: Event) {
+        unimplemented!("Read-only storage only.")
+    }
+
+    fn apply_object_changes(&mut self, _changes: BTreeMap<ObjectID, ObjectChange>) {
+        unimplemented!("Read-only storage only.")
+    }
+}
+
+impl<'state, S: StorageView> ParentSync for LinkageView<'state, S> {
+    fn get_latest_parent_entry_ref(&self, object_id: ObjectID) -> SuiResult<Option<ObjectRef>> {
+        self.state_view.get_latest_parent_entry_ref(object_id)
+    }
+}
+
+impl<'state, S: StorageView> ChildObjectResolver for LinkageView<'state, S> {
+    fn read_child_object(&self, parent: &ObjectID, child: &ObjectID) -> SuiResult<Option<Object>> {
+        self.state_view.read_child_object(parent, child)
+    }
+}

--- a/crates/sui-adapter/src/programmable_transactions/mod.rs
+++ b/crates/sui-adapter/src/programmable_transactions/mod.rs
@@ -3,4 +3,5 @@
 
 pub mod context;
 pub mod execution;
+pub mod linkage_view;
 pub mod types;

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -12,7 +12,7 @@ use fastcrypto::error::FastCryptoError;
 use move_binary_format::{access::ModuleAccess, errors::VMError};
 use move_binary_format::{errors::Location, file_format::FunctionDefinitionIndex};
 use move_core_types::{
-    resolver::{LinkageResolver, ModuleResolver, ResourceResolver},
+    resolver::MoveResolver,
     vm_status::{StatusCode, StatusType},
 };
 pub use move_vm_runtime::move_vm::MoveVM;
@@ -742,14 +742,10 @@ impl From<ExecutionErrorKind> for ExecutionError {
     }
 }
 
-pub fn convert_vm_error<
-    'r,
-    E: Debug,
-    S: ResourceResolver<Error = E> + ModuleResolver<Error = E> + LinkageResolver<Error = E>,
->(
+pub fn convert_vm_error<S: MoveResolver<Err = SuiError>>(
     error: VMError,
-    vm: &'r MoveVM,
-    state_view: &'r S,
+    vm: &MoveVM,
+    state_view: &S,
 ) -> ExecutionError {
     let kind = match (error.major_status(), error.sub_status(), error.location()) {
         (StatusCode::EXECUTED, _, _) => {

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -313,33 +313,33 @@ miniz_oxide = { version = "0.6", default-features = false, features = ["with-all
 mio = { version = "0.8", features = ["net", "os-ext"] }
 mockall = { version = "0.11", default-features = false }
 more-asserts = { version = "0.3", default-features = false }
-move-abigen = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-borrow-graph = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-compiler = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-core-types = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", features = ["address32"] }
-move-coverage = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-docgen = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-errmapgen = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-model = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-package = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-prover = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", features = ["tiered-gas"] }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-borrow-graph = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
+move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
+move-compiler = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
+move-core-types = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", features = ["address32"] }
+move-coverage = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-docgen = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
+move-errmapgen = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
+move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
+move-model = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
+move-package = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
+move-prover = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
+move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", features = ["tiered-gas"] }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
 multiaddr = { version = "0.17" }
 multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }
@@ -971,33 +971,33 @@ mio = { version = "0.8", features = ["net", "os-ext"] }
 mockall = { version = "0.11", default-features = false }
 mockall_derive = { version = "0.11", default-features = false }
 more-asserts = { version = "0.3", default-features = false }
-move-abigen = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-borrow-graph = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-compiler = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-core-types = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", features = ["address32"] }
-move-coverage = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-docgen = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-errmapgen = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-model = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-package = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-prover = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", features = ["tiered-gas"] }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-borrow-graph = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
+move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
+move-compiler = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
+move-core-types = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", features = ["address32"] }
+move-coverage = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-docgen = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
+move-errmapgen = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
+move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
+move-model = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
+move-package = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
+move-prover = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
+move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", features = ["tiered-gas"] }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
 multiaddr = { version = "0.17" }
 multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -313,33 +313,33 @@ miniz_oxide = { version = "0.6", default-features = false, features = ["with-all
 mio = { version = "0.8", features = ["net", "os-ext"] }
 mockall = { version = "0.11", default-features = false }
 more-asserts = { version = "0.3", default-features = false }
-move-abigen = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-borrow-graph = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
-move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
-move-compiler = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
-move-core-types = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", features = ["address32"] }
-move-coverage = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-docgen = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
-move-errmapgen = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
-move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
-move-model = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
-move-package = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
-move-prover = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
-move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", features = ["tiered-gas"] }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-borrow-graph = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
+move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
+move-compiler = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
+move-core-types = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", features = ["address32"] }
+move-coverage = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-docgen = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
+move-errmapgen = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
+move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
+move-model = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
+move-package = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
+move-prover = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
+move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", features = ["tiered-gas"] }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
 multiaddr = { version = "0.17" }
 multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }
@@ -971,33 +971,33 @@ mio = { version = "0.8", features = ["net", "os-ext"] }
 mockall = { version = "0.11", default-features = false }
 mockall_derive = { version = "0.11", default-features = false }
 more-asserts = { version = "0.3", default-features = false }
-move-abigen = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-borrow-graph = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
-move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
-move-compiler = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
-move-core-types = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", features = ["address32"] }
-move-coverage = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-docgen = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
-move-errmapgen = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
-move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
-move-model = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
-move-package = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
-move-prover = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
-move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", default-features = false }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb", features = ["tiered-gas"] }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "5ef16234b9c7367f1e19d1e18d31915c07581ffb" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-borrow-graph = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
+move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
+move-compiler = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
+move-core-types = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", features = ["address32"] }
+move-coverage = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-docgen = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
+move-errmapgen = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
+move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
+move-model = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
+move-package = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
+move-prover = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
+move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", features = ["tiered-gas"] }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
 multiaddr = { version = "0.17" }
 multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }


### PR DESCRIPTION
## Description

WIP: Add an API to set the linkage table based on a `MovePackage`, and read from it when responding to `relocate` and `link_context` queries.

The `LinkageView` now expects a link context to be set -- in turn, calls into the session that load modules will fail because we aren't setting the link context correctly yet.

## Test Plan

Existing tests + newly enabled upgrade tests:

```
$ cargo simtest
$ env SUI_SKIP_SIMTESTS=1 cargo nextest run
```

## Description 

Describe the changes or additions included in this PR.
