### PR TITLE
fix: use `docker-compose` shell command

### DIFF
--- a/nre/docker/README.md
+++ b/nre/docker/README.md
@@ -33,7 +33,7 @@ You may need to explicitly open the ports outlined in [Sui for Node Operators](.
 
 Start Sui Node in detached mode:
 
-`sudo docker compose up -d`
+`sudo docker-compose up -d`
 
 ## Logs
 
@@ -42,7 +42,7 @@ By default, logs are stored at `/var/lib/docker/containers/[container-id]/[conta
 - View and follow
 
 ```shell
-sudo docker compose logs -f validator
+sudo docker-compose logs -f validator
 ```
 
 - By default all logs are output, limit this using `--since`
@@ -72,10 +72,10 @@ sudo docker-compose down -v
 
 - **DO NOT** delete the Sui databases
 
-1. Stop docker compose
+1. Stop docker-compose
 
 ```shell
-sudo docker compose down
+sudo docker-compose down
 ```
 
 2. Update docker-compose.yaml to reference the new image
@@ -88,5 +88,5 @@ sudo docker compose down
 3. Start docker compose in detached mode:
 
 ```shell
-sudo docker compose up -d
+sudo docker-compose up -d
 ```


### PR DESCRIPTION
## Description 

This is a very small modification in your documentation about how to run a validator node by using `docker-compose`. It is `sudo docker-compose up -d` not `sudo docker compose up -d` that let me so confused.  And I cannot run it step by step, for example:

1. `## Prerequisites and Setup 3.` -  I don't know where `genesis.blob` is.
2. `docker-compose.yaml` - This file also does not have a href link. I have to find it for a long time or search it in your repo.

Whatever, In general, I feel that the reading and operational experience of the document are not good.


## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
- nope