### PR TITLE
Less verbose logging in checkpoint executor

### DIFF
--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -616,21 +616,8 @@ async fn handle_execution_effects(
                 // all of its input available.
                 let pending_digest = missing_digests.first().unwrap();
                 let missing_input = transaction_manager.get_missing_input(pending_digest);
-                let pending_transaction = authority_store
-                    .get_transaction_block(pending_digest)
-                    .expect("get_transaction_block cannot fail")
-                    .expect("state-sync should have ensured that the transaction exists");
 
-                warn!(
-                    "Transaction {pending_digest:?} has missing input objects {missing_input:?}\
-                     \nTransaction input: {:?}\nTransaction content: {:?}",
-                    pending_transaction
-                        .data()
-                        .intent_message()
-                        .value
-                        .input_objects(),
-                    pending_transaction,
-                );
+                warn!("Transaction {pending_digest:?} has missing input objects {missing_input:?}");
                 periods += 1;
             }
             Ok(Err(err)) => panic!("Failed to notify_read_executed_effects: {:?}", err),


### PR DESCRIPTION
It's not a good practice to use "\n" in logging because they would become separate lines from the original logging line.
In this case, it's also not needed to print out the transaction content because with the digest we could easily fetch the transaction through other means.
Let me know if this makes sense.