### PR TITLE
[rpc] optimize multi_get_coin

### DIFF
--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -16,7 +16,7 @@ use sui_json_rpc_types::{Balance, Coin as SuiCoin};
 use sui_json_rpc_types::{CoinPage, SuiCoinMetadata};
 use sui_open_rpc::Module;
 use sui_types::balance::Supply;
-use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
+use sui_types::base_types::{MoveObjectType, ObjectID, ObjectRef, SuiAddress};
 use sui_types::coin::{Coin, CoinMetadata, TreasuryCap};
 use sui_types::error::{SuiError, UserInputError};
 use sui_types::gas_coin::GAS;
@@ -38,42 +38,68 @@ impl CoinReadApi {
         Self { state }
     }
 
-    fn multi_get_coin(&self, coins: &[ObjectKey]) -> Result<Vec<Result<SuiCoin, Error>>, Error> {
-        let o = self.state.database.multi_get_object_by_key(coins)?;
+    fn multi_get_coin_objects(&self, coins: &[ObjectRef]) -> Result<Vec<Object>, Error> {
+        Ok(self
+            .state
+            .database
+            .multi_get_object_by_key(&coins.iter().map(ObjectKey::from).collect::<Vec<_>>())?
+            .into_iter()
+            .zip(coins)
+            .map(|(o, (id, version, _digest))| {
+                o.ok_or(UserInputError::ObjectNotFound {
+                    object_id: *id,
+                    version: Some(*version),
+                })
+            })
+            .collect::<Result<Vec<_>, UserInputError>>()?)
+    }
+
+    /// Fetch all of the objects in `coins`. It's the caller's responsibility
+    /// to ensure that every ObjRef in `coins` is in fact a coin by using `Authority::get_owner_coin_iterator`,
+    /// and that every coin is of type `coin_type_tag`.
+    /// Note: if  we are fetching gas coins, `coin_type_tag` should be `Some(SUI)`, not `Some(Coin<SUI>)`
+    fn multi_get_coin(
+        &self,
+        coins: &[ObjectRef],
+        coin_type_tag: Option<&TypeTag>,
+    ) -> Result<Vec<Result<SuiCoin, Error>>, Error> {
+        let o = self
+            .state
+            .database
+            .multi_get_object_by_key(&coins.iter().map(ObjectKey::from).collect::<Vec<_>>())?;
+        // conversion from TypeTag to string is expensive, so do it outside the loop if we already know the coin type
+        // if coin_type_tag is None, we are getting a heterogenous mix of coins and we have no choice but to string-ify in the loop
+        let coin_type_str = coin_type_tag.map(|t| t.to_string());
 
         Ok(o.into_iter()
             .zip(coins)
-            .map(|(o, ObjectKey(id, version))| {
+            .map(|(o, (id, version, digest))| {
                 let o = o.ok_or(UserInputError::ObjectNotFound {
                     object_id: *id,
                     version: Some(*version),
                 })?;
 
                 if let Some(move_object) = o.data.try_as_move() {
-                    let (balance, locked_until_epoch) = if move_object.type_().is_coin() {
-                        let coin: Coin = bcs::from_bytes(move_object.contents())?;
-                        (coin.balance.value(), None)
-                    } else {
-                        return Err(Error::SuiError(SuiError::ObjectDeserializationError {
-                            error: format!(
-                                "{:?} is not a supported coin type",
-                                move_object.type_()
-                            ),
-                        }));
-                    };
-
-                    Ok(SuiCoin {
-                        coin_type: move_object
-                            .type_()
+                    let coin_type = coin_type_str.clone().unwrap_or_else(|| {
+                        o.type_()
+                            .unwrap()
                             .type_params()
                             .first()
                             .unwrap()
-                            .to_string(),
-                        coin_object_id: o.id(),
-                        version: o.version(),
-                        digest: o.digest(),
+                            .to_string()
+                    });
+                    let balance = {
+                        let coin: Coin = bcs::from_bytes(move_object.contents())?;
+                        coin.balance.value()
+                    };
+
+                    Ok(SuiCoin {
+                        coin_type,
+                        coin_object_id: *id,
+                        version: *version,
+                        digest: *digest,
                         balance,
-                        locked_until_epoch,
+                        locked_until_epoch: None,
                         previous_transaction: o.previous_transaction,
                     })
                 } else {
@@ -109,7 +135,7 @@ impl CoinReadApi {
         let next_cursor = coins.last().cloned().map_or(cursor, |(id, _, _)| Some(id));
 
         let data = self
-            .multi_get_coin(&coins.into_iter().map(ObjectKey::from).collect::<Vec<_>>())?
+            .multi_get_coin(&coins, coin_type)?
             .into_iter()
             .collect::<Result<Vec<_>, _>>()?;
 
@@ -221,19 +247,19 @@ impl CoinReadApiServer for CoinReadApi {
         }));
 
         // TODO: Add index to improve performance?
-        let coins = self.get_owner_coin_iterator(owner, Some(&coin_type))?;
+        let coins = self.multi_get_coin_objects(
+            &self
+                .get_owner_coin_iterator(owner, Some(&coin_type))?
+                .collect::<Vec<_>>(),
+        )?;
         let mut total_balance = 0u128;
-        let mut locked_balance = HashMap::new();
         let mut coin_object_count = 0;
-        let coins = coins.map(ObjectKey::from).collect::<Vec<_>>();
 
-        for coin in self.multi_get_coin(&coins)? {
-            let coin = coin?;
-            if let Some(lock) = coin.locked_until_epoch {
-                *locked_balance.entry(lock).or_default() += coin.balance as u128
-            } else {
-                total_balance += coin.balance as u128;
-            }
+        for coin_obj in coins {
+            // unwraps safe because get_owner_coin_iterator can only return coin objects
+            let coin: Coin =
+                bcs::from_bytes(coin_obj.data.try_as_move().unwrap().contents()).unwrap();
+            total_balance += coin.balance.value() as u128;
             coin_object_count += 1;
         }
 
@@ -241,30 +267,33 @@ impl CoinReadApiServer for CoinReadApi {
             coin_type: coin_type.to_string(),
             coin_object_count,
             total_balance,
-            locked_balance,
+            // note: LockedCoin is deprecated
+            locked_balance: Default::default(),
         })
     }
 
     fn get_all_balances(&self, owner: SuiAddress) -> RpcResult<Vec<Balance>> {
-        let coins = self
-            .get_owner_coin_iterator(owner, None)?
-            .map(ObjectKey::from)
-            .collect::<Vec<_>>();
-        let mut balances: HashMap<String, Balance> = HashMap::new();
+        let mut balances: HashMap<MoveObjectType, Balance> = HashMap::new();
+        // TODO: Add index to improve performance?
+        let coin_objs = self.multi_get_coin_objects(
+            &self
+                .get_owner_coin_iterator(owner, None)?
+                .collect::<Vec<_>>(),
+        )?;
+        for coin_obj in coin_objs {
+            // unwraps safe because get_owner_coin_iterator can only return coin objects
+            let move_obj = coin_obj.data.try_as_move().unwrap();
+            let coin_type = move_obj.type_();
+            let coin: Coin = bcs::from_bytes(move_obj.contents()).unwrap();
 
-        for coin in self.multi_get_coin(&coins)? {
-            let coin = coin?;
-            let balance = balances.entry(coin.coin_type.clone()).or_insert(Balance {
-                coin_type: coin.coin_type,
+            let balance = balances.entry(coin_type.clone()).or_insert(Balance {
+                coin_type: coin_type.to_string(),
                 coin_object_count: 0,
                 total_balance: 0,
+                // note: LockedCoin is deprecated
                 locked_balance: Default::default(),
             });
-            if let Some(lock) = coin.locked_until_epoch {
-                *balance.locked_balance.entry(lock).or_default() += coin.balance as u128
-            } else {
-                balance.total_balance += coin.balance as u128;
-            }
+            balance.total_balance += coin.balance.value() as u128;
             balance.coin_object_count += 1;
         }
         Ok(balances.into_values().collect())


### PR DESCRIPTION
- Only use `multi_get_coin` if we want to allocate + return `SuiCoin` objects
- Inside `multi_get_coin`, convert the coin type to a string once outside the loop (if possible)
- Inside `multi_get_coin`, do not recompute the object digest--pass it down from the call site instead

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
