### PR TITLE
[wallet-ext] fix background image peeking through the wallet in popup mode

### DIFF
--- a/apps/wallet/.storybook/preview.js
+++ b/apps/wallet/.storybook/preview.js
@@ -22,7 +22,7 @@ export const parameters = {
             extension: {
                 name: 'Chrome Extension',
                 styles: {
-                    height: '595px',
+                    height: '600px',
                     width: '360px',
                 },
                 type: 'mobile',

--- a/apps/wallet/src/background/Window.ts
+++ b/apps/wallet/src/background/Window.ts
@@ -4,10 +4,16 @@
 import { filter, fromEventPattern, share, take, takeWhile } from 'rxjs';
 import Browser from 'webextension-polyfill';
 
+import { POPUP_HEIGHT, POPUP_WIDTH } from '_src/ui/app/wallet/constants';
+
 const windowRemovedStream = fromEventPattern<number>(
     (handler) => Browser.windows.onRemoved.addListener(handler),
     (handler) => Browser.windows.onRemoved.removeListener(handler)
 ).pipe(share());
+
+// This is arbitrary across different operating systems, and unfortunately
+// there isn't a great way to tell how much extra height we need to tack on
+const windowHeightWithFrame = POPUP_HEIGHT + 28;
 
 export class Window {
     private _id: number | null = null;
@@ -26,8 +32,8 @@ export class Window {
         const w = await Browser.windows.create({
             url: this._url,
             focused: true,
-            width: 360,
-            height: 623,
+            width: POPUP_WIDTH,
+            height: windowHeightWithFrame,
             type: 'popup',
             top: top,
             left: Math.floor(left + width - 450),

--- a/apps/wallet/src/ui/app/wallet/constants.ts
+++ b/apps/wallet/src/ui/app/wallet/constants.ts
@@ -2,3 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export const devQuickUnlockEnabled = process.env.NODE_ENV === 'development';
+export const POPUP_WIDTH = 360;
+export const POPUP_HEIGHT = 600;

--- a/apps/wallet/src/ui/styles/values/sizing.scss
+++ b/apps/wallet/src/ui/styles/values/sizing.scss
@@ -1,5 +1,5 @@
 $popup-width: 360px;
-$popup-height: 595px;
+$popup-height: 600px;
 $nav-height: 76px;
 $main-bottom-space: 12px;
 $main-sides-space: 20px;

--- a/apps/wallet/tailwind.config.js
+++ b/apps/wallet/tailwind.config.js
@@ -26,7 +26,7 @@ module.exports = {
                 7.5: '1.875rem',
                 8: '2rem',
                 15: '3.75rem',
-                'popup-height': '595px',
+                'popup-height': '600px',
                 'popup-width': '360px',
             },
             boxShadow: {


### PR DESCRIPTION
## Description 

The extension has a fixed height of 595px, but the max height for an extension is 600px. This was causing a small visual bug where the background image was peeking through after doing some actions in the wallet, so I updated the height to 600px 😄 

Before:
<img width="386" alt="image" src="https://user-images.githubusercontent.com/7453188/228326482-c540176d-ba16-43ad-bece-8da0d0a8b41d.png">

After:
<img width="361" alt="image" src="https://user-images.githubusercontent.com/7453188/228323358-7933fc0d-9a71-4bed-ac62-a022db1b9aec.png">

<img width="374" alt="image" src="https://user-images.githubusercontent.com/7453188/228326289-d828616c-163c-4276-8a47-4924b24382f0.png">



## Test Plan 
- Manual testing

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
N/A