### PR TITLE
indexer: parallel DB commits

### DIFF
--- a/crates/sui-indexer/benches/indexer_benchmark.rs
+++ b/crates/sui-indexer/benches/indexer_benchmark.rs
@@ -46,7 +46,7 @@ fn indexer_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("persist_checkpoint", |b| {
-        b.iter(|| rt.block_on(store.persist_checkpoint(&checkpoints.pop().unwrap())))
+        b.iter(|| rt.block_on(store.persist_all_checkpoint_data(&checkpoints.pop().unwrap())))
     });
 
     let mut checkpoints = (20..100).cycle().map(CheckpointId::SequenceNumber);
@@ -79,7 +79,7 @@ fn create_checkpoint(sequence_number: i64) -> TemporaryCheckpointStore {
             .map(|_| create_transaction(sequence_number))
             .collect(),
         events: vec![],
-        objects_changes: vec![TransactionObjectChanges {
+        object_changes: vec![TransactionObjectChanges {
             changed_objects: (1..1000).map(|_| create_object(sequence_number)).collect(),
             deleted_objects: vec![],
         }],

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -237,8 +237,6 @@ where
                 }
 
                 // Write checkpoint to DB
-                let checkpoint_db_guard = self.metrics.checkpoint_db_commit_latency.start_timer();
-
                 let TemporaryCheckpointStore {
                     checkpoint,
                     transactions,
@@ -250,10 +248,15 @@ where
                     move_calls,
                     recipients,
                 } = indexed_checkpoint;
+                let checkpoint_seq = checkpoint.sequence_number;
 
                 // NOTE: retrials are necessary here, otherwise results can be popped and discarded.
                 let object_changes_handler = self.clone();
                 spawn_monitored_task!(async move {
+                    let object_db_guard = object_changes_handler
+                        .metrics
+                        .object_db_commit_latency
+                        .start_timer();
                     let mut object_changes_commit_res = object_changes_handler
                         .state
                         .persist_object_changes(&tx_object_changes)
@@ -272,6 +275,16 @@ where
                             .persist_object_changes(&tx_object_changes)
                             .await;
                     }
+                    object_db_guard.stop_and_record();
+                    info!(
+                        "Checkpoint {} committed with {} transactions.",
+                        checkpoint_seq,
+                        tx_object_changes.len(),
+                    );
+                    object_changes_handler
+                        .metrics
+                        .total_object_change_committed
+                        .inc_by(tx_object_changes.len() as u64);
                 });
 
                 let events_handler = self.clone();
@@ -352,6 +365,8 @@ where
                     }
                 });
 
+                let checkpoint_tx_db_guard =
+                    self.metrics.checkpoint_db_commit_latency.start_timer();
                 let mut checkpoint_tx_commit_res = self
                     .state
                     .persist_checkpoint_transactions(&checkpoint, &transactions)
@@ -370,7 +385,7 @@ where
                         .persist_checkpoint_transactions(&checkpoint, &transactions)
                         .await;
                 }
-                checkpoint_db_guard.stop_and_record();
+                checkpoint_tx_db_guard.stop_and_record();
 
                 self.metrics.total_checkpoint_committed.inc();
                 let tx_count = transactions.len();
@@ -378,8 +393,8 @@ where
                     .total_transaction_committed
                     .inc_by(tx_count as u64);
                 info!(
-                    "Checkpoint {} committed with {} transactions",
-                    checkpoint.sequence_number, tx_count,
+                    "Checkpoint {} committed with {} transactions.",
+                    checkpoint_seq, tx_count,
                 );
                 self.metrics
                     .transaction_per_checkpoint

