### PR TITLE
[wallet]: fix non re-rendering issue

### DIFF
--- a/apps/wallet/src/ui/app/pages/home/transactions/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transactions/index.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { getTransactionDigest } from '@mysten/sui.js';
-import { memo } from 'react';
 
 import { ErrorBoundary } from '_components/error-boundary';
 import Loading from '_components/loading';
@@ -58,4 +57,4 @@ function TransactionBlocksPage() {
     );
 }
 
-export default memo(TransactionBlocksPage);
+export default TransactionBlocksPage;


### PR DESCRIPTION
## Description 

- Remove the usage of `memo` that's preventing the re-rendering of the `TransactionBlockPage` component


![activity](https://user-images.githubusercontent.com/127577476/228958950-b35416e2-0a41-4d63-b396-363d942109a3.gif)

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
