### PR TITLE
wallet-ext: approve transaction wait for details before enable submitting

### DIFF
--- a/apps/wallet/src/ui/app/components/user-approve-container/index.tsx
+++ b/apps/wallet/src/ui/app/components/user-approve-container/index.tsx
@@ -19,6 +19,7 @@ type UserApproveContainerProps = {
     rejectTitle: string;
     approveTitle: string;
     approveDisabled?: boolean;
+    approveLoading?: boolean;
     onSubmit: (approved: boolean) => Promise<void>;
     isWarning?: boolean;
     addressHidden?: boolean;
@@ -33,6 +34,7 @@ export function UserApproveContainer({
     rejectTitle,
     approveTitle,
     approveDisabled = false,
+    approveLoading = false,
     onSubmit,
     isWarning,
     addressHidden = false,
@@ -88,7 +90,7 @@ export function UserApproveContainer({
                             handleOnResponse(true);
                         }}
                         disabled={approveDisabled}
-                        loading={submitting}
+                        loading={submitting || approveLoading}
                         text={approveTitle}
                     />
                 </div>

--- a/apps/wallet/src/ui/app/hooks/useTransactionData.ts
+++ b/apps/wallet/src/ui/app/hooks/useTransactionData.ts
@@ -17,10 +17,7 @@ export function useTransactionData(
     return useQuery(
         ['transaction-data', transaction?.serialize()],
         async () => {
-            const clonedTransaction = new TransactionBlock(
-                // make sure cloned transaction doesn't affect the original one
-                TransactionBlock.from(transaction!.serialize())
-            );
+            const clonedTransaction = new TransactionBlock(transaction!);
             if (sender) {
                 clonedTransaction.setSenderIfNotSet(sender);
             }

--- a/apps/wallet/src/ui/app/hooks/useTransactionData.ts
+++ b/apps/wallet/src/ui/app/hooks/useTransactionData.ts
@@ -8,32 +8,28 @@ import {
     TransactionBlock,
 } from '@mysten/sui.js';
 import { useQuery } from '@tanstack/react-query';
-import { useMemo } from 'react';
 
 export function useTransactionData(
     sender?: SuiAddress | null,
     transaction?: TransactionBlock | null
 ) {
     const rpc = useRpcClient();
-    const clonedTransaction = useMemo(() => {
-        if (!transaction) return;
-
-        const tx = new TransactionBlock(transaction);
-        if (sender) {
-            tx.setSenderIfNotSet(sender);
-        }
-        return tx;
-    }, [transaction, sender]);
-
     return useQuery(
-        ['transaction-data', clonedTransaction?.serialize()],
+        ['transaction-data', transaction?.serialize()],
         async () => {
+            const clonedTransaction = new TransactionBlock(
+                // make sure cloned transaction doesn't affect the original one
+                TransactionBlock.from(transaction!.serialize())
+            );
+            if (sender) {
+                clonedTransaction.setSenderIfNotSet(sender);
+            }
             // Build the transaction to bytes, which will ensure that the transaction data is fully populated:
             await clonedTransaction!.build({ provider: rpc });
             return clonedTransaction!.blockData;
         },
         {
-            enabled: !!clonedTransaction,
+            enabled: !!transaction,
         }
     );
 }

--- a/apps/wallet/src/ui/app/pages/approval-request/transaction-request/GasFees.tsx
+++ b/apps/wallet/src/ui/app/pages/approval-request/transaction-request/GasFees.tsx
@@ -19,7 +19,11 @@ interface Props {
 
 export function GasFees({ sender, transaction }: Props) {
     const { data: transactionData } = useTransactionData(sender, transaction);
-    const { data: gasBudget } = useTransactionGasBudget(sender, transaction);
+    const {
+        data: gasBudget,
+        isLoading,
+        isError,
+    } = useTransactionGasBudget(sender, transaction);
     const isSponsored =
         transactionData?.gasConfig.owner &&
         transactionData.sender !== transactionData.gasConfig.owner;
@@ -37,8 +41,11 @@ export function GasFees({ sender, transaction }: Props) {
         >
             <DescriptionList>
                 <DescriptionItem title="You Pay">
-                    {isSponsored ? 0 : gasBudget || '-'}
-                    {isSponsored || gasBudget ? GAS_SYMBOL : null}
+                    {isLoading
+                        ? 'Estimating...'
+                        : isError
+                        ? 'Gas estimation failed'
+                        : `${isSponsored ? 0 : gasBudget} ${GAS_SYMBOL}`}
                 </DescriptionItem>
                 {isSponsored && (
                     <>

--- a/apps/wallet/src/ui/app/pages/approval-request/transaction-request/GasFees.tsx
+++ b/apps/wallet/src/ui/app/pages/approval-request/transaction-request/GasFees.tsx
@@ -20,11 +20,9 @@ interface Props {
 export function GasFees({ sender, transaction }: Props) {
     const { data: transactionData } = useTransactionData(sender, transaction);
     const { data: gasBudget } = useTransactionGasBudget(sender, transaction);
-
     const isSponsored =
         transactionData?.gasConfig.owner &&
         transactionData.sender !== transactionData.gasConfig.owner;
-
     return (
         <SummaryCard
             header="Estimated Gas Fees"
@@ -39,13 +37,13 @@ export function GasFees({ sender, transaction }: Props) {
         >
             <DescriptionList>
                 <DescriptionItem title="You Pay">
-                    {isSponsored ? 0 : gasBudget || '-'} {GAS_SYMBOL}
+                    {isSponsored ? 0 : gasBudget || '-'}
+                    {isSponsored || gasBudget ? GAS_SYMBOL : null}
                 </DescriptionItem>
-
                 {isSponsored && (
                     <>
                         <DescriptionItem title="Sponsor Pays">
-                            {gasBudget || '-'} {GAS_SYMBOL}
+                            {gasBudget ? `${gasBudget} ${GAS_SYMBOL}` : '-'}
                         </DescriptionItem>
                         <DescriptionItem title="Sponsor">
                             {formatAddress(transactionData!.gasConfig.owner!)}

--- a/apps/wallet/src/ui/app/pages/approval-request/transaction-request/TransactionDetails/index.tsx
+++ b/apps/wallet/src/ui/app/pages/approval-request/transaction-request/TransactionDetails/index.tsx
@@ -22,7 +22,11 @@ const Tab = (props: TabProps<'div'>) => (
 );
 
 export function TransactionDetails({ sender, transaction }: Props) {
-    const { data: transactionData } = useTransactionData(sender, transaction);
+    const {
+        data: transactionData,
+        isLoading,
+        isError,
+    } = useTransactionData(sender, transaction);
     if (
         transactionData?.transactions.length === 0 &&
         transactionData.inputs.length === 0
@@ -31,7 +35,11 @@ export function TransactionDetails({ sender, transaction }: Props) {
     }
     return (
         <SummaryCard header="Transaction Details" initialExpanded>
-            {transactionData ? (
+            {isLoading || isError ? (
+                <div className="ml-0 text-steel-darker text-p2 font-medium">
+                    {isLoading ? 'Gathering data...' : "Couldn't gather data"}
+                </div>
+            ) : transactionData ? (
                 <div>
                     <HeadlessTab.Group>
                         <HeadlessTab.List className="flex gap-6 border-0 border-b border-solid border-gray-45 mb-6">
@@ -69,7 +77,7 @@ export function TransactionDetails({ sender, transaction }: Props) {
                     </HeadlessTab.Group>
                 </div>
             ) : (
-                '-'
+                ''
             )}
         </SummaryCard>
     );

--- a/apps/wallet/src/ui/app/pages/approval-request/transaction-request/TransactionDetails/index.tsx
+++ b/apps/wallet/src/ui/app/pages/approval-request/transaction-request/TransactionDetails/index.tsx
@@ -7,7 +7,6 @@ import { type SuiAddress, type TransactionBlock } from '@mysten/sui.js';
 import { SummaryCard } from '../SummaryCard';
 import { Command } from './Command';
 import { Input } from './Input';
-import LoadingIndicator from '_src/ui/app/components/loading/LoadingIndicator';
 import { useTransactionData } from '_src/ui/app/hooks';
 
 interface Props {
@@ -24,14 +23,12 @@ const Tab = (props: TabProps<'div'>) => (
 
 export function TransactionDetails({ sender, transaction }: Props) {
     const { data: transactionData } = useTransactionData(sender, transaction);
-
     if (
         transactionData?.transactions.length === 0 &&
         transactionData.inputs.length === 0
     ) {
         return null;
     }
-
     return (
         <SummaryCard header="Transaction Details" initialExpanded>
             {transactionData ? (
@@ -72,7 +69,7 @@ export function TransactionDetails({ sender, transaction }: Props) {
                     </HeadlessTab.Group>
                 </div>
             ) : (
-                <LoadingIndicator />
+                '-'
             )}
         </SummaryCard>
     );

--- a/apps/wallet/src/ui/app/pages/approval-request/transaction-request/index.tsx
+++ b/apps/wallet/src/ui/app/pages/approval-request/transaction-request/index.tsx
@@ -81,7 +81,7 @@ export function TransactionRequest({ txRequest }: TransactionRequestProps) {
             </UserApproveContainer>
             <ConfirmationModal
                 isOpen={isConfirmationVisible}
-                title="This transaction might fail. Are you sure you still want to Approve the transaction?"
+                title="This transaction might fail. Are you sure you still want to approve the transaction?"
                 hint="You will still be charged a gas fee for this transaction."
                 confirmStyle="primary"
                 confirmText="Approve"

--- a/apps/wallet/src/ui/app/pages/approval-request/transaction-request/index.tsx
+++ b/apps/wallet/src/ui/app/pages/approval-request/transaction-request/index.tsx
@@ -3,12 +3,13 @@
 
 // import { Transaction } from '@mysten/sui.js';
 import { TransactionBlock } from '@mysten/sui.js';
-import { useCallback, useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
+import { ConfirmationModal } from '../../../shared/ConfirmationModal';
 import { GasFees } from './GasFees';
 import { TransactionDetails } from './TransactionDetails';
 import { UserApproveContainer } from '_components/user-approve-container';
-import { useAppDispatch, useSigner } from '_hooks';
+import { useAppDispatch, useSigner, useTransactionData } from '_hooks';
 import { type TransactionApprovalRequest } from '_payloads/transactions/ApprovalRequest';
 import { respondToTransactionRequest } from '_redux/slices/transaction-requests';
 import { PageMainLayoutTitle } from '_src/ui/app/shared/page-main-layout/PageMainLayoutTitle';
@@ -30,45 +31,73 @@ export function TransactionRequest({ txRequest }: TransactionRequestProps) {
         }
         return tx;
     }, [txRequest.tx.data, addressForTransaction]);
-
-    const handleOnSubmit = useCallback(
-        async (approved: boolean) => {
-            await dispatch(
-                respondToTransactionRequest({
-                    approved,
-                    txRequestID: txRequest.id,
-                    signer,
-                })
-            );
-        },
-        [dispatch, txRequest.id, signer]
+    const { isLoading, isError } = useTransactionData(
+        addressForTransaction,
+        transaction
     );
-
+    const [isConfirmationVisible, setConfirmationVisible] = useState(false);
     return (
-        <UserApproveContainer
-            origin={txRequest.origin}
-            originFavIcon={txRequest.originFavIcon}
-            approveTitle="Approve"
-            rejectTitle="Reject"
-            onSubmit={handleOnSubmit}
-            address={addressForTransaction}
-        >
-            <PageMainLayoutTitle title="Approve Transaction" />
-            <section className={st.txInfo}>
-                {/* MUSTFIX(chris) */}
-                {/* <TransactionSummaryCard
+        <>
+            <UserApproveContainer
+                origin={txRequest.origin}
+                originFavIcon={txRequest.originFavIcon}
+                approveTitle="Approve"
+                rejectTitle="Reject"
+                onSubmit={async (approved: boolean) => {
+                    if (isLoading) {
+                        return;
+                    }
+                    if (isError) {
+                        setConfirmationVisible(true);
+                        return;
+                    }
+                    await dispatch(
+                        respondToTransactionRequest({
+                            approved,
+                            txRequestID: txRequest.id,
+                            signer,
+                        })
+                    );
+                }}
+                address={addressForTransaction}
+                approveLoading={isLoading || isConfirmationVisible}
+            >
+                <PageMainLayoutTitle title="Approve Transaction" />
+                <section className={st.txInfo}>
+                    {/* MUSTFIX(chris) */}
+                    {/* <TransactionSummaryCard
                     transaction={tx}
                     address={addressForTransaction}
                 /> */}
-                <GasFees
-                    sender={addressForTransaction}
-                    transaction={transaction}
-                />
-                <TransactionDetails
-                    sender={addressForTransaction}
-                    transaction={transaction}
-                />
-            </section>
-        </UserApproveContainer>
+                    <GasFees
+                        sender={addressForTransaction}
+                        transaction={transaction}
+                    />
+                    <TransactionDetails
+                        sender={addressForTransaction}
+                        transaction={transaction}
+                    />
+                </section>
+            </UserApproveContainer>
+            <ConfirmationModal
+                isOpen={isConfirmationVisible}
+                title="This transaction might fail. Are you sure you still want to Approve the transaction?"
+                hint="You will still be charged a gas fee for this transaction."
+                confirmStyle="primary"
+                confirmText="Approve"
+                cancelText="Reject"
+                cancelStyle="warning"
+                onResponse={async (isConfirmed) => {
+                    await dispatch(
+                        respondToTransactionRequest({
+                            approved: isConfirmed,
+                            txRequestID: txRequest.id,
+                            signer,
+                        })
+                    );
+                    setConfirmationVisible(false);
+                }}
+            />
+        </>
     );
 }

--- a/apps/wallet/src/ui/app/shared/ConfirmationModal.tsx
+++ b/apps/wallet/src/ui/app/shared/ConfirmationModal.tsx
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { useState } from 'react';
+
 import { Button, type ButtonProps } from './ButtonUI';
 import { ModalDialog } from './ModalDialog';
 import { Text } from './text';
@@ -12,6 +14,7 @@ export type ConfirmationModalProps = {
     confirmText?: string;
     confirmStyle?: ButtonProps['variant'];
     cancelText?: string;
+    cancelStyle?: ButtonProps['variant'];
     onResponse: (confirmed: boolean) => void;
 };
 
@@ -22,8 +25,11 @@ export function ConfirmationModal({
     confirmText = 'Confirm',
     confirmStyle = 'primary',
     cancelText = 'Cancel',
+    cancelStyle = 'outline',
     onResponse,
 }: ConfirmationModalProps) {
+    const [isConfirmLoading, setIsConfirmLoading] = useState(false);
+    const [isCancelLoading, setIsCancelLoading] = useState(false);
     return (
         <ModalDialog
             isOpen={isOpen}
@@ -37,23 +43,40 @@ export function ConfirmationModal({
                     </div>
                 ) : null
             }
-            onClose={() => {
-                onResponse(false);
+            onClose={async () => {
+                if (isCancelLoading || isConfirmLoading) {
+                    return;
+                }
+                setIsCancelLoading(true);
+                await onResponse(false);
+                setIsCancelLoading(false);
             }}
             footer={
                 <div className="flex flex-row self-center gap-3">
                     <div>
                         <Button
-                            variant="outline"
+                            variant={cancelStyle}
                             text={cancelText}
-                            onClick={() => onResponse(false)}
+                            loading={isCancelLoading}
+                            disabled={isConfirmLoading}
+                            onClick={async () => {
+                                setIsCancelLoading(true);
+                                await onResponse(false);
+                                setIsCancelLoading(false);
+                            }}
                         />
                     </div>
                     <div>
                         <Button
                             variant={confirmStyle}
                             text={confirmText}
-                            onClick={() => onResponse(true)}
+                            loading={isConfirmLoading}
+                            disabled={isCancelLoading}
+                            onClick={async () => {
+                                setIsConfirmLoading(true);
+                                await onResponse(true);
+                                setIsConfirmLoading(false);
+                            }}
                         />
                     </div>
                 </div>


### PR DESCRIPTION
* show waring confirmation modal for a transaction that dry run failed before submitting
* update loading states for gas fee and tx details, show `Estimating...`/`Gathering data...` when loading
and `Estimation failed`/`Couldn't gather data` for errors
* update confirmation dialog buttons to show loading state until
onResponse method is complete


https://user-images.githubusercontent.com/10210143/230473415-4c94b3fc-b517-466a-9357-895b84d6e47b.mov


https://user-images.githubusercontent.com/10210143/230473424-5e231b1d-ee2f-4666-9d51-b1d38647128e.mov




closes APPS-720