### PR TITLE
Reduce compaction aggresivess by default but keep it configurable

### DIFF
--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -48,6 +48,9 @@ const DEFAULT_DB_WRITE_BUFFER_SIZE: usize = 1024;
 const ENV_VAR_DB_WAL_SIZE: &str = "MYSTEN_DB_WAL_SIZE_MB";
 const DEFAULT_DB_WAL_SIZE: usize = 1024;
 
+const ENV_VAR_L0_NUM_FILES_COMPACTION_TRIGGER: &str = "L0_NUM_FILES_COMPACTION_TRIGGER";
+const ENV_VAR_MAX_BACKGROUND_JOBS: &str = "MAX_BACKGROUND_JOBS";
+
 #[cfg(test)]
 mod tests;
 
@@ -1897,7 +1900,12 @@ pub fn optimized_for_high_throughput_options(
     db_options.options.set_max_write_buffer_number(6);
     db_options
         .options
-        .set_level_zero_file_num_compaction_trigger(2);
+        .set_level_zero_file_num_compaction_trigger(
+            read_size_from_env(ENV_VAR_L0_NUM_FILES_COMPACTION_TRIGGER)
+                .unwrap_or(4)
+                .try_into()
+                .unwrap(),
+        );
     db_options
         .options
         .set_target_file_size_base(64 * 1024 * 1024);
@@ -1905,7 +1913,12 @@ pub fn optimized_for_high_throughput_options(
         .options
         .set_max_bytes_for_level_base(512 * 1024 * 1024);
 
-    db_options.options.set_max_background_jobs(4);
+    db_options.options.set_max_background_jobs(
+        read_size_from_env(ENV_VAR_MAX_BACKGROUND_JOBS)
+            .unwrap_or(2)
+            .try_into()
+            .unwrap(),
+    );
 
     if optimize_for_point_lookup {
         db_options


### PR DESCRIPTION
## Description 

Reduce compaction aggressiveness to prior values i.e. `set_level_zero_file_num_compaction_trigger(4)` and `set_max_background_jobs(2)`
## Test Plan 

I get peak 7.3K owned tps on private testnet (https://metrics.sui.io/d/HH91BjB4z/throughput?orgId=1&from=1680807102391&to=1680808323985) with this.
