### PR TITLE
Fix docs typo

### DIFF
--- a/doc/src/build/move/index.md
+++ b/doc/src/build/move/index.md
@@ -56,7 +56,7 @@ module sui::coin {
 
 Don't worry about the rest of the module contents for now; you can read more about [modules](https://github.com/move-language/move/blob/main/language/documentation/book/src/modules-and-scripts.md#modules) in the Move book later.
 
-**Important:** In Sui Move, package names are always in CamelCase, while the address alias is lowercase, for example `sui = 0x2` and `std = 0x1`. So: `Sui` = name of the imported package (Sui = sui framework), `sui` = address alias of `0x2`, `sui::sui` = module sui under the address `0x2`, and `sui::sui::SUI` = type in the module above.
+**Important:** In Sui Move, package names are always in PascalCase, while the address alias is lowercase, for example `sui = 0x2` and `std = 0x1`. So: `Sui` = name of the imported package (Sui = sui framework), `sui` = address alias of `0x2`, `sui::sui` = module sui under the address `0x2`, and `sui::sui::SUI` = type in the module above.
 
 When you define a module, specify the module name (`coin`) preceded by the name of the package where this module resides (`sui`). The combination of the package name and the module name uniquely identifies a module in Sui Move source code. The package name is globally unique, but different packages can contain modules with the same name. While module names are not unique, when they combine with their unique package name they result in a unique combination.
 


### PR DESCRIPTION
The docs mention package names are always in "CamelCase" but gives an example that's representative of "PascalCase". I think camel case is incorrect in this instance and could create confusion.

## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
