### PR TITLE
[validator] Introduce AuthorityServer::submit_certificate

### DIFF
--- a/crates/sui-network/build.rs
+++ b/crates/sui-network/build.rs
@@ -42,6 +42,15 @@ fn main() -> Result<()> {
         )
         .method(
             Method::builder()
+                .name("submit_certificate")
+                .route_name("SubmitCertificate")
+                .input_type("sui_types::messages::CertifiedTransaction")
+                .output_type("sui_types::messages::SubmitCertificateResponse")
+                .codec_path(codec_path)
+                .build(),
+        )
+        .method(
+            Method::builder()
                 .name("object_info")
                 .route_name("ObjectInfo")
                 .input_type("sui_types::messages::ObjectInfoRequest")

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -2210,6 +2210,12 @@ pub struct HandleCertificateResponse {
     pub events: TransactionEvents,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SubmitCertificateResponse {
+    /// If transaction is already executed, return same result as handle_certificate
+    pub executed: Option<HandleCertificateResponse>,
+}
+
 #[derive(Clone, Debug)]
 pub struct VerifiedHandleCertificateResponse {
     pub signed_effects: VerifiedSignedTransactionEffects,


### PR DESCRIPTION
This PR introduce `submit_certificate` method to authority, that allows to persist certificate in the validator DB, without waiting for it to be executed. This is useful to provide an early finality guarantee to the user in some cases.

When 2f+1 validators returned success on `submit_certificate` RPC, it is guaranteed that transaction will be executed before end of the epoch.

Differences between `handle_certificate` and `submit_certificate`:

(1) Unlike with `handle_certificate`, the result of execution is not always known when `submit_certificate` returns.

(2) `submit_certificate` has lower latency then `handle_certificate`. The difference is significant for shared object transactions, as `submit_certificate` does not wait for transaction to be sequenced in consensus.

It is important to note, that if you want to ensure that you transaction will be executed, you *need* to wait for 2f+1 successful responses from `submit_certificate`. Even if you are sure that validator you are submitting transaction to is not byzantine, single validator response does not provide guarantee that transaction will be sequnced by end of the epoch.
