### PR TITLE
[enhanced-api] Update move call metrics API structure

### DIFF
--- a/crates/sui-indexer/src/apis/extended_api.rs
+++ b/crates/sui-indexer/src/apis/extended_api.rs
@@ -11,8 +11,9 @@ use sui_json_rpc::api::{
 };
 use sui_json_rpc::SuiRpcModule;
 use sui_json_rpc_types::{
-    CheckpointedObjectID, EpochInfo, EpochPage, MoveCallMetrics, NetworkMetrics, Page,
-    QueryObjectsPage, SuiObjectDataFilter, SuiObjectResponse, SuiObjectResponseQuery,
+    CheckpointedObjectID, EpochInfo, EpochPage, MoveCallMetrics, MoveCallMetricsQuery,
+    NetworkMetrics, Page, QueryObjectsPage, SuiObjectDataFilter, SuiObjectResponse,
+    SuiObjectResponseQuery,
 };
 use sui_open_rpc::Module;
 use sui_types::base_types::EpochId;
@@ -125,8 +126,11 @@ impl<S: IndexerStore + Sync + Send + 'static> ExtendedApiServer for ExtendedApi<
         Ok(self.state.get_network_metrics().await?)
     }
 
-    async fn get_move_call_metrics(&self) -> RpcResult<MoveCallMetrics> {
-        Ok(self.state.get_move_call_metrics().await?)
+    async fn get_move_call_metrics(
+        &self,
+        query: MoveCallMetricsQuery,
+    ) -> RpcResult<MoveCallMetrics> {
+        Ok(self.state.get_move_call_metrics(query).await?)
     }
 }
 

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -5,8 +5,8 @@ use async_trait::async_trait;
 
 use sui_json_rpc_types::{
     Checkpoint as RpcCheckpoint, CheckpointId, EpochInfo, EventFilter, EventPage, MoveCallMetrics,
-    NetworkMetrics, SuiObjectData, SuiObjectDataFilter, SuiTransactionBlockResponse,
-    SuiTransactionBlockResponseOptions,
+    MoveCallMetricsQuery, NetworkMetrics, SuiObjectData, SuiObjectDataFilter,
+    SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions,
 };
 use sui_types::base_types::{EpochId, ObjectID, SequenceNumber};
 use sui_types::digests::CheckpointDigest;
@@ -177,7 +177,10 @@ pub trait IndexerStore {
     ) -> Result<Option<i64>, IndexerError>;
 
     async fn get_network_metrics(&self) -> Result<NetworkMetrics, IndexerError>;
-    async fn get_move_call_metrics(&self) -> Result<MoveCallMetrics, IndexerError>;
+    async fn get_move_call_metrics(
+        &self,
+        query: MoveCallMetricsQuery,
+    ) -> Result<MoveCallMetrics, IndexerError>;
 
     async fn persist_fast_path(
         &self,

--- a/crates/sui-json-rpc-types/src/sui_extended.rs
+++ b/crates/sui-json-rpc-types/src/sui_extended.rs
@@ -69,13 +69,30 @@ pub struct NetworkMetrics {
     pub current_checkpoint: u64,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub enum MoveCallMetricsTimeframe {
+    #[serde(rename = "3d")]
+    Days3,
+    #[serde(rename = "7d")]
+    Days7,
+    #[serde(rename = "30d")]
+    Days30,
+}
+
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct MoveCallMetrics {
-    pub rank_3_days: Vec<(MoveFunctionName, usize)>,
-    pub rank_7_days: Vec<(MoveFunctionName, usize)>,
-    pub rank_30_days: Vec<(MoveFunctionName, usize)>,
+pub struct MoveCallMetricsQuery {
+    pub timeframe: MoveCallMetricsTimeframe,
 }
+
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MoveCallMetric {
+    pub name: MoveFunctionName,
+    pub count: usize,
+}
+
+pub type MoveCallMetrics = Vec<MoveCallMetric>;
 
 #[serde_as]
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]

--- a/crates/sui-json-rpc/src/api/extended.rs
+++ b/crates/sui-json-rpc/src/api/extended.rs
@@ -5,8 +5,8 @@ use jsonrpsee::core::RpcResult;
 use jsonrpsee_proc_macros::rpc;
 
 use sui_json_rpc_types::{
-    CheckpointedObjectID, EpochInfo, EpochPage, MoveCallMetrics, NetworkMetrics, QueryObjectsPage,
-    SuiObjectResponseQuery,
+    CheckpointedObjectID, EpochInfo, EpochPage, MoveCallMetrics, MoveCallMetricsQuery,
+    NetworkMetrics, QueryObjectsPage, SuiObjectResponseQuery,
 };
 use sui_open_rpc_macros::open_rpc;
 use sui_types::base_types::EpochId;
@@ -48,5 +48,8 @@ pub trait ExtendedApi {
 
     /// Return Network metrics
     #[method(name = "getMoveCallMetrics")]
-    async fn get_move_call_metrics(&self) -> RpcResult<MoveCallMetrics>;
+    async fn get_move_call_metrics(
+        &self,
+        query: MoveCallMetricsQuery,
+    ) -> RpcResult<MoveCallMetrics>;
 }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1519,12 +1519,23 @@
         }
       ],
       "description": "Return Network metrics",
