### PR TITLE
Fix interleaved upgrades test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8750,6 +8750,7 @@ dependencies = [
  "move-bytecode-utils",
  "move-core-types",
  "move-package",
+ "move-symbol-pool",
  "move-vm-runtime",
  "mysten-common",
  "mysten-metrics",

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -77,6 +77,7 @@ sui-macros = { path = "../sui-macros" }
 shared-crypto = { path = "../shared-crypto" }
 
 [dev-dependencies]
+move-symbol-pool.workspace = true
 clap = { version = "3.2.17", features = ["derive"] }
 criterion = { version = "0.4.0" }
 fs_extra = "1.2.0"


### PR DESCRIPTION
Fixes the interleaved package upgrade test. This resolves two issues:
1. The helper function for building the package, computing the digest, and the like was returning the wrong IDs (it was returning original package IDs and not the new dependency IDs).
2. We were trying to use the new object ID for the dependency as both the `published-at` and address value for the package.



 