### PR TITLE
Fix object lookup in gas computation

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -383,20 +383,6 @@ impl AuthorityStore {
             .await
     }
 
-    pub fn get_object_by_key(
-        &self,
-        object_id: &ObjectID,
-        version: VersionNumber,
-    ) -> Result<Option<Object>, SuiError> {
-        Ok(self
-            .perpetual_tables
-            .objects
-            .get(&ObjectKey(*object_id, version))?
-            .map(|object| self.perpetual_tables.object(object))
-            .transpose()?
-            .flatten())
-    }
-
     pub fn get_object_ref_prior_to_key(
         &self,
         object_id: &ObjectID,
@@ -1522,6 +1508,20 @@ impl ObjectStore for AuthorityStore {
     /// Read an object and return it, or Ok(None) if the object was not found.
     fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
         self.perpetual_tables.as_ref().get_object(object_id)
+    }
+
+    fn get_object_by_key(
+        &self,
+        object_id: &ObjectID,
+        version: VersionNumber,
+    ) -> Result<Option<Object>, SuiError> {
+        Ok(self
+            .perpetual_tables
+            .objects
+            .get(&ObjectKey(*object_id, version))?
+            .map(|object| self.perpetual_tables.object(object))
+            .transpose()?
+            .flatten())
     }
 }
 

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -304,6 +304,19 @@ impl ObjectStore for AuthorityPerpetualTables {
             _ => Ok(None),
         }
     }
+
+    fn get_object_by_key(
+        &self,
+        object_id: &ObjectID,
+        version: VersionNumber,
+    ) -> Result<Option<Object>, SuiError> {
+        let key = ObjectKey(*object_id, version);
+        let obj_entry = self.objects.get(&key);
+        match obj_entry {
+            Ok(Some(wrapper)) => self.object(wrapper),
+            _ => Ok(None),
+        }
+    }
 }
 
 pub struct LiveSetIter<'a> {

--- a/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -16,7 +16,7 @@ use sui_types::{
     move_package::UpgradePolicy,
     object::{Object, Owner},
     programmable_transaction_builder::ProgrammableTransactionBuilder,
-    storage::BackingPackageStore,
+    storage::{BackingPackageStore, ObjectStore},
 };
 
 use std::{

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1544,6 +1544,8 @@ impl ProtocolConfig {
                 let mut cfg = Self::get_for_version_impl(version - 1);
                 // Change reward slashing rate to 100%.
                 cfg.reward_slashing_rate = Some(10000);
+                // protect old and new lookup for object version
+                cfg.gas_model_version = Some(3);
                 cfg
             }
             // Use this template when making changes:

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_4.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_4.snap
@@ -60,7 +60,7 @@ obj_access_cost_read_per_byte: 15
 obj_access_cost_mutate_per_byte: 40
 obj_access_cost_delete_per_byte: 40
 obj_access_cost_verify_per_byte: 200
-gas_model_version: 2
+gas_model_version: 3
 obj_data_cost_refundable: 100
 obj_metadata_cost_non_refundable: 50
 storage_rebate_rate: 9900

--- a/crates/sui-types/src/gas.rs
+++ b/crates/sui-types/src/gas.rs
@@ -60,7 +60,7 @@ impl<'a> SuiGasStatus<'a> {
                 gas_price,
                 config,
             )),
