### PR TITLE
[transaction-block-rename][2/n] rename transaction data structures

### DIFF
--- a/.changeset/little-pears-shave.md
+++ b/.changeset/little-pears-shave.md
@@ -2,4 +2,4 @@
 "@mysten/sui.js": minor
 ---
 
-Update `executeTransaction` and `signAndExecuteTransaction` to take in an additional parameter `SuiTransactionResponseOptions` which is used to specify which fields to include in `SuiTransactionResponse` (e.g., transaction, effects, events, etc). By default, only the transaction digest will be included.
+Update `executeTransaction` and `signAndExecuteTransaction` to take in an additional parameter `SuiTransactionBlockResponseOptions` which is used to specify which fields to include in `SuiTransactionBlockResponse` (e.g., transaction, effects, events, etc). By default, only the transaction digest will be included.

--- a/.changeset/ten-phones-thank.md
+++ b/.changeset/ten-phones-thank.md
@@ -2,4 +2,4 @@
 "@mysten/sui.js": minor
 ---
 
-Rename `provider.getTransactionWithEffects` to `provider.getTransaction`. The new method takes in an additional parameter `SuiTransactionResponseOptions` to configure which fields to fetch(transaction, effects, events, etc). By default, only the transaction digest will be returned.
+Rename `provider.getTransactionWithEffects` to `provider.getTransaction`. The new method takes in an additional parameter `SuiTransactionBlockResponseOptions` to configure which fields to fetch(transaction, effects, events, etc). By default, only the transaction digest will be returned.

--- a/.changeset/tough-yaks-clap.md
+++ b/.changeset/tough-yaks-clap.md
@@ -2,4 +2,4 @@
 "@mysten/sui.js": minor
 ---
 
-Refactor Rust SuiTransactionKind to be internally tagged for Json serialization with tag="type" and SuiEvent to be adjacently tagged with tag="type" and content="content"
+Refactor Rust SuiTransactionBlockKind to be internally tagged for Json serialization with tag="type" and SuiEvent to be adjacently tagged with tag="type" and content="content"

--- a/.changeset/witty-peaches-agree.md
+++ b/.changeset/witty-peaches-agree.md
@@ -3,4 +3,4 @@
 "@mysten/wallet-standard": minor
 ---
 
-Add an optional `contentOptions` field to `SuiSignAndExecuteTransactionOptions` to specify which fields to include in `SuiTransactionResponse` (e.g., transaction, effects, events, etc). By default, only the transaction digest will be included.
+Add an optional `contentOptions` field to `SuiSignAndExecuteTransactionOptions` to specify which fields to include in `SuiTransactionBlockResponse` (e.g., transaction, effects, events, etc). By default, only the transaction digest will be included.

--- a/.changeset/yellow-ants-smoke.md
+++ b/.changeset/yellow-ants-smoke.md
@@ -3,4 +3,4 @@
 "@mysten/sui.js": minor
 ---
 
-Remove old `SuiExecuteTransactionResponse` interface, and `CertifiedTransaction` interface in favor of the new unified `SuiTransactionResponse` interfaces.
+Remove old `SuiExecuteTransactionResponse` interface, and `CertifiedTransaction` interface in favor of the new unified `SuiTransactionBlockResponse` interfaces.

