### PR TITLE
[fix] narwhal nightly

### DIFF
--- a/.github/workflows/nightly-narwhal.yml
+++ b/.github/workflows/nightly-narwhal.yml
@@ -45,7 +45,7 @@ jobs:
       # These are considered the end-to-end "slow" tests for us
       - name: cargo nextest
         run: |
-          cargo nextest run -E 'kind(test) and package(narwhal-primary) and package(narwhal-consensus)' --profile narwhalnightly --run-ignored ignored-only
+          cargo nextest run -E 'kind(test) and not test(test_get_collections_with_missing_certificates) and package(narwhal-primary) + package(narwhal-consensus)' --profile narwhalnightly --run-ignored ignored-only
 
   report-status:
     name: Report Status

--- a/narwhal/consensus/src/tests/randomized_tests.rs
+++ b/narwhal/consensus/src/tests/randomized_tests.rs
@@ -64,8 +64,8 @@ impl ExecutionPlan {
     }
 }
 
-#[tokio::test]
 #[ignore]
+#[tokio::test]
 async fn bullshark_randomised_tests() {
     // Configuration regarding the randomized tests. The tests will run for different values
     // on the below parameters to increase the different cases we can generate.
@@ -73,7 +73,7 @@ async fn bullshark_randomised_tests() {
     // A range of gc_depth to be used
     const GC_DEPTH: RangeInclusive<Round> = 4..=15;
     // A range of the committee size to be used
-    const COMMITTEE_SIZE: RangeInclusive<usize> = 4..=6;
+    const COMMITTEE_SIZE: RangeInclusive<usize> = 4..=4;
     // A range of rounds for which we will create DAGs
     const DAG_ROUNDS: RangeInclusive<Round> = 7..=20;
     // The number of different execution plans to be created and tested against for every generated DAG


### PR DESCRIPTION
## Description 

* fixes narwhal nightly tests run command - previously CI didn't run them now it should pick them up correctly
* exclude a currently flaky test from running
* temporarily reduce committee size in consensus randomised tests to observe how much time it will initially take running the tests for one committee iteration

## Test Plan 

Tested manually locally

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
