### PR TITLE
add tests for current safe mode code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8885,6 +8885,7 @@ dependencies = [
  "shared-crypto",
  "shell-words",
  "signature 1.6.4",
+ "sui-adapter",
  "sui-config",
  "sui-core",
  "sui-framework",

--- a/crates/sui-benchmark/src/workloads/delegation.rs
+++ b/crates/sui-benchmark/src/workloads/delegation.rs
@@ -51,7 +51,7 @@ impl Payload for DelegationTestPayload {
                 coin,
                 self.validator,
                 self.sender,
-                &self.keypair,
+                self.keypair.as_ref(),
                 Some(
                     self.system_state_observer
                         .state

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -28,6 +28,7 @@ rand = "0.8.5"
 tap = "1.0"
 inquire = "0.6.0"
 
+sui-adapter = { path = "../sui-adapter" }
 sui-core = { path = "../sui-core" }
 sui-framework = { path = "../sui-framework" }
 sui-framework-build = { path = "../sui-framework-build" }


### PR DESCRIPTION
## Description 

Add a simple safe mode test using similar trick as `sui_system_injection` to inject epoch change failure.

## Test Plan 

Added a test.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
