### PR TITLE
[wallet-ext] disable the testnet faucet button if the user has been rate limited

### DIFF
--- a/apps/wallet/src/ui/app/components/menu/content/MenuList.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/MenuList.tsx
@@ -52,9 +52,6 @@ function MenuList() {
         FEATURES.WALLET_MULTI_ACCOUNTS
     ).on;
     const [isLogoutDialogOpen, setIsLogoutDialogOpen] = useState(false);
-
-    // useFaucetRateLimiter
-
     return (
         <>
             <MenuLayout title="Wallet Settings">

--- a/apps/wallet/src/ui/app/components/menu/content/MenuList.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/MenuList.tsx
@@ -52,6 +52,9 @@ function MenuList() {
         FEATURES.WALLET_MULTI_ACCOUNTS
     ).on;
     const [isLogoutDialogOpen, setIsLogoutDialogOpen] = useState(false);
+
+    // useFaucetRateLimiter
+
     return (
         <>
             <MenuLayout title="Wallet Settings">

--- a/apps/wallet/src/ui/app/shared/faucet/FaucetRequestButton.tsx
+++ b/apps/wallet/src/ui/app/shared/faucet/FaucetRequestButton.tsx
@@ -1,12 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useCallback, useMemo } from 'react';
+import { FaucetRateLimitError } from '@mysten/sui.js';
 import { toast } from 'react-hot-toast';
-import { debounce } from 'throttle-debounce';
 
 import FaucetMessageInfo from './FaucetMessageInfo';
 import { useFaucetMutation } from './useFaucetMutation';
+import { useFaucetRateLimiter } from './useFaucetRateLimiter';
 import { API_ENV_TO_INFO } from '_app/ApiProvider';
 import { Button, type ButtonProps } from '_app/shared/ButtonUI';
 import { useAppSelector } from '_hooks';
@@ -17,40 +17,40 @@ export type FaucetRequestButtonProps = {
     trackEventSource: 'home' | 'settings';
 };
 
-const debounceWaitInMilliseconds = 2000;
-
 function FaucetRequestButton({
     variant = 'primary',
     trackEventSource,
 }: FaucetRequestButtonProps) {
     const network = useAppSelector(({ app }) => app.apiEnv);
     const networkName = API_ENV_TO_INFO[network].name.replace(/sui\s*/gi, '');
-    const { isMutating, mutateAsync, enabled } = useFaucetMutation();
+    const [isRateLimited, rateLimit] = useFaucetRateLimiter();
+    const mutation = useFaucetMutation({
+        onError: (error) => {
+            if (error instanceof FaucetRateLimitError) {
+                rateLimit();
+            }
+        },
+    });
 
-    const onClick = useCallback(() => {
-        toast.promise(mutateAsync(), {
-            loading: <FaucetMessageInfo loading />,
-            success: (totalReceived) => (
-                <FaucetMessageInfo totalReceived={totalReceived} />
-            ),
-            error: (error) => <FaucetMessageInfo error={error.message} />,
-        });
-
-        trackEvent('RequestGas', {
-            props: { source: trackEventSource, networkName },
-        });
-    }, [mutateAsync, networkName, trackEventSource]);
-
-    const debouncedOnClick = useMemo(
-        () => debounce(debounceWaitInMilliseconds, onClick, { atBegin: true }),
-        [onClick]
-    );
-
-    return enabled ? (
+    return mutation.enabled ? (
         <Button
             variant={variant}
-            onClick={debouncedOnClick}
-            loading={isMutating}
+            disabled={isRateLimited}
+            onClick={() => {
+                toast.promise(mutation.mutateAsync(), {
+                    loading: <FaucetMessageInfo loading />,
+                    success: (totalReceived) => (
+                        <FaucetMessageInfo totalReceived={totalReceived} />
+                    ),
+                    error: (error) => (
+                        <FaucetMessageInfo error={error.message} />
+                    ),
+                });
+                trackEvent('RequestGas', {
+                    props: { source: trackEventSource, networkName },
+                });
+            }}
+            loading={mutation.isMutating}
             text={`Request ${networkName} SUI Tokens`}
         />
     ) : null;

--- a/apps/wallet/src/ui/app/shared/faucet/useFaucetMutation.ts
+++ b/apps/wallet/src/ui/app/shared/faucet/useFaucetMutation.ts
@@ -2,13 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useRpcClient } from '@mysten/core';
-import { useIsMutating, useMutation } from '@tanstack/react-query';
+import {
+    useIsMutating,
+    useMutation,
+    type UseMutationOptions,
+} from '@tanstack/react-query';
 
 import { useActiveAddress } from '../../hooks/useActiveAddress';
 
-export function useFaucetMutation() {
+type UseFaucetMutationOptions = Pick<UseMutationOptions, 'onError'>;
+
+export function useFaucetMutation(options?: UseFaucetMutationOptions) {
     const api = useRpcClient();
     const address = useActiveAddress();
+
     const mutationKey = ['faucet-request-tokens', address];
     const mutation = useMutation({
         mutationKey,
@@ -26,7 +33,9 @@ export function useFaucetMutation() {
                 0
             );
         },
+        ...options,
     });
+
     return {
         ...mutation,
         /** If the currently-configured endpoint supports faucet: */

--- a/apps/wallet/src/ui/app/shared/faucet/useFaucetMutation.ts
+++ b/apps/wallet/src/ui/app/shared/faucet/useFaucetMutation.ts
@@ -15,7 +15,6 @@ type UseFaucetMutationOptions = Pick<UseMutationOptions, 'onError'>;
 export function useFaucetMutation(options?: UseFaucetMutationOptions) {
     const api = useRpcClient();
     const address = useActiveAddress();
-
     const mutationKey = ['faucet-request-tokens', address];
     const mutation = useMutation({
         mutationKey,
@@ -35,7 +34,6 @@ export function useFaucetMutation(options?: UseFaucetMutationOptions) {
         },
         ...options,
     });
-
     return {
         ...mutation,
         /** If the currently-configured endpoint supports faucet: */

--- a/apps/wallet/src/ui/app/shared/faucet/useFaucetRateLimiter.ts
+++ b/apps/wallet/src/ui/app/shared/faucet/useFaucetRateLimiter.ts
@@ -14,13 +14,11 @@ export function useFaucetRateLimiter() {
         const expiryTime = localStorage.getItem(
             FAUCET_RATE_LIMIT_EXPIRY_TIME_KEY
         );
-        const currTime = new Date().getTime();
-        return currTime <= Number(expiryTime);
+        return Date.now() <= Number(expiryTime);
     });
 
     const rateLimit = () => {
-        const currTime = new Date().getTime();
-        const expiryTime = currTime + rateLimitExpiryTime;
+        const expiryTime = Date.now() + rateLimitExpiryTime;
 
         localStorage.setItem(
             FAUCET_RATE_LIMIT_EXPIRY_TIME_KEY,

--- a/apps/wallet/src/ui/app/shared/faucet/useFaucetRateLimiter.ts
+++ b/apps/wallet/src/ui/app/shared/faucet/useFaucetRateLimiter.ts
@@ -1,0 +1,67 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useCallback, useEffect, useState } from 'react';
+import Browser from 'webextension-polyfill';
+
+const IS_RATE_LIMITED_FROM_FAUCET_STORAGE_KEY = 'is_rate_limited_from_faucet';
+
+const FAUCET_RATE_LIMIT_EXPIRY_TIME_STORAGE_KEY =
+    'faucet_rate_limit_expiry_time';
+
+const rateLimitExpiryTime = 5000; // 24 * 60 * 60 * 1000;
+
+export function useFaucetRateLimiter() {
+    const [isRateLimited, setRateLimited] = useState(false);
+
+    const rateLimit = useCallback(() => {
+        Browser.storage.local.set({
+            [IS_RATE_LIMITED_FROM_FAUCET_STORAGE_KEY]: true,
+            [FAUCET_RATE_LIMIT_EXPIRY_TIME_STORAGE_KEY]:
+                new Date().getTime() + rateLimitExpiryTime,
+        });
+    }, []);
+
+    useEffect(() => {
+        Browser.storage.local
+            .get({
+                [FAUCET_RATE_LIMIT_EXPIRY_TIME_STORAGE_KEY]: null,
+            })
+            .then(
+                ({
+                    [FAUCET_RATE_LIMIT_EXPIRY_TIME_STORAGE_KEY]: expiryTime,
+                }) => {
+                    const currTime = new Date().getTime();
+                    if (currTime > expiryTime) {
+                        Browser.storage.local.set({
+                            [IS_RATE_LIMITED_FROM_FAUCET_STORAGE_KEY]: false,
+                            [FAUCET_RATE_LIMIT_EXPIRY_TIME_STORAGE_KEY]: null,
+                        });
+                        setRateLimited(false);
+                    } else {
+                        setRateLimited(true);
+                    }
+                }
+            );
+    }, []);
+
+    useEffect(() => {
+        const changesCallback = (
+            changes: Browser.Storage.StorageAreaOnChangedChangesType
+        ) => {
+            if (IS_RATE_LIMITED_FROM_FAUCET_STORAGE_KEY in changes) {
+                const { newValue } =
+                    changes[IS_RATE_LIMITED_FROM_FAUCET_STORAGE_KEY];
+
+                setRateLimited(Boolean(newValue));
+            }
+        };
+
+        Browser.storage.local.onChanged.addListener(changesCallback);
+        return () => {
+            Browser.storage.local.onChanged.removeListener(changesCallback);
+        };
+    }, []);
+
+    return [isRateLimited, rateLimit] as const;
+}

--- a/apps/wallet/src/ui/app/shared/faucet/useFaucetRateLimiter.ts
+++ b/apps/wallet/src/ui/app/shared/faucet/useFaucetRateLimiter.ts
@@ -9,7 +9,9 @@ const IS_RATE_LIMITED_FROM_FAUCET_STORAGE_KEY = 'is_rate_limited_from_faucet';
 const FAUCET_RATE_LIMIT_EXPIRY_TIME_STORAGE_KEY =
     'faucet_rate_limit_expiry_time';
 
-const rateLimitExpiryTime = 24 * 60 * 60 * 1000;
+// We'll rate limit users for 20 minutes which should
+// more-or-less mock how the faucet API rate limits users
+const rateLimitExpiryTime = 20 * 60 * 1000;
 
 export function useFaucetRateLimiter() {
     const [isRateLimited, setRateLimited] = useState(false);

--- a/apps/wallet/src/ui/app/shared/faucet/useFaucetRateLimiter.ts
+++ b/apps/wallet/src/ui/app/shared/faucet/useFaucetRateLimiter.ts
@@ -2,70 +2,38 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useEffect, useState } from 'react';
-import Browser from 'webextension-polyfill';
 
-const IS_RATE_LIMITED_FROM_FAUCET_STORAGE_KEY = 'is_rate_limited_from_faucet';
-
-const FAUCET_RATE_LIMIT_EXPIRY_TIME_STORAGE_KEY =
-    'faucet_rate_limit_expiry_time';
+const FAUCET_RATE_LIMIT_EXPIRY_TIME_KEY = 'faucet_rate_limit_expiry_time';
 
 // We'll rate limit users for 20 minutes which should
 // more-or-less mock how the faucet API rate limits users
 const rateLimitExpiryTime = 20 * 60 * 1000;
 
 export function useFaucetRateLimiter() {
-    const [isRateLimited, setRateLimited] = useState(false);
+    const [isRateLimited, setRateLimited] = useState(() => {
+        const expiryTime = localStorage.getItem(
+            FAUCET_RATE_LIMIT_EXPIRY_TIME_KEY
+        );
+        const currTime = new Date().getTime();
+        return currTime <= Number(expiryTime);
+    });
 
     const rateLimit = () => {
-        Browser.storage.local.set({
-            [IS_RATE_LIMITED_FROM_FAUCET_STORAGE_KEY]: true,
-            [FAUCET_RATE_LIMIT_EXPIRY_TIME_STORAGE_KEY]:
-                new Date().getTime() + rateLimitExpiryTime,
-        });
+        const currTime = new Date().getTime();
+        const expiryTime = currTime + rateLimitExpiryTime;
+
+        localStorage.setItem(
+            FAUCET_RATE_LIMIT_EXPIRY_TIME_KEY,
+            String(expiryTime)
+        );
+        setRateLimited(true);
     };
 
     useEffect(() => {
-        const onChanged = (
-            changes: Browser.Storage.StorageAreaOnChangedChangesType
-        ) => {
-            if (IS_RATE_LIMITED_FROM_FAUCET_STORAGE_KEY in changes) {
-                const { newValue } =
-                    changes[IS_RATE_LIMITED_FROM_FAUCET_STORAGE_KEY];
-
-                setRateLimited(Boolean(newValue));
-            }
-        };
-
-        Browser.storage.local.onChanged.addListener(onChanged);
-        return () => {
-            Browser.storage.local.onChanged.removeListener(onChanged);
-        };
-    }, []);
-
-    useEffect(() => {
-        Browser.storage.local
-            .get({
-                [IS_RATE_LIMITED_FROM_FAUCET_STORAGE_KEY]: false,
-                [FAUCET_RATE_LIMIT_EXPIRY_TIME_STORAGE_KEY]: null,
-            })
-            .then(
-                ({
-                    [IS_RATE_LIMITED_FROM_FAUCET_STORAGE_KEY]: isRateLimited,
-                    [FAUCET_RATE_LIMIT_EXPIRY_TIME_STORAGE_KEY]: expiryTime,
-                }) => {
-                    const currTime = new Date().getTime();
-                    if (expiryTime && currTime > expiryTime) {
-                        Browser.storage.local.set({
-                            [IS_RATE_LIMITED_FROM_FAUCET_STORAGE_KEY]: false,
-                            [FAUCET_RATE_LIMIT_EXPIRY_TIME_STORAGE_KEY]: null,
-                        });
-                        setRateLimited(false);
-                    } else {
-                        setRateLimited(isRateLimited);
-                    }
-                }
-            );
-    }, []);
+        if (!isRateLimited) {
+            localStorage.removeItem(FAUCET_RATE_LIMIT_EXPIRY_TIME_KEY);
+        }
+    }, [isRateLimited]);
 
     return [isRateLimited, rateLimit] as const;
 }

--- a/apps/wallet/src/ui/app/shared/faucet/useFaucetRateLimiter.ts
+++ b/apps/wallet/src/ui/app/shared/faucet/useFaucetRateLimiter.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import Browser from 'webextension-polyfill';
 
 const IS_RATE_LIMITED_FROM_FAUCET_STORAGE_KEY = 'is_rate_limited_from_faucet';
@@ -16,13 +16,13 @@ const rateLimitExpiryTime = 20 * 60 * 1000;
 export function useFaucetRateLimiter() {
     const [isRateLimited, setRateLimited] = useState(false);
 
-    const rateLimit = useCallback(() => {
+    const rateLimit = () => {
         Browser.storage.local.set({
             [IS_RATE_LIMITED_FROM_FAUCET_STORAGE_KEY]: true,
             [FAUCET_RATE_LIMIT_EXPIRY_TIME_STORAGE_KEY]:
                 new Date().getTime() + rateLimitExpiryTime,
         });
-    }, []);
+    };
 
     useEffect(() => {
         const changesCallback = (

--- a/apps/wallet/src/ui/app/shared/faucet/useFaucetRateLimiter.ts
+++ b/apps/wallet/src/ui/app/shared/faucet/useFaucetRateLimiter.ts
@@ -25,7 +25,7 @@ export function useFaucetRateLimiter() {
     };
 
     useEffect(() => {
-        const changesCallback = (
+        const onChanged = (
             changes: Browser.Storage.StorageAreaOnChangedChangesType
         ) => {
             if (IS_RATE_LIMITED_FROM_FAUCET_STORAGE_KEY in changes) {
@@ -36,9 +36,9 @@ export function useFaucetRateLimiter() {
             }
         };
 
-        Browser.storage.local.onChanged.addListener(changesCallback);
+        Browser.storage.local.onChanged.addListener(onChanged);
         return () => {
-            Browser.storage.local.onChanged.removeListener(changesCallback);
+            Browser.storage.local.onChanged.removeListener(onChanged);
         };
     }, []);
 

--- a/apps/wallet/src/ui/app/shared/faucet/useFaucetRateLimiter.ts
+++ b/apps/wallet/src/ui/app/shared/faucet/useFaucetRateLimiter.ts
@@ -45,10 +45,12 @@ export function useFaucetRateLimiter() {
     useEffect(() => {
         Browser.storage.local
             .get({
+                [IS_RATE_LIMITED_FROM_FAUCET_STORAGE_KEY]: false,
                 [FAUCET_RATE_LIMIT_EXPIRY_TIME_STORAGE_KEY]: null,
             })
             .then(
                 ({
+                    [IS_RATE_LIMITED_FROM_FAUCET_STORAGE_KEY]: isRateLimited,
                     [FAUCET_RATE_LIMIT_EXPIRY_TIME_STORAGE_KEY]: expiryTime,
                 }) => {
                     const currTime = new Date().getTime();
@@ -59,7 +61,7 @@ export function useFaucetRateLimiter() {
                         });
                         setRateLimited(false);
                     } else {
-                        setRateLimited(true);
+                        setRateLimited(isRateLimited);
                     }
                 }
             );

--- a/apps/wallet/src/ui/app/shared/faucet/useFaucetRateLimiter.ts
+++ b/apps/wallet/src/ui/app/shared/faucet/useFaucetRateLimiter.ts
@@ -9,7 +9,7 @@ const IS_RATE_LIMITED_FROM_FAUCET_STORAGE_KEY = 'is_rate_limited_from_faucet';
 const FAUCET_RATE_LIMIT_EXPIRY_TIME_STORAGE_KEY =
     'faucet_rate_limit_expiry_time';
 
-const rateLimitExpiryTime = 5000; // 24 * 60 * 60 * 1000;
+const rateLimitExpiryTime = 24 * 60 * 60 * 1000;
 
 export function useFaucetRateLimiter() {
     const [isRateLimited, setRateLimited] = useState(false);
@@ -20,29 +20,6 @@ export function useFaucetRateLimiter() {
             [FAUCET_RATE_LIMIT_EXPIRY_TIME_STORAGE_KEY]:
                 new Date().getTime() + rateLimitExpiryTime,
         });
-    }, []);
-
-    useEffect(() => {
-        Browser.storage.local
-            .get({
-                [FAUCET_RATE_LIMIT_EXPIRY_TIME_STORAGE_KEY]: null,
-            })
-            .then(
-                ({
-                    [FAUCET_RATE_LIMIT_EXPIRY_TIME_STORAGE_KEY]: expiryTime,
-                }) => {
-                    const currTime = new Date().getTime();
-                    if (currTime > expiryTime) {
-                        Browser.storage.local.set({
-                            [IS_RATE_LIMITED_FROM_FAUCET_STORAGE_KEY]: false,
-                            [FAUCET_RATE_LIMIT_EXPIRY_TIME_STORAGE_KEY]: null,
-                        });
-                        setRateLimited(false);
-                    } else {
-                        setRateLimited(true);
-                    }
-                }
-            );
     }, []);
 
     useEffect(() => {
@@ -61,6 +38,29 @@ export function useFaucetRateLimiter() {
         return () => {
             Browser.storage.local.onChanged.removeListener(changesCallback);
         };
+    }, []);
+
+    useEffect(() => {
+        Browser.storage.local
+            .get({
+                [FAUCET_RATE_LIMIT_EXPIRY_TIME_STORAGE_KEY]: null,
+            })
+            .then(
+                ({
+                    [FAUCET_RATE_LIMIT_EXPIRY_TIME_STORAGE_KEY]: expiryTime,
+                }) => {
+                    const currTime = new Date().getTime();
+                    if (expiryTime && currTime > expiryTime) {
+                        Browser.storage.local.set({
+                            [IS_RATE_LIMITED_FROM_FAUCET_STORAGE_KEY]: false,
+                            [FAUCET_RATE_LIMIT_EXPIRY_TIME_STORAGE_KEY]: null,
+                        });
+                        setRateLimited(false);
+                    } else {
+                        setRateLimited(true);
+                    }
+                }
+            );
     }, []);
 
     return [isRateLimited, rateLimit] as const;


### PR DESCRIPTION
## Description 

We have around 40M events per month of people spam clicking the "Request testnet faucet" button, so this PR disables the testnet faucet button if the user has already been rate limited by the API. This isn't perfect but hopefully, it should deter bots spam clicking the button in the wallet.

https://user-images.githubusercontent.com/7453188/230175456-69b510fd-abee-4189-94db-d89d01cd591a.mov

## Test Plan 
- Manual testing with an expiry time of 5 seconds

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
N/A
