### PR TITLE
[JSONRPC] - offload jsonrpc call to todo blocking thread for method with large response

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2027,7 +2027,7 @@ impl AuthorityState {
         Ok(checkpoint)
     }
 
-    pub async fn get_object_read(&self, object_id: &ObjectID) -> Result<ObjectRead, SuiError> {
+    pub fn get_object_read(&self, object_id: &ObjectID) -> Result<ObjectRead, SuiError> {
         match self.database.get_object_or_tombstone(*object_id)? {
             None => Ok(ObjectRead::NotExists(*object_id)),
             Some(obj_ref) => {
@@ -2067,7 +2067,7 @@ impl AuthorityState {
     where
         T: DeserializeOwned,
     {
-        let o = self.get_object_read(object_id).await?.into_object()?;
+        let o = self.get_object_read(object_id)?.into_object()?;
         if let Some(move_object) = o.data.try_as_move() {
             Ok(bcs::from_bytes(move_object.contents()).map_err(|e| {
                 SuiError::ObjectDeserializationError {
@@ -2297,7 +2297,7 @@ impl AuthorityState {
         transaction.ok_or_else(|| anyhow!(SuiError::TransactionNotFound { digest }))
     }
 
-    pub async fn get_executed_effects(
+    pub fn get_executed_effects(
         &self,
         digest: TransactionDigest,
     ) -> Result<TransactionEffects, anyhow::Error> {
@@ -2305,21 +2305,21 @@ impl AuthorityState {
         effects.ok_or_else(|| anyhow!(SuiError::TransactionNotFound { digest }))
     }
 
-    pub async fn multi_get_executed_transactions(
+    pub fn multi_get_executed_transactions(
         &self,
         digests: &[TransactionDigest],
     ) -> Result<Vec<Option<VerifiedTransaction>>, anyhow::Error> {
         Ok(self.database.multi_get_transaction_blocks(digests)?)
     }
 
-    pub async fn multi_get_executed_effects(
+    pub fn multi_get_executed_effects(
         &self,
         digests: &[TransactionDigest],
     ) -> Result<Vec<Option<TransactionEffects>>, anyhow::Error> {
         Ok(self.database.multi_get_executed_effects(digests)?)
     }
 
-    pub async fn multi_get_transaction_checkpoint(
+    pub fn multi_get_transaction_checkpoint(
         &self,
         digests: &[TransactionDigest],
     ) -> Result<Vec<Option<(EpochId, CheckpointSequenceNumber)>>, anyhow::Error> {
@@ -2555,7 +2555,7 @@ impl AuthorityState {
         Ok(self.get_indexes()?.get_timestamp_ms(digest)?)
     }
 
-    pub async fn query_events(
+    pub fn query_events(
         &self,
         query: EventFilter,
         // If `Some`, the query will start from the next item after the specified cursor

--- a/crates/sui-core/src/unit_tests/move_package_publish_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_publish_tests.rs
@@ -52,7 +52,6 @@ async fn test_publishing_with_unpublished_deps() {
 
     let ObjectRead::Exists(read_ref, package_obj, _) = authority
         .get_object_read(&package.0)
-        .await
         .unwrap()
     else {
         panic!("Can't read package")

--- a/crates/sui-indexer/src/apis/coin_api.rs
+++ b/crates/sui-indexer/src/apis/coin_api.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
+use futures::executor::block_on;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::http_client::HttpClient;
 use jsonrpsee::RpcModule;
@@ -48,16 +49,12 @@ impl CoinReadApiServer for CoinReadApi {
         self.fullnode.get_all_coins(owner, cursor, limit).await
     }
 
-    async fn get_balance(
-        &self,
-        owner: SuiAddress,
-        coin_type: Option<String>,
-    ) -> RpcResult<Balance> {
-        self.fullnode.get_balance(owner, coin_type).await
+    fn get_balance(&self, owner: SuiAddress, coin_type: Option<String>) -> RpcResult<Balance> {
+        block_on(self.fullnode.get_balance(owner, coin_type))
     }
 
-    async fn get_all_balances(&self, owner: SuiAddress) -> RpcResult<Vec<Balance>> {
-        self.fullnode.get_all_balances(owner).await
+    fn get_all_balances(&self, owner: SuiAddress) -> RpcResult<Vec<Balance>> {
+        block_on(self.fullnode.get_all_balances(owner))
     }
 
     async fn get_coin_metadata(&self, coin_type: String) -> RpcResult<SuiCoinMetadata> {

--- a/crates/sui-indexer/src/apis/indexer_api.rs
+++ b/crates/sui-indexer/src/apis/indexer_api.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use anyhow::anyhow;
 use async_trait::async_trait;
 use futures::executor::block_on;
+use futures::future::join_all;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::http_client::HttpClient;
 use jsonrpsee::types::SubscriptionResult;
@@ -337,9 +338,12 @@ where
                 descending_order,
             ));
         }
-        Ok(self
-            .query_transaction_blocks_internal(query, cursor, limit, descending_order)
-            .await?)
+        Ok(block_on(self.query_transaction_blocks_internal(
+            query,
+            cursor,
+            limit,
+            descending_order,
+        ))?)
     }
 
     fn query_events(
@@ -356,9 +360,12 @@ where
                     .query_events(query, cursor, limit, descending_order),
             );
         }
-        Ok(self
-            .query_events_internal(query, cursor, limit, descending_order)
-            .await?)
+        Ok(block_on(self.query_events_internal(
+            query,
+            cursor,
+            limit,
+            descending_order,
+        ))?)
     }
 
     fn get_dynamic_fields(

--- a/crates/sui-indexer/src/apis/indexer_api.rs
+++ b/crates/sui-indexer/src/apis/indexer_api.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use anyhow::anyhow;
 use async_trait::async_trait;
-use futures::future::join_all;
+use futures::executor::block_on;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::http_client::HttpClient;
 use jsonrpsee::types::SubscriptionResult;
@@ -300,7 +300,7 @@ impl<S> IndexerApiServer for IndexerApi<S>
 where
     S: IndexerStore + Sync + Send + 'static,
 {
-    async fn get_owned_objects(
+    fn get_owned_objects(
         &self,
         address: SuiAddress,
         query: Option<SuiObjectResponseQuery>,
@@ -311,17 +311,15 @@ where
             .migrated_methods
             .contains(&"get_owned_objects".to_string())
         {
-            return self
-                .fullnode
-                .get_owned_objects(address, query, cursor, limit)
-                .await;
+            return block_on(
+                self.fullnode
+                    .get_owned_objects(address, query, cursor, limit),
+            );
         }
-        Ok(self
-            .get_owned_objects_internal(address, query, cursor, limit)
-            .await?)
+        block_on(self.get_owned_objects_internal(address, query, cursor, limit))
     }
 
-    async fn query_transaction_blocks(
+    fn query_transaction_blocks(
         &self,
         query: SuiTransactionBlockResponseQuery,
         cursor: Option<TransactionDigest>,
@@ -332,17 +330,19 @@ where
             .migrated_methods
             .contains(&"query_transaction_blocks".to_string())
         {
-            return self
-                .fullnode
-                .query_transaction_blocks(query, cursor, limit, descending_order)
-                .await;
+            return block_on(self.fullnode.query_transaction_blocks(
+                query,
+                cursor,
+                limit,
+                descending_order,
+            ));
         }
         Ok(self
             .query_transaction_blocks_internal(query, cursor, limit, descending_order)
             .await?)
     }
 
-    async fn query_events(
+    fn query_events(
         &self,
         query: EventFilter,
         // exclusive cursor if `Some`, otherwise start from the beginning
@@ -351,25 +351,26 @@ where
         descending_order: Option<bool>,
     ) -> RpcResult<EventPage> {
         if self.migrated_methods.contains(&"query_events".to_string()) {
-            return self
-                .fullnode
-                .query_events(query, cursor, limit, descending_order)
-                .await;
+            return block_on(
+                self.fullnode
+                    .query_events(query, cursor, limit, descending_order),
+            );
         }
         Ok(self
             .query_events_internal(query, cursor, limit, descending_order)
             .await?)
     }
 
-    async fn get_dynamic_fields(
+    fn get_dynamic_fields(
         &self,
         parent_object_id: ObjectID,
         cursor: Option<ObjectID>,
         limit: Option<usize>,
     ) -> RpcResult<DynamicFieldPage> {
-        self.fullnode
-            .get_dynamic_fields(parent_object_id, cursor, limit)
-            .await
+        block_on(
+            self.fullnode
+                .get_dynamic_fields(parent_object_id, cursor, limit),
+        )
     }
 
     async fn get_dynamic_field_object(

--- a/crates/sui-indexer/src/apis/read_api.rs
+++ b/crates/sui-indexer/src/apis/read_api.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
+use futures::executor::block_on;
 use futures::future::join_all;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::http_client::HttpClient;
@@ -125,24 +126,24 @@ impl<S> ReadApiServer for ReadApi<S>
 where
     S: IndexerStore + Sync + Send + 'static,
 {
-    async fn get_object(
+    fn get_object(
         &self,
         object_id: ObjectID,
         options: Option<SuiObjectDataOptions>,
     ) -> RpcResult<SuiObjectResponse> {
         if !self.migrated_methods.contains(&"get_object".into()) {
-            return self.fullnode.get_object(object_id, options).await;
+            return block_on(async { self.fullnode.get_object(object_id, options).await });
         }
 
         Ok(self.get_object_internal(object_id, options).await?)
     }
 
-    async fn multi_get_objects(
+    fn multi_get_objects(
         &self,
         object_ids: Vec<ObjectID>,
         options: Option<SuiObjectDataOptions>,
     ) -> RpcResult<Vec<SuiObjectResponse>> {
-        return self.fullnode.multi_get_objects(object_ids, options).await;
+        block_on(async { self.fullnode.multi_get_objects(object_ids, options).await })
     }
 
     async fn get_total_transaction_blocks(&self) -> RpcResult<BigInt> {
@@ -171,7 +172,7 @@ where
             .await?)
     }
 
-    async fn multi_get_transaction_blocks(
+    fn multi_get_transaction_blocks(
         &self,
         digests: Vec<TransactionDigest>,
         options: Option<SuiTransactionBlockResponseOptions>,
@@ -180,14 +181,11 @@ where
             .migrated_methods
             .contains(&"multi_get_transaction_blocks".to_string())
         {
-            return self
-                .fullnode
-                .multi_get_transaction_blocks(digests, options)
-                .await;
+            return block_on(self.fullnode.multi_get_transaction_blocks(digests, options));
         }
-        Ok(self
-            .multi_get_transaction_blocks_internal(&digests, options)
-            .await?)
+        Ok(block_on(
+            self.multi_get_transaction_blocks_internal(&digests, options),
+        )?)
     }
 
     async fn try_get_past_object(
@@ -201,14 +199,15 @@ where
             .await
     }
 
-    async fn try_multi_get_past_objects(
+    fn try_multi_get_past_objects(
         &self,
         past_objects: Vec<SuiGetPastObjectRequest>,
         options: Option<SuiObjectDataOptions>,
     ) -> RpcResult<Vec<SuiPastObjectResponse>> {
-        self.fullnode
-            .try_multi_get_past_objects(past_objects, options)
-            .await
+        block_on(
+            self.fullnode
+                .try_multi_get_past_objects(past_objects, options),
+        )
     }
 
     async fn get_latest_checkpoint_sequence_number(
@@ -236,20 +235,20 @@ where
         Ok(self.state.get_checkpoint(id).await?)
     }
 
-    async fn get_checkpoints(
+    fn get_checkpoints(
         &self,
         cursor: Option<SuiCheckpointSequenceNumber>,
         limit: Option<usize>,
         descending_order: bool,
     ) -> RpcResult<CheckpointPage> {
-        return self
-            .fullnode
-            .get_checkpoints(cursor, limit, descending_order)
-            .await;
+        return block_on(
+            self.fullnode
+                .get_checkpoints(cursor, limit, descending_order),
+        );
     }
 
-    async fn get_events(&self, transaction_digest: TransactionDigest) -> RpcResult<Vec<SuiEvent>> {
-        self.fullnode.get_events(transaction_digest).await
+    fn get_events(&self, transaction_digest: TransactionDigest) -> RpcResult<Vec<SuiEvent>> {
+        block_on(self.fullnode.get_events(transaction_digest))
     }
 }
 

--- a/crates/sui-indexer/src/apis/read_api.rs
+++ b/crates/sui-indexer/src/apis/read_api.rs
@@ -135,7 +135,7 @@ where
             return block_on(async { self.fullnode.get_object(object_id, options).await });
         }
 
-        Ok(self.get_object_internal(object_id, options).await?)
+        Ok(block_on(self.get_object_internal(object_id, options))?)
     }
 
     fn multi_get_objects(

--- a/crates/sui-json-rpc/src/api/coin.rs
+++ b/crates/sui-json-rpc/src/api/coin.rs
@@ -38,8 +38,8 @@ pub trait CoinReadApi {
     ) -> RpcResult<CoinPage>;
 
     /// Return the total coin balance for one coin type, owned by the address owner.
-    #[method(name = "getBalance")]
-    async fn get_balance(
+    #[method(name = "getBalance", blocking)]
+    fn get_balance(
         &self,
         /// the owner's Sui address
         owner: SuiAddress,
@@ -48,8 +48,8 @@ pub trait CoinReadApi {
     ) -> RpcResult<Balance>;
 
     /// Return the total coin balance for all coin type, owned by the address owner.
-    #[method(name = "getAllBalances")]
-    async fn get_all_balances(
+    #[method(name = "getAllBalances", blocking)]
+    fn get_all_balances(
         &self,
         /// the owner's Sui address
         owner: SuiAddress,

--- a/crates/sui-json-rpc/src/api/indexer.rs
+++ b/crates/sui-json-rpc/src/api/indexer.rs
@@ -22,8 +22,8 @@ pub trait IndexerApi {
     /// the pagination is not accurate, because previous page may have been updated when
     /// the next page is fetched.
     /// Please use suix_queryObjects if this is a concern.
-    #[method(name = "getOwnedObjects")]
-    async fn get_owned_objects(
+    #[method(name = "getOwnedObjects", blocking)]
+    fn get_owned_objects(
         &self,
         /// the owner's Sui address
         address: SuiAddress,
@@ -36,8 +36,8 @@ pub trait IndexerApi {
     ) -> RpcResult<ObjectsPage>;
 
     /// Return list of transactions for a specified query criteria.
-    #[method(name = "queryTransactionBlocks")]
-    async fn query_transaction_blocks(
+    #[method(name = "queryTransactionBlocks", blocking)]
+    fn query_transaction_blocks(
         &self,
         /// the transaction query criteria.
         query: SuiTransactionBlockResponseQuery,
@@ -50,8 +50,8 @@ pub trait IndexerApi {
     ) -> RpcResult<TransactionBlocksPage>;
 
     /// Return list of events for a specified query criteria.
-    #[method(name = "queryEvents")]
-    async fn query_events(
+    #[method(name = "queryEvents", blocking)]
+    fn query_events(
         &self,
         /// the event query criteria.
         query: EventFilter,
@@ -72,8 +72,8 @@ pub trait IndexerApi {
     );
 
     /// Return the list of dynamic field objects owned by an object.
-    #[method(name = "getDynamicFields")]
-    async fn get_dynamic_fields(
+    #[method(name = "getDynamicFields", blocking)]
+    fn get_dynamic_fields(
         &self,
         /// The ID of the parent object
         parent_object_id: ObjectID,

--- a/crates/sui-json-rpc/src/api/read.rs
+++ b/crates/sui-json-rpc/src/api/read.rs
@@ -28,8 +28,8 @@ pub trait ReadApi {
     /// Returns an ordered list of transaction responses
     /// The method will throw an error if the input contains any duplicate or
     /// the input size exceeds QUERY_MAX_RESULT_LIMIT
-    #[method(name = "multiGetTransactionBlocks")]
-    async fn multi_get_transaction_blocks(
+    #[method(name = "multiGetTransactionBlocks", blocking)]
+    fn multi_get_transaction_blocks(
         &self,
         /// A list of transaction digests.
         digests: Vec<TransactionDigest>,
@@ -38,8 +38,8 @@ pub trait ReadApi {
     ) -> RpcResult<Vec<SuiTransactionBlockResponse>>;
 
     /// Return the object information for a specified object
-    #[method(name = "getObject")]
-    async fn get_object(
+    #[method(name = "getObject", blocking)]
+    fn get_object(
         &self,
         /// the ID of the queried object
         object_id: ObjectID,
@@ -48,8 +48,8 @@ pub trait ReadApi {
     ) -> RpcResult<SuiObjectResponse>;
 
     /// Return the object data for a list of objects
-    #[method(name = "multiGetObjects")]
-    async fn multi_get_objects(
+    #[method(name = "multiGetObjects", blocking)]
+    fn multi_get_objects(
         &self,
         /// the IDs of the queried objects
         object_ids: Vec<ObjectID>,
@@ -76,8 +76,8 @@ pub trait ReadApi {
     /// can be retrieved by this API, even if the object and version exists/existed.
     /// The result may vary across nodes depending on their pruning policies.
     /// Return the object information for a specified version
-    #[method(name = "tryMultiGetPastObjects")]
-    async fn try_multi_get_past_objects(
+    #[method(name = "tryMultiGetPastObjects", blocking)]
+    fn try_multi_get_past_objects(
         &self,
         /// a vector of object and versions to be queried
         past_objects: Vec<SuiGetPastObjectRequest>,
@@ -94,8 +94,8 @@ pub trait ReadApi {
     ) -> RpcResult<Checkpoint>;
 
     /// Return paginated list of checkpoints
-    #[method(name = "getCheckpoints")]
-    async fn get_checkpoints(
+    #[method(name = "getCheckpoints", blocking)]
+    fn get_checkpoints(
         &self,
         /// An optional paging cursor. If provided, the query will start from the next item after the specified cursor. Default to start from the first item if not specified.
         cursor: Option<SuiCheckpointSequenceNumber>,
@@ -106,8 +106,8 @@ pub trait ReadApi {
     ) -> RpcResult<CheckpointPage>;
 
     /// Return transaction events.
-    #[method(name = "getEvents")]
-    async fn get_events(
+    #[method(name = "getEvents", blocking)]
+    fn get_events(
         &self,
         /// the event query criteria.
         transaction_digest: TransactionDigest,

--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -51,12 +51,10 @@ impl GovernanceReadApi {
         &self,
         staked_sui_ids: Vec<ObjectID>,
     ) -> Result<Vec<DelegatedStake>, Error> {
-        let stakes_read = futures::future::try_join_all(
-            staked_sui_ids
-                .iter()
-                .map(|id| self.state.get_object_read(id)),
-        )
-        .await?;
+        let stakes_read = staked_sui_ids
+            .iter()
+            .map(|id| self.state.get_object_read(id))
+            .collect::<Result<Vec<_>, _>>()?;
         if stakes_read.is_empty() {
             return Ok(vec![]);
         }

--- a/crates/sui-json-rpc/src/move_utils.rs
+++ b/crates/sui-json-rpc/src/move_utils.rs
@@ -110,7 +110,6 @@ impl MoveUtilsServer for MoveUtils {
         let object_read = self
             .state
             .get_object_read(&package)
-            .await
             .map_err(|e| anyhow!("{e}"))?;
 
         let normalized = match object_read {

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use anyhow::anyhow;
 use async_trait::async_trait;
 use fastcrypto::encoding::Base64;
+use futures::executor::block_on;
 use futures::future::join_all;
 use itertools::Itertools;
 use jsonrpsee::core::RpcResult;
@@ -124,291 +125,12 @@ impl ReadApi {
             }
         })
     }
-}
 
-#[async_trait]
-impl ReadApiServer for ReadApi {
-    async fn get_object(
-        &self,
-        object_id: ObjectID,
-        options: Option<SuiObjectDataOptions>,
-    ) -> RpcResult<SuiObjectResponse> {
-        let object_read = self.state.get_object_read(&object_id).await.map_err(|e| {
-            warn!(?object_id, "Failed to get object: {:?}", e);
-            anyhow!("{e}")
-        })?;
-        let options = options.unwrap_or_default();
-
-        match object_read {
-            ObjectRead::NotExists(id) => Ok(SuiObjectResponse::new_with_error(
-                SuiObjectResponseError::NotExists { object_id: id },
-            )),
-            ObjectRead::Exists(object_ref, o, layout) => {
-                let mut display_fields = None;
-                if options.show_display {
-                    match get_display_fields(self, &o, &layout).await {
-                        Ok(rendered_fields) => display_fields = Some(rendered_fields),
-                        Err(e) => {
-                            return Ok(SuiObjectResponse::new(
-                                Some((object_ref, o, layout, options, None).try_into()?),
-                                Some(SuiObjectResponseError::DisplayError {
-                                    error: e.to_string(),
-                                }),
-                            ))
-                        }
-                    }
-                }
-                Ok(SuiObjectResponse::new_with_data(
-                    (object_ref, o, layout, options, display_fields).try_into()?,
-                ))
-            }
-            ObjectRead::Deleted((object_id, version, digest)) => Ok(
-                SuiObjectResponse::new_with_error(SuiObjectResponseError::Deleted {
-                    object_id,
-                    version,
-                    digest,
-                }),
-            ),
-        }
-    }
-
-    async fn multi_get_objects(
-        &self,
-        object_ids: Vec<ObjectID>,
-        options: Option<SuiObjectDataOptions>,
-    ) -> RpcResult<Vec<SuiObjectResponse>> {
-        if object_ids.len() <= QUERY_MAX_RESULT_LIMIT {
-            let mut futures = vec![];
-            for object_id in object_ids {
-                futures.push(self.get_object(object_id, options.clone()))
-            }
-            let results = join_all(futures).await;
-            let objects_result: Result<Vec<SuiObjectResponse>, String> = results
-                .into_iter()
-                .map(|result| match result {
-                    Ok(response) => Ok(response),
-                    Err(error) => {
-                        error!("Failed to fetch object with error: {error:?}");
-                        Err(format!("Error: {}", error))
-                    }
-                })
-                .collect();
-
-            let objects = objects_result.map_err(|err| {
-                Error::UnexpectedError(format!("Failed to fetch objects with error: {}", err))
-            })?;
-
-            Ok(objects)
-        } else {
-            Err(anyhow!(UserInputError::SizeLimitExceeded {
-                limit: "input limit".to_string(),
-                value: QUERY_MAX_RESULT_LIMIT.to_string()
-            })
-            .into())
-        }
-    }
-
-    async fn try_get_past_object(
-        &self,
-        object_id: ObjectID,
-        version: SequenceNumber,
-        options: Option<SuiObjectDataOptions>,
-    ) -> RpcResult<SuiPastObjectResponse> {
-        let past_read = self
-            .state
-            .get_past_object_read(&object_id, version)
-            .await
-            .map_err(|e| {
-                error!("Failed to call try_get_past_object for object: {object_id:?} version: {version:?} with error: {e:?}");
-                anyhow!("{e}")
-            })?;
-        let options = options.unwrap_or_default();
-        match past_read {
-            PastObjectRead::ObjectNotExists(id) => Ok(SuiPastObjectResponse::ObjectNotExists(id)),
-            PastObjectRead::VersionFound(object_ref, o, layout) => {
-                let display_fields = if options.show_display {
-                    // TODO (jian): api breaking change to also modify past objects.
-                    Some(get_display_fields(self, &o, &layout).await?)
-                } else {
-                    None
-                };
-                Ok(SuiPastObjectResponse::VersionFound(
-                    (object_ref, o, layout, options, display_fields).try_into()?,
-                ))
-            }
-            PastObjectRead::ObjectDeleted(oref) => {
-                Ok(SuiPastObjectResponse::ObjectDeleted(oref.into()))
-            }
-            PastObjectRead::VersionNotFound(id, seq_num) => {
-                Ok(SuiPastObjectResponse::VersionNotFound(id, seq_num))
-            }
-            PastObjectRead::VersionTooHigh {
-                object_id,
-                asked_version,
-                latest_version,
-            } => Ok(SuiPastObjectResponse::VersionTooHigh {
-                object_id,
-                asked_version,
-                latest_version,
-            }),
-        }
-    }
-
-    async fn try_multi_get_past_objects(
-        &self,
-        past_objects: Vec<SuiGetPastObjectRequest>,
-        options: Option<SuiObjectDataOptions>,
-    ) -> RpcResult<Vec<SuiPastObjectResponse>> {
-        if past_objects.len() <= QUERY_MAX_RESULT_LIMIT {
-            let mut futures = vec![];
-            for past_object in past_objects {
-                futures.push(self.try_get_past_object(
-                    past_object.object_id,
-                    past_object.version,
-                    options.clone(),
-                ));
-            }
-            let results = join_all(futures).await;
-            let (oks, errs): (Vec<_>, Vec<_>) = results.into_iter().partition(Result::is_ok);
-            let success = oks.into_iter().filter_map(Result::ok).collect();
-            let errors: Vec<_> = errs.into_iter().filter_map(Result::err).collect();
-            if !errors.is_empty() {
-                let error_string = errors
-                    .iter()
-                    .map(|e| e.to_string())
-                    .collect::<Vec<String>>()
-                    .join("; ");
-                Err(anyhow!("{error_string}").into())
-            } else {
-                Ok(success)
-            }
-        } else {
-            Err(anyhow!(UserInputError::SizeLimitExceeded {
-                limit: "input limit".to_string(),
-                value: QUERY_MAX_RESULT_LIMIT.to_string()
-            })
-            .into())
-        }
-    }
-
-    async fn get_total_transaction_blocks(&self) -> RpcResult<BigInt> {
-        Ok(self.state.get_total_transaction_blocks()?.into())
-    }
-
-    async fn get_transaction_block(
-        &self,
-        digest: TransactionDigest,
-        opts: Option<SuiTransactionBlockResponseOptions>,
-    ) -> RpcResult<SuiTransactionBlockResponse> {
-        let opts = opts.unwrap_or_default();
-        let mut temp_response = IntermediateTransactionResponse::new(digest);
-
-        // Fetch transaction to determine existence
-        let transaction =
-            Some(self.state.get_executed_transaction(digest).await.tap_err(
-                |err| debug!(tx_digest=?digest, "Failed to get transaction: {:?}", err),
-            )?);
-
-        // the input is needed for object_changes to retrieve the sender address.
-        if opts.require_input() {
-            temp_response.transaction = transaction;
-        }
-
-        // Fetch effects when `show_events` is true because events relies on effects
-        if opts.require_effects() {
-            temp_response.effects =
-                Some(self.state.get_executed_effects(digest).await.tap_err(
-                    |err| debug!(tx_digest=?digest, "Failed to get effects: {:?}", err),
-                )?);
-        }
-
-        if let Some((_, seq)) = self
-            .state
-            .get_transaction_checkpoint_sequence(&digest)
-            .map_err(|e| {
-                error!("Failed to retrieve checkpoint sequence for transaction {digest:?} with error: {e:?}");
-                anyhow!("{e}")
-            })?
-        {
-            temp_response.checkpoint_seq = Some(seq.into());
-        }
-
-        if temp_response.checkpoint_seq.is_some() {
-            let checkpoint_id = temp_response.checkpoint_seq.unwrap().into();
-            let checkpoint = self
-                .state
-                // safe to unwrap because we have checked `is_some` above
-                .get_checkpoint_by_sequence_number(checkpoint_id)
-                .map_err(|e|{
-                    error!("Failed to get checkpoint by sequence number: {checkpoint_id:?} with error: {e:?}");
-                    anyhow!("{e}"
-                )})?;
-            // TODO(chris): we don't need to fetch the whole checkpoint summary
-            temp_response.timestamp = checkpoint.as_ref().map(|c| c.timestamp_ms);
-        }
-
-        if opts.show_events && temp_response.effects.is_some() {
-            // safe to unwrap because we have checked is_some
-            if let Some(event_digest) = temp_response.effects.as_ref().unwrap().events_digest() {
-                let events = self
-                    .state
-                    .get_transaction_events(event_digest)
-                    .map_err(|e|
-                        {
-                            error!("Failed to call get transaction events for events digest: {event_digest:?} with error {e:?}");
-                            Error::from(e)
-                        })?;
-                match to_sui_transaction_events(self, digest, events) {
-                    Ok(e) => temp_response.events = Some(e),
-                    Err(e) => temp_response.errors.push(e.to_string()),
-                };
-            } else {
-                // events field will be Some if and only if `show_events` is true and
-                // there is no error in converting fetching events
-                temp_response.events = Some(SuiTransactionBlockEvents::default());
-            }
-        }
-
-        let object_cache = ObjectProviderCache::new(self.state.clone());
-        if opts.show_balance_changes {
-            if let Some(effects) = &temp_response.effects {
-                let balance_changes = get_balance_changes_from_effect(&object_cache, effects)
-                    .await
-                    .map_err(Error::SuiError)?;
-                temp_response.balance_changes = Some(balance_changes);
-            }
-        }
-
-        if opts.show_object_changes {
-            if let (Some(effects), Some(input)) =
-                (&temp_response.effects, &temp_response.transaction)
-            {
-                let sender = input.data().intent_message().value.sender();
-                let object_changes = get_object_changes(
-                    &object_cache,
-                    sender,
-                    effects.modified_at_versions(),
-                    effects.all_changed_objects(),
-                    effects.all_deleted(),
-                )
-                .await
-                .map_err(Error::SuiError)?;
-                temp_response.object_changes = Some(object_changes);
-            }
-        }
-        let epoch_store = self.state.load_epoch_store_one_call_per_task();
-        Ok(convert_to_response(
-            temp_response,
-            &opts,
-            epoch_store.module_cache(),
-        ))
-    }
-
-    async fn multi_get_transaction_blocks(
+    async fn multi_get_transaction_blocks_internal(
         &self,
         digests: Vec<TransactionDigest>,
         opts: Option<SuiTransactionBlockResponseOptions>,
-    ) -> RpcResult<Vec<SuiTransactionBlockResponse>> {
+    ) -> Result<Vec<SuiTransactionBlockResponse>, Error> {
         let num_digests = digests.len();
         if num_digests > QUERY_MAX_RESULT_LIMIT {
             return Err(anyhow!(UserInputError::SizeLimitExceeded {
@@ -435,7 +157,6 @@ impl ReadApiServer for ReadApi {
             let transactions = self
                 .state
                 .multi_get_executed_transactions(&digests)
-                .await
                 .tap_err(
                     |err| debug!(digests=?digests, "Failed to multi get transaction: {:?}", err),
                 )?;
@@ -449,13 +170,9 @@ impl ReadApiServer for ReadApi {
 
         // Fetch effects when `show_events` is true because events relies on effects
         if opts.require_effects() {
-            let effects_list = self
-                .state
-                .multi_get_executed_effects(&digests)
-                .await
-                .tap_err(
-                    |err| debug!(digests=?digests, "Failed to multi get effects: {:?}", err),
-                )?;
+            let effects_list = self.state.multi_get_executed_effects(&digests).tap_err(
+                |err| debug!(digests=?digests, "Failed to multi get effects: {:?}", err),
+            )?;
             for ((_digest, cache_entry), e) in
                 temp_response.iter_mut().zip(effects_list.into_iter())
             {
@@ -464,11 +181,10 @@ impl ReadApiServer for ReadApi {
         }
 
         let checkpoint_seq_list = self
-                .state
-                .multi_get_transaction_checkpoint(&digests)
-                .await
-                .tap_err(
-                    |err| debug!(digests=?digests, "Failed to multi get checkpoint sequence number: {:?}", err))?;
+            .state
+            .multi_get_transaction_checkpoint(&digests)
+            .tap_err(
+                |err| debug!(digests=?digests, "Failed to multi get checkpoint sequence number: {:?}", err))?;
         for ((_digest, cache_entry), seq) in temp_response
             .iter_mut()
             .zip(checkpoint_seq_list.into_iter())
@@ -640,10 +356,300 @@ impl ReadApiServer for ReadApi {
             .map(|c| convert_to_response(c.1, &opts, epoch_store.module_cache()))
             .collect::<Vec<_>>())
     }
+}
 
-    async fn get_events(&self, transaction_digest: TransactionDigest) -> RpcResult<Vec<SuiEvent>> {
+#[async_trait]
+impl ReadApiServer for ReadApi {
+    fn get_object(
+        &self,
+        object_id: ObjectID,
+        options: Option<SuiObjectDataOptions>,
+    ) -> RpcResult<SuiObjectResponse> {
+        let object_read = self.state.get_object_read(&object_id).map_err(|e| {
+            warn!(?object_id, "Failed to get object: {:?}", e);
+            anyhow!("{e}")
+        })?;
+        let options = options.unwrap_or_default();
+
+        match object_read {
+            ObjectRead::NotExists(id) => Ok(SuiObjectResponse::new_with_error(
+                SuiObjectResponseError::NotExists { object_id: id },
+            )),
+            ObjectRead::Exists(object_ref, o, layout) => {
+                let mut display_fields = None;
+                if options.show_display {
+                    match get_display_fields(self, &o, &layout) {
+                        Ok(rendered_fields) => display_fields = Some(rendered_fields),
+                        Err(e) => {
+                            return Ok(SuiObjectResponse::new(
+                                Some((object_ref, o, layout, options, None).try_into()?),
+                                Some(SuiObjectResponseError::DisplayError {
+                                    error: e.to_string(),
+                                }),
+                            ))
+                        }
+                    }
+                }
+                Ok(SuiObjectResponse::new_with_data(
+                    (object_ref, o, layout, options, display_fields).try_into()?,
+                ))
+            }
+            ObjectRead::Deleted((object_id, version, digest)) => Ok(
+                SuiObjectResponse::new_with_error(SuiObjectResponseError::Deleted {
+                    object_id,
+                    version,
+                    digest,
+                }),
+            ),
+        }
+    }
+
+    fn multi_get_objects(
+        &self,
+        object_ids: Vec<ObjectID>,
+        options: Option<SuiObjectDataOptions>,
+    ) -> RpcResult<Vec<SuiObjectResponse>> {
+        if object_ids.len() <= QUERY_MAX_RESULT_LIMIT {
+            let mut results = vec![];
+            for object_id in object_ids {
+                results.push(self.get_object(object_id, options.clone()));
+            }
+            let objects_result: Result<Vec<SuiObjectResponse>, String> = results
+                .into_iter()
+                .map(|result| match result {
+                    Ok(response) => Ok(response),
+                    Err(error) => {
+                        error!("Failed to fetch object with error: {error:?}");
+                        Err(format!("Error: {}", error))
+                    }
+                })
+                .collect();
+
+            let objects = objects_result.map_err(|err| {
+                Error::UnexpectedError(format!("Failed to fetch objects with error: {}", err))
+            })?;
+
+            Ok(objects)
+        } else {
+            Err(anyhow!(UserInputError::SizeLimitExceeded {
+                limit: "input limit".to_string(),
+                value: QUERY_MAX_RESULT_LIMIT.to_string()
+            })
+            .into())
+        }
+    }
+
+    async fn try_get_past_object(
+        &self,
+        object_id: ObjectID,
+        version: SequenceNumber,
+        options: Option<SuiObjectDataOptions>,
+    ) -> RpcResult<SuiPastObjectResponse> {
+        let past_read = self
+            .state
+            .get_past_object_read(&object_id, version)
+            .await
+            .map_err(|e| {
+                error!("Failed to call try_get_past_object for object: {object_id:?} version: {version:?} with error: {e:?}");
+                anyhow!("{e}")
+            })?;
+        let options = options.unwrap_or_default();
+        match past_read {
+            PastObjectRead::ObjectNotExists(id) => Ok(SuiPastObjectResponse::ObjectNotExists(id)),
+            PastObjectRead::VersionFound(object_ref, o, layout) => {
+                let display_fields = if options.show_display {
+                    // TODO (jian): api breaking change to also modify past objects.
+                    Some(get_display_fields(self, &o, &layout)?)
+                } else {
+                    None
+                };
+                Ok(SuiPastObjectResponse::VersionFound(
+                    (object_ref, o, layout, options, display_fields).try_into()?,
+                ))
+            }
+            PastObjectRead::ObjectDeleted(oref) => {
+                Ok(SuiPastObjectResponse::ObjectDeleted(oref.into()))
+            }
+            PastObjectRead::VersionNotFound(id, seq_num) => {
+                Ok(SuiPastObjectResponse::VersionNotFound(id, seq_num))
+            }
+            PastObjectRead::VersionTooHigh {
+                object_id,
+                asked_version,
+                latest_version,
+            } => Ok(SuiPastObjectResponse::VersionTooHigh {
+                object_id,
+                asked_version,
+                latest_version,
+            }),
+        }
+    }
+
+    fn try_multi_get_past_objects(
+        &self,
+        past_objects: Vec<SuiGetPastObjectRequest>,
+        options: Option<SuiObjectDataOptions>,
+    ) -> RpcResult<Vec<SuiPastObjectResponse>> {
+        if past_objects.len() <= QUERY_MAX_RESULT_LIMIT {
+            let results = block_on(async {
+                let mut futures = vec![];
+                for past_object in past_objects {
+                    futures.push(self.try_get_past_object(
+                        past_object.object_id,
+                        past_object.version,
+                        options.clone(),
+                    ));
+                }
+                join_all(futures).await
+            });
+            let (oks, errs): (Vec<_>, Vec<_>) = results.into_iter().partition(Result::is_ok);
+            let success = oks.into_iter().filter_map(Result::ok).collect();
+            let errors: Vec<_> = errs.into_iter().filter_map(Result::err).collect();
+            if !errors.is_empty() {
+                let error_string = errors
+                    .iter()
+                    .map(|e| e.to_string())
+                    .collect::<Vec<String>>()
+                    .join("; ");
+                Err(anyhow!("{error_string}").into())
+            } else {
+                Ok(success)
+            }
+        } else {
+            Err(anyhow!(UserInputError::SizeLimitExceeded {
+                limit: "input limit".to_string(),
+                value: QUERY_MAX_RESULT_LIMIT.to_string()
+            })
+            .into())
+        }
+    }
+
+    async fn get_total_transaction_blocks(&self) -> RpcResult<BigInt> {
+        Ok(self.state.get_total_transaction_blocks()?.into())
+    }
+
+    async fn get_transaction_block(
+        &self,
+        digest: TransactionDigest,
+        opts: Option<SuiTransactionBlockResponseOptions>,
+    ) -> RpcResult<SuiTransactionBlockResponse> {
+        let opts = opts.unwrap_or_default();
+        let mut temp_response = IntermediateTransactionResponse::new(digest);
+
+        // Fetch transaction to determine existence
+        let transaction =
+            Some(self.state.get_executed_transaction(digest).await.tap_err(
+                |err| debug!(tx_digest=?digest, "Failed to get transaction: {:?}", err),
+            )?);
+
+        // the input is needed for object_changes to retrieve the sender address.
+        if opts.require_input() {
+            temp_response.transaction = transaction;
+        }
+
+        // Fetch effects when `show_events` is true because events relies on effects
+        if opts.require_effects() {
+            temp_response.effects =
+                Some(self.state.get_executed_effects(digest).tap_err(
+                    |err| debug!(tx_digest=?digest, "Failed to get effects: {:?}", err),
+                )?);
+        }
+
+        if let Some((_, seq)) = self
+            .state
+            .get_transaction_checkpoint_sequence(&digest)
+            .map_err(|e| {
+                error!("Failed to retrieve checkpoint sequence for transaction {digest:?} with error: {e:?}");
+                anyhow!("{e}")
+            })?
+        {
+            temp_response.checkpoint_seq = Some(seq.into());
+        }
+
+        if temp_response.checkpoint_seq.is_some() {
+            let checkpoint_id = temp_response.checkpoint_seq.unwrap().into();
+            let checkpoint = self
+                .state
+                // safe to unwrap because we have checked `is_some` above
+                .get_checkpoint_by_sequence_number(checkpoint_id)
+                .map_err(|e|{
+                    error!("Failed to get checkpoint by sequence number: {checkpoint_id:?} with error: {e:?}");
+                    anyhow!("{e}"
+                )})?;
+            // TODO(chris): we don't need to fetch the whole checkpoint summary
+            temp_response.timestamp = checkpoint.as_ref().map(|c| c.timestamp_ms);
+        }
+
+        if opts.show_events && temp_response.effects.is_some() {
+            // safe to unwrap because we have checked is_some
+            if let Some(event_digest) = temp_response.effects.as_ref().unwrap().events_digest() {
+                let events = self
+                    .state
+                    .get_transaction_events(event_digest)
+                    .map_err(|e|
+                        {
+                            error!("Failed to call get transaction events for events digest: {event_digest:?} with error {e:?}");
+                            Error::from(e)
+                        })?;
+                match to_sui_transaction_events(self, digest, events) {
+                    Ok(e) => temp_response.events = Some(e),
+                    Err(e) => temp_response.errors.push(e.to_string()),
+                };
+            } else {
+                // events field will be Some if and only if `show_events` is true and
+                // there is no error in converting fetching events
+                temp_response.events = Some(SuiTransactionBlockEvents::default());
+            }
+        }
+
+        let object_cache = ObjectProviderCache::new(self.state.clone());
+        if opts.show_balance_changes {
+            if let Some(effects) = &temp_response.effects {
+                let balance_changes = get_balance_changes_from_effect(&object_cache, effects)
+                    .await
+                    .map_err(Error::SuiError)?;
+                temp_response.balance_changes = Some(balance_changes);
+            }
+        }
+
+        if opts.show_object_changes {
+            if let (Some(effects), Some(input)) =
+                (&temp_response.effects, &temp_response.transaction)
+            {
+                let sender = input.data().intent_message().value.sender();
+                let object_changes = get_object_changes(
+                    &object_cache,
+                    sender,
+                    effects.modified_at_versions(),
+                    effects.all_changed_objects(),
+                    effects.all_deleted(),
+                )
+                .await
+                .map_err(Error::SuiError)?;
+                temp_response.object_changes = Some(object_changes);
+            }
+        }
+        let epoch_store = self.state.load_epoch_store_one_call_per_task();
+        Ok(convert_to_response(
+            temp_response,
+            &opts,
+            epoch_store.module_cache(),
+        ))
+    }
+
+    fn multi_get_transaction_blocks(
+        &self,
+        digests: Vec<TransactionDigest>,
+        opts: Option<SuiTransactionBlockResponseOptions>,
+    ) -> RpcResult<Vec<SuiTransactionBlockResponse>> {
+        Ok(block_on(
+            self.multi_get_transaction_blocks_internal(digests, opts),
+        )?)
+    }
+
+    fn get_events(&self, transaction_digest: TransactionDigest) -> RpcResult<Vec<SuiEvent>> {
         let store = self.state.load_epoch_store_one_call_per_task();
-        let effect = self.state.get_executed_effects(transaction_digest).await?;
+        let effect = self.state.get_executed_effects(transaction_digest)?;
         let events = if let Some(event_digest) = effect.events_digest() {
             self.state
                 .get_transaction_events(event_digest)
@@ -688,7 +694,7 @@ impl ReadApiServer for ReadApi {
         Ok(self.get_checkpoint_internal(id)?)
     }
 
-    async fn get_checkpoints(
+    fn get_checkpoints(
         &self,
         // If `Some`, the query will start from the next item after the specified cursor
         cursor: Option<SuiCheckpointSequenceNumber>,
@@ -753,7 +759,7 @@ fn to_sui_transaction_events(
     .map_err(Error::SuiError)?)
 }
 
-async fn get_display_fields(
+fn get_display_fields(
     fullnode_api: &ReadApi,
     original_object: &Object,
     original_layout: &Option<MoveStructLayout>,
@@ -761,7 +767,7 @@ async fn get_display_fields(
     let Some((object_type, layout)) = get_object_type_and_struct(original_object, original_layout)? else {
         return Ok(DisplayFieldsResponse { data: None, error: None })
     };
-    if let Some(display_object) = get_display_object_by_type(fullnode_api, &object_type).await? {
+    if let Some(display_object) = get_display_object_by_type(fullnode_api, &object_type)? {
         return get_rendered_fields(display_object.fields, &layout);
     }
     Ok(DisplayFieldsResponse {
@@ -770,20 +776,17 @@ async fn get_display_fields(
     })
 }
 
-async fn get_display_object_by_type(
+fn get_display_object_by_type(
     fullnode_api: &ReadApi,
     object_type: &StructTag,
     // TODO: add query version support
 ) -> RpcResult<Option<DisplayVersionUpdatedEvent>> {
-    let mut events = fullnode_api
-        .state
-        .query_events(
-            EventFilter::MoveEventType(DisplayVersionUpdatedEvent::type_(object_type)),
-            None,
-            1,
-            true,
-        )
-        .await?;
+    let mut events = fullnode_api.state.query_events(
+        EventFilter::MoveEventType(DisplayVersionUpdatedEvent::type_(object_type)),
+        None,
+        1,
+        true,
+    )?;
 
     // If there's any recent version of Display, give it to the client.
     // TODO: add support for version query.
@@ -836,7 +839,7 @@ pub async fn get_move_modules_by_package(
     state: &AuthorityState,
     package: ObjectID,
 ) -> RpcResult<BTreeMap<String, NormalizedModule>> {
-    let object_read = state.get_object_read(&package).await.map_err(|e| {
+    let object_read = state.get_object_read(&package).map_err(|e| {
         warn!("Failed to call get_move_modules_by_package for package: {package:?}");
         anyhow!("{e}")
     })?;

--- a/crates/sui-json-rpc/src/transaction_builder_api.rs
+++ b/crates/sui-json-rpc/src/transaction_builder_api.rs
@@ -74,7 +74,7 @@ impl DataReader for AuthorityStateDataReader {
         object_id: ObjectID,
         options: SuiObjectDataOptions,
     ) -> Result<SuiObjectResponse, anyhow::Error> {
-        let result = self.0.get_object_read(&object_id).await?;
+        let result = self.0.get_object_read(&object_id)?;
         Ok((result, options).try_into()?)
     }
 

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -70,7 +70,7 @@ async fn test_full_node_follows_txes() -> Result<(), anyhow::Error> {
     sleep(Duration::from_secs(1)).await;
 
     // verify that the node has seen the transfer
-    let object_read = node.state().get_object_read(&transferred_object).await?;
+    let object_read = node.state().get_object_read(&transferred_object)?;
     let object = object_read.into_object()?;
 
     assert_eq!(object.owner.get_owner_address().unwrap(), receiver);
@@ -910,9 +910,7 @@ async fn get_obj_read_from_node(
     node: &SuiNode,
     object_id: ObjectID,
 ) -> Result<(ObjectRef, Object, Option<MoveStructLayout>), anyhow::Error> {
-    if let ObjectRead::Exists(obj_ref, object, layout) =
-        node.state().get_object_read(&object_id).await?
-    {
+    if let ObjectRead::Exists(obj_ref, object, layout) = node.state().get_object_read(&object_id)? {
         Ok((obj_ref, object, layout))
     } else {
         anyhow::bail!("Can't find object {object_id:?} on fullnode.")
@@ -987,7 +985,7 @@ async fn test_get_objects_read() -> Result<(), anyhow::Error> {
     sleep(Duration::from_secs(1)).await;
 
     // Now test get_object_read
-    let object_ref_v3 = match node.state().get_object_read(&object_id).await? {
+    let object_ref_v3 = match node.state().get_object_read(&object_id)? {
         ObjectRead::Deleted(obj_ref) => obj_ref,
         other => anyhow::bail!("Expect object {object_id:?} deleted but got {other:?}."),
     };


### PR DESCRIPTION
## Description 

jsonrpsee server occasionally refuse to process any request when the request rates are high, after some investigation we narrowed down the problem to json serialisation. When the response object is large, the serde takes significant amount of time and blocks the tokio worker threads, currently the only way to offload the serialisation is to make the RPC method "blocking" and jsonrpsee will use tokio spawn_blocking to process the request.

This PR marked all methods with relatively large response "blocking" to avoid blocking

## Test Plan 

RPC endpoints are covered by integration tests
