### PR TITLE
WIP: Set linkage context for move calls

### DIFF
--- a/.config/hakari.toml
+++ b/.config/hakari.toml
@@ -31,9 +31,9 @@ workspace-members = [ "sui-move" ]
 third-party = [
     ## Exclude the 'move-unit-test' crate in order to ensure that the 'testing'
     # feature isn't enabled in the workspace-hack
-    { name = "move-unit-test", git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" },
-    { name = "move-cli", git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" },
-    { name = "move-transactional-test-runner", git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" },
+    { name = "move-unit-test", git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" },
+    { name = "move-cli", git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" },
+    { name = "move-transactional-test-runner", git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" },
     { name = "object_store" },
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,7 +1370,7 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -4586,7 +4586,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4603,7 +4603,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -4616,12 +4616,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4636,7 +4636,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4648,7 +4648,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "anyhow",
  "fail 0.4.0",
@@ -4661,7 +4661,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -4678,7 +4678,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4724,7 +4724,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "anyhow",
  "difference",
@@ -4741,7 +4741,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4770,7 +4770,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4789,7 +4789,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4809,7 +4809,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -4827,7 +4827,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "anyhow",
  "codespan",
@@ -4845,7 +4845,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4859,7 +4859,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4878,7 +4878,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -4897,7 +4897,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "anyhow",
  "hex",
@@ -4910,7 +4910,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "anyhow",
  "hex",
@@ -4924,7 +4924,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "anyhow",
  "codespan",
@@ -4950,7 +4950,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4986,7 +4986,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5023,7 +5023,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5051,7 +5051,7 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5062,7 +5062,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5077,7 +5077,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -5104,7 +5104,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
@@ -5122,7 +5122,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "anyhow",
  "hex",
@@ -5145,7 +5145,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "once_cell",
  "serde 1.0.152",
@@ -5154,7 +5154,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5171,7 +5171,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -5203,7 +5203,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "anyhow",
  "better_any",
@@ -5234,7 +5234,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "better_any",
  "fail 0.4.0",
@@ -5252,7 +5252,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5265,7 +5265,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -7309,7 +7309,7 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7324,7 +7324,7 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5d7041c92bc66338afa469c0a9524cb06ea5875c#5d7041c92bc66338afa469c0a9524cb06ea5875c"
+source = "git+https://github.com/move-language/move?rev=b8c6985b75a7a668b184f1ce6b5469786a6fb33f#b8c6985b75a7a668b184f1ce6b5469786a6fb33f"
 dependencies = [
  "anyhow",
  "move-binary-format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,26 +110,26 @@ opt-level = 1
 tokio = "1.24.1"
 
 # Move dependencies
-move-binary-format = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-cli = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-compiler = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", features = ["address32"] }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-package = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-prover = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-cli = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-compiler = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", features = ["address32"] }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-package = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-prover = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
 
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "c2f79b1807bff7d09517b631191b61f2614c641c" }
 fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "c2f79b1807bff7d09517b631191b61f2614c641c", package = "fastcrypto-zkp" }

--- a/crates/sui-adapter-transactional-tests/tests/sui/move_call_incorrect_function.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/move_call_incorrect_function.exp
@@ -6,7 +6,7 @@ written: object(103)
 
 task 2 'run'. lines 16-18:
 Error: Transaction Effects Status: Move Bytecode Verification Error. Please run the Bytecode Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VMVerificationOrDeserializationError, source: Some(VMError { major_status: LINKER_ERROR, sub_status: None, message: Some("Cannot find ModuleId { address: _, name: Identifier(\"M\") } in data cache"), exec_state: None, location: Undefined, indices: [], offsets: [] }), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VMVerificationOrDeserializationError, source: Some(VMError { major_status: LINKER_ERROR, sub_status: None, message: Some("Cannot find link context _ in store"), exec_state: None, location: Undefined, indices: [], offsets: [] }), command: Some(0) } }
 
 task 3 'run'. lines 19-19:
 Error: Transaction Effects Status: Function Not Found.

--- a/crates/sui-adapter/src/programmable_transactions/context.rs
+++ b/crates/sui-adapter/src/programmable_transactions/context.rs
@@ -202,7 +202,7 @@ impl<'vm, 'state, 'a, 'b, S: StorageView> ExecutionContext<'vm, 'state, 'a, 'b, 
             Ok(Some(package)) => {
                 self.set_linkage(&package);
                 Ok(())
-            },
+            }
             Ok(None) => invariant_violation!(format!(
                 "Link context not found or not a package: {package_id}",
             )),
@@ -214,6 +214,10 @@ impl<'vm, 'state, 'a, 'b, S: StorageView> ExecutionContext<'vm, 'state, 'a, 'b, 
 
     pub fn set_linkage(&mut self, package: &MovePackage) {
         *self.session.get_resolver_mut() = LinkageView::from_package(self.state_view, package);
+    }
+
+    pub fn reset_linkage(&mut self) {
+        *self.session.get_resolver_mut() = LinkageView::new(self.state_view);
     }
 
     /// Takes the user events from the runtime and tags them with the Move module of the function

--- a/crates/sui-adapter/src/programmable_transactions/types.rs
+++ b/crates/sui-adapter/src/programmable_transactions/types.rs
@@ -15,14 +15,14 @@ use serde::Deserialize;
 use sui_types::{
     base_types::{MoveObjectType, ObjectID, SequenceNumber, SuiAddress},
     coin::Coin,
-    error::{convert_vm_error, ExecutionError, ExecutionErrorKind, SuiError},
+    error::{ExecutionError, ExecutionErrorKind, SuiError},
     messages::CommandArgumentError,
     object::{Data, MoveObject, Object, Owner},
     storage::{BackingPackageStore, ChildObjectResolver, ObjectChange, ParentSync, Storage},
     TypeTag,
 };
 
-use super::linkage_view::LinkageView;
+use super::{context::load_type, linkage_view::LinkageView};
 
 pub trait StorageView:
     ResourceResolver<Error = SuiError>
@@ -188,9 +188,9 @@ impl Value {
 }
 
 impl ObjectValue {
-    pub fn new<S: StorageView>(
-        vm: &MoveVM,
-        session: &Session<LinkageView<S>>,
+    pub fn new<'vm, 'state, S: StorageView>(
+        vm: &'vm MoveVM,
+        session: &mut Session<'state, 'vm, LinkageView<'state, S>>,
         type_: MoveObjectType,
         has_public_transfer: bool,
         used_in_non_entry_move_call: bool,
@@ -205,9 +205,7 @@ impl ObjectValue {
             ObjectContents::Raw(contents.to_vec())
         };
         let tag: StructTag = type_.into();
-        let type_ = session
-            .load_type(&TypeTag::Struct(Box::new(tag)))
-            .map_err(|e| convert_vm_error(e, vm, session.get_resolver()))?;
+        let type_ = load_type(vm, session, &TypeTag::Struct(Box::new(tag)))?;
         Ok(Self {
             type_,
             has_public_transfer,
@@ -216,9 +214,9 @@ impl ObjectValue {
         })
     }
 
-    pub fn from_object<S: StorageView>(
-        vm: &MoveVM,
-        session: &Session<LinkageView<S>>,
+    pub fn from_object<'vm, 'state, S: StorageView>(
+        vm: &'vm MoveVM,
+        session: &mut Session<'state, 'vm, LinkageView<'state, S>>,
         object: &Object,
     ) -> Result<Self, ExecutionError> {
         let Object { data, .. } = object;
@@ -228,9 +226,9 @@ impl ObjectValue {
         }
     }
 
-    pub fn from_move_object<S: StorageView>(
-        vm: &MoveVM,
-        session: &Session<LinkageView<S>>,
+    pub fn from_move_object<'vm, 'state, S: StorageView>(
+        vm: &'vm MoveVM,
+        session: &mut Session<'state, 'vm, LinkageView<'state, S>>,
         object: &MoveObject,
     ) -> Result<Self, ExecutionError> {
         Self::new(

--- a/crates/sui-adapter/src/programmable_transactions/types.rs
+++ b/crates/sui-adapter/src/programmable_transactions/types.rs
@@ -205,7 +205,8 @@ impl ObjectValue {
             ObjectContents::Raw(contents.to_vec())
         };
         let tag: StructTag = type_.into();
-        let type_ = load_type(vm, session, &TypeTag::Struct(Box::new(tag)))?;
+        let type_ = load_type(session, &TypeTag::Struct(Box::new(tag)))
+            .map_err(|e| sui_types::error::convert_vm_error(e, vm, session.get_resolver()))?;
         Ok(Self {
             type_,
             has_public_transfer,

--- a/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -125,7 +125,7 @@ impl UpgradeStateRunner {
             builder.finish()
         };
         let TransactionEffects::V1(effects) = self.run(pt).await;
-        assert!(effects.status.is_ok());
+        assert!(effects.status.is_ok(), "{:#?}", effects.status);
 
         let package = effects
             .created
@@ -185,7 +185,7 @@ async fn test_upgrade_package_happy_path() {
     };
     let TransactionEffects::V1(effects) = runner.run(pt).await;
 
-    assert!(effects.status.is_ok());
+    assert!(effects.status.is_ok(), "{:#?}", effects.status);
     let new_package = effects
         .created
         .iter()
@@ -211,9 +211,7 @@ async fn test_upgrade_package_happy_path() {
         )));
 }
 
-// TODO(tzakian): turn this test on once the Move loader changes.
 #[tokio::test]
-#[ignore]
 async fn test_upgrade_incompatible() {
     let runner = UpgradeStateRunner::new("move_upgrade/base").await;
     let pt = {
@@ -243,7 +241,12 @@ async fn test_upgrade_incompatible() {
     };
     let TransactionEffects::V1(effects) = runner.run(pt).await;
 
-    assert!(effects.status.is_ok());
+    assert_eq!(
+        effects.status.unwrap_err().0,
+        ExecutionFailureStatus::PackageUpgradeError {
+            upgrade_error: PackageUpgradeError::IncompatibleUpgrade,
+        },
+    )
 }
 
 #[tokio::test]
@@ -457,7 +460,7 @@ async fn upgrade_missing_deps() {
 #[tokio::test]
 async fn test_multiple_upgrades_valid() {
     let TransactionEffects::V1(effects) = test_multiple_upgrades(false).await;
-    assert!(effects.status.is_ok());
+    assert!(effects.status.is_ok(), "{:#?}", effects.status);
 }
 
 async fn test_multiple_upgrades(use_empty_deps: bool) -> TransactionEffects {
@@ -488,7 +491,7 @@ async fn test_multiple_upgrades(use_empty_deps: bool) -> TransactionEffects {
         builder.finish()
     };
     let TransactionEffects::V1(effects) = runner.run(pt1).await;
-    assert!(effects.status.is_ok());
+    assert!(effects.status.is_ok(), "{:#?}", effects.status);
 
     let new_package = effects
         .created
@@ -538,7 +541,6 @@ async fn test_multiple_upgrades(use_empty_deps: bool) -> TransactionEffects {
 
 // TODO(tzakian): turn this test on once the Move loader changes.
 #[tokio::test]
-#[ignore]
 async fn test_interleaved_upgrades() {
     let runner = UpgradeStateRunner::new("move_upgrade/base").await;
 
@@ -576,7 +578,7 @@ async fn test_interleaved_upgrades() {
         builder.finish()
     };
     let TransactionEffects::V1(effects) = runner.run(pt1).await;
-    assert!(effects.status.is_ok());
+    assert!(effects.status.is_ok(), "{:#?}", effects.status);
 
     let dep_v2_package = effects
         .created
@@ -616,7 +618,7 @@ async fn test_interleaved_upgrades() {
         builder.finish()
     };
     let TransactionEffects::V1(effects) = runner.run(pt2).await;
-    assert!(effects.status.is_ok());
+    assert!(effects.status.is_ok(), "{:#?}", effects.status);
 }
 
 #[tokio::test]
@@ -660,7 +662,7 @@ async fn test_publish_override_happy_path() {
         builder.finish()
     };
     let TransactionEffects::V1(effects) = runner.run(pt1).await;
-    assert!(effects.status.is_ok());
+    assert!(effects.status.is_ok(), "{:#?}", effects.status);
 
     let dep_v2_package = effects
         .created

--- a/crates/sui-framework/src/natives/event.rs
+++ b/crates/sui-framework/src/natives/event.rs
@@ -95,6 +95,6 @@ pub fn emit(
 
     let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
 
-    obj_runtime.emit_event(*tag, event_value)?;
+    obj_runtime.emit_event(ty, *tag, event_value)?;
     Ok(NativeResult::ok(context.gas_used(), smallvec![]))
 }

--- a/crates/sui-framework/src/natives/object_runtime/mod.rs
+++ b/crates/sui-framework/src/natives/object_runtime/mod.rs
@@ -54,9 +54,9 @@ pub(crate) struct TestInventories {
 }
 
 pub struct RuntimeResults {
-    pub writes: LinkedHashMap<ObjectID, (WriteKind, Owner, Type, MoveObjectType, Value)>,
+    pub writes: LinkedHashMap<ObjectID, (WriteKind, Owner, Type, Value)>,
     pub deletions: LinkedHashMap<ObjectID, DeleteKind>,
-    pub user_events: Vec<(StructTag, Value)>,
+    pub user_events: Vec<(Type, StructTag, Value)>,
     // loaded child objects and their versions
     pub loaded_child_objects: BTreeMap<ObjectID, SequenceNumber>,
 }
@@ -70,8 +70,8 @@ pub(crate) struct ObjectRuntimeState {
     deleted_ids: Set<ObjectID>,
     // transfers to a new owner (shared, immutable, object, or account address)
     // TODO these struct tags can be removed if type_to_type_tag was exposed in the session
-    transfers: LinkedHashMap<ObjectID, (Owner, Type, MoveObjectType, Value)>,
-    events: Vec<(StructTag, Value)>,
+    transfers: LinkedHashMap<ObjectID, (Owner, Type, Value)>,
+    events: Vec<(Type, StructTag, Value)>,
 }
 
 #[derive(Clone)]
@@ -232,7 +232,6 @@ impl<'a> ObjectRuntime<'a> {
         &mut self,
         owner: Owner,
         ty: Type,
-        tag: MoveObjectType,
         obj: Value,
     ) -> PartialVMResult<TransferResult> {
         let id: ObjectID = get_object_id(obj.copy_value()?)?
@@ -277,19 +276,19 @@ impl<'a> ObjectRuntime<'a> {
             }
         };
 
-        self.state.transfers.insert(id, (owner, ty, tag, obj));
+        self.state.transfers.insert(id, (owner, ty, obj));
         Ok(transfer_result)
     }
 
-    pub fn emit_event(&mut self, tag: StructTag, event: Value) -> PartialVMResult<()> {
+    pub fn emit_event(&mut self, ty: Type, tag: StructTag, event: Value) -> PartialVMResult<()> {
         if self.state.events.len() >= (self.constants.max_num_event_emit as usize) {
             return Err(max_event_error(self.constants.max_num_event_emit));
         }
-        self.state.events.push((tag, event));
+        self.state.events.push((ty, tag, event));
         Ok(())
     }
 
-    pub fn take_user_events(&mut self) -> Vec<(StructTag, Value)> {
+    pub fn take_user_events(&mut self) -> Vec<(Type, StructTag, Value)> {
         std::mem::take(&mut self.state.events)
     }
 
@@ -397,7 +396,6 @@ impl ObjectRuntimeState {
                 owner: parent,
                 loaded_version,
                 ty,
-                move_type,
                 effect,
             } = child_object_effect;
             if let Some(v) = loaded_version {
@@ -413,13 +411,13 @@ impl ObjectRuntimeState {
                     debug_assert!(!self.new_ids.contains_key(&child));
                     debug_assert!(loaded_version.is_some());
                     self.transfers
-                        .insert(child, (Owner::ObjectOwner(parent.into()), ty, move_type, v));
+                        .insert(child, (Owner::ObjectOwner(parent.into()), ty, v));
                 }
 
                 Op::New(v) => {
                     debug_assert!(!self.transfers.contains_key(&child));
                     self.transfers
-                        .insert(child, (Owner::ObjectOwner(parent.into()), ty, move_type, v));
+                        .insert(child, (Owner::ObjectOwner(parent.into()), ty, v));
                 }
                 // was transferred so not actually deleted
                 Op::Delete if self.transfers.contains_key(&child) => {
@@ -459,12 +457,12 @@ impl ObjectRuntimeState {
         // TODO can we have cycles in the new system?
         update_owner_map(
             input_owner_map,
-            transfers.iter().map(|(id, (owner, _, _, _))| (*id, *owner)),
+            transfers.iter().map(|(id, (owner, _, _))| (*id, *owner)),
         )?;
         // determine write kinds
         let writes: LinkedHashMap<_, _> = transfers
             .into_iter()
-            .map(|(id, (owner, type_, tag, value))| {
+            .map(|(id, (owner, type_, value))| {
                 let write_kind =
                     if input_objects.contains_key(&id) || loaded_child_objects.contains_key(&id) {
                         debug_assert!(!new_ids.contains_key(&id));
@@ -476,7 +474,7 @@ impl ObjectRuntimeState {
                     } else {
                         WriteKind::Unwrap
                     };
-                (id, (write_kind, owner, type_, tag, value))
+                (id, (write_kind, owner, type_, value))
             })
             .collect();
         // determine delete kinds

--- a/crates/sui-framework/src/natives/object_runtime/object_store.rs
+++ b/crates/sui-framework/src/natives/object_runtime/object_store.rs
@@ -28,7 +28,6 @@ pub(crate) struct ChildObjectEffect {
     // none if it was an input object
     pub(super) loaded_version: Option<SequenceNumber>,
     pub(super) ty: Type,
-    pub(super) move_type: MoveObjectType,
     pub(super) effect: Op<Value>,
 }
 
@@ -363,7 +362,7 @@ impl<'a> ObjectStore<'a> {
                 let ChildObject {
                     owner,
                     ty,
-                    move_type,
+                    move_type: _,
                     value,
                 } = child_object;
                 let loaded_version = self
@@ -376,7 +375,6 @@ impl<'a> ObjectStore<'a> {
                     owner,
                     loaded_version,
                     ty,
-                    move_type,
                     effect,
                 };
                 Some((id, child_effect))

--- a/crates/sui-framework/src/natives/test_scenario.rs
+++ b/crates/sui-framework/src/natives/test_scenario.rs
@@ -118,7 +118,7 @@ pub fn end_transaction(
     // handle transfers, inserting transferred/written objects into their respective inventory
     let mut created = vec![];
     let mut written = vec![];
-    for (id, (kind, owner, ty, _tag, value)) in writes {
+    for (id, (kind, owner, ty, value)) in writes {
         new_object_values.insert(id, (ty.clone(), value.copy_value().unwrap()));
         transferred.push((id, owner));
         incorrect_shared_or_imm_handling = incorrect_shared_or_imm_handling

--- a/crates/sui-framework/src/natives/transfer.rs
+++ b/crates/sui-framework/src/natives/transfer.rs
@@ -14,10 +14,7 @@ use move_vm_types::{
 };
 use smallvec::smallvec;
 use std::collections::VecDeque;
-use sui_types::{
-    base_types::{MoveObjectType, SequenceNumber},
-    object::Owner,
-};
+use sui_types::{base_types::SequenceNumber, object::Owner};
 
 const E_SHARED_NON_NEW_OBJECT: u64 = 0;
 
@@ -150,15 +147,13 @@ fn object_runtime_transfer(
     ty: Type,
     obj: Value,
 ) -> PartialVMResult<TransferResult> {
-    let tag = match context.type_to_type_tag(&ty)? {
-        TypeTag::Struct(s) => *s,
-        _ => {
-            return Err(
-                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                    .with_message("Sui verifier guarantees this is a struct".to_string()),
-            )
-        }
-    };
+    if !matches!(context.type_to_type_tag(&ty)?, TypeTag::Struct(_)) {
+        return Err(
+            PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                .with_message("Sui verifier guarantees this is a struct".to_string()),
+        );
+    }
+
     let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
-    obj_runtime.transfer(owner, ty, MoveObjectType::from(tag), obj)
+    obj_runtime.transfer(owner, ty, obj)
 }

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -313,33 +313,33 @@ miniz_oxide = { version = "0.6", default-features = false, features = ["with-all
 mio = { version = "0.8", features = ["net", "os-ext"] }
 mockall = { version = "0.11", default-features = false }
 more-asserts = { version = "0.3", default-features = false }
-move-abigen = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-borrow-graph = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
-move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
-move-compiler = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
-move-core-types = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", features = ["address32"] }
-move-coverage = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-docgen = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
-move-errmapgen = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
-move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
-move-model = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
-move-package = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
-move-prover = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
-move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", features = ["tiered-gas"] }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", default-features = false }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-borrow-graph = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", default-features = false }
+move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", default-features = false }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", default-features = false }
+move-compiler = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", default-features = false }
+move-core-types = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", features = ["address32"] }
+move-coverage = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-docgen = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", default-features = false }
+move-errmapgen = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", default-features = false }
+move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", default-features = false }
+move-model = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", default-features = false }
+move-package = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", default-features = false }
+move-prover = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", default-features = false }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", default-features = false }
+move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", default-features = false }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", default-features = false }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", default-features = false }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", features = ["tiered-gas"] }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
 multiaddr = { version = "0.17" }
 multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }
@@ -971,33 +971,33 @@ mio = { version = "0.8", features = ["net", "os-ext"] }
 mockall = { version = "0.11", default-features = false }
 mockall_derive = { version = "0.11", default-features = false }
 more-asserts = { version = "0.3", default-features = false }
-move-abigen = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-borrow-graph = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
-move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
-move-compiler = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
-move-core-types = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", features = ["address32"] }
-move-coverage = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-docgen = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
-move-errmapgen = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
-move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
-move-model = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
-move-package = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
-move-prover = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
-move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", default-features = false }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c", features = ["tiered-gas"] }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "5d7041c92bc66338afa469c0a9524cb06ea5875c" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", default-features = false }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-borrow-graph = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", default-features = false }
+move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", default-features = false }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", default-features = false }
+move-compiler = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", default-features = false }
+move-core-types = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", features = ["address32"] }
+move-coverage = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-docgen = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", default-features = false }
+move-errmapgen = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", default-features = false }
+move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", default-features = false }
+move-model = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", default-features = false }
+move-package = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", default-features = false }
+move-prover = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", default-features = false }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", default-features = false }
+move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", default-features = false }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", default-features = false }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", default-features = false }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f", features = ["tiered-gas"] }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "b8c6985b75a7a668b184f1ce6b5469786a6fb33f" }
 multiaddr = { version = "0.17" }
 multibase = { version = "0.9" }
 multihash = { version = "0.17", default-features = false, features = ["identity", "multihash-impl", "std"] }


### PR DESCRIPTION
Initial work on setting the appropriate linkage context for calls into the VM.  Support for setting the correct context for loading types (including type parameters for calls) is TBD, so not all tests will pass.

To help identify issues, this PR also makes it no longer an error to run code without a linkage context set -- this provides basic support for loading types in the absence of upgrades, but will need to be changed back.

## Test Plan

(9 tests failing at the moment, mostly because of issues related to type parameters).

```
$ cargo simtest
$ cargo nextest run
```