### PR TITLE
[gas] Update cost tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9242,6 +9242,7 @@ version = "0.1.0"
 dependencies = [
  "move-cli",
  "move-package",
+ "move-unit-test",
  "sui-framework",
  "sui-framework-build",
  "sui-move",

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/event_limits_tests.exp
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/event_limits_tests.exp
@@ -1,4 +1,4 @@
-processed 10 tasks
+processed 13 tasks
 
 task 1 'publish'. lines 8-57:
 created: object(1,0)
@@ -28,6 +28,18 @@ task 8 'run'. lines 76-78:
 Error: Transaction Effects Status: Move Primitive Runtime Error. Location: sui::event::emit (function index 0) at offset 0. Arithmetic error, stack overflow, max value depth, etc.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MovePrimitiveRuntimeError(MoveLocationOpt(Some(MoveLocation { module: ModuleId { address: sui, name: Identifier("event") }, function: 0, instruction: 0, function_name: Some("emit") }))), source: Some(VMError { major_status: MEMORY_LIMIT_EXCEEDED, sub_status: Some(1), message: Some("Emitting event of size 256001 bytes. Limit is 256000 bytes."), exec_state: None, location: Module(ModuleId { address: sui, name: Identifier("event") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 0)] }), command: Some(0) } }
 
-task 9 'run'. lines 79-79:
+task 9 'run'. lines 79-83:
+Error: Transaction Effects Status: Move Primitive Runtime Error. Location: sui::event::emit (function index 0) at offset 0. Arithmetic error, stack overflow, max value depth, etc.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MovePrimitiveRuntimeError(MoveLocationOpt(Some(MoveLocation { module: ModuleId { address: sui, name: Identifier("event") }, function: 0, instruction: 0, function_name: Some("emit") }))), source: Some(VMError { major_status: MEMORY_LIMIT_EXCEEDED, sub_status: Some(1), message: Some("Emitting event of size 259000 bytes. Limit is 256000 bytes."), exec_state: None, location: Module(ModuleId { address: sui, name: Identifier("event") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 0)] }), command: Some(0) } }
+
+task 10 'run'. lines 84-86:
+Error: Transaction Effects Status: Move Primitive Runtime Error. Location: sui::event::emit (function index 0) at offset 0. Arithmetic error, stack overflow, max value depth, etc.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MovePrimitiveRuntimeError(MoveLocationOpt(Some(MoveLocation { module: ModuleId { address: sui, name: Identifier("event") }, function: 0, instruction: 0, function_name: Some("emit") }))), source: Some(VMError { major_status: MEMORY_LIMIT_EXCEEDED, sub_status: Some(0), message: Some("Emitting more than 256 events is not allowed"), exec_state: None, location: Module(ModuleId { address: sui, name: Identifier("event") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 0)] }), command: Some(0) } }
+
+task 11 'run'. lines 87-89:
+Error: Transaction Effects Status: Move Primitive Runtime Error. Location: sui::event::emit (function index 0) at offset 0. Arithmetic error, stack overflow, max value depth, etc.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MovePrimitiveRuntimeError(MoveLocationOpt(Some(MoveLocation { module: ModuleId { address: sui, name: Identifier("event") }, function: 0, instruction: 0, function_name: Some("emit") }))), source: Some(VMError { major_status: MEMORY_LIMIT_EXCEEDED, sub_status: Some(0), message: Some("Emitting more than 256 events is not allowed"), exec_state: None, location: Module(ModuleId { address: sui, name: Identifier("event") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 0)] }), command: Some(0) } }
+
+task 12 'run'. lines 90-90:
 Error: Transaction Effects Status: Move Primitive Runtime Error. Location: sui::event::emit (function index 0) at offset 0. Arithmetic error, stack overflow, max value depth, etc.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MovePrimitiveRuntimeError(MoveLocationOpt(Some(MoveLocation { module: ModuleId { address: sui, name: Identifier("event") }, function: 0, instruction: 0, function_name: Some("emit") }))), source: Some(VMError { major_status: MEMORY_LIMIT_EXCEEDED, sub_status: Some(1), message: Some("Emitting event of size 259000 bytes. Limit is 256000 bytes."), exec_state: None, location: Module(ModuleId { address: sui, name: Identifier("event") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 0)] }), command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/event_limits_tests.move
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/event_limits_tests.move
@@ -55,25 +55,38 @@ module Test::M1 {
 }
 // Check count limits
 // emit below event count limit should succeed
