### PR TITLE
console log address, derivation path, and pubkey when importing ledger

### DIFF
--- a/apps/wallet/src/background/keyring/LedgerAccount.ts
+++ b/apps/wallet/src/background/keyring/LedgerAccount.ts
@@ -9,23 +9,28 @@ export type SerializedLedgerAccount = {
     type: AccountType.LEDGER;
     address: SuiAddress;
     derivationPath: string;
+    publickey: string;
 };
 
 export class LedgerAccount implements Account {
     readonly type: AccountType;
     readonly address: SuiAddress;
     readonly derivationPath: string;
+    readonly publickey: string;
 
     constructor({
         address,
         derivationPath,
+        publickey,
     }: {
         address: SuiAddress;
         derivationPath: string;
+        publickey: string;
     }) {
         this.type = AccountType.LEDGER;
         this.address = normalizeSuiAddress(address);
         this.derivationPath = derivationPath;
+        this.publickey = publickey;
     }
 
     toJSON(): SerializedLedgerAccount {
@@ -33,6 +38,7 @@ export class LedgerAccount implements Account {
             type: AccountType.LEDGER,
             address: this.address,
             derivationPath: this.derivationPath,
+            publickey: this.publickey,
         };
     }
 }

--- a/apps/wallet/src/background/keyring/index.ts
+++ b/apps/wallet/src/background/keyring/index.ts
@@ -147,6 +147,7 @@ export class Keyring {
             const account = new LedgerAccount({
                 derivationPath: ledgerAccount.derivationPath,
                 address: ledgerAccount.address,
+                publickey: ledgerAccount.publickey,
             });
             this.#accountsMap.set(ledgerAccount.address, account);
         }
@@ -496,6 +497,7 @@ export class Keyring {
                 new LedgerAccount({
                     derivationPath: savedLedgerAccount.derivationPath,
                     address: savedLedgerAccount.address,
+                    publickey: savedLedgerAccount.publickey,
                 })
             );
         }

--- a/apps/wallet/src/ui/app/components/ledger/useDeriveLedgerAccounts.ts
+++ b/apps/wallet/src/ui/app/components/ledger/useDeriveLedgerAccounts.ts
@@ -55,13 +55,15 @@ async function deriveAccountsFromLedger(
         );
         const publicKey = new Ed25519PublicKey(publicKeyResult.publicKey);
         const suiAddress = publicKey.toSuiAddress();
+        const publicKeyB64 = publicKey.toBase64();
         ledgerAccounts.push({
             type: AccountType.LEDGER,
             address: suiAddress,
             derivationPath,
+            publickey: publicKeyB64,
         });
     }
-
+    console.log(ledgerAccounts);
     return ledgerAccounts;
 }
 


### PR DESCRIPTION
## Description 

Add console logging to wallet for multi-sig setup use.

## Test Plan 

To build:
```
pnpm i
pnpm --filter ./apps/wallet build:dev
```
artifact in ‘apps/wallet/dist’


Load app in `manage Extensions`
Import Ledger Addresses
<img width="1317" alt="image" src="https://github.com/MystenLabs/sui/assets/6826729/1e69d9e2-70b6-45ff-85bf-cea9c210e15b">

Connect Ledger

<img width="1309" alt="image" src="https://github.com/MystenLabs/sui/assets/6826729/9842622d-c768-4722-a1e8-1363355d7569">

In the Console, you will see an array-like item:
<img width="586" alt="image" src="https://github.com/MystenLabs/sui/assets/6826729/07726589-95f3-4847-8b20-df691a990619">

Right click on object and copy
<img width="606" alt="image" src="https://github.com/MystenLabs/sui/assets/6826729/94a29f46-1bde-40b9-86b4-7de28c0d7afc">

Save pubkeys for later usage in multisig, or for whatever...
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
