### PR TITLE
Conserve storage rebates in system transactions

### DIFF
--- a/crates/sui-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -5,7 +5,7 @@ expression: genesis_config
 validator_config_info: ~
 parameters:
   chain_start_timestamp_ms: 0
-  protocol_version: 1
+  protocol_version: 3
   allow_insertion_of_extra_objects: true
   epoch_duration_ms: 86400000
   stake_subsidy_start_epoch: 0

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_2.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_2.snap
@@ -2,7 +2,7 @@
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur)"
 ---
-version: 1
+version: 2
 feature_flags:
   package_upgrades: false
   commit_root_state_digest: false

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_3.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_3.snap
@@ -2,11 +2,11 @@
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur)"
 ---
-version: 1
+version: 3
 feature_flags:
   package_upgrades: false
   commit_root_state_digest: false
-  gas_model_v2: false
+  gas_model_v2: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_serialized_tx_effects_size_bytes: 524288

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -821,6 +821,19 @@ impl TransactionKind {
         )
     }
 
+    /// If this is advance epoch transaction, returns (total gas charged, total gas rebated).
+    /// TODO: We should use GasCostSummary directly in ChangeEpoch struct, and return that
+    /// directly.
+    pub fn get_advance_epoch_tx_gas_summary(&self) -> Option<(u64, u64)> {
+        match self {
+            Self::ChangeEpoch(e) => Some((
+                e.computation_charge + e.storage_charge,
+                e.storage_rebate - e.non_refundable_storage_fee,
+            )),
+            _ => None,
+        }
+    }
+
     pub fn contains_shared_object(&self) -> bool {
         self.shared_input_objects().next().is_some()
     }

--- a/crates/sui-types/src/temporary_store.rs
+++ b/crates/sui-types/src/temporary_store.rs
@@ -16,7 +16,6 @@ use tracing::trace;
 
 use crate::coin::Coin;
 use crate::committee::EpochId;
-use crate::is_system_package;
 use crate::messages::TransactionEvents;
 use crate::storage::ObjectStore;
 use crate::sui_system_state::{get_sui_system_state, SuiSystemState};
@@ -36,6 +35,7 @@ use crate::{
         WriteKind,
     },
 };
+use crate::{is_system_package, SUI_SYSTEM_STATE_OBJECT_ID};
 
 #[serde_as]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -538,6 +538,34 @@ impl<S> TemporaryStore<S> {
             self.input_objects.len(),
         )
     }
