### PR TITLE
returning best attempt for objects

### DIFF
--- a/crates/sui-cluster-test/src/helper.rs
+++ b/crates/sui-cluster-test/src/helper.rs
@@ -131,6 +131,9 @@ impl ObjectChecker {
                 }
                 Ok(CheckerResultObject::new(None, Some(object)))
             }
+            (None, Some(SuiObjectResponseError::DisplayError { error })) => {
+                panic!("Display Error: {error:?}");
+            }
             (None, None) | (None, Some(SuiObjectResponseError::Unknown)) => {
                 panic!("Unexpected response: object not found and no specific error provided");
             }

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -543,6 +543,7 @@ impl IndexerStore for PgIndexerStore {
         object_id: ObjectID,
         version: Option<SequenceNumber>,
     ) -> Result<ObjectRead, IndexerError> {
+        // MUSTFIX (jian): add display field error support on implementation
         let object = read_only!(&self.cp, |conn| {
             if let Some(version) = version {
                 objects_history::dsl::objects_history

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -143,11 +143,20 @@ impl ReadApiServer for ReadApi {
                 SuiObjectResponseError::NotExists { object_id: id },
             )),
             ObjectRead::Exists(object_ref, o, layout) => {
-                let display_fields = if options.show_display {
-                    get_display_fields(self, &o, &layout).await?
-                } else {
-                    None
-                };
+                let mut display_fields = None;
+                if options.show_display {
+                    match get_display_fields(self, &o, &layout).await {
+                        Ok(rendered_fields) => display_fields = rendered_fields,
+                        Err(e) => {
+                            return Ok(SuiObjectResponse::new(
+                                Some((object_ref, o, layout, options, None).try_into()?),
+                                Some(SuiObjectResponseError::DisplayError {
+                                    error: e.to_string(),
+                                }),
+                            ))
+                        }
+                    }
+                }
                 Ok(SuiObjectResponse::new_with_data(
                     (object_ref, o, layout, options, display_fields).try_into()?,
                 ))
@@ -173,20 +182,22 @@ impl ReadApiServer for ReadApi {
                 futures.push(self.get_object(object_id, options.clone()))
             }
             let results = join_all(futures).await;
-            let (oks, errs): (Vec<_>, Vec<_>) = results.into_iter().partition(Result::is_ok);
+            let objects_result: Result<Vec<SuiObjectResponse>, String> = results
+                .into_iter()
+                .map(|result| match result {
+                    Ok(response) => Ok(response),
+                    Err(error) => {
+                        error!("Failed to fetch object with error: {error:?}");
+                        Err(format!("Error: {}", error))
+                    }
+                })
+                .collect();
 
-            let success = oks.into_iter().filter_map(Result::ok).collect();
-            let errors: Vec<_> = errs.into_iter().filter_map(Result::err).collect();
-            if !errors.is_empty() {
-                let error_string = errors
-                    .iter()
-                    .map(|e| e.to_string())
-                    .collect::<Vec<String>>()
-                    .join("; ");
-                Err(anyhow!("{error_string}").into())
-            } else {
-                Ok(success)
-            }
+            let objects = objects_result.map_err(|err| {
+                Error::UnexpectedError(format!("Failed to fetch objects with error: {}", err))
+            })?;
+
+            Ok(objects)
         } else {
             Err(anyhow!(UserInputError::SizeLimitExceeded {
                 limit: "input limit".to_string(),
@@ -215,6 +226,7 @@ impl ReadApiServer for ReadApi {
             PastObjectRead::ObjectNotExists(id) => Ok(SuiPastObjectResponse::ObjectNotExists(id)),
             PastObjectRead::VersionFound(object_ref, o, layout) => {
                 let display_fields = if options.show_display {
+                    // TODO (jian): api breaking change to also modify past objects.
                     get_display_fields(self, &o, &layout).await?
                 } else {
                     None
@@ -873,6 +885,7 @@ pub fn get_rendered_fields(
             .iter()
             .map(|entry| match parse_template(&entry.value, &move_struct) {
                 Ok(value) => Ok((entry.key.clone(), value)),
+                // TODO (jian): implement best effort display fields.
                 Err(e) => Err(e),
             })
             .collect::<RpcResult<BTreeMap<_, _>>>();

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -4994,6 +4994,24 @@
                 ]
               }
             }
+          },
+          {
+            "type": "object",
+            "required": [
+              "code",
+              "error"
+            ],
+            "properties": {
+              "code": {
+                "type": "string",
+                "enum": [
+                  "displayError"
+                ]
+              },
+              "error": {
+                "type": "string"
+              }
+            }
           }
         ]
       },

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -218,6 +218,8 @@ pub enum SuiObjectResponseError {
     },
     #[error("Unknown Error.")]
     Unknown,
+    #[error("Display Error: {:?}", error)]
+    DisplayError { error: String },
     // TODO: also integrate SuiPastObjectResponse (VersionNotFound,  VersionTooHigh)
 }
 


### PR DESCRIPTION
## Description 

- adding new error type to suiObjectResponse
- ensuring that multi-get objects does a best effort fail.
## Test Plan 

CI / test with explorer / wallet
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
