### PR TITLE
added to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,9 +15,11 @@ CHANGELOG.md
 
 # Notify Narwhal changes to interested folks.
 /narwhal/crypto/ @joyqvq @kchalkias
-/narwhal/executor/ @asonnino @akichidis
+/narwhal/executor/ @asonnino @akichidis @laura-makdah
 /narwhal/examples/ @arun-koshy
 /narwhal/network/ @bmwill
 /narwhal/storage/ @akichidis
 /narwhal/primary/src/block_synchronizer/ @akichidis
 /narwhal/primary/src/block_waiter.rs @akichidis
+
+/crates/sui-core/src/consensus_adapter.rs @laura-makdah


### PR DESCRIPTION
## Description 

Add self to code owner for consensus adapter and executor 

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
