### PR TITLE
[wallet-ext][explorer] disable autocapture for PostHog

### DIFF
--- a/apps/core/src/PostHogAnalyticsProvider.tsx
+++ b/apps/core/src/PostHogAnalyticsProvider.tsx
@@ -25,6 +25,7 @@ export function PostHogAnalyticsProvider({
                 persistence: 'memory',
                 // We need to manually collect page view events since we use client-side routing
                 capture_pageview: false,
+                autocapture: false,
             }}
         >
             {children}


### PR DESCRIPTION
## Description 

This PR disables `autocapture` because we blew through our trial event volume, and I think we have a decent enough measure of our volume at this point.

## Test Plan 
- Manual testing (only page views are recorded)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
N/A
