### PR TITLE
Fix no CA certificates error on sui-tools

### DIFF
--- a/docker/sui-tools/Dockerfile
+++ b/docker/sui-tools/Dockerfile
@@ -54,6 +54,8 @@ COPY --from=builder /sui/target/release/sui-faucet /usr/local/bin
 COPY --from=builder /sui/target/release/stress /usr/local/bin
 COPY --from=builder /sui/target/release/sui-cluster-test /usr/local/bin
 
+RUN apt update && apt install -y ca-certificates
+
 ARG BUILD_DATE
 ARG GIT_REVISION
 LABEL build-date=$BUILD_DATE


### PR DESCRIPTION
## Description 

When users try to use `sui` command from `sui-tools` docker images.
**no CA certificates found** error occurs like below.

```
root@7cedea42a19a:/sui# sui client gas
Config file ["/root/.sui/sui_config/client.yaml"] doesn't exist, do you want to connect to a Sui Full node server [y/N]?y
Sui Full node server URL (Defaults to Sui Devnet if not specified) :
Select key scheme to generate keypair (0 for ed25519, 1 for secp256k1, 2: for secp256r1):
0
Generated new keypair for address with scheme "ed25519" [0xbbc944bddf53dad446d4cd81f770072a50f8359d088e30b05a171bd1543e9f55]
Secret Recovery Phrase : [dawn catalog hedgehog render ketchup razor announce wool drama voice auto bar]
thread 'main' panicked at 'no CA certificates found', /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/hyper-rustls-0.23.2/src/config.rs:48:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Aborted
root@7cedea42a19a:/sui#
```

To fix this, `ca-certificates` package is installed on the final docker image.

## Test Plan 

Build the fixed docker image on the local machine and run `sui client gas` from inside of the container.

```
~$ docker run -it ca7d07767950
root@2000239b7186:/sui# sui client gas
Config file ["/root/.sui/sui_config/client.yaml"] doesn't exist, do you want to connect to a Sui Full node server [y/N]?y
Sui Full node server URL (Defaults to Sui Devnet if not specified) :
Select key scheme to generate keypair (0 for ed25519, 1 for secp256k1, 2: for secp256r1):
0
Generated new keypair for address with scheme "ed25519" [0x450ab84d96c9ecc1e840b1a11eb0d438f0eb62f58f0ca03ef2128b2b6c1c46d9]
Secret Recovery Phrase : [number trend shift permit dignity decide offer chuckle cabbage forward now kitten]
[warn] Client/Server api version mismatch, client api version : 0.30.0, server api version : 0.29.2
                             Object ID                              |  Gas Value
----------------------------------------------------------------------------------
root@2000239b7186:/sui#
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
