### PR TITLE
[wallet-ext] Reduce API calls and make it partially configurable

### DIFF
--- a/apps/core/src/hooks/useFormatCoin.ts
+++ b/apps/core/src/hooks/useFormatCoin.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Coin } from '@mysten/sui.js';
+import { Coin, CoinMetadata, SUI_TYPE_ARG } from '@mysten/sui.js';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 import BigNumber from 'bignumber.js';
 import { useMemo } from 'react';
@@ -47,6 +47,20 @@ export function useCoinDecimals(coinType?: string | null) {
                 throw new Error(
                     'Fetching coin denomination should be disabled when coin type is disabled.'
                 );
+            }
+
+            // Optimize the known case of SUI to avoid a network call:
+            if (coinType === SUI_TYPE_ARG) {
+                const metadata: CoinMetadata = {
+                    id: null,
+                    decimals: 9,
+                    description: '',
+                    iconUrl: null,
+                    name: 'Sui',
+                    symbol: 'SUI',
+                };
+
+                return metadata;
             }
 
             return rpc.getCoinMetadata({ coinType });

--- a/apps/wallet/src/shared/experimentation/features.ts
+++ b/apps/wallet/src/shared/experimentation/features.ts
@@ -18,6 +18,7 @@ export enum FEATURES {
     WALLET_DAPPS = 'wallet-dapps',
     WALLET_MULTI_ACCOUNTS = 'wallet-multi-accounts',
     WALLET_LEDGER_INTEGRATION = 'wallet-ledger-integration',
+    WALLET_BALANCE_REFETCH_INTERVAL = 'wallet-balance-refetch-interval',
 }
 
 export function setAttributes(

--- a/apps/wallet/src/ui/app/hooks/useGetAllBalances.ts
+++ b/apps/wallet/src/ui/app/hooks/useGetAllBalances.ts
@@ -1,16 +1,23 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { useFeatureValue } from '@growthbook/growthbook-react';
 import { useRpcClient } from '@mysten/core';
 import { type SuiAddress } from '@mysten/sui.js';
 import { useQuery } from '@tanstack/react-query';
 
+import { FEATURES } from '_src/shared/experimentation/features';
+
 export function useGetAllBalances(address?: SuiAddress | null) {
     const rpc = useRpcClient();
+    const refetchInterval = useFeatureValue(
+        FEATURES.WALLET_BALANCE_REFETCH_INTERVAL,
+        8_000
+    );
+
     return useQuery(
         ['get-all-balance', address],
         () => rpc.getAllBalances({ owner: address! }),
-        // refetchInterval is set to 4 seconds
-        { enabled: !!address, refetchInterval: 4000 }
+        { enabled: !!address, refetchInterval }
     );
 }

--- a/apps/wallet/src/ui/app/hooks/useGetCoinBalance.ts
+++ b/apps/wallet/src/ui/app/hooks/useGetCoinBalance.ts
@@ -1,21 +1,29 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { useFeatureValue } from '@growthbook/growthbook-react';
 import { useRpcClient } from '@mysten/core';
 import { type SuiAddress } from '@mysten/sui.js';
 import { useQuery } from '@tanstack/react-query';
+
+import { FEATURES } from '_src/shared/experimentation/features';
 
 export function useGetCoinBalance(
     coinType: string,
     address?: SuiAddress | null
 ) {
     const rpc = useRpcClient();
+    const refetchInterval = useFeatureValue(
+        FEATURES.WALLET_BALANCE_REFETCH_INTERVAL,
+        8_000
+    );
+
     return useQuery(
         ['coin-balance', address, coinType],
         () => rpc.getBalance({ owner: address!, coinType }),
         {
             enabled: !!address && !!coinType,
-            refetchInterval: 4000,
+            refetchInterval,
         }
     );
 }

--- a/apps/wallet/src/ui/app/staking/stake/StakingCard.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/StakingCard.tsx
@@ -55,7 +55,7 @@ function StakingCard() {
     const coinType = SUI_TYPE_ARG;
     const accountAddress = useActiveAddress();
     const { data: suiBalance, isLoading: loadingSuiBalances } =
-        useGetCoinBalance(coinType, accountAddress);
+        useGetCoinBalance(SUI_TYPE_ARG, accountAddress);
     const coinBalance = BigInt(suiBalance?.totalBalance || 0);
     const [searchParams] = useSearchParams();
     const validatorAddress = searchParams.get('address');


### PR DESCRIPTION
## Description

This does two things:
- Reduce the amount of `getCoinMetadata` calls by hard-coding the Sui response. This will never change, and removes one API call per launch on both explorer and wallet. As a side-note, we should make a sync `useFormatSui` hook.
- Moves refetching of balances on the wallet to be configurable via growthbook, and change the default value to 8s instead of 4.

