### PR TITLE
Improve frontend performance of APY calculation

### DIFF
--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -26,6 +26,7 @@
         "@sentry/tracing": "^7.43.0",
         "@tanstack/react-query": "^4.26.1",
         "bignumber.js": "^9.1.1",
+        "decimal.js": "^10.4.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
     },

--- a/apps/core/src/hooks/useGetRollingAverageApys.ts
+++ b/apps/core/src/hooks/useGetRollingAverageApys.ts
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useMemo } from 'react';
-import BigNumber from 'bignumber.js';
+// NOTE: Bignumber's .pow() method is very slow, so we use decimal.js for this use-case.
+// this inflates bundle size quite a bit, so we should move this calculation to the API in the future.
+import Decimal from 'decimal.js';
 
 import { useGetValidatorsEvents } from './useGetValidatorsEvents';
 import { roundFloat } from '../utils/roundFloat';
@@ -40,10 +42,10 @@ export interface ApyByValidator {
 }
 
 const calculateApy = (stake: string, poolStakingReward: string) => {
-    const poolStakingRewardBigNumber = new BigNumber(poolStakingReward);
-    const stakeBigNumber = new BigNumber(stake);
+    const poolStakingRewardBigNumber = new Decimal(poolStakingReward);
+    const stakeBigNumber = new Decimal(stake);
     // Calculate the ratio of pool_staking_reward / stake
-    const ratio = poolStakingRewardBigNumber.dividedBy(stakeBigNumber);
+    const ratio = poolStakingRewardBigNumber.div(stakeBigNumber);
 
     // Perform the exponentiation and subtraction using BigNumber
     const apy = ratio.plus(1).pow(365).minus(1);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       bignumber.js:
         specifier: ^9.1.1
         version: 9.1.1
+      decimal.js:
+        specifier: ^10.4.3
+        version: 10.4.3
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -9171,6 +9174,10 @@ packages:
     resolution: {integrity: sha512-Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: true
+
+  /decimal.js@10.4.3:
+    resolution: {integrity: sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==}
+    dev: false
 
   /decode-named-character-reference@1.0.2:
     resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}


### PR DESCRIPTION
## Description 

The `pow` calculation from `bignumber.js` is very slow and slowing down both wallet and explorer. This moves to use `decimal.js` which is faster at this. Will remove once we have API-driven APY.

## Test Plan 

Ran locally.