### PR TITLE
[consensus] backwards compatible consensus changes

### DIFF
--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -130,7 +130,7 @@ impl<T: ParentSync + Send + Sync> ExecutionState for ConsensusHandler<T> {
 
         /* (serialized, transaction, output_cert) */
         let mut transactions = vec![];
-        let timestamp = consensus_output.sub_dag.commit_timestamp;
+        let timestamp = consensus_output.sub_dag.commit_timestamp();
         let leader_author = consensus_output.sub_dag.leader.header().author();
 
         let epoch_start = self

--- a/narwhal/consensus/benches/process_certificates.rs
+++ b/narwhal/consensus/benches/process_certificates.rs
@@ -14,6 +14,7 @@ use narwhal_consensus as consensus;
 use pprof::criterion::{Output, PProfProfiler};
 use prometheus::Registry;
 use std::{collections::BTreeSet, sync::Arc};
+use storage::NodeStorage;
 use test_utils::{make_consensus_store, make_optimal_certificates, temp_dir, CommitteeFixture};
 use tokio::time::Instant;
 use types::{Certificate, Round};
@@ -41,7 +42,7 @@ pub fn process_certificates(c: &mut Criterion) {
             make_optimal_certificates(&committee, 1..=rounds, &genesis, &keys);
 
         let store_path = temp_dir();
-        let store = make_consensus_store(&store_path);
+        let store = NodeStorage::reopen(&store_path, None);
         let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
 
         let mut state = ConsensusState::new(metrics.clone(), gc_depth);
@@ -54,7 +55,7 @@ pub fn process_certificates(c: &mut Criterion) {
 
         let mut ordering_engine = Bullshark {
             committee: committee.clone(),
-            store,
+            store: store.consensus_store,
             metrics,
             last_successful_leader_election_timestamp: Instant::now(),
             last_leader_election: Default::default(),

--- a/narwhal/consensus/src/bullshark.rs
+++ b/narwhal/consensus/src/bullshark.rs
@@ -9,11 +9,12 @@ use crate::{
 use config::{AuthorityIdentifier, Committee, Stake};
 use fastcrypto::hash::Hash;
 use std::sync::Arc;
+use storage::ConsensusStore;
 use tokio::time::Instant;
 use tracing::{debug, error_span};
 use types::{
-    Certificate, CertificateAPI, CertificateDigest, CommittedSubDag, ConsensusStore, HeaderAPI,
-    ReputationScores, Round,
+    Certificate, CertificateAPI, CertificateDigest, CommittedSubDag, HeaderAPI, ReputationScores,
+    Round,
 };
 
 #[cfg(test)]

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -94,13 +94,11 @@ impl ConsensusState {
                 .unwrap()
                 .expect("Certificate should be found in database");
 
-            Some(CommittedSubDag {
+            Some(CommittedSubDag::from_compressed_sub_dag(
+                latest_sub_dag.clone(),
                 certificates,
                 leader,
-                sub_dag_index: latest_sub_dag.sub_dag_index(),
-                reputation_score: latest_sub_dag.reputation_score(),
-                commit_timestamp: latest_sub_dag.commit_timestamp(),
-            })
+            ))
         } else {
             None
         };

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -14,13 +14,12 @@ use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     sync::Arc,
 };
-use storage::CertificateStore;
+use storage::{CertificateStore, ConsensusStore};
 use tokio::{sync::watch, task::JoinHandle};
 use tracing::{debug, info, instrument};
 use types::{
     metered_channel, Certificate, CertificateAPI, CertificateDigest, CommittedSubDag,
-    CommittedSubDagShell, ConditionalBroadcastReceiver, ConsensusStore, HeaderAPI, Round,
-    Timestamp,
+    CompressedCommittedSubDag, ConditionalBroadcastReceiver, HeaderAPI, Round, Timestamp,
 };
 
 #[cfg(test)]
@@ -65,7 +64,7 @@ impl ConsensusState {
         last_committed_round: Round,
         gc_depth: Round,
         recovered_last_committed: HashMap<AuthorityIdentifier, Round>,
-        latest_sub_dag: Option<CommittedSubDagShell>,
+        latest_sub_dag: Option<CompressedCommittedSubDag>,
         cert_store: CertificateStore,
     ) -> Self {
         let last_round = ConsensusRound::new_with_gc_depth(last_committed_round, gc_depth);
@@ -80,7 +79,7 @@ impl ConsensusState {
 
         let last_committed_sub_dag = if let Some(latest_sub_dag) = latest_sub_dag.as_ref() {
             let certificates = latest_sub_dag
-                .certificates
+                .certificates()
                 .iter()
                 .map(|s| {
                     cert_store
@@ -91,16 +90,16 @@ impl ConsensusState {
                 .collect();
 
             let leader = cert_store
-                .read(latest_sub_dag.leader)
+                .read(latest_sub_dag.leader())
                 .unwrap()
                 .expect("Certificate should be found in database");
 
             Some(CommittedSubDag {
                 certificates,
                 leader,
-                sub_dag_index: latest_sub_dag.sub_dag_index,
-                reputation_score: latest_sub_dag.reputation_score.clone(),
-                commit_timestamp: latest_sub_dag.commit_timestamp,
+                sub_dag_index: latest_sub_dag.sub_dag_index(),
+                reputation_score: latest_sub_dag.reputation_score(),
+                commit_timestamp: latest_sub_dag.commit_timestamp(),
             })
         } else {
             None
@@ -358,9 +357,11 @@ where
         let latest_sub_dag = store.get_latest_sub_dag();
         if let Some(sub_dag) = &latest_sub_dag {
             assert_eq!(
-                sub_dag.leader_round, last_committed_round,
+                sub_dag.leader_round(),
+                last_committed_round,
                 "Last subdag leader round {} is not equal to the last committed round {}!",
-                sub_dag.leader_round, last_committed_round,
+                sub_dag.leader_round(),
+                last_committed_round,
             );
         }
 

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -19,7 +19,7 @@ use tokio::{sync::watch, task::JoinHandle};
 use tracing::{debug, info, instrument};
 use types::{
     metered_channel, Certificate, CertificateAPI, CertificateDigest, CommittedSubDag,
-    CompressedCommittedSubDag, ConditionalBroadcastReceiver, HeaderAPI, Round, Timestamp,
+    ConditionalBroadcastReceiver, ConsensusCommit, HeaderAPI, Round, Timestamp,
 };
 
 #[cfg(test)]
@@ -64,7 +64,7 @@ impl ConsensusState {
         last_committed_round: Round,
         gc_depth: Round,
         recovered_last_committed: HashMap<AuthorityIdentifier, Round>,
-        latest_sub_dag: Option<CompressedCommittedSubDag>,
+        latest_sub_dag: Option<ConsensusCommit>,
         cert_store: CertificateStore,
     ) -> Self {
         let last_round = ConsensusRound::new_with_gc_depth(last_committed_round, gc_depth);
@@ -94,7 +94,7 @@ impl ConsensusState {
                 .unwrap()
                 .expect("Certificate should be found in database");
 
-            Some(CommittedSubDag::from_compressed_sub_dag(
+            Some(CommittedSubDag::from_commit(
                 latest_sub_dag.clone(),
                 certificates,
                 leader,

--- a/narwhal/consensus/src/tests/consensus_utils.rs
+++ b/narwhal/consensus/src/tests/consensus_utils.rs
@@ -3,11 +3,12 @@ use std::num::NonZeroUsize;
 // SPDX-License-Identifier: Apache-2.0
 use config::AuthorityIdentifier;
 use std::sync::Arc;
-use storage::{CertificateStore, CertificateStoreCache};
+use storage::{CertificateStore, CertificateStoreCache, ConsensusStore};
 use store::rocks::MetricConf;
 use store::{reopen, rocks, rocks::DBMap, rocks::ReadWriteOptions};
 use types::{
-    Certificate, CertificateDigest, CommittedSubDagShell, ConsensusStore, Round, SequenceNumber,
+    Certificate, CertificateDigest, CommittedSubDagShell, CompressedCommittedSubDag, Round,
+    SequenceNumber,
 };
 
 pub(crate) const NUM_SUB_DAGS_PER_SCHEDULE: u64 = 100;
@@ -15,21 +16,27 @@ pub(crate) const NUM_SUB_DAGS_PER_SCHEDULE: u64 = 100;
 pub fn make_consensus_store(store_path: &std::path::Path) -> Arc<ConsensusStore> {
     const LAST_COMMITTED_CF: &str = "last_committed";
     const SEQUENCE_CF: &str = "sequence";
+    const COMMITTED_SUB_DAG_CF: &str = "committed_sub_dag";
 
     let rocksdb = rocks::open_cf(
         store_path,
         None,
         MetricConf::default(),
-        &[LAST_COMMITTED_CF, SEQUENCE_CF],
+        &[LAST_COMMITTED_CF, SEQUENCE_CF, COMMITTED_SUB_DAG_CF],
     )
     .expect("Failed to create database");
 
-    let (last_committed_map, sequence_map) = reopen!(&rocksdb,
+    let (last_committed_map, sequence_map, committed_sub_dag_map) = reopen!(&rocksdb,
         LAST_COMMITTED_CF;<AuthorityIdentifier, Round>,
-        SEQUENCE_CF;<SequenceNumber, CommittedSubDagShell>
+        SEQUENCE_CF;<SequenceNumber, CommittedSubDagShell>,
+        COMMITTED_SUB_DAG_CF;<SequenceNumber, CompressedCommittedSubDag>
     );
 
-    Arc::new(ConsensusStore::new(last_committed_map, sequence_map))
+    Arc::new(ConsensusStore::new(
+        last_committed_map,
+        sequence_map,
+        committed_sub_dag_map,
+    ))
 }
 
 pub fn make_certificate_store(store_path: &std::path::Path) -> CertificateStore {

--- a/narwhal/consensus/src/tests/consensus_utils.rs
+++ b/narwhal/consensus/src/tests/consensus_utils.rs
@@ -7,8 +7,7 @@ use storage::{CertificateStore, CertificateStoreCache, ConsensusStore};
 use store::rocks::MetricConf;
 use store::{reopen, rocks, rocks::DBMap, rocks::ReadWriteOptions};
 use types::{
-    Certificate, CertificateDigest, CommittedSubDagShell, CompressedCommittedSubDag, Round,
-    SequenceNumber,
+    Certificate, CertificateDigest, CommittedSubDagShell, ConsensusCommit, Round, SequenceNumber,
 };
 
 pub(crate) const NUM_SUB_DAGS_PER_SCHEDULE: u64 = 100;
@@ -29,7 +28,7 @@ pub fn make_consensus_store(store_path: &std::path::Path) -> Arc<ConsensusStore>
     let (last_committed_map, sequence_map, committed_sub_dag_map) = reopen!(&rocksdb,
         LAST_COMMITTED_CF;<AuthorityIdentifier, Round>,
         SEQUENCE_CF;<SequenceNumber, CommittedSubDagShell>,
-        COMMITTED_SUB_DAG_CF;<SequenceNumber, CompressedCommittedSubDag>
+        COMMITTED_SUB_DAG_CF;<SequenceNumber, ConsensusCommit>
     );
 
     Arc::new(ConsensusStore::new(

--- a/narwhal/executor/src/lib.rs
+++ b/narwhal/executor/src/lib.rs
@@ -103,7 +103,6 @@ pub async fn get_restored_consensus_output<State: ExecutionState>(
 
     let mut sub_dags = Vec::new();
     for compressed_sub_dag in compressed_sub_dags {
-        let sub_dag_index = compressed_sub_dag.sub_dag_index();
         let certificate_digests: Vec<CertificateDigest> = compressed_sub_dag.certificates();
 
         let certificates = certificate_store
@@ -116,13 +115,11 @@ pub async fn get_restored_consensus_output<State: ExecutionState>(
             .read(compressed_sub_dag.leader())?
             .unwrap();
 
-        sub_dags.push(CommittedSubDag {
+        sub_dags.push(CommittedSubDag::from_compressed_sub_dag(
+            compressed_sub_dag,
             certificates,
             leader,
-            sub_dag_index,
-            reputation_score: compressed_sub_dag.reputation_score(),
-            commit_timestamp: compressed_sub_dag.commit_timestamp(),
-        });
+        ));
     }
 
     Ok(sub_dags)

--- a/narwhal/executor/src/lib.rs
+++ b/narwhal/executor/src/lib.rs
@@ -18,12 +18,12 @@ use mockall::automock;
 use network::client::NetworkClient;
 use prometheus::Registry;
 use std::sync::Arc;
-use storage::CertificateStore;
+use storage::{CertificateStore, ConsensusStore};
 use tokio::task::JoinHandle;
 use tracing::info;
 use types::{
     metered_channel, CertificateDigest, CommittedSubDag, ConditionalBroadcastReceiver,
-    ConsensusOutput, ConsensusStore,
+    ConsensusOutput,
 };
 
 /// Convenience type representing a serialized transaction.
@@ -103,8 +103,8 @@ pub async fn get_restored_consensus_output<State: ExecutionState>(
 
     let mut sub_dags = Vec::new();
     for compressed_sub_dag in compressed_sub_dags {
-        let sub_dag_index = compressed_sub_dag.sub_dag_index;
-        let certificate_digests: Vec<CertificateDigest> = compressed_sub_dag.certificates;
+        let sub_dag_index = compressed_sub_dag.sub_dag_index();
+        let certificate_digests: Vec<CertificateDigest> = compressed_sub_dag.certificates();
 
         let certificates = certificate_store
             .read_all(certificate_digests)?
@@ -112,14 +112,16 @@ pub async fn get_restored_consensus_output<State: ExecutionState>(
             .flatten()
             .collect();
 
-        let leader = certificate_store.read(compressed_sub_dag.leader)?.unwrap();
+        let leader = certificate_store
+            .read(compressed_sub_dag.leader())?
+            .unwrap();
 
         sub_dags.push(CommittedSubDag {
             certificates,
             leader,
             sub_dag_index,
-            reputation_score: compressed_sub_dag.reputation_score,
-            commit_timestamp: compressed_sub_dag.commit_timestamp,
+            reputation_score: compressed_sub_dag.reputation_score(),
+            commit_timestamp: compressed_sub_dag.commit_timestamp(),
         });
     }
 

--- a/narwhal/executor/src/lib.rs
+++ b/narwhal/executor/src/lib.rs
@@ -115,7 +115,7 @@ pub async fn get_restored_consensus_output<State: ExecutionState>(
             .read(compressed_sub_dag.leader())?
             .unwrap();
 
-        sub_dags.push(CommittedSubDag::from_compressed_sub_dag(
+        sub_dags.push(CommittedSubDag::from_commit(
             compressed_sub_dag,
             certificates,
             leader,

--- a/narwhal/storage/src/certificate_store.rs
+++ b/narwhal/storage/src/certificate_store.rs
@@ -11,13 +11,14 @@ use std::{cmp::Ordering, collections::BTreeMap, iter};
 use sui_macros::fail_point;
 use tap::Tap;
 
+use crate::StoreResult;
 use config::AuthorityIdentifier;
 use mysten_common::sync::notify_read::NotifyRead;
 use store::{
     rocks::{DBMap, TypedStoreError::RocksDBError},
     Map,
 };
-use types::{Certificate, CertificateDigest, Round, StoreResult};
+use types::{Certificate, CertificateDigest, Round};
 
 #[derive(Clone)]
 pub struct CertificateStoreCacheMetrics {

--- a/narwhal/storage/src/consensus_store.rs
+++ b/narwhal/storage/src/consensus_store.rs
@@ -1,14 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::NodeStorage;
+use crate::{NodeStorage, StoreResult};
 use config::AuthorityIdentifier;
 use std::collections::HashMap;
 use store::rocks::{open_cf, DBMap, MetricConf, ReadWriteOptions};
 use store::{reopen, Map, TypedStoreError};
 use types::{
     CommittedSubDag, CommittedSubDagShell, CompressedCommittedSubDag, CompressedCommittedSubDagV2,
-    Round, SequenceNumber, StoreResult,
+    Round, SequenceNumber,
 };
 
 /// The persistent storage of the sequencer.

--- a/narwhal/storage/src/consensus_store.rs
+++ b/narwhal/storage/src/consensus_store.rs
@@ -1,0 +1,139 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use config::AuthorityIdentifier;
+use std::collections::HashMap;
+use store::rocks::DBMap;
+use store::{Map, TypedStoreError};
+use types::{
+    CommittedSubDag, CommittedSubDagShell, CompressedCommittedSubDag, CompressedCommittedSubDagV2,
+    Round, SequenceNumber, StoreResult,
+};
+
+/// The persistent storage of the sequencer.
+pub struct ConsensusStore {
+    /// The latest committed round of each validator.
+    last_committed: DBMap<AuthorityIdentifier, Round>,
+    /// TODO: remove once released to validators
+    /// The global consensus sequence.
+    committed_sub_dags_by_index: DBMap<SequenceNumber, CommittedSubDagShell>,
+    /// The global consensus sequence
+    committed_sub_dags_by_index_v2: DBMap<SequenceNumber, CompressedCommittedSubDag>,
+}
+
+impl ConsensusStore {
+    /// Create a new consensus store structure by using already loaded maps.
+    pub fn new(
+        last_committed: DBMap<AuthorityIdentifier, Round>,
+        sequence: DBMap<SequenceNumber, CommittedSubDagShell>,
+        committed_sub_dags_map: DBMap<SequenceNumber, CompressedCommittedSubDag>,
+    ) -> Self {
+        Self {
+            last_committed,
+            committed_sub_dags_by_index: sequence,
+            committed_sub_dags_by_index_v2: committed_sub_dags_map,
+        }
+    }
+
+    /// Clear the store.
+    pub fn clear(&self) -> StoreResult<()> {
+        self.last_committed.clear()?;
+        self.committed_sub_dags_by_index.clear()?;
+        self.committed_sub_dags_by_index_v2.clear()?;
+        Ok(())
+    }
+
+    /// Persist the consensus state.
+    pub fn write_consensus_state(
+        &self,
+        last_committed: &HashMap<AuthorityIdentifier, Round>,
+        sub_dag: &CommittedSubDag,
+    ) -> Result<(), TypedStoreError> {
+        let compressed =
+            CompressedCommittedSubDag::V2(CompressedCommittedSubDagV2::from_sub_dag(sub_dag));
+
+        let mut write_batch = self.last_committed.batch();
+        write_batch.insert_batch(&self.last_committed, last_committed.iter())?;
+        write_batch.insert_batch(
+            &self.committed_sub_dags_by_index_v2,
+            std::iter::once((sub_dag.sub_dag_index, compressed)),
+        )?;
+        write_batch.write()
+    }
+
+    /// Load the last committed round of each validator.
+    pub fn read_last_committed(&self) -> HashMap<AuthorityIdentifier, Round> {
+        self.last_committed.iter().collect()
+    }
+
+    /// Gets the latest sub dag index from the store
+    pub fn get_latest_sub_dag_index(&self) -> SequenceNumber {
+        if let Some(s) = self
+            .committed_sub_dags_by_index_v2
+            .iter()
+            .skip_to_last()
+            .next()
+            .map(|(seq, _)| seq)
+        {
+            return s;
+        }
+
+        // TODO: remove once this has been released to the validators
+        // If nothing has been found on v2, just fallback on the previous storage
+        self.committed_sub_dags_by_index
+            .iter()
+            .skip_to_last()
+            .next()
+            .map(|(seq, _)| seq)
+            .unwrap_or_default()
+    }
+
+    /// Returns thet latest subdag committed. If none is committed yet, then
+    /// None is returned instead.
+    pub fn get_latest_sub_dag(&self) -> Option<CompressedCommittedSubDag> {
+        if let Some(sub_dag) = self
+            .committed_sub_dags_by_index_v2
+            .iter()
+            .skip_to_last()
+            .next()
+            .map(|(_, sub_dag)| sub_dag)
+        {
+            return Some(sub_dag);
+        }
+
+        // TODO: remove once this has been released to the validators
+        // If nothing has been found to the v2 table, just fallback to the previous one. We expect this
+        // to happen only after validator has upgraded. After that point the v2 table will populated
+        // and an entry should be found there.
+        self.committed_sub_dags_by_index
+            .iter()
+            .skip_to_last()
+            .next()
+            .map(|(_, sub_dag)| CompressedCommittedSubDag::V1(sub_dag))
+    }
+
+    /// Load all the sub dags committed with sequence number of at least `from`.
+    pub fn read_committed_sub_dags_from(
+        &self,
+        from: &SequenceNumber,
+    ) -> StoreResult<Vec<CompressedCommittedSubDag>> {
+        // TODO: remove once this has been released to the validators
+        // start from the previous table first to ensure we haven't missed anything.
+        let mut sub_dags = self
+            .committed_sub_dags_by_index
+            .iter()
+            .skip_to(from)?
+            .map(|(_, sub_dag)| CompressedCommittedSubDag::V1(sub_dag))
+            .collect::<Vec<CompressedCommittedSubDag>>();
+
+        sub_dags.extend(
+            self.committed_sub_dags_by_index_v2
+                .iter()
+                .skip_to(from)?
+                .map(|(_, sub_dag)| sub_dag)
+                .collect::<Vec<CompressedCommittedSubDag>>(),
+        );
+
+        Ok(sub_dags)
+    }
+}

--- a/narwhal/storage/src/lib.rs
+++ b/narwhal/storage/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod certificate_store;
+mod consensus_store;
 mod header_store;
 mod node_store;
 mod payload_store;
@@ -9,6 +10,7 @@ mod proposer_store;
 mod vote_digest_store;
 
 pub use certificate_store::*;
+pub use consensus_store::*;
 pub use header_store::*;
 pub use node_store::*;
 pub use payload_store::*;

--- a/narwhal/storage/src/lib.rs
+++ b/narwhal/storage/src/lib.rs
@@ -15,4 +15,8 @@ pub use header_store::*;
 pub use node_store::*;
 pub use payload_store::*;
 pub use proposer_store::*;
+use store::TypedStoreError;
 pub use vote_digest_store::*;
+
+/// Convenience type to propagate store errors.
+pub type StoreResult<T> = Result<T, TypedStoreError>;

--- a/narwhal/storage/src/node_store.rs
+++ b/narwhal/storage/src/node_store.rs
@@ -16,8 +16,8 @@ use store::reopen;
 use store::rocks::DBMap;
 use store::rocks::{open_cf, MetricConf, ReadWriteOptions};
 use types::{
-    Batch, BatchDigest, Certificate, CertificateDigest, CommittedSubDagShell,
-    CompressedCommittedSubDag, Header, HeaderDigest, Round, SequenceNumber, VoteInfo,
+    Batch, BatchDigest, Certificate, CertificateDigest, CommittedSubDagShell, ConsensusCommit,
+    Header, HeaderDigest, Round, SequenceNumber, VoteInfo,
 };
 
 // A type alias marking the "payload" tokens sent by workers to their primary as batch acknowledgements
@@ -104,7 +104,7 @@ impl NodeStorage {
             Self::BATCHES_CF;<BatchDigest, Batch>,
             Self::LAST_COMMITTED_CF;<AuthorityIdentifier, Round>,
             Self::SUB_DAG_INDEX_CF;<SequenceNumber, CommittedSubDagShell>,
-            Self::COMMITTED_SUB_DAG_INDEX_CF;<SequenceNumber, CompressedCommittedSubDag>
+            Self::COMMITTED_SUB_DAG_INDEX_CF;<SequenceNumber, ConsensusCommit>
         );
 
         let proposer_store = ProposerStore::new(last_proposed_map);

--- a/narwhal/storage/src/node_store.rs
+++ b/narwhal/storage/src/node_store.rs
@@ -4,8 +4,8 @@ use crate::payload_store::PayloadStore;
 use crate::proposer_store::ProposerKey;
 use crate::vote_digest_store::VoteDigestStore;
 use crate::{
-    CertificateStore, CertificateStoreCache, CertificateStoreCacheMetrics, HeaderStore,
-    ProposerStore,
+    CertificateStore, CertificateStoreCache, CertificateStoreCacheMetrics, ConsensusStore,
+    HeaderStore, ProposerStore,
 };
 use config::{AuthorityIdentifier, WorkerId};
 use std::num::NonZeroUsize;
@@ -16,8 +16,8 @@ use store::reopen;
 use store::rocks::DBMap;
 use store::rocks::{open_cf, MetricConf, ReadWriteOptions};
 use types::{
-    Batch, BatchDigest, Certificate, CertificateDigest, CommittedSubDagShell, ConsensusStore,
-    Header, HeaderDigest, Round, SequenceNumber, VoteInfo,
+    Batch, BatchDigest, Certificate, CertificateDigest, CommittedSubDagShell,
+    CompressedCommittedSubDag, Header, HeaderDigest, Round, SequenceNumber, VoteInfo,
 };
 
 // A type alias marking the "payload" tokens sent by workers to their primary as batch acknowledgements
@@ -47,6 +47,7 @@ impl NodeStorage {
     pub(crate) const BATCHES_CF: &'static str = "batches";
     pub(crate) const LAST_COMMITTED_CF: &'static str = "last_committed";
     pub(crate) const SUB_DAG_INDEX_CF: &'static str = "sub_dag";
+    pub(crate) const COMMITTED_SUB_DAG_INDEX_CF: &'static str = "committed_sub_dag";
 
     // 100 nodes * 60 rounds (assuming 1 round/sec this will hold data for about the last 1 minute
     // which should be more than enough for advancing the protocol and also help other nodes)
@@ -75,6 +76,7 @@ impl NodeStorage {
                 Self::BATCHES_CF,
                 Self::LAST_COMMITTED_CF,
                 Self::SUB_DAG_INDEX_CF,
+                Self::COMMITTED_SUB_DAG_INDEX_CF,
             ],
         )
         .expect("Cannot open database");
@@ -90,6 +92,7 @@ impl NodeStorage {
             batch_map,
             last_committed_map,
             sub_dag_index_map,
+            committed_sub_dag_map,
         ) = reopen!(&rocksdb,
             Self::LAST_PROPOSED_CF;<ProposerKey, Header>,
             Self::VOTES_CF;<AuthorityIdentifier, VoteInfo>,
@@ -100,7 +103,8 @@ impl NodeStorage {
             Self::PAYLOAD_CF;<(BatchDigest, WorkerId), PayloadToken>,
             Self::BATCHES_CF;<BatchDigest, Batch>,
             Self::LAST_COMMITTED_CF;<AuthorityIdentifier, Round>,
-            Self::SUB_DAG_INDEX_CF;<SequenceNumber, CommittedSubDagShell>
+            Self::SUB_DAG_INDEX_CF;<SequenceNumber, CommittedSubDagShell>,
+            Self::COMMITTED_SUB_DAG_INDEX_CF;<SequenceNumber, CompressedCommittedSubDag>
         );
 
         let proposer_store = ProposerStore::new(last_proposed_map);
@@ -119,7 +123,11 @@ impl NodeStorage {
         );
         let payload_store = PayloadStore::new(payload_map);
         let batch_store = batch_map;
-        let consensus_store = Arc::new(ConsensusStore::new(last_committed_map, sub_dag_index_map));
+        let consensus_store = Arc::new(ConsensusStore::new(
+            last_committed_map,
+            sub_dag_index_map,
+            committed_sub_dag_map,
+        ));
 
         Self {
             proposer_store,

--- a/narwhal/storage/src/proposer_store.rs
+++ b/narwhal/storage/src/proposer_store.rs
@@ -1,10 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::StoreResult;
 use store::rocks::{open_cf, MetricConf};
 use store::{reopen, rocks::DBMap, rocks::ReadWriteOptions, Map};
 use sui_macros::fail_point;
-use types::{Header, StoreResult};
+use types::Header;
 
 pub type ProposerKey = u32;
 

--- a/narwhal/types/src/consensus.rs
+++ b/narwhal/types/src/consensus.rs
@@ -9,7 +9,6 @@ use fastcrypto::hash::Hash;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
-use store::TypedStoreError;
 use tokio::sync::mpsc;
 use tracing::warn;
 
@@ -429,6 +428,3 @@ mod tests {
         );
     }
 }
-
-/// Convenience type to propagate store errors.
-pub type StoreResult<T> = Result<T, TypedStoreError>;

--- a/narwhal/types/src/consensus.rs
+++ b/narwhal/types/src/consensus.rs
@@ -36,7 +36,9 @@ pub struct CommittedSubDag {
     /// The timestamp that should identify this commit. This is guaranteed to be monotonically
     /// incremented. This is not necessarily the leader's timestamp. We compare the leader's timestamp
     /// with the previously committed sud dag timestamp and we always keep the max.
-    pub commit_timestamp: TimestampMs,
+    /// Property is explicitly private so the method commit_timestamp() should be used instead which
+    /// bears additional resolution logic.
+    commit_timestamp: TimestampMs,
 }
 
 impl CommittedSubDag {
@@ -64,6 +66,20 @@ impl CommittedSubDag {
             sub_dag_index,
             reputation_score,
             commit_timestamp,
+        }
+    }
+
+    pub fn from_compressed_sub_dag(
+        compressed: CompressedCommittedSubDag,
+        certificates: Vec<Certificate>,
+        leader: Certificate,
+    ) -> Self {
+        Self {
+            certificates,
+            leader,
+            sub_dag_index: compressed.sub_dag_index(),
+            reputation_score: compressed.reputation_score(),
+            commit_timestamp: compressed.commit_timestamp(),
         }
     }
 

--- a/narwhal/types/src/consensus.rs
+++ b/narwhal/types/src/consensus.rs
@@ -69,17 +69,17 @@ impl CommittedSubDag {
         }
     }
 
-    pub fn from_compressed_sub_dag(
-        compressed: CompressedCommittedSubDag,
+    pub fn from_commit(
+        commit: ConsensusCommit,
         certificates: Vec<Certificate>,
         leader: Certificate,
     ) -> Self {
         Self {
             certificates,
             leader,
-            sub_dag_index: compressed.sub_dag_index(),
-            reputation_score: compressed.reputation_score(),
-            commit_timestamp: compressed.commit_timestamp(),
+            sub_dag_index: commit.sub_dag_index(),
+            reputation_score: commit.reputation_score(),
+            commit_timestamp: commit.commit_timestamp(),
         }
     }
 
@@ -160,8 +160,8 @@ impl ReputationScores {
     }
 }
 
-#[enum_dispatch(CompressedCommittedSubDagAPI)]
-trait CompressedCommittedSubDagAPI {
+#[enum_dispatch(ConsensusCommitAPI)]
+trait ConsensusCommitAPI {
     fn certificates(&self) -> Vec<CertificateDigest>;
     fn leader(&self) -> CertificateDigest;
     fn leader_round(&self) -> Round;
@@ -186,7 +186,7 @@ pub struct CommittedSubDagShell {
     pub reputation_score: ReputationScores,
 }
 
-impl CompressedCommittedSubDagAPI for CommittedSubDagShell {
+impl ConsensusCommitAPI for CommittedSubDagShell {
     fn certificates(&self) -> Vec<CertificateDigest> {
         self.certificates.clone()
     }
@@ -215,7 +215,7 @@ impl CompressedCommittedSubDagAPI for CommittedSubDagShell {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct CompressedCommittedSubDagV2 {
+pub struct ConsensusCommitV2 {
     /// The sequence of committed certificates' digests.
     pub certificates: Vec<CertificateDigest>,
     /// The leader certificate's digest responsible of committing this sub-dag.
@@ -231,7 +231,7 @@ pub struct CompressedCommittedSubDagV2 {
     pub commit_timestamp: TimestampMs,
 }
 
-impl CompressedCommittedSubDagV2 {
+impl ConsensusCommitV2 {
     pub fn from_sub_dag(sub_dag: &CommittedSubDag) -> Self {
         Self {
             certificates: sub_dag.certificates.iter().map(|x| x.digest()).collect(),
@@ -244,7 +244,7 @@ impl CompressedCommittedSubDagV2 {
     }
 }
 
-impl CompressedCommittedSubDagAPI for CompressedCommittedSubDagV2 {
+impl ConsensusCommitAPI for ConsensusCommitV2 {
     fn certificates(&self) -> Vec<CertificateDigest> {
         self.certificates.clone()
     }
@@ -271,52 +271,52 @@ impl CompressedCommittedSubDagAPI for CompressedCommittedSubDagV2 {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-#[enum_dispatch(CompressedCommittedSubDagAPI)]
-pub enum CompressedCommittedSubDag {
+#[enum_dispatch(ConsensusCommitAPI)]
+pub enum ConsensusCommit {
     V1(CommittedSubDagShell),
-    V2(CompressedCommittedSubDagV2),
+    V2(ConsensusCommitV2),
 }
 
-impl CompressedCommittedSubDag {
+impl ConsensusCommit {
     pub fn certificates(&self) -> Vec<CertificateDigest> {
         match self {
-            CompressedCommittedSubDag::V1(sub_dag) => sub_dag.certificates(),
-            CompressedCommittedSubDag::V2(sub_dag) => sub_dag.certificates(),
+            ConsensusCommit::V1(sub_dag) => sub_dag.certificates(),
+            ConsensusCommit::V2(sub_dag) => sub_dag.certificates(),
         }
     }
 
     pub fn leader(&self) -> CertificateDigest {
         match self {
-            CompressedCommittedSubDag::V1(sub_dag) => sub_dag.leader(),
-            CompressedCommittedSubDag::V2(sub_dag) => sub_dag.leader(),
+            ConsensusCommit::V1(sub_dag) => sub_dag.leader(),
+            ConsensusCommit::V2(sub_dag) => sub_dag.leader(),
         }
     }
 
     pub fn leader_round(&self) -> Round {
         match self {
-            CompressedCommittedSubDag::V1(sub_dag) => sub_dag.leader_round(),
-            CompressedCommittedSubDag::V2(sub_dag) => sub_dag.leader_round(),
+            ConsensusCommit::V1(sub_dag) => sub_dag.leader_round(),
+            ConsensusCommit::V2(sub_dag) => sub_dag.leader_round(),
         }
     }
 
     pub fn sub_dag_index(&self) -> SequenceNumber {
         match self {
-            CompressedCommittedSubDag::V1(sub_dag) => sub_dag.sub_dag_index(),
-            CompressedCommittedSubDag::V2(sub_dag) => sub_dag.sub_dag_index(),
+            ConsensusCommit::V1(sub_dag) => sub_dag.sub_dag_index(),
+            ConsensusCommit::V2(sub_dag) => sub_dag.sub_dag_index(),
         }
     }
 
     pub fn reputation_score(&self) -> ReputationScores {
         match self {
-            CompressedCommittedSubDag::V1(sub_dag) => sub_dag.reputation_score(),
-            CompressedCommittedSubDag::V2(sub_dag) => sub_dag.reputation_score(),
+            ConsensusCommit::V1(sub_dag) => sub_dag.reputation_score(),
+            ConsensusCommit::V2(sub_dag) => sub_dag.reputation_score(),
         }
     }
 
     pub fn commit_timestamp(&self) -> TimestampMs {
         match self {
-            CompressedCommittedSubDag::V1(sub_dag) => sub_dag.commit_timestamp(),
-            CompressedCommittedSubDag::V2(sub_dag) => sub_dag.commit_timestamp(),
+            ConsensusCommit::V1(sub_dag) => sub_dag.commit_timestamp(),
+            ConsensusCommit::V2(sub_dag) => sub_dag.commit_timestamp(),
         }
     }
 }

--- a/narwhal/types/src/consensus.rs
+++ b/narwhal/types/src/consensus.rs
@@ -4,14 +4,12 @@
 
 use crate::{Batch, Certificate, CertificateAPI, CertificateDigest, HeaderAPI, Round, TimestampMs};
 use config::{AuthorityIdentifier, Committee};
+use enum_dispatch::enum_dispatch;
 use fastcrypto::hash::Hash;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
-use store::{
-    rocks::{DBMap, TypedStoreError},
-    traits::Map,
-};
+use store::TypedStoreError;
 use tokio::sync::mpsc;
 use tracing::warn;
 
@@ -95,6 +93,16 @@ impl CommittedSubDag {
     pub fn leader_round(&self) -> Round {
         self.leader.round()
     }
+
+    pub fn commit_timestamp(&self) -> TimestampMs {
+        // If commit_timestamp is zero, then safely assume that this is an upgraded node that is
+        // replaying this commit and field is never initialised. It's safe to fallback on leader's
+        // timestamp.
+        if self.commit_timestamp == 0 {
+            return *self.leader.header().created_at();
+        }
+        self.commit_timestamp
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default, Eq, PartialEq)]
@@ -137,8 +145,62 @@ impl ReputationScores {
     }
 }
 
+#[enum_dispatch(CompressedCommittedSubDagAPI)]
+trait CompressedCommittedSubDagAPI {
+    fn certificates(&self) -> Vec<CertificateDigest>;
+    fn leader(&self) -> CertificateDigest;
+    fn leader_round(&self) -> Round;
+    fn sub_dag_index(&self) -> SequenceNumber;
+    fn reputation_score(&self) -> ReputationScores;
+    fn commit_timestamp(&self) -> TimestampMs;
+}
+
+// TODO: remove once the upgrade has been rolled out. We want to keep only the
+// CommittedSubDag
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct CommittedSubDagShell {
+    /// The sequence of committed certificates' digests.
+    pub certificates: Vec<CertificateDigest>,
+    /// The leader certificate's digest responsible of committing this sub-dag.
+    pub leader: CertificateDigest,
+    /// The round of the leader
+    pub leader_round: Round,
+    /// Sequence number of the CommittedSubDag
+    pub sub_dag_index: SequenceNumber,
+    /// The so far calculated reputation score for nodes
+    pub reputation_score: ReputationScores,
+}
+
+impl CompressedCommittedSubDagAPI for CommittedSubDagShell {
+    fn certificates(&self) -> Vec<CertificateDigest> {
+        self.certificates.clone()
+    }
+
+    fn leader(&self) -> CertificateDigest {
+        self.leader
+    }
+
+    fn leader_round(&self) -> Round {
+        self.leader_round
+    }
+
+    fn sub_dag_index(&self) -> SequenceNumber {
+        self.sub_dag_index
+    }
+
+    fn reputation_score(&self) -> ReputationScores {
+        self.reputation_score.clone()
+    }
+
+    fn commit_timestamp(&self) -> TimestampMs {
+        // We explicitly return 0 as we don't have this information stored already. This will be
+        // handle accordingly to the CommittedSubdag struct.
+        0
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct CompressedCommittedSubDagV2 {
     /// The sequence of committed certificates' digests.
     pub certificates: Vec<CertificateDigest>,
     /// The leader certificate's digest responsible of committing this sub-dag.
@@ -154,7 +216,7 @@ pub struct CommittedSubDagShell {
     pub commit_timestamp: TimestampMs,
 }
 
-impl CommittedSubDagShell {
+impl CompressedCommittedSubDagV2 {
     pub fn from_sub_dag(sub_dag: &CommittedSubDag) -> Self {
         Self {
             certificates: sub_dag.certificates.iter().map(|x| x.digest()).collect(),
@@ -167,96 +229,97 @@ impl CommittedSubDagShell {
     }
 }
 
-/// Shutdown token dropped when a task is properly shut down.
-pub type ShutdownToken = mpsc::Sender<()>;
+impl CompressedCommittedSubDagAPI for CompressedCommittedSubDagV2 {
+    fn certificates(&self) -> Vec<CertificateDigest> {
+        self.certificates.clone()
+    }
 
-/// Convenience type to propagate store errors.
-pub type StoreResult<T> = Result<T, TypedStoreError>;
+    fn leader(&self) -> CertificateDigest {
+        self.leader
+    }
 
-/// The persistent storage of the sequencer.
-pub struct ConsensusStore {
-    /// The latest committed round of each validator.
-    last_committed: DBMap<AuthorityIdentifier, Round>,
-    /// The global consensus sequence.
-    committed_sub_dags_by_index: DBMap<SequenceNumber, CommittedSubDagShell>,
+    fn leader_round(&self) -> Round {
+        self.leader_round
+    }
+
+    fn sub_dag_index(&self) -> SequenceNumber {
+        self.sub_dag_index
+    }
+
+    fn reputation_score(&self) -> ReputationScores {
+        self.reputation_score.clone()
+    }
+
+    fn commit_timestamp(&self) -> TimestampMs {
+        self.commit_timestamp
+    }
 }
 
-impl ConsensusStore {
-    /// Create a new consensus store structure by using already loaded maps.
-    pub fn new(
-        last_committed: DBMap<AuthorityIdentifier, Round>,
-        sequence: DBMap<SequenceNumber, CommittedSubDagShell>,
-    ) -> Self {
-        Self {
-            last_committed,
-            committed_sub_dags_by_index: sequence,
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[enum_dispatch(CompressedCommittedSubDagAPI)]
+pub enum CompressedCommittedSubDag {
+    V1(CommittedSubDagShell),
+    V2(CompressedCommittedSubDagV2),
+}
+
+impl CompressedCommittedSubDag {
+    pub fn certificates(&self) -> Vec<CertificateDigest> {
+        match self {
+            CompressedCommittedSubDag::V1(sub_dag) => sub_dag.certificates(),
+            CompressedCommittedSubDag::V2(sub_dag) => sub_dag.certificates(),
         }
     }
 
-    /// Clear the store.
-    pub fn clear(&self) -> StoreResult<()> {
-        self.last_committed.clear()?;
-        self.committed_sub_dags_by_index.clear()?;
-        Ok(())
+    pub fn leader(&self) -> CertificateDigest {
+        match self {
+            CompressedCommittedSubDag::V1(sub_dag) => sub_dag.leader(),
+            CompressedCommittedSubDag::V2(sub_dag) => sub_dag.leader(),
+        }
     }
 
-    /// Persist the consensus state.
-    pub fn write_consensus_state(
-        &self,
-        last_committed: &HashMap<AuthorityIdentifier, Round>,
-        sub_dag: &CommittedSubDag,
-    ) -> Result<(), TypedStoreError> {
-        let shell = CommittedSubDagShell::from_sub_dag(sub_dag);
-
-        let mut write_batch = self.last_committed.batch();
-        write_batch.insert_batch(&self.last_committed, last_committed.iter())?;
-        write_batch.insert_batch(
-            &self.committed_sub_dags_by_index,
-            std::iter::once((sub_dag.sub_dag_index, shell)),
-        )?;
-        write_batch.write()
+    pub fn leader_round(&self) -> Round {
+        match self {
+            CompressedCommittedSubDag::V1(sub_dag) => sub_dag.leader_round(),
+            CompressedCommittedSubDag::V2(sub_dag) => sub_dag.leader_round(),
+        }
     }
 
-    /// Load the last committed round of each validator.
-    pub fn read_last_committed(&self) -> HashMap<AuthorityIdentifier, Round> {
-        self.last_committed.iter().collect()
+    pub fn sub_dag_index(&self) -> SequenceNumber {
+        match self {
+            CompressedCommittedSubDag::V1(sub_dag) => sub_dag.sub_dag_index(),
+            CompressedCommittedSubDag::V2(sub_dag) => sub_dag.sub_dag_index(),
+        }
     }
 
-    /// Gets the latest sub dag index from the store
-    pub fn get_latest_sub_dag_index(&self) -> SequenceNumber {
-        let s = self
-            .committed_sub_dags_by_index
-            .iter()
-            .skip_to_last()
-            .next()
-            .map(|(seq, _)| seq)
-            .unwrap_or_default();
-        s
+    pub fn reputation_score(&self) -> ReputationScores {
+        match self {
+            CompressedCommittedSubDag::V1(sub_dag) => sub_dag.reputation_score(),
+            CompressedCommittedSubDag::V2(sub_dag) => sub_dag.reputation_score(),
+        }
     }
 
-    /// Returns thet latest subdag committed. If none is committed yet, then
-    /// None is returned instead.
-    pub fn get_latest_sub_dag(&self) -> Option<CommittedSubDagShell> {
-        self.committed_sub_dags_by_index
-            .iter()
-            .skip_to_last()
-            .next()
-            .map(|(_, subdag)| subdag)
-    }
-
-    /// Load all the sub dags committed with sequence number of at least `from`.
-    pub fn read_committed_sub_dags_from(
-        &self,
-        from: &SequenceNumber,
-    ) -> StoreResult<Vec<CommittedSubDagShell>> {
-        Ok(self
-            .committed_sub_dags_by_index
-            .iter()
-            .skip_to(from)?
-            .map(|(_, sub_dag)| sub_dag)
-            .collect())
+    pub fn commit_timestamp(&self) -> TimestampMs {
+        match self {
+            CompressedCommittedSubDag::V1(sub_dag) => sub_dag.commit_timestamp(),
+            CompressedCommittedSubDag::V2(sub_dag) => sub_dag.commit_timestamp(),
+        }
     }
 }
+
+impl CommittedSubDagShell {
+    pub fn from_sub_dag(sub_dag: &CommittedSubDag) -> Self {
+        Self {
+            certificates: sub_dag.certificates.iter().map(|x| x.digest()).collect(),
+            leader: sub_dag.leader.digest(),
+            leader_round: sub_dag.leader.round(),
+            sub_dag_index: sub_dag.sub_dag_index,
+            reputation_score: sub_dag.reputation_score.clone(),
+        }
+    }
+}
+
+/// Shutdown token dropped when a task is properly shut down.
+pub type ShutdownToken = mpsc::Sender<()>;
 
 #[cfg(test)]
 mod tests {
@@ -266,6 +329,38 @@ mod tests {
     use indexmap::IndexMap;
     use std::collections::BTreeSet;
     use test_utils::CommitteeFixture;
+
+    #[test]
+    fn test_zero_timestamp_in_sub_dag() {
+        let fixture = CommitteeFixture::builder().build();
+        let committee = fixture.committee();
+
+        let header_builder = HeaderV1Builder::default();
+        let header = header_builder
+            .author(AuthorityIdentifier(1u16))
+            .round(2)
+            .epoch(0)
+            .created_at(50)
+            .payload(IndexMap::new())
+            .parents(BTreeSet::new())
+            .build()
+            .unwrap();
+
+        let certificate =
+            Certificate::new_unsigned(&committee, Header::V1(header), Vec::new()).unwrap();
+
+        // AND we initialise the sub dag via the "restore" way
+        let sub_dag_round = CommittedSubDag {
+            certificates: vec![certificate.clone()],
+            leader: certificate,
+            sub_dag_index: 1,
+            reputation_score: ReputationScores::default(),
+            commit_timestamp: 0,
+        };
+
+        // AND commit timestamp is the leader's timestamp
+        assert_eq!(sub_dag_round.commit_timestamp(), 50);
+    }
 
     #[test]
     fn test_monotonically_incremented_commit_timestamps() {
@@ -334,3 +429,6 @@ mod tests {
         );
     }
 }
+
+/// Convenience type to propagate store errors.
+pub type StoreResult<T> = Result<T, TypedStoreError>;


### PR DESCRIPTION
## Description 

This PR is making the changes of https://github.com/MystenLabs/sui/pull/10507 backwards compatible. More specifically it is:
* introducing a new table in consensus store that will store from now on all the Committed Subdags in a versioned format. I've decided to follow the same approach we have used in other parts of narwhal (ex Header, Certificate etc) for consistency reasons, so we don't mix and match approaches.
* making the current timestamp changes backwards compatible by introducing V2
* small refactorings (ex moved the ConsensusStore under the `storage` module where it should be)

## Test Plan 

Existing & new unit/integration tests.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
