### PR TITLE
indexer: fix worker start

### DIFF
--- a/crates/sui-indexer/src/lib.rs
+++ b/crates/sui-indexer/src/lib.rs
@@ -157,16 +157,41 @@ impl Indexer {
             env!("CARGO_PKG_VERSION")
         );
         let event_handler = Arc::new(EventHandler::default());
-        if config.rpc_server_worker {
+        if config.rpc_server_worker && config.fullnode_sync_worker {
+            info!("Starting indexer with both fullnode sync and RPC server");
             let handle =
                 build_json_rpc_server(registry, store.clone(), event_handler.clone(), config)
                     .await
                     .expect("Json rpc server should not run into errors upon start.");
             // let JSON RPC server run forever.
             spawn_monitored_task!(handle.stopped());
-        }
 
-        if config.fullnode_sync_worker {
+            backoff::future::retry(ExponentialBackoff::default(), || async {
+                let event_handler_clone = event_handler.clone();
+                let http_client = get_http_client(config.rpc_client_url.as_str())?;
+                let cp = CheckpointHandler::new(
+                    store.clone(),
+                    http_client,
+                    event_handler_clone,
+                    registry,
+                    config,
+                );
+                cp.spawn()
+                    .await
+                    .expect("Indexer main should not run into errors.");
+                Ok(())
+            })
+            .await
+        } else if config.rpc_server_worker {
+            info!("Starting indexer with only RPC server");
+            let handle =
+                build_json_rpc_server(registry, store.clone(), event_handler.clone(), config)
+                    .await
+                    .expect("Json rpc server should not run into errors upon start.");
+            let _rpc_res = handle.stopped().await;
+            Ok(())
+        } else if config.fullnode_sync_worker {
+            info!("Starting indexer with only fullnode sync");
             backoff::future::retry(ExponentialBackoff::default(), || async {
                 let event_handler_clone = event_handler.clone();
                 let http_client = get_http_client(config.rpc_client_url.as_str())?;

--- a/crates/sui-indexer/src/lib.rs
+++ b/crates/sui-indexer/src/lib.rs
@@ -188,7 +188,7 @@ impl Indexer {
                 build_json_rpc_server(registry, store.clone(), event_handler.clone(), config)
                     .await
                     .expect("Json rpc server should not run into errors upon start.");
-            let _rpc_res = handle.stopped().await;
+            handle.stopped().await;
             Ok(())
         } else if config.fullnode_sync_worker {
             info!("Starting indexer with only fullnode sync");

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -1281,15 +1281,15 @@ WHERE e1.epoch = e2.epoch
     }
 
     async fn persist_epoch(&self, data: &TemporaryEpochStore) -> Result<(), IndexerError> {
-        let last_epoch_cp_id = if data.last_epoch.is_none() {
-            0
-        } else {
-            self.get_current_epoch().await?.first_checkpoint_id as i64
-        };
-
-        self.partition_manager
-            .advance_epoch(&data.new_epoch, last_epoch_cp_id)
-            .await?;
+        // MUSTFIX(gegaowp): temporarily disable the epoch advance logic.
+        // let last_epoch_cp_id = if data.last_epoch.is_none() {
+        //     0
+        // } else {
+        //     self.get_current_epoch().await?.first_checkpoint_id as i64
+        // };
+        // self.partition_manager
+        //     .advance_epoch(&data.new_epoch, last_epoch_cp_id)
+        //     .await?;
 
         transactional!(&self.cp, |conn| async {
             if let Some(last_epoch) = &data.last_epoch {

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -1281,15 +1281,15 @@ WHERE e1.epoch = e2.epoch
     }
 
     async fn persist_epoch(&self, data: &TemporaryEpochStore) -> Result<(), IndexerError> {
-        // MUSTFIX(gegaowp): temporarily disable the epoch advance logic.
-        // let last_epoch_cp_id = if data.last_epoch.is_none() {
-        //     0
-        // } else {
-        //     self.get_current_epoch().await?.first_checkpoint_id as i64
-        // };
-        // self.partition_manager
-        //     .advance_epoch(&data.new_epoch, last_epoch_cp_id)
-        //     .await?;
+        let last_epoch_cp_id = if data.last_epoch.is_none() {
+            0
+        } else {
+            self.get_current_epoch().await?.first_checkpoint_id as i64
+        };
+
+        self.partition_manager
+            .advance_epoch(&data.new_epoch, last_epoch_cp_id)
+            .await?;
 
         transactional!(&self.cp, |conn| async {
             if let Some(last_epoch) = &data.last_epoch {


### PR DESCRIPTION
## Description 

Before this PR, a RPC server only node will exit immediately, which I did not test last time, this PR fixed that

## Test Plan 

local start all flavors of indexers and observe:
1. both FN sync and RPC server
    - expect to see new checkpoints in the logs
    - curl to 3030 and can read latest checkpoint
2. stopped and run RPC server only
    - no new checkpoints in the log
    - curl to 3030, get response but newest checkpoint is always the same
3. stopped and run FN sync
    - new checkpoints
    - curl to 3030, no response
4. stopped and run RPC server only
    - no new checkpoints
    - curl to 3030, response updated
