### PR TITLE
Add code for gas v2 and conservation

### DIFF
--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -229,20 +229,20 @@ fn execute_transaction<
     #[allow(clippy::collapsible_if)]
     if protocol_config.gas_model_version() > 1 {
         if !is_system {
-            temporary_store.charge_gas(gas_object_ref.0, &mut gas_status, &mut result, gas);
-            if protocol_config.conservation_checks() {
-                if !Mode::allow_arbitrary_values() {
-                    // ensure that this transaction did not create or destroy SUI
-                    temporary_store.check_sui_conserved().unwrap();
-                }
-                // else, we're in dev-inspect mode, which lets you turn bytes into arbitrary
-                // objects (including coins). this can violate conservation, but it's expected
+            let cost_summary =
+                temporary_store.charge_gas(gas_object_ref.0, &mut gas_status, &mut result, gas);
+            if !Mode::allow_arbitrary_values() {
+                // ensure that this transaction did not create or destroy SUI
+                temporary_store.check_sui_conserved().unwrap();
             }
+            // else, we're in dev-inspect mode, which lets you turn bytes into arbitrary
+            // objects (including coins). this can violate conservation, but it's expected
+            return (cost_summary, result);
         }
     } else {
         #[allow(clippy::collapsible-else-if)]
         if !gas_status.is_unmetered() {
-            temporary_store.charge_gas(gas_object_ref.0, &mut gas_status, &mut result, gas);
+            temporary_store.charge_gas_legacy(gas_object_ref.0, &mut gas_status, &mut result, gas);
         }
     }
     let cost_summary = gas_status.summary();

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -205,17 +205,13 @@ async fn check_gas(
         }
 
         // check balance and coins consistency
-        if protocol_config.gas_model_version() > 1 {
-            panic!("TBD");
-        } else {
-            let cost_table = SuiCostTable::new(protocol_config);
-            cost_table.check_gas_balance(gas_object, more_gas_objects, gas_budget, gas_price)?;
-            Ok(SuiGasStatus::new_with_budget(
-                gas_budget,
-                gas_price,
-                protocol_config,
-            ))
-        }
+        let cost_table = SuiCostTable::new(protocol_config);
+        cost_table.check_gas_balance(gas_object, more_gas_objects, gas_budget, gas_price)?;
+        Ok(SuiGasStatus::new_with_budget(
+            gas_budget,
+            gas_price,
+            protocol_config,
+        ))
     }
 }
 

