### PR TITLE
Update fastcrypto - includes an update to ECVRF which is not backward compatible with previous ECVRF proofs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,7 +135,7 @@ dependencies = [
  "http",
  "matchit 0.5.0",
  "pin-project-lite",
- "pkcs8",
+ "pkcs8 0.9.0",
  "quinn",
  "quinn-proto",
  "rand 0.8.5",
@@ -1051,6 +1051,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1186,10 +1192,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
-name = "bitcoin_hashes"
-version = "0.11.0"
+name = "bitcoin-private"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
+checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
+dependencies = [
+ "bitcoin-private",
+]
 
 [[package]]
 name = "bitflags"
@@ -1888,9 +1903,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
+checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
 name = "const-str"
@@ -2137,6 +2152,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c2538c4e68e52548bacb3e83ac549f903d44f011ac9d5abb5e132e67d0808f7"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2366,6 +2393,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
  "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc906908ea6458456e5eaa160a9c08543ec3d1e6f71e2235cedd660cb65f9df0"
+dependencies = [
+ "const-oid",
  "zeroize",
 ]
 
@@ -2575,6 +2613,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.3",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -2690,21 +2729,21 @@ version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
- "der",
- "elliptic-curve",
- "rfc6979",
+ "der 0.6.1",
+ "elliptic-curve 0.12.3",
+ "rfc6979 0.3.1",
  "signature 1.6.4",
 ]
 
 [[package]]
 name = "ecdsa"
-version = "0.15.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12844141594ad74185a926d030f3b605f6a903b4e3fec351f3ea338ac5b7637e"
+checksum = "644d3b8674a5fc5b929ae435bca85c2323d85ccb013a5509c2ac9ee11a6284ba"
 dependencies = [
- "der",
- "elliptic-curve",
- "rfc6979",
+ "der 0.7.1",
+ "elliptic-curve 0.13.2",
+ "rfc6979 0.4.0",
  "signature 2.0.0",
 ]
 
@@ -2714,7 +2753,7 @@ version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
- "pkcs8",
+ "pkcs8 0.9.0",
  "serde 1.0.152",
  "signature 1.6.4",
  "zeroize",
@@ -2762,16 +2801,34 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
- "base16ct",
- "crypto-bigint",
- "der",
+ "base16ct 0.1.1",
+ "crypto-bigint 0.4.9",
+ "der 0.6.1",
  "digest 0.10.6",
- "ff",
+ "ff 0.12.1",
  "generic-array",
- "group",
- "pkcs8",
+ "group 0.12.1",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.3.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea5a92946e8614bb585254898bb7dd1ddad241ace60c52149e3765e34cc039d"
+dependencies = [
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.1",
+ "digest 0.10.6",
+ "ff 0.13.0",
+ "generic-array",
+ "group 0.13.0",
+ "pkcs8 0.10.1",
+ "rand_core 0.6.4",
+ "sec1 0.7.1",
  "subtle",
  "zeroize",
 ]
@@ -2926,7 +2983,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto"
 version = "0.1.4"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=c2f79b1807bff7d09517b631191b61f2614c641c#c2f79b1807bff7d09517b631191b61f2614c641c"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=84fd7c7428c5f59185aecc56a2e0a006e8e07de1#84fd7c7428c5f59185aecc56a2e0a006e8e07de1"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2943,9 +3000,9 @@ dependencies = [
  "curve25519-dalek-ng",
  "derive_more",
  "digest 0.10.6",
- "ecdsa 0.15.1",
+ "ecdsa 0.16.2",
  "ed25519-consensus",
- "elliptic-curve",
+ "elliptic-curve 0.13.2",
  "eyre",
  "fastcrypto-derive",
  "generic-array",
