### PR TITLE
crypto: command to serialize payload for pop

### DIFF
--- a/crates/sui-types/src/unit_tests/crypto_tests.rs
+++ b/crates/sui-types/src/unit_tests/crypto_tests.rs
@@ -65,6 +65,11 @@ fn test_proof_of_possession() {
     println!("Pubkey: {:?}", Hex::encode(kp.public().as_bytes()));
     println!("Proof of possession: {:?}", Hex::encode(&pop));
     assert!(verify_proof_of_possession(&pop, kp.public(), address).is_ok());
+
+    // Result from: target/debug/sui validator serialize-payload-pop --account-address 0x1a4623343cd42be47d67314fce0ad042f3c82685544bc91d8c11d24e74ba7357 --protocol-public-key 99f25ef61f8032b914636460982c5cc6f134ef1ddae76657f2cbfec1ebfc8d097374080df6fcf0dcb8bc4b0d8e0af5d80ebbff2b4c599f54f42d6312dfc314276078c1cc347ebbbec5198be258513f386b930d02c2749a803e2330955ebd1a10
+    let msg = Base64::decode("BQAAgAGZ8l72H4AyuRRjZGCYLFzG8TTvHdrnZlfyy/7B6/yNCXN0CA32/PDcuLxLDY4K9dgOu/8rTFmfVPQtYxLfwxQnYHjBzDR+u77FGYviWFE/OGuTDQLCdJqAPiMwlV69GhAaRiM0PNQr5H1nMU/OCtBC88gmhVRLyR2MEdJOdLpzVwAAAAAAAAAA").unwrap();
+    let sig = kp.sign(&msg);
+    assert!(verify_proof_of_possession(&sig, kp.public(), address).is_ok());
 }
 
 proptest! {

--- a/crates/sui/src/validator_commands.rs
+++ b/crates/sui/src/validator_commands.rs
@@ -14,7 +14,7 @@ use sui_framework::{SuiSystem, SystemPackage};
 
 use sui_types::{
     base_types::{ObjectID, ObjectRef, SuiAddress},
-    crypto::{AuthorityPublicKey, NetworkPublicKey},
+    crypto::{AuthorityPublicKey, NetworkPublicKey, Signable, DEFAULT_EPOCH_ID},
     multiaddr::Multiaddr,
     object::Owner,
     sui_system_state::{
@@ -28,10 +28,13 @@ use crate::client_commands::WalletContext;
 use crate::fire_drill::get_gas_obj_ref;
 use clap::*;
 use colored::Colorize;
-use fastcrypto::traits::KeyPair;
 use fastcrypto::traits::ToFromBytes;
+use fastcrypto::{
+    encoding::{Base64, Encoding},
+    traits::KeyPair,
+};
 use serde::Serialize;
-use shared_crypto::intent::Intent;
+use shared_crypto::intent::{Intent, IntentMessage, IntentScope};
 use sui_json_rpc_types::{
     SuiObjectDataOptions, SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions,
 };
@@ -134,6 +137,17 @@ pub enum SuiValidatorCommand {
         #[clap(name = "gas-budget", long)]
         gas_budget: Option<u64>,
     },
+    /// Serialize the payload that is used to generate Proof of Possession.
+    /// This is useful to take the payload offline for an Authority protocol keypair to sign.
+    #[clap(name = "serialize-payload-pop")]
+    SerializePayloadForPoP {
+        /// Authority account address encoded in hex with 0x prefix.
+        #[clap(name = "account-address", long)]
+        account_address: SuiAddress,
+        /// Authority protocol public key encoded in hex.
+        #[clap(name = "protocol-public-key", long)]
+        protocol_public_key: AuthorityPublicKeyBytes,
+    },
 }
 
 #[derive(Serialize)]
@@ -147,6 +161,7 @@ pub enum SuiValidatorCommandResponse {
     UpdateMetadata(SuiTransactionBlockResponse),
     UpdateGasPrice(SuiTransactionBlockResponse),
     ReportValidator(SuiTransactionBlockResponse),
+    SerializedPayload(String),
 }
 
 fn make_key_files(
@@ -375,6 +390,22 @@ impl SuiValidatorCommand {
                 .await?;
                 SuiValidatorCommandResponse::ReportValidator(resp)
             }
+
+            SuiValidatorCommand::SerializePayloadForPoP {
+                account_address,
+                protocol_public_key,
+            } => {
+                let mut msg: Vec<u8> = Vec::new();
+                msg.extend_from_slice(protocol_public_key.as_bytes());
+                msg.extend_from_slice(account_address.as_ref());
+                let mut intent_msg_bytes = bcs::to_bytes(&IntentMessage::new(
+                    Intent::sui_app(IntentScope::ProofOfPossession),
+                    msg,
+                ))
+                .expect("Message serialization should not fail");
+                DEFAULT_EPOCH_ID.write(&mut intent_msg_bytes);
+                SuiValidatorCommandResponse::SerializedPayload(Base64::encode(&intent_msg_bytes))
+            }
         });
         ret
     }
@@ -586,6 +617,9 @@ impl Display for SuiValidatorCommandResponse {
             }
             SuiValidatorCommandResponse::ReportValidator(response) => {
                 write!(writer, "{}", write_transaction_response(response)?)?;
+            }
+            SuiValidatorCommandResponse::SerializedPayload(response) => {
+                write!(writer, "Serialized payload: {}", response)?;
             }
         }
         write!(f, "{}", writer.trim_end_matches('\n'))


### PR DESCRIPTION
## Description 

new command to serialize a payload to create pop. 
```
target/debug/sui validator serialize-payload-pop --account-address 0x1a4623343cd42be47d67314fce0ad042f3c82685544bc91d8c11d24e74ba7357 --protocol-public-key 99f25ef61f8032b914636460982c5cc6f134ef1ddae76657f2cbfec1ebfc8d097374080df6fcf0dcb8bc4b0d8e0af5d80ebbff2b4c599f54f42d6312dfc314276078c1cc347ebbbec5198be258513f386b930d02c2749a803e2330955ebd1a10
Serialized payload: BQAAgAGZ8l72H4AyuRRjZGCYLFzG8TTvHdrnZlfyy/7B6/yNCXN0CA32/PDcuLxLDY4K9dgOu/8rTFmfVPQtYxLfwxQnYHjBzDR+u77FGYviWFE/OGuTDQLCdJqAPiMwlV69GhAaRiM0PNQr5H1nMU/OCtBC88gmhVRLyR2MEdJOdLpzVwAAAAAAAAAA
```

## Test Plan 

added unit test.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
