### PR TITLE
[wallet-ext] fix: convertCommandArgumentToString to support publish transaction arg

### DIFF
--- a/apps/wallet/src/ui/app/pages/approval-request/transaction-request/TransactionDetails/Command.test.ts
+++ b/apps/wallet/src/ui/app/pages/approval-request/transaction-request/TransactionDetails/Command.test.ts
@@ -1,0 +1,79 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+
+import { convertCommandArgumentToString } from './Command';
+
+describe('convertCommandArgumentToString', () => {
+    it('should convert a null when argument is undefined', () => {
+        expect(convertCommandArgumentToString(undefined)).toBe(null);
+    });
+
+    it('should convert a string when argument is a string', () => {
+        expect(convertCommandArgumentToString('test')).toBe('test');
+    });
+
+    it('should convert a [Bytes] when argument is a Number[][]', () => {
+        expect(convertCommandArgumentToString([[1, 2, 3]])).toBe('[Bytes]');
+    });
+
+    it('should convert a null when argument is None in argument', () => {
+        expect(
+            convertCommandArgumentToString({
+                None: null,
+            })
+        ).toBe(null);
+    });
+
+    it('should convert a arg.Some when argument is a Some in argument', () => {
+        expect(
+            convertCommandArgumentToString({
+                Some: 'arg.Some',
+            })
+        ).toBe('arg.Some');
+    });
+
+    it('should convert a string when argument is a string[] with multiple elements', () => {
+        expect(convertCommandArgumentToString(['test', 'test2'])).toBe(
+            '[test, test2]'
+        );
+    });
+
+    it('should convert a GasCoin when argument is a GasCoin in argument', () => {
+        expect(
+            convertCommandArgumentToString({
+                kind: 'GasCoin',
+            })
+        ).toBe('GasCoin');
+    });
+
+    it('should convert a Input when argument is a Input in argument', () => {
+        expect(
+            convertCommandArgumentToString({
+                kind: 'Input',
+                value: 'test',
+                index: 0,
+            })
+        ).toBe('Input(0)');
+    });
+
+    it('should convert a Result when argument is a Result in argument', () => {
+        expect(
+            convertCommandArgumentToString({
+                kind: 'Result',
+                index: 0,
+            })
+        ).toBe('Result(0)');
+    });
+
+    it('should convert a NestedResult when argument is a NestedResult in argument', () => {
+        expect(
+            convertCommandArgumentToString({
+                kind: 'NestedResult',
+                index: 0,
+                resultIndex: 1,
+            })
+        ).toBe('NestedResult(0, 1)');
+    });
+});

--- a/apps/wallet/src/ui/app/pages/approval-request/transaction-request/TransactionDetails/Command.tsx
+++ b/apps/wallet/src/ui/app/pages/approval-request/transaction-request/TransactionDetails/Command.tsx
@@ -13,10 +13,23 @@ import { useState } from 'react';
 
 import { Text } from '_src/ui/app/shared/text';
 
-function convertCommandArgumentToString(
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function isNumberNestArray(arg: any): arg is number[][] {
+    return (
+        Array.isArray(arg) &&
+        arg.every(
+            (item) =>
+                Array.isArray(item) &&
+                item.every((item) => typeof item === 'number')
+        )
+    );
+}
+
+export function convertCommandArgumentToString(
     arg:
         | string
         | string[]
+        | number[][]
         | TransactionArgument
         | TransactionArgument[]
         | MakeMoveVecTransaction['type']
@@ -25,11 +38,16 @@ function convertCommandArgumentToString(
 
     if (typeof arg === 'string') return arg;
 
-    if ('None' in arg) {
+    // This is a special case for the Publish transaction
+    if (Array.isArray(arg) && isNumberNestArray(arg)) {
+        return `[Bytes]`;
+    }
+
+    if (typeof arg === 'object' && 'None' in arg) {
         return null;
     }
 
-    if ('Some' in arg) {
+    if (typeof arg === 'object' && 'Some' in arg) {
         return arg.Some;
     }
 


### PR DESCRIPTION
## Description 

Fixed the bug in wallet-ext, when user using `TransactionBlock.publish`, will throw the type error issue.

## Test Plan 

Added a test in `convertCommandArgumentToString`

---
### Release notes

Fix  the wallet-ext will throw the type error when user using `TransactionBlock.publish`
