### PR TITLE
[indexer] Add MatchNone and fix partial struct filtering

### DIFF
--- a/crates/sui-json-rpc-types/src/sui_object.rs
+++ b/crates/sui-json-rpc-types/src/sui_object.rs
@@ -1043,6 +1043,7 @@ pub struct SuiGetPastObjectRequest {
 pub enum SuiObjectDataFilter {
     MatchAll(Vec<SuiObjectDataFilter>),
     MatchAny(Vec<SuiObjectDataFilter>),
+    MatchNone(Vec<SuiObjectDataFilter>),
     /// Query by type a specified Package.
     Package(ObjectID),
     /// Query by type a specified Move module.
@@ -1079,11 +1080,15 @@ impl SuiObjectDataFilter {
     pub fn or(self, other: Self) -> Self {
         Self::MatchAny(vec![self, other])
     }
+    pub fn not(self, other: Self) -> Self {
+        Self::MatchNone(vec![self, other])
+    }
 
     pub fn matches(&self, object: &ObjectInfo) -> bool {
         match self {
             SuiObjectDataFilter::MatchAll(filters) => !filters.iter().any(|f| !f.matches(object)),
             SuiObjectDataFilter::MatchAny(filters) => filters.iter().any(|f| f.matches(object)),
+            SuiObjectDataFilter::MatchNone(filters) => !filters.iter().any(|f| f.matches(object)),
             SuiObjectDataFilter::StructType(s) => {
                 let obj_tag: StructTag = match &object.type_ {
                     ObjectType::Package => return false,

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -6229,6 +6229,21 @@
             "additionalProperties": false
           },
           {
+            "type": "object",
+            "required": [
+              "MatchNone"
+            ],
+            "properties": {
+              "MatchNone": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/SuiObjectDataFilter"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
             "description": "Query by type a specified Package.",
             "type": "object",
             "required": [


### PR DESCRIPTION
## Description 

This implements `MatchNone` into the queryObjects API allowing for selecting things that do not match a list of criteria. I also noticed that our queries for `StructType` and `MovePackage` were not quite right, so I fixed the SQL generation there to match the FN API + use `LIKE` queries with the placeholder correctly.

This will also unblock the frontend from querying for non-coin objects (`MatchNone(StructType('0x2::coin::Coin'))`).

## Test Plan 

Tests should pass. Probably need to write a new testcase.