--- a/apps/explorer/src/components/module/module-functions-interaction/FunctionExecutionResult.tsx
+++ b/apps/explorer/src/components/module/module-functions-interaction/FunctionExecutionResult.tsx
@@ -10,7 +10,10 @@ import {
 
 import { LinkGroup } from './LinkGroup';
 
-import type { SuiTransactionResponse, OwnedObjectRef } from '@mysten/sui.js';
+import type {
+    SuiTransactionBlockResponse,
+    OwnedObjectRef,
+} from '@mysten/sui.js';
 
 import { Banner } from '~/ui/Banner';
 
@@ -22,7 +25,7 @@ function toObjectLink(object: OwnedObjectRef) {
 }
 
 type FunctionExecutionResultProps = {
-    result: SuiTransactionResponse | null;
+    result: SuiTransactionBlockResponse | null;
     error: string | false;
     onClear: () => void;
 };

--- a/apps/explorer/src/components/transactions/TxCardUtils.tsx
+++ b/apps/explorer/src/components/transactions/TxCardUtils.tsx
@@ -9,7 +9,7 @@ import {
     getTransactionSender,
     type JsonRpcProvider,
     SUI_TYPE_ARG,
-    type SuiTransactionResponse,
+    type SuiTransactionBlockResponse,
 } from '@mysten/sui.js';
 import clsx from 'clsx';
 import { type ReactNode } from 'react';
@@ -71,7 +71,9 @@ export function TxTableCol({
 }
 
 // Generate table data from the transaction data
-export const genTableDataFromTxData = (results: SuiTransactionResponse[]) => ({
+export const genTableDataFromTxData = (
+    results: SuiTransactionBlockResponse[]
+) => ({
     data: results.map((transaction) => {
         const status = getExecutionStatusType(transaction);
         const transfer = getAmount({

--- a/apps/explorer/src/pages/transaction-result/Signatures.tsx
+++ b/apps/explorer/src/pages/transaction-result/Signatures.tsx
@@ -9,7 +9,7 @@ import {
     getTransactionSignature,
     normalizeSuiAddress,
     type SuiAddress,
-    type SuiTransactionResponse,
+    type SuiTransactionBlockResponse,
     type SignaturePubkeyPair,
 } from '@mysten/sui.js';
 
@@ -65,7 +65,7 @@ function getSignatureFromAddress(
 }
 
 interface Props {
-    transaction: SuiTransactionResponse;
+    transaction: SuiTransactionBlockResponse;
 }
 
 export function Signatures({ transaction }: Props) {

--- a/apps/explorer/src/pages/transaction-result/TransactionView.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionView.tsx
@@ -13,7 +13,7 @@ import {
     getTransactionSender,
     type ProgrammableTransaction,
     SUI_TYPE_ARG,
-    type SuiTransactionResponse,
+    type SuiTransactionBlockResponse,
 } from '@mysten/sui.js';
 import clsx from 'clsx';
 import { useMemo, useState } from 'react';
@@ -49,7 +49,7 @@ import { ReactComponent as ChevronDownIcon } from '~/ui/icons/chevron_down.svg';
 
 const MAX_RECIPIENTS_PER_PAGE = 10;
 
-function generateMutatedCreated(tx: SuiTransactionResponse) {
+function generateMutatedCreated(tx: SuiTransactionBlockResponse) {
     return [
         ...(tx.effects!.mutated?.length
             ? [
@@ -117,7 +117,7 @@ function GasAmount({
 export function TransactionView({
     transaction,
 }: {
-    transaction: SuiTransactionResponse;
+    transaction: SuiTransactionBlockResponse;
 }) {
     const sender = getTransactionSender(transaction)!;
     const gasUsed = transaction?.effects!.gasUsed;

--- a/apps/explorer/src/utils/getAmount.ts
+++ b/apps/explorer/src/utils/getAmount.ts
@@ -4,9 +4,9 @@
 import { getTransactionKind, SUI_TYPE_ARG } from '@mysten/sui.js';
 
 import type {
-    SuiTransactionKind,
+    SuiTransactionBlockKind,
     TransactionEffects,
-    SuiTransactionResponse,
+    SuiTransactionBlockResponse,
     TransactionEvents,
 } from '@mysten/sui.js';
 
@@ -35,7 +35,7 @@ type FormattedBalance = {
 
 // For TransferObject, TransferSui, Pay, PaySui, transactions get the amount from the transfer data
 export function getTransfersAmount(
-    txnData: SuiTransactionKind,
+    txnData: SuiTransactionBlockKind,
     txnEffect?: TransactionEffects,
     events?: TransactionEvents
 ): FormattedBalance[] | null {
@@ -90,7 +90,7 @@ export function getAmount({
     txnData,
     suiCoinOnly = false,
 }: {
-    txnData: SuiTransactionResponse;
+    txnData: SuiTransactionBlockResponse;
     suiCoinOnly?: boolean;
 }) {
     const { effects } = txnData;

--- a/apps/wallet/src/background/Transactions.ts
+++ b/apps/wallet/src/background/Transactions.ts
@@ -3,7 +3,7 @@
 
 import {
     type SignedTransaction,
-    type SuiTransactionResponse,
+    type SuiTransactionBlockResponse,
 } from '@mysten/sui.js';
 import { type SuiSignMessageOutput } from '@mysten/wallet-standard';
 import { filter, lastValueFrom, map, race, Subject, take } from 'rxjs';
@@ -44,7 +44,7 @@ class Transactions {
                   sign: SuiSignTransactionSerialized;
               },
         connection: ContentScriptConnection
-    ): Promise<SuiTransactionResponse | SignedTransaction> {
+    ): Promise<SuiTransactionBlockResponse | SignedTransaction> {
         const { txResultError, txResult, txSigned } =
             await this.requestApproval(
                 tx ?? {

--- a/apps/wallet/src/background/connections/ContentScriptConnection.ts
+++ b/apps/wallet/src/background/connections/ContentScriptConnection.ts
@@ -4,7 +4,7 @@
 import {
     type SignedTransaction,
     type SuiAddress,
-    type SuiTransactionResponse,
+    type SuiTransactionBlockResponse,
 } from '@mysten/sui.js';
 import Browser from 'webextension-polyfill';
 
@@ -105,7 +105,7 @@ export class ContentScriptConnection extends Connection {
                     createMessage<ExecuteTransactionResponse>(
                         {
                             type: 'execute-transaction-response',
-                            result: result as SuiTransactionResponse,
+                            result: result as SuiTransactionBlockResponse,
                         },
                         msg.id
                     )

--- a/apps/wallet/src/shared/messaging/messages/payloads/transactions/ApprovalRequest.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/transactions/ApprovalRequest.ts
@@ -9,7 +9,7 @@ import {
 import type {
     SignedTransaction,
     SuiAddress,
-    SuiTransactionResponse,
+    SuiTransactionBlockResponse,
 } from '@mysten/sui.js';
 
 export type TransactionDataType = {
@@ -32,7 +32,7 @@ export type ApprovalRequest = {
     approved: boolean | null;
     origin: string;
     originFavIcon?: string;
-    txResult?: SuiTransactionResponse | SuiSignMessageOutput;
+    txResult?: SuiTransactionBlockResponse | SuiSignMessageOutput;
     txResultError?: string;
     txSigned?: SignedTransaction;
     createdDate: string;
@@ -48,7 +48,7 @@ export interface SignMessageApprovalRequest
 export interface TransactionApprovalRequest
     extends Omit<ApprovalRequest, 'txResult' | 'tx'> {
     tx: TransactionDataType;
-    txResult?: SuiTransactionResponse;
+    txResult?: SuiTransactionBlockResponse;
 }
 
 export function isSignMessageApprovalRequest(

--- a/apps/wallet/src/shared/messaging/messages/payloads/transactions/ExecuteTransactionResponse.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/transactions/ExecuteTransactionResponse.ts
@@ -5,12 +5,12 @@ import { type SuiSignTransactionBlockOutput } from '@mysten/wallet-standard';
 
 import { isBasePayload } from '_payloads';
 
-import type { SuiTransactionResponse } from '@mysten/sui.js';
+import type { SuiTransactionBlockResponse } from '@mysten/sui.js';
 import type { BasePayload, Payload } from '_payloads';
 
 export interface ExecuteTransactionResponse extends BasePayload {
     type: 'execute-transaction-response';
-    result: SuiTransactionResponse;
+    result: SuiTransactionBlockResponse;
 }
 
 export function isExecuteTransactionResponse(

--- a/apps/wallet/src/shared/messaging/messages/payloads/transactions/ui/TransactionRequestResponse.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/transactions/ui/TransactionRequestResponse.ts
@@ -5,14 +5,17 @@ import { type SuiSignMessageOutput } from '@mysten/wallet-standard';
 
 import { isBasePayload } from '_payloads';
 
-import type { SignedTransaction, SuiTransactionResponse } from '@mysten/sui.js';
+import type {
+    SignedTransaction,
+    SuiTransactionBlockResponse,
+} from '@mysten/sui.js';
 import type { BasePayload, Payload } from '_payloads';
 
 export interface TransactionRequestResponse extends BasePayload {
     type: 'transaction-request-response';
     txID: string;
     approved: boolean;
-    txResult?: SuiTransactionResponse | SuiSignMessageOutput;
+    txResult?: SuiTransactionBlockResponse | SuiSignMessageOutput;
     txResultError?: string;
     txSigned?: SignedTransaction;
 }

--- a/apps/wallet/src/ui/app/background-client/index.ts
+++ b/apps/wallet/src/ui/app/background-client/index.ts
@@ -26,7 +26,7 @@ import { setPermissions } from '_redux/slices/permissions';
 import { setTransactionRequests } from '_redux/slices/transaction-requests';
 import { type SerializedLedgerAccount } from '_src/background/keyring/LedgerAccount';
 
-import type { SuiAddress, SuiTransactionResponse } from '@mysten/sui.js';
+import type { SuiAddress, SuiTransactionBlockResponse } from '@mysten/sui.js';
 import type { Message } from '_messages';
 import type { KeyringPayload } from '_payloads/keyring';
 import type {
@@ -98,7 +98,7 @@ export class BackgroundClient {
     public sendTransactionRequestResponse(
         txID: string,
         approved: boolean,
-        txResult?: SuiTransactionResponse | SignedMessage,
+        txResult?: SuiTransactionBlockResponse | SignedMessage,
         txResultError?: string,
         txSigned?: SignedTransaction
     ) {

--- a/apps/wallet/src/ui/app/components/receipt-card/index.tsx
+++ b/apps/wallet/src/ui/app/components/receipt-card/index.tsx
@@ -31,10 +31,10 @@ import { useGetTxnRecipientAddress, useGetTransferAmount } from '_hooks';
 import { TxnGasSummary } from '_src/ui/app/components/receipt-card/TxnGasSummary';
 import { Text } from '_src/ui/app/shared/text';
 
-import type { SuiTransactionResponse, SuiAddress } from '@mysten/sui.js';
+import type { SuiTransactionBlockResponse, SuiAddress } from '@mysten/sui.js';
 
 type ReceiptCardProps = {
-    txn: SuiTransactionResponse;
+    txn: SuiTransactionBlockResponse;
     activeAddress: SuiAddress;
 };
 

--- a/apps/wallet/src/ui/app/components/transactions-card/index.tsx
+++ b/apps/wallet/src/ui/app/components/transactions-card/index.tsx
@@ -23,7 +23,7 @@ import { useGetTransferAmount, useGetTxnRecipientAddress } from '_hooks';
 import type {
     SuiAddress,
     // SuiEvent,
-    SuiTransactionResponse,
+    SuiTransactionBlockResponse,
     // TransactionEvents,
 } from '@mysten/sui.js';
 
@@ -45,7 +45,7 @@ export function TransactionCard({
     txn,
     address,
 }: {
-    txn: SuiTransactionResponse;
+    txn: SuiTransactionBlockResponse;
     address: SuiAddress;
 }) {
     const transaction = getTransactionKind(txn)!;

--- a/apps/wallet/src/ui/app/helpers/checkStakingTxn.ts
+++ b/apps/wallet/src/ui/app/helpers/checkStakingTxn.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { SuiTransactionResponse } from '@mysten/sui.js';
+import type { SuiTransactionBlockResponse } from '@mysten/sui.js';
 
 // TODO: Support programmable transactions:
-export function checkStakingTxn(_txn: SuiTransactionResponse) {
+export function checkStakingTxn(_txn: SuiTransactionBlockResponse) {
     return false;
 }

--- a/apps/wallet/src/ui/app/helpers/getAmount.ts
+++ b/apps/wallet/src/ui/app/helpers/getAmount.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type {
-    SuiTransactionKind,
+    SuiTransactionBlockKind,
     TransactionEffects,
     TransactionEvents,
 } from '@mysten/sui.js';
@@ -14,7 +14,7 @@ type FormattedBalance = {
 }[];
 
 export function getAmount(
-    _txnData: SuiTransactionKind,
+    _txnData: SuiTransactionBlockKind,
     _txnEffect: TransactionEffects,
     _events: TransactionEvents
 ): FormattedBalance | null {

--- a/apps/wallet/src/ui/app/hooks/useGetTransferAmount.ts
+++ b/apps/wallet/src/ui/app/hooks/useGetTransferAmount.ts
@@ -6,13 +6,13 @@ import { useMemo } from 'react';
 
 import { getAmount } from '_helpers';
 
-import type { SuiTransactionResponse, SuiAddress } from '@mysten/sui.js';
+import type { SuiTransactionBlockResponse, SuiAddress } from '@mysten/sui.js';
 
 export function useGetTransferAmount({
     txn,
     activeAddress,
 }: {
-    txn: SuiTransactionResponse;
+    txn: SuiTransactionBlockResponse;
     activeAddress: SuiAddress;
 }) {
     const { effects, events } = txn;

--- a/apps/wallet/src/ui/app/hooks/useGetTxnRecipientAddress.ts
+++ b/apps/wallet/src/ui/app/hooks/useGetTxnRecipientAddress.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
-    type SuiTransactionResponse,
+    type SuiTransactionBlockResponse,
     type SuiAddress,
     getTransactionKind,
     getTransactionSender,
@@ -12,7 +12,7 @@ import { useMemo } from 'react';
 import { getAmount } from '_helpers';
 
 type Props = {
-    txn: SuiTransactionResponse;
+    txn: SuiTransactionBlockResponse;
     address: SuiAddress;
 };
 

--- a/apps/wallet/src/ui/app/index.tsx
+++ b/apps/wallet/src/ui/app/index.tsx
@@ -13,7 +13,7 @@ import { ApprovalRequestPage } from '_pages/approval-request';
 import HomePage, {
     NftsPage,
     TokensPage,
-    TransactionsPage,
+    TransactionBlocksPage,
     TransferCoinPage,
     NFTDetailsPage,
     ReceiptPage,
@@ -66,7 +66,10 @@ const App = () => {
                     path="nft-transfer/:nftId"
                     element={<NftTransferPage />}
                 />
-                <Route path="transactions" element={<TransactionsPage />} />
+                <Route
+                    path="transactions"
+                    element={<TransactionBlocksPage />}
+                />
                 <Route path="send" element={<TransferCoinPage />} />
                 <Route path="send/select" element={<CoinsSelectorPage />} />
                 <Route path="stake/*" element={<Staking />} />

--- a/apps/wallet/src/ui/app/pages/home/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/index.tsx
@@ -38,7 +38,7 @@ const HomePage = ({ disableNavigation }: Props) => {
 export default HomePage;
 export { default as NftsPage } from './nfts';
 export { default as TokensPage } from './tokens';
-export { default as TransactionsPage } from './transactions';
+export { default as TransactionBlocksPage } from './transactions';
 export { default as TransferCoinPage } from './transfer-coin';
 export { default as NFTDetailsPage } from './nft-details';
 export { default as NftTransferPage } from './nft-transfer';

--- a/apps/wallet/src/ui/app/pages/home/transactions/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transactions/index.tsx
@@ -13,7 +13,7 @@ import Alert from '_src/ui/app/components/alert';
 import { useActiveAddress } from '_src/ui/app/hooks/useActiveAddress';
 import PageTitle from '_src/ui/app/shared/PageTitle';
 
-function TransactionsPage() {
+function TransactionBlocksPage() {
     const activeAddress = useActiveAddress();
     const {
         data: txns,
@@ -58,4 +58,4 @@ function TransactionsPage() {
     );
 }
 
-export default memo(TransactionsPage);
+export default memo(TransactionBlocksPage);

--- a/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
@@ -16,7 +16,7 @@ import {
 
 import { getSignerOperationErrorMessage } from '_src/ui/app/helpers/errorMessages';
 
-import type { SuiTransactionResponse } from '@mysten/sui.js';
+import type { SuiTransactionBlockResponse } from '@mysten/sui.js';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import type { ApprovalRequest } from '_payloads/transactions/ApprovalRequest';
 import type { RootState } from '_redux/RootReducer';
@@ -34,7 +34,7 @@ export const respondToTransactionRequest = createAsyncThunk<
     {
         txRequestID: string;
         approved: boolean;
-        txResponse: SuiTransactionResponse | null;
+        txResponse: SuiTransactionBlockResponse | null;
     },
     {
         txRequestID: string;
@@ -54,7 +54,7 @@ export const respondToTransactionRequest = createAsyncThunk<
             throw new Error(`TransactionRequest ${txRequestID} not found`);
         }
         let txSigned: SignedTransaction | undefined = undefined;
-        let txResult: SuiTransactionResponse | SignedMessage | undefined =
+        let txResult: SuiTransactionBlockResponse | SignedMessage | undefined =
             undefined;
         let txResultError: string | undefined;
         if (approved) {

--- a/crates/sui-benchmark/src/workloads/adversarial.rs
+++ b/crates/sui-benchmark/src/workloads/adversarial.rs
@@ -72,7 +72,7 @@ impl Payload for AdversarialTestPayload {
         // Sometimes useful when figuring out why things failed
         let stat = match effects {
             ExecutionEffects::CertifiedTransactionEffects(e, _) => e.data().status(),
-            ExecutionEffects::SuiTransactionEffects(_) => unimplemented!("Not impl"),
+            ExecutionEffects::SuiTransactionBlockEffects(_) => unimplemented!("Not impl"),
         };
 
         debug_assert!(

--- a/crates/sui-cluster-test/src/lib.rs
+++ b/crates/sui-cluster-test/src/lib.rs
@@ -14,7 +14,7 @@ use sui::client_commands::WalletContext;
 use sui_faucet::CoinInfo;
 use sui_json_rpc_types::{
     SuiExecutionStatus, SuiTransactionBlockEffectsAPI, SuiTransactionBlockResponse,
-    SuiTransactionBlockResponseOptions, TransactionBytes,
+    SuiTransactionBlockResponseOptions, TransactionBlockBytes,
 };
 use sui_types::base_types::TransactionDigest;
 use sui_types::messages::ExecuteTransactionRequestType;
@@ -122,7 +122,7 @@ impl TestContext {
         // TODO cache this?
         let rpc_client = HttpClientBuilder::default().build(fn_rpc_url)?;
 
-        TransactionBytes::to_data(rpc_client.request(method, params).await?)
+        TransactionBlockBytes::to_data(rpc_client.request(method, params).await?)
     }
 
     async fn sign_and_execute(

--- a/crates/sui-cluster-test/src/lib.rs
+++ b/crates/sui-cluster-test/src/lib.rs
@@ -13,8 +13,8 @@ use std::sync::Arc;
 use sui::client_commands::WalletContext;
 use sui_faucet::CoinInfo;
 use sui_json_rpc_types::{
-    SuiExecutionStatus, SuiTransactionEffectsAPI, SuiTransactionResponse,
-    SuiTransactionResponseOptions, TransactionBytes,
+    SuiExecutionStatus, SuiTransactionBlockEffectsAPI, SuiTransactionBlockResponse,
+    SuiTransactionBlockResponseOptions, TransactionBytes,
 };
 use sui_types::base_types::TransactionDigest;
 use sui_types::messages::ExecuteTransactionRequestType;
@@ -129,7 +129,7 @@ impl TestContext {
         &self,
         txn_data: TransactionData,
         desc: &str,
-    ) -> SuiTransactionResponse {
+    ) -> SuiTransactionBlockResponse {
         let signature = self.get_context().sign(&txn_data, desc);
         let resp = self
             .get_fullnode_client()
@@ -138,7 +138,7 @@ impl TestContext {
                 Transaction::from_data(txn_data, Intent::default(), vec![signature])
                     .verify()
                     .unwrap(),
-                SuiTransactionResponseOptions::new()
+                SuiTransactionBlockResponseOptions::new()
                     .with_object_changes()
                     .with_balance_changes()
                     .with_effects()
@@ -204,7 +204,7 @@ impl TestContext {
             .client
             .get_fullnode_client()
             .read_api()
-            .get_transaction_with_options(digest, SuiTransactionResponseOptions::new())
+            .get_transaction_with_options(digest, SuiTransactionBlockResponseOptions::new())
             .await
         {
             Ok(_) => (true, digest, retry_times),

--- a/crates/sui-cluster-test/src/test_case/coin_merge_split_test.rs
+++ b/crates/sui-cluster-test/src/test_case/coin_merge_split_test.rs
@@ -4,7 +4,7 @@
 use crate::{helper::ObjectChecker, TestCaseImpl, TestContext};
 use async_trait::async_trait;
 use jsonrpsee::rpc_params;
-use sui_json_rpc_types::{SuiTransactionEffectsAPI, SuiTransactionResponse};
+use sui_json_rpc_types::{SuiTransactionBlockEffectsAPI, SuiTransactionBlockResponse};
 use sui_types::base_types::{ObjectID, SuiAddress};
 use sui_types::object::Owner;
 use tracing::{debug, info};
@@ -117,7 +117,7 @@ impl CoinMergeSplitTest {
         primary_coin: ObjectID,
         coin_to_merge: ObjectID,
         gas_obj_id: ObjectID,
-    ) -> SuiTransactionResponse {
+    ) -> SuiTransactionBlockResponse {
         let params = rpc_params![signer, primary_coin, coin_to_merge, Some(gas_obj_id), 2000];
 
         let data = ctx
@@ -134,7 +134,7 @@ impl CoinMergeSplitTest {
         primary_coin: ObjectID,
         amounts: Vec<u64>,
         gas_obj_id: ObjectID,
-    ) -> SuiTransactionResponse {
+    ) -> SuiTransactionBlockResponse {
         let params = rpc_params![signer, primary_coin, amounts, Some(gas_obj_id), 2000];
 
         let data = ctx

--- a/crates/sui-cluster-test/src/test_case/fullnode_build_publish_transaction_test.rs
+++ b/crates/sui-cluster-test/src/test_case/fullnode_build_publish_transaction_test.rs
@@ -5,7 +5,7 @@ use crate::{TestCaseImpl, TestContext};
 use async_trait::async_trait;
 use jsonrpsee::rpc_params;
 use sui_core::test_utils::compile_basics_package;
-use sui_json_rpc_types::SuiTransactionEffectsAPI;
+use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
 use sui_types::{base_types::ObjectID, object::Owner};
 
 pub struct FullNodeBuildPublishTransactionTest;

--- a/crates/sui-cluster-test/src/test_case/fullnode_execute_transaction_test.rs
+++ b/crates/sui-cluster-test/src/test_case/fullnode_execute_transaction_test.rs
@@ -4,7 +4,7 @@
 use crate::{TestCaseImpl, TestContext};
 use async_trait::async_trait;
 use sui_json_rpc_types::{
-    SuiExecutionStatus, SuiTransactionEffectsAPI, SuiTransactionResponseOptions,
+    SuiExecutionStatus, SuiTransactionBlockEffectsAPI, SuiTransactionBlockResponseOptions,
 };
 use sui_sdk::SuiClient;
 use sui_types::{base_types::TransactionDigest, messages::ExecuteTransactionRequestType};
@@ -16,7 +16,7 @@ impl FullNodeExecuteTransactionTest {
     async fn verify_transaction(fullnode: &SuiClient, tx_digest: TransactionDigest) {
         fullnode
             .read_api()
-            .get_transaction_with_options(tx_digest, SuiTransactionResponseOptions::new())
+            .get_transaction_with_options(tx_digest, SuiTransactionBlockResponseOptions::new())
             .await
             .unwrap_or_else(|e| {
                 panic!(
@@ -59,7 +59,7 @@ impl TestCaseImpl for FullNodeExecuteTransactionTest {
             .quorum_driver()
             .execute_transaction_block(
                 txn,
-                SuiTransactionResponseOptions::new().with_effects(),
+                SuiTransactionBlockResponseOptions::new().with_effects(),
                 Some(ExecuteTransactionRequestType::WaitForEffectsCert),
             )
             .await?;
@@ -86,7 +86,7 @@ impl TestCaseImpl for FullNodeExecuteTransactionTest {
             .quorum_driver()
             .execute_transaction_block(
                 txn,
-                SuiTransactionResponseOptions::new().with_effects(),
+                SuiTransactionBlockResponseOptions::new().with_effects(),
                 Some(ExecuteTransactionRequestType::WaitForLocalExecution),
             )
             .await?;

--- a/crates/sui-cluster-test/src/test_case/native_transfer_test.rs
+++ b/crates/sui-cluster-test/src/test_case/native_transfer_test.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use jsonrpsee::rpc_params;
 use tracing::info;
 
-use sui_json_rpc_types::SuiTransactionResponse;
+use sui_json_rpc_types::SuiTransactionBlockResponse;
 use sui_types::{
     base_types::{ObjectID, SuiAddress},
     crypto::{get_key_pair, AccountKeyPair},
@@ -68,7 +68,7 @@ impl TestCaseImpl for NativeTransferTest {
 impl NativeTransferTest {
     async fn examine_response(
         ctx: &TestContext,
-        response: &mut SuiTransactionResponse,
+        response: &mut SuiTransactionBlockResponse,
         signer: SuiAddress,
         recipient: SuiAddress,
         obj_to_transfer_id: ObjectID,

--- a/crates/sui-cluster-test/src/test_case/shared_object_test.rs
+++ b/crates/sui-cluster-test/src/test_case/shared_object_test.rs
@@ -4,7 +4,7 @@
 use crate::{helper::ObjectChecker, TestCaseImpl, TestContext};
 use async_trait::async_trait;
 use sui::client_commands::WalletContext;
-use sui_json_rpc_types::{SuiExecutionStatus, SuiTransactionEffectsAPI};
+use sui_json_rpc_types::{SuiExecutionStatus, SuiTransactionBlockEffectsAPI};
 use sui_types::object::Owner;
 use test_utils::transaction::{increment_counter, publish_basics_package_and_make_counter};
 use tracing::info;

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -47,7 +47,7 @@ use sui_config::node::{AuthorityStorePruningConfig, DBCheckpointConfig};
 use sui_framework::{MoveStdlib, SuiFramework, SuiSystem, SystemPackage};
 use sui_json_rpc_types::{
     Checkpoint, DevInspectResults, DryRunTransactionResponse, EventFilter, SuiEvent, SuiMoveValue,
-    SuiObjectDataFilter, SuiTransactionEvents,
+    SuiObjectDataFilter, SuiTransactionBlockEvents,
 };
 use sui_macros::{fail_point, fail_point_async, nondeterministic};
 use sui_protocol_config::SupportedProtocolVersions;
@@ -1107,7 +1107,7 @@ impl AuthorityState {
         Ok((
             DryRunTransactionResponse {
                 effects: effects.clone().try_into()?,
-                events: SuiTransactionEvents::try_from(
+                events: SuiTransactionBlockEvents::try_from(
                     inner_temp_store.events.clone(),
                     tx_digest,
                     None,
@@ -1465,7 +1465,7 @@ impl AuthorityState {
                 self.event_handler
                     .process_events(
                         &effects.clone().try_into()?,
-                        &SuiTransactionEvents::try_from(
+                        &SuiTransactionBlockEvents::try_from(
                             events.clone(),
                             *tx_digest,
                             Some(timestamp_ms),

--- a/crates/sui-core/src/event_handler.rs
+++ b/crates/sui-core/src/event_handler.rs
@@ -4,8 +4,8 @@
 use tokio_stream::Stream;
 use tracing::{error, instrument, trace};
 
-use sui_json_rpc_types::{EventFilter, SuiTransactionEffects, SuiTransactionEvents};
-use sui_json_rpc_types::{SuiEvent, SuiTransactionEffectsAPI};
+use sui_json_rpc_types::{EventFilter, SuiTransactionBlockEffects, SuiTransactionBlockEvents};
+use sui_json_rpc_types::{SuiEvent, SuiTransactionBlockEffectsAPI};
 use sui_types::error::SuiResult;
 
 use crate::streamer::Streamer;
@@ -33,8 +33,8 @@ impl EventHandler {
     #[instrument(level = "debug", skip_all, fields(tx_digest=?effects.transaction_digest()), err)]
     pub async fn process_events(
         &self,
-        effects: &SuiTransactionEffects,
-        events: &SuiTransactionEvents,
+        effects: &SuiTransactionBlockEffects,
+        events: &SuiTransactionBlockEvents,
     ) -> SuiResult {
         trace!(
             num_events = events.data.len(),

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -34,7 +34,7 @@ use tracing::info;
 
 use sui_json_rpc_types::{
     SuiArgument, SuiExecutionResult, SuiExecutionStatus, SuiGasCostSummary,
-    SuiTransactionEffectsAPI, SuiTypeTag,
+    SuiTransactionBlockEffectsAPI, SuiTypeTag,
 };
 use sui_macros::{register_fail_point_async, sim_test};
 use sui_protocol_config::{ProtocolConfig, SupportedProtocolVersions};

--- a/crates/sui-core/src/unit_tests/pay_sui_tests.rs
+++ b/crates/sui-core/src/unit_tests/pay_sui_tests.rs
@@ -378,7 +378,7 @@ async fn test_pay_all_sui_success_multiple_input_coins() -> anyhow::Result<()> {
     Ok(())
 }
 
-struct PaySuiTransactionExecutionResult {
+struct PaySuiTransactionBlockExecutionResult {
     pub authority_state: Arc<AuthorityState>,
     pub txn_result: Result<SignedTransactionEffects, SuiError>,
 }
@@ -390,7 +390,7 @@ async fn execute_pay_sui(
     sender: SuiAddress,
     sender_key: AccountKeyPair,
     gas_budget: u64,
-) -> PaySuiTransactionExecutionResult {
+) -> PaySuiTransactionBlockExecutionResult {
     let authority_state = init_state().await;
 
     let input_coin_refs: Vec<ObjectRef> = input_coin_objects
@@ -412,7 +412,7 @@ async fn execute_pay_sui(
         .await
         .map(|(_, effects)| effects);
 
-    PaySuiTransactionExecutionResult {
+    PaySuiTransactionBlockExecutionResult {
         authority_state,
         txn_result,
     }
@@ -424,7 +424,7 @@ async fn execute_pay_all_sui(
     sender: SuiAddress,
     sender_key: AccountKeyPair,
     gas_budget: u64,
-) -> PaySuiTransactionExecutionResult {
+) -> PaySuiTransactionBlockExecutionResult {
     let dir = tempfile::TempDir::new().unwrap();
     let network_config = sui_config::builder::ConfigBuilder::new(&dir)
         .with_objects(
@@ -459,7 +459,7 @@ async fn execute_pay_all_sui(
     let txn_result = send_and_confirm_transaction(&authority_state, tx)
         .await
         .map(|(_, effects)| effects);
-    PaySuiTransactionExecutionResult {
+    PaySuiTransactionBlockExecutionResult {
         authority_state,
         txn_result,
     }

--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -15,8 +15,8 @@ use std::path::Path;
 use shared_crypto::intent::Intent;
 use sui::client_commands::WalletContext;
 use sui_json_rpc_types::{
-    SuiObjectDataOptions, SuiTransactionEffectsAPI, SuiTransactionResponse,
-    SuiTransactionResponseOptions,
+    SuiObjectDataOptions, SuiTransactionBlockEffectsAPI, SuiTransactionBlockResponse,
+    SuiTransactionBlockResponseOptions,
 };
 use sui_keys::keystore::AccountKeystore;
 use sui_types::object::Owner;
@@ -232,7 +232,7 @@ impl SimpleFaucet {
         recipient: SuiAddress,
         coin_id: ObjectID,
         tx_data: TransactionData,
-    ) -> Result<SuiTransactionResponse, FaucetError> {
+    ) -> Result<SuiTransactionBlockResponse, FaucetError> {
         let signature = self
             .wallet
             .config
@@ -370,7 +370,7 @@ impl SimpleFaucet {
         coin_id: ObjectID,
         recipient: SuiAddress,
         uuid: Uuid,
-    ) -> SuiTransactionResponse {
+    ) -> SuiTransactionBlockResponse {
         let mut retry_delay = Duration::from_millis(500);
 
         loop {
@@ -400,7 +400,7 @@ impl SimpleFaucet {
         coin_id: ObjectID,
         recipient: SuiAddress,
         uuid: Uuid,
-    ) -> Result<SuiTransactionResponse, anyhow::Error> {
+    ) -> Result<SuiTransactionBlockResponse, anyhow::Error> {
         self.metrics.current_executions_in_flight.inc();
         let _metrics_guard = scopeguard::guard(self.metrics.clone(), |metrics| {
             metrics.current_executions_in_flight.dec();
@@ -412,7 +412,7 @@ impl SimpleFaucet {
             .quorum_driver()
             .execute_transaction_block(
                 tx.clone(),
-                SuiTransactionResponseOptions::new().with_effects(),
+                SuiTransactionBlockResponseOptions::new().with_effects(),
                 Some(ExecuteTransactionRequestType::WaitForLocalExecution),
             )
             .await
@@ -472,7 +472,7 @@ impl SimpleFaucet {
 
     async fn check_and_map_transfer_gas_result(
         &self,
-        res: SuiTransactionResponse,
+        res: SuiTransactionBlockResponse,
         number_of_coins: usize,
         recipient: SuiAddress,
     ) -> Result<(TransactionDigest, Vec<ObjectID>), FaucetError> {

--- a/crates/sui-indexer/src/apis/indexer_api.rs
+++ b/crates/sui-indexer/src/apis/indexer_api.rs
@@ -17,7 +17,7 @@ use sui_json_rpc::SuiRpcModule;
 use sui_json_rpc_types::{
     CheckpointedObjectID, DynamicFieldPage, EventFilter, EventPage, ObjectsPage, Page,
     SuiObjectDataFilter, SuiObjectResponse, SuiObjectResponseQuery, SuiTransactionBlockResponse,
-    SuiTransactionBlockResponseQuery, TransactionsPage,
+    SuiTransactionBlockResponseQuery, TransactionBlocksPage,
 };
 use sui_open_rpc::Module;
 use sui_types::base_types::{ObjectID, SuiAddress};
@@ -68,7 +68,7 @@ impl<S: IndexerStore> IndexerApi<S> {
         cursor: Option<TransactionDigest>,
         limit: Option<usize>,
         descending_order: Option<bool>,
-    ) -> Result<TransactionsPage, IndexerError> {
+    ) -> Result<TransactionBlocksPage, IndexerError> {
         let limit = validate_limit(limit, QUERY_MAX_RESULT_LIMIT)?;
         let is_descending = descending_order.unwrap_or_default();
         let cursor_str = cursor.map(|digest| digest.to_string());
@@ -289,7 +289,7 @@ where
         cursor: Option<TransactionDigest>,
         limit: Option<usize>,
         descending_order: Option<bool>,
-    ) -> RpcResult<TransactionsPage> {
+    ) -> RpcResult<TransactionBlocksPage> {
         if !self
             .migrated_methods
             .contains(&"query_transactions".to_string())

--- a/crates/sui-indexer/src/apis/indexer_api.rs
+++ b/crates/sui-indexer/src/apis/indexer_api.rs
@@ -16,8 +16,8 @@ use sui_json_rpc::indexer_api::spawn_subscription;
 use sui_json_rpc::SuiRpcModule;
 use sui_json_rpc_types::{
     CheckpointedObjectID, DynamicFieldPage, EventFilter, EventPage, ObjectsPage, Page,
-    SuiObjectDataFilter, SuiObjectResponse, SuiObjectResponseQuery, SuiTransactionResponse,
-    SuiTransactionResponseQuery, TransactionsPage,
+    SuiObjectDataFilter, SuiObjectResponse, SuiObjectResponseQuery, SuiTransactionBlockResponse,
+    SuiTransactionBlockResponseQuery, TransactionsPage,
 };
 use sui_open_rpc::Module;
 use sui_types::base_types::{ObjectID, SuiAddress};
@@ -64,7 +64,7 @@ impl<S: IndexerStore> IndexerApi<S> {
 
     fn query_transactions_internal(
         &self,
-        query: SuiTransactionResponseQuery,
+        query: SuiTransactionBlockResponseQuery,
         cursor: Option<TransactionDigest>,
         limit: Option<usize>,
         descending_order: Option<bool>,
@@ -215,7 +215,7 @@ impl<S: IndexerStore> IndexerApi<S> {
         Ok(Page {
             data: tx_digests
                 .into_iter()
-                .map(SuiTransactionResponse::new)
+                .map(SuiTransactionBlockResponse::new)
                 .collect(),
             next_cursor,
             has_next_page,
@@ -285,7 +285,7 @@ where
 
     async fn query_transaction_blocks(
         &self,
-        query: SuiTransactionResponseQuery,
+        query: SuiTransactionBlockResponseQuery,
         cursor: Option<TransactionDigest>,
         limit: Option<usize>,
         descending_order: Option<bool>,

--- a/crates/sui-indexer/src/apis/read_api.rs
+++ b/crates/sui-indexer/src/apis/read_api.rs
@@ -12,7 +12,7 @@ use sui_json_rpc::SuiRpcModule;
 use sui_json_rpc_types::{
     BigInt, Checkpoint, CheckpointId, CheckpointPage, SuiCheckpointSequenceNumber, SuiEvent,
     SuiGetPastObjectRequest, SuiObjectDataOptions, SuiObjectResponse, SuiPastObjectResponse,
-    SuiTransactionResponse, SuiTransactionResponseOptions,
+    SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions,
 };
 use sui_open_rpc::Module;
 use sui_types::base_types::{ObjectID, SequenceNumber};
@@ -20,7 +20,7 @@ use sui_types::digests::TransactionDigest;
 
 use crate::errors::IndexerError;
 use crate::store::IndexerStore;
-use crate::types::{SuiTransactionFullResponse, SuiTransactionFullResponseWithOptions};
+use crate::types::{SuiTransactionBlockFullResponse, SuiTransactionBlockFullResponseWithOptions};
 
 pub(crate) struct ReadApi<S> {
     fullnode: HttpClient,
@@ -46,17 +46,17 @@ impl<S: IndexerStore> ReadApi<S> {
     async fn get_transaction_with_options_internal(
         &self,
         digest: &TransactionDigest,
-        options: Option<SuiTransactionResponseOptions>,
-    ) -> Result<SuiTransactionResponse, IndexerError> {
+        options: Option<SuiTransactionBlockResponseOptions>,
+    ) -> Result<SuiTransactionBlockResponse, IndexerError> {
         let tx = self
             .state
             .get_transaction_by_digest(&digest.base58_encode())?;
-        let tx_full_resp: SuiTransactionFullResponse = self
+        let tx_full_resp: SuiTransactionBlockFullResponse = self
             .state
             .compose_full_transaction_response(tx, options.clone())
             .await?;
 
-        let sui_transaction_response = SuiTransactionFullResponseWithOptions {
+        let sui_transaction_response = SuiTransactionBlockFullResponseWithOptions {
             response: tx_full_resp,
             options: options.unwrap_or_default(),
         }
@@ -67,8 +67,8 @@ impl<S: IndexerStore> ReadApi<S> {
     async fn multi_get_transactions_with_options_internal(
         &self,
         digests: &[TransactionDigest],
-        options: Option<SuiTransactionResponseOptions>,
-    ) -> Result<Vec<SuiTransactionResponse>, IndexerError> {
+        options: Option<SuiTransactionBlockResponseOptions>,
+    ) -> Result<Vec<SuiTransactionBlockResponse>, IndexerError> {
         let digest_strs = digests
             .iter()
             .map(|digest| digest.base58_encode())
@@ -92,12 +92,12 @@ impl<S: IndexerStore> ReadApi<S> {
             self.state
                 .compose_full_transaction_response(tx, options.clone())
         });
-        let tx_full_resp_vec: Vec<SuiTransactionFullResponse> = join_all(tx_full_resp_futures)
+        let tx_full_resp_vec: Vec<SuiTransactionBlockFullResponse> = join_all(tx_full_resp_futures)
             .await
             .into_iter()
             .collect::<Result<Vec<_>, _>>()?;
 
-        let tx_resp_vec: Vec<SuiTransactionResponse> =
+        let tx_resp_vec: Vec<SuiTransactionBlockResponse> =
             tx_full_resp_vec.into_iter().map(|tx| tx.into()).collect();
         Ok(tx_resp_vec)
     }
@@ -159,8 +159,8 @@ where
     async fn get_transaction_block(
         &self,
         digest: TransactionDigest,
-        options: Option<SuiTransactionResponseOptions>,
-    ) -> RpcResult<SuiTransactionResponse> {
+        options: Option<SuiTransactionBlockResponseOptions>,
+    ) -> RpcResult<SuiTransactionBlockResponse> {
         if !self
             .migrated_methods
             .contains(&"get_transaction".to_string())
@@ -175,8 +175,8 @@ where
     async fn multi_get_transaction_blocks(
         &self,
         digests: Vec<TransactionDigest>,
-        options: Option<SuiTransactionResponseOptions>,
-    ) -> RpcResult<Vec<SuiTransactionResponse>> {
+        options: Option<SuiTransactionBlockResponseOptions>,
+    ) -> RpcResult<Vec<SuiTransactionBlockResponse>> {
         if !self
             .migrated_methods
             .contains(&"multi_get_transactions_with_options".to_string())

--- a/crates/sui-indexer/src/apis/transaction_builder_api.rs
+++ b/crates/sui-indexer/src/apis/transaction_builder_api.rs
@@ -11,7 +11,7 @@ use sui_json_rpc::api::{TransactionBuilderClient, TransactionBuilderServer};
 use sui_json_rpc::SuiRpcModule;
 use sui_json_rpc_types::{
     BigInt, RPCTransactionRequestParams, SuiTransactionBlockBuilderMode, SuiTypeTag,
-    TransactionBytes,
+    TransactionBlockBytes,
 };
 use sui_open_rpc::Module;
 use sui_types::base_types::{ObjectID, SuiAddress};
@@ -37,7 +37,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         gas: Option<ObjectID>,
         gas_budget: u64,
         recipient: SuiAddress,
-    ) -> RpcResult<TransactionBytes> {
+    ) -> RpcResult<TransactionBlockBytes> {
         self.fullnode
             .transfer_object(signer, object_id, gas, gas_budget, recipient)
             .await
@@ -50,7 +50,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         gas_budget: u64,
         recipient: SuiAddress,
         amount: Option<u64>,
-    ) -> RpcResult<TransactionBytes> {
+    ) -> RpcResult<TransactionBlockBytes> {
         self.fullnode
             .transfer_sui(signer, sui_object_id, gas_budget, recipient, amount)
             .await
@@ -64,7 +64,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         amounts: Vec<BigInt>,
         gas: Option<ObjectID>,
         gas_budget: u64,
-    ) -> RpcResult<TransactionBytes> {
+    ) -> RpcResult<TransactionBlockBytes> {
         self.fullnode
             .pay(signer, input_coins, recipients, amounts, gas, gas_budget)
             .await
@@ -77,7 +77,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         recipients: Vec<SuiAddress>,
         amounts: Vec<BigInt>,
         gas_budget: u64,
-    ) -> RpcResult<TransactionBytes> {
+    ) -> RpcResult<TransactionBlockBytes> {
         self.fullnode
             .pay_sui(signer, input_coins, recipients, amounts, gas_budget)
             .await
@@ -89,7 +89,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         input_coins: Vec<ObjectID>,
         recipient: SuiAddress,
         gas_budget: u64,
-    ) -> RpcResult<TransactionBytes> {
+    ) -> RpcResult<TransactionBlockBytes> {
         self.fullnode
             .pay_all_sui(signer, input_coins, recipient, gas_budget)
             .await
@@ -102,7 +102,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         dep_ids: Vec<ObjectID>,
         gas: Option<ObjectID>,
         gas_budget: u64,
-    ) -> RpcResult<TransactionBytes> {
+    ) -> RpcResult<TransactionBlockBytes> {
         self.fullnode
             .publish(sender, compiled_modules, dep_ids, gas, gas_budget)
             .await
@@ -115,7 +115,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         split_amounts: Vec<u64>,
         gas: Option<ObjectID>,
         gas_budget: u64,
-    ) -> RpcResult<TransactionBytes> {
+    ) -> RpcResult<TransactionBlockBytes> {
         self.fullnode
             .split_coin(signer, coin_object_id, split_amounts, gas, gas_budget)
             .await
@@ -128,7 +128,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         split_count: u64,
         gas: Option<ObjectID>,
         gas_budget: u64,
-    ) -> RpcResult<TransactionBytes> {
+    ) -> RpcResult<TransactionBlockBytes> {
         self.fullnode
             .split_coin_equal(signer, coin_object_id, split_count, gas, gas_budget)
             .await
@@ -141,7 +141,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         coin_to_merge: ObjectID,
         gas: Option<ObjectID>,
         gas_budget: u64,
-    ) -> RpcResult<TransactionBytes> {
+    ) -> RpcResult<TransactionBlockBytes> {
         self.fullnode
             .merge_coin(signer, primary_coin, coin_to_merge, gas, gas_budget)
             .await
@@ -158,7 +158,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         gas: Option<ObjectID>,
         gas_budget: u64,
         tx_builder_mode: Option<SuiTransactionBlockBuilderMode>,
-    ) -> RpcResult<TransactionBytes> {
+    ) -> RpcResult<TransactionBlockBytes> {
         self.fullnode
             .move_call(
                 signer,
@@ -181,7 +181,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         gas: Option<ObjectID>,
         gas_budget: u64,
         tx_builder_mode: Option<SuiTransactionBlockBuilderMode>,
-    ) -> RpcResult<TransactionBytes> {
+    ) -> RpcResult<TransactionBlockBytes> {
         self.fullnode
             .batch_transaction(signer, params, gas, gas_budget, tx_builder_mode)
             .await
@@ -195,7 +195,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         validator: SuiAddress,
         gas: Option<ObjectID>,
         gas_budget: u64,
-    ) -> RpcResult<TransactionBytes> {
+    ) -> RpcResult<TransactionBlockBytes> {
         self.fullnode
             .request_add_stake(signer, coins, amount, validator, gas, gas_budget)
             .await
@@ -207,7 +207,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         staked_sui: ObjectID,
         gas: Option<ObjectID>,
         gas_budget: u64,
-    ) -> RpcResult<TransactionBytes> {
+    ) -> RpcResult<TransactionBlockBytes> {
         self.fullnode
             .request_withdraw_stake(signer, staked_sui, gas, gas_budget)
             .await

--- a/crates/sui-indexer/src/apis/transaction_builder_api.rs
+++ b/crates/sui-indexer/src/apis/transaction_builder_api.rs
@@ -10,7 +10,8 @@ use sui_json::SuiJsonValue;
 use sui_json_rpc::api::{TransactionBuilderClient, TransactionBuilderServer};
 use sui_json_rpc::SuiRpcModule;
 use sui_json_rpc_types::{
-    BigInt, RPCTransactionRequestParams, SuiTransactionBuilderMode, SuiTypeTag, TransactionBytes,
+    BigInt, RPCTransactionRequestParams, SuiTransactionBlockBuilderMode, SuiTypeTag,
+    TransactionBytes,
 };
 use sui_open_rpc::Module;
 use sui_types::base_types::{ObjectID, SuiAddress};
@@ -156,7 +157,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         rpc_arguments: Vec<SuiJsonValue>,
         gas: Option<ObjectID>,
         gas_budget: u64,
-        tx_builder_mode: Option<SuiTransactionBuilderMode>,
+        tx_builder_mode: Option<SuiTransactionBlockBuilderMode>,
     ) -> RpcResult<TransactionBytes> {
         self.fullnode
             .move_call(
@@ -179,7 +180,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         params: Vec<RPCTransactionRequestParams>,
         gas: Option<ObjectID>,
         gas_budget: u64,
-        tx_builder_mode: Option<SuiTransactionBuilderMode>,
+        tx_builder_mode: Option<SuiTransactionBlockBuilderMode>,
     ) -> RpcResult<TransactionBytes> {
         self.fullnode
             .batch_transaction(signer, params, gas, gas_budget, tx_builder_mode)

--- a/crates/sui-indexer/src/apis/write_api.rs
+++ b/crates/sui-indexer/src/apis/write_api.rs
@@ -9,8 +9,8 @@ use jsonrpsee::RpcModule;
 use sui_json_rpc::api::{WriteApiClient, WriteApiServer};
 use sui_json_rpc::SuiRpcModule;
 use sui_json_rpc_types::{
-    BigInt, DevInspectResults, DryRunTransactionResponse, SuiTransactionResponse,
-    SuiTransactionResponseOptions,
+    BigInt, DevInspectResults, DryRunTransactionResponse, SuiTransactionBlockResponse,
+    SuiTransactionBlockResponseOptions,
 };
 use sui_open_rpc::Module;
 use sui_types::base_types::{EpochId, SuiAddress};
@@ -34,9 +34,9 @@ impl WriteApiServer for WriteApi {
         &self,
         tx_bytes: Base64,
         signatures: Vec<Base64>,
-        options: Option<SuiTransactionResponseOptions>,
+        options: Option<SuiTransactionBlockResponseOptions>,
         request_type: Option<ExecuteTransactionRequestType>,
-    ) -> RpcResult<SuiTransactionResponse> {
+    ) -> RpcResult<SuiTransactionBlockResponse> {
         self.fullnode
             .execute_transaction_block(tx_bytes, signatures, options, request_type)
             .await

--- a/crates/sui-indexer/src/bin/indexer_data_validation.rs
+++ b/crates/sui-indexer/src/bin/indexer_data_validation.rs
@@ -7,7 +7,7 @@ use tracing::{error, info, warn};
 
 use sui_indexer::new_rpc_client;
 use sui_json_rpc_types::{
-    BigInt, CheckpointId, ObjectChange, SuiObjectDataOptions, SuiTransactionResponseOptions,
+    BigInt, CheckpointId, ObjectChange, SuiObjectDataOptions, SuiTransactionBlockResponseOptions,
 };
 use sui_sdk::SuiClient;
 use sui_types::base_types::{ObjectID, SequenceNumber};
@@ -87,7 +87,7 @@ pub async fn check_transactions(
     tx_vec: Vec<TransactionDigest>,
 ) -> Result<(), anyhow::Error> {
     for digest in tx_vec {
-        let fetch_options = SuiTransactionResponseOptions::full_content();
+        let fetch_options = SuiTransactionBlockResponseOptions::full_content();
         let fn_sui_tx_response = fn_client
             .read_api()
             .get_transaction_with_options(digest, fetch_options.clone())

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -17,7 +17,7 @@ use mysten_metrics::spawn_monitored_task;
 use sui_core::event_handler::EventHandler;
 use sui_json_rpc_types::{
     OwnedObjectRef, SuiGetPastObjectRequest, SuiObjectData, SuiObjectDataOptions, SuiRawData,
-    SuiTransactionDataAPI, SuiTransactionEffectsAPI,
+    SuiTransactionBlockDataAPI, SuiTransactionBlockEffectsAPI,
 };
 use sui_sdk::error::Error;
 use sui_sdk::SuiClient;
@@ -37,7 +37,7 @@ use crate::store::{
     CheckpointData, IndexerStore, TemporaryCheckpointStore, TemporaryEpochStore,
     TransactionObjectChanges,
 };
-use crate::types::SuiTransactionFullResponse;
+use crate::types::SuiTransactionBlockFullResponse;
 use crate::utils::multi_get_full_transactions;
 
 const HANDLER_RETRY_INTERVAL_IN_SECS: u64 = 10;
@@ -493,7 +493,7 @@ where
     }
 
     fn index_packages(
-        transactions: &[SuiTransactionFullResponse],
+        transactions: &[SuiTransactionBlockFullResponse],
         changed_objects: &[(ObjectStatus, SuiObjectData)],
     ) -> Result<Vec<Package>, IndexerError> {
         let object_map = changed_objects

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 
 use sui_json_rpc_types::{
     Checkpoint as RpcCheckpoint, CheckpointId, EpochInfo, EventFilter, EventPage, MoveCallMetrics,
-    NetworkMetrics, SuiObjectData, SuiObjectDataFilter, SuiTransactionResponseOptions,
+    NetworkMetrics, SuiObjectData, SuiObjectDataFilter, SuiTransactionBlockResponseOptions,
 };
 use sui_types::base_types::{EpochId, ObjectID, SequenceNumber};
 use sui_types::digests::CheckpointDigest;
@@ -25,7 +25,7 @@ use crate::models::packages::Package;
 use crate::models::system_state::{DBSystemStateSummary, DBValidatorSummary};
 use crate::models::transaction_index::{InputObject, MoveCall, Recipient};
 use crate::models::transactions::Transaction;
-use crate::types::SuiTransactionFullResponse;
+use crate::types::SuiTransactionBlockFullResponse;
 
 #[async_trait]
 pub trait IndexerStore {
@@ -73,8 +73,8 @@ pub trait IndexerStore {
     async fn compose_full_transaction_response(
         &self,
         tx: Transaction,
-        options: Option<SuiTransactionResponseOptions>,
-    ) -> Result<SuiTransactionFullResponse, IndexerError>;
+        options: Option<SuiTransactionBlockResponseOptions>,
+    ) -> Result<SuiTransactionBlockFullResponse, IndexerError>;
 
     fn get_all_transaction_digest_page(
         &self,
@@ -194,7 +194,7 @@ pub trait IndexerStore {
 #[derive(Clone, Debug)]
 pub struct CheckpointData {
     pub checkpoint: RpcCheckpoint,
-    pub transactions: Vec<SuiTransactionFullResponse>,
+    pub transactions: Vec<SuiTransactionBlockFullResponse>,
     pub changed_objects: Vec<(ObjectStatus, SuiObjectData)>,
 }
 

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -26,8 +26,8 @@ use sui_json_rpc_types::{
     NetworkMetrics, SuiEvent, SuiObjectDataFilter,
 };
 use sui_json_rpc_types::{
-    SuiTransaction, SuiTransactionEffects, SuiTransactionEffectsAPI, SuiTransactionEvents,
-    SuiTransactionResponseOptions,
+    SuiTransactionBlock, SuiTransactionBlockEffects, SuiTransactionBlockEffectsAPI,
+    SuiTransactionBlockEvents, SuiTransactionBlockResponseOptions,
 };
 use sui_types::base_types::{ObjectID, SequenceNumber, SuiAddress};
 use sui_types::committee::{EpochId, ProtocolVersion};
@@ -62,7 +62,7 @@ use crate::store::indexer_store::TemporaryCheckpointStore;
 use crate::store::module_resolver::IndexerModuleResolver;
 use crate::store::query::DBFilter;
 use crate::store::{IndexerStore, TemporaryEpochStore};
-use crate::types::SuiTransactionFullResponse;
+use crate::types::SuiTransactionBlockFullResponse;
 use crate::utils::{get_balance_changes_from_effect, get_object_changes};
 use crate::{get_pg_pool_connection, PgConnectionPool};
 
@@ -409,18 +409,18 @@ impl IndexerStore for PgIndexerStore {
     async fn compose_full_transaction_response(
         &self,
         tx: Transaction,
-        options: Option<SuiTransactionResponseOptions>,
-    ) -> Result<SuiTransactionFullResponse, IndexerError> {
-        let transaction: SuiTransaction =
+        options: Option<SuiTransactionBlockResponseOptions>,
+    ) -> Result<SuiTransactionBlockFullResponse, IndexerError> {
+        let transaction: SuiTransactionBlock =
             serde_json::from_str(&tx.transaction_content).map_err(|err| {
                 IndexerError::InsertableParsingError(format!(
-                    "Failed converting transaction JSON {:?} to SuiTransaction with error: {:?}",
+                    "Failed converting transaction JSON {:?} to SuiTransactionBlock with error: {:?}",
                     tx.transaction_content, err
                 ))
             })?;
-        let effects: SuiTransactionEffects = serde_json::from_str(&tx.transaction_effects_content).map_err(|err| {
+        let effects: SuiTransactionBlockEffects = serde_json::from_str(&tx.transaction_effects_content).map_err(|err| {
         IndexerError::InsertableParsingError(format!(
-            "Failed converting transaction effect JSON {:?} to SuiTransactionEffects with error: {:?}",
+            "Failed converting transaction effect JSON {:?} to SuiTransactionBlockEffects with error: {:?}",
             tx.transaction_effects_content, err
         ))
         })?;
@@ -462,7 +462,7 @@ impl IndexerStore for PgIndexerStore {
             /* descending_order */ false,
         )?;
 
-        Ok(SuiTransactionFullResponse {
+        Ok(SuiTransactionBlockFullResponse {
             digest: tx_digest,
             transaction,
             raw_transaction: tx.raw_transaction,
@@ -470,7 +470,7 @@ impl IndexerStore for PgIndexerStore {
             confirmed_local_execution: tx.confirmed_local_execution,
             timestamp_ms: tx.timestamp_ms as u64,
             checkpoint: tx.checkpoint_sequence_number as u64,
-            events: SuiTransactionEvents { data: events.data },
+            events: SuiTransactionBlockEvents { data: events.data },
             object_changes,
             balance_changes,
         })

--- a/crates/sui-indexer/src/test_utils.rs
+++ b/crates/sui-indexer/src/test_utils.rs
@@ -3,7 +3,7 @@
 
 use anyhow::anyhow;
 use prometheus::Registry;
-use sui_json_rpc_types::SuiTransactionResponse;
+use sui_json_rpc_types::SuiTransactionBlockResponse;
 use tokio::task::JoinHandle;
 
 use crate::errors::IndexerError;
@@ -34,21 +34,21 @@ pub async fn start_test_indexer(
 }
 
 #[derive(Clone)]
-pub struct SuiTransactionResponseBuilder<'a> {
-    response: SuiTransactionResponse,
-    full_response: &'a SuiTransactionResponse,
+pub struct SuiTransactionBlockResponseBuilder<'a> {
+    response: SuiTransactionBlockResponse,
+    full_response: &'a SuiTransactionBlockResponse,
 }
 
-impl<'a> SuiTransactionResponseBuilder<'a> {
-    pub fn new(full_response: &'a SuiTransactionResponse) -> Self {
+impl<'a> SuiTransactionBlockResponseBuilder<'a> {
+    pub fn new(full_response: &'a SuiTransactionBlockResponse) -> Self {
         Self {
-            response: SuiTransactionResponse::default(),
+            response: SuiTransactionBlockResponse::default(),
             full_response,
         }
     }
 
     pub fn with_input(mut self) -> Self {
-        self.response = SuiTransactionResponse {
+        self.response = SuiTransactionBlockResponse {
             transaction: self.full_response.transaction.clone(),
             ..self.response
         };
@@ -56,7 +56,7 @@ impl<'a> SuiTransactionResponseBuilder<'a> {
     }
 
     pub fn with_raw_input(mut self) -> Self {
-        self.response = SuiTransactionResponse {
+        self.response = SuiTransactionBlockResponse {
             raw_transaction: self.full_response.raw_transaction.clone(),
             ..self.response
         };
@@ -64,7 +64,7 @@ impl<'a> SuiTransactionResponseBuilder<'a> {
     }
 
     pub fn with_effects(mut self) -> Self {
-        self.response = SuiTransactionResponse {
+        self.response = SuiTransactionBlockResponse {
             effects: self.full_response.effects.clone(),
             ..self.response
         };
@@ -72,7 +72,7 @@ impl<'a> SuiTransactionResponseBuilder<'a> {
     }
 
     pub fn with_events(mut self) -> Self {
-        self.response = SuiTransactionResponse {
+        self.response = SuiTransactionBlockResponse {
             events: self.full_response.events.clone(),
             ..self.response
         };
@@ -80,7 +80,7 @@ impl<'a> SuiTransactionResponseBuilder<'a> {
     }
 
     pub fn with_balance_changes(mut self) -> Self {
-        self.response = SuiTransactionResponse {
+        self.response = SuiTransactionBlockResponse {
             balance_changes: self.full_response.balance_changes.clone(),
             ..self.response
         };
@@ -88,7 +88,7 @@ impl<'a> SuiTransactionResponseBuilder<'a> {
     }
 
     pub fn with_object_changes(mut self) -> Self {
-        self.response = SuiTransactionResponse {
+        self.response = SuiTransactionBlockResponse {
             object_changes: self.full_response.object_changes.clone(),
             ..self.response
         };
@@ -96,7 +96,7 @@ impl<'a> SuiTransactionResponseBuilder<'a> {
     }
 
     pub fn with_input_and_changes(mut self) -> Self {
-        self.response = SuiTransactionResponse {
+        self.response = SuiTransactionBlockResponse {
             transaction: self.full_response.transaction.clone(),
             balance_changes: self.full_response.balance_changes.clone(),
             object_changes: self.full_response.object_changes.clone(),
@@ -105,8 +105,8 @@ impl<'a> SuiTransactionResponseBuilder<'a> {
         self
     }
 
-    pub fn build(self) -> SuiTransactionResponse {
-        SuiTransactionResponse {
+    pub fn build(self) -> SuiTransactionBlockResponse {
+        SuiTransactionBlockResponse {
             transaction: self.response.transaction,
             raw_transaction: self.response.raw_transaction,
             effects: self.response.effects,

--- a/crates/sui-indexer/tests/integration_tests.rs
+++ b/crates/sui-indexer/tests/integration_tests.rs
@@ -36,7 +36,7 @@ pub mod pg_integration_test {
         BigInt, CheckpointId, EventFilter, SuiMoveObject, SuiObjectData, SuiObjectDataFilter,
         SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery, SuiParsedMoveObject,
         SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions,
-        SuiTransactionBlockResponseQuery, TransactionBytes,
+        SuiTransactionBlockResponseQuery, TransactionBlockBytes,
     };
     use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
     use sui_types::base_types::{ObjectID, SuiAddress};
@@ -83,7 +83,7 @@ pub mod pg_integration_test {
     async fn sign_and_execute_transaction_block(
         test_cluster: &TestCluster,
         indexer_rpc_client: &HttpClient,
-        transaction_bytes: TransactionBytes,
+        transaction_bytes: TransactionBlockBytes,
         sender: &SuiAddress,
     ) -> Result<SuiTransactionBlockResponse, anyhow::Error> {
         let keystore_path = test_cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);
@@ -111,7 +111,7 @@ pub mod pg_integration_test {
         object_id: ObjectID,
         gas: Option<ObjectID>,
     ) -> Result<SuiTransactionBlockResponse, anyhow::Error> {
-        let transaction_bytes: TransactionBytes = indexer_rpc_client
+        let transaction_bytes: TransactionBlockBytes = indexer_rpc_client
             .transfer_object(*sender, object_id, gas, 2000, *recipient)
             .await?;
         let tx_response = sign_and_execute_transaction_block(

--- a/crates/sui-indexer/tests/integration_tests.rs
+++ b/crates/sui-indexer/tests/integration_tests.rs
@@ -27,7 +27,7 @@ pub mod pg_integration_test {
     use sui_indexer::models::owners::OwnerType;
     use sui_indexer::schema::objects;
     use sui_indexer::store::{IndexerStore, PgIndexerStore};
-    use sui_indexer::test_utils::{start_test_indexer, SuiTransactionResponseBuilder};
+    use sui_indexer::test_utils::{start_test_indexer, SuiTransactionBlockResponseBuilder};
     use sui_indexer::{get_pg_pool_connection, new_pg_connection_pool, IndexerConfig};
     use sui_json_rpc::api::ExtendedApiClient;
     use sui_json_rpc::api::IndexerApiClient;
@@ -35,8 +35,8 @@ pub mod pg_integration_test {
     use sui_json_rpc_types::{
         BigInt, CheckpointId, EventFilter, SuiMoveObject, SuiObjectData, SuiObjectDataFilter,
         SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery, SuiParsedMoveObject,
-        SuiTransactionResponse, SuiTransactionResponseOptions, SuiTransactionResponseQuery,
-        TransactionBytes,
+        SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions,
+        SuiTransactionBlockResponseQuery, TransactionBytes,
     };
     use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
     use sui_types::base_types::{ObjectID, SuiAddress};
@@ -85,7 +85,7 @@ pub mod pg_integration_test {
         indexer_rpc_client: &HttpClient,
         transaction_bytes: TransactionBytes,
         sender: &SuiAddress,
-    ) -> Result<SuiTransactionResponse, anyhow::Error> {
+    ) -> Result<SuiTransactionBlockResponse, anyhow::Error> {
         let keystore_path = test_cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);
         let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
         let tx =
@@ -95,7 +95,7 @@ pub mod pg_integration_test {
             .execute_transaction_block(
                 tx_bytes,
                 signatures,
-                Some(SuiTransactionResponseOptions::full_content()),
+                Some(SuiTransactionBlockResponseOptions::full_content()),
                 Some(ExecuteTransactionRequestType::WaitForLocalExecution),
             )
             .await
@@ -110,7 +110,7 @@ pub mod pg_integration_test {
         recipient: &SuiAddress,
         object_id: ObjectID,
         gas: Option<ObjectID>,
-    ) -> Result<SuiTransactionResponse, anyhow::Error> {
+    ) -> Result<SuiTransactionBlockResponse, anyhow::Error> {
         let transaction_bytes: TransactionBytes = indexer_rpc_client
             .transfer_object(*sender, object_id, gas, 2000, *recipient)
             .await?;
@@ -130,7 +130,7 @@ pub mod pg_integration_test {
         indexer_rpc_client: &HttpClient,
     ) -> Result<
         (
-            SuiTransactionResponse,
+            SuiTransactionBlockResponse,
             SuiAddress,
             SuiAddress,
             Vec<ObjectID>,
@@ -187,11 +187,11 @@ pub mod pg_integration_test {
             assert!(transaction.is_ok());
             let _fullnode_rpc_tx = test_cluster
                 .rpc_client()
-                .get_transaction_block(tx_digest, Some(SuiTransactionResponseOptions::new()))
+                .get_transaction_block(tx_digest, Some(SuiTransactionBlockResponseOptions::new()))
                 .await
                 .unwrap();
             let _indexer_rpc_tx = indexer_rpc_client
-                .get_transaction_block(tx_digest, Some(SuiTransactionResponseOptions::new()))
+                .get_transaction_block(tx_digest, Some(SuiTransactionBlockResponseOptions::new()))
                 .await
                 .unwrap();
 
@@ -278,7 +278,7 @@ pub mod pg_integration_test {
 
         // query tx with checkpoint sequence
         let checkpoint_seq_query =
-            SuiTransactionResponseQuery::new_with_filter(TransactionFilter::Checkpoint(2u64));
+            SuiTransactionBlockResponseQuery::new_with_filter(TransactionFilter::Checkpoint(2u64));
         let mut checkpoint_query_tx_digest_vec = indexer_rpc_client
             .query_transaction_blocks(checkpoint_seq_query, None, None, None)
             .await
@@ -299,7 +299,7 @@ pub mod pg_integration_test {
         let tx_read_response = indexer_rpc_client
             .get_transaction_block(
                 tx_response.digest,
-                Some(SuiTransactionResponseOptions::full_content()),
+                Some(SuiTransactionBlockResponseOptions::full_content()),
             )
             .await?;
         assert_eq!(tx_response.digest, tx_read_response.digest);
@@ -314,15 +314,16 @@ pub mod pg_integration_test {
         wait_until_next_checkpoint(&store).await;
 
         // query tx with sender address
-        let from_query =
-            SuiTransactionResponseQuery::new_with_filter(TransactionFilter::FromAddress(sender));
+        let from_query = SuiTransactionBlockResponseQuery::new_with_filter(
+            TransactionFilter::FromAddress(sender),
+        );
         let tx_from_query_response = indexer_rpc_client
             .query_transaction_blocks(from_query, None, None, None)
             .await?;
         assert!(!tx_from_query_response.has_next_page);
         assert_eq!(tx_from_query_response.data.len(), 3);
 
-        let tx_kind_query = SuiTransactionResponseQuery::new_with_filter(
+        let tx_kind_query = SuiTransactionBlockResponseQuery::new_with_filter(
             TransactionFilter::TransactionKind("ProgrammableTransaction".to_string()),
         );
         let tx_kind_query_response = indexer_rpc_client
@@ -332,8 +333,9 @@ pub mod pg_integration_test {
         assert_eq!(tx_kind_query_response.data.len(), 3);
 
         // query tx with recipient address
-        let to_query =
-            SuiTransactionResponseQuery::new_with_filter(TransactionFilter::ToAddress(recipient));
+        let to_query = SuiTransactionBlockResponseQuery::new_with_filter(
+            TransactionFilter::ToAddress(recipient),
+        );
         let tx_to_query_response = indexer_rpc_client
             .query_transaction_blocks(to_query, None, None, None)
             .await?;
@@ -342,11 +344,12 @@ pub mod pg_integration_test {
         assert_eq!(tx_to_query_response.data.len(), 2);
 
         // query tx with both sender and recipient addresses
-        let from_to_query =
-            SuiTransactionResponseQuery::new_with_filter(TransactionFilter::FromAndToAddress {
+        let from_to_query = SuiTransactionBlockResponseQuery::new_with_filter(
+            TransactionFilter::FromAndToAddress {
                 from: sender,
                 to: recipient,
-            });
+            },
+        );
         let tx_from_to_query_response = indexer_rpc_client
             .query_transaction_blocks(from_to_query, None, None, None)
             .await?;
@@ -358,7 +361,7 @@ pub mod pg_integration_test {
         );
 
         // query tx with mutated object id
-        let mutation_query = SuiTransactionResponseQuery::new_with_filter(
+        let mutation_query = SuiTransactionBlockResponseQuery::new_with_filter(
             TransactionFilter::ChangedObject(*gas_objects.first().unwrap()),
         );
         let tx_mutation_query_response = indexer_rpc_client
@@ -369,7 +372,7 @@ pub mod pg_integration_test {
         assert_eq!(tx_mutation_query_response.data.len(), 3);
 
         // query tx with input object id
-        let input_query = SuiTransactionResponseQuery::new_with_filter(
+        let input_query = SuiTransactionBlockResponseQuery::new_with_filter(
             TransactionFilter::InputObject(*gas_objects.first().unwrap()),
         );
         let tx_input_query_response = indexer_rpc_client
@@ -379,7 +382,7 @@ pub mod pg_integration_test {
 
         // query tx with move call
         let move_call_query =
-            SuiTransactionResponseQuery::new_with_filter(TransactionFilter::MoveFunction {
+            SuiTransactionBlockResponseQuery::new_with_filter(TransactionFilter::MoveFunction {
                 package: package_id,
                 module: Some("devnet_nft".to_string()),
                 function: None,
@@ -415,7 +418,7 @@ pub mod pg_integration_test {
         let tx_multi_read_tx_response_1 = indexer_rpc_client
             .multi_get_transaction_blocks(
                 vec![tx_response.digest, nft_digest],
-                Some(SuiTransactionResponseOptions::full_content()),
+                Some(SuiTransactionBlockResponseOptions::full_content()),
             )
             .await?;
         assert_eq!(tx_multi_read_tx_response_1.len(), 2);
@@ -425,7 +428,7 @@ pub mod pg_integration_test {
         let tx_multi_read_tx_response_2 = indexer_rpc_client
             .multi_get_transaction_blocks(
                 vec![nft_digest, tx_response.digest],
-                Some(SuiTransactionResponseOptions::full_content()),
+                Some(SuiTransactionBlockResponseOptions::full_content()),
             )
             .await?;
         assert_eq!(tx_multi_read_tx_response_2.len(), 2);
@@ -1086,17 +1089,17 @@ pub mod pg_integration_test {
         let full_transaction_response = indexer_rpc_client
             .get_transaction_block(
                 tx_response.digest,
-                Some(SuiTransactionResponseOptions::full_content()),
+                Some(SuiTransactionBlockResponseOptions::full_content()),
             )
             .await?;
         let sui_transaction_response_options = vec![
-            SuiTransactionResponseOptions::new().with_input(),
-            SuiTransactionResponseOptions::new().with_raw_input(),
-            SuiTransactionResponseOptions::new().with_effects(),
-            SuiTransactionResponseOptions::new().with_events(),
-            SuiTransactionResponseOptions::new().with_balance_changes(),
-            SuiTransactionResponseOptions::new().with_object_changes(),
-            SuiTransactionResponseOptions::new()
+            SuiTransactionBlockResponseOptions::new().with_input(),
+            SuiTransactionBlockResponseOptions::new().with_raw_input(),
+            SuiTransactionBlockResponseOptions::new().with_effects(),
+            SuiTransactionBlockResponseOptions::new().with_events(),
+            SuiTransactionBlockResponseOptions::new().with_balance_changes(),
+            SuiTransactionBlockResponseOptions::new().with_object_changes(),
+            SuiTransactionBlockResponseOptions::new()
                 .with_input()
                 .with_balance_changes()
                 .with_object_changes(),
@@ -1108,32 +1111,32 @@ pub mod pg_integration_test {
             })
             .collect::<Vec<_>>();
 
-        let received_transaction_results: Vec<SuiTransactionResponse> = join_all(futures)
+        let received_transaction_results: Vec<SuiTransactionBlockResponse> = join_all(futures)
             .await
             .into_iter()
             .collect::<Result<_, _>>()
             .unwrap();
 
         let expected_transaction_results = vec![
-            SuiTransactionResponseBuilder::new(&full_transaction_response)
+            SuiTransactionBlockResponseBuilder::new(&full_transaction_response)
                 .with_input()
                 .build(),
-            SuiTransactionResponseBuilder::new(&full_transaction_response)
+            SuiTransactionBlockResponseBuilder::new(&full_transaction_response)
                 .with_raw_input()
                 .build(),
-            SuiTransactionResponseBuilder::new(&full_transaction_response)
+            SuiTransactionBlockResponseBuilder::new(&full_transaction_response)
                 .with_effects()
                 .build(),
-            SuiTransactionResponseBuilder::new(&full_transaction_response)
+            SuiTransactionBlockResponseBuilder::new(&full_transaction_response)
                 .with_events()
                 .build(),
-            SuiTransactionResponseBuilder::new(&full_transaction_response)
+            SuiTransactionBlockResponseBuilder::new(&full_transaction_response)
                 .with_balance_changes()
                 .build(),
-            SuiTransactionResponseBuilder::new(&full_transaction_response)
+            SuiTransactionBlockResponseBuilder::new(&full_transaction_response)
                 .with_object_changes()
                 .build(),
-            SuiTransactionResponseBuilder::new(&full_transaction_response)
+            SuiTransactionBlockResponseBuilder::new(&full_transaction_response)
                 .with_input()
                 .with_balance_changes()
                 .with_object_changes()
@@ -1177,7 +1180,7 @@ pub mod pg_integration_test {
         let tx_response = indexer_rpc_client
             .get_transaction_block(
                 tx_response.digest,
-                Some(SuiTransactionResponseOptions::full_content()),
+                Some(SuiTransactionBlockResponseOptions::full_content()),
             )
             .await?;
         let next_cp = tx_response.checkpoint.unwrap();

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -94,7 +94,7 @@ impl SuiTransactionBlockResponseQuery {
     }
 }
 
-pub type TransactionsPage = Page<SuiTransactionBlockResponse, TransactionDigest>;
+pub type TransactionBlocksPage = Page<SuiTransactionBlockResponse, TransactionDigest>;
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, Eq, PartialEq, Default)]
 #[serde(

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -1443,7 +1443,7 @@ pub struct MoveCallParams {
 #[serde_as]
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct TransactionBytes {
+pub struct TransactionBlockBytes {
     /// BCS serialized transaction data bytes without its type tag, as base-64 encoded string.
     pub tx_bytes: Base64,
     /// the gas objects to be used
@@ -1452,7 +1452,7 @@ pub struct TransactionBytes {
     pub input_objects: Vec<SuiInputObjectKind>,
 }
 
-impl TransactionBytes {
+impl TransactionBlockBytes {
     pub fn from_data(data: TransactionData) -> Result<Self, anyhow::Error> {
         Ok(Self {
             tx_bytes: Base64::from_bytes(bcs::to_bytes(&data)?.as_slice()),

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -71,17 +71,17 @@ pub type SuiEpochId = BigInt;
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, Default)]
 #[serde(rename_all = "camelCase", rename = "TransactionResponseQuery", default)]
-pub struct SuiTransactionResponseQuery {
+pub struct SuiTransactionBlockResponseQuery {
     /// If None, no filter will be applied
     pub filter: Option<TransactionFilter>,
     /// config which fields to include in the response, by default only digest is included
-    pub options: Option<SuiTransactionResponseOptions>,
+    pub options: Option<SuiTransactionBlockResponseOptions>,
 }
 
-impl SuiTransactionResponseQuery {
+impl SuiTransactionBlockResponseQuery {
     pub fn new(
         filter: Option<TransactionFilter>,
-        options: Option<SuiTransactionResponseOptions>,
+        options: Option<SuiTransactionBlockResponseOptions>,
     ) -> Self {
         Self { filter, options }
     }
@@ -94,7 +94,7 @@ impl SuiTransactionResponseQuery {
     }
 }
 
-pub type TransactionsPage = Page<SuiTransactionResponse, TransactionDigest>;
+pub type TransactionsPage = Page<SuiTransactionBlockResponse, TransactionDigest>;
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, Eq, PartialEq, Default)]
 #[serde(
@@ -102,7 +102,7 @@ pub type TransactionsPage = Page<SuiTransactionResponse, TransactionDigest>;
     rename = "TransactionResponseOptions",
     default
 )]
-pub struct SuiTransactionResponseOptions {
+pub struct SuiTransactionBlockResponseOptions {
     /// Whether to show transaction input data. Default to be False
     pub show_input: bool,
     /// Whether to show bcs-encoded transaction input data
@@ -117,7 +117,7 @@ pub struct SuiTransactionResponseOptions {
     pub show_balance_changes: bool,
 }
 
-impl SuiTransactionResponseOptions {
+impl SuiTransactionBlockResponseOptions {
     pub fn new() -> Self {
         Self::default()
     }
@@ -197,11 +197,11 @@ impl SuiTransactionResponseOptions {
 #[serde_as]
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone, Default)]
 #[serde(rename_all = "camelCase", rename = "TransactionResponse")]
-pub struct SuiTransactionResponse {
+pub struct SuiTransactionBlockResponse {
     pub digest: TransactionDigest,
     /// Transaction input data
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub transaction: Option<SuiTransaction>,
+    pub transaction: Option<SuiTransactionBlock>,
     /// BCS encoded [SenderSignedData] that includes input object references
     /// returns empty array if `show_raw_transaction` is false
     #[serde_as(as = "Base64")]
@@ -209,9 +209,9 @@ pub struct SuiTransactionResponse {
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub raw_transaction: Vec<u8>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub effects: Option<SuiTransactionEffects>,
+    pub effects: Option<SuiTransactionBlockEffects>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub events: Option<SuiTransactionEvents>,
+    pub events: Option<SuiTransactionBlockEvents>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub object_changes: Option<Vec<ObjectChange>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -228,7 +228,7 @@ pub struct SuiTransactionResponse {
     pub errors: Vec<String>,
 }
 
-impl SuiTransactionResponse {
+impl SuiTransactionBlockResponse {
     pub fn new(digest: TransactionDigest) -> Self {
         Self {
             digest,
@@ -242,7 +242,7 @@ impl SuiTransactionResponse {
 }
 
 /// We are specifically ignoring events for now until events become more stable.
-impl PartialEq for SuiTransactionResponse {
+impl PartialEq for SuiTransactionBlockResponse {
     fn eq(&self, other: &Self) -> bool {
         self.transaction == other.transaction
             && self.effects == other.effects
@@ -254,7 +254,7 @@ impl PartialEq for SuiTransactionResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename = "TransactionKind", tag = "kind")]
-pub enum SuiTransactionKind {
+pub enum SuiTransactionBlockKind {
     /// A system transaction that will update epoch information on-chain.
     ChangeEpoch(SuiChangeEpoch),
     /// A system transaction used for initializing the initial state of the chain.
@@ -268,7 +268,7 @@ pub enum SuiTransactionKind {
     // .. more transaction types go here
 }
 
-impl Display for SuiTransactionKind {
+impl Display for SuiTransactionBlockKind {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut writer = String::new();
         match &self {
@@ -300,7 +300,7 @@ impl Display for SuiTransactionKind {
     }
 }
 
-impl SuiTransactionKind {
+impl SuiTransactionBlockKind {
     fn try_from(tx: TransactionKind, module_cache: &impl GetModule) -> Result<Self, anyhow::Error> {
         Ok(match tx {
             TransactionKind::ChangeEpoch(e) => Self::ChangeEpoch(SuiChangeEpoch {
@@ -353,18 +353,18 @@ pub struct SuiChangeEpoch {
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
-#[enum_dispatch(SuiTransactionEffectsAPI)]
+#[enum_dispatch(SuiTransactionBlockEffectsAPI)]
 #[serde(
     rename = "TransactionEffects",
     rename_all = "camelCase",
     tag = "messageVersion"
 )]
-pub enum SuiTransactionEffects {
-    V1(SuiTransactionEffectsV1),
+pub enum SuiTransactionBlockEffects {
+    V1(SuiTransactionBlockEffectsV1),
 }
 
 #[enum_dispatch]
-pub trait SuiTransactionEffectsAPI {
+pub trait SuiTransactionBlockEffectsAPI {
     fn status(&self) -> &SuiExecutionStatus;
     fn into_status(self) -> SuiExecutionStatus;
     fn shared_objects(&self) -> &[SuiObjectRef];
@@ -393,7 +393,7 @@ pub trait SuiTransactionEffectsAPI {
     rename = "TransactionEffectsModifiedAtVersions",
     rename_all = "camelCase"
 )]
-pub struct SuiTransactionEffectsModifiedAtVersions {
+pub struct SuiTransactionBlockEffectsModifiedAtVersions {
     object_id: ObjectID,
     sequence_number: SequenceNumber,
 }
@@ -401,7 +401,7 @@ pub struct SuiTransactionEffectsModifiedAtVersions {
 /// The response from processing a transaction or a certified transaction
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(rename = "TransactionEffectsV1", rename_all = "camelCase")]
-pub struct SuiTransactionEffectsV1 {
+pub struct SuiTransactionBlockEffectsV1 {
     /// The status of the execution
     pub status: SuiExecutionStatus,
     /// The epoch when this transaction was executed.
@@ -410,7 +410,7 @@ pub struct SuiTransactionEffectsV1 {
     /// The version that every modified (mutated or deleted) object had before it was modified by
     /// this transaction.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub modified_at_versions: Vec<SuiTransactionEffectsModifiedAtVersions>,
+    pub modified_at_versions: Vec<SuiTransactionBlockEffectsModifiedAtVersions>,
     /// The object references of the shared objects used in this transaction. Empty if no shared objects were used.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub shared_objects: Vec<SuiObjectRef>,
@@ -448,7 +448,7 @@ pub struct SuiTransactionEffectsV1 {
     pub dependencies: Vec<TransactionDigest>,
 }
 
-impl SuiTransactionEffectsAPI for SuiTransactionEffectsV1 {
+impl SuiTransactionBlockEffectsAPI for SuiTransactionBlockEffectsV1 {
     fn status(&self) -> &SuiExecutionStatus {
         &self.status
     }
@@ -544,9 +544,9 @@ impl SuiTransactionEffectsAPI for SuiTransactionEffectsV1 {
     }
 }
 
-impl SuiTransactionEffects {}
+impl SuiTransactionBlockEffects {}
 
-impl TryFrom<TransactionEffects> for SuiTransactionEffects {
+impl TryFrom<TransactionEffects> for SuiTransactionBlockEffects {
     type Error = SuiError;
 
     fn try_from(effect: TransactionEffects) -> Result<Self, Self::Error> {
@@ -555,36 +555,40 @@ impl TryFrom<TransactionEffects> for SuiTransactionEffects {
             .expect("TransactionEffects defines message_version()");
 
         match message_version {
-            1 => Ok(SuiTransactionEffects::V1(SuiTransactionEffectsV1 {
-                status: effect.status().clone().into(),
-                executed_epoch: effect.executed_epoch().into(),
-                modified_at_versions: effect
-                    .modified_at_versions()
-                    .iter()
-                    .copied()
-                    .map(
-                        |(object_id, sequence_number)| SuiTransactionEffectsModifiedAtVersions {
-                            object_id,
-                            sequence_number,
-                        },
-                    )
-                    .collect(),
-                gas_used: effect.gas_cost_summary().clone().into(),
-                shared_objects: to_sui_object_ref(effect.shared_objects().to_vec()),
-                transaction_digest: *effect.transaction_digest(),
-                created: to_owned_ref(effect.created().to_vec()),
-                mutated: to_owned_ref(effect.mutated().to_vec()),
-                unwrapped: to_owned_ref(effect.unwrapped().to_vec()),
-                deleted: to_sui_object_ref(effect.deleted().to_vec()),
-                unwrapped_then_deleted: to_sui_object_ref(effect.unwrapped_then_deleted().to_vec()),
-                wrapped: to_sui_object_ref(effect.wrapped().to_vec()),
-                gas_object: OwnedObjectRef {
-                    owner: effect.gas_object().1,
-                    reference: effect.gas_object().0.into(),
+            1 => Ok(SuiTransactionBlockEffects::V1(
+                SuiTransactionBlockEffectsV1 {
+                    status: effect.status().clone().into(),
+                    executed_epoch: effect.executed_epoch().into(),
+                    modified_at_versions: effect
+                        .modified_at_versions()
+                        .iter()
+                        .copied()
+                        .map(|(object_id, sequence_number)| {
+                            SuiTransactionBlockEffectsModifiedAtVersions {
+                                object_id,
+                                sequence_number,
+                            }
+                        })
+                        .collect(),
+                    gas_used: effect.gas_cost_summary().clone().into(),
+                    shared_objects: to_sui_object_ref(effect.shared_objects().to_vec()),
+                    transaction_digest: *effect.transaction_digest(),
+                    created: to_owned_ref(effect.created().to_vec()),
+                    mutated: to_owned_ref(effect.mutated().to_vec()),
+                    unwrapped: to_owned_ref(effect.unwrapped().to_vec()),
+                    deleted: to_sui_object_ref(effect.deleted().to_vec()),
+                    unwrapped_then_deleted: to_sui_object_ref(
+                        effect.unwrapped_then_deleted().to_vec(),
+                    ),
+                    wrapped: to_sui_object_ref(effect.wrapped().to_vec()),
+                    gas_object: OwnedObjectRef {
+                        owner: effect.gas_object().1,
+                        reference: effect.gas_object().0.into(),
+                    },
+                    events_digest: effect.events_digest().copied(),
+                    dependencies: effect.dependencies().to_vec(),
                 },
-                events_digest: effect.events_digest().copied(),
-                dependencies: effect.dependencies().to_vec(),
-            })),
+            )),
 
             _ => Err(SuiError::UnexpectedVersion(format!(
                 "Support for TransactionEffects version {} not implemented",
@@ -594,7 +598,7 @@ impl TryFrom<TransactionEffects> for SuiTransactionEffects {
     }
 }
 
-impl Display for SuiTransactionEffects {
+impl Display for SuiTransactionBlockEffects {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut writer = String::new();
         writeln!(writer, "Status : {:?}", self.status())?;
@@ -647,19 +651,19 @@ impl Display for SuiTransactionEffects {
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DryRunTransactionResponse {
-    pub effects: SuiTransactionEffects,
-    pub events: SuiTransactionEvents,
+    pub effects: SuiTransactionBlockEffects,
+    pub events: SuiTransactionBlockEvents,
     pub object_changes: Vec<ObjectChange>,
     pub balance_changes: Vec<BalanceChange>,
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename = "TransactionEvents", transparent)]
-pub struct SuiTransactionEvents {
+pub struct SuiTransactionBlockEvents {
     pub data: Vec<SuiEvent>,
 }
 
-impl SuiTransactionEvents {
+impl SuiTransactionBlockEvents {
     pub fn try_from(
         events: TransactionEvents,
         tx_digest: TransactionDigest,
@@ -686,9 +690,9 @@ pub struct DevInspectResults {
     /// Summary of effects that likely would be generated if the transaction is actually run.
     /// Note however, that not all dev-inspect transactions are actually usable as transactions so
     /// it might not be possible actually generate these effects from a normal transaction.
-    pub effects: SuiTransactionEffects,
+    pub effects: SuiTransactionBlockEffects,
     /// Events that likely would be generated if the transaction is actually run.
-    pub events: SuiTransactionEvents,
+    pub events: SuiTransactionBlockEvents,
     /// Execution results (including return values) from executing the transaction commands
     #[serde(skip_serializing_if = "Option::is_none")]
     pub results: Option<Vec<SuiExecutionResult>>,
@@ -750,7 +754,7 @@ impl DevInspectResults {
         };
         Ok(Self {
             effects: effects.try_into()?,
-            events: SuiTransactionEvents::try_from(events, tx_digest, None, resolver)?,
+            events: SuiTransactionBlockEvents::try_from(events, tx_digest, None, resolver)?,
             results,
             error,
         })
@@ -758,7 +762,7 @@ impl DevInspectResults {
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-pub enum SuiTransactionBuilderMode {
+pub enum SuiTransactionBlockBuilderMode {
     /// Regular Sui Transactions that are committed on chain
     Commit,
     /// Simulated transaction that allows calling any Move function with
@@ -859,33 +863,33 @@ pub struct SuiGasData {
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
-#[enum_dispatch(SuiTransactionDataAPI)]
+#[enum_dispatch(SuiTransactionBlockDataAPI)]
 #[serde(
     rename = "TransactionData",
     rename_all = "camelCase",
     tag = "messageVersion"
 )]
-pub enum SuiTransactionData {
-    V1(SuiTransactionDataV1),
+pub enum SuiTransactionBlockData {
+    V1(SuiTransactionBlockDataV1),
 }
 
 #[enum_dispatch]
-pub trait SuiTransactionDataAPI {
-    fn transaction(&self) -> &SuiTransactionKind;
+pub trait SuiTransactionBlockDataAPI {
+    fn transaction(&self) -> &SuiTransactionBlockKind;
     fn sender(&self) -> &SuiAddress;
     fn gas_data(&self) -> &SuiGasData;
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
 #[serde(rename = "TransactionDataV1", rename_all = "camelCase")]
-pub struct SuiTransactionDataV1 {
-    pub transaction: SuiTransactionKind,
+pub struct SuiTransactionBlockDataV1 {
+    pub transaction: SuiTransactionBlockKind,
     pub sender: SuiAddress,
     pub gas_data: SuiGasData,
 }
 
-impl SuiTransactionDataAPI for SuiTransactionDataV1 {
-    fn transaction(&self) -> &SuiTransactionKind {
+impl SuiTransactionBlockDataAPI for SuiTransactionBlockDataV1 {
+    fn transaction(&self) -> &SuiTransactionBlockKind {
         &self.transaction
     }
     fn sender(&self) -> &SuiAddress {
@@ -896,11 +900,11 @@ impl SuiTransactionDataAPI for SuiTransactionDataV1 {
     }
 }
 
-impl SuiTransactionData {
+impl SuiTransactionBlockData {
     pub fn move_calls(&self) -> Vec<&SuiProgrammableMoveCall> {
         match self {
             Self::V1(data) => match &data.transaction {
-                SuiTransactionKind::ProgrammableTransaction(pt) => pt
+                SuiTransactionBlockKind::ProgrammableTransaction(pt) => pt
                     .commands
                     .iter()
                     .filter_map(|command| match command {
@@ -914,7 +918,7 @@ impl SuiTransactionData {
     }
 }
 
-impl Display for SuiTransactionData {
+impl Display for SuiTransactionBlockData {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Self::V1(data) => {
@@ -933,7 +937,7 @@ impl Display for SuiTransactionData {
     }
 }
 
-impl SuiTransactionData {
+impl SuiTransactionBlockData {
     pub fn try_from(
         data: TransactionData,
         module_cache: &impl GetModule,
@@ -952,9 +956,9 @@ impl SuiTransactionData {
             price: data.gas_price(),
             budget: data.gas_budget(),
         };
-        let transaction = SuiTransactionKind::try_from(data.into_kind(), module_cache)?;
+        let transaction = SuiTransactionBlockKind::try_from(data.into_kind(), module_cache)?;
         match message_version {
-            1 => Ok(SuiTransactionData::V1(SuiTransactionDataV1 {
+            1 => Ok(SuiTransactionBlockData::V1(SuiTransactionBlockDataV1 {
                 transaction,
                 sender,
                 gas_data,
@@ -969,24 +973,27 @@ impl SuiTransactionData {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq)]
 #[serde(rename = "Transaction", rename_all = "camelCase")]
-pub struct SuiTransaction {
-    pub data: SuiTransactionData,
+pub struct SuiTransactionBlock {
+    pub data: SuiTransactionBlockData,
     pub tx_signatures: Vec<GenericSignature>,
 }
 
-impl SuiTransaction {
+impl SuiTransactionBlock {
     pub fn try_from(
         data: SenderSignedData,
         module_cache: &impl GetModule,
     ) -> Result<Self, anyhow::Error> {
         Ok(Self {
-            data: SuiTransactionData::try_from(data.intent_message().value.clone(), module_cache)?,
+            data: SuiTransactionBlockData::try_from(
+                data.intent_message().value.clone(),
+                module_cache,
+            )?,
             tx_signatures: data.tx_signatures().to_vec(),
         })
     }
 }
 
-impl Display for SuiTransaction {
+impl Display for SuiTransactionBlock {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut writer = String::new();
         writeln!(writer, "Transaction Signature: {:?}", self.tx_signatures)?;

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -264,7 +264,7 @@ pub enum SuiTransactionBlockKind {
     ConsensusCommitPrologue(SuiConsensusCommitPrologue),
     /// A series of commands where the results of one command can be used in future
     /// commands
-    ProgrammableTransaction(SuiProgrammableTransaction),
+    ProgrammableTransaction(SuiProgrammableTransactionBlock),
     // .. more transaction types go here
 }
 
@@ -321,7 +321,7 @@ impl SuiTransactionBlockKind {
                 })
             }
             TransactionKind::ProgrammableTransaction(p) => Self::ProgrammableTransaction(
-                SuiProgrammableTransaction::try_from(p, module_cache)?,
+                SuiProgrammableTransactionBlock::try_from(p, module_cache)?,
             ),
         })
     }
@@ -1047,7 +1047,7 @@ pub enum SuiInputObjectKind {
 /// A series of commands where the results of one command can be used in future
 /// commands
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
-pub struct SuiProgrammableTransaction {
+pub struct SuiProgrammableTransactionBlock {
     /// Input objects or primitive values
     pub inputs: Vec<SuiCallArg>,
     /// The commands to be executed sequentially. A failure in any command will
@@ -1055,7 +1055,7 @@ pub struct SuiProgrammableTransaction {
     pub commands: Vec<SuiCommand>,
 }
 
-impl Display for SuiProgrammableTransaction {
+impl Display for SuiProgrammableTransactionBlock {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let Self { inputs, commands } = self;
         writeln!(f, "Inputs: {inputs:?}")?;
@@ -1067,14 +1067,14 @@ impl Display for SuiProgrammableTransaction {
     }
 }
 
-impl SuiProgrammableTransaction {
+impl SuiProgrammableTransactionBlock {
     fn try_from(
         value: ProgrammableTransaction,
         module_cache: &impl GetModule,
     ) -> Result<Self, anyhow::Error> {
         let ProgrammableTransaction { inputs, commands } = value;
         let input_types = Self::resolve_input_type(&inputs, &commands, module_cache);
-        Ok(SuiProgrammableTransaction {
+        Ok(SuiProgrammableTransactionBlock {
             inputs: inputs
                 .into_iter()
                 .zip(input_types)

--- a/crates/sui-json-rpc/src/api/indexer.rs
+++ b/crates/sui-json-rpc/src/api/indexer.rs
@@ -6,7 +6,7 @@ use jsonrpsee_proc_macros::rpc;
 
 use sui_json_rpc_types::{
     CheckpointedObjectID, DynamicFieldPage, EventFilter, EventPage, ObjectsPage, SuiEvent,
-    SuiObjectResponse, SuiObjectResponseQuery, SuiTransactionResponseQuery, TransactionsPage,
+    SuiObjectResponse, SuiObjectResponseQuery, SuiTransactionBlockResponseQuery, TransactionsPage,
 };
 use sui_open_rpc_macros::open_rpc;
 use sui_types::base_types::{ObjectID, SuiAddress};
@@ -36,7 +36,7 @@ pub trait IndexerApi {
     async fn query_transaction_blocks(
         &self,
         /// the transaction query criteria.
-        query: SuiTransactionResponseQuery,
+        query: SuiTransactionBlockResponseQuery,
         /// An optional paging cursor. If provided, the query will start from the next item after the specified cursor. Default to start from the first item if not specified.
         cursor: Option<TransactionDigest>,
         /// Maximum item returned per page, default to QUERY_MAX_RESULT_LIMIT if not specified.

--- a/crates/sui-json-rpc/src/api/indexer.rs
+++ b/crates/sui-json-rpc/src/api/indexer.rs
@@ -6,7 +6,8 @@ use jsonrpsee_proc_macros::rpc;
 
 use sui_json_rpc_types::{
     CheckpointedObjectID, DynamicFieldPage, EventFilter, EventPage, ObjectsPage, SuiEvent,
-    SuiObjectResponse, SuiObjectResponseQuery, SuiTransactionBlockResponseQuery, TransactionsPage,
+    SuiObjectResponse, SuiObjectResponseQuery, SuiTransactionBlockResponseQuery,
+    TransactionBlocksPage,
 };
 use sui_open_rpc_macros::open_rpc;
 use sui_types::base_types::{ObjectID, SuiAddress};
@@ -43,7 +44,7 @@ pub trait IndexerApi {
         limit: Option<usize>,
         /// query result ordering, default to false (ascending order), oldest record first.
         descending_order: Option<bool>,
-    ) -> RpcResult<TransactionsPage>;
+    ) -> RpcResult<TransactionBlocksPage>;
 
     /// Return list of events for a specified query criteria.
     #[method(name = "queryEvents")]

--- a/crates/sui-json-rpc/src/api/read.rs
+++ b/crates/sui-json-rpc/src/api/read.rs
@@ -7,7 +7,7 @@ use jsonrpsee_proc_macros::rpc;
 use sui_json_rpc_types::{
     BigInt, Checkpoint, CheckpointId, CheckpointPage, SuiCheckpointSequenceNumber, SuiEvent,
     SuiGetPastObjectRequest, SuiObjectDataOptions, SuiObjectResponse, SuiPastObjectResponse,
-    SuiTransactionResponse, SuiTransactionResponseOptions,
+    SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions,
 };
 use sui_open_rpc_macros::open_rpc;
 use sui_types::base_types::{ObjectID, SequenceNumber, TransactionDigest};
@@ -22,8 +22,8 @@ pub trait ReadApi {
         /// the digest of the queried transaction
         digest: TransactionDigest,
         /// options for specifying the content to be returned
-        options: Option<SuiTransactionResponseOptions>,
-    ) -> RpcResult<SuiTransactionResponse>;
+        options: Option<SuiTransactionBlockResponseOptions>,
+    ) -> RpcResult<SuiTransactionBlockResponse>;
 
     /// Returns an ordered list of transaction responses
     /// The method will throw an error if the input contains any duplicate or
@@ -34,8 +34,8 @@ pub trait ReadApi {
         /// A list of transaction digests.
         digests: Vec<TransactionDigest>,
         /// config options to control which fields to fetch
-        options: Option<SuiTransactionResponseOptions>,
-    ) -> RpcResult<Vec<SuiTransactionResponse>>;
+        options: Option<SuiTransactionBlockResponseOptions>,
+    ) -> RpcResult<Vec<SuiTransactionBlockResponse>>;
 
     /// Return the object information for a specified object
     #[method(name = "getObject")]

--- a/crates/sui-json-rpc/src/api/transaction_builder.rs
+++ b/crates/sui-json-rpc/src/api/transaction_builder.rs
@@ -7,7 +7,8 @@ use jsonrpsee_proc_macros::rpc;
 
 use sui_json::SuiJsonValue;
 use sui_json_rpc_types::{
-    BigInt, RPCTransactionRequestParams, SuiTransactionBuilderMode, SuiTypeTag, TransactionBytes,
+    BigInt, RPCTransactionRequestParams, SuiTransactionBlockBuilderMode, SuiTypeTag,
+    TransactionBytes,
 };
 
 use sui_open_rpc_macros::open_rpc;
@@ -134,8 +135,8 @@ pub trait TransactionBuilder {
         gas: Option<ObjectID>,
         /// the gas budget, the transaction will fail if the gas cost exceed the budget
         gas_budget: u64,
-        /// Whether this is a Normal transaction or a Dev Inspect Transaction. Default to be `SuiTransactionBuilderMode::Commit` when it's None.
-        execution_mode: Option<SuiTransactionBuilderMode>,
+        /// Whether this is a Normal transaction or a Dev Inspect Transaction. Default to be `SuiTransactionBlockBuilderMode::Commit` when it's None.
+        execution_mode: Option<SuiTransactionBlockBuilderMode>,
     ) -> RpcResult<TransactionBytes>;
 
     /// Create an unsigned transaction to publish a Move package.
@@ -215,7 +216,7 @@ pub trait TransactionBuilder {
         /// the gas budget, the transaction will fail if the gas cost exceed the budget
         gas_budget: u64,
         /// Whether this is a regular transaction or a Dev Inspect Transaction
-        txn_builder_mode: Option<SuiTransactionBuilderMode>,
+        txn_builder_mode: Option<SuiTransactionBlockBuilderMode>,
     ) -> RpcResult<TransactionBytes>;
 
     /// Add stake to a validator's staking pool using multiple coins and amount.

--- a/crates/sui-json-rpc/src/api/transaction_builder.rs
+++ b/crates/sui-json-rpc/src/api/transaction_builder.rs
@@ -8,7 +8,7 @@ use jsonrpsee_proc_macros::rpc;
 use sui_json::SuiJsonValue;
 use sui_json_rpc_types::{
     BigInt, RPCTransactionRequestParams, SuiTransactionBlockBuilderMode, SuiTypeTag,
-    TransactionBytes,
+    TransactionBlockBytes,
 };
 
 use sui_open_rpc_macros::open_rpc;
@@ -32,7 +32,7 @@ pub trait TransactionBuilder {
         gas_budget: u64,
         /// the recipient's Sui address
         recipient: SuiAddress,
-    ) -> RpcResult<TransactionBytes>;
+    ) -> RpcResult<TransactionBlockBytes>;
 
     /// Create an unsigned transaction to send SUI coin object to a Sui address. The SUI object is also used as the gas object.
     #[method(name = "transferSui")]
@@ -48,7 +48,7 @@ pub trait TransactionBuilder {
         recipient: SuiAddress,
         /// the amount to be split out and transferred
         amount: Option<u64>,
-    ) -> RpcResult<TransactionBytes>;
+    ) -> RpcResult<TransactionBlockBytes>;
 
     /// Send `Coin<T>` to a list of addresses, where `T` can be any coin type, following a list of amounts,
     /// The object specified in the `gas` field will be used to pay the gas fee for the transaction.
@@ -69,7 +69,7 @@ pub trait TransactionBuilder {
         gas: Option<ObjectID>,
         /// the gas budget, the transaction will fail if the gas cost exceed the budget
         gas_budget: u64,
-    ) -> RpcResult<TransactionBytes>;
+    ) -> RpcResult<TransactionBlockBytes>;
 
     /// Send SUI coins to a list of addresses, following a list of amounts.
     /// This is for SUI coin only and does not require a separate gas coin object.
@@ -93,7 +93,7 @@ pub trait TransactionBuilder {
         amounts: Vec<BigInt>,
         /// the gas budget, the transaction will fail if the gas cost exceed the budget
         gas_budget: u64,
-    ) -> RpcResult<TransactionBytes>;
+    ) -> RpcResult<TransactionBlockBytes>;
 
     /// Send all SUI coins to one recipient.
     /// This is for SUI coin only and does not require a separate gas coin object.
@@ -113,7 +113,7 @@ pub trait TransactionBuilder {
         recipient: SuiAddress,
         /// the gas budget, the transaction will fail if the gas cost exceed the budget
         gas_budget: u64,
-    ) -> RpcResult<TransactionBytes>;
+    ) -> RpcResult<TransactionBlockBytes>;
 
     /// Create an unsigned transaction to execute a Move call on the network, by calling the specified function in the module of a given package.
     #[method(name = "moveCall")]
@@ -137,7 +137,7 @@ pub trait TransactionBuilder {
         gas_budget: u64,
         /// Whether this is a Normal transaction or a Dev Inspect Transaction. Default to be `SuiTransactionBlockBuilderMode::Commit` when it's None.
         execution_mode: Option<SuiTransactionBlockBuilderMode>,
-    ) -> RpcResult<TransactionBytes>;
+    ) -> RpcResult<TransactionBlockBytes>;
 
     /// Create an unsigned transaction to publish a Move package.
     #[method(name = "publish")]
@@ -153,7 +153,7 @@ pub trait TransactionBuilder {
         gas: Option<ObjectID>,
         /// the gas budget, the transaction will fail if the gas cost exceed the budget
         gas_budget: u64,
-    ) -> RpcResult<TransactionBytes>;
+    ) -> RpcResult<TransactionBlockBytes>;
 
     /// Create an unsigned transaction to split a coin object into multiple coins.
     #[method(name = "splitCoin")]
@@ -169,7 +169,7 @@ pub trait TransactionBuilder {
         gas: Option<ObjectID>,
         /// the gas budget, the transaction will fail if the gas cost exceed the budget
         gas_budget: u64,
-    ) -> RpcResult<TransactionBytes>;
+    ) -> RpcResult<TransactionBlockBytes>;
 
     /// Create an unsigned transaction to split a coin object into multiple equal-size coins.
     #[method(name = "splitCoinEqual")]
@@ -185,7 +185,7 @@ pub trait TransactionBuilder {
         gas: Option<ObjectID>,
         /// the gas budget, the transaction will fail if the gas cost exceed the budget
         gas_budget: u64,
-    ) -> RpcResult<TransactionBytes>;
+    ) -> RpcResult<TransactionBlockBytes>;
 
     /// Create an unsigned transaction to merge multiple coins into one coin.
     #[method(name = "mergeCoins")]
@@ -201,7 +201,7 @@ pub trait TransactionBuilder {
         gas: Option<ObjectID>,
         /// the gas budget, the transaction will fail if the gas cost exceed the budget
         gas_budget: u64,
-    ) -> RpcResult<TransactionBytes>;
+    ) -> RpcResult<TransactionBlockBytes>;
 
     /// Create an unsigned batched transaction.
     #[method(name = "batchTransaction")]
@@ -217,7 +217,7 @@ pub trait TransactionBuilder {
         gas_budget: u64,
         /// Whether this is a regular transaction or a Dev Inspect Transaction
         txn_builder_mode: Option<SuiTransactionBlockBuilderMode>,
-    ) -> RpcResult<TransactionBytes>;
+    ) -> RpcResult<TransactionBlockBytes>;
 
     /// Add stake to a validator's staking pool using multiple coins and amount.
     #[method(name = "requestAddStake")]
@@ -235,7 +235,7 @@ pub trait TransactionBuilder {
         gas: Option<ObjectID>,
         /// the gas budget, the transaction will fail if the gas cost exceed the budget
         gas_budget: u64,
-    ) -> RpcResult<TransactionBytes>;
+    ) -> RpcResult<TransactionBlockBytes>;
 
     /// Withdraw stake from a validator's staking pool.
     #[method(name = "requestWithdrawStake")]
@@ -249,5 +249,5 @@ pub trait TransactionBuilder {
         gas: Option<ObjectID>,
         /// the gas budget, the transaction will fail if the gas cost exceed the budget
         gas_budget: u64,
-    ) -> RpcResult<TransactionBytes>;
+    ) -> RpcResult<TransactionBlockBytes>;
 }

--- a/crates/sui-json-rpc/src/api/write.rs
+++ b/crates/sui-json-rpc/src/api/write.rs
@@ -5,8 +5,8 @@ use fastcrypto::encoding::Base64;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee_proc_macros::rpc;
 use sui_json_rpc_types::{
-    BigInt, DevInspectResults, DryRunTransactionResponse, SuiTransactionResponse,
-    SuiTransactionResponseOptions,
+    BigInt, DevInspectResults, DryRunTransactionResponse, SuiTransactionBlockResponse,
+    SuiTransactionBlockResponseOptions,
 };
 
 use sui_open_rpc_macros::open_rpc;
@@ -34,10 +34,10 @@ pub trait WriteApi {
         /// A list of signatures (`flag || signature || pubkey` bytes, as base-64 encoded string). Signature is committed to the intent message of the transaction data, as base-64 encoded string.
         signatures: Vec<Base64>,
         /// options for specifying the content to be returned
-        options: Option<SuiTransactionResponseOptions>,
-        /// The request type, derived from `SuiTransactionResponseOptions` if None
+        options: Option<SuiTransactionBlockResponseOptions>,
+        /// The request type, derived from `SuiTransactionBlockResponseOptions` if None
         request_type: Option<ExecuteTransactionRequestType>,
-    ) -> RpcResult<SuiTransactionResponse>;
+    ) -> RpcResult<SuiTransactionBlockResponse>;
 
     /// Runs the transaction in dev-inspect mode. Which allows for nearly any
     /// transaction (or Move call) with any arguments. Detailed results are

--- a/crates/sui-json-rpc/src/indexer_api.rs
+++ b/crates/sui-json-rpc/src/indexer_api.rs
@@ -18,7 +18,7 @@ use sui_core::authority::AuthorityState;
 use sui_json_rpc_types::{
     CheckpointedObjectID, DynamicFieldPage, EventFilter, EventPage, ObjectsPage, Page,
     SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery, SuiTransactionBlockResponse,
-    SuiTransactionBlockResponseQuery, TransactionsPage,
+    SuiTransactionBlockResponseQuery, TransactionBlocksPage,
 };
 use sui_open_rpc::Module;
 use sui_types::base_types::{ObjectID, SuiAddress};
@@ -131,7 +131,7 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
         cursor: Option<TransactionDigest>,
         limit: Option<usize>,
         descending_order: Option<bool>,
-    ) -> RpcResult<TransactionsPage> {
+    ) -> RpcResult<TransactionBlocksPage> {
         let limit = cap_page_limit(limit);
         let descending = descending_order.unwrap_or_default();
         let opts = query.options.unwrap_or_default();

--- a/crates/sui-json-rpc/src/indexer_api.rs
+++ b/crates/sui-json-rpc/src/indexer_api.rs
@@ -17,8 +17,8 @@ use mysten_metrics::spawn_monitored_task;
 use sui_core::authority::AuthorityState;
 use sui_json_rpc_types::{
     CheckpointedObjectID, DynamicFieldPage, EventFilter, EventPage, ObjectsPage, Page,
-    SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery, SuiTransactionResponse,
-    SuiTransactionResponseQuery, TransactionsPage,
+    SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery, SuiTransactionBlockResponse,
+    SuiTransactionBlockResponseQuery, TransactionsPage,
 };
 use sui_open_rpc::Module;
 use sui_types::base_types::{ObjectID, SuiAddress};
@@ -126,7 +126,7 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
 
     async fn query_transaction_blocks(
         &self,
-        query: SuiTransactionResponseQuery,
+        query: SuiTransactionBlockResponseQuery,
         // If `Some`, the query will start from the next item after the specified cursor
         cursor: Option<TransactionDigest>,
         limit: Option<usize>,
@@ -146,10 +146,10 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
         digests.truncate(limit);
         let next_cursor = digests.last().cloned().map_or(cursor, Some);
 
-        let data: Vec<SuiTransactionResponse> = if opts.only_digest() {
+        let data: Vec<SuiTransactionBlockResponse> = if opts.only_digest() {
             digests
                 .into_iter()
-                .map(SuiTransactionResponse::new)
+                .map(SuiTransactionBlockResponse::new)
                 .collect()
         } else {
             self.read_api

--- a/crates/sui-json-rpc/src/transaction_builder_api.rs
+++ b/crates/sui-json-rpc/src/transaction_builder_api.rs
@@ -14,7 +14,7 @@ use sui_core::authority::AuthorityState;
 use sui_json::SuiJsonValue;
 use sui_json_rpc_types::{
     BigInt, SuiObjectDataOptions, SuiObjectResponse, SuiTransactionBlockBuilderMode, SuiTypeTag,
-    TransactionBytes,
+    TransactionBlockBytes,
 };
 use sui_json_rpc_types::{RPCTransactionRequestParams, SuiObjectDataFilter};
 use sui_open_rpc::Module;
@@ -93,12 +93,12 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         gas: Option<ObjectID>,
         gas_budget: u64,
         recipient: SuiAddress,
-    ) -> RpcResult<TransactionBytes> {
+    ) -> RpcResult<TransactionBlockBytes> {
         let data = self
             .builder
             .transfer_object(signer, object_id, gas, gas_budget, recipient)
             .await?;
-        Ok(TransactionBytes::from_data(data)?)
+        Ok(TransactionBlockBytes::from_data(data)?)
     }
 
     async fn transfer_sui(
@@ -108,12 +108,12 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         gas_budget: u64,
         recipient: SuiAddress,
         amount: Option<u64>,
-    ) -> RpcResult<TransactionBytes> {
+    ) -> RpcResult<TransactionBlockBytes> {
         let data = self
             .builder
             .transfer_sui(signer, sui_object_id, gas_budget, recipient, amount)
             .await?;
-        Ok(TransactionBytes::from_data(data)?)
+        Ok(TransactionBlockBytes::from_data(data)?)
     }
 
     async fn pay(
@@ -124,7 +124,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         amounts: Vec<BigInt>,
         gas: Option<ObjectID>,
         gas_budget: u64,
-    ) -> RpcResult<TransactionBytes> {
+    ) -> RpcResult<TransactionBlockBytes> {
         let data = self
             .builder
             .pay(
@@ -136,7 +136,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
                 gas_budget,
             )
             .await?;
-        Ok(TransactionBytes::from_data(data)?)
+        Ok(TransactionBlockBytes::from_data(data)?)
     }
 
     async fn pay_sui(
@@ -146,7 +146,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         recipients: Vec<SuiAddress>,
         amounts: Vec<BigInt>,
         gas_budget: u64,
-    ) -> RpcResult<TransactionBytes> {
+    ) -> RpcResult<TransactionBlockBytes> {
         let data = self
             .builder
             .pay_sui(
@@ -157,7 +157,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
                 gas_budget,
             )
             .await?;
-        Ok(TransactionBytes::from_data(data)?)
+        Ok(TransactionBlockBytes::from_data(data)?)
     }
 
     async fn pay_all_sui(
@@ -166,12 +166,12 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         input_coins: Vec<ObjectID>,
         recipient: SuiAddress,
         gas_budget: u64,
-    ) -> RpcResult<TransactionBytes> {
+    ) -> RpcResult<TransactionBlockBytes> {
         let data = self
             .builder
             .pay_all_sui(signer, input_coins, recipient, gas_budget)
             .await?;
-        Ok(TransactionBytes::from_data(data)?)
+        Ok(TransactionBlockBytes::from_data(data)?)
     }
 
     async fn publish(
@@ -181,7 +181,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         dependencies: Vec<ObjectID>,
         gas: Option<ObjectID>,
         gas_budget: u64,
-    ) -> RpcResult<TransactionBytes> {
+    ) -> RpcResult<TransactionBlockBytes> {
         let compiled_modules = compiled_modules
             .into_iter()
             .map(|data| data.to_vec().map_err(|e| anyhow::anyhow!(e)))
@@ -190,7 +190,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
             .builder
             .publish(sender, compiled_modules, dependencies, gas, gas_budget)
             .await?;
-        Ok(TransactionBytes::from_data(data)?)
+        Ok(TransactionBlockBytes::from_data(data)?)
     }
 
     async fn split_coin(
@@ -200,12 +200,12 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         split_amounts: Vec<u64>,
         gas: Option<ObjectID>,
         gas_budget: u64,
-    ) -> RpcResult<TransactionBytes> {
+    ) -> RpcResult<TransactionBlockBytes> {
         let data = self
             .builder
             .split_coin(signer, coin_object_id, split_amounts, gas, gas_budget)
             .await?;
-        Ok(TransactionBytes::from_data(data)?)
+        Ok(TransactionBlockBytes::from_data(data)?)
     }
 
     async fn split_coin_equal(
@@ -215,12 +215,12 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         split_count: u64,
         gas: Option<ObjectID>,
         gas_budget: u64,
-    ) -> RpcResult<TransactionBytes> {
+    ) -> RpcResult<TransactionBlockBytes> {
         let data = self
             .builder
             .split_coin_equal(signer, coin_object_id, split_count, gas, gas_budget)
             .await?;
-        Ok(TransactionBytes::from_data(data)?)
+        Ok(TransactionBlockBytes::from_data(data)?)
     }
 
     async fn merge_coin(
@@ -230,12 +230,12 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         coin_to_merge: ObjectID,
         gas: Option<ObjectID>,
         gas_budget: u64,
-    ) -> RpcResult<TransactionBytes> {
+    ) -> RpcResult<TransactionBlockBytes> {
         let data = self
             .builder
             .merge_coins(signer, primary_coin, coin_to_merge, gas, gas_budget)
             .await?;
-        Ok(TransactionBytes::from_data(data)?)
+        Ok(TransactionBlockBytes::from_data(data)?)
     }
 
     async fn move_call(
@@ -249,7 +249,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         gas: Option<ObjectID>,
         gas_budget: u64,
         txn_builder_mode: Option<SuiTransactionBlockBuilderMode>,
-    ) -> RpcResult<TransactionBytes> {
+    ) -> RpcResult<TransactionBlockBytes> {
         let mode = txn_builder_mode.unwrap_or(SuiTransactionBlockBuilderMode::Commit);
         let data: TransactionData = match mode {
             SuiTransactionBlockBuilderMode::DevInspect => {
@@ -281,7 +281,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
                     .await?
             }
         };
-        Ok(TransactionBytes::from_data(data)?)
+        Ok(TransactionBlockBytes::from_data(data)?)
     }
 
     async fn batch_transaction(
@@ -291,7 +291,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         gas: Option<ObjectID>,
         gas_budget: u64,
         txn_builder_mode: Option<SuiTransactionBlockBuilderMode>,
-    ) -> RpcResult<TransactionBytes> {
+    ) -> RpcResult<TransactionBlockBytes> {
         let mode = txn_builder_mode.unwrap_or(SuiTransactionBlockBuilderMode::Commit);
         let data = match mode {
             SuiTransactionBlockBuilderMode::DevInspect => {
@@ -305,7 +305,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
                     .await?
             }
         };
-        Ok(TransactionBytes::from_data(data)?)
+        Ok(TransactionBlockBytes::from_data(data)?)
     }
 
     async fn request_add_stake(
@@ -316,8 +316,8 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         validator: SuiAddress,
         gas: Option<ObjectID>,
         gas_budget: u64,
-    ) -> RpcResult<TransactionBytes> {
-        Ok(TransactionBytes::from_data(
+    ) -> RpcResult<TransactionBlockBytes> {
+        Ok(TransactionBlockBytes::from_data(
             self.builder
                 .request_add_stake(signer, coins, amount, validator, gas, gas_budget)
                 .await?,
@@ -330,8 +330,8 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         staked_sui: ObjectID,
         gas: Option<ObjectID>,
         gas_budget: u64,
-    ) -> RpcResult<TransactionBytes> {
-        Ok(TransactionBytes::from_data(
+    ) -> RpcResult<TransactionBlockBytes> {
+        Ok(TransactionBlockBytes::from_data(
             self.builder
                 .request_withdraw_stake(signer, staked_sui, gas, gas_budget)
                 .await?,

--- a/crates/sui-json-rpc/src/transaction_builder_api.rs
+++ b/crates/sui-json-rpc/src/transaction_builder_api.rs
@@ -13,7 +13,7 @@ use sui_adapter::execution_mode::{DevInspect, Normal};
 use sui_core::authority::AuthorityState;
 use sui_json::SuiJsonValue;
 use sui_json_rpc_types::{
-    BigInt, SuiObjectDataOptions, SuiObjectResponse, SuiTransactionBuilderMode, SuiTypeTag,
+    BigInt, SuiObjectDataOptions, SuiObjectResponse, SuiTransactionBlockBuilderMode, SuiTypeTag,
     TransactionBytes,
 };
 use sui_json_rpc_types::{RPCTransactionRequestParams, SuiObjectDataFilter};
@@ -248,11 +248,11 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         rpc_arguments: Vec<SuiJsonValue>,
         gas: Option<ObjectID>,
         gas_budget: u64,
-        txn_builder_mode: Option<SuiTransactionBuilderMode>,
+        txn_builder_mode: Option<SuiTransactionBlockBuilderMode>,
     ) -> RpcResult<TransactionBytes> {
-        let mode = txn_builder_mode.unwrap_or(SuiTransactionBuilderMode::Commit);
+        let mode = txn_builder_mode.unwrap_or(SuiTransactionBlockBuilderMode::Commit);
         let data: TransactionData = match mode {
-            SuiTransactionBuilderMode::DevInspect => {
+            SuiTransactionBlockBuilderMode::DevInspect => {
                 self.dev_inspect_builder
                     .move_call(
                         signer,
@@ -266,7 +266,7 @@ impl TransactionBuilderServer for TransactionBuilderApi {
                     )
                     .await?
             }
-            SuiTransactionBuilderMode::Commit => {
+            SuiTransactionBlockBuilderMode::Commit => {
                 self.builder
                     .move_call(
                         signer,
@@ -290,16 +290,16 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         params: Vec<RPCTransactionRequestParams>,
         gas: Option<ObjectID>,
         gas_budget: u64,
-        txn_builder_mode: Option<SuiTransactionBuilderMode>,
+        txn_builder_mode: Option<SuiTransactionBlockBuilderMode>,
     ) -> RpcResult<TransactionBytes> {
-        let mode = txn_builder_mode.unwrap_or(SuiTransactionBuilderMode::Commit);
+        let mode = txn_builder_mode.unwrap_or(SuiTransactionBlockBuilderMode::Commit);
         let data = match mode {
-            SuiTransactionBuilderMode::DevInspect => {
+            SuiTransactionBlockBuilderMode::DevInspect => {
                 self.dev_inspect_builder
                     .batch_transaction(signer, params, gas, gas_budget)
                     .await?
             }
-            SuiTransactionBuilderMode::Commit => {
+            SuiTransactionBlockBuilderMode::Commit => {
                 self.builder
                     .batch_transaction(signer, params, gas, gas_budget)
                     .await?

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -18,8 +18,8 @@ use sui_json_rpc_types::ObjectChange;
 use sui_json_rpc_types::ObjectsPage;
 use sui_json_rpc_types::{
     Balance, CoinPage, DelegatedStake, StakeStatus, SuiCoinMetadata, SuiExecutionStatus,
-    SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery, SuiTransactionEffectsAPI,
-    SuiTransactionResponse, SuiTransactionResponseOptions, TransactionBytes,
+    SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery, SuiTransactionBlockEffectsAPI,
+    SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions, TransactionBytes,
 };
 use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use sui_macros::sim_test;
@@ -115,12 +115,12 @@ async fn test_public_transfer_object() -> Result<(), anyhow::Error> {
     let tx_bytes1 = tx_bytes.clone();
     let dryrun_response = http_client.dry_run_transaction_block(tx_bytes).await?;
 
-    let tx_response: SuiTransactionResponse = http_client
+    let tx_response: SuiTransactionBlockResponse = http_client
         .execute_transaction_block(
             tx_bytes1,
             signatures,
             Some(
-                SuiTransactionResponseOptions::new()
+                SuiTransactionBlockResponseOptions::new()
                     .with_effects()
                     .with_object_changes(),
             ),
@@ -128,7 +128,7 @@ async fn test_public_transfer_object() -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let SuiTransactionResponse {
+    let SuiTransactionBlockResponse {
         effects,
         object_changes,
         ..
@@ -187,11 +187,11 @@ async fn test_publish() -> Result<(), anyhow::Error> {
         .execute_transaction_block(
             tx_bytes,
             signatures,
-            Some(SuiTransactionResponseOptions::new().with_effects()),
+            Some(SuiTransactionBlockResponseOptions::new().with_effects()),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await?;
-    matches!(tx_response, SuiTransactionResponse {effects, ..} if effects.as_ref().unwrap().created().len() == 6);
+    matches!(tx_response, SuiTransactionBlockResponse {effects, ..} if effects.as_ref().unwrap().created().len() == 6);
     Ok(())
 }
 
@@ -248,11 +248,11 @@ async fn test_move_call() -> Result<(), anyhow::Error> {
         .execute_transaction_block(
             tx_bytes,
             signatures,
-            Some(SuiTransactionResponseOptions::new().with_effects()),
+            Some(SuiTransactionBlockResponseOptions::new().with_effects()),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await?;
-    matches!(tx_response, SuiTransactionResponse {effects, ..} if effects.as_ref().unwrap().created().len() == 1);
+    matches!(tx_response, SuiTransactionBlockResponse {effects, ..} if effects.as_ref().unwrap().created().len() == 1);
     Ok(())
 }
 
@@ -436,7 +436,7 @@ async fn test_get_metadata() -> Result<(), anyhow::Error> {
             tx_bytes,
             signatures,
             Some(
-                SuiTransactionResponseOptions::new()
+                SuiTransactionBlockResponseOptions::new()
                     .with_object_changes()
                     .with_events(),
             ),
@@ -513,12 +513,12 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
     let tx = to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
     let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
-    let tx_response: SuiTransactionResponse = http_client
+    let tx_response: SuiTransactionBlockResponse = http_client
         .execute_transaction_block(
             tx_bytes,
             signatures,
             Some(
-                SuiTransactionResponseOptions::new()
+                SuiTransactionBlockResponseOptions::new()
                     .with_object_changes()
                     .with_events(),
             ),
@@ -589,12 +589,12 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
         .execute_transaction_block(
             tx_bytes,
             signatures,
-            Some(SuiTransactionResponseOptions::new().with_effects()),
+            Some(SuiTransactionBlockResponseOptions::new().with_effects()),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await?;
 
-    let SuiTransactionResponse { effects, .. } = tx_response;
+    let SuiTransactionBlockResponse { effects, .. } = tx_response;
 
     assert_eq!(SuiExecutionStatus::Success, *effects.unwrap().status());
 
@@ -651,7 +651,7 @@ async fn test_staking() -> Result<(), anyhow::Error> {
         .execute_transaction_block(
             tx_bytes,
             signatures,
-            Some(SuiTransactionResponseOptions::new()),
+            Some(SuiTransactionBlockResponseOptions::new()),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await?;
@@ -720,7 +720,7 @@ async fn test_unstaking() -> Result<(), anyhow::Error> {
             .execute_transaction_block(
                 tx_bytes,
                 signatures,
-                Some(SuiTransactionResponseOptions::new()),
+                Some(SuiTransactionBlockResponseOptions::new()),
                 Some(ExecuteTransactionRequestType::WaitForLocalExecution),
             )
             .await?;
@@ -777,7 +777,7 @@ async fn test_unstaking() -> Result<(), anyhow::Error> {
         .execute_transaction_block(
             tx_bytes,
             signatures,
-            Some(SuiTransactionResponseOptions::new()),
+            Some(SuiTransactionBlockResponseOptions::new()),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await?;
@@ -861,7 +861,7 @@ async fn test_staking_multiple_coins() -> Result<(), anyhow::Error> {
         .execute_transaction_block(
             tx_bytes,
             signatures,
-            Some(SuiTransactionResponseOptions::new().with_balance_changes()),
+            Some(SuiTransactionBlockResponseOptions::new().with_balance_changes()),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await?;

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -19,7 +19,7 @@ use sui_json_rpc_types::ObjectsPage;
 use sui_json_rpc_types::{
     Balance, CoinPage, DelegatedStake, StakeStatus, SuiCoinMetadata, SuiExecutionStatus,
     SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery, SuiTransactionBlockEffectsAPI,
-    SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions, TransactionBytes,
+    SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions, TransactionBlockBytes,
 };
 use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use sui_macros::sim_test;
@@ -104,7 +104,7 @@ async fn test_public_transfer_object() -> Result<(), anyhow::Error> {
     let obj = objects.clone().first().unwrap().object().unwrap().object_id;
     let gas = objects.clone().last().unwrap().object().unwrap().object_id;
 
-    let transaction_bytes: TransactionBytes = http_client
+    let transaction_bytes: TransactionBlockBytes = http_client
         .transfer_object(*address, obj, Some(gas), 1000, *address)
         .await?;
 
@@ -168,7 +168,7 @@ async fn test_publish() -> Result<(), anyhow::Error> {
         compiled_package.get_package_base64(/* with_unpublished_deps */ false);
     let dependencies = compiled_package.get_dependency_original_package_ids();
 
-    let transaction_bytes: TransactionBytes = http_client
+    let transaction_bytes: TransactionBlockBytes = http_client
         .publish(
             *address,
             compiled_modules_bytes,
@@ -224,7 +224,7 @@ async fn test_move_call() -> Result<(), anyhow::Error> {
     let module = "pay".to_string();
     let function = "split".to_string();
 
-    let transaction_bytes: TransactionBytes = http_client
+    let transaction_bytes: TransactionBlockBytes = http_client
         .move_call(
             *address,
             package_id,
@@ -416,7 +416,7 @@ async fn test_get_metadata() -> Result<(), anyhow::Error> {
         compiled_package.get_package_base64(/* with_unpublished_deps */ false);
     let dependencies = compiled_package.get_dependency_original_package_ids();
 
-    let transaction_bytes: TransactionBytes = http_client
+    let transaction_bytes: TransactionBlockBytes = http_client
         .publish(
             *address,
             compiled_modules_bytes,
@@ -498,7 +498,7 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
         compiled_package.get_package_base64(/* with_unpublished_deps */ false);
     let dependencies = compiled_package.get_dependency_original_package_ids();
 
-    let transaction_bytes: TransactionBytes = http_client
+    let transaction_bytes: TransactionBlockBytes = http_client
         .publish(
             *address,
             compiled_modules_bytes,
@@ -566,7 +566,7 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
 
     // Mint 100000 coin
 
-    let transaction_bytes: TransactionBytes = http_client
+    let transaction_bytes: TransactionBlockBytes = http_client
         .move_call(
             *address,
             SUI_FRAMEWORK_ADDRESS.into(),
@@ -638,7 +638,7 @@ async fn test_staking() -> Result<(), anyhow::Error> {
 
     let coin = objects.data[0].object()?.object_id;
     // Delegate some SUI
-    let transaction_bytes: TransactionBytes = http_client
+    let transaction_bytes: TransactionBlockBytes = http_client
         .request_add_stake(*address, vec![coin], Some(1000000), validator, None, 10000)
         .await?;
     let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);
@@ -699,7 +699,7 @@ async fn test_unstaking() -> Result<(), anyhow::Error> {
 
     // Delegate some SUI
     for i in 0..3 {
-        let transaction_bytes: TransactionBytes = http_client
+        let transaction_bytes: TransactionBlockBytes = http_client
             .request_add_stake(
                 *address,
                 vec![coins.data[i].coin_object_id],
@@ -759,7 +759,7 @@ async fn test_unstaking() -> Result<(), anyhow::Error> {
         }
     ));
 
-    let transaction_bytes: TransactionBytes = http_client
+    let transaction_bytes: TransactionBlockBytes = http_client
         .request_withdraw_stake(
             *address,
             staked_sui_copy[0].stakes[2].staked_sui_id,
@@ -833,7 +833,7 @@ async fn test_staking_multiple_coins() -> Result<(), anyhow::Error> {
         .active_validators[0]
         .sui_address;
     // Delegate some SUI
-    let transaction_bytes: TransactionBytes = http_client
+    let transaction_bytes: TransactionBlockBytes = http_client
         .request_add_stake(
             *address,
             vec![

--- a/crates/sui-json-rpc/src/unit_tests/transaction_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/transaction_tests.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use sui_config::SUI_KEYSTORE_FILENAME;
-use sui_json_rpc_types::SuiTransactionResponseQuery;
+use sui_json_rpc_types::SuiTransactionBlockResponseQuery;
 use sui_json_rpc_types::{
-    SuiObjectDataOptions, SuiObjectResponseQuery, SuiTransactionResponse,
-    SuiTransactionResponseOptions, TransactionBytes,
+    SuiObjectDataOptions, SuiObjectResponseQuery, SuiTransactionBlockResponse,
+    SuiTransactionBlockResponseOptions, TransactionBytes,
 };
 use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use sui_macros::sim_test;
@@ -39,7 +39,7 @@ async fn test_get_transaction_block() -> Result<(), anyhow::Error> {
     let gas_id = objects.last().unwrap().object().unwrap().object_id;
 
     // Make some transactions
-    let mut tx_responses: Vec<SuiTransactionResponse> = Vec::new();
+    let mut tx_responses: Vec<SuiTransactionBlockResponse> = Vec::new();
     for obj in &objects[..objects.len() - 1] {
         let oref = obj.object().unwrap();
         let transaction_bytes: TransactionBytes = http_client
@@ -56,7 +56,7 @@ async fn test_get_transaction_block() -> Result<(), anyhow::Error> {
             .execute_transaction_block(
                 tx_bytes,
                 signatures,
-                Some(SuiTransactionResponseOptions::new()),
+                Some(SuiTransactionBlockResponseOptions::new()),
                 Some(ExecuteTransactionRequestType::WaitForLocalExecution),
             )
             .await?;
@@ -66,8 +66,8 @@ async fn test_get_transaction_block() -> Result<(), anyhow::Error> {
 
     // TODO(chris): re-enable after rewriting get_transactions_in_range_deprecated with query_transactions
     // test get_transaction_batch
-    // let batch_responses: Vec<SuiTransactionResponse> = http_client
-    //     .multi_get_transaction_blocks(tx, Some(SuiTransactionResponseOptions::new()))
+    // let batch_responses: Vec<SuiTransactionBlockResponse> = http_client
+    //     .multi_get_transaction_blocks(tx, Some(SuiTransactionBlockResponseOptions::new()))
     //     .await?;
 
     // assert_eq!(5, batch_responses.len());
@@ -75,19 +75,19 @@ async fn test_get_transaction_block() -> Result<(), anyhow::Error> {
     // for r in batch_responses.iter().skip(1) {
     //     assert!(tx_responses
     //         .iter()
-    //         .any(|resp| matches!(resp, SuiTransactionResponse {digest, ..} if *digest == r.digest)))
+    //         .any(|resp| matches!(resp, SuiTransactionBlockResponse {digest, ..} if *digest == r.digest)))
     // }
 
     // // test get_transaction
     // for tx_digest in tx {
-    //     let response: SuiTransactionResponse = http_client
+    //     let response: SuiTransactionBlockResponse = http_client
     //         .get_transaction_block(
     //             tx_digest,
-    //             Some(SuiTransactionResponseOptions::new().with_raw_input()),
+    //             Some(SuiTransactionBlockResponseOptions::new().with_raw_input()),
     //         )
     //         .await?;
     //     assert!(tx_responses.iter().any(
-    //         |resp| matches!(resp, SuiTransactionResponse {digest, ..} if *digest == response.digest)
+    //         |resp| matches!(resp, SuiTransactionBlockResponse {digest, ..} if *digest == response.digest)
     //     ));
     //     let sender_signed_data: SenderSignedData =
     //         bcs::from_bytes(&response.raw_transaction).unwrap();
@@ -131,7 +131,7 @@ async fn test_get_raw_transaction() -> Result<(), anyhow::Error> {
         .execute_transaction_block(
             tx_bytes,
             signatures,
-            Some(SuiTransactionResponseOptions::new().with_raw_input()),
+            Some(SuiTransactionBlockResponseOptions::new().with_raw_input()),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await?;
@@ -153,7 +153,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
 
     let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);
     let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path).unwrap());
-    let mut tx_responses: Vec<SuiTransactionResponse> = Vec::new();
+    let mut tx_responses: Vec<SuiTransactionBlockResponse> = Vec::new();
 
     let client = context.get_client().await.unwrap();
 
@@ -188,7 +188,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
                 .quorum_driver()
                 .execute_transaction_block(
                     tx,
-                    SuiTransactionResponseOptions::new(),
+                    SuiTransactionBlockResponseOptions::new(),
                     Some(ExecuteTransactionRequestType::WaitForLocalExecution),
                 )
                 .await
@@ -201,7 +201,12 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
     // test get_recent_transactions with smaller range
     let tx = client
         .read_api()
-        .query_transaction_blocks(SuiTransactionResponseQuery::default(), None, Some(3), true)
+        .query_transaction_blocks(
+            SuiTransactionBlockResponseQuery::default(),
+            None,
+            Some(3),
+            true,
+        )
         .await
         .unwrap();
     assert_eq!(3, tx.data.len());
@@ -210,7 +215,12 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
     // test get all transactions paged
     let first_page = client
         .read_api()
-        .query_transaction_blocks(SuiTransactionResponseQuery::default(), None, Some(5), false)
+        .query_transaction_blocks(
+            SuiTransactionBlockResponseQuery::default(),
+            None,
+            Some(5),
+            false,
+        )
         .await
         .unwrap();
     assert_eq!(5, first_page.data.len());
@@ -219,7 +229,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
     let second_page = client
         .read_api()
         .query_transaction_blocks(
-            SuiTransactionResponseQuery::default(),
+            SuiTransactionBlockResponseQuery::default(),
             first_page.next_cursor,
             None,
             false,
@@ -236,7 +246,12 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
     // test get 10 latest transactions paged
     let latest = client
         .read_api()
-        .query_transaction_blocks(SuiTransactionResponseQuery::default(), None, Some(10), true)
+        .query_transaction_blocks(
+            SuiTransactionBlockResponseQuery::default(),
+            None,
+            Some(10),
+            true,
+        )
         .await
         .unwrap();
     assert_eq!(10, latest.data.len());
@@ -248,7 +263,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
     let address_txs_asc = client
         .read_api()
         .query_transaction_blocks(
-            SuiTransactionResponseQuery::new_with_filter(TransactionFilter::FromAddress(
+            SuiTransactionBlockResponseQuery::new_with_filter(TransactionFilter::FromAddress(
                 cluster.accounts[0],
             )),
             None,
@@ -263,7 +278,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
     let address_txs_desc = client
         .read_api()
         .query_transaction_blocks(
-            SuiTransactionResponseQuery::new_with_filter(TransactionFilter::FromAddress(
+            SuiTransactionBlockResponseQuery::new_with_filter(TransactionFilter::FromAddress(
                 cluster.accounts[0],
             )),
             None,
@@ -282,16 +297,21 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
     // test get_recent_transactions
     let tx = client
         .read_api()
-        .query_transaction_blocks(SuiTransactionResponseQuery::default(), None, Some(20), true)
+        .query_transaction_blocks(
+            SuiTransactionBlockResponseQuery::default(),
+            None,
+            Some(20),
+            true,
+        )
         .await
         .unwrap();
     assert_eq!(20, tx.data.len());
 
     // test get_transaction
     for tx_resp in tx.data {
-        let response: SuiTransactionResponse = client
+        let response: SuiTransactionBlockResponse = client
             .read_api()
-            .get_transaction_with_options(tx_resp.digest, SuiTransactionResponseOptions::new())
+            .get_transaction_with_options(tx_resp.digest, SuiTransactionBlockResponseOptions::new())
             .await
             .unwrap();
         assert!(tx_responses

--- a/crates/sui-json-rpc/src/unit_tests/transaction_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/transaction_tests.rs
@@ -5,7 +5,7 @@ use sui_config::SUI_KEYSTORE_FILENAME;
 use sui_json_rpc_types::SuiTransactionBlockResponseQuery;
 use sui_json_rpc_types::{
     SuiObjectDataOptions, SuiObjectResponseQuery, SuiTransactionBlockResponse,
-    SuiTransactionBlockResponseOptions, TransactionBytes,
+    SuiTransactionBlockResponseOptions, TransactionBlockBytes,
 };
 use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use sui_macros::sim_test;
@@ -42,7 +42,7 @@ async fn test_get_transaction_block() -> Result<(), anyhow::Error> {
     let mut tx_responses: Vec<SuiTransactionBlockResponse> = Vec::new();
     for obj in &objects[..objects.len() - 1] {
         let oref = obj.object().unwrap();
-        let transaction_bytes: TransactionBytes = http_client
+        let transaction_bytes: TransactionBlockBytes = http_client
             .transfer_object(*address, oref.object_id, Some(gas_id), 1000, *address)
             .await?;
         let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);
@@ -117,7 +117,7 @@ async fn test_get_raw_transaction() -> Result<(), anyhow::Error> {
     let object_to_transfer = objects.first().unwrap().object().unwrap().object_id;
 
     // Make a transfer transactions
-    let transaction_bytes: TransactionBytes = http_client
+    let transaction_bytes: TransactionBlockBytes = http_client
         .transfer_object(*address, object_to_transfer, None, 1000, *address)
         .await?;
     let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1922,10 +1922,10 @@
         }
       ],
       "result": {
-        "name": "TransactionBytes",
+        "name": "TransactionBlockBytes",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/TransactionBytes"
+          "$ref": "#/components/schemas/TransactionBlockBytes"
         }
       }
     },
@@ -1981,10 +1981,10 @@
         }
       ],
       "result": {
-        "name": "TransactionBytes",
+        "name": "TransactionBlockBytes",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/TransactionBytes"
+          "$ref": "#/components/schemas/TransactionBlockBytes"
         }
       }
     },
@@ -2077,10 +2077,10 @@
         }
       ],
       "result": {
-        "name": "TransactionBytes",
+        "name": "TransactionBlockBytes",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/TransactionBytes"
+          "$ref": "#/components/schemas/TransactionBlockBytes"
         }
       }
     },
@@ -2153,10 +2153,10 @@
         }
       ],
       "result": {
-        "name": "TransactionBytes",
+        "name": "TransactionBlockBytes",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/TransactionBytes"
+          "$ref": "#/components/schemas/TransactionBlockBytes"
         }
       }
     },
@@ -2208,10 +2208,10 @@
         }
       ],
       "result": {
-        "name": "TransactionBytes",
+        "name": "TransactionBlockBytes",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/TransactionBytes"
+          "$ref": "#/components/schemas/TransactionBlockBytes"
         }
       }
     },
@@ -2277,10 +2277,10 @@
         }
       ],
       "result": {
-        "name": "TransactionBytes",
+        "name": "TransactionBlockBytes",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/TransactionBytes"
+          "$ref": "#/components/schemas/TransactionBlockBytes"
         }
       }
     },
@@ -2342,10 +2342,10 @@
         }
       ],
       "result": {
-        "name": "TransactionBytes",
+        "name": "TransactionBlockBytes",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/TransactionBytes"
+          "$ref": "#/components/schemas/TransactionBlockBytes"
         }
       }
     },
@@ -2413,10 +2413,10 @@
         }
       ],
       "result": {
-        "name": "TransactionBytes",
+        "name": "TransactionBlockBytes",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/TransactionBytes"
+          "$ref": "#/components/schemas/TransactionBlockBytes"
         }
       }
     },
@@ -2464,10 +2464,10 @@
         }
       ],
       "result": {
-        "name": "TransactionBytes",
+        "name": "TransactionBlockBytes",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/TransactionBytes"
+          "$ref": "#/components/schemas/TransactionBlockBytes"
         }
       }
     },
@@ -2528,10 +2528,10 @@
         }
       ],
       "result": {
-        "name": "TransactionBytes",
+        "name": "TransactionBlockBytes",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/TransactionBytes"
+          "$ref": "#/components/schemas/TransactionBlockBytes"
         }
       }
     },
@@ -2589,10 +2589,10 @@
         }
       ],
       "result": {
-        "name": "TransactionBytes",
+        "name": "TransactionBlockBytes",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/TransactionBytes"
+          "$ref": "#/components/schemas/TransactionBlockBytes"
         }
       }
     },
@@ -2648,10 +2648,10 @@
         }
       ],
       "result": {
-        "name": "TransactionBytes",
+        "name": "TransactionBlockBytes",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/TransactionBytes"
+          "$ref": "#/components/schemas/TransactionBlockBytes"
         }
       }
     },
@@ -2709,10 +2709,10 @@
         }
       ],
       "result": {
-        "name": "TransactionBytes",
+        "name": "TransactionBlockBytes",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/TransactionBytes"
+          "$ref": "#/components/schemas/TransactionBlockBytes"
         }
       }
     }
@@ -7110,7 +7110,7 @@
           }
         }
       },
-      "TransactionBytes": {
+      "TransactionBlockBytes": {
         "type": "object",
         "required": [
           "gas",

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -126,14 +126,14 @@
         },
         {
           "name": "request_type",
-          "description": "The request type, derived from `SuiTransactionResponseOptions` if None",
+          "description": "The request type, derived from `SuiTransactionBlockResponseOptions` if None",
           "schema": {
             "$ref": "#/components/schemas/ExecuteTransactionRequestType"
           }
         }
       ],
       "result": {
-        "name": "SuiTransactionResponse",
+        "name": "SuiTransactionBlockResponse",
         "required": true,
         "schema": {
           "$ref": "#/components/schemas/TransactionResponse"
@@ -791,7 +791,7 @@
         }
       ],
       "result": {
-        "name": "SuiTransactionResponse",
+        "name": "SuiTransactionBlockResponse",
         "required": true,
         "schema": {
           "$ref": "#/components/schemas/TransactionResponse"
@@ -1007,7 +1007,7 @@
         }
       ],
       "result": {
-        "name": "Vec<SuiTransactionResponse>",
+        "name": "Vec<SuiTransactionBlockResponse>",
         "required": true,
         "schema": {
           "type": "array",
@@ -1917,7 +1917,7 @@
           "name": "txn_builder_mode",
           "description": "Whether this is a regular transaction or a Dev Inspect Transaction",
           "schema": {
-            "$ref": "#/components/schemas/SuiTransactionBuilderMode"
+            "$ref": "#/components/schemas/SuiTransactionBlockBuilderMode"
           }
         }
       ],
@@ -2070,9 +2070,9 @@
         },
         {
           "name": "execution_mode",
-          "description": "Whether this is a Normal transaction or a Dev Inspect Transaction. Default to be `SuiTransactionBuilderMode::Commit` when it's None.",
+          "description": "Whether this is a Normal transaction or a Dev Inspect Transaction. Default to be `SuiTransactionBlockBuilderMode::Commit` when it's None.",
           "schema": {
-            "$ref": "#/components/schemas/SuiTransactionBuilderMode"
+            "$ref": "#/components/schemas/SuiTransactionBlockBuilderMode"
           }
         }
       ],
@@ -6808,7 +6808,7 @@
           }
         }
       },
-      "SuiTransactionBuilderMode": {
+      "SuiTransactionBlockBuilderMode": {
         "oneOf": [
           {
             "description": "Regular Sui Transactions that are committed on chain",

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1829,7 +1829,7 @@
         }
       ],
       "result": {
-        "name": "TransactionsPage",
+        "name": "TransactionBlocksPage",
         "required": true,
         "schema": {
           "$ref": "#/components/schemas/Page_for_TransactionResponse_and_TransactionDigest"

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -25,7 +25,7 @@ use sui_json_rpc_types::{
     SuiObjectResponseQuery, SuiParsedData, SuiPastObjectResponse, SuiTransactionBlock,
     SuiTransactionBlockData, SuiTransactionBlockEffects, SuiTransactionBlockEffectsV1,
     SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions,
-    SuiTransactionBlockResponseQuery, TransactionBlocksPage, TransactionBytes,
+    SuiTransactionBlockResponseQuery, TransactionBlockBytes, TransactionBlocksPage,
     TransferObjectParams,
 };
 use sui_open_rpc::ExamplePairing;
@@ -155,7 +155,7 @@ impl RpcExampleProvider {
             1000,
         );
 
-        let result = TransactionBytes::from_data(data).unwrap();
+        let result = TransactionBlockBytes::from_data(data).unwrap();
 
         Examples::new(
             "sui_batchTransaction",
@@ -175,7 +175,7 @@ impl RpcExampleProvider {
 
     fn execute_transaction_example(&mut self) -> Examples {
         let (data, signatures, _, _, result) = self.get_transfer_data_response();
-        let tx_bytes = TransactionBytes::from_data(data).unwrap();
+        let tx_bytes = TransactionBlockBytes::from_data(data).unwrap();
 
         Examples::new(
             "sui_executeTransaction",

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -22,10 +22,10 @@ use sui_json_rpc_types::{
     Checkpoint, CheckpointId, EventPage, MoveCallParams, ObjectChange, OwnedObjectRef,
     RPCTransactionRequestParams, SuiData, SuiEvent, SuiExecutionStatus, SuiGasCostSummary,
     SuiObjectData, SuiObjectDataFilter, SuiObjectDataOptions, SuiObjectRef, SuiObjectResponse,
-    SuiObjectResponseQuery, SuiParsedData, SuiPastObjectResponse, SuiTransaction,
-    SuiTransactionData, SuiTransactionEffects, SuiTransactionEffectsV1, SuiTransactionResponse,
-    SuiTransactionResponseOptions, SuiTransactionResponseQuery, TransactionBytes, TransactionsPage,
-    TransferObjectParams,
+    SuiObjectResponseQuery, SuiParsedData, SuiPastObjectResponse, SuiTransactionBlock,
+    SuiTransactionBlockData, SuiTransactionBlockEffects, SuiTransactionBlockEffectsV1,
+    SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions,
+    SuiTransactionBlockResponseQuery, TransactionBytes, TransactionsPage, TransferObjectParams,
 };
 use sui_open_rpc::ExamplePairing;
 use sui_types::base_types::random_object_ref;
@@ -191,7 +191,7 @@ impl RpcExampleProvider {
                     ),
                     (
                         "options",
-                        json!(SuiTransactionResponseOptions::full_content()),
+                        json!(SuiTransactionBlockResponseOptions::full_content()),
                     ),
                     (
                         "request_type",
@@ -373,7 +373,7 @@ impl RpcExampleProvider {
                     ("digest", json!(result.digest)),
                     (
                         "options",
-                        json!(SuiTransactionResponseOptions::new()
+                        json!(SuiTransactionBlockResponseOptions::new()
                             .with_input()
                             .with_effects()
                             .with_events()),
@@ -389,7 +389,10 @@ impl RpcExampleProvider {
         let has_next_page = data.len() > (9 - 5);
         data.truncate(9 - 5);
         let next_cursor = data.last().cloned();
-        let data = data.into_iter().map(SuiTransactionResponse::new).collect();
+        let data = data
+            .into_iter()
+            .map(SuiTransactionBlockResponse::new)
+            .collect();
 
         let result = TransactionsPage {
             data,
@@ -403,7 +406,7 @@ impl RpcExampleProvider {
                 vec![
                     (
                         "query",
-                        json!(SuiTransactionResponseQuery {
+                        json!(SuiTransactionBlockResponseQuery {
                             filter: Some(TransactionFilter::InputObject(ObjectID::new(
                                 self.rng.gen()
                             ))),
@@ -433,7 +436,7 @@ impl RpcExampleProvider {
         Vec<GenericSignature>,
         SuiAddress,
         ObjectID,
-        SuiTransactionResponse,
+        SuiTransactionBlockResponse,
     ) {
         let (signer, kp): (_, AccountKeyPair) = get_key_pair_from_rng(&mut self.rng);
         let recipient = SuiAddress::from(ObjectID::new(self.rng.gen()));
@@ -476,48 +479,50 @@ impl RpcExampleProvider {
                 Ok(None)
             }
         }
-        let result = SuiTransactionResponse {
+        let result = SuiTransactionBlockResponse {
             digest: *tx_digest,
-            effects: Some(SuiTransactionEffects::V1(SuiTransactionEffectsV1 {
-                status: SuiExecutionStatus::Success,
-                executed_epoch: 0.into(),
-                modified_at_versions: vec![],
-                gas_used: SuiGasCostSummary {
-                    computation_cost: 100.into(),
-                    storage_cost: 100.into(),
-                    storage_rebate: 10.into(),
-                    non_refundable_storage_fee: 0.into(),
-                },
-                shared_objects: vec![],
-                transaction_digest: TransactionDigest::new(self.rng.gen()),
-                created: vec![],
-                mutated: vec![
-                    OwnedObjectRef {
-                        owner: Owner::AddressOwner(signer),
-                        reference: gas_ref.into(),
+            effects: Some(SuiTransactionBlockEffects::V1(
+                SuiTransactionBlockEffectsV1 {
+                    status: SuiExecutionStatus::Success,
+                    executed_epoch: 0.into(),
+                    modified_at_versions: vec![],
+                    gas_used: SuiGasCostSummary {
+                        computation_cost: 100.into(),
+                        storage_cost: 100.into(),
+                        storage_rebate: 10.into(),
+                        non_refundable_storage_fee: 0.into(),
                     },
-                    OwnedObjectRef {
-                        owner: Owner::AddressOwner(recipient),
-                        reference: object_ref.into(),
+                    shared_objects: vec![],
+                    transaction_digest: TransactionDigest::new(self.rng.gen()),
+                    created: vec![],
+                    mutated: vec![
+                        OwnedObjectRef {
+                            owner: Owner::AddressOwner(signer),
+                            reference: gas_ref.into(),
+                        },
+                        OwnedObjectRef {
+                            owner: Owner::AddressOwner(recipient),
+                            reference: object_ref.into(),
+                        },
+                    ],
+                    unwrapped: vec![],
+                    deleted: vec![],
+                    unwrapped_then_deleted: vec![],
+                    wrapped: vec![],
+                    gas_object: OwnedObjectRef {
+                        owner: Owner::ObjectOwner(signer),
+                        reference: SuiObjectRef::from(gas_ref),
                     },
-                ],
-                unwrapped: vec![],
-                deleted: vec![],
-                unwrapped_then_deleted: vec![],
-                wrapped: vec![],
-                gas_object: OwnedObjectRef {
-                    owner: Owner::ObjectOwner(signer),
-                    reference: SuiObjectRef::from(gas_ref),
+                    events_digest: Some(TransactionEventsDigest::new(self.rng.gen())),
+                    dependencies: vec![],
                 },
-                events_digest: Some(TransactionEventsDigest::new(self.rng.gen())),
-                dependencies: vec![],
-            })),
+            )),
             events: None,
             object_changes: Some(vec![object_change]),
             balance_changes: None,
             timestamp_ms: None,
-            transaction: Some(SuiTransaction {
-                data: SuiTransactionData::try_from(data1, &&mut NoOpsModuleResolver).unwrap(),
+            transaction: Some(SuiTransactionBlock {
+                data: SuiTransactionBlockData::try_from(data1, &&mut NoOpsModuleResolver).unwrap(),
                 tx_signatures: signatures.clone(),
             }),
             raw_transaction,

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -25,7 +25,8 @@ use sui_json_rpc_types::{
     SuiObjectResponseQuery, SuiParsedData, SuiPastObjectResponse, SuiTransactionBlock,
     SuiTransactionBlockData, SuiTransactionBlockEffects, SuiTransactionBlockEffectsV1,
     SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions,
-    SuiTransactionBlockResponseQuery, TransactionBytes, TransactionsPage, TransferObjectParams,
+    SuiTransactionBlockResponseQuery, TransactionBlocksPage, TransactionBytes,
+    TransferObjectParams,
 };
 use sui_open_rpc::ExamplePairing;
 use sui_types::base_types::random_object_ref;
@@ -394,7 +395,7 @@ impl RpcExampleProvider {
             .map(SuiTransactionBlockResponse::new)
             .collect();
 
-        let result = TransactionsPage {
+        let result = TransactionBlocksPage {
             data,
             next_cursor,
             has_next_page,

--- a/crates/sui-rosetta/src/block.rs
+++ b/crates/sui-rosetta/src/block.rs
@@ -11,7 +11,7 @@ use crate::types::{
     TransactionIdentifier,
 };
 use crate::{Error, OnlineServerContext, SuiEnv};
-use sui_json_rpc_types::SuiTransactionResponseOptions;
+use sui_json_rpc_types::SuiTransactionBlockResponseOptions;
 
 /// This module implements the [Rosetta Block API](https://www.rosetta-api.org/docs/BlockApi.html)
 
@@ -48,7 +48,7 @@ pub async fn transaction(
         .read_api()
         .get_transaction_with_options(
             digest,
-            SuiTransactionResponseOptions::new()
+            SuiTransactionBlockResponseOptions::new()
                 .with_input()
                 .with_events()
                 .with_effects()

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -10,7 +10,8 @@ use futures::StreamExt;
 
 use shared_crypto::intent::{Intent, IntentMessage};
 use sui_json_rpc_types::{
-    StakeStatus, SuiObjectDataOptions, SuiTransactionEffectsAPI, SuiTransactionResponseOptions,
+    StakeStatus, SuiObjectDataOptions, SuiTransactionBlockEffectsAPI,
+    SuiTransactionBlockResponseOptions,
 };
 use sui_sdk::rpc_types::SuiExecutionStatus;
 use sui_types::base_types::SuiAddress;
@@ -136,7 +137,7 @@ pub async fn submit(
         .quorum_driver()
         .execute_transaction_block(
             signed_tx,
-            SuiTransactionResponseOptions::new()
+            SuiTransactionBlockResponseOptions::new()
                 .with_input()
                 .with_effects()
                 .with_balance_changes(),

--- a/crates/sui-rosetta/src/operations.rs
+++ b/crates/sui-rosetta/src/operations.rs
@@ -14,7 +14,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use sui_json_rpc_types::SuiProgrammableMoveCall;
-use sui_json_rpc_types::SuiProgrammableTransaction;
+use sui_json_rpc_types::SuiProgrammableTransactionBlock;
 use sui_json_rpc_types::{BalanceChange, SuiArgument};
 use sui_json_rpc_types::{SuiCallArg, SuiCommand};
 use sui_sdk::rpc_types::{
@@ -225,7 +225,7 @@ impl Operations {
     fn parse_programmable_transaction(
         sender: SuiAddress,
         status: Option<OperationStatus>,
-        pt: SuiProgrammableTransaction,
+        pt: SuiProgrammableTransactionBlock,
     ) -> Result<Vec<Operation>, Error> {
         #[derive(Debug)]
         enum KnownValue {
@@ -356,7 +356,7 @@ impl Operations {
             };
             Ok(id.cloned())
         }
-        let SuiProgrammableTransaction { inputs, commands } = &pt;
+        let SuiProgrammableTransactionBlock { inputs, commands } = &pt;
         let mut known_results: Vec<Vec<KnownValue>> = vec![];
         let mut aggregated_recipients: HashMap<SuiAddress, u64> = HashMap::new();
         let mut needs_generic = false;

--- a/crates/sui-rosetta/src/operations.rs
+++ b/crates/sui-rosetta/src/operations.rs
@@ -18,8 +18,8 @@ use sui_json_rpc_types::SuiProgrammableTransaction;
 use sui_json_rpc_types::{BalanceChange, SuiArgument};
 use sui_json_rpc_types::{SuiCallArg, SuiCommand};
 use sui_sdk::rpc_types::{
-    SuiTransactionData, SuiTransactionDataAPI, SuiTransactionEffectsAPI, SuiTransactionKind,
-    SuiTransactionResponse,
+    SuiTransactionBlockData, SuiTransactionBlockDataAPI, SuiTransactionBlockEffectsAPI,
+    SuiTransactionBlockKind, SuiTransactionBlockResponse,
 };
 use sui_types::base_types::{ObjectID, SequenceNumber, SuiAddress};
 use sui_types::gas_coin::{GasCoin, GAS};
@@ -210,12 +210,12 @@ impl Operations {
     }
 
     fn from_transaction(
-        tx: SuiTransactionKind,
+        tx: SuiTransactionBlockKind,
         sender: SuiAddress,
         status: Option<OperationStatus>,
     ) -> Result<Vec<Operation>, Error> {
         Ok(match tx {
-            SuiTransactionKind::ProgrammableTransaction(pt) => {
+            SuiTransactionBlockKind::ProgrammableTransaction(pt) => {
                 Self::parse_programmable_transaction(sender, status, pt)?
             }
             _ => vec![Operation::generic_op(status, sender, tx)],
@@ -433,7 +433,7 @@ impl Operations {
             operations.push(Operation::generic_op(
                 status,
                 sender,
-                SuiTransactionKind::ProgrammableTransaction(pt),
+                SuiTransactionBlockKind::ProgrammableTransaction(pt),
             ))
         }
         Ok(operations)
@@ -487,9 +487,9 @@ impl Operations {
     }
 }
 
-impl TryFrom<SuiTransactionData> for Operations {
+impl TryFrom<SuiTransactionBlockData> for Operations {
     type Error = Error;
-    fn try_from(data: SuiTransactionData) -> Result<Self, Self::Error> {
+    fn try_from(data: SuiTransactionBlockData) -> Result<Self, Self::Error> {
         let sender = *data.sender();
         Ok(Self::new(Self::from_transaction(
             data.transaction().clone(),
@@ -499,9 +499,9 @@ impl TryFrom<SuiTransactionData> for Operations {
     }
 }
 
-impl TryFrom<SuiTransactionResponse> for Operations {
+impl TryFrom<SuiTransactionBlockResponse> for Operations {
     type Error = Error;
-    fn try_from(response: SuiTransactionResponse) -> Result<Self, Self::Error> {
+    fn try_from(response: SuiTransactionBlockResponse) -> Result<Self, Self::Error> {
         let tx = response
             .transaction
             .ok_or_else(|| anyhow!("Response input should not be empty"))?;
@@ -606,7 +606,7 @@ impl TryFrom<TransactionData> for Operations {
             }
         }
         // Rosetta don't need the call args to be parsed into readable format
-        SuiTransactionData::try_from(data, &&mut NoOpsModuleResolver)?.try_into()
+        SuiTransactionBlockData::try_from(data, &&mut NoOpsModuleResolver)?.try_into()
     }
 }
 
@@ -640,7 +640,7 @@ impl PartialEq for Operation {
 
 #[derive(Deserialize, Serialize, Clone, Debug, Eq, PartialEq)]
 pub enum OperationMetadata {
-    GenericTransaction(SuiTransactionKind),
+    GenericTransaction(SuiTransactionBlockKind),
     Stake { validator: SuiAddress },
     WithdrawStake { stake_ids: Vec<ObjectID> },
 }
@@ -649,7 +649,7 @@ impl Operation {
     fn generic_op(
         status: Option<OperationStatus>,
         sender: SuiAddress,
-        tx: SuiTransactionKind,
+        tx: SuiTransactionBlockKind,
     ) -> Self {
         Operation {
             operation_identifier: Default::default(),

--- a/crates/sui-rosetta/src/state.rs
+++ b/crates/sui-rosetta/src/state.rs
@@ -16,7 +16,7 @@ use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, UNIX_EPOCH};
-use sui_json_rpc_types::SuiTransactionResponseOptions;
+use sui_json_rpc_types::SuiTransactionBlockResponseOptions;
 use sui_sdk::rpc_types::Checkpoint;
 use sui_sdk::SuiClient;
 use sui_types::base_types::{EpochId, SuiAddress};
@@ -237,7 +237,7 @@ impl CheckpointBlockProvider {
                 .read_api()
                 .get_transaction_with_options(
                     *digest,
-                    SuiTransactionResponseOptions::new()
+                    SuiTransactionBlockResponseOptions::new()
                         .with_input()
                         .with_effects()
                         .with_balance_changes()

--- a/crates/sui-rosetta/src/types.rs
+++ b/crates/sui-rosetta/src/types.rs
@@ -15,7 +15,7 @@ use serde_json::Value;
 use strum_macros::EnumIter;
 use strum_macros::EnumString;
 
-use sui_sdk::rpc_types::{SuiExecutionStatus, SuiTransactionKind};
+use sui_sdk::rpc_types::{SuiExecutionStatus, SuiTransactionBlockKind};
 use sui_types::base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest};
 use sui_types::crypto::PublicKey as SuiPublicKey;
 use sui_types::crypto::SignatureScheme;
@@ -411,15 +411,15 @@ pub enum OperationType {
     ProgrammableTransaction,
 }
 
-impl From<&SuiTransactionKind> for OperationType {
-    fn from(tx: &SuiTransactionKind) -> Self {
+impl From<&SuiTransactionBlockKind> for OperationType {
+    fn from(tx: &SuiTransactionBlockKind) -> Self {
         match tx {
-            SuiTransactionKind::ChangeEpoch(_) => OperationType::EpochChange,
-            SuiTransactionKind::Genesis(_) => OperationType::Genesis,
-            SuiTransactionKind::ConsensusCommitPrologue(_) => {
+            SuiTransactionBlockKind::ChangeEpoch(_) => OperationType::EpochChange,
+            SuiTransactionBlockKind::Genesis(_) => OperationType::Genesis,
+            SuiTransactionBlockKind::ConsensusCommitPrologue(_) => {
                 OperationType::ConsensusCommitPrologue
             }
-            SuiTransactionKind::ProgrammableTransaction(_) => {
+            SuiTransactionBlockKind::ProgrammableTransaction(_) => {
                 OperationType::ProgrammableTransaction
             }
         }

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -10,7 +10,7 @@ use move_core_types::identifier::Identifier;
 use rand::seq::{IteratorRandom, SliceRandom};
 use serde_json::json;
 use signature::rand_core::OsRng;
-use sui_json_rpc_types::SuiTransactionResponseOptions;
+use sui_json_rpc_types::SuiTransactionBlockResponseOptions;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 
 use crate::operations::Operations;
@@ -22,7 +22,8 @@ use sui_json_rpc_types::{
 use sui_keys::keystore::AccountKeystore;
 use sui_keys::keystore::Keystore;
 use sui_sdk::rpc_types::{
-    OwnedObjectRef, SuiData, SuiExecutionStatus, SuiTransactionEffectsAPI, SuiTransactionResponse,
+    OwnedObjectRef, SuiData, SuiExecutionStatus, SuiTransactionBlockEffectsAPI,
+    SuiTransactionBlockResponse,
 };
 use sui_sdk::SuiClient;
 use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
@@ -569,7 +570,7 @@ async fn test_transaction(
     gas: Vec<ObjectRef>,
     budget: u64,
     expect_fail: bool,
-) -> SuiTransactionResponse {
+) -> SuiTransactionBlockResponse {
     let gas = if !gas.is_empty() {
         gas
     } else {
@@ -614,7 +615,7 @@ async fn test_transaction(
             Transaction::from_data(data.clone(), Intent::default(), vec![signature])
                 .verify()
                 .unwrap(),
-            SuiTransactionResponseOptions::full_content(),
+            SuiTransactionBlockResponseOptions::full_content(),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await

--- a/crates/sui-rosetta/tests/end_to_end_tests.rs
+++ b/crates/sui-rosetta/tests/end_to_end_tests.rs
@@ -7,14 +7,14 @@ use serde_json::json;
 
 use rosetta_client::start_rosetta_test_server;
 use sui_config::genesis_config::{DEFAULT_GAS_AMOUNT, DEFAULT_NUMBER_OF_OBJECT_PER_ACCOUNT};
-use sui_json_rpc_types::SuiTransactionResponseOptions;
+use sui_json_rpc_types::SuiTransactionBlockResponseOptions;
 use sui_keys::keystore::AccountKeystore;
 use sui_rosetta::operations::Operations;
 use sui_rosetta::types::{
     AccountBalanceRequest, AccountBalanceResponse, AccountIdentifier, NetworkIdentifier,
     SubAccount, SubAccountType, SuiEnv,
 };
-use sui_sdk::rpc_types::{SuiExecutionStatus, SuiTransactionEffectsAPI};
+use sui_sdk::rpc_types::{SuiExecutionStatus, SuiTransactionBlockEffectsAPI};
 use sui_types::messages::ExecuteTransactionRequestType;
 use sui_types::utils::to_sender_signed_transaction;
 use test_utils::network::TestClusterBuilder;
@@ -104,7 +104,7 @@ async fn test_get_staked_sui() {
         .quorum_driver()
         .execute_transaction_block(
             tx,
-            SuiTransactionResponseOptions::new(),
+            SuiTransactionBlockResponseOptions::new(),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await
@@ -158,7 +158,7 @@ async fn test_stake() {
         .read_api()
         .get_transaction_with_options(
             response.transaction_identifier.hash,
-            SuiTransactionResponseOptions::new()
+            SuiTransactionBlockResponseOptions::new()
                 .with_input()
                 .with_effects()
                 .with_balance_changes()
@@ -219,7 +219,7 @@ async fn test_stake_all() {
         .read_api()
         .get_transaction_with_options(
             response.transaction_identifier.hash,
-            SuiTransactionResponseOptions::new()
+            SuiTransactionBlockResponseOptions::new()
                 .with_input()
                 .with_effects()
                 .with_balance_changes()
@@ -286,7 +286,7 @@ async fn test_withdraw_stake() {
         .read_api()
         .get_transaction_with_options(
             response.transaction_identifier.hash,
-            SuiTransactionResponseOptions::new()
+            SuiTransactionBlockResponseOptions::new()
                 .with_input()
                 .with_effects()
                 .with_balance_changes()
@@ -336,7 +336,7 @@ async fn test_withdraw_stake() {
         .read_api()
         .get_transaction_with_options(
             response.transaction_identifier.hash,
-            SuiTransactionResponseOptions::new()
+            SuiTransactionBlockResponseOptions::new()
                 .with_input()
                 .with_effects()
                 .with_balance_changes()
@@ -406,7 +406,7 @@ async fn test_pay_sui() {
         .read_api()
         .get_transaction_with_options(
             response.transaction_identifier.hash,
-            SuiTransactionResponseOptions::new()
+            SuiTransactionBlockResponseOptions::new()
                 .with_input()
                 .with_effects()
                 .with_balance_changes()
@@ -467,7 +467,7 @@ async fn test_pay_sui_multiple_times() {
             .read_api()
             .get_transaction_with_options(
                 response.transaction_identifier.hash,
-                SuiTransactionResponseOptions::new()
+                SuiTransactionBlockResponseOptions::new()
                     .with_input()
                     .with_effects()
                     .with_balance_changes()

--- a/crates/sui-rpc-loadgen/src/payload/query_transactions.rs
+++ b/crates/sui-rpc-loadgen/src/payload/query_transactions.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use futures::future::join_all;
 use std::time::Instant;
 use sui_json_rpc_types::{
-    Page, SuiTransactionResponse, SuiTransactionResponseQuery, TransactionsPage,
+    Page, SuiTransactionBlockResponse, SuiTransactionBlockResponseQuery, TransactionsPage,
 };
 use sui_sdk::SuiClient;
 use sui_types::base_types::TransactionDigest;
@@ -33,7 +33,7 @@ impl<'a> ProcessPayload<'a, &'a QueryTransactions> for RpcCommandProcessor {
             (None, Some(address)) => Some(TransactionFilter::ToAddress(address)),
             (None, None) => None,
         };
-        let query = SuiTransactionResponseQuery {
+        let query = SuiTransactionBlockResponseQuery {
             filter,
             options: None, // not supported on indexer
         };
@@ -78,7 +78,7 @@ impl<'a> ProcessPayload<'a, &'a QueryTransactions> for RpcCommandProcessor {
             .await;
 
             // compare results
-            let transactions: Vec<Vec<SuiTransactionResponse>> =
+            let transactions: Vec<Vec<SuiTransactionBlockResponse>> =
                 results.iter().map(|page| page.data.clone()).collect();
 
             cross_validate_entities(&transactions, "Transactions");
@@ -90,10 +90,10 @@ impl<'a> ProcessPayload<'a, &'a QueryTransactions> for RpcCommandProcessor {
 
 async fn query_transaction_blocks(
     client: &SuiClient,
-    query: SuiTransactionResponseQuery,
+    query: SuiTransactionBlockResponseQuery,
     cursor: Option<TransactionDigest>,
     limit: Option<usize>, // TODO: we should probably set a limit and paginate
-) -> Result<Page<SuiTransactionResponse, TransactionDigest>> {
+) -> Result<Page<SuiTransactionBlockResponse, TransactionDigest>> {
     let transactions = client
         .read_api()
         .query_transaction_blocks(query, cursor, limit, true)

--- a/crates/sui-rpc-loadgen/src/payload/query_transactions.rs
+++ b/crates/sui-rpc-loadgen/src/payload/query_transactions.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use futures::future::join_all;
 use std::time::Instant;
 use sui_json_rpc_types::{
-    Page, SuiTransactionBlockResponse, SuiTransactionBlockResponseQuery, TransactionsPage,
+    Page, SuiTransactionBlockResponse, SuiTransactionBlockResponseQuery, TransactionBlocksPage,
 };
 use sui_sdk::SuiClient;
 use sui_types::base_types::TransactionDigest;
@@ -38,7 +38,7 @@ impl<'a> ProcessPayload<'a, &'a QueryTransactions> for RpcCommandProcessor {
             options: None, // not supported on indexer
         };
 
-        let results: Vec<TransactionsPage> = Vec::new();
+        let results: Vec<TransactionBlocksPage> = Vec::new();
 
         // Paginate results, if any
         while results.is_empty() || results.iter().any(|r| r.has_next_page) {

--- a/crates/sui-rpc-loadgen/src/payload/rpc_command_processor.rs
+++ b/crates/sui-rpc-loadgen/src/payload/rpc_command_processor.rs
@@ -9,8 +9,8 @@ use shared_crypto::intent::{Intent, IntentMessage};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use sui_json_rpc_types::{
-    SuiExecutionStatus, SuiObjectDataOptions, SuiTransactionEffectsAPI, SuiTransactionResponse,
-    SuiTransactionResponseOptions,
+    SuiExecutionStatus, SuiObjectDataOptions, SuiTransactionBlockEffectsAPI,
+    SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions,
 };
 use tokio::sync::RwLock;
 use tokio::time::sleep;
@@ -80,7 +80,7 @@ impl RpcCommandProcessor {
         keypair: &SuiKeyPair,
         txn_data: TransactionData,
         request_type: ExecuteTransactionRequestType,
-    ) -> SuiTransactionResponse {
+    ) -> SuiTransactionBlockResponse {
         let resp = sign_and_execute(client, keypair, txn_data, request_type).await;
         let effects = resp.effects.as_ref().unwrap();
         let object_ref_cache = self.object_ref_cache.clone();
@@ -419,7 +419,7 @@ async fn pay_sui(
     gas_budget: u64,
     recipients: Vec<SuiAddress>,
     amounts: Vec<u64>,
-) -> SuiTransactionResponse {
+) -> SuiTransactionBlockResponse {
     let sender = SuiAddress::from(&keypair.public());
     let tx = client
         .transaction_builder()
@@ -475,7 +475,7 @@ pub(crate) async fn sign_and_execute(
     keypair: &SuiKeyPair,
     txn_data: TransactionData,
     request_type: ExecuteTransactionRequestType,
-) -> SuiTransactionResponse {
+) -> SuiTransactionBlockResponse {
     let signature =
         Signature::new_secure(&IntentMessage::new(Intent::default(), &txn_data), keypair);
 
@@ -485,7 +485,7 @@ pub(crate) async fn sign_and_execute(
             Transaction::from_data(txn_data, Intent::default(), vec![signature])
                 .verify()
                 .expect("signature error"),
-            SuiTransactionResponseOptions::new().with_effects(),
+            SuiTransactionBlockResponseOptions::new().with_effects(),
             Some(request_type),
         )
         .await

--- a/crates/sui-rpc-loadgen/src/payload/validation.rs
+++ b/crates/sui-rpc-loadgen/src/payload/validation.rs
@@ -6,8 +6,8 @@ use std::collections::HashSet;
 use std::time::Instant;
 use sui_json_rpc::api::QUERY_MAX_RESULT_LIMIT;
 use sui_json_rpc_types::{
-    SuiObjectDataOptions, SuiObjectResponse, SuiTransactionEffectsAPI, SuiTransactionResponse,
-    SuiTransactionResponseOptions,
+    SuiObjectDataOptions, SuiObjectResponse, SuiTransactionBlockEffectsAPI,
+    SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions,
 };
 use sui_sdk::SuiClient;
 use sui_types::base_types::{ObjectID, TransactionDigest};
@@ -62,14 +62,14 @@ pub(crate) async fn check_transactions(
     cross_validate: bool,
     verify_objects: bool,
 ) {
-    let transactions: Vec<Vec<SuiTransactionResponse>> =
+    let transactions: Vec<Vec<SuiTransactionBlockResponse>> =
         join_all(clients.iter().enumerate().map(|(i, client)| async move {
             let start_time = Instant::now();
             let transactions = client
                 .read_api()
                 .multi_get_transactions_with_options(
                     digests.to_vec(),
-                    SuiTransactionResponseOptions::full_content(), // todo(Will) support options for this
+                    SuiTransactionBlockResponseOptions::full_content(), // todo(Will) support options for this
                 )
                 .await;
             let elapsed_time = start_time.elapsed();
@@ -111,7 +111,7 @@ pub(crate) async fn check_transactions(
     }
 }
 
-pub(crate) fn get_all_object_ids(response: &SuiTransactionResponse) -> Vec<ObjectID> {
+pub(crate) fn get_all_object_ids(response: &SuiTransactionBlockResponse) -> Vec<ObjectID> {
     let objects = match response.effects.as_ref() {
         // TODO: handle deleted and wrapped objects
         Some(effects) => effects.all_changed_objects(),

--- a/crates/sui-sdk/examples/tic_tac_toe.rs
+++ b/crates/sui-sdk/examples/tic_tac_toe.rs
@@ -14,11 +14,11 @@ use clap::Subcommand;
 use serde::Deserialize;
 
 use shared_crypto::intent::Intent;
-use sui_json_rpc_types::{SuiObjectDataOptions, SuiTransactionResponseOptions};
+use sui_json_rpc_types::{SuiObjectDataOptions, SuiTransactionBlockResponseOptions};
 use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use sui_sdk::{
     json::SuiJsonValue,
-    rpc_types::{SuiData, SuiTransactionEffectsAPI},
+    rpc_types::{SuiData, SuiTransactionBlockEffectsAPI},
     types::{
         base_types::{ObjectID, SuiAddress},
         id::UID,
@@ -105,7 +105,7 @@ impl TicTacToe {
             .execute_transaction_block(
                 Transaction::from_data(create_game_call, Intent::default(), vec![signature])
                     .verify()?,
-                SuiTransactionResponseOptions::full_content(),
+                SuiTransactionBlockResponseOptions::full_content(),
                 Some(ExecuteTransactionRequestType::WaitForLocalExecution),
             )
             .await?;
@@ -204,7 +204,7 @@ impl TicTacToe {
                 .execute_transaction_block(
                     Transaction::from_data(place_mark_call, Intent::default(), vec![signature])
                         .verify()?,
-                    SuiTransactionResponseOptions::new().with_effects(),
+                    SuiTransactionBlockResponseOptions::new().with_effects(),
                     Some(ExecuteTransactionRequestType::WaitForLocalExecution),
                 )
                 .await?;

--- a/crates/sui-sdk/examples/transfer_coins.rs
+++ b/crates/sui-sdk/examples/transfer_coins.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use shared_crypto::intent::Intent;
-use sui_json_rpc_types::SuiTransactionResponseOptions;
+use sui_json_rpc_types::SuiTransactionBlockResponseOptions;
 use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use sui_sdk::{
     types::{
@@ -43,7 +43,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .quorum_driver()
         .execute_transaction_block(
             Transaction::from_data(transfer_tx, Intent::default(), vec![signature]).verify()?,
-            SuiTransactionResponseOptions::full_content(),
+            SuiTransactionBlockResponseOptions::full_content(),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await?;

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -19,8 +19,8 @@ use sui_json_rpc_types::{
     DryRunTransactionResponse, DynamicFieldPage, EventFilter, EventPage, ObjectsPage,
     SuiCoinMetadata, SuiCommittee, SuiEvent, SuiGetPastObjectRequest, SuiMoveNormalizedModule,
     SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery, SuiPastObjectResponse,
-    SuiTransactionEffectsAPI, SuiTransactionResponse, SuiTransactionResponseOptions,
-    SuiTransactionResponseQuery, TransactionsPage,
+    SuiTransactionBlockEffectsAPI, SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions,
+    SuiTransactionBlockResponseQuery, TransactionsPage,
 };
 use sui_types::balance::Supply;
 use sui_types::base_types::{ObjectID, SequenceNumber, SuiAddress, TransactionDigest};
@@ -123,8 +123,8 @@ impl ReadApi {
     pub async fn get_transaction_with_options(
         &self,
         digest: TransactionDigest,
-        options: SuiTransactionResponseOptions,
-    ) -> SuiRpcResult<SuiTransactionResponse> {
+        options: SuiTransactionBlockResponseOptions,
+    ) -> SuiRpcResult<SuiTransactionBlockResponse> {
         Ok(self
             .api
             .http
@@ -135,8 +135,8 @@ impl ReadApi {
     pub async fn multi_get_transactions_with_options(
         &self,
         digests: Vec<TransactionDigest>,
-        options: SuiTransactionResponseOptions,
-    ) -> SuiRpcResult<Vec<SuiTransactionResponse>> {
+        options: SuiTransactionBlockResponseOptions,
+    ) -> SuiRpcResult<Vec<SuiTransactionBlockResponse>> {
         Ok(self
             .api
             .http
@@ -150,7 +150,7 @@ impl ReadApi {
 
     pub async fn query_transaction_blocks(
         &self,
-        query: SuiTransactionResponseQuery,
+        query: SuiTransactionBlockResponseQuery,
         cursor: Option<TransactionDigest>,
         limit: Option<usize>,
         descending_order: bool,
@@ -181,10 +181,10 @@ impl ReadApi {
 
     pub fn get_transactions_stream(
         &self,
-        query: SuiTransactionResponseQuery,
+        query: SuiTransactionBlockResponseQuery,
         cursor: Option<TransactionDigest>,
         descending_order: bool,
-    ) -> impl Stream<Item = SuiTransactionResponse> + '_ {
+    ) -> impl Stream<Item = SuiTransactionBlockResponse> + '_ {
         stream::unfold(
             (vec![], cursor, true, query),
             move |(mut data, cursor, first, query)| async move {
@@ -441,12 +441,12 @@ impl QuorumDriver {
     pub async fn execute_transaction_block(
         &self,
         tx: VerifiedTransaction,
-        options: SuiTransactionResponseOptions,
+        options: SuiTransactionBlockResponseOptions,
         request_type: Option<ExecuteTransactionRequestType>,
-    ) -> SuiRpcResult<SuiTransactionResponse> {
+    ) -> SuiRpcResult<SuiTransactionBlockResponse> {
         let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
         let request_type = request_type.unwrap_or_else(|| options.default_execution_request_type());
-        let mut response: SuiTransactionResponse = self
+        let mut response: SuiTransactionBlockResponse = self
             .api
             .http
             .execute_transaction_block(
@@ -490,7 +490,7 @@ impl QuorumDriver {
             let resp = ReadApiClient::get_transaction_block(
                 &c.http,
                 tx_digest,
-                Some(SuiTransactionResponseOptions::new()),
+                Some(SuiTransactionBlockResponseOptions::new()),
             )
             .await;
             if let Err(err) = resp {

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -20,7 +20,7 @@ use sui_json_rpc_types::{
     SuiCoinMetadata, SuiCommittee, SuiEvent, SuiGetPastObjectRequest, SuiMoveNormalizedModule,
     SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery, SuiPastObjectResponse,
     SuiTransactionBlockEffectsAPI, SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions,
-    SuiTransactionBlockResponseQuery, TransactionsPage,
+    SuiTransactionBlockResponseQuery, TransactionBlocksPage,
 };
 use sui_types::balance::Supply;
 use sui_types::base_types::{ObjectID, SequenceNumber, SuiAddress, TransactionDigest};
@@ -154,7 +154,7 @@ impl ReadApi {
         cursor: Option<TransactionDigest>,
         limit: Option<usize>,
         descending_order: bool,
-    ) -> SuiRpcResult<TransactionsPage> {
+    ) -> SuiRpcResult<TransactionBlocksPage> {
         Ok(self
             .api
             .http

--- a/crates/sui-sdk/tests/stream_tests.rs
+++ b/crates/sui-sdk/tests/stream_tests.rs
@@ -17,7 +17,7 @@ use test_utils::network::TestClusterBuilder;
 //     let client = SuiClientBuilder::default().build(rpc_url).await?;
 //     let txs = client
 //         .read_api()
-//         .get_transactions_stream(SuiTransactionResponseQuery::default(), None, true)
+//         .get_transactions_stream(SuiTransactionBlockResponseQuery::default(), None, true)
 //         .collect::<Vec<_>>()
 //         .await;
 
@@ -36,7 +36,7 @@ use test_utils::network::TestClusterBuilder;
 
 //     let txs = client
 //         .read_api()
-//         .get_transactions_stream(SuiTransactionResponseQuery::default(), None, true)
+//         .get_transactions_stream(SuiTransactionBlockResponseQuery::default(), None, true)
 //         .collect::<Vec<_>>()
 //         .await;
 

--- a/crates/sui/intent_signing.md
+++ b/crates/sui/intent_signing.md
@@ -1,6 +1,5 @@
 # Intent Signing
 
-
 ## Description
 
 Intent Signing is a standard used in Sui that defines _what_ the signature is committed to. We call the data that the signature commits to is an intent message. All signatures in Sui MUST commit to an intent message, instead of the message itself.
@@ -8,8 +7,9 @@ Intent Signing is a standard used in Sui that defines _what_ the signature is co
 ## Motivation
 
 Previously, Sui uses a special `Signable` trait, which attaches the Rust struct name as a prefix before the serialized data. This is not ideal because:
-   - Not compact: The prefix of `TransactionData::` is significantly larger than 1 byte.
-   - Not user-friendly: Non-Rust applications need to maintain a list of Rust-struct names.
+
+- Not compact: The prefix of `TransactionData::` is significantly larger than 1 byte.
+- Not user-friendly: Non-Rust applications need to maintain a list of Rust-struct names.
 
 The intent signing standard is proposed to provide a compact domain separator to the data being signed for both user signatures and authority signatures. It has several benefits:
 
@@ -44,7 +44,6 @@ pub struct Intent {
 
 To see detailed definition for each field, see each enum definition [here](https://github.com/MystenLabs/sui/blob/0dc1a38f800fc2d8fabe11477fdef702058cf00d/crates/sui-types/src/intent.rs).
 
-
 The serialization of an `Intent` is a 3-byte array where each field is represented by a byte.
 
 The serialization of an `IntentMessage<T>` is the 3 bytes of the intent concatenated with the BCS serialized message.
@@ -65,8 +64,8 @@ Here is an example in Typescript:
 
 ```typescript
 const intentMessage = messageWithIntent(
-   IntentScope.TransactionData,
-   transactionBytes,
+  IntentScope.TransactionData,
+  TransactionBlockBytes
 );
 const signature = await this.signData(intentMessage);
 ```
@@ -76,6 +75,7 @@ const signature = await this.signData(intentMessage);
 Authority signature is created using the protocol key. The data that it commits to is also an intent message `intent || message`. See all available intent scopes [here](https://github.com/MystenLabs/sui/blob/0dc1a38f800fc2d8fabe11477fdef702058cf00d/crates/sui-types/src/intent.rs#L66)
 
 # Implementation
+
 1. [Struct and enum definitions](https://github.com/MystenLabs/sui/blob/0dc1a38f800fc2d8fabe11477fdef702058cf00d/crates/sui-types/src/intent.rs)
 2. [Test](https://github.com/MystenLabs/sui/blob/d009e82fa35bda4f2b3e7a86a9529d36c32a8159/crates/sui-types/src/unit_tests/intent_tests.rs)
 3. User transaction intent signing [PR 1](https://github.com/MystenLabs/sui/pull/6445), [PR 2](https://github.com/MystenLabs/sui/pull/8321)

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -38,7 +38,8 @@ use sui_framework_build::compiled_package::{
 use sui_json::SuiJsonValue;
 use sui_json_rpc_types::{
     DynamicFieldPage, SuiData, SuiObjectData, SuiObjectResponse, SuiObjectResponseQuery,
-    SuiRawData, SuiTransactionEffectsAPI, SuiTransactionResponse, SuiTransactionResponseOptions,
+    SuiRawData, SuiTransactionBlockEffectsAPI, SuiTransactionBlockResponse,
+    SuiTransactionBlockResponseOptions,
 };
 use sui_json_rpc_types::{SuiExecutionStatus, SuiObjectDataOptions};
 use sui_keys::keystore::AccountKeystore;
@@ -674,7 +675,7 @@ impl SuiClientCommands {
                     )
                     .await?;
                 let effects = response.effects.as_ref().ok_or_else(|| {
-                    anyhow!("Effects from SuiTransactionResult should not be empty")
+                    anyhow!("Effects from SuiTransactionBlockResult should not be empty")
                 })?;
                 let time_total = time_start.elapsed().as_micros();
                 if matches!(effects.status(), SuiExecutionStatus::Failure { .. }) {
@@ -711,7 +712,7 @@ impl SuiClientCommands {
                     )
                     .await?;
                 let effects = response.effects.as_ref().ok_or_else(|| {
-                    anyhow!("Effects from SuiTransactionResult should not be empty")
+                    anyhow!("Effects from SuiTransactionBlockResult should not be empty")
                 })?;
                 if matches!(effects.status(), SuiExecutionStatus::Failure { .. }) {
                     return Err(anyhow!("Error transferring SUI: {:#?}", effects.status()));
@@ -760,7 +761,7 @@ impl SuiClientCommands {
                     )
                     .await?;
                 let effects = response.effects.as_ref().ok_or_else(|| {
-                    anyhow!("Effects from SuiTransactionResult should not be empty")
+                    anyhow!("Effects from SuiTransactionBlockResult should not be empty")
                 })?;
                 if matches!(effects.status(), SuiExecutionStatus::Failure { .. }) {
                     return Err(anyhow!(
@@ -811,7 +812,7 @@ impl SuiClientCommands {
                     )
                     .await?;
                 let effects = response.effects.as_ref().ok_or_else(|| {
-                    anyhow!("Effects from SuiTransactionResult should not be empty")
+                    anyhow!("Effects from SuiTransactionBlockResult should not be empty")
                 })?;
                 if matches!(effects.status(), SuiExecutionStatus::Failure { .. }) {
                     return Err(anyhow!(
@@ -850,7 +851,7 @@ impl SuiClientCommands {
                     )
                     .await?;
                 let effects = response.effects.as_ref().ok_or_else(|| {
-                    anyhow!("Effects from SuiTransactionResult should not be empty")
+                    anyhow!("Effects from SuiTransactionBlockResult should not be empty")
                 })?;
                 if matches!(effects.status(), SuiExecutionStatus::Failure { .. }) {
                     return Err(anyhow!(
@@ -1345,13 +1346,13 @@ impl WalletContext {
     pub async fn execute_transaction_block(
         &self,
         tx: VerifiedTransaction,
-    ) -> anyhow::Result<SuiTransactionResponse> {
+    ) -> anyhow::Result<SuiTransactionBlockResponse> {
         let client = self.get_client().await?;
         Ok(client
             .quorum_driver()
             .execute_transaction_block(
                 tx,
-                SuiTransactionResponseOptions::new()
+                SuiTransactionBlockResponseOptions::new()
                     .with_effects()
                     .with_events()
                     .with_input()
@@ -1564,7 +1565,7 @@ pub async fn call_move(
     gas_budget: u64,
     args: Vec<SuiJsonValue>,
     context: &mut WalletContext,
-) -> Result<SuiTransactionResponse, anyhow::Error> {
+) -> Result<SuiTransactionBlockResponse, anyhow::Error> {
     // Convert all numeric input to String, this will allow number input from the CLI without failing SuiJSON's checks.
     let args = args
         .into_iter()
@@ -1601,7 +1602,7 @@ pub async fn call_move(
     let effects = response
         .effects
         .as_ref()
-        .ok_or_else(|| anyhow!("Effects from SuiTransactionResult should not be empty"))?;
+        .ok_or_else(|| anyhow!("Effects from SuiTransactionBlockResult should not be empty"))?;
     if matches!(effects.status(), SuiExecutionStatus::Failure { .. }) {
         return Err(anyhow!("Error calling module: {:#?}", effects.status()));
     }
@@ -1622,7 +1623,9 @@ fn convert_number_to_string(value: Value) -> Value {
 }
 
 // TODOD(chris): only print out the full response when `--verbose` is provided
-pub fn write_transaction_response(response: &SuiTransactionResponse) -> Result<String, fmt::Error> {
+pub fn write_transaction_response(
+    response: &SuiTransactionBlockResponse,
+) -> Result<String, fmt::Error> {
     let mut writer = String::new();
     writeln!(writer, "{}", "----- Transaction Digest ----".bold())?;
     writeln!(writer, "{}", response.digest)?;
@@ -1696,36 +1699,36 @@ impl SuiClientCommandResult {
 #[derive(Serialize)]
 #[serde(untagged)]
 pub enum SuiClientCommandResult {
-    Upgrade(SuiTransactionResponse),
-    Publish(SuiTransactionResponse),
+    Upgrade(SuiTransactionBlockResponse),
+    Publish(SuiTransactionBlockResponse),
     VerifySource,
     Object(SuiObjectResponse),
     RawObject(SuiObjectResponse),
-    Call(SuiTransactionResponse),
+    Call(SuiTransactionBlockResponse),
     Transfer(
         // Skipping serialisation for elapsed time.
         #[serde(skip)] u128,
-        SuiTransactionResponse,
+        SuiTransactionBlockResponse,
     ),
-    TransferSui(SuiTransactionResponse),
-    Pay(SuiTransactionResponse),
-    PaySui(SuiTransactionResponse),
-    PayAllSui(SuiTransactionResponse),
+    TransferSui(SuiTransactionBlockResponse),
+    Pay(SuiTransactionBlockResponse),
+    PaySui(SuiTransactionBlockResponse),
+    PayAllSui(SuiTransactionBlockResponse),
     Addresses(Vec<SuiAddress>, Option<SuiAddress>),
     Objects(Vec<SuiObjectResponse>),
     DynamicFieldQuery(DynamicFieldPage),
     SyncClientState,
     NewAddress((SuiAddress, String, SignatureScheme)),
     Gas(Vec<GasCoin>),
-    SplitCoin(SuiTransactionResponse),
-    MergeCoin(SuiTransactionResponse),
+    SplitCoin(SuiTransactionBlockResponse),
+    MergeCoin(SuiTransactionBlockResponse),
     Switch(SwitchResponse),
     ActiveAddress(Option<SuiAddress>),
     ActiveEnv(Option<String>),
     Envs(Vec<SuiEnv>, Option<String>),
     SerializeTransferSui(String),
     SerializePublish(String),
-    ExecuteSignedTx(SuiTransactionResponse),
+    ExecuteSignedTx(SuiTransactionBlockResponse),
     NewEnv(SuiEnv),
 }
 

--- a/crates/sui/src/fire_drill.rs
+++ b/crates/sui/src/fire_drill.rs
@@ -20,8 +20,8 @@ use sui_config::node::KeyPairWithPath;
 use sui_config::utils;
 use sui_config::{node::AuthorityKeyPairWithPath, Config, NodeConfig, PersistedConfig};
 use sui_framework::{SuiSystem, SystemPackage};
-use sui_json_rpc_types::{SuiExecutionStatus, SuiTransactionResponseOptions};
-use sui_sdk::{rpc_types::SuiTransactionEffectsAPI, SuiClient, SuiClientBuilder};
+use sui_json_rpc_types::{SuiExecutionStatus, SuiTransactionBlockResponseOptions};
+use sui_sdk::{rpc_types::SuiTransactionBlockEffectsAPI, SuiClient, SuiClientBuilder};
 use sui_types::base_types::{ObjectRef, SuiAddress};
 use sui_types::crypto::{generate_proof_of_possession, get_key_pair, SuiKeyPair};
 use sui_types::messages::{CallArg, ObjectArg, TransactionData};
@@ -343,7 +343,7 @@ async fn execute_tx(
         .quorum_driver()
         .execute_transaction_block(
             tx,
-            SuiTransactionResponseOptions::full_content(),
+            SuiTransactionBlockResponseOptions::full_content(),
             Some(sui_types::messages::ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -28,7 +28,7 @@ use sui_framework_build::compiled_package::{BuildConfig, SuiPackageHooks};
 use sui_json::SuiJsonValue;
 use sui_json_rpc_types::{
     OwnedObjectRef, SuiObjectData, SuiObjectDataFilter, SuiObjectDataOptions, SuiObjectResponse,
-    SuiObjectResponseQuery, SuiTransactionEffects, SuiTransactionEffectsAPI,
+    SuiObjectResponseQuery, SuiTransactionBlockEffects, SuiTransactionBlockEffectsAPI,
 };
 use sui_keys::keystore::{AccountKeystore, FileBasedKeystore};
 use sui_macros::sim_test;
@@ -977,7 +977,7 @@ async fn test_package_upgrade_command() -> Result<(), anyhow::Error> {
         unreachable!("Invalid response");
     };
 
-    let SuiTransactionEffects::V1(effects) = response.effects.unwrap();
+    let SuiTransactionBlockEffects::V1(effects) = response.effects.unwrap();
 
     assert!(effects.status.is_ok());
     let package = effects
@@ -1045,7 +1045,7 @@ async fn test_package_upgrade_command() -> Result<(), anyhow::Error> {
     let SuiClientCommandResult::Upgrade(response) = resp else {
         unreachable!("Invalid upgrade response");
     };
-    let SuiTransactionEffects::V1(effects) = response.effects.unwrap();
+    let SuiTransactionBlockEffects::V1(effects) = response.effects.unwrap();
 
     assert!(effects.status.is_ok());
 

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -15,8 +15,8 @@ use serde_json::json;
 use sui::client_commands::{SuiClientCommandResult, SuiClientCommands, WalletContext};
 use sui_json_rpc_types::EventFilter;
 use sui_json_rpc_types::{
-    type_and_fields_from_move_struct, SuiEvent, SuiExecutionStatus, SuiTransactionEffectsAPI,
-    SuiTransactionResponse, SuiTransactionResponseOptions,
+    type_and_fields_from_move_struct, SuiEvent, SuiExecutionStatus, SuiTransactionBlockEffectsAPI,
+    SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions,
 };
 use sui_keys::keystore::AccountKeystore;
 use sui_macros::*;
@@ -819,15 +819,15 @@ async fn test_execute_tx_with_serialized_signature() -> Result<(), anyhow::Error
         let params = rpc_params![
             tx_bytes,
             signatures,
-            SuiTransactionResponseOptions::new(),
+            SuiTransactionBlockResponseOptions::new(),
             ExecuteTransactionRequestType::WaitForLocalExecution
         ];
-        let response: SuiTransactionResponse = jsonrpc_client
+        let response: SuiTransactionBlockResponse = jsonrpc_client
             .request("sui_executeTransaction", params)
             .await
             .unwrap();
 
-        let SuiTransactionResponse {
+        let SuiTransactionBlockResponse {
             digest,
             confirmed_local_execution,
             ..
@@ -860,15 +860,15 @@ async fn test_full_node_transaction_orchestrator_rpc_ok() -> Result<(), anyhow::
     let params = rpc_params![
         tx_bytes,
         signatures,
-        SuiTransactionResponseOptions::new(),
+        SuiTransactionBlockResponseOptions::new(),
         ExecuteTransactionRequestType::WaitForLocalExecution
     ];
-    let response: SuiTransactionResponse = jsonrpc_client
+    let response: SuiTransactionBlockResponse = jsonrpc_client
         .request("sui_executeTransaction", params)
         .await
         .unwrap();
 
-    let SuiTransactionResponse {
+    let SuiTransactionBlockResponse {
         digest,
         confirmed_local_execution,
         ..
@@ -876,7 +876,7 @@ async fn test_full_node_transaction_orchestrator_rpc_ok() -> Result<(), anyhow::
     assert_eq!(&digest, tx_digest);
     assert!(confirmed_local_execution.unwrap());
 
-    let _response: SuiTransactionResponse = jsonrpc_client
+    let _response: SuiTransactionBlockResponse = jsonrpc_client
         .request("sui_getTransaction", rpc_params![*tx_digest])
         .await
         .unwrap();
@@ -886,15 +886,15 @@ async fn test_full_node_transaction_orchestrator_rpc_ok() -> Result<(), anyhow::
     let params = rpc_params![
         tx_bytes,
         signatures,
-        SuiTransactionResponseOptions::new().with_effects(),
+        SuiTransactionBlockResponseOptions::new().with_effects(),
         ExecuteTransactionRequestType::WaitForEffectsCert
     ];
-    let response: SuiTransactionResponse = jsonrpc_client
+    let response: SuiTransactionBlockResponse = jsonrpc_client
         .request("sui_executeTransaction", params)
         .await
         .unwrap();
 
-    let SuiTransactionResponse {
+    let SuiTransactionBlockResponse {
         effects,
         confirmed_local_execution,
         ..

--- a/crates/test-utils/src/transaction.rs
+++ b/crates/test-utils/src/transaction.rs
@@ -15,8 +15,8 @@ pub use sui_core::test_utils::{
     compile_basics_package, compile_nfts_package, wait_for_all_txes, wait_for_tx,
 };
 use sui_json_rpc_types::{
-    SuiObjectDataOptions, SuiObjectResponseQuery, SuiTransactionDataAPI, SuiTransactionEffectsAPI,
-    SuiTransactionResponse, SuiTransactionResponseOptions,
+    SuiObjectDataOptions, SuiObjectResponseQuery, SuiTransactionBlockDataAPI,
+    SuiTransactionBlockEffectsAPI, SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions,
 };
 use sui_keys::keystore::AccountKeystore;
 use sui_sdk::json::SuiJsonValue;
@@ -139,7 +139,7 @@ pub async fn publish_package_with_wallet(
         .quorum_driver()
         .execute_transaction_block(
             transaction,
-            SuiTransactionResponseOptions::new().with_effects(),
+            SuiTransactionBlockResponseOptions::new().with_effects(),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await
@@ -168,7 +168,7 @@ pub async fn submit_move_transaction(
     arguments: Vec<SuiJsonValue>,
     sender: SuiAddress,
     gas_object: Option<ObjectID>,
-) -> SuiTransactionResponse {
+) -> SuiTransactionBlockResponse {
     debug!(?package_id, ?arguments, "move_transaction");
     let client = context.get_client().await.unwrap();
     let data = client
@@ -202,7 +202,7 @@ pub async fn submit_move_transaction(
         .quorum_driver()
         .execute_transaction_block(
             tx,
-            SuiTransactionResponseOptions::full_content(),
+            SuiTransactionBlockResponseOptions::full_content(),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await
@@ -250,7 +250,7 @@ pub async fn increment_counter(
     gas_object: Option<ObjectID>,
     package_id: ObjectID,
     counter_id: ObjectID,
-) -> SuiTransactionResponse {
+) -> SuiTransactionBlockResponse {
     submit_move_transaction(
         context,
         "counter",
@@ -444,7 +444,7 @@ pub async fn delete_devnet_nft(
     sender: &SuiAddress,
     nfts_package: ObjectID,
     nft_to_delete: ObjectRef,
-) -> SuiTransactionResponse {
+) -> SuiTransactionBlockResponse {
     let gas = get_gas_object_with_wallet_context(context, sender)
         .await
         .unwrap_or_else(|| panic!("Expect {sender} to have at least one gas object"));
@@ -474,7 +474,7 @@ pub async fn delete_devnet_nft(
         .quorum_driver()
         .execute_transaction_block(
             tx,
-            SuiTransactionResponseOptions::full_content(),
+            SuiTransactionBlockResponseOptions::full_content(),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await

--- a/dapps/sponsored-transactions/src/App.tsx
+++ b/dapps/sponsored-transactions/src/App.tsx
@@ -100,7 +100,7 @@ export function App() {
                 try {
                   const signed = await signTransaction({
                     transaction: Transaction.from(
-                      sponsoredTx!.TransactionBlockBytes
+                      sponsoredTx!.transactionBlockBytes
                     ),
                   });
                   setSignedTx(signed);
@@ -122,8 +122,8 @@ export function App() {
               onClick={async () => {
                 setLoading(true);
                 try {
-                  const executed = await provider.executeTransaction({
-                    transaction: signedTx!.TransactionBlockBytes,
+                  const executed = await provider.executeTransactionBlock({
+                    transactionBlock: signedTx!.transactionBlockBytes,
                     signature: [signedTx!.signature, sponsoredTx!.signature],
                     options: {
                       showEffects: true,

--- a/dapps/sponsored-transactions/src/App.tsx
+++ b/dapps/sponsored-transactions/src/App.tsx
@@ -3,7 +3,7 @@
 
 import {
   SignedTransaction,
-  SuiTransactionResponse,
+  SuiTransactionBlockResponse,
   Transaction,
 } from "@mysten/sui.js";
 import { ConnectButton, useWalletKit } from "@mysten/wallet-kit";
@@ -49,9 +49,8 @@ export function App() {
     null
   );
   const [signedTx, setSignedTx] = useState<SignedTransaction | null>(null);
-  const [executedTx, setExecutedTx] = useState<SuiTransactionResponse | null>(
-    null
-  );
+  const [executedTx, setExecutedTx] =
+    useState<SuiTransactionBlockResponse | null>(null);
 
   return (
     <div className="p-8">

--- a/dapps/sponsored-transactions/src/App.tsx
+++ b/dapps/sponsored-transactions/src/App.tsx
@@ -100,7 +100,7 @@ export function App() {
                 try {
                   const signed = await signTransaction({
                     transaction: Transaction.from(
-                      sponsoredTx!.transactionBytes
+                      sponsoredTx!.TransactionBlockBytes
                     ),
                   });
                   setSignedTx(signed);
@@ -123,7 +123,7 @@ export function App() {
                 setLoading(true);
                 try {
                   const executed = await provider.executeTransaction({
-                    transaction: signedTx!.transactionBytes,
+                    transaction: signedTx!.TransactionBlockBytes,
                     signature: [signedTx!.signature, sponsoredTx!.signature],
                     options: {
                       showEffects: true,

--- a/doc/src/build/prog-trans-ts-sdk.md
+++ b/doc/src/build/prog-trans-ts-sdk.md
@@ -136,7 +136,7 @@ In most cases, building requires your JSON RPC Provider to fully resolve input v
 If you have transaction bytes, you can also convert them back into a `Transaction` class:
 
 ```tsx
-const bytes = getTransactionBytesFromSomewhere();
+const bytes = getTransactionBlockBytesFromSomewhere();
 const tx = Transaction.from(bytes);
 ```
 

--- a/doc/src/doc-updates/sui-breaking-changes.md
+++ b/doc/src/doc-updates/sui-breaking-changes.md
@@ -12,7 +12,7 @@ New entries added 03/20/23.
 
 ---
 
-**[Major breaking change]** - This release replaces the `sui_getValidators` and `sui_getSuiSystemState` functions with a new `sui_getLatestSuiSystemState` function. The new function returns a flattened type that contains all information from the latest `SuiSystemState`  object on-chain with type `SuiSystemStateSummary`. It also contains a vector of type `SuiValidatorSummary` that summarizes information from each validator, including: metadata, staking pool, and other data. The release also adds a `p2p_address` to each validator’s metadata. The value for the field is the address the validator used for p2p activities, such as state sync.
+**[Major breaking change]** - This release replaces the `sui_getValidators` and `sui_getSuiSystemState` functions with a new `sui_getLatestSuiSystemState` function. The new function returns a flattened type that contains all information from the latest `SuiSystemState` object on-chain with type `SuiSystemStateSummary`. It also contains a vector of type `SuiValidatorSummary` that summarizes information from each validator, including: metadata, staking pool, and other data. The release also adds a `p2p_address` to each validator’s metadata. The value for the field is the address the validator used for p2p activities, such as state sync.
 
 ---
 
@@ -20,7 +20,7 @@ New entries added 03/20/23.
 
 ---
 
-**[Major breaking change]** - The `sui_getObject` endpoint now takes an additional configuration parameter of type `SuiObjectDataOptions` to control which fields the endpoint retrieves. By default, the endpoint retrieves only object references unless the client request  explicitly specifies other data, such as `type`, `owner`, or `bcs`. To learn more, see [PR 8817](https://github.com/MystenLabs/sui/pull/8817)
+**[Major breaking change]** - The `sui_getObject` endpoint now takes an additional configuration parameter of type `SuiObjectDataOptions` to control which fields the endpoint retrieves. By default, the endpoint retrieves only object references unless the client request explicitly specifies other data, such as `type`, `owner`, or `bcs`. To learn more, see [PR 8817](https://github.com/MystenLabs/sui/pull/8817)
 
 ---
 
@@ -78,27 +78,29 @@ New entries added 03/20/23.
 
 **[Major API breaking changes]** - `GetTransaction` API refactoring
 
- * [RPC] `sui_getTransaction` and `sui_multiGetTransaction` now take in an additional optional parameter called `options` that specifies which fields to retrieve (such as  `transaction`, `effects`, `events`, etc). By default, these operations return only the transaction digest.
- * [TS SDK] Renamed `provider.getTransactionWithEffects` to `provider.getTransactionResponse`. The new method takes in an additional parameter, `SuiTransactionResponseOptions`, to configure which fields to retrieve (such as `transaction`, `effects`, `events`, etc). By default, this method returns only the transaction digest.
+- [RPC] `sui_getTransaction` and `sui_multiGetTransaction` now take in an additional optional parameter called `options` that specifies which fields to retrieve (such as `transaction`, `effects`, `events`, etc). By default, these operations return only the transaction digest.
+- [TS SDK] Renamed `provider.getTransactionWithEffects` to `provider.getTransactionResponse`. The new method takes in an additional parameter, `SuiTransactionBlockResponseOptions`, to configure which fields to retrieve (such as `transaction`, `effects`, `events`, etc). By default, this method returns only the transaction digest.
 
 For more information, see [PR 8888](https://github.com/MystenLabs/sui/pull/8888).
 
 ---
 
 **[Major API breaking changes] sui_executeTransaction refactoring**
- * Removed `sui_executeTransactionSerializedSig` and `sui_submitTransaction` operations.
- * The `sui_executeTransaction` operation now takes a vector of signatures instead of a single signature to support Sponsored Transactions.
-    
+
+- Removed `sui_executeTransactionSerializedSig` and `sui_submitTransaction` operations.
+- The `sui_executeTransaction` operation now takes a vector of signatures instead of a single signature to support Sponsored Transactions.
+
 To learn more, see [PR 9068](https://github.com/MystenLabs/sui/pull/9068).
 
 ---
 
 **[RPC API breaking change]** - Various changes in JSON-RPC governance API:
- * updated `sui_getDelegatedStakes` to the new staking flow
- * grouped all `StakedSui` by staking pool to reduce duplicate validator info in the response
- * improve `ValidatorMetadata` JSON response to make it more human-readable, which affects `getSuiSystemState` as well.
- * make `SuiSystemState` JSON response `camelCased`
- * added `--epoch-duration-ms` option to Sui genesis for configuring localnet epoch duration
+
+- updated `sui_getDelegatedStakes` to the new staking flow
+- grouped all `StakedSui` by staking pool to reduce duplicate validator info in the response
+- improve `ValidatorMetadata` JSON response to make it more human-readable, which affects `getSuiSystemState` as well.
+- make `SuiSystemState` JSON response `camelCased`
+- added `--epoch-duration-ms` option to Sui genesis for configuring localnet epoch duration
 
 For more information, see [PR 8848](https://github.com/MystenLabs/sui/pull/8848).
 
@@ -114,11 +116,11 @@ Added 03/20/23
 
 ---
 
-**[API breaking change]** - All functions that include *delegation* in their name are renamed to use *stake* instead. For example, `request_add_delegation` is now `request_add_stake`. See [PR 9059](https://github.com/MystenLabs/sui/pull/9059) for details.
+**[API breaking change]** - All functions that include _delegation_ in their name are renamed to use _stake_ instead. For example, `request_add_delegation` is now `request_add_stake`. See [PR 9059](https://github.com/MystenLabs/sui/pull/9059) for details.
 
 ---
 
-**[API breaking change]** - This release replaces `SuiCertifiedTransaction` with `SuiTransaction` in `SuiTransactionResponse`. This is because validators can no longer guarantee to return a transaction certificate. This release also unifies `SuiTransactionResponse` and `SuiExecuteTransactionResponse` to simplify the API. See [PR 8369](https://github.com/MystenLabs/sui/pull/8369) for more information.
+**[API breaking change]** - This release replaces `SuiCertifiedTransaction` with `SuiTransactionBlock` in `SuiTransactionBlockResponse`. This is because validators can no longer guarantee to return a transaction certificate. This release also unifies `SuiTransactionBlockResponse` and `SuiExecuteTransactionResponse` to simplify the API. See [PR 8369](https://github.com/MystenLabs/sui/pull/8369) for more information.
 
 ---
 
@@ -130,7 +132,7 @@ Added 03/20/23
 
 ---
 
-**[API breaking change]** - To reduce the size of Sui Full node synchronization payloads, this release removes events from `TransactionEffect`. The events are still included in the `SuiTransactionResponse` returned by `sui_getTransaction` and `sui_submitTransaction` endpoints. For more information, see [PR 7822](https://github.com/MystenLabs/sui/pull/7822).
+**[API breaking change]** - To reduce the size of Sui Full node synchronization payloads, this release removes events from `TransactionEffect`. The events are still included in the `SuiTransactionBlockResponse` returned by `sui_getTransaction` and `sui_submitTransaction` endpoints. For more information, see [PR 7822](https://github.com/MystenLabs/sui/pull/7822).
 
 ---
 

--- a/doc/src/doc-updates/sui-migration-guide.md
+++ b/doc/src/doc-updates/sui-migration-guide.md
@@ -474,7 +474,7 @@ Prior to release .28, the function names were:
         gas: Option<ObjectID>,
         /// the gas budget, the transaction will fail if the gas cost exceed the budget
         gas_budget: u64,
-    ) -> RpcResult<TransactionBytes>;
+    ) -> RpcResult<TransactionBlockBytes>;
 
     /// Withdraw a delegation from a validator's staking pool.
     #[method(name = "requestWithdrawDelegation")]
@@ -490,7 +490,7 @@ Prior to release .28, the function names were:
         gas: Option<ObjectID>,
         /// the gas budget, the transaction will fail if the gas cost exceed the budget
         gas_budget: u64,
-    ) -> RpcResult<TransactionBytes>;
+    ) -> RpcResult<TransactionBlockBytes>;
 
     /// Switch delegation from the current validator to a new one.
     #[method(name = "requestSwitchDelegation")]
@@ -508,7 +508,7 @@ Prior to release .28, the function names were:
         gas: Option<ObjectID>,
         /// the gas budget, the transaction will fail if the gas cost exceed the budget
          gas_budget: u64,
-    ) -> RpcResult<TransactionBytes>;
+    ) -> RpcResult<TransactionBlockBytes>;
 ```
 
 Effective with release .28, the function names are:
@@ -530,7 +530,7 @@ Effective with release .28, the function names are:
         gas: Option<ObjectID>,
         /// the gas budget, the transaction will fail if the gas cost exceed the budget
         gas_budget: u64,
-    ) -> RpcResult<TransactionBytes>;
+    ) -> RpcResult<TransactionBlockBytes>;
 
     /// Withdraw stake from a validator's staking pool.
     #[method(name = "requestWithdrawStake")]
@@ -546,7 +546,7 @@ Effective with release .28, the function names are:
         gas: Option<ObjectID>,
         /// the gas budget, the transaction will fail if the gas cost exceed the budget
         gas_budget: u64,
-    ) -> RpcResult<TransactionBytes>;
+    ) -> RpcResult<TransactionBlockBytes>;
 ```
 
 ### Changes to getDelegatedStakes

--- a/doc/src/doc-updates/sui-migration-guide.md
+++ b/doc/src/doc-updates/sui-migration-guide.md
@@ -16,9 +16,9 @@ The Sui Framework (`sui-framework`) Move package contains modules central to Sui
 
 In [PR 9618](https://github.com/MystenLabs/sui/pull/9618), the `sui-framework` crate now contains three Move packages in the `packages` directory: `move-stdlib`, `sui-framework` and `sui-system`:
 
- * `sui-system` contains modules that were in the `sui-framework/sources/governance` directory, including all the validator management and staking related functions, published at `0x3` with named address `sui_system`.
- * `sui-framework` contains all other modules that were not in the `governance` folder. The framework provides library and utility modules for Sui Move developers. It is still published at `0x2` with named address `sui`.
- * `move-stdlib` contains a copy of the Move standard library that used to be in the `sui-framework/deps` folder. It is still published at `0x1` with named address `std`.
+- `sui-system` contains modules that were in the `sui-framework/sources/governance` directory, including all the validator management and staking related functions, published at `0x3` with named address `sui_system`.
+- `sui-framework` contains all other modules that were not in the `governance` folder. The framework provides library and utility modules for Sui Move developers. It is still published at `0x2` with named address `sui`.
+- `move-stdlib` contains a copy of the Move standard library that used to be in the `sui-framework/deps` folder. It is still published at `0x1` with named address `std`.
 
 If you develop Sui Move code depending on `sui-framework`, the `Move.toml` file of your Move package has to change to reflect the path changes:
 
@@ -60,18 +60,18 @@ If your Sui Move code uses a module in the `governance` folder:
 
 The modules are now in the `sui-system` package. You must list `SuiSystem` as a dependency, and access these modules via `0x3` or the `sui_system` named address.
 
-
 ### Erecover and verify
 
 In this release, `ecdsa_k1::ecrecover` and `ecdsa_k1::secp256k1_verify` now require you to input the raw message instead of a hashed message.
 
- * `ecdsa_k1::ecrecover(sig, hashed_msg, hash_function)` is updated to `ecdsa_k1::secp256k1_ecrecover(sig, msg, hash_function)`
+- `ecdsa_k1::ecrecover(sig, hashed_msg, hash_function)` is updated to `ecdsa_k1::secp256k1_ecrecover(sig, msg, hash_function)`
 
- * `ecdsa_k1::secp256k1_verify(sig, pk, hashed_msg)` is updated to `ecdsa_k1::secp256k1_verify(sig, pk, msg, hash_function)`
+- `ecdsa_k1::secp256k1_verify(sig, pk, hashed_msg)` is updated to `ecdsa_k1::secp256k1_verify(sig, pk, msg, hash_function)`
 
 When you call these APIs, you must provide the raw message instead of the hashed message for verification or EC recover. You must also provide the hash_function name represented by u8. See the source code for more information:
- * [ecdsa_k1.md](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/ecdsa_k1.md)
- * [ecdsa_r1.md](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/ecdsa_r1.md)
+
+- [ecdsa_k1.md](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/ecdsa_k1.md)
+- [ecdsa_r1.md](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/docs/ecdsa_r1.md)
 
 ### ID Leak
 
@@ -122,12 +122,13 @@ To read a detailed description and the motivation behind the standard, see the [
 In Sui Move, to claim a `Display` object, call `display::new<T>(&Publisher)`. As stated in the signature, it requires the `Publisher` object. Once acquired, `Display` can be modified by adding new fields (templates) to it, and when it’s ready to be published, a `display::update_version(&mut Display)` call is required to publish and make it available. All further additions / edits in the `Display` should also be applied by calling `update_version` again.
 
 Fields that we suggest to use in `Display` are:
- * **name:** a displayable name
- * **link:** a link to an object in an application / external link
- * **description:** a broader displayable description
- * **image_url:** an URL or a blob with an image
- * **project_url:** a link to a website
- * **creator:** mentions the creator in any way (text, link, address etc)
+
+- **name:** a displayable name
+- **link:** a link to an object in an application / external link
+- **description:** a broader displayable description
+- **image_url:** an URL or a blob with an image
+- **project_url:** a link to a website
+- **creator:** mentions the creator in any way (text, link, address etc)
 
 See additional information and examples in [Display](http://examples.sui.io/basics/display.html).
 
@@ -137,41 +138,40 @@ The steps in this section provide guidance on making updates related to the chan
 
 ### Reading objects
 
-The `sui_getObject` endpoint now takes an additional configuration parameter of type `SuiObjectDataOptions` to control which fields the endpoint retrieves. By default, the endpoint retrieves only object references unless the client request  explicitly specifies other data, such as `type`, `owner`, or `bcs`.
+The `sui_getObject` endpoint now takes an additional configuration parameter of type `SuiObjectDataOptions` to control which fields the endpoint retrieves. By default, the endpoint retrieves only object references unless the client request explicitly specifies other data, such as `type`, `owner`, or `bcs`.
 
 #### TypeScript Migration
 
 ```tsx
-
-import { JsonRpcProvider } from '@mysten/sui.js';
+import { JsonRpcProvider } from "@mysten/sui.js";
 const provider = new JsonRpcProvider();
 
-    // Prior to release .28
-    const txn = await provider.getObject(
-      '0xcff6ccc8707aa517b4f1b95750a2a8c666012df3',
-    );
-    const txns = await provider.getObjectBatch([
-      '0xcff6ccc8707aa517b4f1b95750a2a8c666012df3',
-      '0xdff6ccc8707aa517b4f1b95750a2a8c666012df3',
-    ]);
+// Prior to release .28
+const txn = await provider.getObject(
+  "0xcff6ccc8707aa517b4f1b95750a2a8c666012df3"
+);
+const txns = await provider.getObjectBatch([
+  "0xcff6ccc8707aa517b4f1b95750a2a8c666012df3",
+  "0xdff6ccc8707aa517b4f1b95750a2a8c666012df3",
+]);
 
-    // Updated for release .28
-    const txn = await provider.getObject({
-      id: '0xcff6ccc8707aa517b4f1b95750a2a8c666012df3',
-      // fetch the object content field and display
-      options: {
-    		showContent: true,
-    		showDisplay: true
-    	},
-    });
-    const txns = await provider.multiGetObjects({
-      ids: [
-        '0xcff6ccc8707aa517b4f1b95750a2a8c666012df3',
-        '0xdff6ccc8707aa517b4f1b95750a2a8c666012df3',
-      ],
-      // only fetch the object type
-      options: { showType: true },
-    });
+// Updated for release .28
+const txn = await provider.getObject({
+  id: "0xcff6ccc8707aa517b4f1b95750a2a8c666012df3",
+  // fetch the object content field and display
+  options: {
+    showContent: true,
+    showDisplay: true,
+  },
+});
+const txns = await provider.multiGetObjects({
+  ids: [
+    "0xcff6ccc8707aa517b4f1b95750a2a8c666012df3",
+    "0xdff6ccc8707aa517b4f1b95750a2a8c666012df3",
+  ],
+  // only fetch the object type
+  options: { showType: true },
+});
 ```
 
 #### JSON RPC Migration
@@ -227,20 +227,22 @@ const provider = new JsonRpcProvider();
 To get a `Display` for an object, pass an additional flag to the `sui_getObject` call.
 
 ```jsx
-{ showDisplay: true }
+{
+  showDisplay: true;
+}
 ```
 
 The returned value is the processed template for a type. For example, for Sui Capys it could be:
 
 ```json
-    {
-        "name": "Capy - one of many",
-        "description": "Join our Capy adventure",
-        "link": "https://capy.art/capy/0x00000000....",
-        "image_url": "https://api.capy.art/capys/0x000adadada..../svg",
-        "project_url": "https://capy.art/",
-        "creator": "Capybara Lovers"
-    }
+{
+  "name": "Capy - one of many",
+  "description": "Join our Capy adventure",
+  "link": "https://capy.art/capy/0x00000000....",
+  "image_url": "https://api.capy.art/capys/0x000adadada..../svg",
+  "project_url": "https://capy.art/",
+  "creator": "Capybara Lovers"
+}
 ```
 
 ### Reading transactions
@@ -248,93 +250,87 @@ The returned value is the processed template for a type. For example, for Sui Ca
 The `sui_getTransaction`and `sui_multiGetTransaction` functions now take an additional optional parameter called `options`. Use `options` to specify which fields to retrieve, such as transaction, effects, or events. By default, it returns only the transaction digest.
 
 ```tsx
+import { JsonRpcProvider } from "@mysten/sui.js";
+const provider = new JsonRpcProvider();
 
-    import { JsonRpcProvider } from '@mysten/sui.js';
-    const provider = new JsonRpcProvider();
+// Prior to release .28
+const provider = new JsonRpcProvider();
+const txn = await provider.getTransactionWithEffects(
+  "6mn5W1CczLwitHCO9OIUbqirNrQ0cuKdyxaNe16SAME="
+);
+// You can also fetch multiple transactions in one batch request
+const txns = await provider.getTransactionWithEffectsBatch([
+  "6mn5W1CczLwitHCO9OIUbqirNrQ0cuKdyxaNe16SAME=",
+  "7mn5W1CczLwitHCO9OIUbqirNrQ0cuKdyxaNe16SAME=",
+]);
 
-    // Prior to release .28
-    const provider = new JsonRpcProvider();
-    const txn = await provider.getTransactionWithEffects(
-      '6mn5W1CczLwitHCO9OIUbqirNrQ0cuKdyxaNe16SAME=',
-    );
-    // You can also fetch multiple transactions in one batch request
-    const txns = await provider.getTransactionWithEffectsBatch([
-      '6mn5W1CczLwitHCO9OIUbqirNrQ0cuKdyxaNe16SAME=',
-      '7mn5W1CczLwitHCO9OIUbqirNrQ0cuKdyxaNe16SAME=',
-    ]);
-
-    // Updated for release .28
-    const provider = new JsonRpcProvider();
-    const txn = await provider.getTransactionBlock({
-      digest: '6mn5W1CczLwitHCO9OIUbqirNrQ0cuKdyxaNe16SAME=',
-      // only fetch the effects field
-      options: { showEffects: true },
-    });
-    // You can also fetch multiple transactions in one batch request
-    const txns = await provider.multiGetTransactionBlocks({
-      digests: [
-        '6mn5W1CczLwitHCO9OIUbqirNrQ0cuKdyxaNe16SAME=',
-        '7mn5W1CczLwitHCO9OIUbqirNrQ0cuKdyxaNe16SAME=',
-      ],
-      // fetch both the input transaction data as well as effects
-      options: { showInput: true, showEffects: true },
-    });
+// Updated for release .28
+const provider = new JsonRpcProvider();
+const txn = await provider.getTransactionBlock({
+  digest: "6mn5W1CczLwitHCO9OIUbqirNrQ0cuKdyxaNe16SAME=",
+  // only fetch the effects field
+  options: { showEffects: true },
+});
+// You can also fetch multiple transactions in one batch request
+const txns = await provider.multiGetTransactionBlocks({
+  digests: [
+    "6mn5W1CczLwitHCO9OIUbqirNrQ0cuKdyxaNe16SAME=",
+    "7mn5W1CczLwitHCO9OIUbqirNrQ0cuKdyxaNe16SAME=",
+  ],
+  // fetch both the input transaction data as well as effects
+  options: { showInput: true, showEffects: true },
+});
 ```
 
 ### Reading Events
 
 This release makes the following changes related to reading events:
 
- * Removes System events such as `Publish`, `TransferObject`, `NewObject` and keeps only `MoveEvents`.
- * Adds an `object_changes` and `balance_changes` field in `SuiTransactionResponse`
+- Removes System events such as `Publish`, `TransferObject`, `NewObject` and keeps only `MoveEvents`.
+- Adds an `object_changes` and `balance_changes` field in `SuiTransactionBlockResponse`
 
 ```tsx
-    import { JsonRpcProvider } from '@mysten/sui.js';
-    const provider = new JsonRpcProvider();
+import { JsonRpcProvider } from "@mysten/sui.js";
+const provider = new JsonRpcProvider();
 
-    // Prior to release .28
-    provider.getEvents(
-    	{ Sender: toolbox.address() },
-      null,
-      2,
-    );
+// Prior to release .28
+provider.getEvents({ Sender: toolbox.address() }, null, 2);
 
-    // Updated for release .28
-    const events = provider.queryEvents({
-      query: { Sender: toolbox.address() },
-      limit: 2,
-    });
+// Updated for release .28
+const events = provider.queryEvents({
+  query: { Sender: toolbox.address() },
+  limit: 2,
+});
 
-    // Subscribe events
+// Subscribe events
 
-    // Prior to release .28
-    const subscriptionId = await provider.subscribeEvent(
-      { SenderAddress: '0xbff6ccc8707aa517b4f1b95750a2a8c666012df3' },
-      (event: SuiEventEnvelope) => {
-        // handle subscription notification message here. This function is called once per subscription message.
-      },
-    );
+// Prior to release .28
+const subscriptionId = await provider.subscribeEvent(
+  { SenderAddress: "0xbff6ccc8707aa517b4f1b95750a2a8c666012df3" },
+  (event: SuiEventEnvelope) => {
+    // handle subscription notification message here. This function is called once per subscription message.
+  }
+);
 
-    // later, to unsubscribe
-    // calls RPC method 'sui_unsubscribeEvent' with params: [ subscriptionId ]
-    const subFoundAndRemoved = await provider.unsubscribeEvent(subscriptionId);
+// later, to unsubscribe
+// calls RPC method 'sui_unsubscribeEvent' with params: [ subscriptionId ]
+const subFoundAndRemoved = await provider.unsubscribeEvent(subscriptionId);
 
-    // Updated for release .28
-    // calls RPC method 'sui_subscribeEvent' with params:
-    // [ { Sender: '0xbff6ccc8707aa517b4f1b95750a2a8c666012df3' } ]
-    const subscriptionId = await provider.subscribeEvent({
-      filter: { Sender: '0xbff6ccc8707aa517b4f1b95750a2a8c666012df3' },
-      onMessage(event: SuiEvent) {
-        // handle subscription notification message here. This function is called once per subscription message.
-      },
-    });
+// Updated for release .28
+// calls RPC method 'sui_subscribeEvent' with params:
+// [ { Sender: '0xbff6ccc8707aa517b4f1b95750a2a8c666012df3' } ]
+const subscriptionId = await provider.subscribeEvent({
+  filter: { Sender: "0xbff6ccc8707aa517b4f1b95750a2a8c666012df3" },
+  onMessage(event: SuiEvent) {
+    // handle subscription notification message here. This function is called once per subscription message.
+  },
+});
 
-    // later, to unsubscribe
-    // calls RPC method 'sui_unsubscribeEvent' with params: [ subscriptionId ]
-    const subFoundAndRemoved = await provider.unsubscribeEvent({
-      id: subscriptionId,
-    });
-
+// later, to unsubscribe
+// calls RPC method 'sui_unsubscribeEvent' with params: [ subscriptionId ]
+const subFoundAndRemoved = await provider.unsubscribeEvent({
+  id: subscriptionId,
+});
 ```
 
 ### Pagination
@@ -342,6 +338,7 @@ This release makes the following changes related to reading events:
 This release changes the `Page` definition.
 
 **Prior to release .28**
+
 ```rust
 
     pub struct Page<T, C> {
@@ -361,8 +358,9 @@ This release changes the `Page` definition.
 ```
 
 Additionally:
- * `next_cursor` is no longer inclusive and now exclusive, it always points to the last item of `data` if data is not empty;
- * To check if the current page is the last page or not, instead of doing `next_cursor.is_none()`, now you can simply use `has_next_page`
+
+- `next_cursor` is no longer inclusive and now exclusive, it always points to the last item of `data` if data is not empty;
+- To check if the current page is the last page or not, instead of doing `next_cursor.is_none()`, now you can simply use `has_next_page`
 
 If you use `Page` to read pages one by one, now you do not have to manually handle the returned `None` value of `next_cursor` when the reading process hits the latest page, instead you can always use the returned `next_cursor` as the input argument of next read. Before this release, the reading process will start from genesis when it hits latest and the `None` value is not properly handled.
 
@@ -371,38 +369,38 @@ If you use `Page` to read pages one by one, now you do not have to manually hand
 The previous transaction builder methods on the `Signer`, and the `SignableTransaction` interface have been removed, and replaced with a new `Transaction` builder class. This new transaction builder takes full advantage of Programmable Transactions.
 
 ```tsx
-    // Construct a new transaction:
-    const tx = new Transaction();
+// Construct a new transaction:
+const tx = new Transaction();
 
-    // Example replacement for a SUI token transfer:
-    const [coin] = tx.splitCoins(tx.gas, [tx.pure(1000)]);
-    tx.transferObjects([coin], tx.pure(keypair.getPublicKey().toSuiAddress()));
+// Example replacement for a SUI token transfer:
+const [coin] = tx.splitCoins(tx.gas, [tx.pure(1000)]);
+tx.transferObjects([coin], tx.pure(keypair.getPublicKey().toSuiAddress()));
 
-    // Merge a list of coins into a primary coin:
-    tx.mergeCoin(tx.object('0xcoinA'), [
-      tx.object('0xcoinB'),
-      tx.object('0xcoinC'),
-    ]);
+// Merge a list of coins into a primary coin:
+tx.mergeCoin(tx.object("0xcoinA"), [
+  tx.object("0xcoinB"),
+  tx.object("0xcoinC"),
+]);
 
-    // Make a move call:
-    tx.moveCall({
-      target: `${packageObjectId}::nft::mint`,
-      arguments: [tx.pure('Example NFT')],
-    });
+// Make a move call:
+tx.moveCall({
+  target: `${packageObjectId}::nft::mint`,
+  arguments: [tx.pure("Example NFT")],
+});
 
-    // Execute a transaction:
-    const result = await signer.signAndExecuteTransaction({ transaction: tx });
+// Execute a transaction:
+const result = await signer.signAndExecuteTransaction({ transaction: tx });
 ```
 
-Transaction now support providing a list of gas coins as payment for a transaction. By default, the transaction builder automatically determines the gas budget and coins to use as payment for a transaction. You can also set these values, for example to  set your own budget, change the gas price, or do your own gas selection:
+Transaction now support providing a list of gas coins as payment for a transaction. By default, the transaction builder automatically determines the gas budget and coins to use as payment for a transaction. You can also set these values, for example to set your own budget, change the gas price, or do your own gas selection:
 
 ```tsx
-    // Set an explicit gas price. By default, uses the current reference gas price:
-    tx.setGasPrice(100);
-    // Change the gas budget (in SUI). By default, this executes a dry run and uses the gas consumed from that as the budget.
-    tx.setGasBudget(customBudgetDefined);
-    // Set the vector of gas objects to use as the gas payment.
-    tx.setGasPayment([coin1, coin2]);
+// Set an explicit gas price. By default, uses the current reference gas price:
+tx.setGasPrice(100);
+// Change the gas budget (in SUI). By default, this executes a dry run and uses the gas consumed from that as the budget.
+tx.setGasBudget(customBudgetDefined);
+// Set the vector of gas objects to use as the gas payment.
+tx.setGasPayment([coin1, coin2]);
 ```
 
 ## Staking changes
@@ -453,8 +451,9 @@ With the removal of locked coin staking and changes to the Sui staking flow, the
 ### Changes to stake deposit / withdraw APIs
 
 This release includes the following changes related to stake deposit and withdrawal requests:
- * Removes the `request_switch_delegation` function
- * Renames all delegation functions to use staking instead of delegation.
+
+- Removes the `request_switch_delegation` function
+- Renames all delegation functions to use staking instead of delegation.
 
 Prior to release .28, the function names were:
 
@@ -605,6 +604,3 @@ With the new `getStakesByIds` it's possible to query the delegated stakes using 
 ### Secp256k1 derive keypair
 
 Match `Secp256k1.deriveKeypair` with Ed25519 on a function signature takes in a mnemonics string and an optional path string instead of a required path string and a mnemonics string. See [PR 8542](https://github.com/MystenLabs/sui/pull/8542/files#diff-66c975e3c863646441ca600b074edb151f357e471bab6a34166caaecd5f546e1L151) for details.
-
-
-

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -14,9 +14,9 @@ import {
   SuiMoveNormalizedModule,
   SuiMoveNormalizedModules,
   SuiMoveNormalizedStruct,
-  SuiTransactionResponse,
+  SuiTransactionBlockResponse,
   TransactionDigest,
-  SuiTransactionResponseQuery,
+  SuiTransactionBlockResponseQuery,
   RpcApiVersion,
   parseVersionFromString,
   PaginatedEvents,
@@ -41,7 +41,7 @@ import {
   DryRunTransactionResponse,
   SuiObjectDataOptions,
   SuiSystemStateSummary,
-  SuiTransactionResponseOptions,
+  SuiTransactionBlockResponseOptions,
   SuiEvent,
   PaginatedObjectsResponse,
   SuiObjectResponseQuery,
@@ -455,7 +455,9 @@ export class JsonRpcProvider {
    * Get transaction blocks for a given query criteria
    */
   async queryTransactionBlocks(
-    input: SuiTransactionResponseQuery & PaginationArguments & OrderArguments,
+    input: SuiTransactionBlockResponseQuery &
+      PaginationArguments &
+      OrderArguments,
   ): Promise<PaginatedTransactionResponse> {
     return await this.client.requestWithType(
       'suix_queryTransactions',
@@ -463,7 +465,7 @@ export class JsonRpcProvider {
         {
           filter: input.filter,
           options: input.options,
-        } as SuiTransactionResponseQuery,
+        } as SuiTransactionBlockResponseQuery,
         input.cursor,
         input.limit,
         (input.order || 'descending') === 'descending',
@@ -475,23 +477,23 @@ export class JsonRpcProvider {
 
   async getTransactionBlock(input: {
     digest: TransactionDigest;
-    options?: SuiTransactionResponseOptions;
-  }): Promise<SuiTransactionResponse> {
+    options?: SuiTransactionBlockResponseOptions;
+  }): Promise<SuiTransactionBlockResponse> {
     if (!isValidTransactionDigest(input.digest)) {
       throw new Error('Invalid Transaction digest');
     }
     return await this.client.requestWithType(
       'sui_getTransaction',
       [input.digest, input.options],
-      SuiTransactionResponse,
+      SuiTransactionBlockResponse,
       this.options.skipDataValidation,
     );
   }
 
   async multiGetTransactionBlocks(input: {
     digests: TransactionDigest[];
-    options?: SuiTransactionResponseOptions;
-  }): Promise<SuiTransactionResponse[]> {
+    options?: SuiTransactionBlockResponseOptions;
+  }): Promise<SuiTransactionBlockResponse[]> {
     input.digests.forEach((d) => {
       if (!isValidTransactionDigest(d)) {
         throw new Error(`Invalid Transaction digest ${d}`);
@@ -506,7 +508,7 @@ export class JsonRpcProvider {
     return await this.client.requestWithType(
       'sui_multiGetTransactions',
       [input.digests, input.options],
-      array(SuiTransactionResponse),
+      array(SuiTransactionBlockResponse),
       this.options.skipDataValidation,
     );
   }
@@ -514,9 +516,9 @@ export class JsonRpcProvider {
   async executeTransactionBlock(input: {
     transactionBlock: Uint8Array | string;
     signature: SerializedSignature | SerializedSignature[];
-    options?: SuiTransactionResponseOptions;
+    options?: SuiTransactionBlockResponseOptions;
     requestType?: ExecuteTransactionRequestType;
-  }): Promise<SuiTransactionResponse> {
+  }): Promise<SuiTransactionBlockResponse> {
     return await this.client.requestWithType(
       'sui_executeTransaction',
       [
@@ -527,7 +529,7 @@ export class JsonRpcProvider {
         input.options,
         input.requestType,
       ],
-      SuiTransactionResponse,
+      SuiTransactionBlockResponse,
       this.options.skipDataValidation,
     );
   }

--- a/sdk/typescript/src/signers/signer-with-provider.ts
+++ b/sdk/typescript/src/signers/signer-with-provider.ts
@@ -82,29 +82,29 @@ export abstract class SignerWithProvider implements Signer {
   async signTransactionBlock(input: {
     transactionBlock: Uint8Array | TransactionBlock;
   }): Promise<SignedTransaction> {
-    let TransactionBlockBytes;
+    let transactionBlockBytes;
 
     if (TransactionBlock.is(input.transactionBlock)) {
       // If the sender has not yet been set on the transaction, then set it.
       // NOTE: This allows for signing transactions with mis-matched senders, which is important for sponsored transactions.
       input.transactionBlock.setSenderIfNotSet(await this.getAddress());
-      TransactionBlockBytes = await input.transactionBlock.build({
+      transactionBlockBytes = await input.transactionBlock.build({
         provider: this.provider,
       });
     } else if (input.transactionBlock instanceof Uint8Array) {
-      TransactionBlockBytes = input.transactionBlock;
+      transactionBlockBytes = input.transactionBlock;
     } else {
       throw new Error('Unknown transaction format');
     }
 
     const intentMessage = messageWithIntent(
       IntentScope.TransactionData,
-      TransactionBlockBytes,
+      transactionBlockBytes,
     );
     const signature = await this.signData(intentMessage);
 
     return {
-      TransactionBlockBytes: toB64(TransactionBlockBytes),
+      transactionBlockBytes: toB64(transactionBlockBytes),
       signature,
     };
   }
@@ -126,13 +126,13 @@ export abstract class SignerWithProvider implements Signer {
      */
     requestType?: ExecuteTransactionRequestType;
   }): Promise<SuiTransactionBlockResponse> {
-    const { TransactionBlockBytes, signature } =
+    const { transactionBlockBytes, signature } =
       await this.signTransactionBlock({
         transactionBlock: input.transactionBlock,
       });
 
     return await this.provider.executeTransactionBlock({
-      transactionBlock: TransactionBlockBytes,
+      transactionBlock: transactionBlockBytes,
       signature,
       options: input.options,
       requestType: input.requestType,

--- a/sdk/typescript/src/signers/signer-with-provider.ts
+++ b/sdk/typescript/src/signers/signer-with-provider.ts
@@ -14,8 +14,8 @@ import {
   SuiAddress,
   DevInspectResults,
   DryRunTransactionResponse,
-  SuiTransactionResponse,
-  SuiTransactionResponseOptions,
+  SuiTransactionBlockResponse,
+  SuiTransactionBlockResponseOptions,
 } from '../types';
 import { IntentScope, messageWithIntent } from '../utils/intent';
 import { Signer } from './signer';
@@ -120,12 +120,12 @@ export abstract class SignerWithProvider implements Signer {
   async signAndExecuteTransactionBlock(input: {
     transactionBlock: Uint8Array | TransactionBlock;
     /** specify which fields to return (e.g., transaction, effects, events, etc). By default, only the transaction digest will be returned. */
-    options?: SuiTransactionResponseOptions;
+    options?: SuiTransactionBlockResponseOptions;
     /** `WaitForEffectsCert` or `WaitForLocalExecution`, see details in `ExecuteTransactionRequestType`.
      * Defaults to `WaitForLocalExecution` if options.show_effects or options.show_events is true
      */
     requestType?: ExecuteTransactionRequestType;
-  }): Promise<SuiTransactionResponse> {
+  }): Promise<SuiTransactionBlockResponse> {
     const { transactionBytes, signature } = await this.signTransactionBlock({
       transactionBlock: input.transactionBlock,
     });

--- a/sdk/typescript/src/signers/signer-with-provider.ts
+++ b/sdk/typescript/src/signers/signer-with-provider.ts
@@ -82,29 +82,29 @@ export abstract class SignerWithProvider implements Signer {
   async signTransactionBlock(input: {
     transactionBlock: Uint8Array | TransactionBlock;
   }): Promise<SignedTransaction> {
-    let transactionBytes;
+    let TransactionBlockBytes;
 
     if (TransactionBlock.is(input.transactionBlock)) {
       // If the sender has not yet been set on the transaction, then set it.
       // NOTE: This allows for signing transactions with mis-matched senders, which is important for sponsored transactions.
       input.transactionBlock.setSenderIfNotSet(await this.getAddress());
-      transactionBytes = await input.transactionBlock.build({
+      TransactionBlockBytes = await input.transactionBlock.build({
         provider: this.provider,
       });
     } else if (input.transactionBlock instanceof Uint8Array) {
-      transactionBytes = input.transactionBlock;
+      TransactionBlockBytes = input.transactionBlock;
     } else {
       throw new Error('Unknown transaction format');
     }
 
     const intentMessage = messageWithIntent(
       IntentScope.TransactionData,
-      transactionBytes,
+      TransactionBlockBytes,
     );
     const signature = await this.signData(intentMessage);
 
     return {
-      transactionBytes: toB64(transactionBytes),
+      TransactionBlockBytes: toB64(TransactionBlockBytes),
       signature,
     };
   }
@@ -126,12 +126,13 @@ export abstract class SignerWithProvider implements Signer {
      */
     requestType?: ExecuteTransactionRequestType;
   }): Promise<SuiTransactionBlockResponse> {
-    const { transactionBytes, signature } = await this.signTransactionBlock({
-      transactionBlock: input.transactionBlock,
-    });
+    const { TransactionBlockBytes, signature } =
+      await this.signTransactionBlock({
+        transactionBlock: input.transactionBlock,
+      });
 
     return await this.provider.executeTransactionBlock({
-      transactionBlock: transactionBytes,
+      transactionBlock: TransactionBlockBytes,
       signature,
       options: input.options,
       requestType: input.requestType,

--- a/sdk/typescript/src/signers/types.ts
+++ b/sdk/typescript/src/signers/types.ts
@@ -4,7 +4,7 @@
 import { SerializedSignature } from '../cryptography/signature';
 
 export type SignedTransaction = {
-  TransactionBlockBytes: string;
+  transactionBlockBytes: string;
   signature: SerializedSignature;
 };
 

--- a/sdk/typescript/src/signers/types.ts
+++ b/sdk/typescript/src/signers/types.ts
@@ -4,7 +4,7 @@
 import { SerializedSignature } from '../cryptography/signature';
 
 export type SignedTransaction = {
-  transactionBytes: string;
+  TransactionBlockBytes: string;
   signature: SerializedSignature;
 };
 

--- a/sdk/typescript/test/e2e/read-transactions.test.ts
+++ b/sdk/typescript/test/e2e/read-transactions.test.ts
@@ -5,13 +5,13 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import {
   getTransactionDigest,
   getTransactionKind,
-  SuiTransactionResponse,
+  SuiTransactionBlockResponse,
 } from '../../src';
 import { executePaySuiNTimes, setup, TestToolbox } from './utils/setup';
 
 describe('Transaction Reading API', () => {
   let toolbox: TestToolbox;
-  let transactions: SuiTransactionResponse[];
+  let transactions: SuiTransactionBlockResponse[];
   const NUM_TRANSACTIONS = 10;
 
   beforeAll(async () => {

--- a/sdk/typescript/test/e2e/txn-builder.test.ts
+++ b/sdk/typescript/test/e2e/txn-builder.test.ts
@@ -9,7 +9,7 @@ import {
   getTransactionDigest,
   ObjectId,
   RawSigner,
-  SuiTransactionResponse,
+  SuiTransactionBlockResponse,
   SUI_SYSTEM_STATE_OBJECT_ID,
   TransactionBlock,
   SuiObjectData,
@@ -27,7 +27,7 @@ import {
 describe('Transaction Builders', () => {
   let toolbox: TestToolbox;
   let packageId: ObjectId;
-  let publishTxn: SuiTransactionResponse;
+  let publishTxn: SuiTransactionBlockResponse;
   let sharedObjectId: ObjectId;
 
   beforeAll(async () => {

--- a/sdk/typescript/test/e2e/txn-serializer.test.ts
+++ b/sdk/typescript/test/e2e/txn-serializer.test.ts
@@ -38,16 +38,19 @@ describe('Transaction Serialization and deserialization', () => {
     mutable: boolean[],
   ) {
     tx.setSender(await toolbox.address());
-    const transactionBytes = await tx.build({ provider: toolbox.provider });
-    const deserializedTxnBuilder =
-      TransactionBlockDataBuilder.fromBytes(transactionBytes);
+    const TransactionBlockBytes = await tx.build({
+      provider: toolbox.provider,
+    });
+    const deserializedTxnBuilder = TransactionBlockDataBuilder.fromBytes(
+      TransactionBlockBytes,
+    );
     expect(
       deserializedTxnBuilder.inputs
         .filter((i) => isSharedObjectInput(i.value))
         .map((i) => isMutableSharedObjectInput(i.value)),
     ).toStrictEqual(mutable);
     const reserializedTxnBytes = await deserializedTxnBuilder.build();
-    expect(reserializedTxnBytes).toEqual(transactionBytes);
+    expect(reserializedTxnBytes).toEqual(TransactionBlockBytes);
   }
 
   it('Move Shared Object Call with mutable reference', async () => {

--- a/sdk/typescript/test/e2e/txn-serializer.test.ts
+++ b/sdk/typescript/test/e2e/txn-serializer.test.ts
@@ -10,7 +10,7 @@ import {
   isSharedObjectInput,
   ObjectId,
   SuiObjectData,
-  SuiTransactionResponse,
+  SuiTransactionBlockResponse,
   SUI_SYSTEM_STATE_OBJECT_ID,
   TransactionBlock,
 } from '../../src';
@@ -20,7 +20,7 @@ import { publishPackage, setup, TestToolbox } from './utils/setup';
 describe('Transaction Serialization and deserialization', () => {
   let toolbox: TestToolbox;
   let packageId: ObjectId;
-  let publishTxn: SuiTransactionResponse;
+  let publishTxn: SuiTransactionBlockResponse;
   let sharedObjectId: ObjectId;
 
   beforeAll(async () => {

--- a/sdk/typescript/test/e2e/txn-serializer.test.ts
+++ b/sdk/typescript/test/e2e/txn-serializer.test.ts
@@ -38,11 +38,11 @@ describe('Transaction Serialization and deserialization', () => {
     mutable: boolean[],
   ) {
     tx.setSender(await toolbox.address());
-    const TransactionBlockBytes = await tx.build({
+    const transactionBlockBytes = await tx.build({
       provider: toolbox.provider,
     });
     const deserializedTxnBuilder = TransactionBlockDataBuilder.fromBytes(
-      TransactionBlockBytes,
+      transactionBlockBytes,
     );
     expect(
       deserializedTxnBuilder.inputs
@@ -50,7 +50,7 @@ describe('Transaction Serialization and deserialization', () => {
         .map((i) => isMutableSharedObjectInput(i.value)),
     ).toStrictEqual(mutable);
     const reserializedTxnBytes = await deserializedTxnBuilder.build();
-    expect(reserializedTxnBytes).toEqual(TransactionBlockBytes);
+    expect(reserializedTxnBytes).toEqual(transactionBlockBytes);
   }
 
   it('Move Shared Object Call with mutable reference', async () => {

--- a/sdk/wallet-adapter/adapters/base-adapter/src/index.ts
+++ b/sdk/wallet-adapter/adapters/base-adapter/src/index.ts
@@ -3,7 +3,7 @@
 
 import {
   SignedTransaction,
-  SuiTransactionResponse,
+  SuiTransactionBlockResponse,
   SignedMessage,
 } from "@mysten/sui.js";
 import {
@@ -43,7 +43,7 @@ export interface WalletAdapter {
    */
   signAndExecuteTransactionBlock(
     transactionInput: SuiSignAndExecuteTransactionBlockInput
-  ): Promise<SuiTransactionResponse>;
+  ): Promise<SuiTransactionBlockResponse>;
 
   getAccounts: () => Promise<readonly WalletAccount[]>;
 }

--- a/sdk/wallet-adapter/wallet-standard/src/features/suiSignAndExecuteTransactionBlock.ts
+++ b/sdk/wallet-adapter/wallet-standard/src/features/suiSignAndExecuteTransactionBlock.ts
@@ -3,8 +3,8 @@
 
 import type {
   ExecuteTransactionRequestType,
-  SuiTransactionResponse,
-  SuiTransactionResponseOptions,
+  SuiTransactionBlockResponse,
+  SuiTransactionBlockResponseOptions,
 } from "@mysten/sui.js";
 import type { SuiSignTransactionBlockInput } from "./suiSignTransactionBlock";
 
@@ -38,9 +38,9 @@ export interface SuiSignAndExecuteTransactionBlockInput
    */
   requestType?: ExecuteTransactionRequestType;
   /** specify which fields to return (e.g., transaction, effects, events, etc). By default, only the transaction digest will be returned. */
-  options?: SuiTransactionResponseOptions;
+  options?: SuiTransactionBlockResponseOptions;
 }
 
 /** Output of signing and sending transactions. */
 export interface SuiSignAndExecuteTransactionBlockOutput
-  extends SuiTransactionResponse {}
+  extends SuiTransactionBlockResponse {}


### PR DESCRIPTION
## Description 

SuiTransaction* -> SuiTransactionBlock*

- SuiTransactionResponse → SuiTransactionBlockResponse
- SuiTransactionResponseQuery → SuiTransactionBlockResponseQuery
- SuiTransactionResponseOptions → SuiTransactionBlockResponseOptions
- SuiTransaction → SuiTransactionBlock
- SuiTransactionData → SuiTransactionBlockData
- SuiTransactionKind → SuiTransactionBlockKind
- SuiProgrammableTransaction → SuiProgrammableTransactionBlock

TransactionBytes → TransactionBlockBytes
TransactionsPage → TransactionBlocksPage


## Next PRs
- SuiCommand → SuiTransaction
- update Serde Rename
- rename RPC endpoint names (and TS usage)
## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
