### PR TITLE
Reduce gas amount in trasnfer tokens

### DIFF
--- a/crates/sui-benchmark/src/workloads/transfer_object.rs
+++ b/crates/sui-benchmark/src/workloads/transfer_object.rs
@@ -149,7 +149,7 @@ impl WorkloadBuilder<dyn Payload> for TransferObjectWorkloadBuilder {
         for _i in 0..self.num_payloads {
             let (address, keypair) = (owner, address_map.get(&owner).unwrap().clone());
             gas_configs.push(GasCoinConfig {
-                amount: MAX_GAS_FOR_TESTING,
+                amount: 1,
                 address,
                 keypair: keypair.clone(),
             });


### PR DESCRIPTION
## Description 

We don't need anything more than 1 MIST in the transfer token. Reducing this value, so we overall require less gas for running this wokrload (as gas is limited now).

## Test Plan 

Existing tests
