### PR TITLE
[fix] state accumulator - do not fail when previous obj version is not found

### DIFF
--- a/crates/sui-core/src/unit_tests/data/object_owner/sources/object_owner.move
+++ b/crates/sui-core/src/unit_tests/data/object_owner/sources/object_owner.move
@@ -83,6 +83,13 @@ module object_owner::object_owner {
         transfer::public_transfer(child, tx_context::sender(ctx));
     }
 
+    public entry fun remove_wrapped_child(parent: &mut Parent, ctx: &mut TxContext) {
+        let child_id = option::extract(&mut parent.child);
+        let child: Child = dynamic_field::remove(&mut parent.id, 0);
+        assert!(object::id(&child) == child_id, 0);
+        transfer::public_transfer(child, tx_context::sender(ctx));
+    }
+
     // Call to delete_child
     public entry fun delete_child(child: Child) {
         let Child { id } = child;


### PR DESCRIPTION
## Description 

It seems that state accumulator is making an assumption on the wrapped object existing in the storage (the previous version - tombstone) when it's unwrapping it. However, if this is a wrapped object that never existed before , we don't expect to find in the storage any tombstone - thus we shouldn't panic. We currently see in DevNet this happening:

```
thread 'tokio-runtime-worker' panicked at 'wrapped tombstone must precede unwrapped object', crates/sui-core/src/state_accumulator.rs:173:30
```

Thanks @amnn @gdanezis for helping on root causing this!

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
