### PR TITLE
Check system storage rebate conservation at epoch boundary

### DIFF
--- a/crates/sui-config/src/builder.rs
+++ b/crates/sui-config/src/builder.rs
@@ -490,6 +490,7 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                     supported_protocol_versions: Some(supported_protocol_versions),
                     db_checkpoint_config: self.db_checkpoint_config.clone(),
                     indirect_objects_threshold: usize::MAX,
+                    enable_expensive_safety_checks: false,
                 }
             })
             .collect();

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -96,6 +96,9 @@ pub struct NodeConfig {
 
     #[serde(default)]
     pub indirect_objects_threshold: usize,
+
+    #[serde(default)]
+    pub enable_expensive_safety_checks: bool,
 }
 
 fn default_authority_store_pruning_config() -> AuthorityStorePruningConfig {

--- a/crates/sui-config/src/swarm.rs
+++ b/crates/sui-config/src/swarm.rs
@@ -285,6 +285,7 @@ impl<'a> FullnodeConfigBuilder<'a> {
             supported_protocol_versions: Some(supported_protocol_versions),
             db_checkpoint_config: self.db_checkpoint_config,
             indirect_objects_threshold: usize::MAX,
+            enable_expensive_safety_checks: false,
         })
     }
 }

--- a/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -74,6 +74,7 @@ validator_configs:
     db-checkpoint-config:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
+    enable-expensive-safety-checks: false
   - protocol-key-pair:
       value: avYcyVgYMXTyaUYh9IRwLK0gSzl7YF6ZQDAbrS1Bhvo=
     worker-key-pair:
@@ -145,6 +146,7 @@ validator_configs:
     db-checkpoint-config:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
+    enable-expensive-safety-checks: false
   - protocol-key-pair:
       value: OXnx3yM1C/ppgnDMx/o1d49fJs7E05kq11mXNae/O+I=
     worker-key-pair:
@@ -216,6 +218,7 @@ validator_configs:
     db-checkpoint-config:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
+    enable-expensive-safety-checks: false
   - protocol-key-pair:
       value: CyNkjqNVr3HrHTH7f/NLs7u5lUHJzuPAw0PqMTD2y2s=
     worker-key-pair:
@@ -287,6 +290,7 @@ validator_configs:
     db-checkpoint-config:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
+    enable-expensive-safety-checks: false
   - protocol-key-pair:
       value: X/I/kM+KvHcxAKEf2UU6Sr7SpN3bhiE9nP5CuM/iIY0=
     worker-key-pair:
@@ -358,6 +362,7 @@ validator_configs:
     db-checkpoint-config:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
+    enable-expensive-safety-checks: false
   - protocol-key-pair:
       value: N272EiFDyKtxRbDKbyN6ujenJ+skPcRoc/XolpOLGnU=
     worker-key-pair:
@@ -429,6 +434,7 @@ validator_configs:
     db-checkpoint-config:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
+    enable-expensive-safety-checks: false
   - protocol-key-pair:
       value: a74f03IOjL8ZFSWFChFVEi+wiMwHNwNCPDGIYkGfgjs=
     worker-key-pair:
@@ -500,6 +506,7 @@ validator_configs:
     db-checkpoint-config:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
+    enable-expensive-safety-checks: false
 account_keys:
   - Hloy4pnf8pWEHGP+4OFsXz56bLdIJhkD2O+OdKMqCA4=
   - pvMScjoMR/DaN0M5IOxS2VpGC59N6kv6gDm63ufLQ5w=

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -40,6 +40,7 @@ use crate::authority::authority_store_types::{
 };
 use crate::authority::epoch_start_configuration::EpochStartConfiguration;
 
+use super::authority_store_tables::LiveObject;
 use super::{authority_store_tables::AuthorityPerpetualTables, *};
 use mysten_common::sync::notify_read::NotifyRead;
 
@@ -1356,7 +1357,7 @@ impl AuthorityStore {
         get_sui_system_state(self.perpetual_tables.as_ref())
     }
 
-    pub fn iter_live_object_set(&self) -> impl Iterator<Item = ObjectRef> + '_ {
+    pub fn iter_live_object_set(&self) -> impl Iterator<Item = LiveObject> + '_ {
         self.perpetual_tables.iter_live_object_set()
     }
 }

