### PR TITLE
[sui-proxy/ add inventory_hostname]

### DIFF
--- a/crates/sui-proxy/src/admin.rs
+++ b/crates/sui-proxy/src/admin.rs
@@ -104,9 +104,16 @@ pub fn make_reqwest_client(settings: RemoteWriteConfig) -> ReqwestClient {
     }
 }
 
+// Labels are adhoc labels we will inject per our config
+#[derive(Clone)]
+pub struct Labels {
+    pub network: String,
+    pub inventory_hostname: String,
+}
+
 /// App will configure our routes. This fn is also used to instrument our tests
 pub fn app(
-    network: String,
+    labels: Labels,
     client: ReqwestClient,
     relay: HistogramRelay,
     allower: Option<SuiNodeProvider>,
@@ -123,7 +130,7 @@ pub fn app(
     }
     router
         .layer(Extension(relay))
-        .layer(Extension(network))
+        .layer(Extension(labels))
         .layer(Extension(client))
         .layer(
             ServiceBuilder::new().layer(

--- a/crates/sui-proxy/src/config.rs
+++ b/crates/sui-proxy/src/config.rs
@@ -12,6 +12,7 @@ use tracing::debug;
 #[serde(rename_all = "kebab-case")]
 pub struct ProxyConfig {
     pub network: String,
+    pub inventory_hostname: String,
     pub listen_address: SocketAddr,
     pub remote_write: RemoteWriteConfig,
     pub json_rpc: PeerValidationConfig,

--- a/crates/sui-proxy/src/data/config.yaml
+++ b/crates/sui-proxy/src/data/config.yaml
@@ -1,4 +1,5 @@
 network: joenet
+inventory-hostname: joenet-local
 listen-address: 192.168.0.2:8080
 remote-write:
   url: http://unittest.abcd.io/api/v1/push

--- a/crates/sui-proxy/src/lib.rs
+++ b/crates/sui-proxy/src/lib.rs
@@ -34,6 +34,7 @@ macro_rules! var {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::admin::Labels;
     use crate::histogram_relay::HistogramRelay;
     use crate::prom_to_mimir::tests::*;
 
@@ -108,7 +109,10 @@ mod tests {
             tls_info.public_key().unwrap().to_string()
         }
         let app = admin::app(
-            "unittest-network".into(),
+            Labels {
+                network: "unittest-network".into(),
+                inventory_hostname: "ansible_inventory_name".into(),
+            },
             client,
             HistogramRelay::new(),
             Some(allower.clone()),

--- a/crates/sui-proxy/src/main.rs
+++ b/crates/sui-proxy/src/main.rs
@@ -7,7 +7,7 @@ use sui_proxy::config::ProxyConfig;
 use sui_proxy::{
     admin::{
         app, create_server_cert_default_allow, create_server_cert_enforce_peer,
-        make_reqwest_client, server, VERSION,
+        make_reqwest_client, server, Labels, VERSION,
     },
     config::load,
     histogram_relay, metrics,
@@ -64,7 +64,15 @@ async fn main() -> Result<()> {
     prometheus_registry
         .register(mysten_metrics::uptime_metric(VERSION))
         .unwrap();
-    let app = app(config.network, client, histogram_relay, allower);
+    let app = app(
+        Labels {
+            network: config.network,
+            inventory_hostname: config.inventory_hostname,
+        },
+        client,
+        histogram_relay,
+        allower,
+    );
 
     server(listener, app, Some(acceptor)).await.unwrap();
 


### PR DESCRIPTION
Summary:

* add an inventory_hostname to our config so we can write that label for metrics that go via remote_push.
* this is important to add since we'll have more than one proxy and we want to know what proxy it passed through
* we need a label different from host since that is the validator host field.  For this, we use the field `relay_host`.

Test Plan:

local


---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