@@ -2956,7 +3013,8 @@ dependencies = [
  "p256",
  "rand 0.8.5",
  "readonly",
- "rfc6979",
+ "rfc6979 0.4.0",
+ "rsa",
  "schemars",
  "secp256k1",
  "serde 1.0.152",
@@ -2964,7 +3022,8 @@ dependencies = [
  "serde_with",
  "sha2 0.10.6",
  "sha3 0.10.6",
- "signature 1.6.4",
+ "signature 2.0.0",
+ "static_assertions",
  "thiserror",
  "tokio",
  "typenum",
@@ -2974,7 +3033,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-derive"
 version = "0.1.2"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=c2f79b1807bff7d09517b631191b61f2614c641c#c2f79b1807bff7d09517b631191b61f2614c641c"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=84fd7c7428c5f59185aecc56a2e0a006e8e07de1#84fd7c7428c5f59185aecc56a2e0a006e8e07de1"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2 1.0.54",
@@ -2985,7 +3044,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-zkp"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=c2f79b1807bff7d09517b631191b61f2614c641c#c2f79b1807bff7d09517b631191b61f2614c641c"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=84fd7c7428c5f59185aecc56a2e0a006e8e07de1#84fd7c7428c5f59185aecc56a2e0a006e8e07de1"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -3034,6 +3093,16 @@ name = "ff"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
@@ -3256,6 +3325,7 @@ dependencies = [
  "serde 1.0.152",
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -3417,7 +3487,18 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
- "ff",
+ "ff 0.12.1",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff 0.13.0",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -4263,7 +4344,7 @@ checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
 dependencies = [
  "cfg-if",
  "ecdsa 0.14.8",
- "elliptic-curve",
+ "elliptic-curve 0.12.3",
  "sha2 0.10.6",
  "sha3 0.10.6",
 ]
@@ -4288,6 +4369,9 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "lazycell"
@@ -4329,6 +4413,12 @@ dependencies = [
  "cfg-if",
  "winapi",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "librocksdb-sys"
@@ -6152,6 +6242,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2399c9463abc5f909349d8aa9ba080e0b88b3ce2885389b60b993f39b1a56905"
+dependencies = [
+ "byteorder",
+ "lazy_static 1.4.0",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits 0.2.15",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6219,6 +6326,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -6400,12 +6508,12 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "p256"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49c124b3cbce43bcbac68c58ec181d98ed6cc7e6d0aa7c3ba97b2563410b0e55"
+checksum = "7270da3e5caa82afd3deb054cc237905853813aea3859544bc082c3fe55b8d47"
 dependencies = [
- "ecdsa 0.15.1",
- "elliptic-curve",
+ "ecdsa 0.16.2",
+ "elliptic-curve 0.13.2",
  "primeorder",
  "sha2 0.10.6",
 ]
@@ -6536,6 +6644,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c64931a1a212348ec4f3b4362585eca7159d0d09cbdf4a7f74f02173596fd4"
 dependencies = [
  "base64 0.13.1",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -6680,13 +6797,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff33bdbdfc54cc98a2eca766ebdec3e1b8fb7387523d5c9c9a2891da856f719"
+dependencies = [
+ "der 0.6.1",
+ "pkcs8 0.9.0",
+ "spki 0.6.0",
+ "zeroize",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
- "der",
- "spki",
+ "der 0.6.1",
+ "spki 0.6.0",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d2820d87d2b008616e5c27212dd9e0e694fb4c6b522de06094106813328cb49"
+dependencies = [
+ "der 0.7.1",
+ "spki 0.7.0",
 ]
 
 [[package]]
@@ -6856,11 +6995,11 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b54f7131b3dba65a2f414cf5bd25b66d4682e4608610668eae785750ba4c5b2"
+checksum = "7613fdcc0831c10060fa69833ea8fa2caa94b6456f51e25356a885b530a2e3d0"
 dependencies = [
- "elliptic-curve",
+ "elliptic-curve 0.13.2",
 ]
 
 [[package]]
@@ -7531,9 +7670,19 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
- "crypto-bigint",
+ "crypto-bigint 0.4.9",
  "hmac",
  "zeroize",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
 ]
 
 [[package]]
@@ -7599,6 +7748,27 @@ dependencies = [
  "base64 0.13.1",
  "bitflags",
  "serde 1.0.152",
+]
+
+[[package]]
+name = "rsa"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55a77d189da1fee555ad95b7e50e7457d91c0e089ec68ca69ad2989413bbdab4"
+dependencies = [
+ "byteorder",
+ "digest 0.10.6",
+ "num-bigint-dig",
+ "num-integer",
+ "num-iter",
+ "num-traits 0.2.15",
+ "pkcs1",
+ "pkcs8 0.9.0",
+ "rand_core 0.6.4",
+ "sha2 0.10.6",
+ "signature 2.0.0",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -7865,19 +8035,32 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.1.1",
+ "der 0.6.1",
  "generic-array",
- "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48518a2b5775ba8ca5b46596aae011caa431e6ce7e4a67ead66d92f08884220e"
+dependencies = [
+ "base16ct 0.2.0",
+ "der 0.7.1",
+ "generic-array",
+ "pkcs8 0.10.1",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "secp256k1"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4124a35fe33ae14259c490fd70fa199a32b9ce9502f2ee6bc4f81ec06fa65894"
+checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
  "bitcoin_hashes",
  "rand 0.8.5",
@@ -7886,9 +8069,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642a62736682fdd8c71da0eb273e453c8ac74e33b9fb310e22ba5b03ec7651ff"
+checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
 dependencies = [
  "cc",
 ]
@@ -8437,7 +8620,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0445c905640145c7ea8c1993555957f65e7c46d0535b91ba501bc9bfc85522f"
+dependencies = [
+ "base64ct",
+ "der 0.7.1",
 ]
 
 [[package]]
@@ -9645,7 +9838,7 @@ dependencies = [
  "axum-server",
  "ed25519",
  "fastcrypto",
- "pkcs8",
+ "pkcs8 0.9.0",
  "rand 0.8.5",
  "rcgen",
  "reqwest",
@@ -11390,7 +11583,8 @@ dependencies = [
  "backoff",
  "backtrace",
  "base-x",
- "base16ct",
+ "base16ct 0.1.1",
+ "base16ct 0.2.0",
  "base64 0.13.1",
  "base64 0.21.0",
  "base64ct",
@@ -11404,6 +11598,7 @@ dependencies = [
  "bip32",
  "bit-set",
  "bit-vec",
+ "bitcoin-private",
  "bitcoin_hashes",
  "bitflags",
  "bitmaps",
@@ -11487,7 +11682,8 @@ dependencies = [
  "crossterm 0.25.0",
  "crossterm_winapi 0.9.0",
  "crunchy",
- "crypto-bigint",
+ "crypto-bigint 0.4.9",
+ "crypto-bigint 0.5.1",
  "crypto-common",
  "csv",
  "csv-core",
@@ -11504,7 +11700,8 @@ dependencies = [
  "datatest-stable",
  "debug-ignore",
  "debugid",
- "der",
+ "der 0.6.1",
+ "der 0.7.1",
  "der-parser",
  "derivative",
  "derive-syn-parse",
@@ -11537,11 +11734,12 @@ dependencies = [
  "duration-str",
  "dyn-clone",
  "ecdsa 0.14.8",
- "ecdsa 0.15.1",
+ "ecdsa 0.16.2",
  "ed25519",
  "ed25519-consensus",
  "either",
- "elliptic-curve",
+ "elliptic-curve 0.12.3",
+ "elliptic-curve 0.13.2",
  "encode_unicode 0.3.6",
  "encode_unicode 1.0.0",
  "encoding_rs",
@@ -11561,7 +11759,8 @@ dependencies = [
  "fastrand",
  "fd-lock",
  "fdlimit",
- "ff",
+ "ff 0.12.1",
+ "ff 0.13.0",
  "findshlibs",
  "fixed-hash",
  "fixedbitset 0.2.0",
@@ -11598,7 +11797,8 @@ dependencies = [
  "gloo-timers",
  "gloo-utils",
  "governor",
- "group",
+ "group 0.12.1",
+ "group 0.13.0",
  "guppy",
  "guppy-summaries",
  "guppy-workspace-hack",
@@ -11676,6 +11876,7 @@ dependencies = [
  "lexical-core",
  "libc",
  "libloading",
+ "libm",
  "librocksdb-sys",
  "libtest-mimic",
  "libz-sys",
@@ -11758,6 +11959,7 @@ dependencies = [
  "nu-ansi-term",
  "num",
  "num-bigint",
+ "num-bigint-dig",
  "num-complex",
  "num-format",
  "num-integer",
@@ -11796,6 +11998,7 @@ dependencies = [
  "pbkdf2",
  "peeking_take_while",
  "pem",
+ "pem-rfc7468",
  "percent-encoding",
  "pest",
  "pest_derive",
@@ -11811,7 +12014,9 @@ dependencies = [
  "pin-project-internal",
  "pin-project-lite",
  "pin-utils",
- "pkcs8",
+ "pkcs1",
+ "pkcs8 0.10.1",
+ "pkcs8 0.9.0",
  "pkg-config",
  "plotters",
  "plotters-backend",
@@ -11879,13 +12084,15 @@ dependencies = [
  "regex-syntax",
  "reqwest",
  "retain_mut",
- "rfc6979",
+ "rfc6979 0.3.1",
+ "rfc6979 0.4.0",
  "rgb",
  "ring",
  "ripemd",
  "roaring",
  "rocksdb",
  "ron",
+ "rsa",
  "rstest",
  "rstest_macros",
  "rust-ini",
@@ -11911,7 +12118,8 @@ dependencies = [
  "schemars_derive",
  "scopeguard",
  "sct",
- "sec1",
+ "sec1 0.3.0",
+ "sec1 0.7.1",
  "secp256k1",
  "secp256k1-sys",
  "security-framework",
@@ -11965,7 +12173,8 @@ dependencies = [
  "socket2",
  "soketto",
  "spin",
- "spki",
+ "spki 0.6.0",
+ "spki 0.7.0",
  "stable_deref_trait",
  "static_assertions",
  "str-buf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,8 +138,8 @@ move-prover-boogie-backend = { git = "https://github.com/move-language/move", re
 move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
 move-symbol-pool = { git = "https://github.com/move-language/move", rev = "dd68cceec4ee9cf7b9343d7ccb6d0ae5a9db3f46" }
 
-fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "c2f79b1807bff7d09517b631191b61f2614c641c" }
-fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "c2f79b1807bff7d09517b631191b61f2614c641c", package = "fastcrypto-zkp" }
+fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "84fd7c7428c5f59185aecc56a2e0a006e8e07de1" }
+fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "84fd7c7428c5f59185aecc56a2e0a006e8e07de1", package = "fastcrypto-zkp" }
 
 # anemo dependencies
 anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "fafd8a33615a1d5f0ea99ae3d0cc993b833fa313" }

--- a/crates/sui-framework/packages/sui-framework/tests/crypto/ecvrf_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/crypto/ecvrf_tests.move
@@ -8,10 +8,10 @@ module sui::ecvrf_tests {
     #[test]
     fun test_ecvrf_verify() {
         // Test vector produced with Fastcrypto
-        let output = x"4ad05aafdaf4f0c76ac1ec46507431de2d81876ff95dd097334d2c257492afe41fe21900ef04e4e1f377143e24e38cf104fc5f983d28f940d4c0721d0823a3af";
+        let output = x"4fad431c7402fa1d4a7652e975aeb9a2b746540eca0b1b1e59c8d19c14a7701918a8249136e355455b8bc73851f7fc62c84f2e39f685b281e681043970026ed8";
         let alpha_string = b"Hello, world!";
-        let public_key = x"2cf96313347d5f1f347464d1f59889b5c736a17e19bf899827aa3400733ea44d";
-        let proof = x"445b02b99b1484e22325b0ad609f666df3d7099c90ed82a15d731ec42603fa4279ef4781ec2b88355dc08f5cbdf6cdae511836d5b5a5566a12fc56db4d8c3f9bf1c85186719706282c525df4b0477502";
+        let public_key = x"1ea6f0f467574295a2cd5d21a3fd3a712ade354d520d3bd0fe6088d7b7c2e00e";
+        let proof = x"d8ad2eafb4f2eaf317447726e541359f26dfce248431fe09984fdc73144abb6ceb006c57a29a742eae5a81dd04239870769e310a81046cbbaff8b0bd27a6d6affee167ebba50549b58ffdf9aa192f506";
         assert!(ecvrf::ecvrf_verify(&output, &alpha_string, &public_key, &proof), 0);
     }
 
@@ -19,8 +19,8 @@ module sui::ecvrf_tests {
     fun test_ecvrf_invalid() {
         let output = b"invalid hash, invalid hash, invalid hash, invalid hash, invalid ";
         let alpha_string = b"Hello, world!";
-        let public_key = x"2cf96313347d5f1f347464d1f59889b5c736a17e19bf899827aa3400733ea44d";
-        let proof = x"445b02b99b1484e22325b0ad609f666df3d7099c90ed82a15d731ec42603fa4279ef4781ec2b88355dc08f5cbdf6cdae511836d5b5a5566a12fc56db4d8c3f9bf1c85186719706282c525df4b0477502";
+        let public_key = x"1ea6f0f467574295a2cd5d21a3fd3a712ade354d520d3bd0fe6088d7b7c2e00e";
+        let proof = x"d8ad2eafb4f2eaf317447726e541359f26dfce248431fe09984fdc73144abb6ceb006c57a29a742eae5a81dd04239870769e310a81046cbbaff8b0bd27a6d6affee167ebba50549b58ffdf9aa192f506";
         assert!(!ecvrf::ecvrf_verify(&output, &alpha_string, &public_key, &proof), 1);
     }
 
@@ -29,27 +29,27 @@ module sui::ecvrf_tests {
     fun test_invalid_length() {
         let output = b"invalid hash";
         let alpha_string = b"Hello, world!";
-        let public_key = x"2cf96313347d5f1f347464d1f59889b5c736a17e19bf899827aa3400733ea44d";
-        let proof = x"445b02b99b1484e22325b0ad609f666df3d7099c90ed82a15d731ec42603fa4279ef4781ec2b88355dc08f5cbdf6cdae511836d5b5a5566a12fc56db4d8c3f9bf1c85186719706282c525df4b0477502";
+        let public_key = x"1ea6f0f467574295a2cd5d21a3fd3a712ade354d520d3bd0fe6088d7b7c2e00e";
+        let proof = x"d8ad2eafb4f2eaf317447726e541359f26dfce248431fe09984fdc73144abb6ceb006c57a29a742eae5a81dd04239870769e310a81046cbbaff8b0bd27a6d6affee167ebba50549b58ffdf9aa192f506";
         ecvrf::ecvrf_verify(&output, &alpha_string, &public_key, &proof);
     }
 
     #[test]
     #[expected_failure(abort_code = ecvrf::EInvalidPublicKeyEncoding)]
     fun test_invalid_public_key() {
-        let output = x"4ad05aafdaf4f0c76ac1ec46507431de2d81876ff95dd097334d2c257492afe41fe21900ef04e4e1f377143e24e38cf104fc5f983d28f940d4c0721d0823a3af";
+        let output = x"4fad431c7402fa1d4a7652e975aeb9a2b746540eca0b1b1e59c8d19c14a7701918a8249136e355455b8bc73851f7fc62c84f2e39f685b281e681043970026ed8";
         let alpha_string = b"Hello, world!";
         let public_key = b"invalid public key";
-        let proof = x"445b02b99b1484e22325b0ad609f666df3d7099c90ed82a15d731ec42603fa4279ef4781ec2b88355dc08f5cbdf6cdae511836d5b5a5566a12fc56db4d8c3f9bf1c85186719706282c525df4b0477502";
+        let proof = x"d8ad2eafb4f2eaf317447726e541359f26dfce248431fe09984fdc73144abb6ceb006c57a29a742eae5a81dd04239870769e310a81046cbbaff8b0bd27a6d6affee167ebba50549b58ffdf9aa192f506";
         ecvrf::ecvrf_verify(&output, &alpha_string, &public_key, &proof);
     }
 
     #[test]
     #[expected_failure(abort_code = ecvrf::EInvalidProofEncoding)]
     fun test_invalid_proof() {
-        let output = x"4ad05aafdaf4f0c76ac1ec46507431de2d81876ff95dd097334d2c257492afe41fe21900ef04e4e1f377143e24e38cf104fc5f983d28f940d4c0721d0823a3af";
+        let output = x"4fad431c7402fa1d4a7652e975aeb9a2b746540eca0b1b1e59c8d19c14a7701918a8249136e355455b8bc73851f7fc62c84f2e39f685b281e681043970026ed8";
         let alpha_string = b"Hello, world!";
-        let public_key = x"2cf96313347d5f1f347464d1f59889b5c736a17e19bf899827aa3400733ea44d";
+        let public_key = x"1ea6f0f467574295a2cd5d21a3fd3a712ade354d520d3bd0fe6088d7b7c2e00e";
         let proof = b"invalid proof";
         ecvrf::ecvrf_verify(&output, &alpha_string, &public_key, &proof);
     }

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -64,7 +64,8 @@ axum-server = { version = "0.4", features = ["tls-rustls"] }
 backoff = { version = "0.4", features = ["tokio"] }
 backtrace = { version = "0.3" }
 base-x = { version = "0.2", default-features = false }
-base16ct = { version = "0.1", default-features = false, features = ["alloc"] }
+base16ct-6f8ce4dd05d13bba = { package = "base16ct", version = "0.2", default-features = false, features = ["alloc"] }
+base16ct-c65f7effa3be6d31 = { package = "base16ct", version = "0.1", default-features = false }
 base64-594e8ee84c453af0 = { package = "base64", version = "0.13", features = ["alloc"] }
 base64-647d43efb71741da = { package = "base64", version = "0.21" }
 base64ct = { version = "1", default-features = false, features = ["alloc"] }
@@ -76,7 +77,8 @@ bincode = { version = "1", default-features = false }
 bip32 = { version = "0.4" }
 bit-set = { version = "0.5" }
 bit-vec = { version = "0.6", default-features = false, features = ["std"] }
-bitcoin_hashes = { version = "0.11", default-features = false }
+bitcoin-private = { version = "0.1" }
+bitcoin_hashes = { version = "0.12", default-features = false }
 bitflags = { version = "1" }
 bitmaps = { version = "2" }
 bitvec-56bd22fc3884b12 = { package = "bitvec", version = "0.20", default-features = false, features = ["std"] }
@@ -143,7 +145,8 @@ crossbeam-epoch = { version = "0.9", default-features = false, features = ["std"
 crossbeam-utils = { version = "0.8" }
 crossterm = { version = "0.25" }
 crunchy = { version = "0.2", default-features = false, features = ["std"] }
-crypto-bigint = { version = "0.4", default-features = false, features = ["generic-array", "rand_core", "zeroize"] }
+crypto-bigint-9fbad63c4bcf4a8f = { package = "crypto-bigint", version = "0.4", default-features = false, features = ["generic-array", "rand_core", "zeroize"] }
+crypto-bigint-d8f496e17d97b5cb = { package = "crypto-bigint", version = "0.5", default-features = false, features = ["generic-array", "rand_core", "zeroize"] }
 crypto-common = { version = "0.1", default-features = false, features = ["getrandom", "std"] }
 csv = { version = "1", default-features = false }
 csv-core = { version = "0.1" }
@@ -154,7 +157,8 @@ data-encoding = { version = "2" }
 data-encoding-macro = { version = "0.1", default-features = false }
 datatest-stable = { version = "0.1", default-features = false }
 debug-ignore = { version = "1", default-features = false }
-der = { version = "0.6", default-features = false, features = ["oid", "std", "zeroize"] }
+der-3b31131e45eafb45 = { package = "der", version = "0.6", default-features = false, features = ["oid", "pem", "std"] }
+der-ca01ad9e24f5d932 = { package = "der", version = "0.7", default-features = false, features = ["oid", "std", "zeroize"] }
 der-parser = { version = "8", features = ["bigint"] }
 derive_builder = { version = "0.12" }
 determinator = { version = "0.10", default-features = false }
@@ -167,7 +171,7 @@ difflib = { version = "0.4", default-features = false }
 diffus = { version = "0.10" }
 diffy = { version = "0.3", default-features = false }
 digest-274715c4dabd11b0 = { package = "digest", version = "0.9", default-features = false, features = ["std"] }
-digest-93f6ce9d446188ac = { package = "digest", version = "0.10", features = ["mac", "std"] }
+digest-93f6ce9d446188ac = { package = "digest", version = "0.10", features = ["mac", "oid", "std"] }
 directories = { version = "4", default-features = false }
 dirs = { version = "4", default-features = false }
 dirs-next = { version = "2", default-features = false }
@@ -178,12 +182,13 @@ doc-comment = { version = "0.3", default-features = false }
 downcast = { version = "0.11" }
 duration-str = { version = "0.4" }
 dyn-clone = { version = "1", default-features = false }
-ecdsa-3575ec1268b04181 = { package = "ecdsa", version = "0.15", features = ["pkcs8", "signing", "std", "verifying"] }
 ecdsa-582f2526e08bb6a0 = { package = "ecdsa", version = "0.14", default-features = false, features = ["der", "sign", "verify"] }
+ecdsa-986da7b5efc2b80e = { package = "ecdsa", version = "0.16", features = ["pkcs8", "signing", "std", "verifying"] }
 ed25519 = { version = "1", features = ["alloc", "zeroize"] }
 ed25519-consensus = { version = "2" }
 either = { version = "1" }
-elliptic-curve = { version = "0.12", features = ["hash2curve", "hazmat", "pkcs8", "std"] }
+elliptic-curve-594e8ee84c453af0 = { package = "elliptic-curve", version = "0.13", features = ["hash2curve", "hazmat", "pkcs8", "std"] }
+elliptic-curve-5ef9efb8ec2df382 = { package = "elliptic-curve", version = "0.12", default-features = false, features = ["arithmetic", "digest", "hazmat", "sec1"] }
 encode_unicode-dff4ba8e3ae991db = { package = "encode_unicode", version = "1" }
 endian-type = { version = "0.1", default-features = false }
 ethnum = { version = "1", default-features = false }
@@ -192,12 +197,13 @@ expect-test = { version = "1", default-features = false }
 eyre = { version = "0.6" }
 fail-9fbad63c4bcf4a8f = { package = "fail", version = "0.4", default-features = false }
 fail-d8f496e17d97b5cb = { package = "fail", version = "0.5", default-features = false }
-fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "c2f79b1807bff7d09517b631191b61f2614c641c", features = ["copy_key"] }
-fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "c2f79b1807bff7d09517b631191b61f2614c641c", default-features = false }
+fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "84fd7c7428c5f59185aecc56a2e0a006e8e07de1", features = ["copy_key"] }
+fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "84fd7c7428c5f59185aecc56a2e0a006e8e07de1", default-features = false }
 fastrand = { version = "1", default-features = false }
 fd-lock = { version = "3", default-features = false }
 fdlimit = { version = "0.2", default-features = false }
-ff = { version = "0.12", default-features = false }
+ff-594e8ee84c453af0 = { package = "ff", version = "0.13", default-features = false, features = ["alloc"] }
+ff-5ef9efb8ec2df382 = { package = "ff", version = "0.12", default-features = false }
 fixed-hash = { version = "0.7", default-features = false, features = ["std"] }
 fixedbitset-6f8ce4dd05d13bba = { package = "fixedbitset", version = "0.2", default-features = false }
 fixedbitset-9fbad63c4bcf4a8f = { package = "fixedbitset", version = "0.4", default-features = false }
@@ -218,7 +224,7 @@ futures-sink = { version = "0.3" }
 futures-task = { version = "0.3", default-features = false, features = ["std", "unstable"] }
 futures-timer = { version = "3", default-features = false, features = ["wasm-bindgen"] }
 futures-util = { version = "0.3", default-features = false, features = ["async-await-macro", "bilock", "channel", "io", "sink", "unstable"] }
-generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "serde"] }
+generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "serde", "zeroize"] }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 getrandom-c65f7effa3be6d31 = { package = "getrandom", version = "0.1", default-features = false, features = ["std"] }
 ghash = { version = "0.5", default-features = false }
@@ -231,7 +237,8 @@ gloo-net = { version = "0.2", default-features = false, features = ["json", "web
 gloo-timers = { version = "0.2", features = ["futures"] }
 gloo-utils = { version = "0.1", default-features = false, features = ["serde"] }
 governor = { version = "0.5" }
-group = { version = "0.12", default-features = false }
+group-594e8ee84c453af0 = { package = "group", version = "0.13", default-features = false, features = ["alloc"] }
+group-5ef9efb8ec2df382 = { package = "group", version = "0.12", default-features = false }
 guppy = { version = "0.15", default-features = false, features = ["rayon1", "summaries"] }
 guppy-summaries = { version = "0.7", default-features = false }
 guppy-workspace-hack = { version = "0.1", default-features = false }
@@ -289,10 +296,11 @@ jsonrpsee-ws-client = { version = "0.16" }
 k256 = { version = "0.11", default-features = false, features = ["ecdsa", "keccak256"] }
 keccak = { version = "0.1", default-features = false }
 lazy_static-6f8ce4dd05d13bba = { package = "lazy_static", version = "0.2", default-features = false }
-lazy_static-dff4ba8e3ae991db = { package = "lazy_static", version = "1", default-features = false }
+lazy_static-dff4ba8e3ae991db = { package = "lazy_static", version = "1", default-features = false, features = ["spin_no_std"] }
 leb128 = { version = "0.2", default-features = false }
 lexical-core = { version = "0.7" }
 libc = { version = "0.2" }
+libm = { version = "0.2" }
 librocksdb-sys = { version = "0.10", features = ["bzip2", "lz4", "snappy", "zlib", "zstd"] }
 libtest-mimic = { version = "0.5", default-features = false }
 libz-sys = { version = "1", default-features = false, features = ["static"] }
@@ -362,11 +370,12 @@ ntest = { version = "0.9", default-features = false }
 nu-ansi-term = { version = "0.46", default-features = false }
 num = { version = "0.4" }
 num-bigint = { version = "0.4" }
+num-bigint-dig = { version = "0.8", default-features = false, features = ["i128", "prime", "u64_digit", "zeroize"] }
 num-complex = { version = "0.4", default-features = false, features = ["std"] }
 num-integer = { version = "0.1", default-features = false, features = ["i128", "std"] }
 num-iter = { version = "0.1", default-features = false, features = ["i128", "std"] }
 num-rational = { version = "0.4", default-features = false, features = ["num-bigint-std", "std"] }
-num-traits-6f8ce4dd05d13bba = { package = "num-traits", version = "0.2", features = ["i128"] }
+num-traits-6f8ce4dd05d13bba = { package = "num-traits", version = "0.2", features = ["i128", "libm"] }
 num-traits-c65f7effa3be6d31 = { package = "num-traits", version = "0.1", default-features = false }
 num_cpus = { version = "1", default-features = false }
 number_prefix = { version = "0.4" }
@@ -381,7 +390,7 @@ ouroboros-274715c4dabd11b0 = { package = "ouroboros", version = "0.9", default-f
 ouroboros-3575ec1268b04181 = { package = "ouroboros", version = "0.15" }
 overload = { version = "0.1", default-features = false }
 owo-colors = { version = "3", default-features = false }
-p256 = { version = "0.12" }
+p256 = { version = "0.13" }
 parity-scale-codec = { version = "2", default-features = false, features = ["max-encoded-len", "std"] }
 parking = { version = "2", default-features = false }
 parking_lot-5ef9efb8ec2df382 = { package = "parking_lot", version = "0.12" }
@@ -391,6 +400,7 @@ parking_lot_core-c38e5c1d305a1b54 = { package = "parking_lot_core", version = "0
 pathdiff = { version = "0.2", default-features = false, features = ["camino"] }
 pbkdf2 = { version = "0.11", default-features = false }
 pem = { version = "1", default-features = false }
+pem-rfc7468 = { version = "0.6", default-features = false, features = ["alloc"] }
 percent-encoding = { version = "2" }
 pest = { version = "2" }
 petgraph-3b31131e45eafb45 = { package = "petgraph", version = "0.6" }
@@ -400,7 +410,9 @@ phf_shared = { version = "0.11", features = ["uncased"] }
 pin-project = { version = "1", default-features = false }
 pin-project-lite = { version = "0.2", default-features = false }
 pin-utils = { version = "0.1", default-features = false }
-pkcs8 = { version = "0.9", default-features = false, features = ["std"] }
+pkcs1 = { version = "0.4", default-features = false, features = ["pem", "std"] }
+pkcs8-274715c4dabd11b0 = { package = "pkcs8", version = "0.9", default-features = false, features = ["pem", "std"] }
+pkcs8-93f6ce9d446188ac = { package = "pkcs8", version = "0.10", default-features = false, features = ["std"] }
 plotters = { version = "0.3", default-features = false, features = ["area_series", "line_series", "svg_backend"] }
 plotters-backend = { version = "0.3", default-features = false }
 plotters-svg = { version = "0.3", default-features = false }
@@ -414,7 +426,7 @@ predicates-tree = { version = "1", default-features = false }
 pretty = { version = "0.10", default-features = false }
 pretty_assertions = { version = "1" }
 prettytable-rs = { version = "0.10" }
-primeorder = { version = "0.12", default-features = false }
+primeorder = { version = "0.13", default-features = false }
 primitive-types = { version = "0.10", features = ["impl-serde"] }
 proc-macro2-dff4ba8e3ae991db = { package = "proc-macro2", version = "1", features = ["span-locations"] }
 prometheus = { version = "0.13" }
@@ -450,12 +462,14 @@ regex-automata = { version = "0.1" }
 regex-syntax = { version = "0.6" }
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 retain_mut = { version = "0.1", default-features = false }
-rfc6979 = { version = "0.3", default-features = false }
+rfc6979-468e82937335b1c9 = { package = "rfc6979", version = "0.3", default-features = false }
+rfc6979-9fbad63c4bcf4a8f = { package = "rfc6979", version = "0.4", default-features = false }
 ring = { version = "0.16" }
 ripemd = { version = "0.1", default-features = false }
 roaring = { version = "0.10", default-features = false }
 rocksdb = { version = "0.20", features = ["multi-threaded-cf"] }
 ron = { version = "0.8" }
+rsa = { version = "0.8", features = ["sha2"] }
 rstest = { version = "0.16" }
 rust-ini = { version = "0.13", default-features = false }
 rust_decimal = { version = "1", default-features = false }
@@ -474,8 +488,9 @@ scheduled-thread-pool = { version = "0.2", default-features = false }
 schemars = { version = "0.8", features = ["either"] }
 scopeguard = { version = "1" }
 sct = { version = "0.7", default-features = false }
-sec1 = { version = "0.3", features = ["alloc", "subtle"] }
-secp256k1 = { version = "0.26", features = ["bitcoin_hashes", "global-context", "rand-std", "recovery"] }
+sec1-468e82937335b1c9 = { package = "sec1", version = "0.3", features = ["subtle", "zeroize"] }
+sec1-ca01ad9e24f5d932 = { package = "sec1", version = "0.7", features = ["std", "subtle"] }
+secp256k1 = { version = "0.27", features = ["bitcoin_hashes", "global-context", "rand-std", "recovery"] }
 secp256k1-sys = { version = "0.8", default-features = false, features = ["recovery", "std"] }
 semver-dff4ba8e3ae991db = { package = "semver", version = "1", features = ["serde"] }
 send_wrapper = { version = "0.4", default-features = false }
@@ -496,7 +511,7 @@ sha-1-274715c4dabd11b0 = { package = "sha-1", version = "0.9", default-features 
 sha-1-93f6ce9d446188ac = { package = "sha-1", version = "0.10" }
 sha1 = { version = "0.10" }
 sha2-274715c4dabd11b0 = { package = "sha2", version = "0.9" }
-sha2-93f6ce9d446188ac = { package = "sha2", version = "0.10" }
+sha2-93f6ce9d446188ac = { package = "sha2", version = "0.10", features = ["oid"] }
 sha3-274715c4dabd11b0 = { package = "sha3", version = "0.9" }
 sha3-93f6ce9d446188ac = { package = "sha3", version = "0.10" }
 sharded-slab = { version = "0.1", default-features = false }
@@ -515,7 +530,9 @@ smallvec = { version = "1", default-features = false }
 snap = { version = "1", default-features = false }
 socket2 = { version = "0.4", default-features = false, features = ["all"] }
 soketto = { version = "0.7", features = ["http"] }
-spki = { version = "0.6", default-features = false, features = ["std"] }
+spin = { version = "0.5", default-features = false }
+spki-3b31131e45eafb45 = { package = "spki", version = "0.6", default-features = false, features = ["pem", "std"] }
+spki-ca01ad9e24f5d932 = { package = "spki", version = "0.7", default-features = false, features = ["std"] }
 stable_deref_trait = { version = "1" }
 static_assertions = { version = "1", default-features = false }
 strip-ansi-escapes = { version = "0.1", default-features = false }
@@ -684,7 +701,8 @@ axum-server = { version = "0.4", features = ["tls-rustls"] }
 backoff = { version = "0.4", features = ["tokio"] }
 backtrace = { version = "0.3" }
 base-x = { version = "0.2", default-features = false }
-base16ct = { version = "0.1", default-features = false, features = ["alloc"] }
+base16ct-6f8ce4dd05d13bba = { package = "base16ct", version = "0.2", default-features = false, features = ["alloc"] }
+base16ct-c65f7effa3be6d31 = { package = "base16ct", version = "0.1", default-features = false }
 base64-594e8ee84c453af0 = { package = "base64", version = "0.13", features = ["alloc"] }
 base64-647d43efb71741da = { package = "base64", version = "0.21" }
 base64ct = { version = "1", default-features = false, features = ["alloc"] }
@@ -698,7 +716,8 @@ bindgen = { version = "0.64", default-features = false, features = ["runtime"] }
 bip32 = { version = "0.4" }
 bit-set = { version = "0.5" }
 bit-vec = { version = "0.6", default-features = false, features = ["std"] }
-bitcoin_hashes = { version = "0.11", default-features = false }
+bitcoin-private = { version = "0.1" }
+bitcoin_hashes = { version = "0.12", default-features = false }
 bitflags = { version = "1" }
 bitmaps = { version = "2" }
 bitvec-56bd22fc3884b12 = { package = "bitvec", version = "0.20", default-features = false, features = ["std"] }
@@ -775,7 +794,8 @@ crossbeam-epoch = { version = "0.9", default-features = false, features = ["std"
 crossbeam-utils = { version = "0.8" }
 crossterm = { version = "0.25" }
 crunchy = { version = "0.2", default-features = false, features = ["std"] }
-crypto-bigint = { version = "0.4", default-features = false, features = ["generic-array", "rand_core", "zeroize"] }
+crypto-bigint-9fbad63c4bcf4a8f = { package = "crypto-bigint", version = "0.4", default-features = false, features = ["generic-array", "rand_core", "zeroize"] }
+crypto-bigint-d8f496e17d97b5cb = { package = "crypto-bigint", version = "0.5", default-features = false, features = ["generic-array", "rand_core", "zeroize"] }
 crypto-common = { version = "0.1", default-features = false, features = ["getrandom", "std"] }
 csv = { version = "1", default-features = false }
 csv-core = { version = "0.1" }
@@ -790,7 +810,8 @@ data-encoding-macro = { version = "0.1", default-features = false }
 data-encoding-macro-internal = { version = "0.1", default-features = false }
 datatest-stable = { version = "0.1", default-features = false }
 debug-ignore = { version = "1", default-features = false }
-der = { version = "0.6", default-features = false, features = ["oid", "std", "zeroize"] }
+der-3b31131e45eafb45 = { package = "der", version = "0.6", default-features = false, features = ["oid", "pem", "std"] }
+der-ca01ad9e24f5d932 = { package = "der", version = "0.7", default-features = false, features = ["oid", "std", "zeroize"] }
 der-parser = { version = "8", features = ["bigint"] }
 derivative = { version = "2", default-features = false, features = ["use_core"] }
 derive-syn-parse = { version = "0.1", default-features = false }
@@ -810,7 +831,7 @@ difflib = { version = "0.4", default-features = false }
 diffus = { version = "0.10" }
 diffy = { version = "0.3", default-features = false }
 digest-274715c4dabd11b0 = { package = "digest", version = "0.9", default-features = false, features = ["std"] }
-digest-93f6ce9d446188ac = { package = "digest", version = "0.10", features = ["mac", "std"] }
+digest-93f6ce9d446188ac = { package = "digest", version = "0.10", features = ["mac", "oid", "std"] }
 directories = { version = "4", default-features = false }
 dirs = { version = "4", default-features = false }
 dirs-next = { version = "2", default-features = false }
@@ -822,12 +843,13 @@ doc-comment = { version = "0.3", default-features = false }
 downcast = { version = "0.11" }
 duration-str = { version = "0.4" }
 dyn-clone = { version = "1", default-features = false }
-ecdsa-3575ec1268b04181 = { package = "ecdsa", version = "0.15", features = ["pkcs8", "signing", "std", "verifying"] }
 ecdsa-582f2526e08bb6a0 = { package = "ecdsa", version = "0.14", default-features = false, features = ["der", "sign", "verify"] }
+ecdsa-986da7b5efc2b80e = { package = "ecdsa", version = "0.16", features = ["pkcs8", "signing", "std", "verifying"] }
 ed25519 = { version = "1", features = ["alloc", "zeroize"] }
 ed25519-consensus = { version = "2" }
 either = { version = "1" }
-elliptic-curve = { version = "0.12", features = ["hash2curve", "hazmat", "pkcs8", "std"] }
+elliptic-curve-594e8ee84c453af0 = { package = "elliptic-curve", version = "0.13", features = ["hash2curve", "hazmat", "pkcs8", "std"] }
+elliptic-curve-5ef9efb8ec2df382 = { package = "elliptic-curve", version = "0.12", default-features = false, features = ["arithmetic", "digest", "hazmat", "sec1"] }
 encode_unicode-dff4ba8e3ae991db = { package = "encode_unicode", version = "1" }
 endian-type = { version = "0.1", default-features = false }
 enum_dispatch = { version = "0.3", default-features = false }
@@ -837,13 +859,14 @@ expect-test = { version = "1", default-features = false }
 eyre = { version = "0.6" }
 fail-9fbad63c4bcf4a8f = { package = "fail", version = "0.4", default-features = false }
 fail-d8f496e17d97b5cb = { package = "fail", version = "0.5", default-features = false }
-fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "c2f79b1807bff7d09517b631191b61f2614c641c", features = ["copy_key"] }
-fastcrypto-derive = { git = "https://github.com/MystenLabs/fastcrypto", rev = "c2f79b1807bff7d09517b631191b61f2614c641c", default-features = false }
-fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "c2f79b1807bff7d09517b631191b61f2614c641c", default-features = false }
+fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "84fd7c7428c5f59185aecc56a2e0a006e8e07de1", features = ["copy_key"] }
+fastcrypto-derive = { git = "https://github.com/MystenLabs/fastcrypto", rev = "84fd7c7428c5f59185aecc56a2e0a006e8e07de1", default-features = false }
+fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "84fd7c7428c5f59185aecc56a2e0a006e8e07de1", default-features = false }
 fastrand = { version = "1", default-features = false }
 fd-lock = { version = "3", default-features = false }
 fdlimit = { version = "0.2", default-features = false }
-ff = { version = "0.12", default-features = false }
+ff-594e8ee84c453af0 = { package = "ff", version = "0.13", default-features = false, features = ["alloc"] }
+ff-5ef9efb8ec2df382 = { package = "ff", version = "0.12", default-features = false }
 fixed-hash = { version = "0.7", default-features = false, features = ["std"] }
 fixedbitset-6f8ce4dd05d13bba = { package = "fixedbitset", version = "0.2", default-features = false }
 fixedbitset-9fbad63c4bcf4a8f = { package = "fixedbitset", version = "0.4", default-features = false }
@@ -865,7 +888,7 @@ futures-sink = { version = "0.3" }
 futures-task = { version = "0.3", default-features = false, features = ["std", "unstable"] }
 futures-timer = { version = "3", default-features = false, features = ["wasm-bindgen"] }
 futures-util = { version = "0.3", default-features = false, features = ["async-await-macro", "bilock", "channel", "io", "sink", "unstable"] }
-generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "serde"] }
+generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "serde", "zeroize"] }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 getrandom-c65f7effa3be6d31 = { package = "getrandom", version = "0.1", default-features = false, features = ["std"] }
 ghash = { version = "0.5", default-features = false }
@@ -879,7 +902,8 @@ gloo-net = { version = "0.2", default-features = false, features = ["json", "web
 gloo-timers = { version = "0.2", features = ["futures"] }
 gloo-utils = { version = "0.1", default-features = false, features = ["serde"] }
 governor = { version = "0.5" }
-group = { version = "0.12", default-features = false }
+group-594e8ee84c453af0 = { package = "group", version = "0.13", default-features = false, features = ["alloc"] }
+group-5ef9efb8ec2df382 = { package = "group", version = "0.12", default-features = false }
 guppy = { version = "0.15", default-features = false, features = ["rayon1", "summaries"] }
 guppy-summaries = { version = "0.7", default-features = false }
 guppy-workspace-hack = { version = "0.1", default-features = false }
@@ -946,12 +970,13 @@ jsonrpsee-ws-client = { version = "0.16" }
 k256 = { version = "0.11", default-features = false, features = ["ecdsa", "keccak256"] }
 keccak = { version = "0.1", default-features = false }
 lazy_static-6f8ce4dd05d13bba = { package = "lazy_static", version = "0.2", default-features = false }
-lazy_static-dff4ba8e3ae991db = { package = "lazy_static", version = "1", default-features = false }
+lazy_static-dff4ba8e3ae991db = { package = "lazy_static", version = "1", default-features = false, features = ["spin_no_std"] }
 lazycell = { version = "1", default-features = false }
 leb128 = { version = "0.2", default-features = false }
 lexical-core = { version = "0.7" }
 libc = { version = "0.2" }
 libloading = { version = "0.7", default-features = false }
+libm = { version = "0.2" }
 librocksdb-sys = { version = "0.10", features = ["bzip2", "lz4", "snappy", "zlib", "zstd"] }
 libtest-mimic = { version = "0.5", default-features = false }
 libz-sys = { version = "1", default-features = false, features = ["static"] }
@@ -1027,11 +1052,12 @@ ntest_timeout = { version = "0.9", default-features = false }
 nu-ansi-term = { version = "0.46", default-features = false }
 num = { version = "0.4" }
 num-bigint = { version = "0.4" }
+num-bigint-dig = { version = "0.8", default-features = false, features = ["i128", "prime", "u64_digit", "zeroize"] }
 num-complex = { version = "0.4", default-features = false, features = ["std"] }
 num-integer = { version = "0.1", default-features = false, features = ["i128", "std"] }
 num-iter = { version = "0.1", default-features = false, features = ["i128", "std"] }
 num-rational = { version = "0.4", default-features = false, features = ["num-bigint-std", "std"] }
-num-traits-6f8ce4dd05d13bba = { package = "num-traits", version = "0.2", features = ["i128"] }
+num-traits-6f8ce4dd05d13bba = { package = "num-traits", version = "0.2", features = ["i128", "libm"] }
 num-traits-c65f7effa3be6d31 = { package = "num-traits", version = "0.1", default-features = false }
 num_cpus = { version = "1", default-features = false }
 number_prefix = { version = "0.4" }
@@ -1048,7 +1074,7 @@ ouroboros_macro-274715c4dabd11b0 = { package = "ouroboros_macro", version = "0.9
 ouroboros_macro-3575ec1268b04181 = { package = "ouroboros_macro", version = "0.15", default-features = false, features = ["std"] }
 overload = { version = "0.1", default-features = false }
 owo-colors = { version = "3", default-features = false }
-p256 = { version = "0.12" }
+p256 = { version = "0.13" }
 parity-scale-codec = { version = "2", default-features = false, features = ["max-encoded-len", "std"] }
 parity-scale-codec-derive = { version = "2", default-features = false, features = ["max-encoded-len"] }
 parking = { version = "2", default-features = false }
@@ -1062,6 +1088,7 @@ pathdiff = { version = "0.2", default-features = false, features = ["camino"] }
 pbkdf2 = { version = "0.11", default-features = false }
 peeking_take_while = { version = "0.1", default-features = false }
 pem = { version = "1", default-features = false }
+pem-rfc7468 = { version = "0.6", default-features = false, features = ["alloc"] }
 percent-encoding = { version = "2" }
 pest = { version = "2" }
 pest_derive = { version = "2" }
@@ -1077,7 +1104,9 @@ pin-project = { version = "1", default-features = false }
 pin-project-internal = { version = "1", default-features = false }
 pin-project-lite = { version = "0.2", default-features = false }
 pin-utils = { version = "0.1", default-features = false }
-pkcs8 = { version = "0.9", default-features = false, features = ["std"] }
+pkcs1 = { version = "0.4", default-features = false, features = ["pem", "std"] }
+pkcs8-274715c4dabd11b0 = { package = "pkcs8", version = "0.9", default-features = false, features = ["pem", "std"] }
+pkcs8-93f6ce9d446188ac = { package = "pkcs8", version = "0.10", default-features = false, features = ["std"] }
 pkg-config = { version = "0.3", default-features = false }
 plotters = { version = "0.3", default-features = false, features = ["area_series", "line_series", "svg_backend"] }
 plotters-backend = { version = "0.3", default-features = false }
@@ -1093,7 +1122,7 @@ pretty = { version = "0.10", default-features = false }
 pretty_assertions = { version = "1" }
 prettyplease = { version = "0.1", default-features = false }
 prettytable-rs = { version = "0.10" }
-primeorder = { version = "0.12", default-features = false }
+primeorder = { version = "0.13", default-features = false }
 primitive-types = { version = "0.10", features = ["impl-serde"] }
 proc-macro-crate = { version = "1", default-features = false }
 proc-macro-error = { version = "1" }
@@ -1140,12 +1169,14 @@ regex-automata = { version = "0.1" }
 regex-syntax = { version = "0.6" }
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 retain_mut = { version = "0.1", default-features = false }
-rfc6979 = { version = "0.3", default-features = false }
+rfc6979-468e82937335b1c9 = { package = "rfc6979", version = "0.3", default-features = false }
+rfc6979-9fbad63c4bcf4a8f = { package = "rfc6979", version = "0.4", default-features = false }
 ring = { version = "0.16" }
 ripemd = { version = "0.1", default-features = false }
 roaring = { version = "0.10", default-features = false }
 rocksdb = { version = "0.20", features = ["multi-threaded-cf"] }
 ron = { version = "0.8" }
+rsa = { version = "0.8", features = ["sha2"] }
 rstest = { version = "0.16" }
 rstest_macros = { version = "0.16", default-features = false, features = ["async-timeout"] }
 rust-ini = { version = "0.13", default-features = false }
@@ -1169,8 +1200,9 @@ schemars = { version = "0.8", features = ["either"] }
 schemars_derive = { version = "0.8", default-features = false }
 scopeguard = { version = "1" }
 sct = { version = "0.7", default-features = false }
-sec1 = { version = "0.3", features = ["alloc", "subtle"] }
-secp256k1 = { version = "0.26", features = ["bitcoin_hashes", "global-context", "rand-std", "recovery"] }
+sec1-468e82937335b1c9 = { package = "sec1", version = "0.3", features = ["subtle", "zeroize"] }
+sec1-ca01ad9e24f5d932 = { package = "sec1", version = "0.7", features = ["std", "subtle"] }
+secp256k1 = { version = "0.27", features = ["bitcoin_hashes", "global-context", "rand-std", "recovery"] }
 secp256k1-sys = { version = "0.8", default-features = false, features = ["recovery", "std"] }
 semver-a6292c17cd707f01 = { package = "semver", version = "0.11" }
 semver-dff4ba8e3ae991db = { package = "semver", version = "1", features = ["serde"] }
@@ -1197,7 +1229,7 @@ sha-1-274715c4dabd11b0 = { package = "sha-1", version = "0.9", default-features 
 sha-1-93f6ce9d446188ac = { package = "sha-1", version = "0.10" }
 sha1 = { version = "0.10" }
 sha2-274715c4dabd11b0 = { package = "sha2", version = "0.9" }
-sha2-93f6ce9d446188ac = { package = "sha2", version = "0.10" }
+sha2-93f6ce9d446188ac = { package = "sha2", version = "0.10", features = ["oid"] }
 sha3-274715c4dabd11b0 = { package = "sha3", version = "0.9" }
 sha3-93f6ce9d446188ac = { package = "sha3", version = "0.10" }
 sharded-slab = { version = "0.1", default-features = false }
@@ -1217,7 +1249,9 @@ smallvec = { version = "1", default-features = false }
 snap = { version = "1", default-features = false }
 socket2 = { version = "0.4", default-features = false, features = ["all"] }
 soketto = { version = "0.7", features = ["http"] }
-spki = { version = "0.6", default-features = false, features = ["std"] }
+spin = { version = "0.5", default-features = false }
+spki-3b31131e45eafb45 = { package = "spki", version = "0.6", default-features = false, features = ["pem", "std"] }
+spki-ca01ad9e24f5d932 = { package = "spki", version = "0.7", default-features = false, features = ["std"] }
 stable_deref_trait = { version = "1" }
 static_assertions = { version = "1", default-features = false }
 strip-ansi-escapes = { version = "0.1", default-features = false }
@@ -1458,7 +1492,6 @@ rustix = { version = "0.36", features = ["fs", "termios"] }
 signal-hook = { version = "0.3" }
 signal-hook-mio = { version = "0.2", default-features = false, features = ["support-v0_8"] }
 signal-hook-registry = { version = "1", default-features = false }
-spin = { version = "0.5", default-features = false }
 str_stack = { version = "0.1", default-features = false }
 symbolic-common = { version = "10", default-features = false }
 symbolic-demangle = { version = "10", default-features = false, features = ["cpp", "rust"] }
@@ -1496,7 +1529,6 @@ rustix = { version = "0.36", features = ["fs", "termios"] }
 signal-hook = { version = "0.3" }
 signal-hook-mio = { version = "0.2", default-features = false, features = ["support-v0_8"] }
 signal-hook-registry = { version = "1", default-features = false }
-spin = { version = "0.5", default-features = false }
 str_stack = { version = "0.1", default-features = false }
 symbolic-common = { version = "10", default-features = false }
 symbolic-demangle = { version = "10", default-features = false, features = ["cpp", "rust"] }
@@ -1516,7 +1548,6 @@ output_vt100 = { version = "0.1", default-features = false }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
 raw-cpuid = { version = "10", default-features = false }
 schannel = { version = "0.1", default-features = false }
-spin = { version = "0.5", default-features = false }
 str-buf = { version = "1", default-features = false }
 web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 widestring = { version = "0.5" }
@@ -1543,7 +1574,6 @@ output_vt100 = { version = "0.1", default-features = false }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
 raw-cpuid = { version = "10", default-features = false }
 schannel = { version = "0.1", default-features = false }
-spin = { version = "0.5", default-features = false }
 str-buf = { version = "1", default-features = false }
 vcpkg = { version = "0.2", default-features = false }
 web-sys = { version = "0.3", default-features = false, features = ["Worker"] }


### PR DESCRIPTION
## Description 
Update fastcrypto - includes an update to ECVRF which is not backward compatible with previous ECVRF proofs.

## Test Plan 
All tests pass

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [x] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Update fastcrypto - includes an update to ECVRF which is not backward compatible with previous ECVRF proofs.