-//# run Test::M1::emit_n_small_events --args 1 --gas-budget 100000000000000
+//# run Test::M1::emit_n_small_events --args 1 --uncharged
 
 // emit at event count limit should succeed
 //# run Test::M1::emit_n_small_events --args 256 --gas-budget 2000000
 
 // emit above event count limit should fail
-//# run Test::M1::emit_n_small_events --args 257 --gas-budget 100000000000000
+//# run Test::M1::emit_n_small_events --args 257 --uncharged
 
 // emit above event count limit should fail
-//# run Test::M1::emit_n_small_events --args 300 --gas-budget 100000000000000
+//# run Test::M1::emit_n_small_events --args 300 --uncharged
 
 // emit below event size limit should succeed
-//# run Test::M1::emit_event_with_size --args 200000 --gas-budget 2000000
+//# run Test::M1::emit_event_with_size --args 200000 --uncharged
 
 // emit at event size limit should succeed
-//# run Test::M1::emit_event_with_size --args 256000 --gas-budget 2000000
+//# run Test::M1::emit_event_with_size --args 256000 --uncharged
 
 // emit above event size limit should succeed
-//# run Test::M1::emit_event_with_size --args 256001 --gas-budget 2000000
+//# run Test::M1::emit_event_with_size --args 256001 --uncharged
 
 // emit above event size limit should fail
-//# run Test::M1::emit_event_with_size --args 259000 --gas-budget 100000000000000
+//# run Test::M1::emit_event_with_size --args 259000 --uncharged
+
+// Check if we run out of gas before hitting limits
+
+// Can't emit above event count limit without running out of gas
+//# run Test::M1::emit_n_small_events --args 257 --gas-budget 1000000000
+
+// emit above event count limit should fail
+//# run Test::M1::emit_n_small_events --args 300 --gas-budget 1000000000
+
+// emit above event size limit should fail
+//# run Test::M1::emit_event_with_size --args 259000 --gas-budget 1000000000
+
+

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/new_id_limits_tests.exp
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/new_id_limits_tests.exp
@@ -1,4 +1,4 @@
-processed 7 tasks
+processed 9 tasks
 
 task 1 'publish'. lines 8-34:
 created: object(1,0)
@@ -12,12 +12,19 @@ mutated: object(0,0)
 
 task 4 'run'. lines 41-43:
 mutated: object(0,0)
-gas summary: computation_cost: 50000, storage_cost: 13000,  storage_rebate: 12870, non_refundable_storage_fee: 130
 
 task 5 'run'. lines 44-46:
 Error: Transaction Effects Status: Move Primitive Runtime Error. Location: sui::tx_context::derive_id (function index 5) at offset 0. Arithmetic error, stack overflow, max value depth, etc.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MovePrimitiveRuntimeError(MoveLocationOpt(Some(MoveLocation { module: ModuleId { address: sui, name: Identifier("tx_context") }, function: 5, instruction: 0, function_name: Some("derive_id") }))), source: Some(VMError { major_status: MEMORY_LIMIT_EXCEEDED, sub_status: Some(2), message: Some("Creating more than 2048 IDs is not allowed"), exec_state: None, location: Module(ModuleId { address: sui, name: Identifier("tx_context") }), indices: [], offsets: [(FunctionDefinitionIndex(5), 0)] }), command: Some(0) } }
 
