### PR TITLE
[sui-system] skip stake subsidy distribution if epoch is short

### DIFF
--- a/crates/sui-framework/packages/sui-system/sources/stake_subsidy.move
+++ b/crates/sui-framework/packages/sui-system/sources/stake_subsidy.move
@@ -90,4 +90,10 @@ module sui_system::stake_subsidy {
     public fun current_epoch_subsidy_amount(self: &StakeSubsidy): u64 {
         math::min(self.current_distribution_amount, balance::value(&self.balance))
     }
+
+    #[test_only]
+    /// Returns the number of distributions that have occurred.
+    public(friend) fun get_distribution_counter(self: &StakeSubsidy): u64 {
+        self.distribution_counter
+    }
 }

--- a/crates/sui-framework/packages/sui-system/sources/sui_system.move
+++ b/crates/sui-framework/packages/sui-system/sources/sui_system.move
@@ -65,6 +65,8 @@ module sui_system::sui_system {
 
     #[test_only]
     friend sui_system::governance_test_utils;
+    #[test_only]
+    friend sui_system::sui_system_tests;
 
     struct SuiSystemState has key {
         id: UID,
@@ -651,6 +653,12 @@ module sui_system::sui_system {
     public fun get_storage_fund_object_rebates(wrapper: &mut SuiSystemState): u64 {
         let self = load_system_state(wrapper);
         sui_system_state_inner::get_storage_fund_object_rebates(self)
+    }
+
+    #[test_only]
+    public fun get_stake_subsidy_distribution_counter(wrapper: &mut SuiSystemState): u64 {
+        let self = load_system_state(wrapper);
+        sui_system_state_inner::get_stake_subsidy_distribution_counter(self)
     }
 
     // CAUTION: THIS CODE IS ONLY FOR TESTING AND THIS MACRO MUST NEVER EVER BE REMOVED.  Creates a

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -19,7 +19,8 @@ const MAX_PROTOCOL_VERSION: u64 = 4;
 // Version 3: gas model v2, including all sui conservation fixes. Fix for loaded child object
 //            changes, enable package upgrades, add limits on `max_size_written_objects`,
 //            `max_size_written_objects_system_tx`
-// Version 4: New reward slashing rate.
+// Version 4: New reward slashing rate. Framework changes to skip stake susbidy when the epoch
+//            length is short.
 
 #[derive(
     Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, JsonSchema,


### PR DESCRIPTION
## Description 

If the length of an epoch is shorter than our set duration then skip stake subsidy distribution.

## Test Plan 

added a test
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
