### PR TITLE
[sui framework] skeleton package for deepbook

### DIFF
--- a/crates/sui-framework-build/src/compiled_package.rs
+++ b/crates/sui-framework-build/src/compiled_package.rs
@@ -44,7 +44,7 @@ use sui_types::{
     base_types::ObjectID,
     error::{SuiError, SuiResult},
     move_package::{FnInfo, FnInfoKey, FnInfoMap, MovePackage},
-    MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS, SUI_SYSTEM_ADDRESS,
+    DEEPBOOK_ADDRESS, MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS, SUI_SYSTEM_ADDRESS,
 };
 use sui_verifier::verifier as sui_bytecode_verifier;
 
@@ -347,6 +347,12 @@ impl CompiledPackage {
             .into_iter()
             .map(|object_id| object_id.to_hex_uncompressed())
             .collect()
+    }
+
+    /// Get bytecode modules from DeepBook that are used by this package
+    pub fn get_deepbook_modules(&self) -> impl Iterator<Item = &CompiledModule> {
+        self.get_modules_and_deps()
+            .filter(|m| *m.self_id().address() == DEEPBOOK_ADDRESS)
     }
 
     /// Get bytecode modules from the Sui System that are used by this package

--- a/crates/sui-framework/build.rs
+++ b/crates/sui-framework/build.rs
@@ -20,20 +20,37 @@ fn main() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     let packages_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("packages");
 
+    let deepbook_path = packages_path.join("deepbook");
     let sui_system_path = packages_path.join("sui-system");
     let sui_framework_path = packages_path.join("sui-framework");
+    let deepbook_path_clone = deepbook_path.clone();
     let sui_system_path_clone = sui_system_path.clone();
     let sui_framework_path_clone = sui_framework_path.clone();
     let move_stdlib_path = packages_path.join("move-stdlib");
 
     Builder::new()
         .stack_size(16 * 1024 * 1024) // build_move_package require bigger stack size on windows.
-        .spawn(move || build_packages(sui_system_path_clone, sui_framework_path_clone, out_dir))
+        .spawn(move || {
+            build_packages(
+                deepbook_path_clone,
+                sui_system_path_clone,
+                sui_framework_path_clone,
+                out_dir,
+            )
+        })
         .unwrap()
         .join()
         .unwrap();
 
     println!("cargo:rerun-if-changed=build.rs");
+    println!(
+        "cargo:rerun-if-changed={}",
+        deepbook_path.join("Move.toml").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        deepbook_path.join("sources").display()
+    );
     println!(
         "cargo:rerun-if-changed={}",
         sui_system_path.join("Move.toml").display()
@@ -60,16 +77,23 @@ fn main() {
     );
 }
 
