### PR TITLE
crypto: Mnemonics word length option

### DIFF
--- a/crates/sui-keys/src/keystore.rs
+++ b/crates/sui-keys/src/keystore.rs
@@ -53,8 +53,10 @@ pub trait AccountKeystore: Send + Sync {
         &mut self,
         key_scheme: SignatureScheme,
         derivation_path: Option<DerivationPath>,
+        word_length: Option<String>,
     ) -> Result<(SuiAddress, String, SignatureScheme), anyhow::Error> {
-        let (address, kp, scheme, phrase) = generate_new_key(key_scheme, derivation_path)?;
+        let (address, kp, scheme, phrase) =
+            generate_new_key(key_scheme, derivation_path, word_length)?;
         self.add_key(kp)?;
         Ok((address, phrase, scheme))
     }

--- a/crates/sui-keys/tests/tests.rs
+++ b/crates/sui-keys/tests/tests.rs
@@ -17,7 +17,7 @@ fn mnemonic_test() {
     let keystore_path = temp_dir.path().join("sui.keystore");
     let mut keystore = Keystore::from(FileBasedKeystore::new(&keystore_path).unwrap());
     let (address, phrase, scheme) = keystore
-        .generate_and_add_new_key(SignatureScheme::ED25519, None)
+        .generate_and_add_new_key(SignatureScheme::ED25519, None, None)
         .unwrap();
 
     let keystore_path_2 = temp_dir.path().join("sui2.keystore");

--- a/crates/sui-rosetta/src/main.rs
+++ b/crates/sui-rosetta/src/main.rs
@@ -247,10 +247,10 @@ fn test_read_keystore() {
     let path = temp_dir.path().join("sui.keystore");
     let mut ks = Keystore::from(FileBasedKeystore::new(&path).unwrap());
     let key1 = ks
-        .generate_and_add_new_key(SignatureScheme::ED25519, None)
+        .generate_and_add_new_key(SignatureScheme::ED25519, None, None)
         .unwrap();
     let key2 = ks
-        .generate_and_add_new_key(SignatureScheme::Secp256k1, None)
+        .generate_and_add_new_key(SignatureScheme::Secp256k1, None, None)
         .unwrap();
 
     let accounts = read_prefunded_account(&path).unwrap();

--- a/crates/sui-sdk/tests/tests.rs
+++ b/crates/sui-sdk/tests/tests.rs
@@ -11,7 +11,7 @@ fn mnemonic_test() {
     let keystore_path = temp_dir.path().join("sui.keystore");
     let mut keystore = Keystore::from(FileBasedKeystore::new(&keystore_path).unwrap());
     let (address, phrase, scheme) = keystore
-        .generate_and_add_new_key(SignatureScheme::ED25519, None)
+        .generate_and_add_new_key(SignatureScheme::ED25519, None, None)
         .unwrap();
 
     let keystore_path_2 = temp_dir.path().join("sui2.keystore");

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -359,10 +359,13 @@ pub enum SuiClientCommands {
     Addresses,
 
     /// Generate new address and keypair with keypair scheme flag {ed25519 | secp256k1 | secp256r1}
-    /// with optional derivation path, default to m/44'/784'/0'/0'/0' for ed25519 or m/54'/784'/0'/0/0 for secp256k1 or m/74'/784'/0'/0/0 for secp256r1.
+    /// with optional derivation path, default to m/44'/784'/0'/0'/0' for ed25519 or
+    /// m/54'/784'/0'/0/0 for secp256k1 or m/74'/784'/0'/0/0 for secp256r1. Word length can be
+    /// { word12 | word15 | word18 | word21 | word24} default to word12 if not specified.
     #[clap(name = "new-address")]
     NewAddress {
         key_scheme: SignatureScheme,
+        word_length: Option<String>,
         derivation_path: Option<DerivationPath>,
     },
 
@@ -898,11 +901,13 @@ impl SuiClientCommands {
             SuiClientCommands::NewAddress {
                 key_scheme,
                 derivation_path,
+                word_length,
             } => {
-                let (address, phrase, scheme) = context
-                    .config
-                    .keystore
-                    .generate_and_add_new_key(key_scheme, derivation_path)?;
+                let (address, phrase, scheme) = context.config.keystore.generate_and_add_new_key(
+                    key_scheme,
+                    derivation_path,
+                    word_length,
+                )?;
                 SuiClientCommandResult::NewAddress((address, phrase, scheme))
             }
             SuiClientCommands::Gas { address } => {

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -553,7 +553,7 @@ async fn prompt_if_no_config(
                 }
             };
             let (new_address, phrase, scheme) =
-                keystore.generate_and_add_new_key(key_scheme, None)?;
+                keystore.generate_and_add_new_key(key_scheme, None, None)?;
             println!(
                 "Generated new keypair for address with scheme {:?} [{new_address}]",
                 scheme.to_string()

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -1305,6 +1305,7 @@ async fn test_switch_command() -> Result<(), anyhow::Error> {
     let os = SuiClientCommands::NewAddress {
         key_scheme: SignatureScheme::ED25519,
         derivation_path: None,
+        word_length: None,
     }
     .execute(context)
     .await?;
@@ -1356,6 +1357,7 @@ async fn test_new_address_command_by_flag() -> Result<(), anyhow::Error> {
     SuiClientCommands::NewAddress {
         key_scheme: SignatureScheme::Secp256k1,
         derivation_path: None,
+        word_length: None,
     }
     .execute(context)
     .await?;

--- a/crates/sui/src/unit_tests/keytool_tests.rs
+++ b/crates/sui/src/unit_tests/keytool_tests.rs
@@ -335,6 +335,7 @@ fn test_keytool_bls12381() -> Result<(), anyhow::Error> {
     KeyToolCommand::Generate {
         key_scheme: SignatureScheme::BLS12381,
         derivation_path: None,
+        word_length: None,
     }
     .execute(&mut keystore)?;
     Ok(())

--- a/crates/sui/src/validator_commands.rs
+++ b/crates/sui/src/validator_commands.rs
@@ -171,7 +171,7 @@ fn make_key_files(
                 key
             }
             None => {
-                let (_, kp, _, _) = generate_new_key(SignatureScheme::ED25519, None)?;
+                let (_, kp, _, _) = generate_new_key(SignatureScheme::ED25519, None, None)?;
                 println!("Generated new key file: {:?}.", file_name);
                 kp
             }


### PR DESCRIPTION
## Description 

Default CLI mnemonics generation to 12 words. Optional flag is allowed to generate / import other lengths. 
```
target/debug/sui client new-address ed25519                                                                                                                                                                                                                                                                       
Created new keypair for address with scheme ED25519: [0xaf3806a93b7fb6ac24fda8cbbf95c7ae7bd8619559a2283bbab0565116ad5940]
Secret Recovery Phrase : [usage empower claw syrup only leave title arrow phone comic earth rely]
target/debug/sui client new-address ed25519 word24                                                                                                                                                                                                                                                                  

Created new keypair for address with scheme ED25519: [0x2c21f35067b22afea0023a81585ada73e54128a7c0cd8ee5d2aa1bb58117e4f9]
Secret Recovery Phrase : [library erode february enter wild claim cave list typical robot write fault eternal symbol enforce chapter advance exact believe between holiday bachelor bring rebel]
```

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
