### PR TITLE
[Rust / TS SDK] Best effort display on display fields

### DIFF
--- a/apps/explorer/src/components/ownedobjects/OwnedObjects.tsx
+++ b/apps/explorer/src/components/ownedobjects/OwnedObjects.tsx
@@ -91,7 +91,7 @@ function OwnedObject({ id, byAddress }: { id: string; byAddress: boolean }) {
                                     const displayMeta =
                                         typeof resp.data === 'object' &&
                                         'display' in resp.data
-                                            ? resp.data.display
+                                            ? resp.data.display?.data
                                             : undefined;
                                     const url = parseImageURL(displayMeta);
                                     return {

--- a/apps/explorer/src/components/ownedobjects/OwnedObjects.tsx
+++ b/apps/explorer/src/components/ownedobjects/OwnedObjects.tsx
@@ -9,6 +9,7 @@ import {
     getObjectOwner,
     PaginatedObjectsResponse,
     is,
+    getObjectDisplay,
 } from '@mysten/sui.js';
 import { useEffect, useState } from 'react';
 
@@ -88,12 +89,8 @@ function OwnedObject({ id, byAddress }: { id: string; byAddress: boolean }) {
                             })
                             .map(
                                 (resp) => {
-                                    const displayMeta =
-                                        typeof resp.data === 'object' &&
-                                        'display' in resp.data
-                                            ? resp.data.display?.data
-                                            : undefined;
-                                    const url = parseImageURL(displayMeta);
+                                    const displayMeta = getObjectDisplay(resp);
+                                    const url = parseImageURL(displayMeta.data);
                                     return {
                                         id: getObjectId(resp),
                                         Type: parseObjectType(resp),
@@ -102,7 +99,8 @@ function OwnedObject({ id, byAddress }: { id: string; byAddress: boolean }) {
                                             ? transformURL(url)
                                             : undefined,
                                         balance: Coin.getBalance(resp),
-                                        name: extractName(displayMeta) || '',
+                                        name:
+                                            extractName(displayMeta.data) || '',
                                     };
                                 }
                                 // TODO - add back version

--- a/apps/explorer/src/pages/object-result/ObjectResultType.tsx
+++ b/apps/explorer/src/pages/object-result/ObjectResultType.tsx
@@ -55,7 +55,7 @@ export function translate(o: SuiObjectResponse): DataType {
             display:
                 (typeof o.data === 'object' &&
                     'display' in o.data &&
-                    o.data.display) ||
+                    o.data.display?.data) ||
                 undefined,
         };
     } else {

--- a/apps/explorer/src/pages/object-result/ObjectResultType.tsx
+++ b/apps/explorer/src/pages/object-result/ObjectResultType.tsx
@@ -8,6 +8,7 @@ import {
     getObjectOwner,
     getObjectFields,
     getObjectPreviousTransactionDigest,
+    getObjectDisplay,
 } from '@mysten/sui.js';
 
 import { parseObjectType } from '../../utils/objectUtils';
@@ -52,11 +53,7 @@ export function translate(o: SuiObjectResponse): DataType {
                 contents: getObjectFields(o) ?? getMovePackageContent(o)!,
                 tx_digest: getObjectPreviousTransactionDigest(o),
             },
-            display:
-                (typeof o.data === 'object' &&
-                    'display' in o.data &&
-                    o.data.display?.data) ||
-                undefined,
+            display: getObjectDisplay(o).data || undefined,
         };
     } else {
         throw new Error(`${o.error}`);

--- a/apps/explorer/src/utils/objectUtils.ts
+++ b/apps/explorer/src/utils/objectUtils.ts
@@ -7,7 +7,7 @@ import { findIPFSvalue } from './stringUtils';
 
 import type { SuiObjectResponse } from '@mysten/sui.js';
 
-export function parseImageURL(display?: Record<string, string>) {
+export function parseImageURL(display?: Record<string, string> | null) {
     const url = display?.image_url;
     if (url) {
         if (findIPFSvalue(url)) return url;
@@ -43,7 +43,7 @@ export function getOwnerStr(owner: ObjectOwner | string): string {
 export const checkIsPropertyType = (value: any) =>
     ['number', 'string'].includes(typeof value);
 
-export const extractName = (display?: Record<string, string>) => {
+export const extractName = (display?: Record<string, string> | null) => {
     if (!display || !('name' in display)) return undefined;
     const name = display.name;
     if (typeof name === 'string') {

--- a/apps/wallet/src/ui/app/hooks/useGetNFTMeta.ts
+++ b/apps/wallet/src/ui/app/hooks/useGetNFTMeta.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { is, SuiObjectData } from '@mysten/sui.js';
+import { getObjectDisplay } from '@mysten/sui.js';
 import { useMemo } from 'react';
 
 import { useGetObject } from './useGetObject';
@@ -16,11 +16,12 @@ export function useGetNFTMeta(objectID: string) {
     const resp = useGetObject(objectID);
     const nftMeta = useMemo(() => {
         if (!resp.data) return null;
-        const { data } = resp.data || {};
-        if (!is(data, SuiObjectData) || !data.display || !data.display?.data)
+        const display = getObjectDisplay(resp.data);
+        if (!display.data) {
             return null;
+        }
         const { name, description, creator, image_url, link, project_url } =
-            data.display.data;
+            display.data;
         return {
             name: name || null,
             description: description || null,

--- a/apps/wallet/src/ui/app/hooks/useGetNFTMeta.ts
+++ b/apps/wallet/src/ui/app/hooks/useGetNFTMeta.ts
@@ -17,9 +17,10 @@ export function useGetNFTMeta(objectID: string) {
     const nftMeta = useMemo(() => {
         if (!resp.data) return null;
         const { data } = resp.data || {};
-        if (!is(data, SuiObjectData) || !data.display) return null;
+        if (!is(data, SuiObjectData) || !data.display || !data.display?.data)
+            return null;
         const { name, description, creator, image_url, link, project_url } =
-            data.display;
+            data.display.data;
         return {
             name: name || null,
             description: description || null,

--- a/apps/wallet/src/ui/app/pages/home/nfts/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nfts/index.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { getObjectDisplay, type SuiObjectData } from '@mysten/sui.js';
 import { Link } from 'react-router-dom';
 
 import { useActiveAddress } from '_app/hooks/useActiveAddress';
@@ -11,8 +12,6 @@ import { NFTDisplayCard } from '_components/nft-display';
 import { useObjectsOwnedByAddress } from '_hooks';
 import PageTitle from '_src/ui/app/shared/PageTitle';
 
-import type { SuiObjectData } from '@mysten/sui.js';
-
 function NftsPage() {
     const accountAddress = useActiveAddress();
     const { data, isLoading, error, isError } = useObjectsOwnedByAddress(
@@ -20,10 +19,7 @@ function NftsPage() {
         { options: { showType: true, showDisplay: true } }
     );
     const nfts = data?.data
-        ?.filter(
-            ({ data }) =>
-                typeof data === 'object' && 'display' in data && data.display
-        )
+        ?.filter((resp) => !!getObjectDisplay(resp).data)
         .map(({ data }) => data as SuiObjectData);
     return (
         <div className="flex flex-1 flex-col flex-nowrap items-center gap-4">

--- a/crates/sui-json-rpc-types/src/sui_object.rs
+++ b/crates/sui-json-rpc-types/src/sui_object.rs
@@ -155,6 +155,12 @@ impl TryFrom<SuiObjectResponse> for ObjectInfo {
     }
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, Eq, PartialEq)]
+pub struct DisplayFieldsResponse {
+    pub data: Option<BTreeMap<String, String>>,
+    pub error: Option<SuiObjectResponseError>,
+}
+
 #[serde_as]
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, Eq, PartialEq)]
 #[serde(rename_all = "camelCase", rename = "ObjectData")]
@@ -186,7 +192,7 @@ pub struct SuiObjectData {
     /// This can also be None if the struct type does not have Display defined
     /// See more details in <https://forums.sui.io/t/nft-object-display-proposal/4872>
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub display: Option<BTreeMap<String, String>>,
+    pub display: Option<DisplayFieldsResponse>,
     /// Move object content or package content, default to be None unless SuiObjectDataOptions.showContent is set to true
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<SuiParsedData>,
@@ -542,7 +548,7 @@ impl
         Object,
         Option<MoveStructLayout>,
         SuiObjectDataOptions,
-        Option<BTreeMap<String, String>>,
+        Option<DisplayFieldsResponse>,
     )> for SuiObjectData
 {
     type Error = anyhow::Error;
@@ -553,7 +559,7 @@ impl
             Object,
             Option<MoveStructLayout>,
             SuiObjectDataOptions,
-            Option<BTreeMap<String, String>>,
+            Option<DisplayFieldsResponse>,
         ),
     ) -> Result<Self, Self::Error> {
         let show_display = options.show_display;

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -79,7 +79,13 @@ async fn test_get_package_with_display_should_not_fail() -> Result<(), anyhow::E
         .await;
     assert!(response.is_ok());
     let response: SuiObjectResponse = response?;
-    assert!(response.into_object().unwrap().display.is_none());
+    assert!(response
+        .into_object()
+        .unwrap()
+        .display
+        .unwrap()
+        .data
+        .is_none());
     Ok(())
 }
 

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -3245,6 +3245,30 @@
           }
         ]
       },
+      "DisplayFieldsResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "error": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ObjectResponseError"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      },
       "DryRunTransactionBlockResponse": {
         "type": "object",
         "required": [
@@ -4665,13 +4689,14 @@
           },
           "display": {
             "description": "The Display metadata for frontend UI rendering, default to be None unless SuiObjectDataOptions.showContent is set to true This can also be None if the struct type does not have Display defined See more details in <https://forums.sui.io/t/nft-object-display-proposal/4872>",
-            "type": [
-              "object",
-              "null"
-            ],
-            "additionalProperties": {
-              "type": "string"
-            }
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DisplayFieldsResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "objectId": {
             "$ref": "#/components/schemas/ObjectID"

--- a/sdk/typescript/src/types/objects.ts
+++ b/sdk/typescript/src/types/objects.ts
@@ -111,6 +111,20 @@ export const MIST_PER_SUI = BigInt(1000000000);
 
 export const ObjectDigest = string();
 export type ObjectDigest = Infer<typeof ObjectDigest>;
+export const SuiObjectResponseError = object({
+  code: string(),
+  error: optional(string()),
+  object_id: optional(ObjectId),
+  version: optional(SequenceNumber),
+  digest: optional(ObjectDigest),
+});
+export type SuiObjectResponseError = Infer<typeof SuiObjectResponseError>;
+
+export const DisplayFieldsResponse = object({
+  data: nullable(record(string(), string())),
+  error: nullable(SuiObjectResponseError),
+});
+export type DisplayFieldsResponse = Infer<typeof DisplayFieldsResponse>;
 
 export const SuiObjectData = object({
   objectId: ObjectId,
@@ -149,7 +163,7 @@ export const SuiObjectData = object({
    * This can also be None if the struct type does not have Display defined
    * See more details in https://forums.sui.io/t/nft-object-display-proposal/4872
    */
-  display: optional(record(string(), string())),
+  display: optional(DisplayFieldsResponse),
 });
 export type SuiObjectData = Infer<typeof SuiObjectData>;
 
@@ -183,14 +197,6 @@ export type ObjectStatus = Infer<typeof ObjectStatus>;
 
 export const GetOwnedObjectsResponse = array(SuiObjectInfo);
 export type GetOwnedObjectsResponse = Infer<typeof GetOwnedObjectsResponse>;
-
-export const SuiObjectResponseError = object({
-  tag: string(),
-  object_id: optional(ObjectId),
-  version: optional(SequenceNumber),
-  digest: optional(ObjectDigest),
-});
-export type SuiObjectResponseError = Infer<typeof SuiObjectResponseError>;
 
 export const SuiObjectResponse = object({
   data: optional(SuiObjectData),
@@ -331,7 +337,7 @@ export function getObjectOwner(
 
 export function getObjectDisplay(
   resp: SuiObjectResponse,
-): Record<string, string> | undefined {
+): DisplayFieldsResponse | undefined {
   return getSuiObjectData(resp)?.display;
 }
 

--- a/sdk/typescript/test/e2e/data/display_test/sources/display_test.move
+++ b/sdk/typescript/test/e2e/data/display_test/sources/display_test.move
@@ -50,6 +50,8 @@ module display_test::boars {
             utf8(b"buyer"),
             utf8(b"full_url"),
             utf8(b"escape_syntax"),
+            utf8(b"id"),
+            utf8(b"bad_name"),
         ], vector[
             utf8(b"{name}"),
             // test multiple fields and UID
@@ -69,6 +71,10 @@ module display_test::boars {
             utf8(b"{full_url}"),
             // test escape syntax
             utf8(b"\\{name\\}"),
+            // bad id
+            utf8(b"{idd}"),
+            // Bad name
+            utf8(b"{namee}")
         ]);
 
         display::update_version(&mut display);

--- a/sdk/typescript/test/e2e/object-display-standard.test.ts
+++ b/sdk/typescript/test/e2e/object-display-standard.test.ts
@@ -15,7 +15,7 @@ describe('Test Object Display Standard', () => {
     ({ packageId } = await publishPackage(packagePath, toolbox));
   });
 
-  it('Test getting Display fields', async () => {
+  it('Test getting Display fields with error object', async () => {
     const resp = (
       await toolbox.provider.getOwnedObjects({
         owner: toolbox.address(),
@@ -32,16 +32,23 @@ describe('Test Object Display Standard', () => {
       }),
     );
     expect(display).toEqual({
-      age: '10',
-      buyer: toolbox.address(),
-      creator: 'Chris',
-      description: `Unique Boar from the Boars collection with First Boar and ${boarId}`,
-      img_url: 'https://get-a-boar.com/first.png',
-      name: 'First Boar',
-      price: '',
-      project_url: 'https://get-a-boar.com/',
-      full_url: 'https://get-a-boar.fullurl.com/',
-      escape_syntax: '{name}',
+      data: {
+        age: '10',
+        buyer: toolbox.address(),
+        creator: 'Chris',
+        description: `Unique Boar from the Boars collection with First Boar and ${boarId}`,
+        img_url: 'https://get-a-boar.com/first.png',
+        name: 'First Boar',
+        price: '',
+        project_url: 'https://get-a-boar.com/',
+        full_url: 'https://get-a-boar.fullurl.com/',
+        escape_syntax: '{name}',
+      },
+      error: {
+        code: 'displayError',
+        error:
+          'RPC call failed: Field value idd cannot be found in struct; RPC call failed: Field value namee cannot be found in struct',
+      },
     });
   });
 
@@ -55,6 +62,6 @@ describe('Test Object Display Standard', () => {
         options: { showDisplay: true },
       }),
     );
-    expect(display).toEqual(undefined);
+    expect(display?.data).toEqual(null);
   });
 });


### PR DESCRIPTION
## Description 

Previously, the rust API just errors out on certain display fields not being set. 
Follow up on top of :returning best attempt for objects #10197

Extra work is to make sure explorer works and renders these fields / parses the error properly.

## Test Plan 

Postman Response: 
<img width="1148" alt="image" src="https://user-images.githubusercontent.com/123408603/229518764-40c3533e-debf-4396-b672-00f015f61670.png">


Explorer renders page and object with error:
<img width="1386" alt="image" src="https://user-images.githubusercontent.com/123408603/229518560-7c4214ba-3e52-4e80-8dd0-7db4820c7dd2.png">
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [x] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
