### PR TITLE
[test] ensure narwhal certificate signers are processed and return in same order

### DIFF
--- a/narwhal/test-utils/src/lib.rs
+++ b/narwhal/test-utils/src/lib.rs
@@ -723,6 +723,7 @@ pub struct Builder<R = OsRng> {
     number_of_workers: NonZeroUsize,
     randomize_ports: bool,
     epoch: Epoch,
+    stake: VecDeque<Stake>,
 }
 
 impl Default for Builder {
@@ -739,6 +740,7 @@ impl Builder {
             committee_size: NonZeroUsize::new(4).unwrap(),
             number_of_workers: NonZeroUsize::new(4).unwrap(),
             randomize_ports: false,
+            stake: VecDeque::new(),
         }
     }
 }
@@ -764,6 +766,11 @@ impl<R> Builder<R> {
         self
     }
 
+    pub fn stake_distribution(mut self, stake: VecDeque<Stake>) -> Self {
+        self.stake = stake;
+        self
+    }
+
     pub fn rng<N: rand::RngCore + rand::CryptoRng>(self, rng: N) -> Builder<N> {
         Builder {
             rng,
@@ -771,12 +778,17 @@ impl<R> Builder<R> {
             committee_size: self.committee_size,
             number_of_workers: self.number_of_workers,
             randomize_ports: self.randomize_ports,
+            stake: self.stake,
         }
     }
 }
 
 impl<R: rand::RngCore + rand::CryptoRng> Builder<R> {
     pub fn build(mut self) -> CommitteeFixture {
+        if !self.stake.is_empty() {
+            assert_eq!(self.stake.len(), self.committee_size.get(), "Stake vector has been provided but is different length the committe - it should be the same");
+        }
+
         let mut authorities: Vec<AuthorityFixture> = (0..self.committee_size.get())
             .map(|_| {
                 AuthorityFixture::generate(
@@ -793,12 +805,16 @@ impl<R: rand::RngCore + rand::CryptoRng> Builder<R> {
             })
             .collect();
 
+        // now order the AuthorityFixtures by the authority PublicKey so when we iterate either via the
+        // committee.authorities() or via the fixture.authorities() we'll get the same order.
+        authorities.sort_by_key(|a1| a1.public_key());
+
         // create the committee in order to assign the ids to the authorities
         let mut committee_builder = CommitteeBuilder::new(self.epoch);
         for a in authorities.iter() {
             committee_builder = committee_builder.add_authority(
                 a.public_key().clone(),
-                a.stake,
+                self.stake.pop_front().unwrap_or(1),
                 a.address.clone(),
                 a.network_public_key(),
             );
@@ -811,11 +827,17 @@ impl<R: rand::RngCore + rand::CryptoRng> Builder<R> {
                 .authority_by_key(authority.keypair.public())
                 .unwrap();
             authority.authority = OnceCell::with_value(a.clone());
+            authority.stake = a.stake();
         }
 
-        // now order the AuthorityFixtures by the authority id so when we iterate either via the
-        // committee.authorities() or via the fixture.authorities() we'll get the same order.
-        authorities.sort_by_key(|a1| a1.authority().id());
+        // Now update the stake to follow the order of the authorities so we produce expected results
+        let authorities: Vec<AuthorityFixture> = authorities
+            .into_iter()
+            .map(|mut authority| {
+                authority.stake = self.stake.pop_front().unwrap_or(1);
+                authority
+            })
+            .collect();
 
         CommitteeFixture {
             authorities,

--- a/narwhal/types/tests/primary_tests.rs
+++ b/narwhal/types/tests/primary_tests.rs
@@ -1,0 +1,61 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use config::{AuthorityIdentifier, Committee, Stake};
+use crypto::{PublicKey, Signature};
+use fastcrypto::traits::KeyPair;
+use indexmap::IndexMap;
+use narwhal_types::{Certificate, Header, HeaderV1, Vote, VoteAPI};
+use rand::rngs::OsRng;
+use rand::seq::SliceRandom;
+use std::collections::BTreeSet;
+use std::num::NonZeroUsize;
+use test_utils::{AuthorityFixture, CommitteeFixture};
+
+#[tokio::test]
+async fn test_certificate_signed_correctly() {
+    // GIVEN
+    let fixture = CommitteeFixture::builder()
+        .committee_size(NonZeroUsize::new(4).unwrap())
+        .stake_distribution((1..=4).collect()) // provide some non-uniform stake
+        .build();
+    let committee: Committee = fixture.committee();
+
+    let authorities = fixture.authorities().collect::<Vec<&AuthorityFixture>>();
+
+    // The authority that creates the Header
+    let authority = authorities[0];
+
+    let header = HeaderV1::new(authority.id(), 1, 1, IndexMap::new(), BTreeSet::new()).await;
+
+    // WHEN
+    let mut votes: Vec<(AuthorityIdentifier, Signature)> = Vec::new();
+    let mut sorted_singers: Vec<PublicKey> = Vec::new();
+
+    // The authorities on position 1, 2, 3 are the ones who would sign
+    for authority in &authorities[1..=3] {
+        sorted_singers.push(authority.keypair().public().clone());
+
+        let vote = Vote::new_with_signer(
+            &Header::V1(header.clone()),
+            &authority.id(),
+            authority.keypair(),
+        );
+        votes.push((vote.author(), vote.signature().clone()));
+    }
+
+    // Just shuffle to ensure that any underlying sorting will work correctly
+    votes.shuffle(&mut OsRng);
+
+    // Create a certificate
+    let certificate = Certificate::new_unverified(&committee, Header::V1(header), votes).unwrap();
+
+    let (stake, signers) = certificate.signed_by(&committee);
+
+    // THEN
+    assert_eq!(signers.len(), 3);
+
+    // AND authorities public keys are returned in order
+    assert_eq!(signers, sorted_singers);
+
+    assert_eq!(stake, 9 as Stake);
+}

--- a/narwhal/types/tests/primary_tests.rs
+++ b/narwhal/types/tests/primary_tests.rs
@@ -12,7 +12,7 @@ use std::num::NonZeroUsize;
 use test_utils::{AuthorityFixture, CommitteeFixture};
 
 #[tokio::test]
-async fn test_certificate_signed_correctly() {
+async fn test_certificate_singers_are_ordered() {
     // GIVEN
     let fixture = CommitteeFixture::builder()
         .committee_size(NonZeroUsize::new(4).unwrap())


### PR DESCRIPTION
## Description 

Resolves https://github.com/MystenLabs/sui/issues/9816 . An integration test that ensures NW certificate signatures are processed in public key alphabetical order - as in SUI.

## Test Plan 

Introduced integration test.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