--- a/crates/sui-core/src/unit_tests/pay_sui_tests.rs
+++ b/crates/sui-core/src/unit_tests/pay_sui_tests.rs
@@ -25,10 +25,10 @@ use sui_types::{base_types::dbg_addr, crypto::get_key_pair, error::SuiError};
 async fn test_pay_sui_failure_empty_recipients() {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
     let coin_id = ObjectID::random();
-    let coin1 = Object::with_id_owner_gas_for_testing(coin_id, sender, 1100);
+    let coin1 = Object::with_id_owner_gas_for_testing(coin_id, sender, 20000);
 
     // an empty set of programmable transaction commands will still charge gas
-    let res = execute_pay_sui(vec![coin1], vec![], vec![], sender, sender_key, 1100).await;
+    let res = execute_pay_sui(vec![coin1], vec![], vec![], sender, sender_key, 20000).await;
 
     let effects = res.txn_result.unwrap().into_data();
     assert_eq!(effects.status(), &ExecutionStatus::Success);
@@ -41,7 +41,7 @@ async fn test_pay_sui_failure_empty_recipients() {
 #[tokio::test]
 async fn test_pay_sui_failure_insufficient_gas_balance_one_input_coin() {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
-    let coin1 = Object::with_id_owner_gas_for_testing(ObjectID::random(), sender, 1000);
+    let coin1 = Object::with_id_owner_gas_for_testing(ObjectID::random(), sender, 2000);
     let recipient1 = dbg_addr(1);
     let recipient2 = dbg_addr(2);
 
@@ -51,15 +51,15 @@ async fn test_pay_sui_failure_insufficient_gas_balance_one_input_coin() {
         vec![100, 100],
         sender,
         sender_key,
-        1200,
+        2200,
     )
     .await;
 
     assert_eq!(
         UserInputError::try_from(res.txn_result.unwrap_err()).unwrap(),
         UserInputError::GasBalanceTooLow {
-            gas_balance: 1000,
-            needed_gas_amount: 1200,
+            gas_balance: 2000,
+            needed_gas_amount: 2200,
         }
     );
 }
@@ -67,7 +67,7 @@ async fn test_pay_sui_failure_insufficient_gas_balance_one_input_coin() {
 #[tokio::test]
 async fn test_pay_sui_failure_insufficient_total_balance_one_input_coin() {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
-    let coin1 = Object::with_id_owner_gas_for_testing(ObjectID::random(), sender, 1000);
+    let coin1 = Object::with_id_owner_gas_for_testing(ObjectID::random(), sender, 2600);
     let recipient1 = dbg_addr(1);
     let recipient2 = dbg_addr(2);
 
@@ -77,7 +77,7 @@ async fn test_pay_sui_failure_insufficient_total_balance_one_input_coin() {
         vec![100, 100],
         sender,
         sender_key,
-        900,
+        2500,
     )
     .await;
 
@@ -93,8 +93,8 @@ async fn test_pay_sui_failure_insufficient_total_balance_one_input_coin() {
 #[tokio::test]
 async fn test_pay_sui_failure_insufficient_gas_balance_multiple_input_coins() {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
-    let coin1 = Object::with_id_owner_gas_for_testing(ObjectID::random(), sender, 400);
-    let coin2 = Object::with_id_owner_gas_for_testing(ObjectID::random(), sender, 600);
+    let coin1 = Object::with_id_owner_gas_for_testing(ObjectID::random(), sender, 800);
+    let coin2 = Object::with_id_owner_gas_for_testing(ObjectID::random(), sender, 700);
     let recipient1 = dbg_addr(1);
     let recipient2 = dbg_addr(2);
 
@@ -104,15 +104,15 @@ async fn test_pay_sui_failure_insufficient_gas_balance_multiple_input_coins() {
         vec![100, 100],
         sender,
         sender_key,
-        1001,
+        2000,
     )
     .await;
 
     assert_eq!(
         UserInputError::try_from(res.txn_result.unwrap_err()).unwrap(),
         UserInputError::GasBalanceTooLow {
-            gas_balance: 1000,
-            needed_gas_amount: 1001,
+            gas_balance: 1500,
+            needed_gas_amount: 2000,
         }
     );
 }
@@ -120,8 +120,8 @@ async fn test_pay_sui_failure_insufficient_gas_balance_multiple_input_coins() {
 #[tokio::test]
 async fn test_pay_sui_failure_insufficient_total_balance_multiple_input_coins() {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
-    let coin1 = Object::with_id_owner_gas_for_testing(ObjectID::random(), sender, 400);
-    let coin2 = Object::with_id_owner_gas_for_testing(ObjectID::random(), sender, 600);
+    let coin1 = Object::with_id_owner_gas_for_testing(ObjectID::random(), sender, 1400);
+    let coin2 = Object::with_id_owner_gas_for_testing(ObjectID::random(), sender, 1300);
     let recipient1 = dbg_addr(1);
     let recipient2 = dbg_addr(2);
 
@@ -131,7 +131,7 @@ async fn test_pay_sui_failure_insufficient_total_balance_multiple_input_coins() 
         vec![400, 400],
         sender,
         sender_key,
-        201,
+        2000,
     )
     .await;
     assert_eq!(
@@ -147,7 +147,7 @@ async fn test_pay_sui_failure_insufficient_total_balance_multiple_input_coins() 
 async fn test_pay_sui_success_one_input_coin() -> anyhow::Result<()> {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
     let object_id = ObjectID::random();
-    let coin_obj = Object::with_id_owner_gas_for_testing(object_id, sender, 2500);
+    let coin_obj = Object::with_id_owner_gas_for_testing(object_id, sender, 120000);
     let recipient1 = dbg_addr(1);
     let recipient2 = dbg_addr(2);
     let recipient3 = dbg_addr(3);
@@ -159,7 +159,7 @@ async fn test_pay_sui_success_one_input_coin() -> anyhow::Result<()> {
         vec![100, 200, 300],
         sender,
         sender_key,
-        1500,
+        100000,
     )
     .await;
 
@@ -209,11 +209,11 @@ async fn test_pay_sui_success_one_input_coin() -> anyhow::Result<()> {
     // the value is equal to all residual values after amounts transferred and gas payment.
     assert_eq!(effects.mutated()[0].0 .0, object_id);
     assert_eq!(effects.mutated()[0].1, sender);
-    let gas_used = effects.gas_cost_summary().gas_used();
+    let gas_used = effects.gas_cost_summary().net_gas_usage() as u64;
     let gas_object = res.authority_state.get_object(&object_id).await?.unwrap();
     assert_eq!(
         GasCoin::try_from(&gas_object)?.value(),
-        2500 - 100 - 200 - 300 - gas_used,
+        120000 - 100 - 200 - 300 - gas_used,
     );
 
     Ok(())
@@ -225,7 +225,7 @@ async fn test_pay_sui_success_multiple_input_coins() -> anyhow::Result<()> {
     let object_id1 = ObjectID::random();
     let object_id2 = ObjectID::random();
     let object_id3 = ObjectID::random();
-    let coin_obj1 = Object::with_id_owner_gas_for_testing(object_id1, sender, 2000);
+    let coin_obj1 = Object::with_id_owner_gas_for_testing(object_id1, sender, 50000);
     let coin_obj2 = Object::with_id_owner_gas_for_testing(object_id2, sender, 1000);
     let coin_obj3 = Object::with_id_owner_gas_for_testing(object_id3, sender, 1000);
     let recipient1 = dbg_addr(1);
@@ -237,7 +237,7 @@ async fn test_pay_sui_success_multiple_input_coins() -> anyhow::Result<()> {
         vec![500, 1500],
         sender,
         sender_key,
-        2000,
+        50000,
     )
     .await;
     let recipient_amount_map: HashMap<_, u64> =
@@ -275,11 +275,11 @@ async fn test_pay_sui_success_multiple_input_coins() -> anyhow::Result<()> {
     // the value is equal to all residual values after amounts transferred and gas payment.
     assert_eq!(effects.mutated()[0].0 .0, object_id1);
     assert_eq!(effects.mutated()[0].1, sender);
-    let gas_used = effects.gas_cost_summary().gas_used();
+    let gas_used = effects.gas_cost_summary().net_gas_usage() as u64;
     let gas_object = res.authority_state.get_object(&object_id1).await?.unwrap();
     assert_eq!(
         GasCoin::try_from(&gas_object)?.value(),
-        4000 - 500 - 1500 - gas_used,
+        52000 - 500 - 1500 - gas_used,
     );
 
     // make sure the second and third input coins are deleted
@@ -292,7 +292,7 @@ async fn test_pay_sui_success_multiple_input_coins() -> anyhow::Result<()> {
 #[tokio::test]
 async fn test_pay_all_sui_failure_insufficient_gas_one_input_coin() {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
-    let coin1 = Object::with_id_owner_gas_for_testing(ObjectID::random(), sender, 1000);
+    let coin1 = Object::with_id_owner_gas_for_testing(ObjectID::random(), sender, 1800);
     let recipient = dbg_addr(2);
 
     let res = execute_pay_all_sui(vec![&coin1], recipient, sender, sender_key, 2000).await;
@@ -300,7 +300,7 @@ async fn test_pay_all_sui_failure_insufficient_gas_one_input_coin() {
     assert_eq!(
         UserInputError::try_from(res.txn_result.unwrap_err()).unwrap(),
         UserInputError::GasBalanceTooLow {
-            gas_balance: 1000,
+            gas_balance: 1800,
             needed_gas_amount: 2000,
         }
     );
@@ -327,9 +327,9 @@ async fn test_pay_all_sui_failure_insufficient_gas_budget_multiple_input_coins()
 async fn test_pay_all_sui_success_one_input_coin() -> anyhow::Result<()> {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
     let object_id = ObjectID::random();
-    let coin_obj = Object::with_id_owner_gas_for_testing(object_id, sender, 3000);
+    let coin_obj = Object::with_id_owner_gas_for_testing(object_id, sender, 30000);
     let recipient = dbg_addr(2);
-    let res = execute_pay_all_sui(vec![&coin_obj], recipient, sender, sender_key, 2000).await;
+    let res = execute_pay_all_sui(vec![&coin_obj], recipient, sender, sender_key, 20000).await;
 
     let effects = res.txn_result.unwrap().into_data();
     assert_eq!(*effects.status(), ExecutionStatus::Success);
@@ -342,7 +342,7 @@ async fn test_pay_all_sui_success_one_input_coin() -> anyhow::Result<()> {
 
     let gas_used = effects.gas_cost_summary().gas_used();
     let gas_object = res.authority_state.get_object(&object_id).await?.unwrap();
-    assert_eq!(GasCoin::try_from(&gas_object)?.value(), 3000 - gas_used,);
+    assert_eq!(GasCoin::try_from(&gas_object)?.value(), 30000 - gas_used,);
     Ok(())
 }
 
@@ -350,7 +350,7 @@ async fn test_pay_all_sui_success_one_input_coin() -> anyhow::Result<()> {
 async fn test_pay_all_sui_success_multiple_input_coins() -> anyhow::Result<()> {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
     let object_id1 = ObjectID::random();
-    let coin_obj1 = Object::with_id_owner_gas_for_testing(object_id1, sender, 2000);
+    let coin_obj1 = Object::with_id_owner_gas_for_testing(object_id1, sender, 30000);
     let coin_obj2 = Object::with_id_owner_gas_for_testing(ObjectID::random(), sender, 1000);
     let coin_obj3 = Object::with_id_owner_gas_for_testing(ObjectID::random(), sender, 1000);
     let recipient = dbg_addr(2);
@@ -359,7 +359,7 @@ async fn test_pay_all_sui_success_multiple_input_coins() -> anyhow::Result<()> {
         recipient,
         sender,
         sender_key,
-        2000,
+        30000,
     )
     .await;
 
@@ -374,7 +374,7 @@ async fn test_pay_all_sui_success_multiple_input_coins() -> anyhow::Result<()> {
 
     let gas_used = effects.gas_cost_summary().gas_used();
     let gas_object = res.authority_state.get_object(&object_id1).await?.unwrap();
-    assert_eq!(GasCoin::try_from(&gas_object)?.value(), 4000 - gas_used,);
+    assert_eq!(GasCoin::try_from(&gas_object)?.value(), 32000 - gas_used,);
     Ok(())
 }
 

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1497,7 +1497,13 @@ impl ProtocolConfig {
             // },
             2 => {
                 let mut cfg = Self::get_for_version_impl(version - 1);
+                // changes for gas model
                 cfg.gas_model_version = Some(2);
+                // max gas budget is in MIST and an absolute value 50SUI
+                cfg.max_tx_gas = Some(50_000_000_000);
+                // min gas budget is in MIST and an absolute value 2000MIST or 0.000002SUI
+                cfg.base_tx_cost_fixed = Some(2_000);
+                // enable conservation checks
                 cfg.feature_flags.conservation_checks = true;
                 cfg
             }

--- a/crates/sui-types/src/gas_model/gas_v2.rs
+++ b/crates/sui-types/src/gas_model/gas_v2.rs
@@ -1,0 +1,491 @@
+// Copyright (c) 2021, Facebook, Inc. and its affiliates
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::error::{UserInputError, UserInputResult};
+use crate::gas::{GasCostSummary, SuiGasStatusAPI};
+use crate::{
+    error::{ExecutionError, ExecutionErrorKind},
+    gas_coin::GasCoin,
+    object::{Object, Owner},
+};
+use move_core_types::vm_status::StatusCode;
+use once_cell::sync::Lazy;
+use std::convert::TryFrom;
+use sui_cost_tables::bytecode_tables::{GasStatus, INITIAL_COST_SCHEDULE};
+use sui_protocol_config::*;
+
+macro_rules! ok_or_gas_balance_error {
+    ($balance:expr, $required:expr) => {
+        if $balance < $required {
+            Err(UserInputError::GasBalanceTooLow {
+                gas_balance: $balance,
+                needed_gas_amount: $required,
+            })
+        } else {
+            Ok(())
+        }
+    };
+}
+
+/// A bucket defines a range of units that will be priced the same.
+/// After execution a call to `GasStatus::bucketize` will round the computation
+/// cost to `cost` for the bucket ([`min`, `max`]) the gas used falls into.
+#[allow(dead_code)]
+pub(crate) struct ComputationBucket {
+    min: u64,
+    max: u64,
+    cost: u64,
+}
+
+impl ComputationBucket {
+    fn new(min: u64, max: u64, cost: u64) -> Self {
+        ComputationBucket { min, max, cost }
+    }
+
+    fn simple(min: u64, max: u64) -> Self {
+        Self::new(min, max, max)
+    }
+}
+
+pub(crate) fn get_bucket_cost(table: &[ComputationBucket], computation_cost: u64) -> u64 {
+    for bucket in table {
+        if bucket.max >= computation_cost {
+            return bucket.cost;
+        }
+    }
+    MAX_BUCKET_COST
+}
+
+// for a RPG of 1000 this amounts to about 5 SUI
+pub(crate) const MAX_BUCKET_COST: u64 = 5_000_000;
+
+// define the bucket table for computation charging
+pub(crate) static COMPUTATION_BUCKETS: Lazy<Vec<ComputationBucket>> = Lazy::new(|| {
+    vec![
+        ComputationBucket::simple(0, 1_000),
+        ComputationBucket::simple(1_000, 5_000),
+        ComputationBucket::simple(5_000, 10_000),
+        ComputationBucket::simple(10_000, 20_000),
+        ComputationBucket::simple(20_000, 50_000),
+        ComputationBucket::simple(50_000, 200_000),
+        ComputationBucket::simple(200_000, 1_000_000),
+        ComputationBucket::simple(1_000_000, MAX_BUCKET_COST),
+    ]
+});
+
+/// Portion of the storage rebate that gets passed on to the transaction sender. The remainder
+/// will be burned, then re-minted + added to the storage fund at the next epoch change
+fn sender_rebate(storage_rebate: u64, storage_rebate_rate: u64) -> u64 {
+    // we round storage rebate such that `>= x.5` goes to x+1 (rounds up) and
+    // `< x.5` goes to x (truncates). We replicate `f32/64::round()`
+    const BASIS_POINTS: u128 = 10000;
+    (((storage_rebate as u128 * storage_rebate_rate as u128)
+        + (BASIS_POINTS / 2)) // integer rounding adds half of the BASIS_POINTS (denominator)
+        / BASIS_POINTS) as u64
+}
+
+/// A list of constant costs of various operations in Sui.
+pub struct SuiCostTable {
+    /// A flat fee charged for every transaction. This is also the minimum amount of
+    /// gas charged for a transaction.
+    pub(crate) min_transaction_cost: u64,
+    /// Maximum allowable budget for a transaction.
+    pub(crate) max_gas_budget: u64,
+    /// Computation cost per byte charged for package publish. This cost is primarily
+    /// determined by the cost to verify and link a package. Note that this does not
+    /// include the cost of writing the package to the store.
+    package_publish_per_byte_cost: u64,
+    /// Per byte cost to read objects from the store. This is computation cost instead of
+    /// storage cost because it does not change the amount of data stored on the db.
+    object_read_per_byte_cost: u64,
+    /// Unit cost of a byte in the storage. This will be used both for charging for
+    /// new storage as well as rebating for deleting storage. That is, we expect users to
+    /// get full refund on the object storage when it's deleted.
+    storage_per_byte_cost: u64,
+}
+
+impl std::fmt::Debug for SuiCostTable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // TODO: dump the fields.
+        write!(f, "SuiCostTable(...)")
+    }
+}
+
+impl SuiCostTable {
+    pub(crate) fn new(c: &ProtocolConfig) -> Self {
+        Self {
+            min_transaction_cost: c.base_tx_cost_fixed(),
+            max_gas_budget: c.max_tx_gas(),
+            package_publish_per_byte_cost: c.package_publish_cost_per_byte(),
+            object_read_per_byte_cost: c.obj_access_cost_read_per_byte(),
+            storage_per_byte_cost: c.obj_data_cost_refundable(),
+        }
+    }
+
+    pub(crate) fn unmetered() -> Self {
+        Self {
+            min_transaction_cost: 0,
+            max_gas_budget: u64::MAX,
+            package_publish_per_byte_cost: 0,
+            object_read_per_byte_cost: 0,
+            storage_per_byte_cost: 0,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct SuiGasStatus<'a> {
+    // GasStatus as used by the VM, that is all the VM sees
+    gas_status: GasStatus<'a>,
+    // Cost table contains a set of constant/config for the gas model/charging
+    cost_table: SuiCostTable,
+    // Gas budget for this gas status instance.
+    // Typically the gas budget as defined in the `TransactionData::GasData`
+    gas_budget: u64,
+    // Computation cost after execution. This is the result of the gas used by the `GasStatus`
+    // properly bucketized.
+    // Starts at 0 and it is assigned in `bucketize_computation`.
+    computation_cost: u64,
+    // Whether to charge or go unmetered
+    charge: bool,
+    // Gas price for computation.
+    // This is a multiplier on the final charge as related to the RGP (reference gas price).
+    // Checked at signing: `gas_price >= reference_gas_price`
+    // and then conceptually
+    // `final_computation_cost = total_computation_cost * gas_price / reference_gas_price`
+    gas_price: u64,
+    // Gas price for storage. This is a multiplier on the final charge
+    // as related to the storage gas price defined in the system
+    // (`ProtocolConfig::storage_gas_price`).
+    // Conceptually, given a constant `obj_data_cost_refundable`
+    // (defined in `ProtocolConfig::obj_data_cost_refundable`)
+    // `total_storage_cost = storage_bytes * obj_data_cost_refundable`
+    // `final_storage_cost = total_storage_cost * storage_gas_price`
+    storage_gas_price: u64,
+    /// storage_cost is the total storage gas to charge. This is an accumulator computed
+    /// at the end of execution while determining storage charges.
+    /// It tracks `total_storage_cost = storage_bytes * obj_data_cost_refundable` as
+    /// described in `storage_gas_price`
+    /// It will be multiplied by the storage gas price.
+    storage_cost: u64,
+    /// storage_rebate is the total storage rebate (in Sui) accumulated in this transaction.
+    /// This is an accumulator computed at the end of execution while determining storage charges.
+    /// It is the sum of all `storage_rebate` of all objects mutated or deleted during
+    /// execution. The value is in Sui.
+    storage_rebate: u64,
+    // storage rebate rate as defined in the ProtocolConfig
+    rebate_rate: u64,
+}
+
+impl<'a> SuiGasStatus<'a> {
+    fn new(
+        move_gas_status: GasStatus<'a>,
+        gas_budget: u64,
+        charge: bool,
+        gas_price: u64,
+        storage_gas_price: u64,
+        rebate_rate: u64,
+        cost_table: SuiCostTable,
+    ) -> SuiGasStatus<'a> {
+        SuiGasStatus {
+            gas_status: move_gas_status,
+            gas_budget,
+            charge,
+            computation_cost: 0,
+            gas_price,
+            storage_gas_price,
+            storage_cost: 0,
+            storage_rebate: 0,
+            rebate_rate,
+            cost_table,
+        }
+    }
+
+    pub(crate) fn new_with_budget(
+        gas_budget: u64,
+        gas_price: u64,
+        config: &ProtocolConfig,
+    ) -> SuiGasStatus<'a> {
+        let storage_gas_price = config.storage_gas_price();
+        // println!(
+        //     "GAS - SuiGasStatus: budget {}, gas_price {}, computation_gas_price {}, storage_unit_gas_price {}",
+        //     gas_budget,
+        //     gas_price,
+        //     gas_price,
+        //     storage_gas_price,
+        // );
+        let max_computation_budget = MAX_BUCKET_COST;
+        let computation_budget = if gas_budget > max_computation_budget {
+            max_computation_budget
+        } else {
+            gas_budget
+        };
+        Self::new(
+            GasStatus::new_v2(&INITIAL_COST_SCHEDULE, computation_budget, gas_price),
+            gas_budget,
+            true,
+            gas_price,
+            storage_gas_price,
+            config.storage_rebate_rate(),
+            SuiCostTable::new(config),
+        )
+    }
+
+    pub(crate) fn new_for_testing(
+        gas_budget: u64,
+        gas_price: u64,
+        storage_gas_price: u64,
+        cost_table: SuiCostTable,
+    ) -> SuiGasStatus<'a> {
+        let rebate_rate = ProtocolConfig::get_for_max_version().storage_rebate_rate();
+        let max_computation_budget = MAX_BUCKET_COST;
+        let computation_budget = if gas_budget > max_computation_budget {
+            max_computation_budget
+        } else {
+            gas_budget
+        };
+        Self::new(
+            GasStatus::new_v2(&INITIAL_COST_SCHEDULE, computation_budget, gas_price),
+            gas_budget,
+            true,
+            gas_price,
+            storage_gas_price,
+            rebate_rate,
+            cost_table,
+        )
+    }
+
+    pub fn new_unmetered() -> SuiGasStatus<'a> {
+        Self::new(
+            GasStatus::new_unmetered(),
+            0,
+            false,
+            0,
+            0,
+            0,
+            SuiCostTable::unmetered(),
+        )
+    }
+}
+
+impl<'a> SuiGasStatusAPI<'a> for SuiGasStatus<'a> {
+    fn is_unmetered(&self) -> bool {
+        !self.charge
+    }
+
+    fn move_gas_status(&mut self) -> &mut GasStatus<'a> {
+        &mut self.gas_status
+    }
+
+    fn bucketize_computation(&mut self) -> Result<(), ExecutionError> {
+        let gas_used = self.gas_status.gas_used_pre_gas_price();
+        let bucket_cost = get_bucket_cost(&COMPUTATION_BUCKETS, gas_used);
+        // charge extra on top of `computation_cost` to make the total computation
+        // cost a bucket value
+        // println!(
+        //     "GAS - Bucketize: gas_used {}, bucket cost {}",
+        //     gas_used, bucket_cost
+        // );
+        let gas_used = bucket_cost * self.gas_price;
+        if self.gas_budget <= gas_used {
+            self.computation_cost = self.gas_budget;
+            Err(ExecutionErrorKind::InsufficientGas.into())
+        } else {
+            self.computation_cost = gas_used;
+            Ok(())
+        }
+    }
+
+    /// Returns the final (computation cost, storage cost, storage rebate) of the gas meter.
+    /// We use initial budget, combined with remaining gas and storage cost to derive
+    /// computation cost.
+    fn summary(&self) -> GasCostSummary {
+        // compute storage rebate, both rebate and non refundable fee
+        let sender_rebate = sender_rebate(self.storage_rebate, self.rebate_rate);
+        assert!(sender_rebate <= self.storage_rebate);
+        let non_refundable_storage_fee = self.storage_rebate - sender_rebate;
+        // let summary = GasCostSummary {
+        GasCostSummary {
+            computation_cost: self.computation_cost,
+            storage_cost: self.storage_cost,
+            storage_rebate: sender_rebate,
+            non_refundable_storage_fee,
+        }
+        // };
+        // println!("GAS - gas_summary: {}", summary);
+        // summary
+    }
+
+    fn gas_budget(&self) -> u64 {
+        self.gas_budget
+    }
+
+    fn storage_gas_units(&self) -> u64 {
+        self.storage_cost
+    }
+
+    fn storage_rebate(&self) -> u64 {
+        self.storage_rebate
+    }
+
+    fn gas_used(&self) -> u64 {
+        self.gas_status.gas_used_pre_gas_price()
+    }
+
+    fn reset_storage_cost_and_rebate(&mut self) {
+        self.storage_cost = 0;
+        self.storage_rebate = 0;
+    }
+
+    fn charge_storage_read(&mut self, size: usize) -> Result<(), ExecutionError> {
+        // println!("GAS - charge_storage_read: size {}", size);
+        self.gas_status
+            .charge_bytes(size, self.cost_table.object_read_per_byte_cost)
+            .map_err(|e| {
+                debug_assert_eq!(e.major_status(), StatusCode::OUT_OF_GAS);
+                ExecutionErrorKind::InsufficientGas.into()
+            })
+    }
+
+    fn charge_storage_mutation(
+        &mut self,
+        new_size: usize,
+        storage_rebate: u64,
+    ) -> Result<u64, ExecutionError> {
+        let size = self.track_storage_mutation(new_size, storage_rebate);
+        self.charge_storage_and_rebate()?;
+        Ok(size)
+        // Err(ExecutionError::invariant_violation(
+        //     "charge_storage_mutation should not be called in v2 gas model",
+        // ))
+    }
+
+    fn charge_publish_package(&mut self, size: usize) -> Result<(), ExecutionError> {
+        // println!("GAS - charge_publish_package: {}", size);
+        self.gas_status
+            .charge_bytes(size, self.cost_table.package_publish_per_byte_cost)
+            .map_err(|e| {
+                debug_assert_eq!(e.major_status(), StatusCode::OUT_OF_GAS);
+                ExecutionErrorKind::InsufficientGas.into()
+            })
+    }
+
+    /// Update `storage_rebate` and `storage_gas_units` for each object in the transaction.
+    /// There is no charge in this function. Charges will all be applied together at the end
+    /// (`track_storage_mutation`).
+    /// Return the new storage rebate (cost of object storage) according to `new_size`.
+    fn track_storage_mutation(&mut self, new_size: usize, storage_rebate: u64) -> u64 {
+        if self.is_unmetered() {
+            return 0;
+        }
+        self.storage_rebate += storage_rebate;
+        // compute and track cost (based on size)
+        let new_size = new_size as u64;
+        let storage_cost =
+            new_size * self.cost_table.storage_per_byte_cost * self.storage_gas_price;
+        // println!(
+        //     "GAS - charge_storage_mutation: bytes {} cost {}, rebate {}",
+        //     new_size, storage_cost, storage_rebate,
+        // );
+        // track rebate
+        self.storage_cost += storage_cost;
+        // return the new object rebate (object storage cost)
+        storage_cost
+    }
+
+    fn charge_storage_and_rebate(&mut self) -> Result<(), ExecutionError> {
+        let sender_rebate = sender_rebate(self.storage_rebate, self.rebate_rate);
+        assert!(sender_rebate <= self.storage_rebate);
+        if sender_rebate >= self.storage_cost {
+            // there is more rebate than cost, when deducting gas we are adding
+            // to whatever is the current amount charged so we are `Ok`
+            Ok(())
+        } else {
+            let gas_left = self.gas_budget - self.computation_cost;
+            // we have to charge for storage and may go out of gas, check
+            if gas_left < self.storage_cost - sender_rebate {
+                // Running out of gas would cause the temporary store to reset
+                // and zero storage and rebate.
+                // The remaining_gas will be 0 and we will charge all in computation
+                Err(ExecutionErrorKind::InsufficientGas.into())
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    fn adjust_computation_on_out_of_gas(&mut self) {
+        self.storage_rebate = 0;
+        self.storage_cost = 0;
+        self.computation_cost = self.gas_budget;
+    }
+}
+
+// Check whether gas arguments are legit:
+// 1. Gas object has an address owner.
+// 2. Gas budget is between min and max budget allowed
+// 3. Gas balance (all gas coins together) is bigger or equal to budget
+pub(crate) fn check_gas_balance(
+    gas_object: &Object,
+    more_gas_objs: Vec<&Object>,
+    gas_budget: u64,
+    cost_table: &SuiCostTable,
+) -> UserInputResult {
+    // 1. Gas object has an address owner.
+    if !(matches!(gas_object.owner, Owner::AddressOwner(_))) {
+        return Err(UserInputError::GasObjectNotOwnedObject {
+            owner: gas_object.owner,
+        });
+    }
+
+    // 2. Gas budget is between min and max budget allowed
+    if gas_budget > cost_table.max_gas_budget {
+        return Err(UserInputError::GasBudgetTooHigh {
+            gas_budget,
+            max_budget: cost_table.max_gas_budget,
+        });
+    }
+    if gas_budget < cost_table.min_transaction_cost {
+        return Err(UserInputError::GasBudgetTooLow {
+            gas_budget,
+            min_budget: cost_table.min_transaction_cost,
+        });
+    }
+
+    // 3. Gas balance (all gas coins together) is bigger or equal to budget
+    let mut gas_balance = get_gas_balance(gas_object)? as u128;
+    for extra_obj in more_gas_objs {
+        gas_balance += get_gas_balance(extra_obj)? as u128;
+    }
+    ok_or_gas_balance_error!(gas_balance, gas_budget as u128)
+}
+
+/// Subtract the gas balance of \p gas_object by \p amount.
+/// This function should never fail, since we checked that the budget is always
+/// less than balance, and the amount is capped at the budget.
+pub fn deduct_gas(gas_object: &mut Object, charge_or_rebate: i64) {
+    // The object must be a gas coin as we have checked in transaction handle phase.
+    let gas_coin = GasCoin::try_from(&*gas_object).unwrap();
+    let balance = gas_coin.value();
+    let new_balance = if charge_or_rebate < 0 {
+        balance + (-charge_or_rebate as u64)
+    } else {
+        assert!(balance >= charge_or_rebate as u64);
+        balance - charge_or_rebate as u64
+    };
+    let new_gas_coin = GasCoin::new(*gas_coin.id(), new_balance);
+    let move_object = gas_object.data.try_as_move_mut().unwrap();
+    // unwrap safe because GasCoin is guaranteed to serialize
+    let new_contents = bcs::to_bytes(&new_gas_coin).unwrap();
+    assert_eq!(move_object.contents().len(), new_contents.len());
+    move_object.update_coin_contents(new_contents);
+}
+
+pub fn get_gas_balance(gas_object: &Object) -> UserInputResult<u64> {
+    Ok(GasCoin::try_from(gas_object)
+        .map_err(|_e| UserInputError::InvalidGasObject {
+            object_id: gas_object.id(),
+        })?
+        .value())
+}

--- a/crates/sui-types/src/gas_model/mod.rs
+++ b/crates/sui-types/src/gas_model/mod.rs
@@ -2,3 +2,4 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod gas_v1;
+pub mod gas_v2;

--- a/crates/sui-types/src/sui_system_state/epoch_start_sui_system_state.rs
+++ b/crates/sui-types/src/sui_system_state/epoch_start_sui_system_state.rs
@@ -92,7 +92,7 @@ impl EpochStartSystemStateV1 {
     pub fn new_for_testing_with_epoch(epoch: EpochId) -> Self {
         Self {
             epoch,
-            protocol_version: ProtocolVersion::MIN.as_u64(),
+            protocol_version: ProtocolVersion::MAX.as_u64(),
             reference_gas_price: 1,
             safe_mode: false,
             epoch_start_timestamp_ms: 0,

--- a/crates/sui-types/src/temporary_store.rs
+++ b/crates/sui-types/src/temporary_store.rs
@@ -682,13 +682,20 @@ impl<S: ObjectStore> TemporaryStore<S> {
         }
         Ok(())
     }
+}
 
+//==============================================================================
+// Charge gas legacy - start
+// This is the original gas charging code, all code between comment
+// "Charge gas legacy - start/end" is exclusively for legacy gas
+//==============================================================================
+impl<S: ObjectStore> TemporaryStore<S> {
     /// 1. Compute tx storage gas costs and tx storage rebates, update storage_rebate field of mutated objects
     /// 2. Deduct computation gas costs and storage costs to `gas_object_id`, credit storage rebates to `gas_object_id`.
     // The happy path of this function follows (1) + (2) and is fairly simple. Most of the complexity is in the unhappy paths:
     // - if execution aborted before calling this function, we have to dump all writes + re-smash gas, then charge for storage
     // - if we run out of gas while charging for storage, we have to dump all writes + re-smash gas, then charge for storage again
-    pub fn charge_gas<T>(
+    pub fn charge_gas_legacy<T>(
         &mut self,
         gas_object_id: ObjectID,
         gas_status: &mut SuiGasStatus<'_>,
@@ -737,7 +744,7 @@ impl<S: ObjectStore> TemporaryStore<S> {
         // Important to fetch the gas object here instead of earlier, as it may have been reset
         // previously in the case of error.
         let mut gas_object = self.read_object(&gas_object_id).unwrap().clone();
-        gas::deduct_gas(
+        gas::deduct_gas_legacy(
             &mut gas_object,
             gas_used,
             // MUSTFIX: This is incorrect. Storage rebate in cost summary need to be consistent with balance change.
@@ -864,6 +871,207 @@ impl<S: ObjectStore> TemporaryStore<S> {
         Ok(total_bytes_written_deleted as u64)
     }
 }
+//==============================================================================
+// Charge gas legacy - end
+//==============================================================================
+
+//==============================================================================
+// Charge gas current - start
+// This is the new/current/latest gas charging code, all code between comment
+// "Charge gas current - start/end" is exclusively for latest gas
+//==============================================================================
+impl<S: ObjectStore> TemporaryStore<S> {
+    /// 1. Compute tx storage gas costs and tx storage rebates, update storage_rebate field of mutated objects
+    /// 2. Deduct computation gas costs and storage costs to `gas_object_id`, credit storage rebates to `gas_object_id`.
+    // The happy path of this function follows (1) + (2) and is fairly simple. Most of the complexity is in the unhappy paths:
+    // - if execution aborted before calling this function, we have to dump all writes + re-smash gas, then charge for storage
+    // - if we run out of gas while charging for storage, we have to dump all writes + re-smash gas, then charge for storage again
+    pub fn charge_gas<T>(
+        &mut self,
+        gas_object_id: ObjectID,
+        gas_status: &mut SuiGasStatus<'_>,
+        execution_result: &mut Result<T, ExecutionError>,
+        gas: &[ObjectRef],
+    ) -> GasCostSummary {
+        // at this point, we have done *all* charging for computation,
+        // but have not yet set the storage rebate or storage gas units
+        assert!(gas_status.storage_rebate() == 0);
+        assert!(gas_status.storage_gas_units() == 0);
+
+        // println!("GAS - charge gas with result error: {}", execution_result.is_err());
+
+        // bucketize computation cost
+        if let Err(err) = gas_status.bucketize_computation() {
+            // println!("GAS - bucketize failed");
+            if execution_result.is_ok() {
+                *execution_result = Err(err);
+            }
+        }
+
+        // On error we need to dump writes, deletes, etc before charging storage gas
+        if execution_result.is_err() {
+            self.reset(gas, gas_status);
+        }
+
+        // collect and charge storage cost
+        self.collect_storage_and_rebate(gas_status, gas_object_id);
+        if let Err(err) = gas_status.charge_storage_and_rebate() {
+            // println!("GAS - Out Of Gas charging storage");
+            // out of gas
+            self.reset(gas, gas_status);
+            self.cleanup_store_on_out_of_gas(gas_status, gas_object_id);
+            if execution_result.is_ok() {
+                *execution_result = Err(err);
+            }
+        }
+
+        let cost_summary = gas_status.summary();
+        let gas_used = cost_summary.net_gas_usage();
+
+        // Important to fetch the gas object here instead of earlier, as it may have been reset
+        // previously in the case of error.
+        let mut gas_object = self.read_object(&gas_object_id).unwrap().clone();
+        gas::deduct_gas(&mut gas_object, gas_used);
+        trace!(gas_used, gas_obj_id =? gas_object.id(), gas_obj_ver =? gas_object.version(), "Updated gas object");
+
+        self.write_object(gas_object, WriteKind::Mutate);
+        self.gas_charged = Some((gas_object_id, cost_summary.clone()));
+        // println!("GAS - gas charged - error: {}", execution_result.is_err());
+        cost_summary
+    }
+
+    /// Return the storage rebate of object `id`
+    fn get_input_storage_rebate(&self, id: &ObjectID, expected_version: SequenceNumber) -> u64 {
+        if let Some(old_obj) = self.input_objects.get(id) {
+            old_obj.storage_rebate
+        } else {
+            // else, this is a dynamic field, not an input object
+            if let Ok(Some(old_obj)) = self.store.get_object(id) {
+                if old_obj.version() != expected_version {
+                    // not a lot we can do safely and under this condition everything is broken
+                    panic!(
+                        "Expected to find old object with version {expected_version}, found {}",
+                        old_obj.version(),
+                    );
+                }
+                old_obj.storage_rebate
+            } else {
+                // not a lot we can do safely and under this condition everything is broken
+                panic!("Looking up storage rebate of mutated object should not fail")
+            }
+        }
+    }
+
+    fn cleanup_store_on_out_of_gas(
+        &mut self,
+        gas_status: &mut SuiGasStatus<'_>,
+        gas_object_id: ObjectID,
+    ) {
+        // If the gas coin was not yet written, charge gas for mutating the gas object in advance.
+        let gas_object = self
+            .read_object(&gas_object_id)
+            .expect("We constructed the object map so it should always have the gas object id")
+            .clone();
+        self.written
+            .entry(gas_object_id)
+            .or_insert_with(|| (gas_object, WriteKind::Mutate));
+        self.ensure_active_inputs_mutated();
+
+        let mut objects_to_update = vec![];
+        for (object, write_kind) in self.written.values() {
+            if !object.is_immutable() {
+                objects_to_update.push((object.clone(), *write_kind));
+            }
+        }
+        for (object, write_kind) in objects_to_update {
+            self.write_object(object, write_kind);
+        }
+        // we do not charge for storage at this point because we are out of gas
+        gas_status.adjust_computation_on_out_of_gas();
+    }
+
+    /// Track storage gas for each mutable input object (including the gas coin)
+    /// and each created object. Compute storage refunds for each deleted object.
+    /// Will *not* charge anything, gas status keeps track of storage cost and rebate.
+    /// All objects will be updated with their new (current) storage rebate/cost.
+    /// `SuiGasStatus` `storage_rebate` and `storage_gas_units` track the transaction
+    /// overall storage rebate and cost.
+    fn collect_storage_and_rebate(
+        &mut self,
+        gas_status: &mut SuiGasStatus<'_>,
+        gas_object_id: ObjectID,
+    ) {
+        // If the gas coin was not yet written, charge gas for mutating the gas object in advance.
+        let gas_object = self
+            .read_object(&gas_object_id)
+            .expect("We constructed the object map so it should always have the gas object id")
+            .clone();
+        self.written
+            .entry(gas_object_id)
+            .or_insert_with(|| (gas_object, WriteKind::Mutate));
+        self.ensure_active_inputs_mutated();
+
+        let mut objects_to_update = vec![];
+        for (object_id, (object, write_kind)) in &mut self.written {
+            // get the object storage_rebate in input for mutated objects
+            let old_storage_rebate = match write_kind {
+                WriteKind::Create | WriteKind::Unwrap => 0,
+                WriteKind::Mutate => {
+                    if let Some(old_obj) = self.input_objects.get(object_id) {
+                        old_obj.storage_rebate
+                    } else {
+                        // else, this is a dynamic field, not an input object
+                        if let Ok(Some(old_obj)) = self.store.get_object(object_id) {
+                            let expected_version = object.version();
+                            if old_obj.version() != expected_version {
+                                // not a lot we can do safely and under this condition everything is broken
+                                panic!(
+                                    "Expected to find old object with version {expected_version}, found {}",
+                                    old_obj.version(),
+                                );
+                            }
+                            old_obj.storage_rebate
+                        } else {
+                            // not a lot we can do safely and under this condition everything is broken
+                            panic!("Looking up storage rebate of mutated object should not fail");
+                        }
+                    }
+                }
+            };
+            // new object size
+            let new_object_size = object.object_size_for_gas_metering();
+            // track changes and compute the new object `storage_rebate`
+            let new_storage_rebate =
+                gas_status.track_storage_mutation(new_object_size, old_storage_rebate);
+            object.storage_rebate = new_storage_rebate;
+            if !object.is_immutable() {
+                objects_to_update.push((object.clone(), *write_kind));
+            }
+        }
+
+        for (object_id, (version, kind)) in &self.deleted {
+            match kind {
+                DeleteKind::Wrap | DeleteKind::Normal => {
+                    // get and track the deleted object `storage_rebate`
+                    let storage_rebate = self.get_input_storage_rebate(object_id, *version);
+                    gas_status.track_storage_mutation(0, storage_rebate);
+                }
+                DeleteKind::UnwrapThenDelete => {
+                    // an unwrapped object does not have a storage rebate, we will charge for storage changes via its wrapper object
+                }
+            }
+        }
+
+        // Write all objects at the end only if all previous gas charges succeeded.
+        // This avoids polluting the temporary store state if this function failed.
+        for (object, write_kind) in objects_to_update {
+            self.write_object(object, write_kind);
+        }
+    }
+}
+//==============================================================================
+// Charge gas current - end
+//==============================================================================
 
 impl<S: GetModule + ObjectStore + BackingPackageStore> TemporaryStore<S> {
     /// Get the total SUI in `obj` at version `v`, which should be the version before the
@@ -894,7 +1102,7 @@ impl<S: GetModule + ObjectStore + BackingPackageStore> TemporaryStore<S> {
         // total amount of SUI in output objects, including both coins and storage rebates
         let mut total_output_sui = 0;
         // sum of the storage_rebate fields of all objects written by this tx
-        let mut _output_rebate_amount = 0;
+        let mut output_rebate_amount = 0;
         for (id, (output_obj, kind)) in &self.written {
             match kind {
                 WriteKind::Mutate => {
@@ -903,12 +1111,12 @@ impl<S: GetModule + ObjectStore + BackingPackageStore> TemporaryStore<S> {
                     let input_version = output_obj.version();
                     total_input_sui += self.get_input_sui(id, input_version)?;
                     total_output_sui += output_obj.get_total_sui(&self)?;
-                    _output_rebate_amount += output_obj.storage_rebate;
+                    output_rebate_amount += output_obj.storage_rebate;
                 }
                 WriteKind::Create => {
                     // created objects did not exist at input, and thus contribute 0 to input SUI
                     total_output_sui += output_obj.get_total_sui(&self)?;
-                    _output_rebate_amount += output_obj.storage_rebate;
+                    output_rebate_amount += output_obj.storage_rebate;
                 }
                 WriteKind::Unwrap => {
                     // an unwrapped object was either:
@@ -916,7 +1124,7 @@ impl<S: GetModule + ObjectStore + BackingPackageStore> TemporaryStore<S> {
                     // 2. wrapped in a dynamic field A, or itself a dynamic field
                     // in both cases, its contribution to input SUI will be captured by looking at A
                     total_output_sui += output_obj.get_total_sui(&self)?;
-                    _output_rebate_amount += output_obj.storage_rebate;
+                    output_rebate_amount += output_obj.storage_rebate;
                 }
             }
         }
@@ -950,25 +1158,24 @@ impl<S: GetModule + ObjectStore + BackingPackageStore> TemporaryStore<S> {
                 )
             })?
             .1;
-        let storage_fund_rebate_inflow =
-            gas_summary.storage_fund_rebate_inflow(self.storage_rebate_rate);
 
         // storage gas cost should be equal to total rebates of mutated objects + storage fund rebate inflow (see below).
         // note: each mutated object O of size N bytes is assessed a storage cost of N * storage_price bytes, but also
-        // has O.storage_rebate credited to the tx storage rebate.
-        // TODO: figure out what's wrong with this check. The one below is more important, but this should still hold.
-        // I suspect the problem is rounding error on `storage_rebate_inflow`
-        /*assert_eq!(
-            gas_summary.storage_cost,
-            output_rebate_amount + storage_fund_rebate_inflow
-        );*/
+        // has O storage_rebate credited to the tx storage rebate.
+        // If we run out of gas we do not perform any storage charges and the assert will fail
+        // `gas_summary.storage_cost` is a good proxy for OOG
+        if gas_summary.storage_cost > 0 {
+            assert_eq!(gas_summary.storage_cost, output_rebate_amount);
+        }
 
         // note: storage_cost flows into the storage_rebate field of the output objects, which is why it is not accounted for here.
         // similarly, all of the storage_rebate *except* the storage_fund_rebate_inflow gets credited to the gas coin
         // both computation costs and storage rebate inflow are
         assert_eq!(
             total_input_sui,
-            total_output_sui + gas_summary.computation_cost + storage_fund_rebate_inflow,
+            total_output_sui
+                + gas_summary.computation_cost
+                + gas_summary.non_refundable_storage_fee,
             "SUI conservation violated--this transaction either mints or burns SUI"
         );
         Ok(())


### PR DESCRIPTION
## Description 

This is built on top of https://github.com/MystenLabs/sui/pull/10053 and adds the code for the new gas model.
The code is not enabled yet and I will put another PR with the switch of the protocol version once this is ready.
It's based off https://github.com/MystenLabs/sui/pull/10053 and so you will only see the new changes.
Given the code is not enabled we want all tests to pass on the previous version.
It also enables conservation checks.

## Test Plan 

Originally I developed this without versioning and almost all tests passed. Tests are problematic because all errors I had were related to tests and not the logic of either gas or conservation.
We'll see how it goes now

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
