### PR TITLE
indexer: fix next cursor of object & epoch page

### DIFF
--- a/crates/sui-indexer/src/apis/extended_api.rs
+++ b/crates/sui-indexer/src/apis/extended_api.rs
@@ -96,9 +96,7 @@ impl<S: IndexerStore + Sync + Send + 'static> ExtendedApiServer for ExtendedApi<
 
         let has_next_page = epochs.len() > limit;
         epochs.truncate(limit);
-        let next_cursor = has_next_page
-            .then_some(epochs.last().map(|e| e.epoch))
-            .flatten();
+        let next_cursor = epochs.last().map(|e| e.epoch);
         Ok(Page {
             data: epochs,
             next_cursor,

--- a/crates/sui-indexer/src/apis/indexer_api.rs
+++ b/crates/sui-indexer/src/apis/indexer_api.rs
@@ -257,7 +257,7 @@ where
 
         let has_next_page = objects.len() > limit;
         objects.truncate(limit);
-        let next_cursor = objects.get(limit).and_then(|o| {
+        let next_cursor = objects.last().and_then(|o| {
             o.object().ok().map(|o| CheckpointedObjectID {
                 object_id: o.id(),
                 at_checkpoint: Some(at_checkpoint),


### PR DESCRIPTION
## Description 

Next cursor should always point to the last() of the truncated vector.
