### PR TITLE
[DONOTLAND] Log all the objects created and written by a forked trans…

### DIFF
--- a/crates/sui-adapter/src/programmable_transactions/context.rs
+++ b/crates/sui-adapter/src/programmable_transactions/context.rs
@@ -615,6 +615,11 @@ impl<'vm, 'state, 'a, 'b, S: StorageView> ExecutionContext<'vm, 'state, 'a, 'b, 
         // Sui Move no longer uses Move's internal event system
         assert_invariant!(events.is_empty(), "Events must be empty");
         let object_runtime: ObjectRuntime = native_context_extensions.remove();
+
+        if tx_digest.base58_encode() == "HJc3mH685wTN6pbfoui6MF2MwWpYmF2Af8PMqXMgh4sR" {
+            tracing::info!("Loaded objects: {:#?}", object_runtime.loaded_objects());
+        }
+
         let new_ids = object_runtime.new_ids().clone();
         // tell the object runtime what input objects were taken and which were transferred
         let external_transfers = additional_writes.keys().copied().collect();

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -171,6 +171,10 @@ impl CheckpointExecutor {
                 // be processed (added to FuturesOrdered) in seq_number order, using FuturesOrdered
                 // guarantees that we will also ratchet the watermarks in order.
                 Some(Ok(checkpoint)) = pending.next() => {
+                    if checkpoint.inner().data().sequence_number == 488547 {
+                        panic!("SUCCESS!!! You made it past the problem TX");
+                    }
+
                     self.process_executed_checkpoint(&checkpoint);
                     highest_executed = Some(checkpoint);
 

--- a/crates/sui-core/src/execution_driver.rs
+++ b/crates/sui-core/src/execution_driver.rs
@@ -35,7 +35,7 @@ pub async fn execution_process(
     info!("Starting pending certificates execution process.");
 
     // Rate limit concurrent executions to # of cpus.
-    let limit = Arc::new(Semaphore::new(num_cpus::get()));
+    let limit = Arc::new(Semaphore::new(1));
 
     // Loop whenever there is a signal that a new transactions is ready to process.
     loop {

--- a/crates/sui-types/src/temporary_store.rs
+++ b/crates/sui-types/src/temporary_store.rs
@@ -365,6 +365,22 @@ impl<S> TemporaryStore<S> {
             }
         }
 
+        let mut modified_versions = BTreeMap::new();
+        for (id, version) in &modified_at_versions {
+            if let Some(prev) = modified_versions.insert(id, version) {
+                panic!("Two modified_at_versions for {id}: {prev} and {version}");
+            }
+        }
+
+        for (id, version, _digest) in &shared_object_refs {
+            if let Some(modified_at) = modified_versions.get(id) {
+                assert_eq!(
+                    *modified_at, version,
+                    "Shared object modified at different version from input",
+                );
+            }
+        }
+
         let effects = TransactionEffects::new_from_execution(
             protocol_version,
             status,


### PR DESCRIPTION
…action

Also limit execution to one transaction at a time to avoid multiple transaction forking simultaneously and corrupting each others' outputs.