### PR TITLE
[bugfix] - make resolve input type for programmable transaction more defensive to avoid array out of bound panic

### DIFF
--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -1091,9 +1091,9 @@ impl SuiProgrammableTransactionBlock {
                         return result_types;
                     };
                     for (arg, type_) in c.arguments.iter().zip(types) {
-                        if let &Argument::Input(i) = arg {
+                        if let (&Argument::Input(i), Some(type_)) = (arg, type_) {
                             if let Some(x) = result_types.get_mut(i as usize) {
-                                *x = type_;
+                                x.replace(type_);
                             }
                         }
                     }
@@ -1102,14 +1102,14 @@ impl SuiProgrammableTransactionBlock {
                     for arg in amounts {
                         if let &Argument::Input(i) = arg {
                             if let Some(x) = result_types.get_mut(i as usize) {
-                                *x = Some(MoveTypeLayout::U64);
+                                x.replace(MoveTypeLayout::U64);
                             }
                         }
                     }
                 }
                 Command::TransferObjects(_, Argument::Input(i)) => {
                     if let Some(x) = result_types.get_mut((*i) as usize) {
-                        *x = Some(MoveTypeLayout::Vector(Box::new(MoveTypeLayout::Address)));
+                        x.replace(MoveTypeLayout::Vector(Box::new(MoveTypeLayout::Address)));
                     }
                 }
                 _ => {}

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -1091,19 +1091,27 @@ impl SuiProgrammableTransactionBlock {
                         return result_types;
                     };
                     for (arg, type_) in c.arguments.iter().zip(types) {
-                        if let &Argument::Input(i) = arg {
-                            result_types[i as usize] = type_;
+                        match arg {
+                            &Argument::Input(i) if (i as usize) < inputs.len() => {
+                                result_types[i as usize] = type_;
+                            }
+                            _ => {}
                         }
                     }
                 }
                 Command::SplitCoins(_, amounts) => {
                     for arg in amounts {
-                        if let &Argument::Input(i) = arg {
-                            result_types[i as usize] = Some(MoveTypeLayout::U64);
+                        match arg {
+                            &Argument::Input(i) if (i as usize) < inputs.len() => {
+                                result_types[i as usize] = Some(MoveTypeLayout::U64);
+                            }
+                            _ => {}
                         }
                     }
                 }
-                Command::TransferObjects(_, Argument::Input(i)) => {
+                Command::TransferObjects(_, Argument::Input(i))
+                    if ((*i) as usize) < inputs.len() =>
+                {
                     result_types[(*i) as usize] = Some(MoveTypeLayout::Address);
                 }
                 _ => {}

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -1109,7 +1109,7 @@ impl SuiProgrammableTransactionBlock {
                 }
                 Command::TransferObjects(_, Argument::Input(i)) => {
                     if let Some(x) = result_types.get_mut((*i) as usize) {
-                        x.replace(MoveTypeLayout::Vector(Box::new(MoveTypeLayout::Address)));
+                        x.replace(MoveTypeLayout::Address);
                     }
                 }
                 _ => {}


### PR DESCRIPTION
## Description 

the code could panic when resolving input types for a malformed programmable transaction, add checks to ensure input arg index is within the input size.

