### PR TITLE
Update gas budget needed for stress tool

### DIFF
--- a/crates/sui-benchmark/src/bank.rs
+++ b/crates/sui-benchmark/src/bank.rs
@@ -3,7 +3,7 @@
 
 use crate::util::{make_pay_tx, UpdatedAndNewlyMintedGasCoins};
 use crate::workloads::payload::Payload;
-use crate::workloads::workload::{Workload, WorkloadBuilder};
+use crate::workloads::workload::{Workload, WorkloadBuilder, MAX_GAS_FOR_TESTING};
 use crate::workloads::{Gas, GasCoinConfig};
 use crate::ValidatorProxy;
 use anyhow::{Error, Result};

--- a/crates/sui-benchmark/src/util.rs
+++ b/crates/sui-benchmark/src/util.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 use sui_keys::keystore::{AccountKeystore, FileBasedKeystore};
 use sui_types::{base_types::SuiAddress, crypto::SuiKeyPair};
 
+use crate::workloads::workload::MAX_GAS_FOR_TESTING;
 use crate::ValidatorProxy;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -16,10 +17,6 @@ use crate::workloads::Gas;
 use sui_types::crypto::{AccountKeyPair, KeypairTraits};
 use test_utils::messages::create_publish_move_package_transaction;
 use test_utils::transaction::parse_package_ref;
-
-// This is the maximum gas we will transfer from primary coin into any gas coin
-// for running the benchmark
-pub const MAX_GAS_FOR_TESTING: u64 = 1_000_000_000;
 
 pub type UpdatedAndNewlyMintedGasCoins = (Gas, Gas, Vec<Gas>);
 

--- a/crates/sui-benchmark/src/workloads/transfer_object.rs
+++ b/crates/sui-benchmark/src/workloads/transfer_object.rs
@@ -149,7 +149,7 @@ impl WorkloadBuilder<dyn Payload> for TransferObjectWorkloadBuilder {
         for _i in 0..self.num_payloads {
             let (address, keypair) = (owner, address_map.get(&owner).unwrap().clone());
             gas_configs.push(GasCoinConfig {
-                amount: MAX_GAS_FOR_TESTING,
+                amount: 1,
                 address,
                 keypair: keypair.clone(),
             });


### PR DESCRIPTION
## Test Plan 

```
cargo run --package sui-benchmark --bin stress -- --fullnode-rpc-addresses "http://fullnode.staging.svc.cluster.local:9000" --num-client-threads 24 --num-server-threads 1 --num-transfer-accounts 2 --local false --primary-gas-id 0x00000000000000000000000059931dcac57ba20d75321acaf55e8eb5a2c47e9f --genesis-blob-path ~/Desktop/genesis.blob --keystore-path ~/Documents/Sui/benchmark-sui.keystore bench --target-qps 100 --in-flight-ratio 15 --shared-counter 49 --transfer-object 49 --delegation 1 --batch-payment 1 --batch-payment-size 100 --adversarial 1 --client-metric-host 0.0.0.0 --num-workers 24
```

```
Benchmark Report:
+-------------+-----+-----+--------+---------------+---------------+---------------+-----------------------+----------------------------+
| duration(s) | tps | cps | error% | latency (min) | latency (p50) | latency (p99) | gas used (MIST total) | gas used/hr (MIST approx.) |
+=======================================================================================================================================+
| 692         | 95  | 95  | 0      | 50            | 201           | 3119          | 2,380,600,398,562     | 12,384,626,350,900         |
+-------------+-----+-----+--------+---------------+---------------+---------------+-----------------------+----------------------------+
```