### PR TITLE
Framework compatibility tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9197,6 +9197,7 @@ dependencies = [
  "sui-framework-build",
  "sui-protocol-config",
  "sui-types",
+ "tracing",
  "workspace-hack",
 ]
 
@@ -9231,6 +9232,7 @@ dependencies = [
  "sui-framework",
  "sui-protocol-config",
  "sui-types",
+ "tokio",
  "workspace-hack",
 ]
 

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -14,7 +14,6 @@ use fastcrypto::encoding::Base58;
 use fastcrypto::encoding::Encoding;
 use fastcrypto::traits::KeyPair;
 use itertools::Itertools;
-use move_binary_format::compatibility::Compatibility;
 use move_binary_format::CompiledModule;
 use move_core_types::language_storage::ModuleId;
 use parking_lot::Mutex;
@@ -3016,7 +3015,8 @@ impl AuthorityState {
             let modules = framework_injection::get_override_modules(system_package.id(), self.name)
                 .unwrap_or(modules);
 
-            let Some(obj_ref) = self.compare_system_package(
+            let Some(obj_ref) = sui_framework::compare_system_package(
+                self.database.as_ref(),
                 system_package.id(),
                 &modules,
                 system_package.dependencies().to_vec(),
@@ -3027,93 +3027,6 @@ impl AuthorityState {
             results.push(obj_ref);
         }
         results
-    }
-
-    /// Check whether the framework defined by `modules` is compatible with the framework that is
-    /// already on-chain at `id`.
-    ///
-    /// - Returns `None` if the current package at `id` cannot be loaded, or the compatibility check
-    ///   fails (This is grounds not to upgrade).
-    /// - Panics if the object at `id` can be loaded but is not a package -- this is an invariant
-    ///   violation.
-    /// - Returns the digest of the current framework (and version) if it is equivalent to the new
-    ///   framework (indicates support for a protocol upgrade without a framework upgrade).
-    /// - Returns the digest of the new framework (and version) if it is compatible (indicates
-    ///   support for a protocol upgrade with a framework upgrade).
-    async fn compare_system_package(
-        &self,
-        id: &ObjectID,
-        modules: &[CompiledModule],
-        dependencies: Vec<ObjectID>,
-        max_binary_format_version: u32,
-    ) -> Option<ObjectRef> {
-        let cur_object = match self.get_object(id).await {
-            Ok(Some(cur_object)) => cur_object,
-
-            Ok(None) => {
-                error!("No framework package at {id}");
-                return None;
-            }
-
-            Err(e) => {
-                error!("Error loading framework object at {id}: {e:?}");
-                return None;
-            }
-        };
-
-        let cur_ref = cur_object.compute_object_reference();
-        let cur_pkg = cur_object
-            .data
-            .try_as_package()
-            .expect("Framework not package");
-
-        let mut new_object = Object::new_system_package(
-            modules,
-            // Start at the same version as the current package, and increment if compatibility is
-            // successful
-            cur_object.version(),
-            dependencies,
-            cur_object.previous_transaction,
-        );
-
-        if cur_ref == new_object.compute_object_reference() {
-            return Some(cur_ref);
-        }
-
-        let compatibility = Compatibility {
-            check_struct_and_pub_function_linking: true,
-            check_struct_layout: true,
-            check_friend_linking: false,
-            check_private_entry_linking: true,
-        };
-
-        let new_pkg = new_object
-            .data
-            .try_as_package_mut()
-            .expect("Created as package");
-
-        let cur_normalized = match cur_pkg.normalize(max_binary_format_version) {
-            Ok(v) => v,
-            Err(e) => {
-                error!("Could not normalize existing package: {e:?}");
-                return None;
-            }
-        };
-        let mut new_normalized = new_pkg.normalize(max_binary_format_version).ok()?;
-
-        for (name, cur_module) in cur_normalized {
-            let Some(new_module) = new_normalized.remove(&name) else {
-                return None;
-            };
-
-            if let Err(e) = compatibility.check(&cur_module, &new_module) {
-                error!("Compatibility check failed, for new version of {id}: {e:?}");
-                return None;
-            }
-        }
-
-        new_pkg.increment_version();
-        Some(new_object.compute_object_reference())
     }
 
     /// Return the new versions, module bytes, and dependencies for the packages that have been

--- a/crates/sui-framework-snapshot/Cargo.toml
+++ b/crates/sui-framework-snapshot/Cargo.toml
@@ -18,3 +18,6 @@ sui-protocol-config = { path = "../sui-protocol-config" }
 sui-types = { path = "../sui-types" }
 
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full"] }

--- a/crates/sui-framework-snapshot/src/lib.rs
+++ b/crates/sui-framework-snapshot/src/lib.rs
@@ -1,8 +1,53 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{io::Read, path::PathBuf};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::{fs, io::Read, path::PathBuf};
 use sui_framework::SystemPackage;
+use sui_types::base_types::ObjectID;
+
+pub type SnapshotManifest = BTreeMap<String, BTreeMap<u64, SingleSnapshot>>;
+
+#[derive(Serialize, Deserialize)]
+pub struct SingleSnapshot {
+    /// Git revision that this snapshot is taken on.
+    git_revision: String,
+    /// List of file names (also identical to object ID) of the bytecode package files.
+    package_ids: Vec<ObjectID>,
+}
+
+pub fn load_bytecode_snapshot_manifest() -> SnapshotManifest {
+    let Ok(bytes) = fs::read(manifest_path()) else {
+        return SnapshotManifest::default();
+    };
+    serde_json::from_slice::<SnapshotManifest>(&bytes)
+        .expect("Could not deserialize SnapshotManifest")
+}
+
+pub fn update_bytecode_snapshot_manifest(
+    network: &str,
+    git_revision: String,
+    version: u64,
+    files: Vec<ObjectID>,
+) {
+    let mut snapshot = load_bytecode_snapshot_manifest();
+
+    let entry = snapshot
+        .entry(network.to_owned())
+        .or_insert_with(BTreeMap::new);
+    entry.insert(
+        version,
+        SingleSnapshot {
+            git_revision,
+            package_ids: files,
+        },
+    );
+
+    let json =
+        serde_json::to_string_pretty(&snapshot).expect("Could not serialize SnapshotManifest");
+    fs::write(manifest_path(), json).expect("Could not update manifest file");
+}
 
 pub fn load_bytecode_snapshot(
     network: &str,
@@ -26,4 +71,10 @@ pub fn load_bytecode_snapshot(
         })
         .collect();
     snapshot_objects
+}
+
+fn manifest_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("bytecode_snapshot")
+        .join("manifest.json")
 }

