### PR TITLE
[debug] Disable printing on nodes

### DIFF
--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -1380,7 +1380,7 @@ fn create_genesis_transaction(
             protocol_config,
         );
 
-        let native_functions = sui_framework::natives::all_natives();
+        let native_functions = sui_framework::natives::all_natives(/* silent */ true);
         let enable_move_vm_paranoid_checks = false;
         let move_vm = std::sync::Arc::new(
             adapter::new_move_vm(
@@ -1440,7 +1440,7 @@ fn create_genesis_objects(
     let protocol_config =
         ProtocolConfig::get_for_version(ProtocolVersion::new(parameters.protocol_version));
 
-    let native_functions = sui_framework::natives::all_natives();
+    let native_functions = sui_framework::natives::all_natives(/* silent */ true);
     // paranoid checks are a last line of defense for malicious code, no need to run them in genesis
     let enable_move_vm_paranoid_checks = false;
     let move_vm = adapter::new_move_vm(
@@ -1939,7 +1939,7 @@ mod test {
         );
 
         let enable_move_vm_paranoid_checks = false;
-        let native_functions = sui_framework::natives::all_natives();
+        let native_functions = sui_framework::natives::all_natives(/* silent */ true);
         let move_vm = std::sync::Arc::new(
             adapter::new_move_vm(
                 native_functions,

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1966,7 +1966,7 @@ impl ExecutionComponents {
         metrics: Arc<ResolverMetrics>,
         expensive_safety_check_config: &ExpensiveSafetyCheckConfig,
     ) -> Self {
-        let native_functions = sui_framework::natives::all_natives();
+        let native_functions = sui_framework::natives::all_natives(/* silent */ true);
         let move_vm = Arc::new(
             adapter::new_move_vm(
                 native_functions.clone(),

--- a/crates/sui-framework/Cargo.toml
+++ b/crates/sui-framework/Cargo.toml
@@ -22,7 +22,7 @@ sui-types = { path = "../sui-types" }
 
 move-binary-format.workspace = true
 move-core-types.workspace = true
-move-stdlib = { workspace = true, default-features = false }
+move-stdlib.workspace = true
 move-vm-runtime.workspace = true
 move-vm-types.workspace = true
 sui-protocol-config = { path = "../sui-protocol-config" }

--- a/crates/sui-framework/src/natives/mod.rs
+++ b/crates/sui-framework/src/natives/mod.rs
@@ -471,7 +471,7 @@ impl NativesCostTable {
     }
 }
 
-pub fn all_natives() -> NativeFunctionTable {
+pub fn all_natives(silent: bool) -> NativeFunctionTable {
     let sui_framework_natives: &[(&str, &str, NativeFunction)] = &[
         ("address", "from_bytes", make_native!(address::from_bytes)),
         ("address", "to_u256", make_native!(address::to_u256)),
@@ -695,6 +695,7 @@ pub fn all_natives() -> NativeFunctionTable {
             GasParameters::zeros(),
         ))
         .chain(move_stdlib::natives::nursery_natives(
+            silent,
             MOVE_STDLIB_ADDRESS,
             // TODO: tune gas params
             NurseryGasParameters::zeros(),

--- a/crates/sui-move/src/cost_calib/runner.rs
+++ b/crates/sui-move/src/cost_calib/runner.rs
@@ -62,7 +62,7 @@ pub fn run_calib_tests(
                 num_threads: 1,
                 ..config
             },
-            natives::all_natives(),
+            natives::all_natives(/* silent */ true),
             Some(initial_cost_schedule_for_unit_tests()),
             false,
             &mut test_output_buf,

--- a/crates/sui-move/src/unit_test.rs
+++ b/crates/sui-move/src/unit_test.rs
@@ -90,7 +90,7 @@ pub fn run_move_unit_tests(
             report_stacktrace_on_abort: true,
             ..config
         },
-        natives::all_natives(),
+        natives::all_natives(/* silent */ false),
         Some(initial_cost_schedule_for_unit_tests()),
         compute_coverage,
         &mut std::io::stdout(),

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -226,7 +226,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
 
         let mut named_address_mapping = NAMED_ADDRESSES.clone();
 
-        let native_functions = sui_framework::natives::all_natives();
+        let native_functions = sui_framework::natives::all_natives(/* silent */ false);
         let mut objects = clone_genesis_packages();
         objects.extend(clone_genesis_objects());
         let mut account_objects = BTreeMap::new();

--- a/external-crates/move/documentation/examples/diem-framework/crates/cli/src/main.rs
+++ b/external-crates/move/documentation/examples/diem-framework/crates/cli/src/main.rs
@@ -36,6 +36,7 @@ fn main() -> Result<()> {
     )
     .into_iter()
     .chain(move_stdlib::natives::nursery_natives(
+        /* silent */ false,
         CORE_CODE_ADDRESS,
         // We may want to switch to a different gas schedule in the future, but for now,
         // the all-zero one should be enough.

--- a/external-crates/move/move-stdlib/src/natives/mod.rs
+++ b/external-crates/move/move-stdlib/src/natives/mod.rs
@@ -157,6 +157,7 @@ impl NurseryGasParameters {
 }
 
 pub fn nursery_natives(
+    silent: bool,
     move_std_addr: AccountAddress,
     gas_params: NurseryGasParameters,
 ) -> NativeFunctionTable {
@@ -171,7 +172,10 @@ pub fn nursery_natives(
     }
 
     add_natives!("event", event::make_all(gas_params.event));
-    add_natives!("debug", debug::make_all(gas_params.debug, move_std_addr));
+    add_natives!(
+        "debug",
+        debug::make_all(silent, gas_params.debug, move_std_addr)
+    );
 
     make_table_from_iter(move_std_addr, natives)
 }

--- a/external-crates/move/move-stdlib/tests/move_unit_test.rs
+++ b/external-crates/move/move-stdlib/tests/move_unit_test.rs
@@ -20,6 +20,7 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>, include_nursery_natives: bo
     );
     if include_nursery_natives {
         natives.extend(nursery_natives(
+            /* silent */ false,
             AccountAddress::from_hex_literal("0x1").unwrap(),
             NurseryGasParameters::zeros(),
         ))

--- a/external-crates/move/tools/move-cli/src/main.rs
+++ b/external-crates/move/tools/move-cli/src/main.rs
@@ -12,7 +12,11 @@ fn main() -> Result<()> {
     let addr = AccountAddress::from_hex_literal("0x1").unwrap();
     let natives = all_natives(addr, GasParameters::zeros())
         .into_iter()
-        .chain(nursery_natives(addr, NurseryGasParameters::zeros()))
+        .chain(nursery_natives(
+            /* silent */ false,
+            addr,
+            NurseryGasParameters::zeros(),
+        ))
         .collect();
 
     move_cli::move_cli(natives, cost_table, &error_descriptions)


### PR DESCRIPTION
## Description

Despite trying to disable printing using feature flags in #8795, it came back because of the additive nature of `feature`s.  This time, disable debug printing on validators and full nodes for good, by controlling their inclusion using a flag passed in during native function creation, that controls whether to link against a silent version of the debug print functions or not.

Unit tests, and other CLI usages of the VM typically link against the unsilenced native functions, and the version used by validators is silenced.

## Test Plan

Run all existing tests:

```
$ cargo simtest
$ env SUI_SKIP_SIMTESTS=1 cargo nextest run
```

Create a test move package with the following content:

```
module test::test {
    struct ImALittleTeapot has copy, drop, store {}
    public entry fun print() {
        std::debug::print(&ImALittleTeapot {});
    }

    #[test]
    fun test_printing() {
        print();
    }
}
```

And confirm that the following does print debug output

```
sui$ cargo build --bin sui --release
sui$ cargo build --bin sui-node --release
sui$ ./target/release/sui move test -p $PKG
```

While publishing to a local network and repeatedly calling `print` does not pollute the validator or fullnode logs.