### PR TITLE
indexer: objects_history table column index

### DIFF
--- a/crates/sui-indexer/migrations/2022-12-01-034426_objects/up.sql
+++ b/crates/sui-indexer/migrations/2022-12-01-034426_objects/up.sql
@@ -57,8 +57,9 @@ CREATE TABLE objects_history
     has_public_transfer    BOOLEAN       NOT NULL,
     storage_rebate         BIGINT        NOT NULL,
     bcs                    bcs_bytes[]   NOT NULL,
-    CONSTRAINT objects_history_pk PRIMARY KEY (checkpoint, object_id, version)
+    CONSTRAINT objects_history_pk PRIMARY KEY (object_id, version, checkpoint)
 ) PARTITION BY RANGE (checkpoint);
+CREATE INDEX objects_history_checkpoint_index ON objects_history (checkpoint);
 CREATE INDEX objects_history_id_version_index ON objects_history (object_id, version);
 CREATE INDEX objects_history_owner_index ON objects_history (owner_type, owner_address);
 CREATE INDEX objects_history_old_owner_index ON objects_history (old_owner_type, old_owner_address);

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -147,7 +147,7 @@ diesel::table! {
     use super::sql_types::ObjectStatus;
     use super::sql_types::BcsBytes;
 
-    objects_history (checkpoint, object_id, version) {
+    objects_history (object_id, version, checkpoint) {
         epoch -> Int8,
         checkpoint -> Int8,
         object_id -> Varchar,


### PR DESCRIPTION
## Description 

We have queries like
```
SELECT * from objects_history WHERE <FILTER> ORDER BY  object_id, version, checkpoint DESC
```
checkpoint is needed here to pick data from real checkpoint over fast-path (which is checkpoint of -1) when objects are in checkpoint already, thus swapping the multi-column index order.

We also have filer like
```
WHERE o.checkpoint <= $1
```
so checkpoint index is also necessary.