-task 6 'run'. lines 47-47:
+task 6 'run'. lines 47-51:
+Error: Transaction Effects Status: Move Primitive Runtime Error. Location: sui::tx_context::derive_id (function index 5) at offset 0. Arithmetic error, stack overflow, max value depth, etc.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MovePrimitiveRuntimeError(MoveLocationOpt(Some(MoveLocation { module: ModuleId { address: sui, name: Identifier("tx_context") }, function: 5, instruction: 0, function_name: Some("derive_id") }))), source: Some(VMError { major_status: MEMORY_LIMIT_EXCEEDED, sub_status: Some(2), message: Some("Creating more than 2048 IDs is not allowed"), exec_state: None, location: Module(ModuleId { address: sui, name: Identifier("tx_context") }), indices: [], offsets: [(FunctionDefinitionIndex(5), 0)] }), command: Some(0) } }
+
+task 7 'run'. lines 52-54:
+Error: Transaction Effects Status: Move Primitive Runtime Error. Location: sui::tx_context::derive_id (function index 5) at offset 0. Arithmetic error, stack overflow, max value depth, etc.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MovePrimitiveRuntimeError(MoveLocationOpt(Some(MoveLocation { module: ModuleId { address: sui, name: Identifier("tx_context") }, function: 5, instruction: 0, function_name: Some("derive_id") }))), source: Some(VMError { major_status: MEMORY_LIMIT_EXCEEDED, sub_status: Some(2), message: Some("Creating more than 2048 IDs is not allowed"), exec_state: None, location: Module(ModuleId { address: sui, name: Identifier("tx_context") }), indices: [], offsets: [(FunctionDefinitionIndex(5), 0)] }), command: Some(0) } }
+
+task 8 'run'. lines 55-55:
 Error: Transaction Effects Status: Move Primitive Runtime Error. Location: sui::tx_context::derive_id (function index 5) at offset 0. Arithmetic error, stack overflow, max value depth, etc.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MovePrimitiveRuntimeError(MoveLocationOpt(Some(MoveLocation { module: ModuleId { address: sui, name: Identifier("tx_context") }, function: 5, instruction: 0, function_name: Some("derive_id") }))), source: Some(VMError { major_status: MEMORY_LIMIT_EXCEEDED, sub_status: Some(2), message: Some("Creating more than 2048 IDs is not allowed"), exec_state: None, location: Module(ModuleId { address: sui, name: Identifier("tx_context") }), indices: [], offsets: [(FunctionDefinitionIndex(5), 0)] }), command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/new_id_limits_tests.move
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/new_id_limits_tests.move
@@ -32,16 +32,24 @@ module Test::M1 {
 }
 
 // create below create count limit should succeed
-//# run Test::M1::create_n_ids --args 1 --gas-budget 100000000000000
+//# run Test::M1::create_n_ids --args 1 --uncharged
 
 // create below create count limit should succeed
-//# run Test::M1::create_n_ids --args 256 --gas-budget 100000000000000
+//# run Test::M1::create_n_ids --args 256 --uncharged
 
 // create at create count limit should succeed
-//# run Test::M1::create_n_ids --args 2048 --gas-budget 100000000000000 --view-gas-used
+//# run Test::M1::create_n_ids --args 2048 --uncharged
 
 // create above create count limit should fail
-//# run Test::M1::create_n_ids --args 2049 --gas-budget 100000000000000
+//# run Test::M1::create_n_ids --args 2049 --uncharged
 
 // create above create count limit should fail
-//# run Test::M1::create_n_ids --args 4096 --gas-budget 100000000000000
+//# run Test::M1::create_n_ids --args 4096 --uncharged
+
+// Check if we run out of gas before hitting limits
+
+// create above create count limit should fail
+//# run Test::M1::create_n_ids --args 2049 --gas-budget 1000000000
+
+// create above create count limit should fail
+//# run Test::M1::create_n_ids --args 4096 --gas-budget 1000000000

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/vector_len_limits.exp
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/vector_len_limits.exp
@@ -1,4 +1,4 @@
-processed 6 tasks
+processed 8 tasks
 
 task 1 'publish'. lines 8-30:
 created: object(1,0)
@@ -13,6 +13,14 @@ mutated: object(0,0)
 task 4 'run'. lines 37-39:
 mutated: object(0,0)
 
