### PR TITLE
[source-validation]  Support validating upgraded deps

### DIFF
--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -137,7 +137,7 @@ pub fn compile_nfts_package() -> CompiledPackage {
 }
 
 pub fn compile_example_package(relative_path: &str) -> CompiledPackage {
-    move_package::package_hooks::register_package_hooks(Box::new(SuiPackageHooks {}));
+    move_package::package_hooks::register_package_hooks(Box::new(SuiPackageHooks));
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push(relative_path);
 

--- a/crates/sui-core/src/unit_tests/move_package_publish_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_publish_tests.rs
@@ -17,7 +17,7 @@ use sui_types::{
 
 use move_package::source_package::manifest_parser;
 use sui_framework_build::compiled_package::{
-    check_unpublished_dependencies, gather_dependencies, BuildConfig,
+    check_unpublished_dependencies, gather_published_ids, BuildConfig,
 };
 use sui_types::{
     crypto::{get_key_pair, AccountKeyPair},
@@ -281,7 +281,7 @@ async fn test_custom_property_check_unpublished_dependencies() {
         .expect("Could not build resolution graph.");
 
     let SuiError::ModulePublishFailure { error } =
-        check_unpublished_dependencies(&gather_dependencies(&resolution_graph).unpublished)
+        check_unpublished_dependencies(&gather_published_ids(&resolution_graph).1.unpublished)
             .err()
             .unwrap()
      else {

--- a/crates/sui-framework-build/src/compiled_package.rs
+++ b/crates/sui-framework-build/src/compiled_package.rs
@@ -27,7 +27,6 @@ use move_core_types::{
     account_address::AccountAddress,
     language_storage::{ModuleId, StructTag, TypeTag},
 };
-use move_package::source_package::parsed_manifest::CustomDepInfo;
 use move_package::{
     compilation::{
         build_plan::BuildPlan, compiled_package::CompiledPackage as MoveCompiledPackage,
@@ -35,6 +34,9 @@ use move_package::{
     package_hooks::PackageHooks,
     resolution::resolution_graph::ResolvedGraph,
     BuildConfig as MoveBuildConfig,
+};
+use move_package::{
+    resolution::resolution_graph::Package, source_package::parsed_manifest::CustomDepInfo,
 };
 use move_symbol_pool::Symbol;
 use serde_reflection::Registry;
@@ -49,8 +51,11 @@ use sui_verifier::verifier as sui_bytecode_verifier;
 use crate::{MOVE_STDLIB_PACKAGE_NAME, SUI_PACKAGE_NAME, SUI_SYSTEM_PACKAGE_NAME};
 
 /// Wrapper around the core Move `CompiledPackage` with some Sui-specific traits and info
+#[derive(Debug)]
 pub struct CompiledPackage {
     pub package: MoveCompiledPackage,
+    /// Address the package is recorded as being published at.
+    pub published_at: Result<ObjectID, PublishedAtError>,
     /// The dependency IDs of this package
     pub dependency_ids: PackageDependencies,
     /// Path to the Move package (i.e., where the Move.toml file is)
@@ -165,7 +170,8 @@ pub fn build_from_resolution_graph(
     run_bytecode_verifier: bool,
     print_diags_to_stderr: bool,
 ) -> SuiResult<CompiledPackage> {
-    let dependency_ids = gather_dependencies(&resolution_graph);
+    let (published_at, dependency_ids) = gather_published_ids(&resolution_graph);
+
     let result = if print_diags_to_stderr {
         BuildConfig::compile_package(resolution_graph, &mut std::io::stderr())
     } else {
@@ -195,6 +201,7 @@ pub fn build_from_resolution_graph(
     }
     Ok(CompiledPackage {
         package,
+        published_at,
         dependency_ids,
         path,
     })
@@ -628,6 +635,7 @@ impl PackageHooks for SuiPackageHooks {
     }
 }
 
+#[derive(Debug)]
 pub struct PackageDependencies {
     /// Set of published dependencies (name and address).
     pub published: BTreeMap<Symbol, ObjectID>,
@@ -637,52 +645,73 @@ pub struct PackageDependencies {
     pub invalid: BTreeMap<Symbol, String>,
 }
 
+#[derive(Debug)]
+pub enum PublishedAtError {
+    Invalid(String),
+    NotPresent,
+}
+
 /// Gather transitive package dependencies, partitioned into two sets:
 /// - published dependencies (which contain `published-at` address in manifest); and
 /// - unpublished dependencies (no `published-at` address in manifest).
-pub fn gather_dependencies(resolution_graph: &ResolvedGraph) -> PackageDependencies {
+
+/// Partition packages in `resolution_graph` into one of four groups:
+/// - The ID that the package itself is published at (if it is published)
+/// - The IDs of dependencies that have been published
+/// - The names of packages that have not been published on chain.
+/// - The names of packages that have a `published-at` field that isn't filled with a valid address.
+pub fn gather_published_ids(
+    resolution_graph: &ResolvedGraph,
+) -> (Result<ObjectID, PublishedAtError>, PackageDependencies) {
+    let root = resolution_graph.root_package();
+
     let mut published = BTreeMap::new();
     let mut unpublished = BTreeSet::new();
     let mut invalid = BTreeMap::new();
+    let mut published_at = Err(PublishedAtError::NotPresent);
 
-    for name in resolution_graph.graph.package_table.keys() {
-        if let Some(package) = &resolution_graph.package_table.get(name) {
-            let value = package
-                .source_package
-                .package
-                .custom_properties
-                .get(&Symbol::from(PUBLISHED_AT_MANIFEST_FIELD));
-
-            if value.is_none() {
-                unpublished.insert(*name);
-                continue;
-            }
-
-            if let Some(id) = value.and_then(|v| ObjectID::from_str(v.as_str()).ok()) {
-                published.insert(*name, id);
-            } else {
-                invalid.insert(*name, value.unwrap().to_string());
-            }
+    for (name, package) in &resolution_graph.package_table {
+        let property = published_at_property(package);
+        if name == &root {
+            // Separate out the root package as a special case
+            published_at = property;
+            continue;
         }
+
+        match property {
+            Ok(id) => {
+                published.insert(*name, id);
+            }
+            Err(PublishedAtError::NotPresent) => {
+                unpublished.insert(*name);
+            }
+            Err(PublishedAtError::Invalid(value)) => {
+                invalid.insert(*name, value);
+            }
+        };
     }
 
-    PackageDependencies {
-        published,
-        unpublished,
-        invalid,
-    }
+    (
+        published_at,
+        PackageDependencies {
+            published,
+            unpublished,
+            invalid,
+        },
+    )
 }
 
-pub fn root_published_at(resolution_graph: &ResolvedGraph) -> Option<ObjectID> {
-    let published_at = resolution_graph
-        .package_table
-        .get(&resolution_graph.graph.root_package)
-        .unwrap()
+pub fn published_at_property(package: &Package) -> Result<ObjectID, PublishedAtError> {
+    let Some(value) = package
         .source_package
         .package
         .custom_properties
-        .get(&Symbol::from(PUBLISHED_AT_MANIFEST_FIELD))?;
-    ObjectID::from_str(published_at.as_str()).ok()
+        .get(&Symbol::from(PUBLISHED_AT_MANIFEST_FIELD))
+    else {
+        return Err(PublishedAtError::NotPresent);
+    };
+
+    ObjectID::from_str(value.as_str()).map_err(|_| PublishedAtError::Invalid(value.to_owned()))
 }
 
 pub fn check_unpublished_dependencies(unpublished: &BTreeSet<Symbol>) -> Result<(), SuiError> {

--- a/crates/sui-framework-build/src/compiled_package.rs
+++ b/crates/sui-framework-build/src/compiled_package.rs
@@ -608,7 +608,7 @@ impl GetModule for CompiledPackage {
 
 pub const PUBLISHED_AT_MANIFEST_FIELD: &str = "published-at";
 
-pub struct SuiPackageHooks {}
+pub struct SuiPackageHooks;
 
 impl PackageHooks for SuiPackageHooks {
     fn custom_package_info_fields(&self) -> Vec<String> {

--- a/crates/sui-framework-build/src/compiled_package.rs
+++ b/crates/sui-framework-build/src/compiled_package.rs
@@ -651,10 +651,6 @@ pub enum PublishedAtError {
     NotPresent,
 }
 
-/// Gather transitive package dependencies, partitioned into two sets:
-/// - published dependencies (which contain `published-at` address in manifest); and
-/// - unpublished dependencies (no `published-at` address in manifest).
-
 /// Partition packages in `resolution_graph` into one of four groups:
 /// - The ID that the package itself is published at (if it is published)
 /// - The IDs of dependencies that have been published

--- a/crates/sui-framework/build.rs
+++ b/crates/sui-framework/build.rs
@@ -16,7 +16,7 @@ const DOCS_DIR: &str = "docs";
 
 /// Save revision info to environment variable
 fn main() {
-    move_package::package_hooks::register_package_hooks(Box::new(SuiPackageHooks {}));
+    move_package::package_hooks::register_package_hooks(Box::new(SuiPackageHooks));
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     let packages_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("packages");
 

--- a/crates/sui-json-rpc-types/src/object_changes.rs
+++ b/crates/sui-json-rpc-types/src/object_changes.rs
@@ -5,7 +5,7 @@ use move_core_types::language_storage::StructTag;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use sui_types::base_types::{ObjectDigest, ObjectID, SequenceNumber, SuiAddress};
+use sui_types::base_types::{ObjectDigest, ObjectID, ObjectRef, SequenceNumber, SuiAddress};
 use sui_types::object::Owner;
 use sui_types::sui_serde::SuiStructTag;
 
@@ -90,6 +90,41 @@ impl ObjectChange {
             | ObjectChange::Deleted { object_id, .. }
             | ObjectChange::Wrapped { object_id, .. }
             | ObjectChange::Created { object_id, .. } => *object_id,
+        }
+    }
+
+    pub fn object_ref(&self) -> ObjectRef {
+        match self {
+            ObjectChange::Published {
+                package_id,
+                version,
+                digest,
+                ..
+            } => (*package_id, *version, *digest),
+            ObjectChange::Transferred {
+                object_id,
+                version,
+                digest,
+                ..
+            }
+            | ObjectChange::Mutated {
+                object_id,
+                version,
+                digest,
+                ..
+            }
+            | ObjectChange::Created {
+                object_id,
+                version,
+                digest,
+                ..
+            } => (*object_id, *version, *digest),
+            ObjectChange::Deleted {
+                object_id, version, ..
+            } => (*object_id, *version, ObjectDigest::OBJECT_DIGEST_DELETED),
+            ObjectChange::Wrapped {
+                object_id, version, ..
+            } => (*object_id, *version, ObjectDigest::OBJECT_DIGEST_WRAPPED),
         }
     }
 

--- a/crates/sui-source-validation/fixture/a/Move.toml
+++ b/crates/sui-source-validation/fixture/a/Move.toml
@@ -1,6 +1,10 @@
 [package]
 name = "a"
 version = "0.0.1"
+published-at = "$STORAGE_ID"
 
 [dependencies]
 b = { local = "../b" }
+
+[addresses]
+a = "$RUNTIME_ID"

--- a/crates/sui-source-validation/fixture/b-v2/Move.toml
+++ b/crates/sui-source-validation/fixture/b-v2/Move.toml
@@ -1,0 +1,7 @@
+[package]
+name = "b"
+version = "0.0.2"
+published-at = "$STORAGE_ID"
+
+[addresses]
+b = "$RUNTIME_ID"

--- a/crates/sui-source-validation/fixture/b-v2/sources/b.move
+++ b/crates/sui-source-validation/fixture/b-v2/sources/b.move
@@ -1,0 +1,12 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module b::b {
+    public fun b(): u64 {
+        42
+    }
+
+    public fun c(): u64 {
+        b() + 1
+    }
+}

--- a/crates/sui-source-validation/fixture/b-v2/sources/c.move
+++ b/crates/sui-source-validation/fixture/b-v2/sources/c.move
@@ -1,0 +1,8 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module b::c {
+    public fun c(): u64 {
+        43
+    }
+}

--- a/crates/sui-source-validation/fixture/b-v2/sources/d.move
+++ b/crates/sui-source-validation/fixture/b-v2/sources/d.move
@@ -1,0 +1,8 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module b::d {
+    public fun d(): u64 {
+        44
+    }
+}

--- a/crates/sui-source-validation/fixture/b/Move.toml
+++ b/crates/sui-source-validation/fixture/b/Move.toml
@@ -1,3 +1,7 @@
 [package]
 name = "b"
 version = "0.0.1"
+published-at = "$STORAGE_ID"
+
+[addresses]
+b = "$RUNTIME_ID"

--- a/crates/sui-source-validation/fixture/c/Move.toml
+++ b/crates/sui-source-validation/fixture/c/Move.toml
@@ -1,3 +1,7 @@
 [package]
 name = "c"
 version = "0.0.1"
+published-at = "$STORAGE_ID"
+
+[addresses]
+c = "$RUNTIME_ID"

--- a/crates/sui-source-validation/fixture/d/Move.toml
+++ b/crates/sui-source-validation/fixture/d/Move.toml
@@ -1,7 +1,11 @@
 [package]
 name = "d"
 version = "0.0.1"
+published-at = "$STORAGE_ID"
 
 [dependencies]
 b = { local = "../b" }
 c = { local = "../c" }
+
+[addresses]
+d = "$RUNTIME_ID"

--- a/crates/sui-source-validation/fixture/e/Move.toml
+++ b/crates/sui-source-validation/fixture/e/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "e"
+version = "0.0.1"
+published-at = "$STORAGE_ID"
+
+[dependencies]
+b = { local = "../b-v2" }
+
+[addresses]
+e = "$RUNTIME_ID"

--- a/crates/sui-source-validation/fixture/e/sources/e.move
+++ b/crates/sui-source-validation/fixture/e/sources/e.move
@@ -1,0 +1,11 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module e::e {
+    use b::b::b;
+    use b::b::c;
+    
+    public fun e() : u64 {
+        b() + c()
+    }
+}

--- a/crates/sui-source-validation/fixture/z/Move.toml
+++ b/crates/sui-source-validation/fixture/z/Move.toml
@@ -1,6 +1,10 @@
 [package]
 name = "z"
 version = "0.0.1"
+published-at = "$STORAGE_ID"
 
 [dependencies]
 Sui = { local = "$REPO_ROOT/crates/sui-framework/packages/sui-framework" }
+
+[addresses]
+z = "$RUNTIME_ID"

--- a/crates/sui-source-validation/src/lib.rs
+++ b/crates/sui-source-validation/src/lib.rs
@@ -259,18 +259,19 @@ impl<'a> BytecodeSourceVerifier<'a> {
         let mut map = OnChainModules::new();
         let mut err = vec![];
 
-        for (address, pkg) in addresses.zip(resp) {
+        for (storage_id, pkg) in addresses.zip(resp) {
             let SuiRawMovePackage { module_map, .. } = pkg?;
             for (name, bytes) in module_map {
                 let Ok(module) = CompiledModule::deserialize(&bytes) else {
                     err.push(SourceVerificationError::OnChainDependencyDeserializationError {
-                        address,
+                        address: storage_id,
                         module: name.into(),
                     });
                     continue;
                 };
 
-                map.insert((address, Symbol::from(name)), module);
+                let runtime_id = *module.self_id().address();
+                map.insert((runtime_id, Symbol::from(name)), module);
             }
         }
 

--- a/crates/sui-source-validation/src/lib.rs
+++ b/crates/sui-source-validation/src/lib.rs
@@ -99,7 +99,6 @@ pub enum SourceMode {
 }
 
 pub struct BytecodeSourceVerifier<'a> {
-    pub verbose: bool,
     rpc_client: &'a ReadApi,
 }
 
@@ -110,11 +109,8 @@ type LocalBytes = HashMap<(AccountAddress, Symbol), (Symbol, Vec<u8>)>;
 type OnChainBytes = HashMap<(AccountAddress, Symbol), Vec<u8>>;
 
 impl<'a> BytecodeSourceVerifier<'a> {
-    pub fn new(rpc_client: &'a ReadApi, verbose: bool) -> Self {
-        BytecodeSourceVerifier {
-            verbose,
-            rpc_client,
-        }
+    pub fn new(rpc_client: &'a ReadApi) -> Self {
+        BytecodeSourceVerifier { rpc_client }
     }
 
     /// Helper wrapper to verify that all local Move package dependencies' and root bytecode matches
@@ -200,15 +196,6 @@ impl<'a> BytecodeSourceVerifier<'a> {
                     package,
                     module,
                 });
-            }
-
-            if self.verbose {
-                println!(
-                    "{}::{} - {} bytes, code matches",
-                    package.as_ref(),
-                    module.as_ref(),
-                    on_chain_bytes.len()
-                );
             }
         }
 

--- a/crates/sui-source-validation/src/tests.rs
+++ b/crates/sui-source-validation/src/tests.rs
@@ -46,7 +46,7 @@ async fn successful_verification() -> anyhow::Result<()> {
         )
     };
     let client = context.get_client().await?;
-    let verifier = BytecodeSourceVerifier::new(client.read_api(), false);
+    let verifier = BytecodeSourceVerifier::new(client.read_api());
     let a_addr: SuiAddress = a_ref.0.into();
 
     // Skip deps and root
@@ -103,7 +103,7 @@ async fn successful_verification_unpublished_deps() -> anyhow::Result<()> {
     let a_ref = publish_package_and_deps(context, sender, a_src).await;
 
     let client = context.get_client().await?;
-    let verifier = BytecodeSourceVerifier::new(client.read_api(), false);
+    let verifier = BytecodeSourceVerifier::new(client.read_api());
 
     // Verify the root package which now includes dependency modules
     verifier
@@ -141,7 +141,7 @@ async fn successful_verification_module_ordering() -> anyhow::Result<()> {
     };
 
     let client = context.get_client().await?;
-    let verifier = BytecodeSourceVerifier::new(client.read_api(), false);
+    let verifier = BytecodeSourceVerifier::new(client.read_api());
 
     let verify_deps = false;
     verifier
@@ -175,7 +175,7 @@ async fn fail_verification_bad_address() -> anyhow::Result<()> {
         )
     };
     let client = context.get_client().await?;
-    let verifier = BytecodeSourceVerifier::new(client.read_api(), false);
+    let verifier = BytecodeSourceVerifier::new(client.read_api());
 
     let expected = expect!["On-chain address cannot be zero"];
     expected.assert_eq(
@@ -201,7 +201,7 @@ async fn fail_to_verify_unpublished_root() -> anyhow::Result<()> {
     };
 
     let client = context.get_client().await?;
-    let verifier = BytecodeSourceVerifier::new(client.read_api(), false);
+    let verifier = BytecodeSourceVerifier::new(client.read_api());
 
     // Trying to verify the root package, which hasn't been published -- this is going to fail
     // because there is no on-chain package to verify against.
@@ -246,7 +246,7 @@ async fn rpc_call_failed_during_verify() -> anyhow::Result<()> {
     let _a_addr: SuiAddress = a_ref.0.into();
 
     let client = context.get_client().await?;
-    let _verifier = BytecodeSourceVerifier::new(client.read_api(), false);
+    let _verifier = BytecodeSourceVerifier::new(client.read_api());
 
     /*
     // TODO: Dropping cluster no longer stops the network. Need to look into this and see
@@ -294,7 +294,7 @@ async fn package_not_found() -> anyhow::Result<()> {
     };
 
     let client = context.get_client().await?;
-    let verifier = BytecodeSourceVerifier::new(client.read_api(), false);
+    let verifier = BytecodeSourceVerifier::new(client.read_api());
 
     let Err(err) = verifier.verify_package_deps(&a_pkg.package).await else {
         panic!("Expected verification to fail");
@@ -348,7 +348,7 @@ async fn dependency_is_an_object() -> anyhow::Result<()> {
         compile_package(a_src)
     };
     let client = context.get_client().await?;
-    let verifier = BytecodeSourceVerifier::new(client.read_api(), false);
+    let verifier = BytecodeSourceVerifier::new(client.read_api());
 
     let expected = expect!["Dependency ID contains a Sui object, not a Move package: 0x0000000000000000000000000000000000000000000000000000000000000005"];
     expected.assert_eq(
@@ -383,7 +383,7 @@ async fn module_not_found_on_chain() -> anyhow::Result<()> {
         compile_package(a_src)
     };
     let client = context.get_client().await?;
-    let verifier = BytecodeSourceVerifier::new(client.read_api(), false);
+    let verifier = BytecodeSourceVerifier::new(client.read_api());
 
     let Err(err) = verifier.verify_package_deps(&a_pkg.package).await else {
         panic!("Expected verification to fail");
@@ -419,7 +419,7 @@ async fn module_not_found_locally() -> anyhow::Result<()> {
     };
 
     let client = context.get_client().await?;
-    let verifier = BytecodeSourceVerifier::new(client.read_api(), false);
+    let verifier = BytecodeSourceVerifier::new(client.read_api());
 
     let Err(err) = verifier.verify_package_deps(&a_pkg.package).await else {
         panic!("Expected verification to fail");
@@ -473,7 +473,7 @@ async fn module_bytecode_mismatch() -> anyhow::Result<()> {
     stable_addrs.insert(a_addr, "<a_addr>");
 
     let client = context.get_client().await?;
-    let verifier = BytecodeSourceVerifier::new(client.read_api(), false);
+    let verifier = BytecodeSourceVerifier::new(client.read_api());
 
     let Err(err) = verifier.verify_package_deps(&a_pkg.package).await else {
         panic!("Expected verification to fail");
@@ -531,7 +531,7 @@ async fn multiple_failures() -> anyhow::Result<()> {
     };
 
     let client = context.get_client().await?;
-    let verifier = BytecodeSourceVerifier::new(client.read_api(), false);
+    let verifier = BytecodeSourceVerifier::new(client.read_api());
 
     let Err(err) = verifier.verify_package_deps(&d_pkg.package).await else {
         panic!("Expected verification to fail");

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1104,7 +1104,7 @@ impl SuiClientCommands {
 
                 let client = context.get_client().await?;
 
-                BytecodeSourceVerifier::new(client.read_api(), false)
+                BytecodeSourceVerifier::new(client.read_api())
                     .verify_package(
                         &compiled_package.package,
                         verify_deps,
@@ -1183,7 +1183,7 @@ async fn compile_package(
     }
     let compiled_modules = compiled_package.get_package_bytes(with_unpublished_dependencies);
     if !skip_dependency_verification {
-        BytecodeSourceVerifier::new(client.read_api(), false)
+        BytecodeSourceVerifier::new(client.read_api())
             .verify_package_deps(&compiled_package.package)
             .await?;
         eprintln!(

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -33,7 +33,7 @@ use sui_types::error::SuiError;
 use shared_crypto::intent::Intent;
 use sui_framework_build::compiled_package::{
     build_from_resolution_graph, check_invalid_dependencies, check_unpublished_dependencies,
-    gather_dependencies, root_published_at, BuildConfig, CompiledPackage, PackageDependencies,
+    gather_published_ids, BuildConfig, CompiledPackage, PackageDependencies, PublishedAtError,
 };
 use sui_json::SuiJsonValue;
 use sui_json_rpc_types::{
@@ -499,6 +499,16 @@ impl SuiClientCommands {
                     )
                     .await?;
 
+                let package_id = package_id.map_err(|e| match e {
+                    PublishedAtError::NotPresent => {
+                        anyhow!("No 'published-at' field in manifest for package to be upgraded.")
+                    }
+                    PublishedAtError::Invalid(v) => anyhow!(
+                        "Invalid 'published-at' field in manifest of package to be upgraded. \
+                         Expected an on-chain address, but found: {v:?}"
+                    ),
+                })?;
+
                 let resp = context
                     .get_client()
                     .await?
@@ -532,7 +542,7 @@ impl SuiClientCommands {
                     .transaction_builder()
                     .upgrade(
                         sender,
-                        package_id.unwrap(),
+                        package_id,
                         compiled_modules,
                         dependencies.published.into_values().collect(),
                         upgrade_capability,
@@ -1106,7 +1116,7 @@ impl SuiClientCommands {
 
                 BytecodeSourceVerifier::new(client.read_api())
                     .verify_package(
-                        &compiled_package.package,
+                        &compiled_package,
                         verify_deps,
                         match (skip_source, address_override) {
                             (true, _) => SourceMode::Skip,
@@ -1141,7 +1151,7 @@ async fn compile_package(
         PackageDependencies,
         Vec<Vec<u8>>,
         CompiledPackage,
-        Option<ObjectID>,
+        Result<ObjectID, PublishedAtError>,
     ),
     anemo::Error,
 > {
@@ -1154,8 +1164,7 @@ async fn compile_package(
         print_diags_to_stderr,
     };
     let resolution_graph = config.resolution_graph(&package_path)?;
-    let dependencies = gather_dependencies(&resolution_graph);
-    let package_id = root_published_at(&resolution_graph);
+    let (package_id, dependencies) = gather_published_ids(&resolution_graph);
     check_invalid_dependencies(&dependencies.invalid)?;
     if !with_unpublished_dependencies {
         check_unpublished_dependencies(&dependencies.unpublished)?;
@@ -1184,7 +1193,7 @@ async fn compile_package(
     let compiled_modules = compiled_package.get_package_bytes(with_unpublished_dependencies);
     if !skip_dependency_verification {
         BytecodeSourceVerifier::new(client.read_api())
-            .verify_package_deps(&compiled_package.package)
+            .verify_package_deps(&compiled_package)
             .await?;
         eprintln!(
             "{}",

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -149,7 +149,7 @@ pub enum SuiCommand {
 
 impl SuiCommand {
     pub async fn execute(self) -> Result<(), anyhow::Error> {
-        move_package::package_hooks::register_package_hooks(Box::new(SuiPackageHooks {}));
+        move_package::package_hooks::register_package_hooks(Box::new(SuiPackageHooks));
         match self {
             SuiCommand::Start {
                 config,

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -912,10 +912,12 @@ async fn test_package_publish_nonexistent_dependency() -> Result<(), anyhow::Err
     .execute(context)
     .await;
 
-    assert!(&result
-        .unwrap_err()
-        .to_string()
-        .contains("DependentPackageNotFound"));
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("Dependency object does not exist or was deleted"),
+        "{}",
+        err
+    );
     Ok(())
 }
 

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -924,7 +924,7 @@ async fn test_package_publish_nonexistent_dependency() -> Result<(), anyhow::Err
 #[sim_test]
 #[ignore]
 async fn test_package_upgrade_command() -> Result<(), anyhow::Error> {
-    move_package::package_hooks::register_package_hooks(Box::new(SuiPackageHooks {}));
+    move_package::package_hooks::register_package_hooks(Box::new(SuiPackageHooks));
     let mut test_cluster = TestClusterBuilder::new().build().await?;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;

--- a/crates/test-utils/src/transaction.rs
+++ b/crates/test-utils/src/transaction.rs
@@ -214,9 +214,9 @@ pub async fn upgrade_package_with_wallet(
         let signature = context
             .config
             .keystore
-            .sign_secure(&sender, &data, Intent::default())
+            .sign_secure(&sender, &data, Intent::sui_transaction())
             .unwrap();
-        Transaction::from_data(data, Intent::default(), vec![signature])
+        Transaction::from_data(data, Intent::sui_transaction(), vec![signature])
             .verify()
             .unwrap()
     };

--- a/crates/test-utils/src/transaction.rs
+++ b/crates/test-utils/src/transaction.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use move_core_types::language_storage::StructTag;
 use serde_json::json;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -15,7 +16,7 @@ pub use sui_core::test_utils::{
     compile_basics_package, compile_nfts_package, wait_for_all_txes, wait_for_tx,
 };
 use sui_json_rpc_types::{
-    SuiObjectDataOptions, SuiObjectResponseQuery, SuiTransactionBlockDataAPI,
+    ObjectChange, SuiObjectDataOptions, SuiObjectResponseQuery, SuiTransactionBlockDataAPI,
     SuiTransactionBlockEffectsAPI, SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions,
 };
 use sui_keys::keystore::AccountKeystore;
@@ -31,7 +32,9 @@ use sui_types::messages::{
     TransactionEffects, TransactionEffectsAPI, TransactionEvents, VerifiedTransaction,
 };
 use sui_types::messages::{ExecuteTransactionRequestType, HandleCertificateResponse};
+use sui_types::move_package::UpgradePolicy;
 use sui_types::object::{Object, Owner};
+use sui_types::SUI_FRAMEWORK_ADDRESS;
 use sui_types::SUI_FRAMEWORK_OBJECT_ID;
 
 use crate::authority::get_client;
@@ -95,7 +98,7 @@ pub async fn publish_nfts_package(
         package.get_dependency_original_package_ids(),
     )
     .await;
-    (result.0 .0, result.1)
+    (result.0 .0, result.2)
 }
 /// Helper function to publish basic package.
 pub async fn publish_basics_package(context: &WalletContext, sender: SuiAddress) -> ObjectRef {
@@ -116,7 +119,7 @@ pub async fn publish_package_with_wallet(
     sender: SuiAddress,
     all_module_bytes: Vec<Vec<u8>>,
     dep_ids: Vec<ObjectID>,
-) -> (ObjectRef, TransactionDigest) {
+) -> (ObjectRef, ObjectRef, TransactionDigest) {
     let client = context.get_client().await.unwrap();
     let gas_price = context.get_reference_gas_price().await.unwrap();
     let transaction = {
@@ -146,7 +149,83 @@ pub async fn publish_package_with_wallet(
         .quorum_driver()
         .execute_transaction_block(
             transaction,
-            SuiTransactionBlockResponseOptions::new().with_effects(),
+            SuiTransactionBlockResponseOptions::new().with_object_changes(),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+        )
+        .await
+        .unwrap();
+
+    assert!(resp.confirmed_local_execution.unwrap());
+    let changes = resp.object_changes.unwrap();
+    (
+        changes
+            .iter()
+            .find(|change| matches!(change, ObjectChange::Published { .. }))
+            .unwrap()
+            .object_ref(),
+        changes
+            .iter()
+            .find(|change| {
+                matches!(change, ObjectChange::Created {
+                    owner: Owner::AddressOwner(_),
+                    object_type: StructTag {
+                        address: SUI_FRAMEWORK_ADDRESS,
+                        module,
+                        name,
+                        ..
+                    },
+                    ..
+                } if module.as_str() == "package" && name.as_str() == "UpgradeCap")
+            })
+            .unwrap()
+            .object_ref(),
+        resp.digest,
+    )
+}
+
+pub async fn upgrade_package_with_wallet(
+    context: &WalletContext,
+    sender: SuiAddress,
+    package_id: ObjectID,
+    upgrade_cap: ObjectID,
+    all_module_bytes: Vec<Vec<u8>>,
+    dep_ids: Vec<ObjectID>,
+    digest: Vec<u8>,
+) -> (ObjectRef, TransactionDigest) {
+    let client = context.get_client().await.unwrap();
+    let gas_price = context.get_reference_gas_price().await.unwrap();
+    let transaction = {
+        let data = client
+            .transaction_builder()
+            .upgrade(
+                sender,
+                package_id,
+                all_module_bytes,
+                dep_ids,
+                upgrade_cap,
+                UpgradePolicy::COMPATIBLE,
+                digest,
+                None,
+                GAS_BUDGET_IN_UNIT * gas_price,
+            )
+            .await
+            .unwrap();
+
+        let signature = context
+            .config
+            .keystore
+            .sign_secure(&sender, &data, Intent::default())
+            .unwrap();
+        Transaction::from_data(data, Intent::default(), vec![signature])
+            .verify()
+            .unwrap()
+    };
+
+    let resp = client
+        .quorum_driver()
+        .execute_transaction_block(
+            transaction,
+            SuiTransactionBlockResponseOptions::new().with_object_changes(),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await
@@ -154,14 +233,12 @@ pub async fn publish_package_with_wallet(
 
     assert!(resp.confirmed_local_execution.unwrap());
     (
-        resp.effects
+        resp.object_changes
             .unwrap()
-            .created()
             .iter()
-            .find(|obj_ref| obj_ref.owner == Owner::Immutable)
+            .find(|change| matches!(change, ObjectChange::Published { .. }))
             .unwrap()
-            .reference
-            .to_object_ref(),
+            .object_ref(),
         resp.digest,
     )
 }


### PR DESCRIPTION
## Description 

Make source validation aware that packages could be upgraded, meaning that the address they are published at is different from their module self-addresses.

## Test Plan 

New test for source validation + upgrades

```
sui-source-validation$ cargo nextest -- successful_verification_upgrades
```

(+ Updating all existing tests to reference the `published-at` address of a package.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Unblocks publishing a package that depends on an upgraded package, and use of `sui client verify-source` on an upgraded package.