### PR TITLE
sui ns rpc: resolve between address and name

### DIFF
--- a/crates/sui-config/src/builder.rs
+++ b/crates/sui-config/src/builder.rs
@@ -513,6 +513,7 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                     db_checkpoint_config: self.db_checkpoint_config.clone(),
                     indirect_objects_threshold: usize::MAX,
                     expensive_safety_check_config: Default::default(),
+                    name_service_resolver_object_id: None,
                 }
             })
             .collect();

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -17,7 +17,7 @@ use std::usize;
 use sui_keys::keypair_file::{read_authority_keypair_from_file, read_keypair_from_file};
 use sui_protocol_config::SupportedProtocolVersions;
 use sui_storage::object_store::ObjectStoreConfig;
-use sui_types::base_types::SuiAddress;
+use sui_types::base_types::{ObjectID, SuiAddress};
 use sui_types::crypto::AuthorityPublicKeyBytes;
 use sui_types::crypto::KeypairTraits;
 use sui_types::crypto::NetworkKeyPair;
@@ -105,6 +105,9 @@ pub struct NodeConfig {
 
     #[serde(default)]
     pub expensive_safety_check_config: ExpensiveSafetyCheckConfig,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name_service_resolver_object_id: Option<ObjectID>,
 }
 
 fn default_authority_store_pruning_config() -> AuthorityStorePruningConfig {

--- a/crates/sui-config/src/swarm.rs
+++ b/crates/sui-config/src/swarm.rs
@@ -287,6 +287,7 @@ impl<'a> FullnodeConfigBuilder<'a> {
             indirect_objects_threshold: usize::MAX,
             // Copy the expensive safety check config from the first validator config.
             expensive_safety_check_config: validator_config.expensive_safety_check_config.clone(),
+            name_service_resolver_object_id: None,
         })
     }
 }

--- a/crates/sui-indexer/src/apis/indexer_api.rs
+++ b/crates/sui-indexer/src/apis/indexer_api.rs
@@ -449,20 +449,12 @@ where
         Ok(())
     }
 
-    async fn resolve_name_service_address(
-        &self,
-        _resolver_id: ObjectID,
-        _name: String,
-    ) -> RpcResult<SuiAddress> {
+    async fn resolve_name_service_address(&self, _name: String) -> RpcResult<SuiAddress> {
         // TODO(gegaowp): implement name service resolver in indexer
         todo!()
     }
 
-    async fn resolve_name_service_names(
-        &self,
-        _resolver_id: ObjectID,
-        _address: SuiAddress,
-    ) -> RpcResult<Vec<String>> {
+    async fn resolve_name_service_names(&self, _address: SuiAddress) -> RpcResult<Vec<String>> {
         // TODO(gegaowp): implement name service resolver in indexer
         todo!()
     }

--- a/crates/sui-indexer/src/apis/indexer_api.rs
+++ b/crates/sui-indexer/src/apis/indexer_api.rs
@@ -448,6 +448,24 @@ where
         spawn_subscription(sink, self.event_handler.subscribe(filter));
         Ok(())
     }
+
+    async fn resolve_name_service_address(
+        &self,
+        _resolver_id: ObjectID,
+        _name: String,
+    ) -> RpcResult<SuiAddress> {
+        // TODO(gegaowp): implement name service resolver in indexer
+        todo!()
+    }
+
+    async fn resolve_name_service_names(
+        &self,
+        _resolver_id: ObjectID,
+        _address: SuiAddress,
+    ) -> RpcResult<Vec<String>> {
+        // TODO(gegaowp): implement name service resolver in indexer
+        todo!()
+    }
 }
 
 impl<S> SuiRpcModule for IndexerApi<S>

--- a/crates/sui-indexer/src/apis/indexer_api.rs
+++ b/crates/sui-indexer/src/apis/indexer_api.rs
@@ -454,7 +454,12 @@ where
         todo!()
     }
 
