### PR TITLE
[narwhal] ensure sub dag timestamp is monotonically incremented

### DIFF
--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -131,8 +131,7 @@ impl<T: ParentSync + Send + Sync> ExecutionState for ConsensusHandler<T> {
 
         /* (serialized, transaction, output_cert) */
         let mut transactions = vec![];
-        // Narwhal enforces some invariants on the header.created_at, so we can use it as a timestamp
-        let timestamp = *consensus_output.sub_dag.leader.header().created_at();
+        let timestamp = consensus_output.sub_dag.commit_timestamp;
 
         let prologue_transaction = self.consensus_commit_prologue_transaction(round, timestamp);
         transactions.push((

--- a/narwhal/consensus/benches/process_certificates.rs
+++ b/narwhal/consensus/benches/process_certificates.rs
@@ -44,7 +44,7 @@ pub fn process_certificates(c: &mut Criterion) {
         let store = make_consensus_store(&store_path);
         let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
 
-        let mut state = ConsensusState::new(metrics.clone(), &committee, gc_depth);
+        let mut state = ConsensusState::new(metrics.clone(), gc_depth);
 
         let data_size: usize = certificates
             .iter()

--- a/narwhal/consensus/src/bullshark.rs
+++ b/narwhal/consensus/src/bullshark.rs
@@ -155,7 +155,7 @@ impl ConsensusProtocol for Bullshark {
             .iter()
             .rev()
         {
-            let sub_dag_index = state.latest_sub_dag_index + 1;
+            let sub_dag_index = state.next_sub_dag_index();
             let _span = error_span!("bullshark_process_sub_dag", sub_dag_index);
 
             debug!("Leader {:?} has enough support", leader);
@@ -179,23 +179,21 @@ impl ConsensusProtocol for Bullshark {
             total_committed_certificates += sequence.len();
 
             // We update the reputation score stored in state
-            let reputation_score = self.update_reputation_score(state, &sequence, sub_dag_index);
+            let reputation_score = self.resolve_reputation_score(state, &sequence, sub_dag_index);
 
             let sub_dag = CommittedSubDag::new(
                 sequence,
                 leader.clone(),
                 sub_dag_index,
                 reputation_score,
-                state.last_committed_sub_dag.clone(),
+                state.last_committed_sub_dag.as_ref(),
             );
 
             // Persist the update.
             self.store
                 .write_consensus_state(&state.last_committed, &sub_dag)?;
 
-            // Increase the global consensus index.
-            state.latest_sub_dag_index = sub_dag_index;
-            state.last_committed_leader = Some(sub_dag.leader.digest());
+            // Update the last sub dag
             state.last_committed_sub_dag = Some(sub_dag.clone());
 
             committed_sub_dags.push(sub_dag);
@@ -304,52 +302,59 @@ impl Bullshark {
         dag.get(&round).and_then(|x| x.get(&leader))
     }
 
-    /// Updates and calculates the reputation score for the current commit managing any internal state.
-    /// It returns the updated reputation score.
-    fn update_reputation_score(
-        &mut self,
+    /// Calculates the reputation score for the current commit by taking into account the reputation
+    /// scores from the previous commit (assuming that exists). It returns the updated reputation score.
+    fn resolve_reputation_score(
+        &self,
         state: &mut ConsensusState,
         committed_sequence: &[Certificate],
         sub_dag_index: u64,
     ) -> ReputationScores {
-        // we reset the scores for every schedule change window.
+        // we reset the scores for every schedule change window, or initialise when it's the first
+        // sub dag we are going to create.
         // TODO: when schedule change is implemented we should probably change a little bit
         // this logic here.
-        if sub_dag_index % self.num_sub_dags_per_schedule == 0 {
-            state.last_consensus_reputation_score = ReputationScores::new(&self.committee)
-        }
+        let mut reputation_score =
+            if sub_dag_index == 1 || sub_dag_index % self.num_sub_dags_per_schedule == 0 {
+                ReputationScores::new(&self.committee)
+            } else {
+                state
+                    .last_committed_sub_dag
+                    .as_ref()
+                    .expect("Committed sub dag should always exist for sub_dag_index > 1")
+                    .reputation_score
+                    .clone()
+            };
 
         // update the score for the previous leader. If no previous leader exists,
         // then this is the first time we commit a leader, so no score update takes place
-        if let Some(previous_leader) = state.last_committed_leader {
+        if let Some(last_committed_sub_dag) = state.last_committed_sub_dag.as_ref() {
             for certificate in committed_sequence {
                 // TODO: we could iterate only the certificates of the round above the previous leader's round
                 if certificate
                     .header()
                     .parents()
                     .iter()
-                    .any(|digest| *digest == previous_leader)
+                    .any(|digest| *digest == last_committed_sub_dag.leader.digest())
                 {
-                    state
-                        .last_consensus_reputation_score
-                        .add_score(certificate.origin(), 1);
+                    reputation_score.add_score(certificate.origin(), 1);
                 }
             }
         }
 
-        // we check if this is the last subdag of the current schedule. If yes then we mark the
+        // we check if this is the last sub dag of the current schedule. If yes then we mark the
         // scores as final_of_schedule = true so any downstream user can now that those are the last
         // ones calculated for the current schedule.
-        state.last_consensus_reputation_score.final_of_schedule =
+        reputation_score.final_of_schedule =
             (sub_dag_index + 1) % self.num_sub_dags_per_schedule == 0;
 
         // Always ensure that all the authorities are present in the reputation scores - even
         // when score is zero.
         assert_eq!(
-            state.last_consensus_reputation_score.total_authorities() as usize,
+            reputation_score.total_authorities() as usize,
             self.committee.size()
         );
 
-        state.last_consensus_reputation_score.clone()
+        reputation_score
     }
 }

--- a/narwhal/consensus/src/bullshark.rs
+++ b/narwhal/consensus/src/bullshark.rs
@@ -178,7 +178,7 @@ impl ConsensusProtocol for Bullshark {
 
             total_committed_certificates += sequence.len();
 
-            // We update the reputation score stored in state
+            // We resolve the reputation score that should be stored alongside with this sub dag.
             let reputation_score = self.resolve_reputation_score(state, &sequence, sub_dag_index);
 
             let sub_dag = CommittedSubDag::new(

--- a/narwhal/consensus/src/bullshark.rs
+++ b/narwhal/consensus/src/bullshark.rs
@@ -181,12 +181,13 @@ impl ConsensusProtocol for Bullshark {
             // We update the reputation score stored in state
             let reputation_score = self.update_reputation_score(state, &sequence, sub_dag_index);
 
-            let sub_dag = CommittedSubDag {
-                certificates: sequence,
-                leader: leader.clone(),
+            let sub_dag = CommittedSubDag::new(
+                sequence,
+                leader.clone(),
                 sub_dag_index,
                 reputation_score,
-            };
+                state.last_committed_sub_dag.clone(),
+            );
 
             // Persist the update.
             self.store
@@ -195,6 +196,7 @@ impl ConsensusProtocol for Bullshark {
             // Increase the global consensus index.
             state.latest_sub_dag_index = sub_dag_index;
             state.last_committed_leader = Some(sub_dag.leader.digest());
+            state.last_committed_sub_dag = Some(sub_dag.clone());
 
             committed_sub_dags.push(sub_dag);
         }

--- a/narwhal/consensus/src/tests/bullshark_tests.rs
+++ b/narwhal/consensus/src/tests/bullshark_tests.rs
@@ -572,7 +572,7 @@ async fn delayed_certificates_are_rejected() {
         test_utils::make_certificates_with_epoch(&committee, 1..=5, epoch, &genesis, &ids);
 
     let store = make_consensus_store(&test_utils::temp_dir());
-    let mut state = ConsensusState::new(metrics.clone(), &committee, gc_depth);
+    let mut state = ConsensusState::new(metrics.clone(), gc_depth);
     let mut bullshark = Bullshark::new(committee, store, metrics, NUM_SUB_DAGS_PER_SCHEDULE);
 
     // Populate DAG with the rounds up to round 5 so we trigger commits
@@ -618,7 +618,7 @@ async fn submitting_equivocating_certificate_should_error() {
         test_utils::make_certificates_with_epoch(&committee, 1..=1, epoch, &genesis, &ids);
 
     let store = make_consensus_store(&test_utils::temp_dir());
-    let mut state = ConsensusState::new(metrics.clone(), &committee, gc_depth);
+    let mut state = ConsensusState::new(metrics.clone(), gc_depth);
     let mut bullshark =
         Bullshark::new(committee.clone(), store, metrics, NUM_SUB_DAGS_PER_SCHEDULE);
 
@@ -676,7 +676,7 @@ async fn reset_consensus_scores_on_every_schedule_change() {
         test_utils::make_certificates_with_epoch(&committee, 1..=50, epoch, &genesis, &ids);
 
     let store = make_consensus_store(&test_utils::temp_dir());
-    let mut state = ConsensusState::new(metrics.clone(), &committee, gc_depth);
+    let mut state = ConsensusState::new(metrics.clone(), gc_depth);
     let mut bullshark = Bullshark::new(committee, store, metrics, NUM_SUB_DAGS_PER_SCHEDULE);
 
     // Populate DAG with the rounds up to round 50 so we trigger commits
@@ -853,7 +853,7 @@ async fn garbage_collection_basic() {
     let store = make_consensus_store(&test_utils::temp_dir());
 
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    let mut state = ConsensusState::new(metrics.clone(), &committee, GC_DEPTH);
+    let mut state = ConsensusState::new(metrics.clone(), GC_DEPTH);
     let mut bullshark = Bullshark::new(committee, store, metrics, NUM_SUB_DAGS_PER_SCHEDULE);
 
     // Now start feeding the certificates per round
@@ -953,7 +953,7 @@ async fn slow_node() {
     // Create Bullshark consensus engine
     let store = make_consensus_store(&test_utils::temp_dir());
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    let mut state = ConsensusState::new(metrics.clone(), &committee, GC_DEPTH);
+    let mut state = ConsensusState::new(metrics.clone(), GC_DEPTH);
     let mut bullshark =
         Bullshark::new(committee.clone(), store, metrics, NUM_SUB_DAGS_PER_SCHEDULE);
 
@@ -1126,7 +1126,7 @@ async fn not_enough_support_and_missing_leaders_and_gc() {
     // Create Bullshark consensus engine
     let store = make_consensus_store(&test_utils::temp_dir());
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    let mut state = ConsensusState::new(metrics.clone(), &committee, GC_DEPTH);
+    let mut state = ConsensusState::new(metrics.clone(), GC_DEPTH);
     let mut bullshark = Bullshark::new(committee, store, metrics, NUM_SUB_DAGS_PER_SCHEDULE);
 
     let mut committed = false;

--- a/narwhal/consensus/src/tests/randomized_tests.rs
+++ b/narwhal/consensus/src/tests/randomized_tests.rs
@@ -425,7 +425,7 @@ fn generate_and_run_execution_plans(
 
         // Now create a new Bullshark engine
         let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-        let mut state = ConsensusState::new(metrics.clone(), &committee, gc_depth);
+        let mut state = ConsensusState::new(metrics.clone(), gc_depth);
         let mut bullshark = Bullshark::new(
             committee.clone(),
             store.clone(),

--- a/narwhal/consensus/src/tusk.rs
+++ b/narwhal/consensus/src/tusk.rs
@@ -105,12 +105,14 @@ impl ConsensusProtocol for Tusk {
             }
             debug!("Subdag has {} certificates", sequence.len());
 
-            let sub_dag = CommittedSubDag {
-                certificates: sequence,
-                leader: leader.clone(),
+            // TODO compute the scores for Tusk as well
+            let sub_dag = CommittedSubDag::new(
+                sequence,
+                leader.clone(),
                 sub_dag_index,
-                reputation_score: ReputationScores::default(), // TODO compute the scores for Tusk as well
-            };
+                ReputationScores::default(),
+                None,
+            );
 
             // Persist the update.
             self.store

--- a/narwhal/consensus/src/tusk.rs
+++ b/narwhal/consensus/src/tusk.rs
@@ -90,7 +90,7 @@ impl ConsensusProtocol for Tusk {
             .iter()
             .rev()
         {
-            let sub_dag_index = state.latest_sub_dag_index + 1;
+            let sub_dag_index = state.next_sub_dag_index();
             let _span = error_span!("tusk_process_sub_dag", sub_dag_index);
 
             let mut sequence = Vec::new();
@@ -119,7 +119,7 @@ impl ConsensusProtocol for Tusk {
                 .write_consensus_state(&state.last_committed, &sub_dag)?;
 
             // Increase the global consensus index.
-            state.latest_sub_dag_index = sub_dag_index;
+            state.last_committed_sub_dag = Some(sub_dag.clone());
 
             committed_sub_dags.push(sub_dag);
         }
@@ -206,7 +206,7 @@ mod tests {
 
         let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
 
-        let mut state = ConsensusState::new(metrics, &committee, gc_depth);
+        let mut state = ConsensusState::new(metrics, gc_depth);
         let mut tusk = Tusk::new(committee, store, gc_depth);
         for certificate in certificates {
             tusk.process_certificate(&mut state, certificate).unwrap();
@@ -244,14 +244,14 @@ mod tests {
         // TODO: evidence that this test fails when `failure_probability` parameter >= 1/3
         let (certificates, _next_parents) =
             test_utils::make_certificates(&committee, 1..=rounds, &genesis, &keys, 0.333);
-        let arc_committee = Arc::new(ArcSwap::from_pointee(committee.clone()));
+        let arc_committee = Arc::new(ArcSwap::from_pointee(committee));
 
         let store_path = test_utils::temp_dir();
         let store = make_consensus_store(&store_path);
 
         let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
 
-        let mut state = ConsensusState::new(metrics, &committee, gc_depth);
+        let mut state = ConsensusState::new(metrics, gc_depth);
         let mut tusk = Tusk::new((**arc_committee.load()).clone(), store, gc_depth);
 
         for certificate in certificates {

--- a/narwhal/executor/src/lib.rs
+++ b/narwhal/executor/src/lib.rs
@@ -121,6 +121,7 @@ pub async fn get_restored_consensus_output<State: ExecutionState>(
             leader,
             sub_dag_index,
             reputation_score: compressed_sub_dag.reputation_score,
+            commit_timestamp: compressed_sub_dag.commit_timestamp,
         });
     }
 

--- a/narwhal/types/src/consensus.rs
+++ b/narwhal/types/src/consensus.rs
@@ -50,6 +50,7 @@ impl CommittedSubDag {
         reputation_score: ReputationScores,
         previous_sub_dag: Option<&CommittedSubDag>,
     ) -> Self {
+        // Narwhal enforces some invariants on the header.created_at, so we can use it as a timestamp.
         let previous_sub_dag_ts = previous_sub_dag
             .map(|s| s.commit_timestamp)
             .unwrap_or_default();

--- a/narwhal/types/src/consensus.rs
+++ b/narwhal/types/src/consensus.rs
@@ -13,6 +13,7 @@ use store::{
     traits::Map,
 };
 use tokio::sync::mpsc;
+use tracing::warn;
 
 /// A global sequence number assigned to every CommittedSubDag.
 pub type SequenceNumber = u64;
@@ -36,7 +37,8 @@ pub struct CommittedSubDag {
     /// The so far calculated reputation score for nodes
     pub reputation_score: ReputationScores,
     /// The timestamp that should identify this commit. This is guaranteed to be monotonically
-    /// incremented
+    /// incremented. This is not necessarily the leader's timestamp. We compare the leader's timestamp
+    /// with the previously committed sud dag timestamp and we always keep the max.
     pub commit_timestamp: TimestampMs,
 }
 
@@ -46,12 +48,17 @@ impl CommittedSubDag {
         leader: Certificate,
         sub_dag_index: SequenceNumber,
         reputation_score: ReputationScores,
-        previous_sub_dag: Option<CommittedSubDag>,
+        previous_sub_dag: Option<&CommittedSubDag>,
     ) -> Self {
         let previous_sub_dag_ts = previous_sub_dag
             .map(|s| s.commit_timestamp)
             .unwrap_or_default();
         let commit_timestamp = previous_sub_dag_ts.max(*leader.header().created_at());
+
+        if previous_sub_dag_ts > *leader.header().created_at() {
+            warn!(sub_dag_index = ?sub_dag_index, "Leader timestamp {} is older than previously committed sub dag timestamp {}. Auto-correcting to max {}.",
+            leader.header().created_at(), previous_sub_dag_ts, commit_timestamp);
+        }
 
         Self {
             certificates,
@@ -247,5 +254,82 @@ impl ConsensusStore {
             .skip_to(from)?
             .map(|(_, sub_dag)| sub_dag)
             .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Certificate, Header, HeaderV1Builder};
+    use crate::{CommittedSubDag, ReputationScores};
+    use config::AuthorityIdentifier;
+    use indexmap::IndexMap;
+    use std::collections::BTreeSet;
+    use test_utils::CommitteeFixture;
+
+    #[test]
+    fn test_monotonically_incremented_commit_timestamps() {
+        // Create a certificate (leader) of round 2 with a high timestamp
+        let newer_timestamp = 100;
+        let older_timestamp = 50;
+
+        let fixture = CommitteeFixture::builder().build();
+        let committee = fixture.committee();
+
+        let header_builder = HeaderV1Builder::default();
+        let header = header_builder
+            .author(AuthorityIdentifier(1u16))
+            .round(2)
+            .epoch(0)
+            .created_at(newer_timestamp)
+            .payload(IndexMap::new())
+            .parents(BTreeSet::new())
+            .build()
+            .unwrap();
+
+        let certificate =
+            Certificate::new_unsigned(&committee, Header::V1(header), Vec::new()).unwrap();
+
+        // AND
+        let sub_dag_round_2 = CommittedSubDag::new(
+            vec![certificate.clone()],
+            certificate,
+            1,
+            ReputationScores::default(),
+            None,
+        );
+
+        // AND commit timestamp is the leader's timestamp
+        assert_eq!(sub_dag_round_2.commit_timestamp, newer_timestamp);
+
+        // Now create the leader of round 4 with the older timestamp
+        let header_builder = HeaderV1Builder::default();
+        let header = header_builder
+            .author(AuthorityIdentifier(1u16))
+            .round(4)
+            .epoch(0)
+            .created_at(older_timestamp)
+            .payload(IndexMap::new())
+            .parents(BTreeSet::new())
+            .build()
+            .unwrap();
+
+        let certificate =
+            Certificate::new_unsigned(&committee, Header::V1(header), Vec::new()).unwrap();
+
+        // WHEN create the sub dag based on the "previously committed" sub dag.
+        let sub_dag_round_4 = CommittedSubDag::new(
+            vec![certificate.clone()],
+            certificate,
+            2,
+            ReputationScores::default(),
+            Some(&sub_dag_round_2),
+        );
+
+        // THEN the latest sub dag should have the highest committed timestamp - basically the
+        // same as the previous commit round
+        assert_eq!(
+            sub_dag_round_4.commit_timestamp,
+            sub_dag_round_2.commit_timestamp
+        );
     }
 }


### PR DESCRIPTION
## Description 

This PR is enforcing the sub dag's commit timestamp to always monotonically increase. Basically we enforce the update `max(previous_sub_dag_commit_timestamp, current_leader_timestamp`.

The motivation behind this change is to ensure extra-safety on our timestamps and avoid any potential downstream issues.

Took the opportunity on this PR to refactor the code a little bit and simplify the information we keep in the consensus state to mainly use the last committed sub dag.

## Test Plan 

Introduced unit tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
