### PR TITLE
[dry run][dev inspect] Fix dynamic field edge case

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -52,14 +52,7 @@ jobs:
 
       - name: Run TS SDK e2e tests
         if: ${{ needs.diff.outputs.isTypescriptSDK == 'true' || needs.diff.outputs.isRust == 'true'}}
-        # usage https://github.com/marketplace/actions/retry-step
-        # TODO: remove this after https://mysten-labs.slack.com/archives/C04FG4Q7YJ3/p1679676070896019 is resolved
-        # retry is added because of flakiness in sui-test-validator dry-run
-        uses: nick-fields/retry@v2
-        with:
-          max_attempts: 5
-          timeout_minutes: 30
-          command: pnpm dlx concurrently --kill-others --success command-1 "$E2E_RUN_LOCAL_NET_CMD" 'pnpm sdk test:e2e'
+        run: pnpm dlx concurrently --kill-others --success command-1 "$E2E_RUN_LOCAL_NET_CMD" 'pnpm sdk test:e2e'
 
       - name: Run Explorer e2e tests
         # need to run Explorer e2e when its upstream(TS SDK and Rust) or itself is changed

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2,7 +2,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use std::{collections::HashMap, fs, pin::Pin, sync::Arc};
@@ -68,7 +68,7 @@ use sui_types::messages_checkpoint::{
     CheckpointSequenceNumber, CheckpointSummary, CheckpointTimestamp, VerifiedCheckpoint,
 };
 use sui_types::messages_checkpoint::{CheckpointRequest, CheckpointResponse};
-use sui_types::object::{MoveObject, Owner, PastObjectRead, OBJECT_START_VERSION};
+use sui_types::object::{Data, MoveObject, Owner, PastObjectRead, OBJECT_START_VERSION};
 use sui_types::query::TransactionFilter;
 use sui_types::storage::{ObjectKey, ObjectStore, WriteKind};
 use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait;