-task 5 'run'. lines 40-40:
+task 5 'run'. lines 40-44:
 Error: Transaction Effects Status: Move Primitive Runtime Error. Location: Test::M1::push_n_items (function index 0) at offset 11. Arithmetic error, stack overflow, max value depth, etc.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MovePrimitiveRuntimeError(MoveLocationOpt(Some(MoveLocation { module: ModuleId { address: Test, name: Identifier("M1") }, function: 0, instruction: 11, function_name: Some("push_n_items") }))), source: Some(VMError { major_status: VECTOR_OPERATION_ERROR, sub_status: Some(4), message: Some("vector size limit is 262144"), exec_state: Some(ExecutionState { stack_trace: [] }), location: Module(ModuleId { address: Test, name: Identifier("M1") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 11)] }), command: Some(0) } }
+
+task 6 'run'. lines 45-47:
+Error: Transaction Effects Status: Insufficient Gas.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: Some(ExecutionState { stack_trace: [] }), location: Module(ModuleId { address: Test, name: Identifier("M1") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 4)] }), command: Some(0) } }
+
+task 7 'run'. lines 48-48:
+Error: Transaction Effects Status: Insufficient Gas.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: Some(ExecutionState { stack_trace: [] }), location: Module(ModuleId { address: Test, name: Identifier("M1") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 4)] }), command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/vector_len_limits.move
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/vector_len_limits.move
@@ -28,13 +28,21 @@ module Test::M1 {
 }
 
 // push below ven len limit should succeed
-//# run Test::M1::push_n_items --args 1 --gas-budget 100000000000000
+//# run Test::M1::push_n_items --args 1 --uncharged
 
 // push below vec len limit should succeed
-//# run Test::M1::push_n_items --args 256 --gas-budget 100000000000000
+//# run Test::M1::push_n_items --args 256 --uncharged
 
 // run at vec len limit should succeed
-//# run Test::M1::push_n_items --args 262144 --gas-budget 100000000000000
+//# run Test::M1::push_n_items --args 262144 --uncharged
 
 // run above vec len limit should fail
-//# run Test::M1::push_n_items --args 262145 --gas-budget 100000000000000
+//# run Test::M1::push_n_items --args 262145 --uncharged
+
+// Check if we run out of gas before hitting limits
+
+// run at vec len limit should succeed
+//# run Test::M1::push_n_items --args 262144 --gas-budget 1000000000
+
+// run above vec len limit should fail
+//# run Test::M1::push_n_items --args 262145 --gas-budget 1000000000

--- a/crates/sui-cost-tables/src/tier_based/tables.rs
+++ b/crates/sui-cost-tables/src/tier_based/tables.rs
@@ -780,27 +780,78 @@ pub fn initial_cost_schedule_v1() -> CostTable {
     }
 }
 
