### PR TITLE
[transaction-builder] Fix place where we were treating gas budget as units instead of Mist

### DIFF
--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -74,11 +74,13 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
         input_objects: Vec<ObjectID>,
         gas_price: u64,
     ) -> Result<ObjectRef, anyhow::Error> {
+        if budget < gas_price {
+            bail!("Gas budget {budget} is less than the reference gas price {gas_price}. The gas budget must be at least the current reference gas price of {gas_price}.")
+        }
         if let Some(gas) = input_gas {
             self.get_object_ref(gas).await
         } else {
             let gas_objs = self.0.get_owned_objects(signer, GasCoin::type_()).await?;
-            let required_gas_amount = (budget as u128) * (gas_price as u128);
 
             for obj in gas_objs {
                 let response = self
@@ -94,13 +96,11 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
                         .ok_or_else(|| anyhow!("Cannot parse move object to gas object"))?
                         .bcs_bytes,
                 )?;
-                if !input_objects.contains(&obj.object_id)
-                    && (gas.value() as u128) >= required_gas_amount
-                {
+                if !input_objects.contains(&obj.object_id) && gas.value() >= budget {
                     return Ok(obj.object_ref());
                 }
             }
-            Err(anyhow!("Cannot find gas coin for signer address [{signer}] with amount sufficient for the required gas amount [{required_gas_amount}]."))
+            Err(anyhow!("Cannot find gas coin for signer address [{signer}] with amount sufficient for the required gas amount [{budget}]."))
         }
     }
 


### PR DESCRIPTION

This fixes an issue where we were treating the gas budget in the transaction builder as representing units of gas instead of Mist.

This fixes this issue and also adds an error if the provided gas budget is below the current RGP (and therefore equivalent to 0 gas units after the div-truncation that is done when entering execution and converting to gas units).