+
+    /// If there are unmetered storage rebate (due to system transaction), we put them into
+    /// the storage rebate of 0x5 object.
+    pub fn conserve_unmetered_storage_rebate(&mut self, unmetered_storage_rebate: u64) {
+        if unmetered_storage_rebate == 0 {
+            // If unmetered_storage_rebate is 0, we are most likely executing the genesis transaction.
+            // And in that case we cannot mutate the 0x5 object because it's newly created.
+            // And there is no storage rebate that needs distribution anyway.
+            return;
+        }
+        if !self.protocol_config.gas_model_v2() {
+            // This is a breaking change. Only do it in gas_v2.
+            return;
+        }
+        tracing::debug!(
+            "Amount of unmetered storage rebate from system tx: {:?}",
+            unmetered_storage_rebate
+        );
+        let mut system_state_wrapper = self
+            .read_object(&SUI_SYSTEM_STATE_OBJECT_ID)
+            .expect("0x5 object must be muated in system tx with unmetered storage rebate")
+            .clone();
+        // In unmetered execution, storage_rebate field of mutated object must be 0.
+        // If not, we would be dropping SUI on the floor by overriding it.
+        assert_eq!(system_state_wrapper.storage_rebate, 0);
+        system_state_wrapper.storage_rebate = unmetered_storage_rebate;
+        self.write_object(system_state_wrapper, WriteKind::Mutate);
+    }
 }
 
 impl<S: ObjectStore> TemporaryStore<S> {
@@ -593,7 +621,9 @@ impl<S: ObjectStore> TemporaryStore<S> {
                 WriteKind::Mutate => {
                     // get owner at beginning of tx, since that's what we have to authenticate against
                     // _new_obj.owner is not relevant here
-                    let old_obj = self.store.get_object(id)?.unwrap();
+                    let old_obj = self.store.get_object(id)?.unwrap_or_else(|| {
+                        panic!("Mutated object must exist in the store: ID = {:?}", id)
+                    });
                     match &old_obj.owner {
                         Owner::ObjectOwner(_parent) => {
                             objs_to_authenticate.push(*id);
@@ -685,12 +715,13 @@ impl<S: ObjectStore> TemporaryStore<S> {
 
     /// 1. Compute tx storage gas costs and tx storage rebates, update storage_rebate field of mutated objects
     /// 2. Deduct computation gas costs and storage costs to `gas_object_id`, credit storage rebates to `gas_object_id`.
+    /// gas_object_id can be None if this is a system transaction.
     // The happy path of this function follows (1) + (2) and is fairly simple. Most of the complexity is in the unhappy paths:
     // - if execution aborted before calling this function, we have to dump all writes + re-smash gas, then charge for storage
     // - if we run out of gas while charging for storage, we have to dump all writes + re-smash gas, then charge for storage again
     pub fn charge_gas<T>(
         &mut self,
-        gas_object_id: ObjectID,
+        gas_object_id: Option<ObjectID>,
         gas_status: &mut SuiGasStatus<'_>,
         execution_result: &mut Result<T, ExecutionError>,
         gas: &[ObjectRef],
@@ -736,17 +767,19 @@ impl<S: ObjectStore> TemporaryStore<S> {
 
         // Important to fetch the gas object here instead of earlier, as it may have been reset
         // previously in the case of error.
-        let mut gas_object = self.read_object(&gas_object_id).unwrap().clone();
-        gas::deduct_gas(
-            &mut gas_object,
-            gas_used,
-            // MUSTFIX: This is incorrect. Storage rebate in cost summary need to be consistent with balance change.
-            cost_summary.sender_rebate(self.storage_rebate_rate),
-        );
-        trace!(gas_used, gas_obj_id =? gas_object.id(), gas_obj_ver =? gas_object.version(), "Updated gas object");
+        if let Some(gas_object_id) = gas_object_id {
+            let mut gas_object = self.read_object(&gas_object_id).unwrap().clone();
+            gas::deduct_gas(
+                &mut gas_object,
+                gas_used,
+                // MUSTFIX: This is incorrect. Storage rebate in cost summary need to be consistent with balance change.
+                cost_summary.sender_rebate(self.storage_rebate_rate),
+            );
+            trace!(gas_used, gas_obj_id =? gas_object.id(), gas_obj_ver =? gas_object.version(), "Updated gas object");
 
-        self.write_object(gas_object, WriteKind::Mutate);
-        self.gas_charged = Some((gas_object_id, cost_summary));
+            self.write_object(gas_object, WriteKind::Mutate);
+            self.gas_charged = Some((gas_object_id, cost_summary));
+        }
     }
 
     /// Return the storage rebate and size of `id` at input
@@ -784,21 +817,25 @@ impl<S: ObjectStore> TemporaryStore<S> {
     /// Compute storage refunds for each deleted object
     /// Will *not* charge any computation gas. Returns the total size in bytes of all deleted objects + all mutated objects,
     /// which the caller can use to charge computation gas
+    /// gas_object_id can be None if this is a system transaction.
     fn charge_gas_for_storage_changes(
         &mut self,
         gas_status: &mut SuiGasStatus<'_>,
-        gas_object_id: ObjectID,
+        gas_object_id: Option<ObjectID>,
     ) -> Result<u64, ExecutionError> {
         let mut total_bytes_written_deleted = 0;
 
         // If the gas coin was not yet written, charge gas for mutating the gas object in advance.
-        let gas_object = self
-            .read_object(&gas_object_id)
-            .expect("We constructed the object map so it should always have the gas object id")
-            .clone();
-        self.written
-            .entry(gas_object_id)
-            .or_insert_with(|| (gas_object, WriteKind::Mutate));
+        if let Some(gas_object_id) = gas_object_id {
+            let gas_object = self
+                .read_object(&gas_object_id)
+                .expect("We constructed the object map so it should always have the gas object id")
+                .clone();
+            self.written
+                .entry(gas_object_id)
+                .or_insert_with(|| (gas_object, WriteKind::Mutate));
+        }
+
         self.ensure_active_inputs_mutated();
         let mut objects_to_update = vec![];
 
@@ -888,7 +925,14 @@ impl<S: GetModule + ObjectStore + BackingPackageStore> TemporaryStore<S> {
     /// the epoch change tx, which mints staking rewards equal to the gas fees burned in the previous epoch.
     /// This intended to be called *after* we have charged for gas + applied the storage rebate to the gas object,
     /// but *before* we have updated object versions
-    pub fn check_sui_conserved(&self) -> SuiResult<()> {
+    /// `epoch_fees` and `epoch_rebates` are only set for advance epoch transactions.
+    /// The advance epoch transaction would mint `epoch_fees` amount of SUI, and burn
+    /// `epoch_rebates` amount of SUI. We need these information for conservation check.
+    /// TODO: We should pass in the epoch GasCostSummary directly.
+    pub fn check_sui_conserved(
+        &self,
+        advance_epoch_gas_summary: Option<(u64, u64)>,
+    ) -> SuiResult<()> {
         // total amount of SUI in input objects, including both coins and storage rebates
         let mut total_input_sui = 0;
         // total amount of SUI in output objects, including both coins and storage rebates
@@ -944,12 +988,8 @@ impl<S: GetModule + ObjectStore + BackingPackageStore> TemporaryStore<S> {
         let gas_summary = &self
             .gas_charged
             .as_ref()
-            .ok_or_else(|| {
-                ExecutionError::invariant_violation(
-                    "Failed unwrapping gas_charged in SUI conservation checking",
-                )
-            })?
-            .1;
+            .map(|(_, summary)| summary.clone())
+            .unwrap_or_default();
         let storage_fund_rebate_inflow =
             gas_summary.storage_fund_rebate_inflow(self.storage_rebate_rate);
 
@@ -966,10 +1006,18 @@ impl<S: GetModule + ObjectStore + BackingPackageStore> TemporaryStore<S> {
         // note: storage_cost flows into the storage_rebate field of the output objects, which is why it is not accounted for here.
         // similarly, all of the storage_rebate *except* the storage_fund_rebate_inflow gets credited to the gas coin
         // both computation costs and storage rebate inflow are
-        assert_eq!(
-            total_input_sui,
-            total_output_sui + gas_summary.computation_cost + storage_fund_rebate_inflow,
-            "SUI conservation violated--this transaction either mints or burns SUI"
+        total_output_sui += gas_summary.computation_cost + storage_fund_rebate_inflow;
+        if let Some((epoch_fees, epoch_rebates)) = advance_epoch_gas_summary {
+            total_input_sui += epoch_fees;
+            total_output_sui += epoch_rebates;
+        }
+        fp_ensure!(
+            total_input_sui == total_output_sui,
+            SuiError::from(format!(
+                "SUI conservation violated: input={}, output={}, this transaction either mints or burns SUI",
+                total_input_sui,
+                total_output_sui,
+            ).as_str())
         );
         Ok(())
     }

--- a/crates/sui/tests/protocol_version_tests.rs
+++ b/crates/sui/tests/protocol_version_tests.rs
@@ -10,9 +10,13 @@ use test_utils::authority::start_node;
 #[should_panic]
 async fn test_validator_panics_on_unsupported_protocol_version() {
     let dir = tempfile::TempDir::new().unwrap();
+    let latest_version = ProtocolVersion::MAX;
     let network_config = sui_config::builder::ConfigBuilder::new(&dir)
-        .with_protocol_version(ProtocolVersion::new(2))
-        .with_supported_protocol_versions(SupportedProtocolVersions::new_for_testing(1, 1))
+        .with_protocol_version(ProtocolVersion::new(latest_version.as_u64() + 1))
+        .with_supported_protocol_versions(SupportedProtocolVersions::new_for_testing(
+            latest_version.as_u64(),
+            latest_version.as_u64(),
+        ))
         .build();
 
     let registry_service = RegistryService::new(Registry::new());
@@ -571,7 +575,7 @@ mod sim_only_tests {
         // a protocol version increment.
         let system_state = test_cluster.wait_for_epoch(Some(1)).await;
         assert_eq!(system_state.epoch(), 1);
-        assert_eq!(system_state.protocol_version(), 2); // protocol version increments
+        assert_eq!(system_state.protocol_version(), FINISH); // protocol version increments
         assert!(system_state.safe_mode()); // enters safe mode
 
         // We are getting out of safe mode soon.
@@ -580,7 +584,7 @@ mod sim_only_tests {
         // This epoch change should execute successfully without any upgrade and get us out of safe mode.
         let system_state = test_cluster.wait_for_epoch(Some(2)).await;
         assert_eq!(system_state.epoch(), 2);
-        assert_eq!(system_state.protocol_version(), 2); // protocol version stays the same
+        assert_eq!(system_state.protocol_version(), FINISH); // protocol version stays the same
         assert!(!system_state.safe_mode()); // out of safe mode
     }
 


### PR DESCRIPTION
This PR accumulates storage rebates during system transaction, and stuff it all into 0x5 object in the result state.
This ensures that we conserve SUI during system transaction.
In order to do this, I made the following changes:
1. Always go through gas charging process even for unmetered transaction
2. In unmetered mode, we track storage rebate in a separate field.

Enabled system transaction conservation check.