### PR TITLE
[core] More failpoint crash testing

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -147,9 +147,18 @@ mod test {
         let dead_validator = dead_validator_orig.clone();
         let client_node = sui_simulator::current_simnode_id();
         register_fail_points(
-            &["batch-write", "transaction-commit", "put-cf"],
+            &[
+                "batch-write-before",
+                "batch-write-after",
+                "put-cf-before",
+                "put-cf-after",
+                "delete-cf-before",
+                "delete-cf-after",
+                "transaction-commit",
+                "highest-executed-checkpoint",
+            ],
             move || {
-                handle_failpoint(dead_validator.clone(), client_node, 0.01);
+                handle_failpoint(dead_validator.clone(), client_node, 0.02);
             },
         );
 

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -29,6 +29,7 @@ use itertools::izip;
 use mysten_metrics::{spawn_monitored_task, MonitoredFutureExt};
 use prometheus::Registry;
 use sui_config::node::CheckpointExecutorConfig;
+use sui_macros::{fail_point, fail_point_async};
 use sui_types::message_envelope::Message;
 use sui_types::messages::VerifiedExecutableTransaction;
 use sui_types::{
@@ -156,6 +157,7 @@ impl CheckpointExecutor {
                     pending.is_empty(),
                     "Pending checkpoint execution buffer should be empty after processing last checkpoint of epoch",
                 );
+                fail_point_async!("crash");
                 return;
             }
             self.schedule_synced_checkpoints(
@@ -239,6 +241,8 @@ impl CheckpointExecutor {
         if seq % 10000 == 0 {
             info!("Finished syncing and executing checkpoint {}", seq);
         }
+
+        fail_point!("highest-executed-checkpoint");
 
         self.checkpoint_store
             .update_highest_executed_checkpoint(checkpoint)


### PR DESCRIPTION
## Description 

As in title

## Test Plan 

Ran the following with no observed failures:

```
for f in `seq 1 50`; do RUST_LOG=sui=debug,error MSIM_TEST_SEED=9$f cargo simtest test_simulated_load_reconfig_crashes -E '(test(test_simulated_load_reconfig_crashes) and !(test(test_simulated_load_reconfig_crashes_during_epoch_change)))' --no-capture > test_$f 2>&1 &; done
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
