### PR TITLE
[explorer]: Add at risk remaining time for validators

### DIFF
--- a/apps/explorer/src/pages/validators/Validators.tsx
+++ b/apps/explorer/src/pages/validators/Validators.tsx
@@ -27,6 +27,7 @@ import { Text } from '~/ui/Text';
 import { getValidatorMoveEvent } from '~/utils/getValidatorMoveEvent';
 
 const APY_DECIMALS = 3;
+const VALIDATOR_LOW_STAKE_GRACE_PERIOD = 7;
 
 const NodeMap = lazy(() => import('../../components/node-map'));
 
@@ -48,6 +49,12 @@ export function validatorsTableData(
                     validatorEvents,
                     validator.suiAddress
                 );
+
+                const atRiskValidator = atRiskValidators.find(
+                    ([address]) => address === validator.suiAddress
+                );
+                const isAtRisk = !!atRiskValidator;
+
                 return {
                     name: {
                         name: validatorName,
@@ -65,9 +72,9 @@ export function validatorsTableData(
                     img: img,
                     address: validator.suiAddress,
                     lastReward: +event?.pool_staking_reward || 0,
-                    atRisk: atRiskValidators.some(
-                        ([address]) => address === validator.suiAddress
-                    ),
+                    atRisk: isAtRisk
+                        ? VALIDATOR_LOW_STAKE_GRACE_PERIOD - atRiskValidator[1]
+                        : null,
                 };
             }),
         columns: [
@@ -175,10 +182,18 @@ export function validatorsTableData(
                 accessorKey: 'atRisk',
                 cell: (props: any) => {
                     const atRisk = props.getValue();
-                    return atRisk ? (
-                        <Text color="issue" variant="bodySmall/medium">
-                            At Risk
-                        </Text>
+                    return atRisk !== null ? (
+                        <div className="flex flex-nowrap items-center">
+                            <Text color="issue" variant="bodySmall/medium">
+                                At Risk
+                            </Text>
+                            &nbsp;
+                            <Text variant="bodySmall/medium" color="steel-dark">
+                                {atRisk > 1
+                                    ? `IN ${atRisk} EPOCHS`
+                                    : 'NEXT EPOCH'}
+                            </Text>
+                        </div>
                     ) : (
                         <Text variant="bodySmall/medium" color="steel-darker">
                             Active

--- a/apps/explorer/src/pages/validators/Validators.tsx
+++ b/apps/explorer/src/pages/validators/Validators.tsx
@@ -24,10 +24,11 @@ import { Stats } from '~/ui/Stats';
 import { TableCard } from '~/ui/TableCard';
 import { TableHeader } from '~/ui/TableHeader';
 import { Text } from '~/ui/Text';
+import { Tooltip } from '~/ui/Tooltip';
 import { getValidatorMoveEvent } from '~/utils/getValidatorMoveEvent';
+import { VALIDATOR_LOW_STAKE_GRACE_PERIOD } from '~/utils/validatorConstants';
 
 const APY_DECIMALS = 3;
-const VALIDATOR_LOW_STAKE_GRACE_PERIOD = 7;
 
 const NodeMap = lazy(() => import('../../components/node-map'));
 
@@ -183,17 +184,23 @@ export function validatorsTableData(
                 cell: (props: any) => {
                     const atRisk = props.getValue();
                     return atRisk !== null ? (
-                        <div className="flex flex-nowrap items-center">
-                            <Text color="issue" variant="bodySmall/medium">
-                                At Risk
-                            </Text>
-                            &nbsp;
-                            <Text variant="bodySmall/medium" color="steel-dark">
-                                {atRisk > 1
-                                    ? `IN ${atRisk} EPOCHS`
-                                    : 'NEXT EPOCH'}
-                            </Text>
-                        </div>
+                        <Tooltip tip="Staked SUI is below the minimum SUI stake threshold to remain a validator.">
+                            <div className="flex cursor-pointer flex-nowrap items-center">
+                                <Text color="issue" variant="bodySmall/medium">
+                                    At Risk
+                                </Text>
+                                &nbsp;
+                                <Text
+                                    uppercase
+                                    variant="bodySmall/medium"
+                                    color="steel-dark"
+                                >
+                                    {atRisk > 1
+                                        ? `in ${atRisk} epochs`
+                                        : 'next epoch'}
+                                </Text>
+                            </div>
+                        </Tooltip>
                     ) : (
                         <Text variant="bodySmall/medium" color="steel-darker">
                             Active

--- a/apps/explorer/src/utils/validatorConstants.ts
+++ b/apps/explorer/src/utils/validatorConstants.ts
@@ -1,0 +1,3 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+export const VALIDATOR_LOW_STAKE_GRACE_PERIOD = 7;


### PR DESCRIPTION
## Description 

https://mysten.atlassian.net/browse/APPS-723

- Update table and validator page
- VALIDATOR_LOW_STAKE_GRACE_PERIOD is defaulted to `7`

<img width="1606" alt="Screenshot 2023-04-03 at 6 06 22 PM" src="https://user-images.githubusercontent.com/127577476/229660976-a355f54c-3b30-45bb-aee4-f0bbc24a4ab2.png">
<img width="1508" alt="Screenshot 2023-04-03 at 5 38 21 PM" src="https://user-images.githubusercontent.com/127577476/229660981-0fbea1c9-292a-4254-b437-f5a7184c07b4.png">
<img width="1527" alt="Screenshot 2023-04-03 at 5 38 04 PM" src="https://user-images.githubusercontent.com/127577476/229660984-6bf2e80a-8da5-4db9-992d-412c70376c61.png">
<img width="379" alt="Screenshot 2023-04-03 at 6 36 10 PM" src="https://user-images.githubusercontent.com/127577476/229663899-739a679c-dddf-453f-be03-0a01ee392d3d.png">

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
