### PR TITLE
use @0x00 in tests to create valdiators and enforce checks

### DIFF
--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0x2c57ac797096d821f01f7f417c3d29bc895cec4090669c68cbe5245056c44b61"
+            id: "0xa2794d3fb22332c88500a8726dcd824bd984abfc32918c1ded2c42439feb62d3"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0xf01e395f91fee123e9c6b4b13cfaee2aaebc9f81fca3e328e7d0b58b4aeb9ffe"
+      operation_cap_id: "0xa061845eb6b545ef561144c935471c64135586fe04738e1d2d1a80fb9ab8a628"
       gas_price: 1000
       staking_pool:
-        id: "0x6a88c152225d331ccd2e87322722785be7269b8a732daf4965eb226cd237c1c3"
+        id: "0xadd6457896f917f14c6e0f4c627a42068898095f4eb6a64c754c9a183f3a87fa"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0xcf11258f4a7319021d11e25afb72baa71d8543181b92ee7c62e228975db4a678"
+          id: "0x46bc49790c7d6865a5f0262fbb9c6cd02cf0ee3885598f01d9bd746c1e5dd580"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0x798e438d12c7dafe7be9281e72b6e86c233566f9aebc669a8c35787c64e49220"
+            id: "0xdc0b936e7171367c562fe7a78ca5b2c4cf03daec1143a7d486a377327567b9c8"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0x924d417ff92e8e31ea5773677659aedab23388169a66578a3fa0f970c8f330d1"
+          id: "0x4258898f1915610cb0724822601028dd0785578208421179906aaf3ef9ba3a55"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x9afb79741e72a743155bcbe8c3a9bcbaf894f641a8a8760f8596537af14d9b62"
+      id: "0xc89786b5d95e881c05bae870442d274c9d0c8ddca4108cce203d9b2527a23968"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0x0b767ac173ddec6621e78fa147c44c181840155ffbb64f770c2a0f4f0154a505"
+    id: "0x7c1d23225362de4691be5dc95c08062dc0129767ecfe8ec6b2f992e943374bbf"
     size: 1
   inactive_validators:
-    id: "0x03e06386abda2843e5d82cc78927a231325db5bd1764c09ad9c3028e70c2b2fa"
+    id: "0x7833ec598b16fd6f916b27ee71b3c8dbad71f1f3c48dea27a830a40aca69bd38"
     size: 0
   validator_candidates:
-    id: "0xbde7a9d543e37e50a68ad7fc28a07cdb43ca5ff541344f2b4b3bdf5a12806f1d"
+    id: "0x495c55c900eb4d29f0f0db1eb8df2dc770bc16e8f8a3f5d149431fe9524730a8"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0xc5cb7edb8f81a9c90edd9cfa3358ab462824c6e528b710ce675c2667e17a73cb"
+      id: "0x641937c34765df3ac5680d9a20ed5b1a7f2b810ca179a28dbcfe149e265afffb"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x5363d2185302242c32532eb3ffbac714eed754f906a01527764f769116cbb088"
+      id: "0x15358e16088e68949f6959b2290115a16f24f99d4359428f5406c6b8b58fd6f4"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 10000
   extra_fields:
     id:
-      id: "0x44d17fd2664b4be905d0692cdd423104cc9cab24284cda707e99c6fc233baf3d"
+      id: "0x930d245e67aa1c0f44fd46f86e270fd92c01365c65840c437b77f2ef48c3caa4"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,6 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0x11524b3694567f917f11b7f14ff0497bc09d98bcba7a45ca646b3435a6545323"
+    id: "0x50231793655ebf9326e05b554f68323864ab005d1fd5a14e368a19483d1ae59a"
   size: 0
 

