### PR TITLE
[State Accumulator] Gate assertion in state accumulator behind protocol config

### DIFF
--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -1681,7 +1681,10 @@ pub async fn send_and_confirm_transaction_(
     let mut state = state_acc.accumulate_live_object_set();
     let result = authority.try_execute_for_test(&certificate).await?;
     let state_after = state_acc.accumulate_live_object_set();
-    let effects_acc = state_acc.accumulate_effects(vec![result.inner().data().clone()]);
+    let effects_acc = state_acc.accumulate_effects(
+        vec![result.inner().data().clone()],
+        epoch_store.protocol_config(),
+    );
     state.union(&effects_acc);
 
     assert_eq!(state_after.digest(), state.digest());


### PR DESCRIPTION
When an earlier fix was landed for unwrapping objects (PR #10260), this assertion was not gated behind the protocol config for the change.

This updates the state accumulator assertion to be behind the same feature flag as the bug fix.

