### PR TITLE
Fix cluster test

### DIFF
--- a/crates/sui-cluster-test/src/test_case/coin_merge_split_test.rs
+++ b/crates/sui-cluster-test/src/test_case/coin_merge_split_test.rs
@@ -124,7 +124,7 @@ impl CoinMergeSplitTest {
             primary_coin,
             coin_to_merge,
             Some(gas_obj_id),
-            10_000 * gas_price
+            2_000_000 * gas_price
         ];
 
         let data = ctx
@@ -148,7 +148,7 @@ impl CoinMergeSplitTest {
             primary_coin,
             amounts,
             Some(gas_obj_id),
-            10_000 * gas_price
+            2_000_000 * gas_price
         ];
 
         let data = ctx

--- a/crates/sui-cluster-test/src/test_case/coin_merge_split_test.rs
+++ b/crates/sui-cluster-test/src/test_case/coin_merge_split_test.rs
@@ -124,7 +124,7 @@ impl CoinMergeSplitTest {
             primary_coin,
             coin_to_merge,
             Some(gas_obj_id),
-            300_000_000 * gas_price
+            10_000 * gas_price
         ];
 
         let data = ctx
@@ -148,7 +148,7 @@ impl CoinMergeSplitTest {
             primary_coin,
             amounts,
             Some(gas_obj_id),
-            300_000_000 * gas_price
+            10_000 * gas_price
         ];
 
         let data = ctx

--- a/crates/sui-cluster-test/src/test_case/fullnode_build_publish_transaction_test.rs
+++ b/crates/sui-cluster-test/src/test_case/fullnode_build_publish_transaction_test.rs
@@ -32,7 +32,7 @@ impl TestCaseImpl for FullNodeBuildPublishTransactionTest {
             all_module_bytes,
             dependencies,
             None::<ObjectID>,
-            10_000 * gas_price
+            50_000_000 * gas_price
         ];
 
         let data = ctx

--- a/crates/sui-cluster-test/src/test_case/fullnode_build_publish_transaction_test.rs
+++ b/crates/sui-cluster-test/src/test_case/fullnode_build_publish_transaction_test.rs
@@ -32,7 +32,7 @@ impl TestCaseImpl for FullNodeBuildPublishTransactionTest {
             all_module_bytes,
             dependencies,
             None::<ObjectID>,
-            300_000_000 * gas_price
+            10_000 * gas_price
         ];
 
         let data = ctx

--- a/crates/sui-cluster-test/src/test_case/native_transfer_test.rs
+++ b/crates/sui-cluster-test/src/test_case/native_transfer_test.rs
@@ -42,7 +42,7 @@ impl TestCaseImpl for NativeTransferTest {
             signer,
             obj_to_transfer,
             Some(*gas_obj.id()),
-            10_000 * gas_price,
+            2_000_000 * gas_price,
             recipient_addr
         ];
         let data = ctx
@@ -57,7 +57,7 @@ impl TestCaseImpl for NativeTransferTest {
         let params = rpc_params![
             signer,
             obj_to_transfer,
-            300_000_000 * gas_price,
+            2_000_000 * gas_price,
             recipient_addr,
             None::<u64>
         ];

--- a/crates/sui-cluster-test/src/test_case/native_transfer_test.rs
+++ b/crates/sui-cluster-test/src/test_case/native_transfer_test.rs
@@ -42,7 +42,7 @@ impl TestCaseImpl for NativeTransferTest {
             signer,
             obj_to_transfer,
             Some(*gas_obj.id()),
-            300_000_000 * gas_price,
+            10_000 * gas_price,
             recipient_addr
         ];
         let data = ctx


### PR DESCRIPTION
## Description 

Cluster test is failing with `GasBalanceTooLow { gas_balance: 10000000, needed_gas_amount: 300000000 }` and I believe with a gas price of 1000 the constant used for budget is ridiculously high. 
So I am scaling it down and hope it works.


## Test Plan 

This is it

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
