### PR TITLE
[object runtime] Fix dynamic object loaded version check     

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/dynamic_object_field_swap.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/dynamic_object_field_swap.exp
@@ -1,0 +1,35 @@
+processed 8 tasks
+
+init:
+A: object(103)
+
+task 1 'publish'. lines 6-62:
+created: object(105)
+mutated: object(104)
+
+task 2 'run'. lines 64-64:
+created: object(107)
+mutated: object(106)
+
+task 3 'run'. lines 66-66:
+created: object(109)
+mutated: object(108)
+
+task 4 'run'. lines 68-68:
+created: object(111)
+mutated: object(107), object(109), object(110)
+
+task 5 'view-object'. lines 70-70:
+Owner: Object ID: ( fake(111) )
+Version: 3
+Contents: test::m::Child {id: sui::object::UID {id: sui::object::ID {bytes: fake(109)}}, value: 0u64}
+
+task 6 'run'. lines 72-72:
+created: object(113)
+mutated: object(107), object(109), object(112)
+deleted: object(111)
+
+task 7 'view-object'. lines 74-74:
+Owner: Account Address ( A )
+Version: 4
+Contents: test::m::Child {id: sui::object::UID {id: sui::object::ID {bytes: fake(109)}}, value: 0u64}

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/dynamic_object_field_swap.move
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/dynamic_object_field_swap.move
@@ -1,0 +1,74 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+
+module test::m {
+    use sui::tx_context::{Self, TxContext};
+    use sui::object::{Self, UID};
+    use sui::transfer;
+    use sui::dynamic_object_field as ofield;
+
+    struct Outer has key {
+        id: UID,
+        inner: Inner,
+    }
+
+    struct Inner has key, store {
+        id: UID,
+    }
+
+    struct Child has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    public fun new_parent(ctx: &mut TxContext): Outer {
+        let inner = Inner { id: object::new(ctx) };
+        Outer { id: object::new(ctx), inner }
+    }
+
+    public entry fun parent(ctx: &mut TxContext) {
+        transfer::share_object(new_parent(ctx))
+    }
+
+    public entry fun child(ctx: &mut TxContext) {
+        let child = Child { id: object::new(ctx), value: 0 };
+        transfer::transfer(child, tx_context::sender(ctx))
+    }
+
+    public entry fun add_field(parent: &mut Outer, child: Child) {
+        ofield::add(&mut parent.inner.id, 0u64, child);
+    }
+
+    public fun buy(parent: &mut Outer, ctx: &mut TxContext) {
+        let new_parent = new_parent(ctx);
+        swap(parent, &mut new_parent);
+        give(&mut new_parent, tx_context::sender(ctx));
+        transfer::share_object(new_parent)
+    }
+
+    public fun swap(old_parent: &mut Outer, new_parent: &mut Outer) {
+        let child: Child = ofield::remove(&mut old_parent.inner.id, 0u64);
+        ofield::add(&mut new_parent.inner.id, 0u64, child);
+    }
+
+    public fun give(parent: &mut Outer, recipient: address) {
+        let child: Child = ofield::remove(&mut parent.inner.id, 0u64);
+        transfer::transfer(child, recipient)
+    }
+}
+
+//# run test::m::parent --sender A
+
+//# run test::m::child --sender A
+
+//# run test::m::add_field --sender A --args object(107) object(109)
+
+//# view-object 109
+
+//# run test::m::buy --sender A --args object(107)
+
+//# view-object 109

--- a/crates/sui-framework/src/natives/object_runtime/object_store.rs
+++ b/crates/sui-framework/src/natives/object_runtime/object_store.rs
@@ -23,6 +23,7 @@ pub(super) struct ChildObject {
     pub(super) value: GlobalValue,
 }
 
