### PR TITLE
group auth agg errors and use concise name

### DIFF
--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -382,26 +382,47 @@ impl AuthorityPublicKeyBytes {
         Ok(())
     }
 
-    /// Get a ConciseAuthorityPublicKeyBytes. Usage:
+    /// Get a ConciseAuthorityPublicKeyBytesRef. Usage:
     ///
     ///   debug!(name = ?authority.concise());
     ///   format!("{:?}", authority.concise());
-    pub fn concise(&self) -> ConciseAuthorityPublicKeyBytes<'_> {
+    pub fn concise(&self) -> ConciseAuthorityPublicKeyBytesRef<'_> {
+        ConciseAuthorityPublicKeyBytesRef(self)
+    }
+
+    pub fn into_concise(self) -> ConciseAuthorityPublicKeyBytes {
         ConciseAuthorityPublicKeyBytes(self)
     }
 }
 
 /// A wrapper around AuthorityPublicKeyBytes that provides a concise Debug impl.
-pub struct ConciseAuthorityPublicKeyBytes<'a>(&'a AuthorityPublicKeyBytes);
+pub struct ConciseAuthorityPublicKeyBytesRef<'a>(&'a AuthorityPublicKeyBytes);
 
-impl Debug for ConciseAuthorityPublicKeyBytes<'_> {
+impl Debug for ConciseAuthorityPublicKeyBytesRef<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         let s = Hex::encode(self.0 .0.get(0..4).ok_or(std::fmt::Error)?);
         write!(f, "k#{}..", s)
     }
 }
 
-impl Display for ConciseAuthorityPublicKeyBytes<'_> {
+impl Display for ConciseAuthorityPublicKeyBytesRef<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        Debug::fmt(self, f)
+    }
+}
+
+/// A wrapper around AuthorityPublicKeyBytes but owns it.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct ConciseAuthorityPublicKeyBytes(AuthorityPublicKeyBytes);
+
+impl Debug for ConciseAuthorityPublicKeyBytes {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        let s = Hex::encode(self.0 .0.get(0..4).ok_or(std::fmt::Error)?);
+        write!(f, "k#{}..", s)
+    }
+}
+
+impl Display for ConciseAuthorityPublicKeyBytes {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         Debug::fmt(self, f)
     }

--- a/crates/sui-types/src/quorum_driver_types.rs
+++ b/crates/sui-types/src/quorum_driver_types.rs
@@ -6,6 +6,7 @@ use std::collections::BTreeMap;
 
 use crate::base_types::{AuthorityName, ObjectRef, TransactionDigest};
 use crate::committee::StakeUnit;
+use crate::crypto::ConciseAuthorityPublicKeyBytes;
 use crate::error::SuiError;
 use crate::messages::{QuorumDriverResponse, VerifiedTransaction};
 use serde::{Deserialize, Serialize};
@@ -41,12 +42,12 @@ pub enum QuorumDriverError {
     #[error("Transaction failed to reach finality with transient error after {total_attempts} attempts.")]
     FailedWithTransientErrorAfterMaximumAttempts { total_attempts: u8 },
     #[error("Transaction has non recoverable errors from at least 1/3 of validators: {errors:?}.")]
-    NonRecoverableTransactionError {
-        errors: Vec<(SuiError, Vec<AuthorityName>, StakeUnit)>,
-    },
+    NonRecoverableTransactionError { errors: GroupedErrors },
     #[error("Transaction is not processed because {overloaded_stake} of validators by stake are overloaded with certificates pending execution.")]
     SystemOverload {
         overloaded_stake: StakeUnit,
-        errors: Vec<(SuiError, Vec<AuthorityName>, StakeUnit)>,
+        errors: GroupedErrors,
     },
 }
+
+pub type GroupedErrors = Vec<(SuiError, StakeUnit, Vec<ConciseAuthorityPublicKeyBytes>)>;


### PR DESCRIPTION
## Description 

This PR does a few things:
1. group tx errors in responses.
2. use concise authority name

With this change, the response will be much easier to read. It also reduces our log volume.


## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
QuorumDriver returns groupped errors.
