### PR TITLE
[JSONRPC] - offload jsonrpc call to todo blocking thread for method with large response

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2003,39 +2003,45 @@ impl AuthorityState {
     }
 
     pub async fn get_object_read(&self, object_id: &ObjectID) -> Result<ObjectRead, SuiError> {
-        match self.database.get_object_or_tombstone(*object_id)? {
-            None => Ok(ObjectRead::NotExists(*object_id)),
-            Some(obj_ref) => {
-                if obj_ref.2.is_alive() {
-                    match self.database.get_object_by_key(object_id, obj_ref.1)? {
-                        None => {
-                            error!("Object with in parent_entry is missing from object store, datastore is inconsistent");
-                            Err(UserInputError::ObjectNotFound {
-                                object_id: *object_id,
-                                version: Some(obj_ref.1),
+        let database = self.database.clone();
+        let module_cache = self
+            .load_epoch_store_one_call_per_task()
+            .module_cache()
+            .clone();
+        let object_id = *object_id;
+        tokio::task::spawn_blocking(move || {
+            match database.get_object_or_tombstone(object_id)? {
+                None => Ok(ObjectRead::NotExists(object_id)),
+                Some(obj_ref) => {
+                    if obj_ref.2.is_alive() {
+                        match database.get_object_by_key(&object_id, obj_ref.1)? {
+                            None => {
+                                error!("Object with in parent_entry is missing from object store, datastore is inconsistent");
+                                Err(UserInputError::ObjectNotFound {
+                                    object_id,
+                                    version: Some(obj_ref.1),
+                                }
+                                    .into())
                             }
-                            .into())
+                            Some(object) => {
+                                let layout = object.get_layout(
+                                    ObjectFormatOptions::default(),
+                                    // threading the epoch_store through this API does not
+                                    // seem possible, so we just read it from the state (self) and fetch
+                                    // the module cache out of it.
+                                    // Notice that no matter what module cache we get things
+                                    // should work
+                                    &module_cache,
+                                )?;
+                                Ok(ObjectRead::Exists(obj_ref, object, layout))
+                            }
                         }
-                        Some(object) => {
-                            let layout = object.get_layout(
-                                ObjectFormatOptions::default(),
-                                // threading the epoch_store through this API does not
-                                // seem possible, so we just read it from the state (self) and fetch
-                                // the module cache out of it.
-                                // Notice that no matter what module cache we get things
-                                // should work
-                                self.load_epoch_store_one_call_per_task()
-                                    .module_cache()
-                                    .as_ref(),
-                            )?;
-                            Ok(ObjectRead::Exists(obj_ref, object, layout))
-                        }
+                    } else {
+                        Ok(ObjectRead::Deleted(obj_ref))
                     }
-                } else {
-                    Ok(ObjectRead::Deleted(obj_ref))
                 }
             }
-        }
+        }).await.map_err(|e|SuiError::GenericStorageError(e.to_string()))?
     }
 
     pub async fn get_move_object<T>(&self, object_id: &ObjectID) -> SuiResult<T>
@@ -2492,89 +2498,95 @@ impl AuthorityState {
         descending: bool,
     ) -> Result<Vec<SuiEvent>, anyhow::Error> {
         let index_store = self.get_indexes()?;
+        let module_cache = self.epoch_store.load().module_cache().clone();
+        let database = self.database.clone();
 
-        //Get the tx_num from tx_digest
-        let (tx_num, event_num) = if let Some(cursor) = cursor.as_ref() {
-            let tx_seq = index_store.get_transaction_seq(&cursor.tx_digest)?.ok_or(
-                SuiError::TransactionNotFound {
-                    digest: cursor.tx_digest,
-                },
-            )?;
-            (tx_seq, cursor.event_seq as usize)
-        } else if descending {
-            (u64::MAX, usize::MAX)
-        } else {
-            (0, 0)
-        };
+        tokio::task::spawn_blocking(move || {
+            //Get the tx_num from tx_digest
+            let (tx_num, event_num) = if let Some(cursor) = cursor.as_ref() {
+                let tx_seq = index_store.get_transaction_seq(&cursor.tx_digest)?.ok_or(
+                    SuiError::TransactionNotFound {
+                        digest: cursor.tx_digest,
+                    },
+                )?;
+                (tx_seq, cursor.event_seq as usize)
+            } else if descending {
+                (u64::MAX, usize::MAX)
+            } else {
+                (0, 0)
+            };
 
-        let limit = limit + 1;
-        let mut event_keys = match query {
-            EventFilter::All(..) => index_store.all_events(tx_num, event_num, limit, descending)?,
-            EventFilter::Transaction(digest) => {
-                index_store.events_by_transaction(&digest, tx_num, event_num, limit, descending)?
-            }
-            EventFilter::MoveModule { package, module } => {
-                let module_id = ModuleId::new(package.into(), module);
-                index_store.events_by_module_id(&module_id, tx_num, event_num, limit, descending)?
-            }
-            EventFilter::MoveEventType(struct_name) => index_store
-                .events_by_move_event_struct_name(
-                    &struct_name,
-                    tx_num,
-                    event_num,
-                    limit,
-                    descending,
-                )?,
-            EventFilter::Sender(sender) => {
-                index_store.events_by_sender(&sender, tx_num, event_num, limit, descending)?
-            }
-            EventFilter::TimeRange {
-                start_time,
-                end_time,
-            } => index_store
-                .event_iterator(start_time, end_time, tx_num, event_num, limit, descending)?,
-            _ => {
-                return Err(anyhow!(
-                    "This query type is not supported by the full node."
-                ))
-            }
-        };
+            let limit = limit + 1;
+            let mut event_keys = match query {
+                EventFilter::All(..) => {
+                    index_store.all_events(tx_num, event_num, limit, descending)?
+                }
+                EventFilter::Transaction(digest) => index_store
+                    .events_by_transaction(&digest, tx_num, event_num, limit, descending)?,
+                EventFilter::MoveModule { package, module } => {
+                    let module_id = ModuleId::new(package.into(), module);
+                    index_store
+                        .events_by_module_id(&module_id, tx_num, event_num, limit, descending)?
+                }
+                EventFilter::MoveEventType(struct_name) => index_store
+                    .events_by_move_event_struct_name(
+                        &struct_name,
+                        tx_num,
+                        event_num,
+                        limit,
+                        descending,
+                    )?,
+                EventFilter::Sender(sender) => {
+                    index_store.events_by_sender(&sender, tx_num, event_num, limit, descending)?
+                }
+                EventFilter::TimeRange {
+                    start_time,
+                    end_time,
+                } => index_store
+                    .event_iterator(start_time, end_time, tx_num, event_num, limit, descending)?,
+                _ => {
+                    return Err(anyhow!(
+                        "This query type is not supported by the full node."
+                    ))
+                }
+            };
 
-        // skip one event if exclusive cursor is provided,
-        // otherwise truncate to the original limit.
-        if cursor.is_some() {
-            if !event_keys.is_empty() {
-                event_keys.remove(0);
+            // skip one event if exclusive cursor is provided,
+            // otherwise truncate to the original limit.
+            if cursor.is_some() {
+                if !event_keys.is_empty() {
+                    event_keys.remove(0);
+                }
+            } else {
+                event_keys.truncate(limit - 1);
             }
-        } else {
-            event_keys.truncate(limit - 1);
-        }
-        let keys = event_keys.iter().map(|(digest, _, seq, _)| (*digest, *seq));
+            let keys = event_keys.iter().map(|(digest, _, seq, _)| (*digest, *seq));
 
-        let stored_events = self
-            .database
-            .perpetual_tables
-            .events
-            .multi_get(keys)?
-            .into_iter()
-            .zip(event_keys.into_iter())
-            .map(|(e, (digest, tx_digest, event_seq, timestamp))| {
-                e.map(|e| (e, tx_digest, event_seq, timestamp))
-                    .ok_or(SuiError::TransactionEventsNotFound { digest })
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+            let stored_events = database
+                .perpetual_tables
+                .events
+                .multi_get(keys)?
+                .into_iter()
+                .zip(event_keys.into_iter())
+                .map(|(e, (digest, tx_digest, event_seq, timestamp))| {
+                    e.map(|e| (e, tx_digest, event_seq, timestamp))
+                        .ok_or(SuiError::TransactionEventsNotFound { digest })
+                })
+                .collect::<Result<Vec<_>, _>>()?;
 
-        let mut events = vec![];
-        for (e, tx_digest, event_seq, timestamp) in stored_events {
-            events.push(SuiEvent::try_from(
-                e,
-                tx_digest,
-                event_seq as u64,
-                Some(timestamp),
-                &**self.epoch_store.load().module_cache(),
-            )?)
-        }
-        Ok(events)
+            let mut events = vec![];
+            for (e, tx_digest, event_seq, timestamp) in stored_events {
+                events.push(SuiEvent::try_from(
+                    e,
+                    tx_digest,
+                    event_seq as u64,
+                    Some(timestamp),
+                    &module_cache,
+                )?)
+            }
+            Ok(events)
+        })
+        .await?
     }
 
     pub async fn insert_genesis_object(&self, object: Object) {

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2272,7 +2272,7 @@ impl AuthorityState {
         transaction.ok_or_else(|| anyhow!(SuiError::TransactionNotFound { digest }))
     }
 
-    pub async fn get_executed_effects(
+    pub fn get_executed_effects(
         &self,
         digest: TransactionDigest,
     ) -> Result<TransactionEffects, anyhow::Error> {
@@ -2280,21 +2280,21 @@ impl AuthorityState {
         effects.ok_or_else(|| anyhow!(SuiError::TransactionNotFound { digest }))
     }
 
-    pub async fn multi_get_executed_transactions(
+    pub fn multi_get_executed_transactions(
         &self,
         digests: &[TransactionDigest],
     ) -> Result<Vec<Option<VerifiedTransaction>>, anyhow::Error> {
         Ok(self.database.multi_get_transaction_blocks(digests)?)
     }
 
-    pub async fn multi_get_executed_effects(
+    pub fn multi_get_executed_effects(
         &self,
         digests: &[TransactionDigest],
     ) -> Result<Vec<Option<TransactionEffects>>, anyhow::Error> {
         Ok(self.database.multi_get_executed_effects(digests)?)
     }
 
-    pub async fn multi_get_transaction_checkpoint(
+    pub fn multi_get_transaction_checkpoint(
         &self,
         digests: &[TransactionDigest],
     ) -> Result<Vec<Option<(EpochId, CheckpointSequenceNumber)>>, anyhow::Error> {

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -61,7 +61,6 @@ async fn test_publishing_with_unpublished_deps() {
 
     let ObjectRead::Exists(read_ref, package_obj, _) = authority
         .get_object_read(&package.0)
-        .await
         .unwrap()
     else {
         panic!("Can't read package")

--- a/crates/sui-indexer/src/apis/coin_api.rs
+++ b/crates/sui-indexer/src/apis/coin_api.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
+use futures::executor::block_on;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::http_client::HttpClient;
 use jsonrpsee::RpcModule;
@@ -48,16 +49,12 @@ impl CoinReadApiServer for CoinReadApi {
         self.fullnode.get_all_coins(owner, cursor, limit).await
     }
 
-    async fn get_balance(
-        &self,
-        owner: SuiAddress,
-        coin_type: Option<String>,
-    ) -> RpcResult<Balance> {
-        self.fullnode.get_balance(owner, coin_type).await
+    fn get_balance(&self, owner: SuiAddress, coin_type: Option<String>) -> RpcResult<Balance> {
+        block_on(self.fullnode.get_balance(owner, coin_type))
     }
 
-    async fn get_all_balances(&self, owner: SuiAddress) -> RpcResult<Vec<Balance>> {
-        self.fullnode.get_all_balances(owner).await
+    fn get_all_balances(&self, owner: SuiAddress) -> RpcResult<Vec<Balance>> {
+        block_on(self.fullnode.get_all_balances(owner))
     }
 
     async fn get_coin_metadata(&self, coin_type: String) -> RpcResult<SuiCoinMetadata> {

--- a/crates/sui-indexer/src/apis/indexer_api.rs
+++ b/crates/sui-indexer/src/apis/indexer_api.rs
@@ -4,6 +4,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use futures::executor::block_on;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::http_client::HttpClient;
 use jsonrpsee::types::SubscriptionResult;
@@ -283,7 +284,7 @@ impl<S> IndexerApiServer for IndexerApi<S>
 where
     S: IndexerStore + Sync + Send + 'static,
 {
-    async fn get_owned_objects(
+    fn get_owned_objects(
         &self,
         address: SuiAddress,
         query: Option<SuiObjectResponseQuery>,
@@ -294,17 +295,17 @@ where
             .migrated_methods
             .contains(&"get_owned_objects".to_string())
         {
-            return self
-                .fullnode
-                .get_owned_objects(address, query, cursor, limit)
-                .await;
+            return block_on(
+                self.fullnode
+                    .get_owned_objects(address, query, cursor, limit),
+            );
         }
-        Ok(self
-            .get_owned_objects_interal(address, query, cursor, limit)
-            .await?)
+        Ok(block_on(
+            self.get_owned_objects_interal(address, query, cursor, limit),
+        )?)
     }
 
-    async fn query_transaction_blocks(
+    fn query_transaction_blocks(
         &self,
         query: SuiTransactionBlockResponseQuery,
         cursor: Option<TransactionDigest>,
@@ -315,15 +316,17 @@ where
             .migrated_methods
             .contains(&"query_transactions".to_string())
         {
-            return self
-                .fullnode
-                .query_transaction_blocks(query, cursor, limit, descending_order)
-                .await;
+            return block_on(self.fullnode.query_transaction_blocks(
+                query,
+                cursor,
+                limit,
+                descending_order,
+            ));
         }
         Ok(self.query_transactions_internal(query, cursor, limit, descending_order)?)
     }
 
-    async fn query_events(
+    fn query_events(
         &self,
         query: EventFilter,
         // exclusive cursor if `Some`, otherwise start from the beginning
@@ -332,23 +335,24 @@ where
         descending_order: Option<bool>,
     ) -> RpcResult<EventPage> {
         if self.migrated_methods.contains(&"get_events".to_string()) {
-            return self
-                .fullnode
-                .query_events(query, cursor, limit, descending_order)
-                .await;
+            return block_on(
+                self.fullnode
+                    .query_events(query, cursor, limit, descending_order),
+            );
         }
         Ok(self.get_events_internal(query, cursor, limit, descending_order)?)
     }
 
-    async fn get_dynamic_fields(
+    fn get_dynamic_fields(
         &self,
         parent_object_id: ObjectID,
         cursor: Option<ObjectID>,
         limit: Option<usize>,
     ) -> RpcResult<DynamicFieldPage> {
-        self.fullnode
-            .get_dynamic_fields(parent_object_id, cursor, limit)
-            .await
+        block_on(
+            self.fullnode
+                .get_dynamic_fields(parent_object_id, cursor, limit),
+        )
     }
 
     async fn get_dynamic_field_object(

--- a/crates/sui-indexer/src/apis/indexer_api.rs
+++ b/crates/sui-indexer/src/apis/indexer_api.rs
@@ -300,9 +300,7 @@ where
                     .get_owned_objects(address, query, cursor, limit),
             );
         }
-        Ok(block_on(
-            self.get_owned_objects_interal(address, query, cursor, limit),
-        )?)
+        block_on(self.get_owned_objects_interal(address, query, cursor, limit))
     }
 
     fn query_transaction_blocks(

--- a/crates/sui-indexer/src/apis/read_api.rs
+++ b/crates/sui-indexer/src/apis/read_api.rs
@@ -7,6 +7,7 @@ use futures::future::join_all;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::http_client::HttpClient;
 use jsonrpsee::RpcModule;
+
 use sui_json_rpc::api::{ReadApiClient, ReadApiServer};
 use sui_json_rpc::SuiRpcModule;
 use sui_json_rpc_types::{
@@ -172,7 +173,7 @@ where
             .await?)
     }
 
-    async fn multi_get_transaction_blocks(
+    fn multi_get_transaction_blocks(
         &self,
         digests: Vec<TransactionDigest>,
         options: Option<SuiTransactionBlockResponseOptions>,
@@ -181,14 +182,11 @@ where
             .migrated_methods
             .contains(&"multi_get_transactions_with_options".to_string())
         {
-            return self
-                .fullnode
-                .multi_get_transaction_blocks(digests, options)
-                .await;
+            return block_on(self.fullnode.multi_get_transaction_blocks(digests, options));
         }
-        Ok(self
-            .multi_get_transactions_with_options_internal(&digests, options)
-            .await?)
+        Ok(block_on(
+            self.multi_get_transactions_with_options_internal(&digests, options),
+        )?)
     }
 
     async fn try_get_past_object(
@@ -202,14 +200,15 @@ where
             .await
     }
 
-    async fn try_multi_get_past_objects(
+    fn try_multi_get_past_objects(
         &self,
         past_objects: Vec<SuiGetPastObjectRequest>,
         options: Option<SuiObjectDataOptions>,
     ) -> RpcResult<Vec<SuiPastObjectResponse>> {
-        self.fullnode
-            .try_multi_get_past_objects(past_objects, options)
-            .await
+        block_on(
+            self.fullnode
+                .try_multi_get_past_objects(past_objects, options),
+        )
     }
 
     async fn get_latest_checkpoint_sequence_number(
@@ -236,20 +235,20 @@ where
         Ok(self.state.get_checkpoint(id)?)
     }
 
-    async fn get_checkpoints(
+    fn get_checkpoints(
         &self,
         cursor: Option<SuiCheckpointSequenceNumber>,
         limit: Option<usize>,
         descending_order: bool,
     ) -> RpcResult<CheckpointPage> {
-        return self
-            .fullnode
-            .get_checkpoints(cursor, limit, descending_order)
-            .await;
+        return block_on(
+            self.fullnode
+                .get_checkpoints(cursor, limit, descending_order),
+        );
     }
 
-    async fn get_events(&self, transaction_digest: TransactionDigest) -> RpcResult<Vec<SuiEvent>> {
-        self.fullnode.get_events(transaction_digest).await
+    fn get_events(&self, transaction_digest: TransactionDigest) -> RpcResult<Vec<SuiEvent>> {
+        block_on(self.fullnode.get_events(transaction_digest))
     }
 }
 

--- a/crates/sui-indexer/src/apis/read_api.rs
+++ b/crates/sui-indexer/src/apis/read_api.rs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
+use futures::executor::block_on;
 use futures::future::join_all;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::http_client::HttpClient;
 use jsonrpsee::RpcModule;
-
 use sui_json_rpc::api::{ReadApiClient, ReadApiServer};
 use sui_json_rpc::SuiRpcModule;
 use sui_json_rpc_types::{
@@ -123,7 +123,7 @@ impl<S> ReadApiServer for ReadApi<S>
 where
     S: IndexerStore + Sync + Send + 'static,
 {
-    async fn get_object(
+    fn get_object(
         &self,
         object_id: ObjectID,
         options: Option<SuiObjectDataOptions>,
@@ -132,18 +132,18 @@ where
             .migrated_methods
             .contains(&"get_object_with_options".into())
         {
-            return self.fullnode.get_object(object_id, options).await;
+            return block_on(async { self.fullnode.get_object(object_id, options).await });
         }
 
         Ok(self.get_object_with_options_internal(object_id, options)?)
     }
 
-    async fn multi_get_objects(
+    fn multi_get_objects(
         &self,
         object_ids: Vec<ObjectID>,
         options: Option<SuiObjectDataOptions>,
     ) -> RpcResult<Vec<SuiObjectResponse>> {
-        return self.fullnode.multi_get_objects(object_ids, options).await;
+        block_on(async { self.fullnode.multi_get_objects(object_ids, options).await })
     }
 
     async fn get_total_transaction_blocks(&self) -> RpcResult<BigInt> {

--- a/crates/sui-json-rpc/src/api/coin.rs
+++ b/crates/sui-json-rpc/src/api/coin.rs
@@ -38,8 +38,8 @@ pub trait CoinReadApi {
     ) -> RpcResult<CoinPage>;
 
     /// Return the total coin balance for one coin type, owned by the address owner.
-    #[method(name = "getBalance")]
-    async fn get_balance(
+    #[method(name = "getBalance", blocking)]
+    fn get_balance(
         &self,
         /// the owner's Sui address
         owner: SuiAddress,
@@ -48,8 +48,8 @@ pub trait CoinReadApi {
     ) -> RpcResult<Balance>;
 
     /// Return the total coin balance for all coin type, owned by the address owner.
-    #[method(name = "getAllBalances")]
-    async fn get_all_balances(
+    #[method(name = "getAllBalances", blocking)]
+    fn get_all_balances(
         &self,
         /// the owner's Sui address
         owner: SuiAddress,

--- a/crates/sui-json-rpc/src/api/indexer.rs
+++ b/crates/sui-json-rpc/src/api/indexer.rs
@@ -34,7 +34,7 @@ pub trait IndexerApi {
 
     /// Return list of transactions for a specified query criteria.
     #[method(name = "queryTransactionBlocks", blocking)]
-     fn query_transaction_blocks(
+    fn query_transaction_blocks(
         &self,
         /// the transaction query criteria.
         query: SuiTransactionBlockResponseQuery,
@@ -48,7 +48,7 @@ pub trait IndexerApi {
 
     /// Return list of events for a specified query criteria.
     #[method(name = "queryEvents", blocking)]
-     fn query_events(
+    fn query_events(
         &self,
         /// the event query criteria.
         query: EventFilter,

--- a/crates/sui-json-rpc/src/api/indexer.rs
+++ b/crates/sui-json-rpc/src/api/indexer.rs
@@ -19,8 +19,8 @@ use sui_types::event::EventID;
 #[rpc(server, client, namespace = "suix")]
 pub trait IndexerApi {
     /// Return the list of objects owned by an address.
-    #[method(name = "getOwnedObjects")]
-    async fn get_owned_objects(
+    #[method(name = "getOwnedObjects", blocking)]
+    fn get_owned_objects(
         &self,
         /// the owner's Sui address
         address: SuiAddress,
@@ -33,8 +33,8 @@ pub trait IndexerApi {
     ) -> RpcResult<ObjectsPage>;
 
     /// Return list of transactions for a specified query criteria.
-    #[method(name = "queryTransactionBlocks")]
-    async fn query_transaction_blocks(
+    #[method(name = "queryTransactionBlocks", blocking)]
+     fn query_transaction_blocks(
         &self,
         /// the transaction query criteria.
         query: SuiTransactionBlockResponseQuery,
@@ -47,8 +47,8 @@ pub trait IndexerApi {
     ) -> RpcResult<TransactionBlocksPage>;
 
     /// Return list of events for a specified query criteria.
-    #[method(name = "queryEvents")]
-    async fn query_events(
+    #[method(name = "queryEvents", blocking)]
+     fn query_events(
         &self,
         /// the event query criteria.
         query: EventFilter,
@@ -69,8 +69,8 @@ pub trait IndexerApi {
     );
 
     /// Return the list of dynamic field objects owned by an object.
-    #[method(name = "getDynamicFields")]
-    async fn get_dynamic_fields(
+    #[method(name = "getDynamicFields", blocking)]
+    fn get_dynamic_fields(
         &self,
         /// The ID of the parent object
         parent_object_id: ObjectID,

--- a/crates/sui-json-rpc/src/api/read.rs
+++ b/crates/sui-json-rpc/src/api/read.rs
@@ -38,8 +38,8 @@ pub trait ReadApi {
     ) -> RpcResult<Vec<SuiTransactionBlockResponse>>;
 
     /// Return the object information for a specified object
-    #[method(name = "getObject")]
-    async fn get_object(
+    #[method(name = "getObject", blocking)]
+    fn get_object(
         &self,
         /// the ID of the queried object
         object_id: ObjectID,
@@ -48,8 +48,8 @@ pub trait ReadApi {
     ) -> RpcResult<SuiObjectResponse>;
 
     /// Return the object data for a list of objects
-    #[method(name = "multiGetObjects")]
-    async fn multi_get_objects(
+    #[method(name = "multiGetObjects", blocking)]
+    fn multi_get_objects(
         &self,
         /// the IDs of the queried objects
         object_ids: Vec<ObjectID>,

--- a/crates/sui-json-rpc/src/api/read.rs
+++ b/crates/sui-json-rpc/src/api/read.rs
@@ -28,8 +28,8 @@ pub trait ReadApi {
     /// Returns an ordered list of transaction responses
     /// The method will throw an error if the input contains any duplicate or
     /// the input size exceeds QUERY_MAX_RESULT_LIMIT
-    #[method(name = "multiGetTransactionBlocks")]
-    async fn multi_get_transaction_blocks(
+    #[method(name = "multiGetTransactionBlocks", blocking)]
+    fn multi_get_transaction_blocks(
         &self,
         /// A list of transaction digests.
         digests: Vec<TransactionDigest>,
@@ -76,8 +76,8 @@ pub trait ReadApi {
     /// can be retrieved by this API, even if the object and version exists/existed.
     /// The result may vary across nodes depending on their pruning policies.
     /// Return the object information for a specified version
-    #[method(name = "tryMultiGetPastObjects")]
-    async fn try_multi_get_past_objects(
+    #[method(name = "tryMultiGetPastObjects", blocking)]
+    fn try_multi_get_past_objects(
         &self,
         /// a vector of object and versions to be queried
         past_objects: Vec<SuiGetPastObjectRequest>,
@@ -94,8 +94,8 @@ pub trait ReadApi {
     ) -> RpcResult<Checkpoint>;
 
     /// Return paginated list of checkpoints
-    #[method(name = "getCheckpoints")]
-    async fn get_checkpoints(
+    #[method(name = "getCheckpoints", blocking)]
+    fn get_checkpoints(
         &self,
         /// An optional paging cursor. If provided, the query will start from the next item after the specified cursor. Default to start from the first item if not specified.
         cursor: Option<SuiCheckpointSequenceNumber>,
@@ -106,8 +106,8 @@ pub trait ReadApi {
     ) -> RpcResult<CheckpointPage>;
 
     /// Return transaction events.
-    #[method(name = "getEvents")]
-    async fn get_events(
+    #[method(name = "getEvents", blocking)]
+    fn get_events(
         &self,
         /// the event query criteria.
         transaction_digest: TransactionDigest,

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -37,17 +37,16 @@ impl CoinReadApi {
         Self { state }
     }
 
-    async fn get_object(&self, object_id: &ObjectID) -> Result<Object, Error> {
+    fn get_object(&self, object_id: &ObjectID) -> Result<Object, Error> {
         Ok(self
             .state
-            .get_object_read(object_id)
-            .await?
+            .get_object_read(object_id)?
             .into_object()
             .map_err(SuiError::from)?)
     }
 
     async fn get_coin(&self, coin_id: &ObjectID) -> Result<SuiCoin, Error> {
-        let o = self.get_object(coin_id).await?;
+        let o = self.get_object(coin_id)?;
         if let Some(move_object) = o.data.try_as_move() {
             let (balance, locked_until_epoch) = if move_object.type_().is_coin() {
                 let coin: Coin = bcs::from_bytes(move_object.contents())?;
@@ -129,7 +128,7 @@ impl CoinReadApi {
         package_id: &ObjectID,
         object_struct_tag: StructTag,
     ) -> Result<Object, Error> {
-        let publish_txn_digest = self.get_object(package_id).await?.previous_transaction;
+        let publish_txn_digest = self.get_object(package_id)?.previous_transaction;
         let (_, effect) = self
             .state
             .get_executed_transaction_and_effects(publish_txn_digest)
@@ -153,7 +152,7 @@ impl CoinReadApi {
             ))
         }
         .await?;
-        self.get_object(&object_id).await
+        self.get_object(&object_id)
     }
 }
 

--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -51,12 +51,10 @@ impl GovernanceReadApi {
         &self,
         staked_sui_ids: Vec<ObjectID>,
     ) -> Result<Vec<DelegatedStake>, Error> {
-        let stakes_read = futures::future::try_join_all(
-            staked_sui_ids
-                .iter()
-                .map(|id| self.state.get_object_read(id)),
-        )
-        .await?;
+        let stakes_read = staked_sui_ids
+            .iter()
+            .map(|id| self.state.get_object_read(id))
+            .collect::<Result<Vec<_>, _>>()?;
         if stakes_read.is_empty() {
             return Ok(vec![]);
         }

--- a/crates/sui-json-rpc/src/indexer_api.rs
+++ b/crates/sui-json-rpc/src/indexer_api.rs
@@ -107,9 +107,7 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
         let data = match options.is_not_in_object_info() {
             true => {
                 let object_ids = objects.iter().map(|obj| obj.object_id).collect();
-                self.read_api
-                    .multi_get_objects(object_ids, Some(options.clone()))
-                    .await?
+                self.read_api.multi_get_objects(object_ids, Some(options))?
             }
             false => objects
                 .into_iter()
@@ -183,8 +181,7 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
         // Retrieve 1 extra item for next cursor
         let mut data = self
             .state
-            .query_events(query, cursor.clone(), limit + 1, descending)
-            .await?;
+            .query_events(query, cursor.clone(), limit + 1, descending)?;
         let has_next_page = data.len() > limit;
         data.truncate(limit);
         let next_cursor = data.last().map_or(cursor, |e| Some(e.id.clone()));
@@ -237,7 +234,6 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
         // TODO(chris): add options to `get_dynamic_field_object` API as well
         self.read_api
             .get_object(id, Some(SuiObjectDataOptions::full_content()))
-            .await
     }
 }
 

--- a/crates/sui-json-rpc/src/indexer_api.rs
+++ b/crates/sui-json-rpc/src/indexer_api.rs
@@ -64,7 +64,7 @@ impl<R: ReadApiServer> IndexerApi<R> {
 
 #[async_trait]
 impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
-    async fn get_owned_objects(
+    fn get_owned_objects(
         &self,
         address: SuiAddress,
         query: Option<SuiObjectResponseQuery>,
@@ -122,7 +122,7 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
         })
     }
 
-    async fn query_transaction_blocks(
+    fn query_transaction_blocks(
         &self,
         query: SuiTransactionBlockResponseQuery,
         // If `Some`, the query will start from the next item after the specified cursor
@@ -151,8 +151,7 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
                 .collect()
         } else {
             self.read_api
-                .multi_get_transaction_blocks(digests, Some(opts))
-                .await?
+                .multi_get_transaction_blocks(digests, Some(opts))?
         };
 
         Ok(Page {
@@ -161,7 +160,7 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
             has_next_page,
         })
     }
-    async fn query_events(
+    fn query_events(
         &self,
         query: EventFilter,
         // exclusive cursor if `Some`, otherwise start from the beginning
@@ -197,7 +196,7 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
         Ok(())
     }
 
-    async fn get_dynamic_fields(
+    fn get_dynamic_fields(
         &self,
         parent_object_id: ObjectID,
         // If `Some`, the query will start from the next item after the specified cursor

--- a/crates/sui-json-rpc/src/move_utils.rs
+++ b/crates/sui-json-rpc/src/move_utils.rs
@@ -110,7 +110,6 @@ impl MoveUtilsServer for MoveUtils {
         let object_read = self
             .state
             .get_object_read(&package)
-            .await
             .map_err(|e| anyhow!("{e}"))?;
 
         let normalized = match object_read {

--- a/crates/sui-json-rpc/src/transaction_builder_api.rs
+++ b/crates/sui-json-rpc/src/transaction_builder_api.rs
@@ -74,7 +74,7 @@ impl DataReader for AuthorityStateDataReader {
         object_id: ObjectID,
         options: SuiObjectDataOptions,
     ) -> Result<SuiObjectResponse, anyhow::Error> {
-        let result = self.0.get_object_read(&object_id).await?;
+        let result = self.0.get_object_read(&object_id)?;
         Ok((result, options).try_into()?)
     }
 

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -70,7 +70,7 @@ async fn test_full_node_follows_txes() -> Result<(), anyhow::Error> {
     sleep(Duration::from_secs(1)).await;
 
     // verify that the node has seen the transfer
-    let object_read = node.state().get_object_read(&transferred_object).await?;
+    let object_read = node.state().get_object_read(&transferred_object)?;
     let object = object_read.into_object()?;
 
     assert_eq!(object.owner.get_owner_address().unwrap(), receiver);
@@ -909,9 +909,7 @@ async fn get_obj_read_from_node(
     node: &SuiNode,
     object_id: ObjectID,
 ) -> Result<(ObjectRef, Object, Option<MoveStructLayout>), anyhow::Error> {
-    if let ObjectRead::Exists(obj_ref, object, layout) =
-        node.state().get_object_read(&object_id).await?
-    {
+    if let ObjectRead::Exists(obj_ref, object, layout) = node.state().get_object_read(&object_id)? {
         Ok((obj_ref, object, layout))
     } else {
         anyhow::bail!("Can't find object {object_id:?} on fullnode.")
@@ -986,7 +984,7 @@ async fn test_get_objects_read() -> Result<(), anyhow::Error> {
     sleep(Duration::from_secs(1)).await;
 
     // Now test get_object_read
-    let object_ref_v3 = match node.state().get_object_read(&object_id).await? {
+    let object_ref_v3 = match node.state().get_object_read(&object_id)? {
         ObjectRead::Deleted(obj_ref) => obj_ref,
         other => anyhow::bail!("Expect object {object_id:?} deleted but got {other:?}."),
     };


### PR DESCRIPTION
## Description 

jsonrpsee server occasionally refuse to process any request when the request rates are high, after some investigation we narrowed down the problem to json serialisation. When the response object is large, the serde takes significant amount of time and blocks the tokio worker threads, currently the only way to offload the serialisation is to make the RPC method "blocking" and jsonrpsee will use tokio spawn_blocking to process the request.

This PR marked all methods with relatively large response "blocking" to avoid blocking

## Test Plan 