--- a/crates/sui-indexer/src/metrics.rs
+++ b/crates/sui-indexer/src/metrics.rs
@@ -20,6 +20,7 @@ pub struct IndexerCheckpointHandlerMetrics {
     pub total_checkpoint_received: IntCounter,
     pub total_checkpoint_committed: IntCounter,
     pub total_transaction_committed: IntCounter,
+    pub total_object_change_committed: IntCounter,
     pub total_epoch_committed: IntCounter,
     // checkpoint E2E latency is:
     // fullnode_download_latency + checkpoint_index_latency + db_commit_latency
@@ -29,6 +30,7 @@ pub struct IndexerCheckpointHandlerMetrics {
     pub fullnode_object_download_latency: Histogram,
     pub checkpoint_index_latency: Histogram,
     pub checkpoint_db_commit_latency: Histogram,
+    pub object_db_commit_latency: Histogram,
     pub epoch_db_commit_latency: Histogram,
     // latency of event websocket subscription
     pub subscription_process_latency: Histogram,
@@ -59,6 +61,12 @@ impl IndexerCheckpointHandlerMetrics {
             total_transaction_committed: register_int_counter_with_registry!(
                 "total_transaction_committed",
                 "Total number of transaction committed",
+                registry,
+            )
+            .unwrap(),
+            total_object_change_committed: register_int_counter_with_registry!(
+                "total_object_change_committed",
+                "Total number of object change committed",
                 registry,
             )
             .unwrap(),
@@ -106,6 +114,13 @@ impl IndexerCheckpointHandlerMetrics {
             checkpoint_db_commit_latency: register_histogram_with_registry!(
                 "checkpoint_db_commit_latency",
                 "Time spent commiting a checkpoint to the db",
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            object_db_commit_latency: register_histogram_with_registry!(
+                "object_db_commit_latency",
+                "Time spent commiting a object to the db",
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -184,10 +184,32 @@ pub trait IndexerStore {
         tx: Transaction,
         tx_object_changes: TransactionObjectChanges,
     ) -> Result<usize, IndexerError>;
-    async fn persist_checkpoint(
+    // TODO(gegaowp): keep this method in this trait for now for easier reverting,
+    // will remove it if it's no longer needed.
+    async fn persist_all_checkpoint_data(
         &self,
         data: &TemporaryCheckpointStore,
     ) -> Result<usize, IndexerError>;
+    async fn persist_checkpoint_transactions(
+        &self,
+        checkpoint: &Checkpoint,
+        transactions: &[Transaction],
+    ) -> Result<usize, IndexerError>;
+    async fn persist_object_changes(
+        &self,
+        tx_object_changes: &[TransactionObjectChanges],
+    ) -> Result<(), IndexerError>;
+    async fn persist_events(&self, events: &[Event]) -> Result<(), IndexerError>;
+    async fn persist_addresses(&self, addresses: &[Address]) -> Result<(), IndexerError>;
+    async fn persist_packages(&self, packages: &[Package]) -> Result<(), IndexerError>;
+    // NOTE: these tables are for tx query performance optimization
+    async fn persist_transaction_index_tables(
+        &self,
+        input_objects: &[InputObject],
+        move_calls: &[MoveCall],
+        recipients: &[Recipient],
+    ) -> Result<(), IndexerError>;
+
     async fn persist_epoch(&self, data: &TemporaryEpochStore) -> Result<(), IndexerError>;
 
     async fn get_epochs(
@@ -249,7 +271,7 @@ pub struct TemporaryCheckpointStore {
     pub checkpoint: Checkpoint,
     pub transactions: Vec<Transaction>,
     pub events: Vec<Event>,
-    pub objects_changes: Vec<TransactionObjectChanges>,
+    pub object_changes: Vec<TransactionObjectChanges>,
     pub addresses: Vec<Address>,
     pub packages: Vec<Package>,
     pub input_objects: Vec<InputObject>,

--- a/crates/sui-indexer/tests/integration_tests.rs
+++ b/crates/sui-indexer/tests/integration_tests.rs
@@ -1185,9 +1185,13 @@ pub mod pg_integration_test {
             start_test_cluster(Some(20000)).await;
         // Allow indexer to sync
         wait_until_next_checkpoint(&store).await;
-        let cp = store.get_latest_checkpoint_sequence_number().await.unwrap() as u64;
+        let mut cp_res = store.get_latest_checkpoint_sequence_number().await;
+        while cp_res.is_err() {
+            cp_res = store.get_latest_checkpoint_sequence_number().await;
+        }
+        let cp = cp_res.unwrap();
         let first_checkpoint = indexer_rpc_client
-            .get_checkpoint(CheckpointId::SequenceNumber(cp))
+            .get_checkpoint(CheckpointId::SequenceNumber(cp as u64))
             .await
             .unwrap();
 
@@ -1202,7 +1206,7 @@ pub mod pg_integration_test {
         // Check if checkpoint validator sig matches
         let fullnode_checkpoint = test_cluster
             .rpc_client()
-            .get_checkpoint(cp.into())
+            .get_checkpoint((cp as u64).into())
             .await
             .unwrap();
 
@@ -1299,7 +1303,11 @@ pub mod pg_integration_test {
 
     async fn wait_until_next_checkpoint(store: &PgIndexerStore) {
         let since = std::time::Instant::now();
-        let mut cp = store.get_latest_checkpoint_sequence_number().await.unwrap();
+        let mut cp_res = store.get_latest_checkpoint_sequence_number().await;
+        while cp_res.is_err() {
+            cp_res = store.get_latest_checkpoint_sequence_number().await;
+        }
+        let mut cp = cp_res.unwrap();
         let target = cp + 1;
         while cp < target {
             let now = std::time::Instant::now();
@@ -1307,20 +1315,32 @@ pub mod pg_integration_test {
                 panic!("wait_until_next_epoch timed out!");
             }
             tokio::task::yield_now().await;
-            cp = store.get_latest_checkpoint_sequence_number().await.unwrap();
+            let mut cp_res = store.get_latest_checkpoint_sequence_number().await;
+            while cp_res.is_err() {
+                cp_res = store.get_latest_checkpoint_sequence_number().await;
+            }
+            cp = cp_res.unwrap();
         }
     }
 
     async fn wait_for_checkpoint(store: &PgIndexerStore, target: i64) {
         let since = std::time::Instant::now();
-        let mut cp = store.get_latest_checkpoint_sequence_number().await.unwrap();
+        let mut cp_res = store.get_latest_checkpoint_sequence_number().await;
+        while cp_res.is_err() {
+            cp_res = store.get_latest_checkpoint_sequence_number().await;
+        }
+        let mut cp = cp_res.unwrap();
         while cp < target {
             let now = std::time::Instant::now();
             if now.duration_since(since).as_secs() > WAIT_UNTIL_TIME_LIMIT {
                 panic!("wait_until_next_epoch timed out!");
             }
             tokio::task::yield_now().await;
-            cp = store.get_latest_checkpoint_sequence_number().await.unwrap();
+            let mut cp_res = store.get_latest_checkpoint_sequence_number().await;
+            while cp_res.is_err() {
+                cp_res = store.get_latest_checkpoint_sequence_number().await;
+            }
+            cp = cp_res.unwrap();
         }
     }
 


### PR DESCRIPTION
## Description 

For data of each checkpoint, instead of committing them in one tx, this PR splits them and run parallel commits with spawned tokio tasks.

## Test Plan 

CI for correctness

Experiment on RPC-11 for benchmarking