### PR TITLE
get_balance

### DIFF
--- a/crates/sui-rpc-loadgen/src/payload/get_all_balances.rs
+++ b/crates/sui-rpc-loadgen/src/payload/get_all_balances.rs
@@ -25,26 +25,42 @@ impl<'a> ProcessPayload<'a, &'a GetAllBalances> for RpcCommandProcessor {
         let chunked = chunk_entities(&op.addresses, Some(op.chunk_size));
         for chunk in chunked {
             let mut tasks = Vec::new();
-            for address in chunk {
+            for address in &chunk {
                 for client in clients.iter() {
                     let owner_address = address;
-                    let task = async move {
-                        get_all_balances(client, owner_address).await.unwrap();
-                    };
+                    let task =
+                        async move { get_all_balances(client, *owner_address).await.unwrap() };
                     tasks.push(task);
                 }
             }
-            join_all(tasks).await;
+            let result = join_all(tasks).await;
+            // arbitrarily pick the 0th vec of results for now
+            let mut client_coin_types: Vec<Vec<String>> = Vec::new();
+            for (idx, balances) in result.into_iter().enumerate() {
+                if idx % clients.len() == 0 {
+                    if let Some(balances) = balances {
+                        let coin_types: Vec<String> = balances
+                            .iter()
+                            .map(|balance| balance.coin_type.clone())
+                            .collect();
+                        client_coin_types.push(coin_types);
+                    }
+                }
+            }
+            for (address, coin_types) in chunk.into_iter().zip(client_coin_types.into_iter()) {
+                self.add_addresses_with_coin_types(address, coin_types);
+            }
         }
         Ok(())
     }
 }
 
-async fn get_all_balances(client: &SuiClient, owner_address: SuiAddress) -> Result<Vec<Balance>> {
-    let balances = client
-        .coin_read_api()
-        .get_all_balances(owner_address)
-        .await
-        .unwrap();
-    Ok(balances)
+pub async fn get_all_balances(
+    client: &SuiClient,
+    owner_address: SuiAddress,
+) -> Result<Option<Vec<Balance>>> {
+    match client.coin_read_api().get_all_balances(owner_address).await {
+        Ok(balances) => Ok(Some(balances)),
+        Err(e) => Ok(None),
+    }
 }

--- a/crates/sui-rpc-loadgen/src/payload/get_all_balances.rs
+++ b/crates/sui-rpc-loadgen/src/payload/get_all_balances.rs
@@ -61,6 +61,6 @@ pub async fn get_all_balances(
 ) -> Result<Option<Vec<Balance>>> {
     match client.coin_read_api().get_all_balances(owner_address).await {
         Ok(balances) => Ok(Some(balances)),
-        Err(e) => Ok(None),
+        Err(_e) => Ok(None),
     }
 }

--- a/crates/sui-rpc-loadgen/src/payload/get_balance.rs
+++ b/crates/sui-rpc-loadgen/src/payload/get_balance.rs
@@ -1,0 +1,68 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::payload::{GetBalance, ProcessPayload, RpcCommandProcessor, SignerInfo};
+use anyhow::Result;
+use async_trait::async_trait;
+use futures::future::join_all;
+use sui_json_rpc_types::Balance;
+use sui_sdk::SuiClient;
+use sui_types::base_types::SuiAddress;
+
+use super::validation::chunk_entities;
+
+#[async_trait]
+impl<'a> ProcessPayload<'a, &'a GetBalance> for RpcCommandProcessor {
+    async fn process(
+        &'a self,
+        op: &'a GetBalance,
+        _signer_info: &Option<SignerInfo>,
+    ) -> Result<()> {
+        if op.addresses_with_coin_types.is_empty() {
+            panic!("No addresses provided, skipping query");
+        }
+
+        // Map address to each coin_type in coin_types
+        let mapped: Vec<(SuiAddress, String)> = op
+            .addresses_with_coin_types
+            .iter()
+            .flat_map(|awct| {
+                awct.coin_types
+                    .iter()
+                    .map(move |coin_type| (awct.address, coin_type.clone()))
+            })
+            .collect();
+
+        let clients = self.get_clients().await?;
+        let chunked = chunk_entities(&mapped, Some(op.chunk_size));
+
+        for chunk in chunked {
+            let mut tasks = Vec::new();
+            for (owner_address, coin_type) in chunk {
+                for client in clients.iter() {
+                    let with_coin_type = coin_type.clone();
+                    let task =
+                        async move { get_balance(client, owner_address, with_coin_type).await };
+                    tasks.push(task);
+                }
+            }
+            join_all(tasks).await;
+        }
+        Ok(())
+    }
+}
+
+async fn get_balance(
+    client: &SuiClient,
+    owner_address: SuiAddress,
+    coin_type: String,
+) -> Result<Option<Balance>> {
+    match client
+        .coin_read_api()
+        .get_balance(owner_address, Some(coin_type))
+        .await
+    {
+        Ok(balance) => Ok(Some(balance)),
+        Err(_error) => Ok(None),
+    }
+}

