### PR TITLE
Update 0% APY conditional checker 

### DIFF
--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -9,3 +9,4 @@ export * from './hooks/useGetValidatorsEvents';
 export * from './hooks/useGetRollingAverageApys';
 export * from './utils/formatAmount';
 export * from './utils/roundFloat';
+export * from './utils/formatPercentageDisplay';

--- a/apps/core/src/utils/formatPercentageDisplay.ts
+++ b/apps/core/src/utils/formatPercentageDisplay.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// For unavailable %, return '--' else return the APY number
+export function formatPercentageDisplay(
+    value: number | null,
+    nullDisplay = '--'
+) {
+    return value === null ? nullDisplay : `${value}%`;
+}

--- a/apps/explorer/src/pages/validators/Validators.tsx
+++ b/apps/explorer/src/pages/validators/Validators.tsx
@@ -6,6 +6,7 @@ import {
     useGetRollingAverageApys,
     type ApyByValidator,
     useGetValidatorsEvents,
+    formatPercentageDisplay,
 } from '@mysten/core';
 import { type SuiEvent, type SuiValidatorSummary } from '@mysten/sui.js';
 import { lazy, Suspense, useMemo } from 'react';
@@ -55,11 +56,7 @@ export function validatorsTableData(
                     },
                     stake: totalStake,
                     // show the rolling average apy even if its zero, otherwise show -- for no data
-                    apy:
-                        rollingAverageApys?.[validator.suiAddress] ||
-                        rollingAverageApys?.[validator.suiAddress] === 0
-                            ? rollingAverageApys?.[validator.suiAddress]
-                            : null,
+                    apy: rollingAverageApys?.[validator.suiAddress] ?? null,
                     nextEpochGasPrice: validator.nextEpochGasPrice,
                     commission: +validator.commissionRate / 100,
                     img: img,
@@ -139,7 +136,7 @@ export function validatorsTableData(
                     const apy = props.getValue();
                     return (
                         <Text variant="bodySmall/medium" color="steel-darker">
-                            {apy === null ? '--' : `${apy}%`}
+                            {formatPercentageDisplay(apy)}
                         </Text>
                     );
                 },
@@ -222,7 +219,7 @@ function ValidatorPageResult() {
             !rollingAverageApys ||
             Object.keys(rollingAverageApys)?.length === 0
         )
-            return 0;
+            return null;
         const apys = Object.values(rollingAverageApys);
         const averageAPY = apys?.reduce((acc, cur) => acc + cur, 0);
         return roundFloat(averageAPY / apys.length, APY_DECIMALS);

--- a/apps/wallet/src/ui/app/components/receipt-card/StakeTxnCard.tsx
+++ b/apps/wallet/src/ui/app/components/receipt-card/StakeTxnCard.tsx
@@ -1,7 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useGetRollingAverageApys } from '@mysten/core';
+import {
+    formatPercentageDisplay,
+    useGetRollingAverageApys,
+} from '@mysten/core';
 import { SUI_TYPE_ARG } from '@mysten/sui.js';
 
 import { useGetTimeBeforeEpochNumber } from '_app/staking/useGetTimeBeforeEpochNumber';
@@ -30,11 +33,7 @@ export function StakeTxnCard({ event }: StakeTxnCardProps) {
         system?.activeValidators?.length || null
     );
 
-    const apy =
-        rollingAverageApys?.[validatorAddress] ||
-        rollingAverageApys?.[validatorAddress] === 0
-            ? rollingAverageApys?.[validatorAddress]
-            : null;
+    const apy = rollingAverageApys?.[validatorAddress] ?? null;
 
     // Reward will be available after 2 epochs
     // TODO: Get epochStartTimestampMs/StartDate for staking epoch + NUM_OF_EPOCH_BEFORE_EARNING
