### PR TITLE
[StateAccumulator] Fix checkpoint accumulator idempotency bug

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -25,7 +25,7 @@ mod test {
     use sui_types::messages_checkpoint::VerifiedCheckpoint;
     use test_utils::messages::get_sui_gas_object_with_wallet_context;
     use test_utils::network::{TestCluster, TestClusterBuilder};
-    use tracing::info;
+    use tracing::{error, info};
     use typed_store::traits::Map;
 
     struct DeadValidator {
@@ -120,6 +120,7 @@ mod test {
         // otherwise, possibly fail the current node
         let mut rng = thread_rng();
         if rng.gen_range(0.0..1.0) < probability {
+            error!("Matched probability threshold for failpoint. Failing...");
             let restart_after = Duration::from_millis(rng.gen_range(10000..20000));
 
             *dead_validator = Some(DeadValidator {

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -3332,8 +3332,9 @@ impl AuthorityState {
         }
         let pending_certificates = epoch_store.pending_consensus_certificates();
         info!(
-            "Reverting {} locally executed transactions that was not included in the epoch",
-            pending_certificates.len()
+            "Reverting {} locally executed transactions that was not included in the epoch: {:?}",
+            pending_certificates.len(),
+            pending_certificates,
         );
         for digest in pending_certificates {
             if self

--- a/crates/sui-core/src/state_accumulator.rs
+++ b/crates/sui-core/src/state_accumulator.rs
@@ -8,7 +8,7 @@ use sui_types::base_types::{ObjectID, SequenceNumber};
 use sui_types::committee::EpochId;
 use sui_types::digests::{ObjectDigest, TransactionDigest};
 use sui_types::storage::ObjectKey;
-use tracing::debug;
+use tracing::{debug, error};
 use typed_store::Map;
 
 use std::collections::{HashMap, HashSet};
@@ -64,6 +64,18 @@ impl StateAccumulator {
         let _scope = monitored_scope("AccumulateCheckpoint");
 
         let acc = self.accumulate_effects(effects);
+
+        if let Some(old_acc) = epoch_store.get_state_hash_for_checkpoint(&checkpoint_seq_num)? {
+            if old_acc != acc {
+                // This should not happen on a non-byzantine Node, as it indicates that the checkpoint
+                // contents are inconsistent. Since checkpoint builder is a callsite here, it could
+                // indicate a proposal that differs from what was finalized in consensus.
+                error!(
+                    "Newly set accumulator for checkpoint {} does not match the already existing one. (Overwriting)",
+                    checkpoint_seq_num,
+                );
+            }
+        }
 
         epoch_store.insert_state_hash_for_checkpoint(&checkpoint_seq_num, &acc)?;
         debug!("Accumulated checkpoint {}", checkpoint_seq_num);

--- a/crates/sui-core/src/state_accumulator.rs
+++ b/crates/sui-core/src/state_accumulator.rs
@@ -55,7 +55,6 @@ impl StateAccumulator {
     }
 
     /// Accumulates the effects of a single checkpoint and persists the accumulator.
-    /// This function is idempotent.
     pub fn accumulate_checkpoint(
         &self,
         effects: Vec<TransactionEffects>,
@@ -63,9 +62,6 @@ impl StateAccumulator {
         epoch_store: Arc<AuthorityPerEpochStore>,
     ) -> SuiResult<Accumulator> {
         let _scope = monitored_scope("AccumulateCheckpoint");
-        if let Some(acc) = epoch_store.get_state_hash_for_checkpoint(&checkpoint_seq_num)? {
-            return Ok(acc);
-        }
 
         let acc = self.accumulate_effects(effects);
 


### PR DESCRIPTION
## Description 

Currently checkpoint accumulation is idempotent, therefore first to write wins. This is an issue, however, given that we have two callsites for checkpoint accumulation - checkpoint executor and checkpoint builder, the latter of which calls accumulation for proposals that have not yet made it through consensus, and therefore may not make it on chain. The below test creates a scenario where a validator, due to untimely crashes, proposes an empty checkpoint, and due to idempotency, locally accumulates this empty checkpoint. Later, the network certifies a checkpoint, but the call to accumulate it from checkpoint executor on the errant node is ignored, causing inconsistency.

The fix is to remove idempotency. 

Repro against commit `a42f67c687` in `mlogan-dario-gas` branch:

```
MSIM_TEST_SEED=9920 RUST_LOG=sui=debug,error cargo simtest test_simulated_load_reconfig_crashes -E '(test(test_simulated_load_reconfig_crashes) and !(test(test_simulated_load_reconfig_crashes_during_epoch_change)))'
```

Crashes with:

```
thread '<unnamed>' panicked at 'Inconsistent state detected: root state hash: ECMHLiveObjectSetDigest { digest: 20V+2YIdMmOUm/3e75tXD35YG55eCECG+0QzhK5Nb6g= }, live object set hash: ECMHLiveObjectSetDigest { digest: z73BdEzrUyr9/TwfjX6aSg/Viw8lCG7uN96/9rRhBss= }', crates/sui-node/src/lib.rs:1077:13
```

## Test Plan 

```
for f in `seq 1 20`; do RUST_LOG=sui=debug,error MSIM_TEST_SEED=9$f cargo simtest test_simulated_load_reconfig_crashes -E '(test(test_simulated_load_reconfig_crashes) and !(test(test_simulated_load_reconfig_crashes_during_epoch_change)))' --no-capture > test_$f 2>&1 &; done

----

for f in `seq 1 20`; do RUST_LOG=sui=debug,error MSIM_TEST_SEED=99$f cargo simtest test_simulated_load_reconfig_crashes -E '(test(test_simulated_load_reconfig_crashes) and !(test(test_simulated_load_reconfig_crashes_during_epoch_change)))' --no-capture > test_$f 2>&1 &; done

```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
