### PR TITLE
[Narwhal] remove verbose logs

### DIFF
--- a/narwhal/worker/src/handlers.rs
+++ b/narwhal/worker/src/handlers.rs
@@ -13,7 +13,7 @@ use rand::seq::SliceRandom;
 use std::{collections::HashSet, time::Duration};
 use store::{rocks::DBMap, Map};
 use tokio::time::sleep;
-use tracing::{debug, info, trace, warn};
+use tracing::{debug, trace, warn};
 use types::{
     Batch, BatchDigest, FetchBatchesRequest, FetchBatchesResponse, PrimaryToWorker,
     RequestBatchRequest, RequestBatchResponse, RequestBatchesRequest, RequestBatchesResponse,
@@ -302,7 +302,7 @@ impl<V: TransactionValidator> PrimaryToWorker for PrimaryReceiverHandler<V> {
                         }
                     }
                     Err(e) => {
-                        info!(
+                        debug!(
                             "RequestBatchRequest to worker {:?} failed: {e:?}",
                             e.peer_id()
                         )


### PR DESCRIPTION
## Description 

Currently the peer_id() method seems not working. And we will likely remove the broadcast logic in synchronize().

## Test Plan 

n/a

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
