### PR TITLE
properly print out epoch change arguments

### DIFF
--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -50,6 +50,7 @@ use sui_types::temporary_store::TemporaryStore;
 
 checked_arithmetic! {
 
+#[derive(Debug)]
 pub struct AdvanceEpochParams {
     pub epoch: u64,
     pub next_protocol_version: ProtocolVersion,
@@ -454,7 +455,7 @@ pub fn construct_advance_epoch_pt(
 
     info!(
         "Call arguments to advance_epoch transaction: {:?}",
-        arguments
+        params
     );
 
     let storage_rebates = builder.programmable_move_call(
@@ -520,7 +521,7 @@ pub fn construct_advance_epoch_safe_mode_pt(
 
     info!(
         "Call arguments to advance_epoch transaction: {:?}",
-        arguments
+        params
     );
 
     builder.programmable_move_call(


### PR DESCRIPTION
## Description 

Right now the info log for advance_epoch arguments looks something like `Call arguments to advance_epoch transaction: [Result(0), Result(1), Input(2), Input(3), Input(4), Input(5), Input(6), Input(7), Input(8), Input(9)]`, which is only helpful in telling you how many arguments there are. This PR changes that and prints out the actual numbers stored in `AdvanceEpochParams`.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
