### PR TITLE
genesis: remove requirement to have all validators sign genesis

### DIFF
--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -768,9 +768,6 @@ impl Builder {
             CertifiedCheckpointSummary::new(checkpoint, signatures, &committee).unwrap()
         };
 
-        // Ensure we have signatures from all validators
-        assert_eq!(checkpoint.auth_sig().len(), self.validators.len() as u64);
-
         let genesis = Genesis {
             checkpoint,
             checkpoint_contents,


### PR DESCRIPTION
We instead will rely on the 2f+1 threshold.
