### PR TITLE
Enable rocksdb stats for all databases

### DIFF
--- a/crates/typed-store/src/metrics.rs
+++ b/crates/typed-store/src/metrics.rs
@@ -33,8 +33,8 @@ pub struct SamplingInterval {
 
 impl Default for SamplingInterval {
     fn default() -> Self {
-        // Disabled by default
-        SamplingInterval::new(Duration::ZERO, u64::MAX - 1)
+        // Enabled with 10 second interval
+        SamplingInterval::new(Duration::from_secs(60), u64::MAX - 1)
     }
 }
 

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -1266,7 +1266,7 @@ impl<'a> DBTransaction<'a> {
             RocksDBRawIter::OptimisticTransaction(db_iter),
             db.cf.clone(),
             &db.db_metrics,
-            &db.iter_latency_sample_interval,
+            &db.iter_bytes_sample_interval,
         )
     }
 


### PR DESCRIPTION
## Description 

PR enables rocksdb stats for all databases. This got turned off sometime ago because we were pushing high cardinality metrics for epoch databases (one different label for every epoch) but that issue has been fixed now. It should be safe to re-enable this now.

## Test Plan 

Existing tests. Ran on labnet at high throughput, observed no difference in performance (we have enough sampling)