--- a/crates/sui-rpc-loadgen/src/payload/mod.rs
+++ b/crates/sui-rpc-loadgen/src/payload/mod.rs
@@ -3,6 +3,7 @@
 
 mod checkpoint_utils;
 mod get_all_balances;
+mod get_balance;
 mod get_checkpoints;
 mod get_object;
 mod get_reference_gas_price;
@@ -25,9 +26,12 @@ use sui_types::{
 
 use crate::load_test::LoadTestConfig;
 pub use rpc_command_processor::{
-    load_addresses_from_file, load_digests_from_file, load_objects_from_file, RpcCommandProcessor,
+    load_addresses_from_file, load_addresses_with_coin_types_from_file, load_digests_from_file,
+    load_objects_from_file, RpcCommandProcessor,
 };
 use sui_types::base_types::ObjectID;
+
+use self::rpc_command_processor::AddressWithCoinTypes;
 
 #[derive(Default, Clone)]
 pub struct SignerInfo {
@@ -140,13 +144,33 @@ impl Command {
         }
     }
 
-    pub fn new_get_all_balances(addresses: Vec<SuiAddress>, chunk_size: usize) -> Self {
+    pub fn new_get_all_balances(
+        addresses: Vec<SuiAddress>,
+        chunk_size: usize,
+        record: bool,
+    ) -> Self {
         let get_all_balances = GetAllBalances {
             addresses,
             chunk_size,
+            record,
         };
         Self {
             data: CommandData::GetAllBalances(get_all_balances),
+            ..Default::default()
+        }
+    }
+
+    pub fn new_get_balance(
+        addresses_with_coin_types: Vec<AddressWithCoinTypes>,
+        chunk_size: usize,
+    ) -> Self {
+        // load data here
+        let get_balance = GetBalance {
+            addresses_with_coin_types,
+            chunk_size,
+        };
+        Self {
+            data: CommandData::GetBalance(get_balance),
             ..Default::default()
         }
     }
@@ -181,6 +205,7 @@ pub enum CommandData {
     MultiGetObjects(MultiGetObjects),
     GetObject(GetObject),
     GetAllBalances(GetAllBalances),
+    GetBalance(GetBalance),
     GetReferenceGasPrice(GetReferenceGasPrice),
 }
 
@@ -246,6 +271,13 @@ pub struct GetObject {
 #[derive(Clone)]
 pub struct GetAllBalances {
     pub addresses: Vec<SuiAddress>,
+    pub chunk_size: usize,
+    pub record: bool,
+}
+
+#[derive(Clone)]
+pub struct GetBalance {
+    pub addresses_with_coin_types: Vec<AddressWithCoinTypes>,
     pub chunk_size: usize,
 }
 

--- a/crates/sui-rpc-loadgen/src/payload/rpc_command_processor.rs
+++ b/crates/sui-rpc-loadgen/src/payload/rpc_command_processor.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use dashmap::{DashMap, DashSet};
 use futures::future::join_all;
 use serde::de::DeserializeOwned;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use shared_crypto::intent::{Intent, IntentMessage};
 use std::fmt;
 use std::fs::{self, File};
@@ -35,7 +35,7 @@ use crate::payload::{
     Payload, ProcessPayload, Processor, QueryTransactionBlocks, SignerInfo,
 };
 
-use super::MultiGetTransactionBlocks;
+use super::{GetBalance, MultiGetTransactionBlocks};
 
 pub(crate) const DEFAULT_GAS_BUDGET: u64 = 500_000_000;
 pub(crate) const DEFAULT_LARGE_GAS_BUDGET: u64 = 50_000_000_000;
@@ -48,6 +48,7 @@ pub struct RpcCommandProcessor {
     object_ref_cache: Arc<DashMap<ObjectID, ObjectRef>>,
     transaction_digests: Arc<DashSet<TransactionDigest>>,
     addresses: Arc<DashSet<SuiAddress>>,
+    addresses_with_coin_types: Arc<DashMap<SuiAddress, Vec<String>>>,
     data_dir: String,
 }
 
@@ -68,6 +69,7 @@ impl RpcCommandProcessor {
             object_ref_cache: Arc::new(DashMap::new()),
             transaction_digests: Arc::new(DashSet::new()),
             addresses: Arc::new(DashSet::new()),
+            addresses_with_coin_types: Arc::new(DashMap::new()),
             data_dir,
         }
     }
@@ -86,6 +88,7 @@ impl RpcCommandProcessor {
             CommandData::MultiGetObjects(ref v) => self.process(v, signer_info).await,
             CommandData::GetObject(ref v) => self.process(v, signer_info).await,
             CommandData::GetAllBalances(ref v) => self.process(v, signer_info).await,
+            CommandData::GetBalance(ref v) => self.process(v, signer_info).await,
             CommandData::GetReferenceGasPrice(ref v) => self.process(v, signer_info).await,
         }
     }
@@ -166,6 +169,14 @@ impl RpcCommandProcessor {
         }
     }
 
