### PR TITLE
[sui-proxy/modify buckets]

### DIFF
--- a/crates/sui-proxy/src/consumer.rs
+++ b/crates/sui-proxy/src/consumer.rs
@@ -41,12 +41,12 @@ static CONSUMER_ENCODE_COMPRESS_DURATION: Lazy<HistogramVec> = Lazy::new(|| {
 });
 static CONSUMER_OPERATION_DURATION: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
-        "protobuf_decode_duration_seconds",
+        "consumer_operations_duration_seconds",
         "The time it takes to perform various consumer operations in seconds.",
         &["operation"],
         vec![
             0.0008, 0.0016, 0.0032, 0.0064, 0.0128, 0.0256, 0.0512, 0.1024, 0.2048, 0.4096, 0.8192,
-            1.0, 1.25, 1.5, 1.75, 2.0, 4.0, 8.0
+            1.0, 1.25, 1.5, 1.75, 2.0, 4.0, 8.0, 10.0, 12.5, 15.0
         ],
     )
     .unwrap()

--- a/crates/sui-proxy/src/histogram_relay.rs
+++ b/crates/sui-proxy/src/histogram_relay.rs
@@ -33,7 +33,11 @@ static RELAY_DURATION: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "relay_duration_seconds",
         "HistogramRelay's submit/export fn latencies in seconds.",
-        &["histogram_relay"]
+        &["histogram_relay"],
+        vec![
+            0.0008, 0.0016, 0.0032, 0.0064, 0.0128, 0.0256, 0.0512, 0.1024, 0.2048, 0.4096, 0.8192,
+            1.0, 1.25, 1.5, 1.75, 2.0, 4.0, 8.0, 10.0, 12.5, 15.0
+        ],
     )
     .unwrap()
 });

--- a/crates/sui-proxy/src/peers.rs
+++ b/crates/sui-proxy/src/peers.rs
@@ -29,7 +29,11 @@ static JSON_RPC_DURATION: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "json_rpc_duration_seconds",
         "The json-rpc latencies in seconds.",
-        &["rpc_method"]
+        &["rpc_method"],
+        vec![
+            0.0008, 0.0016, 0.0032, 0.0064, 0.0128, 0.0256, 0.0512, 0.1024, 0.2048, 0.4096, 0.8192,
+            1.0, 1.25, 1.5, 1.75, 2.0, 4.0, 8.0
+        ],
     )
     .unwrap()
 });


### PR DESCRIPTION
Summary:

* modify the buckets for protobuf_decode_duration_seconds
* rename this poorly named histogram
* add remote label for metrics_4_metrics http histogram/counter.  this will let us track timings against remote peer names from chain data

Test Plan:

cargo build

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
