### PR TITLE
Update stress tool after genesis changes...

### DIFF
--- a/crates/sui-benchmark/src/bank.rs
+++ b/crates/sui-benchmark/src/bank.rs
@@ -3,7 +3,7 @@
 
 use crate::util::{make_pay_tx, UpdatedAndNewlyMintedGasCoins};
 use crate::workloads::payload::Payload;
-use crate::workloads::workload::{Workload, WorkloadBuilder};
+use crate::workloads::workload::{Workload, WorkloadBuilder, MAX_BUDGET_FOR_TESTING};
 use crate::workloads::{Gas, GasCoinConfig};
 use crate::ValidatorProxy;
 use anyhow::{Error, Result};
@@ -19,6 +19,7 @@ use sui_types::messages::{
 };
 use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{coin, SUI_FRAMEWORK_OBJECT_ID};
+use tracing::{debug, error};
 
 /// Bank is used for generating gas for running the benchmark. It is initialized with two gas coins i.e.
 /// `pay_coin` which is split into smaller gas coins and `primary_gas` which is the gas coin used
@@ -29,19 +30,19 @@ pub struct BenchmarkBank {
     // Gas to use for execution of gas generation transaction
     pub primary_gas: Gas,
     // Coin to use for splitting and generating small gas coins
-    pub pay_coin: Gas,
+    pub pay_coins: Vec<Gas>,
 }
 
 impl BenchmarkBank {
     pub fn new(
         proxy: Arc<dyn ValidatorProxy + Send + Sync>,
         primary_gas: Gas,
-        pay_coin: Gas,
+        pay_coins: Vec<Gas>,
     ) -> Self {
         BenchmarkBank {
             proxy,
             primary_gas,
-            pay_coin,
+            pay_coins,
         }
     }
     pub async fn generate(
@@ -66,10 +67,7 @@ impl BenchmarkBank {
         let chunked_coin_configs = all_coin_configs.chunks(chunk_size as usize);
         eprintln!("Number of gas requests = {}", chunked_coin_configs.len());
         for chunk in chunked_coin_configs {
-            let (updated_primary_gas, updated_coin, gas_coins) =
-                self.split_coin_and_pay(chunk, gas_price).await?;
-            self.primary_gas = updated_primary_gas;
-            self.pay_coin = updated_coin;
+            let gas_coins = self.split_coin_and_pay(chunk, gas_price).await?;
             new_gas_coins.extend(gas_coins);
         }
         let mut workloads = vec![];
@@ -105,6 +103,7 @@ impl BenchmarkBank {
         split_amounts: Vec<u64>,
         gas_price: Option<u64>,
         keypair: &AccountKeyPair,
+        pay_coin: &Gas,
     ) -> Result<VerifiedTransaction> {
         let gas_price = gas_price.unwrap_or(DUMMY_GAS_PRICE);
         let split_coin = TransactionData::new_move_call(
@@ -115,10 +114,10 @@ impl BenchmarkBank {
             vec![TypeTag::Struct(Box::new(GAS::type_()))],
             self.primary_gas.0,
             vec![
-                CallArg::Object(ObjectArg::ImmOrOwnedObject(self.pay_coin.0)),
+                CallArg::Object(ObjectArg::ImmOrOwnedObject(pay_coin.0)),
                 CallArg::Pure(bcs::to_bytes(&split_amounts).unwrap()),
             ],
-            500_000_000 * gas_price,
+            MAX_BUDGET_FOR_TESTING,
             gas_price,
         )?;
         let verified_tx = to_sender_signed_transaction(split_coin, keypair);
@@ -134,74 +133,157 @@ impl BenchmarkBank {
         // TODO: Instead of splitting the coin and then using pay tx to transfer it to recipients,
         // we can do both in one tx with pay_sui which will split the coin out for us before
         // transferring it to recipients
-        let verified_tx =
-            self.make_split_coin_tx(split_amounts.clone(), Some(gas_price), &self.primary_gas.2)?;
-        let effects = self
-            .proxy
-            .execute_transaction_block(verified_tx.into())
-            .await?;
-        let updated_gas = effects
-            .mutated()
-            .into_iter()
-            .find(|(k, _)| k.0 == self.primary_gas.0 .0)
-            .ok_or("Input gas missing in the effects")
-            .map_err(Error::msg)?;
-        let created_coins: Vec<ObjectRef> = effects.created().into_iter().map(|c| c.0).collect();
-        assert_eq!(created_coins.len(), split_amounts.len());
-        let updated_coin = effects
-            .mutated()
-            .into_iter()
-            .find(|(k, _)| k.0 == self.pay_coin.0 .0)
-            .ok_or("Input gas missing in the effects")
-            .map_err(Error::msg)?;
-        let recipient_addresses: Vec<SuiAddress> = coin_configs.iter().map(|g| g.address).collect();
-        let verified_tx = make_pay_tx(
-            created_coins,
-            self.primary_gas.1,
-            recipient_addresses,
-            split_amounts,
-            updated_gas.0,
-            &self.primary_gas.2,
-            Some(gas_price),
-        )?;
-        let effects = self
-            .proxy
-            .execute_transaction_block(verified_tx.into())
-            .await?;
-        let address_map: HashMap<SuiAddress, Arc<AccountKeyPair>> = coin_configs
-            .iter()
-            .map(|c| (c.address, c.keypair.clone()))
-            .collect();
-        let transferred_coins: Result<Vec<Gas>> = effects
-            .created()
-            .into_iter()
-            .map(|c| {
-                let address = c.1.get_owner_address()?;
-                let keypair = address_map
-                    .get(&address)
-                    .ok_or("Owner address missing in the address map")
-                    .map_err(Error::msg)?;
-                Ok((c.0, address, keypair.clone()))
-            })
-            .collect();
-        let updated_gas = effects
-            .mutated()
-            .into_iter()
-            .find(|(k, _)| k.0 == self.primary_gas.0 .0)
-            .ok_or("Input gas missing in the effects")
-            .map_err(Error::msg)?;
-        Ok((
-            (
-                updated_gas.0,
-                updated_gas.1.get_owner_address()?,
-                self.primary_gas.2.clone(),
-            ),
-            (
+        let mut updated_pay_coins = Vec::new();
+        let mut transferred_coins: Result<Vec<Gas>> = Err(Error::msg("Failed to split coin"));
+        eprintln!(
+            "Splitting {} coin(s) into {} coin(s) of balance {}",
+            self.pay_coins.len(),
+            split_amounts.len(),
+            split_amounts[0],
+        );
+        for (idx, pay_coin) in self.pay_coins.iter().enumerate() {
+            debug!("Attempting split of coin#{idx}");
+            let verified_tx = self.make_split_coin_tx(
+                split_amounts.clone(),
+                Some(gas_price),
+                &self.primary_gas.2,
+                pay_coin,
+            )?;
+            let effects = self
+                .proxy
+                .execute_transaction_block(verified_tx.into())
+                .await;
+
+            let effects = match effects {
+                Ok(effects) => {
+                    if !effects.is_ok() {
+                        error!("Failed to split coin: {:?}", effects);
+                        // TODO: check effects and make decision on what coin to use
+                        // next based on errors.
+                        let updated_gas = effects
+                            .mutated()
+                            .into_iter()
+                            .find(|(k, _)| k.0 == self.primary_gas.0 .0)
+                            .ok_or("Input gas missing in the effects")
+                            .map_err(Error::msg);
+
+                        match updated_gas {
+                            Ok(updated_gas) => {
+                                self.primary_gas = (
+                                    updated_gas.0,
+                                    updated_gas.1.get_owner_address()?,
+                                    self.primary_gas.2.clone(),
+                                );
+                            }
+                            Err(e) => {
+                                error!("Failed to get mutated gas: {:?}", e);
+                                continue;
+                            }
+                        };
+
+                        let updated_coin = effects
+                            .mutated()
+                            .into_iter()
+                            .find(|(k, _)| k.0 == pay_coin.0 .0)
+                            .ok_or("Pay coin missing in the effects")
+                            .map_err(Error::msg);
+
+                        match updated_coin {
+                            Ok(updated_coin) => {
+                                updated_pay_coins.push((
+                                    updated_coin.0,
+                                    updated_coin.1.get_owner_address()?,
+                                    self.primary_gas.2.clone(),
+                                ));
+                                continue;
+                            }
+                            Err(e) => {
+                                error!("Failed to mutated pay coi: {:?}", e);
+                                continue;
+                            }
+                        };
+                    }
+                    effects
+                }
+                Err(e) => {
+                    error!("Failed to split coin: {:?}", e);
+                    continue;
+                }
+            };
+
+            let updated_gas = effects
+                .mutated()
+                .into_iter()
+                .find(|(k, _)| k.0 == self.primary_gas.0 .0)
+                .ok_or("Input gas missing in the effects")
+                .map_err(Error::msg)?;
+            let created_coins: Vec<ObjectRef> =
+                effects.created().into_iter().map(|c| c.0).collect();
+            assert_eq!(created_coins.len(), split_amounts.len());
+            let updated_coin = effects
+                .mutated()
+                .into_iter()
+                .find(|(k, _)| k.0 == pay_coin.0 .0)
+                .ok_or("Input gas missing in the effects")
+                .map_err(Error::msg)?;
+
+            updated_pay_coins.push((
                 updated_coin.0,
                 updated_coin.1.get_owner_address()?,
                 self.primary_gas.2.clone(),
-            ),
-            transferred_coins?,
-        ))
+            ));
+
+            let recipient_addresses: Vec<SuiAddress> =
+                coin_configs.iter().map(|g| g.address).collect();
+            let verified_tx = make_pay_tx(
+                created_coins,
+                self.primary_gas.1,
+                recipient_addresses,
+                split_amounts,
+                updated_gas.0,
+                &self.primary_gas.2,
+                Some(gas_price),
+            )?;
+            let effects = self
+                .proxy
+                .execute_transaction_block(verified_tx.into())
+                .await?;
+            let address_map: HashMap<SuiAddress, Arc<AccountKeyPair>> = coin_configs
+                .iter()
+                .map(|c| (c.address, c.keypair.clone()))
+                .collect();
+            transferred_coins = effects
+                .created()
+                .into_iter()
+                .map(|c| {
+                    let address = c.1.get_owner_address()?;
+                    let keypair = address_map
+                        .get(&address)
+                        .ok_or("Owner address missing in the address map")
+                        .map_err(Error::msg)?;
+                    Ok((c.0, address, keypair.clone()))
+                })
+                .collect();
+            let updated_gas = effects
+                .mutated()
+                .into_iter()
+                .find(|(k, _)| k.0 == self.primary_gas.0 .0)
+                .ok_or("Input gas missing in the effects")
+                .map_err(Error::msg)?;
+
+            self.primary_gas = (
+                updated_gas.0,
+                updated_gas.1.get_owner_address()?,
+                self.primary_gas.2.clone(),
+            );
+
+            let (_, right) = self.pay_coins.split_at_mut(idx + 1);
+            let remaining_pay_coins = right.to_vec();
+            self.pay_coins = updated_pay_coins;
+            self.pay_coins.extend(remaining_pay_coins);
+            break;
+        }
+
+        transferred_coins
     }
 }

--- a/crates/sui-benchmark/src/benchmark_setup.rs
+++ b/crates/sui-benchmark/src/benchmark_setup.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use std::thread::JoinHandle;
 use std::time::Duration;
 use sui_config::utils;
+use tracing::debug;
 
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::SuiAddress;
@@ -255,7 +256,7 @@ impl Env {
             .choose(&mut rand::thread_rng())
             .context("Failed to choose a random primary gas id")?;
 
-        eprintln!(
+        debug!(
             "Using primary gas id: {} with balance of {balance}",
             primary_gas_obj.id()
         );
@@ -293,7 +294,7 @@ impl Env {
             })
             .collect::<Vec<_>>();
 
-        eprintln!(
+        debug!(
             "Using {} pay coin(s) with balance of {pay_coins_total_balance}",
             pay_coins.len()
         );

--- a/crates/sui-benchmark/src/benchmark_setup.rs
+++ b/crates/sui-benchmark/src/benchmark_setup.rs
@@ -17,6 +17,7 @@ use tokio::time::sleep;
 use crate::bank::BenchmarkBank;
 use crate::options::Opts;
 use crate::util::get_ed25519_keypair_from_keystore;
+use crate::workloads::workload::MAX_GAS_FOR_TESTING;
 use crate::{FullNodeProxy, LocalValidatorAggregatorProxy, ValidatorProxy};
 use sui_types::object::generate_max_test_gas_objects_with_owner;
 use test_utils::authority::test_and_configure_authority_configs_with_objects;
@@ -61,13 +62,13 @@ impl Env {
                 self.setup_remote_env(
                     barrier,
                     registry,
-                    opts.primary_gas_id.as_str(),
-                    opts.primary_gas_objects,
+                    opts.primary_gas_owner_id.as_str(),
                     opts.keystore_path.as_str(),
                     opts.genesis_blob_path.as_str(),
                     opts.use_fullnode_for_reconfig,
                     opts.use_fullnode_for_execution,
                     opts.fullnode_rpc_addresses.clone(),
+                    opts.gas_request_chunk_size,
                 )
                 .await
             }
@@ -160,7 +161,7 @@ impl Env {
         Ok(BenchmarkSetup {
             server_handle: join_handle,
             shutdown_notifier: sender,
-            bank: BenchmarkBank::new(proxy.clone(), primary_gas, pay_coin),
+            bank: BenchmarkBank::new(proxy.clone(), primary_gas, vec![pay_coin]),
             proxies: vec![proxy],
         })
     }
@@ -169,13 +170,13 @@ impl Env {
         &self,
         barrier: Arc<Barrier>,
         registry: &Registry,
-        primary_gas_id: &str,
-        primary_gas_objects: u64,
+        primary_gas_owner_id: &str,
         keystore_path: &str,
         genesis_blob_path: &str,
         use_fullnode_for_reconfig: bool,
         use_fullnode_for_execution: bool,
         fullnode_rpc_address: Vec<String>,
+        chunk_size: u64,
     ) -> Result<BenchmarkSetup> {
         info!("Running benchmark setup in remote mode ..");
         let (sender, recv) = tokio::sync::oneshot::channel::<()>();
@@ -188,6 +189,10 @@ impl Env {
                     recv.await.expect("Unable to wait for terminate signal");
                 });
         });
+
+        let genesis = sui_config::node::Genesis::new_from_file(genesis_blob_path);
+        let genesis = genesis.genesis()?;
+
         let fullnode_rpc_urls = fullnode_rpc_address.clone();
         info!("List of fullnode rpc urls: {:?}", fullnode_rpc_urls);
         let proxies: Vec<Arc<dyn ValidatorProxy + Send + Sync>> = if use_fullnode_for_execution {
@@ -195,9 +200,9 @@ impl Env {
                 bail!("fullnode-rpc-url is required when use-fullnode-for-execution is true");
             }
             let mut fullnodes: Vec<Arc<dyn ValidatorProxy + Send + Sync>> = vec![];
-            for fullnode_rpc_url in fullnode_rpc_urls {
+            for fullnode_rpc_url in fullnode_rpc_urls.iter() {
                 info!("Using FullNodeProxy: {:?}", fullnode_rpc_url);
-                fullnodes.push(Arc::new(FullNodeProxy::from_url(&fullnode_rpc_url).await?));
+                fullnodes.push(Arc::new(FullNodeProxy::from_url(fullnode_rpc_url).await?));
             }
             fullnodes
         } else {
@@ -210,8 +215,6 @@ impl Env {
             } else {
                 None
             };
-            let genesis = sui_config::node::Genesis::new_from_file(genesis_blob_path);
-            let genesis = genesis.genesis()?;
             vec![Arc::new(
                 LocalValidatorAggregatorProxy::from_genesis(
                     genesis,
@@ -229,30 +232,35 @@ impl Env {
             proxy.get_current_epoch(),
         );
 
-        let mut used_ids = vec![];
-        let offset = ObjectID::from_hex_literal(primary_gas_id)?;
-        let ids = ObjectID::in_range(offset, primary_gas_objects)?;
-        let mut primary_gas_id = ids
+        let primary_gas_owner_addr = ObjectID::from_hex_literal(primary_gas_owner_id)?;
+
+        // TODO: Add a way to query local proxy for gas objects.
+        // i.e. get from genesis blob and then query for the latest object version.
+
+        // Require the use of fullnode to query for gas object for now.
+        if fullnode_rpc_urls.is_empty() {
+            bail!("fullnode-rpc-url is required for remote run to get gas objects");
+        }
+        let fn_proxy = Arc::new(FullNodeProxy::from_url(&fullnode_rpc_urls[0]).await?);
+
+        let mut gas_objects = fn_proxy
+            .get_owned_objects(primary_gas_owner_addr.into())
+            .await?;
+        gas_objects.sort_by_key(|&(gas, _)| std::cmp::Reverse(gas));
+
+        let (balance, primary_gas_obj) = gas_objects
+            .iter()
+            .filter(|(balance, _)| balance > &MAX_GAS_FOR_TESTING)
+            .collect::<Vec<_>>()
             .choose(&mut rand::thread_rng())
             .context("Failed to choose a random primary gas id")?;
-        while used_ids.contains(primary_gas_id) {
-            primary_gas_id = ids
-                .choose(&mut rand::thread_rng())
-                .context("Failed to choose a random primary gas id")?;
-        }
-        used_ids.push(*primary_gas_id);
-        let primary_gas = proxy.get_object(*primary_gas_id).await?;
-        let mut pay_coin_id = ids
-            .choose(&mut rand::thread_rng())
-            .context("Failed to choose a random pay coin")?;
-        while used_ids.contains(pay_coin_id) {
-            pay_coin_id = ids
-                .choose(&mut rand::thread_rng())
-                .context("Failed to choose a random primary gas id")?;
-        }
-        used_ids.push(*pay_coin_id);
-        let pay_coin = proxy.get_object(*pay_coin_id).await?;
-        let primary_gas_account = primary_gas.owner.get_owner_address()?;
+
+        eprintln!(
+            "Using primary gas id: {} with balance of {balance}",
+            primary_gas_obj.id()
+        );
+
+        let primary_gas_account = primary_gas_obj.owner.get_owner_address()?;
         let keystore_path = Some(&keystore_path)
             .filter(|s| !s.is_empty())
             .map(PathBuf::from)
@@ -266,20 +274,40 @@ impl Env {
             keystore_path,
             &primary_gas_account,
         )?);
-        let primary_gas = (
-            primary_gas.compute_object_reference(),
-            primary_gas_account,
-            keypair.clone(),
+
+        let pay_coin_objs = gas_objects.iter().filter(|(balance, gas_object)| {
+            gas_object != primary_gas_obj && balance > &(MAX_GAS_FOR_TESTING * chunk_size)
+        });
+        let mut pay_coins_total_balance = 0;
+        let pay_coins = pay_coin_objs
+            .map(|(balance, pay_coin)| {
+                pay_coins_total_balance += balance;
+                (
+                    pay_coin.compute_object_reference(),
+                    pay_coin
+                        .owner
+                        .get_owner_address()
+                        .expect("Failed to get owner address"),
+                    keypair.clone(),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        eprintln!(
+            "Using {} pay coin(s) with balance of {pay_coins_total_balance}",
+            pay_coins.len()
         );
-        let pay_coin = (
-            pay_coin.compute_object_reference(),
-            pay_coin.owner.get_owner_address()?,
+
+        let primary_gas = (
+            primary_gas_obj.compute_object_reference(),
+            primary_gas_account,
             keypair,
         );
+
         Ok(BenchmarkSetup {
             server_handle: join_handle,
             shutdown_notifier: sender,
-            bank: BenchmarkBank::new(proxy.clone(), primary_gas, pay_coin),
+            bank: BenchmarkBank::new(proxy.clone(), primary_gas, pay_coins),
             proxies,
         })
     }

--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -158,6 +158,17 @@ impl ExecutionEffects {
         }
     }
 
+    pub fn status(&self) -> String {
+        match self {
+            ExecutionEffects::CertifiedTransactionEffects(certified_effects, ..) => {
+                format!("{:#?}", certified_effects.data().status())
+            }
+            ExecutionEffects::SuiTransactionBlockEffects(sui_tx_effects) => {
+                format!("{:#?}", sui_tx_effects.status())
+            }
+        }
+    }
+
     pub fn gas_cost_summary(&self) -> GasCostSummary {
         match self {
             crate::ExecutionEffects::CertifiedTransactionEffects(a, _) => {
@@ -175,6 +186,25 @@ impl ExecutionEffects {
 
     pub fn net_gas_used(&self) -> i64 {
         self.gas_cost_summary().net_gas_usage()
+    }
+
+    pub fn print_gas_summary(&self) {
+        let gas_object = self.gas_object();
+        let sender = self.sender();
+        let status = self.status();
+        let gas_cost_summary = self.gas_cost_summary();
+        let gas_used = self.gas_used();
+        let net_gas_used = self.net_gas_used();
+
+        info!(
+            "Summary:\n\
+             Gas Object: {gas_object:?}\n\
+             Sender: {sender:?}\n\
+             status: {status}\n\
+             Gas Cost Summary: {gas_cost_summary:#?}\n\
+             Gas Used: {gas_used}\n\
+             Net Gas Used: {net_gas_used}"
+        );
     }
 }
 

--- a/crates/sui-benchmark/src/options.rs
+++ b/crates/sui-benchmark/src/options.rs
@@ -37,11 +37,9 @@ pub struct Opts {
     /// [Required for remote benchmark]
     /// Object id of the primary gas coin used for benchmark
     /// NOTE: THe remote network should have this coin in its genesis config
-    /// with large enough gas i.e. u64::MAX
+    /// with large enough gas.
     #[clap(long, default_value = "", global = true)]
-    pub primary_gas_id: String,
-    #[clap(long, default_value = "5000", global = true)]
-    pub primary_gas_objects: u64,
+    pub primary_gas_owner_id: String,
     #[clap(long, default_value = "500", global = true)]
     pub gas_request_chunk_size: u64,
     /// Whether to run local or remote benchmark

--- a/crates/sui-benchmark/src/util.rs
+++ b/crates/sui-benchmark/src/util.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use sui_keys::keystore::{AccountKeystore, FileBasedKeystore};
 use sui_types::{base_types::SuiAddress, crypto::SuiKeyPair};
 
-use crate::workloads::workload::MAX_BUDGET_FOR_TESTING;
+use crate::workloads::workload::MAX_BUDGET;
 use crate::ValidatorProxy;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -49,7 +49,7 @@ pub fn make_pay_tx(
         addresses,
         split_amounts,
         gas,
-        MAX_BUDGET_FOR_TESTING,
+        MAX_BUDGET,
         gas_price.unwrap_or(DUMMY_GAS_PRICE),
     )?;
     Ok(to_sender_signed_transaction(pay, keypair))

--- a/crates/sui-benchmark/src/util.rs
+++ b/crates/sui-benchmark/src/util.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 use sui_keys::keystore::{AccountKeystore, FileBasedKeystore};
 use sui_types::{base_types::SuiAddress, crypto::SuiKeyPair};
 
+use crate::workloads::workload::MAX_BUDGET_FOR_TESTING;
 use crate::ValidatorProxy;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -19,9 +20,8 @@ use test_utils::transaction::parse_package_ref;
 
 // This is the maximum gas we will transfer from primary coin into any gas coin
 // for running the benchmark
-pub const MAX_GAS_FOR_TESTING: u64 = 1_000_000_000;
 
-pub type UpdatedAndNewlyMintedGasCoins = (Gas, Gas, Vec<Gas>);
+pub type UpdatedAndNewlyMintedGasCoins = Vec<Gas>;
 
 pub fn get_ed25519_keypair_from_keystore(
     keystore_path: PathBuf,
@@ -49,7 +49,7 @@ pub fn make_pay_tx(
         addresses,
         split_amounts,
         gas,
-        100_000_000,
+        MAX_BUDGET_FOR_TESTING,
         gas_price.unwrap_or(DUMMY_GAS_PRICE),
     )?;
     Ok(to_sender_signed_transaction(pay, keypair))

--- a/crates/sui-benchmark/src/workloads/adversarial.rs
+++ b/crates/sui-benchmark/src/workloads/adversarial.rs
@@ -354,7 +354,7 @@ impl WorkloadBuilder<dyn Payload> for AdversarialWorkloadBuilder {
         // Gas coin for publishing adversarial package
         let (address, keypair) = get_key_pair();
         vec![GasCoinConfig {
-            amount: MAX_GAS_FOR_TESTING,
+            amount: MAX_GAS_FOR_TESTING * 1000,
             address,
             keypair: Arc::new(keypair),
         }]

--- a/crates/sui-benchmark/src/workloads/adversarial.rs
+++ b/crates/sui-benchmark/src/workloads/adversarial.rs
@@ -32,9 +32,12 @@ use sui_types::{base_types::ObjectID, object::Owner};
 use sui_types::{base_types::SuiAddress, crypto::get_key_pair, messages::VerifiedTransaction};
 use sui_types::{messages::TransactionData, utils::to_sender_signed_transaction};
 use test_utils::messages::create_publish_move_package_transaction_with_budget;
+use tracing::debug;
+
 /// Number of vectors to create in LargeTransientRuntimeVectors workload
 const NUM_VECTORS: u64 = 1_000;
 
+// TODO: Need to fix Large* workloads, which are currently failing due to InsufficientGas
 #[derive(Debug, EnumCountMacro, EnumIter, Clone)]
 pub enum AdversarialPayloadType {
     Random = 0,
@@ -354,7 +357,7 @@ impl WorkloadBuilder<dyn Payload> for AdversarialWorkloadBuilder {
         // Gas coin for publishing adversarial package
         let (address, keypair) = get_key_pair();
         vec![GasCoinConfig {
-            amount: MAX_GAS_FOR_TESTING * 1000,
+            amount: MAX_GAS_FOR_TESTING,
             address,
             keypair: Arc::new(keypair),
         }]
@@ -379,7 +382,7 @@ impl WorkloadBuilder<dyn Payload> for AdversarialWorkloadBuilder {
         mut init_gas: Vec<Gas>,
         payload_gas: Vec<Gas>,
     ) -> Box<dyn Workload<dyn Payload>> {
-        eprintln!(
+        debug!(
             "Using `{:?}` adversarial workloads at {}% load factor",
             self.adversarial_payload_cfg.payload_type,
             self.adversarial_payload_cfg.load_factor * 100.0

--- a/crates/sui-benchmark/src/workloads/batch_payment.rs
+++ b/crates/sui-benchmark/src/workloads/batch_payment.rs
@@ -1,29 +1,26 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::in_memory_wallet::InMemoryWallet;
+use crate::system_state_observer::SystemStateObserver;
+use crate::workloads::payload::Payload;
+use crate::workloads::workload::{Workload, STORAGE_COST_PER_COIN};
+use crate::workloads::workload::{WorkloadBuilder, ESTIMATED_COMPUTATION_COST};
+use crate::workloads::{Gas, GasCoinConfig, WorkloadBuilderInfo, WorkloadParams};
+use crate::{ExecutionEffects, ValidatorProxy};
 use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::Arc;
+use sui_core::test_utils::make_pay_sui_transaction;
 use sui_types::base_types::{ObjectID, SequenceNumber};
 use sui_types::digests::ObjectDigest;
 use sui_types::object::Owner;
-
-use std::collections::HashMap;
-use std::sync::Arc;
-
 use sui_types::{
     base_types::{ObjectRef, SuiAddress},
     crypto::get_key_pair,
     messages::VerifiedTransaction,
 };
-
-use crate::in_memory_wallet::InMemoryWallet;
-use crate::system_state_observer::SystemStateObserver;
-use crate::workloads::payload::Payload;
-use crate::workloads::workload::WorkloadBuilder;
-use crate::workloads::{Gas, GasCoinConfig, WorkloadBuilderInfo, WorkloadParams};
-use crate::{ExecutionEffects, ValidatorProxy};
-use sui_core::test_utils::make_pay_sui_transaction;
-
-use super::workload::{Workload, MAX_GAS_FOR_TESTING};
+use tracing::{debug, error};
 
 /// Value of each address's "primary coin" in mist. The first transaction gives
 /// each address a coin worth PRIMARY_COIN_VALUE, and all subsequent transfers
@@ -31,7 +28,7 @@ use super::workload::{Workload, MAX_GAS_FOR_TESTING};
 const PRIMARY_COIN_VALUE: u64 = 100_000_000_000;
 
 /// Number of mist sent to each address on each batch transfer
-const TRANSFER_AMOUNT: u64 = 1;
+const BATCH_TRANSFER_AMOUNT: u64 = 1;
 
 const DUMMY_GAS: ObjectRef = (ObjectID::ZERO, SequenceNumber::MIN, ObjectDigest::MIN);
 
@@ -54,6 +51,11 @@ impl std::fmt::Display for BatchPaymentTestPayload {
 
 impl Payload for BatchPaymentTestPayload {
     fn make_new_payload(&mut self, effects: &ExecutionEffects) {
+        if !effects.is_ok() {
+            effects.print_gas_summary();
+            error!("Batch payment failed...");
+        }
+
         self.state.update(effects);
         if self.num_payments == 0 {
             for (coin_obj, owner) in effects.created().into_iter().chain(effects.mutated()) {
@@ -72,26 +74,28 @@ impl Payload for BatchPaymentTestPayload {
         let num_recipients = addrs.len();
         let sender = if self.num_payments == 0 {
             // first tx--use the address that has gas
+            debug!("First sender sending gas {}...", self.first_sender);
             self.first_sender
         } else {
             // everyone has gas now, round-robin the senders
-            addrs[self.num_payments % num_recipients]
+            let addr = addrs[self.num_payments % num_recipients];
+            debug!("New sender sending gas {}...", addr);
+            addr
         };
         // we're only using gas objects in this benchmark, so safe to assume everything owned by an address is a gas object
         let gas_obj = self.state.gas(&sender).unwrap();
+        debug!("Gas ID being used for tx {gas_obj:#?}");
         let amount = if self.num_payments == 0 {
             PRIMARY_COIN_VALUE
         } else {
-            TRANSFER_AMOUNT
+            BATCH_TRANSFER_AMOUNT
         };
-        let gas_budget = self
-            .system_state_observer
-            .state
-            .borrow()
-            .protocol_config
-            .as_ref()
-            .expect("Protocol config not in system state")
-            .max_tx_gas();
+        debug!("Sending {amount} to {num_recipients} recipients");
+
+        // Have to include not just the coins that are going to be created and sent
+        // but the coin being used as gas as well.
+        let gas_budget =
+            ESTIMATED_COMPUTATION_COST + (STORAGE_COST_PER_COIN * (num_recipients + 1) as u64);
         // pay everything from the gas object, no other coins
         let coins = Vec::new();
         // create a sender -> all transfer, using all of the sender's coins
@@ -160,11 +164,20 @@ impl WorkloadBuilder<dyn Payload> for BatchPaymentWorkloadBuilder {
         vec![]
     }
     async fn generate_coin_config_for_payloads(&self) -> Vec<GasCoinConfig> {
+        // Have to include not just the coins that are going to be created and sent
+        // but the coin being used as gas as well.
+        let amount = (PRIMARY_COIN_VALUE * (self.batch_size + 1) as u64)
+            + ESTIMATED_COMPUTATION_COST
+            + (STORAGE_COST_PER_COIN * self.batch_size as u64);
+        debug!(
+            "Creating gas coins for batch payload {} coin(s) of balance {amount}",
+            self.num_payloads
+        );
         (0..self.num_payloads)
             .map(|_| {
                 let (address, keypair) = get_key_pair();
                 GasCoinConfig {
-                    amount: MAX_GAS_FOR_TESTING * 100,
+                    amount,
                     address,
                     keypair: Arc::new(keypair),
                 }
@@ -204,6 +217,10 @@ impl Workload<dyn Payload> for BatchPaymentWorkload {
         system_state_observer: Arc<SystemStateObserver>,
     ) -> Vec<Box<dyn Payload>> {
         let mut gas_by_address: HashMap<SuiAddress, Vec<Gas>> = HashMap::new();
+        debug!(
+            "Making test payloads with {} payload gas...",
+            self.payload_gas.len()
+        );
         for gas in self.payload_gas.iter() {
             gas_by_address
                 .entry(gas.1)
@@ -217,6 +234,13 @@ impl Workload<dyn Payload> for BatchPaymentWorkload {
         );
 
         let mut payloads = Vec::new();
+
+        debug!(
+            "Creating {} senders & {} recipients per sender...",
+            gas_by_address.len(),
+            self.batch_size
+        );
+
         for (addr, gas) in gas_by_address {
             let mut state = InMemoryWallet::default();
             let key = gas[0].2.clone();

--- a/crates/sui-benchmark/src/workloads/batch_payment.rs
+++ b/crates/sui-benchmark/src/workloads/batch_payment.rs
@@ -164,7 +164,7 @@ impl WorkloadBuilder<dyn Payload> for BatchPaymentWorkloadBuilder {
             .map(|_| {
                 let (address, keypair) = get_key_pair();
                 GasCoinConfig {
-                    amount: MAX_GAS_FOR_TESTING,
+                    amount: MAX_GAS_FOR_TESTING * 100,
                     address,
                     keypair: Arc::new(keypair),
                 }

--- a/crates/sui-benchmark/src/workloads/transfer_object.rs
+++ b/crates/sui-benchmark/src/workloads/transfer_object.rs
@@ -3,24 +3,29 @@
 
 use async_trait::async_trait;
 use rand::seq::IteratorRandom;
+use tracing::error;
 
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use crate::system_state_observer::SystemStateObserver;
+use crate::workloads::payload::Payload;
+use crate::workloads::workload::WorkloadBuilder;
+use crate::workloads::workload::{
+    Workload, ESTIMATED_COMPUTATION_COST, MAX_GAS_FOR_TESTING, STORAGE_COST_PER_COIN,
+};
+use crate::workloads::{Gas, GasCoinConfig, WorkloadBuilderInfo, WorkloadParams};
+use crate::{ExecutionEffects, ValidatorProxy};
+use sui_core::test_utils::make_transfer_object_transaction;
 use sui_types::{
     base_types::{ObjectRef, SuiAddress},
     crypto::{get_key_pair, AccountKeyPair},
     messages::VerifiedTransaction,
 };
 
-use crate::system_state_observer::SystemStateObserver;
-use crate::workloads::payload::Payload;
-use crate::workloads::workload::WorkloadBuilder;
-use crate::workloads::{Gas, GasCoinConfig, WorkloadBuilderInfo, WorkloadParams};
-use crate::{ExecutionEffects, ValidatorProxy};
-use sui_core::test_utils::make_transfer_object_transaction;
-
-use super::workload::{Workload, MAX_GAS_FOR_TESTING};
+/// TODO: This should be the amount that is being transfered instead of MAX_GAS.
+/// Number of mist sent to each address on each batch transfer
+const _TRANSFER_AMOUNT: u64 = 1;
 
 #[derive(Debug)]
 pub struct TransferObjectTestPayload {
@@ -33,6 +38,11 @@ pub struct TransferObjectTestPayload {
 
 impl Payload for TransferObjectTestPayload {
     fn make_new_payload(&mut self, effects: &ExecutionEffects) {
+        if !effects.is_ok() {
+            effects.print_gas_summary();
+            error!("Transfer tx failed...");
+        }
+
         let recipient = self.gas.iter().find(|x| x.1 != self.transfer_to).unwrap().1;
         let updated_gas: Vec<Gas> = self
             .gas
@@ -126,7 +136,11 @@ impl WorkloadBuilder<dyn Payload> for TransferObjectWorkloadBuilder {
     }
     async fn generate_coin_config_for_payloads(&self) -> Vec<GasCoinConfig> {
         let mut address_map = HashMap::new();
-
+        // Have to include not just the coins that are going to be created and sent
+        // but the coin being used as gas as well.
+        let amount = MAX_GAS_FOR_TESTING
+            + ESTIMATED_COMPUTATION_COST
+            + STORAGE_COST_PER_COIN * (self.num_transfer_accounts + 1);
         // gas for payloads
         let mut payload_configs = vec![];
         for _i in 0..self.num_transfer_accounts {
@@ -135,7 +149,7 @@ impl WorkloadBuilder<dyn Payload> for TransferObjectWorkloadBuilder {
             address_map.insert(address, cloned_keypair.clone());
             for _j in 0..self.num_payloads {
                 payload_configs.push(GasCoinConfig {
-                    amount: MAX_GAS_FOR_TESTING,
+                    amount,
                     address,
                     keypair: cloned_keypair.clone(),
                 });
@@ -149,7 +163,7 @@ impl WorkloadBuilder<dyn Payload> for TransferObjectWorkloadBuilder {
         for _i in 0..self.num_payloads {
             let (address, keypair) = (owner, address_map.get(&owner).unwrap().clone());
             gas_configs.push(GasCoinConfig {
-                amount: MAX_GAS_FOR_TESTING,
+                amount,
                 address,
                 keypair: keypair.clone(),
             });

--- a/crates/sui-benchmark/src/workloads/workload.rs
+++ b/crates/sui-benchmark/src/workloads/workload.rs
@@ -12,7 +12,8 @@ use crate::ValidatorProxy;
 
 // This is the maximum gas we will transfer from primary coin into any gas coin
 // for running the benchmark
-pub const MAX_GAS_FOR_TESTING: u64 = 10_000_000_000_000;
+pub const MAX_GAS_FOR_TESTING: u64 = 100_000_000_000;
+pub const MAX_BUDGET_FOR_TESTING: u64 = 50_000_000_000;
 
 #[async_trait]
 pub trait WorkloadBuilder<T: Payload + ?Sized>: Send + Sync + std::fmt::Debug {

--- a/crates/sui-benchmark/src/workloads/workload.rs
+++ b/crates/sui-benchmark/src/workloads/workload.rs
@@ -12,8 +12,17 @@ use crate::ValidatorProxy;
 
 // This is the maximum gas we will transfer from primary coin into any gas coin
 // for running the benchmark
-pub const MAX_GAS_FOR_TESTING: u64 = 100_000_000_000;
-pub const MAX_BUDGET_FOR_TESTING: u64 = 50_000_000_000;
+pub const MAX_GAS_FOR_TESTING: u64 = 1_000_000_000_000;
+
+// TODO: get this information from protocol config
+// This is the maximum budget that can be set for a transaction. 50 SUI.
+pub const MAX_BUDGET: u64 = 50_000_000_000;
+// (COIN_BYTES_SIZE * STORAGE_PRICE * STORAGE_UNITS_PER_BYTE)
+pub const STORAGE_COST_PER_COIN: u64 = 130 * 76 * 100;
+// (COUNTER_BYTES_SIZE * STORAGE_PRICE * STORAGE_UNITS_PER_BYTE)
+pub const STORAGE_COST_PER_COUNTER: u64 = 341 * 76 * 100;
+/// Used to estimate the budget required for each transaction.
+pub const ESTIMATED_COMPUTATION_COST: u64 = 1_000_000;
 
 #[async_trait]
 pub trait WorkloadBuilder<T: Payload + ?Sized>: Send + Sync + std::fmt::Debug {

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -255,7 +255,7 @@ mod test {
                 .await,
         );
 
-        let bank = BenchmarkBank::new(proxy.clone(), primary_gas, pay_coin);
+        let bank = BenchmarkBank::new(proxy.clone(), primary_gas, vec![pay_coin]);
         let system_state_observer = {
             let mut system_state_observer = SystemStateObserver::new(proxy.clone());
             if let Ok(_) = system_state_observer.state.changed().await {


### PR DESCRIPTION
This should mostly get us back to the place we were before the genesis changes and more! Unlocked `BatchSize` to the maximum allowed amount of 511*

\* this is due to the maximum arguments in a programmable transaction of 512, which includes the gas coin used.

Notes
- We do enforce using a `FullnodeProxy` when running remote, will follow up with a path to fetch gas objects using `LocalProxy`
- `Adversarial` workload below needs to be fully fixed in a follow up PR 
    `LargeObjects`,
    `LargeEvents`,
    `LargeTransientRuntimeVectors`,
    `LargePureFunctionArgs`,

## Test Plan 

Example Usage
```
cargo run --package sui-benchmark --bin stress -- --fullnode-rpc-addresses "http://fullnode-internal.staging.sui.io:9000" --num-client-threads 24 --num-server-threads 1 --num-transfer-accounts 2 --local false --genesis-blob-path ~/Desktop/genesis.blob --keystore-path ~/Desktop/sui.keystore bench --target-qps 5 --in-flight-ratio 30 --shared-counter 1 --transfer-object 1 --delegation 1 --batch-payment 1 --batch-payment-size 10 --adversarial 0 --client-metric-host 0.0.0.0 --num-workers 24 --gas-request-chunk-size 500 --primary-gas-owner-id 0x7d20dcdb2bca4f508ea9613994683eb4e76e9c4ed371169677c1be02aaf0b58e
```

Workload sanity test against staging

☑️  1000 Transfer TPS
```
Benchmark Report:
+-------------+-----+-----+--------+---------------+---------------+---------------+-----------------------+----------------------------+
| duration(s) | tps | cps | error% | latency (min) | latency (p50) | latency (p99) | gas used (MIST total) | gas used/hr (MIST approx.) |
+=======================================================================================================================================+
| 135         | 769 | 769 | 0      | 60            | 11351         | 32383         | 2,480,436,480,000     | 66,144,972,800,000         |
+-------------+-----+-----+--------+---------------+---------------+---------------+-----------------------+----------------------------+
```

☑️  1000 Shared TPS
```
Benchmark Report:
+-------------+-----+-----+--------+---------------+---------------+---------------+-----------------------+----------------------------+
| duration(s) | tps | cps | error% | latency (min) | latency (p50) | latency (p99) | gas used (MIST total) | gas used/hr (MIST approx.) |
+=======================================================================================================================================+
| 135         | 769 | 769 | 0      | 60            | 11351         | 32383         | 2,480,436,480,000     | 66,144,972,800,000         |
+-------------+-----+-----+--------+---------------+---------------+---------------+-----------------------+----------------------------+
```

☑️  10 Delegation TPS
```
Benchmark Report:
+-------------+-----+-----+--------+---------------+---------------+---------------+-----------------------+----------------------------+
| duration(s) | tps | cps | error% | latency (min) | latency (p50) | latency (p99) | gas used (MIST total) | gas used/hr (MIST approx.) |
+=======================================================================================================================================+
| 21          | 10  | 15  | 0      | 59            | 91            | 2581          | 2,752,736,400         | 471,897,668,571            |
+-------------+-----+-----+--------+---------------+---------------+---------------+-----------------------+----------------------------+
```

☑️  100 Batch TPS w/ Batch Size 511
```
Benchmark Report:
+-------------+-----+-------+--------+---------------+---------------+---------------+-----------------------+----------------------------+
| duration(s) | tps | cps   | error% | latency (min) | latency (p50) | latency (p99) | gas used (MIST total) | gas used/hr (MIST approx.) |
+=========================================================================================================================================+
| 53          | 27  | 13910 | 0      | 967           | 18879         | 40447         | 2,788,721,712,000     | 189,422,606,852,830        |
+-------------+-----+-------+--------+---------------+---------------+---------------+-----------------------+----------------------------+
```

☑️ 1 Adversarial TPS for [non Large* workloads](https://github.com/MystenLabs/sui/blob/arun/stress-fix/crates/sui-benchmark/src/workloads/adversarial.rs#L39-L56)
```
Benchmark Report:
+-------------+-----+-----+--------+---------------+---------------+---------------+-----------------------+----------------------------+
| duration(s) | tps | cps | error% | latency (min) | latency (p50) | latency (p99) | gas used (MIST total) | gas used/hr (MIST approx.) |
+=======================================================================================================================================+
| 61          | 5   | 56  | 0      | 232           | 1059          | 3521          | 20,051,402,400        | 1,183,361,453,114          |
+-------------+-----+-----+--------+---------------+---------------+---------------+-----------------------+----------------------------+
```