### PR TITLE
[ts-sdk] Normalize sui addresses more in the builder + convenience methods

### DIFF
--- a/sdk/typescript/src/builder/Inputs.ts
+++ b/sdk/typescript/src/builder/Inputs.ts
@@ -45,11 +45,31 @@ export const Inputs = {
       ),
     };
   },
-  ObjectRef(ref: SuiObjectRef): ObjectCallArg {
-    return { Object: { ImmOrOwned: ref } };
+  ObjectRef({ objectId, digest, version }: SuiObjectRef): ObjectCallArg {
+    return {
+      Object: {
+        ImmOrOwned: {
+          digest,
+          version,
+          objectId: normalizeSuiAddress(objectId),
+        },
+      },
+    };
   },
-  SharedObjectRef(ref: SharedObjectRef): ObjectCallArg {
-    return { Object: { Shared: ref } };
+  SharedObjectRef({
+    objectId,
+    mutable,
+    initialSharedVersion,
+  }: SharedObjectRef): ObjectCallArg {
+    return {
+      Object: {
+        Shared: {
+          mutable,
+          initialSharedVersion,
+          objectId: normalizeSuiAddress(objectId),
+        },
+      },
+    };
   },
 };
 
@@ -58,9 +78,9 @@ export function getIdFromCallArg(arg: ObjectId | ObjectCallArg) {
     return normalizeSuiAddress(arg);
   }
   if ('ImmOrOwned' in arg.Object) {
-    return arg.Object.ImmOrOwned.objectId;
+    return normalizeSuiAddress(arg.Object.ImmOrOwned.objectId);
   }
-  return arg.Object.Shared.objectId;
+  return normalizeSuiAddress(arg.Object.Shared.objectId);
 }
 
 export function getSharedObjectInput(

--- a/sdk/typescript/src/builder/TransactionBlock.ts
+++ b/sdk/typescript/src/builder/TransactionBlock.ts
@@ -269,6 +269,22 @@ export class TransactionBlock {
   }
 
   /**
+   * Add a new object input to the transaction using the fully-resolved object reference.
+   * If you only have an object ID, use `builder.object(id)` instead.
+   */
+  objectRef(...args: Parameters<(typeof Inputs)['ObjectRef']>) {
+    return this.object(Inputs.ObjectRef(...args));
+  }
+
+  /**
+   * Add a new shared object input to the transaction using the fully-resolved shared object reference.
+   * If you only have an object ID, use `builder.object(id)` instead.
+   */
+  sharedObjectRef(...args: Parameters<(typeof Inputs)['SharedObjectRef']>) {
+    return this.object(Inputs.SharedObjectRef(...args));
+  }
+
+  /**
    * Add a new non-object input to the transaction.
    */
   pure(


### PR DESCRIPTION
## Description

This normalizes Sui addresses more in the transaction builder so that there are fewer ways for address shorthand to flow through to bcs (eventually we might want to do some normalize there but that's a little scarier for me).

I also added `builder.objectRef()` and `builder.sharedObjectRef()` shorthand methods so that folks don't need to manually use the `Input` to construct a valid reference.

## Test Plan

Tests should still pass.
