### PR TITLE
[StateAccumuator] Re-introduce idempotency

### DIFF
--- a/crates/sui-core/src/state_accumulator.rs
+++ b/crates/sui-core/src/state_accumulator.rs
@@ -8,7 +8,7 @@ use sui_types::base_types::{ObjectID, SequenceNumber};
 use sui_types::committee::EpochId;
 use sui_types::digests::{ObjectDigest, TransactionDigest};
 use sui_types::storage::ObjectKey;
-use tracing::{debug, error};
+use tracing::debug;
 use typed_store::Map;
 
 use std::collections::{HashMap, HashSet};
@@ -62,20 +62,11 @@ impl StateAccumulator {
         epoch_store: Arc<AuthorityPerEpochStore>,
     ) -> SuiResult<Accumulator> {
         let _scope = monitored_scope("AccumulateCheckpoint");
+        if let Some(acc) = epoch_store.get_state_hash_for_checkpoint(&checkpoint_seq_num)? {
+            return Ok(acc);
+        }
 
         let acc = self.accumulate_effects(effects);
-
-        if let Some(old_acc) = epoch_store.get_state_hash_for_checkpoint(&checkpoint_seq_num)? {
-            if old_acc != acc {
-                // This should not happen on a non-byzantine Node, as it indicates that the checkpoint
-                // contents are inconsistent. Since checkpoint builder is a callsite here, it could
-                // indicate a proposal that differs from what was finalized in consensus.
-                error!(
-                    "Newly set accumulator for checkpoint {} does not match the already existing one. (Overwriting)",
-                    checkpoint_seq_num,
-                );
-            }
-        }
 
         epoch_store.insert_state_hash_for_checkpoint(&checkpoint_seq_num, &acc)?;
         debug!("Accumulated checkpoint {}", checkpoint_seq_num);


### PR DESCRIPTION
## Description 

This was removed to mitigate a checkpoint proposals bug. However, this led to other issues. Now that the checkpoint proposals bug  is root caused and fixed, let's re-introduce this. 

## Test Plan 

Let existing tests run, also run the following and ensure all seeds pass: 
```
for f in `seq 1 50`; do RUST_LOG=sui=debug,error MSIM_TEST_SEED=9$f cargo simtest test_simulated_load_reconfig_crashes -E '(test(test_simulated_load_reconfig_crashes) and !(test(test_simulated_load_reconfig_crashes_during_epoch_change)))' --no-capture > test_$f 2>&1 &; done
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
