### PR TITLE
Expose constants to the bench orchestrator

### DIFF
--- a/crates/sui-config/src/lib.rs
+++ b/crates/sui-config/src/lib.rs
@@ -22,7 +22,7 @@ pub use swarm::FullnodeConfigBuilder;
 pub use swarm::NetworkConfig;
 
 const SUI_DIR: &str = ".sui";
-const SUI_CONFIG_DIR: &str = "sui_config";
+pub const SUI_CONFIG_DIR: &str = "sui_config";
 pub const SUI_NETWORK_CONFIG: &str = "network.yaml";
 pub const SUI_FULLNODE_CONFIG: &str = "fullnode.yaml";
 pub const SUI_CLIENT_CONFIG: &str = "client.yaml";


### PR DESCRIPTION
Expose default constants for use in the orchestrator (only for benchmakrs).