-fn build_packages(sui_system_path: PathBuf, sui_framework_path: PathBuf, out_dir: PathBuf) {
+fn build_packages(
+    deepbook_path: PathBuf,
+    sui_system_path: PathBuf,
+    sui_framework_path: PathBuf,
+    out_dir: PathBuf,
+) {
     let config = MoveBuildConfig {
         generate_docs: true,
         ..Default::default()
     };
     debug_assert!(!config.test_mode);
     build_packages_with_move_config(
+        deepbook_path.clone(),
         sui_system_path.clone(),
         sui_framework_path.clone(),
         out_dir.clone(),
+        "deepbook",
         "sui-system",
         "sui-framework",
         "move-stdlib",
@@ -81,9 +105,11 @@ fn build_packages(sui_system_path: PathBuf, sui_framework_path: PathBuf, out_dir
         ..Default::default()
     };
     build_packages_with_move_config(
+        deepbook_path,
         sui_system_path,
         sui_framework_path,
         out_dir,
+        "deepbook-test",
         "sui-system-test",
         "sui-framework-test",
         "move-stdlib-test",
@@ -92,14 +118,23 @@ fn build_packages(sui_system_path: PathBuf, sui_framework_path: PathBuf, out_dir
 }
 
 fn build_packages_with_move_config(
+    deepbook_path: PathBuf,
     sui_system_path: PathBuf,
     sui_framework_path: PathBuf,
     out_dir: PathBuf,
+    deepbook_dir: &str,
     system_dir: &str,
     framework_dir: &str,
     stdlib_dir: &str,
     config: MoveBuildConfig,
 ) {
+    let deepbook_pkg = BuildConfig {
+        config: config.clone(),
+        run_bytecode_verifier: true,
+        print_diags_to_stderr: false,
+    }
+    .build(deepbook_path)
+    .unwrap();
     let system_pkg = BuildConfig {
         config: config.clone(),
         run_bytecode_verifier: true,
@@ -115,21 +150,27 @@ fn build_packages_with_move_config(
     .build(sui_framework_path)
     .unwrap();
 
+    let deepbook = deepbook_pkg.get_deepbook_modules();
     let sui_system = system_pkg.get_sui_system_modules();
     let sui_framework = framework_pkg.get_sui_framework_modules();
     let move_stdlib = framework_pkg.get_stdlib_modules();
 
+    serialize_modules_to_file(deepbook, &out_dir.join(deepbook_dir)).unwrap();
     serialize_modules_to_file(sui_system, &out_dir.join(system_dir)).unwrap();
     serialize_modules_to_file(sui_framework, &out_dir.join(framework_dir)).unwrap();
     serialize_modules_to_file(move_stdlib, &out_dir.join(stdlib_dir)).unwrap();
     // write out generated docs
     // TODO: remove docs of deleted files
+    for (fname, doc) in deepbook_pkg.package.compiled_docs.unwrap() {
+        let mut dst_path = PathBuf::from(DOCS_DIR);
+        dst_path.push(fname);
+        fs::write(dst_path, doc).unwrap();
+    }
     for (fname, doc) in system_pkg.package.compiled_docs.unwrap() {
         let mut dst_path = PathBuf::from(DOCS_DIR);
         dst_path.push(fname);
         fs::write(dst_path, doc).unwrap();
     }
-
     for (fname, doc) in framework_pkg.package.compiled_docs.unwrap() {
         let mut dst_path = PathBuf::from(DOCS_DIR);
         dst_path.push(fname);

--- a/crates/sui-framework/docs/clob.md
+++ b/crates/sui-framework/docs/clob.md
@@ -1,0 +1,11 @@
+
+<a name="0xdee9_clob"></a>
+
+# Module `0xdee9::clob`
+
+A placedholder for the real DeepBook code
+
+
+
+
+<pre><code></code></pre>

--- a/crates/sui-framework/packages/deepbook/Move.toml
+++ b/crates/sui-framework/packages/deepbook/Move.toml
@@ -1,0 +1,11 @@
+[package]
+name = "DeepBook"
+version = "0.0.1"
+published-at = "0xdee9"
+
+[dependencies]
+MoveStdlib = { local = "../move-stdlib" }
+Sui = { local = "../sui-framework" }
+
+[addresses]
+deepbook = "0xdee9"

--- a/crates/sui-framework/packages/deepbook/sources/clob.move
+++ b/crates/sui-framework/packages/deepbook/sources/clob.move
@@ -1,0 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// A placedholder for the real DeepBook code
+module deepbook::clob {
+}

--- a/crates/sui-framework/src/lib.rs
+++ b/crates/sui-framework/src/lib.rs
@@ -12,7 +12,7 @@ use sui_types::{
     error::SuiResult,
     move_package::MovePackage,
     object::{Object, OBJECT_START_VERSION},
-    MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS, SUI_SYSTEM_ADDRESS,
+    DEEPBOOK_ADDRESS, MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS, SUI_SYSTEM_ADDRESS,
 };
 
 pub mod natives;
@@ -100,6 +100,20 @@ define_system_package!(
     SUI_SYSTEM_ADDRESS,
     SuiSystemTest,
     "sui-system-test",
+    [MoveStdlib, SuiFramework]
+);
+
+define_system_package!(
+    DEEPBOOK_ADDRESS,
+    DeepBook,
+    "deepbook",
+    [MoveStdlib, SuiFramework]
+);
+
+define_system_package!(
+    DEEPBOOK_ADDRESS,
+    DeepBookTest,
+    "deepbook-test",
     [MoveStdlib, SuiFramework]
 );
 

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -76,6 +76,11 @@ pub const SUI_FRAMEWORK_OBJECT_ID: ObjectID = ObjectID::from_address(SUI_FRAMEWO
 pub const SUI_SYSTEM_ADDRESS: AccountAddress = address_from_single_byte(3);
 pub const SUI_SYSTEM_PACKAGE_ID: ObjectID = ObjectID::from_address(SUI_SYSTEM_ADDRESS);
 
+/// 0xdee9-- account address where DeepBook modules are stored
+/// Same as the ObjectID
+pub const DEEPBOOK_ADDRESS: AccountAddress = deepbook_addr();
+pub const DEEPBOOK_PACKAGE_ID: ObjectID = ObjectID::from_address(DEEPBOOK_ADDRESS);
+
 /// 0x5: hardcoded object ID for the singleton sui system state object.
 pub const SUI_SYSTEM_STATE_OBJECT_ID: ObjectID = ObjectID::from_single_byte(5);
 pub const SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION: SequenceNumber = OBJECT_START_VERSION;
@@ -95,13 +100,24 @@ pub const SUI_CLOCK_OBJECT_SHARED_VERSION: SequenceNumber = OBJECT_START_VERSION
 pub fn is_system_package(id: ObjectID) -> bool {
     matches!(
         id,
-        MOVE_STDLIB_OBJECT_ID | SUI_FRAMEWORK_OBJECT_ID | SUI_SYSTEM_PACKAGE_ID
+        MOVE_STDLIB_OBJECT_ID
+            | SUI_FRAMEWORK_OBJECT_ID
+            | SUI_SYSTEM_PACKAGE_ID
+            | DEEPBOOK_PACKAGE_ID
     )
 }
 
 const fn address_from_single_byte(b: u8) -> AccountAddress {
     let mut addr = [0u8; AccountAddress::LENGTH];
     addr[AccountAddress::LENGTH - 1] = b;
+    AccountAddress::new(addr)
+}
+
+/// return 0x0...dee9
+const fn deepbook_addr() -> AccountAddress {
+    let mut addr = [0u8; AccountAddress::LENGTH];
+    addr[AccountAddress::LENGTH - 2] = 0xde;
+    addr[AccountAddress::LENGTH - 1] = 0xe9;
     AccountAddress::new(addr)
 }
 


### PR DESCRIPTION
## Description 

Create a skeleton package for deepbook in the Sui Framework, with special address `0xdee9`. We will add the code in a follow-up PR.

This + the real code will need to be added via a Sui Framework upgrade, but will not be a breaking change.

## Test Plan 

Modified `clob` to add a public function, created a new Move project and added a dependency on `deepbook` that calls the function, it builds successfully.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