-    async fn resolve_name_service_names(&self, _address: SuiAddress) -> RpcResult<Vec<String>> {
+    async fn resolve_name_service_names(
+        &self,
+        _address: SuiAddress,
+        _cursor: Option<ObjectID>,
+        _limit: Option<usize>,
+    ) -> RpcResult<Page<String, ObjectID>> {
         // TODO(gegaowp): implement name service resolver in indexer
         todo!()
     }

--- a/crates/sui-json-rpc-types/src/sui_move.rs
+++ b/crates/sui-json-rpc-types/src/sui_move.rs
@@ -427,6 +427,14 @@ impl SuiMoveStruct {
             }
         }
     }
+
+    pub fn read_dynamic_field_value(&self, field_name: &str) -> Option<SuiMoveValue> {
+        match self {
+            SuiMoveStruct::WithFields(fields) => fields.get(field_name).cloned(),
+            SuiMoveStruct::WithTypes { type_: _, fields } => fields.get(field_name).cloned(),
+            _ => None,
+        }
+    }
 }
 
 impl Display for SuiMoveStruct {

--- a/crates/sui-json-rpc-types/src/sui_object.rs
+++ b/crates/sui-json-rpc-types/src/sui_object.rs
@@ -820,6 +820,32 @@ impl Display for SuiParsedData {
     }
 }
 
+impl SuiParsedData {
+    pub fn try_from_object_read(object_read: ObjectRead) -> Result<Self, anyhow::Error> {
+        match object_read {
+            ObjectRead::NotExists(id) => Err(anyhow::anyhow!("Object {} does not exist", id)),
+            ObjectRead::Exists(_object_ref, o, layout) => {
+                let data = match o.data {
+                    Data::Move(m) => {
+                        let layout = layout.ok_or_else(|| {
+                            anyhow!("Layout is required to convert Move object to json")
+                        })?;
+                        SuiParsedData::try_from_object(m, layout)?
+                    }
+                    Data::Package(p) => SuiParsedData::try_from_package(p)?,
+                };
+                Ok(data)
+            }
+            ObjectRead::Deleted((object_id, version, digest)) => Err(anyhow::anyhow!(
+                "Object {} was deleted at version {} with digest {}",
+                object_id,
+                version,
+                digest
+            )),
+        }
+    }
+}
+
 pub trait SuiMoveObject: Sized {
     fn try_from_layout(object: MoveObject, layout: MoveStructLayout)
         -> Result<Self, anyhow::Error>;
@@ -870,6 +896,24 @@ impl SuiMoveObject for SuiParsedMoveObject {
 
     fn type_(&self) -> &StructTag {
         &self.type_
+    }
+}
+
+impl SuiParsedMoveObject {
+    pub fn try_from_object_read(object_read: ObjectRead) -> Result<Self, anyhow::Error> {
+        let parsed_data = SuiParsedData::try_from_object_read(object_read)?;
+        match parsed_data {
+            SuiParsedData::MoveObject(o) => Ok(o),
+            SuiParsedData::Package(_) => Err(anyhow::anyhow!("Object is not a Move object")),
+        }
+    }
+
+    pub fn read_dynamic_field_value(&self, field_name: &str) -> Option<SuiMoveValue> {
+        match &self.fields {
+            SuiMoveStruct::WithFields(fields) => fields.get(field_name).cloned(),
+            SuiMoveStruct::WithTypes { fields, .. } => fields.get(field_name).cloned(),
+            _ => None,
+        }
     }
 }
 

--- a/crates/sui-json-rpc/src/api/indexer.rs
+++ b/crates/sui-json-rpc/src/api/indexer.rs
@@ -97,8 +97,6 @@ pub trait IndexerApi {
     #[method(name = "resolveNameServiceAddress")]
     async fn resolve_name_service_address(
         &self,
-        /// The resolver address
-        resolver_id: ObjectID,
         /// The name to resolve
         name: String,
     ) -> RpcResult<SuiAddress>;
@@ -108,7 +106,6 @@ pub trait IndexerApi {
     #[method(name = "resolveNameServiceNames")]
     async fn resolve_name_service_names(
         &self,
-        resolver_id: ObjectID,
         /// The address to resolve
         address: SuiAddress,
     ) -> RpcResult<Vec<String>>;

--- a/crates/sui-json-rpc/src/api/indexer.rs
+++ b/crates/sui-json-rpc/src/api/indexer.rs
@@ -92,4 +92,24 @@ pub trait IndexerApi {
         /// The Name of the dynamic field
         name: DynamicFieldName,
     ) -> RpcResult<SuiObjectResponse>;
+
+    /// Return the resolved address given resolver and name
+    #[method(name = "resolveNameServiceAddress")]
+    async fn resolve_name_service_address(
+        &self,
+        /// The resolver address
+        resolver_id: ObjectID,
+        /// The name to resolve
+        name: String,
+    ) -> RpcResult<SuiAddress>;
+
+    /// Return the resolved names given address,
+    /// if multiple names are resolved, the first one is the primary name.
+    #[method(name = "resolveNameServiceNames")]
+    async fn resolve_name_service_names(
+        &self,
+        resolver_id: ObjectID,
+        /// The address to resolve
+        address: SuiAddress,
+    ) -> RpcResult<Vec<String>>;
 }

--- a/crates/sui-json-rpc/src/api/indexer.rs
+++ b/crates/sui-json-rpc/src/api/indexer.rs
@@ -5,7 +5,7 @@ use jsonrpsee::core::RpcResult;
 use jsonrpsee_proc_macros::rpc;
 
 use sui_json_rpc_types::{
-    DynamicFieldPage, EventFilter, EventPage, ObjectsPage, SuiEvent, SuiObjectResponse,
+    DynamicFieldPage, EventFilter, EventPage, ObjectsPage, Page, SuiEvent, SuiObjectResponse,
     SuiObjectResponseQuery, SuiTransactionBlockResponseQuery, TransactionBlocksPage,
 };
 use sui_open_rpc_macros::open_rpc;
@@ -108,5 +108,7 @@ pub trait IndexerApi {
         &self,
         /// The address to resolve
         address: SuiAddress,
-    ) -> RpcResult<Vec<String>>;
+        cursor: Option<ObjectID>,
+        limit: Option<usize>,
+    ) -> RpcResult<Page<String, ObjectID>>;
 }

