### PR TITLE
[rusk sdk] Adding AggregateAuthoritySig to Checkpoint

### DIFF
--- a/crates/sui-indexer/benches/indexer_benchmark.rs
+++ b/crates/sui-indexer/benches/indexer_benchmark.rs
@@ -21,6 +21,7 @@ use sui_indexer::store::{
 use sui_indexer::utils::reset_database;
 use sui_json_rpc_types::CheckpointId;
 use sui_types::base_types::{ObjectDigest, ObjectID, SequenceNumber, SuiAddress};
+use sui_types::crypto::AggregateAuthoritySignature;
 use sui_types::digests::TransactionDigest;
 use sui_types::gas_coin::GasCoin;
 use sui_types::messages::TransactionData;
@@ -60,6 +61,7 @@ fn create_checkpoint(sequence_number: i64) -> TemporaryCheckpointStore {
             transactions: vec![],
             previous_checkpoint_digest: Some(CheckpointDigest::random().base58_encode()),
             end_of_epoch: false,
+            validator_signature: AggregateAuthoritySignature::default().to_string(),
             total_gas_cost: i64::MAX,
             total_computation_cost: i64::MAX,
             total_storage_cost: i64::MAX,

--- a/crates/sui-indexer/migrations/2023-01-16-233119_checkpoint/up.sql
+++ b/crates/sui-indexer/migrations/2023-01-16-233119_checkpoint/up.sql
@@ -6,6 +6,7 @@ CREATE TABLE checkpoints
     transactions               TEXT[]       NOT NULL,
     previous_checkpoint_digest VARCHAR(255),
     end_of_epoch               BOOLEAN      NOT NULL,
+    validator_signature        TEXT         NOT NULL,
     -- derived from GasCostSummary
     total_gas_cost             BIGINT       NOT NULL,
     total_computation_cost     BIGINT       NOT NULL,

--- a/crates/sui-indexer/migrations/2023-01-16-233119_checkpoint/up.sql
+++ b/crates/sui-indexer/migrations/2023-01-16-233119_checkpoint/up.sql
@@ -6,6 +6,7 @@ CREATE TABLE checkpoints
     transactions               TEXT[]       NOT NULL,
     previous_checkpoint_digest VARCHAR(255),
     end_of_epoch               BOOLEAN      NOT NULL,
+    -- TODO (Jian): Change validator signature to bytes
     validator_signature        TEXT         NOT NULL,
     -- derived from GasCostSummary
     total_gas_cost             BIGINT       NOT NULL,

--- a/crates/sui-indexer/src/models/checkpoints.rs
+++ b/crates/sui-indexer/src/models/checkpoints.rs
@@ -23,7 +23,6 @@ pub struct Checkpoint {
     pub transactions: Vec<Option<String>>,
     pub previous_checkpoint_digest: Option<String>,
     pub end_of_epoch: bool,
-    #[diesel(sql_type = Text)]
     pub validator_signature: String,
     pub total_gas_cost: i64,
     pub total_computation_cost: i64,

--- a/crates/sui-indexer/src/models/checkpoints.rs
+++ b/crates/sui-indexer/src/models/checkpoints.rs
@@ -3,14 +3,16 @@
 
 use diesel::prelude::*;
 
+use fastcrypto::traits::EncodeDecodeBase64;
 use sui_json_rpc_types::Checkpoint as RpcCheckpoint;
 use sui_types::base_types::TransactionDigest;
+use sui_types::crypto::AggregateAuthoritySignature;
 use sui_types::digests::CheckpointDigest;
 use sui_types::gas::GasCostSummary;
 use sui_types::messages_checkpoint::EndOfEpochData;
 
 use crate::errors::IndexerError;
-use crate::schema::checkpoints;
+use crate::schema::checkpoints::{self};
 
 #[derive(Queryable, Insertable, Debug, Clone, Default)]
 #[diesel(table_name = checkpoints)]
@@ -21,6 +23,8 @@ pub struct Checkpoint {
     pub transactions: Vec<Option<String>>,
     pub previous_checkpoint_digest: Option<String>,
     pub end_of_epoch: bool,
+    #[diesel(sql_type = Text)]
+    pub validator_signature: String,
     pub total_gas_cost: i64,
     pub total_computation_cost: i64,
     pub total_storage_cost: i64,
@@ -57,6 +61,7 @@ impl Checkpoint {
             transactions: checkpoint_transactions,
             previous_checkpoint_digest: rpc_checkpoint.previous_digest.map(|d| d.base58_encode()),
             end_of_epoch: rpc_checkpoint.end_of_epoch_data.is_some(),
+            validator_signature: rpc_checkpoint.validator_signature.encode_base64(),
             total_gas_cost: total_gas_cost as i64,
             total_computation_cost: rpc_checkpoint
                 .epoch_rolling_gas_cost_summary
@@ -110,6 +115,13 @@ impl Checkpoint {
                 })
             })
             .collect::<Result<Vec<TransactionDigest>, IndexerError>>()?;
+        let validator_sig = AggregateAuthoritySignature::decode_base64(&self.validator_signature)
+            .map_err(|e| {
+            IndexerError::SerdeError(format!(
+                "Failed to decode validator signature: {:?} with err: {:?}",
+                self.validator_signature, e
+            ))
+        })?;
 
         Ok(RpcCheckpoint {
             epoch: self.epoch as u64,
@@ -117,6 +129,7 @@ impl Checkpoint {
             digest: parsed_digest,
             previous_digest: parsed_previous_digest,
             end_of_epoch_data,
+            validator_signature: validator_sig,
             epoch_rolling_gas_cost_summary: GasCostSummary {
                 computation_cost: self.total_computation_cost as u64,
                 storage_cost: self.total_storage_cost as u64,

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -41,6 +41,7 @@ diesel::table! {
         transactions -> Array<Nullable<Text>>,
         previous_checkpoint_digest -> Nullable<Varchar>,
         end_of_epoch -> Bool,
+        validator_signature -> Text,
         total_gas_cost -> Int8,
         total_computation_cost -> Int8,
         total_storage_cost -> Int8,

--- a/crates/sui-indexer/tests/integration_tests.rs
+++ b/crates/sui-indexer/tests/integration_tests.rs
@@ -1203,6 +1203,18 @@ pub mod pg_integration_test {
         assert_eq!(first_checkpoint.previous_digest, None);
         assert_eq!(first_checkpoint.transactions.len(), 1);
 
+        // Check if checkpoint validator sig matches
+        let fullnode_checkpoint = test_cluster
+            .rpc_client()
+            .get_checkpoint(cp.into())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            first_checkpoint.validator_signature,
+            fullnode_checkpoint.validator_signature
+        );
+
         let (tx_response, _, _, _) =
             execute_simple_transfer(&mut test_cluster, &indexer_rpc_client)
                 .await

--- a/crates/sui-json-rpc-types/src/sui_checkpoint.rs
+++ b/crates/sui-json-rpc-types/src/sui_checkpoint.rs
@@ -1,10 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use fastcrypto::encoding::Base64;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 use sui_types::base_types::TransactionDigest;
 use sui_types::committee::EpochId;
+use sui_types::crypto::AggregateAuthoritySignature;
 use sui_types::digests::CheckpointDigest;
 use sui_types::gas::GasCostSummary;
 use sui_types::message_envelope::Message;
@@ -20,6 +23,7 @@ pub type SuiCheckpointSequenceNumber = BigInt;
 pub type CheckpointPage = Page<Checkpoint, SuiCheckpointSequenceNumber>;
 
 #[derive(Clone, Debug, JsonSchema, Serialize, Deserialize, PartialEq, Eq)]
+#[serde_as]
 #[serde(rename_all = "camelCase")]
 pub struct Checkpoint {
     /// Checkpoint's epoch ID
@@ -49,10 +53,26 @@ pub struct Checkpoint {
 
     /// Commitments to checkpoint state
     pub checkpoint_commitments: Vec<CheckpointCommitment>,
+    /// Validator Signature
+    #[schemars(with = "Base64")]
+    #[serde_as(as = "Readable<Base64, Bytes>")]
+    pub validator_signature: AggregateAuthoritySignature,
 }
 
-impl From<(CheckpointSummary, CheckpointContents)> for Checkpoint {
-    fn from((summary, contents): (CheckpointSummary, CheckpointContents)) -> Self {
+impl
+    From<(
+        CheckpointSummary,
+        CheckpointContents,
+        AggregateAuthoritySignature,
+    )> for Checkpoint
+{
+    fn from(
+        (summary, contents, signature): (
+            CheckpointSummary,
+            CheckpointContents,
+            AggregateAuthoritySignature,
+        ),
+    ) -> Self {
         let digest = summary.digest();
         let CheckpointSummary {
             epoch,
@@ -79,6 +99,7 @@ impl From<(CheckpointSummary, CheckpointContents)> for Checkpoint {
             // info (if they need it, they need to get signed BCS data anyway in order to trust
             // it).
             checkpoint_commitments: Default::default(),
+            validator_signature: signature,
         }
     }
 }

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -92,16 +92,35 @@ impl ReadApi {
     fn get_checkpoint_internal(&self, id: CheckpointId) -> Result<Checkpoint, Error> {
         Ok(match id {
             CheckpointId::SequenceNumber(seq) => {
-                let summary = self
+                let verified_summary = self
                     .state
-                    .get_checkpoint_summary_by_sequence_number(seq.into())?;
-                let content = self.state.get_checkpoint_contents(summary.content_digest)?;
-                (summary, content).into()
+                    .get_verified_checkpoint_by_sequence_number(seq.into())?;
+                let content = self
+                    .state
+                    .get_checkpoint_contents(verified_summary.content_digest)?;
+                let signature = &verified_summary.auth_sig().signature;
+                (
+                    verified_summary.clone().into_inner().into_data(),
+                    content,
+                    signature.clone(),
+                )
+                    .into()
             }
             CheckpointId::Digest(digest) => {
-                let summary = self.state.get_checkpoint_summary_by_digest(digest)?;
-                let content = self.state.get_checkpoint_contents(summary.content_digest)?;
-                (summary, content).into()
+                let verified_summary = self
+                    .state
+                    .get_verified_checkpoint_summary_by_digest(digest)?;
+                // summary.content_digest
+                let content = self
+                    .state
+                    .get_checkpoint_contents(verified_summary.content_digest)?;
+                let signature = &verified_summary.auth_sig().signature;
+                (
+                    verified_summary.clone().into_inner().into_data(),
+                    content,
+                    signature.clone(),
+                )
+                    .into()
             }
         })
     }

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -98,11 +98,11 @@ impl ReadApi {
                 let content = self
                     .state
                     .get_checkpoint_contents(verified_summary.content_digest)?;
-                let signature = &verified_summary.auth_sig().signature;
+                let signature = verified_summary.auth_sig().signature.clone();
                 (
-                    verified_summary.clone().into_inner().into_data(),
+                    verified_summary.into_inner().into_data(),
                     content,
-                    signature.clone(),
+                    signature,
                 )
                     .into()
             }
@@ -110,15 +110,14 @@ impl ReadApi {
                 let verified_summary = self
                     .state
                     .get_verified_checkpoint_summary_by_digest(digest)?;
-                // summary.content_digest
                 let content = self
                     .state
                     .get_checkpoint_contents(verified_summary.content_digest)?;
-                let signature = &verified_summary.auth_sig().signature;
+                let signature = verified_summary.auth_sig().signature.clone();
                 (
-                    verified_summary.clone().into_inner().into_data(),
+                    verified_summary.into_inner().into_data(),
                     content,
-                    signature.clone(),
+                    signature,
                 )
                     .into()
             }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -343,7 +343,8 @@
               "transactions": [
                 "3bpzHaSLTQ6p4trLDk2euZxzQ6XqLeWDmUNTAdEXXL2c"
               ],
-              "checkpointCommitments": []
+              "checkpointCommitments": [],
+              "validatorSignature": "wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
             }
           }
         }
@@ -2853,7 +2854,8 @@
           "networkTotalTransactions",
           "sequenceNumber",
           "timestampMs",
-          "transactions"
+          "transactions",
+          "validatorSignature"
         ],
         "properties": {
           "checkpointCommitments": {
@@ -2933,6 +2935,14 @@
             "items": {
               "$ref": "#/components/schemas/TransactionDigest"
             }
+          },
+          "validatorSignature": {
+            "description": "Validator Signature",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Base64"
+              }
+            ]
           }
         }
       },

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -33,7 +33,7 @@ use sui_types::base_types::{
     MoveObjectType, ObjectDigest, ObjectID, ObjectType, SequenceNumber, SuiAddress,
     TransactionDigest,
 };
-use sui_types::crypto::{get_key_pair_from_rng, AccountKeyPair};
+use sui_types::crypto::{get_key_pair_from_rng, AccountKeyPair, AggregateAuthoritySignature};
 use sui_types::digests::TransactionEventsDigest;
 use sui_types::event::EventID;
 use sui_types::gas_coin::GasCoin;
@@ -295,6 +295,7 @@ impl RpcExampleProvider {
             end_of_epoch_data: None,
             transactions: vec![TransactionDigest::new(self.rng.gen())],
             checkpoint_commitments: vec![],
+            validator_signature: AggregateAuthoritySignature::default(),
         };
 
         Examples::new(

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -10,7 +10,9 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use crate::accumulator::Accumulator;
 use crate::base_types::{ExecutionData, ExecutionDigests, VerifiedExecutionData};
 use crate::committee::{EpochId, ProtocolVersion, StakeUnit};
-use crate::crypto::{default_hash, AuthoritySignInfo, AuthorityStrongQuorumSignInfo};
+use crate::crypto::{
+    default_hash, AggregateAuthoritySignature, AuthoritySignInfo, AuthorityStrongQuorumSignInfo,
+};
 use crate::error::SuiResult;
 use crate::gas::GasCostSummary;
 use crate::message_envelope::{Envelope, Message, TrustedEnvelope, VerifiedEnvelope};
@@ -248,6 +250,10 @@ impl VerifiedCheckpoint {
     pub fn into_summary_and_sequence(self) -> (CheckpointSequenceNumber, CheckpointSummary) {
         let summary = self.into_inner().into_data();
         (summary.sequence_number, summary)
+    }
+
+    pub fn get_validator_signature(self) -> AggregateAuthoritySignature {
+        self.auth_sig().signature.clone()
     }
 }
 

--- a/sdk/typescript/src/types/checkpoints.ts
+++ b/sdk/typescript/src/types/checkpoints.ts
@@ -38,6 +38,9 @@ export type ECMHLiveObjectSetDigest = Infer<typeof ECMHLiveObjectSetDigest>;
 export const CheckpointCommitment = any();
 export type CheckpointCommitment = Infer<typeof CheckpointCommitment>;
 
+export const ValidatorSignature = string();
+export type ValidatorSignature = Infer<typeof ValidatorSignature>;
+
 export const EndOfEpochData = object({
   nextEpochCommittee: array(tuple([string(), number()])),
   nextEpochProtocolVersion: number(),
@@ -59,6 +62,7 @@ export const Checkpoint = object({
   epochRollingGasCostSummary: GasCostSummary,
   timestampMs: number(),
   endOfEpochData: optional(EndOfEpochData),
+  validatorSignature: ValidatorSignature,
   transactions: array(TransactionDigest),
   checkpointCommitments: array(CheckpointCommitment),
 });

--- a/sdk/typescript/src/types/checkpoints.ts
+++ b/sdk/typescript/src/types/checkpoints.ts
@@ -62,7 +62,8 @@ export const Checkpoint = object({
   epochRollingGasCostSummary: GasCostSummary,
   timestampMs: number(),
   endOfEpochData: optional(EndOfEpochData),
-  validatorSignature: ValidatorSignature,
+  // TODO(jian): remove optional after 0.30.0 is released
+  validatorSignature: optional(ValidatorSignature),
   transactions: array(TransactionDigest),
   checkpointCommitments: array(CheckpointCommitment),
 });


### PR DESCRIPTION
## Description 

Adding a validator signature field to checkpoint 

## Test Plan 
Postman local call vs FN
![image](https://user-images.githubusercontent.com/123408603/228853281-548b56c1-f09b-426f-8648-27794da07d7b.png)

Indexer + FN signatures match for a single checkpoint
![image](https://user-images.githubusercontent.com/123408603/228853969-9b5733e3-5ddf-4abd-a15e-12bf96fdcb7e.png)

Indexer call:
![image](https://user-images.githubusercontent.com/123408603/228859487-9e680616-b140-4b40-b99c-06df3cf9bfed.png)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
