### PR TITLE
calculate the rolling apy avg after subsidy starts

### DIFF
--- a/apps/explorer/src/components/top-validators-card/TopValidatorsCard.tsx
+++ b/apps/explorer/src/components/top-validators-card/TopValidatorsCard.tsx
@@ -1,13 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { useGetSystemObject } from '@mysten/core';
 import { type SuiValidatorSummary } from '@mysten/sui.js';
 import { useMemo } from 'react';
 
 import { ReactComponent as ArrowRight } from '../../assets/SVGIcons/12px/ArrowRight.svg';
 import { StakeColumn } from './StakeColumn';
 
-import { useGetSystemObject } from '~/hooks/useGetObject';
 import { Banner } from '~/ui/Banner';
 import { ImageIcon } from '~/ui/ImageIcon';
 import { ValidatorLink } from '~/ui/InternalLink';

--- a/apps/explorer/src/hooks/useGetObject.ts
+++ b/apps/explorer/src/hooks/useGetObject.ts
@@ -5,11 +5,6 @@ import { useRpcClient } from '@mysten/core';
 import { type SuiObjectResponse, normalizeSuiAddress } from '@mysten/sui.js';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
-export function useGetSystemObject() {
-    const rpc = useRpcClient();
-    return useQuery(['system', 'state'], () => rpc.getLatestSuiSystemState());
-}
-
 export function useGetObject(
     objectId?: string | null
 ): UseQueryResult<SuiObjectResponse, unknown> {

--- a/apps/explorer/src/pages/epochs/stats/ValidatorStatus.tsx
+++ b/apps/explorer/src/pages/epochs/stats/ValidatorStatus.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-import { useGetSystemObject } from '~/hooks/useGetObject';
+import { useGetSystemObject } from '@mysten/core';
+
 import { RingChart } from '~/ui/RingChart';
 
 export function ValidatorStatus() {

--- a/apps/explorer/src/pages/validator/ValidatorDetails.tsx
+++ b/apps/explorer/src/pages/validator/ValidatorDetails.tsx
@@ -1,14 +1,17 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useGetRollingAverageApys, useGetValidatorsEvents } from '@mysten/core';
+import {
+    useGetRollingAverageApys,
+    useGetValidatorsEvents,
+    useGetSystemObject,
+} from '@mysten/core';
 import { type SuiSystemStateSummary } from '@mysten/sui.js';
 import React, { useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { ValidatorMeta } from '~/components/validator/ValidatorMeta';
 import { ValidatorStats } from '~/components/validator/ValidatorStats';
-import { useGetSystemObject } from '~/hooks/useGetObject';
 import { Banner } from '~/ui/Banner';
 import { LoadingSpinner } from '~/ui/LoadingSpinner';
 import { Text } from '~/ui/Text';

--- a/apps/explorer/src/pages/validators/Validators.tsx
+++ b/apps/explorer/src/pages/validators/Validators.tsx
@@ -7,6 +7,7 @@ import {
     type ApyByValidator,
     useGetValidatorsEvents,
     formatPercentageDisplay,
+    useGetSystemObject,
 } from '@mysten/core';
 import { type SuiEvent, type SuiValidatorSummary } from '@mysten/sui.js';
 import { lazy, Suspense, useMemo } from 'react';
@@ -14,7 +15,6 @@ import { lazy, Suspense, useMemo } from 'react';
 import { ErrorBoundary } from '~/components/error-boundary/ErrorBoundary';
 import { StakeColumn } from '~/components/top-validators-card/StakeColumn';
 import { DelegationAmount } from '~/components/validator/DelegationAmount';
-import { useGetSystemObject } from '~/hooks/useGetObject';
 import { Banner } from '~/ui/Banner';
 import { Card } from '~/ui/Card';
 import { Heading } from '~/ui/Heading';


### PR DESCRIPTION
## Description 

Describe the changes or additions included in this PR.

- Calculate the rolling APY average after the subsidy starts
- move useGetSystemObject to mysten/core

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
