### PR TITLE
enable conservation

### DIFF
--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -167,6 +167,7 @@ fn execute_transaction<
     GasCostSummary,
     Result<Mode::ExecutionResults, ExecutionError>,
 ) {
+    println!("GAS - gas coins {}", gas.len());
     // First smash gas into the first coin if more than 1 was provided
     let gas_object_ref = match temporary_store.smash_gas(gas) {
         Ok(obj_ref) => obj_ref,
@@ -179,11 +180,10 @@ fn execute_transaction<
             && gas_status.storage_gas_units() == 0,
         "No gas charges must be applied yet"
     );
-    // TODO(conservation)
-    // #[cfg(debug_assertions)]
-    // let is_genesis_tx = matches!(transaction_kind, TransactionKind::Genesis(_));
-    // #[cfg(debug_assertions)]
-    // let advance_epoch_gas_summary = transaction_kind.get_advance_epoch_tx_gas_summary();
+    #[cfg(debug_assertions)]
+    let is_genesis_tx = matches!(transaction_kind, TransactionKind::Genesis(_));
+    #[cfg(debug_assertions)]
+    let advance_epoch_gas_summary = transaction_kind.get_advance_epoch_tx_gas_summary();
 
     // We must charge object read here during transaction execution, because if this fails
     // we must still ensure an effect is committed and all objects versions incremented
@@ -284,27 +284,26 @@ fn execute_transaction<
         // Put all the storage rebate accumulated in the system transaction
         // to the 0x5 object so that it's not lost.
         temporary_store.conserve_unmetered_storage_rebate(gas_status.unmetered_storage_rebate());
-        // TODO(conservation)
-        // #[cfg(debug_assertions)]
-        // {
-        //     // Genesis transactions mint sui supply, and hence does not satisfy SUI conservation.
-        //     if !is_genesis_tx {
-        //         // For advance epoch transaction, we need to provide epoch rewards and rebates as extra
-        //         // information provided to check_sui_conserved, because we mint rewards, and burn
-        //         // the rebates. We also need to pass in the unmetered_storage_rebate because storage
-        //         // rebate is not reflected in the storage_rebate of gas summary. This is a bit confusing.
-        //         // We could probably clean up the code a bit.
-        //         if !Mode::allow_arbitrary_values() {
-        //             // ensure that this transaction did not create or destroy SUI
-        //             temporary_store
-        //                 .check_sui_conserved(advance_epoch_gas_summary)
-        //                 .unwrap();
-        //         }
-        //         // else, we're in dev-inspect mode, which lets you turn bytes into arbitrary
-        //         // objects (including coins). this can violate conservation, but it's expected
-        //         return (cost_summary, result);
-        //     }
-        // }
+        #[cfg(debug_assertions)]
+        {
+            // Genesis transactions mint sui supply, and hence does not satisfy SUI conservation.
+            if !is_genesis_tx {
+                // For advance epoch transaction, we need to provide epoch rewards and rebates as extra
+                // information provided to check_sui_conserved, because we mint rewards, and burn
+                // the rebates. We also need to pass in the unmetered_storage_rebate because storage
+                // rebate is not reflected in the storage_rebate of gas summary. This is a bit confusing.
+                // We could probably clean up the code a bit.
+                if !Mode::allow_arbitrary_values() {
+                    // ensure that this transaction did not create or destroy SUI
+                    temporary_store
+                        .check_sui_conserved(advance_epoch_gas_summary)
+                        .unwrap();
+                }
+                // else, we're in dev-inspect mode, which lets you turn bytes into arbitrary
+                // objects (including coins). this can violate conservation, but it's expected
+                return (cost_summary, result);
+            }
+        }
         (cost_summary, result)
     } else {
         // legacy code before gas v2, leave it alone

--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -167,7 +167,6 @@ fn execute_transaction<
     GasCostSummary,
     Result<Mode::ExecutionResults, ExecutionError>,
 ) {
-    println!("GAS - gas coins {}", gas.len());
     // First smash gas into the first coin if more than 1 was provided
     let gas_object_ref = match temporary_store.smash_gas(gas) {
         Ok(obj_ref) => obj_ref,

--- a/crates/sui-cost-tables/src/tier_based/tables.rs
+++ b/crates/sui-cost-tables/src/tier_based/tables.rs
@@ -81,10 +81,6 @@ impl<'a> GasStatus<'a> {
         assert!(gas_price > 0, "gas price cannot be 0");
         let budget_in_unit = budget / gas_price;
         let gas_left = Self::to_internal_units(budget_in_unit);
-        // println!(
-        //     "GAS - GasStatus: budget {}, gas price: {}, gas_left {}",
-        //     budget, gas_price, gas_left,
-        // );
         let (stack_height_current_tier_mult, stack_height_next_tier_start) =
             cost_table.stack_height_tier(0);
         let (stack_size_current_tier_mult, stack_size_next_tier_start) =
@@ -112,7 +108,6 @@ impl<'a> GasStatus<'a> {
     }
 
     pub fn new(cost_table: &'a CostTable, gas_left: Gas) -> Self {
-        // println!("GAS - GasStatus: gas_left {}", gas_left);
         let (stack_height_current_tier_mult, stack_height_next_tier_start) =
             cost_table.stack_height_tier(0);
         let (stack_size_current_tier_mult, stack_size_next_tier_start) =
@@ -319,7 +314,6 @@ impl<'a> GasStatus<'a> {
 
     // Deduct the amount provided with no conversion, as if it was InternalGasUnit
     fn deduct_units(&mut self, amount: u64) -> PartialVMResult<()> {
-        // println!("GAS - deduct_units: {}", amount);
         self.deduct_gas(InternalGas::new(amount))
     }
 
@@ -332,7 +326,6 @@ impl<'a> GasStatus<'a> {
         let gas: Gas = match self.initial_budget.checked_sub(self.gas_left) {
             Some(val) => InternalGas::to_unit_round_down(val),
             None => {
-                // println!("GAS - ERROR: gas use underflow");
                 InternalGas::to_unit_round_down(self.initial_budget)
             }
         };
@@ -342,10 +335,6 @@ impl<'a> GasStatus<'a> {
     // Charge the number of bytes with the cost per byte value
     pub fn charge_bytes(&mut self, size: usize, cost_per_byte: u64) -> PartialVMResult<()> {
         let computation_cost = size as u64 * cost_per_byte;
-        // println!(
-        //     "GAS - charge_bytes: {} from {} - {}",
-        //     computation_cost, size, cost_per_byte
-        // );
         self.deduct_units(computation_cost)
     }
 }

--- a/crates/sui-cost-tables/src/tier_based/tables.rs
+++ b/crates/sui-cost-tables/src/tier_based/tables.rs
@@ -325,9 +325,7 @@ impl<'a> GasStatus<'a> {
     pub fn gas_used_pre_gas_price(&self) -> u64 {
         let gas: Gas = match self.initial_budget.checked_sub(self.gas_left) {
             Some(val) => InternalGas::to_unit_round_down(val),
-            None => {
-                InternalGas::to_unit_round_down(self.initial_budget)
-            }
+            None => InternalGas::to_unit_round_down(self.initial_budget),
         };
         u64::from(gas)
     }

--- a/crates/sui-types/src/gas_model/gas_v2.rs
+++ b/crates/sui-types/src/gas_model/gas_v2.rs
@@ -358,17 +358,12 @@ impl<'a> SuiGasStatusAPI<'a> for SuiGasStatus<'a> {
 
     fn charge_storage_mutation(
         &mut self,
-        new_size: usize,
-        storage_rebate: u64,
+        _new_size: usize,
+        _storage_rebate: u64,
     ) -> Result<u64, ExecutionError> {
-        // TODO: this is exclusively called from testing as it breaks too much
-        // if we fork tests between old and new, revisit
-        let size = self.track_storage_mutation(new_size, storage_rebate);
-        self.charge_storage_and_rebate()?;
-        Ok(size)
-        // Err(ExecutionError::invariant_violation(
-        //     "charge_storage_mutation should not be called in v2 gas model",
-        // ))
+        Err(ExecutionError::invariant_violation(
+            "charge_storage_mutation should not be called in v2 gas model",
+        ))
     }
 
     fn charge_publish_package(&mut self, size: usize) -> Result<(), ExecutionError> {

--- a/crates/sui-types/src/gas_model/gas_v2.rs
+++ b/crates/sui-types/src/gas_model/gas_v2.rs
@@ -212,13 +212,6 @@ impl<'a> SuiGasStatus<'a> {
         config: &ProtocolConfig,
     ) -> SuiGasStatus<'a> {
         let storage_gas_price = config.storage_gas_price();
-        // println!(
-        //     "GAS - SuiGasStatus: budget {}, gas_price {}, computation_gas_price {}, storage_unit_gas_price {}",
-        //     gas_budget,
-        //     gas_price,
-        //     gas_price,
-        //     storage_gas_price,
-        // );
         let max_computation_budget = MAX_BUCKET_COST;
         let computation_budget = if gas_budget > max_computation_budget {
             max_computation_budget
@@ -287,10 +280,6 @@ impl<'a> SuiGasStatusAPI<'a> for SuiGasStatus<'a> {
         let bucket_cost = get_bucket_cost(&COMPUTATION_BUCKETS, gas_used);
         // charge extra on top of `computation_cost` to make the total computation
         // cost a bucket value
-        // println!(
-        //     "GAS - Bucketize: gas_used {}, bucket cost {}",
-        //     gas_used, bucket_cost
-        // );
         let gas_used = bucket_cost * self.gas_price;
         if self.gas_budget <= gas_used {
             self.computation_cost = self.gas_budget;
@@ -309,16 +298,12 @@ impl<'a> SuiGasStatusAPI<'a> for SuiGasStatus<'a> {
         let sender_rebate = sender_rebate(self.storage_rebate, self.rebate_rate);
         assert!(sender_rebate <= self.storage_rebate);
         let non_refundable_storage_fee = self.storage_rebate - sender_rebate;
-        // let summary = GasCostSummary {
         GasCostSummary {
             computation_cost: self.computation_cost,
             storage_cost: self.storage_cost,
             storage_rebate: sender_rebate,
             non_refundable_storage_fee,
         }
-        // };
-        // println!("GAS - gas_summary: {}", summary);
-        // summary
     }
 
     fn gas_budget(&self) -> u64 {
@@ -347,7 +332,6 @@ impl<'a> SuiGasStatusAPI<'a> for SuiGasStatus<'a> {
     }
 
     fn charge_storage_read(&mut self, size: usize) -> Result<(), ExecutionError> {
-        // println!("GAS - charge_storage_read: size {}", size);
         self.gas_status
             .charge_bytes(size, self.cost_table.object_read_per_byte_cost)
             .map_err(|e| {
@@ -367,7 +351,6 @@ impl<'a> SuiGasStatusAPI<'a> for SuiGasStatus<'a> {
     }
 
     fn charge_publish_package(&mut self, size: usize) -> Result<(), ExecutionError> {
-        // println!("GAS - charge_publish_package: {}", size);
         self.gas_status
             .charge_bytes(size, self.cost_table.package_publish_per_byte_cost)
             .map_err(|e| {
@@ -390,10 +373,6 @@ impl<'a> SuiGasStatusAPI<'a> for SuiGasStatus<'a> {
         let new_size = new_size as u64;
         let storage_cost =
             new_size * self.cost_table.storage_per_byte_cost * self.storage_gas_price;
-        // println!(
-        //     "GAS - charge_storage_mutation: bytes {} cost {}, rebate {}",
-        //     new_size, storage_cost, storage_rebate,
-        // );
         // track rebate
         self.storage_cost += storage_cost;
         // return the new object rebate (object storage cost)

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -827,10 +827,9 @@ impl TransactionKind {
     /// directly.
     pub fn get_advance_epoch_tx_gas_summary(&self) -> Option<(u64, u64)> {
         match self {
-            Self::ChangeEpoch(e) => Some((
-                e.computation_charge + e.storage_charge,
-                e.storage_rebate,
-            )),
+            Self::ChangeEpoch(e) => {
+                Some((e.computation_charge + e.storage_charge, e.storage_rebate))
+            }
             _ => None,
         }
     }

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -829,7 +829,7 @@ impl TransactionKind {
         match self {
             Self::ChangeEpoch(e) => Some((
                 e.computation_charge + e.storage_charge,
-                e.storage_rebate - e.non_refundable_storage_fee,
+                e.storage_rebate,
             )),
             _ => None,
         }


### PR DESCRIPTION
## Description 

Re-enable conservation checks and cleans up the code a bit, refactoring some of the checks.
It fixes an issue with tracking storage rebate for the advance epoch transaction and an issue with deleted coins when an Out Of Gas happens while collecting storage cost.
I need to make few more changes:
1- enable the simple check for conservation as defined here https://github.com/MystenLabs/sui/pull/10167
2- final cleanup with incorporating feedback from previous PR and better comments
3- more clear, obvious and simple tests
They will happen next and hopefully soon.
However this would allow us to start running a full node with those checks and learning from it

## Test Plan 

Existing test

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