--- a/crates/sui-framework/docs/validator_cap.md
+++ b/crates/sui-framework/docs/validator_cap.md
@@ -161,13 +161,11 @@ or rotating an existing validaotr's <code>operation_cap_id</code>.
     validator_address: <b>address</b>,
     ctx: &<b>mut</b> TxContext,
 ): ID {
-    // MUSTFIX: <b>update</b> all tests <b>to</b> <b>use</b> @0x0 <b>to</b> create validators so we can
-    // enforce the <b>assert</b> below.
     // This function needs <b>to</b> be called only by the <a href="validator.md#0x3_validator">validator</a> itself, <b>except</b>
     // 1. in <a href="genesis.md#0x3_genesis">genesis</a> <b>where</b> all valdiators are created by @0x0
     // 2. in tests <b>where</b> @0x0 could be used <b>to</b> simplify the setup
-    // <b>let</b> sender_address = <a href="_sender">tx_context::sender</a>(ctx);
-    // <b>assert</b>!(sender_address == @0x0 || sender_address == validator_address, 0);
+    <b>let</b> sender_address = <a href="_sender">tx_context::sender</a>(ctx);
+    <b>assert</b>!(sender_address == @0x0 || sender_address == validator_address, 0);
 
     <b>let</b> operation_cap = <a href="validator_cap.md#0x3_validator_cap_UnverifiedValidatorOperationCap">UnverifiedValidatorOperationCap</a> {
         id: <a href="_new">object::new</a>(ctx),

--- a/crates/sui-framework/packages/sui-system/sources/validator_cap.move
+++ b/crates/sui-framework/packages/sui-system/sources/validator_cap.move
@@ -4,7 +4,7 @@
 module sui_system::validator_cap {
     use sui::object::{Self, ID, UID};
     use sui::transfer;
-    use sui::tx_context::TxContext;
+    use sui::tx_context::{Self, TxContext};
     friend sui_system::sui_system_state_inner;
     friend sui_system::validator;
     friend sui_system::validator_set;
@@ -50,13 +50,11 @@ module sui_system::validator_cap {
         validator_address: address,
         ctx: &mut TxContext,
     ): ID {
-        // MUSTFIX: update all tests to use @0x0 to create validators so we can
-        // enforce the assert below.
         // This function needs to be called only by the validator itself, except
         // 1. in genesis where all valdiators are created by @0x0
         // 2. in tests where @0x0 could be used to simplify the setup
-        // let sender_address = tx_context::sender(ctx);
-        // assert!(sender_address == @0x0 || sender_address == validator_address, 0);
+        let sender_address = tx_context::sender(ctx);
+        assert!(sender_address == @0x0 || sender_address == validator_address, 0);
 
         let operation_cap = UnverifiedValidatorOperationCap {
             id: object::new(ctx),

--- a/crates/sui-framework/packages/sui-system/tests/delegation_tests.move
+++ b/crates/sui-framework/packages/sui-system/tests/delegation_tests.move
@@ -4,7 +4,7 @@
 #[test_only]
 module sui_system::stake_tests {
     use sui::coin;
-    use sui::test_scenario::{Self, Scenario};
+    use sui::test_scenario;
     use sui_system::sui_system::{Self, SuiSystemState};
     use sui_system::staking_pool::{Self, StakedSui};
     use sui::test_utils::assert_eq;
@@ -44,10 +44,10 @@ module sui_system::stake_tests {
 
     #[test]
     fun test_split_join_staked_sui() {
+        // All this is just to generate a dummy StakedSui object to split and join later
+        set_up_sui_system_state();
         let scenario_val = test_scenario::begin(STAKER_ADDR_1);
         let scenario = &mut scenario_val;
-        // All this is just to generate a dummy StakedSui object to split and join later
-        set_up_sui_system_state(scenario);
         governance_test_utils::stake_with(STAKER_ADDR_1, VALIDATOR_ADDR_1, 60, scenario);
 
         test_scenario::next_tx(scenario, STAKER_ADDR_1);
@@ -83,9 +83,9 @@ module sui_system::stake_tests {
     #[test]
     #[expected_failure(abort_code = staking_pool::EIncompatibleStakedSui)]
     fun test_join_different_epochs() {
+        set_up_sui_system_state();
         let scenario_val = test_scenario::begin(STAKER_ADDR_1);
         let scenario = &mut scenario_val;
-        set_up_sui_system_state(scenario);
         // Create two instances of staked sui w/ different epoch activations
         governance_test_utils::stake_with(STAKER_ADDR_1, VALIDATOR_ADDR_1, 60, scenario);
         governance_test_utils::advance_epoch(scenario);
@@ -108,9 +108,9 @@ module sui_system::stake_tests {
     #[test]
     #[expected_failure(abort_code = staking_pool::EStakedSuiBelowThreshold)]
     fun test_split_below_threshold() {
+        set_up_sui_system_state();
         let scenario_val = test_scenario::begin(STAKER_ADDR_1);
         let scenario = &mut scenario_val;
-        set_up_sui_system_state(scenario);
         // Stake 2 SUI
         governance_test_utils::stake_with(STAKER_ADDR_1, VALIDATOR_ADDR_1, 2, scenario);
 
@@ -127,9 +127,9 @@ module sui_system::stake_tests {
 
     #[test]
     fun test_add_remove_stake_flow() {
+        set_up_sui_system_state();
         let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
         let scenario = &mut scenario_val;
-        set_up_sui_system_state(scenario);
 
         test_scenario::next_tx(scenario, STAKER_ADDR_1);
         {
@@ -194,9 +194,9 @@ module sui_system::stake_tests {
     }
 
     fun test_remove_stake_post_active_flow(should_distribute_rewards: bool) {
+        set_up_sui_system_state_with_storage_fund();
         let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
         let scenario = &mut scenario_val;
-        set_up_sui_system_state_with_storage_fund(scenario);
 
         governance_test_utils::stake_with(STAKER_ADDR_1, VALIDATOR_ADDR_1, 100, scenario);
 
@@ -260,9 +260,9 @@ module sui_system::stake_tests {
 
     #[test]
     fun test_earns_rewards_at_last_epoch() {
+        set_up_sui_system_state_with_storage_fund();
         let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
         let scenario = &mut scenario_val;
-        set_up_sui_system_state_with_storage_fund(scenario);
 
         stake_with(STAKER_ADDR_1, VALIDATOR_ADDR_1, 100, scenario);
 
@@ -313,9 +313,9 @@ module sui_system::stake_tests {
     #[test]
     #[expected_failure(abort_code = validator_set::ENotAValidator)]
     fun test_add_stake_post_active_flow() {
+        set_up_sui_system_state();
         let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
         let scenario = &mut scenario_val;
-        set_up_sui_system_state(scenario);
 
         governance_test_utils::stake_with(STAKER_ADDR_1, VALIDATOR_ADDR_1, 100, scenario);
 
@@ -347,9 +347,9 @@ module sui_system::stake_tests {
 
     #[test]
     fun test_add_preactive_remove_preactive() {
+        set_up_sui_system_state();
         let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
         let scenario = &mut scenario_val;
-        set_up_sui_system_state(scenario);
 
         governance_test_utils::add_validator_candidate(NEW_VALIDATOR_ADDR, NEW_VALIDATOR_PUBKEY, NEW_VALIDATOR_POP, scenario);
 
@@ -370,9 +370,9 @@ module sui_system::stake_tests {
     #[test]
     #[expected_failure(abort_code = validator_set::ENotAValidator)]
     fun test_add_preactive_remove_pending_failure() {
+        set_up_sui_system_state();
         let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
         let scenario = &mut scenario_val;
-        set_up_sui_system_state(scenario);
 
         governance_test_utils::add_validator_candidate(NEW_VALIDATOR_ADDR, NEW_VALIDATOR_PUBKEY, NEW_VALIDATOR_POP, scenario);
 
@@ -387,9 +387,9 @@ module sui_system::stake_tests {
 
     #[test]
     fun test_add_preactive_remove_active() {
+        set_up_sui_system_state_with_storage_fund();
         let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
         let scenario = &mut scenario_val;
-        set_up_sui_system_state_with_storage_fund(scenario);
 
         add_validator_candidate(NEW_VALIDATOR_ADDR, NEW_VALIDATOR_PUBKEY, NEW_VALIDATOR_POP, scenario);
 
@@ -431,9 +431,9 @@ module sui_system::stake_tests {
 
     #[test]
     fun test_add_preactive_remove_post_active() {
+        set_up_sui_system_state();
         let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
         let scenario = &mut scenario_val;
-        set_up_sui_system_state(scenario);
 
         add_validator_candidate(NEW_VALIDATOR_ADDR, NEW_VALIDATOR_PUBKEY, NEW_VALIDATOR_POP, scenario);
 
@@ -461,9 +461,9 @@ module sui_system::stake_tests {
 
     #[test]
     fun test_add_preactive_candidate_drop_out() {
+        set_up_sui_system_state();
         let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
         let scenario = &mut scenario_val;
-        set_up_sui_system_state(scenario);
 
         add_validator_candidate(NEW_VALIDATOR_ADDR, NEW_VALIDATOR_PUBKEY, NEW_VALIDATOR_POP, scenario);
 
@@ -491,9 +491,9 @@ module sui_system::stake_tests {
     #[test]
     fun test_stake_during_safe_mode() {
         // test that stake and unstake can work during safe mode too.
+        set_up_sui_system_state();
         let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
         let scenario = &mut scenario_val;
-        set_up_sui_system_state(scenario);
         // Stake with exchange rate of 1.0
         stake_with(STAKER_ADDR_1, VALIDATOR_ADDR_1, 100, scenario);
         advance_epoch(scenario);
@@ -521,7 +521,9 @@ module sui_system::stake_tests {
         test_scenario::end(scenario_val);
     }
 
-    fun set_up_sui_system_state(scenario: &mut Scenario) {
+    fun set_up_sui_system_state() {
+        let scenario_val = test_scenario::begin(@0x0);
+        let scenario = &mut scenario_val;
         let ctx = test_scenario::ctx(scenario);
 
         let validators = vector[
@@ -529,9 +531,12 @@ module sui_system::stake_tests {
             create_validator_for_testing(VALIDATOR_ADDR_2, 100, ctx)
         ];
         create_sui_system_state_for_testing(validators, 0, 0, ctx);
+        test_scenario::end(scenario_val);
     }
 
-    fun set_up_sui_system_state_with_storage_fund(scenario: &mut Scenario) {
+    fun set_up_sui_system_state_with_storage_fund() {
+        let scenario_val = test_scenario::begin(@0x0);
+        let scenario = &mut scenario_val;
         let ctx = test_scenario::ctx(scenario);
 
         let validators = vector[
@@ -539,5 +544,6 @@ module sui_system::stake_tests {
             create_validator_for_testing(VALIDATOR_ADDR_2, 100, ctx)
         ];
         create_sui_system_state_for_testing(validators, 300, 100, ctx);
+        test_scenario::end(scenario_val);
     }
 }

--- a/crates/sui-framework/packages/sui-system/tests/governance_test_utils.move
+++ b/crates/sui-framework/packages/sui-system/tests/governance_test_utils.move
@@ -97,7 +97,9 @@ module sui_system::governance_test_utils {
         )
     }
 
-    public fun set_up_sui_system_state(addrs: vector<address>, scenario: &mut Scenario) {
+    public fun set_up_sui_system_state(addrs: vector<address>) {
+        let scenario_val = test_scenario::begin(@0x0);
+        let scenario = &mut scenario_val;
         let ctx = test_scenario::ctx(scenario);
         let validators = vector::empty();
 
@@ -109,6 +111,7 @@ module sui_system::governance_test_utils {
         };
 
         create_sui_system_state_for_testing(validators, 1000, 0, ctx);
+        test_scenario::end(scenario_val);
     }
 
     public fun advance_epoch(scenario: &mut Scenario) {

--- a/crates/sui-framework/packages/sui-system/tests/rewards_distribution_tests.move
+++ b/crates/sui-framework/packages/sui-system/tests/rewards_distribution_tests.move
@@ -38,9 +38,9 @@ module sui_system::rewards_distribution_tests {
 
     #[test]
     fun test_validator_rewards() {
+        set_up_sui_system_state();
         let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
         let scenario = &mut scenario_val;
-        set_up_sui_system_state(scenario);
 
         // need to advance epoch so validator's staking starts counting
         governance_test_utils::advance_epoch(scenario);
@@ -68,9 +68,9 @@ module sui_system::rewards_distribution_tests {
 
     #[test]
     fun test_stake_subsidy() {
+        set_up_sui_system_state_with_big_amounts();
         let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
         let scenario = &mut scenario_val;
-        set_up_sui_system_state_with_big_amounts(scenario);
 
         // need to advance epoch so validator's staking starts counting
         governance_test_utils::advance_epoch(scenario);
@@ -82,9 +82,9 @@ module sui_system::rewards_distribution_tests {
 
     #[test]
     fun test_stake_rewards() {
+        set_up_sui_system_state();
         let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
         let scenario = &mut scenario_val;
-        set_up_sui_system_state(scenario);
 
         stake_with(STAKER_ADDR_1, VALIDATOR_ADDR_1, 200, scenario);
         stake_with(STAKER_ADDR_2, VALIDATOR_ADDR_2, 100, scenario);
@@ -121,9 +121,9 @@ module sui_system::rewards_distribution_tests {
 
     #[test]
     fun test_stake_tiny_rewards() {
+        set_up_sui_system_state_with_big_amounts();
         let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
         let scenario = &mut scenario_val;
-        set_up_sui_system_state_with_big_amounts(scenario);
 
         // stake a large amount
         stake_with(STAKER_ADDR_1, VALIDATOR_ADDR_1, 200000000, scenario);
@@ -146,9 +146,9 @@ module sui_system::rewards_distribution_tests {
 
     #[test]
     fun test_validator_commission() {
+        set_up_sui_system_state();
         let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
         let scenario = &mut scenario_val;
-        set_up_sui_system_state(scenario);
 
         stake_with(STAKER_ADDR_1, VALIDATOR_ADDR_1, 100, scenario);
         stake_with(STAKER_ADDR_2, VALIDATOR_ADDR_2, 100, scenario);
@@ -180,9 +180,9 @@ module sui_system::rewards_distribution_tests {
 
     #[test]
     fun test_rewards_slashing() {
+        set_up_sui_system_state();
         let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
         let scenario = &mut scenario_val;
-        set_up_sui_system_state(scenario);
 
         advance_epoch(scenario);
 
@@ -224,9 +224,9 @@ module sui_system::rewards_distribution_tests {
 
     #[test]
     fun test_rewards_slashing_with_storage_fund() {
+        set_up_sui_system_state();
         let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
         let scenario = &mut scenario_val;
-        set_up_sui_system_state(scenario);
 
         // Put 300 SUI into the storage fund.
         advance_epoch_with_reward_amounts(300, 0, scenario);
@@ -268,9 +268,9 @@ module sui_system::rewards_distribution_tests {
 
     #[test]
     fun test_mul_rewards_withdraws_at_same_epoch() {
+        set_up_sui_system_state();
         let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
         let scenario = &mut scenario_val;
-        set_up_sui_system_state(scenario);
 
         stake_with(STAKER_ADDR_1, VALIDATOR_ADDR_1, 220, scenario);
 
@@ -329,7 +329,7 @@ module sui_system::rewards_distribution_tests {
 
     #[test]
     fun test_uncapped_rewards() {
-        let scenario_val = test_scenario::begin(VALIDATOR_ADDR_1);
+        let scenario_val = test_scenario::begin(@0x0);
         let scenario = &mut scenario_val;
 
         let ctx = test_scenario::ctx(scenario);
@@ -362,7 +362,9 @@ module sui_system::rewards_distribution_tests {
         test_scenario::end(scenario_val);
     }
 
-    fun set_up_sui_system_state(scenario: &mut Scenario) {
+    fun set_up_sui_system_state() {
+        let scenario_val = test_scenario::begin(@0x0);
+        let scenario = &mut scenario_val;
         let ctx = test_scenario::ctx(scenario);
 
         let validators = vector[
@@ -372,9 +374,12 @@ module sui_system::rewards_distribution_tests {
             create_validator_for_testing(VALIDATOR_ADDR_4, 400, ctx),
         ];
         create_sui_system_state_for_testing(validators, 1000, 0, ctx);
+        test_scenario::end(scenario_val);
     }
 
-    fun set_up_sui_system_state_with_big_amounts(scenario: &mut Scenario) {
+    fun set_up_sui_system_state_with_big_amounts() {
+        let scenario_val = test_scenario::begin(@0x0);
+        let scenario = &mut scenario_val;
         let ctx = test_scenario::ctx(scenario);
 
         let validators = vector[
@@ -384,6 +389,7 @@ module sui_system::rewards_distribution_tests {
             create_validator_for_testing(VALIDATOR_ADDR_4, 400000000, ctx),
         ];
         create_sui_system_state_for_testing(validators, 1000000000, 0, ctx);
+        test_scenario::end(scenario_val);
     }
 
     fun validator_addrs() : vector<address> {

--- a/crates/sui-framework/packages/sui-system/tests/safe_mode_tests.move
+++ b/crates/sui-framework/packages/sui-system/tests/safe_mode_tests.move
@@ -18,7 +18,7 @@ module sui::safe_mode_tests {
 
     #[test]
     fun test_safe_mode_gas_accumulation() {
-        let scenario_val = test_scenario::begin(@0x1);
+        let scenario_val = test_scenario::begin(@0x0);
         let scenario = &mut scenario_val;
         {
             // First, set up the system with 4 validators.

--- a/crates/sui-framework/packages/sui-system/tests/sui_system_tests.move
+++ b/crates/sui-framework/packages/sui-system/tests/sui_system_tests.move
@@ -31,7 +31,7 @@ module sui_system::sui_system_tests {
         let scenario_val = test_scenario::begin(@0x0);
         let scenario = &mut scenario_val;
 
-        set_up_sui_system_state(vector[@0x1, @0x2, @0x3], scenario);
+        set_up_sui_system_state(vector[@0x1, @0x2, @0x3]);
 
         report_helper(@0x1, @0x2, false, scenario);
         assert!(get_reporters_of(@0x2, scenario) == vector[@0x1], 0);
@@ -75,7 +75,7 @@ module sui_system::sui_system_tests {
     fun test_validator_ops_by_stakee_ok() {
         let scenario_val = test_scenario::begin(@0x0);
         let scenario = &mut scenario_val;
-        set_up_sui_system_state(vector[@0x1, @0x2], scenario);
+        set_up_sui_system_state(vector[@0x1, @0x2]);
 
         // @0x1 transfers the cap object to stakee.
         let stakee_address = @0xbeef;
@@ -130,7 +130,7 @@ module sui_system::sui_system_tests {
     fun test_report_validator_by_stakee_revoked() {
         let scenario_val = test_scenario::begin(@0x0);
         let scenario = &mut scenario_val;
-        set_up_sui_system_state(vector[@0x1, @0x2], scenario);
+        set_up_sui_system_state(vector[@0x1, @0x2]);
 
         // @0x1 transfers the cap object to stakee.
         let stakee_address = @0xbeef;
@@ -156,7 +156,7 @@ module sui_system::sui_system_tests {
     fun test_set_reference_gas_price_by_stakee_revoked() {
         let scenario_val = test_scenario::begin(@0x0);
         let scenario = &mut scenario_val;
-        set_up_sui_system_state(vector[@0x1, @0x2], scenario);
+        set_up_sui_system_state(vector[@0x1, @0x2]);
 
         // @0x1 transfers the cap object to stakee.
         let stakee_address = @0xbeef;
@@ -189,7 +189,7 @@ module sui_system::sui_system_tests {
         let scenario_val = test_scenario::begin(@0x0);
         let scenario = &mut scenario_val;
 
-        set_up_sui_system_state(vector[@0x1, @0x2, @0x3], scenario);
+        set_up_sui_system_state(vector[@0x1, @0x2, @0x3]);
         report_helper(@0x1, @0x42, false, scenario);
         test_scenario::end(scenario_val);
     }
@@ -200,7 +200,7 @@ module sui_system::sui_system_tests {
         let scenario_val = test_scenario::begin(@0x0);
         let scenario = &mut scenario_val;
 
-        set_up_sui_system_state(vector[@0x1, @0x2, @0x3], scenario);
+        set_up_sui_system_state(vector[@0x1, @0x2, @0x3]);
         report_helper(@0x1, @0x1, false, scenario);
         test_scenario::end(scenario_val);
     }
@@ -211,7 +211,7 @@ module sui_system::sui_system_tests {
         let scenario_val = test_scenario::begin(@0x0);
         let scenario = &mut scenario_val;
 
-        set_up_sui_system_state(vector[@0x1, @0x2, @0x3], scenario);
+        set_up_sui_system_state(vector[@0x1, @0x2, @0x3]);
         report_helper(@0x2, @0x1, true, scenario);
         test_scenario::end(scenario_val);
     }
@@ -221,7 +221,7 @@ module sui_system::sui_system_tests {
         let scenario_val = test_scenario::begin(@0x0);
         let scenario = &mut scenario_val;
 
-        set_up_sui_system_state(vector[@0x1, @0x2, @0x3], scenario);
+        set_up_sui_system_state(vector[@0x1, @0x2, @0x3]);
         test_scenario::next_tx(scenario, @0x1);
         let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
         let pool_id_1 = sui_system::validator_staking_pool_id(&mut system_state, @0x1);
@@ -738,7 +738,7 @@ module sui_system::sui_system_tests {
         let scenario_val = test_scenario::begin(validator_addr);
         let scenario = &mut scenario_val;
 
-        set_up_sui_system_state(vector[@0x1, @0x2, @0x3], scenario);
+        set_up_sui_system_state(vector[@0x1, @0x2, @0x3]);
         test_scenario::next_tx(scenario, validator_addr);
         let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
         test_scenario::next_tx(scenario, validator_addr);
@@ -807,7 +807,7 @@ module sui_system::sui_system_tests {
         let pubkey = x"99f25ef61f8032b914636460982c5cc6f134ef1ddae76657f2cbfec1ebfc8d097374080df6fcf0dcb8bc4b0d8e0af5d80ebbff2b4c599f54f42d6312dfc314276078c1cc347ebbbec5198be258513f386b930d02c2749a803e2330955ebd1a10";
         let pop = x"83809369ce6572be211512d85621a075ee6a8da57fbb2d867d05e6a395e71f10e4e957796944d68a051381eb91720fba";
 
-        set_up_sui_system_state(vector[@0x1, @0x2, @0x3], scenario);
+        set_up_sui_system_state(vector[@0x1, @0x2, @0x3]);
         test_scenario::next_tx(scenario, new_validator_addr);
         let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
         sui_system::request_add_validator_candidate(
@@ -841,7 +841,7 @@ module sui_system::sui_system_tests {
         let pubkey = x"99f25ef61f8032b914636460982c5cc6f134ef1ddae76657f2cbfec1ebfc8d097374080df6fcf0dcb8bc4b0d8e0af5d80ebbff2b4c599f54f42d6312dfc314276078c1cc347ebbbec5198be258513f386b930d02c2749a803e2330955ebd1a10";
         let pop = x"83809369ce6572be211512d85621a075ee6a8da57fbb2d867d05e6a395e71f10e4e957796944d68a051381eb91720fba";
 
-        set_up_sui_system_state(vector[@0x1, @0x2, @0x3], scenario);
+        set_up_sui_system_state(vector[@0x1, @0x2, @0x3]);
         test_scenario::next_tx(scenario, new_validator_addr);
         let system_state = test_scenario::take_shared<SuiSystemState>(scenario);
         sui_system::request_add_validator_candidate(


### PR DESCRIPTION
## Description 

In tests, use `0x00` to create validators so can we enforce the checks in `new_unverified_validator_operation_cap_and_transfer`

## Test Plan 

existing tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
In tests, use @0x00 to create validators so can we enforce the checks in `new_unverified_validator_operation_cap_and_transfer`

