### PR TITLE
[cherry-pick #10172][validator-cli] only return input and effects (#10172)

### DIFF
--- a/crates/sui/src/validator_commands.rs
+++ b/crates/sui/src/validator_commands.rs
@@ -554,7 +554,9 @@ async fn call_0x5(
         .quorum_driver()
         .execute_transaction_block(
             transaction,
-            SuiTransactionBlockResponseOptions::full_content(),
+            SuiTransactionBlockResponseOptions::new()
+                .with_input()
+                .with_effects(),
             Some(sui_types::messages::ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await


### PR DESCRIPTION
## Description 

This PR is a short-term mitigation for a CLI/Fullnode error:

Validators are reporting the following errors

```
RPC call failed: ErrorObject { code: ServerError(-32000), message: "Error checking transaction input objects: ObjectSequenceNumberTooHigh { object_id: 0x0000000000000000000000000000000000000000000000000000000000000005, asked_version: SequenceNumber(42390), latest_version: SequenceNumber(42387) }", data: None }
```

After the transaction is executed successfully, fullnode tries to [get balance
changes](https://github.com/MystenLabs/sui/blob/main/crates/sui-json-rpc/src/transaction_execution_api.rs#L120), which tries to fetch the shared object with the [most up to date version](https://github.com/MystenLabs/sui/blob/e76948d1c4551e08f8eb58c67b9b26f75f20d67b/crates/sui-json-rpc/src/balance_changes.rs#L135-L144) and failed because for some reason the fullnode does not have the latest version for the mutated shared object despite WaitForLocalExecution is true.

@patrickkuo is investigating the root cause of the fullnode error. This PR disables the fetching or balances and objects change in the CLI since it's not being used.


## Test Plan 

build

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
