### PR TITLE
Match ts Publish schema to rust sdk

### DIFF
--- a/.changeset/great-brooms-argue.md
+++ b/.changeset/great-brooms-argue.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Match ts Publish schema to rust sdk

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -81,7 +81,7 @@ export const SuiTransaction = union([
   object({ TransferObjects: tuple([array(SuiArgument), SuiArgument]) }),
   object({ SplitCoins: tuple([SuiArgument, array(SuiArgument)]) }),
   object({ MergeCoins: tuple([SuiArgument, array(SuiArgument)]) }),
-  object({ Publish: SuiMovePackage }),
+  object({ Publish: tuple([SuiMovePackage, array(ObjectId)]) }),
   object({ MakeMoveVec: tuple([nullable(string()), array(SuiArgument)]) }),
 ]);
 


### PR DESCRIPTION
## Description 

for http://localhost:3000/txblock/EVgru8Vu9fCNrWXZoqLG2Y7kiXYeUtayymoRbrW7ayCC?network=https%3A%2F%2Fexplorer-rpc.devnet.sui.io the 

Publish is defined as `Publish(SuiMovePackage, Vec<ObjectID>)` at https://github.com/MystenLabs/sui/blob/fix-publish-on-ts-sdk/crates/sui-json-rpc-types/src/sui_transaction.rs#L1159 `. Update TS SDK to match

addresses bug 3
https://mysten-labs.slack.com/archives/C03GKUEA5PF/p1680056451952799?thread_ts=1680034768.120819&cid=C03GKUEA5PF

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
