### PR TITLE
[fix] committed sub dag timestamp backwards compatibility

### DIFF
--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -130,7 +130,7 @@ impl<T: ParentSync + Send + Sync> ExecutionState for ConsensusHandler<T> {
 
         /* (serialized, transaction, output_cert) */
         let mut transactions = vec![];
-        let timestamp = consensus_output.sub_dag.commit_timestamp;
+        let timestamp = consensus_output.sub_dag.commit_timestamp();
 
         let epoch_start = self
             .epoch_store


### PR DESCRIPTION
## Description 

As part of https://github.com/MystenLabs/sui/pull/10210 I've introduced the `commit_timestamp` field in the `CommittedSubdagShell`. When this feature gets rolled out via a protocol upgrade we'll come across two issues:
* CommittedSubdagShell deserialisation will probably fail as the field will be absent from the stored sub dags
* even if the above wasn't an issue, the field will be zero leading to timestamp inconsistencies

to bypass the above on this PR I am:
* adding as default the zero to the `CommittedSubdagShell` when deserialising
* adding a method to fallback to leader's timestamp when the `committed_timestamp` is zero, to ensure that we'll remain consistent.

## Test Plan 

Unit tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