--- a/crates/sui-json-rpc/src/indexer_api.rs
+++ b/crates/sui-json-rpc/src/indexer_api.rs
@@ -287,7 +287,12 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
         Ok(addr)
     }
 
-    async fn resolve_name_service_names(&self, address: SuiAddress) -> RpcResult<Vec<String>> {
+    async fn resolve_name_service_names(
+        &self,
+        address: SuiAddress,
+        _cursor: Option<ObjectID>,
+        _limit: Option<usize>,
+    ) -> RpcResult<Page<String, ObjectID>> {
         let dynmaic_field_table_object_id =
             self.get_name_service_dynamic_field_table_object_id(/* reverse_lookup */ true)?;
         let addr_type_tag = TypeTag::Address;
@@ -325,7 +330,11 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
                 address_info_move_value
             )),
         }?;
-        Ok(vec![primary_name])
+        Ok(Page {
+            data: vec![primary_name],
+            next_cursor: Some(addr_object_id),
+            has_next_page: false,
+        })
     }
 }
 

--- a/crates/sui-json-rpc/src/indexer_api.rs
+++ b/crates/sui-json-rpc/src/indexer_api.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::str::FromStr;
 use std::sync::Arc;
 
 use anyhow::anyhow;
@@ -13,12 +14,13 @@ use jsonrpsee::{RpcModule, SubscriptionSink};
 use serde::Serialize;
 use tracing::{debug, warn};
 
+use move_core_types::language_storage::TypeTag;
 use mysten_metrics::spawn_monitored_task;
 use sui_core::authority::AuthorityState;
 use sui_json_rpc_types::{
-    DynamicFieldPage, EventFilter, EventPage, ObjectsPage, Page, SuiObjectDataOptions,
-    SuiObjectResponse, SuiObjectResponseQuery, SuiTransactionBlockResponse,
-    SuiTransactionBlockResponseQuery, TransactionBlocksPage,
+    DynamicFieldPage, EventFilter, EventPage, ObjectsPage, Page, SuiMoveValue,
+    SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery, SuiParsedMoveObject,
+    SuiTransactionBlockResponse, SuiTransactionBlockResponseQuery, TransactionBlocksPage,
 };
 use sui_open_rpc::Module;
 use sui_types::base_types::{ObjectID, SuiAddress};
