### PR TITLE
 [sdk] Support for upgrade programmable transaction command

### DIFF
--- a/.changeset/empty-kiwis-pull.md
+++ b/.changeset/empty-kiwis-pull.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Adding support for the `upgrade` transaction type.

--- a/crates/sui-move/src/build.rs
+++ b/crates/sui-move/src/build.rs
@@ -86,6 +86,7 @@ impl Build {
                 json!({
                     "modules": pkg.get_package_base64(with_unpublished_deps),
                     "dependencies": json!(package_dependencies),
+                    "digest": pkg.get_package_digest(with_unpublished_deps),
                 })
             )
         }

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -242,26 +242,23 @@ import {
   JsonRpcProvider,
   RawSigner,
   TransactionBlock,
-  normalizeSuiObjectId,
 } from '@mysten/sui.js';
 const { execSync } = require('child_process');
 // Generate a new Keypair
 const keypair = new Ed25519Keypair();
 const provider = new JsonRpcProvider();
 const signer = new RawSigner(keypair, provider);
-const compiledModulesAndDeps = JSON.parse(
+const { modules, dependencies } = JSON.parse(
   execSync(
     `${cliPath} move build --dump-bytecode-as-base64 --path ${packagePath}`,
     { encoding: 'utf-8' },
   ),
 );
 const tx = new TransactionBlock();
-const [upgradeCap] = tx.publish(
-  compiledModulesAndDeps.modules.map((m: any) => Array.from(fromB64(m))),
-  compiledModulesAndDeps.dependencies.map((addr: string) =>
-    normalizeSuiObjectId(addr),
-  ),
-);
+const [upgradeCap] = tx.publish({
+  modules,
+  dependencies,
+});
 tx.transferObjects([upgradeCap], tx.pure(await signer.getAddress()));
 const result = await signer.signAndExecuteTransactionBlock({
   transactionBlock: tx,

--- a/sdk/typescript/src/builder/TransactionBlock.ts
+++ b/sdk/typescript/src/builder/TransactionBlock.ts
@@ -327,6 +327,9 @@ export class TransactionBlock {
   publish(...args: Parameters<(typeof Transactions)['Publish']>) {
     return this.add(Transactions.Publish(...args));
   }
+  upgrade(...args: Parameters<(typeof Transactions)['Upgrade']>) {
+    return this.add(Transactions.Upgrade(...args));
+  }
   moveCall(...args: Parameters<(typeof Transactions)['MoveCall']>) {
     return this.add(Transactions.MoveCall(...args));
   }

--- a/sdk/typescript/src/builder/TransactionBlock.ts
+++ b/sdk/typescript/src/builder/TransactionBlock.ts
@@ -658,7 +658,7 @@ export class TransactionBlock {
         });
         if (dryRunResult.effects.status.status !== 'success') {
           throw new Error(
-            'Dry run failed, could not automatically determine a budget',
+            `Dry run failed, could not automatically determine a budget: ${dryRunResult.effects.status.error}`,
             { cause: dryRunResult },
           );
         }

--- a/sdk/typescript/src/builder/Transactions.ts
+++ b/sdk/typescript/src/builder/Transactions.ts
@@ -109,12 +109,23 @@ export const PublishTransaction = object({
 });
 export type PublishTransaction = Infer<typeof PublishTransaction>;
 
+export const UpgradeTransaction = object({
+  kind: literal('Upgrade'),
+  modules: array(array(integer())),
+  dependencies: array(ObjectId),
+  package_id: ObjectId,
+  ticket: TransactionArgument,
+});
+export type UpgradeTransaction = Infer<typeof UpgradeTransaction>;
+
+
 const TransactionTypes = [
   MoveCallTransaction,
   TransferObjectsTransaction,
   SplitCoinsTransaction,
   MergeCoinsTransaction,
   PublishTransaction,
+  UpgradeTransaction,
   MakeMoveVecTransaction,
 ] as const;
 
@@ -174,6 +185,17 @@ export const Transactions = {
     return create(
       { kind: 'Publish', modules, dependencies },
       PublishTransaction,
+    );
+  },
+  Upgrade(
+    modules: number[][],
+    dependencies: ObjectId[],
+    package_id: ObjectId,
+    ticket: TransactionArgument,
+  ): UpgradeTransaction {
+    return create(
+      { kind: 'Upgrade', modules, dependencies, package_id, ticket },
+      UpgradeTransaction,
     );
   },
   MakeMoveVec({

--- a/sdk/typescript/src/builder/Transactions.ts
+++ b/sdk/typescript/src/builder/Transactions.ts
@@ -109,7 +109,8 @@ export const PublishTransaction = object({
 });
 export type PublishTransaction = Infer<typeof PublishTransaction>;
 
-// Keep this value in sync with the one in crates/sui-types/src/move_package.rs
+// Keep in sync with constants in
+// crates/sui-framework/packages/sui-framework/sources/package.move
 export enum UpgradePolicy {
   COMPATIBLE = 0,
   ADDITIVE = 128,

--- a/sdk/typescript/src/builder/Transactions.ts
+++ b/sdk/typescript/src/builder/Transactions.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { BCS } from '@mysten/bcs';
+import { BCS, fromB64 } from '@mysten/bcs';
 import {
   is,
   any,
@@ -17,7 +17,7 @@ import {
   Struct,
   define,
 } from 'superstruct';
-import { ObjectId } from '../types/common';
+import { ObjectId, normalizeSuiObjectId } from '../types/common';
 import { TRANSACTION_TYPE, WellKnownEncoding, create } from './utils';
 
 const option = <T extends Struct<any, any>>(some: T) =>
@@ -109,15 +109,21 @@ export const PublishTransaction = object({
 });
 export type PublishTransaction = Infer<typeof PublishTransaction>;
 
+// Keep this value in sync with the one in crates/sui-types/src/move_package.rs
+export enum UpgradePolicy {
+  COMPATIBLE = 0,
+  ADDITIVE = 128,
+  DEP_ONLY = 192,
+}
+
 export const UpgradeTransaction = object({
   kind: literal('Upgrade'),
   modules: array(array(integer())),
   dependencies: array(ObjectId),
-  package_id: ObjectId,
-  ticket: TransactionArgument,
+  packageId: ObjectId,
+  ticket: ObjectTransactionArgument,
 });
 export type UpgradeTransaction = Infer<typeof UpgradeTransaction>;
-
 
 const TransactionTypes = [
   MoveCallTransaction,
@@ -181,20 +187,45 @@ export const Transactions = {
       MergeCoinsTransaction,
     );
   },
-  Publish(modules: number[][], dependencies: ObjectId[]): PublishTransaction {
+  Publish({
+    modules,
+    dependencies,
+  }: {
+    modules: number[][] | string[];
+    dependencies: ObjectId[];
+  }): PublishTransaction {
     return create(
-      { kind: 'Publish', modules, dependencies },
+      {
+        kind: 'Publish',
+        modules: modules.map((module) =>
+          typeof module === 'string' ? Array.from(fromB64(module)) : module,
+        ),
+        dependencies: dependencies.map((dep) => normalizeSuiObjectId(dep)),
+      },
       PublishTransaction,
     );
   },
-  Upgrade(
-    modules: number[][],
-    dependencies: ObjectId[],
-    package_id: ObjectId,
-    ticket: TransactionArgument,
-  ): UpgradeTransaction {
+  Upgrade({
+    modules,
+    dependencies,
+    packageId,
+    ticket,
+  }: {
+    modules: number[][] | string[];
+    dependencies: ObjectId[];
+    packageId: ObjectId;
+    ticket: TransactionArgument;
+  }): UpgradeTransaction {
     return create(
-      { kind: 'Upgrade', modules, dependencies, package_id, ticket },
+      {
+        kind: 'Upgrade',
+        modules: modules.map((module) =>
+          typeof module === 'string' ? Array.from(fromB64(module)) : module,
+        ),
+        dependencies: dependencies.map((dep) => normalizeSuiObjectId(dep)),
+        packageId,
+        ticket,
+      },
       UpgradeTransaction,
     );
   },

--- a/sdk/typescript/src/builder/bcs.ts
+++ b/sdk/typescript/src/builder/bcs.ts
@@ -49,6 +49,7 @@ export const builder = new BCS(bcs)
     type_arguments: [VECTOR, TYPE_TAG],
     arguments: [VECTOR, ARGUMENT],
   })
+  // Keep this in sync with crates/sui-types/src/messages.rs
   .registerEnumType(TRANSACTION_INNER, {
     /**
      * A Move Call - any public Move function can be called via
@@ -86,6 +87,13 @@ export const builder = new BCS(bcs)
     MakeMoveVec: {
       type: [OPTION, TYPE_TAG],
       objects: [VECTOR, ARGUMENT],
+    },
+    /**  */
+    Upgrade: {
+      modules: [VECTOR, [VECTOR, BCS.U8]],
+      dependencies: [VECTOR, BCS.ADDRESS],
+      packageId: BCS.ADDRESS,
+      ticket: ARGUMENT,
     },
   });
 

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -82,6 +82,9 @@ export const SuiTransaction = union([
   object({ SplitCoins: tuple([SuiArgument, array(SuiArgument)]) }),
   object({ MergeCoins: tuple([SuiArgument, array(SuiArgument)]) }),
   object({ Publish: tuple([SuiMovePackage, array(ObjectId)]) }),
+  object({
+    Upgrade: tuple([SuiMovePackage, array(ObjectId), ObjectId, SuiArgument]),
+  }),
   object({ MakeMoveVec: tuple([nullable(string()), array(SuiArgument)]) }),
 ]);
 

--- a/sdk/typescript/test/e2e/data/serializer_upgrade/Move.toml
+++ b/sdk/typescript/test/e2e/data/serializer_upgrade/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "serializer"
+version = "0.0.2"
+
+[dependencies]
+Sui = { local = "../../../../../../crates/sui-framework/packages/sui-framework" }
+
+[addresses]
+serializer =  "0x0"

--- a/sdk/typescript/test/e2e/data/serializer_upgrade/sources/serializer.move
+++ b/sdk/typescript/test/e2e/data/serializer_upgrade/sources/serializer.move
@@ -35,14 +35,14 @@ module serializer::serializer_tests {
     }
 
     public entry fun value(clock: &MutableShared) {
-        assert!(clock.value > 0, 1);
+        assert!(clock.value > 10, 2);
     }
 
     public entry fun set_value(clock: &mut MutableShared) {
-        clock.value = 10;
+        clock.value = 20;
     }
 
     public fun test_abort() {
-        abort 0
+        abort 1
     }
 }

--- a/sdk/typescript/test/e2e/txn-builder.test.ts
+++ b/sdk/typescript/test/e2e/txn-builder.test.ts
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { is } from 'superstruct';
+
 import {
   getExecutionStatusType,
   getObjectId,
@@ -15,6 +17,7 @@ import {
   SuiObjectData,
   getCreatedObjects,
   SUI_CLOCK_OBJECT_ID,
+  SuiObjectChangeCreated,
 } from '../../src';
 import {
   DEFAULT_RECIPIENT,
@@ -142,6 +145,48 @@ describe('Transaction Builders', () => {
     });
     await validateTransaction(toolbox.signer, tx);
   });
+
+  it('Publish and Upgrade Package', async () => {
+    // Step 1. Publish the package
+    const originalPackagePath = __dirname + '/./data/serializer';
+    const { packageId, publishTxn } = await publishPackage(
+      originalPackagePath,
+      toolbox,
+    );
+
+    const capId = (publishTxn.objectChanges?.find((a) =>
+      is(a, SuiObjectChangeCreated) &&
+      a.objectType.endsWith("UpgradeCap") &&
+      'Immutable' !== a.owner &&
+      'AddressOwner' in a.owner &&
+      a.owner.AddressOwner === toolbox.address()
+    ) as SuiObjectChangeCreated)?.objectId;
+
+    expect(capId).toBeTruthy();
+
+    const sharedObjectId = getObjectId(getCreatedObjects(publishTxn)!
+      .filter((o) => getSharedObjectInitialVersion(o.owner) !== undefined,
+    )[0]);
+
+    // Step 2. Confirm that its functions work as expected in its
+    // first version
+    let callOrigTx = new TransactionBlock();
+    callOrigTx.moveCall({
+      target: `${packageId}::serializer_tests::value`,
+      arguments: [callOrigTx.object(sharedObjectId)],
+    });
+    callOrigTx.moveCall({
+      target: `${packageId}::serializer_tests::set_value`,
+      arguments: [callOrigTx.object(sharedObjectId)],
+    });
+    await validateTransaction(toolbox.signer, callOrigTx);
+
+    // Step 3. Publish the upgrade for the package.
+    const upgradedPackagePath = __dirname + '/./data/serializer_upgrade';
+
+    // Step 4. Make sure the behaviour of the upgrade package matches
+    // the newly introduced function
+  })
 });
 
 async function validateTransaction(signer: RawSigner, tx: TransactionBlock) {

--- a/sdk/typescript/test/e2e/txn-builder.test.ts
+++ b/sdk/typescript/test/e2e/txn-builder.test.ts
@@ -25,6 +25,7 @@ import {
   setup,
   TestToolbox,
   publishPackage,
+  upgradePackage,
 } from './utils/setup';
 
 describe('Transaction Builders', () => {
@@ -154,19 +155,24 @@ describe('Transaction Builders', () => {
       toolbox,
     );
 
-    const capId = (publishTxn.objectChanges?.find((a) =>
-      is(a, SuiObjectChangeCreated) &&
-      a.objectType.endsWith("UpgradeCap") &&
-      'Immutable' !== a.owner &&
-      'AddressOwner' in a.owner &&
-      a.owner.AddressOwner === toolbox.address()
-    ) as SuiObjectChangeCreated)?.objectId;
+    const capId = (
+      publishTxn.objectChanges?.find(
+        (a) =>
+          is(a, SuiObjectChangeCreated) &&
+          a.objectType.endsWith('UpgradeCap') &&
+          'Immutable' !== a.owner &&
+          'AddressOwner' in a.owner &&
+          a.owner.AddressOwner === toolbox.address(),
+      ) as SuiObjectChangeCreated
+    )?.objectId;
 
     expect(capId).toBeTruthy();
 
-    const sharedObjectId = getObjectId(getCreatedObjects(publishTxn)!
-      .filter((o) => getSharedObjectInitialVersion(o.owner) !== undefined,
-    )[0]);
+    const sharedObjectId = getObjectId(
+      getCreatedObjects(publishTxn)!.filter(
+        (o) => getSharedObjectInitialVersion(o.owner) !== undefined,
+      )[0],
+    );
 
     // Step 2. Confirm that its functions work as expected in its
     // first version
@@ -186,7 +192,8 @@ describe('Transaction Builders', () => {
 
     // Step 4. Make sure the behaviour of the upgrade package matches
     // the newly introduced function
-  })
+    await upgradePackage(packageId, capId, upgradedPackagePath, toolbox);
+  });
 });
 
 async function validateTransaction(signer: RawSigner, tx: TransactionBlock) {

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -114,7 +114,7 @@ export async function publishPackage(
 
   const tmpobj = tmp.dirSync({ unsafeCleanup: true });
 
-  const compiledModulesAndDeps = JSON.parse(
+  const { modules, dependencies } = JSON.parse(
     execSync(
       `${SUI_BIN} move build --dump-bytecode-as-base64 --path ${packagePath} --install-dir ${tmpobj.name}`,
       { encoding: 'utf-8' },
@@ -122,10 +122,8 @@ export async function publishPackage(
   );
   const tx = new TransactionBlock();
   const cap = tx.publish(
-    compiledModulesAndDeps.modules.map((m: any) => Array.from(fromB64(m))),
-    compiledModulesAndDeps.dependencies.map((addr: string) =>
-      normalizeSuiObjectId(addr),
-    ),
+    modules.map((m: any) => Array.from(fromB64(m))),
+    dependencies.map((addr: string) => normalizeSuiObjectId(addr)),
   );
 
   // Transfer the upgrade capability to the sender so they can upgrade the package later if they want.
@@ -152,6 +150,17 @@ export async function publishPackage(
 
   return { packageId, publishTxn };
 }
+
+export async function upgradePackage(
+  packageId: ObjectId,
+  capId: ObjectId,
+  packagePath: string,
+  toolbox?: TestToolbox,
+) {
+  // TODO: Finish
+}
+
+
 
 export function getRandomAddresses(n: number): SuiAddress[] {
   return Array(n)


### PR DESCRIPTION
## Description 

Add support to the TypeScript SDK for adding `upgrade` commands into programmable transactions.  This enables the creation and use of custom upgrade policies (which require the creation of programmable transactions that call into their custom Move code to authorize and commit upgrades).

## Test Plan 

New E2E test exercise upgrades:

```
$ pnpm sdk prepare:e2e # in one shell
$ pnpm sdk test:e2e # in another
```
