### PR TITLE
wallet-ext,explorer: fix wrong display nft image url

### DIFF
--- a/apps/explorer/src/utils/objectUtils.ts
+++ b/apps/explorer/src/utils/objectUtils.ts
@@ -8,7 +8,7 @@ import { findIPFSvalue } from './stringUtils';
 import type { SuiObjectResponse } from '@mysten/sui.js';
 
 export function parseImageURL(display?: Record<string, string>) {
-    const url = display?.img_url;
+    const url = display?.image_url;
     if (url) {
         if (findIPFSvalue(url)) return url;
         // String representing true http/https URLs are valid:

--- a/apps/wallet/src/ui/app/hooks/useGetNFTMeta.ts
+++ b/apps/wallet/src/ui/app/hooks/useGetNFTMeta.ts
@@ -18,12 +18,12 @@ export function useGetNFTMeta(objectID: string) {
         if (!resp.data) return null;
         const { data } = resp.data || {};
         if (!is(data, SuiObjectData) || !data.display) return null;
-        const { name, description, creator, img_url, link, project_url } =
+        const { name, description, creator, image_url, link, project_url } =
             data.display;
         return {
             name: name || null,
             description: description || null,
-            imageUrl: img_url || null,
+            imageUrl: image_url || null,
             link: link || null,
             projectUrl: project_url || null,
             creator: creator || null,


### PR DESCRIPTION
* img_url -> image_url to match the standard https://docs.sui.io/build/sui-object-display