### PR TITLE
indexer easy: more granular FN download metrics

### DIFF
--- a/crates/sui-indexer/src/metrics.rs
+++ b/crates/sui-indexer/src/metrics.rs
@@ -21,7 +21,9 @@ pub struct IndexerCheckpointHandlerMetrics {
     pub total_epoch_committed: IntCounter,
     // checkpoint E2E latency is:
     // fullnode_download_latency + checkpoint_index_latency + db_commit_latency
-    pub fullnode_download_latency: Histogram,
+    pub fullnode_checkpoint_download_latency: Histogram,
+    pub fullnode_transaction_download_latency: Histogram,
+    pub fullnode_object_download_latency: Histogram,
     pub checkpoint_index_latency: Histogram,
     pub checkpoint_db_commit_latency: Histogram,
     pub epoch_db_commit_latency: Histogram,
@@ -63,36 +65,50 @@ impl IndexerCheckpointHandlerMetrics {
                 registry,
             )
             .unwrap(),
-            fullnode_download_latency: register_histogram_with_registry!(
-                "checkpoint_full_node_read_request_latency",
+            fullnode_checkpoint_download_latency: register_histogram_with_registry!(
+                "fullnode_checkpoint_download_latency",
                 "Time spent in waiting for a new checkpoint from the Full Node",
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
             .unwrap(),
+            fullnode_transaction_download_latency: register_histogram_with_registry!(
+                "fullnode_transaction_download_latency",
+                "Time spent in waiting for a new transaction from the Full Node",
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            fullnode_object_download_latency: register_histogram_with_registry!(
+                "fullnode_object_download_latency",
+                "Time spent in waiting for a new epoch from the Full Node",
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
             checkpoint_index_latency: register_histogram_with_registry!(
-                "checkpoint_index_request_latency",
+                "checkpoint_index_latency",
                 "Time spent in indexing a checkpoint",
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
             .unwrap(),
             checkpoint_db_commit_latency: register_histogram_with_registry!(
-                "checkpoint_db_write_request_latency",
+                "checkpoint_db_commit_latency",
                 "Time spent commiting a checkpoint to the db",
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
             .unwrap(),
             epoch_db_commit_latency: register_histogram_with_registry!(
-                "epoch_db_write_request_latency",
+                "epoch_db_commit_latency",
                 "Time spent commiting a epoch to the db",
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
             .unwrap(),
             subscription_process_latency: register_histogram_with_registry!(
-                "subscription_processing_latency",
+                "subscription_process_latency",
                 "Time spent in process Websocket subscription",
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry,


### PR DESCRIPTION
## Description 

several problems with downloading latency before this PR:
1. it counts the checkpoint generation time if indexer has caught up
2. the sleep time is 1 second, which is too long as checkpoint is generated every a couple of seconds

Other than fixing that, this PR also added more granular download latency metrics.
