### PR TITLE
[hardening] cheaper storage fee and rebate conservation checks to be …

### DIFF
--- a/crates/sui-types/src/gas.rs
+++ b/crates/sui-types/src/gas.rs
@@ -227,13 +227,6 @@ impl GasCostSummary {
             / BASIS_POINTS) as u64
     }
 
-    /// Portion of the storage rebate that flows back into the storage fund.
-    /// This will be burned, then re-minted + added to the storage fund at the next epoch change.
-    /// Note: these funds are not accounted for in the `storage_refund` field of any Sui object
-    pub fn storage_fund_rebate_inflow(&self, storage_rebate_rate: u64) -> u64 {
-        self.storage_rebate - self.sender_rebate(storage_rebate_rate)
-    }
-
     /// Get net gas usage, positive number means used gas; negative number means refund.
     pub fn net_gas_usage(&self) -> i64 {
         self.gas_used() as i64 - self.storage_rebate as i64


### PR DESCRIPTION
…called in prod

Currently, we have `check_sui_conservation`, which actually checks two different things
1. We conserve SUI in the Move part of an object
2. We conserve SUI in the `storage_rebate` part of an object w.r.t the storage fees, storage rebate, and non-refundable storage rebate of a tx

All of the conservation bugs we have identified have been in (2), and (1) is much, much more expensive to check because it involves computing type layouts for all input/output objects, re-serializing them, and recursively iterating through every field and vector entry looking for SUI.

This PR exposes a separate function that only checks (2), which should be cheap enough to call in production, and will save us from future issues that look like the ones we have seen in the past. This raises an `invariant_violation` for the tx currently being executed if we cannot verify conservation.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
