### PR TITLE
[Narwhal] sleep in proposer until max parent time

### DIFF
--- a/narwhal/primary/src/metrics.rs
+++ b/narwhal/primary/src/metrics.rs
@@ -314,6 +314,8 @@ pub struct PrimaryMetrics {
     pub proposer_resend_batches: IntCounter,
     /// Time it takes for a header to be materialised to a certificate
     pub header_to_certificate_latency: Histogram,
+    /// Millisecs taken to wait for max parent time, when proposing headers.
+    pub header_max_parent_wait_ms: IntCounter,
 }
 
 impl PrimaryMetrics {
@@ -476,7 +478,12 @@ impl PrimaryMetrics {
                 "Time it takes for a header to be materialised to a certificate",
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry
-            ).unwrap()
+            ).unwrap(),
+            header_max_parent_wait_ms: register_int_counter_with_registry!(
+                "header_max_parent_wait_ms",
+                "Millisecs taken to wait for max parent time, when proposing headers.",
+                registry
+            ).unwrap(),
         }
     }
 }


### PR DESCRIPTION
## Description 

The header creation time is set later than the added sleep, so it becomes
less likely that a Header with inaccurate timestamp get proposed. We
still need https://github.com/MystenLabs/sui/pull/10145 to enforce the invariant.

## Test Plan 

n/a

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
