### PR TITLE
wallet-ext: fix stake countdown

### DIFF
--- a/apps/wallet/src/ui/app/components/receipt-card/StakeTxnCard.tsx
+++ b/apps/wallet/src/ui/app/components/receipt-card/StakeTxnCard.tsx
@@ -24,7 +24,7 @@ export function StakeTxnCard({ event }: StakeTxnCardProps) {
     const { data: system } = useSystemState();
     const validatorAddress = event.parsedJson?.validator_address;
     const stakedAmount = event.parsedJson?.amount;
-    const stakedEpoch = event.parsedJson?.epoch || 0;
+    const stakedEpoch = Number(event.parsedJson?.epoch || 0);
 
     const { data: rollingAverageApys } = useGetRollingAverageApys(
         system?.activeValidators?.length || null

--- a/apps/wallet/src/ui/app/staking/home/StakedCard.tsx
+++ b/apps/wallet/src/ui/app/staking/home/StakedCard.tsx
@@ -133,7 +133,8 @@ export function StakeCard({
     // TODO: Once two step withdraw is available, add cool down and withdraw now logic
     // For cool down epoch, show Available to withdraw add rewards to principal
     // Reward earning epoch is 2 epochs after stake request epoch
-    const earningRewardsEpoch = stakeRequestEpoch + NUM_OF_EPOCH_BEFORE_EARNING;
+    const earningRewardsEpoch =
+        Number(stakeRequestEpoch) + NUM_OF_EPOCH_BEFORE_EARNING;
     const isEarnedRewards = currentEpoch >= Number(earningRewardsEpoch);
     const delegationState = inactiveValidator
         ? StakeState.IN_ACTIVE


### PR DESCRIPTION
## Description 

fixes stake start time countdown

for the following stake:

<img width="367" alt="Screenshot 2023-03-31 at 12 27 14" src="https://user-images.githubusercontent.com/10210143/229108949-768bdfe0-0ee0-4901-bbde-2e5c81299bee.png">


| before | after |
| - | - |
| <img width="367" alt="Screenshot 2023-03-31 at 12 28 32" src="https://user-images.githubusercontent.com/10210143/229108697-cf33a75e-4cd4-4c5f-8757-d12e715f9660.png"> | <img width="367" alt="Screenshot 2023-03-31 at 12 32 27" src="https://user-images.githubusercontent.com/10210143/229109428-03da74d8-32ef-4198-a7b1-24c7a377102a.png"> |
| <img width="367" alt="Screenshot 2023-03-31 at 12 28 16" src="https://user-images.githubusercontent.com/10210143/229108800-514b1bf0-aba2-42ea-90df-886f76439b37.png"> | <img width="367" alt="Screenshot 2023-03-31 at 12 27 29" src="https://user-images.githubusercontent.com/10210143/229108864-88928541-d193-48e8-b28c-d9b5c8847fb3.png"> |



