### PR TITLE
[ts-sdk] Fix transaction cloning

### DIFF
--- a/sdk/typescript/src/builder/TransactionBlock.ts
+++ b/sdk/typescript/src/builder/TransactionBlock.ts
@@ -222,7 +222,7 @@ export class TransactionBlock {
 
   constructor(transaction?: TransactionBlock) {
     this.#blockData = new TransactionBlockDataBuilder(
-      transaction ? transaction.#blockData : undefined,
+      transaction ? transaction.blockData : undefined,
     );
   }
 

--- a/sdk/typescript/src/builder/TransactionBlockData.ts
+++ b/sdk/typescript/src/builder/TransactionBlockData.ts
@@ -163,7 +163,7 @@ export class TransactionBlockDataBuilder {
   inputs: TransactionBlockInput[];
   transactions: TransactionType[];
 
-  constructor(clone?: TransactionBlockDataBuilder) {
+  constructor(clone?: SerializedTransactionDataBuilder) {
     this.sender = clone?.sender;
     this.expiration = clone?.expiration;
     this.gasConfig = clone?.gasConfig ?? {};

--- a/sdk/typescript/src/builder/__tests__/Transaction.test.ts
+++ b/sdk/typescript/src/builder/__tests__/Transaction.test.ts
@@ -58,6 +58,22 @@ describe('offline build', () => {
     await tx.build();
   });
 
+  it('breaks reference equality', () => {
+    const tx = setup();
+    const tx2 = new TransactionBlock(tx);
+
+    tx.setGasBudget(999);
+
+    // Ensure that setting budget after a clone does not affect the original:
+    expect(tx2.blockData).not.toEqual(tx.blockData);
+
+    // Ensure `blockData` always breaks reference equality:
+    expect(tx.blockData).not.toBe(tx.blockData);
+    expect(tx.blockData.gasConfig).not.toBe(tx.blockData.gasConfig);
+    expect(tx.blockData.transactions).not.toBe(tx.blockData.transactions);
+    expect(tx.blockData.inputs).not.toBe(tx.blockData.inputs);
+  });
+
   it('can determine the type of inputs for built-in transactions', async () => {
     const tx = setup();
     tx.add(Transactions.SplitCoins(tx.gas, [tx.pure(100)]));


### PR DESCRIPTION
## Description

Transaction cloning used private data, which meant object references were retained when cloning. This isn't really good, so instead we use the snapshot, where object references will be broken.

## Test Plan

Adding new test.
