### PR TITLE
rpc & indexer: get latest owned objects

### DIFF
--- a/.changeset/poor-rats-dream.md
+++ b/.changeset/poor-rats-dream.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Change getOwnedObject to ignore checkpoint and return latest objects

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -85,6 +85,7 @@ mod test {
         test_simulated_load(test_cluster, 120).await;
     }
 
+    #[ignore = "MUSTFIX"]
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_reconfig_restarts() {
         sui_protocol_config::ProtocolConfig::poison_get_for_min_version();

--- a/crates/sui-indexer/src/apis/extended_api.rs
+++ b/crates/sui-indexer/src/apis/extended_api.rs
@@ -11,8 +11,8 @@ use sui_json_rpc::api::{
 };
 use sui_json_rpc::SuiRpcModule;
 use sui_json_rpc_types::{
-    CheckpointedObjectID, EpochInfo, EpochPage, MoveCallMetrics, NetworkMetrics, ObjectsPage, Page,
-    SuiObjectDataFilter, SuiObjectResponse, SuiObjectResponseQuery,
+    CheckpointedObjectID, EpochInfo, EpochPage, MoveCallMetrics, NetworkMetrics, Page,
+    QueryObjectsPage, SuiObjectDataFilter, SuiObjectResponse, SuiObjectResponseQuery,
 };
 use sui_open_rpc::Module;
 use sui_types::base_types::EpochId;
@@ -34,7 +34,7 @@ impl<S: IndexerStore> ExtendedApi<S> {
         query: SuiObjectResponseQuery,
         cursor: Option<CheckpointedObjectID>,
         limit: Option<usize>,
-    ) -> Result<ObjectsPage, IndexerError> {
+    ) -> Result<QueryObjectsPage, IndexerError> {
         let limit = validate_limit(limit, QUERY_MAX_RESULT_LIMIT_OBJECTS)?;
 
         let at_checkpoint = if let Some(CheckpointedObjectID {
@@ -54,7 +54,7 @@ impl<S: IndexerStore> ExtendedApi<S> {
 
         let objects_from_db =
             self.state
-                .query_objects(filter, at_checkpoint, object_cursor, limit + 1)?;
+                .query_objects_history(filter, at_checkpoint, object_cursor, limit + 1)?;
 
         let mut data = objects_from_db
             .into_iter()
@@ -113,7 +113,7 @@ impl<S: IndexerStore + Sync + Send + 'static> ExtendedApiServer for ExtendedApi<
         query: SuiObjectResponseQuery,
         cursor: Option<CheckpointedObjectID>,
         limit: Option<usize>,
-    ) -> RpcResult<ObjectsPage> {
+    ) -> RpcResult<QueryObjectsPage> {
         Ok(self.query_objects_internal(query, cursor, limit)?)
     }
 

--- a/crates/sui-indexer/src/errors.rs
+++ b/crates/sui-indexer/src/errors.rs
@@ -53,8 +53,8 @@ pub enum IndexerError {
     #[error("Indexer failed to serialize/deserialize with error: `{0}`")]
     SerdeError(String),
 
-    #[error("Indexer does not support the feature yet with error: `{0}`")]
-    NotImplementedError(String),
+    #[error("Indexer does not support the feature with error: `{0}`")]
+    NotSupportedError(String),
 
     #[error(transparent)]
     UncategorizedError(#[from] anyhow::Error),

--- a/crates/sui-indexer/src/lib.rs
+++ b/crates/sui-indexer/src/lib.rs
@@ -50,11 +50,12 @@ pub type PgPoolConnection = PooledConnection<ConnectionManager<PgConnection>>;
 /// Returns all endpoints for which we have implemented on the indexer,
 /// some of them are not validated yet.
 /// NOTE: we only use this for integration testing
-const IMPLEMENTED_METHODS: [&str; 8] = [
+const IMPLEMENTED_METHODS: [&str; 9] = [
     // read apis
     "get_checkpoint",
     "get_latest_checkpoint_sequence_number",
     "get_object",
+    "get_owned_objects",
     "get_total_transaction_blocks",
     "get_transaction_block",
     "multi_get_transaction_blocks",

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -54,10 +54,17 @@ pub trait IndexerStore {
         version: Option<SequenceNumber>,
     ) -> Result<ObjectRead, IndexerError>;
 
-    fn query_objects(
+    fn query_objects_history(
         &self,
         filter: SuiObjectDataFilter,
         at_checkpoint: CheckpointSequenceNumber,
+        cursor: Option<ObjectID>,
+        limit: usize,
+    ) -> Result<Vec<ObjectRead>, IndexerError>;
+
+    fn query_latest_objects(
+        &self,
+        filter: SuiObjectDataFilter,
         cursor: Option<ObjectID>,
         limit: usize,
     ) -> Result<Vec<ObjectRead>, IndexerError>;

--- a/crates/sui-indexer/src/store/query.rs
+++ b/crates/sui-indexer/src/store/query.rs
@@ -5,11 +5,18 @@ use sui_json_rpc_types::SuiObjectDataFilter;
 use sui_types::base_types::ObjectID;
 
 pub trait DBFilter<C> {
-    fn to_sql(&self, cursor: Option<C>, limit: usize, columns: Vec<&str>) -> String;
+    fn to_objects_history_sql(&self, cursor: Option<C>, limit: usize, columns: Vec<&str>)
+        -> String;
+    fn to_latest_objects_sql(&self, cursor: Option<C>, limit: usize, columns: Vec<&str>) -> String;
 }
 
 impl DBFilter<ObjectID> for SuiObjectDataFilter {
-    fn to_sql(&self, cursor: Option<ObjectID>, limit: usize, columns: Vec<&str>) -> String {
+    fn to_objects_history_sql(
+        &self,
+        cursor: Option<ObjectID>,
+        limit: usize,
+        columns: Vec<&str>,
+    ) -> String {
         let inner_clauses = to_clauses(self);
         let inner_clauses = if let Some(inner_clauses) = inner_clauses {
             format!("\n      AND {inner_clauses}")
@@ -23,7 +30,7 @@ impl DBFilter<ObjectID> for SuiObjectDataFilter {
             "".to_string()
         };
         let cursor = if let Some(cursor) = cursor {
-            format!("\n      AND o.object_id = '{cursor}'")
+            format!("\n      AND o.object_id > '{cursor}'")
         } else {
             "".to_string()
         };
@@ -33,16 +40,58 @@ impl DBFilter<ObjectID> for SuiObjectDataFilter {
             .map(|c| format!("t1.{c}"))
             .collect::<Vec<_>>()
             .join(", ");
-
+        // NOTE: order by checkpoint DESC so that whenever a row from checkpoint is available,
+        // we will pick that over the one from fast-path, which has checkpoint of -1.
         format!(
             "SELECT {columns}
 FROM (SELECT DISTINCT ON (o.object_id) *
       FROM objects_history o
       WHERE o.checkpoint <= $1{cursor}{inner_clauses}
-      ORDER BY o.object_id, version DESC) AS t1
+      ORDER BY o.object_id, version, o.checkpoint DESC) AS t1
 WHERE t1.object_status NOT IN ('deleted', 'wrapped', 'unwrapped_then_deleted'){outer_clauses}
 LIMIT {limit};"
         )
+    }
+
+    fn to_latest_objects_sql(
+        &self,
+        cursor: Option<ObjectID>,
+        limit: usize,
+        columns: Vec<&str>,
+    ) -> String {
+        let columns = columns
+            .iter()
+            .map(|c| format!("o.{c}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        let cursor = if let Some(cursor) = cursor {
+            format!(" AND o.object_id > '{cursor}'")
+        } else {
+            "".to_string()
+        };
+
+        let inner_clauses = to_latest_objects_clauses(self);
+        let inner_clauses = if let Some(inner_clauses) = inner_clauses {
+            format!(" AND {inner_clauses}")
+        } else {
+            "".to_string()
+        };
+
+        format!(
+            "SELECT {columns} 
+FROM objects o WHERE o.object_status NOT IN ('deleted', 'wrapped', 'unwrapped_then_deleted'){cursor}{inner_clauses}
+LIMIT {limit};"
+        )
+    }
+}
+
+fn to_latest_objects_clauses(filter: &SuiObjectDataFilter) -> Option<String> {
+    match filter {
+        SuiObjectDataFilter::AddressOwner(a) => Some(format!(
+            "(o.owner_type = 'address_owner' AND o.owner_address = '{a}')"
+        )),
+        _ => None,
     }
 }
 
@@ -159,11 +208,14 @@ FROM (SELECT DISTINCT ON (o.object_id) *
       FROM objects_history o
       WHERE o.checkpoint <= $1
       AND ((o.owner_type = 'address_owner' AND o.owner_address = '0x92dd4d9b0150c251661d821583ef078024ae9e9ee11063e216500861eec7f381') OR (o.old_owner_type = 'address_owner' AND o.old_owner_address = '0x92dd4d9b0150c251661d821583ef078024ae9e9ee11063e216500861eec7f381'))
-      ORDER BY o.object_id, version DESC) AS t1
+      ORDER BY o.object_id, version, o.checkpoint DESC) AS t1
 WHERE t1.object_status NOT IN ('deleted', 'wrapped', 'unwrapped_then_deleted')
 AND t1.owner_address = '0x92dd4d9b0150c251661d821583ef078024ae9e9ee11063e216500861eec7f381'
 LIMIT 100;";
-        assert_eq!(expected_sql, filter.to_sql(None, 100, vec!["*"]));
+        assert_eq!(
+            expected_sql,
+            filter.to_objects_history_sql(None, 100, vec!["*"])
+        );
     }
 
     #[test]
@@ -180,10 +232,13 @@ FROM (SELECT DISTINCT ON (o.object_id) *
       FROM objects_history o
       WHERE o.checkpoint <= $1
       AND o.object_type LIKE '0x485d947e293f07e659127dc5196146b49cdf2efbe4b233f4d293fc56aff2aa17::test_module'
-      ORDER BY o.object_id, version DESC) AS t1
+      ORDER BY o.object_id, version, o.checkpoint DESC) AS t1
 WHERE t1.object_status NOT IN ('deleted', 'wrapped', 'unwrapped_then_deleted')
 LIMIT 100;";
-        assert_eq!(expected_sql, filter.to_sql(None, 100, vec!["*"]));
+        assert_eq!(
+            expected_sql,
+            filter.to_objects_history_sql(None, 100, vec!["*"])
+        );
     }
 
     #[test]
@@ -193,10 +248,13 @@ LIMIT 100;";
 FROM (SELECT DISTINCT ON (o.object_id) *
       FROM objects_history o
       WHERE o.checkpoint <= $1
-      ORDER BY o.object_id, version DESC) AS t1
+      ORDER BY o.object_id, version, o.checkpoint DESC) AS t1
 WHERE t1.object_status NOT IN ('deleted', 'wrapped', 'unwrapped_then_deleted')
 LIMIT 100;";
-        assert_eq!(expected_sql, filter.to_sql(None, 100, vec!["*"]));
+        assert_eq!(
+            expected_sql,
+            filter.to_objects_history_sql(None, 100, vec!["*"])
+        );
     }
 
     #[test]
@@ -207,10 +265,13 @@ FROM (SELECT DISTINCT ON (o.object_id) *
       FROM objects_history o
       WHERE o.checkpoint <= $1
       AND FALSE
-      ORDER BY o.object_id, version DESC) AS t1
+      ORDER BY o.object_id, version, o.checkpoint DESC) AS t1
 WHERE t1.object_status NOT IN ('deleted', 'wrapped', 'unwrapped_then_deleted')
 LIMIT 100;";
-        assert_eq!(expected_sql, filter.to_sql(None, 100, vec!["*"]));
+        assert_eq!(
+            expected_sql,
+            filter.to_objects_history_sql(None, 100, vec!["*"])
+        );
     }
 
     #[test]
@@ -230,9 +291,12 @@ FROM (SELECT DISTINCT ON (o.object_id) *
       FROM objects_history o
       WHERE o.checkpoint <= $1
       AND (o.object_id = '0xef9fb75a7b3d4cb5551ef0b08c83528b94d5f5cd8be28b1d08a87dbbf3731738' AND o.object_type = '0x2::test::Test')
-      ORDER BY o.object_id, version DESC) AS t1
+      ORDER BY o.object_id, version, o.checkpoint DESC) AS t1
 WHERE t1.object_status NOT IN ('deleted', 'wrapped', 'unwrapped_then_deleted')
 LIMIT 100;";
-        assert_eq!(expected_sql, filter.to_sql(None, 100, vec!["*"]));
+        assert_eq!(
+            expected_sql,
+            filter.to_objects_history_sql(None, 100, vec!["*"])
+        );
     }
 }

--- a/crates/sui-indexer/tests/integration_tests.rs
+++ b/crates/sui-indexer/tests/integration_tests.rs
@@ -139,7 +139,10 @@ pub mod pg_integration_test {
     > {
         let sender = test_cluster.accounts.first().unwrap();
         let recipient = test_cluster.accounts.last().unwrap();
-        let gas_objects: Vec<ObjectID> = indexer_rpc_client
+        // TODO(gegaowp): today indexer's get_owned_objects only supports filter
+        // by owner address, will revert this when the feature is complete.
+        let gas_objects: Vec<ObjectID> = test_cluster
+            .rpc_client()
             .get_owned_objects(
                 *sender,
                 Some(SuiObjectResponseQuery::new_with_filter(

--- a/crates/sui-json-rpc-types/src/sui_object.rs
+++ b/crates/sui-json-rpc-types/src/sui_object.rs
@@ -1018,7 +1018,8 @@ pub struct SuiMovePackage {
     pub disassembled: BTreeMap<String, Value>,
 }
 
-pub type ObjectsPage = Page<SuiObjectResponse, CheckpointedObjectID>;
+pub type QueryObjectsPage = Page<SuiObjectResponse, CheckpointedObjectID>;
+pub type ObjectsPage = Page<SuiObjectResponse, ObjectID>;
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]

--- a/crates/sui-json-rpc/src/api/extended.rs
+++ b/crates/sui-json-rpc/src/api/extended.rs
@@ -5,7 +5,7 @@ use jsonrpsee::core::RpcResult;
 use jsonrpsee_proc_macros::rpc;
 
 use sui_json_rpc_types::{
-    CheckpointedObjectID, EpochInfo, EpochPage, MoveCallMetrics, NetworkMetrics, ObjectsPage,
+    CheckpointedObjectID, EpochInfo, EpochPage, MoveCallMetrics, NetworkMetrics, QueryObjectsPage,
     SuiObjectResponseQuery,
 };
 use sui_open_rpc_macros::open_rpc;
@@ -40,7 +40,7 @@ pub trait ExtendedApi {
         cursor: Option<CheckpointedObjectID>,
         /// Max number of items returned per page, default to [QUERY_MAX_RESULT_LIMIT_OBJECTS] if not specified.
         limit: Option<usize>,
-    ) -> RpcResult<ObjectsPage>;
+    ) -> RpcResult<QueryObjectsPage>;
 
     /// Return Network metrics
     #[method(name = "getNetworkMetrics")]

--- a/crates/sui-json-rpc/src/api/indexer.rs
+++ b/crates/sui-json-rpc/src/api/indexer.rs
@@ -5,9 +5,8 @@ use jsonrpsee::core::RpcResult;
 use jsonrpsee_proc_macros::rpc;
 
 use sui_json_rpc_types::{
-    CheckpointedObjectID, DynamicFieldPage, EventFilter, EventPage, ObjectsPage, SuiEvent,
-    SuiObjectResponse, SuiObjectResponseQuery, SuiTransactionBlockResponseQuery,
-    TransactionBlocksPage,
+    DynamicFieldPage, EventFilter, EventPage, ObjectsPage, SuiEvent, SuiObjectResponse,
+    SuiObjectResponseQuery, SuiTransactionBlockResponseQuery, TransactionBlocksPage,
 };
 use sui_open_rpc_macros::open_rpc;
 use sui_types::base_types::{ObjectID, SuiAddress};
@@ -19,6 +18,10 @@ use sui_types::event::EventID;
 #[rpc(server, client, namespace = "suix")]
 pub trait IndexerApi {
     /// Return the list of objects owned by an address.
+    /// Note that if the address owns more than `QUERY_MAX_RESULT_LIMIT_OBJECTS` objects,
+    /// the pagination is not accurate, because previous page may have been updated when
+    /// the next page is fetched.
+    /// Please use suix_queryObjects if this is a concern.
     #[method(name = "getOwnedObjects")]
     async fn get_owned_objects(
         &self,
@@ -27,7 +30,7 @@ pub trait IndexerApi {
         /// the objects query criteria.
         query: Option<SuiObjectResponseQuery>,
         /// An optional paging cursor. If provided, the query will start from the next item after the specified cursor. Default to start from the first item if not specified.
-        cursor: Option<CheckpointedObjectID>,
+        cursor: Option<ObjectID>,
         /// Max number of items returned per page, default to [QUERY_MAX_RESULT_LIMIT_OBJECTS] if not specified.
         limit: Option<usize>,
     ) -> RpcResult<ObjectsPage>;

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1551,7 +1551,7 @@
           "name": "Extended API"
         }
       ],
-      "description": "Return the list of objects owned by an address.",
+      "description": "Return the list of objects owned by an address. Note that if the address owns more than `QUERY_MAX_RESULT_LIMIT_OBJECTS` objects, the pagination is not accurate, because previous page may have been updated when the next page is fetched. Please use suix_queryObjects if this is a concern.",
       "params": [
         {
           "name": "address",
@@ -1572,7 +1572,7 @@
           "name": "cursor",
           "description": "An optional paging cursor. If provided, the query will start from the next item after the specified cursor. Default to start from the first item if not specified.",
           "schema": {
-            "$ref": "#/components/schemas/CheckpointedObjectID"
+            "$ref": "#/components/schemas/ObjectID"
           }
         },
         {
@@ -1589,7 +1589,7 @@
         "name": "ObjectsPage",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/Page_for_SuiObjectResponse_and_CheckpointedObjectID"
+          "$ref": "#/components/schemas/Page_for_SuiObjectResponse_and_ObjectID"
         }
       }
     },
@@ -1779,7 +1779,7 @@
         }
       ],
       "result": {
-        "name": "ObjectsPage",
+        "name": "QueryObjectsPage",
         "required": true,
         "schema": {
           "$ref": "#/components/schemas/Page_for_SuiObjectResponse_and_CheckpointedObjectID"
@@ -5266,6 +5266,35 @@
             "anyOf": [
               {
                 "$ref": "#/components/schemas/CheckpointedObjectID"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      },
+      "Page_for_SuiObjectResponse_and_ObjectID": {
+        "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
+        "type": "object",
+        "required": [
+          "data",
+          "hasNextPage"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SuiObjectResponse"
+            }
+          },
+          "hasNextPage": {
+            "type": "boolean"
+          },
+          "nextCursor": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ObjectID"
               },
               {
                 "type": "null"

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -1,21 +1,23 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::error::{Error, SuiRpcResult};
-use crate::{RpcClient, WAIT_FOR_TX_TIMEOUT_SEC};
-use fastcrypto::encoding::Base64;
-use futures::stream;
-use futures_core::Stream;
-use jsonrpsee::core::client::Subscription;
 use std::collections::BTreeMap;
 use std::future;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+
+use fastcrypto::encoding::Base64;
+use futures::stream;
+use futures::StreamExt;
+use futures_core::Stream;
+use jsonrpsee::core::client::Subscription;
+
 use sui_json_rpc::api::GovernanceReadApiClient;
-use sui_json_rpc::api::IndexerApiClient;
-use sui_json_rpc::api::MoveUtilsClient;
+use sui_json_rpc::api::{
+    CoinReadApiClient, IndexerApiClient, MoveUtilsClient, ReadApiClient, WriteApiClient,
+};
 use sui_json_rpc_types::{
-    Balance, Checkpoint, CheckpointId, CheckpointedObjectID, Coin, CoinPage, DelegatedStake,
+    Balance, Checkpoint, CheckpointId, Coin, CoinPage, DelegatedStake,
     DryRunTransactionBlockResponse, DynamicFieldPage, EventFilter, EventPage, ObjectsPage,
     SuiCoinMetadata, SuiCommittee, SuiEvent, SuiGetPastObjectRequest, SuiMoveNormalizedModule,
     SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery, SuiPastObjectResponse,
@@ -29,10 +31,10 @@ use sui_types::error::TRANSACTION_NOT_FOUND_MSG_PREFIX;
 use sui_types::event::EventID;
 use sui_types::messages::{ExecuteTransactionRequestType, TransactionData, VerifiedTransaction};
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
-
-use futures::StreamExt;
-use sui_json_rpc::api::{CoinReadApiClient, ReadApiClient, WriteApiClient};
 use sui_types::sui_system_state::sui_system_state_summary::SuiSystemStateSummary;
+
+use crate::error::{Error, SuiRpcResult};
+use crate::{RpcClient, WAIT_FOR_TX_TIMEOUT_SEC};
 
 #[derive(Debug)]
 pub struct ReadApi {
@@ -48,7 +50,7 @@ impl ReadApi {
         &self,
         address: SuiAddress,
         query: Option<SuiObjectResponseQuery>,
-        cursor: Option<CheckpointedObjectID>,
+        cursor: Option<ObjectID>,
         limit: Option<usize>,
     ) -> SuiRpcResult<ObjectsPage> {
         Ok(self

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -955,6 +955,14 @@ impl ObjectRead {
             Self::Exists(_, o, _) => Ok(o),
         }
     }
+
+    pub fn object_id(&self) -> ObjectID {
+        match self {
+            Self::Deleted(oref) => oref.0,
+            Self::NotExists(id) => *id,
+            Self::Exists(oref, _, _) => oref.0,
+        }
+    }
 }
 
 impl Default for ObjectFormatOptions {

--- a/sdk/typescript/src/types/objects.ts
+++ b/sdk/typescript/src/types/objects.ts
@@ -425,7 +425,7 @@ export type CheckpointedObjectId = Infer<typeof CheckpointedObjectId>;
 
 export const PaginatedObjectsResponse = object({
   data: array(SuiObjectResponse),
-  nextCursor: nullable(CheckpointedObjectId),
+  nextCursor: nullable(ObjectId),
   hasNextPage: boolean(),
 });
 export type PaginatedObjectsResponse = Infer<typeof PaginatedObjectsResponse>;


### PR DESCRIPTION
## Description 

getOwnedObjects should always return latest objects, if pagination happens, it is expected to have some accuracy problems; If ppl care, they should use `queryObjects` and specify checkpoint instead.

## Test

CI
