### PR TITLE
[easy / cli] Adding pagination on objects call for CLI

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -870,19 +870,29 @@ impl SuiClientCommands {
             SuiClientCommands::Objects { address } => {
                 let address = address.unwrap_or(context.active_address()?);
                 let client = context.get_client().await?;
-                let address_object = client
-                    .read_api()
-                    .get_owned_objects(
-                        address,
-                        Some(SuiObjectResponseQuery::new_with_options(
-                            SuiObjectDataOptions::full_content(),
-                        )),
-                        None,
-                        None,
-                    )
-                    .await?;
-                // TODO: paginate here
-                SuiClientCommandResult::Objects(address_object.data)
+                let mut objects: Vec<SuiObjectResponse> = Vec::new();
+                let mut cursor = None;
+                loop {
+                    let response = client
+                        .read_api()
+                        .get_owned_objects(
+                            address,
+                            Some(SuiObjectResponseQuery::new_with_options(
+                                SuiObjectDataOptions::full_content(),
+                            )),
+                            cursor,
+                            None,
+                        )
+                        .await?;
+                    objects.extend(response.data);
+
+                    if response.has_next_page {
+                        cursor = response.next_cursor;
+                    } else {
+                        break;
+                    }
+                }
+                SuiClientCommandResult::Objects(objects)
             }
 
             SuiClientCommands::NewAddress {


### PR DESCRIPTION
## Description 

Adding pagination to CLI for get_owned_objects

## Test Plan 

CI/
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
