### PR TITLE
[bug fix] - indexer failed to insert into database due to unicode in json data

### DIFF
--- a/crates/sui-indexer/migrations/2023-04-01-211603_drop_events_parsed_json/up.sql
+++ b/crates/sui-indexer/migrations/2023-04-01-211603_drop_events_parsed_json/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE events
+    DROP COLUMN IF EXISTS parsed_json;

--- a/crates/sui-indexer/src/models/events.rs
+++ b/crates/sui-indexer/src/models/events.rs
@@ -1,16 +1,21 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::errors::IndexerError;
-use crate::schema::events;
-use diesel::prelude::*;
-use move_core_types::identifier::Identifier;
-use serde_json::Value;
 use std::str::FromStr;
-use sui_json_rpc_types::SuiEvent;
+
+use diesel::prelude::*;
+use move_bytecode_utils::module_cache::GetModule;
+use move_core_types::identifier::Identifier;
+use move_core_types::value::MoveStruct;
+
+use sui_json_rpc_types::{SuiEvent, SuiMoveStruct};
 use sui_types::base_types::TransactionDigest;
 use sui_types::event::EventID;
+use sui_types::object::{MoveObject, ObjectFormatOptions};
 use sui_types::parse_sui_struct_tag;
+
+use crate::errors::IndexerError;
+use crate::schema::events;
 
 #[derive(Queryable, Insertable, Debug, Clone)]
 #[diesel(table_name = events)]
@@ -24,7 +29,6 @@ pub struct Event {
     pub module: String,
     pub event_type: String,
     pub event_time_ms: Option<i64>,
-    pub parsed_json: Value,
     pub event_bcs: Vec<u8>,
 }
 
@@ -39,15 +43,13 @@ impl From<SuiEvent> for Event {
             module: se.transaction_module.to_string(),
             event_type: se.type_.to_string(),
             event_time_ms: se.timestamp_ms.map(|t| t as i64),
-            parsed_json: se.parsed_json,
             event_bcs: se.bcs,
         }
     }
 }
 
-impl TryInto<SuiEvent> for Event {
-    type Error = IndexerError;
-    fn try_into(self) -> Result<SuiEvent, Self::Error> {
+impl Event {
+    pub fn try_into(self, module_cache: &impl GetModule) -> Result<SuiEvent, IndexerError> {
         // Event in this table is always MoveEvent
         let package_id = self.package.parse().map_err(|e| {
             IndexerError::SerdeError(format!("Failed to parse event package ID: {:?}", e))
@@ -55,6 +57,18 @@ impl TryInto<SuiEvent> for Event {
         let sender = self.sender.parse().map_err(|e| {
             IndexerError::SerdeError(format!("Failed to parse event sender address: {:?}", e))
         })?;
+
+        let type_ = parse_sui_struct_tag(&self.event_type)?;
+
+        let layout = MoveObject::get_layout_from_struct_tag(
+            type_.clone(),
+            ObjectFormatOptions::default(),
+            module_cache,
+        )?;
+        let move_object = MoveStruct::simple_deserialize(&self.event_bcs, &layout)
+            .map_err(|e| IndexerError::SerdeError(e.to_string()))?;
+        let parsed_json = SuiMoveStruct::from(move_object).to_json_value();
+
         Ok(SuiEvent {
             id: EventID {
                 tx_digest: TransactionDigest::from_str(&self.transaction_digest)?,
@@ -63,9 +77,9 @@ impl TryInto<SuiEvent> for Event {
             package_id,
             transaction_module: Identifier::from_str(&self.module)?,
             sender,
-            type_: parse_sui_struct_tag(&self.event_type)?,
+            type_,
             bcs: self.event_bcs,
-            parsed_json: self.parsed_json,
+            parsed_json,
             timestamp_ms: self.event_time_ms.map(|t| t as u64),
         })
     }

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -88,7 +88,6 @@ diesel::table! {
         module -> Text,
         event_type -> Text,
         event_time_ms -> Nullable<Int8>,
-        parsed_json -> Jsonb,
         event_bcs -> Bytea,
     }
 }

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -371,7 +371,7 @@ impl IndexerStore for PgIndexerStore {
 
         let mut sui_event_vec = events_vec
             .into_iter()
-            .map(|event| event.try_into())
+            .map(|event| event.try_into(&self.module_cache))
             .collect::<Result<Vec<SuiEvent>, _>>()?;
         // reset to original limit for checking and truncating
         page_limit -= 1;

--- a/crates/sui-indexer/tests/integration_tests.rs
+++ b/crates/sui-indexer/tests/integration_tests.rs
@@ -497,12 +497,26 @@ pub mod pg_integration_test {
 
         let filter_on_event_type = EventFilter::MoveEventType(target_struct_tag.clone());
         let query_response = indexer_rpc_client
-            .query_events(filter_on_event_type, None, None, None)
+            .query_events(filter_on_event_type.clone(), None, None, None)
             .await?;
         assert_eq!(query_response.data.len(), 2);
         assert_eq!(digest_one, query_response.data[0].id.tx_digest);
         assert_eq!(digest_two, query_response.data[1].id.tx_digest);
 
+        // check parsed event data with FN
+        let fn_query_response = test_cluster
+            .rpc_client()
+            .query_events(filter_on_event_type, None, None, None)
+            .await?;
+
+        assert_eq!(fn_query_response.data.len(), 2);
+        assert_eq!(digest_one, fn_query_response.data[0].id.tx_digest);
+        assert_eq!(digest_two, fn_query_response.data[1].id.tx_digest);
+
+        assert_eq!(
+            query_response.data[0].parsed_json,
+            fn_query_response.data[0].parsed_json
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Description 

Removing parsed_json column from database, we will parse it from bcs bytes instead

## Test Plan 

Integration test and testing it manually
