### PR TITLE
Change charging for out of gas during storage charges

### DIFF
--- a/crates/sui-core/src/unit_tests/data/move_random/sources/move_random.move
+++ b/crates/sui-core/src/unit_tests/data/move_random/sources/move_random.move
@@ -2,8 +2,31 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module examples::move_random {
+    use std::vector;
+    use sui::object::{Self, UID};
+    use sui::transfer;
+    use sui::tx_context::TxContext;
+
+    struct Object has key, store {
+        id: UID,
+        data: vector<u64>,
+    }
+
     // simple infinite loop to go out of gas in computation
     public entry fun loopy() {
         loop { }
+    }
+
+    // create an object with a vector of size `size` and transfer to recipient
+    public entry fun storage_heavy(size: u64, recipient: address, ctx: &mut TxContext) {
+        let data = vector::empty();
+        while (size > 0) {
+            vector::push_back(&mut data, size);
+            size = size - 1;
+        };
+        transfer::public_transfer(
+            Object { id: object::new(ctx), data },
+            recipient
+        )
     }
 }

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -55,70 +55,375 @@ async fn test_tx_more_than_maximum_gas_budget() {
     );
 }
 
-// #[tokio::test]
-// async fn test_tx_max_computation() -> SuiResult {
-//     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
-//     let gas_object_id = ObjectID::random();
-//     let authority_state = init_state_with_ids(vec![(sender, gas_object_id)]).await;
 //
-//     let response = build_and_try_publish_test_package(
-//         &authority_state,
-//         &sender,
-//         &sender_key,
-//         &gas_object_id,
-//         "move_random",
-//         *MAX_GAS_BUDGET,
-//         /* with_unpublished_deps */ false,
-//     )
-//     .await;
-//     let effects = response.1.into_data();
-//     assert!(effects.status().is_ok());
-//     let package = effects
-//         .created()
-//         .iter()
-//         .find(|(_, owner)| matches!(owner, Owner::Immutable))
-//         .unwrap()
-//         .0
-//         .0;
+// Out Of Gas Scenarios
+// "minimal storage" is storage for input objects after reset. Operations for
+// "minimal storage" can only happen if storage charges fail.
+// Single gas coin:
+// - OOG computation, storage (minimal storage) ok
+// - OOG for computation, OOG for minimal storage (e.g. computation is entire budget)
+// - computation ok, OOG for storage, minimal storage ok
+// - computation ok, OOG for storage, OOG for minimal storage (e.g. computation is entire budget)
 //
-//     let gas_object = authority_state.get_object(&gas_object_id).await.unwrap().unwrap();
-//     let initial_value = GasCoin::try_from(&gas_object)?.value();
-//     let gas_object_ref = gas_object.compute_object_reference();
-//     let module = ident_str!("move_random").to_owned();
-//     let function = ident_str!("loopy").to_owned();
-//     let args = vec![];
-//     let budget = 1_500_000_000;
-//     let data = TransactionData::new_move_call(
-//         sender,
-//         package,
-//         module,
-//         function,
-//         vec![],
-//         gas_object_ref,
-//         args,
-//         budget,
-//         300,
-//     )
-//     .unwrap();
+// With multiple gas coins is practically impossible to fail storage cost because we
+// get a significant among of MIST back from smashing. So we try:
+// - OOG computation, storage ok
 //