-      "params": [],
+      "params": [
+        {
+          "name": "query",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/MoveCallMetricsQuery"
+          }
+        }
+      ],
       "result": {
         "name": "MoveCallMetrics",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/MoveCallMetrics"
+          "type": "array",
+          "items": {
+            "$ref": "#/components/schemas/MoveCallMetric"
+          }
         }
       }
     },
@@ -4072,69 +4083,41 @@
           }
         ]
       },
-      "MoveCallMetrics": {
+      "MoveCallMetric": {
         "type": "object",
         "required": [
-          "rank30Days",
-          "rank3Days",
-          "rank7Days"
+          "count",
+          "name"
         ],
         "properties": {
-          "rank30Days": {
-            "type": "array",
-            "items": {
-              "type": "array",
-              "items": [
-                {
-                  "$ref": "#/components/schemas/MoveFunctionName"
-                },
-                {
-                  "type": "integer",
-                  "format": "uint",
-                  "minimum": 0.0
-                }
-              ],
-              "maxItems": 2,
-              "minItems": 2
-            }
+          "count": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0.0
           },
-          "rank3Days": {
-            "type": "array",
-            "items": {
-              "type": "array",
-              "items": [
-                {
-                  "$ref": "#/components/schemas/MoveFunctionName"
-                },
-                {
-                  "type": "integer",
-                  "format": "uint",
-                  "minimum": 0.0
-                }
-              ],
-              "maxItems": 2,
-              "minItems": 2
-            }
-          },
-          "rank7Days": {
-            "type": "array",
-            "items": {
-              "type": "array",
-              "items": [
-                {
-                  "$ref": "#/components/schemas/MoveFunctionName"
-                },
-                {
-                  "type": "integer",
-                  "format": "uint",
-                  "minimum": 0.0
-                }
-              ],
-              "maxItems": 2,
-              "minItems": 2
-            }
+          "name": {
+            "$ref": "#/components/schemas/MoveFunctionName"
           }
         }
+      },
+      "MoveCallMetricsQuery": {
+        "type": "object",
+        "required": [
+          "timeframe"
+        ],
+        "properties": {
+          "timeframe": {
+            "$ref": "#/components/schemas/MoveCallMetricsTimeframe"
+          }
+        }
+      },
+      "MoveCallMetricsTimeframe": {
+        "type": "string",
+        "enum": [
+          "3d",
+          "7d",
+          "30d"
+        ]
       },
       "MoveCallParams": {
         "type": "object",


### PR DESCRIPTION
## Description

This updates the API for `getMoveCallMetrics` to move to a filter-based API vs returning all of the data sets. This should work a little better in the future if we start to do things like current epoch metrics (which would be computed differently, I imagine), and also aligns with how the UI fetches this data.

## Test Plan

Will update tests.