+pub fn initial_cost_schedule_v2() -> CostTable {
+    let instruction_tiers: BTreeMap<u64, u64> = vec![
+        (0, 1),
+        (3000, 2),
+        (6000, 3),
+        (8000, 5),
+        (9000, 9),
+        (9500, 16),
+        (10000, 29),
+        (10500, 50),
+        (12000, 150),
+        (15000, 250),
+    ]
+    .into_iter()
+    .collect();
+
+    let stack_height_tiers: BTreeMap<u64, u64> = vec![
+        (0, 1),
+        (400, 2),
+        (800, 3),
+        (1200, 5),
+        (1500, 9),
+        (1800, 16),
+        (2000, 29),
+        (2200, 50),
+        (3000, 150),
+        (5000, 250),
+    ]
+    .into_iter()
+    .collect();
+
+    let stack_size_tiers: BTreeMap<u64, u64> = vec![
+        (0, 1),
+        (2000, 2),
+        (5000, 3),
+        (8000, 5),
+        (10000, 9),
+        (11000, 16),
+        (11500, 29),
+        (11500, 50),
+        (15000, 150),
+        (20000, 250),
+    ]
+    .into_iter()
+    .collect();
+
+    CostTable {
+        instruction_tiers,
+        stack_size_tiers,
+        stack_height_tiers,
+    }
+}
+
 // Convert from our representation of gas costs to the type that the MoveVM expects for unit tests.
 // We don't want our gas depending on the MoveVM test utils and we don't want to fix our
 // representation to whatever is there, so instead we perform this translation from our gas units
 // and cost schedule to the one expected by the Move unit tests.
 pub fn initial_cost_schedule_for_unit_tests() -> move_vm_test_utils::gas_schedule::CostTable {
+    let table = initial_cost_schedule_v2();
     move_vm_test_utils::gas_schedule::CostTable {
-        instruction_tiers: INITIAL_COST_SCHEDULE
+        instruction_tiers: table
             .instruction_tiers
-            .clone()
             .into_iter()
             .map(|(k, v)| (k, v))
             .collect(),
-        stack_height_tiers: INITIAL_COST_SCHEDULE
+        stack_height_tiers: table
             .stack_height_tiers
-            .clone()
             .into_iter()
             .map(|(k, v)| (k, v))
             .collect(),
-        stack_size_tiers: INITIAL_COST_SCHEDULE
+        stack_size_tiers: table
             .stack_size_tiers
-            .clone()
             .into_iter()
             .map(|(k, v)| (k, v))
             .collect(),

--- a/crates/sui-framework-tests/Cargo.toml
+++ b/crates/sui-framework-tests/Cargo.toml
@@ -14,6 +14,7 @@ sui-framework-build = { path = "../sui-framework-build" }
 
 move-cli.workspace = true
 move-package.workspace = true
+move-unit-test.workspace = true
 
 [dependencies]
 workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/crates/sui-framework-tests/src/lib.rs
+++ b/crates/sui-framework-tests/src/lib.rs
@@ -4,6 +4,7 @@
 #[cfg(test)]
 mod test {
     use move_cli::base::test::UnitTestResult;
+    use move_unit_test::UnitTestingConfig;
     use std::path::{Path, PathBuf};
     use sui_framework::build_move_package;
     use sui_framework_build::compiled_package::BuildConfig;
@@ -60,13 +61,14 @@ mod test {
         config.run_bytecode_verifier = true;
         config.print_diags_to_stderr = true;
         let move_config = config.config.clone();
+        let testing_config = UnitTestingConfig::default_with_bound(Some(3_000_000));
 
         // build tests first to enable Sui-specific test code verification
         build_move_package(path, config)
             .unwrap_or_else(|e| panic!("Building tests at {}.\nWith error {e}", path.display()));
 
         assert_eq!(
-            run_move_unit_tests(path, move_config, None, false).unwrap(),
+            run_move_unit_tests(path, move_config, Some(testing_config), false).unwrap(),
             UnitTestResult::Success
         );
     }

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -26,6 +26,8 @@ pub struct SuiRunArgs {
     pub view_events: bool,
     #[clap(long = "view-gas-used")]
     pub view_gas_used: bool,
+    #[clap(long = "uncharged")]
+    pub uncharged: bool,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -373,7 +373,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
             TransactionData::new_programmable(sender, vec![gas], pt, gas_budget, 1)
         };
         let transaction = self.sign_txn(sender, data);
-        let summary = self.execute_txn(transaction, gas_budget)?;
+        let summary = self.execute_txn(transaction, gas_budget, false)?;
         let created_package = summary
             .created
             .iter()
@@ -434,6 +434,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
             sender,
             view_events,
             view_gas_used,
+            uncharged,
         } = extra;
         let mut builder = ProgrammableTransactionBuilder::new();
         let arguments = args
@@ -455,7 +456,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
             TransactionData::new_programmable(sender, vec![gas], pt, gas_budget, 1)
         };
         let transaction = self.sign_txn(sender, data);
-        let summary = self.execute_txn(transaction, gas_budget)?;
+        let summary = self.execute_txn(transaction, gas_budget, uncharged)?;
         let output = self.object_summary_output(&summary, view_events, view_gas_used);
         let empty = SerializedReturnValues {
             mutable_reference_outputs: vec![],
@@ -575,7 +576,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                     let pt = builder.finish();
                     TransactionData::new_programmable(sender, vec![gas], pt, gas_budget, 1)
                 });
