### PR TITLE
[execution] Log execution errors

### DIFF
--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -87,14 +87,55 @@ pub fn execute_transaction_to_effects<
         protocol_config,
     );
 
-    let (status, execution_result) = match execution_result {
-        Ok(results) => (ExecutionStatus::Success, Ok(results)),
-        Err(error) => {
-            let (status, command) = error.to_execution_status();
-            (ExecutionStatus::new_failure(status, command), Err(error))
-        }
+    let status = if let Err(error) = &execution_result {
+        // Elaborate errors in logs if they are unexpected or their status is terse.
+        use ExecutionErrorKind as K;
+        match error.kind() {
+            K::InvariantViolation |
+            K::VMInvariantViolation => {
+                #[skip_checked_arithmetic]
+                tracing::error!(
+                    kind = ?error.kind(),
+                    tx_digest = ?transaction_digest,
+                    "INVARIANT VIOLATION! Source: {:?}",
+                    error.source(),
+                );
+            },
+
+            K::SuiMoveVerificationError |
+            K::VMVerificationOrDeserializationError => {
+                #[skip_checked_arithmetic]
+                tracing::info!(
+                    kind = ?error.kind(),
+                    tx_digest = ?transaction_digest,
+                    "VERIFICATION ERROR! Source: {:?}",
+                    error.source(),
+                );
+            }
+
+            K::PublishUpgradeMissingDependency |
+            K::PublishUpgradeDependencyDowngrade => {
+                #[skip_checked_arithmetic]
+                tracing::info!(
+                    kind = ?error.kind(),
+                    tx_digest = ?transaction_digest,
+                    "PUBLISH ERROR! Source: {:?}",
+                    error.source(),
+                )
+            }
+
+            _ => (),
+        };
+
+        let (status, command) = error.to_execution_status();
+        ExecutionStatus::new_failure(status, command)
+    } else {
+        ExecutionStatus::Success
     };
+
+    #[skip_checked_arithmetic]
     trace!(
+        tx_digest = ?transaction_digest,
         computation_gas_cost = gas_cost_summary.computation_cost,
         storage_gas_cost = gas_cost_summary.storage_cost,
         storage_gas_rebate = gas_cost_summary.storage_rebate,

--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -108,7 +108,7 @@ pub fn execute_transaction_to_effects<
                 tracing::info!(
                     kind = ?error.kind(),
                     tx_digest = ?transaction_digest,
-                    "VERIFICATION ERROR! Source: {:?}",
+                    "Verification Error. Source: {:?}",
                     error.source(),
                 );
             }
@@ -119,7 +119,7 @@ pub fn execute_transaction_to_effects<
                 tracing::info!(
                     kind = ?error.kind(),
                     tx_digest = ?transaction_digest,
-                    "PUBLISH ERROR! Source: {:?}",
+                    "Publish/Upgrade Error. Source: {:?}",
                     error.source(),
                 )
             }

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -1322,10 +1322,10 @@ fn write_sep<T: Display>(
 ) -> std::fmt::Result {
     let mut xs = items.into_iter().peekable();
     while let Some(x) = xs.next() {
+        write!(f, "{x}")?;
         if xs.peek().is_some() {
             write!(f, "{sep}")?;
         }
-        write!(f, "{x}")?;
     }
     Ok(())
 }


### PR DESCRIPTION
# Description

Add more logging for error cases where ExecutionStatus provides too terse a response.  In particular, log various invariant violations as `error!`s and other errors with `info!`.

This should help us set-up alerting when unexpected errors (particularly invariant violations) show up in production logs.

Also fix `write_sep` function used to print multi-arity arguments in JSON RPC.

# Test Plan

Build a version of Sui with various consistency checks turned off or errors introduced (e.g. turn off verification during publish or introduce linkage errors), and run transactions while inspecting the logs.