### PR TITLE
indexer: split FN sync worker and rpc server worker

### DIFF
--- a/crates/sui-indexer/src/apis/write_api.rs
+++ b/crates/sui-indexer/src/apis/write_api.rs
@@ -10,24 +10,33 @@ use jsonrpsee::RpcModule;
 use sui_json_rpc::api::{WriteApiClient, WriteApiServer};
 use sui_json_rpc::SuiRpcModule;
 use sui_json_rpc_types::{
-    DevInspectResults, DryRunTransactionBlockResponse, SuiTransactionBlockEffectsAPI,
-    SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions,
+    DevInspectResults,
+    DryRunTransactionBlockResponse,
+    // TODO(gegaowp): temp. disable fast-path
+    // SuiTransactionBlockEffectsAPI,
+    SuiTransactionBlockResponse,
+    SuiTransactionBlockResponseOptions,
 };
 use sui_open_rpc::Module;
 use sui_types::base_types::SuiAddress;
 use sui_types::messages::ExecuteTransactionRequestType;
 use sui_types::sui_serde::BigInt;
 
-use crate::handlers::checkpoint_handler::{
-    fetch_changed_objects, get_deleted_db_objects, get_object_changes, to_changed_db_objects,
-};
-use crate::models::transactions::Transaction;
-use crate::store::{IndexerStore, TransactionObjectChanges};
-use crate::types::{
-    FastPathTransactionBlockResponse, SuiTransactionBlockResponseWithOptions,
-    TemporaryTransactionBlockResponseStore,
-};
+// TODO(gegaowp): temp. disable fast-path
+// use crate::handlers::checkpoint_handler::{
+//     fetch_changed_objects, get_deleted_db_objects, get_object_changes, to_changed_db_objects,
+// };
+// use crate::models::transactions::Transaction;
+// use crate::store::{IndexerStore, TransactionObjectChanges};
+// use crate::types::{
+//         FastPathTransactionBlockResponse, SuiTransactionBlockResponseWithOptions,
+//         TemporaryTransactionBlockResponseStore,
+//     };
+use crate::store::IndexerStore;
+use crate::types::SuiTransactionBlockResponseWithOptions;
 
+// TODO(gegaowp): temp. disable fast-path and allow dead code.
+#[allow(dead_code)]
 pub(crate) struct WriteApi<S> {
     fullnode: HttpClient,
     state: S,
@@ -59,26 +68,28 @@ where
             .fullnode
             .execute_transaction_block(tx_bytes, signatures, Some(fast_path_options), request_type)
             .await?;
-        let fast_path_resp: FastPathTransactionBlockResponse =
-            sui_transaction_response.clone().try_into()?;
-        let effects = &fast_path_resp.effects;
-        let epoch = effects.executed_epoch();
 
-        let object_changes = get_object_changes(effects);
-        let changed_objects = fetch_changed_objects(self.fullnode.clone(), object_changes).await?;
-        let changed_db_objects =
-            to_changed_db_objects(changed_objects, epoch, /* checkpoint */ None);
-        let deleted_db_objects = get_deleted_db_objects(effects, epoch, /* checkpoint */ None);
-        let tx_object_changes = TransactionObjectChanges {
-            changed_objects: changed_db_objects,
-            deleted_objects: deleted_db_objects,
-        };
+        // TODO(gegaowp): turn off DB commits on fast-path for now
+        // let fast_path_resp: FastPathTransactionBlockResponse =
+        //     sui_transaction_response.clone().try_into()?;
+        // let effects = &fast_path_resp.effects;
+        // let epoch = effects.executed_epoch();
 
-        let transaction_store: TemporaryTransactionBlockResponseStore = fast_path_resp.into();
-        let transaction: Transaction = transaction_store.try_into()?;
-        self.state
-            .persist_fast_path(transaction, tx_object_changes)
-            .await?;
+        // let object_changes = get_object_changes(effects);
+        // let changed_objects = fetch_changed_objects(self.fullnode.clone(), object_changes).await?;
+        // let changed_db_objects =
+        //     to_changed_db_objects(changed_objects, epoch, /* checkpoint */ None);
+        // let deleted_db_objects = get_deleted_db_objects(effects, epoch, /* checkpoint */ None);
+        // let tx_object_changes = TransactionObjectChanges {
+        //     changed_objects: changed_db_objects,
+        //     deleted_objects: deleted_db_objects,
+        // };
+
+        // let transaction_store: TemporaryTransactionBlockResponseStore = fast_path_resp.into();
+        // let transaction: Transaction = transaction_store.try_into()?;
+        // self.state
+        //     .persist_fast_path(transaction, tx_object_changes)
+        //     .await?;
 
         Ok(SuiTransactionBlockResponseWithOptions {
             response: sui_transaction_response,

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -697,16 +697,17 @@ pub async fn fetch_changed_objects(
     })
 }
 
-pub fn to_changed_db_objects(
-    changed_objects: Vec<(ObjectStatus, SuiObjectData)>,
-    epoch: u64,
-    checkpoint: Option<CheckpointSequenceNumber>,
-) -> Vec<Object> {
-    changed_objects
-        .into_iter()
-        .map(|(status, o)| Object::from(epoch, checkpoint.map(<u64>::from), &status, &o))
-        .collect::<Vec<_>>()
-}
+// TODO(gegaowp): temp. disable fast-path
+// pub fn to_changed_db_objects(
+//     changed_objects: Vec<(ObjectStatus, SuiObjectData)>,
+//     epoch: u64,
+//     checkpoint: Option<CheckpointSequenceNumber>,
+// ) -> Vec<Object> {
+//     changed_objects
+//         .into_iter()
+//         .map(|(status, o)| Object::from(epoch, checkpoint.map(<u64>::from), &status, &o))
+//         .collect::<Vec<_>>()
+// }
 
 pub fn get_deleted_db_objects(
     effects: &SuiTransactionBlockEffects,


### PR DESCRIPTION
## Description 

Split the worker, as now it looks like indexer binary cannot do both FN sync & RPC serving very well in the same binary / K8 

Discussions are in inc 280.

## Test Plan 

CI 
