### PR TITLE
command to get staked sui

### DIFF
--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -359,6 +359,13 @@ impl ObjectType {
             ObjectType::Package => false,
         }
     }
+
+    pub fn is_staked_sui(&self) -> bool {
+        match self {
+            ObjectType::Struct(s) => s.is_staked_sui(),
+            ObjectType::Package => false,
+        }
+    }
 }
 
 impl From<ObjectInfo> for ObjectRef {


### PR DESCRIPTION
## Description 

Add `sui client stake-sui` to display StakedSui. Can filter with `validator-address`. 

## Test Plan 

tested locally

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Add `sui client stake-sui` to display StakedSui. Can filter with `validator-address`. 
