### PR TITLE
explorer: epochs table rename time column to epoch end

### DIFF
--- a/apps/explorer/src/pages/epochs/EpochsTable.tsx
+++ b/apps/explorer/src/pages/epochs/EpochsTable.tsx
@@ -128,7 +128,7 @@ export function EpochsTable({
                               accessorKey: 'storageRevenue',
                           },
                           {
-                              header: 'Time',
+                              header: 'Epoch End',
                               accessorKey: 'time',
                           },
                       ],
@@ -158,7 +158,7 @@ export function EpochsTable({
                         'Stake Rewards',
                         'Checkpoint Set',
                         'Storage Revenue',
-                        'Time',
+                        'Epoch End',
                     ]}
                     colWidths={[
                         '100px',


### PR DESCRIPTION
* to make it more clear that it is the relative time since the epoch ended and not the duration of the epoch

| before | after |
| - | - |
| <img width="727" alt="Screenshot 2023-04-03 at 10 18 00" src="https://user-images.githubusercontent.com/10210143/229537176-4f7b124e-611d-44f4-861e-f0d46dac274f.png"> | <img width="740" alt="Screenshot 2023-04-03 at 10 16 06" src="https://user-images.githubusercontent.com/10210143/229537297-994de332-e678-4aa5-b7ae-4a4230fdf12e.png"> |
| <img width="1453" alt="Screenshot 2023-04-03 at 10 18 12" src="https://user-images.githubusercontent.com/10210143/229537375-57c82879-37f2-4b0d-9f64-a45159a18361.png"> | <img width="1449" alt="Screenshot 2023-04-03 at 10 16 18" src="https://user-images.githubusercontent.com/10210143/229537465-9c257407-028f-46cf-845e-93b0c9a1524a.png"> |
