### PR TITLE
[hardening] add option to enable Move VM paranoid checks

### DIFF
--- a/crates/sui-adapter/src/adapter.rs
+++ b/crates/sui-adapter/src/adapter.rs
@@ -95,6 +95,7 @@ pub fn default_verifier_config(
 pub fn new_move_vm(
     natives: NativeFunctionTable,
     protocol_config: &ProtocolConfig,
+    paranoid_type_checks: bool,
 ) -> Result<MoveVM, SuiError> {
     MoveVM::new_with_config(
         natives,
@@ -104,7 +105,7 @@ pub fn new_move_vm(
                 false, /* we do not enable metering in execution*/
             ),
             max_binary_format_version: protocol_config.move_binary_format_version(),
-            paranoid_type_checks: false,
+            paranoid_type_checks,
             runtime_limits_config: VMRuntimeLimitsConfig {
                 vector_len_max: protocol_config.max_move_vector_len(),
             },

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -1381,9 +1381,14 @@ fn create_genesis_transaction(
         );
 
         let native_functions = sui_framework::natives::all_natives();
+        let enable_move_vm_paranoid_checks = false;
         let move_vm = std::sync::Arc::new(
-            adapter::new_move_vm(native_functions, protocol_config)
-                .expect("We defined natives to not fail here"),
+            adapter::new_move_vm(
+                native_functions,
+                protocol_config,
+                enable_move_vm_paranoid_checks,
+            )
+            .expect("We defined natives to not fail here"),
         );
 
         let transaction_data = &genesis_transaction.data().intent_message().value;
@@ -1436,8 +1441,14 @@ fn create_genesis_objects(
         ProtocolConfig::get_for_version(ProtocolVersion::new(parameters.protocol_version));
 
     let native_functions = sui_framework::natives::all_natives();
-    let move_vm = adapter::new_move_vm(native_functions.clone(), &protocol_config)
-        .expect("We defined natives to not fail here");
+    // paranoid checks are a last line of defense for malicious code, no need to run them in genesis
+    let enable_move_vm_paranoid_checks = false;
+    let move_vm = adapter::new_move_vm(
+        native_functions.clone(),
+        &protocol_config,
+        enable_move_vm_paranoid_checks,
+    )
+    .expect("We defined natives to not fail here");
 
     for (modules, dependencies) in modules {
         process_package(
@@ -1927,10 +1938,15 @@ mod test {
             &protocol_config,
         );
 
+        let enable_move_vm_paranoid_checks = false;
         let native_functions = sui_framework::natives::all_natives();
         let move_vm = std::sync::Arc::new(
-            adapter::new_move_vm(native_functions, &protocol_config)
-                .expect("We defined natives to not fail here"),
+            adapter::new_move_vm(
+                native_functions,
+                &protocol_config,
+                enable_move_vm_paranoid_checks,
+            )
+            .expect("We defined natives to not fail here"),
         );
 
         let transaction_data = &genesis_transaction.data().intent_message().value;

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -288,6 +288,11 @@ pub struct ExpensiveSafetyCheckConfig {
     /// Disable state consistency check even when we are running in debug mode.
     #[serde(default)]
     force_disable_state_consistency_check: bool,
+
+    /// If enabled, we run the Move VM in paranoid mode, which provides protection
+    /// against some (but not all) potential bugs in the bytecode verifier
+    #[serde(default)]
+    enable_move_vm_paranoid_checks: bool,
     // TODO: Add more expensive checks here
 }
 
@@ -298,7 +303,12 @@ impl ExpensiveSafetyCheckConfig {
             force_disable_epoch_sui_conservation_check: false,
             enable_state_consistency_check: true,
             force_disable_state_consistency_check: false,
+            enable_move_vm_paranoid_checks: true,
         }
+    }
+
+    pub fn enable_paranoid_checks(&mut self) {
+        self.enable_move_vm_paranoid_checks = true
     }
 
     pub fn force_disable_epoch_sui_conservation_check(&mut self) {
@@ -317,6 +327,10 @@ impl ExpensiveSafetyCheckConfig {
     pub fn enable_state_consistency_check(&self) -> bool {
         (self.enable_state_consistency_check || cfg!(debug_assertions))
             && !self.force_disable_state_consistency_check
+    }
+
+    pub fn enable_move_vm_paranoid_checks(&self) -> bool {
+        self.enable_move_vm_paranoid_checks
     }
 }
 

--- a/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -80,6 +80,7 @@ validator_configs:
       force-disable-epoch-sui-conservation-check: false
       enable-state-consistency-check: false
       force-disable-state-consistency-check: false
+      enable-move-vm-paranoid-checks: false
   - protocol-key-pair:
       value: avYcyVgYMXTyaUYh9IRwLK0gSzl7YF6ZQDAbrS1Bhvo=
     worker-key-pair:
@@ -157,6 +158,7 @@ validator_configs:
       force-disable-epoch-sui-conservation-check: false
       enable-state-consistency-check: false
       force-disable-state-consistency-check: false
+      enable-move-vm-paranoid-checks: false
   - protocol-key-pair:
       value: OXnx3yM1C/ppgnDMx/o1d49fJs7E05kq11mXNae/O+I=
     worker-key-pair:
@@ -234,6 +236,7 @@ validator_configs:
       force-disable-epoch-sui-conservation-check: false
       enable-state-consistency-check: false
       force-disable-state-consistency-check: false
+      enable-move-vm-paranoid-checks: false
   - protocol-key-pair:
       value: CyNkjqNVr3HrHTH7f/NLs7u5lUHJzuPAw0PqMTD2y2s=
     worker-key-pair:
@@ -311,6 +314,7 @@ validator_configs:
       force-disable-epoch-sui-conservation-check: false
       enable-state-consistency-check: false
       force-disable-state-consistency-check: false
+      enable-move-vm-paranoid-checks: false
   - protocol-key-pair:
       value: X/I/kM+KvHcxAKEf2UU6Sr7SpN3bhiE9nP5CuM/iIY0=
     worker-key-pair:
@@ -388,6 +392,7 @@ validator_configs:
       force-disable-epoch-sui-conservation-check: false
       enable-state-consistency-check: false
       force-disable-state-consistency-check: false
+      enable-move-vm-paranoid-checks: false
   - protocol-key-pair:
       value: N272EiFDyKtxRbDKbyN6ujenJ+skPcRoc/XolpOLGnU=
     worker-key-pair:
@@ -465,6 +470,7 @@ validator_configs:
       force-disable-epoch-sui-conservation-check: false
       enable-state-consistency-check: false
       force-disable-state-consistency-check: false
+      enable-move-vm-paranoid-checks: false
   - protocol-key-pair:
       value: a74f03IOjL8ZFSWFChFVEi+wiMwHNwNCPDGIYkGfgjs=
     worker-key-pair:
@@ -542,6 +548,7 @@ validator_configs:
       force-disable-epoch-sui-conservation-check: false
       enable-state-consistency-check: false
       force-disable-state-consistency-check: false
+      enable-move-vm-paranoid-checks: false
 account_keys:
   - Hloy4pnf8pWEHGP+4OFsXz56bLdIJhkD2O+OdKMqCA4=
   - pvMScjoMR/DaN0M5IOxS2VpGC59N6kv6gDm63ufLQ5w=

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -3,6 +3,7 @@
 
 use super::*;
 use fastcrypto::traits::KeyPair;
+use sui_config::node::ExpensiveSafetyCheckConfig;
 use sui_types::gas::GasCostSummary;
 use tempfile::tempdir;
 
@@ -233,7 +234,7 @@ pub async fn test_checkpoint_executor_cross_epoch() {
             EpochStartConfiguration::new_v1(system_state, Default::default()),
             &executor,
             accumulator,
-            true,
+            &ExpensiveSafetyCheckConfig::default(),
         )
         .await
         .unwrap();

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2967,6 +2967,7 @@ async fn test_authority_persist() {
             store.clone(),
             cache_metrics,
             async_batch_verifier_metrics,
+            &ExpensiveSafetyCheckConfig::default(),
         );
 
         let checkpoint_store_path = dir.join(format!("DB_{:?}", ObjectID::random()));

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -217,6 +217,7 @@ impl SuiNode {
             store.clone(),
             cache_metrics,
             signature_verifier_metrics,
+            &config.expensive_safety_check_config,
         );
 
         let effective_buffer_stake = epoch_store.get_effective_buffer_stake_bps();
@@ -1075,9 +1076,7 @@ impl SuiNode {
                 epoch_start_configuration,
                 checkpoint_executor,
                 self.accumulator.clone(),
-                self.config
-                    .expensive_safety_check_config
-                    .enable_state_consistency_check(),
+                &self.config.expensive_safety_check_config,
             )
             .await
             .expect("Reconfigure authority state cannot fail");

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -241,8 +241,16 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
             account_objects.insert(account.clone(), obj);
         }
 
+        let enable_move_vm_paranoid_checks = false;
         let mut test_adapter = Self {
-            vm: Arc::new(new_move_vm(native_functions, &PROTOCOL_CONSTANTS).unwrap()),
+            vm: Arc::new(
+                new_move_vm(
+                    native_functions,
+                    &PROTOCOL_CONSTANTS,
+                    enable_move_vm_paranoid_checks,
+                )
+                .unwrap(),
+            ),
             storage: Arc::new(InMemoryStorage::new(objects)),
             compiled_state: CompiledState::new(
                 named_address_mapping,


### PR DESCRIPTION
These have a performance hit, but can catch transactions that hit bugs in the bytecode verifier.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