@@ -1013,7 +1013,7 @@ impl AuthorityState {
 
         // make a gas object if one was not provided
         let mut gas_object_refs = transaction.gas().to_vec();
-        let (gas_status, input_objects) = if transaction.gas().is_empty() {
+        let (gas_status, mut input_objects) = if transaction.gas().is_empty() {
             let sender = transaction.sender();
             // use a 100M sui coin
             const MIST_TO_SUI: u64 = 1_000_000_000;
@@ -1042,9 +1042,9 @@ impl AuthorityState {
             )
             .await?
         };
+        advance_gas_object_version_for_mock_transaction(&mut gas_object_refs, &mut input_objects);
 
         let shared_object_refs = input_objects.filter_shared_objects();
-
         let transaction_dependencies = input_objects.transaction_dependencies();
         let temporary_store = TemporaryStore::new(
             self.database.clone(),
@@ -1136,22 +1136,25 @@ impl AuthorityState {
             Owner::AddressOwner(sender),
             TransactionDigest::genesis(),
         );
-        let (gas_object_ref, input_objects) = transaction_input_checker::check_dev_inspect_input(
-            &self.database,
-            protocol_config,
-            &transaction_kind,
-            gas_object,
-        )
-        .await?;
+        let (gas_object_ref, mut input_objects) =
+            transaction_input_checker::check_dev_inspect_input(
+                &self.database,
+                protocol_config,
+                &transaction_kind,
+                gas_object,
+            )
+            .await?;
+        let mut gas_object_refs = vec![gas_object_ref];
+        advance_gas_object_version_for_mock_transaction(&mut gas_object_refs, &mut input_objects);
         let shared_object_refs = input_objects.filter_shared_objects();
 
         // TODO should we error instead for 0?
         let gas_price = std::cmp::max(gas_price, 1);
         let gas_budget = max_tx_gas;
-        let data = TransactionData::new(
+        let data = TransactionData::new_with_gas_coins(
             transaction_kind,
             sender,
-            gas_object_ref,
+            gas_object_refs.clone(),
             gas_price,
             gas_budget,
         );
@@ -1183,7 +1186,7 @@ impl AuthorityState {
                 temporary_store,
                 transaction_kind,
                 sender,
-                &[gas_object_ref],
+                &gas_object_refs,
                 transaction_digest,
                 transaction_dependencies,
                 &move_vm,
@@ -3417,6 +3420,46 @@ fn calculate_checkpoint_numbers(
     } else {
         (start_index..=end_index).collect()
     }
+}
+
+/// In dry run and dev inspect, you might load a dynamic field that is actually too new for the
+/// transaction. Ideally, we would want to load the "correct" dynamic fields, but as that is
+/// not easily determined, we instead set the sequence number of the gas objects to MAX - 1, to
+/// ensure that the lamport version for the transaction is MAX, and as such, a valid lamport
+/// version for any object used in the transaction (preventing internal assertions or
+/// invariant violations from being triggered)
+fn advance_gas_object_version_for_mock_transaction(
+    gas_object_refs: &mut Vec<(ObjectID, SequenceNumber, ObjectDigest)>,
+    input_objects: &mut InputObjects,
+) {
+    const FAKE_SEQ: SequenceNumber = SequenceNumber::from_u64(SequenceNumber::MAX.value() - 1);
+    let mut remapped = HashSet::new();
+    for (id, seq, _digest) in gas_object_refs {
+        remapped.insert(*id);
+        *seq = FAKE_SEQ
+    }
+    let objs = std::mem::replace(input_objects, /* dummy */ InputObjects::new(vec![]));
+    let objs = objs.into_objects();
+    let fixed_objs = objs
+        .into_iter()
+        .map(|(mut kind, mut object)| {
+            let InputObjectKind::ImmOrOwnedMoveObject((id, seq, _digest)) = &mut kind else {
+                return (kind, object)
+            };
+            if !remapped.contains(id) {
+                return (kind, object);
+            }
+            if let Data::Move(move_obj) = &mut object.data {
+                if move_obj.version() == FAKE_SEQ {
+                    return (kind, object);
+                }
+                move_obj.increment_version_to(FAKE_SEQ);
+            }
+            *seq = FAKE_SEQ;
+            (kind, object)
+        })
+        .collect();
+    *input_objects = InputObjects::new(fixed_objs);
 }
 
 #[cfg(test)]

--- a/crates/sui-json-rpc-types/src/object_changes.rs
+++ b/crates/sui-json-rpc-types/src/object_changes.rs
@@ -80,3 +80,39 @@ pub enum ObjectChange {
         digest: ObjectDigest,
     },
 }
+
+impl ObjectChange {
+    pub fn object_id(&self) -> ObjectID {
+        match self {
+            ObjectChange::Published { package_id, .. } => *package_id,
+            ObjectChange::Transferred { object_id, .. }
+            | ObjectChange::Mutated { object_id, .. }
+            | ObjectChange::Deleted { object_id, .. }
+            | ObjectChange::Wrapped { object_id, .. }
+            | ObjectChange::Created { object_id, .. } => *object_id,
+        }
+    }
+
+    pub fn mask_for_test(&mut self, new_version: SequenceNumber, new_digest: ObjectDigest) {
+        match self {
+            ObjectChange::Published {
+                version, digest, ..
+            }
+            | ObjectChange::Transferred {
+                version, digest, ..
+            }
+            | ObjectChange::Mutated {
+                version, digest, ..
+            }
+            | ObjectChange::Created {
+                version, digest, ..
+            } => {
+                *version = new_version;
+                *digest = new_digest
+            }
+            ObjectChange::Deleted { version, .. } | ObjectChange::Wrapped { version, .. } => {
+                *version = new_version
+            }
+        }
+    }
+}

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -759,11 +759,11 @@ impl SequenceNumber {
     pub const MIN: SequenceNumber = SequenceNumber(u64::MIN);
     pub const MAX: SequenceNumber = SequenceNumber(0x7fff_ffff_ffff_ffff);
 
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         SequenceNumber(0)
     }
 
-    pub fn value(&self) -> u64 {
+    pub const fn value(&self) -> u64 {
         self.0
     }
 

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -3163,6 +3163,10 @@ impl InputObjects {
         SequenceNumber::lamport_increment(input_versions)
     }
 
+    pub fn into_objects(self) -> Vec<(InputObjectKind, Object)> {
+        self.objects
+    }
+
     pub fn into_object_map(self) -> BTreeMap<ObjectID, Object> {
         self.objects
             .into_iter()


### PR DESCRIPTION
## Description 

Set gas objects in dry run and dev-inspect to the max version to avoid dynamic field issues we have seen with faucet (and faucet tests). 
In dry run and dev inspect, you might load a dynamic field that is actually too new for the transaction. Ideally, we would want to load the "correct" dynamic fields, but as that is not easily determined, we instead can set the sequence number of the gas objects to MAX - 1, to ensure that the lamport version for the transaction is MAX, and as such, a valid lamport version for any object used in the transaction (preventing internal assertions or invariant violations from being triggered)

## Test Plan 

- Added new tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
