### PR TITLE
Add protocol version for gas and conservation

### DIFF
--- a/crates/sui-adapter/src/programmable_transactions/context.rs
+++ b/crates/sui-adapter/src/programmable_transactions/context.rs
@@ -17,7 +17,7 @@ use sui_types::{
     base_types::{ObjectID, SequenceNumber, SuiAddress, TxContext},
     coin::Coin,
     error::{ExecutionError, ExecutionErrorKind},
-    gas::SuiGasStatus,
+    gas::{SuiGasStatus, SuiGasStatusAPI},
     messages::{Argument, CallArg, CommandArgumentError, ObjectArg},
     move_package::MovePackage,
     object::{MoveObject, Object, Owner, OBJECT_START_VERSION},
@@ -130,7 +130,7 @@ impl<'vm, 'state, 'a, 'b, S: StorageView> ExecutionContext<'vm, 'state, 'a, 'b, 
             })) = &mut gas.inner.value else {
                 invariant_violation!("Gas object should be a populated coin")
             };
-            let max_gas_in_balance = gas_status.max_gax_budget_in_balance();
+            let max_gas_in_balance = gas_status.gas_budget();
             let Some(new_balance) = coin.balance.value().checked_sub(max_gas_in_balance) else {
                 invariant_violation!(
                     "Transaction input checker should check that there is enough gas"
@@ -904,7 +904,7 @@ fn refund_max_gas_budget(
     let Some(new_balance) = coin
         .balance
         .value()
-        .checked_add(gas_status.max_gax_budget_in_balance()) else {
+        .checked_add(gas_status.gas_budget()) else {
             return Err(ExecutionError::new_with_source(
                 ExecutionErrorKind::CoinBalanceOverflow,
                 "Gas coin too large after returning the max gas budget",

--- a/crates/sui-adapter/src/programmable_transactions/execution.rs
+++ b/crates/sui-adapter/src/programmable_transactions/execution.rs
@@ -33,7 +33,7 @@ use sui_types::{
     coin::Coin,
     error::{ExecutionError, ExecutionErrorKind},
     event::Event,
-    gas::SuiGasStatus,
+    gas::{SuiGasStatus, SuiGasStatusAPI},
     id::UID,
     messages::{
         Argument, Command, CommandArgumentError, PackageUpgradeError, ProgrammableMoveCall,
@@ -691,7 +691,7 @@ fn vm_move_call<S: StorageView>(
             function,
             type_arguments,
             serialized_arguments,
-            context.gas_status.create_move_gas_status(),
+            context.gas_status.move_gas_status(),
         )
         .map_err(|e| context.convert_vm_error(e))?;
 
@@ -785,7 +785,7 @@ fn publish_and_verify_modules<S: StorageView>(
             AccountAddress::from(package_id),
             // TODO: publish_module_bundle() currently doesn't charge gas.
             // Do we want to charge there?
-            context.gas_status.create_move_gas_status(),
+            context.gas_status.move_gas_status(),
         )
         .map_err(|e| context.convert_vm_error(e))?;
 

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -1416,7 +1416,7 @@ fn create_genesis_transaction(
                 *genesis_transaction.digest(),
                 Default::default(),
                 &move_vm,
-                SuiGasStatus::new_unmetered(),
+                SuiGasStatus::new_unmetered(protocol_config),
                 epoch_data,
                 protocol_config,
             );
@@ -1529,7 +1529,7 @@ fn process_package(
         ctx.digest(),
         protocol_config,
     );
-    let mut gas_status = SuiGasStatus::new_unmetered();
+    let mut gas_status = SuiGasStatus::new_unmetered(protocol_config);
     let module_bytes = modules
         .into_iter()
         .map(|m| {
@@ -1638,7 +1638,7 @@ pub fn generate_genesis_system_object(
         move_vm,
         &mut temporary_store,
         genesis_ctx,
-        &mut SuiGasStatus::new_unmetered(),
+        &mut SuiGasStatus::new_unmetered(&protocol_config),
         None,
         pt,
     )?;
@@ -1917,7 +1917,7 @@ mod test {
                 *genesis_transaction.digest(),
                 Default::default(),
                 &move_vm,
-                SuiGasStatus::new_unmetered(),
+                SuiGasStatus::new_unmetered(&protocol_config),
                 &EpochData::new_test(),
                 &protocol_config,
             );

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -61,7 +61,7 @@ use sui_types::digests::TransactionEventsDigest;
 use sui_types::dynamic_field::{DynamicFieldInfo, DynamicFieldName, DynamicFieldType, Field};
 use sui_types::error::UserInputError;
 use sui_types::event::{Event, EventID};
-use sui_types::gas::{GasCostSummary, GasPrice, SuiCostTable, SuiGasStatus};
+use sui_types::gas::{GasCostSummary, SuiGasStatus};
 use sui_types::message_envelope::Message;
 use sui_types::messages_checkpoint::{
     CheckpointCommitment, CheckpointContents, CheckpointContentsDigest, CheckpointDigest,
@@ -1122,12 +1122,18 @@ impl AuthorityState {
 
         transaction_kind.check_version_supported(epoch_store.protocol_config())?;
 
-        let gas_price = gas_price.unwrap_or_else(|| epoch_store.reference_gas_price());
-
+        let gas_price = match gas_price {
+            None => epoch_store.reference_gas_price(),
+            Some(gas) => {
+                if gas == 0 {
+                    epoch_store.reference_gas_price()
+                } else {
+                    gas
+                }
+            }
+        };
         let protocol_config = epoch_store.protocol_config();
-
         let max_tx_gas = protocol_config.max_tx_gas();
-        let storage_gas_price = protocol_config.storage_gas_price();
 
         let gas_object_id = ObjectID::random();
         // give the gas object 2x the max gas to have coin balance to play with during execution
@@ -1145,8 +1151,6 @@ impl AuthorityState {
         .await?;
         let shared_object_refs = input_objects.filter_shared_objects();
 
-        // TODO should we error instead for 0?
-        let gas_price = std::cmp::max(gas_price, 1);
         let gas_budget = max_tx_gas;
         let data = TransactionData::new(
             transaction_kind,
@@ -1164,12 +1168,7 @@ impl AuthorityState {
             transaction_digest,
             protocol_config,
         );
-        let gas_status = SuiGasStatus::new_with_budget(
-            max_tx_gas,
-            GasPrice::from(gas_price),
-            storage_gas_price.into(),
-            SuiCostTable::new(protocol_config),
-        );
+        let gas_status = SuiGasStatus::new_with_budget(max_tx_gas, gas_price, protocol_config);
         let move_vm = Arc::new(
             adapter::new_move_vm(
                 epoch_store.native_functions().clone(),

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -9,7 +9,6 @@ use sui_macros::checked_arithmetic;
 use sui_protocol_config::ProtocolConfig;
 use sui_types::base_types::ObjectRef;
 use sui_types::error::{UserInputError, UserInputResult};
-use sui_types::gas::SuiCostTable;
 use sui_types::messages::{
     TransactionKind, VerifiedExecutableTransaction, VersionedProtocolMessage,
 };
@@ -17,7 +16,7 @@ use sui_types::{
     base_types::{SequenceNumber, SuiAddress},
     error::SuiResult,
     fp_ensure,
-    gas::{self, SuiGasStatus},
+    gas::{SuiCostTable, SuiGasStatus},
     messages::{InputObjectKind, InputObjects, TransactionData, TransactionDataAPI},
     object::{Object, Owner},
 };
@@ -173,8 +172,9 @@ async fn check_gas(
     gas_price: u64,
     tx_kind: &TransactionKind,
 ) -> SuiResult<SuiGasStatus<'static>> {
+    let protocol_config = epoch_store.protocol_config();
     if tx_kind.is_system_tx() {
-        Ok(SuiGasStatus::new_unmetered())
+        Ok(SuiGasStatus::new_unmetered(protocol_config))
     } else {
         // gas price must be bigger or equal to reference gas price
         let reference_gas_price = epoch_store.reference_gas_price();
@@ -205,20 +205,17 @@ async fn check_gas(
         }
 
         // check balance and coins consistency
-        let protocol_config = epoch_store.protocol_config();
-        let cost_table = SuiCostTable::new(protocol_config);
-        gas::check_gas_balance(
-            gas_object,
-            more_gas_objects,
-            gas_budget,
-            gas_price,
-            &cost_table,
-        )?;
-
-        // make the gas status to be used by execution
-        let storage_gas_price = protocol_config.storage_gas_price();
-        gas::start_gas_metering(gas_budget, gas_price, storage_gas_price, cost_table)
-            .map_err(|e| e.into())
+        if protocol_config.gas_model_version() > 1 {
+            panic!("TBD");
+        } else {
+            let cost_table = SuiCostTable::new(protocol_config);
+            cost_table.check_gas_balance(gas_object, more_gas_objects, gas_budget, gas_price)?;
+            Ok(SuiGasStatus::new_with_budget(
+                gas_budget,
+                gas_price,
+                protocol_config,
+            ))
+        }
     }
 }
 

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -282,7 +282,7 @@ async fn test_dry_run_no_gas_big_transfer() {
         sender,
         vec![],
         pt,
-        SuiCostTable::new_for_testing().max_gas_budget,
+        ProtocolConfig::get_for_max_version().max_tx_gas(),
     );
 
     let signed = to_sender_signed_transaction(data, &sender_key);
@@ -2541,7 +2541,6 @@ async fn test_move_call_mutable_object_not_mutated() {
     );
 }
 
-// skipped because it violates SUI conservation checks
 #[tokio::test]
 async fn test_move_call_insufficient_gas() {
     // This test attempts to trigger a transaction execution that would fail due to insufficient gas.
@@ -4998,7 +4997,6 @@ fn test_choose_next_system_packages() {
     );
 }
 
-// skipped because it violates SUI conservation checks
 #[tokio::test]
 async fn test_gas_smashing() {
     // run a create move object transaction with a given set o gas coins and a budget

--- a/crates/sui-proc-macros/src/lib.rs
+++ b/crates/sui-proc-macros/src/lib.rs
@@ -35,11 +35,14 @@ pub fn init_static_initializers(_args: TokenStream, item: TokenStream) -> TokenS
             // iteration of a multi-iteration test run.
             std::thread::spawn(|| {
                 use sui_simulator::sui_framework::SystemPackage;
+                use sui_protocol_config::ProtocolConfig;
                 ::sui_simulator::telemetry_subscribers::init_for_testing();
                 ::sui_simulator::sui_framework::MoveStdlib::as_modules();
                 ::sui_simulator::sui_framework::SuiFramework::as_modules();
                 ::sui_simulator::sui_framework::SuiSystem::as_modules();
-                ::sui_simulator::sui_types::gas::SuiGasStatus::new_unmetered();
+                ::sui_simulator::sui_types::gas::SuiGasStatus::new_unmetered(
+                    &ProtocolConfig::get_for_min_version(),
+                );
 
                 // For reasons I can't understand, LruCache causes divergent behavior the second
                 // time one is constructed and inserted into, so construct one before the first

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_1.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_1.snap
@@ -6,6 +6,7 @@ version: 1
 feature_flags:
   package_upgrades: false
   commit_root_state_digest: false
+  conservation_checks: false
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_serialized_tx_effects_size_bytes: 524288

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -50,7 +50,6 @@ use sui_types::{
     base_types::{ObjectID, ObjectRef, SuiAddress, TransactionDigest, SUI_ADDRESS_LENGTH},
     crypto::{get_key_pair_from_rng, AccountKeyPair},
     event::Event,
-    gas,
     messages::{
         ExecutionStatus, TransactionData, TransactionDataAPI, TransactionEffectsAPI,
         VerifiedTransaction,
@@ -624,10 +623,9 @@ impl<'a> SuiTestAdapter<'a> {
         gas_budget: u64,
     ) -> anyhow::Result<TxnSummary> {
         let gas_status = if transaction.inner().is_system_tx() {
-            SuiGasStatus::new_unmetered()
+            SuiGasStatus::new_unmetered(&PROTOCOL_CONSTANTS)
         } else {
-            gas::start_gas_metering(gas_budget, 1, 1, SuiCostTable::new(&PROTOCOL_CONSTANTS))
-                .unwrap()
+            SuiCostTable::new(&PROTOCOL_CONSTANTS).into_gas_status_for_testing(gas_budget, 1, 1)
         };
         transaction
             .data()

--- a/crates/sui-types/src/gas.rs
+++ b/crates/sui-types/src/gas.rs
@@ -2,103 +2,139 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::error::{UserInputError, UserInputResult};
-use crate::messages::TransactionEffects;
 use crate::{
-    error::{ExecutionError, ExecutionErrorKind},
+    error::{ExecutionError, UserInputError, UserInputResult},
     gas_coin::GasCoin,
-    messages::TransactionEffectsAPI,
-    object::{Object, Owner},
+    gas_model::gas_v1::{self, SuiCostTable as SuiCostTableV0, SuiGasStatus as SuiGasStatusV0},
+    messages::{TransactionEffects, TransactionEffectsAPI},
+    object::Object,
 };
+use enum_dispatch::enum_dispatch;
 use itertools::MultiUnzip;
-use move_core_types::{
-    gas_algebra::{GasQuantity, InternalGas, InternalGasPerByte, NumBytes, UnitDiv},
-    vm_status::StatusCode,
-};
-use once_cell::sync::Lazy;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::ops::AddAssign;
-use std::{
-    convert::TryFrom,
-    ops::{Add, Deref, Mul},
-};
-use sui_cost_tables::{
-    bytecode_tables::{GasStatus, INITIAL_COST_SCHEDULE},
-    units_types::GasUnit,
-};
-use sui_protocol_config::*;
-
-macro_rules! ok_or_gas_balance_error {
-    ($balance:expr, $required:expr) => {
-        if $balance < $required {
-            Err(UserInputError::GasBalanceTooLow {
-                gas_balance: $balance,
-                needed_gas_amount: $required,
-            })
-        } else {
-            Ok(())
-        }
-    };
-}
+use sui_cost_tables::bytecode_tables::GasStatus;
+use sui_protocol_config::ProtocolConfig;
 
 sui_macros::checked_arithmetic! {
 
-// A bucket defines a range of units that will be priced the same.
-// A cost for the bucket is defined to make the step function non linear.
-#[allow(dead_code)]
-struct ComputationBucket {
-    min: u64,
-    max: u64,
-    cost: u64,
+#[enum_dispatch]
+pub trait SuiGasStatusAPI<'a> {
+    fn is_unmetered(&self) -> bool;
+    fn bucketize_computation(&mut self) -> Result<(), ExecutionError>;
+    fn summary(&self) -> GasCostSummary;
+    fn gas_budget(&self) -> u64;
+    fn storage_gas_units(&self) -> u64;
+    fn storage_rebate(&self) -> u64;
+    fn gas_used(&self) -> u64;
+    fn reset_storage_cost_and_rebate(&mut self);
+    fn charge_storage_read(&mut self, size: usize) -> Result<(), ExecutionError>;
+    fn charge_storage_mutation(
+        &mut self,
+        new_size: usize,
+        storage_rebate: u64,
+    ) -> Result<u64, ExecutionError>;
+    fn charge_publish_package(&mut self, size: usize) -> Result<(), ExecutionError>;
+    fn move_gas_status(&mut self) -> &mut GasStatus<'a>;
 }
 
-impl ComputationBucket {
-    fn new(min: u64, max: u64, cost: u64) -> Self {
-        ComputationBucket { min, max, cost }
+#[enum_dispatch(SuiGasStatusAPI)]
+pub enum SuiGasStatus<'a> {
+    V0(SuiGasStatusV0<'a>),
+}
+
+impl<'a> SuiGasStatus<'a> {
+    pub fn new_with_budget(gas_budget: u64, gas_price: u64, config: &ProtocolConfig) -> Self {
+        match config.gas_model_version() {
+            1 => Self::V0(SuiGasStatusV0::new_with_budget(
+                gas_budget,
+                gas_price,
+                config,
+            )),
+            _ => panic!("unknown gas model version"),
+        }
     }
 
-    fn simple(min: u64, max: u64) -> Self {
-        ComputationBucket {
-            min,
-            max,
-            cost: max,
+    pub fn new_unmetered(config: &ProtocolConfig) -> Self {
+        match config.gas_model_version() {
+            1 => Self::V0(SuiGasStatusV0::new_unmetered()),
+            _ => panic!("unknown gas model version"),
         }
     }
 }
 
-fn get_bucket_cost(table: &[ComputationBucket], computation_cost: u64) -> u64 {
-    for bucket in table {
-        if bucket.max >= computation_cost {
-            return bucket.cost;
-        }
-    }
-    MAX_BUCKET_COST
+pub enum SuiCostTable {
+    V0(SuiCostTableV0),
 }
 
-// for a RPG of 1000 this amounts to about 1 SUI
-const MAX_BUCKET_COST: u64 = 1_000_000;
+impl SuiCostTable {
+    pub fn new(config: &ProtocolConfig) -> Self {
+        match config.gas_model_version() {
+            1 => Self::V0(SuiCostTableV0::new(config)),
+            _ => panic!("unknown gas model version"),
+        }
+    }
 
-// define the bucket table for computation charging
-static COMPUTATION_BUCKETS: Lazy<Vec<ComputationBucket>> = Lazy::new(|| {
-    vec![
-        ComputationBucket::simple(0, 1_000),
-        ComputationBucket::simple(1_001, 5_000),
-        ComputationBucket::simple(5_001, 10_000),
-        ComputationBucket::simple(10_001, 20_000),
-        ComputationBucket::simple(20_001, 50_000),
-        ComputationBucket::new(50_001, u64::MAX, MAX_BUCKET_COST),
-    ]
-});
+    pub fn new_for_testing() -> Self {
+        Self::new(&ProtocolConfig::get_for_max_version())
+    }
 
-pub type GasUnits = GasQuantity<GasUnit>;
-pub enum GasPriceUnit {}
-pub enum SuiGasUnit {}
+    pub fn unmetered(config: &ProtocolConfig) -> Self {
+        match config.gas_model_version() {
+            1 => Self::V0(SuiCostTableV0::unmetered()),
+            _ => panic!("unknown gas model version"),
+        }
+    }
 
-pub type ComputeGasPricePerUnit = GasQuantity<UnitDiv<GasUnit, GasUnit>>;
+    pub fn max_gas_budget(&self) -> u64 {
+        match self {
+            Self::V0(cost_table) => cost_table.max_gas_budget,
+        }
+    }
 
-pub type GasPrice = GasQuantity<GasPriceUnit>;
-pub type SuiGas = GasQuantity<SuiGasUnit>;
+    pub fn min_gas_budget(&self) -> u64 {
+        match self {
+            Self::V0(cost_table) => cost_table.min_gas_budget_external(),
+        }
+    }
+
+    // Check whether gas arguments are legit:
+    // 1. Gas object has an address owner.
+    // 2. Gas budget is between min and max budget allowed
+    pub fn check_gas_balance(
+        &self,
+        gas_object: &Object,
+        more_gas_objs: Vec<&Object>,
+        gas_budget: u64,
+        gas_price: u64,
+    ) -> UserInputResult {
+        match self {
+            Self::V0(cost_table) => gas_v1::check_gas_balance(
+                gas_object,
+                more_gas_objs,
+                gas_budget,
+                gas_price,
+                cost_table,
+            ),
+        }
+    }
+
+    pub fn into_gas_status_for_testing<'a>(
+        self,
+        gas_budget: u64,
+        gas_price: u64,
+        storage_price: u64,
+    ) -> SuiGasStatus<'a> {
+        match self {
+            Self::V0(cost_table) => SuiGasStatus::V0(SuiGasStatusV0::new_for_testing(
+                gas_budget,
+                gas_price,
+                storage_price,
+                cost_table,
+            )),
+        }
+    }
+}
 
 /// Summary of the charges in a transaction.
 /// Storage is charged independently of computation.
@@ -177,22 +213,27 @@ impl GasCostSummary {
     pub fn new_from_txn_effects<'a>(
         transactions: impl Iterator<Item = &'a TransactionEffects>,
     ) -> GasCostSummary {
-        let (storage_costs, computation_costs, storage_rebates): (Vec<u64>, Vec<u64>, Vec<u64>) =
-            transactions
-                .map(|e| {
-                    (
-                        e.gas_cost_summary().storage_cost,
-                        e.gas_cost_summary().computation_cost,
-                        e.gas_cost_summary().storage_rebate,
-                    )
-                })
-                .multiunzip();
+        let (storage_costs, computation_costs, storage_rebates, non_refundable_storage_fee): (
+            Vec<u64>,
+            Vec<u64>,
+            Vec<u64>,
+            Vec<u64>,
+        ) = transactions
+            .map(|e| {
+                (
+                    e.gas_cost_summary().storage_cost,
+                    e.gas_cost_summary().computation_cost,
+                    e.gas_cost_summary().storage_rebate,
+                    e.gas_cost_summary().non_refundable_storage_fee,
+                )
+            })
+            .multiunzip();
 
         GasCostSummary {
             storage_cost: storage_costs.iter().sum(),
             computation_cost: computation_costs.iter().sum(),
             storage_rebate: storage_rebates.iter().sum(),
-            non_refundable_storage_fee: 0,
+            non_refundable_storage_fee: non_refundable_storage_fee.iter().sum(),
         }
     }
 }
@@ -205,428 +246,6 @@ impl std::fmt::Display for GasCostSummary {
             self.computation_cost, self.storage_cost, self.storage_rebate
         )
     }
-}
-
-// Fixed cost type
-#[derive(Clone)]
-pub struct FixedCost(InternalGas);
-impl FixedCost {
-    pub fn new(x: u64) -> Self {
-        FixedCost(InternalGas::new(x))
-    }
-}
-impl Deref for FixedCost {
-    type Target = InternalGas;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-/// ComputationCostPerByte is a newtype wrapper of InternalGas
-/// to ensure a value of this type is used specifically for computation cost.
-/// Anything that does not change the amount of bytes stored in the authority data store
-/// will charge ComputationCostPerByte.
-pub struct ComputationCostPerByte(InternalGasPerByte);
-
-impl ComputationCostPerByte {
-    pub fn new(x: u64) -> Self {
-        ComputationCostPerByte(InternalGasPerByte::new(x))
-    }
-}
-
-impl Deref for ComputationCostPerByte {
-    type Target = InternalGasPerByte;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-/// StorageCostPerByte is a newtype wrapper of InternalGas
-/// to ensure a value of this type is used specifically for storage cost.
-/// Anything that changes the amount of bytes stored in the authority data store
-/// will charge StorageCostPerByte.
-pub struct StorageCostPerByte(InternalGasPerByte);
-
-impl Deref for StorageCostPerByte {
-    type Target = InternalGasPerByte;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl StorageCostPerByte {
-    pub fn new(x: u64) -> Self {
-        StorageCostPerByte(InternalGasPerByte::new(x))
-    }
-}
-
-/// A list of constant costs of various operations in Sui.
-pub struct SuiCostTable {
-    /// A flat fee charged for every transaction. This is also the mimmum amount of
-    /// gas charged for a transaction.
-    pub min_transaction_cost: FixedCost,
-    /// Maximum allowable budget for a transaction.
-    pub max_gas_budget: u64,
-    /// Computation cost per byte charged for package publish. This cost is primarily
-    /// determined by the cost to verify and link a package. Note that this does not
-    /// include the cost of writing the package to the store.
-    pub package_publish_per_byte_cost: ComputationCostPerByte,
-    /// Per byte cost to read objects from the store. This is computation cost instead of
-    /// storage cost because it does not change the amount of data stored on the db.
-    pub object_read_per_byte_cost: ComputationCostPerByte,
-    /// Per byte cost to write objects to the store. This is computation cost instead of
-    /// storage cost because it does not change the amount of data stored on the db.
-    pub object_mutation_per_byte_cost: ComputationCostPerByte,
-    /// Unit cost of a byte in the storage. This will be used both for charging for
-    /// new storage as well as rebating for deleting storage. That is, we expect users to
-    /// get full refund on the object storage when it's deleted.
-    pub storage_per_byte_cost: StorageCostPerByte,
-}
-
-impl std::fmt::Debug for SuiCostTable {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // TODO: dump the fields.
-        write!(f, "SuiCostTable(...)")
-    }
-}
-
-impl SuiCostTable {
-    pub fn new(c: &ProtocolConfig) -> Self {
-        Self {
-            min_transaction_cost: FixedCost::new(c.base_tx_cost_fixed()),
-            max_gas_budget: c.max_tx_gas(),
-            package_publish_per_byte_cost: ComputationCostPerByte::new(
-                c.package_publish_cost_per_byte(),
-            ),
-            object_read_per_byte_cost: ComputationCostPerByte::new(
-                c.obj_access_cost_read_per_byte(),
-            ),
-            object_mutation_per_byte_cost: ComputationCostPerByte::new(
-                c.obj_access_cost_mutate_per_byte(),
-            ),
-            storage_per_byte_cost: StorageCostPerByte::new(c.obj_data_cost_refundable()),
-        }
-    }
-
-    pub fn new_for_testing() -> Self {
-        Self::new(&ProtocolConfig::get_for_max_version())
-    }
-
-    fn unmetered() -> Self {
-        Self {
-            min_transaction_cost: FixedCost::new(0),
-            max_gas_budget: u64::MAX,
-            package_publish_per_byte_cost: ComputationCostPerByte::new(0),
-            object_read_per_byte_cost: ComputationCostPerByte::new(0),
-            object_mutation_per_byte_cost: ComputationCostPerByte::new(0),
-            storage_per_byte_cost: StorageCostPerByte::new(0),
-        }
-    }
-
-    pub fn min_gas_budget_external(&self) -> u64 {
-        u64::from(to_external(*self.min_transaction_cost))
-    }
-}
-
-fn to_external(internal_units: InternalGas) -> GasUnits {
-    InternalGas::to_unit_round_down(internal_units)
-}
-
-#[derive(Debug)]
-pub struct SuiGasStatus<'a> {
-    gas_status: GasStatus<'a>,
-    init_budget: GasUnits,
-    charge: bool,
-    computation_gas_unit_price: ComputeGasPricePerUnit,
-    storage_gas_unit_price: ComputeGasPricePerUnit,
-    /// storage_cost is the total storage gas units charged so far, due to writes into storage.
-    /// It will be multiplied by the storage gas unit price in the end to obtain the Sui cost.
-    storage_gas_units: GasUnits,
-    /// storage_rebate is the total storage rebate (in Sui) accumulated in this transaction.
-    /// It's directly coming from each mutated object's storage rebate field, which
-    /// was the storage cost paid when the object was last mutated. It is not affected
-    /// by the current storage gas unit price.
-    storage_rebate: SuiGas,
-
-    cost_table: SuiCostTable,
-}
-
-fn to_internal(external_units: GasUnits) -> InternalGas {
-    GasUnits::to_unit(external_units)
-}
-
-impl<'a> SuiGasStatus<'a> {
-    pub fn new_with_budget(
-        gas_budget: u64,
-        computation_gas_unit_price: GasPrice,
-        storage_gas_unit_price: GasPrice,
-        cost_table: SuiCostTable,
-    ) -> SuiGasStatus<'a> {
-        let gas_price: u64 = computation_gas_unit_price.into();
-        let budget_in_unit = gas_budget / gas_price; // truncate the value and move to units
-        Self::new(
-            GasStatus::new(&INITIAL_COST_SCHEDULE, GasUnits::new(budget_in_unit)),
-            budget_in_unit,
-            true,
-            computation_gas_unit_price,
-            storage_gas_unit_price.into(),
-            cost_table,
-        )
-    }
-
-    pub fn new_unmetered() -> SuiGasStatus<'a> {
-        Self::new(
-            GasStatus::new_unmetered(),
-            0,
-            false,
-            0.into(),
-            0,
-            SuiCostTable::unmetered(),
-        )
-    }
-
-    pub fn is_unmetered(&self) -> bool {
-        !self.charge
-    }
-
-    pub fn computation_gas_remaining(&self) -> u64 {
-        self.gas_status.remaining_gas().into()
-    }
-
-    pub fn storage_rebate(&self) -> u64 {
-        self.storage_rebate.into()
-    }
-
-    pub fn storage_gas_units(&self) -> u64 {
-        self.storage_gas_units.into()
-    }
-
-    pub fn max_gax_budget_in_balance(&self) -> u64 {
-        // MUSTFIX: Properly compute gas budget
-        let max_gas_unit_price =
-            std::cmp::max(self.computation_gas_unit_price, self.storage_gas_unit_price);
-        self.init_budget.mul(max_gas_unit_price).into()
-    }
-
-    pub fn create_move_gas_status(&mut self) -> &mut GasStatus<'a> {
-        &mut self.gas_status
-    }
-
-    pub fn bucketize_computation(&mut self) -> Result<(), ExecutionError> {
-        let computation_cost: u64 = self.gas_used().into();
-        let bucket_cost = get_bucket_cost(&COMPUTATION_BUCKETS, computation_cost);
-        // charge extra on top of `computation_cost` to make the total computation
-        // gas cost a bucket value
-        let extra_charge = bucket_cost.saturating_sub(computation_cost);
-        if extra_charge > 0 {
-            self.deduct_computation_cost(&GasUnits::new(extra_charge).to_unit())
-        } else {
-            // we hit the last bucket and the computation is already more then the
-            // max bucket so just charge as much as it is without buckets
-            Ok(())
-        }
-    }
-
-    pub fn reset_storage_cost_and_rebate(&mut self) {
-        self.storage_gas_units = GasQuantity::zero();
-        self.storage_rebate = GasQuantity::zero();
-    }
-
-    /// Try to charge the minimal amount of gas from the gas object.
-    /// This function is called in tx signing phase to make sure
-    /// the gas object has enough balance to cover minimal transaction cost.
-    pub fn charge_min_tx_gas(&mut self) -> UserInputResult {
-        let cost = self.cost_table.min_transaction_cost.clone();
-        self.deduct_computation_cost(cost.deref())
-            .map_err(|_e| UserInputError::InsufficientBalanceToCoverMinimalGas)
-    }
-
-    pub fn charge_publish_package(&mut self, size: usize) -> Result<(), ExecutionError> {
-        let computation_cost =
-            NumBytes::new(size as u64).mul(*self.cost_table.package_publish_per_byte_cost);
-
-        self.deduct_computation_cost(&computation_cost)
-    }
-
-    pub fn charge_storage_read(&mut self, size: usize) -> Result<(), ExecutionError> {
-        let cost = NumBytes::new(size as u64).mul(*self.cost_table.object_read_per_byte_cost);
-        self.deduct_computation_cost(&cost)
-    }
-
-    pub fn charge_computation_gas_for_storage_mutation(
-        &mut self,
-        size: u64,
-    ) -> Result<(), ExecutionError> {
-        let cost = NumBytes::new(size).mul(*self.cost_table.object_mutation_per_byte_cost);
-        self.deduct_computation_cost(&cost)
-    }
-
-    pub fn charge_storage_mutation(
-        &mut self,
-        new_size: usize,
-        storage_rebate: SuiGas,
-    ) -> Result<u64, ExecutionError> {
-        if self.is_unmetered() {
-            return Ok(0);
-        }
-
-        let storage_cost =
-            NumBytes::new(new_size as u64).mul(*self.cost_table.storage_per_byte_cost);
-        self.deduct_storage_cost(&storage_cost).map(|gu| {
-            self.storage_rebate.add_assign(storage_rebate);
-            gu.into()
-        })
-    }
-
-    /// This function is only called during testing, where we need to mock
-    /// Move VM charging gas.
-    pub fn charge_vm_exec_test_only(&mut self, cost: u64) -> Result<(), ExecutionError> {
-        self.gas_status
-            .deduct_gas(InternalGas::new(cost))
-            .map_err(|e| {
-                debug_assert_eq!(e.major_status(), StatusCode::OUT_OF_GAS);
-                ExecutionErrorKind::InsufficientGas.into()
-            })
-    }
-
-    /// Returns the final (computation cost, storage cost, storage rebate) of the gas meter.
-    /// We use initial budget, combined with remaining gas and storage cost to derive
-    /// computation cost.
-    pub fn summary(&self) -> GasCostSummary {
-        let remaining_gas = self.gas_status.remaining_gas();
-        let storage_cost = self.storage_gas_units;
-        // MUSTFIX: handle underflow how?
-        let computation_cost = self
-            .init_budget
-            .checked_sub(remaining_gas)
-            .expect("Subtraction overflowed")
-            .checked_sub(storage_cost)
-            .expect("Subtraction overflowed");
-
-        let computation_cost_in_sui = computation_cost.mul(self.computation_gas_unit_price).into();
-        GasCostSummary {
-            computation_cost: computation_cost_in_sui,
-            storage_cost: storage_cost.mul(self.storage_gas_unit_price).into(),
-            storage_rebate: self.storage_rebate.into(),
-            non_refundable_storage_fee: 0,
-        }
-    }
-
-    fn new(
-        move_gas_status: GasStatus<'a>,
-        gas_budget: u64,
-        charge: bool,
-        computation_gas_unit_price: GasPrice,
-        storage_gas_unit_price: u64,
-        cost_table: SuiCostTable,
-    ) -> SuiGasStatus<'a> {
-        SuiGasStatus {
-            gas_status: move_gas_status,
-            init_budget: GasUnits::new(gas_budget),
-            charge,
-            computation_gas_unit_price: ComputeGasPricePerUnit::new(
-                computation_gas_unit_price.into(),
-            ),
-            storage_gas_unit_price: ComputeGasPricePerUnit::new(storage_gas_unit_price),
-            storage_gas_units: GasUnits::new(0),
-            storage_rebate: 0.into(),
-            cost_table,
-        }
-    }
-
-    fn deduct_computation_cost(&mut self, cost: &InternalGas) -> Result<(), ExecutionError> {
-        self.gas_status.deduct_gas(*cost).map_err(|e| {
-            debug_assert_eq!(e.major_status(), StatusCode::OUT_OF_GAS);
-            ExecutionErrorKind::InsufficientGas.into()
-        })
-    }
-
-    fn deduct_storage_cost(&mut self, cost: &InternalGas) -> Result<GasUnits, ExecutionError> {
-        if self.is_unmetered() {
-            return Ok(0.into());
-        }
-        let ext_cost = to_external(NumBytes::new(1).mul(InternalGasPerByte::new(u64::from(*cost))));
-        let charge_amount = to_internal(ext_cost);
-        let remaining_gas = self.gas_status.remaining_gas();
-        if self.gas_status.deduct_gas(charge_amount).is_err() {
-            debug_assert_eq!(u64::from(self.gas_status.remaining_gas()), 0);
-            // Even when we run out of gas, we still keep track of the storage_cost change,
-            // so that at the end, we could still use it to accurately derive the
-            // computation cost.
-            self.storage_gas_units = self.storage_gas_units.add(remaining_gas);
-            Err(ExecutionErrorKind::InsufficientGas.into())
-        } else {
-            self.storage_gas_units = self.storage_gas_units.add(ext_cost);
-            Ok(ext_cost.mul(self.storage_gas_unit_price))
-        }
-    }
-
-    pub fn gas_used(&self) -> GasUnits {
-        let remaining_gas = self.gas_status.remaining_gas();
-        self.init_budget
-            .checked_sub(remaining_gas)
-            .expect("Subtraction overflowed")
-    }
-}
-
-// Check whether gas arguments are legit:
-// 1. Gas object has an address owner.
-// 2. Gas budget is between min and max budget allowed
-pub fn check_gas_balance(
-    gas_object: &Object,
-    more_gas_objs: Vec<&Object>,
-    gas_budget: u64,
-    gas_price: u64,
-    cost_table: &SuiCostTable,
-) -> UserInputResult {
-    // 1. Gas object has an address owner.
-    if !(matches!(gas_object.owner, Owner::AddressOwner(_))) {
-        return Err(UserInputError::GasObjectNotOwnedObject {
-            owner: gas_object.owner,
-        });
-    }
-
-    // 2. Gas budget is between min and max budget allowed
-    let max_gas_budget = cost_table.max_gas_budget as u128 * gas_price as u128;
-    let min_gas_budget = cost_table.min_gas_budget_external() as u128 * gas_price as u128;
-    let required_gas_amount = gas_budget as u128;
-    if required_gas_amount > max_gas_budget {
-        return Err(UserInputError::GasBudgetTooHigh {
-            gas_budget,
-            max_budget: cost_table.max_gas_budget,
-        });
-    }
-    if required_gas_amount < min_gas_budget {
-        return Err(UserInputError::GasBudgetTooLow {
-            gas_budget,
-            min_budget: cost_table.min_gas_budget_external(),
-        });
-    }
-
-    // 3. Gas balance (all gas coins together) is bigger or equal to budget
-    let mut gas_balance = get_gas_balance(gas_object)? as u128;
-    for extra_obj in more_gas_objs {
-        gas_balance += get_gas_balance(extra_obj)? as u128;
-    }
-    ok_or_gas_balance_error!(gas_balance, required_gas_amount)
-}
-
-/// Create a new gas status with the given `gas_budget`, and charge the transaction flat fee.
-pub fn start_gas_metering(
-    gas_budget: u64,
-    computation_gas_unit_price: u64,
-    storage_gas_unit_price: u64,
-    cost_table: SuiCostTable,
-) -> UserInputResult<SuiGasStatus<'static>> {
-    Ok(SuiGasStatus::new_with_budget(
-        gas_budget,
-        computation_gas_unit_price.into(),
-        storage_gas_unit_price.into(),
-        cost_table,
-    ))
 }
 
 /// Subtract the gas balance of \p gas_object by \p amount.

--- a/crates/sui-types/src/gas_model/gas_v1.rs
+++ b/crates/sui-types/src/gas_model/gas_v1.rs
@@ -1,0 +1,489 @@
+// Copyright (c) 2021, Facebook, Inc. and its affiliates
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::error::{UserInputError, UserInputResult};
+use crate::{
+    error::{ExecutionError, ExecutionErrorKind},
+    gas::{get_gas_balance, GasCostSummary, SuiGasStatusAPI},
+    object::{Object, Owner},
+};
+use move_core_types::{
+    gas_algebra::{GasQuantity, InternalGas, InternalGasPerByte, NumBytes, UnitDiv},
+    vm_status::StatusCode,
+};
+use once_cell::sync::Lazy;
+use std::ops::AddAssign;
+use std::ops::{Add, Deref, Mul};
+use sui_cost_tables::{
+    bytecode_tables::{GasStatus, INITIAL_COST_SCHEDULE},
+    units_types::GasUnit,
+};
+use sui_protocol_config::*;
+
+macro_rules! ok_or_gas_balance_error {
+    ($balance:expr, $required:expr) => {
+        if $balance < $required {
+            Err(UserInputError::GasBalanceTooLow {
+                gas_balance: $balance,
+                needed_gas_amount: $required,
+            })
+        } else {
+            Ok(())
+        }
+    };
+}
+
+sui_macros::checked_arithmetic! {
+
+// A bucket defines a range of units that will be priced the same.
+// A cost for the bucket is defined to make the step function non linear.
+#[allow(dead_code)]
+struct ComputationBucket {
+    min: u64,
+    max: u64,
+    cost: u64,
+}
+
+impl ComputationBucket {
+    fn new(min: u64, max: u64, cost: u64) -> Self {
+        ComputationBucket { min, max, cost }
+    }
+
+    fn simple(min: u64, max: u64) -> Self {
+        ComputationBucket {
+            min,
+            max,
+            cost: max,
+        }
+    }
+}
+
+fn get_bucket_cost(table: &[ComputationBucket], computation_cost: u64) -> u64 {
+    for bucket in table {
+        if bucket.max >= computation_cost {
+            return bucket.cost;
+        }
+    }
+    MAX_BUCKET_COST
+}
+
+// for a RPG of 1000 this amounts to about 1 SUI
+const MAX_BUCKET_COST: u64 = 1_000_000;
+
+// define the bucket table for computation charging
+static COMPUTATION_BUCKETS: Lazy<Vec<ComputationBucket>> = Lazy::new(|| {
+    vec![
+        ComputationBucket::simple(0, 1_000),
+        ComputationBucket::simple(1_001, 5_000),
+        ComputationBucket::simple(5_001, 10_000),
+        ComputationBucket::simple(10_001, 20_000),
+        ComputationBucket::simple(20_001, 50_000),
+        ComputationBucket::new(50_001, u64::MAX, MAX_BUCKET_COST),
+    ]
+});
+
+type GasUnits = GasQuantity<GasUnit>;
+enum GasPriceUnit {}
+enum SuiGasUnit {}
+
+type ComputeGasPricePerUnit = GasQuantity<UnitDiv<GasUnit, GasUnit>>;
+
+type GasPrice = GasQuantity<GasPriceUnit>;
+type SuiGas = GasQuantity<SuiGasUnit>;
+
+// Fixed cost type
+#[derive(Clone)]
+struct FixedCost(InternalGas);
+impl FixedCost {
+    fn new(x: u64) -> Self {
+        FixedCost(InternalGas::new(x))
+    }
+}
+impl Deref for FixedCost {
+    type Target = InternalGas;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// ComputationCostPerByte is a newtype wrapper of InternalGas
+/// to ensure a value of this type is used specifically for computation cost.
+/// Anything that does not change the amount of bytes stored in the authority data store
+/// will charge ComputationCostPerByte.
+struct ComputationCostPerByte(InternalGasPerByte);
+
+impl ComputationCostPerByte {
+    fn new(x: u64) -> Self {
+        ComputationCostPerByte(InternalGasPerByte::new(x))
+    }
+}
+
+impl Deref for ComputationCostPerByte {
+    type Target = InternalGasPerByte;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// StorageCostPerByte is a newtype wrapper of InternalGas
+/// to ensure a value of this type is used specifically for storage cost.
+/// Anything that changes the amount of bytes stored in the authority data store
+/// will charge StorageCostPerByte.
+struct StorageCostPerByte(InternalGasPerByte);
+
+impl Deref for StorageCostPerByte {
+    type Target = InternalGasPerByte;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl StorageCostPerByte {
+    fn new(x: u64) -> Self {
+        StorageCostPerByte(InternalGasPerByte::new(x))
+    }
+}
+
+/// A list of constant costs of various operations in Sui.
+pub struct SuiCostTable {
+    /// A flat fee charged for every transaction. This is also the mimmum amount of
+    /// gas charged for a transaction.
+    min_transaction_cost: FixedCost,
+    /// Maximum allowable budget for a transaction.
+    pub(crate) max_gas_budget: u64,
+    /// Computation cost per byte charged for package publish. This cost is primarily
+    /// determined by the cost to verify and link a package. Note that this does not
+    /// include the cost of writing the package to the store.
+    package_publish_per_byte_cost: ComputationCostPerByte,
+    /// Per byte cost to read objects from the store. This is computation cost instead of
+    /// storage cost because it does not change the amount of data stored on the db.
+    object_read_per_byte_cost: ComputationCostPerByte,
+    /// Unit cost of a byte in the storage. This will be used both for charging for
+    /// new storage as well as rebating for deleting storage. That is, we expect users to
+    /// get full refund on the object storage when it's deleted.
+    storage_per_byte_cost: StorageCostPerByte,
+}
+
+impl std::fmt::Debug for SuiCostTable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // TODO: dump the fields.
+        write!(f, "SuiCostTable(...)")
+    }
+}
+
+impl SuiCostTable {
+    pub(crate) fn new(c: &ProtocolConfig) -> Self {
+        Self {
+            min_transaction_cost: FixedCost::new(c.base_tx_cost_fixed()),
+            max_gas_budget: c.max_tx_gas(),
+            package_publish_per_byte_cost: ComputationCostPerByte::new(
+                c.package_publish_cost_per_byte(),
+            ),
+            object_read_per_byte_cost: ComputationCostPerByte::new(
+                c.obj_access_cost_read_per_byte(),
+            ),
+            storage_per_byte_cost: StorageCostPerByte::new(c.obj_data_cost_refundable()),
+        }
+    }
+
+    pub(crate) fn unmetered() -> Self {
+        Self {
+            min_transaction_cost: FixedCost::new(0),
+            max_gas_budget: u64::MAX,
+            package_publish_per_byte_cost: ComputationCostPerByte::new(0),
+            object_read_per_byte_cost: ComputationCostPerByte::new(0),
+            storage_per_byte_cost: StorageCostPerByte::new(0),
+        }
+    }
+
+    pub(crate) fn min_gas_budget_external(&self) -> u64 {
+        u64::from(to_external(*self.min_transaction_cost))
+    }
+}
+
+fn to_external(internal_units: InternalGas) -> GasUnits {
+    InternalGas::to_unit_round_down(internal_units)
+}
+
+#[derive(Debug)]
+pub struct SuiGasStatus<'a> {
+    gas_status: GasStatus<'a>,
+    init_budget: GasUnits,
+    charge: bool,
+    computation_gas_unit_price: ComputeGasPricePerUnit,
+    storage_gas_unit_price: ComputeGasPricePerUnit,
+    /// storage_cost is the total storage gas units charged so far, due to writes into storage.
+    /// It will be multiplied by the storage gas unit price in the end to obtain the Sui cost.
+    storage_gas_units: GasUnits,
+    /// storage_rebate is the total storage rebate (in Sui) accumulated in this transaction.
+    /// It's directly coming from each mutated object's storage rebate field, which
+    /// was the storage cost paid when the object was last mutated. It is not affected
+    /// by the current storage gas unit price.
+    storage_rebate: SuiGas,
+
+    cost_table: SuiCostTable,
+}
+
+fn to_internal(external_units: GasUnits) -> InternalGas {
+    GasUnits::to_unit(external_units)
+}
+
+impl<'a> SuiGasStatus<'a> {
+    pub(crate) fn new_for_testing(
+        gas_budget: u64,
+        computation_gas_unit_price: u64,
+        storage_gas_unit_price: u64,
+        cost_table: SuiCostTable,
+    ) -> SuiGasStatus<'a> {
+        let budget_in_unit = gas_budget / computation_gas_unit_price; // truncate the value and move to units
+        Self::new(
+            GasStatus::new(&INITIAL_COST_SCHEDULE, GasUnits::new(budget_in_unit)),
+            budget_in_unit,
+            true,
+            computation_gas_unit_price.into(),
+            storage_gas_unit_price,
+            cost_table,
+        )
+    }
+
+    pub(crate) fn new_with_budget(
+        gas_budget: u64,
+        computation_gas_unit_price: u64,
+        config: &ProtocolConfig,
+    ) -> SuiGasStatus<'a> {
+        let storage_gas_unit_price: GasPrice = config.storage_gas_price().into();
+         // truncate the value and move to units
+        let budget_in_unit = gas_budget / computation_gas_unit_price;
+        Self::new(
+            GasStatus::new(&INITIAL_COST_SCHEDULE, GasUnits::new(budget_in_unit)),
+            budget_in_unit,
+            true,
+            computation_gas_unit_price.into(),
+            storage_gas_unit_price.into(),
+            SuiCostTable::new(config),
+        )
+    }
+
+    pub(crate) fn new_unmetered() -> SuiGasStatus<'a> {
+        Self::new(
+            GasStatus::new_unmetered(),
+            0,
+            false,
+            0.into(),
+            0,
+            SuiCostTable::unmetered(),
+        )
+    }
+
+    fn charge_storage_mutation_with_rebate(
+        &mut self,
+        new_size: usize,
+        storage_rebate: SuiGas,
+    ) -> Result<u64, ExecutionError> {
+        if self.is_unmetered() {
+            return Ok(0);
+        }
+
+        let storage_cost =
+            NumBytes::new(new_size as u64).mul(*self.cost_table.storage_per_byte_cost);
+        self.deduct_storage_cost(&storage_cost).map(|gu| {
+            self.storage_rebate.add_assign(storage_rebate);
+            gu.into()
+        })
+    }
+
+    fn new(
+        move_gas_status: GasStatus<'_>,
+        gas_budget: u64,
+        charge: bool,
+        computation_gas_unit_price: GasPrice,
+        storage_gas_unit_price: u64,
+        cost_table: SuiCostTable,
+    ) -> SuiGasStatus<'_> {
+        SuiGasStatus {
+            gas_status: move_gas_status,
+            init_budget: GasUnits::new(gas_budget),
+            charge,
+            computation_gas_unit_price: ComputeGasPricePerUnit::new(
+                computation_gas_unit_price.into(),
+            ),
+            storage_gas_unit_price: ComputeGasPricePerUnit::new(storage_gas_unit_price),
+            storage_gas_units: GasUnits::new(0),
+            storage_rebate: 0.into(),
+            cost_table,
+        }
+    }
+
+    fn deduct_computation_cost(&mut self, cost: &InternalGas) -> Result<(), ExecutionError> {
+        self.gas_status.deduct_gas(*cost).map_err(|e| {
+            debug_assert_eq!(e.major_status(), StatusCode::OUT_OF_GAS);
+            ExecutionErrorKind::InsufficientGas.into()
+        })
+    }
+
+    fn deduct_storage_cost(&mut self, cost: &InternalGas) -> Result<GasUnits, ExecutionError> {
+        if self.is_unmetered() {
+            return Ok(0.into());
+        }
+        let ext_cost = to_external(NumBytes::new(1).mul(InternalGasPerByte::new(u64::from(*cost))));
+        let charge_amount = to_internal(ext_cost);
+        let remaining_gas = self.gas_status.remaining_gas();
+        if self.gas_status.deduct_gas(charge_amount).is_err() {
+            debug_assert_eq!(u64::from(self.gas_status.remaining_gas()), 0);
+            // Even when we run out of gas, we still keep track of the storage_cost change,
+            // so that at the end, we could still use it to accurately derive the
+            // computation cost.
+            self.storage_gas_units = self.storage_gas_units.add(remaining_gas);
+            Err(ExecutionErrorKind::InsufficientGas.into())
+        } else {
+            self.storage_gas_units = self.storage_gas_units.add(ext_cost);
+            Ok(ext_cost.mul(self.storage_gas_unit_price))
+        }
+    }
+
+    fn gas_used_in_gas_units(&self) -> GasUnits {
+        let remaining_gas = self.gas_status.remaining_gas();
+        self.init_budget
+            .checked_sub(remaining_gas)
+            .expect("Subtraction overflowed")
+    }
+}
+
+impl<'a> SuiGasStatusAPI<'a> for SuiGasStatus<'a> {
+    fn is_unmetered(&self) -> bool {
+        !self.charge
+    }
+
+    fn move_gas_status(&mut self) -> &mut GasStatus<'a> {
+        &mut self.gas_status
+    }
+
+    fn bucketize_computation(&mut self) -> Result<(), ExecutionError> {
+        let computation_cost: u64 = self.gas_used();
+        let bucket_cost = get_bucket_cost(&COMPUTATION_BUCKETS, computation_cost);
+        // charge extra on top of `computation_cost` to make the total computation
+        // gas cost a bucket value
+        let extra_charge = bucket_cost.saturating_sub(computation_cost);
+        if extra_charge > 0 {
+            self.deduct_computation_cost(&GasUnits::new(extra_charge).to_unit())
+        } else {
+            // we hit the last bucket and the computation is already more then the
+            // max bucket so just charge as much as it is without buckets
+            Ok(())
+        }
+    }
+
+    /// Returns the final (computation cost, storage cost, storage rebate) of the gas meter.
+    /// We use initial budget, combined with remaining gas and storage cost to derive
+    /// computation cost.
+    fn summary(&self) -> GasCostSummary {
+        let remaining_gas = self.gas_status.remaining_gas();
+        let storage_cost = self.storage_gas_units;
+        let computation_cost = self
+            .init_budget
+            .checked_sub(remaining_gas)
+            .expect("Subtraction overflowed")
+            .checked_sub(storage_cost)
+            .expect("Subtraction overflowed");
+
+        let computation_cost_in_sui = computation_cost.mul(self.computation_gas_unit_price).into();
+        GasCostSummary {
+            computation_cost: computation_cost_in_sui,
+            storage_cost: storage_cost.mul(self.storage_gas_unit_price).into(),
+            storage_rebate: self.storage_rebate.into(),
+            non_refundable_storage_fee: 0,
+        }
+    }
+
+    fn gas_budget(&self) -> u64 {
+        // MUSTFIX: Properly compute gas budget
+        let max_gas_unit_price =
+            std::cmp::max(self.computation_gas_unit_price, self.storage_gas_unit_price);
+        self.init_budget.mul(max_gas_unit_price).into()
+    }
+
+    fn storage_rebate(&self) -> u64 {
+        self.storage_rebate.into()
+    }
+
+    fn storage_gas_units(&self) -> u64 {
+        self.storage_gas_units.into()
+    }
+
+    fn gas_used(&self) -> u64 {
+        self.gas_used_in_gas_units().into()
+    }
+
+    fn reset_storage_cost_and_rebate(&mut self) {
+        self.storage_gas_units = GasQuantity::zero();
+        self.storage_rebate = GasQuantity::zero();
+    }
+
+    fn charge_storage_read(&mut self, size: usize) -> Result<(), ExecutionError> {
+        let cost = NumBytes::new(size as u64).mul(*self.cost_table.object_read_per_byte_cost);
+        self.deduct_computation_cost(&cost)
+    }
+
+    fn charge_storage_mutation(
+        &mut self,
+        new_size: usize,
+        storage_rebate: u64,
+    ) -> Result<u64, ExecutionError> {
+        self.charge_storage_mutation_with_rebate(new_size, storage_rebate.into())
+    }
+
+    fn charge_publish_package(&mut self, size: usize) -> Result<(), ExecutionError> {
+        let computation_cost =
+            NumBytes::new(size as u64).mul(*self.cost_table.package_publish_per_byte_cost);
+
+        self.deduct_computation_cost(&computation_cost)
+    }
+}
+
+// Check whether gas arguments are legit:
+// 1. Gas object has an address owner.
+// 2. Gas budget is between min and max budget allowed
+pub(crate) fn check_gas_balance(
+    gas_object: &Object,
+    more_gas_objs: Vec<&Object>,
+    gas_budget: u64,
+    gas_price: u64,
+    cost_table: &SuiCostTable,
+) -> UserInputResult {
+    // 1. Gas object has an address owner.
+    if !(matches!(gas_object.owner, Owner::AddressOwner(_))) {
+        return Err(UserInputError::GasObjectNotOwnedObject {
+            owner: gas_object.owner,
+        });
+    }
+
+    // 2. Gas budget is between min and max budget allowed
+    let max_gas_budget = cost_table.max_gas_budget as u128 * gas_price as u128;
+    let min_gas_budget = cost_table.min_gas_budget_external() as u128 * gas_price as u128;
+    let required_gas_amount = gas_budget as u128;
+    if required_gas_amount > max_gas_budget {
+        return Err(UserInputError::GasBudgetTooHigh {
+            gas_budget,
+            max_budget: cost_table.max_gas_budget,
+        });
+    }
+    if required_gas_amount < min_gas_budget {
+        return Err(UserInputError::GasBudgetTooLow {
+            gas_budget,
+            min_budget: cost_table.min_gas_budget_external(),
+        });
+    }
+
+    // 3. Gas balance (all gas coins together) is bigger or equal to budget
+    let mut gas_balance = get_gas_balance(gas_object)? as u128;
+    for extra_obj in more_gas_objs {
+        gas_balance += get_gas_balance(extra_obj)? as u128;
+    }
+    ok_or_gas_balance_error!(gas_balance, required_gas_amount)
+}
+
+}

--- a/crates/sui-types/src/gas_model/mod.rs
+++ b/crates/sui-types/src/gas_model/mod.rs
@@ -1,0 +1,4 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod gas_v1;

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -35,6 +35,7 @@ pub mod dynamic_field;
 pub mod event;
 pub mod gas;
 pub mod gas_coin;
+pub mod gas_model;
 pub mod governance;
 pub mod id;
 pub mod in_memory_storage;

--- a/crates/sui-types/src/temporary_store.rs
+++ b/crates/sui-types/src/temporary_store.rs
@@ -27,7 +27,7 @@ use crate::{
     error::{ExecutionError, SuiError, SuiResult},
     event::Event,
     fp_bail, gas,
-    gas::{GasCostSummary, SuiGasStatus},
+    gas::{GasCostSummary, SuiGasStatus, SuiGasStatusAPI},
     messages::{ExecutionStatus, InputObjects, TransactionEffects},
     object::Owner,
     object::{Data, Object},
@@ -834,7 +834,7 @@ impl<S: ObjectStore> TemporaryStore<S> {
             };
             let new_object_size = object.object_size_for_gas_metering();
             let new_storage_rebate =
-                gas_status.charge_storage_mutation(new_object_size, old_storage_rebate.into())?;
+                gas_status.charge_storage_mutation(new_object_size, old_storage_rebate)?;
             object.storage_rebate = new_storage_rebate;
             if !object.is_immutable() {
                 objects_to_update.push((object.clone(), *write_kind));
@@ -847,7 +847,7 @@ impl<S: ObjectStore> TemporaryStore<S> {
                 DeleteKind::Wrap | DeleteKind::Normal => {
                     let (storage_rebate, object_size) =
                         self.get_input_storage_rebate_and_size(object_id, *version)?;
-                    gas_status.charge_storage_mutation(0, storage_rebate.into())?;
+                    gas_status.charge_storage_mutation(0, storage_rebate)?;
                     total_bytes_written_deleted += object_size;
                 }
                 DeleteKind::UnwrapThenDelete => {


### PR DESCRIPTION
## Description 

This PR creates an abstraction around different versions of gas models and controls it via protocol config.
Also it creates a feature flag (protocol config) for conservation checks (@sblackshear @lxfind) so that turning conservation on and off can be controlled by a config change.

This change does not affect anything and it does not introduce the new model yet. It just allows new models to be deployed side by side with old ones.

Gas code is moved in `sui-types/src/gas_model` with the original `gas.rs` containing the "interface" for core code to talk to.
The original `gas.rs` is essentially split with the implementation details in `gas_v1.rs`.

I'll comment and cleanup properly once we have the new model on top of this

## Test Plan 

Run existing tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
