### PR TITLE
[explorer]: fix types for metric response

### DIFF
--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -819,6 +819,7 @@ export class JsonRpcProvider {
       'suix_getNetworkMetrics',
       [],
       NetworkMetrics,
+      this.options.skipDataValidation,
     );
   }
   /**


### PR DESCRIPTION
## Description 

- network metric needs to skip data validation
- https://mysten.atlassian.net/browse/APPS-749

```
{
    "currentTps": 14.9,
    "tps30Days": 79.1,
    "totalPackages": 22634,
    "totalAddresses": 514446,
    "totalObjects": 23479280,
    "currentEpoch": 13,
    "currentCheckpoint": 1263662
}
```

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
