### PR TITLE
[future proof/hardening] Hide internals of MoveObjectType

### DIFF
--- a/crates/sui-adapter/src/programmable_transactions/execution.rs
+++ b/crates/sui-adapter/src/programmable_transactions/execution.rs
@@ -1132,8 +1132,9 @@ fn build_move_args<S: StorageView, Mode: ExecutionMode>(
                     let TypeTag::Struct(struct_tag) = type_tag else {
                         invariant_violation!("Struct type make a non struct type tag")
                     };
+                    let type_ = (*struct_tag).into();
                     ValueKind::Object {
-                        type_: MoveObjectType::Other(*struct_tag),
+                        type_,
                         has_public_transfer: *has_public_transfer,
                     }
                 } else {

--- a/crates/sui-core/src/generate_format.rs
+++ b/crates/sui-core/src/generate_format.rs
@@ -10,7 +10,7 @@ use move_core_types::{
 use pretty_assertions::assert_str_eq;
 use serde_reflection::{Registry, Result, Samples, Tracer, TracerConfig};
 use std::{fs::File, io::Write};
-use sui_types::crypto::Signer;
+use sui_types::{base_types::MoveObjectType_, crypto::Signer};
 use sui_types::{
     base_types::{
         self, MoveObjectType, ObjectDigest, ObjectID, TransactionDigest, TransactionEffectsDigest,
@@ -86,6 +86,7 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_type::<MoveStructLayout>(&samples)?;
     tracer.trace_type::<MoveTypeLayout>(&samples)?;
     tracer.trace_type::<MoveObjectType>(&samples)?;
+    tracer.trace_type::<MoveObjectType_>(&samples)?;
     tracer.trace_type::<base_types::SuiAddress>(&samples)?;
     tracer.trace_type::<DeleteKind>(&samples)?;
     tracer.trace_type::<Argument>(&samples)?;

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -311,6 +311,9 @@ MoveObject:
         TYPENAME: SequenceNumber
     - contents: BYTES
 MoveObjectType:
+  NEWTYPESTRUCT:
+    TYPENAME: MoveObjectType_
+MoveObjectType_:
   ENUM:
     0:
       Other:

--- a/crates/sui-json-rpc-types/src/sui_object.rs
+++ b/crates/sui-json-rpc-types/src/sui_object.rs
@@ -23,8 +23,8 @@ use sui_types::sui_serde::SuiStructTag;
 
 use sui_protocol_config::ProtocolConfig;
 use sui_types::base_types::{
-    MoveObjectType, ObjectDigest, ObjectID, ObjectInfo, ObjectRef, ObjectType, SequenceNumber,
-    SuiAddress, TransactionDigest,
+    ObjectDigest, ObjectID, ObjectInfo, ObjectRef, ObjectType, SequenceNumber, SuiAddress,
+    TransactionDigest,
 };
 use sui_types::error::{SuiObjectResponseError, UserInputError, UserInputResult};
 use sui_types::gas_coin::GasCoin;
@@ -209,7 +209,7 @@ impl SuiObjectData {
 
     pub fn is_gas_coin(&self) -> bool {
         match self.type_.as_ref() {
-            Some(ObjectType::Struct(MoveObjectType::GasCoin)) => true,
+            Some(ObjectType::Struct(ty)) if ty.is_gas_coin() => true,
             Some(_) => false,
             None => false,
         }

--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -43,7 +43,7 @@ impl GovernanceReadApi {
     async fn get_staked_sui(&self, owner: SuiAddress) -> Result<Vec<StakedSui>, Error> {
         Ok(self
             .state
-            .get_move_objects(owner, MoveObjectType::StakedSui)
+            .get_move_objects(owner, MoveObjectType::staked_sui())
             .await?)
     }
 

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -224,7 +224,7 @@ impl RpcExampleProvider {
             object_id,
             version: SequenceNumber::from_u64(1),
             digest: ObjectDigest::new(self.rng.gen()),
-            type_: Some(ObjectType::Struct(MoveObjectType::GasCoin)),
+            type_: Some(ObjectType::Struct(MoveObjectType::gas_coin())),
             bcs: None,
             display: None,
         });
@@ -263,7 +263,7 @@ impl RpcExampleProvider {
             object_id,
             version: SequenceNumber::from_u64(4),
             digest: ObjectDigest::new(self.rng.gen()),
-            type_: Some(ObjectType::Struct(MoveObjectType::GasCoin)),
+            type_: Some(ObjectType::Struct(MoveObjectType::gas_coin())),
             bcs: None,
             display: None,
         });
@@ -313,7 +313,7 @@ impl RpcExampleProvider {
                 object_id: ObjectID::new(self.rng.gen()),
                 version: Default::default(),
                 digest: ObjectDigest::new(self.rng.gen()),
-                type_: Some(ObjectType::Struct(MoveObjectType::GasCoin)),
+                type_: Some(ObjectType::Struct(MoveObjectType::gas_coin())),
                 owner: Some(Owner::AddressOwner(owner)),
                 previous_transaction: Some(TransactionDigest::new(self.rng.gen())),
                 storage_rebate: None,

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -120,12 +120,16 @@ pub fn random_object_ref() -> ObjectRef {
 }
 
 /// Wrapper around StructTag with a space-efficient representation for common types like coins
-/// The StructTag for a gas coin is 84 bytes, so using 1 byte instead is a win
+/// The StructTag for a gas coin is 84 bytes, so using 1 byte instead is a win.
+/// The inner representation is private to prevent incorrectly constructing an `Other` instead of
+/// one of the specialized variants, e.g. `Other(GasCoin::type_())` instead of `GasCoin`
 #[derive(Eq, PartialEq, PartialOrd, Ord, Debug, Clone, Deserialize, Serialize, Hash)]
 pub struct MoveObjectType(MoveObjectType_);
 
+/// Even though it is declared public, it is the "private", internal representation for
+/// `MoveObjectType`
 #[derive(Eq, PartialEq, PartialOrd, Ord, Debug, Clone, Deserialize, Serialize, Hash)]
-enum MoveObjectType_ {
+pub enum MoveObjectType_ {
     /// A type that is not 0x2::coin::Coin<T>
     Other(StructTag),
     /// A SUI coin (i.e., 0x2::coin::Coin<0x2::sui::SUI>)

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -153,7 +153,7 @@ impl MoveObjectType {
     }
 
     pub fn address(&self) -> AccountAddress {
-        match self {
+        match &self.0 {
             MoveObjectType_::GasCoin | MoveObjectType_::Coin(_) => SUI_FRAMEWORK_ADDRESS,
             MoveObjectType_::StakedSui => SUI_SYSTEM_ADDRESS,
             MoveObjectType_::Other(s) => s.address,

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -122,7 +122,10 @@ pub fn random_object_ref() -> ObjectRef {
 /// Wrapper around StructTag with a space-efficient representation for common types like coins
 /// The StructTag for a gas coin is 84 bytes, so using 1 byte instead is a win
 #[derive(Eq, PartialEq, PartialOrd, Ord, Debug, Clone, Deserialize, Serialize, Hash)]
-pub enum MoveObjectType {
+pub struct MoveObjectType(MoveObjectType_);
+
+#[derive(Eq, PartialEq, PartialOrd, Ord, Debug, Clone, Deserialize, Serialize, Hash)]
+enum MoveObjectType_ {
     /// A type that is not 0x2::coin::Coin<T>
     Other(StructTag),
     /// A SUI coin (i.e., 0x2::coin::Coin<0x2::sui::SUI>)
@@ -137,45 +140,53 @@ pub enum MoveObjectType {
 }
 
 impl MoveObjectType {
+    pub fn gas_coin() -> Self {
+        Self(MoveObjectType_::GasCoin)
+    }
+
+    pub fn staked_sui() -> Self {
+        Self(MoveObjectType_::StakedSui)
+    }
+
     pub fn address(&self) -> AccountAddress {
         match self {
-            MoveObjectType::GasCoin | MoveObjectType::Coin(_) => SUI_FRAMEWORK_ADDRESS,
-            MoveObjectType::StakedSui => SUI_SYSTEM_ADDRESS,
-            MoveObjectType::Other(s) => s.address,
+            MoveObjectType_::GasCoin | MoveObjectType_::Coin(_) => SUI_FRAMEWORK_ADDRESS,
+            MoveObjectType_::StakedSui => SUI_SYSTEM_ADDRESS,
+            MoveObjectType_::Other(s) => s.address,
         }
     }
 
     pub fn module(&self) -> &IdentStr {
-        match self {
-            MoveObjectType::GasCoin | MoveObjectType::Coin(_) => COIN_MODULE_NAME,
-            MoveObjectType::StakedSui => STAKING_POOL_MODULE_NAME,
-            MoveObjectType::Other(s) => &s.module,
+        match &self.0 {
+            MoveObjectType_::GasCoin | MoveObjectType_::Coin(_) => COIN_MODULE_NAME,
+            MoveObjectType_::StakedSui => STAKING_POOL_MODULE_NAME,
+            MoveObjectType_::Other(s) => &s.module,
         }
     }
 
     pub fn name(&self) -> &IdentStr {
-        match self {
-            MoveObjectType::GasCoin | MoveObjectType::Coin(_) => COIN_STRUCT_NAME,
-            MoveObjectType::StakedSui => STAKED_SUI_STRUCT_NAME,
-            MoveObjectType::Other(s) => &s.name,
+        match &self.0 {
+            MoveObjectType_::GasCoin | MoveObjectType_::Coin(_) => COIN_STRUCT_NAME,
+            MoveObjectType_::StakedSui => STAKED_SUI_STRUCT_NAME,
+            MoveObjectType_::Other(s) => &s.name,
         }
     }
 
     pub fn type_params(&self) -> Vec<TypeTag> {
-        match self {
-            MoveObjectType::GasCoin => vec![GAS::type_tag()],
-            MoveObjectType::StakedSui => vec![],
-            MoveObjectType::Coin(inner) => vec![inner.clone()],
-            MoveObjectType::Other(s) => s.type_params.clone(),
+        match &self.0 {
+            MoveObjectType_::GasCoin => vec![GAS::type_tag()],
+            MoveObjectType_::StakedSui => vec![],
+            MoveObjectType_::Coin(inner) => vec![inner.clone()],
+            MoveObjectType_::Other(s) => s.type_params.clone(),
         }
     }
 
     pub fn into_type_params(self) -> Vec<TypeTag> {
-        match self {
-            MoveObjectType::GasCoin => vec![GAS::type_tag()],
-            MoveObjectType::StakedSui => vec![],
-            MoveObjectType::Coin(inner) => vec![inner],
-            MoveObjectType::Other(s) => s.type_params,
+        match self.0 {
+            MoveObjectType_::GasCoin => vec![GAS::type_tag()],
+            MoveObjectType_::StakedSui => vec![],
+            MoveObjectType_::Coin(inner) => vec![inner],
+            MoveObjectType_::Other(s) => s.type_params,
         }
     }
 
@@ -185,96 +196,104 @@ impl MoveObjectType {
 
     pub fn size_for_gas_metering(&self) -> usize {
         // unwraps safe because a `StructTag` cannot fail to serialize
-        match self {
-            MoveObjectType::GasCoin => 1,
-            MoveObjectType::StakedSui => 1,
-            MoveObjectType::Coin(inner) => bcs::serialized_size(inner).unwrap() + 1,
-            MoveObjectType::Other(s) => bcs::serialized_size(s).unwrap() + 1,
+        match &self.0 {
+            MoveObjectType_::GasCoin => 1,
+            MoveObjectType_::StakedSui => 1,
+            MoveObjectType_::Coin(inner) => bcs::serialized_size(inner).unwrap() + 1,
+            MoveObjectType_::Other(s) => bcs::serialized_size(s).unwrap() + 1,
         }
     }
 
     /// Return true if `self` is 0x2::coin::Coin<T> for some T (note: T can be SUI)
     pub fn is_coin(&self) -> bool {
-        match self {
-            MoveObjectType::GasCoin | MoveObjectType::Coin(_) => true,
-            MoveObjectType::StakedSui | MoveObjectType::Other(_) => false,
+        match &self.0 {
+            MoveObjectType_::GasCoin | MoveObjectType_::Coin(_) => true,
+            MoveObjectType_::StakedSui | MoveObjectType_::Other(_) => false,
         }
     }
 
     /// Return true if `self` is 0x2::coin::Coin<0x2::sui::SUI>
     pub fn is_gas_coin(&self) -> bool {
-        match self {
-            MoveObjectType::GasCoin => true,
-            MoveObjectType::StakedSui | MoveObjectType::Coin(_) | MoveObjectType::Other(_) => false,
+        match &self.0 {
+            MoveObjectType_::GasCoin => true,
+            MoveObjectType_::StakedSui | MoveObjectType_::Coin(_) | MoveObjectType_::Other(_) => {
+                false
+            }
         }
     }
 
     pub fn is_staked_sui(&self) -> bool {
-        match self {
-            MoveObjectType::StakedSui => true,
-            MoveObjectType::GasCoin | MoveObjectType::Coin(_) | MoveObjectType::Other(_) => false,
+        match &self.0 {
+            MoveObjectType_::StakedSui => true,
+            MoveObjectType_::GasCoin | MoveObjectType_::Coin(_) | MoveObjectType_::Other(_) => {
+                false
+            }
         }
     }
 
     pub fn is_coin_metadata(&self) -> bool {
-        match self {
-            MoveObjectType::GasCoin | MoveObjectType::StakedSui | MoveObjectType::Coin(_) => false,
-            MoveObjectType::Other(s) => CoinMetadata::is_coin_metadata(s),
+        match &self.0 {
+            MoveObjectType_::GasCoin | MoveObjectType_::StakedSui | MoveObjectType_::Coin(_) => {
+                false
+            }
+            MoveObjectType_::Other(s) => CoinMetadata::is_coin_metadata(s),
         }
     }
 
     pub fn is_dynamic_field(&self) -> bool {
-        match self {
-            MoveObjectType::GasCoin | MoveObjectType::StakedSui | MoveObjectType::Coin(_) => false,
-            MoveObjectType::Other(s) => DynamicFieldInfo::is_dynamic_field(s),
+        match &self.0 {
+            MoveObjectType_::GasCoin | MoveObjectType_::StakedSui | MoveObjectType_::Coin(_) => {
+                false
+            }
+            MoveObjectType_::Other(s) => DynamicFieldInfo::is_dynamic_field(s),
         }
     }
 
     pub fn try_extract_field_name(&self, type_: &DynamicFieldType) -> SuiResult<TypeTag> {
-        match self {
-            MoveObjectType::GasCoin | MoveObjectType::StakedSui | MoveObjectType::Coin(_) => {
+        match &self.0 {
+            MoveObjectType_::GasCoin | MoveObjectType_::StakedSui | MoveObjectType_::Coin(_) => {
                 Err(SuiError::ObjectDeserializationError {
                     error: "Error extracting dynamic object name from Coin object".to_string(),
                 })
             }
-            MoveObjectType::Other(s) => DynamicFieldInfo::try_extract_field_name(s, type_),
+            MoveObjectType_::Other(s) => DynamicFieldInfo::try_extract_field_name(s, type_),
         }
     }
 
     pub fn is(&self, s: &StructTag) -> bool {
-        match self {
-            MoveObjectType::GasCoin => GasCoin::is_gas_coin(s),
-            MoveObjectType::StakedSui => StakedSui::is_staked_sui(s),
-            MoveObjectType::Coin(inner) => {
+        match &self.0 {
+            MoveObjectType_::GasCoin => GasCoin::is_gas_coin(s),
+            MoveObjectType_::StakedSui => StakedSui::is_staked_sui(s),
+            MoveObjectType_::Coin(inner) => {
                 Coin::is_coin(s) && s.type_params.len() == 1 && inner == &s.type_params[0]
             }
-            MoveObjectType::Other(o) => s == o,
+            MoveObjectType_::Other(o) => s == o,
         }
     }
 }
 
 impl From<StructTag> for MoveObjectType {
     fn from(mut s: StructTag) -> Self {
-        if GasCoin::is_gas_coin(&s) {
-            MoveObjectType::GasCoin
+        Self(if GasCoin::is_gas_coin(&s) {
+            MoveObjectType_::GasCoin
         } else if Coin::is_coin(&s) {
             // unwrap safe because a coin has exactly one type parameter
-            MoveObjectType::Coin(s.type_params.pop().unwrap())
+            MoveObjectType_::Coin(s.type_params.pop().unwrap())
         } else if StakedSui::is_staked_sui(&s) {
-            MoveObjectType::StakedSui
+            MoveObjectType_::StakedSui
         } else {
-            MoveObjectType::Other(s)
-        }
+            MoveObjectType_::Other(s)
+        })
     }
 }
 
 impl From<MoveObjectType> for StructTag {
-    fn from(o: MoveObjectType) -> Self {
-        match o {
-            MoveObjectType::GasCoin => GasCoin::type_(),
-            MoveObjectType::StakedSui => StakedSui::type_(),
-            MoveObjectType::Coin(inner) => Coin::type_(inner),
-            MoveObjectType::Other(s) => s,
+    fn from(t: MoveObjectType) -> Self {
+        match t.0 {
+            MoveObjectType_::GasCoin => GasCoin::type_(),
+            MoveObjectType_::StakedSui => StakedSui::type_(),
+            MoveObjectType_::Coin(inner) => Coin::type_(inner),
+            MoveObjectType_::Other(s) => s,
         }
     }
 }


### PR DESCRIPTION
## Description 

Made the enum for MoveObjectType private to avoid manually constructing an Other. This is potentially an issue as the type does not support equality currently over similar types, e.g. `GasCoin != Other(GasCoin::type_())`. 
In other words, this is more about trying to make sure buggy code isn't introduced in the future. 

## Test Plan 

- Internal change 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
