### PR TITLE
[framework] Adds `kiosk::set_owner_custom` to set the owner field manually

### DIFF
--- a/crates/sui-framework/docs/kiosk.md
+++ b/crates/sui-framework/docs/kiosk.md
@@ -44,6 +44,7 @@ be used to implement application-specific transfer rules.
 -  [Function `new`](#0x2_kiosk_new)
 -  [Function `close_and_withdraw`](#0x2_kiosk_close_and_withdraw)
 -  [Function `set_owner`](#0x2_kiosk_set_owner)
+-  [Function `set_owner_custom`](#0x2_kiosk_set_owner_custom)
 -  [Function `place`](#0x2_kiosk_place)
 -  [Function `lock`](#0x2_kiosk_lock)
 -  [Function `take`](#0x2_kiosk_take)
@@ -631,6 +632,35 @@ in a third party module.
 ) {
     <b>assert</b>!(<a href="object.md#0x2_object_id">object::id</a>(self) == cap.for, <a href="kiosk.md#0x2_kiosk_ENotOwner">ENotOwner</a>);
     self.owner = sender(ctx);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_kiosk_set_owner_custom"></a>
+
+## Function `set_owner_custom`
+
+Update the <code>owner</code> field with a custom address. Can be used for
+implementing a custom logic that relies on the <code><a href="kiosk.md#0x2_kiosk_Kiosk">Kiosk</a></code> owner.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="kiosk.md#0x2_kiosk_set_owner_custom">set_owner_custom</a>(self: &<b>mut</b> <a href="kiosk.md#0x2_kiosk_Kiosk">kiosk::Kiosk</a>, cap: &<a href="kiosk.md#0x2_kiosk_KioskOwnerCap">kiosk::KioskOwnerCap</a>, owner: <b>address</b>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="kiosk.md#0x2_kiosk_set_owner_custom">set_owner_custom</a>(
+    self: &<b>mut</b> <a href="kiosk.md#0x2_kiosk_Kiosk">Kiosk</a>, cap: &<a href="kiosk.md#0x2_kiosk_KioskOwnerCap">KioskOwnerCap</a>, owner: <b>address</b>
+) {
+    <b>assert</b>!(<a href="object.md#0x2_object_id">object::id</a>(self) == cap.for, <a href="kiosk.md#0x2_kiosk_ENotOwner">ENotOwner</a>);
+    self.owner = owner
 }
 </code></pre>
 

--- a/crates/sui-framework/packages/sui-framework/sources/kiosk/kiosk.move
+++ b/crates/sui-framework/packages/sui-framework/sources/kiosk/kiosk.move
@@ -196,6 +196,15 @@ module sui::kiosk {
         self.owner = sender(ctx);
     }
 
+    /// Update the `owner` field with a custom address. Can be used for
+    /// implementing a custom logic that relies on the `Kiosk` owner.
+    public fun set_owner_custom(
+        self: &mut Kiosk, cap: &KioskOwnerCap, owner: address
+    ) {
+        assert!(object::id(self) == cap.for, ENotOwner);
+        self.owner = owner
+    }
+
     // === Place, Lock and Take from the Kiosk ===
 
     /// Place any object into a Kiosk.

--- a/crates/sui-framework/packages/sui-framework/tests/kiosk/kiosk_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/kiosk/kiosk_tests.move
@@ -16,6 +16,22 @@ module sui::kiosk_tests {
     const AMT: u64 = 10_000;
 
     #[test]
+    fun test_set_owner_custom() {
+        let ctx = &mut test::ctx();
+        let (kiosk, owner_cap) = test::get_kiosk(ctx);
+
+        let old_owner = kiosk::owner(&kiosk);
+        kiosk::set_owner(&mut kiosk, &owner_cap, ctx);
+        assert!(kiosk::owner(&kiosk) == old_owner, 0);
+
+        kiosk::set_owner_custom(&mut kiosk, &owner_cap, @0xA11CE);
+        assert!(kiosk::owner(&kiosk) != old_owner, 0);
+        assert!(kiosk::owner(&kiosk) == @0xA11CE, 0);
+
+        test::return_kiosk(kiosk, owner_cap, ctx);
+    }
+
+    #[test]
     fun test_place_and_take() {
         let ctx = &mut test::ctx();
         let (asset, item_id) = test::get_asset(ctx);


### PR DESCRIPTION
## Description 

Allows setting any address as the `owner` of the `Kiosk`. While it is intended to be a cosmetic feature, we assume someone might use it for ownership checks.

## Test Plan 

More tests for the owner-related functions.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

- adds `kiosk::set_owner_custom(Kiosk, KioskOwnerCap, address)`
