### PR TITLE
Coin index

### DIFF
--- a/crates/sui-cluster-test/src/test_case.rs
+++ b/crates/sui-cluster-test/src/test_case.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod coin_index_test;
 pub mod coin_merge_split_test;
 pub mod fullnode_build_publish_transaction_test;
 pub mod fullnode_execute_transaction_test;

--- a/crates/sui-cluster-test/src/test_case/coin_index_test.rs
+++ b/crates/sui-cluster-test/src/test_case/coin_index_test.rs
@@ -1,0 +1,703 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{TestCaseImpl, TestContext};
+use async_trait::async_trait;
+use jsonrpsee::rpc_params;
+use move_core_types::language_storage::StructTag;
+use serde_json::json;
+use std::collections::HashMap;
+use sui_core::test_utils::compile_managed_coin_package;
+use sui_json::SuiJsonValue;
+use sui_json_rpc_types::ObjectChange;
+use sui_json_rpc_types::SuiTransactionBlockResponse;
+use sui_json_rpc_types::{Balance, SuiTransactionBlockResponseOptions};
+use sui_types::base_types::{ObjectID, ObjectRef};
+use sui_types::gas_coin::GAS;
+use sui_types::messages::ExecuteTransactionRequestType;
+use sui_types::object::Owner;
+use test_utils::messages::make_staking_transaction_with_wallet_context;
+use tracing::info;
+
+pub struct CoinIndexTest;
+
+#[async_trait]
+impl TestCaseImpl for CoinIndexTest {
+    fn name(&self) -> &'static str {
+        "CoinIndex"
+    }
+
+    fn description(&self) -> &'static str {
+        "Test coin index"
+    }
+
+    async fn run(&self, ctx: &mut TestContext) -> Result<(), anyhow::Error> {
+        let account = ctx.get_wallet_address();
+        let client = ctx.clone_fullnode_client();
+        let rgp = ctx.get_reference_gas_price().await;
+
+        // 0. Get some coins first
+        ctx.get_sui_from_faucet(None).await;
+
+        // Record initial balances
+        let Balance {
+            coin_object_count: mut old_coin_object_count,
+            total_balance: mut old_total_balance,
+            ..
+        } = client.coin_read_api().get_balance(account, None).await?;
+
+        // 1. Exeute one transfer coin transation (to another address)
+        let txn = ctx.make_transactions(1).await.swap_remove(0);
+        let response = client
+            .quorum_driver()
+            .execute_transaction_block(
+                txn,
+                SuiTransactionBlockResponseOptions::new()
+                    .with_effects()
+                    .with_balance_changes(),
+                Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+            )
+            .await?;
+
+        let balance_change = response.balance_changes.unwrap();
+        let owner_balance = balance_change
+            .iter()
+            .find(|b| b.owner == Owner::AddressOwner(account))
+            .unwrap();
+        let recipient_balance = balance_change
+            .iter()
+            .find(|b| b.owner != Owner::AddressOwner(account))
+            .unwrap();
+        let Balance {
+            coin_object_count,
+            total_balance,
+            coin_type,
+            ..
+        } = client.coin_read_api().get_balance(account, None).await?;
+        assert_eq!(coin_type, GAS::type_().to_string());
+
+        assert_eq!(coin_object_count, old_coin_object_count);
+        assert_eq!(
+            total_balance,
+            (old_total_balance as i128 + owner_balance.amount) as u128
+        );
+        old_coin_object_count = coin_object_count;
+        old_total_balance = total_balance;
+
+        let Balance {
+            coin_object_count,
+            total_balance,
+            ..
+        } = client
+            .coin_read_api()
+            .get_balance(recipient_balance.owner.get_owner_address().unwrap(), None)
+            .await?;
+        assert_eq!(coin_object_count, 1);
+        assert!(recipient_balance.amount > 0);
+        assert_eq!(total_balance, recipient_balance.amount as u128);
+
+        // 2. Test Staking
+        let validator_addr = ctx
+            .get_latest_sui_system_state()
+            .await
+            .active_validators
+            .get(0)
+            .unwrap()
+            .sui_address;
+        let txn =
+            make_staking_transaction_with_wallet_context(ctx.get_wallet_mut(), validator_addr)
+                .await;
+
+        let response = client
+            .quorum_driver()
+            .execute_transaction_block(
+                txn,
+                SuiTransactionBlockResponseOptions::new()
+                    .with_effects()
+                    .with_balance_changes(),
+                Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+            )
+            .await?;
+
+        let balance_change = &response.balance_changes.unwrap()[0];
+        assert_eq!(balance_change.owner, Owner::AddressOwner(account));
+
+        let Balance {
+            coin_object_count,
+            total_balance,
+            ..
+        } = client.coin_read_api().get_balance(account, None).await?;
+        assert_eq!(coin_object_count, old_coin_object_count - 1); // an object is staked
+        assert_eq!(
+            total_balance,
+            (old_total_balance as i128 + balance_change.amount) as u128,
+            "total_balance: {}, old_total_balance: {}, sui_balance_change.amount: {}",
+            total_balance,
+            old_total_balance,
+            balance_change.amount
+        );
+        old_coin_object_count = coin_object_count;
+
+        // 3. Publish a new token package MANAGED
+        let (package, cap, envelope) = publish_managed_coin_package(ctx).await?;
+        let Balance { total_balance, .. } =
+            client.coin_read_api().get_balance(account, None).await?;
+        old_total_balance = total_balance;
+
+        info!(
+            "token package published, package: {:?}, cap: {:?}",
+            package, cap
+        );
+        let sui_type_str = "0x2::sui::SUI";
+        let coin_type_str = format!("{}::managed::MANAGED", package.0);
+        info!("coin type: {}", coin_type_str);
+
+        // 4. Mint 1 MANAGED coin to account, balance 10000
+        let args = vec![
+            SuiJsonValue::from_object_id(cap.0),
+            SuiJsonValue::new(json!("10000"))?,
+            SuiJsonValue::new(json!(account))?,
+        ];
+        let txn = client
+            .transaction_builder()
+            .move_call(
+                account,
+                package.0,
+                "managed",
+                "mint",
+                vec![],
+                args,
+                None,
+                rgp * 2_000_000,
+            )
+            .await
+            .unwrap();
+        let response = ctx.sign_and_execute(txn, "mint managed coin to self").await;
+
+        let balance_changes = &response.balance_changes.unwrap();
+        let sui_balance_change = balance_changes
+            .iter()
+            .find(|b| b.coin_type.to_string().contains("SUI"))
+            .unwrap();
+        let managed_balance_change = balance_changes
+            .iter()
+            .find(|b| b.coin_type.to_string().contains("MANAGED"))
+            .unwrap();
+
+        assert_eq!(sui_balance_change.owner, Owner::AddressOwner(account));
+        assert_eq!(managed_balance_change.owner, Owner::AddressOwner(account));
+
+        let Balance { total_balance, .. } =
+            client.coin_read_api().get_balance(account, None).await?;
+        assert_eq!(coin_object_count, old_coin_object_count);
+        assert_eq!(
+            total_balance,
+            (old_total_balance as i128 + sui_balance_change.amount) as u128,
+            "total_balance: {}, old_total_balance: {}, sui_balance_change.amount: {}",
+            total_balance,
+            old_total_balance,
+            sui_balance_change.amount
+        );
+        old_coin_object_count = coin_object_count;
+
+        let Balance {
+            coin_object_count: managed_coin_object_count,
+            total_balance: managed_total_balance,
+            // Important: update coin_type_str here because the leading 0s are truncated!
+            coin_type: coin_type_str,
+            ..
+        } = client
+            .coin_read_api()
+            .get_balance(account, Some(coin_type_str.clone()))
+            .await?;
+        assert_eq!(managed_coin_object_count, 1); // minted one object
+        assert_eq!(
+            managed_total_balance,
+            10000, // mint amount
+        );
+
+        let balances = client.coin_read_api().get_all_balances(account).await?;
+        // Comes with asc order.
+        assert_eq!(
+            balances,
+            vec![
+                Balance {
+                    coin_type: sui_type_str.into(),
+                    coin_object_count: old_coin_object_count,
+                    total_balance,
+                    locked_balance: HashMap::new(),
+                },
+                Balance {
+                    coin_type: coin_type_str.clone(),
+                    coin_object_count: 1,
+                    total_balance: 10000,
+                    locked_balance: HashMap::new(),
+                },
+            ],
+        );
+
+        // 5. Mint another MANAGED coin to account, balance 10
+        let txn = client
+            .transaction_builder()
+            .move_call(
+                account,
+                package.0,
+                "managed",
+                "mint",
+                vec![],
+                vec![
+                    SuiJsonValue::from_object_id(cap.0),
+                    SuiJsonValue::new(json!("10"))?,
+                    SuiJsonValue::new(json!(account))?,
+                ],
+                None,
+                rgp * 2_000_000,
+            )
+            .await
+            .unwrap();
+        let response = ctx.sign_and_execute(txn, "mint managed coin to self").await;
+        assert!(response.status_ok().unwrap());
+
+        let managed_balance = client
+            .coin_read_api()
+            .get_balance(account, Some(coin_type_str.clone()))
+            .await
+            .unwrap();
+        let managed_coins = client
+            .coin_read_api()
+            .get_coins(account, Some(coin_type_str.clone()), None, None)
+            .await
+            .unwrap()
+            .data;
+        assert_eq!(managed_balance.total_balance, 10000 + 10);
+        assert_eq!(managed_balance.coin_object_count, 1 + 1);
+        assert_eq!(managed_coins.len(), 1 + 1);
+        let managed_old_total_balance = managed_balance.total_balance;
+        let managed_old_total_count = managed_balance.coin_object_count;
+
+        // 6. Put the balance 10 MANAGED coin into the envelope
+        let managed_coin_id = managed_coins
+            .iter()
+            .find(|c| c.balance == 10)
+            .unwrap()
+            .coin_object_id;
+        let managed_coin_id_10k = managed_coins
+            .iter()
+            .find(|c| c.balance == 10000)
+            .unwrap()
+            .coin_object_id;
+        let _ = add_to_envelope(ctx, package.0, envelope.0, managed_coin_id).await;
+
+        let managed_balance = client
+            .coin_read_api()
+            .get_balance(account, Some(coin_type_str.clone()))
+            .await
+            .unwrap();
+        assert_eq!(
+            managed_balance.total_balance,
+            managed_old_total_balance - 10
+        );
+        assert_eq!(
+            managed_balance.coin_object_count,
+            managed_old_total_count - 1
+        );
+        let managed_old_total_balance = managed_balance.total_balance;
+        let managed_old_total_count = managed_balance.coin_object_count;
+
+        // 7. take back the balance 10 MANAGED coin
+        let args = vec![SuiJsonValue::from_object_id(envelope.0)];
+        let txn = client
+            .transaction_builder()
+            .move_call(
+                account,
+                package.0,
+                "managed",
+                "take_from_envelope",
+                vec![],
+                args,
+                None,
+                rgp * 2_000_000,
+            )
+            .await
+            .unwrap();
+        let response = ctx
+            .sign_and_execute(txn, "take back managed coin from envelope")
+            .await;
+        assert!(response.status_ok().unwrap());
+        let managed_balance = client
+            .coin_read_api()
+            .get_balance(account, Some(coin_type_str.clone()))
+            .await
+            .unwrap();
+        assert_eq!(
+            managed_balance.total_balance,
+            managed_old_total_balance + 10
+        );
+        assert_eq!(
+            managed_balance.coin_object_count,
+            managed_old_total_count + 1
+        );
+
+        // 8. Put the balance = 10 MANAGED coin back to envelope
+        let _ = add_to_envelope(ctx, package.0, envelope.0, managed_coin_id).await;
+
+        // 9. Take from envelope and burn
+        let txn = client
+            .transaction_builder()
+            .move_call(
+                account,
+                package.0,
+                "managed",
+                "take_from_envelope_and_burn",
+                vec![],
+                vec![
+                    SuiJsonValue::from_object_id(cap.0),
+                    SuiJsonValue::from_object_id(envelope.0),
+                ],
+                None,
+                rgp * 2_000_000,
+            )
+            .await
+            .unwrap();
+        let response = ctx
+            .sign_and_execute(txn, "take back managed coin from envelope and burn")
+            .await;
+        assert!(response.status_ok().unwrap());
+        let managed_balance = client
+            .coin_read_api()
+            .get_balance(account, Some(coin_type_str.clone()))
+            .await
+            .unwrap();
+        // Values are the same as in the end of step 6
+        assert_eq!(managed_balance.total_balance, managed_old_total_balance);
+        assert_eq!(managed_balance.coin_object_count, managed_old_total_count);
+
+        // 10. Burn the balance=10000 MANAGED coin
+        let txn = client
+            .transaction_builder()
+            .move_call(
+                account,
+                package.0,
+                "managed",
+                "burn",
+                vec![],
+                vec![
+                    SuiJsonValue::from_object_id(cap.0),
+                    SuiJsonValue::from_object_id(managed_coin_id_10k),
+                ],
+                None,
+                rgp * 2_000_000,
+            )
+            .await
+            .unwrap();
+        let response = ctx.sign_and_execute(txn, "burn coin").await;
+        assert!(response.status_ok().unwrap());
+        let managed_balance = client
+            .coin_read_api()
+            .get_balance(account, Some(coin_type_str.clone()))
+            .await
+            .unwrap();
+        assert_eq!(managed_balance.total_balance, 0);
+        assert_eq!(managed_balance.coin_object_count, 0);
+
+        // =========================== Test Get Coins Starts ===========================
+
+        let sui_coins = client
+            .coin_read_api()
+            .get_coins(account, Some(sui_type_str.into()), None, None)
+            .await
+            .unwrap()
+            .data;
+
+        assert_eq!(
+            sui_coins,
+            client
+                .coin_read_api()
+                .get_coins(account, None, None, None)
+                .await
+                .unwrap()
+                .data,
+        );
+        assert_eq!(
+            // this is only SUI coins at the moment
+            sui_coins,
+            client
+                .coin_read_api()
+                .get_all_coins(account, None, None)
+                .await
+                .unwrap()
+                .data,
+        );
+
+        let sui_balance = client
+            .coin_read_api()
+            .get_balance(account, None)
+            .await
+            .unwrap();
+        assert_eq!(
+            sui_balance.total_balance,
+            sui_coins.iter().map(|c| c.balance as u128).sum::<u128>()
+        );
+
+        // 11. Mint 100 MANAGED coins with balance 5
+        let txn = client
+            .transaction_builder()
+            .move_call(
+                account,
+                package.0,
+                "managed",
+                "mint_multi",
+                vec![],
+                vec![
+                    SuiJsonValue::from_object_id(cap.0),
+                    SuiJsonValue::new(json!("5"))?,   // balance = 5
+                    SuiJsonValue::new(json!("100"))?, // num = 100
+                    SuiJsonValue::new(json!(account))?,
+                ],
+                None,
+                rgp * 2_000_000,
+            )
+            .await
+            .unwrap();
+        let response = ctx.sign_and_execute(txn, "multi mint").await;
+        assert!(response.status_ok().unwrap());
+
+        let sui_coins = client
+            .coin_read_api()
+            .get_coins(account, Some(sui_type_str.into()), None, None)
+            .await
+            .unwrap()
+            .data;
+
+        // No more even if ask for more
+        assert_eq!(
+            sui_coins,
+            client
+                .coin_read_api()
+                .get_coins(account, None, None, Some(sui_coins.len() + 1))
+                .await
+                .unwrap()
+                .data,
+        );
+
+        let managed_coins = client
+            .coin_read_api()
+            .get_coins(account, Some(coin_type_str.clone()), None, None)
+            .await
+            .unwrap()
+            .data;
+        let first_managed_coin = managed_coins.first().unwrap().coin_object_id;
+        let last_managed_coin = managed_coins.last().unwrap().coin_object_id;
+
+        assert_eq!(managed_coins.len(), 100);
+        assert!(managed_coins.iter().all(|c| c.balance == 5));
+
+        assert_eq!(
+            sui_coins.len() + managed_coins.len(),
+            client
+                .coin_read_api()
+                .get_all_coins(account, None, None)
+                .await
+                .unwrap()
+                .data
+                .len(),
+        );
+
+        let sui_coins_with_managed_coin_1 = client
+            .coin_read_api()
+            .get_all_coins(account, None, Some(sui_coins.len() + 1))
+            .await
+            .unwrap();
+        assert_eq!(
+            sui_coins_with_managed_coin_1.data.len(),
+            sui_coins.len() + 1
+        );
+        assert_eq!(
+            sui_coins_with_managed_coin_1.next_cursor,
+            Some(first_managed_coin)
+        );
+        assert!(sui_coins_with_managed_coin_1.has_next_page);
+        let cursor = sui_coins_with_managed_coin_1.next_cursor;
+
+        let managed_coins_2_11 = client
+            .coin_read_api()
+            .get_all_coins(account, cursor, Some(10))
+            .await
+            .unwrap();
+        assert_eq!(
+            managed_coins_2_11,
+            client
+                .coin_read_api()
+                .get_coins(account, Some(coin_type_str.clone()), cursor, Some(10))
+                .await
+                .unwrap(),
+        );
+
+        assert_eq!(managed_coins_2_11.data.len(), 10);
+        assert_ne!(
+            managed_coins_2_11.data.first().unwrap().coin_object_id,
+            first_managed_coin
+        );
+        assert!(managed_coins_2_11.has_next_page);
+        let cursor = managed_coins_2_11.next_cursor;
+
+        let managed_coins_12_100 = client
+            .coin_read_api()
+            .get_all_coins(account, cursor, None)
+            .await
+            .unwrap();
+        assert_eq!(
+            managed_coins_12_100,
+            client
+                .coin_read_api()
+                .get_coins(account, Some(coin_type_str.clone()), cursor, None)
+                .await
+                .unwrap(),
+        );
+        assert_eq!(managed_coins_12_100.data.len(), 89);
+        assert_eq!(
+            managed_coins_12_100.data.last().unwrap().coin_object_id,
+            last_managed_coin
+        );
+        assert!(!managed_coins_12_100.has_next_page);
+
+        let managed_coins_12_100 = client
+            .coin_read_api()
+            .get_all_coins(account, cursor, Some(90))
+            .await
+            .unwrap();
+        assert_eq!(
+            managed_coins_12_100,
+            client
+                .coin_read_api()
+                .get_coins(account, Some(coin_type_str.clone()), cursor, Some(90))
+                .await
+                .unwrap(),
+        );
+        assert_eq!(managed_coins_12_100.data.len(), 89);
+        assert_eq!(
+            managed_coins_12_100.data.last().unwrap().coin_object_id,
+            last_managed_coin
+        );
+        assert!(!managed_coins_12_100.has_next_page);
+
+        // 12. add one to envelope
+        let managed_coin_id = managed_coins.get(40).unwrap().coin_object_id;
+        let _ = add_to_envelope(ctx, package.0, envelope.0, managed_coin_id).await;
+        let managed_coins_12_99 = client
+            .coin_read_api()
+            .get_all_coins(account, cursor, Some(90))
+            .await
+            .unwrap();
+        assert_eq!(
+            managed_coins_12_99,
+            client
+                .coin_read_api()
+                .get_coins(account, Some(coin_type_str.clone()), cursor, Some(90))
+                .await
+                .unwrap(),
+        );
+        assert_eq!(managed_coins_12_99.data.len(), 88);
+        assert_eq!(
+            managed_coins_12_99.data.last().unwrap().coin_object_id,
+            last_managed_coin
+        );
+        assert!(!managed_coins_12_99.has_next_page);
+
+        // =========================== Test Get Coins Ends ===========================
+
+        Ok(())
+    }
+}
+
+async fn publish_managed_coin_package(
+    ctx: &mut TestContext,
+) -> Result<(ObjectRef, ObjectRef, ObjectRef), anyhow::Error> {
+    let compiled_package = compile_managed_coin_package();
+    let all_module_bytes =
+        compiled_package.get_package_base64(/* with_unpublished_deps */ false);
+    let dependencies = compiled_package.get_dependency_original_package_ids();
+
+    let params = rpc_params![
+        ctx.get_wallet_address(),
+        all_module_bytes,
+        dependencies,
+        None::<ObjectID>,
+        // Doesn't need to be scaled by RGP since most of the cost is storage
+        500_000_000.to_string()
+    ];
+
+    let data = ctx
+        .build_transaction_remotely("unsafe_publish", params)
+        .await?;
+    let response = ctx.sign_and_execute(data, "publish ft package").await;
+    let changes = response.object_changes.unwrap();
+    info!("changes: {:?}", changes);
+    let pkg = changes
+        .iter()
+        .find(|change| matches!(change, ObjectChange::Published { .. }))
+        .unwrap()
+        .object_ref();
+    let treasury_cap = changes
+        .iter()
+        .find(|change| {
+            matches!(change, ObjectChange::Created {
+            owner: Owner::AddressOwner(_),
+            object_type: StructTag {
+                name,
+                ..
+            },
+            ..
+        } if name.as_str() == "TreasuryCap")
+        })
+        .unwrap()
+        .object_ref();
+    let envelope = changes
+        .iter()
+        .find(|change| {
+            matches!(change, ObjectChange::Created {
+            owner: Owner::Shared {..},
+            object_type: StructTag {
+                name,
+                ..
+            },
+            ..
+        } if name.as_str() == "PublicRedEnvelope")
+        })
+        .unwrap()
+        .object_ref();
+    Ok((pkg, treasury_cap, envelope))
+}
+
+async fn add_to_envelope(
+    ctx: &mut TestContext,
+    pkg_id: ObjectID,
+    envelope: ObjectID,
+    coin: ObjectID,
+) -> SuiTransactionBlockResponse {
+    let account = ctx.get_wallet_address();
+    let client = ctx.clone_fullnode_client();
+    let rgp = ctx.get_reference_gas_price().await;
+    let txn = client
+        .transaction_builder()
+        .move_call(
+            account,
+            pkg_id,
+            "managed",
+            "add_to_envelope",
+            vec![],
+            vec![
+                SuiJsonValue::from_object_id(envelope),
+                SuiJsonValue::from_object_id(coin),
+            ],
+            None,
+            rgp * 2_000_000,
+        )
+        .await
+        .unwrap();
+    let response = ctx
+        .sign_and_execute(txn, "add managed coin to envelope")
+        .await;
+    assert!(response.status_ok().unwrap());
+    response
+}

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -140,6 +140,10 @@ pub fn compile_nfts_package() -> CompiledPackage {
     compile_example_package("../../sui_programmability/examples/nfts")
 }
 
