### PR TITLE
[cherrypick #10159][easy] Fix GasBudgetTooHigh and GasBudgetTooLow error (#10159)

### DIFF
--- a/crates/sui-types/src/gas.rs
+++ b/crates/sui-types/src/gas.rs
@@ -593,13 +593,13 @@ pub fn check_gas_balance(
     if required_gas_amount > max_gas_budget {
         return Err(UserInputError::GasBudgetTooHigh {
             gas_budget,
-            max_budget: cost_table.max_gas_budget,
+            max_budget: max_gas_budget as u64,
         });
     }
     if required_gas_amount < min_gas_budget {
         return Err(UserInputError::GasBudgetTooLow {
             gas_budget,
-            min_budget: cost_table.min_gas_budget_external(),
+            min_budget: min_gas_budget as u64,
         });
     }
 


### PR DESCRIPTION
## Description 

Community is reporting seeing confusing error message like

```
message": "Error checking transaction input objects: GasBudgetTooLow { gas_budget: 30000, min_budget: 110 }"
```

where their provided gas_budget is greater than the min_budget. This is because `min_budget` does not take rgp into consideration

## Test Plan 

CI build

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
