### PR TITLE
[rpc] optimize coin type checking

### DIFF
--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -226,6 +226,15 @@ impl MoveObjectType {
         }
     }
 
+    /// Return true if `self` is 0x2::coin::Coin<t>
+    pub fn is_coin_t(&self, t: &TypeTag) -> bool {
+        match &self.0 {
+            MoveObjectType_::GasCoin => GAS::is_gas_type(t),
+            MoveObjectType_::Coin(c) => t == c,
+            MoveObjectType_::StakedSui | MoveObjectType_::Other(_) => false,
+        }
+    }
+
     pub fn is_staked_sui(&self) -> bool {
         match &self.0 {
             MoveObjectType_::StakedSui => true,
@@ -379,6 +388,21 @@ impl ObjectType {
     pub fn is_gas_coin(&self) -> bool {
         match self {
             ObjectType::Struct(s) => s.is_gas_coin(),
+            ObjectType::Package => false,
+        }
+    }
+
+    pub fn is_coin(&self) -> bool {
+        match self {
+            ObjectType::Struct(s) => s.is_coin(),
+            ObjectType::Package => false,
+        }
+    }
+
+    /// Return true if `self` is 0x2::coin::Coin<t>
+    pub fn is_coin_t(&self, t: &TypeTag) -> bool {
+        match self {
+            ObjectType::Struct(s) => s.is_coin_t(t),
             ObjectType::Package => false,
         }
     }


### PR DESCRIPTION
Minimize copying of `StructTag`'s (which can be big) and eliminate conversion from `StructTag` to string.


---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
