### PR TITLE
[build] fix release build

### DIFF
--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -180,9 +180,7 @@ fn execute_transaction<
             && gas_status.storage_gas_units() == 0,
         "No gas charges must be applied yet"
     );
-    #[cfg(debug_assertions)]
     let is_genesis_tx = matches!(transaction_kind, TransactionKind::Genesis(_));
-    #[cfg(debug_assertions)]
     let advance_epoch_gas_summary = transaction_kind.get_advance_epoch_tx_gas_summary();
 
     // We must charge object read here during transaction execution, because if this fails


### PR DESCRIPTION
Some variables read in release mode were gated with `cfg(debug_assertions)`

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
