### PR TITLE
Prolog tx cannot fail execution

### DIFF
--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -380,7 +380,7 @@ fn execution_loop<
                 move_vm,
                 gas_status,
                 protocol_config,
-            )?;
+            ).expect("ConsensusCommitPrologue cannot fail");
             Ok(Mode::empty_results())
         }
         TransactionKind::ProgrammableTransaction(pt) => {


### PR DESCRIPTION
Make sure prolog system tx can never fail. This also make it easier to debug if it does