### PR TITLE
ts: add missing show_raw_input option

### DIFF
--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -395,6 +395,8 @@ export type SuiTransactionBlockResponse = Infer<
 export const SuiTransactionBlockResponseOptions = object({
   /* Whether to show transaction input data. Default to be false. */
   showInput: optional(boolean()),
+  /* Whether to show transaction raw input data. Default to be false. */
+  showRawInput: optional(boolean()),
   /* Whether to show transaction effects. Default to be false. */
   showEffects: optional(boolean()),
   /* Whether to show transaction events. Default to be false. */


### PR DESCRIPTION
on RPC end, the option is 
```
pub struct SuiTransactionBlockResponseOptions {
    /// Whether to show transaction input data. Default to be False
    pub show_input: bool,
    /// Whether to show bcs-encoded transaction input data
    pub show_raw_input: bool,
    /// Whether to show transaction effects. Default to be False
    pub show_effects: bool,
    /// Whether to show transaction events. Default to be False
    pub show_events: bool,
    /// Whether to show object_changes. Default to be False
    pub show_object_changes: bool,
    /// Whether to show balance_changes. Default to be False
    pub show_balance_changes: bool,
}
```

no `show_raw_input` on the TS end.