### PR TITLE
[sdk] Fixed types issue with moduleResolution in nodenext/node16.

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -19,7 +19,8 @@
     ".": {
       "source": "./src/index.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Description 

I noticed that when moduleResolution is set to nodenext/node16, the module path for types cannot be resolved correctly, resulting in compilation type errors.

![image](https://user-images.githubusercontent.com/13028241/229285712-dec08ec1-fc82-4f3d-bb17-eb32a2716cfc.png)


## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