@@ -30,6 +32,13 @@ use crate::api::{
     cap_page_limit, validate_limit, IndexerApiServer, ReadApiServer, QUERY_MAX_RESULT_LIMIT_OBJECTS,
 };
 use crate::SuiRpcModule;
+
+const NAME_SERVICE_LOOKUP_KEY: &str = "records";
+const NAME_SERVICE_REVERSE_LOOKUP_KEY: &str = "reverse";
+const NAME_SERVICE_VALUE: &str = "value";
+const NAME_SERVICE_ID: &str = "id";
+const NAME_SERVICE_MARKER: &str = "marker";
+const STRING_TYPE_TAG: &str = "0x1::string::String";
 
 pub fn spawn_subscription<S, T>(mut sink: SubscriptionSink, rx: S)
 where
@@ -216,6 +225,122 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
         self.read_api
             .get_object(id, Some(SuiObjectDataOptions::full_content()))
     }
+
+    async fn resolve_name_service_address(
+        &self,
+        // TODOggao: configure this in sui-node
+        resolver_id: ObjectID,
+        name: String,
+    ) -> RpcResult<SuiAddress> {
+        let dynmaic_field_table_object_id = self.get_name_service_dynamic_field_table_object_id(
+            resolver_id,
+            /* reverse_lookup */ false,
+        )?;
+        // NOTE: 0x1::string::String is the type tag of fields in dynmaic_field_table
+        let ns_type_tag = TypeTag::from_str(STRING_TYPE_TAG)?;
+        let ns_dynamic_field_name = DynamicFieldName {
+            type_: ns_type_tag,
+            value: name.clone().into(),
+        };
+        // record of the input `name`
+        let record_object_id = self
+            .state
+            .get_dynamic_field_object_id(dynmaic_field_table_object_id, &ns_dynamic_field_name)
+            .map_err(|e| {
+                anyhow!(
+                    "Read name service dynamic field table failed with error: {:?}",
+                    e
+                )
+            })?
+            .ok_or_else(|| {
+                anyhow!(
+                    "Record not found for name: {:?} in name service: {:?}",
+                    name,
+                    resolver_id
+                )
+            })?;
+        let record_object_read = self.state.get_object_read(&record_object_id).map_err(|e| {
+            warn!(
+                ?record_object_id,
+                "Failed to get object read of record {:?} with error: {:?}", record_object_id, e
+            );
+            anyhow!("{e}")
+        })?;
+        let record_parsed_move_object =
+            SuiParsedMoveObject::try_from_object_read(record_object_read)?;
+        // NOTE: "value" is the field name to get the address info
+        let address_info_move_value = record_parsed_move_object
+            .read_dynamic_field_value(NAME_SERVICE_VALUE)
+            .ok_or_else(|| anyhow!("Cannot find value field in record Move struct"))?;
+        let address_info_move_struct = match address_info_move_value {
+            SuiMoveValue::Struct(a) => Ok(a),
+            _ => Err(anyhow!("value field is not found.")),
+        }?;
+        // NOTE: "marker" is the field name to get the address
+        let address_str_move_value = address_info_move_struct
+            .read_dynamic_field_value(NAME_SERVICE_MARKER)
+            .ok_or_else(|| {
+                anyhow!(
+                    "Cannot find marker field in address info Move struct: {:?}",
+                    address_info_move_struct
+                )
+            })?;
+        let addr = match address_str_move_value {
+            SuiMoveValue::Address(addr) => Ok(addr),
+            _ => Err(anyhow!(
+                "No SuiAddress found in: {:?}",
+                address_str_move_value
+            )),
+        }?;
+        Ok(addr)
+    }
+
+    async fn resolve_name_service_names(
+        &self,
+        resolver_id: ObjectID,
+        address: SuiAddress,
+    ) -> RpcResult<Vec<String>> {
+        let dynmaic_field_table_object_id = self.get_name_service_dynamic_field_table_object_id(
+            resolver_id,
+            /* reverse_lookup */ true,
+        )?;
+        let addr_type_tag = TypeTag::Address;
+        let ns_dynamic_field_name = DynamicFieldName {
+            type_: addr_type_tag,
+            value: address.to_string().into(),
+        };
+
+        let addr_object_id = self
+            .state
+            .get_dynamic_field_object_id(dynmaic_field_table_object_id, &ns_dynamic_field_name)
+            .map_err(|e| {
+                anyhow!(
+                    "Read name service dynamic field table failed with error: {:?}",
+                    e
+                )
+            })?
+            .ok_or_else(|| anyhow!("Record not found for address: {:?}", address))?;
+        let addr_object_read = self.state.get_object_read(&addr_object_id).map_err(|e| {
+            warn!(
+                ?addr_object_id,
+                "Failed to get object read of record {:?} with error: {:?}", addr_object_id, e
+            );
+            anyhow!("{e}")
+        })?;
+        let addr_parsed_move_object = SuiParsedMoveObject::try_from_object_read(addr_object_read)?;
+        let address_info_move_value = addr_parsed_move_object
+            .read_dynamic_field_value(NAME_SERVICE_VALUE)
+            .ok_or_else(|| anyhow!("Cannot find value field in record Move struct"))?;
+
+        let primary_name = match address_info_move_value {
+            SuiMoveValue::String(s) => Ok(s),
+            _ => Err(anyhow!(
+                "No string field for primary name is found in {:?}",
+                address_info_move_value
+            )),
+        }?;
+        Ok(vec![primary_name])
+    }
 }
 
 impl<R: ReadApiServer> SuiRpcModule for IndexerApi<R> {
@@ -225,5 +350,46 @@ impl<R: ReadApiServer> SuiRpcModule for IndexerApi<R> {
 
     fn rpc_doc_module() -> Module {
         crate::api::IndexerApiOpenRpc::module_doc()
+    }
+}
+
+impl<R: ReadApiServer> IndexerApi<R> {
+    fn get_name_service_dynamic_field_table_object_id(
+        &self,
+        resolver_id: ObjectID,
+        reverse_lookup: bool,
+    ) -> RpcResult<ObjectID> {
+        let resolver_object_read = self.state.get_object_read(&resolver_id).map_err(|e| {
+            warn!(
+                ?resolver_id,
+                "Failed to get object read of resolver {:?} with error: {:?}", resolver_id, e
+            );
+            anyhow!("{e}")
+        })?;
+
+        let resolved_parsed_move_object =
+            SuiParsedMoveObject::try_from_object_read(resolver_object_read)?;
+        // NOTE: "records" is the field name to get "records" Move struct
+        let dynamic_field_table_key = if reverse_lookup {
+            NAME_SERVICE_REVERSE_LOOKUP_KEY
+        } else {
+            NAME_SERVICE_LOOKUP_KEY
+        };
+        let records_value = resolved_parsed_move_object
+            .read_dynamic_field_value(dynamic_field_table_key)
+            .ok_or_else(|| anyhow!("Cannot find records field in resolved object"))?;
+        let records_move_struct = match records_value {
+            SuiMoveValue::Struct(s) => Ok(s),
+            _ => Err(anyhow!("records field is not a Move struct")),
+        }?;
+        // NOTE: "id" is the field name to get dynamic field table object ID
+        let dynmaic_field_table_object_id_struct = records_move_struct
+            .read_dynamic_field_value(NAME_SERVICE_ID)
+            .ok_or_else(|| anyhow!("Cannot find id field in records Move struct"))?;
+        let dynmaic_field_table_object_id = match dynmaic_field_table_object_id_struct {
+            SuiMoveValue::UID { id } => Ok(id),
+            _ => Err(anyhow!("id field is not a UID")),
+        }?;
+        Ok(dynmaic_field_table_object_id)
     }
 }

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1141,7 +1141,11 @@ pub async fn build_server(
         ))?;
     }
 
