### PR TITLE
Fix wallet bug with some transaction kinds

### DIFF
--- a/sdk/wallet-adapter/example/src/App.tsx
+++ b/sdk/wallet-adapter/example/src/App.tsx
@@ -6,19 +6,10 @@ import { ConnectButton, useWalletKit } from "@mysten/wallet-kit";
 import { TransactionBlock } from "@mysten/sui.js";
 import { useEffect } from "react";
 
-const transactionBlock = new TransactionBlock();
-transactionBlock.moveCall({
-  target: `0x2::devnet_nft::mint`,
-  arguments: [
-    transactionBlock.pure("foo"),
-    transactionBlock.pure("bar"),
-    transactionBlock.pure("baz"),
-  ],
-});
-
 function App() {
   const {
     currentWallet,
+    currentAccount,
     signTransactionBlock,
     signAndExecuteTransactionBlock,
     signMessage,
@@ -34,7 +25,11 @@ function App() {
       <div>
         <button
           onClick={async () => {
-            console.log(await signTransactionBlock({ transactionBlock }));
+            const txb = new TransactionBlock();
+            const [coin] = txb.splitCoins(txb.gas, [txb.pure(1)]);
+            txb.transferObjects([coin], txb.pure(currentAccount!.address));
+
+            console.log(await signTransactionBlock({ transactionBlock: txb }));
           }}
         >
           Sign Transaction
@@ -43,9 +38,13 @@ function App() {
       <div>
         <button
           onClick={async () => {
+            const txb = new TransactionBlock();
+            const [coin] = txb.splitCoins(txb.gas, [txb.pure(1)]);
+            txb.transferObjects([coin], txb.pure(currentAccount!.address));
+
             console.log(
               await signAndExecuteTransactionBlock({
-                transactionBlock,
+                transactionBlock: txb,
                 options: { showEffects: true },
               })
             );


### PR DESCRIPTION
## Description

This fixes wallet bugs that happen with some transaction kinds. This was caused by an unexpected property in `MakeMoveVec`.

## Test Plan

Ran locally with a move vec transaction

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