--- a/crates/sui-framework-snapshot/tests/compatibility_tests.rs
+++ b/crates/sui-framework-snapshot/tests/compatibility_tests.rs
@@ -1,0 +1,71 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+mod compatibility_tests {
+    use std::collections::BTreeMap;
+    use sui_framework::{compare_system_package, BuiltInFramework};
+    use sui_framework_snapshot::{load_bytecode_snapshot, load_bytecode_snapshot_manifest};
+    use sui_protocol_config::{ProtocolConfig, ProtocolVersion};
+
+    #[tokio::test]
+    async fn test_framework_compatibility() {
+        // This test checks that the current framework is compatible with all previous framework
+        // bytecode snapshots.
+        for (network, snapshots) in load_bytecode_snapshot_manifest() {
+            for (version, _) in snapshots {
+                let max_binary_format_version =
+                    ProtocolConfig::get_for_version(ProtocolVersion::new(version))
+                        .move_binary_format_version();
+                let framework = load_bytecode_snapshot(&network, version).unwrap();
+                let old_framework_store: BTreeMap<_, _> = framework
+                    .into_iter()
+                    .map(|package| (*package.id(), package.genesis_object()))
+                    .collect();
+                for cur_package in BuiltInFramework::iter_system_packages() {
+                    if compare_system_package(
+                        &old_framework_store,
+                        cur_package.id(),
+                        &cur_package.modules(),
+                        cur_package.dependencies().to_vec(),
+                        max_binary_format_version,
+                    )
+                    .await
+                    .is_none()
+                    {
+                        panic!("The current {:?} Sui framework {:?} is not compatible with version {:?}",
+                               &network,
+                               cur_package.id(),
+                               version);
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn check_framework_change_with_protocol_upgrade() {
+        // This test checks that if we ever update the framework, the current protocol version must differ
+        // the latest bytecode snapshot in each network.
+        for (network, snapshots) in load_bytecode_snapshot_manifest() {
+            let latest_snapshot_version = *snapshots.keys().max().unwrap();
+            if latest_snapshot_version != ProtocolVersion::MAX.as_u64() {
+                // If we have already incremented the protocol version, then we are fine and we don't
+                // care if the framework has changed.
+                continue;
+            }
+            let latest_snapshot =
+                load_bytecode_snapshot(&network, *snapshots.keys().max().unwrap()).unwrap();
+            // Turn them into BTreeMap for deterministic comparison.
+            let latest_snapshot_ref: BTreeMap<_, _> =
+                latest_snapshot.iter().map(|p| (p.id(), p)).collect();
+            let current_framework: BTreeMap<_, _> = BuiltInFramework::iter_system_packages()
+                .map(|p| (p.id(), p))
+                .collect();
+            assert_eq!(
+                latest_snapshot_ref,
+                current_framework,
+                "The current framework differs the latest bytecode snapshot. Did you forget to upgrade protocol version?"
+            );
+        }
+    }
+}

--- a/crates/sui-framework/Cargo.toml
+++ b/crates/sui-framework/Cargo.toml
@@ -14,6 +14,7 @@ linked-hash-map = "0.5.6"
 serde = { version = "1.0.144", features = ["derive"] }
 smallvec = "1.9.0"
 once_cell = "1.16"
+tracing = "0.1.36"
 
 fastcrypto.workspace = true
 fastcrypto-zkp.workspace = true

--- a/crates/sui-types/src/storage.rs
+++ b/crates/sui-types/src/storage.rs
@@ -725,6 +725,26 @@ impl ObjectStore for BTreeMap<ObjectID, (ObjectRef, Object, WriteKind)> {
     }
 }
 
+impl ObjectStore for BTreeMap<ObjectID, Object> {
+    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
+        Ok(self.get(object_id).cloned())
+    }
+
+    fn get_object_by_key(
+        &self,
+        object_id: &ObjectID,
+        version: VersionNumber,
+    ) -> Result<Option<Object>, SuiError> {
+        Ok(self.get(object_id).and_then(|o| {
+            if o.version() == version {
+                Some(o.clone())
+            } else {
+                None
+            }
+        }))
+    }
+}
+
 impl<T: ObjectStore> ObjectStore for Arc<T> {
     fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
         self.as_ref().get_object(object_id)


### PR DESCRIPTION
This PR adds framework bytecode compatibility tests:
1. The current framework must be compatible with all previous snapshots
2. If we ever change the framework, the current protocol version must be different from the latest snapshot version (as an upgrade from the most recent snapshot).