### PR TITLE
Add input to dry run result

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -47,7 +47,7 @@ use sui_config::node::{AuthorityStorePruningConfig, DBCheckpointConfig};
 use sui_framework::{MoveStdlib, SuiFramework, SuiSystem, SystemPackage};
 use sui_json_rpc_types::{
     Checkpoint, DevInspectResults, DryRunTransactionBlockResponse, EventFilter, SuiEvent,
-    SuiMoveValue, SuiObjectDataFilter, SuiTransactionBlockEvents,
+    SuiMoveValue, SuiObjectDataFilter, SuiTransactionBlockData, SuiTransactionBlockEvents,
 };
 use sui_macros::{fail_point, fail_point_async, nondeterministic};
 use sui_protocol_config::SupportedProtocolVersions;
@@ -1102,6 +1102,7 @@ impl AuthorityState {
 
         Ok((
             DryRunTransactionBlockResponse {
+                input: SuiTransactionBlockData::try_from(transaction.clone(), &module_cache)?,
                 effects: effects.clone().try_into()?,
                 events: SuiTransactionBlockEvents::try_from(
                     inner_temp_store.events.clone(),

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -660,6 +660,7 @@ pub struct DryRunTransactionBlockResponse {
     pub events: SuiTransactionBlockEvents,
     pub object_changes: Vec<ObjectChange>,
     pub balance_changes: Vec<BalanceChange>,
+    pub input: SuiTransactionBlockData,
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -893,7 +893,11 @@ async fn test_staking_multiple_coins() -> Result<(), anyhow::Error> {
         .execute_transaction_block(
             tx_bytes,
             signatures,
-            Some(SuiTransactionBlockResponseOptions::new().with_balance_changes()),
+            Some(
+                SuiTransactionBlockResponseOptions::new()
+                    .with_balance_changes()
+                    .with_input(),
+            ),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await?;
@@ -902,6 +906,12 @@ async fn test_staking_multiple_coins() -> Result<(), anyhow::Error> {
     assert_eq!(
         dryrun_response.balance_changes,
         executed_response.balance_changes.unwrap()
+    );
+
+    // Check that inputs for dry run match the executed transaction
+    assert_eq!(
+        dryrun_response.input,
+        executed_response.transaction.unwrap().data
     );
 
     // Check DelegatedStake object

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -3251,6 +3251,7 @@
           "balanceChanges",
           "effects",
           "events",
+          "input",
           "objectChanges"
         ],
         "properties": {
@@ -3268,6 +3269,9 @@
             "items": {
               "$ref": "#/components/schemas/Event"
             }
+          },
+          "input": {
+            "$ref": "#/components/schemas/TransactionBlockData"
           },
           "objectChanges": {
             "type": "array",

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -422,6 +422,8 @@ export const DryRunTransactionBlockResponse = object({
   events: TransactionEvents,
   objectChanges: array(SuiObjectChange),
   balanceChanges: array(BalanceChange),
+  // TODO: Remove optional when this is rolled out to all networks:
+  input: optional(SuiTransactionBlockData),
 });
 export type DryRunTransactionBlockResponse = Infer<
   typeof DryRunTransactionBlockResponse


### PR DESCRIPTION
## Description

This adds `input` to the dry run result, which wallets can use this to easily deserialize input values, which can be hard to do otherwise. This also means clients can easily get the parsed structure of a transaction without needing to either execute the transaction or needing a full BCS parser (neat!).

Two notes:
- I opted for `input` here, whereas on the execute transaction block result it's `transaction`. The `transaction` terminology seemed out of date, and this aligns closer with `showInput` on execute transaction block.
- This doesn't return the same thing as the input on the `executeTransactionBlock` because they take different inputs (signed transaction vs just transaction data). It's not really possible to reconcile this and I think this is fine in the sense that it still hands back the parsed input.

## Test Plan

Added to TS SDK, tests should continue to pass.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
