### PR TITLE
Upgrade Sui System State object type

### DIFF
--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -841,13 +841,14 @@ impl Builder {
         } = self.parameters.to_genesis_chain_parameters();
 
         // In non-testing code, genesis type must always be V1.
-        #[cfg(not(msim))]
-        let SuiSystemState::V1(system_state) = unsigned_genesis.sui_system_object();
-
-        #[cfg(msim)]
-        let SuiSystemState::V1(system_state) = unsigned_genesis.sui_system_object() else {
-            // Types other than V1 used in simtests do not need to be validated.
-            return;
+        let system_state = match unsigned_genesis.sui_system_object() {
+            SuiSystemState::V1(inner) => inner,
+            SuiSystemState::V2(_) => unreachable!(),
+            #[cfg(msim)]
+            _ => {
+                // Types other than V1 used in simtests do not need to be validated.
+                return;
+            }
         };
 
         assert_eq!(

--- a/crates/sui-framework/docs/sui_system.md
+++ b/crates/sui-framework/docs/sui_system.md
@@ -1348,7 +1348,7 @@ version
 
 
 
-<pre><code><b>fun</b> <a href="sui_system.md#0x3_sui_system_load_system_state">load_system_state</a>(self: &<b>mut</b> <a href="sui_system.md#0x3_sui_system_SuiSystemState">sui_system::SuiSystemState</a>): &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>
+<pre><code><b>fun</b> <a href="sui_system.md#0x3_sui_system_load_system_state">load_system_state</a>(self: &<b>mut</b> <a href="sui_system.md#0x3_sui_system_SuiSystemState">sui_system::SuiSystemState</a>): &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>
 </code></pre>
 
 
@@ -1357,7 +1357,7 @@ version
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="sui_system.md#0x3_sui_system_load_system_state">load_system_state</a>(self: &<b>mut</b> <a href="sui_system.md#0x3_sui_system_SuiSystemState">SuiSystemState</a>): &SuiSystemStateInner {
+<pre><code><b>fun</b> <a href="sui_system.md#0x3_sui_system_load_system_state">load_system_state</a>(self: &<b>mut</b> <a href="sui_system.md#0x3_sui_system_SuiSystemState">SuiSystemState</a>): &SuiSystemStateInnerV2 {
     <a href="sui_system.md#0x3_sui_system_load_inner_maybe_upgrade">load_inner_maybe_upgrade</a>(self)
 }
 </code></pre>
@@ -1372,7 +1372,7 @@ version
 
 
 
-<pre><code><b>fun</b> <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(self: &<b>mut</b> <a href="sui_system.md#0x3_sui_system_SuiSystemState">sui_system::SuiSystemState</a>): &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>
+<pre><code><b>fun</b> <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(self: &<b>mut</b> <a href="sui_system.md#0x3_sui_system_SuiSystemState">sui_system::SuiSystemState</a>): &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>
 </code></pre>
 
 
@@ -1381,7 +1381,7 @@ version
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(self: &<b>mut</b> <a href="sui_system.md#0x3_sui_system_SuiSystemState">SuiSystemState</a>): &<b>mut</b> SuiSystemStateInner {
+<pre><code><b>fun</b> <a href="sui_system.md#0x3_sui_system_load_system_state_mut">load_system_state_mut</a>(self: &<b>mut</b> <a href="sui_system.md#0x3_sui_system_SuiSystemState">SuiSystemState</a>): &<b>mut</b> SuiSystemStateInnerV2 {
     <a href="sui_system.md#0x3_sui_system_load_inner_maybe_upgrade">load_inner_maybe_upgrade</a>(self)
 }
 </code></pre>
@@ -1396,7 +1396,7 @@ version
 
 
 
-<pre><code><b>fun</b> <a href="sui_system.md#0x3_sui_system_load_inner_maybe_upgrade">load_inner_maybe_upgrade</a>(self: &<b>mut</b> <a href="sui_system.md#0x3_sui_system_SuiSystemState">sui_system::SuiSystemState</a>): &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>
+<pre><code><b>fun</b> <a href="sui_system.md#0x3_sui_system_load_inner_maybe_upgrade">load_inner_maybe_upgrade</a>(self: &<b>mut</b> <a href="sui_system.md#0x3_sui_system_SuiSystemState">sui_system::SuiSystemState</a>): &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>
 </code></pre>
 
 
@@ -1405,17 +1405,15 @@ version
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="sui_system.md#0x3_sui_system_load_inner_maybe_upgrade">load_inner_maybe_upgrade</a>(self: &<b>mut</b> <a href="sui_system.md#0x3_sui_system_SuiSystemState">SuiSystemState</a>): &<b>mut</b> SuiSystemStateInner {
-    // TODO: This is <b>where</b> we check the version and perform upgrade <b>if</b> necessary.
-    // <b>if</b> (self.version == 1) {
-    //   <b>let</b> v1 = <a href="_remove">dynamic_field::remove</a>(&<b>mut</b> self.id, self.version);
-    //   <b>let</b> v2 = sui_system_state_inner::v1_to_v2(v1);
-    //   <b>assert</b>!(v2.system_state_version = 2, <a href="sui_system.md#0x3_sui_system_EWrongInnerVersion">EWrongInnerVersion</a>);
-    //   self.version = 2;
-    //   <a href="_add">dynamic_field::add</a>(&<b>mut</b> self.id, self.version, v2);
-    // }
+<pre><code><b>fun</b> <a href="sui_system.md#0x3_sui_system_load_inner_maybe_upgrade">load_inner_maybe_upgrade</a>(self: &<b>mut</b> <a href="sui_system.md#0x3_sui_system_SuiSystemState">SuiSystemState</a>): &<b>mut</b> SuiSystemStateInnerV2 {
+    <b>if</b> (self.version == 1) {
+      <b>let</b> v1 = <a href="_remove">dynamic_field::remove</a>(&<b>mut</b> self.id, self.version);
+      <b>let</b> v2 = <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_v1_to_v2">sui_system_state_inner::v1_to_v2</a>(v1);
+      self.version = 2;
+      <a href="_add">dynamic_field::add</a>(&<b>mut</b> self.id, self.version, v2);
+    };
 
-    <b>let</b> inner: &<b>mut</b> SuiSystemStateInner = <a href="_borrow_mut">dynamic_field::borrow_mut</a>(&<b>mut</b> self.id, self.version);
+    <b>let</b> inner = <a href="_borrow_mut">dynamic_field::borrow_mut</a>(&<b>mut</b> self.id, self.version);
     <b>assert</b>!(<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_system_state_version">sui_system_state_inner::system_state_version</a>(inner) == self.version, <a href="sui_system.md#0x3_sui_system_EWrongInnerVersion">EWrongInnerVersion</a>);
     inner
 }

--- a/crates/sui-framework/docs/sui_system_state_inner.md
+++ b/crates/sui-framework/docs/sui_system_state_inner.md
@@ -6,11 +6,14 @@
 
 
 -  [Struct `SystemParameters`](#0x3_sui_system_state_inner_SystemParameters)
+-  [Struct `SystemParametersV2`](#0x3_sui_system_state_inner_SystemParametersV2)
 -  [Struct `SuiSystemStateInner`](#0x3_sui_system_state_inner_SuiSystemStateInner)
+-  [Struct `SuiSystemStateInnerV2`](#0x3_sui_system_state_inner_SuiSystemStateInnerV2)
 -  [Struct `SystemEpochInfoEvent`](#0x3_sui_system_state_inner_SystemEpochInfoEvent)
 -  [Constants](#@Constants_0)
 -  [Function `create`](#0x3_sui_system_state_inner_create)
 -  [Function `create_system_parameters`](#0x3_sui_system_state_inner_create_system_parameters)
+-  [Function `v1_to_v2`](#0x3_sui_system_state_inner_v1_to_v2)
 -  [Function `request_add_validator_candidate`](#0x3_sui_system_state_inner_request_add_validator_candidate)
 -  [Function `request_remove_validator_candidate`](#0x3_sui_system_state_inner_request_remove_validator_candidate)
 -  [Function `request_add_validator`](#0x3_sui_system_state_inner_request_add_validator)
@@ -160,6 +163,87 @@ A list of system config parameters.
 
 </details>
 
+<a name="0x3_sui_system_state_inner_SystemParametersV2"></a>
+
+## Struct `SystemParametersV2`
+
+Added min_validator_count.
+
+
+<pre><code><b>struct</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SystemParametersV2">SystemParametersV2</a> <b>has</b> store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>epoch_duration_ms: u64</code>
+</dt>
+<dd>
+ The duration of an epoch, in milliseconds.
+</dd>
+<dt>
+<code>stake_subsidy_start_epoch: u64</code>
+</dt>
+<dd>
+ The starting epoch in which stake subsidies start being paid out
+</dd>
+<dt>
+<code>min_validator_count: u64</code>
+</dt>
+<dd>
+ Minimum number of active validators at any moment.
+</dd>
+<dt>
+<code>max_validator_count: u64</code>
+</dt>
+<dd>
+ Maximum number of active validators at any moment.
+ We do not allow the number of validators in any epoch to go above this.
+</dd>
+<dt>
+<code>min_validator_joining_stake: u64</code>
+</dt>
+<dd>
+ Lower-bound on the amount of stake required to become a validator.
+</dd>
+<dt>
+<code>validator_low_stake_threshold: u64</code>
+</dt>
+<dd>
+ Validators with stake amount below <code>validator_low_stake_threshold</code> are considered to
+ have low stake and will be escorted out of the validator set after being below this
+ threshold for more than <code>validator_low_stake_grace_period</code> number of epochs.
+</dd>
+<dt>
+<code>validator_very_low_stake_threshold: u64</code>
+</dt>
+<dd>
+ Validators with stake below <code>validator_very_low_stake_threshold</code> will be removed
+ immediately at epoch change, no grace period.
+</dd>
+<dt>
+<code>validator_low_stake_grace_period: u64</code>
+</dt>
+<dd>
+ A validator can have stake below <code>validator_low_stake_threshold</code>
+ for this many epochs before being kicked out.
+</dd>
+<dt>
+<code>extra_fields: <a href="_Bag">bag::Bag</a></code>
+</dt>
+<dd>
+ Any extra fields that's not defined statically.
+</dd>
+</dl>
+
+
+</details>
+
 <a name="0x3_sui_system_state_inner_SuiSystemStateInner"></a>
 
 ## Struct `SuiSystemStateInner`
@@ -211,6 +295,138 @@ The top-level object containing all information of the Sui system.
 </dd>
 <dt>
 <code>parameters: <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SystemParameters">sui_system_state_inner::SystemParameters</a></code>
+</dt>
+<dd>
+ A list of system config parameters.
+</dd>
+<dt>
+<code>reference_gas_price: u64</code>
+</dt>
+<dd>
+ The reference gas price for the current epoch.
+</dd>
+<dt>
+<code>validator_report_records: <a href="_VecMap">vec_map::VecMap</a>&lt;<b>address</b>, <a href="_VecSet">vec_set::VecSet</a>&lt;<b>address</b>&gt;&gt;</code>
+</dt>
+<dd>
+ A map storing the records of validator reporting each other.
+ There is an entry in the map for each validator that has been reported
+ at least once. The entry VecSet contains all the validators that reported
+ them. If a validator has never been reported they don't have an entry in this map.
+ This map persists across epoch: a peer continues being in a reported state until the
+ reporter doesn't explicitly remove their report.
+ Note that in case we want to support validator address change in future,
+ the reports should be based on validator ids
+</dd>
+<dt>
+<code><a href="stake_subsidy.md#0x3_stake_subsidy">stake_subsidy</a>: <a href="stake_subsidy.md#0x3_stake_subsidy_StakeSubsidy">stake_subsidy::StakeSubsidy</a></code>
+</dt>
+<dd>
+ Schedule of stake subsidies given out each epoch.
+</dd>
+<dt>
+<code>safe_mode: bool</code>
+</dt>
+<dd>
+ Whether the system is running in a downgraded safe mode due to a non-recoverable bug.
+ This is set whenever we failed to execute advance_epoch, and ended up executing advance_epoch_safe_mode.
+ It can be reset once we are able to successfully execute advance_epoch.
+ The rest of the fields starting with <code>safe_mode_</code> are accmulated during safe mode
+ when advance_epoch_safe_mode is executed. They will eventually be processed once we
+ are out of safe mode.
+</dd>
+<dt>
+<code>safe_mode_storage_rewards: <a href="_Balance">balance::Balance</a>&lt;<a href="_SUI">sui::SUI</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>safe_mode_computation_rewards: <a href="_Balance">balance::Balance</a>&lt;<a href="_SUI">sui::SUI</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>safe_mode_storage_rebates: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>safe_mode_non_refundable_storage_fee: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>epoch_start_timestamp_ms: u64</code>
+</dt>
+<dd>
+ Unix timestamp of the current epoch start
+</dd>
+<dt>
+<code>extra_fields: <a href="_Bag">bag::Bag</a></code>
+</dt>
+<dd>
+ Any extra fields that's not defined statically.
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x3_sui_system_state_inner_SuiSystemStateInnerV2"></a>
+
+## Struct `SuiSystemStateInnerV2`
+
+Uses SystemParametersV2 as the parameters.
+
+
+<pre><code><b>struct</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a> <b>has</b> store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>epoch: u64</code>
+</dt>
+<dd>
+ The current epoch ID, starting from 0.
+</dd>
+<dt>
+<code>protocol_version: u64</code>
+</dt>
+<dd>
+ The current protocol version, starting from 1.
+</dd>
+<dt>
+<code>system_state_version: u64</code>
+</dt>
+<dd>
+ The current version of the system state data structure type.
+ This is always the same as SuiSystemState.version. Keeping a copy here so that
+ we know what version it is by inspecting SuiSystemStateInner as well.
+</dd>
+<dt>
+<code>validators: <a href="validator_set.md#0x3_validator_set_ValidatorSet">validator_set::ValidatorSet</a></code>
+</dt>
+<dd>
+ Contains all information about the validators.
+</dd>
+<dt>
+<code><a href="storage_fund.md#0x3_storage_fund">storage_fund</a>: <a href="storage_fund.md#0x3_storage_fund_StorageFund">storage_fund::StorageFund</a></code>
+</dt>
+<dd>
+ The storage fund.
+</dd>
+<dt>
+<code>parameters: <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SystemParametersV2">sui_system_state_inner::SystemParametersV2</a></code>
 </dt>
 <dd>
  A list of system config parameters.
@@ -617,6 +833,85 @@ This function will be called only once in genesis.
 
 </details>
 
+<a name="0x3_sui_system_state_inner_v1_to_v2"></a>
+
+## Function `v1_to_v2`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_v1_to_v2">v1_to_v2</a>(self: <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>): <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_v1_to_v2">v1_to_v2</a>(self: <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>): <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a> {
+    <b>let</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a> {
+        epoch,
+        protocol_version,
+        system_state_version: _,
+        validators,
+        <a href="storage_fund.md#0x3_storage_fund">storage_fund</a>,
+        parameters,
+        reference_gas_price,
+        validator_report_records,
+        <a href="stake_subsidy.md#0x3_stake_subsidy">stake_subsidy</a>,
+        safe_mode,
+        safe_mode_storage_rewards,
+        safe_mode_computation_rewards,
+        safe_mode_storage_rebates,
+        safe_mode_non_refundable_storage_fee,
+        epoch_start_timestamp_ms,
+        extra_fields: state_extra_fields,
+    } = self;
+    <b>let</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SystemParameters">SystemParameters</a> {
+        epoch_duration_ms,
+        stake_subsidy_start_epoch,
+        max_validator_count,
+        min_validator_joining_stake,
+        validator_low_stake_threshold,
+        validator_very_low_stake_threshold,
+        validator_low_stake_grace_period,
+        extra_fields: param_extra_fields,
+    } = parameters;
+    <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a> {
+        epoch,
+        protocol_version,
+        system_state_version: 2,
+        validators,
+        <a href="storage_fund.md#0x3_storage_fund">storage_fund</a>,
+        parameters: <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SystemParametersV2">SystemParametersV2</a> {
+            epoch_duration_ms,
+            stake_subsidy_start_epoch,
+            min_validator_count: 4,
+            max_validator_count,
+            min_validator_joining_stake,
+            validator_low_stake_threshold,
+            validator_very_low_stake_threshold,
+            validator_low_stake_grace_period,
+            extra_fields: param_extra_fields,
+        },
+        reference_gas_price,
+        validator_report_records,
+        <a href="stake_subsidy.md#0x3_stake_subsidy">stake_subsidy</a>,
+        safe_mode,
+        safe_mode_storage_rewards,
+        safe_mode_computation_rewards,
+        safe_mode_storage_rebates,
+        safe_mode_non_refundable_storage_fee,
+        epoch_start_timestamp_ms,
+        extra_fields: state_extra_fields
+    }
+}
+</code></pre>
+
+
+
+</details>
+
 <a name="0x3_sui_system_state_inner_request_add_validator_candidate"></a>
 
 ## Function `request_add_validator_candidate`
@@ -629,7 +924,7 @@ Note: <code>proof_of_possession</code> MUST be a valid signature using sui_addre
 To produce a valid PoP, run [fn test_proof_of_possession].
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_add_validator_candidate">request_add_validator_candidate</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, network_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, worker_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, proof_of_possession: <a href="">vector</a>&lt;u8&gt;, name: <a href="">vector</a>&lt;u8&gt;, description: <a href="">vector</a>&lt;u8&gt;, image_url: <a href="">vector</a>&lt;u8&gt;, project_url: <a href="">vector</a>&lt;u8&gt;, net_address: <a href="">vector</a>&lt;u8&gt;, p2p_address: <a href="">vector</a>&lt;u8&gt;, primary_address: <a href="">vector</a>&lt;u8&gt;, worker_address: <a href="">vector</a>&lt;u8&gt;, gas_price: u64, commission_rate: u64, ctx: &<b>mut</b> <a href="_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_add_validator_candidate">request_add_validator_candidate</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, network_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, worker_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;, proof_of_possession: <a href="">vector</a>&lt;u8&gt;, name: <a href="">vector</a>&lt;u8&gt;, description: <a href="">vector</a>&lt;u8&gt;, image_url: <a href="">vector</a>&lt;u8&gt;, project_url: <a href="">vector</a>&lt;u8&gt;, net_address: <a href="">vector</a>&lt;u8&gt;, p2p_address: <a href="">vector</a>&lt;u8&gt;, primary_address: <a href="">vector</a>&lt;u8&gt;, worker_address: <a href="">vector</a>&lt;u8&gt;, gas_price: u64, commission_rate: u64, ctx: &<b>mut</b> <a href="_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -639,7 +934,7 @@ To produce a valid PoP, run [fn test_proof_of_possession].
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_add_validator_candidate">request_add_validator_candidate</a>(
-    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     pubkey_bytes: <a href="">vector</a>&lt;u8&gt;,
     network_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;,
     worker_pubkey_bytes: <a href="">vector</a>&lt;u8&gt;,
@@ -691,7 +986,7 @@ Called by a validator candidate to remove themselves from the candidacy. After t
 their staking pool becomes deactivate.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_remove_validator_candidate">request_remove_validator_candidate</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, ctx: &<b>mut</b> <a href="_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_remove_validator_candidate">request_remove_validator_candidate</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, ctx: &<b>mut</b> <a href="_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -701,7 +996,7 @@ their staking pool becomes deactivate.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_remove_validator_candidate">request_remove_validator_candidate</a>(
-    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     ctx: &<b>mut</b> TxContext,
 ) {
     <a href="validator_set.md#0x3_validator_set_request_remove_validator_candidate">validator_set::request_remove_validator_candidate</a>(&<b>mut</b> self.validators, ctx);
@@ -722,7 +1017,7 @@ stake the validator has doesn't meet the min threshold, or if the number of new 
 epoch has already reached the maximum.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_add_validator">request_add_validator</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, ctx: &<b>mut</b> <a href="_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_add_validator">request_add_validator</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, ctx: &<b>mut</b> <a href="_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -732,7 +1027,7 @@ epoch has already reached the maximum.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_add_validator">request_add_validator</a>(
-    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     ctx: &<b>mut</b> TxContext,
 ) {
     <b>assert</b>!(
@@ -759,7 +1054,7 @@ At the end of the epoch, the <code><a href="validator.md#0x3_validator">validato
 of the validator.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_remove_validator">request_remove_validator</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, ctx: &<b>mut</b> <a href="_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_remove_validator">request_remove_validator</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, ctx: &<b>mut</b> <a href="_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -769,9 +1064,19 @@ of the validator.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_remove_validator">request_remove_validator</a>(
-    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     ctx: &<b>mut</b> TxContext,
 ) {
+    // Only check <b>min</b> <a href="validator.md#0x3_validator">validator</a> condition <b>if</b> the current number of validators satisfy the constraint.
+    // This is so that <b>if</b> we somehow already are in a state <b>where</b> we have less than <b>min</b> validators, it no longer matters
+    // and is ok <b>to</b> stay so. This is useful for a test setup.
+    <b>if</b> (<a href="_length">vector::length</a>(<a href="validator_set.md#0x3_validator_set_active_validators">validator_set::active_validators</a>(&self.validators)) &gt;= self.parameters.min_validator_count) {
+        <b>assert</b>!(
+            <a href="validator_set.md#0x3_validator_set_next_epoch_validator_count">validator_set::next_epoch_validator_count</a>(&self.validators) &gt; self.parameters.min_validator_count,
+            <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_ELimitExceeded">ELimitExceeded</a>,
+        );
+    };
+
     <a href="validator_set.md#0x3_validator_set_request_remove_validator">validator_set::request_remove_validator</a>(
         &<b>mut</b> self.validators,
         ctx,
@@ -791,7 +1096,7 @@ A validator can call this function to submit a new gas price quote, to be
 used for the reference gas price calculation at the end of the epoch.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_set_gas_price">request_set_gas_price</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, cap: &<a href="validator_cap.md#0x3_validator_cap_UnverifiedValidatorOperationCap">validator_cap::UnverifiedValidatorOperationCap</a>, new_gas_price: u64)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_set_gas_price">request_set_gas_price</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, cap: &<a href="validator_cap.md#0x3_validator_cap_UnverifiedValidatorOperationCap">validator_cap::UnverifiedValidatorOperationCap</a>, new_gas_price: u64)
 </code></pre>
 
 
@@ -801,7 +1106,7 @@ used for the reference gas price calculation at the end of the epoch.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_set_gas_price">request_set_gas_price</a>(
-    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     cap: &UnverifiedValidatorOperationCap,
     new_gas_price: u64,
 ) {
@@ -824,7 +1129,7 @@ used for the reference gas price calculation at the end of the epoch.
 This function is used to set new gas price for candidate validators
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_set_candidate_validator_gas_price">set_candidate_validator_gas_price</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, cap: &<a href="validator_cap.md#0x3_validator_cap_UnverifiedValidatorOperationCap">validator_cap::UnverifiedValidatorOperationCap</a>, new_gas_price: u64)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_set_candidate_validator_gas_price">set_candidate_validator_gas_price</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, cap: &<a href="validator_cap.md#0x3_validator_cap_UnverifiedValidatorOperationCap">validator_cap::UnverifiedValidatorOperationCap</a>, new_gas_price: u64)
 </code></pre>
 
 
@@ -834,7 +1139,7 @@ This function is used to set new gas price for candidate validators
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_set_candidate_validator_gas_price">set_candidate_validator_gas_price</a>(
-    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     cap: &UnverifiedValidatorOperationCap,
     new_gas_price: u64,
 ) {
@@ -857,7 +1162,7 @@ A validator can call this function to set a new commission rate, updated at the 
 the epoch.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_set_commission_rate">request_set_commission_rate</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, new_commission_rate: u64, ctx: &<b>mut</b> <a href="_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_set_commission_rate">request_set_commission_rate</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, new_commission_rate: u64, ctx: &<b>mut</b> <a href="_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -867,7 +1172,7 @@ the epoch.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_set_commission_rate">request_set_commission_rate</a>(
-    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     new_commission_rate: u64,
     ctx: &<b>mut</b> TxContext,
 ) {
@@ -890,7 +1195,7 @@ the epoch.
 This function is used to set new commission rate for candidate validators
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_set_candidate_validator_commission_rate">set_candidate_validator_commission_rate</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, new_commission_rate: u64, ctx: &<b>mut</b> <a href="_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_set_candidate_validator_commission_rate">set_candidate_validator_commission_rate</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, new_commission_rate: u64, ctx: &<b>mut</b> <a href="_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -900,7 +1205,7 @@ This function is used to set new commission rate for candidate validators
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_set_candidate_validator_commission_rate">set_candidate_validator_commission_rate</a>(
-    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     new_commission_rate: u64,
     ctx: &<b>mut</b> TxContext,
 ) {
@@ -920,7 +1225,7 @@ This function is used to set new commission rate for candidate validators
 Add stake to a validator's staking pool.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_add_stake">request_add_stake</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, stake: <a href="_Coin">coin::Coin</a>&lt;<a href="_SUI">sui::SUI</a>&gt;, validator_address: <b>address</b>, ctx: &<b>mut</b> <a href="_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_add_stake">request_add_stake</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, stake: <a href="_Coin">coin::Coin</a>&lt;<a href="_SUI">sui::SUI</a>&gt;, validator_address: <b>address</b>, ctx: &<b>mut</b> <a href="_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -930,7 +1235,7 @@ Add stake to a validator's staking pool.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_add_stake">request_add_stake</a>(
-    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     stake: Coin&lt;SUI&gt;,
     validator_address: <b>address</b>,
     ctx: &<b>mut</b> TxContext,
@@ -955,7 +1260,7 @@ Add stake to a validator's staking pool.
 Add stake to a validator's staking pool using multiple coins.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_add_stake_mul_coin">request_add_stake_mul_coin</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, stakes: <a href="">vector</a>&lt;<a href="_Coin">coin::Coin</a>&lt;<a href="_SUI">sui::SUI</a>&gt;&gt;, stake_amount: <a href="_Option">option::Option</a>&lt;u64&gt;, validator_address: <b>address</b>, ctx: &<b>mut</b> <a href="_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_add_stake_mul_coin">request_add_stake_mul_coin</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, stakes: <a href="">vector</a>&lt;<a href="_Coin">coin::Coin</a>&lt;<a href="_SUI">sui::SUI</a>&gt;&gt;, stake_amount: <a href="_Option">option::Option</a>&lt;u64&gt;, validator_address: <b>address</b>, ctx: &<b>mut</b> <a href="_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -965,7 +1270,7 @@ Add stake to a validator's staking pool using multiple coins.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_add_stake_mul_coin">request_add_stake_mul_coin</a>(
-    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     stakes: <a href="">vector</a>&lt;Coin&lt;SUI&gt;&gt;,
     stake_amount: <a href="_Option">option::Option</a>&lt;u64&gt;,
     validator_address: <b>address</b>,
@@ -987,7 +1292,7 @@ Add stake to a validator's staking pool using multiple coins.
 Withdraw some portion of a stake from a validator's staking pool.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_withdraw_stake">request_withdraw_stake</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, staked_sui: <a href="staking_pool.md#0x3_staking_pool_StakedSui">staking_pool::StakedSui</a>, ctx: &<b>mut</b> <a href="_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_withdraw_stake">request_withdraw_stake</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, staked_sui: <a href="staking_pool.md#0x3_staking_pool_StakedSui">staking_pool::StakedSui</a>, ctx: &<b>mut</b> <a href="_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -997,7 +1302,7 @@ Withdraw some portion of a stake from a validator's staking pool.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_request_withdraw_stake">request_withdraw_stake</a>(
-    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     staked_sui: StakedSui,
     ctx: &<b>mut</b> TxContext,
 ) {
@@ -1027,7 +1332,7 @@ Succeeds if all the following are satisfied:
 This function is idempotent.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_report_validator">report_validator</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, cap: &<a href="validator_cap.md#0x3_validator_cap_UnverifiedValidatorOperationCap">validator_cap::UnverifiedValidatorOperationCap</a>, reportee_addr: <b>address</b>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_report_validator">report_validator</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, cap: &<a href="validator_cap.md#0x3_validator_cap_UnverifiedValidatorOperationCap">validator_cap::UnverifiedValidatorOperationCap</a>, reportee_addr: <b>address</b>)
 </code></pre>
 
 
@@ -1037,7 +1342,7 @@ This function is idempotent.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_report_validator">report_validator</a>(
-    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     cap: &UnverifiedValidatorOperationCap,
     reportee_addr: <b>address</b>,
 ) {
@@ -1063,7 +1368,7 @@ Undo a <code>report_validator</code> action. Aborts if
 3. the cap is not valid
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_undo_report_validator">undo_report_validator</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, cap: &<a href="validator_cap.md#0x3_validator_cap_UnverifiedValidatorOperationCap">validator_cap::UnverifiedValidatorOperationCap</a>, reportee_addr: <b>address</b>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_undo_report_validator">undo_report_validator</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, cap: &<a href="validator_cap.md#0x3_validator_cap_UnverifiedValidatorOperationCap">validator_cap::UnverifiedValidatorOperationCap</a>, reportee_addr: <b>address</b>)
 </code></pre>
 
 
@@ -1073,7 +1378,7 @@ Undo a <code>report_validator</code> action. Aborts if
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_undo_report_validator">undo_report_validator</a>(
-    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     cap: &UnverifiedValidatorOperationCap,
     reportee_addr: <b>address</b>,
 ) {
@@ -1168,7 +1473,7 @@ Create a new <code>UnverifiedValidatorOperationCap</code>, transfer it to the
 validator and registers it. The original object is thus revoked.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_rotate_operation_cap">rotate_operation_cap</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, ctx: &<b>mut</b> <a href="_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_rotate_operation_cap">rotate_operation_cap</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, ctx: &<b>mut</b> <a href="_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -1178,7 +1483,7 @@ validator and registers it. The original object is thus revoked.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_rotate_operation_cap">rotate_operation_cap</a>(
-    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     ctx: &<b>mut</b> TxContext,
 ) {
     <b>let</b> <a href="validator.md#0x3_validator">validator</a> = <a href="validator_set.md#0x3_validator_set_get_validator_mut_with_ctx_including_candidates">validator_set::get_validator_mut_with_ctx_including_candidates</a>(&<b>mut</b> self.validators, ctx);
@@ -1197,7 +1502,7 @@ validator and registers it. The original object is thus revoked.
 Update a validator's name.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_name">update_validator_name</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, name: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_name">update_validator_name</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, name: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -1207,7 +1512,7 @@ Update a validator's name.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_name">update_validator_name</a>(
-    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     name: <a href="">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
@@ -1228,7 +1533,7 @@ Update a validator's name.
 Update a validator's description
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_description">update_validator_description</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, description: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_description">update_validator_description</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, description: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -1238,7 +1543,7 @@ Update a validator's description
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_description">update_validator_description</a>(
-    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     description: <a href="">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
@@ -1258,7 +1563,7 @@ Update a validator's description
 Update a validator's image url
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_image_url">update_validator_image_url</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, image_url: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_image_url">update_validator_image_url</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, image_url: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -1268,7 +1573,7 @@ Update a validator's image url
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_image_url">update_validator_image_url</a>(
-    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     image_url: <a href="">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
@@ -1288,7 +1593,7 @@ Update a validator's image url
 Update a validator's project url
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_project_url">update_validator_project_url</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, project_url: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_project_url">update_validator_project_url</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, project_url: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -1298,7 +1603,7 @@ Update a validator's project url
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_project_url">update_validator_project_url</a>(
-    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     project_url: <a href="">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
@@ -1319,7 +1624,7 @@ Update a validator's network address.
 The change will only take effects starting from the next epoch.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_next_epoch_network_address">update_validator_next_epoch_network_address</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, network_address: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_next_epoch_network_address">update_validator_next_epoch_network_address</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, network_address: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -1329,7 +1634,7 @@ The change will only take effects starting from the next epoch.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_next_epoch_network_address">update_validator_next_epoch_network_address</a>(
-    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     network_address: <a href="">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
@@ -1351,7 +1656,7 @@ The change will only take effects starting from the next epoch.
 Update candidate validator's network address.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_candidate_validator_network_address">update_candidate_validator_network_address</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, network_address: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_candidate_validator_network_address">update_candidate_validator_network_address</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, network_address: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -1361,7 +1666,7 @@ Update candidate validator's network address.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_candidate_validator_network_address">update_candidate_validator_network_address</a>(
-    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     network_address: <a href="">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
@@ -1382,7 +1687,7 @@ Update a validator's p2p address.
 The change will only take effects starting from the next epoch.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_next_epoch_p2p_address">update_validator_next_epoch_p2p_address</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, p2p_address: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_next_epoch_p2p_address">update_validator_next_epoch_p2p_address</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, p2p_address: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -1392,7 +1697,7 @@ The change will only take effects starting from the next epoch.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_next_epoch_p2p_address">update_validator_next_epoch_p2p_address</a>(
-    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     p2p_address: <a href="">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
@@ -1414,7 +1719,7 @@ The change will only take effects starting from the next epoch.
 Update candidate validator's p2p address.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_candidate_validator_p2p_address">update_candidate_validator_p2p_address</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, p2p_address: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_candidate_validator_p2p_address">update_candidate_validator_p2p_address</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, p2p_address: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -1424,7 +1729,7 @@ Update candidate validator's p2p address.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_candidate_validator_p2p_address">update_candidate_validator_p2p_address</a>(
-    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     p2p_address: <a href="">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
@@ -1445,7 +1750,7 @@ Update a validator's narwhal primary address.
 The change will only take effects starting from the next epoch.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_next_epoch_primary_address">update_validator_next_epoch_primary_address</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, primary_address: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_next_epoch_primary_address">update_validator_next_epoch_primary_address</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, primary_address: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -1455,7 +1760,7 @@ The change will only take effects starting from the next epoch.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_next_epoch_primary_address">update_validator_next_epoch_primary_address</a>(
-    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     primary_address: <a href="">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
@@ -1475,7 +1780,7 @@ The change will only take effects starting from the next epoch.
 Update candidate validator's narwhal primary address.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_candidate_validator_primary_address">update_candidate_validator_primary_address</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, primary_address: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_candidate_validator_primary_address">update_candidate_validator_primary_address</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, primary_address: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -1485,7 +1790,7 @@ Update candidate validator's narwhal primary address.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_candidate_validator_primary_address">update_candidate_validator_primary_address</a>(
-    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     primary_address: <a href="">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
@@ -1506,7 +1811,7 @@ Update a validator's narwhal worker address.
 The change will only take effects starting from the next epoch.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_next_epoch_worker_address">update_validator_next_epoch_worker_address</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, worker_address: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_next_epoch_worker_address">update_validator_next_epoch_worker_address</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, worker_address: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -1516,7 +1821,7 @@ The change will only take effects starting from the next epoch.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_next_epoch_worker_address">update_validator_next_epoch_worker_address</a>(
-    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     worker_address: <a href="">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
@@ -1536,7 +1841,7 @@ The change will only take effects starting from the next epoch.
 Update candidate validator's narwhal worker address.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_candidate_validator_worker_address">update_candidate_validator_worker_address</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, worker_address: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_candidate_validator_worker_address">update_candidate_validator_worker_address</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, worker_address: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -1546,7 +1851,7 @@ Update candidate validator's narwhal worker address.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_candidate_validator_worker_address">update_candidate_validator_worker_address</a>(
-    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     worker_address: <a href="">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
@@ -1567,7 +1872,7 @@ Update a validator's public key of protocol key and proof of possession.
 The change will only take effects starting from the next epoch.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_next_epoch_protocol_pubkey">update_validator_next_epoch_protocol_pubkey</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, protocol_pubkey: <a href="">vector</a>&lt;u8&gt;, proof_of_possession: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_next_epoch_protocol_pubkey">update_validator_next_epoch_protocol_pubkey</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, protocol_pubkey: <a href="">vector</a>&lt;u8&gt;, proof_of_possession: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -1577,7 +1882,7 @@ The change will only take effects starting from the next epoch.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_next_epoch_protocol_pubkey">update_validator_next_epoch_protocol_pubkey</a>(
-    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     protocol_pubkey: <a href="">vector</a>&lt;u8&gt;,
     proof_of_possession: <a href="">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
@@ -1600,7 +1905,7 @@ The change will only take effects starting from the next epoch.
 Update candidate validator's public key of protocol key and proof of possession.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_candidate_validator_protocol_pubkey">update_candidate_validator_protocol_pubkey</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, protocol_pubkey: <a href="">vector</a>&lt;u8&gt;, proof_of_possession: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_candidate_validator_protocol_pubkey">update_candidate_validator_protocol_pubkey</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, protocol_pubkey: <a href="">vector</a>&lt;u8&gt;, proof_of_possession: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -1610,7 +1915,7 @@ Update candidate validator's public key of protocol key and proof of possession.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_candidate_validator_protocol_pubkey">update_candidate_validator_protocol_pubkey</a>(
-    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     protocol_pubkey: <a href="">vector</a>&lt;u8&gt;,
     proof_of_possession: <a href="">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
@@ -1632,7 +1937,7 @@ Update a validator's public key of worker key.
 The change will only take effects starting from the next epoch.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_next_epoch_worker_pubkey">update_validator_next_epoch_worker_pubkey</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, worker_pubkey: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_next_epoch_worker_pubkey">update_validator_next_epoch_worker_pubkey</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, worker_pubkey: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -1642,7 +1947,7 @@ The change will only take effects starting from the next epoch.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_next_epoch_worker_pubkey">update_validator_next_epoch_worker_pubkey</a>(
-    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     worker_pubkey: <a href="">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
@@ -1664,7 +1969,7 @@ The change will only take effects starting from the next epoch.
 Update candidate validator's public key of worker key.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_candidate_validator_worker_pubkey">update_candidate_validator_worker_pubkey</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, worker_pubkey: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_candidate_validator_worker_pubkey">update_candidate_validator_worker_pubkey</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, worker_pubkey: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -1674,7 +1979,7 @@ Update candidate validator's public key of worker key.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_candidate_validator_worker_pubkey">update_candidate_validator_worker_pubkey</a>(
-    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     worker_pubkey: <a href="">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
@@ -1695,7 +2000,7 @@ Update a validator's public key of network key.
 The change will only take effects starting from the next epoch.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_next_epoch_network_pubkey">update_validator_next_epoch_network_pubkey</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, network_pubkey: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_next_epoch_network_pubkey">update_validator_next_epoch_network_pubkey</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, network_pubkey: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -1705,7 +2010,7 @@ The change will only take effects starting from the next epoch.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_validator_next_epoch_network_pubkey">update_validator_next_epoch_network_pubkey</a>(
-    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     network_pubkey: <a href="">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
@@ -1727,7 +2032,7 @@ The change will only take effects starting from the next epoch.
 Update candidate validator's public key of network key.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_candidate_validator_network_pubkey">update_candidate_validator_network_pubkey</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, network_pubkey: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_candidate_validator_network_pubkey">update_candidate_validator_network_pubkey</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, network_pubkey: <a href="">vector</a>&lt;u8&gt;, ctx: &<a href="_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -1737,7 +2042,7 @@ Update candidate validator's public key of network key.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_update_candidate_validator_network_pubkey">update_candidate_validator_network_pubkey</a>(
-    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     network_pubkey: <a href="">vector</a>&lt;u8&gt;,
     ctx: &TxContext,
 ) {
@@ -1763,7 +2068,7 @@ gas coins.
 4. Update all validators.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_advance_epoch">advance_epoch</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, new_epoch: u64, next_protocol_version: u64, storage_reward: <a href="_Balance">balance::Balance</a>&lt;<a href="_SUI">sui::SUI</a>&gt;, computation_reward: <a href="_Balance">balance::Balance</a>&lt;<a href="_SUI">sui::SUI</a>&gt;, storage_rebate_amount: u64, non_refundable_storage_fee_amount: u64, storage_fund_reinvest_rate: u64, reward_slashing_rate: u64, epoch_start_timestamp_ms: u64, ctx: &<b>mut</b> <a href="_TxContext">tx_context::TxContext</a>): <a href="_Balance">balance::Balance</a>&lt;<a href="_SUI">sui::SUI</a>&gt;
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_advance_epoch">advance_epoch</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, new_epoch: u64, next_protocol_version: u64, storage_reward: <a href="_Balance">balance::Balance</a>&lt;<a href="_SUI">sui::SUI</a>&gt;, computation_reward: <a href="_Balance">balance::Balance</a>&lt;<a href="_SUI">sui::SUI</a>&gt;, storage_rebate_amount: u64, non_refundable_storage_fee_amount: u64, storage_fund_reinvest_rate: u64, reward_slashing_rate: u64, epoch_start_timestamp_ms: u64, ctx: &<b>mut</b> <a href="_TxContext">tx_context::TxContext</a>): <a href="_Balance">balance::Balance</a>&lt;<a href="_SUI">sui::SUI</a>&gt;
 </code></pre>
 
 
@@ -1773,7 +2078,7 @@ gas coins.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_advance_epoch">advance_epoch</a>(
-    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     new_epoch: u64,
     next_protocol_version: u64,
     storage_reward: Balance&lt;SUI&gt;,
@@ -1927,7 +2232,7 @@ system running and continue making epoch changes.
 version
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_advance_epoch_safe_mode">advance_epoch_safe_mode</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, new_epoch: u64, next_protocol_version: u64, storage_reward: <a href="_Balance">balance::Balance</a>&lt;<a href="_SUI">sui::SUI</a>&gt;, computation_reward: <a href="_Balance">balance::Balance</a>&lt;<a href="_SUI">sui::SUI</a>&gt;, storage_rebate: u64, non_refundable_storage_fee: u64, epoch_start_timestamp_ms: u64, ctx: &<b>mut</b> <a href="_TxContext">tx_context::TxContext</a>)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_advance_epoch_safe_mode">advance_epoch_safe_mode</a>(self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, new_epoch: u64, next_protocol_version: u64, storage_reward: <a href="_Balance">balance::Balance</a>&lt;<a href="_SUI">sui::SUI</a>&gt;, computation_reward: <a href="_Balance">balance::Balance</a>&lt;<a href="_SUI">sui::SUI</a>&gt;, storage_rebate: u64, non_refundable_storage_fee: u64, epoch_start_timestamp_ms: u64, ctx: &<b>mut</b> <a href="_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -1937,7 +2242,7 @@ version
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_advance_epoch_safe_mode">advance_epoch_safe_mode</a>(
-    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>,
+    self: &<b>mut</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>,
     new_epoch: u64,
     next_protocol_version: u64,
     storage_reward: Balance&lt;SUI&gt;,
@@ -1974,7 +2279,7 @@ Return the current epoch number. Useful for applications that need a coarse-grai
 since epochs are ever-increasing and epoch changes are intended to happen every 24 hours.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_epoch">epoch</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>): u64
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_epoch">epoch</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>): u64
 </code></pre>
 
 
@@ -1983,7 +2288,7 @@ since epochs are ever-increasing and epoch changes are intended to happen every 
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_epoch">epoch</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>): u64 {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_epoch">epoch</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>): u64 {
     self.epoch
 }
 </code></pre>
@@ -1998,7 +2303,7 @@ since epochs are ever-increasing and epoch changes are intended to happen every 
 
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_protocol_version">protocol_version</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>): u64
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_protocol_version">protocol_version</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>): u64
 </code></pre>
 
 
@@ -2007,7 +2312,7 @@ since epochs are ever-increasing and epoch changes are intended to happen every 
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_protocol_version">protocol_version</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>): u64 {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_protocol_version">protocol_version</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>): u64 {
     self.protocol_version
 }
 </code></pre>
@@ -2022,7 +2327,7 @@ since epochs are ever-increasing and epoch changes are intended to happen every 
 
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_system_state_version">system_state_version</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>): u64
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_system_state_version">system_state_version</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>): u64
 </code></pre>
 
 
@@ -2031,7 +2336,7 @@ since epochs are ever-increasing and epoch changes are intended to happen every 
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_system_state_version">system_state_version</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>): u64 {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_system_state_version">system_state_version</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>): u64 {
     self.system_state_version
 }
 </code></pre>
@@ -2073,7 +2378,7 @@ It should never change for a given network.
 Returns unix timestamp of the start of current epoch
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_epoch_start_timestamp_ms">epoch_start_timestamp_ms</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>): u64
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_epoch_start_timestamp_ms">epoch_start_timestamp_ms</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>): u64
 </code></pre>
 
 
@@ -2082,7 +2387,7 @@ Returns unix timestamp of the start of current epoch
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_epoch_start_timestamp_ms">epoch_start_timestamp_ms</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>): u64 {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_epoch_start_timestamp_ms">epoch_start_timestamp_ms</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>): u64 {
     self.epoch_start_timestamp_ms
 }
 </code></pre>
@@ -2099,7 +2404,7 @@ Returns the total amount staked with <code>validator_addr</code>.
 Aborts if <code>validator_addr</code> is not an active validator.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_validator_stake_amount">validator_stake_amount</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, validator_addr: <b>address</b>): u64
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_validator_stake_amount">validator_stake_amount</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, validator_addr: <b>address</b>): u64
 </code></pre>
 
 
@@ -2108,7 +2413,7 @@ Aborts if <code>validator_addr</code> is not an active validator.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_validator_stake_amount">validator_stake_amount</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>, validator_addr: <b>address</b>): u64 {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_validator_stake_amount">validator_stake_amount</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>, validator_addr: <b>address</b>): u64 {
     <a href="validator_set.md#0x3_validator_set_validator_total_stake_amount">validator_set::validator_total_stake_amount</a>(&self.validators, validator_addr)
 }
 </code></pre>
@@ -2125,7 +2430,7 @@ Returns the staking pool id of a given validator.
 Aborts if <code>validator_addr</code> is not an active validator.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_validator_staking_pool_id">validator_staking_pool_id</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, validator_addr: <b>address</b>): <a href="_ID">object::ID</a>
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_validator_staking_pool_id">validator_staking_pool_id</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, validator_addr: <b>address</b>): <a href="_ID">object::ID</a>
 </code></pre>
 
 
@@ -2134,7 +2439,7 @@ Aborts if <code>validator_addr</code> is not an active validator.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_validator_staking_pool_id">validator_staking_pool_id</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>, validator_addr: <b>address</b>): ID {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_validator_staking_pool_id">validator_staking_pool_id</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>, validator_addr: <b>address</b>): ID {
 
     <a href="validator_set.md#0x3_validator_set_validator_staking_pool_id">validator_set::validator_staking_pool_id</a>(&self.validators, validator_addr)
 }
@@ -2151,7 +2456,7 @@ Aborts if <code>validator_addr</code> is not an active validator.
 Returns reference to the staking pool mappings that map pool ids to active validator addresses
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_validator_staking_pool_mappings">validator_staking_pool_mappings</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>): &<a href="_Table">table::Table</a>&lt;<a href="_ID">object::ID</a>, <b>address</b>&gt;
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_validator_staking_pool_mappings">validator_staking_pool_mappings</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>): &<a href="_Table">table::Table</a>&lt;<a href="_ID">object::ID</a>, <b>address</b>&gt;
 </code></pre>
 
 
@@ -2160,7 +2465,7 @@ Returns reference to the staking pool mappings that map pool ids to active valid
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_validator_staking_pool_mappings">validator_staking_pool_mappings</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>): &Table&lt;ID, <b>address</b>&gt; {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_validator_staking_pool_mappings">validator_staking_pool_mappings</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>): &Table&lt;ID, <b>address</b>&gt; {
 
     <a href="validator_set.md#0x3_validator_set_staking_pool_mappings">validator_set::staking_pool_mappings</a>(&self.validators)
 }
@@ -2177,7 +2482,7 @@ Returns reference to the staking pool mappings that map pool ids to active valid
 Returns all the validators who are currently reporting <code>addr</code>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_get_reporters_of">get_reporters_of</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>, addr: <b>address</b>): <a href="_VecSet">vec_set::VecSet</a>&lt;<b>address</b>&gt;
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_get_reporters_of">get_reporters_of</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>, addr: <b>address</b>): <a href="_VecSet">vec_set::VecSet</a>&lt;<b>address</b>&gt;
 </code></pre>
 
 
@@ -2186,7 +2491,7 @@ Returns all the validators who are currently reporting <code>addr</code>
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_get_reporters_of">get_reporters_of</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>, addr: <b>address</b>): VecSet&lt;<b>address</b>&gt; {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_get_reporters_of">get_reporters_of</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>, addr: <b>address</b>): VecSet&lt;<b>address</b>&gt; {
 
     <b>if</b> (<a href="_contains">vec_map::contains</a>(&self.validator_report_records, &addr)) {
         *<a href="_get">vec_map::get</a>(&self.validator_report_records, &addr)
@@ -2206,7 +2511,7 @@ Returns all the validators who are currently reporting <code>addr</code>
 
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_get_storage_fund_total_balance">get_storage_fund_total_balance</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>): u64
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_get_storage_fund_total_balance">get_storage_fund_total_balance</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>): u64
 </code></pre>
 
 
@@ -2215,7 +2520,7 @@ Returns all the validators who are currently reporting <code>addr</code>
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_get_storage_fund_total_balance">get_storage_fund_total_balance</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>): u64 {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_get_storage_fund_total_balance">get_storage_fund_total_balance</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>): u64 {
     <a href="storage_fund.md#0x3_storage_fund_total_balance">storage_fund::total_balance</a>(&self.<a href="storage_fund.md#0x3_storage_fund">storage_fund</a>)
 }
 </code></pre>
@@ -2230,7 +2535,7 @@ Returns all the validators who are currently reporting <code>addr</code>
 
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_get_storage_fund_object_rebates">get_storage_fund_object_rebates</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">sui_system_state_inner::SuiSystemStateInner</a>): u64
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_get_storage_fund_object_rebates">get_storage_fund_object_rebates</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">sui_system_state_inner::SuiSystemStateInnerV2</a>): u64
 </code></pre>
 
 
@@ -2239,7 +2544,7 @@ Returns all the validators who are currently reporting <code>addr</code>
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_get_storage_fund_object_rebates">get_storage_fund_object_rebates</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInner">SuiSystemStateInner</a>): u64 {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="sui_system_state_inner.md#0x3_sui_system_state_inner_get_storage_fund_object_rebates">get_storage_fund_object_rebates</a>(self: &<a href="sui_system_state_inner.md#0x3_sui_system_state_inner_SuiSystemStateInnerV2">SuiSystemStateInnerV2</a>): u64 {
     <a href="storage_fund.md#0x3_storage_fund_total_object_storage_rebates">storage_fund::total_object_storage_rebates</a>(&self.<a href="storage_fund.md#0x3_storage_fund">storage_fund</a>)
 }
 </code></pre>

--- a/crates/sui-framework/packages/sui-system/sources/sui_system.move
+++ b/crates/sui-framework/packages/sui-system/sources/sui_system.move
@@ -49,7 +49,7 @@ module sui_system::sui_system {
     use sui::tx_context::{Self, TxContext};
     use sui_system::validator::Validator;
     use sui_system::validator_cap::UnverifiedValidatorOperationCap;
-    use sui_system::sui_system_state_inner::{Self, SystemParameters, SuiSystemStateInner};
+    use sui_system::sui_system_state_inner::{Self, SystemParameters, SuiSystemStateInnerV2};
     use sui_system::stake_subsidy::StakeSubsidy;
     use std::option;
     use sui::dynamic_field;
@@ -567,25 +567,23 @@ module sui_system::sui_system {
         )
     }
 
-    fun load_system_state(self: &mut SuiSystemState): &SuiSystemStateInner {
+    fun load_system_state(self: &mut SuiSystemState): &SuiSystemStateInnerV2 {
         load_inner_maybe_upgrade(self)
     }
 
-    fun load_system_state_mut(self: &mut SuiSystemState): &mut SuiSystemStateInner {
+    fun load_system_state_mut(self: &mut SuiSystemState): &mut SuiSystemStateInnerV2 {
         load_inner_maybe_upgrade(self)
     }
 
-    fun load_inner_maybe_upgrade(self: &mut SuiSystemState): &mut SuiSystemStateInner {
-        // TODO: This is where we check the version and perform upgrade if necessary.
-        // if (self.version == 1) {
-        //   let v1 = dynamic_field::remove(&mut self.id, self.version);
-        //   let v2 = sui_system_state_inner::v1_to_v2(v1);
-        //   assert!(v2.system_state_version = 2, EWrongInnerVersion);
-        //   self.version = 2;
-        //   dynamic_field::add(&mut self.id, self.version, v2);
-        // }
+    fun load_inner_maybe_upgrade(self: &mut SuiSystemState): &mut SuiSystemStateInnerV2 {
+        if (self.version == 1) {
+          let v1 = dynamic_field::remove(&mut self.id, self.version);
+          let v2 = sui_system_state_inner::v1_to_v2(v1);
+          self.version = 2;
+          dynamic_field::add(&mut self.id, self.version, v2);
+        };
 
-        let inner: &mut SuiSystemStateInner = dynamic_field::borrow_mut(&mut self.id, self.version);
+        let inner = dynamic_field::borrow_mut(&mut self.id, self.version);
         assert!(sui_system_state_inner::system_state_version(inner) == self.version, EWrongInnerVersion);
         inner
     }

--- a/crates/sui-framework/packages/sui-system/sources/sui_system_state_inner.move
+++ b/crates/sui-framework/packages/sui-system/sources/sui_system_state_inner.move
@@ -72,6 +72,41 @@ module sui_system::sui_system_state_inner {
         extra_fields: Bag,
     }
 
+    /// Added min_validator_count.
+    struct SystemParametersV2 has store {
+        /// The duration of an epoch, in milliseconds.
+        epoch_duration_ms: u64,
+
+        /// The starting epoch in which stake subsidies start being paid out
+        stake_subsidy_start_epoch: u64,
+
+        /// Minimum number of active validators at any moment.
+        min_validator_count: u64,
+
+        /// Maximum number of active validators at any moment.
+        /// We do not allow the number of validators in any epoch to go above this.
+        max_validator_count: u64,
+
+        /// Lower-bound on the amount of stake required to become a validator.
+        min_validator_joining_stake: u64,
+
+        /// Validators with stake amount below `validator_low_stake_threshold` are considered to
+        /// have low stake and will be escorted out of the validator set after being below this
+        /// threshold for more than `validator_low_stake_grace_period` number of epochs.
+        validator_low_stake_threshold: u64,
+
+        /// Validators with stake below `validator_very_low_stake_threshold` will be removed
+        /// immediately at epoch change, no grace period.
+        validator_very_low_stake_threshold: u64,
+
+        /// A validator can have stake below `validator_low_stake_threshold`
+        /// for this many epochs before being kicked out.
+        validator_low_stake_grace_period: u64,
+
+        /// Any extra fields that's not defined statically.
+        extra_fields: Bag,
+    }
+
     /// The top-level object containing all information of the Sui system.
     struct SuiSystemStateInner has store {
         /// The current epoch ID, starting from 0.
@@ -88,6 +123,54 @@ module sui_system::sui_system_state_inner {
         storage_fund: StorageFund,
         /// A list of system config parameters.
         parameters: SystemParameters,
+        /// The reference gas price for the current epoch.
+        reference_gas_price: u64,
+        /// A map storing the records of validator reporting each other.
+        /// There is an entry in the map for each validator that has been reported
+        /// at least once. The entry VecSet contains all the validators that reported
+        /// them. If a validator has never been reported they don't have an entry in this map.
+        /// This map persists across epoch: a peer continues being in a reported state until the
+        /// reporter doesn't explicitly remove their report.
+        /// Note that in case we want to support validator address change in future,
+        /// the reports should be based on validator ids
+        validator_report_records: VecMap<address, VecSet<address>>,
+        /// Schedule of stake subsidies given out each epoch.
+        stake_subsidy: StakeSubsidy,
+
+        /// Whether the system is running in a downgraded safe mode due to a non-recoverable bug.
+        /// This is set whenever we failed to execute advance_epoch, and ended up executing advance_epoch_safe_mode.
+        /// It can be reset once we are able to successfully execute advance_epoch.
+        /// The rest of the fields starting with `safe_mode_` are accmulated during safe mode
+        /// when advance_epoch_safe_mode is executed. They will eventually be processed once we
+        /// are out of safe mode.
+        safe_mode: bool,
+        safe_mode_storage_rewards: Balance<SUI>,
+        safe_mode_computation_rewards: Balance<SUI>,
+        safe_mode_storage_rebates: u64,
+        safe_mode_non_refundable_storage_fee: u64,
+
+        /// Unix timestamp of the current epoch start
+        epoch_start_timestamp_ms: u64,
+        /// Any extra fields that's not defined statically.
+        extra_fields: Bag,
+    }
+
+    /// Uses SystemParametersV2 as the parameters.
+    struct SuiSystemStateInnerV2 has store {
+        /// The current epoch ID, starting from 0.
+        epoch: u64,
+        /// The current protocol version, starting from 1.
+        protocol_version: u64,
+        /// The current version of the system state data structure type.
+        /// This is always the same as SuiSystemState.version. Keeping a copy here so that
+        /// we know what version it is by inspecting SuiSystemStateInner as well.
+        system_state_version: u64,
+        /// Contains all information about the validators.
+        validators: ValidatorSet,
+        /// The storage fund.
+        storage_fund: StorageFund,
+        /// A list of system config parameters.
+        parameters: SystemParametersV2,
         /// The reference gas price for the current epoch.
         reference_gas_price: u64,
         /// A map storing the records of validator reporting each other.
@@ -211,6 +294,65 @@ module sui_system::sui_system_state_inner {
         }
     }
 
+    public(friend) fun v1_to_v2(self: SuiSystemStateInner): SuiSystemStateInnerV2 {
+        let SuiSystemStateInner {
+            epoch,
+            protocol_version,
+            system_state_version: _,
+            validators,
+            storage_fund,
+            parameters,
+            reference_gas_price,
+            validator_report_records,
+            stake_subsidy,
+            safe_mode,
+            safe_mode_storage_rewards,
+            safe_mode_computation_rewards,
+            safe_mode_storage_rebates,
+            safe_mode_non_refundable_storage_fee,
+            epoch_start_timestamp_ms,
+            extra_fields: state_extra_fields,
+        } = self;
+        let SystemParameters {
+            epoch_duration_ms,
+            stake_subsidy_start_epoch,
+            max_validator_count,
+            min_validator_joining_stake,
+            validator_low_stake_threshold,
+            validator_very_low_stake_threshold,
+            validator_low_stake_grace_period,
+            extra_fields: param_extra_fields,
+        } = parameters;
+        SuiSystemStateInnerV2 {
+            epoch,
+            protocol_version,
+            system_state_version: 2,
+            validators,
+            storage_fund,
+            parameters: SystemParametersV2 {
+                epoch_duration_ms,
+                stake_subsidy_start_epoch,
+                min_validator_count: 4,
+                max_validator_count,
+                min_validator_joining_stake,
+                validator_low_stake_threshold,
+                validator_very_low_stake_threshold,
+                validator_low_stake_grace_period,
+                extra_fields: param_extra_fields,
+            },
+            reference_gas_price,
+            validator_report_records,
+            stake_subsidy,
+            safe_mode,
+            safe_mode_storage_rewards,
+            safe_mode_computation_rewards,
+            safe_mode_storage_rebates,
+            safe_mode_non_refundable_storage_fee,
+            epoch_start_timestamp_ms,
+            extra_fields: state_extra_fields
+        }
+    }
+
     // ==== public(friend) functions ====
 
     /// Can be called by anyone who wishes to become a validator candidate and starts accuring delegated
@@ -220,7 +362,7 @@ module sui_system::sui_system_state_inner {
     /// Note: `proof_of_possession` MUST be a valid signature using sui_address and protocol_pubkey_bytes.
     /// To produce a valid PoP, run [fn test_proof_of_possession].
     public(friend) fun request_add_validator_candidate(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         pubkey_bytes: vector<u8>,
         network_pubkey_bytes: vector<u8>,
         worker_pubkey_bytes: vector<u8>,
@@ -262,7 +404,7 @@ module sui_system::sui_system_state_inner {
     /// Called by a validator candidate to remove themselves from the candidacy. After this call
     /// their staking pool becomes deactivate.
     public(friend) fun request_remove_validator_candidate(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         ctx: &mut TxContext,
     ) {
         validator_set::request_remove_validator_candidate(&mut self.validators, ctx);
@@ -273,7 +415,7 @@ module sui_system::sui_system_state_inner {
     /// stake the validator has doesn't meet the min threshold, or if the number of new validators for the next
     /// epoch has already reached the maximum.
     public(friend) fun request_add_validator(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         ctx: &mut TxContext,
     ) {
         assert!(
@@ -290,9 +432,19 @@ module sui_system::sui_system_state_inner {
     /// At the end of the epoch, the `validator` object will be returned to the sui_address
     /// of the validator.
     public(friend) fun request_remove_validator(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         ctx: &mut TxContext,
     ) {
+        // Only check min validator condition if the current number of validators satisfy the constraint.
+        // This is so that if we somehow already are in a state where we have less than min validators, it no longer matters
+        // and is ok to stay so. This is useful for a test setup.
+        if (vector::length(validator_set::active_validators(&self.validators)) >= self.parameters.min_validator_count) {
+            assert!(
+                validator_set::next_epoch_validator_count(&self.validators) > self.parameters.min_validator_count,
+                ELimitExceeded,
+            );
+        };
+
         validator_set::request_remove_validator(
             &mut self.validators,
             ctx,
@@ -302,7 +454,7 @@ module sui_system::sui_system_state_inner {
     /// A validator can call this function to submit a new gas price quote, to be
     /// used for the reference gas price calculation at the end of the epoch.
     public(friend) fun request_set_gas_price(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         cap: &UnverifiedValidatorOperationCap,
         new_gas_price: u64,
     ) {
@@ -315,7 +467,7 @@ module sui_system::sui_system_state_inner {
 
     /// This function is used to set new gas price for candidate validators
     public(friend) fun set_candidate_validator_gas_price(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         cap: &UnverifiedValidatorOperationCap,
         new_gas_price: u64,
     ) {
@@ -328,7 +480,7 @@ module sui_system::sui_system_state_inner {
     /// A validator can call this function to set a new commission rate, updated at the end of
     /// the epoch.
     public(friend) fun request_set_commission_rate(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         new_commission_rate: u64,
         ctx: &mut TxContext,
     ) {
@@ -341,7 +493,7 @@ module sui_system::sui_system_state_inner {
 
     /// This function is used to set new commission rate for candidate validators
     public(friend) fun set_candidate_validator_commission_rate(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         new_commission_rate: u64,
         ctx: &mut TxContext,
     ) {
@@ -351,7 +503,7 @@ module sui_system::sui_system_state_inner {
 
     /// Add stake to a validator's staking pool.
     public(friend) fun request_add_stake(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         stake: Coin<SUI>,
         validator_address: address,
         ctx: &mut TxContext,
@@ -366,7 +518,7 @@ module sui_system::sui_system_state_inner {
 
     /// Add stake to a validator's staking pool using multiple coins.
     public(friend) fun request_add_stake_mul_coin(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         stakes: vector<Coin<SUI>>,
         stake_amount: option::Option<u64>,
         validator_address: address,
@@ -378,7 +530,7 @@ module sui_system::sui_system_state_inner {
 
     /// Withdraw some portion of a stake from a validator's staking pool.
     public(friend) fun request_withdraw_stake(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         staked_sui: StakedSui,
         ctx: &mut TxContext,
     ) {
@@ -398,7 +550,7 @@ module sui_system::sui_system_state_inner {
     /// 3. the cap object is still valid.
     /// This function is idempotent.
     public(friend) fun report_validator(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         cap: &UnverifiedValidatorOperationCap,
         reportee_addr: address,
     ) {
@@ -415,7 +567,7 @@ module sui_system::sui_system_state_inner {
     /// 2. the sender has not previously reported the `reportee_addr`, or
     /// 3. the cap is not valid
     public(friend) fun undo_report_validator(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         cap: &UnverifiedValidatorOperationCap,
         reportee_addr: address,
     ) {
@@ -462,7 +614,7 @@ module sui_system::sui_system_state_inner {
     /// Create a new `UnverifiedValidatorOperationCap`, transfer it to the
     /// validator and registers it. The original object is thus revoked.
     public(friend) fun rotate_operation_cap(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         ctx: &mut TxContext,
     ) {
         let validator = validator_set::get_validator_mut_with_ctx_including_candidates(&mut self.validators, ctx);
@@ -471,7 +623,7 @@ module sui_system::sui_system_state_inner {
 
     /// Update a validator's name.
     public(friend) fun update_validator_name(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         name: vector<u8>,
         ctx: &TxContext,
     ) {
@@ -482,7 +634,7 @@ module sui_system::sui_system_state_inner {
 
     /// Update a validator's description
     public(friend) fun update_validator_description(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         description: vector<u8>,
         ctx: &TxContext,
     ) {
@@ -492,7 +644,7 @@ module sui_system::sui_system_state_inner {
 
     /// Update a validator's image url
     public(friend) fun update_validator_image_url(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         image_url: vector<u8>,
         ctx: &TxContext,
     ) {
@@ -502,7 +654,7 @@ module sui_system::sui_system_state_inner {
 
     /// Update a validator's project url
     public(friend) fun update_validator_project_url(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         project_url: vector<u8>,
         ctx: &TxContext,
     ) {
@@ -513,7 +665,7 @@ module sui_system::sui_system_state_inner {
     /// Update a validator's network address.
     /// The change will only take effects starting from the next epoch.
     public(friend) fun update_validator_next_epoch_network_address(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         network_address: vector<u8>,
         ctx: &TxContext,
     ) {
@@ -525,7 +677,7 @@ module sui_system::sui_system_state_inner {
 
     /// Update candidate validator's network address.
     public(friend) fun update_candidate_validator_network_address(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         network_address: vector<u8>,
         ctx: &TxContext,
     ) {
@@ -536,7 +688,7 @@ module sui_system::sui_system_state_inner {
     /// Update a validator's p2p address.
     /// The change will only take effects starting from the next epoch.
     public(friend) fun update_validator_next_epoch_p2p_address(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         p2p_address: vector<u8>,
         ctx: &TxContext,
     ) {
@@ -548,7 +700,7 @@ module sui_system::sui_system_state_inner {
 
     /// Update candidate validator's p2p address.
     public(friend) fun update_candidate_validator_p2p_address(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         p2p_address: vector<u8>,
         ctx: &TxContext,
     ) {
@@ -559,7 +711,7 @@ module sui_system::sui_system_state_inner {
     /// Update a validator's narwhal primary address.
     /// The change will only take effects starting from the next epoch.
     public(friend) fun update_validator_next_epoch_primary_address(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         primary_address: vector<u8>,
         ctx: &TxContext,
     ) {
@@ -569,7 +721,7 @@ module sui_system::sui_system_state_inner {
 
     /// Update candidate validator's narwhal primary address.
     public(friend) fun update_candidate_validator_primary_address(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         primary_address: vector<u8>,
         ctx: &TxContext,
     ) {
@@ -580,7 +732,7 @@ module sui_system::sui_system_state_inner {
     /// Update a validator's narwhal worker address.
     /// The change will only take effects starting from the next epoch.
     public(friend) fun update_validator_next_epoch_worker_address(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         worker_address: vector<u8>,
         ctx: &TxContext,
     ) {
@@ -590,7 +742,7 @@ module sui_system::sui_system_state_inner {
 
     /// Update candidate validator's narwhal worker address.
     public(friend) fun update_candidate_validator_worker_address(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         worker_address: vector<u8>,
         ctx: &TxContext,
     ) {
@@ -601,7 +753,7 @@ module sui_system::sui_system_state_inner {
     /// Update a validator's public key of protocol key and proof of possession.
     /// The change will only take effects starting from the next epoch.
     public(friend) fun update_validator_next_epoch_protocol_pubkey(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         protocol_pubkey: vector<u8>,
         proof_of_possession: vector<u8>,
         ctx: &TxContext,
@@ -614,7 +766,7 @@ module sui_system::sui_system_state_inner {
 
     /// Update candidate validator's public key of protocol key and proof of possession.
     public(friend) fun update_candidate_validator_protocol_pubkey(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         protocol_pubkey: vector<u8>,
         proof_of_possession: vector<u8>,
         ctx: &TxContext,
@@ -626,7 +778,7 @@ module sui_system::sui_system_state_inner {
     /// Update a validator's public key of worker key.
     /// The change will only take effects starting from the next epoch.
     public(friend) fun update_validator_next_epoch_worker_pubkey(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         worker_pubkey: vector<u8>,
         ctx: &TxContext,
     ) {
@@ -638,7 +790,7 @@ module sui_system::sui_system_state_inner {
 
     /// Update candidate validator's public key of worker key.
     public(friend) fun update_candidate_validator_worker_pubkey(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         worker_pubkey: vector<u8>,
         ctx: &TxContext,
     ) {
@@ -649,7 +801,7 @@ module sui_system::sui_system_state_inner {
     /// Update a validator's public key of network key.
     /// The change will only take effects starting from the next epoch.
     public(friend) fun update_validator_next_epoch_network_pubkey(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         network_pubkey: vector<u8>,
         ctx: &TxContext,
     ) {
@@ -661,7 +813,7 @@ module sui_system::sui_system_state_inner {
 
     /// Update candidate validator's public key of network key.
     public(friend) fun update_candidate_validator_network_pubkey(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         network_pubkey: vector<u8>,
         ctx: &TxContext,
     ) {
@@ -677,7 +829,7 @@ module sui_system::sui_system_state_inner {
     /// 3. Distribute computation charge to validator stake.
     /// 4. Update all validators.
     public(friend) fun advance_epoch(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         new_epoch: u64,
         next_protocol_version: u64,
         storage_reward: Balance<SUI>,
@@ -821,7 +973,7 @@ module sui_system::sui_system_state_inner {
     ///   - When advancing to a new protocol version, we want to be able to change the protocol
     ///     version
     public(friend) fun advance_epoch_safe_mode(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         new_epoch: u64,
         next_protocol_version: u64,
         storage_reward: Balance<SUI>,
@@ -847,15 +999,15 @@ module sui_system::sui_system_state_inner {
 
     /// Return the current epoch number. Useful for applications that need a coarse-grained concept of time,
     /// since epochs are ever-increasing and epoch changes are intended to happen every 24 hours.
-    public(friend) fun epoch(self: &SuiSystemStateInner): u64 {
+    public(friend) fun epoch(self: &SuiSystemStateInnerV2): u64 {
         self.epoch
     }
 
-    public(friend) fun protocol_version(self: &SuiSystemStateInner): u64 {
+    public(friend) fun protocol_version(self: &SuiSystemStateInnerV2): u64 {
         self.protocol_version
     }
 
-    public(friend) fun system_state_version(self: &SuiSystemStateInner): u64 {
+    public(friend) fun system_state_version(self: &SuiSystemStateInnerV2): u64 {
         self.system_state_version
     }
 
@@ -866,31 +1018,31 @@ module sui_system::sui_system_state_inner {
     }
 
     /// Returns unix timestamp of the start of current epoch
-    public(friend) fun epoch_start_timestamp_ms(self: &SuiSystemStateInner): u64 {
+    public(friend) fun epoch_start_timestamp_ms(self: &SuiSystemStateInnerV2): u64 {
         self.epoch_start_timestamp_ms
     }
 
     /// Returns the total amount staked with `validator_addr`.
     /// Aborts if `validator_addr` is not an active validator.
-    public(friend) fun validator_stake_amount(self: &SuiSystemStateInner, validator_addr: address): u64 {
+    public(friend) fun validator_stake_amount(self: &SuiSystemStateInnerV2, validator_addr: address): u64 {
         validator_set::validator_total_stake_amount(&self.validators, validator_addr)
     }
 
     /// Returns the staking pool id of a given validator.
     /// Aborts if `validator_addr` is not an active validator.
-    public(friend) fun validator_staking_pool_id(self: &SuiSystemStateInner, validator_addr: address): ID {
+    public(friend) fun validator_staking_pool_id(self: &SuiSystemStateInnerV2, validator_addr: address): ID {
 
         validator_set::validator_staking_pool_id(&self.validators, validator_addr)
     }
 
     /// Returns reference to the staking pool mappings that map pool ids to active validator addresses
-    public(friend) fun validator_staking_pool_mappings(self: &SuiSystemStateInner): &Table<ID, address> {
+    public(friend) fun validator_staking_pool_mappings(self: &SuiSystemStateInnerV2): &Table<ID, address> {
 
         validator_set::staking_pool_mappings(&self.validators)
     }
 
     /// Returns all the validators who are currently reporting `addr`
-    public(friend) fun get_reporters_of(self: &SuiSystemStateInner, addr: address): VecSet<address> {
+    public(friend) fun get_reporters_of(self: &SuiSystemStateInnerV2, addr: address): VecSet<address> {
 
         if (vec_map::contains(&self.validator_report_records, &addr)) {
             *vec_map::get(&self.validator_report_records, &addr)
@@ -899,11 +1051,11 @@ module sui_system::sui_system_state_inner {
         }
     }
 
-    public(friend) fun get_storage_fund_total_balance(self: &SuiSystemStateInner): u64 {
+    public(friend) fun get_storage_fund_total_balance(self: &SuiSystemStateInnerV2): u64 {
         storage_fund::total_balance(&self.storage_fund)
     }
 
-    public(friend) fun get_storage_fund_object_rebates(self: &SuiSystemStateInner): u64 {
+    public(friend) fun get_storage_fund_object_rebates(self: &SuiSystemStateInnerV2): u64 {
         storage_fund::total_object_storage_rebates(&self.storage_fund)
     }
 
@@ -931,36 +1083,36 @@ module sui_system::sui_system_state_inner {
 
     #[test_only]
     /// Return the current validator set
-    public(friend) fun validators(self: &SuiSystemStateInner): &ValidatorSet {
+    public(friend) fun validators(self: &SuiSystemStateInnerV2): &ValidatorSet {
         &self.validators
     }
 
     #[test_only]
     /// Return the currently active validator by address
-    public(friend) fun active_validator_by_address(self: &SuiSystemStateInner, validator_address: address): &Validator {
+    public(friend) fun active_validator_by_address(self: &SuiSystemStateInnerV2, validator_address: address): &Validator {
         validator_set::get_active_validator_ref(validators(self), validator_address)
     }
 
     #[test_only]
     /// Return the currently pending validator by address
-    public(friend) fun pending_validator_by_address(self: &SuiSystemStateInner, validator_address: address): &Validator {
+    public(friend) fun pending_validator_by_address(self: &SuiSystemStateInnerV2, validator_address: address): &Validator {
         validator_set::get_pending_validator_ref(validators(self), validator_address)
     }
 
     #[test_only]
     /// Return the currently candidate validator by address
-    public(friend) fun candidate_validator_by_address(self: &SuiSystemStateInner, validator_address: address): &Validator {
+    public(friend) fun candidate_validator_by_address(self: &SuiSystemStateInnerV2, validator_address: address): &Validator {
         validator_set::get_candidate_validator_ref(validators(self), validator_address)
     }
 
     #[test_only]
-    public(friend) fun set_epoch_for_testing(self: &mut SuiSystemStateInner, epoch_num: u64) {
+    public(friend) fun set_epoch_for_testing(self: &mut SuiSystemStateInnerV2, epoch_num: u64) {
         self.epoch = epoch_num
     }
 
     #[test_only]
     public(friend) fun request_add_validator_for_testing(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         min_joining_stake_for_testing: u64,
         ctx: &mut TxContext,
     ) {
@@ -977,7 +1129,7 @@ module sui_system::sui_system_state_inner {
     // in the process.
     #[test_only]
     public(friend) fun request_add_validator_candidate_for_testing(
-        self: &mut SuiSystemStateInner,
+        self: &mut SuiSystemStateInnerV2,
         pubkey_bytes: vector<u8>,
         network_pubkey_bytes: vector<u8>,
         worker_pubkey_bytes: vector<u8>,

--- a/crates/sui-framework/packages/sui-system/tests/sui_system_tests.move
+++ b/crates/sui-framework/packages/sui-system/tests/sui_system_tests.move
@@ -221,17 +221,19 @@ module sui_system::sui_system_tests {
         let scenario_val = test_scenario::begin(@0x0);
         let scenario = &mut scenario_val;
 
-        set_up_sui_system_state(vector[@0x1, @0x2, @0x3]);
+        set_up_sui_system_state(vector[@0x1, @0x2, @0x3, @0x4]);
         test_scenario::next_tx(scenario, @0x1);
         let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
         let pool_id_1 = sui_system::validator_staking_pool_id(&mut system_state, @0x1);
         let pool_id_2 = sui_system::validator_staking_pool_id(&mut system_state, @0x2);
         let pool_id_3 = sui_system::validator_staking_pool_id(&mut system_state, @0x3);
+        let pool_id_4 = sui_system::validator_staking_pool_id(&mut system_state, @0x4);
         let pool_mappings = sui_system::validator_staking_pool_mappings(&mut system_state);
-        assert_eq(table::length(pool_mappings), 3);
+        assert_eq(table::length(pool_mappings), 4);
         assert_eq(*table::borrow(pool_mappings, pool_id_1), @0x1);
         assert_eq(*table::borrow(pool_mappings, pool_id_2), @0x2);
         assert_eq(*table::borrow(pool_mappings, pool_id_3), @0x3);
+        assert_eq(*table::borrow(pool_mappings, pool_id_4), @0x4);
         test_scenario::return_shared(system_state);
 
         let new_validator_addr = @0xaf76afe6f866d8426d2be85d6ef0b11f871a251d043b2f11e15563bf418f5a5a;
@@ -247,14 +249,15 @@ module sui_system::sui_system_tests {
 
         test_scenario::next_tx(scenario, @0x1);
         let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
-        let pool_id_4 = sui_system::validator_staking_pool_id(&mut system_state, new_validator_addr);
+        let pool_id_5 = sui_system::validator_staking_pool_id(&mut system_state, new_validator_addr);
         pool_mappings = sui_system::validator_staking_pool_mappings(&mut system_state);
         // Check that the previous mappings didn't change as well.
-        assert_eq(table::length(pool_mappings), 4);
+        assert_eq(table::length(pool_mappings), 5);
         assert_eq(*table::borrow(pool_mappings, pool_id_1), @0x1);
         assert_eq(*table::borrow(pool_mappings, pool_id_2), @0x2);
         assert_eq(*table::borrow(pool_mappings, pool_id_3), @0x3);
-        assert_eq(*table::borrow(pool_mappings, pool_id_4), new_validator_addr);
+        assert_eq(*table::borrow(pool_mappings, pool_id_4), @0x4);
+        assert_eq(*table::borrow(pool_mappings, pool_id_5), new_validator_addr);
         test_scenario::return_shared(system_state);
 
         // Remove one of the original validators.
@@ -265,11 +268,12 @@ module sui_system::sui_system_tests {
         let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
         pool_mappings = sui_system::validator_staking_pool_mappings(&mut system_state);
         // Check that the previous mappings didn't change as well.
-        assert_eq(table::length(pool_mappings), 3);
+        assert_eq(table::length(pool_mappings), 4);
         assert_eq(table::contains(pool_mappings, pool_id_1), false);
         assert_eq(*table::borrow(pool_mappings, pool_id_2), @0x2);
         assert_eq(*table::borrow(pool_mappings, pool_id_3), @0x3);
-        assert_eq(*table::borrow(pool_mappings, pool_id_4), new_validator_addr);
+        assert_eq(*table::borrow(pool_mappings, pool_id_4), @0x4);
+        assert_eq(*table::borrow(pool_mappings, pool_id_5), new_validator_addr);
         test_scenario::return_shared(system_state);
 
         test_scenario::end(scenario_val);

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -222,7 +222,7 @@ pub async fn metadata(
             let amount = amounts.iter().sum::<u64>();
             (Some(amount), vec![], 2000)
         }
-        InternalOperation::Stake { amount, .. } => (*amount, vec![], 2000),
+        InternalOperation::Stake { amount, .. } => (*amount, vec![], 10000),
         InternalOperation::WithdrawStake { sender, stake_ids } => {
             let stake_ids = if stake_ids.is_empty() {
                 // unstake all

--- a/crates/sui-types/src/sui_system_state/mod.rs
+++ b/crates/sui-types/src/sui_system_state/mod.rs
@@ -7,6 +7,7 @@ use crate::dynamic_field::get_dynamic_field_from_store;
 use crate::error::SuiError;
 use crate::storage::ObjectStore;
 use crate::sui_system_state::epoch_start_sui_system_state::EpochStartSystemState;
+use crate::sui_system_state::sui_system_state_inner_v2::SuiSystemStateInnerV2;
 use crate::versioned::Versioned;
 use crate::{id::UID, MoveTypeTagTrait, SUI_SYSTEM_ADDRESS, SUI_SYSTEM_STATE_OBJECT_ID};
 use anyhow::Result;
@@ -21,6 +22,7 @@ use self::sui_system_state_summary::{SuiSystemStateSummary, SuiValidatorSummary}
 
 pub mod epoch_start_sui_system_state;
 pub mod sui_system_state_inner_v1;
+pub mod sui_system_state_inner_v2;
 pub mod sui_system_state_summary;
 
 #[cfg(msim)]
@@ -91,6 +93,7 @@ pub trait SuiSystemStateTrait {
 #[enum_dispatch(SuiSystemStateTrait)]
 pub enum SuiSystemState {
     V1(SuiSystemStateInnerV1),
+    V2(SuiSystemStateInnerV2),
     #[cfg(msim)]
     SimTestV1(SimTestSuiSystemStateInnerV1),
     #[cfg(msim)]
@@ -111,7 +114,6 @@ impl SuiSystemState {
     pub fn into_genesis_version_for_tooling(self) -> SuiSystemStateInnerGenesis {
         match self {
             SuiSystemState::V1(inner) => inner,
-            #[cfg(msim)]
             _ => unreachable!(),
         }
     }
@@ -159,6 +161,18 @@ where
                     },
                 )?;
             Ok(SuiSystemState::V1(result))
+        }
+        2 => {
+            let result: SuiSystemStateInnerV2 =
+                get_dynamic_field_from_store(object_store, id, &wrapper.version).map_err(
+                    |err| {
+                        SuiError::DynamicFieldReadError(format!(
+                            "Failed to load sui system state inner object with ID {:?} and version {:?}: {:?}",
+                            id, wrapper.version, err
+                        ))
+                    },
+                )?;
+            Ok(SuiSystemState::V2(result))
         }
         #[cfg(msim)]
         SUI_SYSTEM_STATE_SIM_TEST_V1 => {

--- a/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
@@ -455,7 +455,6 @@ pub struct StorageFundV1 {
 }
 
 /// Rust version of the Move sui_system::sui_system::SuiSystemStateInner type
-/// We want to keep it named as SuiSystemState in Rust since this is the primary interface type.
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct SuiSystemStateInnerV1 {
     pub epoch: u64,

--- a/crates/sui-types/src/sui_system_state/sui_system_state_inner_v2.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_inner_v2.rs
@@ -1,0 +1,284 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::balance::Balance;
+use crate::base_types::SuiAddress;
+use crate::collection_types::{Bag, Table, TableVec, VecMap, VecSet};
+use crate::committee::{Committee, CommitteeWithNetworkMetadata, NetworkMetadata};
+use crate::sui_system_state::epoch_start_sui_system_state::EpochStartSystemState;
+use crate::sui_system_state::sui_system_state_inner_v1::{
+    StakeSubsidyV1, StorageFundV1, ValidatorSetV1,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+use super::epoch_start_sui_system_state::EpochStartValidatorInfoV1;
+use super::sui_system_state_summary::SuiSystemStateSummary;
+use super::SuiSystemStateTrait;
+
+/// Rust version of the Move sui::sui_system::SystemParametersV2 type
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
+pub struct SystemParametersV2 {
+    /// The duration of an epoch, in milliseconds.
+    pub epoch_duration_ms: u64,
+
+    /// The starting epoch in which stake subsidies start being paid out
+    pub stake_subsidy_start_epoch: u64,
+
+    /// Minimum number of active validators at any moment.
+    pub min_validator_count: u64,
+
+    /// Maximum number of active validators at any moment.
+    /// We do not allow the number of validators in any epoch to go above this.
+    pub max_validator_count: u64,
+
+    /// Lower-bound on the amount of stake required to become a validator.
+    pub min_validator_joining_stake: u64,
+
+    /// Validators with stake amount below `validator_low_stake_threshold` are considered to
+    /// have low stake and will be escorted out of the validator set after being below this
+    /// threshold for more than `validator_low_stake_grace_period` number of epochs.
+    pub validator_low_stake_threshold: u64,
+
+    /// Validators with stake below `validator_very_low_stake_threshold` will be removed
+    /// immediately at epoch change, no grace period.
+    pub validator_very_low_stake_threshold: u64,
+
+    /// A validator can have stake below `validator_low_stake_threshold`
+    /// for this many epochs before being kicked out.
+    pub validator_low_stake_grace_period: u64,
+
+    pub extra_fields: Bag,
+}
+
+/// Rust version of the Move sui_system::sui_system::SuiSystemStateInnerV2 type
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
+pub struct SuiSystemStateInnerV2 {
+    pub epoch: u64,
+    pub protocol_version: u64,
+    pub system_state_version: u64,
+    pub validators: ValidatorSetV1,
+    pub storage_fund: StorageFundV1,
+    pub parameters: SystemParametersV2,
+    pub reference_gas_price: u64,
+    pub validator_report_records: VecMap<SuiAddress, VecSet<SuiAddress>>,
+    pub stake_subsidy: StakeSubsidyV1,
+    pub safe_mode: bool,
+    pub safe_mode_storage_rewards: Balance,
+    pub safe_mode_computation_rewards: Balance,
+    pub safe_mode_storage_rebates: u64,
+    pub safe_mode_non_refundable_storage_fee: u64,
+    pub epoch_start_timestamp_ms: u64,
+    pub extra_fields: Bag,
+    // TODO: Use getters instead of all pub.
+}
+
+impl SuiSystemStateTrait for SuiSystemStateInnerV2 {
+    fn epoch(&self) -> u64 {
+        self.epoch
+    }
+
+    fn reference_gas_price(&self) -> u64 {
+        self.reference_gas_price
+    }
+
+    fn protocol_version(&self) -> u64 {
+        self.protocol_version
+    }
+
+    fn system_state_version(&self) -> u64 {
+        self.system_state_version
+    }
+
+    fn epoch_start_timestamp_ms(&self) -> u64 {
+        self.epoch_start_timestamp_ms
+    }
+
+    fn epoch_duration_ms(&self) -> u64 {
+        self.parameters.epoch_duration_ms
+    }
+
+    fn safe_mode(&self) -> bool {
+        self.safe_mode
+    }
+
+    fn get_current_epoch_committee(&self) -> CommitteeWithNetworkMetadata {
+        let mut voting_rights = BTreeMap::new();
+        let mut network_metadata = BTreeMap::new();
+        for validator in &self.validators.active_validators {
+            let verified_metadata = validator.verified_metadata();
+            let name = verified_metadata.sui_pubkey_bytes();
+            voting_rights.insert(name, validator.voting_power);
+            network_metadata.insert(
+                name,
+                NetworkMetadata {
+                    network_address: verified_metadata.net_address.clone(),
+                    narwhal_primary_address: verified_metadata.primary_address.clone(),
+                },
+            );
+        }
+        CommitteeWithNetworkMetadata {
+            committee: Committee::new(self.epoch, voting_rights),
+            network_metadata,
+        }
+    }
+
+    fn into_epoch_start_state(self) -> EpochStartSystemState {
+        EpochStartSystemState::new_v1(
+            self.epoch,
+            self.protocol_version,
+            self.reference_gas_price,
+            self.safe_mode,
+            self.epoch_start_timestamp_ms,
+            self.parameters.epoch_duration_ms,
+            self.validators
+                .active_validators
+                .iter()
+                .map(|validator| {
+                    let metadata = validator.verified_metadata();
+                    EpochStartValidatorInfoV1 {
+                        sui_address: metadata.sui_address,
+                        protocol_pubkey: metadata.protocol_pubkey.clone(),
+                        narwhal_network_pubkey: metadata.network_pubkey.clone(),
+                        narwhal_worker_pubkey: metadata.worker_pubkey.clone(),
+                        sui_net_address: metadata.net_address.clone(),
+                        p2p_address: metadata.p2p_address.clone(),
+                        narwhal_primary_address: metadata.primary_address.clone(),
+                        narwhal_worker_address: metadata.worker_address.clone(),
+                        voting_power: validator.voting_power,
+                        hostname: metadata.name.clone(),
+                    }
+                })
+                .collect(),
+        )
+    }
+
+    fn into_sui_system_state_summary(self) -> SuiSystemStateSummary {
+        // If you are making any changes to SuiSystemStateV1 or any of its dependent types before
+        // mainnet, please also update SuiSystemStateSummary and its corresponding TS type.
+        // Post-mainnet, we will need to introduce a new version.
+        let Self {
+            epoch,
+            protocol_version,
+            system_state_version,
+            validators:
+                ValidatorSetV1 {
+                    total_stake,
+                    active_validators,
+                    pending_active_validators:
+                        TableVec {
+                            contents:
+                                Table {
+                                    id: pending_active_validators_id,
+                                    size: pending_active_validators_size,
+                                },
+                        },
+                    pending_removals,
+                    staking_pool_mappings:
+                        Table {
+                            id: staking_pool_mappings_id,
+                            size: staking_pool_mappings_size,
+                        },
+                    inactive_validators:
+                        Table {
+                            id: inactive_pools_id,
+                            size: inactive_pools_size,
+                        },
+                    validator_candidates:
+                        Table {
+                            id: validator_candidates_id,
+                            size: validator_candidates_size,
+                        },
+                    at_risk_validators:
+                        VecMap {
+                            contents: at_risk_validators,
+                        },
+                    extra_fields: _,
+                },
+            storage_fund,
+            parameters:
+                SystemParametersV2 {
+                    stake_subsidy_start_epoch,
+                    epoch_duration_ms,
+                    min_validator_count: _, // TODO: Add it to RPC layer in the future.
+                    max_validator_count,
+                    min_validator_joining_stake,
+                    validator_low_stake_threshold,
+                    validator_very_low_stake_threshold,
+                    validator_low_stake_grace_period,
+                    extra_fields: _,
+                },
+            reference_gas_price,
+            validator_report_records:
+                VecMap {
+                    contents: validator_report_records,
+                },
+            stake_subsidy:
+                StakeSubsidyV1 {
+                    balance: stake_subsidy_balance,
+                    distribution_counter: stake_subsidy_distribution_counter,
+                    current_distribution_amount: stake_subsidy_current_distribution_amount,
+                    stake_subsidy_period_length,
+                    stake_subsidy_decrease_rate,
+                    extra_fields: _,
+                },
+            safe_mode,
+            safe_mode_storage_rewards,
+            safe_mode_computation_rewards,
+            safe_mode_storage_rebates,
+            safe_mode_non_refundable_storage_fee,
+            epoch_start_timestamp_ms,
+            extra_fields: _,
+        } = self;
+        SuiSystemStateSummary {
+            epoch,
+            protocol_version,
+            system_state_version,
+            storage_fund_total_object_storage_rebates: storage_fund
+                .total_object_storage_rebates
+                .value(),
+            storage_fund_non_refundable_balance: storage_fund.non_refundable_balance.value(),
+            reference_gas_price,
+            safe_mode,
+            safe_mode_storage_rewards: safe_mode_storage_rewards.value(),
+            safe_mode_computation_rewards: safe_mode_computation_rewards.value(),
+            safe_mode_storage_rebates,
+            safe_mode_non_refundable_storage_fee,
+            epoch_start_timestamp_ms,
+            stake_subsidy_start_epoch,
+            epoch_duration_ms,
+            stake_subsidy_distribution_counter,
+            stake_subsidy_balance: stake_subsidy_balance.value(),
+            stake_subsidy_current_distribution_amount,
+            total_stake,
+            active_validators: active_validators
+                .into_iter()
+                .map(|v| v.into_sui_validator_summary())
+                .collect(),
+            pending_active_validators_id,
+            pending_active_validators_size,
+            pending_removals,
+            staking_pool_mappings_id,
+            staking_pool_mappings_size,
+            inactive_pools_id,
+            inactive_pools_size,
+            validator_candidates_id,
+            validator_candidates_size,
+            at_risk_validators: at_risk_validators
+                .into_iter()
+                .map(|e| (e.key, e.value))
+                .collect(),
+            validator_report_records: validator_report_records
+                .into_iter()
+                .map(|e| (e.key, e.value.contents))
+                .collect(),
+            max_validator_count,
+            min_validator_joining_stake,
+            validator_low_stake_threshold,
+            validator_very_low_stake_threshold,
+            validator_low_stake_grace_period,
+            stake_subsidy_period_length,
+            stake_subsidy_decrease_rate,
+        }
+    }
+}

--- a/crates/sui/tests/protocol_version_tests.rs
+++ b/crates/sui/tests/protocol_version_tests.rs
@@ -715,8 +715,8 @@ mod sim_only_tests {
         // The system state object will be upgraded next time we execute advance_epoch transaction
         // at epoch boundary.
         let system_state = test_cluster.wait_for_epoch(Some(2)).await;
-        if let SuiSystemState::V1(_inner) = system_state {
-            // TODO: Check _inner data integrity.
+        if let SuiSystemState::V2(inner) = system_state {
+            assert_eq!(inner.parameters.min_validator_count, 4);
         } else {
             unreachable!("Unexpected sui system state version");
         }


### PR DESCRIPTION
## Description 

This PR upgrades the sui system state by adding a new field `min_validator_count` to system parameters.
It's checked when requesting to remove a validator.
The change follows the guide on how to upgrade system state object, by changing both Move and Rust types.

## Test Plan 

I used protocol version tests to trigger this upgrade and verified that it works.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
