### PR TITLE
Add network metrics from anemo/quinn to ConnectionMonitor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,9 +153,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "anemo"
+version = "0.0.0"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e#82875616a86f94652b1c8d374b839917791d805e"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bincode",
+ "bytes",
+ "ed25519",
+ "futures",
+ "hex",
+ "http",
+ "matchit 0.5.0",
+ "pin-project-lite",
+ "pkcs8",
+ "quinn",
+ "quinn-proto",
+ "rand 0.8.5",
+ "rcgen",
+ "ring",
+ "rustls",
+ "serde 1.0.152",
+ "serde_json",
+ "tap",
+ "tokio",
+ "tokio-util 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower",
+ "tracing",
+ "webpki",
+ "x509-parser",
+]
+
+[[package]]
 name = "anemo-build"
 version = "0.0.0"
 source = "git+https://github.com/mystenlabs/anemo.git?rev=4ebf4a86952827ff0fcce6a2d8a80f42f34efed9#4ebf4a86952827ff0fcce6a2d8a80f42f34efed9"
+dependencies = [
+ "prettyplease",
+ "proc-macro2 1.0.54",
+ "quote 1.0.26",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "anemo-build"
+version = "0.0.0"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e#82875616a86f94652b1c8d374b839917791d805e"
 dependencies = [
  "prettyplease",
  "proc-macro2 1.0.54",
@@ -168,8 +212,24 @@ name = "anemo-cli"
 version = "0.0.0"
 source = "git+https://github.com/mystenlabs/anemo.git?rev=4ebf4a86952827ff0fcce6a2d8a80f42f34efed9#4ebf4a86952827ff0fcce6a2d8a80f42f34efed9"
 dependencies = [
- "anemo",
- "anemo-tower",
+ "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=4ebf4a86952827ff0fcce6a2d8a80f42f34efed9)",
+ "anemo-tower 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=4ebf4a86952827ff0fcce6a2d8a80f42f34efed9)",
+ "bytes",
+ "clap 4.1.4",
+ "dashmap",
+ "rand 0.8.5",
+ "tokio",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "anemo-cli"
+version = "0.0.0"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e#82875616a86f94652b1c8d374b839917791d805e"
+dependencies = [
+ "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
+ "anemo-tower 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
  "bytes",
  "clap 4.1.4",
  "dashmap",
@@ -184,7 +244,25 @@ name = "anemo-tower"
 version = "0.0.0"
 source = "git+https://github.com/mystenlabs/anemo.git?rev=4ebf4a86952827ff0fcce6a2d8a80f42f34efed9#4ebf4a86952827ff0fcce6a2d8a80f42f34efed9"
 dependencies = [
- "anemo",
+ "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=4ebf4a86952827ff0fcce6a2d8a80f42f34efed9)",
+ "bytes",
+ "dashmap",
+ "futures",
+ "governor",
+ "nonzero_ext",
+ "pin-project-lite",
+ "tokio",
+ "tower",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "anemo-tower"
+version = "0.0.0"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e#82875616a86f94652b1c8d374b839917791d805e"
+dependencies = [
+ "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
  "bytes",
  "dashmap",
  "futures",
@@ -5452,7 +5530,7 @@ dependencies = [
 name = "mysten-network"
 version = "0.2.0"
 dependencies = [
- "anemo",
+ "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
  "bcs",
  "bytes",
  "eyre",
@@ -5625,7 +5703,7 @@ dependencies = [
 name = "narwhal-executor"
 version = "0.1.0"
 dependencies = [
- "anemo",
+ "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
  "anyhow",
  "async-trait",
  "bcs",
@@ -5663,8 +5741,8 @@ dependencies = [
 name = "narwhal-network"
 version = "0.1.0"
 dependencies = [
- "anemo",
- "anemo-tower",
+ "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
+ "anemo-tower 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
  "anyhow",
  "async-trait",
  "axum",
@@ -5682,6 +5760,7 @@ dependencies = [
  "narwhal-types",
  "parking_lot 0.12.1",
  "prometheus",
+ "quinn-proto",
  "rand 0.8.5",
  "tokio",
  "tower",
@@ -5693,7 +5772,7 @@ dependencies = [
 name = "narwhal-node"
 version = "0.1.0"
 dependencies = [
- "anemo",
+ "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
  "arc-swap",
  "async-trait",
  "axum",
@@ -5739,8 +5818,8 @@ dependencies = [
 name = "narwhal-primary"
 version = "0.1.0"
 dependencies = [
- "anemo",
- "anemo-tower",
+ "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
+ "anemo-tower 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
  "anyhow",
  "arc-swap",
  "async-trait",
@@ -5816,7 +5895,7 @@ dependencies = [
 name = "narwhal-test-utils"
 version = "0.1.0"
 dependencies = [
- "anemo",
+ "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
  "fastcrypto",
  "fdlimit",
  "indexmap",
@@ -5848,8 +5927,8 @@ dependencies = [
 name = "narwhal-types"
 version = "0.1.0"
 dependencies = [
- "anemo",
- "anemo-build",
+ "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
+ "anemo-build 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
  "async-trait",
  "base64 0.13.1",
  "bcs",
@@ -5894,8 +5973,8 @@ dependencies = [
 name = "narwhal-worker"
 version = "0.1.0"
 dependencies = [
- "anemo",
- "anemo-tower",
+ "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
+ "anemo-tower 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
  "anyhow",
  "arc-swap",
  "async-trait",
@@ -8556,7 +8635,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 name = "sui"
 version = "0.30.0"
 dependencies = [
- "anemo",
+ "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
  "anyhow",
  "assert_cmd",
  "async-trait",
@@ -8742,7 +8821,7 @@ dependencies = [
 name = "sui-config"
 version = "0.0.0"
 dependencies = [
- "anemo",
+ "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
  "anyhow",
  "bcs",
  "camino",
@@ -9207,9 +9286,9 @@ dependencies = [
 name = "sui-network"
 version = "0.0.0"
 dependencies = [
- "anemo",
- "anemo-build",
- "anemo-tower",
+ "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
+ "anemo-build 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
+ "anemo-tower 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
  "anyhow",
  "ed25519-consensus",
  "fastcrypto",
@@ -9236,8 +9315,8 @@ dependencies = [
 name = "sui-node"
 version = "0.30.0"
 dependencies = [
- "anemo",
- "anemo-tower",
+ "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
+ "anemo-tower 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
  "anyhow",
  "arc-swap",
  "axum",
@@ -9509,8 +9588,8 @@ dependencies = [
 name = "sui-simulator"
 version = "0.7.0"
 dependencies = [
- "anemo",
- "anemo-tower",
+ "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
+ "anemo-tower 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
  "fastcrypto",
  "lru",
  "move-package",
@@ -9661,8 +9740,8 @@ dependencies = [
 name = "sui-tool"
 version = "0.30.0"
 dependencies = [
- "anemo",
- "anemo-cli",
+ "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
+ "anemo-cli 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
  "anyhow",
  "clap 4.1.4",
  "colored",
@@ -9736,7 +9815,7 @@ dependencies = [
 name = "sui-types"
 version = "0.1.0"
 dependencies = [
- "anemo",
+ "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
  "anyhow",
  "bcs",
  "bincode",
@@ -11316,10 +11395,10 @@ dependencies = [
  "aliasable",
  "alloc-no-stdlib",
  "alloc-stdlib",
- "anemo",
- "anemo-build",
- "anemo-cli",
- "anemo-tower",
+ "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=4ebf4a86952827ff0fcce6a2d8a80f42f34efed9)",
+ "anemo-build 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=4ebf4a86952827ff0fcce6a2d8a80f42f34efed9)",
+ "anemo-cli 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=4ebf4a86952827ff0fcce6a2d8a80f42f34efed9)",
+ "anemo-tower 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=4ebf4a86952827ff0fcce6a2d8a80f42f34efed9)",
  "anes",
  "ansi_term",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,38 +123,6 @@ dependencies = [
 [[package]]
 name = "anemo"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=4ebf4a86952827ff0fcce6a2d8a80f42f34efed9#4ebf4a86952827ff0fcce6a2d8a80f42f34efed9"
-dependencies = [
- "anyhow",
- "async-trait",
- "bincode",
- "bytes",
- "ed25519",
- "futures",
- "hex",
- "http",
- "matchit 0.5.0",
- "pin-project-lite",
- "pkcs8",
- "quinn",
- "rand 0.8.5",
- "rcgen",
- "ring",
- "rustls",
- "serde 1.0.152",
- "serde_json",
- "tap",
- "tokio",
- "tokio-util 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower",
- "tracing",
- "webpki",
- "x509-parser",
-]
-
-[[package]]
-name = "anemo"
-version = "0.0.0"
 source = "git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e#82875616a86f94652b1c8d374b839917791d805e"
 dependencies = [
  "anyhow",
@@ -188,17 +156,6 @@ dependencies = [
 [[package]]
 name = "anemo-build"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=4ebf4a86952827ff0fcce6a2d8a80f42f34efed9#4ebf4a86952827ff0fcce6a2d8a80f42f34efed9"
-dependencies = [
- "prettyplease",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
-]
-
-[[package]]
-name = "anemo-build"
-version = "0.0.0"
 source = "git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e#82875616a86f94652b1c8d374b839917791d805e"
 dependencies = [
  "prettyplease",
@@ -210,26 +167,10 @@ dependencies = [
 [[package]]
 name = "anemo-cli"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=4ebf4a86952827ff0fcce6a2d8a80f42f34efed9#4ebf4a86952827ff0fcce6a2d8a80f42f34efed9"
-dependencies = [
- "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=4ebf4a86952827ff0fcce6a2d8a80f42f34efed9)",
- "anemo-tower 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=4ebf4a86952827ff0fcce6a2d8a80f42f34efed9)",
- "bytes",
- "clap 4.1.4",
- "dashmap",
- "rand 0.8.5",
- "tokio",
- "tower",
- "tracing",
-]
-
-[[package]]
-name = "anemo-cli"
-version = "0.0.0"
 source = "git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e#82875616a86f94652b1c8d374b839917791d805e"
 dependencies = [
- "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
- "anemo-tower 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
+ "anemo",
+ "anemo-tower",
  "bytes",
  "clap 4.1.4",
  "dashmap",
@@ -242,27 +183,9 @@ dependencies = [
 [[package]]
 name = "anemo-tower"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=4ebf4a86952827ff0fcce6a2d8a80f42f34efed9#4ebf4a86952827ff0fcce6a2d8a80f42f34efed9"
-dependencies = [
- "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=4ebf4a86952827ff0fcce6a2d8a80f42f34efed9)",
- "bytes",
- "dashmap",
- "futures",
- "governor",
- "nonzero_ext",
- "pin-project-lite",
- "tokio",
- "tower",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "anemo-tower"
-version = "0.0.0"
 source = "git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e#82875616a86f94652b1c8d374b839917791d805e"
 dependencies = [
- "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
+ "anemo",
  "bytes",
  "dashmap",
  "futures",
@@ -5530,7 +5453,7 @@ dependencies = [
 name = "mysten-network"
 version = "0.2.0"
 dependencies = [
- "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
+ "anemo",
  "bcs",
  "bytes",
  "eyre",
@@ -5703,7 +5626,7 @@ dependencies = [
 name = "narwhal-executor"
 version = "0.1.0"
 dependencies = [
- "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
+ "anemo",
  "anyhow",
  "async-trait",
  "bcs",
@@ -5741,8 +5664,8 @@ dependencies = [
 name = "narwhal-network"
 version = "0.1.0"
 dependencies = [
- "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
- "anemo-tower 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
+ "anemo",
+ "anemo-tower",
  "anyhow",
  "async-trait",
  "axum",
@@ -5772,7 +5695,7 @@ dependencies = [
 name = "narwhal-node"
 version = "0.1.0"
 dependencies = [
- "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
+ "anemo",
  "arc-swap",
  "async-trait",
  "axum",
@@ -5818,8 +5741,8 @@ dependencies = [
 name = "narwhal-primary"
 version = "0.1.0"
 dependencies = [
- "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
- "anemo-tower 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
+ "anemo",
+ "anemo-tower",
  "anyhow",
  "arc-swap",
  "async-trait",
@@ -5895,7 +5818,7 @@ dependencies = [
 name = "narwhal-test-utils"
 version = "0.1.0"
 dependencies = [
- "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
+ "anemo",
  "fastcrypto",
  "fdlimit",
  "indexmap",
@@ -5927,8 +5850,8 @@ dependencies = [
 name = "narwhal-types"
 version = "0.1.0"
 dependencies = [
- "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
- "anemo-build 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
+ "anemo",
+ "anemo-build",
  "async-trait",
  "base64 0.13.1",
  "bcs",
@@ -5973,8 +5896,8 @@ dependencies = [
 name = "narwhal-worker"
 version = "0.1.0"
 dependencies = [
- "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
- "anemo-tower 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
+ "anemo",
+ "anemo-tower",
  "anyhow",
  "arc-swap",
  "async-trait",
@@ -8635,7 +8558,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 name = "sui"
 version = "0.30.0"
 dependencies = [
- "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
+ "anemo",
  "anyhow",
  "assert_cmd",
  "async-trait",
@@ -8821,7 +8744,7 @@ dependencies = [
 name = "sui-config"
 version = "0.0.0"
 dependencies = [
- "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
+ "anemo",
  "anyhow",
  "bcs",
  "camino",
@@ -9286,9 +9209,9 @@ dependencies = [
 name = "sui-network"
 version = "0.0.0"
 dependencies = [
- "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
- "anemo-build 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
- "anemo-tower 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
+ "anemo",
+ "anemo-build",
+ "anemo-tower",
  "anyhow",
  "ed25519-consensus",
  "fastcrypto",
@@ -9315,8 +9238,8 @@ dependencies = [
 name = "sui-node"
 version = "0.30.0"
 dependencies = [
- "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
- "anemo-tower 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
+ "anemo",
+ "anemo-tower",
  "anyhow",
  "arc-swap",
  "axum",
@@ -9588,8 +9511,8 @@ dependencies = [
 name = "sui-simulator"
 version = "0.7.0"
 dependencies = [
- "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
- "anemo-tower 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
+ "anemo",
+ "anemo-tower",
  "fastcrypto",
  "lru",
  "move-package",
@@ -9740,8 +9663,8 @@ dependencies = [
 name = "sui-tool"
 version = "0.30.0"
 dependencies = [
- "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
- "anemo-cli 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
+ "anemo",
+ "anemo-cli",
  "anyhow",
  "clap 4.1.4",
  "colored",
@@ -9815,7 +9738,7 @@ dependencies = [
 name = "sui-types"
 version = "0.1.0"
 dependencies = [
- "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=82875616a86f94652b1c8d374b839917791d805e)",
+ "anemo",
  "anyhow",
  "bcs",
  "bincode",
@@ -11395,10 +11318,10 @@ dependencies = [
  "aliasable",
  "alloc-no-stdlib",
  "alloc-stdlib",
- "anemo 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=4ebf4a86952827ff0fcce6a2d8a80f42f34efed9)",
- "anemo-build 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=4ebf4a86952827ff0fcce6a2d8a80f42f34efed9)",
- "anemo-cli 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=4ebf4a86952827ff0fcce6a2d8a80f42f34efed9)",
- "anemo-tower 0.0.0 (git+https://github.com/mystenlabs/anemo.git?rev=4ebf4a86952827ff0fcce6a2d8a80f42f34efed9)",
+ "anemo",
+ "anemo-build",
+ "anemo-cli",
+ "anemo-tower",
  "anes",
  "ansi_term",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,10 +141,10 @@ fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "c2f79b18
 fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "c2f79b1807bff7d09517b631191b61f2614c641c", package = "fastcrypto-zkp" }
 
 # anemo dependencies
-anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "4ebf4a86952827ff0fcce6a2d8a80f42f34efed9" }
-anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "4ebf4a86952827ff0fcce6a2d8a80f42f34efed9" }
-anemo-cli = { git = "https://github.com/mystenlabs/anemo.git", rev = "4ebf4a86952827ff0fcce6a2d8a80f42f34efed9" }
-anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "4ebf4a86952827ff0fcce6a2d8a80f42f34efed9" }
+anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "82875616a86f94652b1c8d374b839917791d805e" }
+anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "82875616a86f94652b1c8d374b839917791d805e" }
+anemo-cli = { git = "https://github.com/mystenlabs/anemo.git", rev = "82875616a86f94652b1c8d374b839917791d805e" }
+anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "82875616a86f94652b1c8d374b839917791d805e" }
 
 # Use the same workspace-hack across crates.
 workspace-hack = { path = "crates/workspace-hack" }

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -364,6 +364,7 @@ impl SuiNode {
                 p2p_network.downgrade(),
                 network_connection_metrics,
                 HashMap::new(),
+                None,
             );
 
         let connection_monitor_status = ConnectionMonitorStatus {

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -26,9 +26,9 @@ aho-corasick = { version = "0.7" }
 aliasable = { version = "0.1" }
 alloc-no-stdlib = { version = "2", default-features = false }
 alloc-stdlib = { version = "0.2", default-features = false }
-anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "4ebf4a86952827ff0fcce6a2d8a80f42f34efed9", default-features = false }
-anemo-cli = { git = "https://github.com/mystenlabs/anemo.git", rev = "4ebf4a86952827ff0fcce6a2d8a80f42f34efed9", default-features = false }
-anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "4ebf4a86952827ff0fcce6a2d8a80f42f34efed9", default-features = false }
+anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "82875616a86f94652b1c8d374b839917791d805e", default-features = false }
+anemo-cli = { git = "https://github.com/mystenlabs/anemo.git", rev = "82875616a86f94652b1c8d374b839917791d805e", default-features = false }
+anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "82875616a86f94652b1c8d374b839917791d805e", default-features = false }
 anes = { version = "0.1" }
 ansi_term = { version = "0.12", default-features = false }
 anyhow = { version = "1", features = ["backtrace"] }
@@ -427,7 +427,7 @@ quanta = { version = "0.9" }
 quick-error-dff4ba8e3ae991db = { package = "quick-error", version = "1", default-features = false }
 quick-error-f595c2ba2a3f28df = { package = "quick-error", version = "2", default-features = false }
 quinn = { version = "0.9", default-features = false, features = ["futures-io", "runtime-tokio", "tls-rustls"] }
-quinn-proto = { version = "0.9", default-features = false, features = ["tls-rustls"] }
+quinn-proto = { version = "0.9" }
 quinn-udp = { version = "0.3", default-features = false }
 quote-dff4ba8e3ae991db = { package = "quote", version = "1" }
 r2d2 = { version = "0.8", default-features = false }
@@ -637,10 +637,10 @@ aho-corasick = { version = "0.7" }
 aliasable = { version = "0.1" }
 alloc-no-stdlib = { version = "2", default-features = false }
 alloc-stdlib = { version = "0.2", default-features = false }
-anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "4ebf4a86952827ff0fcce6a2d8a80f42f34efed9", default-features = false }
-anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "4ebf4a86952827ff0fcce6a2d8a80f42f34efed9", default-features = false }
-anemo-cli = { git = "https://github.com/mystenlabs/anemo.git", rev = "4ebf4a86952827ff0fcce6a2d8a80f42f34efed9", default-features = false }
-anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "4ebf4a86952827ff0fcce6a2d8a80f42f34efed9", default-features = false }
+anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "82875616a86f94652b1c8d374b839917791d805e", default-features = false }
+anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "82875616a86f94652b1c8d374b839917791d805e", default-features = false }
+anemo-cli = { git = "https://github.com/mystenlabs/anemo.git", rev = "82875616a86f94652b1c8d374b839917791d805e", default-features = false }
+anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "82875616a86f94652b1c8d374b839917791d805e", default-features = false }
 anes = { version = "0.1" }
 ansi_term = { version = "0.12", default-features = false }
 anyhow = { version = "1", features = ["backtrace"] }
@@ -1115,7 +1115,7 @@ quanta = { version = "0.9" }
 quick-error-dff4ba8e3ae991db = { package = "quick-error", version = "1", default-features = false }
 quick-error-f595c2ba2a3f28df = { package = "quick-error", version = "2", default-features = false }
 quinn = { version = "0.9", default-features = false, features = ["futures-io", "runtime-tokio", "tls-rustls"] }
-quinn-proto = { version = "0.9", default-features = false, features = ["tls-rustls"] }
+quinn-proto = { version = "0.9" }
 quinn-udp = { version = "0.3", default-features = false }
 quote-3b31131e45eafb45 = { package = "quote", version = "0.6" }
 quote-dff4ba8e3ae991db = { package = "quote", version = "1" }

--- a/narwhal/network/Cargo.toml
+++ b/narwhal/network/Cargo.toml
@@ -13,6 +13,7 @@ backoff = { version = "0.4.0", features = ["tokio"] }
 bytes = "1.3.0"
 futures = "0.3.24"
 parking_lot = "0.12.1"
+quinn-proto = "^0.9.2"
 prometheus = "0.13.3"
 rand = { version = "0.8.5", features = ["small_rng"] }
 tokio = { workspace = true, features = ["rt", "net", "sync", "macros", "time"] }

--- a/narwhal/network/src/connectivity.rs
+++ b/narwhal/network/src/connectivity.rs
@@ -96,6 +96,7 @@ impl ConnectionMonitor {
             } else {
                 // If no shutdown receiver is provided, wait forever.
                 let future = future::pending();
+                #[allow(clippy::let_unit_value)]
                 let () = future.await;
                 Ok(())
             }

--- a/narwhal/network/src/metrics.rs
+++ b/narwhal/network/src/metrics.rs
@@ -9,12 +9,42 @@ use prometheus::{
 use std::sync::Arc;
 use tracing::warn;
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct NetworkConnectionMetrics {
     /// The connection status of known peers. 0 if not connected, 1 if connected.
     pub network_peer_connected: IntGaugeVec,
     /// The number of connected peers
     pub network_peers: IntGauge,
+
+    /// PathStats
+    /// The rtt for a peer connection.
+    pub network_peer_rtt: HistogramVec,
+    /// The total number of lost packets for a peer connection.
+    pub network_peer_lost_packets: IntGaugeVec,
+    /// The total number of lost bytes for a peer connection.
+    pub network_peer_lost_bytes: IntGaugeVec,
+    /// The total number of packets sent for a peer connection.
+    pub network_peer_sent_packets: IntGaugeVec,
+    /// The total number of congestion events for a peer connection.
+    pub network_peer_congestion_events: IntGaugeVec,
+    /// The congestion window for a peer connection.
+    pub network_peer_congestion_window: HistogramVec,
+
+    /// FrameStats
+    /// The number of max data frames for a peer connection.
+    pub network_peer_max_data: IntGaugeVec,
+    /// The number of closed connections frames for a peer connection.
+    pub network_peer_closed_connections: IntGaugeVec,
+    /// The number of data blocked frames for a peer connection.
+    pub network_peer_data_blocked: IntGaugeVec,
+
+    /// UDPStats
+    /// The total number datagrams observed by the UDP peer connection.
+    pub network_peer_udp_datagrams: IntGaugeVec,
+    /// The total number bytes observed by the UDP peer connection.
+    pub network_peer_udp_bytes: IntGaugeVec,
+    /// The total number transmits observed by the UDP peer connection.
+    pub network_peer_udp_transmits: IntGaugeVec,
 }
 
 impl NetworkConnectionMetrics {
@@ -30,6 +60,98 @@ impl NetworkConnectionMetrics {
             network_peers: register_int_gauge_with_registry!(
                 format!("{node}_network_peers"),
                 "The number of connected peers.",
+                registry
+            )
+            .unwrap(),
+
+            // PathStats
+            network_peer_rtt: register_histogram_vec_with_registry!(
+                format!("{node}_network_peer_rtt"),
+                "The rtt for a peer connection.",
+                &["peer_id"],
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry
+            )
+            .unwrap(),
+            network_peer_lost_packets: register_int_gauge_vec_with_registry!(
+                format!("{node}_network_peer_lost_packets"),
+                "The total number of lost packets for a peer connection.",
+                &["peer_id"],
+                registry
+            )
+            .unwrap(),
+            network_peer_lost_bytes: register_int_gauge_vec_with_registry!(
+                format!("{node}_network_peer_lost_bytes"),
+                "The total number of lost bytes for a peer connection.",
+                &["peer_id"],
+                registry
+            )
+            .unwrap(),
+            network_peer_sent_packets: register_int_gauge_vec_with_registry!(
+                format!("{node}_network_peer_sent_packets"),
+                "The total number of sent packets for a peer connection.",
+                &["peer_id"],
+                registry
+            )
+            .unwrap(),
+            network_peer_congestion_events: register_int_gauge_vec_with_registry!(
+                format!("{node}_network_peer_congestion_events"),
+                "The total number of congestion events for a peer connection.",
+                &["peer_id"],
+                registry
+            )
+            .unwrap(),
+            network_peer_congestion_window: register_histogram_vec_with_registry!(
+                format!("{node}_network_peer_congestion_window"),
+                "The congestion window for a peer connection.",
+                &["peer_id"],
+                SIZE_BYTE_BUCKETS.to_vec(),
+                registry
+            )
+            .unwrap(),
+
+            // FrameStats
+            network_peer_closed_connections: register_int_gauge_vec_with_registry!(
+                format!("{node}_network_peer_closed_connections"),
+                "The number of closed connections for a peer connection.",
+                &["peer_id", "direction"],
+                registry
+            )
+            .unwrap(),
+            network_peer_max_data: register_int_gauge_vec_with_registry!(
+                format!("{node}_network_peer_max_data"),
+                "The number of max data frames for a peer connection.",
+                &["peer_id", "direction"],
+                registry
+            )
+            .unwrap(),
+            network_peer_data_blocked: register_int_gauge_vec_with_registry!(
+                format!("{node}_network_peer_data_blocked"),
+                "The number of data blocked frames for a peer connection.",
+                &["peer_id", "direction"],
+                registry
+            )
+            .unwrap(),
+
+            // UDPStats
+            network_peer_udp_datagrams: register_int_gauge_vec_with_registry!(
+                format!("{node}_network_peer_udp_datagrams"),
+                "The total number datagrams observed by the UDP peer connection.",
+                &["peer_id", "direction"],
+                registry
+            )
+            .unwrap(),
+            network_peer_udp_bytes: register_int_gauge_vec_with_registry!(
+                format!("{node}_network_peer_udp_bytes"),
+                "The total number bytes observed by the UDP peer connection.",
+                &["peer_id", "direction"],
+                registry
+            )
+            .unwrap(),
+            network_peer_udp_transmits: register_int_gauge_vec_with_registry!(
+                format!("{node}_network_peer_udp_transmits"),
+                "The total number transmits observed by the UDP peer connection.",
+                &["peer_id", "direction"],
                 registry
             )
             .unwrap(),

--- a/narwhal/network/src/metrics.rs
+++ b/narwhal/network/src/metrics.rs
@@ -17,8 +17,8 @@ pub struct NetworkConnectionMetrics {
     pub network_peers: IntGauge,
 
     /// PathStats
-    /// The rtt for a peer connection.
-    pub network_peer_rtt: HistogramVec,
+    /// The rtt for a peer connection in ms.
+    pub network_peer_rtt: IntGaugeVec,
     /// The total number of lost packets for a peer connection.
     pub network_peer_lost_packets: IntGaugeVec,
     /// The total number of lost bytes for a peer connection.
@@ -28,7 +28,7 @@ pub struct NetworkConnectionMetrics {
     /// The total number of congestion events for a peer connection.
     pub network_peer_congestion_events: IntGaugeVec,
     /// The congestion window for a peer connection.
-    pub network_peer_congestion_window: HistogramVec,
+    pub network_peer_congestion_window: IntGaugeVec,
 
     /// FrameStats
     /// The number of max data frames for a peer connection.
@@ -65,11 +65,10 @@ impl NetworkConnectionMetrics {
             .unwrap(),
 
             // PathStats
-            network_peer_rtt: register_histogram_vec_with_registry!(
+            network_peer_rtt: register_int_gauge_vec_with_registry!(
                 format!("{node}_network_peer_rtt"),
-                "The rtt for a peer connection.",
+                "The rtt for a peer connection in ms.",
                 &["peer_id"],
-                LATENCY_SEC_BUCKETS.to_vec(),
                 registry
             )
             .unwrap(),
@@ -101,11 +100,10 @@ impl NetworkConnectionMetrics {
                 registry
             )
             .unwrap(),
-            network_peer_congestion_window: register_histogram_vec_with_registry!(
+            network_peer_congestion_window: register_int_gauge_vec_with_registry!(
                 format!("{node}_network_peer_congestion_window"),
                 "The congestion window for a peer connection.",
                 &["peer_id"],
-                SIZE_BYTE_BUCKETS.to_vec(),
                 registry
             )
             .unwrap(),

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -83,7 +83,7 @@ pub mod primary_tests;
 pub const CHANNEL_CAPACITY: usize = 1_000;
 
 /// The number of shutdown receivers to create on startup. We need one per component loop.
-pub const NUM_SHUTDOWN_RECEIVERS: u64 = 26;
+pub const NUM_SHUTDOWN_RECEIVERS: u64 = 27;
 
 /// Maximum duration to fetch certificates from local storage.
 const FETCH_CERTIFICATES_MAX_HANDLER_TIME: Duration = Duration::from_secs(10);
@@ -436,6 +436,7 @@ impl Primary {
             network.downgrade(),
             network_connection_metrics,
             peer_types,
+            Some(tx_shutdown.subscribe()),
         );
 
         info!(

--- a/narwhal/worker/src/lib.rs
+++ b/narwhal/worker/src/lib.rs
@@ -24,4 +24,4 @@ pub use crate::tx_validator::{TransactionValidator, TrivialTransactionValidator}
 pub use crate::worker::Worker;
 
 /// The number of shutdown receivers to create on startup. We need one per component loop.
-pub const NUM_SHUTDOWN_RECEIVERS: u64 = 25;
+pub const NUM_SHUTDOWN_RECEIVERS: u64 = 26;

--- a/narwhal/worker/src/worker.rs
+++ b/narwhal/worker/src/worker.rs
@@ -332,6 +332,7 @@ impl Worker {
             network.downgrade(),
             network_connection_metrics,
             peer_types,
+            Some(shutdown_receivers.pop().unwrap()),
         );
 
         let network_admin_server_base_port = parameters


### PR DESCRIPTION
## Description 

Exported quinn metrics. 

Follow up PR to use [ClosureMetric](https://github.com/MystenLabs/sui/blob/main/crates/prometheus-closure-metric/src/lib.rs) instead as per @aschran suggestion. Would have required a little bit of a refactor of the `ConnectionMonitor` so put it off for another PR.

## Test Plan 

[private-testnet](https://metrics.sui.io/d/k1e0Y8BVz/anemo-metrics?orgId=1&var-Environment=mysten-metrics-internal&var-network=private-testnet&from=1680232014920&to=1680236015994&var-validator=All)
