### PR TITLE
Check 10B SUI conservation at epoch boundary

### DIFF
--- a/crates/sui-benchmark/src/benchmark_setup.rs
+++ b/crates/sui-benchmark/src/benchmark_setup.rs
@@ -89,6 +89,12 @@ impl Env {
             test_and_configure_authority_configs_with_objects(committee_size, generated_gas);
         let mut metric_port = server_metric_port;
         for node_config in network_config.validator_configs.iter_mut() {
+            // Benchmark setup allocates very large gas objects, which will lead to overflow if we attempt
+            // to calculate the amount of SUI in the network. Hence we disable SUI conservation checks
+            // even when we are running in debug mode.
+            node_config
+                .expensive_safety_check_config
+                .force_disable_epoch_sui_conservation_check();
             let parameters = &mut node_config
                 .consensus_config
                 .as_mut()

--- a/crates/sui-config/src/builder.rs
+++ b/crates/sui-config/src/builder.rs
@@ -512,7 +512,7 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                     supported_protocol_versions: Some(supported_protocol_versions),
                     db_checkpoint_config: self.db_checkpoint_config.clone(),
                     indirect_objects_threshold: usize::MAX,
-                    enable_expensive_safety_checks: false,
+                    expensive_safety_check_config: Default::default(),
                 }
             })
             .collect();

--- a/crates/sui-config/src/swarm.rs
+++ b/crates/sui-config/src/swarm.rs
@@ -285,7 +285,8 @@ impl<'a> FullnodeConfigBuilder<'a> {
             supported_protocol_versions: Some(supported_protocol_versions),
             db_checkpoint_config: self.db_checkpoint_config,
             indirect_objects_threshold: usize::MAX,
-            enable_expensive_safety_checks: false,
+            // Copy the expensive safety check config from the first validator config.
+            expensive_safety_check_config: validator_config.expensive_safety_check_config.clone(),
         })
     }
 }

--- a/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -75,7 +75,9 @@ validator_configs:
     db-checkpoint-config:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
-    enable-expensive-safety-checks: false
+    expensive-safety-check-config:
+      enable-epoch-sui-conservation-check: false
+      force-disable-epoch-sui-conservation-check: false
   - protocol-key-pair:
       value: avYcyVgYMXTyaUYh9IRwLK0gSzl7YF6ZQDAbrS1Bhvo=
     worker-key-pair:
@@ -148,7 +150,9 @@ validator_configs:
     db-checkpoint-config:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
-    enable-expensive-safety-checks: false
+    expensive-safety-check-config:
+      enable-epoch-sui-conservation-check: false
+      force-disable-epoch-sui-conservation-check: false
   - protocol-key-pair:
       value: OXnx3yM1C/ppgnDMx/o1d49fJs7E05kq11mXNae/O+I=
     worker-key-pair:
@@ -221,7 +225,9 @@ validator_configs:
     db-checkpoint-config:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
-    enable-expensive-safety-checks: false
+    expensive-safety-check-config:
+      enable-epoch-sui-conservation-check: false
+      force-disable-epoch-sui-conservation-check: false
   - protocol-key-pair:
       value: CyNkjqNVr3HrHTH7f/NLs7u5lUHJzuPAw0PqMTD2y2s=
     worker-key-pair:
@@ -294,7 +300,9 @@ validator_configs:
     db-checkpoint-config:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
-    enable-expensive-safety-checks: false
+    expensive-safety-check-config:
+      enable-epoch-sui-conservation-check: false
+      force-disable-epoch-sui-conservation-check: false
   - protocol-key-pair:
       value: X/I/kM+KvHcxAKEf2UU6Sr7SpN3bhiE9nP5CuM/iIY0=
     worker-key-pair:
@@ -367,7 +375,9 @@ validator_configs:
     db-checkpoint-config:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
-    enable-expensive-safety-checks: false
+    expensive-safety-check-config:
+      enable-epoch-sui-conservation-check: false
+      force-disable-epoch-sui-conservation-check: false
   - protocol-key-pair:
       value: N272EiFDyKtxRbDKbyN6ujenJ+skPcRoc/XolpOLGnU=
     worker-key-pair:
