### PR TITLE
indexer: object fast path, the writing part

### DIFF
--- a/crates/sui-indexer/benches/indexer_benchmark.rs
+++ b/crates/sui-indexer/benches/indexer_benchmark.rs
@@ -74,7 +74,7 @@ fn create_checkpoint(sequence_number: i64) -> TemporaryCheckpointStore {
             .collect(),
         events: vec![],
         objects_changes: vec![TransactionObjectChanges {
-            mutated_objects: (1..1000).map(|_| create_object(sequence_number)).collect(),
+            changed_objects: (1..1000).map(|_| create_object(sequence_number)).collect(),
             deleted_objects: vec![],
         }],
         addresses: vec![],

--- a/crates/sui-indexer/migrations/2022-12-01-034426_objects/up.sql
+++ b/crates/sui-indexer/migrations/2022-12-01-034426_objects/up.sql
@@ -62,6 +62,9 @@ CREATE TABLE objects_history
 CREATE INDEX objects_history_id_version_index ON objects_history (object_id, version);
 CREATE INDEX objects_history_owner_index ON objects_history (owner_type, owner_address);
 CREATE INDEX objects_history_old_owner_index ON objects_history (old_owner_type, old_owner_address);
+-- fast-path partition for the most recent objects before checkpoint, range is half-open.
+-- partition name need to match regex of '.*(_partition_)\d+'.
+CREATE TABLE objects_history_fast_path_partition_0 PARTITION OF objects_history FOR VALUES FROM (-1) TO (0);
 CREATE TABLE objects_history_partition_0 PARTITION OF objects_history FOR VALUES FROM (0) TO (MAXVALUE);
 
 CREATE OR REPLACE FUNCTION objects_modified_func() RETURNS TRIGGER AS
@@ -82,6 +85,8 @@ BEGIN
                 NEW.initial_shared_version,
                 NEW.previous_transaction, NEW.object_type, NEW.object_status, NEW.has_public_transfer,
                 NEW.storage_rebate, NEW.bcs);
+        -- MUSTFIX(gegaowp): we cannot update checkpoint in-place, b/c checkpoint is a partition key,
+        -- we need to prune old data in this partition periodically, like pruning old epochs upon new epoch.
         RETURN NEW;
     ELSIF (TG_OP = 'DELETE') THEN
         -- object deleted from the main table, archive the history for that object

--- a/crates/sui-indexer/src/errors.rs
+++ b/crates/sui-indexer/src/errors.rs
@@ -47,8 +47,8 @@ pub enum IndexerError {
     #[error(transparent)]
     PostgresError(#[from] diesel::result::Error),
 
-    #[error("Indexer failed to initialize fullnode RPC client with error: `{0}`")]
-    RpcClientInitError(String),
+    #[error("Indexer failed to initialize fullnode Http client with error: `{0}`")]
+    HttpClientInitError(String),
 
     #[error("Indexer failed to serialize/deserialize with error: `{0}`")]
     SerdeError(String),

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -171,7 +171,11 @@ pub trait IndexerStore {
     fn get_network_metrics(&self) -> Result<NetworkMetrics, IndexerError>;
     fn get_move_call_metrics(&self) -> Result<MoveCallMetrics, IndexerError>;
 
-    fn persist_fast_path(&self, tx: Transaction) -> Result<usize, IndexerError>;
+    fn persist_fast_path(
+        &self,
+        tx: Transaction,
+        tx_object_changes: TransactionObjectChanges,
+    ) -> Result<usize, IndexerError>;
     fn persist_checkpoint(&self, data: &TemporaryCheckpointStore) -> Result<usize, IndexerError>;
     fn persist_epoch(&self, data: &TemporaryEpochStore) -> Result<(), IndexerError>;
 
@@ -226,7 +230,7 @@ pub struct TemporaryCheckpointStore {
 
 #[derive(Debug)]
 pub struct TransactionObjectChanges {
-    pub mutated_objects: Vec<Object>,
+    pub changed_objects: Vec<Object>,
     pub deleted_objects: Vec<DeletedObject>,
 }
 

--- a/crates/sui-indexer/src/utils.rs
+++ b/crates/sui-indexer/src/utils.rs
@@ -7,15 +7,16 @@ use anyhow::anyhow;
 use diesel::migration::MigrationSource;
 use diesel::{PgConnection, RunQueryDsl};
 use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
+use jsonrpsee::http_client::HttpClient;
 use tracing::info;
 
+use sui_json_rpc::api::ReadApiClient;
 use sui_json_rpc::{get_balance_changes, ObjectProvider};
 use sui_json_rpc_types::SuiTransactionBlockResponseOptions;
 use sui_json_rpc_types::{
     BalanceChange, SuiExecutionStatus, SuiTransactionBlockEffects, SuiTransactionBlockEffectsAPI,
 };
 use sui_json_rpc_types::{ObjectChange, OwnedObjectRef, SuiObjectRef};
-use sui_sdk::apis::ReadApi as SuiReadApi;
 use sui_types::base_types::TransactionDigest;
 use sui_types::base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress};
 use sui_types::gas::GasCostSummary;
@@ -79,18 +80,20 @@ pub fn drop_all_tables(conn: &mut PgConnection) -> Result<(), diesel::result::Er
 }
 
 pub async fn multi_get_full_transactions(
-    read_api: &SuiReadApi,
+    http_client: HttpClient,
     digests: Vec<TransactionDigest>,
 ) -> Result<Vec<CheckpointTransactionBlockResponse>, IndexerError> {
-    let sui_transactions = read_api
-        .multi_get_transactions_with_options(
+    let sui_transactions = http_client
+        .multi_get_transaction_blocks(
             digests.clone(),
             // MUSTFIX(gegaowp): avoid double fetching both input and raw_input
-            SuiTransactionBlockResponseOptions::new()
-                .with_input()
-                .with_effects()
-                .with_events()
-                .with_raw_input(),
+            Some(
+                SuiTransactionBlockResponseOptions::new()
+                    .with_input()
+                    .with_effects()
+                    .with_events()
+                    .with_raw_input(),
+            ),
         )
         .await
         .map_err(|e| {


### PR DESCRIPTION
## Description 

Fast path object, the writing path

some following action items:
- implement get_latest_owned_object to be on top of `objects` table
- change `get_owned_objects` to include fresh object data if `checkpoint` arg is not provided
- now we have both tx and object fast-path, we can change some testing to not count on "waiting for X"
- fast-path partition of object history cannot be updated in-place, it needs to be pruned periodically

## Test Plan 

CI 
