### PR TITLE
Add new macro for all system packages

### DIFF
--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use sui_config::genesis::Genesis;
 use sui_config::ValidatorInfo;
+use sui_framework::BuiltInFramework;
 use sui_framework_build::compiled_package::{BuildConfig, CompiledPackage, SuiPackageHooks};
 use sui_protocol_config::ProtocolConfig;
 use sui_types::base_types::{random_object_ref, ObjectID};
@@ -155,11 +156,12 @@ async fn init_genesis(
 ) {
     // add object_basics package object to genesis
     let modules: Vec<_> = compile_basics_package().get_modules().cloned().collect();
+    let genesis_move_packages: Vec<_> = BuiltInFramework::genesis_move_packages().collect();
     let pkg = Object::new_package(
         &modules,
         TransactionDigest::genesis(),
         ProtocolConfig::get_for_max_version().max_move_package_size(),
-        &sui_framework::make_system_packages(),
+        &genesis_move_packages,
     )
     .unwrap();
     let pkg_id = pkg.id();

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -10,7 +10,6 @@ use std::collections::BTreeMap;
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
-use sui_framework::make_system_packages;
 use sui_framework_build::compiled_package::BuildConfig;
 use sui_types::crypto::get_key_pair_from_rng;
 use sui_types::crypto::{get_key_pair, AccountKeyPair, AuthorityKeyPair};
@@ -29,6 +28,7 @@ use crate::test_authority_clients::{
     MockAuthorityApi,
 };
 use crate::test_utils::init_local_authorities;
+use sui_framework::BuiltInFramework;
 use sui_types::utils::to_sender_signed_transaction;
 use tokio::time::Instant;
 
@@ -332,7 +332,7 @@ async fn test_quorum_map_and_reduce_timeout() {
     let pkg = Object::new_package_for_testing(
         &modules,
         TransactionDigest::genesis(),
-        &make_system_packages(),
+        BuiltInFramework::genesis_move_packages(),
     )
     .unwrap();
     let (addr1, key1): (_, AccountKeyPair) = get_key_pair();

--- a/crates/sui-core/src/unit_tests/move_package_publish_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_publish_tests.rs
@@ -6,7 +6,6 @@ use crate::authority::{
     move_integration_tests::{build_and_publish_test_package, build_test_package},
 };
 
-use sui_framework::system_package_ids;
 use sui_types::{
     base_types::ObjectID,
     error::UserInputError,
@@ -30,6 +29,7 @@ use std::env;
 use std::fs::File;
 use std::io::Read;
 use std::{collections::HashSet, path::PathBuf};
+use sui_framework::BuiltInFramework;
 
 const MAX_GAS: u64 = 10000;
 
@@ -164,7 +164,7 @@ async fn test_publish_duplicate_modules() {
         sender,
         gas_object_ref,
         modules,
-        system_package_ids(),
+        BuiltInFramework::all_package_ids(),
         MAX_GAS,
     );
     let transaction = to_sender_signed_transaction(data, &sender_key);

--- a/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -3,7 +3,6 @@
 
 use move_core_types::{account_address::AccountAddress, ident_str, language_storage::StructTag};
 use move_symbol_pool::Symbol;
-use sui_framework::{MoveStdlib, SuiFramework, SystemPackage};
 use sui_framework_build::compiled_package::BuildConfig;
 use sui_protocol_config::ProtocolConfig;
 use sui_types::{
@@ -17,6 +16,7 @@ use sui_types::{
     object::{Object, Owner},
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     storage::BackingPackageStore,
+    MOVE_STDLIB_OBJECT_ID, SUI_FRAMEWORK_OBJECT_ID,
 };
 
 use std::{
@@ -189,11 +189,11 @@ impl UpgradeStateRunner {
             let digest = builder.pure(digest).unwrap();
             let ticket = move_call! {
                 builder,
-                (SuiFramework::ID)::package::authorize_upgrade(cap, policy, digest)
+                (SUI_FRAMEWORK_OBJECT_ID)::package::authorize_upgrade(cap, policy, digest)
             };
 
             let receipt = builder.upgrade(package_id, ticket, dep_ids, modules);
-            move_call! { builder, (SuiFramework::ID)::package::commit_upgrade(cap, receipt) };
+            move_call! { builder, (SUI_FRAMEWORK_OBJECT_ID)::package::commit_upgrade(cap, receipt) };
 
             builder.finish()
         };
@@ -306,7 +306,7 @@ async fn test_upgrade_introduces_type_then_uses_it() {
             UpgradePolicy::COMPATIBLE,
             digest,
             modules,
-            vec![SuiFramework::ID, MoveStdlib::ID],
+            vec![SUI_FRAMEWORK_OBJECT_ID, MOVE_STDLIB_OBJECT_ID],
         )
         .await;
 
@@ -320,7 +320,7 @@ async fn test_upgrade_introduces_type_then_uses_it() {
             UpgradePolicy::COMPATIBLE,
             digest,
             modules,
-            vec![SuiFramework::ID, MoveStdlib::ID],
+            vec![SUI_FRAMEWORK_OBJECT_ID, MOVE_STDLIB_OBJECT_ID],
         )
         .await;
 
@@ -419,7 +419,7 @@ async fn test_upgrade_package_compatibility_too_permissive() {
             let cap = builder
                 .obj(ObjectArg::ImmOrOwnedObject(runner.upgrade_cap))
                 .unwrap();
-            move_call! { builder, (SuiFramework::ID)::package::only_dep_upgrades(cap) };
+            move_call! { builder, (SUI_FRAMEWORK_OBJECT_ID)::package::only_dep_upgrades(cap) };
             builder.finish()
         })
         .await;
@@ -543,7 +543,7 @@ async fn test_upgrade_package_dep_only_mode() {
             UpgradePolicy::DEP_ONLY,
             digest,
             modules,
-            vec![SuiFramework::ID, MoveStdlib::ID],
+            vec![SUI_FRAMEWORK_OBJECT_ID, MOVE_STDLIB_OBJECT_ID],
         )
         .await;
 
@@ -591,9 +591,9 @@ async fn test_upgrade_ticket_doesnt_match() {
         let digest_arg = builder.pure(digest).unwrap();
         let upgrade_ticket = move_call! {
             builder,
-            (SuiFramework::ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
+            (SUI_FRAMEWORK_OBJECT_ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
         };
-        builder.upgrade(MoveStdlib::ID, upgrade_ticket, vec![], modules);
+        builder.upgrade(MOVE_STDLIB_OBJECT_ID, upgrade_ticket, vec![], modules);
         builder.finish()
     };
     let TransactionEffects::V1(effects) = runner.run(pt).await;
@@ -646,7 +646,7 @@ async fn test_multiple_upgrades(use_empty_deps: bool) -> TransactionEffectsV1 {
             if use_empty_deps {
                 vec![]
             } else {
-                vec![SuiFramework::ID, MoveStdlib::ID]
+                vec![SUI_FRAMEWORK_OBJECT_ID, MOVE_STDLIB_OBJECT_ID]
             },
         )
         .await
@@ -680,12 +680,12 @@ async fn test_interleaved_upgrades() {
         let digest_arg = builder.pure(digest).unwrap();
         let upgrade_ticket = move_call! {
             builder,
-            (SuiFramework::ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
+            (SUI_FRAMEWORK_OBJECT_ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
         };
         let upgrade_receipt = builder.upgrade(current_package_id, upgrade_ticket, vec![], modules);
         move_call! {
             builder,
-            (SuiFramework::ID)::package::commit_upgrade(Argument::Input(0), upgrade_receipt)
+            (SUI_FRAMEWORK_OBJECT_ID)::package::commit_upgrade(Argument::Input(0), upgrade_receipt)
         };
 
         builder.finish()
@@ -721,12 +721,12 @@ async fn test_interleaved_upgrades() {
         let digest_arg = builder.pure(digest).unwrap();
         let upgrade_ticket = move_call! {
             builder,
-            (SuiFramework::ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
+            (SUI_FRAMEWORK_OBJECT_ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
         };
         let upgrade_receipt = builder.upgrade(current_package_id, upgrade_ticket, dep_ids, modules);
         move_call! {
             builder,
-            (SuiFramework::ID)::package::commit_upgrade(Argument::Input(0), upgrade_receipt)
+            (SUI_FRAMEWORK_OBJECT_ID)::package::commit_upgrade(Argument::Input(0), upgrade_receipt)
         };
 
         builder.finish()
@@ -766,12 +766,12 @@ async fn test_publish_override_happy_path() {
         let digest_arg = builder.pure(digest).unwrap();
         let upgrade_ticket = move_call! {
             builder,
-            (SuiFramework::ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
+            (SUI_FRAMEWORK_OBJECT_ID)::package::authorize_upgrade(Argument::Input(0), upgrade_arg, digest_arg)
         };
         let upgrade_receipt = builder.upgrade(current_package_id, upgrade_ticket, vec![], modules);
         move_call! {
             builder,
-            (SuiFramework::ID)::package::commit_upgrade(Argument::Input(0), upgrade_receipt)
+            (SUI_FRAMEWORK_OBJECT_ID)::package::commit_upgrade(Argument::Input(0), upgrade_receipt)
         };
 
         builder.finish()

--- a/crates/sui-json/src/tests.rs
+++ b/crates/sui-json/src/tests.rs
@@ -12,7 +12,7 @@ use move_core_types::{
     account_address::AccountAddress, ident_str, identifier::Identifier, value::MoveTypeLayout,
 };
 use serde_json::{json, Value};
-use sui_framework::make_system_packages;
+use sui_framework::BuiltInFramework;
 use sui_framework_build::compiled_package::BuildConfig;
 use test_fuzz::runtime::num_traits::ToPrimitive;
 
@@ -416,7 +416,7 @@ fn test_basic_args_linter_top_level() {
     let example_package = Object::new_package_for_testing(
         &compiled_modules,
         TransactionDigest::genesis(),
-        &make_system_packages(),
+        BuiltInFramework::genesis_move_packages(),
     )
     .unwrap();
     let example_package = example_package.data.try_as_package().unwrap();
@@ -542,7 +542,7 @@ fn test_basic_args_linter_top_level() {
     let example_package = Object::new_package_for_testing(
         &compiled_modules,
         TransactionDigest::genesis(),
-        &make_system_packages(),
+        BuiltInFramework::genesis_move_packages(),
     )
     .unwrap();
     let framework_pkg = example_package.data.try_as_package().unwrap();
@@ -645,7 +645,7 @@ fn test_basic_args_linter_top_level() {
     let example_package = Object::new_package_for_testing(
         &compiled_modules,
         TransactionDigest::genesis(),
-        &make_system_packages(),
+        BuiltInFramework::genesis_move_packages(),
     )
     .unwrap();
     let example_package = example_package.data.try_as_package().unwrap();

--- a/crates/sui-proc-macros/src/lib.rs
+++ b/crates/sui-proc-macros/src/lib.rs
@@ -35,12 +35,9 @@ pub fn init_static_initializers(_args: TokenStream, item: TokenStream) -> TokenS
             // be very important for being able to reproduce a failure that occurs in the Nth
             // iteration of a multi-iteration test run.
             std::thread::spawn(|| {
-                use sui_simulator::sui_framework::SystemPackage;
                 use sui_protocol_config::ProtocolConfig;
                 ::sui_simulator::telemetry_subscribers::init_for_testing();
-                ::sui_simulator::sui_framework::MoveStdlib::as_modules();
-                ::sui_simulator::sui_framework::SuiFramework::as_modules();
-                ::sui_simulator::sui_framework::SuiSystem::as_modules();
+                ::sui_simulator::sui_framework::BuiltInFramework::all_package_ids();
                 ::sui_simulator::sui_types::gas::SuiGasStatus::new_unmetered(
                     &ProtocolConfig::get_for_min_version(),
                 );

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -611,16 +611,17 @@ impl Object {
         ))
     }
 
-    pub fn new_package_for_testing<'p>(
+    pub fn new_package_for_testing(
         modules: &[CompiledModule],
         previous_transaction: TransactionDigest,
-        dependencies: impl IntoIterator<Item = &'p MovePackage>,
+        dependencies: impl IntoIterator<Item = MovePackage>,
     ) -> Result<Self, ExecutionError> {
+        let dependencies: Vec<_> = dependencies.into_iter().collect();
         Self::new_package(
             modules,
             previous_transaction,
             ProtocolConfig::get_for_max_version().max_move_package_size(),
-            dependencies,
+            &dependencies,
         )
     }
 

--- a/crates/sui/src/fire_drill.rs
+++ b/crates/sui/src/fire_drill.rs
@@ -21,7 +21,6 @@ use std::path::{Path, PathBuf};
 use sui_config::node::KeyPairWithPath;
 use sui_config::utils;
 use sui_config::{node::AuthorityKeyPairWithPath, Config, NodeConfig, PersistedConfig};
-use sui_framework::{SuiSystem, SystemPackage};
 use sui_json_rpc_types::{SuiExecutionStatus, SuiTransactionBlockResponseOptions};
 use sui_keys::keypair_file::read_keypair_from_file;
 use sui_sdk::{rpc_types::SuiTransactionBlockEffectsAPI, SuiClient, SuiClientBuilder};
@@ -29,7 +28,7 @@ use sui_types::base_types::{ObjectRef, SuiAddress};
 use sui_types::crypto::{generate_proof_of_possession, get_key_pair, SuiKeyPair};
 use sui_types::messages::{CallArg, ObjectArg, Transaction, TransactionData};
 use sui_types::multiaddr::{Multiaddr, Protocol};
-use sui_types::{committee::EpochId, crypto::get_authority_key_pair};
+use sui_types::{committee::EpochId, crypto::get_authority_key_pair, SUI_SYSTEM_PACKAGE_ID};
 use sui_types::{SUI_SYSTEM_STATE_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION};
 use tracing::info;
 
@@ -316,7 +315,7 @@ async fn update_metadata_on_chain(
     args.extend(call_args);
     let tx_data = TransactionData::new_move_call(
         sui_address,
-        SuiSystem::ID,
+        SUI_SYSTEM_PACKAGE_ID,
         ident_str!("sui_system").to_owned(),
         ident_str!(function).to_owned(),
         vec![],

--- a/crates/sui/src/validator_commands.rs
+++ b/crates/sui/src/validator_commands.rs
@@ -10,7 +10,6 @@ use std::{
     path::PathBuf,
 };
 use sui_config::genesis::GenesisValidatorInfo;
-use sui_framework::{SuiSystem, SystemPackage};
 
 use sui_types::{
     base_types::{ObjectID, ObjectRef, SuiAddress},
@@ -21,6 +20,7 @@ use sui_types::{
         sui_system_state_inner_v1::{UnverifiedValidatorOperationCapV1, ValidatorV1},
         sui_system_state_summary::{SuiSystemStateSummary, SuiValidatorSummary},
     },
+    SUI_SYSTEM_PACKAGE_ID,
 };
 use tap::tap::TapOptional;
 
@@ -564,7 +564,7 @@ async fn call_0x5(
     let gas_obj_ref = get_gas_obj_ref(sender, &sui_client, gas_budget).await?;
     let tx_data = TransactionData::new_move_call(
         sender,
-        SuiSystem::ID,
+        SUI_SYSTEM_PACKAGE_ID,
         ident_str!("sui_system").to_owned(),
         ident_str!(function).to_owned(),
         vec![],

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -16,7 +16,6 @@ use sui_core::authority_aggregator::{AuthAggMetrics, AuthorityAggregator};
 use sui_core::consensus_adapter::position_submit_certificate;
 use sui_core::safe_client::SafeClientMetricsBase;
 use sui_core::test_utils::make_transfer_sui_transaction;
-use sui_framework::{SuiSystem, SystemPackage};
 use sui_macros::sim_test;
 use sui_node::SuiNodeHandle;
 use sui_types::base_types::{AuthorityName, ObjectRef, SuiAddress};
@@ -40,7 +39,9 @@ use sui_types::sui_system_state::{
     SuiSystemStateTrait,
 };
 use sui_types::utils::to_sender_signed_transaction;
-use sui_types::{SUI_SYSTEM_STATE_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION};
+use sui_types::{
+    SUI_SYSTEM_PACKAGE_ID, SUI_SYSTEM_STATE_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
+};
 use test_utils::authority::start_node;
 use test_utils::{
     authority::{
@@ -609,7 +610,7 @@ async fn test_inactive_validator_pool_read() {
 
     let tx_data = TransactionData::new_move_call_with_dummy_gas_price(
         address,
-        SuiSystem::ID,
+        SUI_SYSTEM_PACKAGE_ID,
         ident_str!("sui_system").to_owned(),
         ident_str!("request_remove_validator").to_owned(),
         vec![],
@@ -1155,7 +1156,7 @@ async fn execute_add_validator_candidate_tx(
 
     let candidate_tx_data = TransactionData::new_move_call_with_dummy_gas_price(
         sender,
-        SuiSystem::ID,
+        SUI_SYSTEM_PACKAGE_ID,
         ident_str!("sui_system").to_owned(),
         ident_str!("request_add_validator_candidate").to_owned(),
         vec![],
@@ -1219,7 +1220,7 @@ async fn execute_join_committee_txes(
     // Step 2: Give the candidate enough stake.
     let stake_tx_data = TransactionData::new_move_call_with_dummy_gas_price(
         sender,
-        SuiSystem::ID,
+        SUI_SYSTEM_PACKAGE_ID,
         ident_str!("sui_system").to_owned(),
         ident_str!("request_add_stake").to_owned(),
         vec![],
@@ -1247,7 +1248,7 @@ async fn execute_join_committee_txes(
     // Step 3: Convert the candidate to an active valdiator.
     let activation_tx_data = TransactionData::new_move_call_with_dummy_gas_price(
         sender,
-        SuiSystem::ID,
+        SUI_SYSTEM_PACKAGE_ID,
         ident_str!("sui_system").to_owned(),
         ident_str!("request_add_validator").to_owned(),
         vec![],
@@ -1278,7 +1279,7 @@ async fn execute_leave_committee_tx(
     let sui_address: SuiAddress = account_kp.public().into();
     let tx_data = TransactionData::new_move_call_with_dummy_gas_price(
         sui_address,
-        SuiSystem::ID,
+        SUI_SYSTEM_PACKAGE_ID,
         ident_str!("sui_system").to_owned(),
         ident_str!("request_remove_validator").to_owned(),
         vec![],


### PR DESCRIPTION
This PR changes how we define the system packages in the build:
Instead of defining each package as a type implementing a trait, this PR changes it such that they becomes a lazily initialized global vector of SystemPackage struct.
This allows us to naturally iterates through all of them whenever we need to access all system packages.
This will make changes like https://github.com/MystenLabs/sui/pull/10220 much much less error-prone because we would not miss a place where need to add the new package. It also simplifies a few places where we need to access all system packages.
For framework_injection, I changed it such that it's only turned on in msim mode (less to worry in prod code).
All changes in this PR are NFC.

@bmwill for the genesis changes
@mystenmark for the simtest macro changes
@amnn for the changes in sui-framework
@sblackshear for reference