+pub fn compile_managed_coin_package() -> CompiledPackage {
+    compile_example_package("../../crates/sui-core/src/unit_tests/data/managed_coin")
+}
+
 pub fn compile_example_package(relative_path: &str) -> CompiledPackage {
     move_package::package_hooks::register_package_hooks(Box::new(SuiPackageHooks));
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));

--- a/crates/sui-core/src/unit_tests/data/managed_coin/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/managed_coin/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "FungibleTokens"
+version = "0.0.1"
+
+[dependencies]
+Sui = { local = "../../../../../sui-framework/packages/sui-framework" }
+
+[addresses]
+fungible_tokens = "0x0"

--- a/crates/sui-core/src/unit_tests/data/managed_coin/sources/managed.move
+++ b/crates/sui-core/src/unit_tests/data/managed_coin/sources/managed.move
@@ -1,0 +1,75 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// A module to test coin index.
+module fungible_tokens::managed {
+    use std::option;
+    use sui::coin::{Self, Coin, TreasuryCap};
+    use sui::transfer;
+    use sui::object::{Self, UID};
+    use sui::table_vec::{Self, TableVec};
+    use sui::tx_context::{Self, TxContext};
+
+    struct PublicRedEnvelope has key, store {
+        id: UID,
+        coins: TableVec<Coin<MANAGED>>,
+    }
+
+    /// Name of the coin. By convention, this type has the same name as its parent module
+    /// and has no fields. The full type of the coin defined by this module will be `COIN<MANAGED>`.
+    struct MANAGED has drop {}
+
+    /// Register the managed currency to acquire its `TreasuryCap`. Because
+    /// this is a module initializer, it ensures the currency only gets
+    /// registered once.
+    fun init(witness: MANAGED, ctx: &mut TxContext) {
+        // Get a treasury cap for the coin and give it to the transaction sender
+        let (treasury_cap, metadata) = coin::create_currency<MANAGED>(witness, 2, b"MANAGED", b"", b"", option::none(), ctx);
+        transfer::public_freeze_object(metadata);
+        transfer::public_transfer(treasury_cap, tx_context::sender(ctx));
+
+        let red_envelopes = PublicRedEnvelope { id: object::new(ctx), coins: table_vec::empty(ctx) };
+        transfer::share_object(red_envelopes)
+    }
+
+    public entry fun mint(
+        treasury_cap: &mut TreasuryCap<MANAGED>, amount: u64, recipient: address, ctx: &mut TxContext
+    ) {
+        coin::mint_and_transfer(treasury_cap, amount, recipient, ctx)
+    }
+
+    public entry fun mint_multi(
+        treasury_cap: &mut TreasuryCap<MANAGED>, amount: u64, num: u64, recipient: address, ctx: &mut TxContext
+    ) {
+        let i = 0;
+        while (i < num) {
+            coin::mint_and_transfer(treasury_cap, amount, recipient, ctx);
+            i = i + 1;
+        }
+    }
+    
+    public entry fun add_to_envelope(
+        red_envelopes: &mut PublicRedEnvelope, coin: Coin<MANAGED>,
+    ) {
+        table_vec::push_back(&mut red_envelopes.coins, coin)
+    }
+
+    public entry fun take_from_envelope(
+        red_envelopes: &mut PublicRedEnvelope, ctx: &mut TxContext
+    ) {
+        let coin = table_vec::pop_back(&mut red_envelopes.coins);
+        transfer::public_transfer(coin, tx_context::sender(ctx))
+    }
+
+    public entry fun take_from_envelope_and_burn(
+        treasury_cap: &mut TreasuryCap<MANAGED>, 
+        red_envelopes: &mut PublicRedEnvelope, 
+    ) {
+        let coin = table_vec::pop_back(&mut red_envelopes.coins);
+        coin::burn(treasury_cap, coin);
+    }
+
+    public entry fun burn(treasury_cap: &mut TreasuryCap<MANAGED>, coin: Coin<MANAGED>) {
+        coin::burn(treasury_cap, coin);
+    }
+}

