### PR TITLE
move: upgrade command in transactional tests

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/upgrade/basic.exp
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/basic.exp
@@ -1,0 +1,13 @@
+processed 3 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 6-11:
+created: object(1,0), object(1,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6194000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'upgrade'. lines 13-17:
+Error: Transaction Effects Status: Invalid package upgrade. New package is incompatible with previous version
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: PackageUpgradeError { upgrade_error: IncompatibleUpgrade }, source: Some(PartialVMError { major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE, sub_status: None, message: None, exec_state: None, indices: [], offsets: [] }), command: Some(1) } }

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/basic.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/basic.move
@@ -1,0 +1,17 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses Test=0x0 --accounts A
+
+//# publish --upgradeable --sender A
+module Test::M1 {
+    use sui::tx_context::TxContext;
+    fun init(_ctx: &mut TxContext) { }
+    public fun f1() { }
+}
+
+//# upgrade --package Test --upgrade-capability 1,1 --sender A
+module Test::M1 {
+    use sui::tx_context::TxContext;
+    fun init(_ctx: &mut TxContext) { }
+}

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/multi_version.exp
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/multi_version.exp
@@ -1,0 +1,18 @@
+processed 4 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 6-10:
+created: object(1,0), object(1,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6080000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'upgrade'. lines 12-17:
+created: object(2,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 6194000,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 3 'upgrade'. lines 19-23:
+Error: Transaction Effects Status: Invalid package upgrade. New package is incompatible with previous version
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: PackageUpgradeError { upgrade_error: IncompatibleUpgrade }, source: Some(PartialVMError { major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE, sub_status: None, message: None, exec_state: None, indices: [], offsets: [] }), command: Some(1) } }

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/multi_version.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/multi_version.move
@@ -1,0 +1,24 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses Test_V1=0x0 Test_V2=0x0 Test_V3=0x0 --accounts A
+
+//# publish --upgradeable --sender A
+module Test_V1::M1 {
+    use sui::tx_context::TxContext;
+    fun init(_ctx: &mut TxContext) { }
+}
+
+//# upgrade --package Test_V1 --upgrade-capability 1,1 --sender A
+module Test_V2::M1 {
+    use sui::tx_context::TxContext;
+    fun init(_ctx: &mut TxContext) { }
+    public fun f1() { }
+}
+
+//# upgrade --package Test_V2 --upgrade-capability 1,1 --sender A
+module Test_V3::M1 {
+    use sui::tx_context::TxContext;
+    fun init(_ctx: &mut TxContext) { }
+}
+

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -9,6 +9,7 @@ use move_command_line_common::{parser::Parser as MoveCLParser, values::ValueToke
 use move_core_types::identifier::Identifier;
 use move_core_types::u256::U256;
 use move_core_types::value::{MoveStruct, MoveValue};
+use move_transactional_test_runner::tasks::SyntaxChoice;
 use sui_types::base_types::SuiAddress;
 use sui_types::messages::{Argument, CallArg, ObjectArg};
 use sui_types::object::Owner;
@@ -96,6 +97,26 @@ pub struct ProgrammableTransactionCommand {
 }
 
 #[derive(Debug, clap::Parser)]
+pub struct UpgradePackageCommand {
+    #[clap(long = "package")]
+    pub package: String,
+    #[clap(long = "upgrade-capability", parse(try_from_str = parse_fake_id))]
+    pub upgrade_capability: FakeID,
+    #[clap(
+        long = "dependencies",
+        multiple_values(true),
+        multiple_occurrences(false)
+    )]
+    pub dependencies: Vec<String>,
+    #[clap(long = "sender")]
+    pub sender: String,
+    #[clap(long = "gas-budget")]
+    pub gas_budget: Option<u64>,
+    #[clap(long = "syntax")]
+    pub syntax: Option<SyntaxChoice>,
+}
+
+#[derive(Debug, clap::Parser)]
 pub enum SuiSubcommand {
     #[clap(name = "view-object")]
     ViewObject(ViewObjectCommand),
@@ -105,6 +126,8 @@ pub enum SuiSubcommand {
     ConsensusCommitPrologue(ConsensusCommitPrologueCommand),
     #[clap(name = "programmable")]
     ProgrammableTransaction(ProgrammableTransactionCommand),
+    #[clap(name = "upgrade")]
+    UpgradePackage(UpgradePackageCommand),
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
## Description 

Enables `#upgrade` in transactional tests.

## Test Plan 

It is tests.