### PR TITLE
[wallet-ext] Fix displaying publish transactions

### DIFF
--- a/apps/wallet/src/ui/app/pages/approval-request/transaction-request/TransactionDetails/Command.tsx
+++ b/apps/wallet/src/ui/app/pages/approval-request/transaction-request/TransactionDetails/Command.tsx
@@ -8,6 +8,8 @@ import {
     type TransactionType,
     normalizeSuiAddress,
     type MakeMoveVecTransaction,
+    type PublishTransaction,
+    toB64,
 } from '@mysten/sui.js';
 import { useState } from 'react';
 
@@ -16,24 +18,32 @@ import { Text } from '_src/ui/app/shared/text';
 function convertCommandArgumentToString(
     arg:
         | string
+        | number
         | string[]
+        | number[]
         | TransactionArgument
         | TransactionArgument[]
         | MakeMoveVecTransaction['type']
+        | PublishTransaction['modules']
 ): string | null {
     if (!arg) return null;
 
-    if (typeof arg === 'string') return arg;
+    if (typeof arg === 'string' || typeof arg === 'number') return String(arg);
 
-    if ('None' in arg) {
+    if (typeof arg === 'object' && 'None' in arg) {
         return null;
     }
 
-    if ('Some' in arg) {
+    if (typeof arg === 'object' && 'Some' in arg) {
         return arg.Some;
     }
 
     if (Array.isArray(arg)) {
+        // Publish transaction special casing:
+        if (typeof arg[0] === 'number') {
+            return toB64(new Uint8Array(arg as number[]));
+        }
+
         return `[${arg
             .map((argVal) => convertCommandArgumentToString(argVal))
             .join(', ')}]`;


### PR DESCRIPTION
## Description 

Fixes the `publish` transaction on wallet so that we correctly show the bytes instead of failing.

## Test Plan 

With my hands.