### PR TITLE
Fix object lookup in gas computation (#10532)

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -384,20 +384,6 @@ impl AuthorityStore {
             .await
     }
 
-    pub fn get_object_by_key(
-        &self,
-        object_id: &ObjectID,
-        version: VersionNumber,
-    ) -> Result<Option<Object>, SuiError> {
-        Ok(self
-            .perpetual_tables
-            .objects
-            .get(&ObjectKey(*object_id, version))?
-            .map(|object| self.perpetual_tables.object(object))
-            .transpose()?
-            .flatten())
-    }
-
     pub fn get_object_ref_prior_to_key(
         &self,
         object_id: &ObjectID,
@@ -1523,7 +1509,13 @@ impl ObjectStore for AuthorityStore {
         object_id: &ObjectID,
         version: VersionNumber,
     ) -> Result<Option<Object>, SuiError> {
-        self.perpetual_tables.get_object_by_key(object_id, version)
+        Ok(self
+            .perpetual_tables
+            .objects
+            .get(&ObjectKey(*object_id, version))?
+            .map(|object| self.perpetual_tables.object(object))
+            .transpose()?
+            .flatten())
     }
 }
 

--- a/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -16,7 +16,7 @@ use sui_types::{
     move_package::UpgradePolicy,
     object::{Object, Owner},
     programmable_transaction_builder::ProgrammableTransactionBuilder,
-    storage::BackingPackageStore,
+    storage::{BackingPackageStore, ObjectStore},
 };
 
 use std::{

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1547,6 +1547,8 @@ impl ProtocolConfig {
                 let mut cfg = Self::get_for_version_impl(version - 1);
                 // Change reward slashing rate to 100%.
                 cfg.reward_slashing_rate = Some(10000);
+                // protect old and new lookup for object version
+                cfg.gas_model_version = Some(3);
                 cfg
             }
             // Use this template when making changes:

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_4.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_4.snap
@@ -60,7 +60,7 @@ obj_access_cost_read_per_byte: 15
 obj_access_cost_mutate_per_byte: 40
 obj_access_cost_delete_per_byte: 40
 obj_access_cost_verify_per_byte: 200
-gas_model_version: 2
+gas_model_version: 3
 obj_data_cost_refundable: 100
 obj_metadata_cost_non_refundable: 50
 storage_rebate_rate: 9900

--- a/crates/sui-types/src/gas.rs
+++ b/crates/sui-types/src/gas.rs
@@ -57,7 +57,7 @@ impl<'a> SuiGasStatus<'a> {
                 gas_price,
                 config,
             )),
-            2 => Self::V2(SuiGasStatusV2::new_with_budget(
+            2 | 3 => Self::V2(SuiGasStatusV2::new_with_budget(
                 gas_budget,
                 gas_price,
                 config,
@@ -69,7 +69,7 @@ impl<'a> SuiGasStatus<'a> {
     pub fn new_unmetered(config: &ProtocolConfig) -> Self {
         match config.gas_model_version() {
             1 => Self::V1(SuiGasStatusV1::new_unmetered()),
-            2 => Self::V2(SuiGasStatusV2::new_unmetered()),
+            2 | 3 => Self::V2(SuiGasStatusV2::new_unmetered()),
             _ => panic!("unknown gas model version"),
         }
     }
@@ -84,7 +84,7 @@ impl SuiCostTable {
     pub fn new(config: &ProtocolConfig) -> Self {
         match config.gas_model_version() {
             1 => Self::V1(SuiCostTableV1::new(config)),
-            2 => Self::V2(SuiCostTableV2::new(config)),
+            2 | 3 => Self::V2(SuiCostTableV2::new(config)),
             _ => panic!("unknown gas model version"),
         }
     }
@@ -96,7 +96,7 @@ impl SuiCostTable {
     pub fn unmetered(config: &ProtocolConfig) -> Self {
         match config.gas_model_version() {
             1 => Self::V1(SuiCostTableV1::unmetered()),
-            2 => Self::V2(SuiCostTableV2::unmetered()),
+            2 | 3 => Self::V2(SuiCostTableV2::unmetered()),
             _ => panic!("unknown gas model version"),
         }
     }

--- a/crates/sui-types/src/temporary_store.rs
+++ b/crates/sui-types/src/temporary_store.rs
@@ -950,8 +950,13 @@ impl<S: ObjectStore> TemporaryStore<S> {
     ) -> GasCostSummary {
         // at this point, we have done *all* charging for computation,
         // but have not yet set the storage rebate or storage gas units
-        debug_assert!(gas_status.storage_rebate() == 0);
-        debug_assert!(gas_status.storage_gas_units() == 0);
+        if self.protocol_config.gas_model_version() < 2 {
+            assert!(gas_status.storage_rebate() == 0);
+            assert!(gas_status.storage_gas_units() == 0);
+        } else {
+            debug_assert!(gas_status.storage_rebate() == 0);
+            debug_assert!(gas_status.storage_gas_units() == 0);
+        }
 
         if gas_object_id.is_some() {
             // bucketize computation cost
@@ -1000,11 +1005,29 @@ impl<S: ObjectStore> TemporaryStore<S> {
             old_obj.storage_rebate
         } else {
             // else, this is a dynamic field, not an input object
-            if let Ok(Some(old_obj)) = self.store.get_object_by_key(id, expected_version) {
-                old_obj.storage_rebate
+            if self.protocol_config.gas_model_version() < 2 {
+                if let Ok(Some(old_obj)) = self.store.get_object(id) {
+                    if old_obj.version() != expected_version {
+                        // not a lot we can do safely and under this condition everything is broken
+                        panic!(
+                            "Expected to find old object with version {expected_version}, found {}",
+                            old_obj.version(),
+                        );
+                    }
+                    old_obj.storage_rebate
+                } else {
+                    // not a lot we can do safely and under this condition everything is broken
+                    panic!("Looking up storage rebate of mutated object should not fail")
+                }
             } else {
-                // not a lot we can do safely and under this condition everything is broken
-                panic!("Looking up storage rebate of mutated object should not fail")
+                // let's keep the if/else on gas version well separated
+                #[allow(clippy::collapsible-else-if)]
+                if let Ok(Some(old_obj)) = self.store.get_object_by_key(id, expected_version) {
+                    old_obj.storage_rebate
+                } else {
+                    // not a lot we can do safely and under this condition everything is broken
+                    panic!("Looking up storage rebate of mutated object should not fail")
+                }
             }
         }
     }
@@ -1039,14 +1062,35 @@ impl<S: ObjectStore> TemporaryStore<S> {
                         old_obj.storage_rebate
                     } else {
                         // else, this is a dynamic field, not an input object
-                        let expected_version = object.version();
-                        if let Ok(Some(old_obj)) =
-                            self.store.get_object_by_key(object_id, expected_version)
-                        {
-                            old_obj.storage_rebate
+                        if self.protocol_config.gas_model_version() < 2 {
+                            if let Ok(Some(old_obj)) = self.store.get_object(object_id) {
+                                let expected_version = object.version();
+                                if old_obj.version() != expected_version {
+                                    // not a lot we can do safely and under this condition everything is broken
+                                    panic!(
+                                        "Expected to find old object with version {expected_version}, found {}",
+                                        old_obj.version(),
+                                    );
+                                }
+                                old_obj.storage_rebate
+                            } else {
+                                // not a lot we can do safely and under this condition everything is broken
+                                panic!(
+                                    "Looking up storage rebate of mutated object should not fail"
+                                );
+                            }
                         } else {
-                            // not a lot we can do safely and under this condition everything is broken
-                            panic!("Looking up storage rebate of mutated object should not fail");
+                            let expected_version = object.version();
+                            if let Ok(Some(old_obj)) =
+                                self.store.get_object_by_key(object_id, expected_version)
+                            {
+                                old_obj.storage_rebate
+                            } else {
+                                // not a lot we can do safely and under this condition everything is broken
+                                panic!(
+                                    "Looking up storage rebate of mutated object should not fail"
+                                );
+                            }
                         }
                     }
                 }
@@ -1111,6 +1155,7 @@ impl<S: GetModule + ObjectStore + BackingPackageStore> TemporaryStore<S> {
         do_expensive_checks: bool,
     ) -> Result<(u64, u64), ExecutionError> {
         if let Some(obj) = self.input_objects.get(id) {
+            // the assumption here is that if it is in the input objects must be the right one
             if obj.version() != expected_version {
                 return Err(ExecutionError::invariant_violation(format!("Version mismatching when resolving input object to check conservation--expected {}, got {}", expected_version, obj.version())));
             }
@@ -1126,29 +1171,58 @@ impl<S: GetModule + ObjectStore + BackingPackageStore> TemporaryStore<S> {
             Ok((input_sui, obj.storage_rebate))
         } else {
             // not in input objects, must be a dynamic field
-            let obj = self
-                .store
-                .get_object_by_key(id, expected_version)
-                .map_err(|_e| {
-                    ExecutionError::invariant_violation(
-                        "Failed looking up input object in SUI conservation checking",
-                    )
-                })?
-                .ok_or_else(|| {
-                    ExecutionError::invariant_violation(
-                        "Failed looking up input object in SUI conservation checking",
-                    )
-                })?;
-            let input_sui = if do_expensive_checks {
-                obj.get_total_sui(&self).map_err(|_e| {
-                    ExecutionError::invariant_violation(
-                        "Failed looking up output SUI in SUI conservation checking",
-                    )
-                })?
+            if self.protocol_config.gas_model_version() < 2 {
+                let obj = self
+                    .store
+                    .get_object(id)
+                    .map_err(|_e| {
+                        ExecutionError::invariant_violation(
+                            "Failed looking up input object in SUI conservation checking",
+                        )
+                    })?
+                    .ok_or_else(|| {
+                        ExecutionError::invariant_violation(
+                            "Failed looking up input object in SUI conservation checking",
+                        )
+                    })?;
+                if obj.version() != expected_version {
+                    return Err(ExecutionError::invariant_violation(format!("Version mismatching when resolving dynamic field to check conservation--expected {}, got {}", expected_version, obj.version())));
+                }
+                let input_sui = if do_expensive_checks {
+                    obj.get_total_sui(&self).map_err(|_e| {
+                        ExecutionError::invariant_violation(
+                            "Failed looking up output SUI in SUI conservation checking",
+                        )
+                    })?
+                } else {
+                    0
+                };
+                Ok((input_sui, obj.storage_rebate))
             } else {
-                0
-            };
-            Ok((input_sui, obj.storage_rebate))
+                let obj = self
+                    .store
+                    .get_object_by_key(id, expected_version)
+                    .map_err(|_e| {
+                        ExecutionError::invariant_violation(
+                            "Failed looking up input object in SUI conservation checking",
+                        )
+                    })?
+                    .ok_or_else(|| {
+                        ExecutionError::invariant_violation(
+                            "Failed looking up input object in SUI conservation checking",
+                        )
+                    })?;
+                let input_sui = if do_expensive_checks {
+                    obj.get_total_sui(&self).map_err(|_e| {
+                        ExecutionError::invariant_violation(
+                            "Failed looking up output SUI in SUI conservation checking",
+                        )
+                    })?
+                } else {
+                    0
+                };
+                Ok((input_sui, obj.storage_rebate))
+            }
         }
     }
 


### PR DESCRIPTION
@gdanezis suggested the change implemented here (if we got it right) which would fix the issue with gas computation and partly for conservation that is bugging us.
We change calls to `get_object` to use `get_object_by_key` and remove panic for version checks.
We have the version already at the point we call so we can use it and be more precise and correct.

The change ended up being more intrusive that we wanted because of traits implementation.
We would love more eyes on this to make sure things are correct

Existing tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