@@ -440,7 +450,9 @@ validator_configs:
     db-checkpoint-config:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
-    enable-expensive-safety-checks: false
+    expensive-safety-check-config:
+      enable-epoch-sui-conservation-check: false
+      force-disable-epoch-sui-conservation-check: false
   - protocol-key-pair:
       value: a74f03IOjL8ZFSWFChFVEi+wiMwHNwNCPDGIYkGfgjs=
     worker-key-pair:
@@ -513,7 +525,9 @@ validator_configs:
     db-checkpoint-config:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
-    enable-expensive-safety-checks: false
+    expensive-safety-check-config:
+      enable-epoch-sui-conservation-check: false
+      force-disable-epoch-sui-conservation-check: false
 account_keys:
   - Hloy4pnf8pWEHGP+4OFsXz56bLdIJhkD2O+OdKMqCA4=
   - pvMScjoMR/DaN0M5IOxS2VpGC59N6kv6gDm63ufLQ5w=

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -43,7 +43,9 @@ use shared_crypto::intent::{Intent, IntentScope};
 use sui_adapter::execution_engine;
 use sui_adapter::{adapter, execution_mode};
 use sui_config::genesis::Genesis;
-use sui_config::node::{AuthorityStorePruningConfig, DBCheckpointConfig};
+use sui_config::node::{
+    AuthorityStorePruningConfig, DBCheckpointConfig, ExpensiveSafetyCheckConfig,
+};
 use sui_framework::{MoveStdlib, SuiFramework, SuiSystem, SystemPackage};
 use sui_json_rpc_types::{
     Checkpoint, DevInspectResults, DryRunTransactionBlockResponse, EventFilter, SuiEvent,
@@ -489,6 +491,9 @@ pub struct AuthorityState {
 
     /// Take db checkpoints af different dbs
     db_checkpoint_config: DBCheckpointConfig,
+
+    /// Config controlling what kind of expensive safety checks to perform.
+    _expensive_safety_check_config: ExpensiveSafetyCheckConfig,
 }
 
 /// The authority state encapsulates all state, drives execution, and ensures safety.
@@ -1623,6 +1628,7 @@ impl AuthorityState {
         pruning_config: AuthorityStorePruningConfig,
         genesis_objects: &[Object],
         db_checkpoint_config: &DBCheckpointConfig,
+        expensive_safety_check_config: ExpensiveSafetyCheckConfig,
     ) -> Arc<Self> {
         Self::check_protocol_version(supported_protocol_versions, epoch_store.protocol_version());
 
@@ -1661,6 +1667,7 @@ impl AuthorityState {
             _objects_pruner,
             _authority_per_epoch_pruner,
             db_checkpoint_config: db_checkpoint_config.clone(),
+            _expensive_safety_check_config: expensive_safety_check_config,
         });
 
         // Start a task to execute ready certificates.
@@ -1746,6 +1753,7 @@ impl AuthorityState {
             AuthorityStorePruningConfig::default(),
             genesis.objects(),
             &DBCheckpointConfig::default(),
+            ExpensiveSafetyCheckConfig::new_enable_all(),
         )
         .await;
 
@@ -1836,6 +1844,7 @@ impl AuthorityState {
         let mut execution_lock = db.execution_lock_for_reconfiguration().await;
         self.revert_uncommitted_epoch_transactions(cur_epoch_store)
             .await?;
+        self.check_system_consistency();
         if let Some(checkpoint_path) = &self.db_checkpoint_config.checkpoint_path {
             if self
                 .db_checkpoint_config
@@ -1858,6 +1867,18 @@ impl AuthorityState {
         // see also assert in AuthorityState::process_certificate
         // on the epoch store and execution lock epoch match
         Ok(new_epoch_store)
+    }
+
+    fn check_system_consistency(&self) {
+        if let Err(err) = self.database.expensive_check_sui_conservation() {
+            if cfg!(debug_assertions) {
+                panic!("{}", err);
+            } else {
+                // We cannot panic in production yet because it is known that there are some
+                // inconsistencies in testnet. We will enable this once we make it balanced again in testnet.
+                warn!("System consistency check failed: {}", err);
+            }
+        }
     }
 
     pub fn db(&self) -> Arc<AuthorityStore> {

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -97,6 +97,12 @@ pub struct AuthorityPerpetualTables {
 
     /// A singleton table that stores latest pruned checkpoint. Used to keep objects pruner progress
     pub(crate) pruned_checkpoint: DBMap<(), CheckpointSequenceNumber>,
+
+    /// Expected total amount of SUI in the network. This is expected to remain constant
+    /// throughout the lifetime of the network. We check it at the end of each epoch if
+    /// expensive checks are enabled. We cannot use 10B today because in tests we often
+    /// inject extra gas objects into genesis.
+    pub(crate) expected_network_sui_amount: DBMap<(), u64>,
 }
 
 impl AuthorityPerpetualTables {

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -19,7 +19,6 @@ use anyhow::Result;
 use arc_swap::ArcSwap;
 use futures::TryFutureExt;
 use prometheus::Registry;
-use sui_core::authority::authority_store_tables::LiveObject;
 use sui_core::consensus_adapter::LazyNarwhalClient;
 use sui_types::sui_system_state::SuiSystemState;
 use tap::tap::TapFallible;
@@ -192,6 +191,9 @@ impl SuiNode {
                 genesis,
                 &committee_store,
                 config.indirect_objects_threshold,
+                config
+                    .expensive_safety_check_config
+                    .enable_epoch_sui_conservation_check(),
             )
             .await?,
         );
@@ -300,6 +302,7 @@ impl SuiNode {
             config.authority_store_pruning_config,
             genesis.objects(),
             &db_checkpoint_config,
+            config.expensive_safety_check_config.clone(),
         )
         .await;
         // ensure genesis txn was executed
@@ -1016,8 +1019,6 @@ impl SuiNode {
                     None
                 }
             } else {
-                self.check_system_consistency();
-
                 let new_epoch_store = self
                     .reconfigure_state(
                         &cur_epoch_store,
@@ -1110,43 +1111,6 @@ impl SuiNode {
         info!(next_epoch, "Validator State has been reconfigured");
         assert_eq!(next_epoch, new_epoch_store.epoch());
         new_epoch_store
-    }
-
-    fn check_system_consistency(&self) {
-        if !self.config.enable_expensive_safety_checks && cfg!(not(debug_assertions)) {
-            // We only do these checks if either the expensive safety checks are enabled or we are
-            // running in debug mode.
-            return;
-        }
-        let total_storage_rebate: u64 = self
-            .state
-            .db()
-            .iter_live_object_set()
-            .map(|o| match o {
-                LiveObject::Normal(object) => object.storage_rebate,
-                LiveObject::Wrapped(_) => 0,
-            })
-            .sum();
-        let system_state = self
-            .state
-            .get_sui_system_state_object_during_reconfig()
-            .expect("Reading sui system state object cannot fail")
-            .into_sui_system_state_summary();
-
-        let storage_fund_balance = system_state.storage_fund_total_object_storage_rebates;
-        if total_storage_rebate != storage_fund_balance {
-            let err = format!(
-                "Inconsistent state detected at epoch {}: total storage rebate: {}, storage fund balance: {}",
-                system_state.epoch, total_storage_rebate, storage_fund_balance
-            );
-            if cfg!(debug_assertions) {
-                panic!("{}", err);
-            } else {
-                // We cannot panic in production yet because it is known that there are some
-                // inconsistencies in testnet. We will enable this once we make it balanced again in testnet.
-                warn!(err);
-            }
-        }
     }
 }
 


### PR DESCRIPTION
Adds a config to dictate whether we want to make expensive checks at epoch boundary.
Checks that storage fund balance is equal to all storage rebates.
Checks that total SUI in the network is 10B.