### PR TITLE
[kiosk+] Kicking off Kiosk+ section in examples

### DIFF
--- a/sui_programmability/examples/kiosk/Move.toml
+++ b/sui_programmability/examples/kiosk/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "Kiosk+"
+version = "0.0.1"
+
+[dependencies]
+Sui = { local = "../../../crates/sui-framework/packages/sui-framework" }
+
+[addresses]
+kiosk = "0x0"

--- a/sui_programmability/examples/kiosk/README.md
+++ b/sui_programmability/examples/kiosk/README.md
@@ -1,0 +1,3 @@
+# Kiosk+
+
+This package features examples of extensions for Kiosk.

--- a/sui_programmability/examples/kiosk/README.md
+++ b/sui_programmability/examples/kiosk/README.md
@@ -1,3 +1,16 @@
 # Kiosk+
 
 This package features examples of extensions for Kiosk.
+
+## Outline of features of the Kiosk
+
+1. Place
+2. Borrow
+3. Take
+4. List
+
+```
+1111 - full feature set (1 + 2 + 4 + 8 == 15) - 0-15 options.
+0100 - only borrow
+0110 - borrow and take
+```

--- a/sui_programmability/examples/kiosk/sources/collectible.move
+++ b/sui_programmability/examples/kiosk/sources/collectible.move
@@ -1,0 +1,323 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// The module which defines the `Collectible` type. It is an all-in-one
+/// package to create a `Display`, a `Publisher` and a `TransferPolicy` to
+/// enable `Kiosk` trading from the start.
+module kiosk::collectible {
+    use sui::transfer;
+    use std::vector as vec;
+    use std::string::String;
+    use std::option::{Self, Option};
+    use sui::package::{Self, Publisher};
+    use sui::display::{Self, Display};
+    use sui::borrow::{Self, Referent, Borrow};
+    use sui::tx_context::{sender, TxContext};
+    use sui::object::{Self, UID};
+    use sui::transfer_policy::{
+        Self as policy,
+        TransferPolicyCap
+    };
+
+    /// Trying to `claim_ticket` with a non OTW struct.
+    const ENotOneTimeWitness: u64 = 0;
+    /// The type parameter `T` is not from the same module as the `OTW`.
+    const ETypeNotFromModule: u64 = 1;
+    /// Maximum size of the Collection is reached - minting forbidden.
+    const ECapReached: u64 = 2;
+    /// Names length does not match `image_urls` length
+    const EWrongNamesLength: u64 = 3;
+    /// Descriptions length does not match `image_urls` length
+    const EWrongDescriptionsLength: u64 = 4;
+    /// Creators length does not match `image_urls` length
+    const EWrongCreatorsLength: u64 = 5;
+    /// Metadatas length does not match `image_urls` length
+    const EWrongMetadatasLength: u64 = 6;
+
+    /// Centralized registry to provide access to system features of
+    /// the Collectible. Sharing the `Publisher` object is necessary
+    /// to create `TransferPolicy` and `Display` objects for the Collectible
+    /// type.
+    struct Registry has key {
+        id: UID,
+        publisher: Publisher
+    }
+
+    /// One-in-all capability wrapping all necessary functions such as
+    /// `Display`, `PolicyCap` and the `Publisher`.
+    struct CollectionCap<T: store> has key, store {
+        id: UID,
+        publisher: Referent<Publisher>,
+        display: Referent<Display<Collectible<T>>>,
+        policy_cap: Referent<TransferPolicyCap<Collectible<T>>>,
+        max_supply: Option<u32>,
+        minted: u32,
+        burned: u32,
+    }
+
+    /// Special object which connects init function and the collection
+    /// initialization.
+    struct CollectionTicket<phantom T: store> has key, store {
+        id: UID,
+        publisher: Publisher,
+        max_supply: Option<u32>
+    }
+
+    /// Basic collectible containing most of the fields from the proposed
+    /// Display set. The `metadata` field is a generic type which can be
+    /// used to store any custom data.
+    struct Collectible<T: store> has key, store {
+        id: UID,
+        image_url: String,
+        name: Option<String>,
+        description: Option<String>,
+        creator: Option<String>,
+        meta: Option<T>,
+    }
+
+    /// OTW to initialize the Registry and the base type.
+    struct COLLECTIBLE has drop {}
+
+    /// Create the centralized Registry of Collectibles to provide access
+    /// to the Publisher functionality of the Collectible.
+    fun init(otw: COLLECTIBLE, ctx: &mut TxContext) {
+        transfer::share_object(Registry {
+            id: object::new(ctx),
+            publisher: package::claim(otw, ctx)
+        })
+    }
+
+    /// Called in the external module initializer. Sends a `CollectionTicket`
+    /// to the transaction sender which then enables them to initialize the
+    /// Collection.
+    ///
+    /// - The OTW parameter is a One-Time-Witness;
+    /// - The T parameter is the expected Metadata / custom type to use for
+    /// the Collection;
+    public fun claim_ticket<OTW: drop, T: store>(otw: OTW, max_supply: Option<u32>, ctx: &mut TxContext) {
+        assert!(sui::types::is_one_time_witness(&otw), ENotOneTimeWitness);
+
+        let publisher = package::claim(otw, ctx);
+
+        assert!(package::from_module<T>(&publisher), ETypeNotFromModule);
+        transfer::transfer(CollectionTicket<T> {
+            id: object::new(ctx),
+            publisher,
+            max_supply
+        }, sender(ctx));
+    }
+
+    /// Use the `CollectionTicket` to start a new collection and receive a
+    /// `CollectionCap`.
+    ///
+    /// This function creates a `Display<Collectible<T>>` for the caller and
+    /// creates and shares a `TransferPolicy<Collectible<T>>` while keeping
+    /// the `Display` and `TransferPolicyCap` objects in the `CollectionCap`.
+    public fun create_collection<T: store>(
+        registry: &Registry,
+        ticket: CollectionTicket<T>,
+        ctx: &mut TxContext
+    ): CollectionCap<T> {
+        let CollectionTicket { id, publisher, max_supply } = ticket;
+        object::delete(id);
+
+        let display = display::new<Collectible<T>>(&registry.publisher, ctx);
+        let (policy, policy_cap) = policy::new<Collectible<T>>(
+            &registry.publisher, ctx
+        );
+
+        transfer::public_share_object(policy);
+
+        CollectionCap<T> {
+            id: object::new(ctx),
+            display: borrow::new(display, ctx),
+            publisher: borrow::new(publisher, ctx),
+            policy_cap: borrow::new(policy_cap, ctx),
+            max_supply,
+            minted: 0,
+            burned: 0,
+        }
+    }
+
+    // === Minting ===
+
+    /// Mint a single Collectible specifying the fields.
+    /// Can only be performed by the owner of the `CollectionCap`.
+    public fun mint<T: store>(
+        cap: &mut CollectionCap<T>,
+        image_url: String,
+        name: Option<String>,
+        description: Option<String>,
+        creator: Option<String>,
+        meta: Option<T>,
+        ctx: &mut TxContext
+    ): Collectible<T> {
+        assert!(option::is_none(&cap.max_supply) || *option::borrow(&cap.max_supply) > cap.minted, ECapReached);
+        cap.minted = cap.minted + 1;
+
+        Collectible {
+            id: object::new(ctx),
+            image_url,
+            name,
+            description,
+            creator,
+            meta
+        }
+    }
+
+    /// Batch mint a vector of Collectibles specifying the fields. Lengths of
+    /// the optional fields must match the length of the `image_urls` vector.
+    /// Metadata vector is also optional, which
+    public fun batch_mint<T: store>(
+        cap: &mut CollectionCap<T>,
+        image_urls: vector<String>,
+        names: Option<vector<String>>,
+        descriptions: Option<vector<String>>,
+        creators: Option<vector<String>>,
+        metas: Option<vector<T>>,
+        ctx: &mut TxContext
+    ) {
+        let len = vec::length(&image_urls);
+
+        // perform a dummy check to make sure collection does not overflow
+        // safe to downcast since the length will never be greater than u32::MAX
+        assert!(
+            option::is_none(&cap.max_supply)
+            || cap.minted + (len as u32) < *option::borrow(&cap.max_supply)
+        , ECapReached);
+
+        assert!(
+            option::is_none(&names)
+            || vec::length(option::borrow(&names)) == len
+        , EWrongNamesLength);
+
+        assert!(
+            option::is_none(&creators)
+            || vec::length(option::borrow(&creators)) == len
+        , EWrongCreatorsLength);
+
+        assert!(
+            option::is_none(&descriptions)
+            || vec::length(option::borrow(&descriptions)) == len
+        , EWrongDescriptionsLength);
+
+        assert!(
+            option::is_none(&metas)
+            || vec::length(option::borrow(&metas)) == len
+        , EWrongMetadatasLength);
+
+        while (len > 0) {
+            transfer::transfer(mint(
+                cap,
+                vec::pop_back(&mut image_urls),
+                pop_or_none(&mut names),
+                pop_or_none(&mut descriptions),
+                pop_or_none(&mut creators),
+                pop_or_none(&mut metas),
+                ctx
+            ), sender(ctx));
+
+            len = len - 1;
+        };
+
+        if (option::is_some(&metas)) {
+            let metas = option::destroy_some(metas);
+            vec::destroy_empty(metas)
+        } else {
+            option::destroy_none(metas);
+        };
+    }
+
+    // === Borrowing methods ===
+
+    /// Take the `TransferPolicyCap` from the `CollectionCap`.
+    public fun borrow_policy_cap<T: store>(
+        self: &mut CollectionCap<T>
+    ): (TransferPolicyCap<Collectible<T>>, Borrow) {
+        borrow::borrow(&mut self.policy_cap)
+    }
+
+    /// Return the `TransferPolicyCap` to the `CollectionCap`. Must be called if
+    /// the capability was borrowed, or a transaction would fail.
+    public fun return_policy_cap<T: store>(
+        self: &mut CollectionCap<T>,
+        cap: TransferPolicyCap<Collectible<T>>,
+        borrow: Borrow
+    ) {
+        borrow::put_back(&mut self.policy_cap, cap, borrow)
+    }
+
+    /// Take the `Display` from the `CollectionCap`.
+    public fun borrow_display<T: store>(
+        self: &mut CollectionCap<T>
+    ): (Display<Collectible<T>>, Borrow) {
+        borrow::borrow(&mut self.display)
+    }
+
+    /// Return the `Display` to the `CollectionCap`. Must be called if
+    /// the capability was borrowed, or a transaction would fail.
+    public fun return_display<T: store>(
+        self: &mut CollectionCap<T>,
+        display: Display<Collectible<T>>,
+        borrow: Borrow
+    ) {
+        borrow::put_back(&mut self.display, display, borrow)
+    }
+
+    /// Take the `Publisher` from the `CollectionCap`.
+    public fun borrow_publisher<T: store>(
+        self: &mut CollectionCap<T>
+    ): (Publisher, Borrow) {
+        borrow::borrow(&mut self.publisher)
+    }
+
+    /// Return the `Publisher` to the `CollectionCap`. Must be called if
+    /// the capability was borrowed, or a transaction would fail.
+    public fun return_publisher<T: store>(
+        self: &mut CollectionCap<T>,
+        publisher: Publisher,
+        borrow: Borrow
+    ) {
+        borrow::put_back(&mut self.publisher, publisher, borrow)
+    }
+
+    // === Internal ===
+
+    /// Pop the value from the optional vector or return `none`.
+    fun pop_or_none<T>(opt: &mut Option<vector<T>>): Option<T> {
+        if (option::is_none(opt)) {
+            option::none()
+        } else {
+            option::some(vec::pop_back(option::borrow_mut(opt)))
+        }
+    }
+}
+
+#[test_only]
+/// A reference implementation for the published module. Sender receives
+/// the `CollectionTicket` which then can be used to initialize the `Collection`.
+///
+/// The reason for 2 step process is that to initialize the `TransferPolicy`
+/// and the `Display` for the `Collectible<T>` we need to use the `Publisher`
+/// for the `Collectible` and it's currently not possible to pass arguments to
+/// the module initializer. See the `create_collection` function for more details.
+module kiosk::template {
+    use std::option::some;
+    use sui::tx_context::TxContext;
+    use collectible::collectible;
+
+    /// The maximum supply setting for the collectible.
+    const MAX_SUPPLY: u32 = 1000;
+
+    /// OTW to initialize the collection.
+    struct TEMPLATE has drop {}
+    /// The type of the collectible.
+    struct Template has store {}
+
+    fun init(otw: ARTYBARA, ctx: &mut TxContext) {
+        collectible::claim_ticket<
+            TEMPLATE,
+            Template
+        >(otw, some(MAX_SUPPLY), ctx)
+    }
+}

