### PR TITLE
[indirect objects] check presence via multi_get_raw_bytes api

### DIFF
--- a/crates/typed-store/src/rocks/util.rs
+++ b/crates/typed-store/src/rocks/util.rs
@@ -40,6 +40,10 @@ pub fn empty_compaction_filter(_level: u32, _key: &[u8], value: &[u8]) -> Compac
     }
 }
 
+pub fn is_ref_count_value(value: &[u8]) -> bool {
+    value.is_empty() || value.len() == 8
+}
+
 fn deserialize_ref_count_value(bytes: &[u8]) -> (Option<&[u8]>, i64) {
     assert!(bytes.len() >= 8);
     let (value, rc_bytes) = bytes.split_at(bytes.len() - 8);

--- a/crates/typed-store/src/traits.rs
+++ b/crates/typed-store/src/traits.rs
@@ -74,6 +74,19 @@ where
         keys.into_iter().map(|key| self.get(key.borrow())).collect()
     }
 
+    /// Returns a vector of raw values corresponding to the keys provided, non-atomically.
+    fn multi_get_raw_bytes<J>(
+        &self,
+        keys: impl IntoIterator<Item = J>,
+    ) -> Result<Vec<Option<Vec<u8>>>, Self::Error>
+    where
+        J: Borrow<K>,
+    {
+        keys.into_iter()
+            .map(|key| self.get_raw_bytes(key.borrow()))
+            .collect()
+    }
+
     /// Inserts key-value pairs, non-atomically.
     fn multi_insert<J, U>(
         &self,


### PR DESCRIPTION
When the reference count of the indirect move object goes to zero, the value in rocksdb might still be present for some time before two consecutive compaction jobs clear it out. 
This is expected and represents a valid state of the system. 
However, for the `get` method, the return value will be merged into the reference count on read. The call site for `update_objects_and_locks` performs a read-before-write operation and needs to be switched to the `multi_get_raw_bytes` API instead because the squashed reference count value cannot be deserialized as a `StoreMoveObject`.

Furthermore, if the database value is indeed a reference count, we need to trigger a full merge for the object instead of a partial merge. That's because we can't differentiate between two system states:
* the value is merged to a zero reference count, but the original full merge operand is still present
* the value is merged to zero, but the original operand was erased during the first round of compaction

    