-//     let tx = to_sender_signed_transaction(data, &sender_key);
-//     let effects = send_and_confirm_transaction(&authority_state, tx)
-//         .await
-//         .unwrap()
-//         .1
-//         .into_data();
-//     assert_eq!(
-//         effects.status().clone().unwrap_err().0,
-//         ExecutionFailureStatus::InsufficientGas
-//     );
-//     let gas_ref = effects.gas_object().0;
-//     let gas_object = authority_state.get_object(&gas_ref.0).await.unwrap().unwrap();
-//     let final_value = GasCoin::try_from(&gas_object)?.value();
-//     let summary = effects.gas_cost_summary();
-//     assert!(summary.computation_cost == budget);
-//     assert!(initial_value - budget == final_value);
-//     Ok(())
-// }
+// impossible scenarios:
+// - OOG for computation, OOG for storage, minimal storage ok - OOG for computation implies
+// minimal storage is the only extra charge, so storage == minimal storage
+//
+
+//
+// Helpers for OOG scenarios
+//
+
+async fn publish_move_random_package(
+    authority_state: &Arc<AuthorityState>,
+    sender: &SuiAddress,
+    sender_key: &AccountKeyPair,
+    gas_object_id: &ObjectID,
+) -> ObjectID {
+    const PUBLISH_BUDGET: u64 = 10_000_000;
+
+    let response = build_and_try_publish_test_package(
+        authority_state,
+        sender,
+        sender_key,
+        gas_object_id,
+        "move_random",
+        PUBLISH_BUDGET,
+        /* with_unpublished_deps */ false,
+    )
+    .await;
+    let effects = response.1.into_data();
+    assert!(effects.status().is_ok());
+    effects
+        .created()
+        .iter()
+        .find(|(_, owner)| matches!(owner, Owner::Immutable))
+        .unwrap()
+        .0
+         .0
+}
+
+async fn check_oog_transaction<F>(
+    sender: SuiAddress,
+    sender_key: AccountKeyPair,
+    function: &'static str,
+    args: Vec<CallArg>,
+    budget: u64,
+    gas_price: u64,
+    coin_num: u64,
+    checker: F,
+) -> SuiResult
+where
+    F: FnOnce(&GasCostSummary, u64, u64) -> SuiResult,
+{
+    // initial system with given gas coins
+    const GAS_AMOUNT: u64 = 10_000_000_000;
+    let gas_coins = make_gas_coins(sender, GAS_AMOUNT, coin_num);
+    let gas_coin_ids: Vec<_> = gas_coins.iter().map(|obj| obj.id()).collect();
+    let authority_state = init_state().await;
+    for obj in gas_coins {
+        authority_state.insert_genesis_object(obj).await;
+    }
+
+    let gas_object_id = ObjectID::random();
+    let gas_coin = Object::with_id_owner_gas_for_testing(gas_object_id, sender, GAS_AMOUNT);
+    authority_state.insert_genesis_object(gas_coin).await;
+    // touch gas coins so that `storage_rebate` is set (not 0 as in genesis)
+    touch_gas_coins(
+        &authority_state,
+        sender,
+        &sender_key,
+        sender,
+        &gas_coin_ids,
+        gas_object_id,
+    )
+    .await;
+    // publish move module
+    let package =
+        publish_move_random_package(&authority_state, &sender, &sender_key, &gas_object_id).await;
+
+    // call move entry function
+    let mut gas_coin_refs = vec![];
+    for coin_id in &gas_coin_ids {
+        let coin_ref = authority_state
+            .get_object(coin_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .compute_object_reference();
+        gas_coin_refs.push(coin_ref);
+    }
+    let module = ident_str!("move_random").to_owned();
+    let function = ident_str!(function).to_owned();
+    let data = TransactionData::new_move_call_with_gas_coins(
+        sender,
+        package,
+        module,
+        function,
+        vec![],
+        gas_coin_refs,
+        args,
+        budget,
+        gas_price,
+    )
+    .unwrap();
+
+    // sign and execute transaction
+    let tx = to_sender_signed_transaction(data, &sender_key);
+    let effects = send_and_confirm_transaction(&authority_state, tx)
+        .await
+        .unwrap()
+        .1
+        .into_data();
+
+    // check effects
+    assert_eq!(
+        effects.status().clone().unwrap_err().0,
+        ExecutionFailureStatus::InsufficientGas
+    );
+    // gas object in effects is first coin in vector of coins
+    assert_eq!(gas_coin_ids[0], effects.gas_object().0 .0);
+    //  gas at position 0 mutated
+    assert_eq!(effects.mutated().len(), 1);
+    // extra coins are deleted
+    assert_eq!(effects.deleted().len() as u64, coin_num - 1);
+    for gas_coin_id in &gas_coin_ids[1..] {
+        assert!(effects
+            .deleted()
+            .iter()
+            .any(|deleted| deleted.0 == *gas_coin_id));
+    }
+    let gas_ref = effects.gas_object().0;
+    let gas_object = authority_state
+        .get_object(&gas_ref.0)
+        .await
+        .unwrap()
+        .unwrap();
+    let final_value = GasCoin::try_from(&gas_object)?.value();
+    let summary = effects.gas_cost_summary();
+
+    // call checker
+    checker(summary, GAS_AMOUNT, final_value)
+}
+
+// make a `coin_num` coins distributing `gas_amount` across them
+fn make_gas_coins(owner: SuiAddress, gas_amount: u64, coin_num: u64) -> Vec<Object> {
+    let mut objects = vec![];
+    let coin_balance = gas_amount / coin_num;
+    for _ in 1..coin_num {
+        let gas_object_id = ObjectID::random();
+        objects.push(Object::with_id_owner_gas_for_testing(
+            gas_object_id,
+            owner,
+            coin_balance,
+        ));
+    }
+    // in case integer division dropped something, make a coin with whatever is left
+    let amount_left = gas_amount - (coin_balance * (coin_num - 1));
+    let gas_object_id = ObjectID::random();
+    objects.push(Object::with_id_owner_gas_for_testing(
+        gas_object_id,
+        owner,
+        amount_left,
+    ));
+    objects
+}
+
+// Touch gas coins so that `storage_rebate` is set
+async fn touch_gas_coins(
+    authority_state: &AuthorityState,
+    sender: SuiAddress,
+    sender_key: &AccountKeyPair,
+    recipient: SuiAddress,
+    coin_ids: &[ObjectID],
+    gas_object_id: ObjectID,
+) {
+    let mut builder = ProgrammableTransactionBuilder::new();
+    for coin_id in coin_ids {
+        let coin_ref = authority_state
+            .get_object(coin_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .compute_object_reference();
+        builder.transfer_object(recipient, coin_ref).unwrap();
+    }
+    let pt = builder.finish();
+    let kind = TransactionKind::ProgrammableTransaction(pt);
+    let gas_object_ref = authority_state
+        .get_object(&gas_object_id)
+        .await
+        .unwrap()
+        .unwrap()
+        .compute_object_reference();
+    let data = TransactionData::new(kind, sender, gas_object_ref, 100_000_000, 1);
+    let tx = to_sender_signed_transaction(data, sender_key);
+
+    send_and_confirm_transaction(authority_state, tx)
+        .await
+        .unwrap();
+}
+
+// - OOG computation, storage ok
+#[ignore]
+#[tokio::test]
+async fn test_oog_computation_storage_ok() -> SuiResult {
+    const MAX_BUDGET: u64 = 10_000_000;
+    const GAS_PRICE: u64 = 30;
+    const BUDGET: u64 = MAX_BUDGET * GAS_PRICE;
+    let (sender, sender_key) = get_key_pair();
+    check_oog_transaction(
+        sender,
+        sender_key,
+        "loopy",
+        vec![],
+        BUDGET,
+        GAS_PRICE,
+        1,
+        |summary, initial_value, final_value| {
+            let gas_used = summary.net_gas_usage() as u64;
+            assert!(
+                summary.computation_cost > 0
+                    && summary.storage_cost > 0
+                    && summary.storage_rebate > 0
+                    && summary.non_refundable_storage_fee > 0
+            );
+            assert!(initial_value - gas_used == final_value);
+            Ok(())
+        },
+    )
+    .await
+}
+
+// OOG for computation, OOG for minimal storage (e.g. computation is entire budget)
+#[ignore]
+#[tokio::test]
+async fn test_oog_computation_oog_storage() -> SuiResult {
+    const GAS_PRICE: u64 = 30;
+    // WARNING: this value is taken from gas_v2.rs::MAX_BUCKET_COST and when
+    // that value changes this test will break!
+    // TODO: when buckets move to ProtocolConfig change this value to use ProtocolConfig
+    const MAX_UNIT_BUDGET: u64 = 5_000_000;
+    const BUDGET: u64 = MAX_UNIT_BUDGET * GAS_PRICE;
+    let (sender, sender_key) = get_key_pair();
+    check_oog_transaction(
+        sender,
+        sender_key,
+        "loopy",
+        vec![],
+        BUDGET,
+        GAS_PRICE,
+        1,
+        |summary, initial_value, final_value| {
+            let gas_used = summary.net_gas_usage() as u64;
+            assert!(summary.computation_cost > 0);
+            // currently when storage charges go out of gas, the storage data in the summary is zero
+            assert_eq!(summary.storage_cost, 0);
+            assert_eq!(summary.storage_rebate, 0);
+            assert_eq!(summary.non_refundable_storage_fee, 0);
+            assert_eq!(initial_value - gas_used, final_value);
+            Ok(())
+        },
+    )
+    .await
+}
+
+// - computation ok, OOG for storage, minimal storage ok
+#[tokio::test]
+async fn test_computation_ok_oog_storage_minimal_ok() -> SuiResult {
+    const GAS_PRICE: u64 = 30;
+    const BUDGET: u64 = 1_100_000;
+    let (sender, sender_key) = get_key_pair();
+    check_oog_transaction(
+        sender,
+        sender_key,
+        "storage_heavy",
+        vec![
+            CallArg::Pure(bcs::to_bytes(&(100_u64)).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&sender).unwrap()),
+        ],
+        BUDGET,
+        GAS_PRICE,
+        1,
+        |summary, initial_value, final_value| {
+            let gas_used = summary.net_gas_usage() as u64;
+            assert!(
+                summary.computation_cost > 0
+                    && summary.storage_cost > 0
+                    && summary.storage_rebate > 0
+                    && summary.non_refundable_storage_fee > 0
+            );
+            assert_eq!(initial_value - gas_used, final_value);
+            Ok(())
+        },
+    )
+    .await
+}
+
+// - computation ok, OOG for storage, OOG for minimal storage (e.g. computation is entire budget)
+#[tokio::test]
+async fn test_computation_ok_oog_storage() -> SuiResult {
+    const GAS_PRICE: u64 = 30;
+    const BUDGET: u64 = 35_000;
+    let (sender, sender_key) = get_key_pair();
+    check_oog_transaction(
+        sender,
+        sender_key,
+        "storage_heavy",
+        vec![
+            CallArg::Pure(bcs::to_bytes(&(100_u64)).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&sender).unwrap()),
+        ],
+        BUDGET,
+        GAS_PRICE,
+        1,
+        |summary, initial_value, final_value| {
+            let gas_used = summary.net_gas_usage() as u64;
+            assert!(summary.computation_cost > 0);
+            // currently when storage charges go out of gas, the storage data in the summary is zero
+            assert_eq!(summary.storage_cost, 0);
+            assert_eq!(summary.storage_rebate, 0);
+            assert_eq!(summary.non_refundable_storage_fee, 0);
+            assert_eq!(initial_value - gas_used, final_value);
+            Ok(())
+        },
+    )
+    .await
+}
+
+#[ignore]
+#[tokio::test]
+async fn test_oog_computation_storage_ok_multi_coins() -> SuiResult {
+    const MAX_BUDGET: u64 = 4_000_000;
+    const GAS_PRICE: u64 = 30;
+    const BUDGET: u64 = MAX_BUDGET * GAS_PRICE;
+    let (sender, sender_key) = get_key_pair();
+    check_oog_transaction(
+        sender,
+        sender_key,
+        "loopy",
+        vec![],
+        BUDGET,
+        GAS_PRICE,
+        5,
+        |summary, initial_value, final_value| {
+            let gas_used = summary.net_gas_usage() as u64;
+            assert!(
+                summary.computation_cost > 0
+                    && summary.storage_cost > 0
+                    && summary.storage_rebate > 0
+                    && summary.non_refundable_storage_fee > 0
+            );
+            assert!(initial_value - gas_used == final_value);
+            Ok(())
+        },
+    )
+    .await
+}
 
 #[tokio::test]
 async fn test_tx_gas_balance_less_than_budget() {
@@ -359,14 +664,10 @@ async fn test_publish_gas() -> anyhow::Result<()> {
 
     assert_eq!(err, ExecutionFailureStatus::InsufficientGas);
 
-    // Make sure that we are not charging storage cost at failure.
-    assert_eq!(gas_cost.storage_cost, 0);
-    assert_eq!(gas_cost.storage_rebate, 0);
-    // Upon OOG failure, we should charge the whole budget
-    assert_eq!(gas_cost.gas_used(), budget);
+    assert!(gas_cost.gas_used() > 0);
 
     let gas_object = authority_state.get_object(&gas_object_id).await?.unwrap();
-    let expected_gas_balance = expected_gas_balance - gas_cost.gas_used();
+    let expected_gas_balance = expected_gas_balance - gas_cost.net_gas_usage() as u64;
     assert_eq!(
         GasCoin::try_from(&gas_object)?.value(),
         expected_gas_balance,

--- a/crates/sui-types/src/temporary_store.rs
+++ b/crates/sui-types/src/temporary_store.rs
@@ -975,15 +975,29 @@ impl<S: ObjectStore> TemporaryStore<S> {
             }
         }
 
+        // compute and collect storage charges
         self.ensure_gas_and_input_mutated(gas_object_id);
         self.collect_storage_and_rebate(gas_status);
+        // system transactions (None gas_object_id)  do not have gas and so do not charge
+        // for storage, however they track storage values to check for conservation rules
         if let Some(gas_object_id) = gas_object_id {
             if let Err(err) = gas_status.charge_storage_and_rebate() {
+                // we run out of gas charging storage, reset and try charging for storage again.
+                // Input objects are touched and so they have a storage cost
                 self.reset(gas, gas_status);
-                gas_status.adjust_computation_on_out_of_gas();
                 self.ensure_gas_and_input_mutated(Some(gas_object_id));
-                self.collect_rebate(gas_status);
-                if execution_result.is_ok() {
+                self.collect_storage_and_rebate(gas_status);
+                if let Err(err) = gas_status.charge_storage_and_rebate() {
+                    // we run out of gas attempting to charge for the input objects exclusively,
+                    // deal with this edge case by not charging for storage
+                    self.reset(gas, gas_status);
+                    gas_status.adjust_computation_on_out_of_gas();
+                    self.ensure_gas_and_input_mutated(Some(gas_object_id));
+                    self.collect_rebate(gas_status);
+                    if execution_result.is_ok() {
+                        *execution_result = Err(err);
+                    }
+                } else if execution_result.is_ok() {
                     *execution_result = Err(err);
                 }
             }


### PR DESCRIPTION
## Description 

This PR changes the way we charge for gas when an OutOfGas is reached while charging for storage.
It's a breaking change and will need to be protected by a protocol change which is coming soon and will be lined up with [10480](https://github.com/MystenLabs/sui/pull/10480).
https://www.notion.so/mystenlabs/Gas-Charges describes all changes and behavior of gas charging.
I really think we should push this next week.
The changes are made to be as simple as possible to make the diff clear and non intrusive.
Protocol change protection coming soon

## Test Plan 

New unit tests and existing tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
