### PR TITLE
Do not re-print test failures at the end of CI

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,7 +1,6 @@
 [profile.ci]
-# Print out output for failing tests as soon as they fail, and also at the end
-# of the run (for easy scrollability).
-failure-output = "immediate-final"
+# Print output for failing tests only when they fail.
+failure-output = "immediate"
 # Show skipped tests in the CI output.
 status-level = "skip"
 # Do not cancel the test run on the first failure.


### PR DESCRIPTION
## Description 

So we can have a concise view of which tests failed.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