+    pub(crate) fn add_addresses_with_coin_types(
+        &self,
+        address: SuiAddress,
+        coin_types: Vec<String>,
+    ) {
+        self.addresses_with_coin_types.insert(address, coin_types);
+    }
+
     pub(crate) fn add_object_ids_from_response(&self, responses: &[SuiTransactionBlockResponse]) {
         for response in responses {
             let effects = &response.effects;
@@ -187,6 +198,7 @@ impl RpcCommandProcessor {
             write_data_to_file(
                 &digests,
                 &format!("{}/{}", &self.data_dir, CacheType::TransactionDigest),
+                Some(false),
             )
             .unwrap();
         }
@@ -197,6 +209,7 @@ impl RpcCommandProcessor {
             write_data_to_file(
                 &addresses,
                 &format!("{}/{}", &self.data_dir, CacheType::SuiAddress),
+                Some(false),
             )
             .unwrap();
         }
@@ -214,10 +227,17 @@ impl RpcCommandProcessor {
             write_data_to_file(
                 &object_ids,
                 &format!("{}/{}", &self.data_dir, CacheType::ObjectID),
+                Some(false),
             )
             .unwrap();
         }
     }
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+pub struct AddressWithCoinTypes {
+    pub address: SuiAddress,
+    pub coin_types: Vec<String>,
 }
 
 #[async_trait]
@@ -282,6 +302,13 @@ impl Processor for RpcCommandProcessor {
                     divide_get_all_balances_tasks(data, config.num_threads).await
                 }
             }
