### PR TITLE
[Narwhal] initialize primary->worker handler with Network

### DIFF
--- a/narwhal/worker/src/tests/handlers_tests.rs
+++ b/narwhal/worker/src/tests/handlers_tests.rs
@@ -21,19 +21,7 @@ async fn synchronize() {
     // Create a new test store.
     let store = test_utils::create_batch_store();
 
-    let handler = PrimaryReceiverHandler {
-        authority_id,
-        id,
-        committee,
-        worker_cache,
-        store: store.clone(),
-        request_batch_timeout: Duration::from_secs(999),
-        request_batch_retry_nodes: 3, // Not used in this test.
-        batch_fetcher: None,
-        validator: TrivialTransactionValidator,
-    };
-
-    // Set up mock behavior for child RequestBatches RPC.
+    // Create network with mock behavior to respond to RequestBatch request.
     let target_primary = fixture.authorities().nth(1).unwrap();
     let batch = test_utils::batch();
     let digest = batch.digest();
@@ -56,12 +44,6 @@ async fn synchronize() {
     let routes = anemo::Router::new().add_rpc_service(WorkerToWorkerServer::new(mock_server));
     let target_worker = target_primary.worker(id);
     let _recv_network = target_worker.new_network(routes);
-
-    // Check not in store
-    assert!(store.get(&digest).unwrap().is_none());
-
-    // Send a sync request.
-    let mut request = anemo::Request::new(message);
     let send_network = test_utils::random_network();
     send_network
         .connect_with_peer_id(
@@ -74,13 +56,28 @@ async fn synchronize() {
         )
         .await
         .unwrap();
-    assert!(request
-        .extensions_mut()
-        .insert(send_network.downgrade())
-        .is_none());
+
+    let handler = PrimaryReceiverHandler {
+        authority_id,
+        id,
+        committee,
+        worker_cache,
+        store: store.clone(),
+        request_batch_timeout: Duration::from_secs(999),
+        request_batch_retry_nodes: 3, // Not used in this test.
+        network: Some(send_network),
+        batch_fetcher: None,
+        validator: TrivialTransactionValidator,
+    };
+
+    // Verify the batch is not in store
+    assert!(store.get(&digest).unwrap().is_none());
+
+    // Send a sync request.
+    let request = anemo::Request::new(message);
     handler.synchronize(request).await.unwrap();
 
-    // Check its now stored
+    // Verify it is now stored
     assert!(store.get(&digest).unwrap().is_some())
 }
 
@@ -97,6 +94,9 @@ async fn synchronize_when_batch_exists() {
     // Create a new test store.
     let store = test_utils::create_batch_store();
 
+    // Create network without mock behavior since it will not be needed.
+    let send_network = test_utils::random_network();
+
     let handler = PrimaryReceiverHandler {
         authority_id,
         id,
@@ -105,6 +105,7 @@ async fn synchronize_when_batch_exists() {
         store: store.clone(),
         request_batch_timeout: Duration::from_secs(999),
         request_batch_retry_nodes: 3, // Not used in this test.
+        network: Some(send_network),
         batch_fetcher: None,
         validator: TrivialTransactionValidator,
     };
@@ -115,16 +116,14 @@ async fn synchronize_when_batch_exists() {
     let missing = vec![batch_id];
     store.insert(&batch_id, &batch).unwrap();
 
-    // Set up mock behavior for child RequestBatches RPC.
+    // Send a sync request.
     let target_primary = fixture.authorities().nth(1).unwrap();
     let message = WorkerSynchronizeMessage {
         digests: missing.clone(),
         target: target_primary.id(),
         is_certified: false,
     };
-
-    // Send a sync request.
-    // Don't bother to inject a fake network because handler shouldn't need it.
+    // The sync request should succeed.
     handler
         .synchronize(anemo::Request::new(message))
         .await
@@ -156,6 +155,7 @@ async fn delete_batches() {
         store: store.clone(),
         request_batch_timeout: Duration::from_secs(999),
         request_batch_retry_nodes: 3, // Not used in this test.
+        network: None,
         batch_fetcher: None,
         validator: TrivialTransactionValidator,
     };

--- a/narwhal/worker/src/worker.rs
+++ b/narwhal/worker/src/worker.rs
@@ -128,6 +128,7 @@ impl Worker {
             ));
         }
 
+        // Legacy RPC interface, only used by delete_batches() for external consensus.
         let primary_service = PrimaryToWorkerServer::new(PrimaryReceiverHandler {
             authority_id: worker.authority.id(),
             id: worker.id,
@@ -136,6 +137,7 @@ impl Worker {
             store: worker.store.clone(),
             request_batch_timeout: worker.parameters.sync_retry_delay,
             request_batch_retry_nodes: worker.parameters.sync_retry_nodes,
+            network: None,
             batch_fetcher: None,
             validator: validator.clone(),
         });
@@ -282,6 +284,7 @@ impl Worker {
                 store: worker.store.clone(),
                 request_batch_timeout: worker.parameters.sync_retry_delay,
                 request_batch_retry_nodes: worker.parameters.sync_retry_nodes,
+                network: Some(network.clone()),
                 batch_fetcher: Some(batch_fetcher),
                 validator: validator.clone(),
             }),


### PR DESCRIPTION
## Description 

Worker's PrimaryReceiverHandler was a dependency for creating Network, so it could not have a Network member variable in a straightforward way. But Network is needed to send outgoing RPCs. The workaround was to get the Network object from the incoming request.

Now for handling local connections, Network object is already available when constructing the primary->worker local handler, but no longer available as part of the request. So we store Network in PrimaryReceiverHandler optionally, when it is used as a local handler.

## Test Plan 

unit test

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
