### PR TITLE
[indexer] - use diesel_async to prevent db calls from blocking rpc request processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,6 +1078,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
 
 [[package]]
+name = "bb8"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1627eccf3aa91405435ba240be23513eeca466b5dc33866422672264de061582"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-util",
+ "parking_lot 0.12.1",
+ "tokio",
+]
+
+[[package]]
 name = "bcs"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1846,7 +1859,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "libc",
  "unicode-width",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2488,6 +2501,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "diesel-async"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67d310b8050b1068b32fd03c55bd73f8d9ef5a789e2443c5b4e92f4587c63ed3"
+dependencies = [
+ "async-trait",
+ "bb8",
+ "diesel",
+ "futures",
+ "scoped-futures",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
 name = "diesel-derive-enum"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2923,6 +2951,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
 name = "fastcrypto"
 version = "0.1.4"
 source = "git+https://github.com/MystenLabs/fastcrypto?rev=c2f79b1807bff7d09517b631191b61f2614c641c#c2f79b1807bff7d09517b631191b61f2614c641c"
@@ -3016,7 +3050,7 @@ checksum = "bb21c69b9fea5e15dbc1049e4b77145dd0ba1c84019c488102de0dc4ea4b0a27"
 dependencies = [
  "cfg-if",
  "rustix",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3728,7 +3762,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -4007,7 +4041,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -4034,7 +4068,7 @@ dependencies = [
  "hermit-abi 0.2.6",
  "io-lifetimes",
  "rustix",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -4464,6 +4498,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
 
 [[package]]
+name = "md-5"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
+dependencies = [
+ "digest 0.10.6",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4582,7 +4625,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -5341,7 +5384,7 @@ dependencies = [
  "rand 0.8.5",
  "real_tokio",
  "serde 1.0.152",
- "socket2",
+ "socket2 0.4.9",
  "tap",
  "tokio-util 0.7.4 (git+https://github.com/mystenmark/tokio-madsim-fork.git?rev=8b166d79d8b7d81ce9b6db87c3aa8ab53b2d3082)",
  "toml",
@@ -6485,7 +6528,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -6738,6 +6781,35 @@ name = "portable-atomic"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b7fa9f396f51dffd61546fd8573ee20592287996568e6175ceb0f8699ad75d"
+dependencies = [
+ "base64 0.21.0",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand 0.8.5",
+ "sha2 0.10.6",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f028f05971fe20f512bcc679e2c10227e57809a3af86a7606304435bc8896cd6"
+dependencies = [
+ "bytes",
+ "fallible-iterator",
+ "postgres-protocol",
+]
 
 [[package]]
 name = "pprof"
@@ -7167,9 +7239,9 @@ checksum = "641538578b21f5e5c8ea733b736895576d0fe329bb883b937db6f4d163dbaaf4"
 dependencies = [
  "libc",
  "quinn-proto",
- "socket2",
+ "socket2 0.4.9",
  "tracing",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -7407,9 +7479,9 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
- "tokio-macros 1.8.2 (git+https://github.com/mystenmark/tokio-madsim-fork.git?rev=8b166d79d8b7d81ce9b6db87c3aa8ab53b2d3082)",
- "windows-sys",
+ "socket2 0.4.9",
+ "tokio-macros 1.8.2",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -7689,7 +7761,7 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -7799,14 +7871,14 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
 name = "scheduled-thread-pool"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977a7519bff143a44f842fd07e80ad1329295bd71686457f18e496736f4bf9bf"
+checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
 dependencies = [
  "parking_lot 0.12.1",
 ]
@@ -7834,6 +7906,16 @@ dependencies = [
  "quote 1.0.26",
  "serde_derive_internals",
  "syn 1.0.107",
+]
+
+[[package]]
+name = "scoped-futures"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1473e24c637950c9bd38763220bea91ec3e095a89f672bbd7a10d03e77ba467"
+dependencies = [
+ "cfg-if",
+ "pin-utils",
 ]
 
 [[package]]
@@ -8399,12 +8481,22 @@ checksum = "5e9f0ab6ef7eb7353d9119c170a436d1bf248eea575ac42d19d12f4e34130831"
 
 [[package]]
 name = "socket2"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc8d618c6641ae355025c449427f9e96b98abf99a772be3cef6708d15c77147a"
+dependencies = [
+ "libc",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -8462,6 +8554,16 @@ name = "str_stack"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
+
+[[package]]
+name = "stringprep"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee348cb74b87454fff4b551cbf727025810a004f88aeacae7f85b87f4e9a1c1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "strip-ansi-escapes"
@@ -8996,6 +9098,7 @@ dependencies = [
  "clap 3.2.23",
  "criterion",
  "diesel",
+ "diesel-async",
  "diesel-derive-enum",
  "diesel_migrations",
  "fastcrypto",
@@ -9950,7 +10053,7 @@ dependencies = [
  "fastrand",
  "redox_syscall",
  "rustix",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -10242,23 +10345,22 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.24.1"
+version = "1.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
+checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
 dependencies = [
  "autocfg",
  "bytes",
  "libc",
- "memchr",
  "mio 0.8.5",
  "num_cpus",
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
- "tokio-macros 1.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "socket2 0.4.9",
+ "tokio-macros 2.0.0",
  "tracing",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -10274,8 +10376,7 @@ dependencies = [
 [[package]]
 name = "tokio-macros"
 version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+source = "git+https://github.com/mystenmark/tokio-madsim-fork.git?rev=8b166d79d8b7d81ce9b6db87c3aa8ab53b2d3082#8b166d79d8b7d81ce9b6db87c3aa8ab53b2d3082"
 dependencies = [
  "proc-macro2 1.0.54",
  "quote 1.0.26",
@@ -10284,12 +10385,37 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.2"
-source = "git+https://github.com/mystenmark/tokio-madsim-fork.git?rev=8b166d79d8b7d81ce9b6db87c3aa8ab53b2d3082#8b166d79d8b7d81ce9b6db87c3aa8ab53b2d3082"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2 1.0.54",
  "quote 1.0.26",
- "syn 1.0.107",
+ "syn 2.0.10",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e89f6234aa8fd43779746012fcf53603cdb91fdd8399aa0de868c2d56b6dde1"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot 0.12.1",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "socket2 0.5.1",
+ "tokio",
+ "tokio-util 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -11247,46 +11373,70 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+name = "windows-sys"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winreg"
@@ -11366,6 +11516,7 @@ dependencies = [
  "base64 0.13.1",
  "base64 0.21.0",
  "base64ct",
+ "bb8",
  "bcs",
  "beef",
  "better_any",
@@ -11487,6 +11638,7 @@ dependencies = [
  "determinator",
  "deunicode",
  "diesel",
+ "diesel-async",
  "diesel-derive-enum",
  "diesel_derives",
  "diesel_migrations",
@@ -11527,6 +11679,7 @@ dependencies = [
  "eyre",
  "fail 0.4.0",
  "fail 0.5.1",
+ "fallible-iterator",
  "fastcrypto",
  "fastcrypto-derive",
  "fastcrypto-zkp",
@@ -11662,6 +11815,7 @@ dependencies = [
  "matchers",
  "matchit 0.5.0",
  "matchit 0.7.0",
+ "md-5",
  "memchr",
  "memmap2",
  "memoffset 0.6.5",
@@ -11790,6 +11944,8 @@ dependencies = [
  "plotters-svg",
  "polyval",
  "portable-atomic",
+ "postgres-protocol",
+ "postgres-types",
  "pprof",
  "ppv-lite86",
  "pq-sys",
@@ -11881,6 +12037,7 @@ dependencies = [
  "scheduled-thread-pool",
  "schemars",
  "schemars_derive",
+ "scoped-futures",
  "scopeguard",
  "sct",
  "sec1",
@@ -11934,7 +12091,8 @@ dependencies = [
  "slug",
  "smallvec",
  "snap",
- "socket2",
+ "socket2 0.4.9",
+ "socket2 0.5.1",
  "soketto",
  "spin",
  "spki",
@@ -11942,6 +12100,7 @@ dependencies = [
  "static_assertions",
  "str-buf",
  "str_stack",
+ "stringprep",
  "strip-ansi-escapes",
  "strsim 0.10.0",
  "strsim 0.8.0",
@@ -11990,7 +12149,8 @@ dependencies = [
  "tinyvec_macros",
  "tokio",
  "tokio-io-timeout",
- "tokio-macros 1.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-macros 2.0.0",
+ "tokio-postgres",
  "tokio-retry",
  "tokio-rustls",
  "tokio-stream",
@@ -12070,7 +12230,9 @@ dependencies = [
  "widestring",
  "winapi",
  "winapi-util",
- "windows-sys",
+ "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
+ "windows-targets",
  "windows_x86_64_msvc",
  "winreg",
  "wyz",

--- a/crates/sui-indexer/Cargo.toml
+++ b/crates/sui-indexer/Cargo.toml
@@ -15,6 +15,7 @@ bcs = "0.1.4"
 chrono = { version = "0.4.23", features = ["clock", "serde"] }
 clap = { version = "3.2.17", features = ["derive"] }
 diesel = { version = "2.0.3", features = ["chrono", "postgres", "r2d2", "serde_json", "64-column-tables"] }
+diesel-async = { version = "0.2.1", features = ["postgres", "bb8"] }
 diesel-derive-enum = { version = "2.0.1", features = ["postgres"] }
 futures = "0.3.23"
 jsonrpsee = { version = "0.16.2", features = ["full"] }
@@ -56,7 +57,7 @@ sui-framework-build = { path = "../sui-framework-build" }
 sui-keys = { path = "../sui-keys" }
 test-utils = { path = "../test-utils" }
 ntest = "0.9.0"
-criterion = { version = "0.4.0", features = ["html_reports"] }
+criterion = { version = "0.4.0", features = ["html_reports", "async_tokio"] }
 
 [[bin]]
 name = "sui-indexer"

--- a/crates/sui-indexer/benches/indexer_benchmark.rs
+++ b/crates/sui-indexer/benches/indexer_benchmark.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 
 use chrono::Utc;
 use criterion::Criterion;
+use tokio::runtime::Runtime;
 
 use sui_indexer::models::checkpoints::Checkpoint;
 use sui_indexer::models::objects::{NamedBcsBytes, Object as DBObject, ObjectStatus};
@@ -33,21 +34,27 @@ fn indexer_benchmark(c: &mut Criterion) {
     let pw = env::var("POSTGRES_PASSWORD").unwrap_or_else(|_| "postgrespw".into());
     let db_url = format!("postgres://postgres:{pw}@{pg_host}:{pg_port}");
 
-    let pg_connection_pool = new_pg_connection_pool(&db_url).unwrap();
-    reset_database(&mut pg_connection_pool.get().unwrap(), true).unwrap();
-    let store = PgIndexerStore::new(pg_connection_pool);
+    let rt = Runtime::new().unwrap();
+    let (mut checkpoints, store) = rt.block_on(async {
+        let (blocking_cp, async_cp) = new_pg_connection_pool(&db_url).await.unwrap();
+        reset_database(&mut blocking_cp.get().unwrap(), true).unwrap();
+        let store = PgIndexerStore::new(async_cp, blocking_cp).await;
 
-    let mut checkpoints = (0..150).map(create_checkpoint).collect::<Vec<_>>();
+        let checkpoints = (0..150).map(create_checkpoint).collect::<Vec<_>>();
+        (checkpoints, store)
+    });
 
     c.bench_function("persist_checkpoint", |b| {
-        b.iter(|| store.persist_checkpoint(&checkpoints.pop().unwrap()))
+        b.iter(|| rt.block_on(store.persist_checkpoint(&checkpoints.pop().unwrap())))
     });
 
     let mut checkpoints = (20..100)
         .cycle()
         .map(|i| CheckpointId::SequenceNumber(i.into()));
+
     c.bench_function("get_checkpoint", |b| {
-        b.iter(|| store.get_checkpoint(checkpoints.next().unwrap()).unwrap())
+        b.to_async(Runtime::new().unwrap())
+            .iter(|| store.get_checkpoint(checkpoints.next().unwrap()))
     });
 }
 

--- a/crates/sui-indexer/src/apis/extended_api.rs
+++ b/crates/sui-indexer/src/apis/extended_api.rs
@@ -29,7 +29,7 @@ impl<S: IndexerStore> ExtendedApi<S> {
         Self { state }
     }
 
-    fn query_objects_internal(
+    async fn query_objects_internal(
         &self,
         query: SuiObjectResponseQuery,
         cursor: Option<CheckpointedObjectID>,
@@ -44,7 +44,7 @@ impl<S: IndexerStore> ExtendedApi<S> {
         {
             cp
         } else {
-            self.state.get_latest_checkpoint_sequence_number()? as u64
+            self.state.get_latest_checkpoint_sequence_number().await? as u64
         };
 
         let object_cursor = cursor.as_ref().map(|c| c.object_id);
@@ -52,9 +52,10 @@ impl<S: IndexerStore> ExtendedApi<S> {
         let SuiObjectResponseQuery { filter, options } = query;
         let filter = filter.unwrap_or_else(|| SuiObjectDataFilter::MatchAll(vec![]));
 
-        let objects_from_db =
-            self.state
-                .query_objects(filter, at_checkpoint, object_cursor, limit + 1)?;
+        let objects_from_db = self
+            .state
+            .query_objects(filter, at_checkpoint, object_cursor, limit + 1)
+            .await?;
 
         let mut data = objects_from_db
             .into_iter()
@@ -92,7 +93,10 @@ impl<S: IndexerStore + Sync + Send + 'static> ExtendedApiServer for ExtendedApi<
         descending_order: Option<bool>,
     ) -> RpcResult<EpochPage> {
         let limit = validate_limit(limit, QUERY_MAX_RESULT_LIMIT_CHECKPOINTS)?;
-        let mut epochs = self.state.get_epochs(cursor, limit + 1, descending_order)?;
+        let mut epochs = self
+            .state
+            .get_epochs(cursor, limit + 1, descending_order)
+            .await?;
 
         let has_next_page = epochs.len() > limit;
         epochs.truncate(limit);
@@ -105,7 +109,7 @@ impl<S: IndexerStore + Sync + Send + 'static> ExtendedApiServer for ExtendedApi<
     }
 
     async fn get_current_epoch(&self) -> RpcResult<EpochInfo> {
-        Ok(self.state.get_current_epoch()?)
+        Ok(self.state.get_current_epoch().await?)
     }
 
     async fn query_objects(
@@ -114,15 +118,15 @@ impl<S: IndexerStore + Sync + Send + 'static> ExtendedApiServer for ExtendedApi<
         cursor: Option<CheckpointedObjectID>,
         limit: Option<usize>,
     ) -> RpcResult<ObjectsPage> {
-        Ok(self.query_objects_internal(query, cursor, limit)?)
+        Ok(self.query_objects_internal(query, cursor, limit).await?)
     }
 
     async fn get_network_metrics(&self) -> RpcResult<NetworkMetrics> {
-        Ok(self.state.get_network_metrics()?)
+        Ok(self.state.get_network_metrics().await?)
     }
 
     async fn get_move_call_metrics(&self) -> RpcResult<MoveCallMetrics> {
-        Ok(self.state.get_move_call_metrics()?)
+        Ok(self.state.get_move_call_metrics().await?)
     }
 }
 

--- a/crates/sui-indexer/src/apis/indexer_api.rs
+++ b/crates/sui-indexer/src/apis/indexer_api.rs
@@ -52,7 +52,7 @@ impl<S: IndexerStore> IndexerApi<S> {
         }
     }
 
-    pub fn query_events_internal(
+    async fn query_events_internal(
         &self,
         query: EventFilter,
         cursor: Option<EventID>,
@@ -61,6 +61,7 @@ impl<S: IndexerStore> IndexerApi<S> {
     ) -> Result<EventPage, IndexerError> {
         self.state
             .get_events(query, cursor, limit, descending_order.unwrap_or_default())
+            .await
     }
 
     async fn query_transaction_blocks_internal(
@@ -77,20 +78,25 @@ impl<S: IndexerStore> IndexerApi<S> {
             None => {
                 let indexer_seq_number = self
                     .state
-                    .get_transaction_sequence_by_digest(cursor_str, is_descending)?;
+                    .get_transaction_sequence_by_digest(cursor_str, is_descending)
+                    .await?;
                 self.state
                     .get_all_transaction_page(indexer_seq_number, limit + 1, is_descending)
+                    .await
             }
             Some(TransactionFilter::Checkpoint(checkpoint_id)) => {
                 let indexer_seq_number = self
                     .state
-                    .get_transaction_sequence_by_digest(cursor_str, is_descending)?;
-                self.state.get_transaction_page_by_checkpoint(
-                    checkpoint_id as i64,
-                    indexer_seq_number,
-                    limit + 1,
-                    is_descending,
-                )
+                    .get_transaction_sequence_by_digest(cursor_str, is_descending)
+                    .await?;
+                self.state
+                    .get_transaction_page_by_checkpoint(
+                        checkpoint_id as i64,
+                        indexer_seq_number,
+                        limit + 1,
+                        is_descending,
+                    )
+                    .await
             }
             Some(TransactionFilter::MoveFunction {
                 package,
@@ -99,85 +105,106 @@ impl<S: IndexerStore> IndexerApi<S> {
             }) => {
                 let move_call_seq_number = self
                     .state
-                    .get_move_call_sequence_by_digest(cursor_str, is_descending)?;
-                self.state.get_transaction_page_by_move_call(
-                    package.to_string(),
-                    module,
-                    function,
-                    move_call_seq_number,
-                    limit + 1,
-                    is_descending,
-                )
+                    .get_move_call_sequence_by_digest(cursor_str, is_descending)
+                    .await?;
+                self.state
+                    .get_transaction_page_by_move_call(
+                        package.to_string(),
+                        module,
+                        function,
+                        move_call_seq_number,
+                        limit + 1,
+                        is_descending,
+                    )
+                    .await
             }
             Some(TransactionFilter::InputObject(input_obj_id)) => {
                 let input_obj_seq = self
                     .state
-                    .get_input_object_sequence_by_digest(cursor_str, is_descending)?;
-                self.state.get_transaction_page_by_input_object(
-                    input_obj_id.to_string(),
-                    /* version */ None,
-                    input_obj_seq,
-                    limit + 1,
-                    is_descending,
-                )
+                    .get_input_object_sequence_by_digest(cursor_str, is_descending)
+                    .await?;
+                self.state
+                    .get_transaction_page_by_input_object(
+                        input_obj_id.to_string(),
+                        /* version */ None,
+                        input_obj_seq,
+                        limit + 1,
+                        is_descending,
+                    )
+                    .await
             }
             Some(TransactionFilter::ChangedObject(mutated_obj_id)) => {
                 let indexer_seq_number = self
                     .state
-                    .get_transaction_sequence_by_digest(cursor_str, is_descending)?;
-                self.state.get_transaction_page_by_mutated_object(
-                    mutated_obj_id.to_string(),
-                    indexer_seq_number,
-                    limit + 1,
-                    is_descending,
-                )
+                    .get_transaction_sequence_by_digest(cursor_str, is_descending)
+                    .await?;
+                self.state
+                    .get_transaction_page_by_mutated_object(
+                        mutated_obj_id.to_string(),
+                        indexer_seq_number,
+                        limit + 1,
+                        is_descending,
+                    )
+                    .await
             }
             // NOTE: more efficient to run this query over transactions table
             Some(TransactionFilter::FromAddress(sender_address)) => {
                 let indexer_seq_number = self
                     .state
-                    .get_transaction_sequence_by_digest(cursor_str, is_descending)?;
-                self.state.get_transaction_page_by_sender_address(
-                    sender_address.to_string(),
-                    indexer_seq_number,
-                    limit + 1,
-                    is_descending,
-                )
+                    .get_transaction_sequence_by_digest(cursor_str, is_descending)
+                    .await?;
+                self.state
+                    .get_transaction_page_by_sender_address(
+                        sender_address.to_string(),
+                        indexer_seq_number,
+                        limit + 1,
+                        is_descending,
+                    )
+                    .await
             }
             Some(TransactionFilter::ToAddress(recipient_address)) => {
                 let recipient_seq_number = self
                     .state
-                    .get_recipient_sequence_by_digest(cursor_str, is_descending)?;
-                self.state.get_transaction_page_by_sender_recipient_address(
-                    /* from */ None,
-                    recipient_address.to_string(),
-                    recipient_seq_number,
-                    limit + 1,
-                    is_descending,
-                )
+                    .get_recipient_sequence_by_digest(cursor_str, is_descending)
+                    .await?;
+                self.state
+                    .get_transaction_page_by_sender_recipient_address(
+                        /* from */ None,
+                        recipient_address.to_string(),
+                        recipient_seq_number,
+                        limit + 1,
+                        is_descending,
+                    )
+                    .await
             }
             Some(TransactionFilter::FromAndToAddress { from, to }) => {
                 let recipient_seq_number = self
                     .state
-                    .get_recipient_sequence_by_digest(cursor_str, is_descending)?;
-                self.state.get_transaction_page_by_sender_recipient_address(
-                    Some(from.to_string()),
-                    to.to_string(),
-                    recipient_seq_number,
-                    limit + 1,
-                    is_descending,
-                )
+                    .get_recipient_sequence_by_digest(cursor_str, is_descending)
+                    .await?;
+                self.state
+                    .get_transaction_page_by_sender_recipient_address(
+                        Some(from.to_string()),
+                        to.to_string(),
+                        recipient_seq_number,
+                        limit + 1,
+                        is_descending,
+                    )
+                    .await
             }
             Some(TransactionFilter::TransactionKind(tx_kind_name)) => {
                 let indexer_seq_number = self
                     .state
-                    .get_transaction_sequence_by_digest(cursor_str, is_descending)?;
-                self.state.get_transaction_page_by_transaction_kind(
-                    tx_kind_name,
-                    indexer_seq_number,
-                    limit + 1,
-                    is_descending,
-                )
+                    .get_transaction_sequence_by_digest(cursor_str, is_descending)
+                    .await?;
+                self.state
+                    .get_transaction_page_by_transaction_kind(
+                        tx_kind_name,
+                        indexer_seq_number,
+                        limit + 1,
+                        is_descending,
+                    )
+                    .await
             }
         }?;
 
@@ -245,15 +272,16 @@ where
         {
             at_checkpoint
         } else {
-            self.state.get_latest_checkpoint_sequence_number()? as u64
+            self.state.get_latest_checkpoint_sequence_number().await? as u64
         };
         let object_cursor = cursor.as_ref().map(|c| c.object_id);
 
         let limit = validate_limit(limit, QUERY_MAX_RESULT_LIMIT)?;
         let options = options.unwrap_or_default();
-        let mut objects =
-            self.state
-                .query_objects(filter, at_checkpoint, object_cursor, limit + 1)?;
+        let mut objects = self
+            .state
+            .query_objects(filter, at_checkpoint, object_cursor, limit + 1)
+            .await?;
 
         let has_next_page = objects.len() > limit;
         objects.truncate(limit);
@@ -311,7 +339,9 @@ where
                 .query_events(query, cursor, limit, descending_order)
                 .await;
         }
-        Ok(self.query_events_internal(query, cursor, limit, descending_order)?)
+        Ok(self
+            .query_events_internal(query, cursor, limit, descending_order)
+            .await?)
     }
 
     async fn get_dynamic_fields(

--- a/crates/sui-indexer/src/apis/read_api.rs
+++ b/crates/sui-indexer/src/apis/read_api.rs
@@ -37,9 +37,10 @@ impl<S: IndexerStore> ReadApi<S> {
         }
     }
 
-    fn get_total_transaction_blocks_internal(&self) -> Result<u64, IndexerError> {
+    async fn get_total_transaction_blocks_internal(&self) -> Result<u64, IndexerError> {
         self.state
             .get_total_transaction_number_from_checkpoints()
+            .await
             .map(|n| n as u64)
     }
 
@@ -50,7 +51,8 @@ impl<S: IndexerStore> ReadApi<S> {
     ) -> Result<SuiTransactionBlockResponse, IndexerError> {
         let tx = self
             .state
-            .get_transaction_by_digest(&digest.base58_encode())?;
+            .get_transaction_by_digest(&digest.base58_encode())
+            .await?;
         let sui_tx_resp = self
             .state
             .compose_sui_transaction_block_response(tx, options.as_ref())
@@ -72,7 +74,10 @@ impl<S: IndexerStore> ReadApi<S> {
             .iter()
             .map(|digest| digest.base58_encode())
             .collect::<Vec<_>>();
-        let tx_vec = self.state.multi_get_transactions_by_digests(&digest_strs)?;
+        let tx_vec = self
+            .state
+            .multi_get_transactions_by_digests(&digest_strs)
+            .await?;
         let ordered_tx_vec = digest_strs
             .iter()
             .filter_map(|digest| {
@@ -98,18 +103,19 @@ impl<S: IndexerStore> ReadApi<S> {
         Ok(sui_tx_resp_vec)
     }
 
-    fn get_object_internal(
+    async fn get_object_internal(
         &self,
         object_id: ObjectID,
         options: Option<SuiObjectDataOptions>,
     ) -> Result<SuiObjectResponse, IndexerError> {
-        let read = self.state.get_object(object_id, None)?;
+        let read = self.state.get_object(object_id, None).await?;
         Ok((read, options.unwrap_or_default()).try_into()?)
     }
 
-    fn get_latest_checkpoint_sequence_number_internal(&self) -> Result<u64, IndexerError> {
+    async fn get_latest_checkpoint_sequence_number_internal(&self) -> Result<u64, IndexerError> {
         self.state
             .get_latest_checkpoint_sequence_number()
+            .await
             .map(|n| n as u64)
     }
 }
@@ -128,7 +134,7 @@ where
             return self.fullnode.get_object(object_id, options).await;
         }
 
-        Ok(self.get_object_internal(object_id, options)?)
+        Ok(self.get_object_internal(object_id, options).await?)
     }
 
     async fn multi_get_objects(
@@ -146,7 +152,7 @@ where
         {
             return self.fullnode.get_total_transaction_blocks().await;
         }
-        Ok(self.get_total_transaction_blocks_internal()?.into())
+        Ok(self.get_total_transaction_blocks_internal().await?.into())
     }
 
     async fn get_transaction_block(
@@ -215,7 +221,8 @@ where
             return self.fullnode.get_latest_checkpoint_sequence_number().await;
         }
         Ok(self
-            .get_latest_checkpoint_sequence_number_internal()?
+            .get_latest_checkpoint_sequence_number_internal()
+            .await?
             .into())
     }
 
@@ -226,7 +233,7 @@ where
         {
             return self.fullnode.get_checkpoint(id).await;
         }
-        Ok(self.state.get_checkpoint(id)?)
+        Ok(self.state.get_checkpoint(id).await?)
     }
 
     async fn get_checkpoints(

--- a/crates/sui-indexer/src/apis/write_api.rs
+++ b/crates/sui-indexer/src/apis/write_api.rs
@@ -59,7 +59,7 @@ where
             sui_transaction_response.clone().try_into()?;
         let transaction_store: TemporaryTransactionBlockResponseStore = fast_path_resp.into();
         let transaction: Transaction = transaction_store.try_into()?;
-        self.state.persist_fast_path(transaction)?;
+        self.state.persist_fast_path(transaction).await?;
 
         Ok(SuiTransactionBlockResponseWithOptions {
             response: sui_transaction_response,

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -87,7 +87,8 @@ where
 
     async fn start(&self) -> Result<(), IndexerError> {
         info!("Indexer checkpoint handler started...");
-        let mut next_cursor_sequence_number = self.state.get_latest_checkpoint_sequence_number()?;
+        let mut next_cursor_sequence_number =
+            self.state.get_latest_checkpoint_sequence_number().await?;
         if next_cursor_sequence_number > 0 {
             info!("Resuming from checkpoint {next_cursor_sequence_number}");
         }
@@ -117,7 +118,7 @@ where
             let object_count = indexed_checkpoint.objects_changes.len();
 
             let checkpoint_db_guard = self.metrics.checkpoint_db_commit_latency.start_timer();
-            self.state.persist_checkpoint(&indexed_checkpoint)?;
+            self.state.persist_checkpoint(&indexed_checkpoint).await?;
             checkpoint_db_guard.stop_and_record();
 
             self.metrics.total_checkpoint_committed.inc();
@@ -135,7 +136,7 @@ where
             // Write epoch to DB if needed
             if let Some(indexed_epoch) = indexed_epoch {
                 let epoch_db_guard = self.metrics.epoch_db_commit_latency.start_timer();
-                self.state.persist_epoch(&indexed_epoch)?;
+                self.state.persist_epoch(&indexed_epoch).await?;
                 epoch_db_guard.stop_and_record();
                 self.metrics.total_epoch_committed.inc();
             }

--- a/crates/sui-indexer/src/models/transactions.rs
+++ b/crates/sui-indexer/src/models/transactions.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use diesel::prelude::*;
-use diesel::result::Error;
 
 use sui_json_rpc_types::{
     OwnedObjectRef, SuiObjectRef, SuiTransactionBlockDataAPI, SuiTransactionBlockEffectsAPI,
@@ -10,9 +9,7 @@ use sui_json_rpc_types::{
 
 use crate::errors::IndexerError;
 use crate::schema::transactions;
-use crate::schema::transactions::transaction_digest;
 use crate::types::TemporaryTransactionBlockResponseStore;
-use crate::PgPoolConnection;
 
 #[derive(Clone, Debug, Queryable, Insertable)]
 #[diesel(table_name = transactions)]
@@ -49,8 +46,8 @@ pub struct Transaction {
     pub confirmed_local_execution: Option<bool>,
 }
 
-pub fn commit_transactions(
-    pg_pool_conn: &mut PgPoolConnection,
+/*pub fn commit_transactions(
+    pg_pool_conn: &mut PgPoolConnection<'_>,
     tx_resps: Vec<TemporaryTransactionBlockResponseStore>,
 ) -> Result<usize, IndexerError> {
     let new_txs: Vec<Transaction> = tx_resps
@@ -75,7 +72,7 @@ pub fn commit_transactions(
             new_txs, e
         ))
     })
-}
+}*/
 
 impl TryFrom<TemporaryTransactionBlockResponseStore> for Transaction {
     type Error = IndexerError;

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -32,15 +32,15 @@ use crate::types::CheckpointTransactionBlockResponse;
 pub trait IndexerStore {
     type ModuleCache;
 
-    fn get_latest_checkpoint_sequence_number(&self) -> Result<i64, IndexerError>;
-    fn get_checkpoint(&self, id: CheckpointId) -> Result<RpcCheckpoint, IndexerError>;
-    fn get_checkpoint_sequence_number(
+    async fn get_latest_checkpoint_sequence_number(&self) -> Result<i64, IndexerError>;
+    async fn get_checkpoint(&self, id: CheckpointId) -> Result<RpcCheckpoint, IndexerError>;
+    async fn get_checkpoint_sequence_number(
         &self,
         digest: CheckpointDigest,
     ) -> Result<CheckpointSequenceNumber, IndexerError>;
 
-    fn get_event(&self, id: EventID) -> Result<Event, IndexerError>;
-    fn get_events(
+    async fn get_event(&self, id: EventID) -> Result<Event, IndexerError>;
+    async fn get_events(
         &self,
         query: EventFilter,
         cursor: Option<EventID>,
@@ -48,13 +48,13 @@ pub trait IndexerStore {
         descending_order: bool,
     ) -> Result<EventPage, IndexerError>;
 
-    fn get_object(
+    async fn get_object(
         &self,
         object_id: ObjectID,
         version: Option<SequenceNumber>,
     ) -> Result<ObjectRead, IndexerError>;
 
-    fn query_objects(
+    async fn query_objects(
         &self,
         filter: SuiObjectDataFilter,
         at_checkpoint: CheckpointSequenceNumber,
@@ -62,11 +62,12 @@ pub trait IndexerStore {
         limit: usize,
     ) -> Result<Vec<ObjectRead>, IndexerError>;
 
-    fn get_total_transaction_number_from_checkpoints(&self) -> Result<i64, IndexerError>;
+    async fn get_total_transaction_number_from_checkpoints(&self) -> Result<i64, IndexerError>;
 
     // TODO: combine all get_transaction* methods
-    fn get_transaction_by_digest(&self, tx_digest: &str) -> Result<Transaction, IndexerError>;
-    fn multi_get_transactions_by_digests(
+    async fn get_transaction_by_digest(&self, tx_digest: &str)
+        -> Result<Transaction, IndexerError>;
+    async fn multi_get_transactions_by_digests(
         &self,
         tx_digests: &[String],
     ) -> Result<Vec<Transaction>, IndexerError>;
@@ -77,14 +78,14 @@ pub trait IndexerStore {
         options: Option<&SuiTransactionBlockResponseOptions>,
     ) -> Result<SuiTransactionBlockResponse, IndexerError>;
 
-    fn get_all_transaction_page(
+    async fn get_all_transaction_page(
         &self,
         start_sequence: Option<i64>,
         limit: usize,
         is_descending: bool,
     ) -> Result<Vec<Transaction>, IndexerError>;
 
-    fn get_transaction_page_by_checkpoint(
+    async fn get_transaction_page_by_checkpoint(
         &self,
         checkpoint_sequence_number: i64,
         start_sequence: Option<i64>,
@@ -92,7 +93,7 @@ pub trait IndexerStore {
         is_descending: bool,
     ) -> Result<Vec<Transaction>, IndexerError>;
 
-    fn get_transaction_page_by_transaction_kind(
+    async fn get_transaction_page_by_transaction_kind(
         &self,
         kind: String,
         start_sequence: Option<i64>,
@@ -100,7 +101,7 @@ pub trait IndexerStore {
         is_descending: bool,
     ) -> Result<Vec<Transaction>, IndexerError>;
 
-    fn get_transaction_page_by_sender_address(
+    async fn get_transaction_page_by_sender_address(
         &self,
         sender_address: String,
         start_sequence: Option<i64>,
@@ -108,7 +109,7 @@ pub trait IndexerStore {
         is_descending: bool,
     ) -> Result<Vec<Transaction>, IndexerError>;
 
-    fn get_transaction_page_by_mutated_object(
+    async fn get_transaction_page_by_mutated_object(
         &self,
         object_id: String,
         start_sequence: Option<i64>,
@@ -116,7 +117,7 @@ pub trait IndexerStore {
         is_descending: bool,
     ) -> Result<Vec<Transaction>, IndexerError>;
 
-    fn get_transaction_page_by_sender_recipient_address(
+    async fn get_transaction_page_by_sender_recipient_address(
         &self,
         sender_address: Option<String>,
         recipient_address: String,
@@ -125,7 +126,7 @@ pub trait IndexerStore {
         is_descending: bool,
     ) -> Result<Vec<Transaction>, IndexerError>;
 
-    fn get_transaction_page_by_input_object(
+    async fn get_transaction_page_by_input_object(
         &self,
         object_id: String,
         version: Option<i64>,
@@ -134,7 +135,7 @@ pub trait IndexerStore {
         is_descending: bool,
     ) -> Result<Vec<Transaction>, IndexerError>;
 
-    fn get_transaction_page_by_move_call(
+    async fn get_transaction_page_by_move_call(
         &self,
         package: String,
         module: Option<String>,
@@ -144,45 +145,48 @@ pub trait IndexerStore {
         is_descending: bool,
     ) -> Result<Vec<Transaction>, IndexerError>;
 
-    fn get_transaction_sequence_by_digest(
+    async fn get_transaction_sequence_by_digest(
         &self,
         tx_digest: Option<String>,
         is_descending: bool,
     ) -> Result<Option<i64>, IndexerError>;
 
-    fn get_move_call_sequence_by_digest(
+    async fn get_move_call_sequence_by_digest(
         &self,
         tx_digest: Option<String>,
         is_descending: bool,
     ) -> Result<Option<i64>, IndexerError>;
 
-    fn get_input_object_sequence_by_digest(
+    async fn get_input_object_sequence_by_digest(
         &self,
         tx_digest: Option<String>,
         is_descending: bool,
     ) -> Result<Option<i64>, IndexerError>;
 
-    fn get_recipient_sequence_by_digest(
+    async fn get_recipient_sequence_by_digest(
         &self,
         tx_digest: Option<String>,
         is_descending: bool,
     ) -> Result<Option<i64>, IndexerError>;
 
-    fn get_network_metrics(&self) -> Result<NetworkMetrics, IndexerError>;
-    fn get_move_call_metrics(&self) -> Result<MoveCallMetrics, IndexerError>;
+    async fn get_network_metrics(&self) -> Result<NetworkMetrics, IndexerError>;
+    async fn get_move_call_metrics(&self) -> Result<MoveCallMetrics, IndexerError>;
 
-    fn persist_fast_path(&self, tx: Transaction) -> Result<usize, IndexerError>;
-    fn persist_checkpoint(&self, data: &TemporaryCheckpointStore) -> Result<usize, IndexerError>;
-    fn persist_epoch(&self, data: &TemporaryEpochStore) -> Result<(), IndexerError>;
+    async fn persist_fast_path(&self, tx: Transaction) -> Result<usize, IndexerError>;
+    async fn persist_checkpoint(
+        &self,
+        data: &TemporaryCheckpointStore,
+    ) -> Result<usize, IndexerError>;
+    async fn persist_epoch(&self, data: &TemporaryEpochStore) -> Result<(), IndexerError>;
 
-    fn get_epochs(
+    async fn get_epochs(
         &self,
         cursor: Option<EpochId>,
         limit: usize,
         descending_order: Option<bool>,
     ) -> Result<Vec<EpochInfo>, IndexerError>;
 
-    fn get_current_epoch(&self) -> Result<EpochInfo, IndexerError>;
+    async fn get_current_epoch(&self) -> Result<EpochInfo, IndexerError>;
 
     fn module_cache(&self) -> &Self::ModuleCache;
 }

--- a/crates/sui-indexer/src/store/mod.rs
+++ b/crates/sui-indexer/src/store/mod.rs
@@ -10,9 +10,9 @@ mod pg_indexer_store;
 mod query;
 
 mod diesel_marco {
-    macro_rules! read_only {
+    macro_rules! read_only_blocking {
         ($pool:expr, $query:expr) => {{
-            let mut pg_pool_conn = get_pg_pool_connection($pool)?;
+            let mut pg_pool_conn = crate::get_pg_pool_connection($pool)?;
             pg_pool_conn
                 .build_transaction()
                 .read_only()
@@ -21,17 +21,31 @@ mod diesel_marco {
         }};
     }
 
+    macro_rules! read_only {
+        ($pool:expr, $query:expr) => {{
+            let mut pg_pool_conn = crate::get_async_pg_pool_connection($pool).await?;
+            pg_pool_conn
+                .build_transaction()
+                .read_only()
+                .run($query)
+                .await
+                .map_err(|e| IndexerError::PostgresReadError(e.to_string()))
+        }};
+    }
+
     macro_rules! transactional {
         ($pool:expr, $query:expr) => {{
-            let mut pg_pool_conn = get_pg_pool_connection($pool)?;
+            let mut pg_pool_conn = crate::get_async_pg_pool_connection($pool).await?;
             pg_pool_conn
                 .build_transaction()
                 .serializable()
                 .read_write()
                 .run($query)
+                .await
                 .map_err(|e| IndexerError::PostgresWriteError(e.to_string()))
         }};
     }
     pub(crate) use read_only;
+    pub(crate) use read_only_blocking;
     pub(crate) use transactional;
 }

--- a/crates/sui-indexer/src/store/module_resolver.rs
+++ b/crates/sui-indexer/src/store/module_resolver.rs
@@ -11,8 +11,8 @@ use move_core_types::resolver::ModuleResolver;
 use sui_types::base_types::ObjectID;
 
 use crate::errors::{Context, IndexerError};
-use crate::store::diesel_marco::read_only;
-use crate::{get_pg_pool_connection, PgConnectionPool};
+use crate::store::diesel_marco::read_only_blocking;
+use crate::PgConnectionPool;
 
 pub struct IndexerModuleResolver {
     cp: PgConnectionPool,
@@ -42,7 +42,8 @@ impl ModuleResolver for IndexerModuleResolver {
         let package_id = ObjectID::from(*id.address()).to_string();
         let module_name = id.name().to_string();
 
-        let module_bytes = read_only!(&self.cp, |conn| {
+        // TODO: do we need to make this async?
+        let module_bytes = read_only_blocking!(&self.cp, |conn| {
             diesel::sql_query(LATEST_MODULE_QUERY)
                 .bind::<Text, _>(package_id)
                 .bind::<Text, _>(module_name)

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -7,20 +7,21 @@ use std::sync::Arc;
 
 use anyhow::anyhow;
 use async_trait::async_trait;
+use cached::proc_macro::once;
 use diesel::dsl::max;
 use diesel::query_builder::AsQuery;
 use diesel::sql_types::{BigInt, VarChar};
 use diesel::upsert::excluded;
+use diesel::QueryDsl;
 use diesel::{ExpressionMethods, PgArrayExpressionMethods};
 use diesel::{OptionalExtension, QueryableByName};
-use diesel::{QueryDsl, RunQueryDsl};
+use diesel_async::RunQueryDsl;
 use fastcrypto::hash::Digest;
 use fastcrypto::traits::ToFromBytes;
 use move_bytecode_utils::module_cache::SyncModuleCache;
 use move_core_types::identifier::Identifier;
 use tracing::info;
 
-use cached::proc_macro::once;
 use sui_json_rpc::{ObjectProvider, ObjectProviderCache};
 use sui_json_rpc_types::{
     CheckpointId, EpochInfo, EventFilter, EventPage, MoveCallMetrics, MoveFunctionName,
@@ -64,7 +65,7 @@ use crate::store::module_resolver::IndexerModuleResolver;
 use crate::store::query::DBFilter;
 use crate::store::{IndexerStore, TemporaryEpochStore};
 use crate::utils::{get_balance_changes_from_effect, get_object_changes};
-use crate::{get_pg_pool_connection, PgConnectionPool};
+use crate::{AsyncPgConnectionPool, PgConnectionPool};
 
 const MAX_EVENT_PAGE_SIZE: usize = 1000;
 const PG_COMMIT_CHUNK_SIZE: usize = 1000;
@@ -89,27 +90,29 @@ struct TempDigestTable {
 
 #[derive(Clone)]
 pub struct PgIndexerStore {
-    cp: PgConnectionPool,
+    cp: AsyncPgConnectionPool,
     partition_manager: PartitionManager,
     module_cache: Arc<SyncModuleCache<IndexerModuleResolver>>,
 }
 
 impl PgIndexerStore {
-    pub fn new(cp: PgConnectionPool) -> Self {
-        let module_cache = Arc::new(SyncModuleCache::new(IndexerModuleResolver::new(cp.clone())));
+    pub async fn new(cp: AsyncPgConnectionPool, blocking_cp: PgConnectionPool) -> Self {
+        let module_cache = Arc::new(SyncModuleCache::new(IndexerModuleResolver::new(
+            blocking_cp.clone(),
+        )));
         PgIndexerStore {
             cp: cp.clone(),
-            partition_manager: PartitionManager::new(cp).unwrap(),
+            partition_manager: PartitionManager::new(cp).await.unwrap(),
             module_cache,
         }
     }
 
-    pub fn get_sui_types_object(
+    pub async fn get_sui_types_object(
         &self,
         object_id: &ObjectID,
         version: &SequenceNumber,
     ) -> Result<sui_types::object::Object, IndexerError> {
-        let pg_object = read_only!(&self.cp, |conn| {
+        let pg_object = read_only!(&self.cp, |conn| Box::pin(async {
             objects_history::dsl::objects_history
                 .select((
                     objects_history::epoch,
@@ -130,7 +133,8 @@ impl PgIndexerStore {
                 .filter(objects_history::object_id.eq(object_id.to_string()))
                 .filter(objects_history::version.eq(version.value() as i64))
                 .first::<Object>(conn)
-        })
+                .await
+        }))
         .context("Failed reading Object from PostgresDB");
         match pg_object {
             Ok(pg_object) => {
@@ -141,12 +145,12 @@ impl PgIndexerStore {
         }
     }
 
-    pub fn find_sui_types_object_lt_or_eq_version(
+    pub async fn find_sui_types_object_lt_or_eq_version(
         &self,
         id: &ObjectID,
         version: &SequenceNumber,
     ) -> Result<Option<sui_types::object::Object>, IndexerError> {
-        let pg_object = read_only!(&self.cp, |conn| {
+        let pg_object = read_only!(&self.cp, |conn| Box::pin(async {
             objects_history::dsl::objects_history
                 .select((
                     objects_history::epoch,
@@ -168,8 +172,9 @@ impl PgIndexerStore {
                 .filter(objects_history::version.le(version.value() as i64))
                 .order_by(objects_history::version.desc())
                 .first::<Object>(conn)
+                .await
                 .optional()
-        })
+        }))
         .context("Failed reading Object before version from PostgresDB");
         match pg_object {
             Ok(Some(pg_object)) => {
@@ -186,31 +191,38 @@ impl PgIndexerStore {
 impl IndexerStore for PgIndexerStore {
     type ModuleCache = SyncModuleCache<IndexerModuleResolver>;
 
-    fn get_latest_checkpoint_sequence_number(&self) -> Result<i64, IndexerError> {
-        read_only!(&self.cp, |conn| {
+    async fn get_latest_checkpoint_sequence_number(&self) -> Result<i64, IndexerError> {
+        read_only!(&self.cp, |conn| Box::pin(async {
             checkpoints_dsl::checkpoints
                 .select(max(checkpoints::sequence_number))
                 .first::<Option<i64>>(conn)
+                .await
                 // -1 to differentiate between no checkpoints and the first checkpoint
                 .map(|o| o.unwrap_or(-1))
-        })
+        }))
         .context("Failed reading latest checkpoint sequence number from PostgresDB")
     }
 
-    fn get_checkpoint(
+    async fn get_checkpoint(
         &self,
         id: CheckpointId,
     ) -> Result<sui_json_rpc_types::Checkpoint, IndexerError> {
-        read_only!(&self.cp, |conn| {
+        read_only!(&self.cp, |conn| Box::pin(async {
             let cp: Checkpoint = match id {
-                CheckpointId::SequenceNumber(seq) => checkpoints_dsl::checkpoints
-                    .filter(checkpoints::sequence_number.eq(<u64>::from(seq) as i64))
-                    .limit(1)
-                    .first(conn),
-                CheckpointId::Digest(digest) => checkpoints_dsl::checkpoints
-                    .filter(checkpoints::checkpoint_digest.eq(digest.base58_encode()))
-                    .limit(1)
-                    .first(conn),
+                CheckpointId::SequenceNumber(seq) => {
+                    checkpoints_dsl::checkpoints
+                        .filter(checkpoints::sequence_number.eq(<u64>::from(seq) as i64))
+                        .limit(1)
+                        .first(conn)
+                        .await
+                }
+                CheckpointId::Digest(digest) => {
+                    checkpoints_dsl::checkpoints
+                        .filter(checkpoints::checkpoint_digest.eq(digest.base58_encode()))
+                        .limit(1)
+                        .first(conn)
+                        .await
+                }
             }?;
             let end_of_epoch_data = if cp.end_of_epoch {
                 let (
@@ -231,7 +243,8 @@ impl IndexerStore for PgIndexerStore {
                         Vec<Option<Vec<u8>>>,
                         Vec<Option<i64>>,
                         Vec<Option<Vec<u8>>>,
-                    )>(conn)?;
+                    )>(conn)
+                    .await?;
 
                 let next_epoch_committee = next_epoch_committee
                     .iter()
@@ -266,34 +279,35 @@ impl IndexerStore for PgIndexerStore {
             } else {
                 None
             };
-
             cp.into_rpc(end_of_epoch_data)
-        })
+        }))
         .context("Failed reading previous checkpoint from PostgresDB")
     }
 
-    fn get_checkpoint_sequence_number(
+    async fn get_checkpoint_sequence_number(
         &self,
         digest: CheckpointDigest,
     ) -> Result<CheckpointSequenceNumber, IndexerError> {
-        Ok(read_only!(&self.cp, |conn| checkpoints_dsl::checkpoints
-            .select(checkpoints::sequence_number)
-            .filter(checkpoints::checkpoint_digest.eq(digest.base58_encode()))
-            .first::<i64>(conn))
+        Ok(read_only!(&self.cp, |conn| Box::pin(
+            checkpoints_dsl::checkpoints
+                .select(checkpoints::sequence_number)
+                .filter(checkpoints::checkpoint_digest.eq(digest.base58_encode()))
+                .first::<i64>(conn)
+        ))
         .context("Failed reading checkpoint seq number from PostgresDB")? as u64)
     }
 
-    fn get_event(&self, id: EventID) -> Result<Event, IndexerError> {
-        read_only!(&self.cp, |conn| {
+    async fn get_event(&self, id: EventID) -> Result<Event, IndexerError> {
+        read_only!(&self.cp, |conn| Box::pin(
             events::table
                 .filter(events::dsl::transaction_digest.eq(id.tx_digest.base58_encode()))
                 .filter(events::dsl::event_sequence.eq(id.event_seq as i64))
                 .first::<Event>(conn)
-        })
+        ))
         .context("Failed reading event from PostgresDB")
     }
 
-    fn get_events(
+    async fn get_events(
         &self,
         query: EventFilter,
         cursor: Option<EventID>,
@@ -345,13 +359,15 @@ impl IndexerStore for PgIndexerStore {
         // fetch one more item to tell if there is next page
         page_limit += 1;
 
-        let pg_cursor = cursor
-            .map(|c| {
-                self.get_event(c)?
-                    .id
-                    .ok_or_else(|| IndexerError::PostgresReadError("Event ID is None".to_string()))
-            })
-            .transpose()?;
+        let pg_cursor =
+            if let Some(cursor) = cursor {
+                Some(self.get_event(cursor).await?.id.ok_or_else(|| {
+                    IndexerError::PostgresReadError("Event ID is None".to_string())
+                })?)
+            } else {
+                None
+            };
+
         let events_vec: Vec<Event> = read_only!(&self.cp, |conn| {
             if let Some(pg_cursor) = pg_cursor {
                 if descending_order {
@@ -365,7 +381,7 @@ impl IndexerStore for PgIndexerStore {
             } else {
                 boxed_query = boxed_query.order(events::id.asc());
             }
-            boxed_query.load(conn)
+            Box::pin(boxed_query.load(conn))
         })
         .context("Failed reading events from PostgresDB")?;
 
@@ -385,21 +401,28 @@ impl IndexerStore for PgIndexerStore {
         })
     }
 
-    fn get_total_transaction_number_from_checkpoints(&self) -> Result<i64, IndexerError> {
+    async fn get_total_transaction_number_from_checkpoints(&self) -> Result<i64, IndexerError> {
         let checkpoint: Checkpoint = read_only!(&self.cp, |conn| {
-            checkpoints_dsl::checkpoints
-                .order(checkpoints_dsl::network_total_transactions.desc())
-                .first::<Checkpoint>(conn)
+            Box::pin(
+                checkpoints_dsl::checkpoints
+                    .order(checkpoints_dsl::network_total_transactions.desc())
+                    .first::<Checkpoint>(conn),
+            )
         })
         .context("Failed reading total transaction number")?;
         Ok(checkpoint.network_total_transactions)
     }
 
-    fn get_transaction_by_digest(&self, tx_digest: &str) -> Result<Transaction, IndexerError> {
+    async fn get_transaction_by_digest(
+        &self,
+        tx_digest: &str,
+    ) -> Result<Transaction, IndexerError> {
         read_only!(&self.cp, |conn| {
-            transactions_dsl::transactions
-                .filter(transactions_dsl::transaction_digest.eq(tx_digest))
-                .first::<Transaction>(conn)
+            Box::pin(
+                transactions_dsl::transactions
+                    .filter(transactions_dsl::transaction_digest.eq(tx_digest))
+                    .first::<Transaction>(conn),
+            )
         })
         .context(&format!(
             "Failed reading transaction with digest {tx_digest}"
@@ -455,12 +478,14 @@ impl IndexerStore for PgIndexerStore {
                 );
             }
             if options.show_events {
-                let event_page = self.get_events(
-                    EventFilter::Transaction(tx_digest),
-                    None,
-                    None,
-                    /* descending_order */ false,
-                )?;
+                let event_page = self
+                    .get_events(
+                        EventFilter::Transaction(tx_digest),
+                        None,
+                        None,
+                        /* descending_order */ false,
+                    )
+                    .await?;
                 events = Some(SuiTransactionBlockEvents {
                     data: event_page.data,
                 });
@@ -491,53 +516,55 @@ impl IndexerStore for PgIndexerStore {
         })
     }
 
-    fn multi_get_transactions_by_digests(
+    async fn multi_get_transactions_by_digests(
         &self,
         tx_digests: &[String],
     ) -> Result<Vec<Transaction>, IndexerError> {
         read_only!(&self.cp, |conn| {
-            transactions_dsl::transactions
-                .filter(transactions_dsl::transaction_digest.eq_any(tx_digests))
-                .load::<Transaction>(conn)
+            Box::pin(
+                transactions_dsl::transactions
+                    .filter(transactions_dsl::transaction_digest.eq_any(tx_digests))
+                    .load::<Transaction>(conn),
+            )
         })
         .context(&format!(
             "Failed reading transactions with digests {tx_digests:?}"
         ))
     }
 
-    fn get_transaction_sequence_by_digest(
+    async fn get_transaction_sequence_by_digest(
         &self,
         tx_digest: Option<String>,
         is_descending: bool,
     ) -> Result<Option<i64>, IndexerError> {
-        read_only!(&self.cp, |conn| {
-            tx_digest
-                .as_ref()
-                .map(|digest| {
-                    let mut boxed_query = transactions_dsl::transactions
-                        .filter(transactions_dsl::transaction_digest.eq(digest))
-                        .select(transactions_dsl::id)
-                        .into_boxed();
-                    if is_descending {
-                        boxed_query = boxed_query.order(transactions_dsl::id.desc());
-                    } else {
-                        boxed_query = boxed_query.order(transactions_dsl::id.asc());
-                    }
-                    boxed_query.first::<i64>(conn)
-                })
-                .transpose()
-        })
+        read_only!(&self.cp, |conn| Box::pin(async {
+            if let Some(digest) = &tx_digest {
+                let mut boxed_query = transactions_dsl::transactions
+                    .filter(transactions_dsl::transaction_digest.eq(digest))
+                    .select(transactions_dsl::id)
+                    .into_boxed();
+                if is_descending {
+                    boxed_query = boxed_query.order(transactions_dsl::id.desc());
+                } else {
+                    boxed_query = boxed_query.order(transactions_dsl::id.asc());
+                }
+                Some(boxed_query.first::<i64>(conn).await)
+            } else {
+                None
+            }
+            .transpose()
+        }))
         .context(&format!(
             "Failed reading transaction sequence with digest {tx_digest:?}"
         ))
     }
 
-    fn get_object(
+    async fn get_object(
         &self,
         object_id: ObjectID,
         version: Option<SequenceNumber>,
     ) -> Result<ObjectRead, IndexerError> {
-        let object = read_only!(&self.cp, |conn| {
+        let object = read_only!(&self.cp, |conn| Box::pin(async {
             if let Some(version) = version {
                 objects_history::dsl::objects_history
                     .select((
@@ -559,14 +586,16 @@ impl IndexerStore for PgIndexerStore {
                     .filter(objects_history::object_id.eq(object_id.to_string()))
                     .filter(objects_history::version.eq(version.value() as i64))
                     .get_result::<Object>(conn)
+                    .await
                     .optional()
             } else {
                 objects_dsl::objects
                     .filter(objects_dsl::object_id.eq(object_id.to_string()))
                     .first::<Object>(conn)
+                    .await
                     .optional()
             }
-        })
+        }))
         .context(&format!("Failed reading object with id {object_id}"))?;
 
         match object {
@@ -575,14 +604,14 @@ impl IndexerStore for PgIndexerStore {
         }
     }
 
-    fn query_objects(
+    async fn query_objects(
         &self,
         filter: SuiObjectDataFilter,
         at_checkpoint: CheckpointSequenceNumber,
         cursor: Option<ObjectID>,
         limit: usize,
     ) -> Result<Vec<ObjectRead>, IndexerError> {
-        let objects = read_only!(&self.cp, |conn| {
+        let objects = read_only!(&self.cp, |conn| Box::pin(async {
             let columns = vec![
                 "epoch",
                 "checkpoint",
@@ -602,7 +631,8 @@ impl IndexerStore for PgIndexerStore {
             diesel::sql_query(filter.to_sql(cursor, limit, columns))
                 .bind::<BigInt, _>(at_checkpoint as i64)
                 .get_results::<Object>(conn)
-        })?;
+                .await
+        }))?;
 
         objects
             .into_iter()
@@ -610,85 +640,88 @@ impl IndexerStore for PgIndexerStore {
             .collect()
     }
 
-    fn get_move_call_sequence_by_digest(
+    async fn get_move_call_sequence_by_digest(
         &self,
         tx_digest: Option<String>,
         is_descending: bool,
     ) -> Result<Option<i64>, IndexerError> {
-        read_only!(&self.cp, |conn| {
-            tx_digest
-                .as_ref()
-                .map(|digest| {
-                    let mut boxed_query = move_calls_dsl::move_calls
-                        .filter(move_calls_dsl::transaction_digest.eq(digest))
-                        .into_boxed();
-                    if is_descending {
-                        boxed_query = boxed_query.order(move_calls_dsl::id.desc());
-                    } else {
-                        boxed_query = boxed_query.order(move_calls_dsl::id.asc());
-                    }
-                    boxed_query.select(move_calls_dsl::id).first::<i64>(conn)
-                })
-                .transpose()
-        })
+        read_only!(&self.cp, |conn| Box::pin(async {
+            if let Some(digest) = &tx_digest {
+                let mut boxed_query = move_calls_dsl::move_calls
+                    .filter(move_calls_dsl::transaction_digest.eq(digest))
+                    .select(move_calls_dsl::id)
+                    .into_boxed();
+                if is_descending {
+                    boxed_query = boxed_query.order(move_calls_dsl::id.desc());
+                } else {
+                    boxed_query = boxed_query.order(move_calls_dsl::id.asc());
+                }
+                Some(boxed_query.first::<i64>(conn).await)
+            } else {
+                None
+            }
+            .transpose()
+        }))
         .context(&format!(
             "Failed reading move call sequence with digest {tx_digest:?}"
         ))
     }
 
-    fn get_input_object_sequence_by_digest(
+    async fn get_input_object_sequence_by_digest(
         &self,
         tx_digest: Option<String>,
         is_descending: bool,
     ) -> Result<Option<i64>, IndexerError> {
-        read_only!(&self.cp, |conn| {
-            tx_digest
-                .as_ref()
-                .map(|digest| {
-                    let mut boxed_query = input_objects_dsl::input_objects
-                        .filter(input_objects_dsl::transaction_digest.eq(digest))
-                        .into_boxed();
-                    if is_descending {
-                        boxed_query = boxed_query.order(input_objects_dsl::id.desc());
-                    } else {
-                        boxed_query = boxed_query.order(input_objects_dsl::id.asc());
-                    }
-                    boxed_query.select(input_objects_dsl::id).first::<i64>(conn)
-                })
-                .transpose()
-        })
+        read_only!(&self.cp, |conn| Box::pin(async {
+            if let Some(digest) = &tx_digest {
+                let mut boxed_query = input_objects_dsl::input_objects
+                    .filter(input_objects_dsl::transaction_digest.eq(digest))
+                    .select(input_objects_dsl::id)
+                    .into_boxed();
+                if is_descending {
+                    boxed_query = boxed_query.order(input_objects_dsl::id.desc());
+                } else {
+                    boxed_query = boxed_query.order(input_objects_dsl::id.asc());
+                }
+                Some(boxed_query.first::<i64>(conn).await)
+            } else {
+                None
+            }
+            .transpose()
+        }))
         .context(&format!(
             "Failed reading input object sequence with digest {tx_digest:?}"
         ))
     }
 
-    fn get_recipient_sequence_by_digest(
+    async fn get_recipient_sequence_by_digest(
         &self,
         tx_digest: Option<String>,
         is_descending: bool,
     ) -> Result<Option<i64>, IndexerError> {
-        read_only!(&self.cp, |conn| {
-            tx_digest
-                .as_ref()
-                .map(|tx_digest| {
-                    let mut boxed_query = recipients_dsl::recipients
-                        .filter(recipients_dsl::transaction_digest.eq(tx_digest))
-                        .into_boxed();
-                    if is_descending {
-                        boxed_query = boxed_query.order(recipients_dsl::id.desc());
-                    } else {
-                        boxed_query = boxed_query.order(recipients_dsl::id.asc());
-                    }
-                    boxed_query.select(recipients_dsl::id).first::<i64>(conn)
-                })
-                .transpose()
-        })
+        read_only!(&self.cp, |conn| Box::pin(async {
+            if let Some(digest) = &tx_digest {
+                let mut boxed_query = recipients_dsl::recipients
+                    .filter(recipients_dsl::transaction_digest.eq(digest))
+                    .select(recipients_dsl::id)
+                    .into_boxed();
+                if is_descending {
+                    boxed_query = boxed_query.order(recipients_dsl::id.desc());
+                } else {
+                    boxed_query = boxed_query.order(recipients_dsl::id.asc());
+                }
+                Some(boxed_query.first::<i64>(conn).await)
+            } else {
+                None
+            }
+            .transpose()
+        }))
         .context(&format!(
             "Failed reading recipients sequence with digest {tx_digest:?}"
         ))
     }
 
-    fn get_all_transaction_page(
+    async fn get_all_transaction_page(
         &self,
         start_sequence: Option<i64>,
         limit: usize,
@@ -705,20 +738,20 @@ impl IndexerStore for PgIndexerStore {
             }
 
             if is_descending {
-                boxed_query
+                Box::pin(boxed_query
                     .order(transactions_dsl::id.desc())
                     .limit((limit) as i64)
-                    .load::<Transaction>(conn)
+                    .load::<Transaction>(conn))
             } else {
-                boxed_query
+              Box::pin(  boxed_query
                     .order(transactions_dsl::id.asc())
                     .limit((limit) as i64)
-                    .load::<Transaction>(conn)
+                    .load::<Transaction>(conn))
             }
         }).context(&format!("Failed reading all transaction digests with start_sequence {start_sequence:?} and limit {limit}"))
     }
 
-    fn get_transaction_page_by_checkpoint(
+    async fn get_transaction_page_by_checkpoint(
         &self,
         checkpoint_sequence_number: i64,
         start_sequence: Option<i64>,
@@ -737,20 +770,20 @@ impl IndexerStore for PgIndexerStore {
                 }
             }
             if is_descending {
-                boxed_query
+                Box::pin(boxed_query
                     .order(transactions_dsl::id.desc())
                     .limit((limit) as i64)
-                    .load::<Transaction>(conn)
+                    .load::<Transaction>(conn))
             } else {
-                boxed_query
+                Box::pin(boxed_query
                     .order(transactions_dsl::id.asc())
                     .limit((limit) as i64)
-                    .load::<Transaction>(conn)
+                    .load::<Transaction>(conn))
             }
         }).context(&format!("Failed reading transaction digests with checkpoint_sequence_number {checkpoint_sequence_number:?} and start_sequence {start_sequence:?} and limit {limit}"))
     }
 
-    fn get_transaction_page_by_transaction_kind(
+    async fn get_transaction_page_by_transaction_kind(
         &self,
         kind: String,
         start_sequence: Option<i64>,
@@ -770,20 +803,20 @@ impl IndexerStore for PgIndexerStore {
             }
 
             if is_descending {
-                boxed_query
+                Box::pin(boxed_query
                     .order(transactions_dsl::id.desc())
                     .limit((limit) as i64)
-                    .load::<Transaction>(conn)
+                    .load::<Transaction>(conn))
             } else {
-                boxed_query
+               Box::pin( boxed_query
                     .order(transactions_dsl::id.asc())
                     .limit((limit) as i64)
-                    .load::<Transaction>(conn)
+                    .load::<Transaction>(conn))
             }
         }).context(&format!("Failed reading transaction digests with kind {kind} and start_sequence {start_sequence:?} and limit {limit}"))
     }
 
-    fn get_transaction_page_by_mutated_object(
+    async fn get_transaction_page_by_mutated_object(
         &self,
         object_id: String,
         start_sequence: Option<i64>,
@@ -804,20 +837,20 @@ impl IndexerStore for PgIndexerStore {
                 }
             }
             if is_descending {
-                boxed_query
+                Box::pin(boxed_query
                     .order(transactions_dsl::id.desc())
                     .limit(limit as i64)
-                    .load::<Transaction>(conn)
+                    .load::<Transaction>(conn))
             } else {
-                boxed_query
+              Box::pin(  boxed_query
                     .order(transactions_dsl::id.asc())
                     .limit(limit as i64)
-                    .load::<Transaction>(conn)
+                    .load::<Transaction>(conn))
             }
         }).context(&format!("Failed reading transaction digests by mutated object id {object_id} with start_sequence {start_sequence:?} and limit {limit}"))
     }
 
-    fn get_transaction_page_by_sender_address(
+    async fn get_transaction_page_by_sender_address(
         &self,
         sender_address: String,
         start_sequence: Option<i64>,
@@ -837,20 +870,20 @@ impl IndexerStore for PgIndexerStore {
             }
 
             if is_descending {
-                boxed_query
+                Box::pin(boxed_query
                     .order(transactions_dsl::id.desc())
                     .limit(limit as i64)
-                    .load::<Transaction>(conn)
+                    .load::<Transaction>(conn))
             } else {
-                boxed_query
+               Box::pin( boxed_query
                     .order(transactions_dsl::id.asc())
                     .limit(limit as i64)
-                    .load::<Transaction>(conn)
+                    .load::<Transaction>(conn))
             }
         }).context(&format!("Failed reading transaction digests by sender address {sender_address} with start_sequence {start_sequence:?} and limit {limit}"))
     }
 
-    fn get_transaction_page_by_input_object(
+    async fn get_transaction_page_by_input_object(
         &self,
         object_id: String,
         version: Option<i64>,
@@ -884,15 +917,15 @@ impl IndexerStore for PgIndexerStore {
             if is_descending { "DESC" } else { "ASC" },
             limit
         );
-        let tx_digests: Vec<String> = read_only!(&self.cp, |conn| diesel::sql_query(sql_query).load(conn))
+        let tx_digests: Vec<String> = read_only!(&self.cp, |conn| Box::pin(diesel::sql_query(sql_query).load(conn)))
                 .context(&format!("Failed reading transaction digests by input object ID {object_id} and version {version:?} with start_sequence {start_sequence:?} and limit {limit}"))?
                 .into_iter()
                 .map(|table: TempDigestTable| table.digest_name)
                 .collect();
-        self.multi_get_transactions_by_digests(&tx_digests)
+        self.multi_get_transactions_by_digests(&tx_digests).await
     }
 
-    fn get_transaction_page_by_move_call(
+    async fn get_transaction_page_by_move_call(
         &self,
         package_name: String,
         module_name: Option<String>,
@@ -932,17 +965,17 @@ impl IndexerStore for PgIndexerStore {
             if is_descending { "DESC" } else { "ASC" },
             limit
         );
-        let tx_digests: Vec<String> = read_only!(&self.cp, |conn| diesel::sql_query(sql_query).load(conn))
+        let tx_digests: Vec<String> = read_only!(&self.cp, |conn| Box::pin(diesel::sql_query(sql_query).load(conn)))
                 .context(&format!(
                         "Failed reading transaction digests with package_name {} module_name {:?} and function_name {:?} and start_sequence {:?} and limit {}",
                         package_name, module_name, function_name, start_sequence, limit))?
                 .into_iter()
                 .map(|table: TempDigestTable| table.digest_name)
                 .collect();
-        self.multi_get_transactions_by_digests(&tx_digests)
+        self.multi_get_transactions_by_digests(&tx_digests).await
     }
 
-    fn get_transaction_page_by_sender_recipient_address(
+    async fn get_transaction_page_by_sender_recipient_address(
         &self,
         from: Option<String>,
         to: String,
@@ -975,22 +1008,24 @@ impl IndexerStore for PgIndexerStore {
             if is_descending { "DESC" } else { "ASC" },
             limit
         );
-        let tx_digests: Vec<String> = read_only!(&self.cp, |conn| { diesel::sql_query(sql_query).load(conn) })
+        let tx_digests: Vec<String> = read_only!(&self.cp, |conn| { Box::pin(diesel::sql_query(sql_query).load(conn)) })
                 .context(&format!("Failed reading transaction digests by recipient address {to} with start_sequence {start_sequence:?} and limit {limit}"))?
                 .into_iter()
                 .map(|table: TempDigestTable| table.digest_name)
                 .collect();
-        self.multi_get_transactions_by_digests(&tx_digests)
+        self.multi_get_transactions_by_digests(&tx_digests).await
     }
 
-    fn get_network_metrics(&self) -> Result<NetworkMetrics, IndexerError> {
-        get_network_metrics_cached(&self.cp)
+    async fn get_network_metrics(&self) -> Result<NetworkMetrics, IndexerError> {
+        get_network_metrics_cached(&self.cp).await
     }
 
-    fn get_move_call_metrics(&self) -> Result<MoveCallMetrics, IndexerError> {
+    async fn get_move_call_metrics(&self) -> Result<MoveCallMetrics, IndexerError> {
         let metrics = read_only!(&self.cp, |conn| {
-            diesel::sql_query("SELECT * FROM epoch_move_call_metrics;")
-                .get_results::<DBMoveCallMetrics>(conn)
+            Box::pin(
+                diesel::sql_query("SELECT * FROM epoch_move_call_metrics;")
+                    .get_results::<DBMoveCallMetrics>(conn),
+            )
         })?;
 
         let mut d3 = vec![];
@@ -1021,18 +1056,22 @@ impl IndexerStore for PgIndexerStore {
         })
     }
 
-    fn persist_fast_path(&self, tx: Transaction) -> Result<usize, IndexerError> {
-        transactional!(&self.cp, |conn| {
+    async fn persist_fast_path(&self, tx: Transaction) -> Result<usize, IndexerError> {
+        transactional!(&self.cp, |conn| Box::pin(async {
             diesel::insert_into(transactions::table)
                 .values(vec![tx])
                 .on_conflict_do_nothing()
                 .execute(conn)
+                .await
                 .map_err(IndexerError::from)
                 .context("Failed writing transactions to PostgresDB")
-        })
+        }))
     }
 
-    fn persist_checkpoint(&self, data: &TemporaryCheckpointStore) -> Result<usize, IndexerError> {
+    async fn persist_checkpoint(
+        &self,
+        data: &TemporaryCheckpointStore,
+    ) -> Result<usize, IndexerError> {
         let TemporaryCheckpointStore {
             checkpoint,
             transactions,
@@ -1045,7 +1084,7 @@ impl IndexerStore for PgIndexerStore {
             recipients,
         } = data;
 
-        transactional!(&self.cp, |conn| {
+        transactional!(&self.cp, |conn| Box::pin(async {
             // Commit indexed transactions
             for transaction_chunk in transactions.chunks(PG_COMMIT_CHUNK_SIZE) {
                 diesel::insert_into(transactions::table)
@@ -1058,6 +1097,7 @@ impl IndexerStore for PgIndexerStore {
                             .eq(excluded(transactions::checkpoint_sequence_number)),
                     ))
                     .execute(conn)
+                    .await
                     .map_err(IndexerError::from)
                     .context("Failed writing transactions to PostgresDB")?;
             }
@@ -1068,6 +1108,7 @@ impl IndexerStore for PgIndexerStore {
                     .values(event_chunk)
                     .on_conflict_do_nothing()
                     .execute(conn)
+                    .await
                     .map_err(IndexerError::from)
                     .context("Failed writing events to PostgresDB")?;
             }
@@ -1091,7 +1132,7 @@ impl IndexerStore for PgIndexerStore {
                 // bulk insert/update via UNNEST trick
                 let insert_update_query =
                     compose_object_bulk_insert_update_query(&mutated_object_group);
-                diesel::sql_query(insert_update_query).execute(conn)?;
+                diesel::sql_query(insert_update_query).execute(conn).await?;
             }
             // TODO(gegao): monitor the deletion batch size to see
             // if bulk update via unnest is necessary.
@@ -1116,6 +1157,7 @@ impl IndexerStore for PgIndexerStore {
                         objects::object_status.eq(excluded(objects::object_status)),
                     ))
                     .execute(conn)
+                    .await
                     .map_err(IndexerError::from)
                     .context(&format!(
                         "Failed writing deleted objects to PostgresDB with chunk: {:?}",
@@ -1130,6 +1172,7 @@ impl IndexerStore for PgIndexerStore {
                     .on_conflict(addresses::account_address)
                     .do_nothing()
                     .execute(conn)
+                    .await
                     .map_err(IndexerError::from)
                     .context("Failed writing addresses to PostgresDB")?;
             }
@@ -1140,6 +1183,7 @@ impl IndexerStore for PgIndexerStore {
                     .values(packages_chunk)
                     .on_conflict_do_nothing()
                     .execute(conn)
+                    .await
                     .map_err(IndexerError::from)
                     .context("Failed writing packages to PostgresDB")?;
             }
@@ -1150,6 +1194,7 @@ impl IndexerStore for PgIndexerStore {
                     .values(move_calls_chunk)
                     .on_conflict_do_nothing()
                     .execute(conn)
+                    .await
                     .map_err(IndexerError::from)
                     .context("Failed writing move_calls to PostgresDB")?;
             }
@@ -1160,6 +1205,7 @@ impl IndexerStore for PgIndexerStore {
                     .values(input_objects_chunk)
                     .on_conflict_do_nothing()
                     .execute(conn)
+                    .await
                     .map_err(IndexerError::from)
                     .context("Failed writing input_objects to PostgresDB")?;
             }
@@ -1170,6 +1216,7 @@ impl IndexerStore for PgIndexerStore {
                     .values(recipients_chunk)
                     .on_conflict_do_nothing()
                     .execute(conn)
+                    .await
                     .map_err(IndexerError::from)
                     .context("Failed writing recipients to PostgresDB")?;
             }
@@ -1184,84 +1231,80 @@ WHERE e1.epoch = e2.epoch
                 .bind::<BigInt, _>(checkpoint.transactions.len() as i64)
                 .bind::<BigInt, _>(checkpoint.epoch)
                 .as_query()
-                .execute(conn)?;
+                .execute(conn)
+                .await?;
             // Commit indexed checkpoint last, so that if the checkpoint is committed,
             // all related data have been committed as well.
             diesel::insert_into(checkpoints::table)
                 .values(checkpoint)
                 .on_conflict_do_nothing()
                 .execute(conn)
+                .await
                 .map_err(IndexerError::from)
                 .context("Failed writing checkpoint to PostgresDB")
-        })
+        }))
     }
 
-    fn persist_epoch(&self, data: &TemporaryEpochStore) -> Result<(), IndexerError> {
+    async fn persist_epoch(&self, data: &TemporaryEpochStore) -> Result<(), IndexerError> {
         let last_epoch_cp_id = if data.last_epoch.is_none() {
             0
         } else {
-            self.get_current_epoch()?.first_checkpoint_id as i64
+            self.get_current_epoch().await?.first_checkpoint_id as i64
         };
 
         self.partition_manager
-            .advance_epoch(&data.new_epoch, last_epoch_cp_id)?;
-        let mut pg_pool_conn = get_pg_pool_connection(&self.cp)?;
-        pg_pool_conn
-            .build_transaction()
-            .serializable()
-            .read_write()
-            .run(|conn| {
-                if let Some(last_epoch) = &data.last_epoch {
-                    diesel::insert_into(epochs::table)
-                        .values(last_epoch)
-                        .on_conflict(epochs::epoch)
-                        .do_update()
-                        .set((
-                            epochs::last_checkpoint_id.eq(excluded(epochs::last_checkpoint_id)),
-                            epochs::epoch_end_timestamp.eq(excluded(epochs::epoch_end_timestamp)),
-                            epochs::protocol_version.eq(excluded(epochs::protocol_version)),
-                            epochs::next_epoch_version.eq(excluded(epochs::next_epoch_version)),
-                            epochs::next_epoch_committee.eq(excluded(epochs::next_epoch_committee)),
-                            epochs::next_epoch_committee_stake
-                                .eq(excluded(epochs::next_epoch_committee_stake)),
-                            epochs::epoch_commitments.eq(excluded(epochs::epoch_commitments)),
-                            epochs::reference_gas_price.eq(excluded(epochs::reference_gas_price)),
-                            epochs::total_stake.eq(excluded(epochs::total_stake)),
-                            epochs::storage_fund_reinvestment
-                                .eq(excluded(epochs::storage_fund_reinvestment)),
-                            epochs::storage_charge.eq(excluded(epochs::storage_charge)),
-                            epochs::storage_rebate.eq(excluded(epochs::storage_rebate)),
-                            epochs::storage_fund_balance.eq(excluded(epochs::storage_fund_balance)),
-                            epochs::stake_subsidy_amount.eq(excluded(epochs::stake_subsidy_amount)),
-                            epochs::total_gas_fees.eq(excluded(epochs::total_gas_fees)),
-                            epochs::total_stake_rewards_distributed
-                                .eq(excluded(epochs::total_stake_rewards_distributed)),
-                            epochs::leftover_storage_fund_inflow
-                                .eq(excluded(epochs::leftover_storage_fund_inflow)),
-                        ))
-                        .execute(conn)?;
-                }
+            .advance_epoch(&data.new_epoch, last_epoch_cp_id)
+            .await?;
+        transactional!(&self.cp, |conn| Box::pin(async {
+            if let Some(last_epoch) = &data.last_epoch {
                 diesel::insert_into(epochs::table)
-                    .values(&data.new_epoch)
-                    .on_conflict_do_nothing()
-                    .execute(conn)?;
-
-                diesel::insert_into(system_states::table)
-                    .values(&data.system_state)
-                    .on_conflict_do_nothing()
-                    .execute(conn)?;
-
-                diesel::insert_into(validators::table)
-                    .values(&data.validators)
-                    .on_conflict_do_nothing()
+                    .values(last_epoch)
+                    .on_conflict(epochs::epoch)
+                    .do_update()
+                    .set((
+                        epochs::last_checkpoint_id.eq(excluded(epochs::last_checkpoint_id)),
+                        epochs::epoch_end_timestamp.eq(excluded(epochs::epoch_end_timestamp)),
+                        epochs::protocol_version.eq(excluded(epochs::protocol_version)),
+                        epochs::next_epoch_version.eq(excluded(epochs::next_epoch_version)),
+                        epochs::next_epoch_committee.eq(excluded(epochs::next_epoch_committee)),
+                        epochs::next_epoch_committee_stake
+                            .eq(excluded(epochs::next_epoch_committee_stake)),
+                        epochs::epoch_commitments.eq(excluded(epochs::epoch_commitments)),
+                        epochs::reference_gas_price.eq(excluded(epochs::reference_gas_price)),
+                        epochs::total_stake.eq(excluded(epochs::total_stake)),
+                        epochs::storage_fund_reinvestment
+                            .eq(excluded(epochs::storage_fund_reinvestment)),
+                        epochs::storage_charge.eq(excluded(epochs::storage_charge)),
+                        epochs::storage_rebate.eq(excluded(epochs::storage_rebate)),
+                        epochs::storage_fund_balance.eq(excluded(epochs::storage_fund_balance)),
+                        epochs::stake_subsidy_amount.eq(excluded(epochs::stake_subsidy_amount)),
+                        epochs::total_gas_fees.eq(excluded(epochs::total_gas_fees)),
+                        epochs::total_stake_rewards_distributed
+                            .eq(excluded(epochs::total_stake_rewards_distributed)),
+                        epochs::leftover_storage_fund_inflow
+                            .eq(excluded(epochs::leftover_storage_fund_inflow)),
+                    ))
                     .execute(conn)
-            })
-            .map_err(|e| {
-                IndexerError::PostgresWriteError(format!(
-                    "Failed writing epoch to PostgresDB with error: {:?}",
-                    e
-                ))
-            })?;
+                    .await?;
+            }
+            diesel::insert_into(epochs::table)
+                .values(&data.new_epoch)
+                .on_conflict_do_nothing()
+                .execute(conn)
+                .await?;
+
+            diesel::insert_into(system_states::table)
+                .values(&data.system_state)
+                .on_conflict_do_nothing()
+                .execute(conn)
+                .await?;
+
+            diesel::insert_into(validators::table)
+                .values(&data.validators)
+                .on_conflict_do_nothing()
+                .execute(conn)
+                .await
+        }))?;
         Ok(())
     }
 
@@ -1269,7 +1312,7 @@ WHERE e1.epoch = e2.epoch
         &self.module_cache
     }
 
-    fn get_epochs(
+    async fn get_epochs(
         &self,
         cursor: Option<EpochId>,
         limit: usize,
@@ -1279,7 +1322,6 @@ WHERE e1.epoch = e2.epoch
         let id = cursor
             .map(|id| id as i64)
             .unwrap_or(if is_descending { i64::MAX } else { -1 });
-        let mut pg_pool_conn = get_pg_pool_connection(&self.cp)?;
         let mut query = epochs_dsl::epochs.into_boxed();
         if is_descending {
             query = query
@@ -1291,29 +1333,29 @@ WHERE e1.epoch = e2.epoch
                 .order_by(epochs::epoch.asc());
         }
 
-        let epoch_info :Vec<DBEpochInfo> = pg_pool_conn
-            .build_transaction()
-            .read_only()
-            .run(|conn| query.limit(limit as i64).load(conn))
-            .map_err(|e| {
-                IndexerError::PostgresReadError(format!(
-                    "Failed reading latest checkpoint sequence number in PostgresDB with error {:?}",
-                    e
-                ))
-            })?;
+        let epoch_info: Vec<DBEpochInfo> = read_only!(&self.cp, |conn| Box::pin(
+            query.limit(limit as i64).load(conn)
+        ))
+        .map_err(|e| {
+            IndexerError::PostgresReadError(format!(
+                "Failed reading latest checkpoint sequence number in PostgresDB with error {:?}",
+                e
+            ))
+        })?;
 
-        let validators : Vec<DBValidatorSummary> = pg_pool_conn
-            .build_transaction()
-            .read_only()
-            .run(|conn| {
-                validators::dsl::validators.filter(validators::epoch.gt(id)).load(conn)
-            })
-            .map_err(|e| {
-                IndexerError::PostgresReadError(format!(
-                    "Failed reading latest checkpoint sequence number in PostgresDB with error {:?}",
-                    e
-                ))
-            })?;
+        let validators: Vec<DBValidatorSummary> = read_only!(&self.cp, |conn| {
+            Box::pin(
+                validators::dsl::validators
+                    .filter(validators::epoch.gt(id))
+                    .load(conn),
+            )
+        })
+        .map_err(|e| {
+            IndexerError::PostgresReadError(format!(
+                "Failed reading latest checkpoint sequence number in PostgresDB with error {:?}",
+                e
+            ))
+        })?;
 
         let mut validators =
             validators
@@ -1332,37 +1374,22 @@ WHERE e1.epoch = e2.epoch
             .collect()
     }
 
-    fn get_current_epoch(&self) -> Result<EpochInfo, IndexerError> {
-        let mut pg_pool_conn = get_pg_pool_connection(&self.cp)?;
-        let epoch_info: DBEpochInfo = pg_pool_conn
-            .build_transaction()
-            .read_only()
-            .run(|conn| {
-                epochs::dsl::epochs
-                    .order_by(epochs::epoch.desc())
-                    .first::<DBEpochInfo>(conn)
-            })
-            .map_err(|e| {
-                IndexerError::PostgresReadError(format!(
-                    "Failed reading latest epoch in PostgresDB with error {:?}",
-                    e
-                ))
-            })?;
+    async fn get_current_epoch(&self) -> Result<EpochInfo, IndexerError> {
+        let epoch_info: DBEpochInfo = read_only!(&self.cp, |conn| Box::pin(async {
+            epochs::dsl::epochs
+                .order_by(epochs::epoch.desc())
+                .first::<DBEpochInfo>(conn)
+                .await
+        }))
+        .context("Failed reading latest epoch")?;
 
-        let validators: Vec<DBValidatorSummary> = pg_pool_conn
-            .build_transaction()
-            .read_only()
-            .run(|conn| {
-                validators::dsl::validators
-                    .filter(validators::epoch.eq(epoch_info.epoch))
-                    .load(conn)
-            })
-            .map_err(|e| {
-                IndexerError::PostgresReadError(format!(
-                    "Failed reading latest validator summary in PostgresDB with error {:?}",
-                    e
-                ))
-            })?;
+        let validators: Vec<DBValidatorSummary> = read_only!(&self.cp, |conn| Box::pin(async {
+            validators::dsl::validators
+                .filter(validators::epoch.eq(epoch_info.epoch))
+                .load(conn)
+                .await
+        }))
+        .context("Failed reading latest validator summary")?;
 
         epoch_info.to_epoch_info(validators)
     }
@@ -1370,14 +1397,14 @@ WHERE e1.epoch = e2.epoch
 
 #[derive(Clone)]
 struct PartitionManager {
-    cp: PgConnectionPool,
+    cp: AsyncPgConnectionPool,
 }
 
 impl PartitionManager {
-    fn new(cp: PgConnectionPool) -> Result<Self, IndexerError> {
+    async fn new(cp: AsyncPgConnectionPool) -> Result<Self, IndexerError> {
         // Find all tables with partition
         let manager = Self { cp };
-        let tables = manager.get_table_partitions()?;
+        let tables = manager.get_table_partitions().await?;
         info!(
             "Found {} tables with partitions : [{:?}]",
             tables.len(),
@@ -1386,7 +1413,7 @@ impl PartitionManager {
         Ok(manager)
     }
 
-    fn advance_epoch(
+    async fn advance_epoch(
         &self,
         new_epoch: &DBEpochInfo,
         last_epoch_start_cp: i64,
@@ -1395,8 +1422,37 @@ impl PartitionManager {
         let last_epoch_id = new_epoch.epoch - 1;
         let next_epoch_start_cp = new_epoch.first_checkpoint_id;
 
-        let tables = self.get_table_partitions()?;
-        let table_updated = transactional!(&self.cp, |conn| {
+        let tables = self.get_table_partitions().await?;
+
+        /* let mut pg_pool_conn = crate::get_async_pg_pool_connection(&self.cp).await?;
+                let table_updated = pg_pool_conn
+                    .build_transaction()
+                    .serializable()
+                    .read_write()
+                    .run(|conn| Box::pin(async {
+                        let mut updated_table = vec![];
+                        for (table, last_partition) in &tables {
+                            if last_partition < &(next_epoch_id as u64) {
+                                let detach_partition = format!(
+                                    "ALTER TABLE {table} DETACH PARTITION {table}_partition_{last_epoch_id};"
+                                );
+                                let attach_partition_with_new_range = format!("ALTER TABLE {table} ATTACH PARTITION {table}_partition_{last_epoch_id} FOR VALUES FROM ('{last_epoch_start_cp}') TO ('{next_epoch_start_cp}');");
+                                let new_partition = format!("CREATE TABLE {table}_partition_{next_epoch_id} PARTITION OF {table} FOR VALUES FROM ({next_epoch_start_cp}) TO (MAXVALUE);");
+                                diesel::sql_query(detach_partition).execute(conn).await?;
+                                diesel::sql_query(attach_partition_with_new_range)
+                                    .execute(conn)
+                                    .await?;
+                                diesel::sql_query(new_partition).execute(conn).await?;
+                                updated_table.push(table.clone());
+                            }
+                        }
+                        Ok::<_, diesel::result::Error>(updated_table)
+
+                    }))
+                    .await
+                    .map_err(|e| IndexerError::PostgresWriteError(e.to_string()))?;
+        */
+        let table_updated = transactional!(&self.cp, |conn| Box::pin(async {
             let mut updated_table = vec![];
             for (table, last_partition) in &tables {
                 if last_partition < &(next_epoch_id as u64) {
@@ -1405,19 +1461,21 @@ impl PartitionManager {
                     );
                     let attach_partition_with_new_range = format!("ALTER TABLE {table} ATTACH PARTITION {table}_partition_{last_epoch_id} FOR VALUES FROM ('{last_epoch_start_cp}') TO ('{next_epoch_start_cp}');");
                     let new_partition = format!("CREATE TABLE {table}_partition_{next_epoch_id} PARTITION OF {table} FOR VALUES FROM ({next_epoch_start_cp}) TO (MAXVALUE);");
-                    diesel::sql_query(detach_partition).execute(conn)?;
-                    diesel::sql_query(attach_partition_with_new_range).execute(conn)?;
-                    diesel::sql_query(new_partition).execute(conn)?;
-                    updated_table.push(table);
+                    diesel::sql_query(detach_partition).execute(conn).await?;
+                    diesel::sql_query(attach_partition_with_new_range)
+                        .execute(conn)
+                        .await?;
+                    diesel::sql_query(new_partition).execute(conn).await?;
+                    updated_table.push(table.clone());
                 }
             }
             Ok::<_, diesel::result::Error>(updated_table)
-        })?;
+        }))?;
         info! {"Created epoch partition {next_epoch_id} for {table_updated:?}"};
         Ok(())
     }
 
-    fn get_table_partitions(&self) -> Result<BTreeMap<String, u64>, IndexerError> {
+    async fn get_table_partitions(&self) -> Result<BTreeMap<String, u64>, IndexerError> {
         #[derive(QueryableByName, Debug, Clone)]
         struct PartitionedTable {
             #[diesel(sql_type = VarChar)]
@@ -1426,25 +1484,28 @@ impl PartitionManager {
             last_partition: String,
         }
 
-        Ok(
-            read_only!(&self.cp, |conn| diesel::sql_query(GET_PARTITION_SQL)
-                .load(conn))?
-            .into_iter()
-            .map(|table: PartitionedTable| {
-                u64::from_str(&table.last_partition)
-                    .map(|last_partition| (table.table_name, last_partition))
-                    .map_err(|e| anyhow!(e))
-            })
-            .collect::<Result<_, _>>()?,
-        )
+        Ok(read_only!(&self.cp, |conn| Box::pin(
+            diesel::sql_query(GET_PARTITION_SQL).load(conn)
+        ))?
+        .into_iter()
+        .map(|table: PartitionedTable| {
+            u64::from_str(&table.last_partition)
+                .map(|last_partition| (table.table_name, last_partition))
+                .map_err(|e| anyhow!(e))
+        })
+        .collect::<Result<_, _>>()?)
     }
 }
 
 #[once(time = 2, result = true)]
-fn get_network_metrics_cached(cp: &PgConnectionPool) -> Result<NetworkMetrics, IndexerError> {
-    let metrics = read_only!(cp, |conn| {
-        diesel::sql_query("SELECT * FROM network_metrics;").get_result::<DBNetworkMetrics>(conn)
-    })?;
+async fn get_network_metrics_cached(
+    cp: &AsyncPgConnectionPool,
+) -> Result<NetworkMetrics, IndexerError> {
+    let metrics = read_only!(cp, |conn| Box::pin(async {
+        diesel::sql_query("SELECT * FROM network_metrics;")
+            .get_result::<DBNetworkMetrics>(conn)
+            .await
+    }))?;
     Ok(metrics.into())
 }
 
@@ -1456,7 +1517,7 @@ impl ObjectProvider for PgIndexerStore {
         id: &ObjectID,
         version: &SequenceNumber,
     ) -> Result<sui_types::object::Object, Self::Error> {
-        self.get_sui_types_object(id, version)
+        self.get_sui_types_object(id, version).await
     }
 
     async fn find_object_lt_or_eq_version(
@@ -1465,5 +1526,6 @@ impl ObjectProvider for PgIndexerStore {
         version: &SequenceNumber,
     ) -> Result<Option<sui_types::object::Object>, Self::Error> {
         self.find_sui_types_object_lt_or_eq_version(id, version)
+            .await
     }
 }

--- a/crates/sui-indexer/tests/integration_tests.rs
+++ b/crates/sui-indexer/tests/integration_tests.rs
@@ -180,10 +180,12 @@ pub mod pg_integration_test {
         // Allow indexer to sync
         wait_until_next_checkpoint(&store).await;
 
-        let checkpoint = store.get_checkpoint(0.into()).unwrap();
+        let checkpoint = store.get_checkpoint(0.into()).await.unwrap();
 
         for tx_digest in checkpoint.transactions {
-            let transaction = store.get_transaction_by_digest(&tx_digest.base58_encode());
+            let transaction = store
+                .get_transaction_by_digest(&tx_digest.base58_encode())
+                .await;
             assert!(transaction.is_ok());
             let _fullnode_rpc_tx = test_cluster
                 .rpc_client()
@@ -209,7 +211,7 @@ pub mod pg_integration_test {
         let (_test_cluster, _, store, _handle) = start_test_cluster(None).await;
         // Allow indexer to sync genesis
         wait_until_next_checkpoint(&store).await;
-        let total_address_count = store.get_network_metrics().unwrap().total_addresses;
+        let total_address_count = store.get_network_metrics().await.unwrap().total_addresses;
         assert_eq!(10, total_address_count);
         Ok(())
     }
@@ -220,7 +222,7 @@ pub mod pg_integration_test {
         let (_test_cluster, _, store, _handle) = start_test_cluster(None).await;
         // Allow indexer to sync genesis
         wait_until_next_checkpoint(&store).await;
-        let total_object_count = store.get_network_metrics().unwrap().total_objects;
+        let total_object_count = store.get_network_metrics().await.unwrap().total_objects;
         assert_eq!(48, total_object_count);
         Ok(())
     }
@@ -230,7 +232,7 @@ pub mod pg_integration_test {
         let (_test_cluster, _, store, _handle) = start_test_cluster(None).await;
         // Allow indexer to sync genesis
         wait_until_next_checkpoint(&store).await;
-        let total_package_count = store.get_network_metrics().unwrap().total_packages;
+        let total_package_count = store.get_network_metrics().await.unwrap().total_packages;
         assert_eq!(3, total_package_count);
         Ok(())
     }
@@ -249,6 +251,7 @@ pub mod pg_integration_test {
         .await;
         let tx_count = store
             .get_total_transaction_number_from_checkpoints()
+            .await
             .unwrap();
         // At least 1 transaction + 1 genesis, others are like Consensus Commit Prologue
         assert!(tx_count >= 2);
@@ -798,6 +801,7 @@ pub mod pg_integration_test {
 
         let coin_object = store
             .get_object(coins[0].coin_object_id, Some(coins[0].version))
+            .await
             .unwrap()
             .into_object()
             .unwrap();
@@ -828,15 +832,15 @@ pub mod pg_integration_test {
         // Allow indexer to sync
         wait_until_next_checkpoint(&store).await;
 
-        let current_epoch = store.get_current_epoch().unwrap();
-        let epoch_page = store.get_epochs(None, 100, None).unwrap();
+        let current_epoch = store.get_current_epoch().await.unwrap();
+        let epoch_page = store.get_epochs(None, 100, None).await.unwrap();
         assert_eq!(0, current_epoch.epoch);
         assert!(current_epoch.end_of_epoch_info.is_none());
         assert_eq!(1, epoch_page.len());
         wait_until_next_epoch(&store).await;
 
-        let current_epoch = store.get_current_epoch().unwrap();
-        let epoch_page = store.get_epochs(None, 100, None).unwrap();
+        let current_epoch = store.get_current_epoch().await.unwrap();
+        let epoch_page = store.get_epochs(None, 100, None).await.unwrap();
 
         assert_eq!(1, current_epoch.epoch);
         assert!(current_epoch.end_of_epoch_info.is_none());
@@ -856,13 +860,14 @@ pub mod pg_integration_test {
         // Allow indexer to sync geneis epoch
         wait_until_next_checkpoint(&store).await;
         wait_until_next_epoch(&store).await;
-        let current_epoch = store.get_current_epoch().unwrap();
+        let current_epoch = store.get_current_epoch().await.unwrap();
         let prev_epoch_last_checkpoint_id = current_epoch.first_checkpoint_id - 1;
 
         let checkpoint = store
             .get_checkpoint(CheckpointId::SequenceNumber(<BigInt>::from(
                 prev_epoch_last_checkpoint_id,
             )))
+            .await
             .unwrap();
         assert_eq!(checkpoint.epoch as u64, current_epoch.epoch - 1);
         assert_eq!(
@@ -949,7 +954,7 @@ pub mod pg_integration_test {
         let pg_port = env::var("POSTGRES_PORT").unwrap_or_else(|_| "32770".into());
         let pw = env::var("POSTGRES_PASSWORD").unwrap_or_else(|_| "postgrespw".into());
         let db_url = format!("postgres://postgres:{pw}@{pg_host}:{pg_port}");
-        let pg_connection_pool = new_pg_connection_pool(&db_url).unwrap();
+        let (pg_connection_pool, _) = new_pg_connection_pool(&db_url).await.unwrap();
         let mut pg_pool_conn = get_pg_pool_connection(&pg_connection_pool).unwrap();
 
         let lot_of_data = (1..10000)
@@ -1011,7 +1016,7 @@ pub mod pg_integration_test {
         let pg_port = env::var("POSTGRES_PORT").unwrap_or_else(|_| "32770".into());
         let pw = env::var("POSTGRES_PASSWORD").unwrap_or_else(|_| "postgrespw".into());
         let db_url = format!("postgres://postgres:{pw}@{pg_host}:{pg_port}");
-        let pg_connection_pool = new_pg_connection_pool(&db_url).unwrap();
+        let (pg_connection_pool, _) = new_pg_connection_pool(&db_url).await.unwrap();
         let mut pg_pool_conn = get_pg_pool_connection(&pg_connection_pool).unwrap();
 
         let bulk_data = (1..=10000)
@@ -1173,8 +1178,8 @@ pub mod pg_integration_test {
             start_test_cluster(Some(20000)).await;
         // Allow indexer to sync
         wait_until_next_checkpoint(&store).await;
-        let current_epoch = store.get_current_epoch().unwrap();
-        let cp = store.get_latest_checkpoint_sequence_number().unwrap() as u64;
+        let current_epoch = store.get_current_epoch().await.unwrap();
+        let cp = store.get_latest_checkpoint_sequence_number().await.unwrap() as u64;
         let first_checkpoint = indexer_rpc_client
             .get_checkpoint(CheckpointId::SequenceNumber(cp.try_into().unwrap()))
             .await
@@ -1206,7 +1211,7 @@ pub mod pg_integration_test {
         let next_checkpoint = indexer_rpc_client
             .get_checkpoint(CheckpointId::SequenceNumber(next_cp.try_into().unwrap()))
             .await?;
-        let current_epoch = store.get_current_epoch().unwrap();
+        let current_epoch = store.get_current_epoch().await.unwrap();
 
         assert_eq!(next_checkpoint.epoch, current_epoch.epoch);
         assert!(
@@ -1280,7 +1285,7 @@ pub mod pg_integration_test {
 
     async fn wait_until_next_checkpoint(store: &PgIndexerStore) {
         let since = std::time::Instant::now();
-        let mut cp = store.get_latest_checkpoint_sequence_number().unwrap();
+        let mut cp = store.get_latest_checkpoint_sequence_number().await.unwrap();
         let target = cp + 1;
         while cp < target {
             let now = std::time::Instant::now();
@@ -1288,13 +1293,13 @@ pub mod pg_integration_test {
                 panic!("wait_until_next_epoch timed out!");
             }
             tokio::task::yield_now().await;
-            cp = store.get_latest_checkpoint_sequence_number().unwrap();
+            cp = store.get_latest_checkpoint_sequence_number().await.unwrap();
         }
     }
 
     async fn wait_until_next_epoch(store: &PgIndexerStore) {
         let since = std::time::Instant::now();
-        let mut cp = store.get_current_epoch().unwrap().epoch;
+        let mut cp = store.get_current_epoch().await.unwrap().epoch;
         let target = cp + 1;
         while cp < target {
             let now = std::time::Instant::now();
@@ -1302,27 +1307,27 @@ pub mod pg_integration_test {
                 panic!("wait_until_next_epoch timed out!");
             }
             tokio::task::yield_now().await;
-            cp = store.get_current_epoch().unwrap().epoch;
+            cp = store.get_current_epoch().await.unwrap().epoch;
         }
     }
 
     async fn wait_until_transaction_synced(store: &PgIndexerStore, tx_digest: &str) {
         let since = std::time::Instant::now();
-        let mut tx = store.get_transaction_by_digest(tx_digest);
+        let mut tx = store.get_transaction_by_digest(tx_digest).await;
         while tx.is_err() {
             let now = std::time::Instant::now();
             if now.duration_since(since).as_secs() > WAIT_UNTIL_TIME_LIMIT {
                 panic!("wait_until_transaction_synced timed out!");
             }
             tokio::task::yield_now().await;
-            tx = store.get_transaction_by_digest(tx_digest);
+            tx = store.get_transaction_by_digest(tx_digest).await;
         }
     }
 
     async fn wait_until_transaction_synced_in_checkpoint(store: &PgIndexerStore, tx_digest: &str) {
         let since = std::time::Instant::now();
         loop {
-            let tx = store.get_transaction_by_digest(tx_digest);
+            let tx = store.get_transaction_by_digest(tx_digest).await;
             if let Ok(t) = tx {
                 if t.checkpoint_sequence_number.is_some() {
                     break;

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -68,6 +68,7 @@ base16ct = { version = "0.1", default-features = false, features = ["alloc"] }
 base64-594e8ee84c453af0 = { package = "base64", version = "0.13", features = ["alloc"] }
 base64-647d43efb71741da = { package = "base64", version = "0.21" }
 base64ct = { version = "1", default-features = false, features = ["alloc"] }
+bb8 = { version = "0.8", default-features = false }
 bcs = { version = "0.1", default-features = false }
 beef = { version = "0.5", features = ["impl_serde"] }
 better_any = { version = "0.1", default-features = false }
@@ -159,7 +160,8 @@ der-parser = { version = "8", features = ["bigint"] }
 derive_builder = { version = "0.12" }
 determinator = { version = "0.10", default-features = false }
 deunicode = { version = "0.4", default-features = false }
-diesel = { version = "2", features = ["64-column-tables", "chrono", "postgres", "r2d2", "serde_json"] }
+diesel = { version = "2", features = ["64-column-tables", "chrono", "i-implement-a-third-party-backend-and-opt-into-breaking-changes", "postgres", "r2d2", "serde_json"] }
+diesel-async = { version = "0.2", features = ["bb8", "postgres"] }
 diesel_migrations = { version = "2" }
 diff = { version = "0.1", default-features = false }
 difference = { version = "2" }
@@ -192,6 +194,7 @@ expect-test = { version = "1", default-features = false }
 eyre = { version = "0.6" }
 fail-9fbad63c4bcf4a8f = { package = "fail", version = "0.4", default-features = false }
 fail-d8f496e17d97b5cb = { package = "fail", version = "0.5", default-features = false }
+fallible-iterator = { version = "0.2" }
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "c2f79b1807bff7d09517b631191b61f2614c641c", features = ["copy_key"] }
 fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "c2f79b1807bff7d09517b631191b61f2614c641c", default-features = false }
 fastrand = { version = "1", default-features = false }
@@ -217,7 +220,7 @@ futures-lite = { version = "1" }
 futures-sink = { version = "0.3" }
 futures-task = { version = "0.3", default-features = false, features = ["std", "unstable"] }
 futures-timer = { version = "3", default-features = false, features = ["wasm-bindgen"] }
-futures-util = { version = "0.3", default-features = false, features = ["async-await-macro", "bilock", "channel", "io", "sink", "unstable"] }
+futures-util = { version = "0.3", features = ["bilock", "channel", "io", "sink", "unstable"] }
 generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "serde"] }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 getrandom-c65f7effa3be6d31 = { package = "getrandom", version = "0.1", default-features = false, features = ["std"] }
@@ -305,6 +308,7 @@ match_opt = { version = "0.1", default-features = false }
 matchers = { version = "0.1", default-features = false }
 matchit-ca01ad9e24f5d932 = { package = "matchit", version = "0.7" }
 matchit-d8f496e17d97b5cb = { package = "matchit", version = "0.5" }
+md-5 = { version = "0.10" }
 memchr = { version = "2", features = ["use_std"] }
 memoffset-ca01ad9e24f5d932 = { package = "memoffset", version = "0.7" }
 merlin = { version = "3" }
@@ -395,7 +399,7 @@ percent-encoding = { version = "2" }
 pest = { version = "2" }
 petgraph-3b31131e45eafb45 = { package = "petgraph", version = "0.6" }
 petgraph-d8f496e17d97b5cb = { package = "petgraph", version = "0.5" }
-phf = { version = "0.11", default-features = false, features = ["uncased"] }
+phf = { version = "0.11", features = ["uncased"] }
 phf_shared = { version = "0.11", features = ["uncased"] }
 pin-project = { version = "1", default-features = false }
 pin-project-lite = { version = "0.2", default-features = false }
@@ -406,6 +410,8 @@ plotters-backend = { version = "0.3", default-features = false }
 plotters-svg = { version = "0.3", default-features = false }
 polyval = { version = "0.6", default-features = false }
 portable-atomic = { version = "0.3" }
+postgres-protocol = { version = "0.6", default-features = false }
+postgres-types = { version = "0.2", default-features = false }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 pq-sys = { version = "0.4", default-features = false }
 predicates = { version = "2" }
@@ -472,6 +478,7 @@ ryu = { version = "1", default-features = false }
 same-file = { version = "1", default-features = false }
 scheduled-thread-pool = { version = "0.2", default-features = false }
 schemars = { version = "0.8", features = ["either"] }
+scoped-futures = { version = "0.1" }
 scopeguard = { version = "1" }
 sct = { version = "0.7", default-features = false }
 sec1 = { version = "0.3", features = ["alloc", "subtle"] }
@@ -513,11 +520,13 @@ slip10_ed25519 = { version = "0.1", default-features = false }
 slug = { version = "0.1", default-features = false }
 smallvec = { version = "1", default-features = false }
 snap = { version = "1", default-features = false }
-socket2 = { version = "0.4", default-features = false, features = ["all"] }
+socket2-9fbad63c4bcf4a8f = { package = "socket2", version = "0.4", default-features = false, features = ["all"] }
+socket2-d8f496e17d97b5cb = { package = "socket2", version = "0.5", default-features = false, features = ["all"] }
 soketto = { version = "0.7", features = ["http"] }
 spki = { version = "0.6", default-features = false, features = ["std"] }
 stable_deref_trait = { version = "1" }
 static_assertions = { version = "1", default-features = false }
+stringprep = { version = "0.1", default-features = false }
 strip-ansi-escapes = { version = "0.1", default-features = false }
 strsim-93f6ce9d446188ac = { package = "strsim", version = "0.10", default-features = false }
 strsim-c38e5c1d305a1b54 = { package = "strsim", version = "0.8", default-features = false }
@@ -555,6 +564,7 @@ tinyvec = { version = "1", features = ["alloc"] }
 tinyvec_macros = { version = "0.1", default-features = false }
 tokio = { version = "1", features = ["full", "test-util", "tracing"] }
 tokio-io-timeout = { version = "1", default-features = false }
+tokio-postgres = { version = "0.7" }
 tokio-retry = { version = "0.3", default-features = false }
 tokio-rustls = { version = "0.23" }
 tokio-stream = { version = "0.1", features = ["net", "sync"] }
@@ -689,6 +699,7 @@ base16ct = { version = "0.1", default-features = false, features = ["alloc"] }
 base64-594e8ee84c453af0 = { package = "base64", version = "0.13", features = ["alloc"] }
 base64-647d43efb71741da = { package = "base64", version = "0.21" }
 base64ct = { version = "1", default-features = false, features = ["alloc"] }
+bb8 = { version = "0.8", default-features = false }
 bcs = { version = "0.1", default-features = false }
 beef = { version = "0.5", features = ["impl_serde"] }
 better_any = { version = "0.1", default-features = false }
@@ -801,7 +812,8 @@ derive_builder_macro = { version = "0.12", default-features = false }
 derive_more = { version = "0.99" }
 determinator = { version = "0.10", default-features = false }
 deunicode = { version = "0.4", default-features = false }
-diesel = { version = "2", features = ["64-column-tables", "chrono", "postgres", "r2d2", "serde_json"] }
+diesel = { version = "2", features = ["64-column-tables", "chrono", "i-implement-a-third-party-backend-and-opt-into-breaking-changes", "postgres", "r2d2", "serde_json"] }
+diesel-async = { version = "0.2", features = ["bb8", "postgres"] }
 diesel-derive-enum = { version = "2", default-features = false, features = ["postgres"] }
 diesel_derives = { version = "2", features = ["64-column-tables", "postgres", "with-deprecated"] }
 diesel_migrations = { version = "2" }
@@ -838,6 +850,7 @@ expect-test = { version = "1", default-features = false }
 eyre = { version = "0.6" }
 fail-9fbad63c4bcf4a8f = { package = "fail", version = "0.4", default-features = false }
 fail-d8f496e17d97b5cb = { package = "fail", version = "0.5", default-features = false }
+fallible-iterator = { version = "0.2" }
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "c2f79b1807bff7d09517b631191b61f2614c641c", features = ["copy_key"] }
 fastcrypto-derive = { git = "https://github.com/MystenLabs/fastcrypto", rev = "c2f79b1807bff7d09517b631191b61f2614c641c", default-features = false }
 fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "c2f79b1807bff7d09517b631191b61f2614c641c", default-features = false }
@@ -865,7 +878,7 @@ futures-macro = { version = "0.3", default-features = false }
 futures-sink = { version = "0.3" }
 futures-task = { version = "0.3", default-features = false, features = ["std", "unstable"] }
 futures-timer = { version = "3", default-features = false, features = ["wasm-bindgen"] }
-futures-util = { version = "0.3", default-features = false, features = ["async-await-macro", "bilock", "channel", "io", "sink", "unstable"] }
+futures-util = { version = "0.3", features = ["bilock", "channel", "io", "sink", "unstable"] }
 generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "serde"] }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 getrandom-c65f7effa3be6d31 = { package = "getrandom", version = "0.1", default-features = false, features = ["std"] }
@@ -965,6 +978,7 @@ match_opt = { version = "0.1", default-features = false }
 matchers = { version = "0.1", default-features = false }
 matchit-ca01ad9e24f5d932 = { package = "matchit", version = "0.7" }
 matchit-d8f496e17d97b5cb = { package = "matchit", version = "0.5" }
+md-5 = { version = "0.10" }
 memchr = { version = "2", features = ["use_std"] }
 memoffset-ca01ad9e24f5d932 = { package = "memoffset", version = "0.7" }
 merlin = { version = "3" }
@@ -1070,7 +1084,7 @@ pest_generator = { version = "2", default-features = false, features = ["std"] }
 pest_meta = { version = "2", default-features = false }
 petgraph-3b31131e45eafb45 = { package = "petgraph", version = "0.6" }
 petgraph-d8f496e17d97b5cb = { package = "petgraph", version = "0.5" }
-phf = { version = "0.11", default-features = false, features = ["uncased"] }
+phf = { version = "0.11", features = ["uncased"] }
 phf_codegen = { version = "0.11", default-features = false }
 phf_generator = { version = "0.11", default-features = false }
 phf_shared = { version = "0.11", features = ["uncased"] }
@@ -1085,6 +1099,8 @@ plotters-backend = { version = "0.3", default-features = false }
 plotters-svg = { version = "0.3", default-features = false }
 polyval = { version = "0.6", default-features = false }
 portable-atomic = { version = "0.3" }
+postgres-protocol = { version = "0.6", default-features = false }
+postgres-types = { version = "0.2", default-features = false }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 pq-sys = { version = "0.4", default-features = false }
 predicates = { version = "2" }
@@ -1168,6 +1184,7 @@ same-file = { version = "1", default-features = false }
 scheduled-thread-pool = { version = "0.2", default-features = false }
 schemars = { version = "0.8", features = ["either"] }
 schemars_derive = { version = "0.8", default-features = false }
+scoped-futures = { version = "0.1" }
 scopeguard = { version = "1" }
 sct = { version = "0.7", default-features = false }
 sec1 = { version = "0.3", features = ["alloc", "subtle"] }
@@ -1216,11 +1233,13 @@ slip10_ed25519 = { version = "0.1", default-features = false }
 slug = { version = "0.1", default-features = false }
 smallvec = { version = "1", default-features = false }
 snap = { version = "1", default-features = false }
-socket2 = { version = "0.4", default-features = false, features = ["all"] }
+socket2-9fbad63c4bcf4a8f = { package = "socket2", version = "0.4", default-features = false, features = ["all"] }
+socket2-d8f496e17d97b5cb = { package = "socket2", version = "0.5", default-features = false, features = ["all"] }
 soketto = { version = "0.7", features = ["http"] }
 spki = { version = "0.6", default-features = false, features = ["std"] }
 stable_deref_trait = { version = "1" }
 static_assertions = { version = "1", default-features = false }
+stringprep = { version = "0.1", default-features = false }
 strip-ansi-escapes = { version = "0.1", default-features = false }
 strsim-93f6ce9d446188ac = { package = "strsim", version = "0.10", default-features = false }
 strsim-c38e5c1d305a1b54 = { package = "strsim", version = "0.8", default-features = false }
@@ -1267,7 +1286,8 @@ tinyvec = { version = "1", features = ["alloc"] }
 tinyvec_macros = { version = "0.1", default-features = false }
 tokio = { version = "1", features = ["full", "test-util", "tracing"] }
 tokio-io-timeout = { version = "1", default-features = false }
-tokio-macros = { version = "1", default-features = false }
+tokio-macros = { version = "2", default-features = false }
+tokio-postgres = { version = "0.7" }
 tokio-retry = { version = "0.3", default-features = false }
 tokio-rustls = { version = "0.23" }
 tokio-stream = { version = "0.1", features = ["net", "sync"] }
@@ -1524,7 +1544,9 @@ web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 widestring = { version = "0.5" }
 winapi = { version = "0.3", default-features = false, features = ["basetsd", "cfg", "combaseapi", "consoleapi", "errhandlingapi", "evntrace", "fileapi", "handleapi", "heapapi", "ifdef", "impl-debug", "impl-default", "in6addr", "inaddr", "ioapiset", "iphlpapi", "knownfolders", "libloaderapi", "lmaccess", "lmapibuf", "lmcons", "memoryapi", "minwinbase", "minwindef", "namedpipeapi", "netioapi", "ntdef", "ntlsa", "ntsecapi", "ntstatus", "objbase", "objidl", "oleauto", "pdh", "powerbase", "processenv", "processthreadsapi", "profileapi", "psapi", "rpcdce", "securitybaseapi", "shellapi", "shlobj", "std", "stringapiset", "synchapi", "sysinfoapi", "timezoneapi", "wbemcli", "winbase", "wincon", "windef", "winerror", "winioctl", "winnt", "winreg", "winsock2", "winuser", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
 winapi-util = { version = "0.1", default-features = false }
-windows-sys = { version = "0.42", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse"] }
+windows-sys-53888c27b7ba5cf4 = { package = "windows-sys", version = "0.45", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming"] }
+windows-sys-b32c9ddb6d93a9d2 = { package = "windows-sys", version = "0.42", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse"] }
+windows-targets = { version = "0.42", default-features = false }
 windows_x86_64_msvc = { version = "0.42", default-features = false }
 winreg = { version = "0.10", default-features = false }
 
@@ -1550,7 +1572,9 @@ web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 widestring = { version = "0.5" }
 winapi = { version = "0.3", default-features = false, features = ["basetsd", "cfg", "combaseapi", "consoleapi", "errhandlingapi", "evntrace", "fileapi", "handleapi", "heapapi", "ifdef", "impl-debug", "impl-default", "in6addr", "inaddr", "ioapiset", "iphlpapi", "knownfolders", "libloaderapi", "lmaccess", "lmapibuf", "lmcons", "memoryapi", "minwinbase", "minwindef", "namedpipeapi", "netioapi", "ntdef", "ntlsa", "ntsecapi", "ntstatus", "objbase", "objidl", "oleauto", "pdh", "powerbase", "processenv", "processthreadsapi", "profileapi", "psapi", "rpcdce", "securitybaseapi", "shellapi", "shlobj", "std", "stringapiset", "synchapi", "sysinfoapi", "timezoneapi", "wbemcli", "winbase", "wincon", "windef", "winerror", "winioctl", "winnt", "winreg", "winsock2", "winuser", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
 winapi-util = { version = "0.1", default-features = false }
-windows-sys = { version = "0.42", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse"] }
+windows-sys-53888c27b7ba5cf4 = { package = "windows-sys", version = "0.45", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming"] }
+windows-sys-b32c9ddb6d93a9d2 = { package = "windows-sys", version = "0.42", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse"] }
+windows-targets = { version = "0.42", default-features = false }
 windows_x86_64_msvc = { version = "0.42", default-features = false }
 winreg = { version = "0.10", default-features = false }
 


### PR DESCRIPTION
## Description 

use diesel_async to prevent db calls from blocking rpc request processing

## Test Plan 

Tested locally and changes are covered by integration tests