### PR TITLE
[wallet-ext] Remove discord button override for testnet faucet

### DIFF
--- a/apps/wallet/src/ui/app/shared/faucet/FaucetRequestButton.tsx
+++ b/apps/wallet/src/ui/app/shared/faucet/FaucetRequestButton.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ArrowUpRight16 } from '@mysten/icons';
 import { toast } from 'react-hot-toast';
 
 import FaucetMessageInfo from './FaucetMessageInfo';
@@ -23,23 +22,6 @@ function FaucetRequestButton({
     const network = useAppSelector(({ app }) => app.apiEnv);
     const networkName = API_ENV_TO_INFO[network].name.replace(/sui\s*/gi, '');
     const mutation = useFaucetMutation();
-
-    //TODO: remove this TestNet check after testnet
-    if (network === 'testNet') {
-        return (
-            <Button
-                variant={variant}
-                href="https://discord.com/channels/916379725201563759/1037811694564560966"
-                onClick={() =>
-                    trackEvent('DiscordRequestSUIToken', {
-                        props: { source: trackEventSource },
-                    })
-                }
-                after={<ArrowUpRight16 />}
-                text="Request Testnet SUI on Discord"
-            />
-        );
-    }
 
     return mutation.enabled ? (
         <Button


### PR DESCRIPTION
## Description 

This removes the discord faucet button that was overriding testnet faucet.

## Test Plan 

Ran locally.