### PR TITLE
Adding async thread to faucet

### DIFF
--- a/crates/sui-faucet/src/faucet/mod.rs
+++ b/crates/sui-faucet/src/faucet/mod.rs
@@ -66,6 +66,9 @@ pub struct FaucetConfig {
 
     #[clap(long)]
     pub write_ahead_log: PathBuf,
+
+    #[clap(long, default_value_t = 300)]
+    pub wal_retry_interval: u64,
 }
 
 impl Default for FaucetConfig {
@@ -79,6 +82,7 @@ impl Default for FaucetConfig {
             max_request_per_second: 10,
             wallet_client_timeout_secs: 60,
             write_ahead_log: Default::default(),
+            wal_retry_interval: 300,
         }
     }
 }

--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -11,6 +11,7 @@ use shared_crypto::intent::Intent;
 #[cfg(test)]
 use std::collections::HashSet;
 use std::path::Path;
+use typed_store::Map;
 
 use sui::client_commands::WalletContext;
 use sui_json_rpc_types::{
@@ -90,6 +91,7 @@ impl SimpleFaucet {
                 uuid,
                 recipient,
                 tx,
+                retry_count: _,
             }) = wal.reclaim(coin_id).map_err(FaucetError::internal)?
             {
                 let uuid = Uuid::from_bytes(uuid);
@@ -223,6 +225,32 @@ impl SimpleFaucet {
         }))
     }
 
+    /// Clear the WAL list in the faucet
+    pub async fn retry_wal_coins(&self) -> Result<(), FaucetError> {
+        let mut wal = self.wal.lock().await;
+        let log = wal.log.clone();
+
+        let mut pending = vec![];
+
+        for item in log.safe_iter() {
+            // Safe unwrap as we are the only ones that ever add to the WAL.
+            let (coin_id, entry) = item.unwrap();
+            wal.increment_retry_count(coin_id)
+                .map_err(FaucetError::internal)?;
+            let uuid = Uuid::from_bytes(entry.uuid);
+            pending.push((uuid, entry.recipient, coin_id, entry.tx));
+        }
+        // Drops the lock early because sign_and_execute_txn requires the lock.
+        drop(wal);
+
+        futures::future::join_all(pending.into_iter().map(|(uuid, recipient, coin_id, tx)| {
+            self.sign_and_execute_txn(uuid, recipient, coin_id, tx)
+        }))
+        .await;
+
+        Ok(())
+    }
+
     /// Sign an already created transaction (in `tx_data`) and keep trying to execute it until
     /// fullnode returns a definite response or a timeout is hit.
     async fn sign_and_execute_txn(
@@ -282,9 +310,7 @@ impl SimpleFaucet {
                 if self.wal.lock().await.commit(coin_id).is_err() {
                     error!(?coin_id, "Failed to remove coin from WAL");
                 }
-
                 self.recycle_gas_coin(coin_id, uuid).await;
-
                 Ok(result)
             }
         }
@@ -742,7 +768,57 @@ mod tests {
         );
     }
 
-    // TODO (jian): fix this test later
+    #[tokio::test]
+    async fn test_clear_wal() {
+        telemetry_subscribers::init_for_testing();
+        let test_cluster = TestClusterBuilder::new().build().await.unwrap();
+        let context = test_cluster.wallet;
+        let tmp = tempfile::tempdir().unwrap();
+        let prom_registry = Registry::new();
+        let config = FaucetConfig::default();
+        let mut faucet = SimpleFaucet::new(
+            context,
+            &prom_registry,
+            &tmp.path().join("faucet.wal"),
+            config,
+        )
+        .await
+        .unwrap();
+
+        let recipient = SuiAddress::random_for_testing_only();
+        let faucet_address = faucet.wallet_mut().active_address().unwrap();
+        let uuid = Uuid::new_v4();
+        let coin_response = faucet.prepare_gas_coin(100, uuid).await;
+
+        match coin_response {
+            GasCoinResponse::ValidGasCoin(gas) => {
+                let tx_data = faucet
+                    .build_pay_sui_txn(gas, faucet_address, recipient, &[100], 200_000_000)
+                    .await
+                    .map_err(FaucetError::internal)
+                    .unwrap();
+
+                let mut wal = faucet.wal.lock().await;
+                // Check no wal
+                assert!(wal.log.is_empty());
+                wal.reserve(Uuid::new_v4(), gas, recipient, tx_data)
+                    .map_err(FaucetError::internal)
+                    .ok();
+                // Check the wal has one entry
+                assert!(!wal.log.is_empty());
+                drop(wal);
+            }
+            _ => {
+                panic!("prepare_gas_coin_did not give a valid function.");
+            }
+        }
+
+        faucet.retry_wal_coins().await.ok();
+
+        let wal_2 = faucet.wal.lock().await;
+        assert!(wal_2.log.is_empty());
+    }
+
     // #[tokio::test]
     // async fn test_discard_smaller_amount_gas() {
     //     telemetry_subscribers::init_for_testing();
