### PR TITLE
chore: factor out move publish tests

### DIFF
--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -33,6 +33,9 @@ mod transaction_manager;
 pub mod transaction_orchestrator;
 
 #[cfg(test)]
+#[path = "unit_tests/move_package_publish_tests.rs"]
+mod move_package_publish_tests;
+#[cfg(test)]
 #[path = "unit_tests/move_package_tests.rs"]
 mod move_package_tests;
 #[cfg(test)]

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -13,27 +13,21 @@ use move_core_types::{
     language_storage::StructTag,
     u256::U256,
 };
-use sui_framework::system_package_ids;
+
 use sui_types::{
-    error::ExecutionErrorKind, object::Data,
-    programmable_transaction_builder::ProgrammableTransactionBuilder,
+    error::ExecutionErrorKind, programmable_transaction_builder::ProgrammableTransactionBuilder,
     utils::to_sender_signed_transaction,
 };
 
 use move_core_types::language_storage::TypeTag;
-use move_package::source_package::manifest_parser;
-use sui_framework_build::compiled_package::{
-    check_unpublished_dependencies, gather_dependencies, BuildConfig,
-};
+
+use sui_framework_build::compiled_package::BuildConfig;
 use sui_types::{
     crypto::{get_key_pair, AccountKeyPair},
     error::SuiError,
     messages::ExecutionStatus,
 };
 
-use expect_test::expect;
-use std::fs::File;
-use std::io::Read;
 use std::{collections::HashSet, path::PathBuf};
 use std::{env, str::FromStr};
 use sui_verifier::entry_points_verifier::{
@@ -41,155 +35,6 @@ use sui_verifier::entry_points_verifier::{
 };
 
 const MAX_GAS: u64 = 10000;
-
-#[tokio::test]
-#[cfg_attr(msim, ignore)]
-async fn test_publishing_with_unpublished_deps() {
-    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
-    let gas = ObjectID::random();
-    let authority = init_state_with_ids(vec![(sender, gas)]).await;
-
-    let package = build_and_publish_test_package(
-        &authority,
-        &sender,
-        &sender_key,
-        &gas,
-        "depends_on_basics",
-        /* with_unpublished_deps */ true,
-    )
-    .await;
-
-    let ObjectRead::Exists(read_ref, package_obj, _) = authority
-        .get_object_read(&package.0)
-        .await
-        .unwrap()
-    else {
-        panic!("Can't read package")
-    };
-
-    assert_eq!(package, read_ref);
-    let Data::Package(move_package) = package_obj.data else {
-        panic!("Not a package")
-    };
-
-    // Check that the published package includes its depended upon module.
-    assert_eq!(
-        move_package
-            .serialized_module_map()
-            .keys()
-            .map(String::as_str)
-            .collect::<HashSet<_>>(),
-        HashSet::from(["depends_on_basics", "object_basics"]),
-    );
-
-    let effects = call_move(
-        &authority,
-        &gas,
-        &sender,
-        &sender_key,
-        &package.0,
-        "depends_on_basics",
-        "delegate",
-        vec![],
-        vec![],
-    )
-    .await
-    .unwrap();
-
-    assert!(effects.status().is_ok());
-    assert_eq!(effects.created().len(), 1);
-    let ((_, v, _), owner) = effects.created()[0];
-
-    // Check that calling the function does what we expect
-    assert!(matches!(
-        owner,
-        Owner::Shared { initial_shared_version: initial } if initial == v
-    ));
-}
-
-#[tokio::test]
-#[cfg_attr(msim, ignore)]
-async fn test_publish_empty_package() {
-    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
-    let gas = ObjectID::random();
-    let authority = init_state_with_ids(vec![(sender, gas)]).await;
-    let gas_object = authority.get_object(&gas).await.unwrap();
-    let gas_object_ref = gas_object.unwrap().compute_object_reference();
-
-    // empty package
-    let data = TransactionData::new_module_with_dummy_gas_price(
-        sender,
-        gas_object_ref,
-        vec![],
-        vec![],
-        MAX_GAS,
-    );
-    let transaction = to_sender_signed_transaction(data, &sender_key);
-    let err = send_and_confirm_transaction(&authority, transaction)
-        .await
-        .unwrap_err();
-    assert_eq!(
-        err,
-        SuiError::UserInputError {
-            error: UserInputError::EmptyCommandInput
-        }
-    );
-
-    // empty module
-    let data = TransactionData::new_module_with_dummy_gas_price(
-        sender,
-        gas_object_ref,
-        vec![vec![]],
-        vec![],
-        MAX_GAS,
-    );
-    let transaction = to_sender_signed_transaction(data, &sender_key);
-    let result = send_and_confirm_transaction(&authority, transaction)
-        .await
-        .unwrap()
-        .1;
-    assert_eq!(
-        result.status(),
-        &ExecutionStatus::Failure {
-            error: ExecutionFailureStatus::VMVerificationOrDeserializationError,
-            command: Some(0)
-        }
-    )
-}
-
-#[tokio::test]
-#[cfg_attr(msim, ignore)]
-async fn test_publish_duplicate_modules() {
-    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
-    let gas = ObjectID::random();
-    let authority = init_state_with_ids(vec![(sender, gas)]).await;
-    let gas_object = authority.get_object(&gas).await.unwrap();
-    let gas_object_ref = gas_object.unwrap().compute_object_reference();
-
-    // empty package
-    let mut modules = build_test_package("object_owner", /* with_unpublished_deps */ false);
-    assert_eq!(modules.len(), 1);
-    modules.push(modules[0].clone());
-    let data = TransactionData::new_module_with_dummy_gas_price(
-        sender,
-        gas_object_ref,
-        modules,
-        system_package_ids(),
-        MAX_GAS,
-    );
-    let transaction = to_sender_signed_transaction(data, &sender_key);
-    let result = send_and_confirm_transaction(&authority, transaction)
-        .await
-        .unwrap()
-        .1;
-    assert_eq!(
-        result.status(),
-        &ExecutionStatus::Failure {
-            error: ExecutionFailureStatus::VMVerificationOrDeserializationError,
-            command: Some(0)
-        }
-    )
-}
 
 #[tokio::test]
 #[cfg_attr(msim, ignore)]
@@ -2753,119 +2598,6 @@ async fn test_object_no_id_error() {
                  err_str.contains("SuiMoveVerificationError")
                  && err_str.contains("First field of struct NotObject must be 'id'"));
 }
