### PR TITLE
[sui-proxy/histogram scrape]

### DIFF
--- a/crates/sui-proxy/src/config.rs
+++ b/crates/sui-proxy/src/config.rs
@@ -16,6 +16,7 @@ pub struct ProxyConfig {
     pub remote_write: RemoteWriteConfig,
     pub json_rpc: PeerValidationConfig,
     pub metrics_address: SocketAddr,
+    pub histogram_address: SocketAddr,
 }
 
 #[serde_as]

--- a/crates/sui-proxy/src/data/config.yaml
+++ b/crates/sui-proxy/src/data/config.yaml
@@ -10,3 +10,4 @@ json-rpc:
   certificate-file: /opt/joeman/fullchain.pem
   private-key: /opt/joeman/privkey.pem
 metrics-address: 192.168.0.2:9184
+histogram-address: 192.168.0.2:9185

--- a/crates/sui-proxy/src/handlers.rs
+++ b/crates/sui-proxy/src/handlers.rs
@@ -1,7 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crate::admin::ReqwestClient;
-use crate::consumer::{convert_to_remote_write, NodeMetric};
+use crate::consumer::{convert_to_remote_write, populate_labels, NodeMetric};
+use crate::histogram_relay::HistogramRelay;
 use crate::middleware::LenDelimProtobuf;
 use crate::peers::SuiPeer;
 use axum::{
@@ -19,17 +20,18 @@ pub async fn publish_metrics(
     Extension(network): Extension<String>,
     Extension(client): Extension<ReqwestClient>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
-    Extension(peer): Extension<SuiPeer>,
+    Extension(host): Extension<SuiPeer>,
+    Extension(relay): Extension<HistogramRelay>,
     LenDelimProtobuf(data): LenDelimProtobuf,
 ) -> (StatusCode, &'static str) {
+    let data = populate_labels(host.name, network, data);
+    relay.submit(data.clone());
     convert_to_remote_write(
         client.clone(),
         NodeMetric {
-            host: peer.name,
-            network,
             data,
             peer_addr: Multiaddr::from(addr.ip()),
-            public_key: peer.public_key,
+            public_key: host.public_key,
         },
     )
     .await

--- a/crates/sui-proxy/src/histogram_relay.rs
+++ b/crates/sui-proxy/src/histogram_relay.rs
@@ -1,0 +1,212 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use anyhow::{bail, Result};
+use axum::{extract::Extension, http::StatusCode, routing::get, Router};
+use prometheus::proto::{Metric, MetricFamily};
+use std::time::{SystemTime, UNIX_EPOCH};
+use std::{
+    collections::VecDeque,
+    net::SocketAddr,
+    sync::{Arc, Mutex},
+};
+use tower::ServiceBuilder;
+use tower_http::trace::{DefaultOnResponse, TraceLayer};
+use tower_http::LatencyUnit;
+use tracing::{info, Level};
+
+const METRICS_ROUTE: &str = "/metrics";
+
+// Creates a new http server that has as a sole purpose to expose
+// and endpoint that prometheus agent can use to poll for the metrics.
+// A RegistryService is returned that can be used to get access in prometheus Registries.
+pub fn start_prometheus_server(addr: SocketAddr) -> HistogramRelay {
+    let relay = HistogramRelay::new();
+    let app = Router::new()
+        .route(METRICS_ROUTE, get(metrics))
+        .layer(Extension(relay.clone()))
+        .layer(
+            ServiceBuilder::new().layer(
+                TraceLayer::new_for_http().on_response(
+                    DefaultOnResponse::new()
+                        .level(Level::INFO)
+                        .latency_unit(LatencyUnit::Seconds),
+                ),
+            ),
+        );
+
+    tokio::spawn(async move {
+        axum::Server::bind(&addr)
+            .serve(app.into_make_service())
+            .await
+            .unwrap();
+    });
+    relay
+}
+
+async fn metrics(Extension(relay): Extension<HistogramRelay>) -> (StatusCode, String) {
+    let Ok(expformat) = relay.export() else {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "unable to pop metrics from HistogramRelay".into(),
+        );
+    };
+    (StatusCode::OK, expformat)
+}
+
+struct Wrapper(i64, Vec<MetricFamily>);
+
+#[derive(Clone)]
+pub struct HistogramRelay(Arc<Mutex<VecDeque<Wrapper>>>);
+
+impl Default for HistogramRelay {
+    fn default() -> Self {
+        HistogramRelay(Arc::new(Mutex::new(VecDeque::new())))
+    }
+}
+impl HistogramRelay {
+    pub fn new() -> Self {
+        Self::default()
+    }
+    /// submit will take metric family submissions and store them for scraping
+    /// in doing so, it will also wrap each entry in a timestamp which will be use
+    /// for pruning old entires on each submission call. this may not be ideal long term.
+    pub fn submit(&self, data: Vec<MetricFamily>) {
+        //  represents a collection timestamp
+        let timestamp_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+
+        let mut queue = self
+            .0
+            .lock()
+            .expect("couldn't get mut lock on HistogramRelay");
+        queue.retain(|v| (timestamp_ms - v.0) < 300000); // drain anything 5 mins or older
+        queue.push_back(Wrapper(timestamp_ms, data));
+    }
+    pub fn export(&self) -> Result<String> {
+        // totally drain all metrics whenever we get a scrape request from the metrics handler
+        let mut queue = self
+            .0
+            .lock()
+            .expect("couldn't get mut lock on HistogramRelay");
+
+        let data: Vec<Wrapper> = queue.drain(..).collect();
+        info!(
+            "histogram queue drained {} items; remaining count {}",
+            data.len(),
+            queue.len()
+        );
+
+        let mut histograms = vec![];
+        for mf in data {
+            histograms.extend(mf.1);
+        }
+
+        let histograms: Vec<MetricFamily> = extract_histograms(histograms).collect();
+        let encoder = prometheus::TextEncoder::new();
+        let string = match encoder.encode_to_string(&histograms) {
+            Ok(s) => s,
+            Err(error) => bail!("{error}"),
+        };
+        Ok(string)
+    }
+}
+
+fn extract_histograms(data: Vec<MetricFamily>) -> impl Iterator<Item = MetricFamily> {
+    data.into_iter().filter_map(|mf| {
+        let metrics = mf.get_metric().iter().filter_map(|m| {
+            if !m.has_histogram() {
+                return None;
+            }
+            let mut v = Metric::default();
+            v.set_label(protobuf::RepeatedField::from_slice(m.get_label()));
+            v.set_histogram(m.get_histogram().to_owned());
+            v.set_timestamp_ms(m.get_timestamp_ms());
+            Some(v)
+        });
+
+        let only_histograms = protobuf::RepeatedField::from_iter(metrics);
+        if only_histograms.len() == 0 {
+            return None;
+        }
+
+        let mut v = MetricFamily::default();
+        v.set_name(mf.get_name().to_owned());
+        v.set_help(mf.get_help().to_owned());
+        v.set_field_type(mf.get_field_type());
+        v.set_metric(only_histograms);
+        Some(v)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use prometheus::proto;
+    use protobuf;
+
+    use crate::{
+        histogram_relay::extract_histograms,
+        prom_to_mimir::tests::{
+            create_counter, create_histogram, create_labels, create_metric_counter,
+            create_metric_family, create_metric_histogram,
+        },
+    };
+
+    #[test]
+    fn filter_histograms() {
+        struct Test {
+            data: Vec<proto::MetricFamily>,
+            expected: Vec<proto::MetricFamily>,
+        }
+
+        let tests = vec![
+            Test {
+                data: vec![create_metric_family(
+                    "test_counter",
+                    "i'm a help message",
+                    Some(proto::MetricType::GAUGE),
+                    protobuf::RepeatedField::from(vec![create_metric_counter(
+                        protobuf::RepeatedField::from_vec(create_labels(vec![
+                            ("host", "local-test-validator"),
+                            ("network", "unittest-network"),
+                        ])),
+                        create_counter(2046.0),
+                    )]),
+                )],
+                expected: vec![],
+            },
+            Test {
+                data: vec![create_metric_family(
+                    "test_histogram",
+                    "i'm a help message",
+                    Some(proto::MetricType::HISTOGRAM),
+                    protobuf::RepeatedField::from(vec![create_metric_histogram(
+                        protobuf::RepeatedField::from_vec(create_labels(vec![
+                            ("host", "local-test-validator"),
+                            ("network", "unittest-network"),
+                        ])),
+                        create_histogram(),
+                    )]),
+                )],
+                expected: vec![create_metric_family(
+                    "test_histogram",
+                    "i'm a help message",
+                    Some(proto::MetricType::HISTOGRAM),
+                    protobuf::RepeatedField::from(vec![create_metric_histogram(
+                        protobuf::RepeatedField::from_vec(create_labels(vec![
+                            ("host", "local-test-validator"),
+                            ("network", "unittest-network"),
+                        ])),
+                        create_histogram(),
+                    )]),
+                )],
+            },
+        ];
+
+        for test in tests {
+            let extracted: Vec<proto::MetricFamily> = extract_histograms(test.data).collect();
+            assert_eq!(extracted, test.expected);
+        }
+    }
+}

--- a/crates/sui-proxy/src/lib.rs
+++ b/crates/sui-proxy/src/lib.rs
@@ -4,6 +4,7 @@ pub mod admin;
 pub mod config;
 pub mod consumer;
 pub mod handlers;
+pub mod histogram_relay;
 pub mod metrics;
 pub mod middleware;
 pub mod peers;
@@ -33,6 +34,7 @@ macro_rules! var {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::histogram_relay::HistogramRelay;
     use crate::prom_to_mimir::tests::*;
 
     use crate::{admin::CertKeyPair, config::RemoteWriteConfig, peers::SuiNodeProvider};
@@ -105,7 +107,12 @@ mod tests {
         async fn handler(tls_info: axum::Extension<TlsConnectionInfo>) -> String {
             tls_info.public_key().unwrap().to_string()
         }
-        let app = admin::app("unittest-network".into(), client, Some(allower.clone()));
+        let app = admin::app(
+            "unittest-network".into(),
+            client,
+            HistogramRelay::new(),
+            Some(allower.clone()),
+        );
 
         let listener = std::net::TcpListener::bind("localhost:0").unwrap();
         let server_address = listener.local_addr().unwrap();

--- a/crates/sui-proxy/src/metrics.rs
+++ b/crates/sui-proxy/src/metrics.rs
@@ -4,6 +4,10 @@ use axum::{extract::Extension, http::StatusCode, routing::get, Router};
 use mysten_metrics::RegistryService;
 use prometheus::{Registry, TextEncoder};
 use std::net::SocketAddr;
+use tower::ServiceBuilder;
+use tower_http::trace::{DefaultOnResponse, TraceLayer};
+use tower_http::LatencyUnit;
+use tracing::Level;
 
 const METRICS_ROUTE: &str = "/metrics";
 
@@ -17,7 +21,16 @@ pub fn start_prometheus_server(addr: SocketAddr) -> RegistryService {
 
     let app = Router::new()
         .route(METRICS_ROUTE, get(metrics))
-        .layer(Extension(registry_service.clone()));
+        .layer(Extension(registry_service.clone()))
+        .layer(
+            ServiceBuilder::new().layer(
+                TraceLayer::new_for_http().on_response(
+                    DefaultOnResponse::new()
+                        .level(Level::INFO)
+                        .latency_unit(LatencyUnit::Seconds),
+                ),
+            ),
+        );
 
     tokio::spawn(async move {
         axum::Server::bind(&addr)

--- a/crates/sui-proxy/src/peers.rs
+++ b/crates/sui-proxy/src/peers.rs
@@ -79,7 +79,7 @@ impl SuiNodeProvider {
         let client = reqwest::Client::builder().build().unwrap();
         let request = serde_json::json!({
             "jsonrpc": "2.0",
-            "method":"sui_getLatestSuiSystemState",
+            "method":"suix_getLatestSuiSystemState",
             "id":1,
         });
         let response = client

--- a/crates/sui-proxy/src/prom_to_mimir.rs
+++ b/crates/sui-proxy/src/prom_to_mimir.rs
@@ -241,6 +241,28 @@ pub mod tests {
         m
     }
 
+    pub fn create_metric_histogram(
+        labels: RepeatedField<proto::LabelPair>,
+        histogram: proto::Histogram,
+    ) -> proto::Metric {
+        let mut m = proto::Metric::default();
+        m.set_label(labels);
+        m.set_histogram(histogram);
+        m.set_timestamp_ms(12345);
+        m
+    }
+
+    pub fn create_histogram() -> proto::Histogram {
+        let mut h = proto::Histogram::default();
+        h.set_sample_count(1);
+        h.set_sample_sum(1.0);
+        let mut b = proto::Bucket::default();
+        b.set_cumulative_count(1);
+        b.set_upper_bound(1.0);
+        h.mut_bucket().push(b);
+        h
+    }
+
     pub fn create_labels(labels: Vec<(&str, &str)>) -> Vec<proto::LabelPair> {
         labels
             .into_iter()


### PR DESCRIPTION
Summary:

* scrape relayed histograms from this server
* we split the incoming metrics that are pushed to us into two groups, one histograms and another for all the rest.  The histograms go into a vecdeque and are drained based on a ttl on each submission.  This is not ideal long term but was the easiest to implement quickly.  Future work would be to use a btree for this instead, most likely.
* after we have our two groups, the remote_push op will send them to mimir and the rest will be made available for an agent scrape.  Scraping should only include histograms, no other metric types.

Test Plan:

tested locally

```
# HELP validator_service_tx_verification_latency Latency of verifying a transaction
# TYPE validator_service_tx_verification_latency histogram
validator_service_tx_verification_latency_bucket{network="joenet",host="validator-3",le="0.001"} 0 1680127115211
validator_service_tx_verification_latency_bucket{network="joenet",host="validator-3",le="0.005"} 0 1680127115211
validator_service_tx_verification_latency_bucket{network="joenet",host="validator-3",le="0.01"} 0 1680127115211
validator_service_tx_verification_latency_bucket{network="joenet",host="validator-3",le="0.025"} 0 1680127115211
validator_service_tx_verification_latency_bucket{network="joenet",host="validator-3",le="0.05"} 0 1680127115211
validator_service_tx_verification_latency_bucket{network="joenet",host="validator-3",le="0.1"} 0 1680127115211
validator_service_tx_verification_latency_bucket{network="joenet",host="validator-3",le="0.25"} 0 1680127115211
validator_service_tx_verification_latency_bucket{network="joenet",host="validator-3",le="0.5"} 0 1680127115211
validator_service_tx_verification_latency_bucket{network="joenet",host="validator-3",le="1"} 0 1680127115211
validator_service_tx_verification_latency_bucket{network="joenet",host="validator-3",le="2.5"} 0 1680127115211
validator_service_tx_verification_latency_bucket{network="joenet",host="validator-3",le="5"} 0 1680127115211
validator_service_tx_verification_latency_bucket{network="joenet",host="validator-3",le="10"} 0 1680127115211
validator_service_tx_verification_latency_bucket{network="joenet",host="validator-3",le="20"} 0 1680127115211
validator_service_tx_verification_latency_bucket{network="joenet",host="validator-3",le="30"} 0 1680127115211
validator_service_tx_verification_latency_bucket{network="joenet",host="validator-3",le="60"} 0 1680127115211
validator_service_tx_verification_latency_bucket{network="joenet",host="validator-3",le="90"} 0 1680127115211
validator_service_tx_verification_latency_bucket{network="joenet",host="validator-3",le="+Inf"} 0 1680127115211
validator_service_tx_verification_latency_sum{network="joenet",host="validator-3"} 0 1680127115211
validator_service_tx_verification_latency_count{network="joenet",host="validator-3"} 0 1680127115211
```

## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
