### PR TITLE
[execution] Invariant violations are internal errors

### DIFF
--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -94,7 +94,7 @@ pub fn execute_transaction_to_effects<
             K::InvariantViolation |
             K::VMInvariantViolation => {
                 #[skip_checked_arithmetic]
-                tracing::debug!(
+                tracing::error!(
                     kind = ?error.kind(),
                     tx_digest = ?transaction_digest,
                     "INVARIANT VIOLATION! Source: {:?}",


### PR DESCRIPTION
## Description

While the other execution error traces can be triggered by user error, it's only possible to trigger an invariant violation if there is a bug -- this should be treated as a legitimate error.

## Test Plan

CI