### PR TITLE
[loader] Fix linker/loader backward compatibility

### DIFF
--- a/crates/sui-adapter/src/programmable_transactions/context.rs
+++ b/crates/sui-adapter/src/programmable_transactions/context.rs
@@ -217,7 +217,7 @@ impl<'vm, 'state, 'a, 'b, S: StorageView> ExecutionContext<'vm, 'state, 'a, 'b, 
         let resolver = self.session.get_resolver();
         if resolver.has_linkage(package_id) {
             // Setting same context again, can skip.
-            return Ok(resolver.original_package_id());
+            return Ok(resolver.original_package_id().unwrap_or(*package_id));
         }
 
         let package =

--- a/crates/sui-adapter/src/programmable_transactions/linkage_view.rs
+++ b/crates/sui-adapter/src/programmable_transactions/linkage_view.rs
@@ -183,11 +183,11 @@ impl<'state, S: StorageView> LinkageView<'state, S> {
         self.state_view
     }
 
-    pub fn original_package_id(&self) -> AccountAddress {
+    pub fn original_package_id(&self) -> Option<AccountAddress> {
         if let LinkageInfo::Set(linkage) = &self.linkage_info {
-            linkage.runtime_id
+            Some(linkage.runtime_id)
         } else {
-            AccountAddress::ZERO
+            None
         }
     }
 

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -8,7 +8,6 @@ use fastcrypto::encoding::{Base64, Encoding};
 use fastcrypto::hash::HashFunction;
 use fastcrypto::traits::KeyPair;
 use move_binary_format::CompiledModule;
-use move_core_types::account_address::AccountAddress;
 use move_core_types::ident_str;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_with::serde_as;
@@ -1485,6 +1484,7 @@ fn process_package(
     #[cfg(debug_assertions)]
     {
         use std::collections::HashSet;
+        use move_core_types::account_address::AccountAddress;
         let to_be_published_addresses: HashSet<_> = modules
             .iter()
             .map(|module| *module.self_id().address())

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -1483,8 +1483,8 @@ fn process_package(
     // that don't exist on-chain because they are yet to be published.
     #[cfg(debug_assertions)]
     {
-        use std::collections::HashSet;
         use move_core_types::account_address::AccountAddress;
+        use std::collections::HashSet;
         let to_be_published_addresses: HashSet<_> = modules
             .iter()
             .map(|module| *module.self_id().address())


### PR DESCRIPTION
## Description 

When running with backward compatibility enabled, we were incorrectly returning 0x0 as the original package ID for packages, and then passing that in as the package ID for the function being called, which caused an error when we tried to fetch a package at that address.

## Test Plan 

Re-sync fullnode with testnet, running the new node software, previously it was forking immediately, now it works fine.


---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