--- a/crates/sui-core/src/state_accumulator.rs
+++ b/crates/sui-core/src/state_accumulator.rs
@@ -21,6 +21,7 @@ use sui_types::messages_checkpoint::{CheckpointSequenceNumber, ECMHLiveObjectSet
 use typed_store::rocks::TypedStoreError;
 
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
+use crate::authority::authority_store_tables::LiveObject;
 use crate::authority::AuthorityStore;
 
 pub struct StateAccumulator {
@@ -29,6 +30,7 @@ pub struct StateAccumulator {
 
 /// Serializable representation of the ObjectRef of an
 /// object that has been wrapped
+/// TODO: This can be replaced with ObjectKey.
 #[derive(Serialize)]
 struct WrappedObject {
     id: ObjectID,
@@ -282,14 +284,17 @@ impl StateAccumulator {
     /// Returns the result of accumulatng the live object set, without side effects
     pub fn accumulate_live_object_set(&self) -> Accumulator {
         let mut acc = Accumulator::default();
-        for oref in self.authority_store.iter_live_object_set() {
-            if oref.2 == ObjectDigest::OBJECT_DIGEST_WRAPPED {
-                acc.insert(
-                    bcs::to_bytes(&WrappedObject::new(oref.0, oref.1))
-                        .expect("Failed to serialize WrappedObject"),
-                );
-            } else {
-                acc.insert(oref.2);
+        for live_object in self.authority_store.iter_live_object_set() {
+            match live_object {
+                LiveObject::Normal(object) => {
+                    acc.insert(object.compute_object_reference().2);
+                }
+                LiveObject::Wrapped(key) => {
+                    acc.insert(
+                        bcs::to_bytes(&WrappedObject::new(key.0, key.1))
+                            .expect("Failed to serialize WrappedObject"),
+                    );
+                }
             }
         }
         acc

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -3796,7 +3796,8 @@ async fn test_iter_live_object_set() {
     let starting_live_set: HashSet<_> = authority
         .database
         .iter_live_object_set()
-        .filter_map(|(id, _, _)| {
+        .filter_map(|object| {
+            let id = object.object_id();
             if id != gas && id != obj_id {
                 Some(id)
             } else {
@@ -3979,11 +3980,12 @@ fn check_live_set(
     let actual: Vec<_> = authority
         .database
         .iter_live_object_set()
-        .filter_map(|(id, v, _)| {
+        .filter_map(|object| {
+            let id = object.object_id();
             if ignore.contains(&id) {
                 None
             } else {
-                Some((id, v))
+                Some((id, object.version()))
             }
         })
         .collect();

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -19,6 +19,7 @@ use anyhow::Result;
 use arc_swap::ArcSwap;
 use futures::TryFutureExt;
 use prometheus::Registry;
+use sui_core::authority::authority_store_tables::LiveObject;
 use sui_core::consensus_adapter::LazyNarwhalClient;
 use sui_types::sui_system_state::SuiSystemState;
 use tap::tap::TapFallible;
@@ -1015,6 +1016,9 @@ impl SuiNode {
                     None
                 }
             } else {
+                // TODO: Enable this when we can.
+                self.check_system_consistency();
+
                 let new_epoch_store = self
                     .reconfigure_state(
                         &cur_epoch_store,
@@ -1114,6 +1118,44 @@ impl SuiNode {
         info!(next_epoch, "Validator State has been reconfigured");
         assert_eq!(next_epoch, new_epoch_store.epoch());
         new_epoch_store
+    }
+
+    fn check_system_consistency(&self) {
+        if !self.config.enable_expensive_safety_checks && cfg!(not(debug_assertions)) {
+            return;
+        }
+        let total_storage_rebate: u64 = self
+            .state
+            .db()
+            .iter_live_object_set()
+            .map(|o| {
+                if let LiveObject::Normal(object) = o {
+                    object.storage_rebate
+                } else {
+                    0
+                }
+            })
+            .sum();
+        let system_state = self
+            .state
+            .get_sui_system_state_object_during_reconfig()
+            .expect("Reading sui system state object cannot fail")
+            .into_sui_system_state_summary();
+
+        let storage_fund_balance = system_state.storage_fund_total_object_storage_rebates;
+        if total_storage_rebate != storage_fund_balance {
+            let err = format!(
+                "Inconsistent state detected at epoch {}: total storage rebate: {}, storage fund balance: {}",
+                system_state.epoch, total_storage_rebate, storage_fund_balance
+            );
+            if cfg!(debug_assertions) {
+                panic!(err);
+            } else {
+                // We cannot panic in production yet because it is known that there are some
+                // inconsistencies in testnet. We will enable this once we make it balanced again in testnet.
+                warn!(err);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
At epoch boundary, if a node config flag is enabled, we iterate through all live objects, sum their storage rebate, and compare it to the storage fund balance, make sure they matches.
In order to ship this to testnet, however, we will need to know (after we fix all the conservation issues) the balance gap and compensate that manually.