### PR TITLE
[bug] check that all gas coins have object owners

### DIFF
--- a/crates/sui-adapter/src/programmable_transactions/context.rs
+++ b/crates/sui-adapter/src/programmable_transactions/context.rs
@@ -713,7 +713,10 @@ impl<'vm, 'state, 'a, 'b, S: StorageView> ExecutionContext<'vm, 'state, 'a, 'b, 
         }
         for (id, delete_kind) in deletions {
             let version = match input_object_metadata.get(&id) {
-                Some(metadata) => metadata.version,
+                Some(metadata) => {
+                    assert_invariant!(!matches!(metadata.owner, Owner::Immutable), format!("Attempting to delete immutable object {id} via delete kind {delete_kind}"));
+                    metadata.version
+                }
                 None => match state_view.get_latest_parent_entry_ref(id) {
                     Ok(Some((_, previous_version, _))) => previous_version,
                     // This object was not created this transaction but has never existed in

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -241,6 +241,115 @@ async fn test_transfer_sui_insufficient_gas() {
     assert_eq!(effects.mutated()[0].1, sender);
 }
 
+/// - All gas coins should be owned by an address (not shared or immutable)
+/// - All gas coins should be owned by the sender, or the sponsor
+#[tokio::test]
+async fn test_invalid_gas_owners() {
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let authority_state = init_state().await;
+
+    let init_object = |o: Object| async {
+        let obj_ref = o.compute_object_reference();
+        authority_state.insert_genesis_object(o).await;
+        obj_ref
+    };
+
+    let gas_object1 = init_object(Object::with_owner_for_testing(sender)).await;
+    let gas_object2 = init_object(Object::with_owner_for_testing(sender)).await;
+    let gas_object3 = init_object(Object::with_owner_for_testing(sender)).await;
+    let gas_object4 = init_object(Object::with_owner_for_testing(sender)).await;
+
+    let shared_object = init_object(Object::shared_for_testing()).await;
+    let immutable_object = init_object(Object::immutable_for_testing()).await;
+    let id_owned_object = init_object(Object::with_object_owner_for_testing(
+        ObjectID::random(),
+        gas_object3.0,
+    ))
+    .await;
+    let non_sender_owned_object =
+        init_object(Object::with_owner_for_testing(SuiAddress::ZERO)).await;
+
+    async fn test(
+        good_gas_object: ObjectRef,
+        bad_gas_object: ObjectRef,
+        sender: SuiAddress,
+        sender_key: &AccountKeyPair,
+        authority_state: &AuthorityState,
+    ) -> UserInputError {
+        let pt = {
+            let mut builder = ProgrammableTransactionBuilder::new();
+            let recipient = dbg_addr(2);
+            builder.transfer_sui(recipient, None);
+            builder.finish()
+        };
+        let kind = TransactionKind::ProgrammableTransaction(pt);
+        let data = TransactionData::new_with_gas_coins(
+            kind,
+            sender,
+            vec![good_gas_object, bad_gas_object],
+            *MAX_GAS_BUDGET,
+            1,
+        );
+        let tx = to_sender_signed_transaction(data, sender_key);
+
+        let result = send_and_confirm_transaction(authority_state, tx).await;
+        UserInputError::try_from(result.unwrap_err()).unwrap()
+    }
+
+    assert_eq!(
+        test(
+            gas_object1,
+            shared_object,
+            sender,
+            &sender_key,
+            &authority_state
+        )
+        .await,
+        UserInputError::GasObjectNotOwnedObject {
+            owner: Owner::Shared {
+                initial_shared_version: OBJECT_START_VERSION
+            }
+        }
+    );
+    assert_eq!(
+        test(
+            gas_object2,
+            immutable_object,
+            sender,
+            &sender_key,
+            &authority_state
+        )
+        .await,
+        UserInputError::GasObjectNotOwnedObject {
+            owner: Owner::Immutable
+        }
+    );
+    assert_eq!(
+        test(
+            gas_object3,
+            id_owned_object,
+            sender,
+            &sender_key,
+            &authority_state
+        )
+        .await,
+        UserInputError::GasObjectNotOwnedObject {
+            owner: Owner::ObjectOwner(gas_object3.0.into())
+        }
+    );
+    assert!(matches!(
+        test(
+            gas_object4,
+            non_sender_owned_object,
+            sender,
+            &sender_key,
+            &authority_state
+        )
+        .await,
+        UserInputError::IncorrectUserSignature { .. }
+    ))
+}
+
 #[tokio::test]
 async fn test_native_transfer_insufficient_gas_reading_objects() {
     // This test creates a transfer transaction with a gas budget, that's more than

--- a/crates/sui-types/src/gas_model/gas_v2.rs
+++ b/crates/sui-types/src/gas_model/gas_v2.rs
@@ -12,6 +12,7 @@ use crate::{
 use move_core_types::vm_status::StatusCode;
 use once_cell::sync::Lazy;
 use std::convert::TryFrom;
+use std::iter;
 use sui_cost_tables::bytecode_tables::{GasStatus, INITIAL_COST_SCHEDULE};
 use sui_protocol_config::*;
 
@@ -418,11 +419,13 @@ pub(crate) fn check_gas_balance(
     gas_budget: u64,
     cost_table: &SuiCostTable,
 ) -> UserInputResult {
-    // 1. Gas object has an address owner.
-    if !(matches!(gas_object.owner, Owner::AddressOwner(_))) {
-        return Err(UserInputError::GasObjectNotOwnedObject {
-            owner: gas_object.owner,
-        });
+    // 1. All gas objects have an address owner
+    for gas_object in more_gas_objs.iter().chain(iter::once(&gas_object)) {
+        if !(matches!(gas_object.owner, Owner::AddressOwner(_))) {
+            return Err(UserInputError::GasObjectNotOwnedObject {
+                owner: gas_object.owner,
+            });
+        }
     }
 
     // 2. Gas budget is between min and max budget allowed

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -766,6 +766,14 @@ impl Object {
         }
     }
 
+    pub fn immutable_for_testing() -> Self {
+        thread_local! {
+            static IMMUTABLE_OBJECT_ID: ObjectID = ObjectID::random();
+        }
+
+        Self::immutable_with_id_for_testing(IMMUTABLE_OBJECT_ID.with(|id| *id))
+    }
+
     /// make a test shared object.
     pub fn shared_for_testing() -> Object {
         thread_local! {

--- a/crates/sui-types/src/storage.rs
+++ b/crates/sui-types/src/storage.rs
@@ -30,6 +30,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::collections::{BTreeMap, HashMap};
 use std::convert::Infallible;
+use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 use tap::Pipe;
 
@@ -694,5 +695,15 @@ impl ObjectStore for BTreeMap<ObjectID, (ObjectRef, Object, WriteKind)> {
 impl<T: ObjectStore> ObjectStore for Arc<T> {
     fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
         self.as_ref().get_object(object_id)
+    }
+}
+
+impl Display for DeleteKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DeleteKind::Wrap => write!(f, "Wrap"),
+            DeleteKind::Normal => write!(f, "Normal"),
+            DeleteKind::UnwrapThenDelete => write!(f, "UnwrapThenDelete"),
+        }
     }
 }


### PR DESCRIPTION
## Description 

The tx validation logic checks previously checked that the first gas coin had an address owner, but not the others. Passing shared or object-owned gas coins worked correctly, but passing an immutable gas coin leads to this object getting deleted by gas smashing, which is obviously not intended.

This PR fixes the issue and adds some hardening for deletion of immutable objects via runtime checks.

Credit to Alexis at Halborn for this finding.

## Test Plan 

Added tests for each kind of potential gas object owner

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
