### PR TITLE
[StateAccumulator] Check consistency in expensive mode

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -279,6 +279,15 @@ pub struct ExpensiveSafetyCheckConfig {
     /// Disable epoch SUI conservation check even when we are running in debug mode.
     #[serde(default)]
     force_disable_epoch_sui_conservation_check: bool,
+
+    /// If enabled, at epoch boundary, we will check that the accumulated
+    /// live object state matches the end of epoch root state digest.
+    #[serde(default)]
+    enable_state_consistency_check: bool,
+
+    /// Disable state consistency check even when we are running in debug mode.
+    #[serde(default)]
+    force_disable_state_consistency_check: bool,
     // TODO: Add more expensive checks here
 }
 
@@ -287,6 +296,8 @@ impl ExpensiveSafetyCheckConfig {
         Self {
             enable_epoch_sui_conservation_check: true,
             force_disable_epoch_sui_conservation_check: false,
+            enable_state_consistency_check: true,
+            force_disable_state_consistency_check: false,
         }
     }
 
@@ -297,6 +308,15 @@ impl ExpensiveSafetyCheckConfig {
     pub fn enable_epoch_sui_conservation_check(&self) -> bool {
         (self.enable_epoch_sui_conservation_check || cfg!(debug_assertions))
             && !self.force_disable_epoch_sui_conservation_check
+    }
+
+    pub fn force_disable_state_consistency_check(&mut self) {
+        self.force_disable_state_consistency_check = true;
+    }
+
+    pub fn enable_state_consistency_check(&self) -> bool {
+        (self.enable_state_consistency_check || cfg!(debug_assertions))
+            && !self.force_disable_state_consistency_check
     }
 }
 

--- a/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -78,6 +78,8 @@ validator_configs:
     expensive-safety-check-config:
       enable-epoch-sui-conservation-check: false
       force-disable-epoch-sui-conservation-check: false
+      enable-state-consistency-check: false
+      force-disable-state-consistency-check: false
   - protocol-key-pair:
       value: avYcyVgYMXTyaUYh9IRwLK0gSzl7YF6ZQDAbrS1Bhvo=
     worker-key-pair:
@@ -153,6 +155,8 @@ validator_configs:
     expensive-safety-check-config:
       enable-epoch-sui-conservation-check: false
       force-disable-epoch-sui-conservation-check: false
+      enable-state-consistency-check: false
+      force-disable-state-consistency-check: false
   - protocol-key-pair:
       value: OXnx3yM1C/ppgnDMx/o1d49fJs7E05kq11mXNae/O+I=
     worker-key-pair:
@@ -228,6 +232,8 @@ validator_configs:
     expensive-safety-check-config:
       enable-epoch-sui-conservation-check: false
       force-disable-epoch-sui-conservation-check: false
+      enable-state-consistency-check: false
+      force-disable-state-consistency-check: false
   - protocol-key-pair:
       value: CyNkjqNVr3HrHTH7f/NLs7u5lUHJzuPAw0PqMTD2y2s=
     worker-key-pair:
@@ -303,6 +309,8 @@ validator_configs:
     expensive-safety-check-config:
       enable-epoch-sui-conservation-check: false
       force-disable-epoch-sui-conservation-check: false
+      enable-state-consistency-check: false
+      force-disable-state-consistency-check: false
   - protocol-key-pair:
       value: X/I/kM+KvHcxAKEf2UU6Sr7SpN3bhiE9nP5CuM/iIY0=
     worker-key-pair:
@@ -378,6 +386,8 @@ validator_configs:
     expensive-safety-check-config:
       enable-epoch-sui-conservation-check: false
       force-disable-epoch-sui-conservation-check: false
+      enable-state-consistency-check: false
+      force-disable-state-consistency-check: false
   - protocol-key-pair:
       value: N272EiFDyKtxRbDKbyN6ujenJ+skPcRoc/XolpOLGnU=
     worker-key-pair:
@@ -453,6 +463,8 @@ validator_configs:
     expensive-safety-check-config:
       enable-epoch-sui-conservation-check: false
       force-disable-epoch-sui-conservation-check: false
+      enable-state-consistency-check: false
+      force-disable-state-consistency-check: false
   - protocol-key-pair:
       value: a74f03IOjL8ZFSWFChFVEi+wiMwHNwNCPDGIYkGfgjs=
     worker-key-pair:
@@ -528,6 +540,8 @@ validator_configs:
     expensive-safety-check-config:
       enable-epoch-sui-conservation-check: false
       force-disable-epoch-sui-conservation-check: false
+      enable-state-consistency-check: false
+      force-disable-state-consistency-check: false
 account_keys:
   - Hloy4pnf8pWEHGP+4OFsXz56bLdIJhkD2O+OdKMqCA4=
   - pvMScjoMR/DaN0M5IOxS2VpGC59N6kv6gDm63ufLQ5w=

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -114,7 +114,7 @@ pub async fn test_checkpoint_executor_cross_epoch() {
     let tempdir = tempdir().unwrap();
     let checkpoint_store = CheckpointStore::new(tempdir.path());
 
-    let (authority_state, mut executor, _accumulator, checkpoint_sender, first_committee): (
+    let (authority_state, mut executor, accumulator, checkpoint_sender, first_committee): (
         Arc<AuthorityState>,
         CheckpointExecutor,
         Arc<StateAccumulator>,
@@ -231,6 +231,9 @@ pub async fn test_checkpoint_executor_cross_epoch() {
             SupportedProtocolVersions::SYSTEM_DEFAULT,
             second_committee.committee().clone(),
             EpochStartConfiguration::new_v1(system_state, Default::default()),
+            &executor,
+            accumulator,
+            true,
         )
         .await
         .unwrap();


### PR DESCRIPTION
## Description 

Checking for state consistency is too expensive to be run blocking between epochs in general. So either we run in the background or we make this check opt-in only. 

Option (1) may be introduced later via RocksDB snapshots, but for now this PR introduces option (2). 

## Test Plan 

Existing tests since this will run in expensive mode or debug mode.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
