### PR TITLE
[rocksdb] safe iterator: migrate call sites

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6073,6 +6073,7 @@ dependencies = [
  "dashmap",
  "fastcrypto",
  "futures",
+ "itertools",
  "lru",
  "mysten-common",
  "narwhal-config",

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -106,7 +106,7 @@ use sui_types::{
     SUI_SYSTEM_ADDRESS,
 };
 use sui_types::{is_system_package, TypeTag, SUI_CLOCK_OBJECT_ID};
-use typed_store::Map;
+use typed_store::{Map, TypedStoreError};
 
 use crate::authority::authority_per_epoch_store::{AuthorityPerEpochStore, CertTxGuard};
 use crate::authority::authority_per_epoch_store_pruner::AuthorityPerEpochStorePruner;
@@ -1882,7 +1882,7 @@ impl AuthorityState {
             Some(seq) => self
                 .checkpoint_store
                 .get_checkpoint_by_sequence_number(seq)?,
-            None => self.checkpoint_store.get_latest_certified_checkpoint(),
+            None => self.checkpoint_store.get_latest_certified_checkpoint()?,
         }
         .map(|v| v.into_inner());
         let contents = match &summary {
@@ -2510,7 +2510,8 @@ impl AuthorityState {
         cursor: (String, ObjectID),
         limit: usize,
         one_coin_type_only: bool,
-    ) -> SuiResult<impl Iterator<Item = (String, ObjectID, CoinInfo)> + '_> {
+    ) -> SuiResult<impl Iterator<Item = Result<(String, ObjectID, CoinInfo), TypedStoreError>> + '_>
+    {
         if let Some(indexes) = &self.indexes {
             indexes.get_owned_coins_iterator_with_cursor(owner, cursor, limit, one_coin_type_only)
         } else {
@@ -2524,7 +2525,7 @@ impl AuthorityState {
         // If `Some`, the query will start from the next item after the specified cursor
         cursor: Option<ObjectID>,
         filter: Option<SuiObjectDataFilter>,
-    ) -> SuiResult<impl Iterator<Item = ObjectInfo> + '_> {
+    ) -> SuiResult<impl Iterator<Item = Result<ObjectInfo, TypedStoreError>> + '_> {
         let cursor_u = cursor.unwrap_or(ObjectID::ZERO);
         if let Some(indexes) = &self.indexes {
             indexes.get_owner_objects_iterator(owner, cursor_u, filter)
@@ -2543,12 +2544,12 @@ impl AuthorityState {
     {
         let object_ids = self
             .get_owner_objects_iterator(owner, None, None)?
-            .filter(|o| match &o.type_ {
+            .filter_ok(|o| match &o.type_ {
                 ObjectType::Struct(s) => &type_ == s,
                 ObjectType::Package => false,
             })
-            .map(|info| ObjectKey(info.object_id, info.version))
-            .collect::<Vec<_>>();
+            .map_ok(|info| ObjectKey(info.object_id, info.version))
+            .collect::<Result<Vec<_>, _>>()?;
         let mut move_objects = vec![];
 
         let objects = self.database.multi_get_object_by_key(&object_ids)?;

--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -618,9 +618,8 @@ mod tests {
             // so we can read the accurate number of retained versions
             &ReadWriteOptions::default(),
         )?;
-        let iter = objects.unbounded_iter();
-        for (k, _v) in iter {
-            after_pruning.insert(k);
+        for item in objects.safe_iter() {
+            after_pruning.insert(item.unwrap().0);
         }
         Ok(after_pruning)
     }

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -369,7 +369,9 @@ impl ConsensusAdapter {
         // Currently narwhal worker might lose transactions on restart, so we need to resend them
         // todo - get_all_pending_consensus_transactions is called twice when
         // initializing AuthorityPerEpochStore and here, should not be a big deal but can be optimized
-        let mut recovered = epoch_store.get_all_pending_consensus_transactions();
+        let mut recovered = epoch_store
+            .get_all_pending_consensus_transactions()
+            .expect("failed to get all pending consensus transactions");
 
         #[allow(clippy::collapsible_if)] // This if can be collapsed but it will be ugly
         if epoch_store

--- a/crates/sui-core/src/state_accumulator.rs
+++ b/crates/sui-core/src/state_accumulator.rs
@@ -303,9 +303,10 @@ impl StateAccumulator {
             .authority_store
             .perpetual_tables
             .root_state_hash_by_epoch
-            .unbounded_iter()
+            .safe_iter()
             .skip_to_last()
             .next()
+            .transpose()?
             .map(|(epoch, (highest, hash))| {
                 (
                     epoch,

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -45,6 +45,7 @@ use tokio::time::timeout;
 use tracing::{debug, error, error_span, info, instrument, warn, Instrument};
 
 use sui_types::transaction::VerifiedTransaction;
+use typed_store::TypedStoreError;
 
 // How long to wait for local execution (including parents) before a timeout
 // is returned to client.
@@ -480,7 +481,10 @@ where
         pending_tx_log: &Arc<WritePathPendingTransactionLog>,
         quorum_driver: &Arc<QuorumDriverHandler<A>>,
     ) {
-        let pending_txes = pending_tx_log.load_all_pending_transactions();
+        let Ok(pending_txes) = pending_tx_log.load_all_pending_transactions() else {
+            error!("Failed to schedule pending transactions");
+            return;
+        };
         for tx in pending_txes {
             let tx_digest = *tx.digest();
             // It's not impossible we fail to enqueue a task but that's not the end of world.
@@ -495,7 +499,9 @@ where
         }
     }
 
-    pub fn load_all_pending_transactions(&self) -> Vec<VerifiedTransaction> {
+    pub fn load_all_pending_transactions(
+        &self,
+    ) -> Result<Vec<VerifiedTransaction>, TypedStoreError> {
         self.pending_tx_log.load_all_pending_transactions()
     }
 }

--- a/crates/sui-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -145,7 +145,7 @@ async fn test_fullnode_wal_log() -> Result<(), anyhow::Error> {
 
     // Because the tx did not go through, we expect to see it in the WAL log
     let pending_txes = orchestrator.load_all_pending_transactions();
-    assert_eq!(pending_txes, vec![txn.clone()]);
+    assert_eq!(pending_txes.unwrap(), vec![txn.clone()]);
 
     // Bring up 1 validator, we obtain quorum again and tx should succeed
     test_cluster.start_node(&validator_addresses[0]).await;
@@ -164,7 +164,7 @@ async fn test_fullnode_wal_log() -> Result<(), anyhow::Error> {
     tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
     // The tx should be erased in wal log.
     let pending_txes = orchestrator.load_all_pending_transactions();
-    assert!(pending_txes.is_empty());
+    assert!(pending_txes.unwrap().is_empty());
 
     Ok(())
 }

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use cached::proc_macro::cached;
 use cached::SizedCache;
+use itertools::Itertools;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::RpcModule;
 use move_core_types::language_storage::{StructTag, TypeTag};
@@ -59,7 +60,7 @@ impl CoinReadApi {
                         limit + 1,
                         one_coin_type_only,
                     )?
-                    .map(|(coin_type, coin_object_id, coin)| SuiCoin {
+                    .map_ok(|(coin_type, coin_object_id, coin)| SuiCoin {
                         coin_type,
                         coin_object_id,
                         version: coin.version,
@@ -67,7 +68,7 @@ impl CoinReadApi {
                         balance: coin.balance,
                         previous_transaction: coin.previous_transaction,
                     })
-                    .collect::<Vec<_>>(),
+                    .collect::<Result<Vec<_>, _>>()?,
             )
         })
         .await??;

--- a/crates/sui-json-rpc/src/transaction_builder_api.rs
+++ b/crates/sui-json-rpc/src/transaction_builder_api.rs
@@ -57,7 +57,7 @@ impl DataReader for AuthorityStateDataReader {
                 None,
                 Some(SuiObjectDataFilter::StructType(object_type)),
             )?
-            .collect())
+            .collect::<Result<_, _>>()?)
     }
 
     async fn get_object_with_options(

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -1895,7 +1895,10 @@ async fn create_epoch_store(
     let registry = Registry::new();
     let cache_metrics = Arc::new(ResolverMetrics::new(&registry));
     let signature_verifier_metrics = SignatureVerifierMetrics::new(&registry);
-    let mut committee = authority_state.committee_store().get_latest_committee();
+    let mut committee = authority_state
+        .committee_store()
+        .get_latest_committee()
+        .expect("failed to fetch latest committee");
 
     // Overwrite the epoch so it matches this TXs
     committee.epoch = executed_epoch;

--- a/crates/sui-tool/src/db_tool/mod.rs
+++ b/crates/sui-tool/src/db_tool/mod.rs
@@ -181,7 +181,7 @@ pub fn print_db_all_tables(db_path: PathBuf) -> anyhow::Result<()> {
 
 pub fn print_db_duplicates_summary(db_path: PathBuf) -> anyhow::Result<()> {
     let (total_count, duplicate_count, total_bytes, duplicated_bytes) =
-        duplicate_objects_summary(db_path);
+        duplicate_objects_summary(db_path)?;
     println!(
         "Total objects = {}, duplicated objects = {}, total bytes = {}, duplicated bytes = {}",
         total_count, duplicate_count, total_bytes, duplicated_bytes

--- a/crates/typed-store-derive/src/lib.rs
+++ b/crates/typed-store-derive/src/lib.rs
@@ -550,11 +550,11 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
                     #(
                         stringify!(#field_names) => {
                             typed_store::traits::Map::try_catch_up_with_primary(&self.#field_names)?;
-                            typed_store::traits::Map::unbounded_iter(&self.#field_names)
+                            typed_store::traits::Map::safe_iter(&self.#field_names)
                                 .skip((page_number * (page_size) as usize))
                                 .take(page_size as usize)
-                                .map(|(k, v)| (format!("{:?}", k), format!("{:?}", v)))
-                                .collect::<std::collections::BTreeMap<_, _>>()
+                                .map(|item| item.map(|(k, v)| (format!("{:?}", k), format!("{:?}", v))))
+                                .collect::<Result<std::collections::BTreeMap<_, _>, _>>().unwrap()
                         }
                     )*
 
@@ -587,7 +587,7 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
                     #(
                         stringify!(#field_names) => {
                             typed_store::traits::Map::try_catch_up_with_primary(&self.#field_names)?;
-                            typed_store::traits::Map::unbounded_iter(&self.#field_names).count()
+                            typed_store::traits::Map::safe_iter(&self.#field_names).count()
                         }
                     )*
 
@@ -908,11 +908,11 @@ pub fn derive_sallydb_general(input: TokenStream) -> TokenStream {
                             match &self.#field_names {
                                 SallyColumn::RocksDB((db_map, typed_store::sally::SallyConfig { mode: typed_store::sally::SallyRunMode::FallbackToDB })) => {
                                     typed_store::traits::Map::try_catch_up_with_primary(db_map)?;
-                                    typed_store::traits::Map::unbounded_iter(db_map)
+                                    typed_store::traits::Map::safe_iter(db_map)
                                         .skip((page_number * (page_size) as usize))
                                         .take(page_size as usize)
-                                        .map(|(k, v)| (format!("{:?}", k), format!("{:?}", v)))
-                                        .collect::<std::collections::BTreeMap<_, _>>()
+                                        .map(|item| item.map(|(k, v)| (format!("{:?}", k), format!("{:?}", v))))
+                                        .collect::<Result<std::collections::BTreeMap<_, _>, _>>().unwrap()
                                 }
                                 _ => unimplemented!(),
                             }
@@ -952,7 +952,7 @@ pub fn derive_sallydb_general(input: TokenStream) -> TokenStream {
                             match &self.#field_names {
                                 SallyColumn::RocksDB((db_map, typed_store::sally::SallyConfig { mode: typed_store::sally::SallyRunMode::FallbackToDB })) => {
                                     typed_store::traits::Map::try_catch_up_with_primary(db_map)?;
-                                    typed_store::traits::Map::unbounded_iter(db_map).count()
+                                    typed_store::traits::Map::safe_iter(db_map).count()
                                 }
                                 _ => unimplemented!(),
                             }

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -1784,10 +1784,9 @@ where
             .op_metrics
             .rocksdb_iter_keys
             .with_label_values(&[&self.cf]);
-        let mut db_iter = self
+        let db_iter = self
             .rocksdb
             .raw_iterator_cf(&self.cf(), self.opts.readopts());
-        db_iter.seek_to_first();
         SafeIter::new(
             self.cf.clone(),
             db_iter,
@@ -1918,6 +1917,83 @@ where
 
         let db_iter = self.rocksdb.raw_iterator_cf(&self.cf(), readopts);
         Iter::new(
+            self.cf.clone(),
+            db_iter,
+            Some(_timer),
+            _perf_ctx,
+            Some(bytes_scanned),
+            Some(keys_scanned),
+            Some(self.db_metrics.clone()),
+        )
+    }
+
+    fn safe_range_iter(&'a self, range: impl RangeBounds<K>) -> Self::SafeIterator {
+        // TODO: Change the metrics?
+        let _timer = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_iter_latency_seconds
+            .with_label_values(&[&self.cf])
+            .start_timer();
+        let bytes_scanned = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_iter_bytes
+            .with_label_values(&[&self.cf]);
+        let keys_scanned = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_iter_keys
+            .with_label_values(&[&self.cf]);
+        let _perf_ctx = if self.iter_sample_interval.sample() {
+            Some(RocksDBPerfContext::default())
+        } else {
+            None
+        };
+        let mut readopts = ReadOptions::default();
+
+        let lower_bound = range.start_bound();
+        let upper_bound = range.end_bound();
+
+        match lower_bound {
+            Bound::Included(lower_bound) => {
+                // Rocksdb lower bound is inclusive by default so nothing to do
+                let key_buf = be_fix_int_ser(&lower_bound).expect("Serialization must not fail");
+                readopts.set_iterate_lower_bound(key_buf);
+            }
+            Bound::Excluded(lower_bound) => {
+                let mut key_buf =
+                    be_fix_int_ser(&lower_bound).expect("Serialization must not fail");
+
+                // Since we want exclusive, we need to increment the key to exclude the previous
+                big_endian_saturating_add_one(&mut key_buf);
+                readopts.set_iterate_lower_bound(key_buf);
+            }
+            Bound::Unbounded => (),
+        };
+
+        match upper_bound {
+            Bound::Included(upper_bound) => {
+                let mut key_buf =
+                    be_fix_int_ser(&upper_bound).expect("Serialization must not fail");
+
+                // If the key is already at the limit, there's nowhere else to go, so no upper bound
+                if !is_max(&key_buf) {
+                    // Since we want exclusive, we need to increment the key to get the upper bound
+                    big_endian_saturating_add_one(&mut key_buf);
+                    readopts.set_iterate_upper_bound(key_buf);
+                }
+            }
+            Bound::Excluded(upper_bound) => {
+                // Rocksdb upper bound is inclusive by default so nothing to do
+                let key_buf = be_fix_int_ser(&upper_bound).expect("Serialization must not fail");
+                readopts.set_iterate_upper_bound(key_buf);
+            }
+            Bound::Unbounded => (),
+        };
+
+        let db_iter = self.rocksdb.raw_iterator_cf(&self.cf(), readopts);
+        SafeIter::new(
             self.cf.clone(),
             db_iter,
             Some(_timer),

--- a/crates/typed-store/src/rocks/safe_iter.rs
+++ b/crates/typed-store/src/rocks/safe_iter.rs
@@ -17,6 +17,7 @@ pub struct SafeIter<'a, K, V> {
     db_iter: RocksDBRawIter<'a>,
     _phantom: PhantomData<(K, V)>,
     direction: Direction,
+    is_initialized: bool,
     _timer: Option<HistogramTimer>,
     _perf_ctx: Option<RocksDBPerfContext>,
     bytes_scanned: Option<Histogram>,
@@ -41,6 +42,7 @@ impl<'a, K: DeserializeOwned, V: DeserializeOwned> SafeIter<'a, K, V> {
             db_iter,
             _phantom: PhantomData,
             direction: Direction::Forward,
+            is_initialized: false,
             _timer,
             _perf_ctx,
             bytes_scanned,
@@ -56,6 +58,12 @@ impl<'a, K: DeserializeOwned, V: DeserializeOwned> Iterator for SafeIter<'a, K, 
     type Item = Result<(K, V), TypedStoreError>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        // implicitly set iterator to the first entry in the column family if it hasn't been initialized
+        // used for backward compatibility
+        if !self.is_initialized {
+            self.db_iter.seek_to_first();
+            self.is_initialized = true;
+        }
         if self.db_iter.valid() {
             let config = bincode::DefaultOptions::new()
                 .with_big_endian()
@@ -107,6 +115,7 @@ impl<'a, K: Serialize, V> SafeIter<'a, K, V> {
     /// and either lands on the key or the first one greater than
     /// the key.
     pub fn skip_to(mut self, key: &K) -> Result<Self, TypedStoreError> {
+        self.is_initialized = true;
         self.db_iter.seek(be_fix_int_ser(key)?);
         Ok(self)
     }
@@ -115,12 +124,14 @@ impl<'a, K: Serialize, V> SafeIter<'a, K, V> {
     /// the one prior to it if it does not exist. If there is
     /// no element prior to it, it returns an empty iterator.
     pub fn skip_prior_to(mut self, key: &K) -> Result<Self, TypedStoreError> {
+        self.is_initialized = true;
         self.db_iter.seek_for_prev(be_fix_int_ser(key)?);
         Ok(self)
     }
 
     /// Seeks to the last key in the database (at this column family).
     pub fn skip_to_last(mut self) -> Self {
+        self.is_initialized = true;
         self.db_iter.seek_to_last();
         self
     }

--- a/crates/typed-store/src/test_db.rs
+++ b/crates/typed-store/src/test_db.rs
@@ -286,6 +286,10 @@ where
         unimplemented!("umplemented API");
     }
 
+    fn safe_range_iter(&'a self, _range: impl RangeBounds<K>) -> Self::SafeIterator {
+        unimplemented!("umplemented API");
+    }
+
     fn safe_iter(&'a self) -> Self::SafeIterator {
         TestDBIterBuilder {
             rows: self.rows.read().unwrap(),

--- a/crates/typed-store/src/traits.rs
+++ b/crates/typed-store/src/traits.rs
@@ -83,6 +83,9 @@ where
     /// Same as `iter` but performs status check
     fn safe_iter(&'a self) -> Self::SafeIterator;
 
+    /// Similar to `iter_with_bounds` but allows specifying inclusivity/exclusivity of ranges explicitly.
+    fn safe_range_iter(&'a self, range: impl RangeBounds<K>) -> Self::SafeIterator;
+
     /// Returns an iterator over each key in the map.
     fn keys(&'a self) -> Self::Keys;
 

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -334,13 +334,17 @@ impl Consensus {
         metrics: Arc<ConsensusMetrics>,
     ) -> JoinHandle<()> {
         // The consensus state (everything else is immutable).
-        let recovered_last_committed = store.read_last_committed();
+        let recovered_last_committed = store
+            .read_last_committed()
+            .expect("failed to read last committed");
         let last_committed_round = recovered_last_committed
             .iter()
             .max_by(|a, b| a.1.cmp(b.1))
             .map(|(_k, v)| *v)
             .unwrap_or_else(|| 0);
-        let latest_sub_dag = store.get_latest_sub_dag();
+        let latest_sub_dag = store
+            .get_latest_sub_dag()
+            .expect("failed to read latest subdag");
         if let Some(sub_dag) = &latest_sub_dag {
             assert_eq!(
                 sub_dag.leader_round(),

--- a/narwhal/consensus/src/tests/consensus_tests.rs
+++ b/narwhal/consensus/src/tests/consensus_tests.rs
@@ -136,7 +136,7 @@ async fn test_consensus_recovery_with_bullshark() {
     }
 
     // AND the last committed store should be updated correctly
-    let last_committed = consensus_store.read_last_committed();
+    let last_committed = consensus_store.read_last_committed().unwrap();
 
     for id in ids.clone() {
         let last_round = *last_committed.get(&id).unwrap();

--- a/narwhal/primary/src/synchronizer.rs
+++ b/narwhal/primary/src/synchronizer.rs
@@ -320,7 +320,9 @@ impl Synchronizer {
     ) -> Self {
         let committee: &Committee = &committee;
         let genesis = Self::make_genesis(committee);
-        let highest_processed_round = certificate_store.highest_round_number();
+        let highest_processed_round = certificate_store
+            .highest_round_number()
+            .expect("failed to read highest round number");
         let highest_created_certificate = certificate_store.last_round(authority_id).unwrap();
         let gc_round = rx_consensus_round_updates.borrow().gc_round;
         let (tx_own_certificate_broadcast, _rx_own_certificate_broadcast) =

--- a/narwhal/storage/Cargo.toml
+++ b/narwhal/storage/Cargo.toml
@@ -25,6 +25,7 @@ prometheus = "0.13.3"
 lru = "0.10"
 parking_lot = "0.12.1"
 tap = "1.0.1"
+itertools = "0.10.5"
 
 [dev-dependencies]
 test-utils = { path = "../test-utils", package = "narwhal-test-utils" }


### PR DESCRIPTION
first batch of call site migrations from iter to safe_iter (see details [here](https://github.com/MystenLabs/sui/pull/10203)) 
Includes call sites and dependencies for `sui-core` crate