### PR TITLE
use reference gas price in cluster test

### DIFF
--- a/crates/sui-cluster-test/src/lib.rs
+++ b/crates/sui-cluster-test/src/lib.rs
@@ -107,6 +107,14 @@ impl TestContext {
         self.client.get_wallet_address()
     }
 
+    async fn get_reference_gas_price(&self) -> u64 {
+        self.get_fullnode_client()
+            .governance_api()
+            .get_reference_gas_price()
+            .await
+            .expect("failed to get reference gas price")
+    }
+
     /// See `make_transactions_with_wallet_context` for potential caveats
     /// of this helper function.
     pub async fn make_transactions(&mut self, max_txn_num: usize) -> Vec<VerifiedTransaction> {

--- a/crates/sui-cluster-test/src/lib.rs
+++ b/crates/sui-cluster-test/src/lib.rs
@@ -19,7 +19,7 @@ use sui_json_rpc_types::{
 use sui_types::base_types::TransactionDigest;
 use sui_types::messages::ExecuteTransactionRequestType;
 use sui_types::object::Owner;
-use test_utils::messages::make_transactions_with_wallet_context;
+use test_utils::messages::make_transactions_with_wallet_context_and_rgp;
 
 use shared_crypto::intent::Intent;
 use sui_sdk::SuiClient;
@@ -110,7 +110,7 @@ impl TestContext {
     /// See `make_transactions_with_wallet_context` for potential caveats
     /// of this helper function.
     pub async fn make_transactions(&mut self, max_txn_num: usize) -> Vec<VerifiedTransaction> {
-        make_transactions_with_wallet_context(self.get_wallet_mut(), max_txn_num).await
+        make_transactions_with_wallet_context_and_rgp(self.get_wallet_mut(), max_txn_num).await
     }
 
     pub async fn build_transaction_remotely(

--- a/crates/sui-cluster-test/src/test_case/coin_merge_split_test.rs
+++ b/crates/sui-cluster-test/src/test_case/coin_merge_split_test.rs
@@ -118,12 +118,7 @@ impl CoinMergeSplitTest {
         coin_to_merge: ObjectID,
         gas_obj_id: ObjectID,
     ) -> SuiTransactionBlockResponse {
-        let gas_price = ctx
-            .get_fullnode_client()
-            .governance_api()
-            .get_reference_gas_price()
-            .await
-            .unwrap();
+        let gas_price = ctx.get_reference_gas_price().await;
         let params = rpc_params![
             signer,
             primary_coin,
@@ -147,12 +142,7 @@ impl CoinMergeSplitTest {
         amounts: Vec<u64>,
         gas_obj_id: ObjectID,
     ) -> SuiTransactionBlockResponse {
-        let gas_price = ctx
-            .get_fullnode_client()
-            .governance_api()
-            .get_reference_gas_price()
-            .await
-            .unwrap();
+        let gas_price = ctx.get_reference_gas_price().await;
         let params = rpc_params![
             signer,
             primary_coin,

--- a/crates/sui-cluster-test/src/test_case/coin_merge_split_test.rs
+++ b/crates/sui-cluster-test/src/test_case/coin_merge_split_test.rs
@@ -118,7 +118,19 @@ impl CoinMergeSplitTest {
         coin_to_merge: ObjectID,
         gas_obj_id: ObjectID,
     ) -> SuiTransactionBlockResponse {
-        let params = rpc_params![signer, primary_coin, coin_to_merge, Some(gas_obj_id), 2000];
+        let gas_price = ctx
+            .get_fullnode_client()
+            .governance_api()
+            .get_reference_gas_price()
+            .await
+            .unwrap();
+        let params = rpc_params![
+            signer,
+            primary_coin,
+            coin_to_merge,
+            Some(gas_obj_id),
+            2000 * gas_price
+        ];
 
         let data = ctx
             .build_transaction_remotely("unsafe_mergeCoins", params)
@@ -135,7 +147,19 @@ impl CoinMergeSplitTest {
         amounts: Vec<u64>,
         gas_obj_id: ObjectID,
     ) -> SuiTransactionBlockResponse {
-        let params = rpc_params![signer, primary_coin, amounts, Some(gas_obj_id), 2000];
+        let gas_price = ctx
+            .get_fullnode_client()
+            .governance_api()
+            .get_reference_gas_price()
+            .await
+            .unwrap();
+        let params = rpc_params![
+            signer,
+            primary_coin,
+            amounts,
+            Some(gas_obj_id),
+            2000 * gas_price
+        ];
 
         let data = ctx
             .build_transaction_remotely("unsafe_splitCoin", params)

--- a/crates/sui-cluster-test/src/test_case/fullnode_build_publish_transaction_test.rs
+++ b/crates/sui-cluster-test/src/test_case/fullnode_build_publish_transaction_test.rs
@@ -26,12 +26,18 @@ impl TestCaseImpl for FullNodeBuildPublishTransactionTest {
             compiled_package.get_package_base64(/* with_unpublished_deps */ false);
         let dependencies = compiled_package.get_dependency_original_package_ids();
 
+        let gas_price = ctx
+            .get_fullnode_client()
+            .governance_api()
+            .get_reference_gas_price()
+            .await
+            .unwrap();
         let params = rpc_params![
             ctx.get_wallet_address(),
             all_module_bytes,
             dependencies,
             None::<ObjectID>,
-            10000
+            10000 * gas_price
         ];
 
         let data = ctx

--- a/crates/sui-cluster-test/src/test_case/fullnode_build_publish_transaction_test.rs
+++ b/crates/sui-cluster-test/src/test_case/fullnode_build_publish_transaction_test.rs
@@ -26,12 +26,7 @@ impl TestCaseImpl for FullNodeBuildPublishTransactionTest {
             compiled_package.get_package_base64(/* with_unpublished_deps */ false);
         let dependencies = compiled_package.get_dependency_original_package_ids();
 
-        let gas_price = ctx
-            .get_fullnode_client()
-            .governance_api()
-            .get_reference_gas_price()
-            .await
-            .unwrap();
+        let gas_price = ctx.get_reference_gas_price().await;
         let params = rpc_params![
             ctx.get_wallet_address(),
             all_module_bytes,

--- a/crates/sui-cluster-test/src/test_case/native_transfer_test.rs
+++ b/crates/sui-cluster-test/src/test_case/native_transfer_test.rs
@@ -35,11 +35,7 @@ impl TestCaseImpl for NativeTransferTest {
         let gas_obj = sui_objs.swap_remove(0);
         let signer = ctx.get_wallet_address();
         let (recipient_addr, _): (_, AccountKeyPair) = get_key_pair();
-        let gas_price = ctx
-            .get_fullnode_client()
-            .governance_api()
-            .get_reference_gas_price()
-            .await?;
+        let gas_price = ctx.get_reference_gas_price().await;
         // Test transfer object
         let obj_to_transfer = *sui_objs.swap_remove(0).id();
         let params = rpc_params![

--- a/crates/sui-cluster-test/src/test_case/native_transfer_test.rs
+++ b/crates/sui-cluster-test/src/test_case/native_transfer_test.rs
@@ -35,14 +35,18 @@ impl TestCaseImpl for NativeTransferTest {
         let gas_obj = sui_objs.swap_remove(0);
         let signer = ctx.get_wallet_address();
         let (recipient_addr, _): (_, AccountKeyPair) = get_key_pair();
-
+        let gas_price = ctx
+            .get_fullnode_client()
+            .governance_api()
+            .get_reference_gas_price()
+            .await?;
         // Test transfer object
         let obj_to_transfer = *sui_objs.swap_remove(0).id();
         let params = rpc_params![
             signer,
             obj_to_transfer,
             Some(*gas_obj.id()),
-            5000,
+            5000 * gas_price,
             recipient_addr
         ];
         let data = ctx
@@ -54,7 +58,13 @@ impl TestCaseImpl for NativeTransferTest {
 
         // Test transfer sui
         let obj_to_transfer = *sui_objs.swap_remove(0).id();
-        let params = rpc_params![signer, obj_to_transfer, 5000, recipient_addr, None::<u64>];
+        let params = rpc_params![
+            signer,
+            obj_to_transfer,
+            5000 * gas_price,
+            recipient_addr,
+            None::<u64>
+        ];
         let data = ctx
             .build_transaction_remotely("unsafe_transferSui", params)
             .await?;

--- a/crates/sui-config/src/lib.rs
+++ b/crates/sui-config/src/lib.rs
@@ -35,6 +35,7 @@ pub const AUTHORITIES_DB_NAME: &str = "authorities_db";
 pub const CONSENSUS_DB_NAME: &str = "consensus_db";
 pub const FULL_NODE_DB_PATH: &str = "full_node_db";
 
+// TODO: change this to a more realistic value like 1000.
 const DEFAULT_GAS_PRICE: u64 = 1;
 const DEFAULT_COMMISSION_RATE: u64 = 0;
 

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -50,6 +50,7 @@ use tap::Pipe;
 use thiserror::Error;
 use tracing::trace;
 
+// TODO: use RGP instead.
 pub const DUMMY_GAS_PRICE: u64 = 1;
 
 const BLOCKED_MOVE_FUNCTIONS: [(ObjectID, &str, &str); 0] = [];

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1343,6 +1343,12 @@ impl WalletContext {
         ))
     }
 
+    pub async fn get_reference_gas_price(&self) -> Result<u64, anyhow::Error> {
+        let client = self.get_client().await?;
+        let gas_price = client.governance_api().get_reference_gas_price().await?;
+        Ok(gas_price)
+    }
+
     pub async fn execute_transaction_block(
         &self,
         tx: VerifiedTransaction,

--- a/crates/test-utils/src/transaction.rs
+++ b/crates/test-utils/src/transaction.rs
@@ -41,7 +41,7 @@ use crate::messages::{
     make_tx_certs_and_signed_effects_with_committee, MAX_GAS,
 };
 
-const GAS_BUDGET: u64 = 10000;
+const GAS_BUDGET_IN_UNIT: u64 = 10000;
 
 pub fn make_publish_package(gas_object: Object, path: PathBuf) -> VerifiedTransaction {
     let (sender, keypair) = deterministic_random_account_key();
@@ -118,10 +118,21 @@ pub async fn publish_package_with_wallet(
     dep_ids: Vec<ObjectID>,
 ) -> (ObjectRef, TransactionDigest) {
     let client = context.get_client().await.unwrap();
+    let gas_price = client
+        .governance_api()
+        .get_reference_gas_price()
+        .await
+        .unwrap();
     let transaction = {
         let data = client
             .transaction_builder()
-            .publish(sender, all_module_bytes, dep_ids, None, GAS_BUDGET)
+            .publish(
+                sender,
+                all_module_bytes,
+                dep_ids,
+                None,
+                GAS_BUDGET_IN_UNIT * gas_price,
+            )
             .await
             .unwrap();
 
@@ -171,6 +182,11 @@ pub async fn submit_move_transaction(
 ) -> SuiTransactionBlockResponse {
     debug!(?package_id, ?arguments, "move_transaction");
     let client = context.get_client().await.unwrap();
+    let gas_price = client
+        .governance_api()
+        .get_reference_gas_price()
+        .await
+        .unwrap();
     let data = client
         .transaction_builder()
         .move_call(
@@ -181,7 +197,7 @@ pub async fn submit_move_transaction(
             vec![], // type_args
             arguments,
             gas_object,
-            GAS_BUDGET,
+            GAS_BUDGET_IN_UNIT * gas_price,
         )
         .await
         .unwrap();
@@ -270,6 +286,8 @@ pub async fn create_devnet_nft(
 ) -> Result<(SuiAddress, ObjectID, TransactionDigest), anyhow::Error> {
     let (sender, gas_objects) = get_account_and_gas_coins(context).await?.swap_remove(0);
     let gas_object = gas_objects.get(0).unwrap().id();
+    let client = context.get_client().await?;
+    let gas_price = client.governance_api().get_reference_gas_price().await?;
 
     let args_json = json!([
         "example_nft_name",
@@ -288,7 +306,7 @@ pub async fn create_devnet_nft(
         type_args: vec![],
         args,
         gas: Some(*gas_object),
-        gas_budget: GAS_BUDGET,
+        gas_budget: GAS_BUDGET_IN_UNIT * gas_price,
     }
     .execute(context)
     .await?;
@@ -318,6 +336,8 @@ pub async fn transfer_sui(
     sender: Option<SuiAddress>,
     receiver: Option<SuiAddress>,
 ) -> Result<(ObjectID, SuiAddress, SuiAddress, TransactionDigest), anyhow::Error> {
+    let client = context.get_client().await?;
+    let gas_price = client.governance_api().get_reference_gas_price().await?;
     let sender = match sender {
         None => context.config.keystore.addresses().get(0).cloned().unwrap(),
         Some(addr) => addr,
@@ -334,7 +354,7 @@ pub async fn transfer_sui(
         to: receiver,
         amount: None,
         sui_coin_object_id: gas_ref.0,
-        gas_budget: GAS_BUDGET,
+        gas_budget: GAS_BUDGET_IN_UNIT * gas_price,
     }
     .execute(context)
     .await?;
@@ -361,6 +381,8 @@ pub async fn transfer_coin(
     ),
     anyhow::Error,
 > {
+    let client = context.get_client().await?;
+    let gas_price = client.governance_api().get_reference_gas_price().await?;
     let sender = context.config.keystore.addresses().get(0).cloned().unwrap();
     let receiver = context.config.keystore.addresses().get(1).cloned().unwrap();
     let client = context.get_client().await.unwrap();
@@ -393,7 +415,7 @@ pub async fn transfer_coin(
         to: receiver,
         object_id: object_to_send,
         gas: None,
-        gas_budget: GAS_BUDGET,
+        gas_budget: GAS_BUDGET_IN_UNIT * gas_price,
     }
     .execute(context)
     .await?;
@@ -427,12 +449,18 @@ pub async fn transfer_coin(
 }
 
 pub async fn split_coin_with_wallet_context(context: &mut WalletContext, coin_id: ObjectID) {
+    let client = context.get_client().await.unwrap();
+    let gas_price = client
+        .governance_api()
+        .get_reference_gas_price()
+        .await
+        .unwrap();
     SuiClientCommands::SplitCoin {
         coin_id,
         amounts: None,
         count: Some(2),
         gas: None,
-        gas_budget: MAX_GAS,
+        gas_budget: GAS_BUDGET_IN_UNIT * gas_price,
     }
     .execute(context)
     .await

--- a/crates/test-utils/src/transaction.rs
+++ b/crates/test-utils/src/transaction.rs
@@ -118,11 +118,7 @@ pub async fn publish_package_with_wallet(
     dep_ids: Vec<ObjectID>,
 ) -> (ObjectRef, TransactionDigest) {
     let client = context.get_client().await.unwrap();
-    let gas_price = client
-        .governance_api()
-        .get_reference_gas_price()
-        .await
-        .unwrap();
+    let gas_price = context.get_reference_gas_price().await.unwrap();
     let transaction = {
         let data = client
             .transaction_builder()
@@ -182,11 +178,7 @@ pub async fn submit_move_transaction(
 ) -> SuiTransactionBlockResponse {
     debug!(?package_id, ?arguments, "move_transaction");
     let client = context.get_client().await.unwrap();
-    let gas_price = client
-        .governance_api()
-        .get_reference_gas_price()
-        .await
-        .unwrap();
+    let gas_price = context.get_reference_gas_price().await.unwrap();
     let data = client
         .transaction_builder()
         .move_call(
@@ -286,8 +278,7 @@ pub async fn create_devnet_nft(
 ) -> Result<(SuiAddress, ObjectID, TransactionDigest), anyhow::Error> {
     let (sender, gas_objects) = get_account_and_gas_coins(context).await?.swap_remove(0);
     let gas_object = gas_objects.get(0).unwrap().id();
-    let client = context.get_client().await?;
-    let gas_price = client.governance_api().get_reference_gas_price().await?;
+    let gas_price = context.get_reference_gas_price().await?;
 
     let args_json = json!([
         "example_nft_name",
@@ -336,8 +327,7 @@ pub async fn transfer_sui(
     sender: Option<SuiAddress>,
     receiver: Option<SuiAddress>,
 ) -> Result<(ObjectID, SuiAddress, SuiAddress, TransactionDigest), anyhow::Error> {
-    let client = context.get_client().await?;
-    let gas_price = client.governance_api().get_reference_gas_price().await?;
+    let gas_price = context.get_reference_gas_price().await?;
     let sender = match sender {
         None => context.config.keystore.addresses().get(0).cloned().unwrap(),
         Some(addr) => addr,
@@ -381,8 +371,7 @@ pub async fn transfer_coin(
     ),
     anyhow::Error,
 > {
-    let client = context.get_client().await?;
-    let gas_price = client.governance_api().get_reference_gas_price().await?;
+    let gas_price = context.get_reference_gas_price().await?;
     let sender = context.config.keystore.addresses().get(0).cloned().unwrap();
     let receiver = context.config.keystore.addresses().get(1).cloned().unwrap();
     let client = context.get_client().await.unwrap();
@@ -449,12 +438,7 @@ pub async fn transfer_coin(
 }
 
 pub async fn split_coin_with_wallet_context(context: &mut WalletContext, coin_id: ObjectID) {
-    let client = context.get_client().await.unwrap();
-    let gas_price = client
-        .governance_api()
-        .get_reference_gas_price()
-        .await
-        .unwrap();
+    let gas_price = context.get_reference_gas_price().await.unwrap();
     SuiClientCommands::SplitCoin {
         coin_id,
         amounts: None,


### PR DESCRIPTION
## Description 

This PR modifies our cluster test and some other necessary places so that we use the reference gas price for transactions in cluster test instead of dummy gas price.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