-            2 => Self::V2(SuiGasStatusV2::new_with_budget(
+            2 | 3 => Self::V2(SuiGasStatusV2::new_with_budget(
                 gas_budget,
                 gas_price,
                 config,
@@ -72,7 +72,7 @@ impl<'a> SuiGasStatus<'a> {
     pub fn new_unmetered(config: &ProtocolConfig) -> Self {
         match config.gas_model_version() {
             1 => Self::V1(SuiGasStatusV1::new_unmetered()),
-            2 => Self::V2(SuiGasStatusV2::new_unmetered()),
+            2 | 3 => Self::V2(SuiGasStatusV2::new_unmetered()),
             _ => panic!("unknown gas model version"),
         }
     }
@@ -87,7 +87,7 @@ impl SuiCostTable {
     pub fn new(config: &ProtocolConfig) -> Self {
         match config.gas_model_version() {
             1 => Self::V1(SuiCostTableV1::new(config)),
-            2 => Self::V2(SuiCostTableV2::new(config)),
+            2 | 3 => Self::V2(SuiCostTableV2::new(config)),
             _ => panic!("unknown gas model version"),
         }
     }
@@ -99,7 +99,7 @@ impl SuiCostTable {
     pub fn unmetered(config: &ProtocolConfig) -> Self {
         match config.gas_model_version() {
             1 => Self::V1(SuiCostTableV1::unmetered()),
-            2 => Self::V2(SuiCostTableV2::unmetered()),
+            2 | 3 => Self::V2(SuiCostTableV2::unmetered()),
             _ => panic!("unknown gas model version"),
         }
     }

--- a/crates/sui-types/src/in_memory_storage.rs
+++ b/crates/sui-types/src/in_memory_storage.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::base_types::VersionNumber;
 use crate::storage::get_module_by_id;
 use crate::{
     base_types::{ObjectID, ObjectRef, SequenceNumber},
@@ -83,11 +84,47 @@ impl ObjectStore for InMemoryStorage {
     fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
         Ok(self.persistent.get(object_id).cloned())
     }
+
+    fn get_object_by_key(
+        &self,
+        object_id: &ObjectID,
+        version: VersionNumber,
+    ) -> Result<Option<Object>, SuiError> {
+        Ok(self
+            .persistent
+            .get(object_id)
+            .and_then(|obj| {
+                if obj.version() == version {
+                    Some(obj)
+                } else {
+                    None
+                }
+            })
+            .cloned())
+    }
 }
 
 impl ObjectStore for &mut InMemoryStorage {
     fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
         Ok(self.persistent.get(object_id).cloned())
+    }
+
+    fn get_object_by_key(
+        &self,
+        object_id: &ObjectID,
+        version: VersionNumber,
+    ) -> Result<Option<Object>, SuiError> {
+        Ok(self
+            .persistent
+            .get(object_id)
+            .and_then(|obj| {
+                if obj.version() == version {
+                    Some(obj)
+                } else {
+                    None
+                }
+            })
+            .cloned())
     }
 }
 

--- a/crates/sui-types/src/storage.rs
+++ b/crates/sui-types/src/storage.rs
@@ -678,11 +678,27 @@ pub fn transaction_input_object_keys(tx: &SenderSignedData) -> SuiResult<Vec<Obj
 
 pub trait ObjectStore {
     fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError>;
+    fn get_object_by_key(
+        &self,
+        object_id: &ObjectID,
+        version: VersionNumber,
+    ) -> Result<Option<Object>, SuiError>;
 }
 
 impl ObjectStore for &[Object] {
     fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
         Ok(self.iter().find(|o| o.id() == *object_id).cloned())
+    }
+
+    fn get_object_by_key(
+        &self,
+        object_id: &ObjectID,
+        version: VersionNumber,
+    ) -> Result<Option<Object>, SuiError> {
+        Ok(self
+            .iter()
+            .find(|o| o.id() == *object_id && o.version() == version)
+            .cloned())
     }
 }
 
@@ -690,11 +706,36 @@ impl ObjectStore for BTreeMap<ObjectID, (ObjectRef, Object, WriteKind)> {
     fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
         Ok(self.get(object_id).map(|(_, obj, _)| obj).cloned())
     }
+
+    fn get_object_by_key(
+        &self,
+        object_id: &ObjectID,
+        version: VersionNumber,
+    ) -> Result<Option<Object>, SuiError> {
+        Ok(self
+            .get(object_id)
+            .and_then(|(_, obj, _)| {
+                if obj.version() == version {
+                    Some(obj)
+                } else {
+                    None
+                }
+            })
+            .cloned())
+    }
 }
 
 impl<T: ObjectStore> ObjectStore for Arc<T> {
     fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
         self.as_ref().get_object(object_id)
+    }
+
+    fn get_object_by_key(
+        &self,
+        object_id: &ObjectID,
+        version: VersionNumber,
+    ) -> Result<Option<Object>, SuiError> {
+        self.as_ref().get_object_by_key(object_id, version)
     }
 }
 


### PR DESCRIPTION
## Description 

@gdanezis suggested the change implemented here (if we got it right) which would fix the issue with gas computation and partly for conservation that is bugging us.
We change calls to get_object to use get_object_by_key and remove panic for version checks.
We have the version already at the point we call so we can use it and be more precise and correct.

The change ended up being more intrusive that we wanted because of traits implementation.
We would love more eyes on this to make sure things are correct

## Test Plan 

Existing tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