-
-#[tokio::test]
-#[cfg_attr(msim, ignore)]
-async fn test_generate_lock_file() {
-    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    path.extend(["src", "unit_tests", "data", "generate_move_lock_file"]);
-
-    let tmp = tempfile::tempdir().expect("Could not create temp dir for Move.lock");
-    let lock_file_path = tmp.path().join("Move.lock");
-
-    let mut build_config = BuildConfig::new_for_testing();
-    build_config.config.lock_file = Some(lock_file_path.clone());
-    sui_framework::build_move_package(&path, build_config).expect("Move package did not build");
-
-    let mut lock_file_contents = String::new();
-    File::open(lock_file_path)
-        .expect("Cannot open lock file")
-        .read_to_string(&mut lock_file_contents)
-        .expect("Error reading Move.lock file");
-
-    let expected = expect![[r##"
-        # @generated by Move, please check-in and do not edit manually.
-
-        [move]
-        version = 0
-
-        dependencies = [
-          { name = "Examples" },
-          { name = "Sui" },
-        ]
-
-        [[move.package]]
-        name = "Examples"
-        source = { local = "../object_basics" }
-
-        dependencies = [
-          { name = "Sui" },
-        ]
-
-        [[move.package]]
-        name = "MoveStdlib"
-        source = { local = "../../../../../sui-framework/packages/move-stdlib" }
-
-        [[move.package]]
-        name = "Sui"
-        source = { local = "../../../../../sui-framework/packages/sui-framework" }
-
-        dependencies = [
-          { name = "MoveStdlib" },
-        ]
-    "##]];
-    expected.assert_eq(lock_file_contents.as_str());
-}
-
-#[tokio::test]
-#[cfg_attr(msim, ignore)]
-async fn test_custom_property_parse_published_at() {
-    let build_config = BuildConfig::new_for_testing();
-    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    path.extend(["src", "unit_tests", "data", "custom_properties_in_manifest"]);
-
-    sui_framework::build_move_package(&path, build_config).expect("Move package did not build");
-    let manifest = manifest_parser::parse_move_manifest_from_file(path.as_path())
-        .expect("Could not parse Move.toml");
-    let properties = manifest
-        .package
-        .custom_properties
-        .iter()
-        .map(|(k, v)| (k.to_string(), v.to_string()))
-        .collect::<Vec<_>>();
-
-    let expected = expect![[r#"
-        [
-            (
-                "published-at",
-                "0x777",
-            ),
-        ]
-    "#]];
-    expected.assert_debug_eq(&properties)
-}
-
-#[tokio::test]
-#[cfg_attr(msim, ignore)]
-async fn test_custom_property_check_unpublished_dependencies() {
-    let build_config = BuildConfig::new_for_testing();
-    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    path.extend([
-        "src",
-        "unit_tests",
-        "data",
-        "custom_properties_in_manifest_ensure_published_at",
-    ]);
-
-    let resolution_graph = build_config
-        .config
-        .resolution_graph_for_package(&path, &mut std::io::sink())
-        .expect("Could not build resolution graph.");
-
-    let SuiError::ModulePublishFailure { error } =
-        check_unpublished_dependencies(&gather_dependencies(&resolution_graph).unpublished)
-            .err()
-            .unwrap()
-     else {
-        panic!("Expected ModulePublishFailure")
-    };
-
-    let expected = expect![[r#"
-        Package dependency "CustomPropertiesInManifestDependencyMissingPublishedAt" does not specify a published address (the Move.toml manifest for "CustomPropertiesInManifestDependencyMissingPublishedAt" does not contain a published-at field).
-        If this is intentional, you may use the --with-unpublished-dependencies flag to continue publishing these dependencies as part of your package (they won't be linked against existing packages on-chain)."#]];
-    expected.assert_eq(&error)
-}
-
 pub fn build_test_package(test_dir: &str, with_unpublished_deps: bool) -> Vec<Vec<u8>> {
     let build_config = BuildConfig::new_for_testing();
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));

--- a/crates/sui-core/src/unit_tests/move_package_publish_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_publish_tests.rs
@@ -1,0 +1,295 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::authority::{
+    authority_tests::{call_move, init_state_with_ids, send_and_confirm_transaction},
+    move_integration_tests::{build_and_publish_test_package, build_test_package},
+};
+
+use sui_framework::system_package_ids;
+use sui_types::{
+    base_types::ObjectID,
+    error::UserInputError,
+    messages::{ExecutionFailureStatus, TransactionData, TransactionEffectsAPI},
+    object::{Data, ObjectRead, Owner},
+    utils::to_sender_signed_transaction,
+};
+
+use move_package::source_package::manifest_parser;
+use sui_framework_build::compiled_package::{
+    check_unpublished_dependencies, gather_dependencies, BuildConfig,
+};
+use sui_types::{
+    crypto::{get_key_pair, AccountKeyPair},
+    error::SuiError,
+    messages::ExecutionStatus,
+};
+
+use expect_test::expect;
+use std::env;
+use std::fs::File;
+use std::io::Read;
+use std::{collections::HashSet, path::PathBuf};
+
+const MAX_GAS: u64 = 10000;
+
+#[tokio::test]
+#[cfg_attr(msim, ignore)]
+async fn test_publishing_with_unpublished_deps() {
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let gas = ObjectID::random();
+    let authority = init_state_with_ids(vec![(sender, gas)]).await;
+
+    let package = build_and_publish_test_package(
+        &authority,
+        &sender,
+        &sender_key,
+        &gas,
+        "depends_on_basics",
+        /* with_unpublished_deps */ true,
+    )
+    .await;
+
+    let ObjectRead::Exists(read_ref, package_obj, _) = authority
+        .get_object_read(&package.0)
+        .await
+        .unwrap()
+    else {
+        panic!("Can't read package")
+    };
+
+    assert_eq!(package, read_ref);
+    let Data::Package(move_package) = package_obj.data else {
+        panic!("Not a package")
+    };
+
+    // Check that the published package includes its depended upon module.
+    assert_eq!(
+        move_package
+            .serialized_module_map()
+            .keys()
+            .map(String::as_str)
+            .collect::<HashSet<_>>(),
+        HashSet::from(["depends_on_basics", "object_basics"]),
+    );
+
+    let effects = call_move(
+        &authority,
+        &gas,
+        &sender,
+        &sender_key,
+        &package.0,
+        "depends_on_basics",
+        "delegate",
+        vec![],
+        vec![],
+    )
+    .await
+    .unwrap();
+
+    assert!(effects.status().is_ok());
+    assert_eq!(effects.created().len(), 1);
+    let ((_, v, _), owner) = effects.created()[0];
+
+    // Check that calling the function does what we expect
+    assert!(matches!(
+        owner,
+        Owner::Shared { initial_shared_version: initial } if initial == v
+    ));
+}
+
+#[tokio::test]
+#[cfg_attr(msim, ignore)]
+async fn test_publish_empty_package() {
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let gas = ObjectID::random();
+    let authority = init_state_with_ids(vec![(sender, gas)]).await;
+    let gas_object = authority.get_object(&gas).await.unwrap();
+    let gas_object_ref = gas_object.unwrap().compute_object_reference();
+
+    // empty package
+    let data = TransactionData::new_module_with_dummy_gas_price(
+        sender,
+        gas_object_ref,
+        vec![],
+        vec![],
+        MAX_GAS,
+    );
+    let transaction = to_sender_signed_transaction(data, &sender_key);
+    let err = send_and_confirm_transaction(&authority, transaction)
+        .await
+        .unwrap_err();
+    assert_eq!(
+        err,
+        SuiError::UserInputError {
+            error: UserInputError::EmptyCommandInput
+        }
+    );
+
+    // empty module
+    let data = TransactionData::new_module_with_dummy_gas_price(
+        sender,
+        gas_object_ref,
+        vec![vec![]],
+        vec![],
+        MAX_GAS,
+    );
+    let transaction = to_sender_signed_transaction(data, &sender_key);
+    let result = send_and_confirm_transaction(&authority, transaction)
+        .await
+        .unwrap()
+        .1;
+    assert_eq!(
+        result.status(),
+        &ExecutionStatus::Failure {
+            error: ExecutionFailureStatus::VMVerificationOrDeserializationError,
+            command: Some(0)
+        }
+    )
+}
+
+#[tokio::test]
+#[cfg_attr(msim, ignore)]
+async fn test_publish_duplicate_modules() {
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let gas = ObjectID::random();
+    let authority = init_state_with_ids(vec![(sender, gas)]).await;
+    let gas_object = authority.get_object(&gas).await.unwrap();
+    let gas_object_ref = gas_object.unwrap().compute_object_reference();
+
+    // empty package
+    let mut modules = build_test_package("object_owner", /* with_unpublished_deps */ false);
+    assert_eq!(modules.len(), 1);
+    modules.push(modules[0].clone());
+    let data = TransactionData::new_module_with_dummy_gas_price(
+        sender,
+        gas_object_ref,
+        modules,
+        system_package_ids(),
+        MAX_GAS,
+    );
+    let transaction = to_sender_signed_transaction(data, &sender_key);
+    let result = send_and_confirm_transaction(&authority, transaction)
+        .await
+        .unwrap()
+        .1;
+    assert_eq!(
+        result.status(),
+        &ExecutionStatus::Failure {
+            error: ExecutionFailureStatus::VMVerificationOrDeserializationError,
+            command: Some(0)
+        }
+    )
+}
+
+#[tokio::test]
+#[cfg_attr(msim, ignore)]
+async fn test_generate_lock_file() {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.extend(["src", "unit_tests", "data", "generate_move_lock_file"]);
+
+    let tmp = tempfile::tempdir().expect("Could not create temp dir for Move.lock");
+    let lock_file_path = tmp.path().join("Move.lock");
+
+    let mut build_config = BuildConfig::new_for_testing();
+    build_config.config.lock_file = Some(lock_file_path.clone());
+    sui_framework::build_move_package(&path, build_config).expect("Move package did not build");
+
+    let mut lock_file_contents = String::new();
+    File::open(lock_file_path)
+        .expect("Cannot open lock file")
+        .read_to_string(&mut lock_file_contents)
+        .expect("Error reading Move.lock file");
+
+    let expected = expect![[r##"
+        # @generated by Move, please check-in and do not edit manually.
+
+        [move]
+        version = 0
+
+        dependencies = [
+          { name = "Examples" },
+          { name = "Sui" },
+        ]
+
+        [[move.package]]
+        name = "Examples"
+        source = { local = "../object_basics" }
+
+        dependencies = [
+          { name = "Sui" },
+        ]
+
+        [[move.package]]
+        name = "MoveStdlib"
+        source = { local = "../../../../../sui-framework/packages/move-stdlib" }
+
+        [[move.package]]
+        name = "Sui"
+        source = { local = "../../../../../sui-framework/packages/sui-framework" }
+
+        dependencies = [
+          { name = "MoveStdlib" },
+        ]
+    "##]];
+    expected.assert_eq(lock_file_contents.as_str());
+}
+
+#[tokio::test]
+#[cfg_attr(msim, ignore)]
+async fn test_custom_property_parse_published_at() {
+    let build_config = BuildConfig::new_for_testing();
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.extend(["src", "unit_tests", "data", "custom_properties_in_manifest"]);
+
+    sui_framework::build_move_package(&path, build_config).expect("Move package did not build");
+    let manifest = manifest_parser::parse_move_manifest_from_file(path.as_path())
+        .expect("Could not parse Move.toml");
+    let properties = manifest
+        .package
+        .custom_properties
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect::<Vec<_>>();
+
+    let expected = expect![[r#"
+        [
+            (
+                "published-at",
+                "0x777",
+            ),
+        ]
+    "#]];
+    expected.assert_debug_eq(&properties)
+}
+
+#[tokio::test]
+#[cfg_attr(msim, ignore)]
+async fn test_custom_property_check_unpublished_dependencies() {
+    let build_config = BuildConfig::new_for_testing();
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.extend([
+        "src",
+        "unit_tests",
+        "data",
+        "custom_properties_in_manifest_ensure_published_at",
+    ]);
+
+    let resolution_graph = build_config
+        .config
+        .resolution_graph_for_package(&path, &mut std::io::sink())
+        .expect("Could not build resolution graph.");
+
+    let SuiError::ModulePublishFailure { error } =
+        check_unpublished_dependencies(&gather_dependencies(&resolution_graph).unpublished)
+            .err()
+            .unwrap()
+     else {
+        panic!("Expected ModulePublishFailure")
+    };
+
+    let expected = expect![[r#"
+        Package dependency "CustomPropertiesInManifestDependencyMissingPublishedAt" does not specify a published address (the Move.toml manifest for "CustomPropertiesInManifestDependencyMissingPublishedAt" does not contain a published-at field).
+        If this is intentional, you may use the --with-unpublished-dependencies flag to continue publishing these dependencies as part of your package (they won't be linked against existing packages on-chain)."#]];
+    expected.assert_eq(&error)
+}


### PR DESCRIPTION
## Description 

Just moves `publish` tests out of `move_integration_tests.rs` into its own file `move_package_publish_tests.rs`. This aligns with package upgrades having its own test file, and `move_integration_tests.rs` is getting bloated.

## Test Plan 

Ran test suite.