--- a/crates/sui-faucet/src/faucet/mod.rs
+++ b/crates/sui-faucet/src/faucet/mod.rs
@@ -36,6 +36,9 @@ pub trait Faucet {
     ) -> Result<FaucetReceipt, FaucetError>;
 }
 
+pub const DEFAULT_AMOUNT: u64 = 200_000_000;
+pub const DEFAULT_NUM_OF_COINS: usize = 5;
+
 #[derive(Parser, Clone)]
 #[clap(
     name = "Sui Faucet",
@@ -49,10 +52,10 @@ pub struct FaucetConfig {
     #[clap(long, default_value = "127.0.0.1")]
     pub host_ip: Ipv4Addr,
 
-    #[clap(long, default_value_t = 200_000_000)]
+    #[clap(long, default_value_t = DEFAULT_AMOUNT)]
     pub amount: u64,
 
-    #[clap(long, default_value_t = 5)]
+    #[clap(long, default_value_t = DEFAULT_NUM_OF_COINS)]
     pub num_coins: usize,
 
     #[clap(long, default_value_t = 10)]

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -36,7 +36,7 @@ pub type DynamicFieldPage = Page<DynamicFieldInfo, ObjectID>;
 /// `next_cursor` points to the last item in the page;
 /// Reading with `next_cursor` will start from the next item after `next_cursor` if
 /// `next_cursor` is `Some`, otherwise it will start from the first item.
-#[derive(Clone, Debug, JsonSchema, Serialize, Deserialize)]
+#[derive(Clone, Debug, JsonSchema, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Page<T, C> {
     pub data: Vec<T>,

--- a/crates/sui-json-rpc-types/src/sui_coin.rs
+++ b/crates/sui-json-rpc-types/src/sui_coin.rs
@@ -20,7 +20,7 @@ use sui_types::sui_serde::SequenceNumber as AsSequenceNumber;
 pub type CoinPage = Page<Coin, ObjectID>;
 
 #[serde_as]
-#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Balance {
     pub coin_type: String,
@@ -35,7 +35,7 @@ pub struct Balance {
 }
 
 #[serde_as]
-#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Coin {
     pub coin_type: String,

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::anyhow;
+use itertools::Itertools;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -18,12 +19,11 @@ use sui_open_rpc::Module;
 use sui_types::balance::Supply;
 use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
 use sui_types::coin::{CoinMetadata, TreasuryCap};
-use sui_types::error::{SuiError, UserInputError};
+use sui_types::error::SuiError;
 use sui_types::gas_coin::GAS;
 use sui_types::messages::TransactionEffectsAPI;
 use sui_types::object::{Object, Owner};
 use sui_types::parse_sui_struct_tag;
-use sui_types::storage::ObjectKey;
 
 use crate::api::{cap_page_limit, CoinReadApiServer};
 use crate::error::Error;
@@ -38,103 +38,35 @@ impl CoinReadApi {
         Self { state }
     }
 
-    fn multi_get_coin_objects(&self, coins: &[ObjectRef]) -> Result<Vec<Object>, Error> {
-        Ok(self
-            .state
-            .database
-            .multi_get_object_by_key(&coins.iter().map(ObjectKey::from).collect::<Vec<_>>())?
-            .into_iter()
-            .zip(coins)
-            .map(|(o, (id, version, _digest))| {
-                o.ok_or(UserInputError::ObjectNotFound {
-                    object_id: *id,
-                    version: Some(*version),
-                })
-            })
-            .collect::<Result<Vec<_>, UserInputError>>()?)
-    }
-
-    /// Fetch all of the objects in `coins`. It's the caller's responsibility
-    /// to ensure that every ObjRef in `coins` is in fact a coin by using `Authority::get_owner_coin_iterator`,
-    /// and that every coin is of type `coin_type_tag`.
-    /// Note: if  we are fetching gas coins, `coin_type_tag` should be `Some(SUI)`, not `Some(Coin<SUI>)`
-    fn multi_get_coin(
-        &self,
-        coins: &[ObjectRef],
-        coin_type_tag: Option<&TypeTag>,
-    ) -> Result<Vec<Result<SuiCoin, Error>>, Error> {
-        let o = self
-            .state
-            .database
-            .multi_get_object_by_key(&coins.iter().map(ObjectKey::from).collect::<Vec<_>>())?;
-        // conversion from TypeTag to string is expensive, so do it outside the loop if we already know the coin type
-        // if coin_type_tag is None, we are getting a heterogenous mix of coins and we have no choice but to string-ify in the loop
-        let coin_type_str = coin_type_tag.map(|t| t.to_string());
-
-        Ok(o.into_iter()
-            .zip(coins)
-            .map(|(o, (id, version, digest))| {
-                let o = o.ok_or(UserInputError::ObjectNotFound {
-                    object_id: *id,
-                    version: Some(*version),
-                })?;
-
-                if let Some(move_object) = o.data.try_as_move() {
-                    let coin_type = coin_type_str.clone().unwrap_or_else(|| {
-                        o.type_()
-                            .unwrap()
-                            .type_params()
-                            .first()
-                            .unwrap()
-                            .to_string()
-                    });
-                    let balance = move_object.get_coin_value_unsafe();
-                    Ok(SuiCoin {
-                        coin_type,
-                        coin_object_id: *id,
-                        version: *version,
-                        digest: *digest,
-                        balance,
-                        locked_until_epoch: None,
-                        previous_transaction: o.previous_transaction,
-                    })
-                } else {
-                    Err(Error::UnexpectedError(format!(
-                        "Provided object : [{}] is not a Move object.",
-                        o.id()
-                    )))
-                }
-            })
-            .collect())
-    }
-
-    async fn get_coins_internal(
+    fn get_coins_iterator(
         &self,
         owner: SuiAddress,
-        coin_type: Option<&TypeTag>,
-        // exclusive cursor if `Some`, otherwise start from the beginning
-        cursor: Option<ObjectID>,
+        cursor: (String, ObjectID),
         limit: Option<usize>,
-    ) -> Result<CoinPage, Error> {
-        // TODO: Add index to improve performance?
+        one_coin_type_only: bool,
+    ) -> anyhow::Result<CoinPage> {
         let limit = cap_page_limit(limit);
-        let mut coins = self
-            .get_owner_coin_iterator(owner, coin_type)?
-            .skip_while(|o| matches!(&cursor, Some(cursor) if cursor != &o.0))
-            // skip an extra b/c the cursor is exclusive
-            .skip(usize::from(cursor.is_some()))
-            .take(limit + 1)
+        let coins = self
+            .state
+            .get_owned_coins_iterator_with_cursor(owner, cursor, limit + 1, one_coin_type_only)?
+            .map(|(coin_type, obj_id, coin)| (coin_type, obj_id, coin));
+
+        let mut data = coins
+            .map(|(coin_type, coin_object_id, coin)| SuiCoin {
+                coin_type,
+                coin_object_id,
+                version: coin.version,
+                digest: coin.digest,
+                balance: coin.balance,
+                locked_until_epoch: None,
+                previous_transaction: coin.previous_transaction,
+            })
             .collect::<Vec<_>>();
 
-        let has_next_page = coins.len() > limit;
-        coins.truncate(limit);
-        let next_cursor = coins.last().cloned().map_or(cursor, |(id, _, _)| Some(id));
+        let has_next_page = data.len() > limit;
+        data.truncate(limit);
 
-        let data = self
-            .multi_get_coin(&coins, coin_type)?
-            .into_iter()
-            .collect::<Result<Vec<_>, _>>()?;
-
+        let next_cursor = data.last().map(|coin| coin.coin_object_id);
         Ok(CoinPage {
             data,
             next_cursor,
@@ -142,22 +74,54 @@ impl CoinReadApi {
         })
     }
 
-    fn get_owner_coin_iterator<'a>(
-        &'a self,
+    fn get_balance_iterator(
+        &self,
         owner: SuiAddress,
-        coin_type: Option<&'a TypeTag>,
-    ) -> Result<impl Iterator<Item = ObjectRef> + '_, Error> {
-        Ok(self
+        coin_type: String,
+    ) -> anyhow::Result<Balance> {
+        let coins = self
             .state
-            .get_owner_objects_iterator(owner, None, None)?
-            .filter(move |o| {
-                if let Some(coin_type) = coin_type {
-                    o.type_.is_coin_t(coin_type)
-                } else {
-                    o.type_.is_coin()
-                }
-            })
-            .map(|info| (info.object_id, info.version, info.digest)))
+            .get_owned_coins_iterator(owner, Some(coin_type.clone()))?
+            .map(|(_coin_type, obj_id, coin)| (coin_type.to_string(), obj_id, coin));
+
+        let mut total_balance = 0u128;
+        let mut coin_object_count = 0;
+        for (_coin_type, _obj_id, coin_info) in coins {
+            total_balance += coin_info.balance as u128;
+            coin_object_count += 1;
+        }
+
+        Ok(Balance {
+            coin_type,
+            coin_object_count,
+            total_balance,
+            locked_balance: HashMap::new(),
+        })
+    }
+
+    fn get_all_balances_iterator(&self, owner: SuiAddress) -> anyhow::Result<Vec<Balance>> {
+        let coins = self
+            .state
+            .get_owned_coins_iterator(owner, None)?
+            .map(|(coin_type, obj_id, coin)| (coin_type, obj_id, coin))
+            .group_by(|(coin_type, _obj_id, _coin)| coin_type.clone());
+        let mut balances = vec![];
+        for (coin_type, coins) in &coins {
+            let mut total_balance = 0u128;
+            let mut coin_object_count = 0;
+            for (_coin_type, _obj_id, coin_info) in coins {
+                total_balance += coin_info.balance as u128;
+                coin_object_count += 1;
+            }
+
+            balances.push(Balance {
+                coin_type,
+                coin_object_count,
+                total_balance,
+                locked_balance: HashMap::new(),
+            });
+        }
+        Ok(balances)
     }
 
     async fn find_package_object(
@@ -217,13 +181,22 @@ impl CoinReadApiServer for CoinReadApi {
         cursor: Option<ObjectID>,
         limit: Option<usize>,
     ) -> RpcResult<CoinPage> {
-        let coin_type = TypeTag::Struct(Box::new(match coin_type {
+        let coin_type_tag = TypeTag::Struct(Box::new(match coin_type {
             Some(c) => parse_sui_struct_tag(&c)?,
             None => GAS::type_(),
         }));
-        Ok(self
-            .get_coins_internal(owner, Some(&coin_type), cursor, limit)
-            .await?)
+
+        let cursor = match cursor {
+            Some(c) => (coin_type_tag.to_string(), c),
+            // If cursor is not specified, we need to start from the beginning of the coin type, which is the minimal possible ObjectID.
+            None => (coin_type_tag.to_string(), ObjectID::ZERO),
+        };
+
+        let coins = self.get_coins_iterator(
+            owner, cursor, limit, true, // only care about one type of coin
+        )?;
+
+        Ok(coins)
     }
 
     async fn get_all_coins(
@@ -233,67 +206,73 @@ impl CoinReadApiServer for CoinReadApi {
         cursor: Option<ObjectID>,
         limit: Option<usize>,
     ) -> RpcResult<CoinPage> {
-        Ok(self.get_coins_internal(owner, None, cursor, limit).await?)
+        let cursor = match cursor {
+            Some(object_id) => {
+                let obj = self
+                    .state
+                    .get_object(&object_id)
+                    .await
+                    .map_err(Error::from)?;
+                match obj {
+                    Some(obj) => {
+                        let coin_type = obj.coin_type_maybe();
+                        if coin_type.is_none() {
+                            Err(anyhow!(
+                                "Invalid Cursor {:?}, Object is not a coin",
+                                object_id
+                            ))
+                        } else {
+                            Ok((coin_type.unwrap().to_string(), object_id))
+                        }
+                    }
+                    None => Err(anyhow!("Invalid Cursor {:?}, Object not found", object_id)),
+                }
+            }
+            None => {
+                // If cursor is None, start from the beginning
+                Ok((String::from_utf8([0u8].to_vec()).unwrap(), ObjectID::ZERO))
+            }
+        }?;
+
+        let coins = self.get_coins_iterator(
+            owner, cursor, limit, false, // return all types of coins
+        )?;
+
+        Ok(coins)
     }
 
     fn get_balance(&self, owner: SuiAddress, coin_type: Option<String>) -> RpcResult<Balance> {
-        let coin_type = TypeTag::Struct(Box::new(match coin_type {
+        let coin_type_tag = TypeTag::Struct(Box::new(match coin_type {
             Some(c) => parse_sui_struct_tag(&c)?,
             None => GAS::type_(),
         }));
 
-        // TODO: Add index to improve performance?
-        let coins = self.multi_get_coin_objects(
-            &self
-                .get_owner_coin_iterator(owner, Some(&coin_type))?
-                .collect::<Vec<_>>(),
-        )?;
-        let mut total_balance = 0u128;
-        let mut coin_object_count = 0;
+        let balance = self.get_balance_iterator(owner, coin_type_tag.to_string())?;
 
-        for coin_obj in coins {
-            // unwraps safe because get_owner_coin_iterator can only return coin objects
-            total_balance += coin_obj.data.try_as_move().unwrap().get_coin_value_unsafe() as u128;
-            coin_object_count += 1;
-        }
-
-        Ok(Balance {
-            coin_type: coin_type.to_string(),
-            coin_object_count,
-            total_balance,
-            // note: LockedCoin is deprecated
-            locked_balance: Default::default(),
-        })
+        Ok(balance)
     }
 
     fn get_all_balances(&self, owner: SuiAddress) -> RpcResult<Vec<Balance>> {
-        let mut balances: HashMap<TypeTag, Balance> = HashMap::new();
-        // TODO: Add index to improve performance?
-        let coin_objs = self.multi_get_coin_objects(
-            &self
-                .get_owner_coin_iterator(owner, None)?
-                .collect::<Vec<_>>(),
-        )?;
-        for coin_obj in coin_objs {
-            // unwrap safe because get_owner_coin_iterator can only return coin objects
-            let move_obj = coin_obj.data.try_as_move().unwrap();
-            // unwrap safe because each coin object has one type param
-            let coin_type = move_obj.type_().type_params().first().unwrap().clone();
-            let balance = balances.entry(coin_type.clone()).or_insert(Balance {
-                coin_type: coin_type.to_string(),
-                coin_object_count: 0,
-                total_balance: 0,
-                // note: LockedCoin is deprecated
-                locked_balance: Default::default(),
-            });
-            balance.total_balance += move_obj.get_coin_value_unsafe() as u128;
-            balance.coin_object_count += 1;
-        }
-        Ok(balances.into_values().collect())
+        let all_balances = self.get_all_balances_iterator(owner)?;
+
+        Ok(all_balances)
     }
 
     async fn get_coin_metadata(&self, coin_type: String) -> RpcResult<SuiCoinMetadata> {
         let coin_struct = parse_sui_struct_tag(&coin_type)?;
+        if GAS::is_gas(&coin_struct) {
+            // TODO: We need to special case for `CoinMetadata<0x2::sui::SUI> because `get_transaction`
+            // will fail for genesis transaction. However, instead of hardcoding the values here, We
+            // can store the object id for `CoinMetadata<0x2::sui::SUI>` in the Sui System object
+            return Ok(SuiCoinMetadata {
+                id: None,
+                decimals: 9,
+                symbol: "SUI".to_string(),
+                name: "Sui".to_string(),
+                description: "".to_string(),
+                icon_url: None,
+            });
+        }
 
         let metadata_object = self
             .find_package_object(

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -194,6 +194,15 @@ impl MoveObjectType {
         }
     }
 
+    pub fn coin_type_maybe(&self) -> Option<TypeTag> {
+        match &self.0 {
+            MoveObjectType_::GasCoin => Some(GAS::type_tag()),
+            MoveObjectType_::Coin(inner) => Some(inner.clone()),
+            MoveObjectType_::StakedSui => None,
+            MoveObjectType_::Other(_) => None,
+        }
+    }
+
     pub fn module_id(&self) -> ModuleId {
         ModuleId::new(self.address(), self.module().to_owned())
     }

--- a/crates/sui-types/src/temporary_store.rs
+++ b/crates/sui-types/src/temporary_store.rs
@@ -38,12 +38,17 @@ use crate::{
 };
 use crate::{is_system_package, SUI_SYSTEM_STATE_OBJECT_ID};
 
+pub type WrittenObjects = BTreeMap<ObjectID, (ObjectRef, Object, WriteKind)>;
+pub type ObjectMap = BTreeMap<ObjectID, Object>;
+pub type TxCoins = (ObjectMap, WrittenObjects);
+
 #[serde_as]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct InnerTemporaryStore {
-    pub objects: BTreeMap<ObjectID, Object>,
+    pub objects: ObjectMap,
     pub mutable_inputs: Vec<ObjectRef>,
-    pub written: BTreeMap<ObjectID, (ObjectRef, Object, WriteKind)>,
+    pub written: WrittenObjects,
+    // deleted or wrapped or unwrap-then-delete
     pub deleted: BTreeMap<ObjectID, (SequenceNumber, DeleteKind)>,
     pub events: TransactionEvents,
     pub max_binary_format_version: u32,


### PR DESCRIPTION
## Description 

Adds a `coin_index` table in the fullnode indexes. Keyed by <SuiAddress, CoinTypeStr, ObjectID>, valued by `CoinInfo`:
```
pub struct CoinInfo {
    pub version: SequenceNumber,
    pub digest: ObjectDigest,
    pub balance: u64,
    pub previous_transaction: TransactionDigest,
}
```
In this way, when a user asks about balance(s) or (coins), we can sequentially read these small-sized entries and perform cheap aggregation, even when the number of coins is huge.

This PR applies to get balances(s) and get (coins).

**The meat is in `authority.rs`, `indexes.rs` and `coin_api.rs`.**

## authority.rs
Return coin objects from `AuthorityState::commit_certificate`. 
We look at `inner_temporary_store.written` and `inner_temporary_store.objects` and grab the `Object` info if they are coins. Why do we need this? Two reasons:
a. if an object is deleted, we can no longer get the content from the object table after the commit, then no way to know its coin type at that point. But to delete an entry in the coin index, we need to know its coin type.
b. it's much cheaper to grab them here compared to fetching them from the db later, especially when the number of coins is big which is the problem we tried to avoid initially.

## indexes.rs
In the post processing job, we leverage the coin info returned from `commit_certificate` and `object_index_changes` which is used to update the ownership table. It works in the following way.
1. to delete old entries for object that is deleted or transferred/wrapped, we iterate over `object_index_changes.deleted_owners`, which only has objects owned by AccountOwner before the tx but not dynamic fields. For each item, we see if it's in the input objects from inner_temporary_store. If so, then it's a coin, and we get its coin type from the `Object` value and delete the entry in coin_index.
2. to upsert new entries for object that is created, transferred or unwrapped, we iterate over `object_index_changes.new_owners` which only has objects owned by AccountOwner after the tx but not dynamic fields. For each item, we see if it's in the written objects from inner_temporary_store. If so, then it's a coin and we construct the new entry from the `Object` and insert it to coin_index.

To query a user's all balances or a balance of a certain coin type, we skip to right key, and iterate until the key is no longer valid. 

## coin_api.rs
As sanity checks, in the initial commit of this PR, the get all balance and get balance api calls both the new and old implementation and `assert_eq!` them to check correctness.


## Test Plan 

production deployments + extensive e2e tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
