### PR TITLE
[Narwhal] limit fetch certificate response size to 2k; limit timeout to 10s

### DIFF
--- a/narwhal/network/src/p2p.rs
+++ b/narwhal/network/src/p2p.rs
@@ -106,10 +106,11 @@ impl PrimaryToPrimaryRpc for anemo::Network {
             .map_err(|e| format_err!("Network error {:?}", e))?;
         Ok(response.into_body())
     }
+
     async fn fetch_certificates(
         &self,
         peer: &NetworkPublicKey,
-        request: FetchCertificatesRequest,
+        request: impl anemo::types::request::IntoRequest<FetchCertificatesRequest> + Send,
     ) -> Result<FetchCertificatesResponse> {
         let peer_id = PeerId(peer.0.to_bytes());
         let peer = self

--- a/narwhal/network/src/traits.rs
+++ b/narwhal/network/src/traits.rs
@@ -68,7 +68,7 @@ pub trait PrimaryToPrimaryRpc {
     async fn fetch_certificates(
         &self,
         peer: &NetworkPublicKey,
-        request: FetchCertificatesRequest,
+        request: impl anemo::types::request::IntoRequest<FetchCertificatesRequest> + Send,
     ) -> Result<FetchCertificatesResponse>;
 }
 


### PR DESCRIPTION
## Description 

This reduces load on the rpc layer, and seems to improves stability.

## Test Plan 

Deployed to private testnet.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