-                let summary = self.execute_txn(transaction, gas_budget)?;
+                let summary = self.execute_txn(transaction, gas_budget, false)?;
                 let output = self.object_summary_output(&summary, false, view_gas_used);
                 Ok(output)
             }
@@ -584,7 +585,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
             }) => {
                 let transaction =
                     VerifiedTransaction::new_consensus_commit_prologue(0, 0, timestamp_ms);
-                let summary = self.execute_txn(transaction, DEFAULT_GAS_BUDGET)?;
+                let summary = self.execute_txn(transaction, DEFAULT_GAS_BUDGET, false)?;
                 let output = self.object_summary_output(&summary, false, false);
                 Ok(output)
             }
@@ -620,7 +621,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                         1,
                     )
                 });
-                let summary = self.execute_txn(transaction, gas_budget)?;
+                let summary = self.execute_txn(transaction, gas_budget, false)?;
                 let output = self.object_summary_output(&summary, view_events, view_gas_used);
                 Ok(output)
             }
@@ -654,12 +655,25 @@ impl<'a> SuiTestAdapter<'a> {
         &mut self,
         transaction: VerifiedTransaction,
         gas_budget: u64,
+        uncharged: bool,
     ) -> anyhow::Result<TxnSummary> {
-        let gas_status = if transaction.inner().is_system_tx() {
+        let mut gas_status = if transaction.inner().is_system_tx() {
             SuiGasStatus::new_unmetered(&PROTOCOL_CONSTANTS)
         } else {
             SuiCostTable::new(&PROTOCOL_CONSTANTS).into_gas_status_for_testing(gas_budget, 1, 1)
         };
+        // Unmetered is set in the transaction run without metering. NB that this will still keep
+        // in place the normal transaction execution limits.
+        if uncharged {
+            match &mut gas_status {
+                SuiGasStatus::V1(gas_status) => {
+                    gas_status.gas_status.set_metering(false);
+                }
+                SuiGasStatus::V2(gas_status) => {
+                    gas_status.gas_status.set_metering(false);
+                }
+            }
+        }
         transaction
             .data()
             .transaction_data()

--- a/crates/sui-types/src/gas_model/gas_v2.rs
+++ b/crates/sui-types/src/gas_model/gas_v2.rs
@@ -13,7 +13,9 @@ use move_core_types::vm_status::StatusCode;
 use once_cell::sync::Lazy;
 use std::convert::TryFrom;
 use std::iter;
-use sui_cost_tables::bytecode_tables::{initial_cost_schedule_v1, GasStatus, ZERO_COST_SCHEDULE};
+use sui_cost_tables::bytecode_tables::{
+    initial_cost_schedule_v1, initial_cost_schedule_v2, GasStatus, ZERO_COST_SCHEDULE,
+};
 use sui_cost_tables::units_types::CostTable;
 use sui_protocol_config::*;
 
@@ -142,7 +144,8 @@ impl SuiCostTable {
 
 fn cost_table_for_version(config: &ProtocolConfig) -> CostTable {
     match config.gas_model_version() {
-        1 | 2 | 3 | 4 => initial_cost_schedule_v1(),
+        1 | 2 | 3 => initial_cost_schedule_v1(),
+        4 => initial_cost_schedule_v2(),
         _ => panic!("Unknown gas cost table version"),
     }
 }


### PR DESCRIPTION
Updates cost tables to be more resilient to adversarial workloads.

The current tiers have remained unchanged, but the tail-end of the tables is increased to guard against large instruction/large allocation.

This also adds versioning for the cost table, and adds support for running transactions `unmetered` in the transactional test runner. The `GasStatus` no longer holds a reference to the cost table but now owns the cost table -- this then caused a bunch of removals of lifetimes from parts of the codebase.

