### PR TITLE
[sui-framework] change test_only clock creation to return Clock object instead of sharing

### DIFF
--- a/crates/sui-framework/packages/sui-framework/sources/clock.move
+++ b/crates/sui-framework/packages/sui-framework/sources/clock.move
@@ -62,16 +62,21 @@ module sui::clock {
     #[test_only]
     /// Expose the functionality of `create()` (usually only done during
     /// genesis) for tests that want to create a Clock.
-    public fun create_for_testing(ctx: &mut sui::tx_context::TxContext) {
-        transfer::share_object(Clock {
+    public fun create_for_testing(ctx: &mut sui::tx_context::TxContext): Clock {
+        Clock {
             id: object::new(ctx),
             timestamp_ms: 0,
-        })
+        }
     }
-
 
     #[test_only]
     public fun increment_for_testing(clock: &mut Clock, tick: u64) {
         clock.timestamp_ms = clock.timestamp_ms + tick;
+    }
+
+    #[test_only]
+    public fun destroy_for_testing(clock: Clock) {
+        let Clock { id, timestamp_ms: _ }  = clock;
+        object::delete(id);
     }
 }

--- a/crates/sui-framework/packages/sui-framework/sources/clock.move
+++ b/crates/sui-framework/packages/sui-framework/sources/clock.move
@@ -75,6 +75,12 @@ module sui::clock {
     }
 
     #[test_only]
+    public fun set_for_testing(clock: &mut Clock, timestamp_ms: u64) {
+        assert!(timestamp_ms >= clock.timestamp_ms, 0);
+        clock.timestamp_ms = timestamp_ms;
+    }
+
+    #[test_only]
     public fun destroy_for_testing(clock: Clock) {
         let Clock { id, timestamp_ms: _ }  = clock;
         object::delete(id);

--- a/crates/sui-framework/packages/sui-framework/tests/clock_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/clock_tests.move
@@ -3,30 +3,17 @@
 
 #[test_only]
 module sui::clock_tests {
-    use std::vector;
-    use sui::clock::{Self, Clock};
-    use sui::test_scenario as ts;
+    use sui::clock;
+    use sui::tx_context;
 
     #[test]
     fun creating_a_clock_and_incrementing_it() {
-        let ts = ts::begin(@0x1);
-        let ctx = ts::ctx(&mut ts);
-        clock::create_for_testing(ctx);
+        let ctx = tx_context::dummy();
+        let clock = clock::create_for_testing(&mut ctx);
 
-        let eff = ts::next_tx(&mut ts, @0x2);
-        // Make sure the clock was created
-        assert!(vector::length(&ts::shared(&eff)) == 1, 0);
-
-        // ...and that we can fetch it and update it
-        let clock = ts::take_shared<Clock>(&ts);
         clock::increment_for_testing(&mut clock, 42);
-        ts::return_shared(clock);
-
-        ts::next_tx(&mut ts, @0x3);
-        let clock = ts::take_shared<Clock>(&ts);
-        // ...and read the updates
         assert!(clock::timestamp_ms(&clock) == 42, 1);
-        ts::return_shared(clock);
-        ts::end(ts);
+
+        clock::destroy_for_testing(clock);
     }
 }

--- a/crates/sui-framework/packages/sui-framework/tests/clock_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/clock_tests.move
@@ -14,6 +14,9 @@ module sui::clock_tests {
         clock::increment_for_testing(&mut clock, 42);
         assert!(clock::timestamp_ms(&clock) == 42, 1);
 
+        clock::set_for_testing(&mut clock, 50);
+        assert!(clock::timestamp_ms(&clock) == 50, 1);
+
         clock::destroy_for_testing(clock);
     }
 }


### PR DESCRIPTION
## Description 

I propose that the `create_for_testing` function in the `clock` module be changed so that it returns the `Clock` object instead of sharing it.
When the object is shared it requires the tests that rely on clock to utilize `test_scenario` which adds a lot of boilerplate to tests that otherwise wouldn't need it. AFAICT there's no advantage to sharing it.

Also added `set_for_testing` function to manually set the timestamp to any value >= current timestamp.

## Test Plan 

`sui move test`

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
 - [Breaking Change] `sui::clock::create_for_testing` now returns the created `Clock` rather than sharing it.