### PR TITLE
[Narwhal] move batch fetching for certificates from primary to worker

### DIFF
--- a/crates/sui-config/tests/snapshot_tests.rs
+++ b/crates/sui-config/tests/snapshot_tests.rs
@@ -51,7 +51,6 @@ fn genesis_config_snapshot_matches() {
 
 #[ignore]
 #[test]
-#[cfg_attr(msim, ignore)]
 fn populated_genesis_snapshot_matches() {
     let genesis_config = GenesisConfig::for_local_testing();
     let (_account_keys, objects) = genesis_config

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -705,6 +705,7 @@ async fn test_staking() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+#[ignore]
 #[sim_test]
 async fn test_unstaking() -> Result<(), anyhow::Error> {
     let cluster = TestClusterBuilder::new()

--- a/narwhal/executor/src/metrics.rs
+++ b/narwhal/executor/src/metrics.rs
@@ -1,9 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use prometheus::{
-    default_registry, register_histogram_with_registry, register_int_counter_vec_with_registry,
-    register_int_counter_with_registry, register_int_gauge_with_registry, Histogram, IntCounter,
-    IntCounterVec, IntGauge, Registry,
+    default_registry, register_histogram_with_registry, register_int_counter_with_registry,
+    register_int_gauge_with_registry, Histogram, IntCounter, IntGauge, Registry,
 };
 
 // buckets defined in seconds
@@ -20,10 +19,6 @@ const POSITIVE_INT_BUCKETS: &[f64] = &[
 pub struct ExecutorMetrics {
     /// occupancy of the channel from the `Subscriber` to `Notifier`
     pub tx_notifier: IntGauge,
-    /// Time it takes to download a payload from local worker peer
-    pub subscriber_local_fetch_latency: Histogram,
-    /// Time it takes to download a payload from remote peer
-    pub subscriber_remote_fetch_latency: Histogram,
     /// Number of batches processed by subscriber
     pub subscriber_processed_batches: IntCounter,
     /// Round of last certificate seen by subscriber
@@ -34,8 +29,6 @@ pub struct ExecutorMetrics {
     /// The number of certificates processed by Subscriber
     /// during the recovery period to fetch their payloads.
     pub subscriber_recovered_certificates_count: IntCounter,
-    /// The number of pending remote calls to request_batch
-    pub pending_remote_request_batch: IntGauge,
     /// The number of pending payload downloads
     pub waiting_elements_subscriber: IntGauge,
     /// Latency between the time when the batch has been
@@ -46,8 +39,6 @@ pub struct ExecutorMetrics {
     /// Latency for time taken to fetch all batches for committed subdag
     /// either from local or remote worker.
     pub batch_fetch_for_committed_subdag_total_latency: Histogram,
-    /// Counter of remote/local batch fetch statuses.
-    pub subscriber_batch_fetch: IntCounterVec,
 }
 
 impl ExecutorMetrics {
@@ -56,20 +47,6 @@ impl ExecutorMetrics {
             tx_notifier: register_int_gauge_with_registry!(
                 "tx_notifier",
                 "occupancy of the channel from the `Subscriber` to `Notifier`",
-                registry
-            )
-            .unwrap(),
-            subscriber_local_fetch_latency: register_histogram_with_registry!(
-                "subscriber_local_fetch_latency",
-                "Time it takes to download a payload from local worker peer",
-                LATENCY_SEC_BUCKETS.to_vec(),
-                registry
-            )
-            .unwrap(),
-            subscriber_remote_fetch_latency: register_histogram_with_registry!(
-                "subscriber_remote_fetch_latency",
-                "Time it takes to download a payload from remote worker peer",
-                LATENCY_SEC_BUCKETS.to_vec(),
                 registry
             )
             .unwrap(),
@@ -101,11 +78,6 @@ impl ExecutorMetrics {
                 "Round of last certificate seen by subscriber",
                 registry
             ).unwrap(),
-            pending_remote_request_batch: register_int_gauge_with_registry!(
-                "pending_remote_request_batch",
-                "The number of pending remote calls to request_batch",
-                registry
-            ).unwrap(),
             waiting_elements_subscriber: register_int_gauge_with_registry!(
                 "waiting_elements_subscriber",
                 "The number of pending payload downloads",
@@ -121,12 +93,6 @@ impl ExecutorMetrics {
                 "subscriber_certificate_latency",
                 "Latency between when the certificate has been created and when it reached the executor",
                 LATENCY_SEC_BUCKETS.to_vec(),
-                registry
-            ).unwrap(),
-            subscriber_batch_fetch: register_int_counter_vec_with_registry!(
-                "subscriber_batch_fetch",
-                "Counter of remote/local batch fetch statuses",
-                &["source", "status"],
                 registry
             ).unwrap(),
         }

--- a/narwhal/executor/src/subscriber.rs
+++ b/narwhal/executor/src/subscriber.rs
@@ -5,54 +5,51 @@ use crate::{errors::SubscriberResult, metrics::ExecutorMetrics, ExecutionState};
 use config::{AuthorityIdentifier, Committee, WorkerCache, WorkerId};
 use crypto::NetworkPublicKey;
 
-use futures::stream::{FuturesOrdered, FuturesUnordered};
-use futures::{FutureExt, StreamExt};
+use futures::stream::FuturesOrdered;
+use futures::StreamExt;
 
-use network::WorkerRpc;
+use network::PrimaryToWorkerClient;
 
-use anyhow::bail;
-use prometheus::IntGauge;
+use network::client::NetworkClient;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::{sync::Arc, time::Duration, vec};
-use types::RequestBatchesRequest;
+use types::FetchBatchesRequest;
 
-use async_trait::async_trait;
 use fastcrypto::hash::Hash;
 use mysten_metrics::spawn_logged_monitored_task;
-use tokio::time::Instant;
-use tokio::{sync::oneshot, task::JoinHandle};
-use tracing::{debug, error, trace, warn};
-use tracing::{info, instrument};
+use tokio::task::JoinHandle;
+use tracing::{debug, error, info};
 use types::{
     metered_channel, Batch, BatchAPI, BatchDigest, Certificate, CertificateAPI, CommittedSubDag,
-    ConditionalBroadcastReceiver, ConsensusOutput, HeaderAPI, RequestBatchesResponse, Timestamp,
+    ConditionalBroadcastReceiver, ConsensusOutput, HeaderAPI, Timestamp,
 };
 
 /// The `Subscriber` receives certificates sequenced by the consensus and waits until the
 /// downloaded all the transactions references by the certificates; it then
 /// forward the certificates to the Executor.
-pub struct Subscriber<Network> {
+pub struct Subscriber {
     /// Receiver for shutdown
     rx_shutdown: ConditionalBroadcastReceiver,
     /// A channel to receive sequenced consensus messages.
     rx_sequence: metered_channel::Receiver<CommittedSubDag>,
-    /// The metrics handler
-    metrics: Arc<ExecutorMetrics>,
-
-    fetcher: Fetcher<Network>,
+    /// Inner state.
+    inner: Arc<Inner>,
 }
 
-struct Fetcher<Network> {
-    network: Network,
+struct Inner {
+    authority_id: AuthorityIdentifier,
+    worker_cache: WorkerCache,
+    committee: Committee,
+    client: NetworkClient,
     metrics: Arc<ExecutorMetrics>,
 }
 
 pub fn spawn_subscriber<State: ExecutionState + Send + Sync + 'static>(
     authority_id: AuthorityIdentifier,
-    network: oneshot::Receiver<anemo::Network>,
     worker_cache: WorkerCache,
     committee: Committee,
+    client: NetworkClient,
     mut shutdown_receivers: Vec<ConditionalBroadcastReceiver>,
     rx_sequence: metered_channel::Receiver<CommittedSubDag>,
     metrics: Arc<ExecutorMetrics>,
@@ -82,11 +79,11 @@ pub fn spawn_subscriber<State: ExecutionState + Send + Sync + 'static>(
         spawn_logged_monitored_task!(
             create_and_run_subscriber(
                 authority_id,
-                network,
                 worker_cache,
                 committee,
                 rx_shutdown_subscriber,
                 rx_sequence,
+                client,
                 metrics,
                 restored_consensus_output,
                 tx_notifier,
@@ -98,12 +95,12 @@ pub fn spawn_subscriber<State: ExecutionState + Send + Sync + 'static>(
 
 async fn run_notify<State: ExecutionState + Send + Sync + 'static>(
     state: State,
-    mut tr_notify: metered_channel::Receiver<ConsensusOutput>,
+    mut rx_notify: metered_channel::Receiver<ConsensusOutput>,
     mut rx_shutdown: ConditionalBroadcastReceiver,
 ) {
     loop {
         tokio::select! {
-            Some(message) = tr_notify.recv() => {
+            Some(message) = rx_notify.recv() => {
                 state.handle_consensus_output(message).await;
             }
 
@@ -117,32 +114,26 @@ async fn run_notify<State: ExecutionState + Send + Sync + 'static>(
 
 async fn create_and_run_subscriber(
     authority_id: AuthorityIdentifier,
-    network: oneshot::Receiver<anemo::Network>,
     worker_cache: WorkerCache,
     committee: Committee,
     rx_shutdown: ConditionalBroadcastReceiver,
     rx_sequence: metered_channel::Receiver<CommittedSubDag>,
+    client: NetworkClient,
     metrics: Arc<ExecutorMetrics>,
     restored_consensus_output: Vec<CommittedSubDag>,
     tx_notifier: metered_channel::Sender<ConsensusOutput>,
 ) {
-    let network = network.await.expect("Failed to receive network");
     info!("Starting subscriber");
-    let network = SubscriberNetworkImpl {
-        authority_id,
-        worker_cache,
-        committee,
-        network,
-    };
-    let fetcher = Fetcher {
-        network,
-        metrics: metrics.clone(),
-    };
     let subscriber = Subscriber {
         rx_shutdown,
         rx_sequence,
-        metrics,
-        fetcher,
+        inner: Arc::new(Inner {
+            authority_id,
+            committee,
+            worker_cache,
+            client,
+            metrics,
+        }),
     };
     subscriber
         .run(restored_consensus_output, tx_notifier)
@@ -150,7 +141,7 @@ async fn create_and_run_subscriber(
         .expect("Failed to run subscriber")
 }
 
-impl<Network: SubscriberNetwork> Subscriber<Network> {
+impl Subscriber {
     /// Returns the max number of sub-dag to fetch payloads concurrently.
     const MAX_PENDING_PAYLOADS: usize = 1000;
 
@@ -171,10 +162,13 @@ impl<Network: SubscriberNetwork> Subscriber<Network> {
         // First handle any consensus output messages that were restored due to a restart.
         // This needs to happen before we start listening on rx_sequence and receive messages sequenced after these.
         for message in restored_consensus_output {
-            let future = self.fetcher.fetch_batches(message);
+            let future = Self::fetch_batches(self.inner.clone(), message);
             waiting.push_back(future);
 
-            self.metrics.subscriber_recovered_certificates_count.inc();
+            self.inner
+                .metrics
+                .subscriber_recovered_certificates_count
+                .inc();
         }
 
         // Listen to sequenced consensus message and process them.
@@ -185,7 +179,7 @@ impl<Network: SubscriberNetwork> Subscriber<Network> {
                     // We can schedule more then MAX_PENDING_PAYLOADS payloads but
                     // don't process more consensus messages when more
                     // then MAX_PENDING_PAYLOADS is pending
-                    waiting.push_back(self.fetcher.fetch_batches(sub_dag));
+                    waiting.push_back(Self::fetch_batches(self.inner.clone(), sub_dag));
                 },
 
                 // Receive here consensus messages for which we have downloaded all transactions data.
@@ -202,19 +196,17 @@ impl<Network: SubscriberNetwork> Subscriber<Network> {
 
             }
 
-            self.metrics
+            self.inner
+                .metrics
                 .waiting_elements_subscriber
                 .set(waiting.len() as i64);
         }
     }
-}
 
-impl<Network: SubscriberNetwork> Fetcher<Network> {
     /// Returns ordered vector of futures for downloading batches for certificates
-    /// Order of futures returned follows order of batches in the certificate
-    /// See fetch_batches_from_worker for more details
-    #[instrument(level = "debug", skip_all, fields(certificate = % deliver.leader.digest()))]
-    async fn fetch_batches(&self, deliver: CommittedSubDag) -> ConsensusOutput {
+    /// Order of futures returned follows order of batches in the certificates.
+    /// See BatchFetcher for more details.
+    async fn fetch_batches(inner: Arc<Inner>, deliver: CommittedSubDag) -> ConsensusOutput {
         let num_batches = deliver.num_batches();
         let num_certs = deliver.len();
         if num_batches == 0 {
@@ -232,39 +224,43 @@ impl<Network: SubscriberNetwork> Fetcher<Network> {
         };
 
         let mut batch_digests_and_workers: HashMap<
-            WorkerId,
+            NetworkPublicKey,
             (HashSet<BatchDigest>, HashSet<NetworkPublicKey>),
         > = HashMap::new();
 
         for cert in &sub_dag.certificates {
             for (digest, (worker_id, _)) in cert.header().payload().iter() {
-                let workers = self.network.workers_for_certificate(cert, worker_id);
-                batch_digests_and_workers
-                    .entry(*worker_id)
-                    .and_modify(|(batch_set, worker_set)| {
-                        worker_set.extend(workers.clone());
-                        batch_set.insert(*digest);
-                    })
-                    .or_insert_with(|| {
-                        let mut batch_set = HashSet::new();
-                        let mut worker_set = HashSet::new();
-                        worker_set.extend(workers);
-                        batch_set.insert(*digest);
-                        (batch_set, worker_set)
-                    });
+                let own_worker_name = inner
+                    .worker_cache
+                    .worker(
+                        inner
+                            .committee
+                            .authority(&inner.authority_id)
+                            .unwrap()
+                            .protocol_key(),
+                        worker_id,
+                    )
+                    .unwrap_or_else(|_| panic!("worker_id {worker_id} is not in the worker cache"))
+                    .name;
+                let workers = Self::workers_for_certificate(&inner, cert, worker_id);
+                let (batch_set, worker_set) = batch_digests_and_workers
+                    .entry(own_worker_name)
+                    .or_default();
+                batch_set.insert(*digest);
+                worker_set.extend(workers);
             }
         }
 
-        let fetched_batches_timer = self
+        let fetched_batches_timer = inner
             .metrics
             .batch_fetch_for_committed_subdag_total_latency
             .start_timer();
-        self.metrics
+        inner
+            .metrics
             .committed_subdag_batch_count
             .observe(num_batches as f64);
-        let fetched_batches = self
-            .fetch_batches_from_worker(batch_digests_and_workers)
-            .await;
+        let fetched_batches =
+            Self::fetch_batches_from_workers(&inner, batch_digests_and_workers).await;
         drop(fetched_batches_timer);
 
         // Map all fetched batches to their respective certificates and submit as
@@ -273,16 +269,18 @@ impl<Network: SubscriberNetwork> Fetcher<Network> {
             let mut output_batches = Vec::with_capacity(cert.header().payload().len());
             let output_cert = cert.clone();
 
-            self.metrics
+            inner
+                .metrics
                 .subscriber_current_round
                 .set(cert.round() as i64);
 
-            self.metrics
+            inner
+                .metrics
                 .subscriber_certificate_latency
                 .observe(cert.metadata().created_at.elapsed().as_secs_f64());
 
             for (digest, (_, _)) in cert.header().payload().iter() {
-                self.metrics.subscriber_processed_batches.inc();
+                inner.metrics.subscriber_processed_batches.inc();
                 let batch = fetched_batches
                     .get(digest)
                     .expect("[Protocol violation] Batch not found in fetched batches from workers of certificate signers");
@@ -300,341 +298,16 @@ impl<Network: SubscriberNetwork> Fetcher<Network> {
         subscriber_output
     }
 
-    /// Bulk fetches payload from workers
-    /// This future performs infinite retries and blocks until all batches are available
-    /// As an optimization it tries to download from local worker first, but then fans out
-    /// requests to remote worker if not found locally
-    async fn fetch_batches_from_worker(
-        &self,
-        batch_digests_and_workers: HashMap<
-            WorkerId,
-            (HashSet<BatchDigest>, HashSet<NetworkPublicKey>),
-        >,
-    ) -> HashMap<BatchDigest, Batch> {
-        let mut fetched_batches = HashMap::new();
-
-        for (worker_id, (digests, workers)) in batch_digests_and_workers {
-            debug!(
-                "Attempting to fetch {} digests from {} worker_{worker_id}'s",
-                digests.len(),
-                workers.len()
-            );
-            // TODO: Can further parallelize this by worker_id if necessary.
-            // Only have one worker for now so will leave this for a future
-            // optimization.
-            let mut remaining_digests = digests.clone();
-
-            let local_batches = self
-                .try_fetch_locally(remaining_digests.clone().into_iter().collect(), worker_id)
-                .await;
-            for (local_batch_digest, local_batch) in local_batches {
-                if remaining_digests.remove(&local_batch_digest) {
-                    let batch_fetch_duration =
-                        local_batch.metadata().created_at.elapsed().as_secs_f64();
-                    self.metrics
-                        .batch_execution_latency
-                        .observe(batch_fetch_duration);
-                    trace!(
-                        "Batch {local_batch_digest:?} took {batch_fetch_duration} seconds to be fetched for execution since creation",
-                    );
-                    fetched_batches.insert(local_batch_digest, local_batch);
-                }
-            }
-
-            if remaining_digests.is_empty() {
-                continue;
-            }
-
-            let _timer = self.metrics.subscriber_remote_fetch_latency.start_timer();
-            let mut stagger = Duration::from_secs(0);
-            let mut futures = FuturesUnordered::new();
-            for worker in &workers {
-                let future = self.fetch_remote(stagger, worker.clone(), remaining_digests.clone());
-                futures.push(future.boxed());
-                // TODO: Make this a parameter, and also record workers / authorities that are down
-                // to request from them batches later.
-                stagger += Duration::from_millis(500);
-            }
-
-            while let Some(remote_batches) = futures.next().await {
-                for (remote_batch_digest, remote_batch) in remote_batches {
-                    if remaining_digests.remove(&remote_batch_digest) {
-                        let batch_fetch_duration =
-                            remote_batch.metadata().created_at.elapsed().as_secs_f64();
-                        self.metrics
-                            .batch_execution_latency
-                            .observe(batch_fetch_duration);
-                        trace!(
-                            "Batch {remote_batch_digest:?} took {batch_fetch_duration} seconds to be fetched for execution since creation"
-                        );
-
-                        fetched_batches.insert(remote_batch_digest, remote_batch);
-                    }
-                }
-
-                if remaining_digests.is_empty() {
-                    break;
-                }
-            }
-        }
-        fetched_batches
-    }
-
-    #[instrument(level = "debug", skip_all, fields(digests = ? digests, worker_id = % worker_id))]
-    async fn try_fetch_locally(
-        &self,
-        digests: HashSet<BatchDigest>,
-        worker_id: WorkerId,
-    ) -> HashMap<BatchDigest, Batch> {
-        let _timer = self.metrics.subscriber_local_fetch_latency.start_timer();
-        let mut fetched_batches: HashMap<BatchDigest, Batch> = HashMap::new();
-        let worker = self.network.my_worker(&worker_id);
-        let mut digests_to_fetch = digests;
-
-        // Continue to bulk request from local worker until no remaining digests
-        // are available.
-        loop {
-            if digests_to_fetch.is_empty() {
-                break;
-            }
-            debug!("Local attempt to fetch {} digests", digests_to_fetch.len());
-            let timeout = Duration::from_secs(10);
-            let rpc_response = self
-                .network
-                .request_batches(
-                    digests_to_fetch.clone().into_iter().collect(),
-                    worker.clone(),
-                    timeout,
-                )
-                .await;
-
-            match rpc_response {
-                Ok(request_batches_response) => {
-                    let RequestBatchesResponse {
-                        batches,
-                        is_size_limit_reached,
-                    } = request_batches_response;
-                    debug!("Locally found {} batches", batches.len());
-                    for local_batch in batches {
-                        self.metrics
-                            .subscriber_batch_fetch
-                            .with_label_values(&["local", "success"])
-                            .inc();
-                        digests_to_fetch.remove(&local_batch.digest());
-                        fetched_batches.insert(local_batch.digest(), local_batch);
-                    }
-
-                    if !is_size_limit_reached {
-                        break;
-                    }
-                }
-                Err(err) => {
-                    if err.to_string().contains("Timeout") {
-                        self.metrics
-                            .subscriber_batch_fetch
-                            .with_label_values(&["local", "timeout"])
-                            .inc();
-                    } else {
-                        self.metrics
-                            .subscriber_batch_fetch
-                            .with_label_values(&["local", "fail"])
-                            .inc();
-                    }
-                    warn!("Error communicating with our own worker: {err}");
-                    break;
-                }
-            }
-        }
-
-        fetched_batches
-    }
-
-    /// This future performs a fetch from a given remote worker
-    /// This future performs infinite retries with exponential backoff
-    /// You can specify stagger_delay before request is issued
-    #[instrument(level = "debug", skip_all, fields(stagger_delay = ? stagger_delay, worker = % worker, digests = ? digests))]
-    async fn fetch_remote(
-        &self,
-        stagger_delay: Duration,
-        worker: NetworkPublicKey,
-        digests: HashSet<BatchDigest>,
-    ) -> HashMap<BatchDigest, Batch> {
-        tokio::time::sleep(stagger_delay).await;
-        // TODO: Make these config parameters
-        let max_timeout = Duration::from_secs(60);
-        let mut timeout = Duration::from_secs(10);
-        let mut attempt = 0usize;
-        let mut fetched_batches: HashMap<BatchDigest, Batch> = HashMap::new();
-        loop {
-            attempt += 1;
-            debug!(
-                "Remote attempt #{attempt} to fetch {} digests from {worker}",
-                digests.len(),
-            );
-            let deadline = Instant::now() + timeout;
-            let request_batch_guard =
-                PendingGuard::make_inc(&self.metrics.pending_remote_request_batch);
-            let response = self
-                .safe_request_batches(digests.clone(), worker.clone(), timeout)
-                .await;
-            drop(request_batch_guard);
-            match response {
-                Ok(remote_batches) => {
-                    self.metrics
-                        .subscriber_batch_fetch
-                        .with_label_values(&["remote", "success"])
-                        .inc();
-                    debug!("Found {} batches remotely", remote_batches.len());
-                    for (remote_batch_digest, remote_batch) in remote_batches {
-                        if digests.contains(&remote_batch_digest) {
-                            fetched_batches.insert(remote_batch_digest, remote_batch);
-                        }
-                    }
-                    return fetched_batches;
-                }
-                Err(err) => {
-                    if err.to_string().contains("Timeout") {
-                        self.metrics
-                            .subscriber_batch_fetch
-                            .with_label_values(&["remote", "timeout"])
-                            .inc();
-                    } else {
-                        self.metrics
-                            .subscriber_batch_fetch
-                            .with_label_values(&["remote", "fail"])
-                            .inc();
-                    }
-                    debug!("Error retrieving payloads {digests:?} from {worker} attempt {attempt}: {err}")
-                }
-            }
-
-            timeout += timeout / 2;
-            timeout = std::cmp::min(max_timeout, timeout);
-            // Since the call might have returned before timeout, we wait until originally planned deadline
-            tokio::time::sleep_until(deadline).await;
-        }
-    }
-
-    /// Issue request_batches RPC and verifies response integrity
-    #[instrument(level = "debug", skip_all, fields(worker = % worker, digests = ? digests, timeout = ? timeout))]
-    async fn safe_request_batches(
-        &self,
-        digests: HashSet<BatchDigest>,
-        worker: NetworkPublicKey,
-        timeout: Duration,
-    ) -> anyhow::Result<HashMap<BatchDigest, Batch>> {
-        let mut verified_batches = HashMap::new();
-        let mut digests_to_fetch = digests.clone();
-
-        // Continue to bulk request from remote worker until no remaining
-        // digests are available.
-        loop {
-            if digests_to_fetch.is_empty() {
-                break;
-            }
-            let RequestBatchesResponse {
-                batches,
-                is_size_limit_reached,
-            } = self
-                .network
-                .request_batches(
-                    digests_to_fetch.clone().into_iter().collect(),
-                    worker.clone(),
-                    timeout,
-                )
-                .await?;
-            // Use this flag to determine if the worker returned a valid digest
-            // to protect against an adversarial worker returning size limit reached
-            // and no batches leading us to retry this worker forever or until
-            // we get batches from other workers.
-            let mut is_digest_received = false;
-            for batch in batches {
-                let batch_digest = batch.digest();
-                if !digests_to_fetch.contains(&batch_digest) {
-                    bail!("[Protocol violation] Worker {worker} returned batch with digest {batch_digest} which is not part of the requested digests: {digests:?}");
-                } else {
-                    is_digest_received = true;
-                    verified_batches.insert(batch_digest, batch);
-                    digests_to_fetch.remove(&batch_digest);
-                }
-            }
-            if !is_size_limit_reached || !is_digest_received {
-                break;
-            }
-        }
-
-        Ok(verified_batches)
-    }
-}
-
-// todo - make it generic so that other can reuse
-struct PendingGuard<'a> {
-    metric: &'a IntGauge,
-}
-
-impl<'a> PendingGuard<'a> {
-    pub fn make_inc(metric: &'a IntGauge) -> Self {
-        metric.inc();
-        Self { metric }
-    }
-}
-
-impl<'a> Drop for PendingGuard<'a> {
-    fn drop(&mut self) {
-        self.metric.dec()
-    }
-}
-
-// Trait for unit tests
-#[async_trait]
-pub trait SubscriberNetwork: Send + Sync {
-    fn my_worker(&self, worker_id: &WorkerId) -> NetworkPublicKey;
     fn workers_for_certificate(
-        &self,
-        certificate: &Certificate,
-        worker_id: &WorkerId,
-    ) -> Vec<NetworkPublicKey>;
-
-    async fn request_batches(
-        &self,
-        batch_digests: Vec<BatchDigest>,
-        worker: NetworkPublicKey,
-        timeout: Duration,
-    ) -> anyhow::Result<RequestBatchesResponse>;
-}
-
-struct SubscriberNetworkImpl {
-    authority_id: AuthorityIdentifier,
-    network: anemo::Network,
-    worker_cache: WorkerCache,
-    committee: Committee,
-}
-
-#[async_trait]
-impl SubscriberNetwork for SubscriberNetworkImpl {
-    fn my_worker(&self, worker_id: &WorkerId) -> NetworkPublicKey {
-        self.worker_cache
-            .worker(
-                self.committee
-                    .authority(&self.authority_id)
-                    .unwrap()
-                    .protocol_key(),
-                worker_id,
-            )
-            .expect("Own worker not found in cache")
-            .name
-    }
-
-    fn workers_for_certificate(
-        &self,
+        inner: &Inner,
         certificate: &Certificate,
         worker_id: &WorkerId,
     ) -> Vec<NetworkPublicKey> {
-        let authorities = certificate.signed_authorities(&self.committee);
+        let authorities = certificate.signed_authorities(&inner.committee);
         authorities
             .into_iter()
             .filter_map(|authority| {
-                let worker = self.worker_cache.worker(&authority, worker_id);
+                let worker = inner.worker_cache.worker(&authority, worker_id);
                 match worker {
                     Ok(worker) => Some(worker.name),
                     Err(err) => {
@@ -649,372 +322,56 @@ impl SubscriberNetwork for SubscriberNetworkImpl {
             .collect()
     }
 
-    async fn request_batches(
-        &self,
-        batch_digests: Vec<BatchDigest>,
-        worker: NetworkPublicKey,
-        timeout: Duration,
-    ) -> anyhow::Result<RequestBatchesResponse> {
-        let request =
-            anemo::Request::new(RequestBatchesRequest { batch_digests }).with_timeout(timeout);
-        self.network.request_batches(worker, request).await
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crypto::NetworkKeyPair;
-    use fastcrypto::hash::Hash;
-    use fastcrypto::traits::KeyPair;
-    use itertools::Itertools;
-    use rand::rngs::StdRng;
-    use std::collections::HashMap;
-
-    #[tokio::test]
-    pub async fn test_fetcher() {
-        let mut network = TestSubscriberNetwork::new(1);
-        let batch1 = Batch::new(vec![vec![1]]);
-        let batch2 = Batch::new(vec![vec![2]]);
-        let batch_digests_and_workers: HashMap<
-            WorkerId,
+    async fn fetch_batches_from_workers(
+        inner: &Inner,
+        batch_digests_and_workers: HashMap<
+            NetworkPublicKey,
             (HashSet<BatchDigest>, HashSet<NetworkPublicKey>),
-        > = HashMap::from_iter(vec![(
-            0,
-            (
-                HashSet::from_iter(vec![batch1.digest(), batch2.digest()]),
-                HashSet::from_iter(test_pks(&[1, 2])),
-            ),
-        )]);
-        network.put(0, &[1, 2], batch1.clone());
-        network.put(0, &[2, 3], batch2.clone());
-        let fetcher = Fetcher {
-            network,
-            metrics: Arc::new(ExecutorMetrics::default()),
-        };
-        let expected_batches = HashMap::from_iter(vec![
-            (batch1.digest(), batch1.clone()),
-            (batch2.digest(), batch2.clone()),
-        ]);
-        let fetched_batches = fetcher
-            .fetch_batches_from_worker(batch_digests_and_workers)
-            .await;
-        assert_eq!(fetched_batches, expected_batches);
-    }
+        >,
+    ) -> HashMap<BatchDigest, Batch> {
+        let mut fetched_batches = HashMap::new();
 
-    #[tokio::test]
-    pub async fn test_fetcher_multi_worker() {
-        let mut network = TestSubscriberNetwork::new(2);
-        let batch1 = Batch::new(vec![vec![1]]);
-        let batch2 = Batch::new(vec![vec![2]]);
-        let batch_digests_and_workers: HashMap<
-            WorkerId,
-            (HashSet<BatchDigest>, HashSet<NetworkPublicKey>),
-        > = HashMap::from_iter(vec![
-            (
-                0,
-                (
-                    HashSet::from_iter(vec![batch2.digest()]),
-                    HashSet::from_iter(test_pks(&[4, 5])),
-                ),
-            ),
-            (
-                1,
-                (
-                    HashSet::from_iter(vec![batch1.digest()]),
-                    HashSet::from_iter(test_pks(&[1, 2, 3])),
-                ),
-            ),
-        ]);
-        // one batch available locally on worker 1
-        network.put(1, &[1, 2, 3], batch1.clone());
-        // other batch available remotely on worker 0
-        network.put(0, &[4, 5], batch2.clone());
-        let fetcher = Fetcher {
-            network,
-            metrics: Arc::new(ExecutorMetrics::default()),
-        };
-        let expected_batches = HashMap::from_iter(vec![
-            (batch1.digest(), batch1.clone()),
-            (batch2.digest(), batch2.clone()),
-        ]);
-        let fetched_batches = fetcher
-            .fetch_batches_from_worker(batch_digests_and_workers)
-            .await;
-        assert_eq!(fetched_batches, expected_batches);
-    }
-
-    #[tokio::test]
-    pub async fn test_fetcher_locally_with_remaining() {
-        // Limit is set to two batches in test request_batches(). Request 3 batches
-        // and ensure another request is sent to get the remaining batches.
-        let mut network = TestSubscriberNetwork::new(1);
-        let batch1 = Batch::new(vec![vec![1]]);
-        let batch2 = Batch::new(vec![vec![2]]);
-        let batch3 = Batch::new(vec![vec![3]]);
-        let batch_digests_and_workers: HashMap<
-            WorkerId,
-            (HashSet<BatchDigest>, HashSet<NetworkPublicKey>),
-        > = HashMap::from_iter(vec![(
-            0,
-            (
-                HashSet::from_iter(vec![batch1.digest(), batch2.digest(), batch3.digest()]),
-                HashSet::from_iter(test_pks(&[1, 2, 3])),
-            ),
-        )]);
-        network.put(0, &[0, 1, 2], batch1.clone());
-        network.put(0, &[0, 2, 3], batch2.clone());
-        network.put(0, &[0, 3, 4], batch3.clone());
-        let fetcher = Fetcher {
-            network,
-            metrics: Arc::new(ExecutorMetrics::default()),
-        };
-        let expected_batches = HashMap::from_iter(vec![
-            (batch1.digest(), batch1.clone()),
-            (batch2.digest(), batch2.clone()),
-            (batch3.digest(), batch3.clone()),
-        ]);
-        let fetched_batches = fetcher
-            .fetch_batches_from_worker(batch_digests_and_workers)
-            .await;
-        assert_eq!(fetched_batches, expected_batches);
-    }
-
-    #[tokio::test]
-    pub async fn test_fetcher_remote_with_remaining() {
-        // Limit is set to two batches in test request_batches(). Request 3 batches
-        // and ensure another request is sent to get the remaining batches.
-        let mut network = TestSubscriberNetwork::new(1);
-        let batch1 = Batch::new(vec![vec![1]]);
-        let batch2 = Batch::new(vec![vec![2]]);
-        let batch3 = Batch::new(vec![vec![3]]);
-        let batch_digests_and_workers: HashMap<
-            WorkerId,
-            (HashSet<BatchDigest>, HashSet<NetworkPublicKey>),
-        > = HashMap::from_iter(vec![(
-            0,
-            (
-                HashSet::from_iter(vec![batch1.digest(), batch2.digest(), batch3.digest()]),
-                HashSet::from_iter(test_pks(&[2, 3, 4])),
-            ),
-        )]);
-        network.put(0, &[3, 4], batch1.clone());
-        network.put(0, &[2, 3], batch2.clone());
-        network.put(0, &[2, 3, 4], batch3.clone());
-        let fetcher = Fetcher {
-            network,
-            metrics: Arc::new(ExecutorMetrics::default()),
-        };
-        let expected_batches = HashMap::from_iter(vec![
-            (batch1.digest(), batch1.clone()),
-            (batch2.digest(), batch2.clone()),
-            (batch3.digest(), batch3.clone()),
-        ]);
-        let fetched_batches = fetcher
-            .fetch_batches_from_worker(batch_digests_and_workers)
-            .await;
-        assert_eq!(fetched_batches, expected_batches);
-    }
-
-    #[tokio::test]
-    pub async fn test_fetcher_local_and_remote() {
-        let mut network = TestSubscriberNetwork::new(1);
-        let batch1 = Batch::new(vec![vec![1]]);
-        let batch2 = Batch::new(vec![vec![2]]);
-        let batch3 = Batch::new(vec![vec![3]]);
-        let batch_digests_and_workers: HashMap<
-            WorkerId,
-            (HashSet<BatchDigest>, HashSet<NetworkPublicKey>),
-        > = HashMap::from_iter(vec![(
-            0,
-            (
-                HashSet::from_iter(vec![batch1.digest(), batch2.digest(), batch3.digest()]),
-                HashSet::from_iter(test_pks(&[1, 2, 3, 4])),
-            ),
-        )]);
-        network.put(0, &[0, 1, 2, 3], batch1.clone());
-        network.put(0, &[2, 3, 4], batch2.clone());
-        network.put(0, &[1, 4], batch3.clone());
-        let fetcher = Fetcher {
-            network,
-            metrics: Arc::new(ExecutorMetrics::default()),
-        };
-        let expected_batches = HashMap::from_iter(vec![
-            (batch1.digest(), batch1.clone()),
-            (batch2.digest(), batch2.clone()),
-            (batch3.digest(), batch3.clone()),
-        ]);
-        let fetched_batches = fetcher
-            .fetch_batches_from_worker(batch_digests_and_workers)
-            .await;
-        assert_eq!(fetched_batches, expected_batches);
-    }
-
-    #[tokio::test]
-    pub async fn test_fetcher_response_size_limit() {
-        let mut network = TestSubscriberNetwork::new(1);
-        let num_digests = 12;
-        let mut expected_batches = Vec::new();
-        // 6 batches available locally with response size limit of 2
-        for i in 0..num_digests / 2 {
-            let batch = Batch::new(vec![vec![i]]);
-            network.put(0, &[0, 1, 2, 3], batch.clone());
-            expected_batches.push(batch);
-        }
-        // 6 batches available locally with response size limit of 2
-        for i in (num_digests / 2)..num_digests {
-            let batch = Batch::new(vec![vec![i]]);
-            network.put(0, &[1, 2, 3], batch.clone());
-            expected_batches.push(batch);
-        }
-
-        let expected_batches = HashMap::from_iter(
-            expected_batches
-                .iter()
-                .map(|batch| (batch.digest(), batch.clone())),
-        );
-        let batch_digests_and_workers: HashMap<
-            WorkerId,
-            (HashSet<BatchDigest>, HashSet<NetworkPublicKey>),
-        > = HashMap::from_iter(vec![(
-            0,
-            (
-                HashSet::from_iter(expected_batches.clone().into_keys()),
-                HashSet::from_iter(test_pks(&[1, 2, 3])),
-            ),
-        )]);
-        let fetcher = Fetcher {
-            network,
-            metrics: Arc::new(ExecutorMetrics::default()),
-        };
-        let fetched_batches = fetcher
-            .fetch_batches_from_worker(batch_digests_and_workers)
-            .await;
-        assert_eq!(fetched_batches, expected_batches);
-    }
-
-    struct TestSubscriberNetwork {
-        data: HashMap<WorkerId, HashMap<BatchDigest, HashMap<NetworkPublicKey, Batch>>>,
-        worker_cache: HashMap<NetworkPublicKey, WorkerId>,
-        my: HashMap<WorkerId, NetworkPublicKey>,
-    }
-
-    impl TestSubscriberNetwork {
-        pub fn new(workers: u8) -> Self {
-            let mut my = HashMap::new();
-            let mut worker_cache = HashMap::new();
-            for i in 0..workers {
-                let pk = test_pk(i);
-                // Not ideal but keys 0..workers are reserved for local worker keys.
-                my.insert(i as u32, pk.clone());
-                worker_cache.insert(pk, i as u32);
-            }
-            let data = Default::default();
-            Self {
-                data,
-                worker_cache,
-                my,
-            }
-        }
-
-        pub fn put(&mut self, worker_id: WorkerId, keys: &[u8], batch: Batch) {
-            let digest = batch.digest();
-            let entry = self
-                .data
-                .entry(worker_id)
-                .or_default()
-                .entry(digest)
-                .or_default();
-            for key in keys {
-                let key = test_pk(*key);
-                entry.insert(key.clone(), batch.clone());
-                if let Some(existing_worker_id) = self.worker_cache.insert(key, worker_id) {
-                    assert!(
-                        existing_worker_id == worker_id,
-                        "Worker key should be unique across worker ids"
-                    );
-                }
-            }
-        }
-    }
-
-    #[async_trait]
-    impl SubscriberNetwork for TestSubscriberNetwork {
-        fn my_worker(&self, worker_id: &WorkerId) -> NetworkPublicKey {
-            self.my.get(worker_id).expect("invalid worker id").clone()
-        }
-
-        fn workers_for_certificate(
-            &self,
-            certificate: &Certificate,
-            worker_id: &WorkerId,
-        ) -> Vec<NetworkPublicKey> {
-            let payload = certificate.header().payload().to_owned();
-            let digest = payload.keys().next().unwrap();
-            self.data
-                .get(worker_id)
-                .unwrap()
-                .get(digest)
-                .unwrap()
-                .keys()
-                .cloned()
-                .collect()
-        }
-
-        async fn request_batches(
-            &self,
-            digests: Vec<BatchDigest>,
-            worker: NetworkPublicKey,
-            _timeout: Duration,
-        ) -> anyhow::Result<RequestBatchesResponse> {
-            // Use this to simulate server side response size limit in RequestBatches
-            const MAX_REQUEST_BATCHES_RESPONSE_SIZE: usize = 2;
-            const MAX_READ_BATCH_DIGESTS: usize = 5;
-
-            let mut is_size_limit_reached = false;
-            let mut batches = Vec::new();
-            let mut total_size = 0;
-
-            let digests_chunks = digests
-                .chunks(MAX_READ_BATCH_DIGESTS)
-                .map(|chunk| chunk.to_vec())
-                .collect_vec();
-            let worker_id = self.worker_cache.get(&worker).unwrap();
-            for digests_chunk in digests_chunks {
-                for digest in digests_chunk {
-                    if let Some(batch) = self
-                        .data
-                        .get(worker_id)
-                        .unwrap()
-                        .get(&digest)
-                        .unwrap()
-                        .get(&worker)
-                    {
-                        if total_size < MAX_REQUEST_BATCHES_RESPONSE_SIZE {
-                            batches.push(batch.clone());
-                            total_size += batch.size();
-                        } else {
-                            is_size_limit_reached = true;
-                            break;
-                        }
+        for (worker_name, (digests, known_workers)) in batch_digests_and_workers {
+            debug!(
+                "Attempting to fetch {} digests from {} known workers, {worker_name}'s",
+                digests.len(),
+                known_workers.len()
+            );
+            // TODO: Can further parallelize this by worker if necessary. Maybe move the logic
+            // to NetworkClient.
+            // Only have one worker for now so will leave this for a future
+            // optimization.
+            let request = FetchBatchesRequest {
+                digests,
+                known_workers,
+            };
+            let batches = loop {
+                match inner
+                    .client
+                    .fetch_batches(worker_name.clone(), request.clone())
+                    .await
+                {
+                    Ok(resp) => break resp.batches,
+                    Err(e) => {
+                        error!("Failed to fetch batches from worker {worker_name}: {e:?}");
+                        // Loop forever on failure. During shutdown, this should get cancelled.
+                        tokio::time::sleep(Duration::from_secs(1)).await;
+                        continue;
                     }
                 }
+            };
+            for (digest, batch) in batches {
+                let batch_fetch_duration = batch.metadata().created_at.elapsed().as_secs_f64();
+                inner
+                    .metrics
+                    .batch_execution_latency
+                    .observe(batch_fetch_duration);
+                fetched_batches.insert(digest, batch);
             }
-
-            Ok(RequestBatchesResponse {
-                batches,
-                is_size_limit_reached,
-            })
         }
-    }
 
-    fn test_pk(i: u8) -> NetworkPublicKey {
-        use rand::SeedableRng;
-        let mut rng = StdRng::from_seed([i; 32]);
-        NetworkKeyPair::generate(&mut rng).public().clone()
-    }
-
-    fn test_pks(i: &[u8]) -> Vec<NetworkPublicKey> {
-        i.iter().map(|i| test_pk(*i)).collect()
+        fetched_batches
     }
 }
+
+// TODO: add a unit test

--- a/narwhal/executor/src/subscriber.rs
+++ b/narwhal/executor/src/subscriber.rs
@@ -303,6 +303,8 @@ impl Subscriber {
         certificate: &Certificate,
         worker_id: &WorkerId,
     ) -> Vec<NetworkPublicKey> {
+        // Can include own authority and worker, but worker will always check local storage when
+        // fetching paylods.
         let authorities = certificate.signed_authorities(&inner.committee);
         authorities
             .into_iter()

--- a/narwhal/network/src/p2p.rs
+++ b/narwhal/network/src/p2p.rs
@@ -17,8 +17,7 @@ use types::{
     Batch, BatchDigest, FetchCertificatesRequest, FetchCertificatesResponse,
     GetCertificatesRequest, GetCertificatesResponse, PrimaryToPrimaryClient, PrimaryToWorkerClient,
     RequestBatchRequest, RequestBatchesRequest, RequestBatchesResponse, WorkerBatchMessage,
-    WorkerDeleteBatchesMessage, WorkerOthersBatchMessage, WorkerOurBatchMessage,
-    WorkerSynchronizeMessage, WorkerToPrimaryClient, WorkerToWorkerClient,
+    WorkerDeleteBatchesMessage, WorkerSynchronizeMessage, WorkerToWorkerClient,
 };
 
 fn unreliable_send<F, R, Fut>(
@@ -145,52 +144,6 @@ impl UnreliableNetwork<WorkerSynchronizeMessage> for anemo::Network {
                 .await
         };
         unreliable_send(self, peer, f)
-    }
-}
-
-//
-// Worker-to-Primary
-//
-
-impl ReliableNetwork<WorkerOurBatchMessage> for anemo::Network {
-    type Response = ();
-    fn send(
-        &self,
-        peer: NetworkPublicKey,
-        message: &WorkerOurBatchMessage,
-    ) -> CancelOnDropHandler<Result<anemo::Response<()>>> {
-        let message = message.to_owned();
-        let f = move |peer| {
-            let message = message.clone();
-            async move {
-                WorkerToPrimaryClient::new(peer)
-                    .report_our_batch(message)
-                    .await
-            }
-        };
-
-        send(self.clone(), peer, f)
-    }
-}
-
-impl ReliableNetwork<WorkerOthersBatchMessage> for anemo::Network {
-    type Response = ();
-    fn send(
-        &self,
-        peer: NetworkPublicKey,
-        message: &WorkerOthersBatchMessage,
-    ) -> CancelOnDropHandler<Result<anemo::Response<()>>> {
-        let message = message.to_owned();
-        let f = move |peer| {
-            let message = message.clone();
-            async move {
-                WorkerToPrimaryClient::new(peer)
-                    .report_others_batch(message)
-                    .await
-            }
-        };
-
-        send(self.clone(), peer, f)
     }
 }
 

--- a/narwhal/network/src/traits.rs
+++ b/narwhal/network/src/traits.rs
@@ -6,10 +6,10 @@ use async_trait::async_trait;
 use crypto::NetworkPublicKey;
 use tokio::task::JoinHandle;
 use types::{
-    error::LocalClientError, Batch, BatchDigest, FetchCertificatesRequest,
-    FetchCertificatesResponse, GetCertificatesRequest, GetCertificatesResponse,
-    RequestBatchesRequest, RequestBatchesResponse, WorkerOthersBatchMessage, WorkerOurBatchMessage,
-    WorkerSynchronizeMessage,
+    error::LocalClientError, Batch, BatchDigest, FetchBatchesRequest, FetchBatchesResponse,
+    FetchCertificatesRequest, FetchCertificatesResponse, GetCertificatesRequest,
+    GetCertificatesResponse, RequestBatchesRequest, RequestBatchesResponse,
+    WorkerOthersBatchMessage, WorkerOurBatchMessage, WorkerSynchronizeMessage,
 };
 
 pub trait UnreliableNetwork<Request: Clone + Send + Sync> {
@@ -87,6 +87,12 @@ pub trait PrimaryToWorkerClient {
         worker_name: NetworkPublicKey,
         request: WorkerSynchronizeMessage,
     ) -> Result<(), LocalClientError>;
+
+    async fn fetch_batches(
+        &self,
+        worker_name: NetworkPublicKey,
+        request: FetchBatchesRequest,
+    ) -> Result<FetchBatchesResponse, LocalClientError>;
 }
 
 #[async_trait]

--- a/narwhal/node/src/primary_node.rs
+++ b/narwhal/node/src/primary_node.rs
@@ -19,7 +19,7 @@ use prometheus::{IntGauge, Registry};
 use std::sync::Arc;
 use std::time::Instant;
 use storage::NodeStorage;
-use tokio::sync::{oneshot, watch, RwLock};
+use tokio::sync::{watch, RwLock};
 use tokio::task::JoinHandle;
 use tracing::{debug, info, instrument};
 use types::{
@@ -240,7 +240,6 @@ impl PrimaryNodeInner {
             .unwrap_or_else(|| panic!("Our node with key {:?} should be in committee", name));
 
         let mut handles = Vec::new();
-        let (tx_executor_network, rx_executor_network) = oneshot::channel();
         let (tx_consensus_round_updates, rx_consensus_round_updates) =
             watch::channel(ConsensusRound::new(0, 0));
         let (dag, network_model) = if !internal_consensus {
@@ -259,9 +258,9 @@ impl PrimaryNodeInner {
         } else {
             let consensus_handles = Self::spawn_consensus(
                 authority.id(),
-                rx_executor_network,
                 worker_cache.clone(),
                 committee.clone(),
+                client.clone(),
                 store,
                 parameters.clone(),
                 execution_state,
@@ -300,7 +299,6 @@ impl PrimaryNodeInner {
             tx_shutdown,
             tx_committed_certificates,
             registry,
-            Some(tx_executor_network),
         );
         handles.extend(primary_handles);
 
@@ -310,9 +308,9 @@ impl PrimaryNodeInner {
     /// Spawn the consensus core and the client executing transactions.
     async fn spawn_consensus<State>(
         authority_id: AuthorityIdentifier,
-        rx_executor_network: oneshot::Receiver<anemo::Network>,
         worker_cache: WorkerCache,
         committee: Committee,
+        client: NetworkClient,
         store: &NodeStorage,
         parameters: Parameters,
         execution_state: State,
@@ -375,9 +373,9 @@ impl PrimaryNodeInner {
         // subscriber handler if it missed some transactions.
         let executor_handles = Executor::spawn(
             authority_id,
-            rx_executor_network,
             worker_cache,
             committee.clone(),
+            client,
             execution_state,
             shutdown_receivers,
             rx_sequence,

--- a/narwhal/node/src/primary_node.rs
+++ b/narwhal/node/src/primary_node.rs
@@ -277,6 +277,9 @@ impl PrimaryNodeInner {
             (None, NetworkModel::PartiallySynchronous)
         };
 
+        // TODO: the same set of variables are sent to primary, consensus and downstream
+        // components. Consider using a holder struct to pass them around.
+
         // Spawn the primary.
         let primary_handles = Primary::spawn(
             authority.clone(),

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -120,8 +120,6 @@ impl Primary {
         tx_shutdown: &mut PreSubscribedBroadcastSender,
         tx_committed_certificates: Sender<(Round, Vec<Certificate>)>,
         registry: &Registry,
-        // See comments in Subscriber::spawn
-        tx_executor_network: Option<oneshot::Sender<anemo::Network>>,
     ) -> Vec<JoinHandle<()>> {
         // Write the parameters to the logs.
         parameters.tracing();
@@ -455,12 +453,6 @@ impl Primary {
             network.clone(),
             tx_shutdown.subscribe(),
         );
-
-        if let Some(tx_executor_network) = tx_executor_network {
-            if tx_executor_network.send(network.clone()).is_err() {
-                panic!("Executor shut down before primary has a chance to start");
-            }
-        }
 
         let core_handle = Certifier::spawn(
             authority.id(),

--- a/narwhal/primary/src/tests/primary_tests.rs
+++ b/narwhal/primary/src/tests/primary_tests.rs
@@ -117,7 +117,6 @@ async fn get_network_peers_from_admin_server() {
         &mut tx_shutdown,
         tx_feedback,
         &Registry::new(),
-        None,
     );
 
     // Wait for tasks to start
@@ -242,7 +241,6 @@ async fn get_network_peers_from_admin_server() {
         &mut tx_shutdown_2,
         tx_feedback_2,
         &Registry::new(),
-        None,
     );
 
     // Wait for tasks to start

--- a/narwhal/primary/tests/integration_tests_proposer_api.rs
+++ b/narwhal/primary/tests/integration_tests_proposer_api.rs
@@ -137,7 +137,6 @@ async fn test_rounds_errors() {
         &mut tx_shutdown,
         tx_feedback,
         &Registry::new(),
-        None,
     );
 
     // AND Wait for tasks to start
@@ -232,7 +231,6 @@ async fn test_rounds_return_successful_response() {
         &mut tx_shutdown,
         tx_feedback,
         &Registry::new(),
-        None,
     );
 
     // AND Wait for tasks to start
@@ -397,7 +395,6 @@ async fn test_node_read_causal_signed_certificates() {
         &mut tx_shutdown,
         tx_feedback,
         &Registry::new(),
-        None,
     );
 
     let (tx_new_certificates_2, rx_new_certificates_2) =
@@ -446,7 +443,6 @@ async fn test_node_read_causal_signed_certificates() {
         &mut tx_shutdown_2,
         tx_feedback_2,
         &Registry::new(),
-        None,
     );
 
     // Wait for tasks to start

--- a/narwhal/primary/tests/integration_tests_validator_api.rs
+++ b/narwhal/primary/tests/integration_tests_validator_api.rs
@@ -134,7 +134,6 @@ async fn test_get_collections() {
         &mut tx_shutdown,
         tx_feedback,
         &Registry::new(),
-        None,
     );
 
     let registry = Registry::new();
@@ -334,7 +333,6 @@ async fn test_remove_collections() {
         &mut tx_shutdown,
         tx_feedback,
         &Registry::new(),
-        None,
     );
 
     // Wait for tasks to start
@@ -588,7 +586,6 @@ async fn test_read_causal_signed_certificates() {
         &mut tx_shutdown,
         tx_feedback,
         &Registry::new(),
-        None,
     );
 
     let (tx_new_certificates_2, rx_new_certificates_2) =
@@ -638,7 +635,6 @@ async fn test_read_causal_signed_certificates() {
         &mut tx_shutdown_2,
         tx_feedback_2,
         &Registry::new(),
-        None,
     );
 
     // Wait for tasks to start
@@ -818,7 +814,6 @@ async fn test_read_causal_unsigned_certificates() {
         &mut tx_shutdown,
         tx_feedback,
         &Registry::new(),
-        None,
     );
 
     let (tx_new_certificates_2, rx_new_certificates_2) =
@@ -862,7 +857,6 @@ async fn test_read_causal_unsigned_certificates() {
         &mut tx_shutdown_2,
         tx_feedback_2,
         &Registry::new(),
-        None,
     );
 
     // Wait for tasks to start
@@ -1043,7 +1037,6 @@ async fn test_get_collections_with_missing_certificates() {
         &mut tx_shutdown,
         tx_feedback_1,
         &Registry::new(),
-        None,
     );
 
     let registry_1 = Registry::new();
@@ -1108,7 +1101,6 @@ async fn test_get_collections_with_missing_certificates() {
         &mut tx_shutdown_2,
         tx_feedback_2,
         &Registry::new(),
-        None,
     );
 
     let registry_2 = Registry::new();

--- a/narwhal/types/build.rs
+++ b/narwhal/types/build.rs
@@ -114,6 +114,15 @@ fn build_anemo_services(out_dir: &Path) {
         )
         .method(
             anemo_build::manual::Method::builder()
+                .name("fetch_batches")
+                .route_name("FetchBatches")
+                .request_type("crate::FetchBatchesRequest")
+                .response_type("crate::FetchBatchesResponse")
+                .codec_path(codec_path)
+                .build(),
+        )
+        .method(
+            anemo_build::manual::Method::builder()
                 .name("delete_batches")
                 .route_name("DeleteBatches")
                 .request_type("crate::WorkerDeleteBatchesMessage")

--- a/narwhal/types/src/primary.rs
+++ b/narwhal/types/src/primary.rs
@@ -10,7 +10,8 @@ use bytes::Bytes;
 use config::{AuthorityIdentifier, Committee, Epoch, Stake, WorkerCache, WorkerId, WorkerInfo};
 use crypto::{
     to_intent_message, AggregateSignature, AggregateSignatureBytes,
-    NarwhalAuthorityAggregateSignature, NarwhalAuthoritySignature, PublicKey, Signature,
+    NarwhalAuthorityAggregateSignature, NarwhalAuthoritySignature, NetworkPublicKey, PublicKey,
+    Signature,
 };
 use dag::node_dag::Affiliated;
 use derive_builder::Builder;
@@ -27,10 +28,13 @@ use proptest_derive::Arbitrary;
 use roaring::RoaringBitmap;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use std::time::{Duration, SystemTime};
 use std::{
     collections::{BTreeMap, BTreeSet, VecDeque},
     fmt,
+};
+use std::{
+    collections::{HashMap, HashSet},
+    time::{Duration, SystemTime},
 };
 use tracing::warn;
 
@@ -1284,6 +1288,20 @@ pub struct WorkerSynchronizeMessage {
     // the batch it receives because it is part of a certificate. Only digest
     // verification is required.
     pub is_certified: bool,
+}
+
+/// Used by the primary to request that the worker fetch the missing batches and reply
+/// with all of the content.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FetchBatchesRequest {
+    pub digests: HashSet<BatchDigest>,
+    pub known_workers: HashSet<NetworkPublicKey>,
+}
+
+/// All batches requested by the primary.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FetchBatchesResponse {
+    pub batches: HashMap<BatchDigest, Batch>,
 }
 
 /// Used by the primary to request that the worker delete the specified batches.

--- a/narwhal/worker/src/batch_fetcher.rs
+++ b/narwhal/worker/src/batch_fetcher.rs
@@ -1,0 +1,530 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::Duration,
+};
+
+use anemo::Network;
+use anyhow::bail;
+use async_trait::async_trait;
+use crypto::NetworkPublicKey;
+use fastcrypto::hash::Hash;
+use futures::{stream::FuturesUnordered, FutureExt, StreamExt};
+use itertools::Itertools;
+use network::WorkerRpc;
+use prometheus::IntGauge;
+use rand::{rngs::ThreadRng, seq::SliceRandom};
+use store::{rocks::DBMap, Map};
+use tracing::debug;
+use types::{Batch, BatchDigest, RequestBatchesRequest, RequestBatchesResponse};
+
+use crate::metrics::WorkerMetrics;
+
+const REMOTE_PARALLEL_FETCH_INTERVAL: Duration = Duration::from_secs(2);
+
+pub struct BatchFetcher {
+    network: Arc<dyn SubscriberNetwork>,
+    batch_store: DBMap<BatchDigest, Batch>,
+    metrics: Arc<WorkerMetrics>,
+}
+
+impl BatchFetcher {
+    pub fn new(
+        network: Network,
+        batch_store: DBMap<BatchDigest, Batch>,
+        metrics: Arc<WorkerMetrics>,
+    ) -> Self {
+        Self {
+            network: Arc::new(SubscriberNetworkImpl { network }),
+            batch_store,
+            metrics,
+        }
+    }
+
+    /// Bulk fetches payload from local storage and remote workers.
+    /// This function performs infinite retries and blocks until all batches are available.
+    pub async fn fetch(
+        &self,
+        digests: HashSet<BatchDigest>,
+        known_workers: HashSet<NetworkPublicKey>,
+    ) -> HashMap<BatchDigest, Batch> {
+        debug!(
+            "Attempting to fetch {} digests from {} workers",
+            digests.len(),
+            known_workers.len()
+        );
+
+        let mut remaining_digests = digests;
+        let mut fetched_batches = HashMap::new();
+        loop {
+            if remaining_digests.is_empty() {
+                return fetched_batches;
+            }
+
+            let _timer = self.metrics.worker_local_fetch_latency.start_timer();
+            fetched_batches.extend(self.fetch_local(remaining_digests.clone()).await);
+            drop(_timer);
+
+            remaining_digests.retain(|d| !fetched_batches.contains_key(d));
+            if remaining_digests.is_empty() {
+                return fetched_batches;
+            }
+
+            // TODO: Can further parallelize this by target worker_id if necessary.
+            let _timer = self.metrics.worker_remote_fetch_latency.start_timer();
+            let mut known_workers = known_workers.clone().into_iter().collect_vec();
+            known_workers.shuffle(&mut ThreadRng::default());
+            let mut stagger = Duration::from_secs(0);
+            let mut futures = FuturesUnordered::new();
+            for worker in &known_workers {
+                let future = self.fetch_remote(stagger, worker.clone(), remaining_digests.clone());
+                futures.push(future.boxed());
+                // TODO: Make this a parameter, and also record workers / authorities that are down
+                // to request from them batches later.
+                stagger += REMOTE_PARALLEL_FETCH_INTERVAL;
+            }
+
+            while let Some(remote_batches) = futures.next().await {
+                for (remote_batch_digest, remote_batch) in remote_batches {
+                    if remaining_digests.remove(&remote_batch_digest) {
+                        fetched_batches.insert(remote_batch_digest, remote_batch);
+                    }
+                }
+
+                if remaining_digests.is_empty() {
+                    return fetched_batches;
+                }
+            }
+        }
+    }
+
+    async fn fetch_local(&self, digests: HashSet<BatchDigest>) -> HashMap<BatchDigest, Batch> {
+        let _timer = self.metrics.worker_local_fetch_latency.start_timer();
+        let mut fetched_batches = HashMap::new();
+        if digests.is_empty() {
+            return fetched_batches;
+        }
+
+        // Continue to bulk request from local worker until no remaining digests
+        // are available.
+        debug!("Local attempt to fetch {} digests", digests.len());
+        let local_batches = self
+            .batch_store
+            .multi_get(digests.clone().into_iter())
+            .expect("Failed to get batches");
+        for (digest, batch) in digests.into_iter().zip(local_batches.into_iter()) {
+            if let Some(batch) = batch {
+                self.metrics
+                    .worker_batch_fetch
+                    .with_label_values(&["local", "success"])
+                    .inc();
+                fetched_batches.insert(digest, batch);
+            } else {
+                self.metrics
+                    .worker_batch_fetch
+                    .with_label_values(&["local", "failure"])
+                    .inc();
+            }
+        }
+
+        fetched_batches
+    }
+
+    /// This future performs a fetch from a given remote worker
+    /// This future performs infinite retries with exponential backoff
+    /// You can specify stagger_delay before request is issued
+    async fn fetch_remote(
+        &self,
+        stagger_delay: Duration,
+        worker: NetworkPublicKey,
+        digests: HashSet<BatchDigest>,
+    ) -> HashMap<BatchDigest, Batch> {
+        tokio::time::sleep(stagger_delay).await;
+        // TODO: Make these config parameters
+        let timeout = Duration::from_secs(10);
+        let mut attempt = 0usize;
+        let mut fetched_batches: HashMap<BatchDigest, Batch> = HashMap::new();
+        loop {
+            attempt += 1;
+            debug!(
+                "Remote attempt #{attempt} to fetch {} digests from {worker}",
+                digests.len(),
+            );
+            let request_batch_guard =
+                PendingGuard::make_inc(&self.metrics.pending_remote_request_batch);
+            let response = self
+                .safe_request_batches(digests.clone(), worker.clone(), timeout)
+                .await;
+            drop(request_batch_guard);
+            match response {
+                Ok(remote_batches) => {
+                    self.metrics
+                        .worker_batch_fetch
+                        .with_label_values(&["remote", "success"])
+                        .inc();
+                    debug!("Found {} batches remotely", remote_batches.len());
+                    for (remote_batch_digest, remote_batch) in remote_batches {
+                        if digests.contains(&remote_batch_digest) {
+                            fetched_batches.insert(remote_batch_digest, remote_batch);
+                        }
+                    }
+                    return fetched_batches;
+                }
+                Err(err) => {
+                    if err.to_string().contains("Timeout") {
+                        self.metrics
+                            .worker_batch_fetch
+                            .with_label_values(&["remote", "timeout"])
+                            .inc();
+                    } else {
+                        self.metrics
+                            .worker_batch_fetch
+                            .with_label_values(&["remote", "fail"])
+                            .inc();
+                    }
+                    debug!("Error retrieving payloads {digests:?} from {worker} attempt {attempt}: {err}")
+                }
+            }
+            tokio::time::sleep(timeout).await;
+        }
+    }
+
+    /// Issue request_batches RPC and verifies response integrity
+    async fn safe_request_batches(
+        &self,
+        digests: HashSet<BatchDigest>,
+        worker: NetworkPublicKey,
+        timeout: Duration,
+    ) -> anyhow::Result<HashMap<BatchDigest, Batch>> {
+        let mut verified_batches = HashMap::new();
+        let mut digests_to_fetch = digests.clone();
+
+        // Continue to bulk request from remote worker until no remaining
+        // digests are available.
+        loop {
+            if digests_to_fetch.is_empty() {
+                break;
+            }
+            let RequestBatchesResponse {
+                batches,
+                is_size_limit_reached,
+            } = self
+                .network
+                .request_batches(
+                    digests_to_fetch.clone().into_iter().collect(),
+                    worker.clone(),
+                    timeout,
+                )
+                .await?;
+            // Use this flag to determine if the worker returned a valid digest
+            // to protect against an adversarial worker returning size limit reached
+            // and no batches leading us to retry this worker forever or until
+            // we get batches from other workers.
+            let mut is_digest_received = false;
+            for batch in batches {
+                let batch_digest = batch.digest();
+                if !digests_to_fetch.contains(&batch_digest) {
+                    bail!("[Protocol violation] Worker {worker} returned batch with digest {batch_digest} which is not part of the requested digests: {digests:?}");
+                } else {
+                    is_digest_received = true;
+                    verified_batches.insert(batch_digest, batch);
+                    digests_to_fetch.remove(&batch_digest);
+                }
+            }
+            if !is_size_limit_reached || !is_digest_received {
+                break;
+            }
+        }
+
+        Ok(verified_batches)
+    }
+}
+
+// todo - make it generic so that other can reuse
+struct PendingGuard<'a> {
+    metric: &'a IntGauge,
+}
+
+impl<'a> PendingGuard<'a> {
+    pub fn make_inc(metric: &'a IntGauge) -> Self {
+        metric.inc();
+        Self { metric }
+    }
+}
+
+impl<'a> Drop for PendingGuard<'a> {
+    fn drop(&mut self) {
+        self.metric.dec()
+    }
+}
+
+// Trait for unit tests
+#[async_trait]
+pub trait SubscriberNetwork: Send + Sync {
+    async fn request_batches(
+        &self,
+        batch_digests: Vec<BatchDigest>,
+        worker: NetworkPublicKey,
+        timeout: Duration,
+    ) -> anyhow::Result<RequestBatchesResponse>;
+}
+
+struct SubscriberNetworkImpl {
+    network: anemo::Network,
+}
+
+#[async_trait]
+impl SubscriberNetwork for SubscriberNetworkImpl {
+    async fn request_batches(
+        &self,
+        batch_digests: Vec<BatchDigest>,
+        worker: NetworkPublicKey,
+        timeout: Duration,
+    ) -> anyhow::Result<RequestBatchesResponse> {
+        let request =
+            anemo::Request::new(RequestBatchesRequest { batch_digests }).with_timeout(timeout);
+        self.network.request_batches(worker, request).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crypto::NetworkKeyPair;
+    use fastcrypto::hash::Hash;
+    use fastcrypto::traits::KeyPair;
+    use itertools::Itertools;
+    use rand::rngs::StdRng;
+    use std::collections::HashMap;
+
+    #[tokio::test]
+    pub async fn test_fetcher() {
+        let mut network = TestSubscriberNetwork::new();
+        let batch_store = test_utils::create_batch_store();
+        let batch1 = Batch::new(vec![vec![1]]);
+        let batch2 = Batch::new(vec![vec![2]]);
+        let (digests, known_workers) = (
+            HashSet::from_iter(vec![batch1.digest(), batch2.digest()]),
+            HashSet::from_iter(test_pks(&[1, 2])),
+        );
+        network.put(&[1, 2], batch1.clone());
+        network.put(&[2, 3], batch2.clone());
+        let fetcher = BatchFetcher {
+            network: Arc::new(network.clone()),
+            batch_store,
+            metrics: Arc::new(WorkerMetrics::default()),
+        };
+        let expected_batches = HashMap::from_iter(vec![
+            (batch1.digest(), batch1.clone()),
+            (batch2.digest(), batch2.clone()),
+        ]);
+        let fetched_batches = fetcher.fetch(digests, known_workers).await;
+        assert_eq!(fetched_batches, expected_batches);
+    }
+
+    #[tokio::test]
+    pub async fn test_fetcher_locally_with_remaining() {
+        // Limit is set to two batches in test request_batches(). Request 3 batches
+        // and ensure another request is sent to get the remaining batches.
+        let mut network = TestSubscriberNetwork::new();
+        let batch_store = test_utils::create_batch_store();
+        let batch1 = Batch::new(vec![vec![1]]);
+        let batch2 = Batch::new(vec![vec![2]]);
+        let batch3 = Batch::new(vec![vec![3]]);
+        let (digests, known_workers) = (
+            HashSet::from_iter(vec![batch1.digest(), batch2.digest(), batch3.digest()]),
+            HashSet::from_iter(test_pks(&[1, 2, 3])),
+        );
+        for batch in &[&batch1, &batch2, &batch3] {
+            batch_store.insert(&batch.digest(), batch).unwrap();
+        }
+        network.put(&[1, 2], batch1.clone());
+        network.put(&[2, 3], batch2.clone());
+        network.put(&[3, 4], batch3.clone());
+        let fetcher = BatchFetcher {
+            network: Arc::new(network.clone()),
+            batch_store,
+            metrics: Arc::new(WorkerMetrics::default()),
+        };
+        let expected_batches = HashMap::from_iter(vec![
+            (batch1.digest(), batch1.clone()),
+            (batch2.digest(), batch2.clone()),
+            (batch3.digest(), batch3.clone()),
+        ]);
+        let fetched_batches = fetcher.fetch(digests, known_workers).await;
+        assert_eq!(fetched_batches, expected_batches);
+    }
+
+    #[tokio::test]
+    pub async fn test_fetcher_remote_with_remaining() {
+        // Limit is set to two batches in test request_batches(). Request 3 batches
+        // and ensure another request is sent to get the remaining batches.
+        let mut network = TestSubscriberNetwork::new();
+        let batch_store = test_utils::create_batch_store();
+        let batch1 = Batch::new(vec![vec![1]]);
+        let batch2 = Batch::new(vec![vec![2]]);
+        let batch3 = Batch::new(vec![vec![3]]);
+        let (digests, known_workers) = (
+            HashSet::from_iter(vec![batch1.digest(), batch2.digest(), batch3.digest()]),
+            HashSet::from_iter(test_pks(&[2, 3, 4])),
+        );
+        network.put(&[3, 4], batch1.clone());
+        network.put(&[2, 3], batch2.clone());
+        network.put(&[2, 3, 4], batch3.clone());
+        let fetcher = BatchFetcher {
+            network: Arc::new(network.clone()),
+            batch_store,
+            metrics: Arc::new(WorkerMetrics::default()),
+        };
+        let expected_batches = HashMap::from_iter(vec![
+            (batch1.digest(), batch1.clone()),
+            (batch2.digest(), batch2.clone()),
+            (batch3.digest(), batch3.clone()),
+        ]);
+        let fetched_batches = fetcher.fetch(digests, known_workers).await;
+        assert_eq!(fetched_batches, expected_batches);
+    }
+
+    #[tokio::test]
+    pub async fn test_fetcher_local_and_remote() {
+        let mut network = TestSubscriberNetwork::new();
+        let batch_store = test_utils::create_batch_store();
+        let batch1 = Batch::new(vec![vec![1]]);
+        let batch2 = Batch::new(vec![vec![2]]);
+        let batch3 = Batch::new(vec![vec![3]]);
+        let (digests, known_workers) = (
+            HashSet::from_iter(vec![batch1.digest(), batch2.digest(), batch3.digest()]),
+            HashSet::from_iter(test_pks(&[1, 2, 3, 4])),
+        );
+        batch_store.insert(&batch1.digest(), &batch1).unwrap();
+        network.put(&[1, 2, 3], batch1.clone());
+        network.put(&[2, 3, 4], batch2.clone());
+        network.put(&[1, 4], batch3.clone());
+        let fetcher = BatchFetcher {
+            network: Arc::new(network.clone()),
+            batch_store,
+            metrics: Arc::new(WorkerMetrics::default()),
+        };
+        let expected_batches = HashMap::from_iter(vec![
+            (batch1.digest(), batch1.clone()),
+            (batch2.digest(), batch2.clone()),
+            (batch3.digest(), batch3.clone()),
+        ]);
+        let fetched_batches = fetcher.fetch(digests, known_workers).await;
+        assert_eq!(fetched_batches, expected_batches);
+    }
+
+    #[tokio::test]
+    pub async fn test_fetcher_response_size_limit() {
+        let mut network = TestSubscriberNetwork::new();
+        let batch_store = test_utils::create_batch_store();
+        let num_digests = 12;
+        let mut expected_batches = Vec::new();
+        // 6 batches available locally with response size limit of 2
+        for i in 0..num_digests / 2 {
+            let batch = Batch::new(vec![vec![i]]);
+            batch_store.insert(&batch.digest(), &batch).unwrap();
+            network.put(&[1, 2, 3], batch.clone());
+            expected_batches.push(batch);
+        }
+        // 6 batches available remotely with response size limit of 2
+        for i in (num_digests / 2)..num_digests {
+            let batch = Batch::new(vec![vec![i]]);
+            network.put(&[1, 2, 3], batch.clone());
+            expected_batches.push(batch);
+        }
+
+        let expected_batches = HashMap::from_iter(
+            expected_batches
+                .iter()
+                .map(|batch| (batch.digest(), batch.clone())),
+        );
+        let (digests, known_workers) = (
+            HashSet::from_iter(expected_batches.clone().into_keys()),
+            HashSet::from_iter(test_pks(&[1, 2, 3])),
+        );
+        let fetcher = BatchFetcher {
+            network: Arc::new(network.clone()),
+            batch_store,
+            metrics: Arc::new(WorkerMetrics::default()),
+        };
+        let fetched_batches = fetcher.fetch(digests, known_workers).await;
+        assert_eq!(fetched_batches, expected_batches);
+    }
+
+    #[derive(Clone)]
+    struct TestSubscriberNetwork {
+        // Worker name -> batch digests it has -> batches.
+        data: HashMap<NetworkPublicKey, HashMap<BatchDigest, Batch>>,
+    }
+
+    impl TestSubscriberNetwork {
+        pub fn new() -> Self {
+            Self {
+                data: HashMap::new(),
+            }
+        }
+
+        pub fn put(&mut self, keys: &[u8], batch: Batch) {
+            for key in keys {
+                let key = test_pk(*key);
+                let entry = self.data.entry(key).or_default();
+                entry.insert(batch.digest(), batch.clone());
+            }
+        }
+    }
+
+    #[async_trait]
+    impl SubscriberNetwork for TestSubscriberNetwork {
+        async fn request_batches(
+            &self,
+            digests: Vec<BatchDigest>,
+            worker: NetworkPublicKey,
+            _timeout: Duration,
+        ) -> anyhow::Result<RequestBatchesResponse> {
+            // Use this to simulate server side response size limit in RequestBatches
+            const MAX_REQUEST_BATCHES_RESPONSE_SIZE: usize = 2;
+            const MAX_READ_BATCH_DIGESTS: usize = 5;
+
+            let mut is_size_limit_reached = false;
+            let mut batches = Vec::new();
+            let mut total_size = 0;
+
+            let digests_chunks = digests
+                .chunks(MAX_READ_BATCH_DIGESTS)
+                .map(|chunk| chunk.to_vec())
+                .collect_vec();
+            for digests_chunk in digests_chunks {
+                for digest in digests_chunk {
+                    if let Some(batch) = self.data.get(&worker).unwrap().get(&digest) {
+                        if total_size < MAX_REQUEST_BATCHES_RESPONSE_SIZE {
+                            batches.push(batch.clone());
+                            total_size += batch.size();
+                        } else {
+                            is_size_limit_reached = true;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            Ok(RequestBatchesResponse {
+                batches,
+                is_size_limit_reached,
+            })
+        }
+    }
+
+    fn test_pk(i: u8) -> NetworkPublicKey {
+        use rand::SeedableRng;
+        let mut rng = StdRng::from_seed([i; 32]);
+        NetworkKeyPair::generate(&mut rng).public().clone()
+    }
+
+    fn test_pks(i: &[u8]) -> Vec<NetworkPublicKey> {
+        i.iter().map(|i| test_pk(*i)).collect()
+    }
+}

--- a/narwhal/worker/src/lib.rs
+++ b/narwhal/worker/src/lib.rs
@@ -8,6 +8,7 @@
     rust_2021_compatibility
 )]
 
+mod batch_fetcher;
 mod batch_maker;
 mod client;
 mod handlers;

--- a/narwhal/worker/src/tests/batch_maker_tests.rs
+++ b/narwhal/worker/src/tests/batch_maker_tests.rs
@@ -5,10 +5,7 @@ use super::*;
 
 use crate::NUM_SHUTDOWN_RECEIVERS;
 use prometheus::Registry;
-use store::rocks;
-use store::rocks::MetricConf;
-use store::rocks::ReadWriteOptions;
-use test_utils::{temp_dir, transaction};
+use test_utils::{create_batch_store, transaction};
 use types::MockWorkerToPrimary;
 use types::PreSubscribedBroadcastSender;
 
@@ -16,21 +13,10 @@ fn create_network_client() -> NetworkClient {
     NetworkClient::new_with_empty_id()
 }
 
-fn create_batches_store() -> DBMap<BatchDigest, Batch> {
-    rocks::DBMap::<BatchDigest, Batch>::open(
-        temp_dir(),
-        MetricConf::default(),
-        None,
-        Some("batches"),
-        &ReadWriteOptions::default(),
-    )
-    .unwrap()
-}
-
 #[tokio::test]
 async fn make_batch() {
     let client = create_network_client();
-    let store = create_batches_store();
+    let store = create_batch_store();
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
     let (tx_batch_maker, rx_batch_maker) = test_utils::test_channel!(1);
     let (tx_quorum_waiter, mut rx_quorum_waiter) = test_utils::test_channel!(1);
@@ -85,7 +71,7 @@ async fn make_batch() {
 #[tokio::test]
 async fn batch_timeout() {
     let client = create_network_client();
-    let store = create_batches_store();
+    let store = create_batch_store();
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
     let (tx_batch_maker, rx_batch_maker) = test_utils::test_channel!(1);
     let (tx_quorum_waiter, mut rx_quorum_waiter) = test_utils::test_channel!(1);

--- a/narwhal/worker/src/tests/handlers_tests.rs
+++ b/narwhal/worker/src/tests/handlers_tests.rs
@@ -19,7 +19,7 @@ async fn synchronize() {
     let id = 0;
 
     // Create a new test store.
-    let store = test_utils::open_batch_store();
+    let store = test_utils::create_batch_store();
 
     let handler = PrimaryReceiverHandler {
         authority_id,
@@ -29,6 +29,7 @@ async fn synchronize() {
         store: store.clone(),
         request_batch_timeout: Duration::from_secs(999),
         request_batch_retry_nodes: 3, // Not used in this test.
+        batch_fetcher: None,
         validator: TrivialTransactionValidator,
     };
 
@@ -94,7 +95,7 @@ async fn synchronize_when_batch_exists() {
     let id = 0;
 
     // Create a new test store.
-    let store = test_utils::open_batch_store();
+    let store = test_utils::create_batch_store();
 
     let handler = PrimaryReceiverHandler {
         authority_id,
@@ -104,6 +105,7 @@ async fn synchronize_when_batch_exists() {
         store: store.clone(),
         request_batch_timeout: Duration::from_secs(999),
         request_batch_retry_nodes: 3, // Not used in this test.
+        batch_fetcher: None,
         validator: TrivialTransactionValidator,
     };
 
@@ -140,7 +142,7 @@ async fn delete_batches() {
     let id = 0;
 
     // Create a new test store.
-    let store = test_utils::open_batch_store();
+    let store = test_utils::create_batch_store();
     let batch = test_utils::batch();
     let digest = batch.digest();
     store.insert(&digest, &batch).unwrap();
@@ -154,6 +156,7 @@ async fn delete_batches() {
         store: store.clone(),
         request_batch_timeout: Duration::from_secs(999),
         request_batch_retry_nodes: 3, // Not used in this test.
+        batch_fetcher: None,
         validator: TrivialTransactionValidator,
     };
     let message = WorkerDeleteBatchesMessage {

--- a/narwhal/worker/src/tests/worker_tests.rs
+++ b/narwhal/worker/src/tests/worker_tests.rs
@@ -425,7 +425,6 @@ async fn get_network_peers_from_admin_server() {
         &mut tx_shutdown,
         tx_feedback,
         &Registry::new(),
-        None,
     );
 
     // Wait for tasks to start
@@ -550,7 +549,6 @@ async fn get_network_peers_from_admin_server() {
         &mut tx_shutdown_2,
         tx_feedback_2,
         &Registry::new(),
-        None,
     );
 
     // Wait for tasks to start

--- a/narwhal/worker/src/worker.rs
+++ b/narwhal/worker/src/worker.rs
@@ -80,7 +80,8 @@ impl Worker {
         metrics: Metrics,
         tx_shutdown: &mut PreSubscribedBroadcastSender,
     ) -> Vec<JoinHandle<()>> {
-        let worker_peer_id = PeerId(keypair.public().0.to_bytes());
+        let worker_name = keypair.public().clone();
+        let worker_peer_id = PeerId(worker_name.0.to_bytes());
         info!("Boot worker node with id {} peer id {}", id, worker_peer_id,);
 
         // Define a worker instance.
@@ -265,8 +266,12 @@ impl Worker {
 
         info!("Worker {} listening to worker messages on {}", id, address);
 
-        let batch_fetcher =
-            BatchFetcher::new(network.clone(), worker.store.clone(), node_metrics.clone());
+        let batch_fetcher = BatchFetcher::new(
+            worker_name,
+            network.clone(),
+            worker.store.clone(),
+            node_metrics.clone(),
+        );
         client.set_primary_to_worker_local_handler(
             worker_peer_id,
             Arc::new(PrimaryReceiverHandler {


### PR DESCRIPTION
## Description 

Primary calling `request_batches` on own worker is the last place where local communications happen over the network. To simplify the migrate, we have to split the fetch logic from primary subscriber to worker, and having a separate route (`fetch_batches`). This also avoids the current inconsistency where the primary is calling the `request_batches` RPC from the `WorkerToWorker` service.

After the split, primary subscriber now communicates strictly with its own worker(s).

## Test Plan 

unit test

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
