### PR TITLE
Gate sui conservation check on protocol version

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1381,6 +1381,15 @@ impl AuthorityStore {
         if !self.enable_epoch_sui_conservation_check {
             return Ok(());
         }
+        let protocol_version = ProtocolVersion::new(
+            self.get_sui_system_state_object()
+                .expect("Read sui system state object cannot fail")
+                .protocol_version(),
+        );
+        // Prior to gas model v2, SUI conservation is not guaranteed.
+        if ProtocolConfig::get_for_version(protocol_version).gas_model_version() <= 1 {
+            return Ok(());
+        }
 
         let mut total_storage_rebate = 0;
         let mut total_sui = 0;

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -103,6 +103,11 @@ pub struct AuthorityPerpetualTables {
     /// expensive checks are enabled. We cannot use 10B today because in tests we often
     /// inject extra gas objects into genesis.
     pub(crate) expected_network_sui_amount: DBMap<(), u64>,
+
+    /// Expected imbalance between storage fund balance and the sum of storage rebate of all live objects.
+    /// This could be non-zero due to bugs in earlier protocol versions.
+    /// This number is the result of storage_fund_balance - sum(storage_rebate).
+    pub(crate) expected_storage_fund_imbalance: DBMap<(), i64>,
 }
 
 impl AuthorityPerpetualTables {

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -235,7 +235,10 @@ impl CheckpointExecutor {
         } else {
             assert_eq!(seq, 0);
         }
-        debug!("Bumping highest_executed_checkpoint watermark to {:?}", seq,);
+        debug!("Bumping highest_executed_checkpoint watermark to {:?}", seq);
+        if seq % 10000 == 0 {
+            info!("Finished syncing and executing checkpoint {}", seq);
+        }
 
         self.checkpoint_store
             .update_highest_executed_checkpoint(checkpoint)


### PR DESCRIPTION
We can only start SUI conservation check after the network has switched to gas model v2.
Also added info! every 10000 checkpoints we sync. This will help us monitor progress on a fullnode locally