### PR TITLE
[storage] store gas coin as a separate enum variant

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -411,12 +411,15 @@ impl AuthorityStore {
         &self,
         object_keys: &[ObjectKey],
     ) -> Result<Vec<Option<Object>>, SuiError> {
-        let wrappers = self.perpetual_tables.objects.multi_get(object_keys)?;
+        let wrappers = self
+            .perpetual_tables
+            .objects
+            .multi_get(object_keys.to_vec())?;
         let mut ret = vec![];
 
-        for w in wrappers {
+        for (idx, w) in wrappers.into_iter().enumerate() {
             ret.push(
-                w.map(|object| self.perpetual_tables.object(object))
+                w.map(|object| self.perpetual_tables.object(&object_keys[idx], object))
                     .transpose()?
                     .flatten(),
             );
@@ -1216,6 +1219,7 @@ impl AuthorityStore {
                         let obj = self
                             .perpetual_tables
                             .object(
+                                &key,
                                 obj_opt
                                     .expect(&format!("Older object version not found: {:?}", key)),
                             )

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1519,13 +1519,7 @@ impl ObjectStore for AuthorityStore {
         object_id: &ObjectID,
         version: VersionNumber,
     ) -> Result<Option<Object>, SuiError> {
-        Ok(self
-            .perpetual_tables
-            .objects
-            .get(&ObjectKey(*object_id, version))?
-            .map(|object| self.perpetual_tables.object(object))
-            .transpose()?
-            .flatten())
+        self.perpetual_tables.get_object_by_key(object_id, version)
     }
 }
 

--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -538,7 +538,7 @@ mod tests {
     async fn test_db_size_after_compaction() -> Result<(), anyhow::Error> {
         let primary_path = tempfile::tempdir()?.into_path();
         let perpetual_db = Arc::new(AuthorityPerpetualTables::open(&primary_path, None));
-        let total_unique_object_ids = 100_000;
+        let total_unique_object_ids = 200_000;
         let num_versions_per_object = 10;
         let ids = ObjectID::in_range(ObjectID::ZERO, total_unique_object_ids)?;
         let mut to_delete = vec![];

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -321,12 +321,12 @@ impl ObjectStore for AuthorityPerpetualTables {
         object_id: &ObjectID,
         version: VersionNumber,
     ) -> Result<Option<Object>, SuiError> {
-        let key = ObjectKey(*object_id, version);
-        let obj_entry = self.objects.get(&key);
-        match obj_entry {
-            Ok(Some(wrapper)) => self.object(wrapper),
-            _ => Ok(None),
-        }
+        Ok(self
+            .objects
+            .get(&ObjectKey(*object_id, version))?
+            .map(|object| self.object(&ObjectKey(*object_id, version), object))
+            .transpose()?
+            .flatten())
     }
 }
 

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -18,7 +18,7 @@ use typed_store::rocks::{
 use typed_store::traits::{Map, TableSummary, TypedStoreDebug};
 
 use crate::authority::authority_store_types::{
-    MigratedStoreObjectPair, ObjectContentDigest, StoreData, StoreMoveObjectWrapper, StoreObject,
+    try_construct_object, ObjectContentDigest, StoreData, StoreMoveObjectWrapper, StoreObject,
     StoreObjectValue, StoreObjectWrapper,
 };
 use crate::authority::epoch_start_configuration::EpochStartConfiguration;
@@ -152,10 +152,14 @@ impl AuthorityPerpetualTables {
         };
         iter.reverse()
             .next()
-            .and_then(|(_, o)| self.object(o).ok().flatten())
+            .and_then(|(key, o)| self.object(&key, o).ok().flatten())
     }
 
-    fn construct_object(&self, store_object: StoreObjectValue) -> Result<Object, SuiError> {
+    fn construct_object(
+        &self,
+        object_key: &ObjectKey,
+        store_object: StoreObjectValue,
+    ) -> Result<Object, SuiError> {
         let indirect_object = match store_object.data {
             StoreData::IndirectObject(ref metadata) => self
                 .indirect_move_objects
@@ -163,15 +167,18 @@ impl AuthorityPerpetualTables {
                 .map(|o| o.migrate().into_inner()),
             _ => None,
         };
-        let object = MigratedStoreObjectPair(store_object, indirect_object).try_into()?;
-        Ok(object)
+        try_construct_object(object_key, store_object, indirect_object)
     }
 
     // Constructs `sui_types::object::Object` from `StoreObjectWrapper`.
     // Returns `None` if object was deleted/wrapped
-    pub fn object(&self, store_object: StoreObjectWrapper) -> Result<Option<Object>, SuiError> {
+    pub fn object(
+        &self,
+        object_key: &ObjectKey,
+        store_object: StoreObjectWrapper,
+    ) -> Result<Option<Object>, SuiError> {
         let StoreObject::Value(store_object) = store_object.migrate().into_inner() else {return Ok(None)};
-        Ok(Some(self.construct_object(store_object)?))
+        Ok(Some(self.construct_object(object_key, store_object)?))
     }
 
     pub fn object_reference(
@@ -180,7 +187,9 @@ impl AuthorityPerpetualTables {
         store_object: StoreObjectWrapper,
     ) -> Result<ObjectRef, SuiError> {
         let obj_ref = match store_object.migrate().into_inner() {
-            StoreObject::Value(object) => self.construct_object(object)?.compute_object_reference(),
+            StoreObject::Value(object) => self
+                .construct_object(object_key, object)?
+                .compute_object_reference(),
             StoreObject::Deleted => (
                 object_key.0,
                 object_key.1,
@@ -300,7 +309,9 @@ impl ObjectStore for AuthorityPerpetualTables {
             .next();
 
         match obj_entry {
-            Some((ObjectKey(obj_id, _), obj)) if obj_id == *object_id => Ok(self.object(obj)?),
+            Some((ObjectKey(obj_id, version), obj)) if obj_id == *object_id => {
+                Ok(self.object(&ObjectKey(obj_id, version), obj)?)
+            }
             _ => Ok(None),
         }
     }
@@ -355,7 +366,7 @@ fn store_object_wrapper_to_live_object(
     match store_object.migrate().into_inner() {
         StoreObject::Value(object) => {
             let object = tables
-                .construct_object(object)
+                .construct_object(&object_key, object)
                 .expect("Constructing object from store cannot fail");
             Some(LiveObject::Normal(object))
         }

--- a/crates/sui-core/src/authority/authority_store_types.rs
+++ b/crates/sui-core/src/authority/authority_store_types.rs
@@ -217,7 +217,7 @@ pub(crate) fn get_store_object_pair(
                 let digest = move_object.digest();
                 indirect_object = Some(move_object);
                 StoreData::IndirectObject(IndirectObjectMetadata { version, digest })
-            } else if move_obj.type_() == &MoveObjectType::gas_coin() {
+            } else if move_obj.type_().is_gas_coin() {
                 StoreData::Coin(
                     Coin::from_bcs_bytes(move_obj.contents())
                         .expect("failed to deserialize coin")

--- a/crates/sui-core/src/authority/authority_store_types.rs
+++ b/crates/sui-core/src/authority/authority_store_types.rs
@@ -4,13 +4,14 @@
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use serde_with::Bytes;
-use std::convert::TryFrom;
 use sui_types::base_types::MoveObjectType;
 use sui_types::base_types::{ObjectDigest, SequenceNumber, TransactionDigest};
+use sui_types::coin::Coin;
 use sui_types::crypto::{default_hash, Signable};
 use sui_types::error::SuiError;
 use sui_types::move_package::MovePackage;
 use sui_types::object::{Data, MoveObject, Object, Owner};
+use sui_types::storage::ObjectKey;
 
 pub type ObjectContentDigest = ObjectDigest;
 
@@ -105,6 +106,7 @@ pub enum StoreData {
     Move(MoveObject),
     Package(MovePackage),
     IndirectObject(IndirectObjectMetadata),
+    Coin(u64),
 }
 
 /// Metadata of stored moved object
@@ -215,6 +217,13 @@ pub(crate) fn get_store_object_pair(
                 let digest = move_object.digest();
                 indirect_object = Some(move_object);
                 StoreData::IndirectObject(IndirectObjectMetadata { version, digest })
+            } else if move_obj.type_() == &MoveObjectType::gas_coin() {
+                StoreData::Coin(
+                    Coin::from_bcs_bytes(move_obj.contents())
+                        .expect("failed to deserialize coin")
+                        .balance
+                        .value(),
+                )
             } else {
                 StoreData::Move(move_obj)
             }
@@ -232,38 +241,44 @@ pub(crate) fn get_store_object_pair(
     )
 }
 
-pub struct MigratedStoreObjectPair(pub StoreObjectValue, pub Option<StoreMoveObject>);
-impl TryFrom<MigratedStoreObjectPair> for Object {
-    type Error = SuiError;
+pub(crate) fn try_construct_object(
+    object_key: &ObjectKey,
+    store_object: StoreObjectValue,
+    indirect_object: Option<StoreMoveObject>,
+) -> Result<Object, SuiError> {
+    let data = match (store_object.data, indirect_object) {
+        (StoreData::Move(object), None) => Data::Move(object),
+        (StoreData::Package(package), None) => Data::Package(package),
+        (StoreData::IndirectObject(metadata), Some(indirect_obj)) => unsafe {
+            Data::Move(MoveObject::new_from_execution_with_limit(
+                indirect_obj.type_,
+                indirect_obj.has_public_transfer,
+                metadata.version,
+                indirect_obj.contents,
+                // verification is already done during initial execution
+                u64::MAX,
+            )?)
+        },
+        (StoreData::Coin(balance), None) => unsafe {
+            Data::Move(MoveObject::new_from_execution_with_limit(
+                MoveObjectType::gas_coin(),
+                true,
+                object_key.1,
+                bcs::to_bytes(&(object_key.0, balance)).expect("serialization failed"),
+                u64::MAX,
+            )?)
+        },
+        _ => {
+            return Err(SuiError::StorageCorruptedFieldError(
+                "inconsistent object representation".to_string(),
+            ))
+        }
+    };
 
-    fn try_from(object: MigratedStoreObjectPair) -> Result<Self, Self::Error> {
-        let MigratedStoreObjectPair(store_object, indirect_object) = object;
-
-        let data = match (store_object.data, indirect_object) {
-            (StoreData::Move(object), None) => Data::Move(object),
-            (StoreData::Package(package), None) => Data::Package(package),
-            (StoreData::IndirectObject(metadata), Some(indirect_obj)) => unsafe {
-                Data::Move(MoveObject::new_from_execution_with_limit(
-                    indirect_obj.type_,
-                    indirect_obj.has_public_transfer,
-                    metadata.version,
-                    indirect_obj.contents,
-                    // verification is already done during initial execution
-                    u64::MAX,
-                )?)
-            },
-            _ => {
-                return Err(SuiError::StorageCorruptedFieldError(
-                    "inconsistent object representation".to_string(),
-                ))
-            }
-        };
-
-        Ok(Self {
-            data,
-            owner: store_object.owner,
-            previous_transaction: store_object.previous_transaction,
-            storage_rebate: store_object.storage_rebate,
-        })
-    }
+    Ok(Object {
+        data,
+        owner: store_object.owner,
+        previous_transaction: store_object.previous_transaction,
+        storage_rebate: store_object.storage_rebate,
+    })
 }


### PR DESCRIPTION
The supermajority of objects on the testnet are gas coins. 
A typical gas coin consumes 128 bytes. 
We can optimize this by removing the object_id and version fields from the gas coin values stored in the database, as those fields are also part of the key. Here is an example of two gas coins, one with the optimization and one without:
```
V1(Value(StoreObjectValue { data: Coin(1), owner: AddressOwner(0xad4a51c549ea55befd70bce836e2128ca8d2f0cdfb7b6903fea68bbee0b94880), previous_transaction: TransactionDigest(6ahJ6gAGvVCRrKq23A1fjaUf4UPtrmgbToa6HXRtR62y), storage_rebate: 988000 }))

number of bytes: 85

V1(Value(StoreObjectValue { data: Move(MoveObject { type_: MoveObjectType(GasCoin), has_public_transfer: true, version: SequenceNumber(6), contents: [255, 234, 132, 30, 149, 70, 238, 175, 161, 161, 122, 199, 130, 103, 145, 104, 106, 84, 186, 29, 165, 32, 158, 79, 1, 107, 150, 24, 224, 57, 61, 114, 1, 0, 0, 0, 0, 0, 0, 0] }), owner: AddressOwner(0x90c677f11b65510bc05b5b27b510010904b1a1f51e91535191449d6ef7b183a7), previous_transaction: TransactionDigest(C1Mzco26AQPMwuLxT4jCFyP9XrA7ptUhxbzwf55o2inb), storage_rebate: 988000 }))

number of bytes: 128
```
We can save roughly 33% on the object table with this change. 

The change is backward compatible, meaning all new gas coins will be written to the database as `StoreData::Coin`, while existing objects in the testnet will still be `Move(MoveObject)`
 