### PR TITLE
[explorer]: fix pagination type

### DIFF
--- a/.changeset/real-windows-sleep.md
+++ b/.changeset/real-windows-sleep.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Update PaginatedObjectsResponse type for nextCursor

--- a/sdk/typescript/src/types/objects.ts
+++ b/sdk/typescript/src/types/objects.ts
@@ -17,6 +17,7 @@ import {
   is,
   nullable,
 } from 'superstruct';
+
 import {
   ObjectId,
   ObjectOwner,
@@ -423,9 +424,11 @@ export const CheckpointedObjectId = object({
 });
 export type CheckpointedObjectId = Infer<typeof CheckpointedObjectId>;
 
+const PaginatedNextCursor = union([object({ objectId: ObjectId }), ObjectId]);
+
 export const PaginatedObjectsResponse = object({
   data: array(SuiObjectResponse),
-  nextCursor: nullable(ObjectId),
+  nextCursor: nullable(PaginatedNextCursor),
   hasNextPage: boolean(),
 });
 export type PaginatedObjectsResponse = Infer<typeof PaginatedObjectsResponse>;


### PR DESCRIPTION
## Description 

- Update the type for `PaginatedObjectsResponse`. The evaluation here https://github.com/MystenLabs/sui/blob/main/apps/explorer/src/components/ownedobjects/OwnedObjects.tsx#L53 never resolves correctly due to the wrong data type

Example: 
https://explorer.sui.io/address/0xdf2dda5c0d8f86a950bd9aeed1ef68a13048505298e0031ae867c1445299f050?network=testnet

<img width="1209" alt="Screenshot 2023-04-03 at 12 38 42 PM" src="https://user-images.githubusercontent.com/127577476/229610826-f36dc67b-c4f2-4755-83c4-f6d5f6d03a01.png">


## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
