### PR TITLE
[experiment] cache type layout for Coin<SUI>

### DIFF
--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -271,7 +271,12 @@ impl MoveObject {
         format: ObjectFormatOptions,
         resolver: &impl GetModule,
     ) -> Result<MoveStructLayout, SuiError> {
-        Self::get_layout_from_struct_tag(self.type_().clone().into(), format, resolver)
+        if self.type_().is_gas_coin() {
+            // optimization for common Coin<SUI> case
+            Ok(GasCoin::layout())
+        } else {
+            Self::get_layout_from_struct_tag(self.type_().clone().into(), format, resolver)
+        }
     }
 
     pub fn get_layout_from_struct_tag(


### PR DESCRIPTION
## Description 

Describe the changes or additions included in this PR.

Every call to `get_object(id)` actually does a lot of work:
1. Find the object associated with `id`
2. If it's a Move object, get the type and compute the type layout
3. Use the type layout to create a nice human-readable version of the object

Step (2) is more expensive than you might think--to compute a type layout for `M::T`, we will:
- Fetch the package containing `M`
- Serialize `M` and look up the definition of `T`
- If the definition of `T` contains another non-primitive type `M'::T'`, we will continue the process recursively with `M'::T'`

I'm wondering if this is making `get_object` slow, and whether adding a type -> layout cache in key places (e.g., https://github.com/MystenLabs/sui/blob/main/crates/sui-indexer/src/store/pg_indexer_store.rs#L99) would help. This PR is a lightweight experiment that "caches" the layout for `Coin<SUI>` (the most common object type by far) to get an idea of whether this is worth pursuing. This cache would also benefit events (which also need to compute type layouts), and would probably not be too hard if it's helpful.

## Test Plan 

Looking for ideas to test whether this helps or not.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
