### PR TITLE
Multi get transaction blocks

### DIFF
--- a/crates/sui-rpc-loadgen/README.md
+++ b/crates/sui-rpc-loadgen/README.md
@@ -53,6 +53,11 @@ cargo run --bin sui-rpc-loadgen -- --urls "http://127.0.0.1:9000" --num-threads 
 cargo run --bin sui-rpc-loadgen -- --urls "http://127.0.0.1:9000" "http://127.0.0.1:9000" --num-threads 4 query-transaction-blocks --address-type from
 ```
 
+### Multi Get Transaction Blocks
+```bash
+cargo run --bin sui-rpc-loadgen -- --urls "http://127.0.0.1:9000" "http://127.0.0.1:9000" --num-threads 4 multi-get-transaction-blocks
+```
+
 ### Multi Get Objects
 
 ```bash

--- a/crates/sui-rpc-loadgen/src/main.rs
+++ b/crates/sui-rpc-loadgen/src/main.rs
@@ -17,7 +17,8 @@ use tracing::info;
 
 use crate::load_test::{LoadTest, LoadTestConfig};
 use crate::payload::{
-    load_addresses_from_file, load_objects_from_file, Command, RpcCommandProcessor, SignerInfo,
+    load_addresses_from_file, load_digests_from_file, load_objects_from_file, Command,
+    RpcCommandProcessor, SignerInfo,
 };
 
 #[derive(Parser)]
@@ -98,6 +99,11 @@ pub enum ClapCommand {
         #[clap(long, parse(try_from_str), case_insensitive = true)]
         address_type: AddressQueryType,
 
+        #[clap(flatten)]
+        common: CommonOptions,
+    },
+    #[clap(name = "multi-get-transaction-blocks")]
+    MultiGetTransactionBlocks {
         #[clap(flatten)]
         common: CommonOptions,
     },
@@ -210,6 +216,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
             let addresses = load_addresses_from_file(expand_path(&opts.data_directory));
             (
                 Command::new_query_transaction_blocks(address_type, addresses),
+                common,
+                false,
+            )
+        }
+        ClapCommand::MultiGetTransactionBlocks { common } => {
+            let digests = load_digests_from_file(expand_path(&opts.data_directory));
+            (
+                Command::new_multi_get_transaction_blocks(digests),
                 common,
                 false,
             )

--- a/crates/sui-rpc-loadgen/src/payload/mod.rs
+++ b/crates/sui-rpc-loadgen/src/payload/mod.rs
@@ -7,6 +7,7 @@ mod get_checkpoints;
 mod get_object;
 mod get_reference_gas_price;
 mod multi_get_objects;
+mod multi_get_transaction_blocks;
 mod pay_sui;
 mod query_transactions;
 mod rpc_command_processor;
@@ -17,11 +18,14 @@ use anyhow::Result;
 use async_trait::async_trait;
 use core::default::Default;
 use std::time::Duration;
-use sui_types::{base_types::SuiAddress, messages_checkpoint::CheckpointSequenceNumber};
+use sui_types::{
+    base_types::SuiAddress, digests::TransactionDigest,
+    messages_checkpoint::CheckpointSequenceNumber,
+};
 
 use crate::load_test::LoadTestConfig;
 pub use rpc_command_processor::{
-    load_addresses_from_file, load_objects_from_file, RpcCommandProcessor,
+    load_addresses_from_file, load_digests_from_file, load_objects_from_file, RpcCommandProcessor,
 };
 use sui_types::base_types::ObjectID;
 
@@ -109,6 +113,14 @@ impl Command {
         }
     }
 
+    pub fn new_multi_get_transaction_blocks(digests: Vec<TransactionDigest>) -> Self {
+        let multi_get_transaction_blocks = MultiGetTransactionBlocks { digests };
+        Self {
+            data: CommandData::MultiGetTransactionBlocks(multi_get_transaction_blocks),
+            ..Default::default()
+        }
+    }
+
     pub fn new_multi_get_objects(object_ids: Vec<ObjectID>) -> Self {
         let multi_get_objects = MultiGetObjects { object_ids };
         Self {
@@ -165,6 +177,7 @@ pub enum CommandData {
     GetCheckpoints(GetCheckpoints),
     PaySui(PaySui),
     QueryTransactionBlocks(QueryTransactionBlocks),
+    MultiGetTransactionBlocks(MultiGetTransactionBlocks),
     MultiGetObjects(MultiGetObjects),
     GetObject(GetObject),
     GetAllBalances(GetAllBalances),
@@ -198,6 +211,11 @@ pub struct PaySui {}
 pub struct QueryTransactionBlocks {
     pub address_type: AddressQueryType,
     pub addresses: Vec<SuiAddress>,
+}
+
+#[derive(Clone)]
+pub struct MultiGetTransactionBlocks {
+    pub digests: Vec<TransactionDigest>,
 }
 
 #[derive(Clone, EnumString)]

--- a/crates/sui-rpc-loadgen/src/payload/multi_get_transaction_blocks.rs
+++ b/crates/sui-rpc-loadgen/src/payload/multi_get_transaction_blocks.rs
@@ -6,7 +6,6 @@ use anyhow::Result;
 use crate::payload::{MultiGetTransactionBlocks, ProcessPayload, RpcCommandProcessor, SignerInfo};
 use async_trait::async_trait;
 use futures::future::join_all;
-use tracing::log::warn;
 
 use super::validation::{check_transactions, chunk_entities};
 

--- a/crates/sui-rpc-loadgen/src/payload/multi_get_transaction_blocks.rs
+++ b/crates/sui-rpc-loadgen/src/payload/multi_get_transaction_blocks.rs
@@ -1,0 +1,38 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+
+use crate::payload::{MultiGetTransactionBlocks, ProcessPayload, RpcCommandProcessor, SignerInfo};
+use async_trait::async_trait;
+use futures::future::join_all;
+use tracing::log::warn;
+
+use super::validation::{check_transactions, chunk_entities};
+
+#[async_trait]
+impl<'a> ProcessPayload<'a, &'a MultiGetTransactionBlocks> for RpcCommandProcessor {
+    async fn process(
+        &'a self,
+        op: &'a MultiGetTransactionBlocks,
+        _signer_info: &Option<SignerInfo>,
+    ) -> Result<()> {
+        let clients = self.get_clients().await?;
+        let digests = &op.digests;
+
+        if op.digests.is_empty() {
+            panic!("No digests provided, skipping query");
+        }
+
+        let chunks = chunk_entities(digests, None);
+        let chunk_futures = chunks.into_iter().map(|chunk| {
+            let clients = clients.clone();
+            async move {
+                check_transactions(&clients, &chunk, false, false).await;
+            }
+        });
+        join_all(chunk_futures).await;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Description 

I believe we can reuse `multi_get_transactions` as it calls `multi_get_transaction_blocks` under the hood

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