+            CommandData::GetBalance(data) => {
+                if !config.divide_tasks {
+                    vec![config.command.clone(); config.num_threads]
+                } else {
+                    divide_get_balance_tasks(data, config.num_threads).await
+                }
+            }
             CommandData::MultiGetObjects(data) => {
                 if !config.divide_tasks {
                     vec![config.command.clone(); config.num_threads]
@@ -341,6 +368,10 @@ impl Processor for RpcCommandProcessor {
             if data.record {
                 self.dump_cache_to_file();
             }
+        } else if let CommandData::GetAllBalances(data) = &config.command.data {
+            if data.record {
+                self.dump_cache_to_file();
+            }
         }
     }
 }
@@ -353,12 +384,16 @@ impl<'a> ProcessPayload<'a, &'a DryRun> for RpcCommandProcessor {
     }
 }
 
-fn write_data_to_file<T: Serialize>(data: &T, file_path: &str) -> Result<(), anyhow::Error> {
+fn write_data_to_file<T: Serialize>(
+    data: &T,
+    file_path: &str,
+    _use_timestamp: Option<bool>,
+) -> Result<(), anyhow::Error> {
     let mut path_buf = PathBuf::from(&file_path);
     path_buf.pop();
     fs::create_dir_all(&path_buf).map_err(|e| anyhow!("Error creating directory: {}", e))?;
-
     let file_name = format!("{}.json", file_path);
+
     let file = File::create(&file_name).map_err(|e| anyhow!("Error creating file: {}", e))?;
     serde_json::to_writer(file, data).map_err(|e| anyhow!("Error writing to file: {}", e))?;
 
@@ -369,6 +404,7 @@ pub enum CacheType {
     SuiAddress,
     TransactionDigest,
     ObjectID,
+    AddressWithCoinTypes,
 }
 
 impl fmt::Display for CacheType {
@@ -377,6 +413,7 @@ impl fmt::Display for CacheType {
             CacheType::SuiAddress => write!(f, "SuiAddress"),
             CacheType::TransactionDigest => write!(f, "TransactionDigest"),
             CacheType::ObjectID => write!(f, "ObjectID"),
+            CacheType::AddressWithCoinTypes => write!(f, "AddressesWithCoinTypes"),
         }
     }
 }
@@ -385,6 +422,13 @@ impl fmt::Display for CacheType {
 pub fn load_addresses_from_file(filepath: String) -> Vec<SuiAddress> {
     let path = format!("{}/{}", filepath, CacheType::SuiAddress);
     let addresses: Vec<SuiAddress> = read_data_from_file(&path).expect("Failed to read addresses");
+    addresses
+}
+
+pub fn load_addresses_with_coin_types_from_file(filepath: String) -> Vec<AddressWithCoinTypes> {
+    let path = format!("{}/{}", filepath, CacheType::AddressWithCoinTypes);
+    let addresses: Vec<AddressWithCoinTypes> =
+        read_data_from_file(&path).expect("Failed to read addresses");
     addresses
 }
 
@@ -504,7 +548,24 @@ async fn divide_get_all_balances_tasks(data: &GetAllBalances, num_threads: usize
     let chunked = chunk_entities(data.addresses.as_slice(), Some(per_thread_size));
     chunked
         .into_iter()
-        .map(|chunk| Command::new_get_all_balances(chunk, data.chunk_size))
+        .map(|chunk| Command::new_get_all_balances(chunk, data.chunk_size, data.record))
+        .collect()
+}
+
+async fn divide_get_balance_tasks(data: &GetBalance, num_threads: usize) -> Vec<Command> {
+    let per_thread_size = if data.addresses_with_coin_types.len() < num_threads {
+        1
+    } else {
+        data.addresses_with_coin_types.len() / num_threads
+    };
+
+    let chunked = chunk_entities(
+        data.addresses_with_coin_types.as_slice(),
+        Some(per_thread_size),
+    );
+    chunked
+        .into_iter()
+        .map(|chunk| Command::new_get_balance(chunk, data.chunk_size))
         .collect()
 }
 


### PR DESCRIPTION
## Description 

Implement get_balance and add functionality for get_all_balances to dump to cache. map of address -> Vec<String> of coin types

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