@@ -756,20 +832,15 @@ mod tests {
     //     let tiny_value = 1;
     //     let res = SuiClientCommands::SplitCoin {
     //         coin_id: *gases[0].id(),
-    //         amounts: Some(vec![tiny_value + DEFAULT_GAS_COMPUTATION_BUCKET]),
-    //         gas_budget: 50000,
+    //         amounts: Some(vec![tiny_value]),
+    //         gas_budget: 50000000,
     //         gas: None,
     //         count: None,
     //     }
     //     .execute(&mut context)
-    //     .await
-    //     .unwrap();
+    //     .await;
 
-    //     let tiny_coin_id = if let SuiClientCommandResult::SplitCoin(resp) = res {
-    //         assert!(matches!(
-    //             resp.effects.as_ref().unwrap().status(),
-    //             SuiExecutionStatus::Success
-    //         ));
+    //     let tiny_coin_id = if let SuiClientCommandResult::SplitCoin(resp) = res.unwrap() {
     //         resp.effects.as_ref().unwrap().created()[0]
     //             .reference
     //             .object_id
@@ -784,8 +855,7 @@ mod tests {
     //         .find(|gas| gas.id() == &tiny_coin_id)
     //         .unwrap()
     //         .value();
-    //     assert_eq!(tiny_amount, tiny_value + DEFAULT_GAS_COMPUTATION_BUCKET);
-    //     info!("tiny coin id: {:?}, amount: {}", tiny_coin_id, tiny_amount);
+    //     assert_eq!(tiny_amount, tiny_value);
 
     //     let gases: HashSet<ObjectID> = HashSet::from_iter(gases.into_iter().map(|gas| *gas.id()));
 

--- a/crates/sui-faucet/src/faucet/write_ahead_log.rs
+++ b/crates/sui-faucet/src/faucet/write_ahead_log.rs
@@ -20,16 +20,17 @@ use uuid::Uuid;
 ///
 /// This allows the faucet to go down and back up, and not forget which requests were in-flight that
 /// it needs to confirm succeeded or failed.
-#[derive(DBMapUtils)]
+#[derive(DBMapUtils, Clone)]
 pub struct WriteAheadLog {
-    log: DBMap<ObjectID, Entry>,
+    pub log: DBMap<ObjectID, Entry>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct Entry {
     pub uuid: uuid::Bytes,
     pub recipient: SuiAddress,
     pub tx: TransactionData,
+    pub retry_count: u64,
 }
 
 impl WriteAheadLog {
@@ -66,6 +67,7 @@ impl WriteAheadLog {
                 uuid,
                 recipient,
                 tx,
+                retry_count: 0,
             },
         )
     }
@@ -81,6 +83,14 @@ impl WriteAheadLog {
     /// be removed.
     pub(crate) fn commit(&mut self, coin: ObjectID) -> Result<(), TypedStoreError> {
         self.log.remove(&coin)
+    }
+
+    pub(crate) fn increment_retry_count(&mut self, coin: ObjectID) -> Result<(), TypedStoreError> {
+        if let Some(mut entry) = self.log.get(&coin)? {
+            entry.retry_count += 1;
+            self.log.insert(&coin, &entry)?;
+        }
+        Ok(())
     }
 }
 
@@ -118,6 +128,22 @@ mod tests {
         assert_eq!(uuid, Uuid::from_bytes(entry.uuid));
         assert_eq!(recv, entry.recipient);
         assert_eq!(tx, entry.tx);
+    }
+
+    #[tokio::test]
+    async fn test_increment_wal() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut wal = WriteAheadLog::open(&tmp.path().join("wal"));
+        let uuid = Uuid::new_v4();
+        let coin = random_object_ref();
+        let (recv0, tx0) = random_request(coin);
+
+        // First write goes through
+        wal.reserve(uuid, coin.0, recv0, tx0).unwrap();
+        wal.increment_retry_count(coin.0).unwrap();
+
+        let entry = wal.reclaim(coin.0).unwrap().unwrap();
+        assert_eq!(entry.retry_count, 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description 

Adding a worker thread to clear WAL on faucet

## Test Plan 

Locally
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
