### PR TITLE
[hardening] harden against sql injection in indexer

### DIFF
--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -4,12 +4,13 @@
 use async_trait::async_trait;
 use prometheus::Histogram;
 
+use move_core_types::identifier::Identifier;
 use sui_json_rpc_types::{
     Checkpoint as RpcCheckpoint, CheckpointId, EpochInfo, EventFilter, EventPage, MoveCallMetrics,
     NetworkMetrics, SuiObjectData, SuiObjectDataFilter, SuiTransactionBlockResponse,
     SuiTransactionBlockResponseOptions,
 };
-use sui_types::base_types::{EpochId, ObjectID, SequenceNumber, VersionNumber};
+use sui_types::base_types::{EpochId, ObjectID, SequenceNumber, SuiAddress, VersionNumber};
 use sui_types::digests::CheckpointDigest;
 use sui_types::error::SuiError;
 use sui_types::event::EventID;
@@ -127,8 +128,8 @@ pub trait IndexerStore {
 
     async fn get_transaction_page_by_sender_recipient_address(
         &self,
-        sender_address: Option<String>,
-        recipient_address: String,
+        sender_address: Option<SuiAddress>,
+        recipient_address: SuiAddress,
         start_sequence: Option<i64>,
         limit: usize,
         is_descending: bool,
@@ -136,7 +137,7 @@ pub trait IndexerStore {
 
     async fn get_transaction_page_by_input_object(
         &self,
-        object_id: String,
+        object_id: ObjectID,
         version: Option<i64>,
         start_sequence: Option<i64>,
         limit: usize,
@@ -145,9 +146,9 @@ pub trait IndexerStore {
 
     async fn get_transaction_page_by_move_call(
         &self,
-        package: String,
-        module: Option<String>,
-        function: Option<String>,
+        package: ObjectID,
+        module: Option<Identifier>,
+        function: Option<Identifier>,
         start_sequence: Option<i64>,
         limit: usize,
         is_descending: bool,

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -943,7 +943,7 @@ impl IndexerStore for PgIndexerStore {
 
     async fn get_transaction_page_by_input_object(
         &self,
-        object_id: String,
+        object_id: ObjectID,
         version: Option<i64>,
         start_sequence: Option<i64>,
         limit: usize,
@@ -951,10 +951,10 @@ impl IndexerStore for PgIndexerStore {
     ) -> Result<Vec<Transaction>, IndexerError> {
         let sql_query = format!(
             "SELECT transaction_digest as digest_name FROM (
-                SELECT transaction_digest, max(id) AS max_id 
+                SELECT transaction_digest, max(id) AS max_id
                 FROM input_objects
-                WHERE object_id = '{}' {} {} 
-                GROUP BY transaction_digest 
+                WHERE object_id = '{}' {} {}
+                GROUP BY transaction_digest
                 ORDER BY max_id {} LIMIT {}
             ) AS t",
             object_id,
@@ -985,19 +985,22 @@ impl IndexerStore for PgIndexerStore {
 
     async fn get_transaction_page_by_move_call(
         &self,
-        package_name: String,
-        module_name: Option<String>,
-        function_name: Option<String>,
+        package_name: ObjectID,
+        module_name: Option<Identifier>,
+        function_name: Option<Identifier>,
         start_sequence: Option<i64>,
         limit: usize,
         is_descending: bool,
     ) -> Result<Vec<Transaction>, IndexerError> {
+        // note: module_name and function_name are user-controlled, which is scary.
+        // however, but valid Move identifiers can only contain 0-9, a-z, A-Z, and _,
+        // so it is safe to use them as-is in the query below
         let sql_query = format!(
             "SELECT transaction_digest as digest_name FROM (
-                SELECT transaction_digest, max(id) AS max_id 
+                SELECT transaction_digest, max(id) AS max_id
                 FROM move_calls
                 WHERE move_package = '{}' {} {} {}
-                GROUP BY transaction_digest 
+                GROUP BY transaction_digest
                 ORDER BY max_id {} LIMIT {}
             ) AS t",
             package_name,
@@ -1035,8 +1038,8 @@ impl IndexerStore for PgIndexerStore {
 
     async fn get_transaction_page_by_sender_recipient_address(
         &self,
-        from: Option<String>,
-        to: String,
+        from: Option<SuiAddress>,
+        to: SuiAddress,
         start_sequence: Option<i64>,
         limit: usize,
         is_descending: bool,


### PR DESCRIPTION
- In Move call queries, use Move identifiers (which have a very restricted form) instead of arbitrary strings
- In queries that accept object ID's and addresses, use the strongly typed form to make it clear that it's safe to use in a format string
- More hardening could be done here, but this PR sticks to the obvious stuff (insisting that only strongly typed values can be piped into a SQL query created by `format!`)
  
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
