### PR TITLE
Reduce execution failure log severity

### DIFF
--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -94,7 +94,7 @@ pub fn execute_transaction_to_effects<
             K::InvariantViolation |
             K::VMInvariantViolation => {
                 #[skip_checked_arithmetic]
-                tracing::error!(
+                tracing::debug!(
                     kind = ?error.kind(),
                     tx_digest = ?transaction_digest,
                     "INVARIANT VIOLATION! Source: {:?}",
@@ -105,7 +105,7 @@ pub fn execute_transaction_to_effects<
             K::SuiMoveVerificationError |
             K::VMVerificationOrDeserializationError => {
                 #[skip_checked_arithmetic]
-                tracing::info!(
+                tracing::debug!(
                     kind = ?error.kind(),
                     tx_digest = ?transaction_digest,
                     "Verification Error. Source: {:?}",
@@ -116,7 +116,7 @@ pub fn execute_transaction_to_effects<
             K::PublishUpgradeMissingDependency |
             K::PublishUpgradeDependencyDowngrade => {
                 #[skip_checked_arithmetic]
-                tracing::info!(
+                tracing::debug!(
                     kind = ?error.kind(),
                     tx_digest = ?transaction_digest,
                     "Publish/Upgrade Error. Source: {:?}",


### PR DESCRIPTION
## Description 

These errors are due to user requests. If we need to investigate, we can start a fullnode and enable debug logging.

## Test Plan 

n/a

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
