### PR TITLE
[package upgrades] Update tests to make sure we handle private entry functions correctly

### DIFF
--- a/.config/hakari.toml
+++ b/.config/hakari.toml
@@ -31,9 +31,9 @@ workspace-members = [ "sui-move" ]
 third-party = [
     ## Exclude the 'move-unit-test' crate in order to ensure that the 'testing'
     # feature isn't enabled in the workspace-hack
-    { name = "move-unit-test", git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" },
-    { name = "move-cli", git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" },
-    { name = "move-transactional-test-runner", git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" },
+    { name = "move-unit-test", git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" },
+    { name = "move-cli", git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" },
+    { name = "move-transactional-test-runner", git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" },
     { name = "object_store" },
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,7 +1370,7 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -4586,7 +4586,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4603,7 +4603,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -4616,12 +4616,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4636,7 +4636,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4648,7 +4648,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "anyhow",
  "fail 0.4.0",
@@ -4661,7 +4661,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -4678,7 +4678,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4724,7 +4724,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "anyhow",
  "difference",
@@ -4741,7 +4741,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4770,7 +4770,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4789,7 +4789,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4809,7 +4809,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -4827,7 +4827,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "anyhow",
  "codespan",
@@ -4845,7 +4845,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4859,7 +4859,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4878,7 +4878,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -4897,7 +4897,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "anyhow",
  "hex",
@@ -4910,7 +4910,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "anyhow",
  "hex",
@@ -4924,7 +4924,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "anyhow",
  "codespan",
@@ -4950,7 +4950,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4986,7 +4986,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5023,7 +5023,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5051,7 +5051,7 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5062,7 +5062,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5077,7 +5077,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -5104,7 +5104,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
@@ -5122,7 +5122,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "anyhow",
  "hex",
@@ -5145,7 +5145,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "once_cell",
  "serde 1.0.152",
@@ -5154,7 +5154,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5171,7 +5171,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -5203,7 +5203,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "anyhow",
  "better_any",
@@ -5234,7 +5234,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "better_any",
  "fail 0.4.0",
@@ -5252,7 +5252,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5265,7 +5265,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -7309,7 +7309,7 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7324,7 +7324,7 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=60cec12b1ed9382836aa4c141e445656d39375e1#60cec12b1ed9382836aa4c141e445656d39375e1"
+source = "git+https://github.com/move-language/move?rev=b55a72f4110baa4b85a89a95ce015f2020461c0f#b55a72f4110baa4b85a89a95ce015f2020461c0f"
 dependencies = [
  "anyhow",
  "move-binary-format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,26 +110,26 @@ opt-level = 1
 tokio = "1.24.1"
 
 # Move dependencies
-move-binary-format = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-cli = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-compiler = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", features = ["address32"] }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-package = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-prover = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-cli = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-compiler = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", features = ["address32"] }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-package = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-prover = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
 
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "c2f79b1807bff7d09517b631191b61f2614c641c" }
 fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "c2f79b1807bff7d09517b631191b61f2614c641c", package = "fastcrypto-zkp" }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -3009,14 +3009,12 @@ impl AuthorityState {
             return Some(cur_ref);
         }
 
-        let check_struct_and_pub_function_linking = true;
-        let check_struct_layout = true;
-        let check_friend_linking = false;
-        let compatibility = Compatibility::new(
-            check_struct_and_pub_function_linking,
-            check_struct_layout,
-            check_friend_linking,
-        );
+        let compatibility = Compatibility {
+            check_struct_and_pub_function_linking: true,
+            check_struct_layout: true,
+            check_friend_linking: false,
+            check_private_entry_linking: true,
+        };
 
         let new_pkg = new_object
             .data

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/additive_upgrade/sources/base.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/additive_upgrade/sources/base.move
@@ -26,4 +26,6 @@ module base_addr::base {
     public(friend) fun friend_fun(x: u64): u64 { x }
 
     fun non_public_fun(y: bool): u64 { if (y) 0 else 1 }
+
+    entry fun entry_fun() { }
 }

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/additive_upgrade_invalid/sources/base.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/additive_upgrade_invalid/sources/base.move
@@ -27,4 +27,6 @@ module base_addr::base {
 
     // This is invalid since I just changed the code
     fun non_public_fun(y: bool): u64 { if (y) 0 else 2 }
+
+    entry fun entry_fun() { }
 }

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/base/sources/base.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/base/sources/base.move
@@ -17,4 +17,6 @@ module base_addr::base {
     public(friend) fun friend_fun(x: u64): u64 { x }
 
     fun non_public_fun(y: bool): u64 { if (y) 0 else 1 }
+
+    entry fun entry_fun() { }
 }

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/base_as_dep/sources/base.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/base_as_dep/sources/base.move
@@ -17,4 +17,6 @@ module base_addr::base {
     public(friend) fun friend_fun(x: u64): u64 { x }
 
     fun non_public_fun(y: bool): u64 { if (y) 0 else 1 }
+
+    entry fun entry_fun() { }
 }

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/base_as_dep/sources/friend_module.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/base_as_dep/sources/friend_module.move
@@ -16,3 +16,4 @@ module base_addr::friend_module {
 
     fun non_public_fun(y: bool): u64 { if (y) 0 else 1 }
 }
+

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/compatibility_invalid/sources/base.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/compatibility_invalid/sources/base.move
@@ -17,4 +17,6 @@ module base_addr::base {
     public(friend) fun friend_fun(x: u64): u64 { x }
 
     fun non_public_fun(y: bool): u64 { if (y) 0 else 1 }
+
+    entry fun entry_fun() { }
 }

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/dep_only_upgrade/sources/base.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/dep_only_upgrade/sources/base.move
@@ -17,4 +17,6 @@ module base_addr::base {
     public(friend) fun friend_fun(x: u64): u64 { x }
 
     fun non_public_fun(y: bool): u64 { if (y) 0 else 1 }
+
+    entry fun entry_fun() { }
 }

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/stage1_basic_compatibility_valid/sources/base.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/stage1_basic_compatibility_valid/sources/base.move
@@ -25,4 +25,7 @@ module base_addr::base {
 
     // Change this private function
     fun non_public_fun(y: bool, g: u64): u64 { if (y) 0 else g }
+
+    // Note that this is fine since the entry function is private
+    entry fun entry_fun(x: u64): u64 { x }
 }

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/stage2_basic_compatibility_valid/sources/base.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/stage2_basic_compatibility_valid/sources/base.move
@@ -25,4 +25,6 @@ module base_addr::base {
 
     // Change this private function
     fun non_public_fun(y: bool, g: u64): u64 { if (y) 0 else g }
+
+    entry fun entry_fun() { }
 }

--- a/crates/sui-types/src/move_package.rs
+++ b/crates/sui-types/src/move_package.rs
@@ -138,17 +138,13 @@ impl UpgradePolicy {
         new_module: &normalized::Module,
     ) -> PartialVMResult<()> {
         match self {
-            Self::Compatible => {
-                let check_struct_and_pub_function_linking = true;
-                let check_struct_layout = true;
-                let check_friend_linking = false;
-                Compatibility::new(
-                    check_struct_and_pub_function_linking,
-                    check_struct_layout,
-                    check_friend_linking,
-                )
-                .check(old_module, new_module)
+            Self::Compatible => Compatibility {
+                check_struct_and_pub_function_linking: true,
+                check_struct_layout: true,
+                check_friend_linking: false,
+                check_private_entry_linking: false,
             }
+            .check(old_module, new_module),
             Self::Additive => InclusionCheck::Subset.check(old_module, new_module),
             Self::DepOnly => InclusionCheck::Equal.check(old_module, new_module),
         }

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -313,33 +313,33 @@ miniz_oxide = { version = "0.6", default-features = false, features = ["with-all
 mio = { version = "0.8", features = ["net", "os-ext"] }
 mockall = { version = "0.11", default-features = false }
 more-asserts = { version = "0.3", default-features = false }
-move-abigen = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-borrow-graph = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-compiler = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-core-types = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", features = ["address32"] }
-move-coverage = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-docgen = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-errmapgen = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-model = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-package = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-prover = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", features = ["tiered-gas"] }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", default-features = false }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-borrow-graph = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", default-features = false }
+move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", default-features = false }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", default-features = false }
+move-compiler = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", default-features = false }
+move-core-types = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", features = ["address32"] }
+move-coverage = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-docgen = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", default-features = false }
+move-errmapgen = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", default-features = false }
+move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", default-features = false }
+move-model = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", default-features = false }
+move-package = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", default-features = false }
+move-prover = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", default-features = false }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", default-features = false }
+move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", default-features = false }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", default-features = false }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", default-features = false }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", features = ["tiered-gas"] }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
 multiaddr = { version = "0.17" }
 multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }
@@ -971,33 +971,33 @@ mio = { version = "0.8", features = ["net", "os-ext"] }
 mockall = { version = "0.11", default-features = false }
 mockall_derive = { version = "0.11", default-features = false }
 more-asserts = { version = "0.3", default-features = false }
-move-abigen = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-borrow-graph = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-compiler = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-core-types = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", features = ["address32"] }
-move-coverage = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-docgen = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-errmapgen = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-model = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-package = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-prover = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", default-features = false }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1", features = ["tiered-gas"] }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "60cec12b1ed9382836aa4c141e445656d39375e1" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", default-features = false }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-borrow-graph = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", default-features = false }
+move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", default-features = false }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", default-features = false }
+move-compiler = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", default-features = false }
+move-core-types = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", features = ["address32"] }
+move-coverage = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-docgen = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", default-features = false }
+move-errmapgen = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", default-features = false }
+move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", default-features = false }
+move-model = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", default-features = false }
+move-package = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", default-features = false }
+move-prover = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", default-features = false }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", default-features = false }
+move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", default-features = false }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", default-features = false }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", default-features = false }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f", features = ["tiered-gas"] }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "b55a72f4110baa4b85a89a95ce015f2020461c0f" }
 multiaddr = { version = "0.17" }
 multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }


### PR DESCRIPTION
This PR depends on the changes in https://github.com/move-language/move/pull/1012 and can probably simply be rolled into the Move pointer bump when that is done.

It also adds a private entry function to the base package which we then change in the valid upgrade path. 