### PR TITLE
Reduce max gas for testing

### DIFF
--- a/crates/sui-benchmark/src/workloads/workload.rs
+++ b/crates/sui-benchmark/src/workloads/workload.rs
@@ -12,7 +12,7 @@ use crate::ValidatorProxy;
 
 // This is the maximum gas we will transfer from primary coin into any gas coin
 // for running the benchmark
-pub const MAX_GAS_FOR_TESTING: u64 = 1_000_000_000_000_000;
+pub const MAX_GAS_FOR_TESTING: u64 = 10_000_000_000_000;
 
 #[async_trait]
 pub trait WorkloadBuilder<T: Payload + ?Sized>: Send + Sync + std::fmt::Debug {


### PR DESCRIPTION
## Description 

Temp fix to unblock CI & Staging. Need to further investigate the real issue.

## Test Plan 

```
     Running `target/release/stress --log-path /tmp/stress.log --num-client-threads 16 --num-server-threads 32 --num-transfer-accounts 2 bench --committee-size 4 --target-qps 500 --num-workers 16 --transfer-object 100 --run-duration 20s --stress-stat-collection`
Found new state (reference gas price and/or protocol config) from system state object = 1
Number of gas requests = 15
Benchmark Report:
+-------------+-----+-----+--------+---------------+---------------+---------------+-----------------------+----------------------------+
| duration(s) | tps | cps | error% | latency (min) | latency (p50) | latency (p99) | gas used (MIST total) | gas used/hr (MIST approx.) |
+=======================================================================================================================================+
| 20          | 500 | 500 | 0      | 9             | 15            | 28            | 25,666,416            | 4,619,954,880              |
+-------------+-----+-----+--------+---------------+---------------+---------------+-----------------------+----------------------------+
Stress Performance Report:
+-----------+-----+-----+
| metric    | p50 | p99 |
+=======================+
| cpu usage | 63  | 93  |
+-----------+-----+-----+
```


```
❯ SIM_STRESS_TEST_QPS=100 cargo simtest test_simulated_load_basic
        PASS [  65.697s] sui-benchmark::simtest test::test_simulated_load_basic
------------
     Summary [  65.697s] 1 tests run: 1 passed (1 slow), 1114 skipped
```