### PR TITLE
[explorer]: add Banner variances

### DIFF
--- a/apps/explorer/src/pages/validator/ValidatorDetails.tsx
+++ b/apps/explorer/src/pages/validator/ValidatorDetails.tsx
@@ -95,18 +95,22 @@ function ValidatorDetails() {
             </div>
             {atRiskRemainingEpochs !== null && (
                 <div className="mt-5">
-                    <Banner fullWidth variant="error">
-                        <div className="flex flex-col gap-1">
+                    <Banner
+                        fullWidth
+                        border
+                        variant="error"
+                        title={
                             <Text uppercase variant="bodySmall/semibold">
                                 at risk of being removed as a validator after{' '}
                                 {atRiskRemainingEpochs} epoch
                                 {atRiskRemainingEpochs > 1 ? 's' : ''}
                             </Text>
-                            <Text variant="bodySmall/medium">
-                                Staked SUI is below the minimum SUI stake
-                                threshold to remain a validator.
-                            </Text>
-                        </div>
+                        }
+                    >
+                        <Text variant="bodySmall/medium">
+                            Staked SUI is below the minimum SUI stake threshold
+                            to remain a validator.
+                        </Text>
                     </Banner>
                 </div>
             )}

--- a/apps/explorer/src/ui/Banner.tsx
+++ b/apps/explorer/src/ui/Banner.tsx
@@ -8,8 +8,10 @@ import { type ReactNode } from 'react';
 import { IconButton } from './IconButton';
 import { ReactComponent as InfoIcon } from './icons/info.svg';
 
+import { Text } from '~/ui/Text';
+
 const bannerStyles = cva(
-    'inline-flex text-p2 font-medium rounded-lg overflow-hidden gap-2 items-center flex-nowrap relative',
+    'inline-flex text-p2 font-medium rounded-2xl overflow-hidden gap-2 items-center flex-nowrap relative',
     {
         variants: {
             variant: {
@@ -17,6 +19,8 @@ const bannerStyles = cva(
                 warning: 'bg-warning-light text-warning-dark',
                 error: 'bg-issue-light text-issue-dark',
                 message: 'bg-sui-light text-hero',
+                neutralGrey: 'bg-steel text-white',
+                neutralWhite: 'bg-white text-steel-darker',
             },
             align: {
                 left: 'justify-start',
@@ -29,27 +33,69 @@ const bannerStyles = cva(
                 md: 'px-3 py-2',
                 lg: 'p-5',
             },
+            shadow: {
+                true: 'shadow-md',
+            },
+            border: {
+                true: '',
+            },
         },
         defaultVariants: {
             variant: 'message',
             spacing: 'md',
         },
+        compoundVariants: [
+            {
+                variant: 'positive',
+                border: true,
+                class: 'border border-success/30',
+            },
+            {
+                variant: 'warning',
+                border: true,
+                class: 'border border-warning-dark/30',
+            },
+            {
+                variant: 'error',
+                border: true,
+                class: 'border border-issue-dark/30',
+            },
+            {
+                variant: 'message',
+                border: true,
+                class: 'border border-sui/30',
+            },
+            {
+                variant: 'neutralGrey',
+                border: true,
+                class: 'border border-steel',
+            },
+            {
+                variant: 'neutralWhite',
+                border: true,
+                class: 'border border-gray-45',
+            },
+        ],
     }
 );
 
 export interface BannerProps extends VariantProps<typeof bannerStyles> {
     icon?: ReactNode | null;
+    title?: ReactNode | string;
     children: ReactNode;
     onDismiss?: () => void;
 }
 
 export function Banner({
     icon = <InfoIcon />,
+    title,
     children,
     variant,
     align,
     fullWidth,
     spacing,
+    border,
+    shadow,
     onDismiss,
 }: BannerProps) {
     return (
@@ -58,6 +104,8 @@ export function Banner({
                 variant,
                 align,
                 fullWidth,
+                shadow,
+                border,
                 spacing,
                 class: onDismiss && 'pr-9',
             })}
@@ -65,7 +113,10 @@ export function Banner({
             {icon && (
                 <div className="flex items-center justify-center">{icon}</div>
             )}
-            <div className="overflow-hidden break-words">{children}</div>
+            <div className="flex flex-col gap-1">
+                {title && <Text variant="bodySmall/semibold">{title}</Text>}
+                <div className="overflow-hidden break-words">{children}</div>
+            </div>
             {onDismiss ? (
                 <div className="absolute right-0 top-0">
                     <IconButton

--- a/apps/explorer/src/ui/stories/Banner.stories.tsx
+++ b/apps/explorer/src/ui/stories/Banner.stories.tsx
@@ -15,6 +15,7 @@ export const Positive: StoryObj<BannerProps> = {
     args: {
         variant: 'positive',
         children: 'Positive',
+        border: true,
     },
 };
 
@@ -36,6 +37,21 @@ export const Message: StoryObj<BannerProps> = {
     args: {
         variant: 'message',
         children: 'Message',
+    },
+};
+
+export const NeutralGrey: StoryObj<BannerProps> = {
+    args: {
+        variant: 'neutralGrey',
+        children: 'Neutral Grey',
+        border: false,
+    },
+};
+
+export const NeutralWhite: StoryObj<BannerProps> = {
+    args: {
+        variant: 'neutralWhite',
+        children: 'Neutral White',
     },
 };
 
@@ -98,4 +114,25 @@ export const DismissibleCenteredFullWidth: StoryObj<BannerProps> = {
         children: 'Message',
         onDismiss: () => null,
     },
+};
+
+const variants = [
+    'positive',
+    'warning',
+    'error',
+    'message',
+    'neutralGrey',
+    'neutralWhite',
+];
+
+export const BannersWithBorder = {
+    render: () => (
+        <div className="flex flex-col gap-2">
+            {variants.map((variant) => (
+                <Banner key={variant} border shadow variant={variant as any}>
+                    <div className="capitalize">{variant}</div>
+                </Banner>
+            ))}
+        </div>
+    ),
 };


### PR DESCRIPTION
## Description 

https://mysten.atlassian.net/browse/APPS-730
- Add more variances to banner

<img width="1438" alt="Screenshot 2023-04-04 at 1 40 55 PM" src="https://user-images.githubusercontent.com/127577476/229915461-ec2c5f52-188c-4370-b78b-c851d8dce285.png">


## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