+#[derive(Debug)]
 pub(crate) struct ChildObjectEffect {
     pub(super) owner: ObjectID,
     // none if it was an input object
@@ -356,8 +357,19 @@ impl<'a> ObjectStore<'a> {
     }
 
     // retrieve the `Op` effects for the child objects
-    pub(super) fn take_effects(&mut self) -> BTreeMap<ObjectID, ChildObjectEffect> {
-        std::mem::take(&mut self.store)
+    pub(super) fn take_effects(
+        &mut self,
+    ) -> (
+        BTreeMap<ObjectID, SequenceNumber>,
+        BTreeMap<ObjectID, ChildObjectEffect>,
+    ) {
+        let loaded_versions: BTreeMap<ObjectID, SequenceNumber> = self
+            .inner
+            .cached_objects
+            .iter()
+            .filter_map(|(id, obj_opt)| Some((*id, obj_opt.as_ref()?.version())))
+            .collect();
+        let child_object_effects = std::mem::take(&mut self.store)
             .into_iter()
             .filter_map(|(id, child_object)| {
                 let ChildObject {
@@ -366,11 +378,7 @@ impl<'a> ObjectStore<'a> {
                     move_type,
                     value,
                 } = child_object;
-                let loaded_version = self
-                    .inner
-                    .cached_objects
-                    .get(&id)
-                    .and_then(|obj_opt| Some(obj_opt.as_ref()?.version()));
+                let loaded_version = loaded_versions.get(&id).copied();
                 let effect = value.into_effect()?;
                 let child_effect = ChildObjectEffect {
                     owner,
@@ -381,7 +389,8 @@ impl<'a> ObjectStore<'a> {
                 };
                 Some((id, child_effect))
             })
-            .collect()
+            .collect();
+        (loaded_versions, child_object_effects)
     }
 
     pub(super) fn all_active_objects(&self) -> impl Iterator<Item = (&ObjectID, &Type, Value)> {

--- a/crates/sui-framework/src/natives/test_scenario.rs
+++ b/crates/sui-framework/src/natives/test_scenario.rs
@@ -70,7 +70,13 @@ pub fn end_transaction(
     let object_runtime_state = object_runtime_ref.take_state();
     // Determine writes and deletes
     // We pass an empty map as we do not expose dynamic field objects in the system
-    let results = object_runtime_state.finish(BTreeSet::new(), BTreeSet::new(), BTreeMap::new());
+    let results = object_runtime_state.finish(
+        BTreeSet::new(),
+        BTreeSet::new(),
+        BTreeMap::new(),
+        BTreeMap::new(),
+        false,
+    );
     let RuntimeResults {
         writes,
         deletions,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -16,7 +16,8 @@ const MAX_PROTOCOL_VERSION: u64 = 3;
 //
 // Version 1: Original version.
 // Version 2: Framework changes, including advancing epoch_start_time in safemode.
-// Version 3: gas model v2, including all sui conservation fixes.
+// Version 3: gas model v2, including all sui conservation fixes. Fix for loaded child object
+//            changes.
 
 #[derive(
     Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, JsonSchema,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -121,6 +121,9 @@ struct FeatureFlags {
     commit_root_state_digest: bool,
     // Pass epoch start time to advance_epoch safe mode function.
     advance_epoch_start_time_in_safe_mode: bool,
+    // If true, apply the fix to correctly capturing loaded child object versions in execution's
+    // object runtime.
+    loaded_child_objects_fixed: bool,
 }
 
 /// Constants that change the behavior of the protocol.
@@ -561,6 +564,10 @@ impl ProtocolConfig {
 
     pub fn get_advance_epoch_start_time_in_safe_mode(&self) -> bool {
         self.feature_flags.advance_epoch_start_time_in_safe_mode
+    }
+
+    pub fn loaded_child_objects_fixed(&self) -> bool {
+        self.feature_flags.loaded_child_objects_fixed
     }
 }
 
@@ -1494,6 +1501,7 @@ impl ProtocolConfig {
                 cfg.base_tx_cost_fixed = Some(2_000);
                 // storage gas price multiplier
                 cfg.storage_gas_price = Some(76);
+                cfg.feature_flags.loaded_child_objects_fixed = true;
                 cfg
             }
             // Use this template when making changes:

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -115,15 +115,23 @@ pub struct Error(pub String);
 struct FeatureFlags {
     // Add feature flags here, e.g.:
     // new_protocol_feature: bool,
+    #[serde(skip_serializing_if = "is_false")]
     package_upgrades: bool,
     // If true, validators will commit to the root state digest
     // in end of epoch checkpoint proposals
+    #[serde(skip_serializing_if = "is_false")]
     commit_root_state_digest: bool,
     // Pass epoch start time to advance_epoch safe mode function.
+    #[serde(skip_serializing_if = "is_false")]
     advance_epoch_start_time_in_safe_mode: bool,
     // If true, apply the fix to correctly capturing loaded child object versions in execution's
     // object runtime.
+    #[serde(skip_serializing_if = "is_false")]
     loaded_child_objects_fixed: bool,
+}
+
+fn is_false(b: &bool) -> bool {
+    !b
 }
 
 /// Constants that change the behavior of the protocol.

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_1.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_1.snap
@@ -3,10 +3,7 @@ source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur)"
 ---
 version: 1
-feature_flags:
-  package_upgrades: false
-  commit_root_state_digest: false
-  advance_epoch_start_time_in_safe_mode: false
+feature_flags: {}
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_serialized_tx_effects_size_bytes: 524288

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_2.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_2.snap
@@ -4,8 +4,6 @@ expression: "ProtocolConfig::get_for_version(cur)"
 ---
 version: 2
 feature_flags:
-  package_upgrades: false
-  commit_root_state_digest: false
   advance_epoch_start_time_in_safe_mode: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_3.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_3.snap
@@ -4,9 +4,8 @@ expression: "ProtocolConfig::get_for_version(cur)"
 ---
 version: 3
 feature_flags:
-  package_upgrades: false
-  commit_root_state_digest: false
   advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_serialized_tx_effects_size_bytes: 524288


### PR DESCRIPTION
## Description 

- Loaded object version was not properly populated if the object value did not have an effect

## Test Plan 

- New test

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
