### PR TITLE
[explorer] change persistence method of PostHog to memory

### DIFF
--- a/apps/explorer/src/components/analytics/PostHogAnalyticsProvider.tsx
+++ b/apps/explorer/src/components/analytics/PostHogAnalyticsProvider.tsx
@@ -20,11 +20,10 @@ export function PostHogAnalyticsProvider({ children }: PostHogProviderProps) {
         <PostHogProvider
             apiKey="phc_IggVMJtR5vawlA4H3IIYnIyWjcK8rPiqAI1FlmKZPjp"
             options={{
-                // We'll set local storage as the default persistence method so
-                // that we don't have to show cookie banners in our applications
-                persistence: 'localStorage',
-                // We need to manually collect page view events since
-                // all of our applications use client-side routing
+                // We'll set memory as the default persistence method so that
+                // we aren't required to show a cookie acceptance banner
+                persistence: 'memory',
+                // We need to manually collect page view events since we use client-side routing
                 capture_pageview: false,
             }}
         >


### PR DESCRIPTION
## Description 

I actually misinterpreted https://posthog.com/tutorials/cookieless-tracking, we need to set the persistence method to `memory` and not `localStorage` in order to not have to show a cookie banner.

## Test Plan 
- Manual testing

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
N/A