--- a/sui_programmability/examples/kiosk/sources/collectible.move
+++ b/sui_programmability/examples/kiosk/sources/collectible.move
@@ -304,7 +304,7 @@ module kiosk::collectible {
 module kiosk::template {
     use std::option::some;
     use sui::tx_context::TxContext;
-    use collectible::collectible;
+    use kiosk::collectible;
 
     /// The maximum supply setting for the collectible.
     const MAX_SUPPLY: u32 = 1000;
@@ -314,7 +314,7 @@ module kiosk::template {
     /// The type of the collectible.
     struct Template has store {}
 
-    fun init(otw: ARTYBARA, ctx: &mut TxContext) {
+    fun init(otw: TEMPLATE, ctx: &mut TxContext) {
         collectible::claim_ticket<
             TEMPLATE,
             Template

--- a/sui_programmability/examples/kiosk/sources/extensions/airdrop_ext.move
+++ b/sui_programmability/examples/kiosk/sources/extensions/airdrop_ext.move
@@ -1,0 +1,36 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Implements a module for AirDrops - unifies the interface for airdrops
+/// by creating a standard dynamic field to store the airdropped items.
+module kiosk::airdrop_ext {
+    use sui::dynamic_field as df;
+    use sui::object::{Self, ID};
+    use sui::kiosk::{Self, Kiosk, KioskOwnerCap};
+
+    struct ItemDropped<phantom T> has store, copy, drop {
+        kiosk_id: ID,
+        item_id: ID
+    }
+
+    /// AirdropKey is a dynamic field that stores the airdropped items.
+    struct AirdropKey<phantom T> has store, copy, drop { item_id: ID }
+
+    /// One can airdrop an item to a Kiosk by calling this function.
+    public fun add<T: key + store>(kiosk: &mut Kiosk, item: T) {
+        sui::event::emit(ItemDropped<T> {
+            kiosk_id: object::id(kiosk),
+            item_id: object::id(&item)
+        });
+
+        df::add(kiosk::uid_mut(kiosk), AirdropKey<T> {
+            item_id: object::id(&item)
+        }, item);
+    }
+
+    /// Accept an airdropped item and place it into the Kiosk.
+    public fun accept<T: key + store>(kiosk: &mut Kiosk, kiosk_cap: &KioskOwnerCap, item_id: ID) {
+        let item = df::remove(kiosk::uid_mut(kiosk), AirdropKey<T> { item_id });
+        kiosk::place<T>(kiosk, kiosk_cap, item)
+    }
+}

--- a/sui_programmability/examples/kiosk/sources/extensions/auction_ext.move
+++ b/sui_programmability/examples/kiosk/sources/extensions/auction_ext.move
@@ -1,0 +1,157 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Implements an English auction extension for the Kiosk.
+module kiosk::auction_ext {
+    use std::option::{Self, Option};
+    use sui::dynamic_field as df;
+    use sui::transfer_policy::TransferRequest;
+    use sui::kiosk::{Self, Kiosk, PurchaseCap, KioskOwnerCap};
+    use sui::tx_context::{sender, epoch, TxContext};
+    use sui::coin::{Self, Coin};
+    use sui::object::{Self, ID};
+    use sui::sui::SUI;
+    use sui::event;
+
+    /// Bid is lower than the previous one.
+    const EBidTooLow: u64 = 0;
+    /// Auction is over.
+    const ETooLate: u64 = 1;
+    /// Auction is not over yet.
+    const ETooSoon: u64 = 2;
+    /// No bid has been made; cannot end the auction.
+    const ENoBid: u64 = 3;
+    /// Only the current leader can end the auction.
+    const ENotWinner: u64 = 4;
+
+    /// Stores Auction configuration as well as the state (current bid,
+    /// current winner, etc.)
+    struct Auction<phantom T: key + store> has store {
+        purchase_cap: PurchaseCap<T>,
+        current_bid: Option<Coin<SUI>>,
+        current_leader: address,
+        start_price: u64,
+        until_epoch: u64
+    }
+
+    /// Dynamic field key for the `PurchaseCap` of the auctioned item.
+    /// To support multiple auctions in parallel uses `item_id` as
+    /// a uniqueness guarantee.
+    struct AuctionedKey has copy, drop, store { item_id: ID }
+
+    /// Emitted when an Auction is started
+    struct AuctionStarted<phantom T> has copy, drop, store {
+        kiosk_id: ID,
+        item_id: ID,
+        start_price: u64,
+        until_epoch: u64
+    }
+
+    /// Start the auction by issuing a `PurchaseCap` and locking the
+    /// asset in the `Kiosk`. Fails if `KioskOwnerCap` does not match
+    /// the `Kiosk` or if `item_id` is not found in the `Kiosk`.
+    public fun start<T: key + store>(
+        kiosk: &mut Kiosk,
+        kiosk_cap: &KioskOwnerCap,
+        item_id: ID,
+        start_price: u64,
+        until_epoch: u64,
+        ctx: &mut TxContext
+    ) {
+        let purchase_cap = kiosk::list_with_purchase_cap<T>(
+            kiosk, kiosk_cap, item_id, start_price, ctx
+        );
+
+        event::emit(AuctionStarted<T> {
+            kiosk_id: object::id(kiosk),
+            item_id,
+            start_price,
+            until_epoch
+        });
+
+        df::add(
+            kiosk::uid_mut(kiosk),
+            AuctionedKey { item_id },
+            Auction {
+                purchase_cap,
+                current_bid: option::none(),
+                current_leader: sender(ctx),
+                start_price,
+                until_epoch
+            }
+        )
+    }
+
+    /// Make a bid. To succeed it must be higher than the previous.
+    public fun bid<T: key + store>(
+        kiosk: &mut Kiosk, item_id: ID, payment: Coin<SUI>, ctx: &TxContext
+    ) {
+        let paid_amt = coin::value(&payment);
+        let auction_mut: &mut Auction<T> = df::borrow_mut(
+            kiosk::uid_mut(kiosk),
+            AuctionedKey { item_id }
+        );
+
+        let old_coin = option::swap(&mut auction_mut.current_bid, payment);
+        let old_bidder = auction_mut.current_leader;
+
+        assert!(epoch(ctx) <= auction_mut.until_epoch, ETooLate);
+        assert!(paid_amt > auction_mut.start_price, EBidTooLow);
+        assert!(coin::value(&old_coin) > paid_amt, EBidTooLow);
+
+        sui::transfer::public_transfer(old_coin, old_bidder);
+        auction_mut.current_leader = sender(ctx)
+    }
+
+    /// End the auction and release the asset (along with `TransferRequest`).
+    /// Fails if the auction is not over yet, if the sender is not the current
+    /// leader or if there is no bid.
+    public fun end<T: key + store>(
+        kiosk: &mut Kiosk, item_id: ID, ctx: &mut TxContext
+    ): (T, TransferRequest<T>) {
+        let Auction<T> {
+            purchase_cap,
+            current_bid,
+            current_leader,
+            start_price: _,
+            until_epoch
+        } = df::remove(
+            kiosk::uid_mut(kiosk),
+            AuctionedKey { item_id }
+        );
+
+        assert!(sender(ctx) == current_leader, ENotWinner);
+        assert!(option::is_some(&current_bid), ENoBid);
+        assert!(epoch(ctx) > until_epoch, ETooSoon);
+
+        kiosk::purchase_with_cap(
+            kiosk,
+            purchase_cap,
+            option::destroy_some(current_bid)
+        )
+    }
+
+    /// An auction can only be canceled at any time if there hasn't been
+    /// a single bid yet. The item is returned to the `Kiosk` and the `PurchaseCap`
+    /// is destroyed.
+    public fun cancel<T: key + store>(
+        kiosk: &mut Kiosk, item_id: ID
+    ) {
+        let Auction<T> {
+            purchase_cap,
+            current_bid,
+            start_price: _,
+            current_leader: _,
+            until_epoch: _
+        } = df::remove(
+            kiosk::uid_mut(kiosk),
+            AuctionedKey { item_id }
+        );
+
+        assert!(option::is_none(&current_bid), ENoBid);
+        // assert!(epoch(ctx) > until_epoch, ETooSoon);
+
+        option::destroy_none(current_bid);
+        kiosk::return_purchase_cap(kiosk, purchase_cap)
+    }
+}

--- a/sui_programmability/examples/kiosk/sources/extensions/marketplace_ext.move
+++ b/sui_programmability/examples/kiosk/sources/extensions/marketplace_ext.move
@@ -1,0 +1,70 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module kiosk::marketplace_ext {
+    use sui::coin::{Self, Coin};
+    use sui::dynamic_field as df;
+    use sui::kiosk::{Self, Kiosk, KioskOwnerCap};
+    use sui::object::ID;
+    use sui::sui::SUI;
+    use sui::transfer_policy::TransferRequest;
+    use sui::tx_context::TxContext;
+
+    /// Only owner can delist the item.
+    const ENotOwner: u64 = 1;
+
+    /// The key for the Marketplace listing.
+    struct MarketplaceListingKey<phantom T> has store, copy, drop {
+        item_id: ID
+    }
+
+    /// Lists an item in the Kiosk for the sale on a marketplace (requires witness).
+    public fun list<Market: drop, T: key + store>(
+        _market: Market,
+        kiosk: &mut Kiosk,
+        cap: &KioskOwnerCap,
+        item_id: ID,
+        price: u64,
+        ctx: &mut TxContext
+    ) {
+        let purchase_cap = kiosk::list_with_purchase_cap<T>(kiosk, cap, item_id, price, ctx);
+        df::add(
+            kiosk::uid_mut(kiosk),
+            MarketplaceListingKey<T>{ item_id },
+            purchase_cap
+        );
+    }
+
+    /// Purchase an item after receiving the Marketplace confirmation (the fee was paid).
+    public fun purchase<Market: drop, T: key + store>(
+        _market: Market,
+        kiosk: &mut Kiosk,
+        item_id: ID,
+        payment: &mut Coin<SUI>,
+        ctx: &mut TxContext
+    ): (T, TransferRequest<T>) {
+        let purchase_cap = df::remove(
+            kiosk::uid_mut(kiosk),
+            MarketplaceListingKey<T>{ item_id }
+        );
+
+        let to_pay = coin::split(payment, kiosk::purchase_cap_min_price(&purchase_cap), ctx);
+        kiosk::purchase_with_cap(kiosk, purchase_cap, to_pay)
+    }
+
+    /// Delist an item and make it impossible to purchase.
+    public fun delist<Market: drop, T: key + store>(
+        kiosk: &mut Kiosk,
+        cap: &KioskOwnerCap,
+        item_id: ID,
+    ) {
+        assert!(kiosk::has_access(kiosk, cap), ENotOwner);
+
+        let purchase_cap = df::remove(
+            kiosk::uid_mut(kiosk),
+            MarketplaceListingKey<T>{ item_id }
+        );
+
+        kiosk::return_purchase_cap<T>(kiosk, purchase_cap);
+    }
+}

--- a/sui_programmability/examples/kiosk/sources/rules/kiosk_lock_rule.move
+++ b/sui_programmability/examples/kiosk/sources/rules/kiosk_lock_rule.move
@@ -1,0 +1,43 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// This module defines a Rule which forces buyers to put the purchased
+/// item into the Kiosk and lock it. The most common use case for the
+/// Rule is making sure an item never leaves Kiosks and has policies
+/// enforced on every transfer.
+///
+/// Note: "locking" mechanic disallows the `kiosk::take` function and
+/// forces the owner to use `list` or `list_with_purchase_cap` methods
+/// if they wish to move the item somewhere else.
+module kiosk::kiosk_lock_rule {
+    use sui::kiosk::{Self, Kiosk};
+    use sui::transfer_policy::{
+        Self as policy,
+        TransferPolicy,
+        TransferPolicyCap,
+        TransferRequest
+    };
+
+    /// Item is not in the `Kiosk`.
+    const ENotInKiosk: u64 = 0;
+
+    /// The type identifier for the Rule.
+    struct Rule has drop {}
+
+    /// An empty configuration for the Rule.
+    struct Config has store, drop {}
+
+    /// Creator: Adds a `kiosk_lock_rule` Rule to the `TransferPolicy` forcing
+    /// buyers to lock the item in a Kiosk on purchase.
+    public fun set<T>(policy: &mut TransferPolicy<T>, cap: &TransferPolicyCap<T>) {
+        policy::add_rule(Rule {}, policy, cap, Config {})
+    }
+
+    /// Buyer: Prove the item was locked in the Kiosk to get the receipt and
+    /// unblock the transfer request confirmation.
+    public fun prove<T>(request: &mut TransferRequest<T>, kiosk: &Kiosk) {
+        let item = policy::item(request);
+        assert!(kiosk::has_item(kiosk, item) && kiosk::is_locked(kiosk, item), ENotInKiosk);
+        policy::add_receipt(Rule {}, request)
+    }
+}

--- a/sui_programmability/examples/kiosk/sources/rules/kiosk_lock_rule.move
+++ b/sui_programmability/examples/kiosk/sources/rules/kiosk_lock_rule.move
@@ -1,14 +1,24 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/// Description:
 /// This module defines a Rule which forces buyers to put the purchased
 /// item into the Kiosk and lock it. The most common use case for the
 /// Rule is making sure an item never leaves Kiosks and has policies
 /// enforced on every transfer.
 ///
-/// Note: "locking" mechanic disallows the `kiosk::take` function and
-/// forces the owner to use `list` or `list_with_purchase_cap` methods
-/// if they wish to move the item somewhere else.
+/// Configuration:
+/// - None
+///
+/// Use cases:
+/// - Enforcing policies on every trade
+/// - Making sure an item never leaves the Kiosk / certain ecosystem
+///
+/// Notes:
+/// - "locking" mechanic disallows the `kiosk::take` function and forces
+/// the owner to use `list` or `list_with_purchase_cap` methods if they
+/// wish to move the item somewhere else.
+///
 module kiosk::kiosk_lock_rule {
     use sui::kiosk::{Self, Kiosk};
     use sui::transfer_policy::{

--- a/sui_programmability/examples/kiosk/sources/rules/witness_rule.move
+++ b/sui_programmability/examples/kiosk/sources/rules/witness_rule.move
@@ -1,0 +1,51 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Description:
+/// This module implements a Rule that requires a "Proof" witness to be
+/// presented on every transfer. The "Proof" witness is a type chosen by
+/// the owner of the policy.
+///
+/// Configuration:
+/// - The type to require for every transfer.
+///
+/// Use Cases:
+/// - Can be used to link custom logic to the TransferPolicy via the Witness.
+/// - Only allow trading on a certain marketplace.
+/// - Require a confirmation in a third party module
+/// - Implement a custom requirement on the creator side an link the logic.
+///
+module kiosk::witness_rule {
+    use sui::transfer_policy::{
+        Self as policy,
+        TransferPolicy,
+        TransferPolicyCap,
+        TransferRequest
+    };
+
+    /// When a Proof does not find its Rule<Proof>.
+    const ERuleNotFound: u64 = 0;
+
+    /// Custom witness-key for the "proof policy".
+    struct Rule<phantom Proof: drop> has drop {}
+
+    /// Creator action: adds the Rule.
+    /// Requires a "Proof" witness confirmation on every transfer.
+    public fun set<T: key + store, Proof: drop>(
+        policy: &mut TransferPolicy<T>,
+        cap: &TransferPolicyCap<T>
+    ) {
+        policy::add_rule(Rule<Proof> {}, policy, cap, true);
+    }
+
+    /// Buyer action: follow the policy.
+    /// Present the required "Proof" instance to get a receipt.
+    public fun prove<T: key + store, Proof: drop>(
+        _proof: Proof,
+        policy: &TransferPolicy<T>,
+        request: &mut TransferRequest<T>
+    ) {
+        assert!(policy::has_rule<T, Rule<Proof>>(policy), ERuleNotFound);
+        policy::add_receipt(Rule<Proof> {}, request)
+    }
+}

--- a/sui_programmability/examples/kiosk/sources/solutions/custody_marketplace.move
+++ b/sui_programmability/examples/kiosk/sources/solutions/custody_marketplace.move
@@ -44,6 +44,7 @@ module kiosk::kiosk_custody_marketplace {
     use sui::kiosk::{Self, Kiosk, KioskOwnerCap};
     use sui::object::{Self, ID, UID};
     use sui::sui::SUI;
+    use sui::transfer_policy::{Self as policy, TransferRequest};
     use sui::tx_context::TxContext;
     use sui::transfer;
 
@@ -73,7 +74,9 @@ module kiosk::kiosk_custody_marketplace {
     /// Generated based on the Kiosk ID check (via a lookup of a key in the Marketplace).
     ///
     /// Can be used to enforce trades inside the marketplace via the WitnessRule.
-    struct MarketplaceConfirmation has drop {}
+    struct TradeConfirmation has drop {}
+
+    struct PlacementConfirmation has drop {}
 
     /// A custom dynamic field key to store the `KioskOwnerCap`.
     struct OwnerKey has store, copy, drop { kiosk_id: ID }
@@ -176,7 +179,7 @@ module kiosk::kiosk_custody_marketplace {
     /// Kiosk balance is not changed.
     public fun return_cap(
         self: &mut Marketplace,
-        kiosk: &Kiosk,
+        kiosk: &mut Kiosk,
         kiosk_cap: KioskOwnerCap,
         borrow: Borrow,
     ) {
@@ -192,9 +195,9 @@ module kiosk::kiosk_custody_marketplace {
 
     /// Confirm that TransferRequest is coming from the Marketplace by
     /// checking the Kiosk ID in the Marketplace.
-    public fun confirm_trade(
+    public fun confirm_trade<T>(
         self: &Marketplace,
-        req: &TransferRequest
+        req: &TransferRequest<T>
     ): TradeConfirmation {
         assert!(df::exists_(
             &self.id,
@@ -207,9 +210,9 @@ module kiosk::kiosk_custody_marketplace {
     /// Confirm that the item is placed in the Kiosk that belongs to
     /// the Marketplace. This witness can make sure the item never leaves
     /// the Marketplace if the creator has chosen to check that.
-    public fun confirm_placement(
+    public fun confirm_placement<T>(
         self: &Marketplace,
-        req: &TransferRequest,
+        req: &TransferRequest<T>,
         kiosk: &Kiosk
     ): PlacementConfirmation {
         let item_id = policy::item(req);

--- a/sui_programmability/examples/kiosk/sources/solutions/kiosk_custody_marketplace.move
+++ b/sui_programmability/examples/kiosk/sources/solutions/kiosk_custody_marketplace.move
@@ -1,0 +1,212 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Kiosk Custody Marketplace
+///
+/// Description:
+/// A Marketplace design, where sellers entrust their Kiosk to the
+/// marketplace; Marketplace provides the discovery mechanism for the
+/// sellers (and the interface). Marketplace does not control the Kiosks
+/// (there's no implementation for that) but may decide which listings
+/// to show on the website - eg only verified collections.
+///
+/// Details:
+/// - The marketplace is a custodian of the Kiosk, and they
+/// charge the fee for the discovery service. The marketplace allows
+/// Kiosks owners to leave at any time (with a fee).
+///
+/// - Although the marketplace is a custodian of the Kiosk, the user
+/// is free to use all the features of the Kiosk except for the `withdraw`.
+/// If a Kiosk balance change is detected, the transaction aborts; all other
+/// operations are allowed.
+///
+/// Caveats:
+/// - Marketplace publisher keeps all owner Caps, and may submit an upgrade
+/// to take Kiosks in possession. Although this is the issue with all
+/// custodian models, wonder if there's an easy way to mitigate this. Perhaps,
+/// moving the authorization (MarketplaceKioskCap -> KioskOwnerCap) module
+/// into another package and burning the UpgradeCap to make upgrades impossible.
+///
+/// TODOs:
+/// - Add the MarketplaceManagerCap which allows withdrawing the fees.
+/// - Add some functionality to update fees.
+/// - Generalize the solution so that someone could lock any Kiosk this way (locking
+/// profits, but allowing to use the rest of the Kiosk's function as usual)
+///
+/// Notes (intended fixes for Kiosk):
+/// #1 - `kiosk` module has no way to read Kiosk.id from the `KioskOwnerCap`
+module kiosk::kiosk_custody_marketplace {
+    use std::option::none;
+    use sui::balance::{Self, Balance};
+    use sui::coin::{Self, Coin};
+    use sui::dynamic_field as df;
+    use sui::event;
+    use sui::kiosk::{Self, Kiosk, KioskOwnerCap};
+    use sui::object::{Self, ID, UID};
+    use sui::sui::SUI;
+    use sui::tx_context::TxContext;
+    use sui::transfer;
+
+    /// Trying to participate with a Kiosk which is not owned by the user.
+    const ENotOwner: u64 = 0;
+    /// Trying to use a `MarketplaceKioskCap` for a different Kiosk.
+    const EWrongKiosk: u64 = 1;
+    /// Profits were withdrawn from the Kiosk ignoring the fees.
+    const EAmountChanged: u64 = 2;
+
+    /// The Marketplace object - holds the trusted `KioskOwnerCap`s,
+    /// and the collected fees from trades.
+    struct Marketplace has key {
+        id: UID,
+        fee_bp: u32,
+        balance: Balance<SUI>,
+    }
+
+    /// A Capabalility which gives access to the `KioskOwnerCap` for
+    /// the Marketplace participants.
+    struct MarketplaceKioskCap has key, store {
+        id: UID,
+        kiosk_id: ID,
+    }
+
+    /// A custom dynamic field key to store the `KioskOwnerCap`.
+    struct OwnerKey has store, copy, drop { kiosk_id: ID }
+
+    /// Hot potato which makes sure that the `KioskOwnerCap` is returned
+    /// and that the Kiosk balance is not changed.
+    struct Borrow { kiosk_id: ID, kiosk_profits: u64 }
+
+    // === Events ===
+
+    /// A new Kiosk has joined the Marketplace. Useful for discovery.
+    struct KioskParticipated has store, copy, drop {
+        kiosk_id: ID,
+    }
+
+    /// A Kiosk has left the Marketplace.
+    struct KioskLeft has store, copy, drop {
+        kiosk_id: ID,
+    }
+
+    // === In and Out ===
+
+    /// Become a participant of the Marketplace, give up the `KioskOwnerCap`
+    /// and get a `MarketplaceKioskCap` which gives access the `KioskOwnerCap`.
+    public fun participate(
+        self: &mut Marketplace,
+        // TODO: see note #1
+        kiosk: &mut Kiosk,
+        kiosk_cap: KioskOwnerCap,
+        ctx: &mut TxContext
+    ): MarketplaceKioskCap {
+        let kiosk_id = object::id(kiosk);
+        assert!(kiosk::has_access(kiosk, &kiosk_cap), ENotOwner);
+        df::add(&mut self.id, OwnerKey { kiosk_id }, kiosk_cap);
+        event::emit(KioskParticipated { kiosk_id });
+
+        MarketplaceKioskCap {
+            kiosk_id,
+            id: object::new(ctx),
+        }
+    }
+
+    /// Leave the Marketplace, get back the `KioskOwnerCap` and pay the exit fee.
+    public fun leave(
+        self: &mut Marketplace,
+        kiosk: &mut Kiosk,
+        mkt_cap: MarketplaceKioskCap,
+        ctx: &mut TxContext,
+    ): (KioskOwnerCap, Coin<SUI>) {
+        let MarketplaceKioskCap { id, kiosk_id } = mkt_cap;
+        let kiosk_cap = df::remove(&mut self.id, OwnerKey { kiosk_id });
+
+        event::emit(KioskLeft { kiosk_id });
+        object::delete(id);
+
+        let profits = kiosk::withdraw(kiosk, &kiosk_cap, none(), ctx);
+        collect_fee(self, &mut profits);
+        (kiosk_cap, profits)
+    }
+
+    // === Using the Kiosk ===
+
+    /// Withdraw all profits from the `Kiosk` and take the markeptlace fee.
+    public fun withdraw_profits(
+        self: &mut Marketplace,
+        kiosk: &mut Kiosk,
+        mkt_cap: &MarketplaceKioskCap,
+        ctx: &mut TxContext,
+    ): Coin<SUI> {
+        let kiosk_id = mkt_cap.kiosk_id;
+        let kiosk_cap = df::borrow(&mut self.id, OwnerKey { kiosk_id });
+
+        assert!(kiosk_id == object::id(kiosk), EWrongKiosk);
+        assert!(kiosk::has_access(kiosk, kiosk_cap), ENotOwner);
+
+        let profits = kiosk::withdraw(kiosk, kiosk_cap, none(), ctx);
+        collect_fee(self, &mut profits);
+        profits
+    }
+
+    /// Borrow the `KioskOwnerCap` from the Marketplace and give the user
+    /// full access to their Kiosk with one limitation - they cannot `withdraw`
+    /// the profits.
+    public fun borrow_cap(
+        self: &mut Marketplace,
+        kiosk: &Kiosk,
+        mkt_cap: &MarketplaceKioskCap,
+    ): (KioskOwnerCap, Borrow) {
+        let kiosk_id = object::id(kiosk);
+        let kiosk_profits = kiosk::profits_amount(kiosk);
+        assert!(kiosk_id == mkt_cap.kiosk_id, EWrongKiosk);
+
+        (
+            df::remove(&mut self.id, OwnerKey { kiosk_id }),
+            Borrow { kiosk_profits, kiosk_id },
+        )
+    }
+
+    /// Return the `KioskOwnerCap` to the Marketplace and make sure that the
+    /// Kiosk balance is not changed.
+    public fun return_cap(
+        self: &mut Marketplace,
+        kiosk: &Kiosk,
+        kiosk_cap: KioskOwnerCap,
+        borrow: Borrow,
+    ) {
+        let Borrow { kiosk_profits, kiosk_id } = borrow;
+        assert!(kiosk::has_access(kiosk, &kiosk_cap), ENotOwner);
+        assert!(kiosk_id == object::id(kiosk), EWrongKiosk);
+        assert!(kiosk_profits == kiosk::profits_amount(kiosk), EAmountChanged);
+
+        df::add(&mut self.id, OwnerKey { kiosk_id }, kiosk_cap);
+    }
+
+    // === Init + Display ===
+
+    /// The OTW to claim the `Publisher`.
+    struct KIOSK_CUSTODY_MARKETPLACE has drop {}
+
+    /// Share the Markeptlace object and claim the `Publisher`.
+    fun init(otw: KIOSK_CUSTODY_MARKETPLACE, ctx: &mut TxContext) {
+        sui::package::claim_and_keep(otw, ctx);
+        transfer::share_object(Marketplace {
+            id: object::new(ctx),
+            fee_bp: 1000, // 10%
+            balance: balance::zero(),
+        })
+    }
+
+    // === Utility methods ===
+
+    /// Collect fees from the profits Coin and put them to the Marketplace balance.
+    fun collect_fee(self: &mut Marketplace, profits: &mut Coin<SUI>) {
+        // calculate the marketplace fee
+        let amount = coin::value(profits);
+        let fee_amt = (((amount as u128) * (self.fee_bp as u128) / 10_000) as u64);
+
+        // leave the fee in the marketplace
+        let fee = balance::split(coin::balance_mut(profits), fee_amt);
+        balance::join(&mut self.balance, fee);
+    }
+}

--- a/sui_programmability/examples/kiosk/sources/solutions/marketplace.move
+++ b/sui_programmability/examples/kiosk/sources/solutions/marketplace.move
@@ -1,0 +1,4 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module kiosk::marketplace {}

--- a/sui_programmability/examples/kiosk/tests/extension_cap.move
+++ b/sui_programmability/examples/kiosk/tests/extension_cap.move
@@ -1,0 +1,52 @@
+/// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Kiosk Extension Capabilities
+/// [Lock, List, Borrow, Place]
+///
+/// 0000 - for bits - one for each of the actions
+/// 1001 - can place
+/// 1111 - can do everything
+/// 1100 - can borrow
+///
+/// Extension Capability does not allow: `take` and `list`. Any third party can
+/// expose access to the witness data of the extension therefore creating a security
+/// vulnerability of one's Kiosk.
+module kiosk::extension_cap {
+
+    /// Holds the bitmask for the set of permissions of the extension.
+    struct ExtensionCap has store, drop { value: u16 }
+
+    /// Check whether the first bit of the value is set (odd value)
+    public fun can_place(self: &ExtensionCap): bool { self.value & 0x01 != 0 }
+    /// Check whether the second bit of the value is set (value greater than 2)
+    public fun can_borrow(self: &ExtensionCap): bool { self.value & 0x02 != 0 }
+    /// Check whether the fifth bit of the value is set (value greater than 16)
+    public fun can_lock(self: &ExtensionCap): bool { self.value & 0x10 != 0 }
+
+    #[test]
+    /// Test the bits of the value.
+    fun test_bits() {
+        assert!(check(ExtensionCap { value: 0x0 }) == vector[false, false, false, false, false], 0);
+        assert!(check(ExtensionCap { value: 0x1 }) == vector[false, false, false, false, true], 0);
+        assert!(check(ExtensionCap { value: 0x2 }) == vector[false, false, false, true, false], 0);
+        assert!(check(ExtensionCap { value: 0x3 }) == vector[false, false, false, true, true], 0);
+        assert!(check(ExtensionCap { value: 0x4 }) == vector[false, false, true, false, false], 0);
+        assert!(check(ExtensionCap { value: 0x5 }) == vector[false, false, true, false, true], 0);
+        assert!(check(ExtensionCap { value: 0x8 }) == vector[false, true, false, false, false], 0);
+        assert!(check(ExtensionCap { value: 0x9 }) == vector[false, true, false, false, true], 0);
+        assert!(check(ExtensionCap { value: 0x11 }) == vector[true, false, false, false, true], 0);
+    }
+
+    #[test_only]
+    /// Turn the bits into a vector of booleans for testing.
+    fun check(self: ExtensionCap): vector<bool> {
+        vector[
+            can_lock(&self),
+            can_list(&self),
+            can_take(&self),
+            can_borrow(&self),
+            can_place(&self),
+        ]
+    }
+}


### PR DESCRIPTION
## Description 

Starts a new section in Sui Move examples. The goal of this section is to inspire extension builders, serve as the proof of fun and set the foundation for the main set of extensions / policies.

## Test Plan 

No tests yet but will be.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

- adds new kiosk+ package to examples