-    server.register_module(IndexerApi::new(state.clone(), ReadApi::new(state.clone())))?;
+    server.register_module(IndexerApi::new(
+        state.clone(),
+        ReadApi::new(state.clone()),
+        config.name_service_resolver_object_id,
+    ))?;
     server.register_module(MoveUtils::new(state.clone()))?;
 
     let rpc_server_handle = server.start(config.json_rpc_address).await?;

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1785,16 +1785,27 @@
           "schema": {
             "$ref": "#/components/schemas/SuiAddress"
           }
+        },
+        {
+          "name": "cursor",
+          "schema": {
+            "$ref": "#/components/schemas/ObjectID"
+          }
+        },
+        {
+          "name": "limit",
+          "schema": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0.0
+          }
         }
       ],
       "result": {
-        "name": "Vec<String>",
+        "name": "Page<String,ObjectID>",
         "required": true,
         "schema": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "$ref": "#/components/schemas/Page_for_String_and_ObjectID"
         }
       }
     },
@@ -4872,6 +4883,35 @@
             "anyOf": [
               {
                 "$ref": "#/components/schemas/EventID"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      },
+      "Page_for_String_and_ObjectID": {
+        "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
+        "type": "object",
+        "required": [
+          "data",
+          "hasNextPage"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "hasNextPage": {
+            "type": "boolean"
+          },
+          "nextCursor": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ObjectID"
               },
               {
                 "type": "null"

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1744,6 +1744,61 @@
       ]
     },
     {
+      "name": "suix_resolveNameServiceAddress",
+      "tags": [
+        {
+          "name": "Extended API"
+        }
+      ],
+      "description": "Return the resolved address given resolver and name",
+      "params": [
+        {
+          "name": "name",
+          "description": "The name to resolve",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "SuiAddress",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/SuiAddress"
+        }
+      }
+    },
+    {
+      "name": "suix_resolveNameServiceNames",
+      "tags": [
+        {
+          "name": "Extended API"
+        }
+      ],
+      "description": "Return the resolved names given address, if multiple names are resolved, the first one is the primary name.",
+      "params": [
+        {
+          "name": "address",
+          "description": "The address to resolve",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/SuiAddress"
+          }
+        }
+      ],
+      "result": {
+        "name": "Vec<String>",
+        "required": true,
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    {
       "name": "suix_subscribeEvent",
       "tags": [
         {


### PR DESCRIPTION
The related Move change is: 
https://github.com/MystenLabs/sui/compare/ds/archive?expand=1

## Test Plan 

Test locally with Move contract ^^
1. start Sui network, publish module and make move calls to add new pairs
```
target/debug/sui start

// under sui/sui_programmability/examples/archive
sui client publish --gas-budget 100000000

sui client call --package 0xf12ab3bf6c1b53add39529bedd0ebb1b083a3dc7e4736ff35bbeccf2be80f80f --module archive --function add_record --gas-budget 100000000 --args 0xd3db0bd1b6847412b1aa0e4f0ff5c96eceba1a8cc0f30df5946f38102b8da3fa 0x6 0x54f349899f6b521547bcfcb2605c65f307934b4f32c256fd3e2d4df6feecb870 "ccc"
```
2. stop Sui network, override FN config file with the fetched resolver object ID by adding this line to ~/.sui/sui_config/fullnode.yaml
```
name-service-resolver-object-id: <archive_object_id>
```

3. restart Sui network without FN; start FN based on config with fetched resolved object ID
```
target/debug/sui start --no-full-node

cargo run --bin sui-node -- --config-path  /Users/gegao/.sui/sui_config/fullnode.yaml

```
5. test on RPC
```
curl --location --request POST http://127.0.0.1:9000 \
--header 'Content-Type: application/json' \
--data-raw '{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "suix_resolveNameServiceAddress",
    "params": ["ccc"]
}'
{"jsonrpc":"2.0","result":"0x54f349899f6b521547bcfcb2605c65f307934b4f32c256fd3e2d4df6feecb870","id":1}%                                                                 

curl --location --request POST http://127.0.0.1:9000 \
--header 'Content-Type: application/json' \
--data-raw '{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "suix_resolveNameServiceNames",
    "params": ["0x54f349899f6b521547bcfcb2605c65f307934b4f32c256fd3e2d4df6feecb870"]
}'
{"jsonrpc":"2.0","result":["ccc"],"id":1}%

```