@@ -76,7 +75,7 @@ export function StakeTxnCard({ event }: StakeTxnCardProps) {
                         <IconTooltip tip="This is the Annualized Percentage Yield of the a specific validator’s past operations. Note there is no guarantee this APY will be true in the future." />
                     </div>
                     <Text variant="body" weight="medium" color="steel-darker">
-                        {apy === null ? '--' : apy + ' %'}
+                        {formatPercentageDisplay(apy)}
                     </Text>
                 </div>
                 <div className="flex justify-between w-full py-3.5">

--- a/apps/wallet/src/ui/app/shared/delegated-apy/index.tsx
+++ b/apps/wallet/src/ui/app/shared/delegated-apy/index.tsx
@@ -23,7 +23,7 @@ export function DelegatedAPY({ stakedValidators }: DelegatedAPYProps) {
     );
 
     const averageNetworkAPY = useMemo(() => {
-        if (!data || !rollingAverageApys) return 0;
+        if (!data || !rollingAverageApys) return null;
 
         let stakedAPYs = 0;
 
@@ -45,7 +45,7 @@ export function DelegatedAPY({ stakedValidators }: DelegatedAPYProps) {
     }
     return (
         <div className="flex gap-0.5 items-center">
-            {averageNetworkAPY > 0 ? (
+            {averageNetworkAPY !== null ? (
                 <>
                     <Text variant="body" weight="semibold" color="steel-dark">
                         {averageNetworkAPY}

--- a/apps/wallet/src/ui/app/staking/stake/ValidatorFormDetail.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/ValidatorFormDetail.tsx
@@ -1,7 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useGetRollingAverageApys } from '@mysten/core';
+import {
+    formatPercentageDisplay,
+    useGetRollingAverageApys,
+} from '@mysten/core';
 import { useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
@@ -75,18 +78,14 @@ export function ValidatorFormDetail({
     }, [system]);
 
     const totalStakePercentage = useMemo(() => {
-        if (!system || !stakeData) return 0;
+        if (!system || !stakeData) return null;
         return calculateStakeShare(
             getTokenStakeSuiForValidator(stakeData, validatorAddress),
             BigInt(totalValidatorsStake)
         );
     }, [stakeData, system, totalValidatorsStake, validatorAddress]);
 
-    const apy =
-        rollingAverageApys?.[validatorAddress] ||
-        rollingAverageApys?.[validatorAddress] === 0
-            ? rollingAverageApys?.[validatorAddress]
-            : null;
+    const apy = rollingAverageApys?.[validatorAddress] ?? null;
 
     if (isLoading || loadingValidators) {
         return (
@@ -179,9 +178,7 @@ export function ValidatorFormDetail({
                                 weight="semibold"
                                 color="gray-90"
                             >
-                                {totalStakePercentage > 0
-                                    ? `${totalStakePercentage}%`
-                                    : '--'}
+                                {formatPercentageDisplay(totalStakePercentage)}
                             </Text>
                         </div>
 

--- a/apps/wallet/src/ui/app/staking/validators/SelectValidatorCard.tsx
+++ b/apps/wallet/src/ui/app/staking/validators/SelectValidatorCard.tsx
@@ -1,7 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useGetRollingAverageApys } from '@mysten/core';
+import {
+    useGetRollingAverageApys,
+    formatPercentageDisplay,
+} from '@mysten/core';
 import { ArrowRight16 } from '@mysten/icons';
 import cl from 'classnames';
 import { useState, useMemo } from 'react';
@@ -63,7 +66,7 @@ export function SelectValidatorCard() {
         const sortedAsc = validatorsRandomOrder.map((validator) => ({
             name: validator.name,
             address: validator.suiAddress,
-            apy: rollingAverageApys?.[validator.suiAddress] || 0,
+            apy: rollingAverageApys?.[validator.suiAddress] ?? null,
             stakeShare: calculateStakeShare(
                 BigInt(validator.stakingPoolSuiBalance),
                 BigInt(totalStake)
@@ -77,7 +80,8 @@ export function SelectValidatorCard() {
                         numeric: true,
                     });
                 }
-                return a[sortKey] - b[sortKey];
+                // since apy can be null, fallback to 0
+                return (a[sortKey] || 0) - (b[sortKey] || 0);
             });
 
             return sortAscending ? sortedAsc : sortedAsc.reverse();
@@ -185,11 +189,12 @@ export function SelectValidatorCard() {
                                         selectedValidator === validator.address
                                     }
                                     validatorAddress={validator.address}
-                                    value={
+                                    value={formatPercentageDisplay(
                                         !sortKey || sortKey === 'name'
-                                            ? '-'
-                                            : `${validator[sortKey]}%`
-                                    }
+                                            ? null
+                                            : validator[sortKey],
+                                        '-'
+                                    )}
                                 />
                             </div>
                         ))}


### PR DESCRIPTION
## Description 

Describe the changes or additions included in this PR.

This addresses the feedback from previous PR https://github.com/MystenLabs/sui/pull/10232

- Create a util that displays APY% or null fallback `--`
- replace `rollingAverageApys?.[validator.suiAddress] || rollingAverageApys?.[validator.suiAddress] === 0 ?rollingAverageApys?.[validator.suiAddress]  : null,` with `rollingAverageApys?.[validator.suiAddress] ?? null`


 

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
