### PR TITLE
Add caching for account address balance computation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2928,6 +2928,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "errno-dragonfly"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3091,7 +3102,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb21c69b9fea5e15dbc1049e4b77145dd0ba1c84019c488102de0dc4ea4b0a27"
 dependencies = [
  "cfg-if",
- "rustix",
+ "rustix 0.36.6",
  "windows-sys 0.42.0",
 ]
 
@@ -3713,6 +3724,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4125,14 +4142,14 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.2"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi 0.3.1",
  "io-lifetimes",
- "rustix",
- "windows-sys 0.42.0",
+ "rustix 0.37.7",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4416,9 +4433,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
 
 [[package]]
 name = "libloading"
@@ -4494,6 +4511,12 @@ name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
 
 [[package]]
 name = "lock_api"
@@ -7854,11 +7877,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
 dependencies = [
  "bitflags",
- "errno",
+ "errno 0.2.8",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.1.4",
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aae838e49b3d63e9274e1c01833cc8139d3fec468c3b84688c628f44b1ae11d"
+dependencies = [
+ "bitflags",
+ "errno 0.3.1",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.1",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -9815,10 +9852,12 @@ dependencies = [
  "anyhow",
  "async-trait",
  "backoff",
+ "bcs",
  "bytes",
  "criterion",
  "eyre",
  "futures",
+ "itertools",
  "lru",
  "move-binary-format",
  "move-bytecode-utils",
@@ -9829,6 +9868,7 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.1",
  "pretty_assertions",
+ "prometheus",
  "rocksdb",
  "serde 1.0.152",
  "sui-json-rpc-types",
@@ -10245,7 +10285,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall",
- "rustix",
+ "rustix 0.36.6",
  "windows-sys 0.42.0",
 ]
 
@@ -11295,9 +11335,9 @@ checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
 
 [[package]]
 name = "utf8parse"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
@@ -11593,13 +11633,13 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -11608,7 +11648,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -11617,13 +11666,28 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -11633,10 +11697,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -11645,10 +11721,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -11657,16 +11745,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winreg"
@@ -11913,7 +12019,8 @@ dependencies = [
  "encoding_rs",
  "endian-type",
  "enum_dispatch",
- "errno",
+ "errno 0.2.8",
+ "errno 0.3.1",
  "error-code",
  "ethnum",
  "event-listener",
@@ -12050,7 +12157,8 @@ dependencies = [
  "libtest-mimic",
  "libz-sys",
  "linked-hash-map",
- "linux-raw-sys",
+ "linux-raw-sys 0.1.4",
+ "linux-raw-sys 0.3.1",
  "lock_api",
  "log",
  "lru",
@@ -12283,7 +12391,8 @@ dependencies = [
  "rustc-hex",
  "rustc_version",
  "rusticata-macros",
- "rustix",
+ "rustix 0.36.6",
+ "rustix 0.37.7",
  "rustls",
  "rustls-native-certs",
  "rustls-pemfile",
@@ -12496,8 +12605,11 @@ dependencies = [
  "winapi-util",
  "windows-sys 0.42.0",
  "windows-sys 0.45.0",
- "windows-targets",
- "windows_x86_64_msvc",
+ "windows-sys 0.48.0",
+ "windows-targets 0.42.2",
+ "windows-targets 0.48.0",
+ "windows_x86_64_msvc 0.42.2",
+ "windows_x86_64_msvc 0.48.0",
  "winreg",
  "wyz",
  "x509-parser",

--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -120,7 +120,7 @@ impl TestAuthorityBuilder {
         ));
 
         let checkpoint_store = CheckpointStore::new(&path.join("checkpoints"));
-        let index_store = Some(Arc::new(IndexStore::new(path.join("indexes"))));
+        let index_store = Some(Arc::new(IndexStore::new(path.join("indexes"), &registry)));
         AuthorityState::new(
             name,
             secret,

--- a/crates/sui-indexer/src/apis/coin_api.rs
+++ b/crates/sui-indexer/src/apis/coin_api.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
-use futures::executor::block_on;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::http_client::HttpClient;
 use jsonrpsee::RpcModule;
@@ -49,12 +48,16 @@ impl CoinReadApiServer for CoinReadApi {
         self.fullnode.get_all_coins(owner, cursor, limit).await
     }
 
-    fn get_balance(&self, owner: SuiAddress, coin_type: Option<String>) -> RpcResult<Balance> {
-        block_on(self.fullnode.get_balance(owner, coin_type))
+    async fn get_balance(
+        &self,
+        owner: SuiAddress,
+        coin_type: Option<String>,
+    ) -> RpcResult<Balance> {
+        self.fullnode.get_balance(owner, coin_type).await
     }
 
-    fn get_all_balances(&self, owner: SuiAddress) -> RpcResult<Vec<Balance>> {
-        block_on(self.fullnode.get_all_balances(owner))
+    async fn get_all_balances(&self, owner: SuiAddress) -> RpcResult<Vec<Balance>> {
+        self.fullnode.get_all_balances(owner).await
     }
 
     async fn get_coin_metadata(&self, coin_type: String) -> RpcResult<SuiCoinMetadata> {

--- a/crates/sui-json-rpc/src/api/coin.rs
+++ b/crates/sui-json-rpc/src/api/coin.rs
@@ -38,8 +38,8 @@ pub trait CoinReadApi {
     ) -> RpcResult<CoinPage>;
 
     /// Return the total coin balance for one coin type, owned by the address owner.
-    #[method(name = "getBalance", blocking)]
-    fn get_balance(
+    #[method(name = "getBalance")]
+    async fn get_balance(
         &self,
         /// the owner's Sui address
         owner: SuiAddress,
@@ -48,8 +48,8 @@ pub trait CoinReadApi {
     ) -> RpcResult<Balance>;
 
     /// Return the total coin balance for all coin type, owned by the address owner.
-    #[method(name = "getAllBalances", blocking)]
-    fn get_all_balances(
+    #[method(name = "getAllBalances")]
+    async fn get_all_balances(
         &self,
         /// the owner's Sui address
         owner: SuiAddress,

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -260,7 +260,10 @@ impl SuiNode {
         );
 
         let index_store = if is_full_node && config.enable_index_processing {
-            Some(Arc::new(IndexStore::new(config.db_path().join("indexes"))))
+            Some(Arc::new(IndexStore::new(
+                config.db_path().join("indexes"),
+                &prometheus_registry,
+            )))
         } else {
             None
         };

--- a/crates/sui-storage/Cargo.toml
+++ b/crates/sui-storage/Cargo.toml
@@ -20,6 +20,9 @@ object_store = { version = "=0.5.4", features = ["aws", "aws_profile", "gcp", "a
 backoff = "0.4.0"
 bytes = "1.4.0"
 parking_lot = "0.12.1"
+bcs = "0.1.4"
+prometheus = "0.13.3"
+itertools = "0.10.5"
 
 sui-simulator = { path = "../sui-simulator" }
 sui-types = { path = "../sui-types" }

--- a/crates/sui-storage/src/lib.rs
+++ b/crates/sui-storage/src/lib.rs
@@ -7,4 +7,5 @@ pub use indexes::{IndexStore, IndexStoreTables};
 pub mod mutex_table;
 pub mod object_store;
 pub mod package_object_cache;
+pub mod sharded_lru;
 pub mod write_path_pending_tx_log;

--- a/crates/sui-storage/src/sharded_lru.rs
+++ b/crates/sui-storage/src/sharded_lru.rs
@@ -1,0 +1,107 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::hash_map::RandomState,
+    hash::{self, BuildHasher, Hash},
+};
+
+use hash::Hasher;
+use lru::LruCache;
+use std::collections::HashMap;
+use std::future::Future;
+use std::num::NonZeroUsize;
+use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+pub struct ShardedLruCache<K, V, S = RandomState> {
+    shards: Vec<RwLock<LruCache<K, V>>>,
+    hasher: S,
+}
+
+unsafe impl<K, V, S> Send for ShardedLruCache<K, V, S> {}
+unsafe impl<K, V, S> Sync for ShardedLruCache<K, V, S> {}
+
+impl<K, V> ShardedLruCache<K, V, RandomState>
+where
+    K: Send + Sync + Hash + Eq + Clone,
+    V: Send + Sync + Clone,
+{
+    pub fn new(capacity: u64, num_shards: u64) -> Self {
+        let cap_per_shard = (capacity + num_shards - 1) / num_shards;
+        let hasher = RandomState::default();
+        Self {
+            hasher,
+            shards: (0..num_shards)
+                .map(|_| {
+                    RwLock::new(LruCache::new(
+                        NonZeroUsize::new(cap_per_shard as usize).unwrap(),
+                    ))
+                })
+                .collect(),
+        }
+    }
+}
+
+impl<K, V, S> ShardedLruCache<K, V, S>
+where
+    K: Hash + Eq + Clone,
+    V: Clone,
+    S: BuildHasher,
+{
+    fn shard_id(&self, key: &K) -> usize {
+        let mut hasher = self.hasher.build_hasher();
+        key.hash(&mut hasher);
+        let h = hasher.finish() as usize;
+        h % self.shards.len()
+    }
+
+    async fn read_shard(&self, key: &K) -> RwLockReadGuard<'_, LruCache<K, V>> {
+        let shard_idx = self.shard_id(key);
+        self.shards[shard_idx].read().await
+    }
+
+    async fn write_shard(&self, key: &K) -> RwLockWriteGuard<'_, LruCache<K, V>> {
+        let shard_idx = self.shard_id(key);
+        self.shards[shard_idx].write().await
+    }
+
+    pub async fn invalidate(&self, key: &K) -> Option<V> {
+        self.write_shard(key).await.pop(key)
+    }
+
+    pub async fn batch_invalidate(&self, keys: impl IntoIterator<Item = K>) {
+        let mut grouped = HashMap::new();
+        for key in keys.into_iter() {
+            let shard_idx = self.shard_id(&key);
+            grouped.entry(shard_idx).or_insert(vec![]).push(key);
+        }
+        for (shard_idx, keys) in grouped.into_iter() {
+            let mut lock = self.shards[shard_idx].write().await;
+            for key in keys {
+                lock.pop(&key);
+            }
+        }
+    }
+
+    pub async fn get(&self, key: &K) -> Option<V> {
+        self.read_shard(key).await.peek(key).cloned()
+    }
+
+    pub async fn get_with(&self, key: K, init: impl Future<Output = V>) -> V {
+        let shard = self.read_shard(&key).await;
+        let value = shard.peek(&key);
+        if value.is_some() {
+            return value.unwrap().clone();
+        }
+        drop(shard);
+        let mut shard = self.write_shard(&key).await;
+        let value = shard.get(&key);
+        if value.is_some() {
+            return value.unwrap().clone();
+        }
+        let value = init.await;
+        let cloned_value = value.clone();
+        shard.push(key, value);
+        cloned_value
+    }
+}

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -1446,7 +1446,8 @@ cpp_demangle = { version = "0.4" }
 cpufeatures = { version = "0.2", default-features = false }
 debugid = { version = "0.8", default-features = false }
 encoding_rs = { version = "0.8" }
-errno = { version = "0.2", default-features = false }
+errno-468e82937335b1c9 = { package = "errno", version = "0.3", default-features = false }
+errno-6f8ce4dd05d13bba = { package = "errno", version = "0.2", default-features = false }
 findshlibs = { version = "0.10", default-features = false }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
 inferno = { version = "0.11", default-features = false, features = ["nameattr"] }
@@ -1466,7 +1467,8 @@ pprof = { version = "0.11", features = ["criterion", "flamegraph", "frame-pointe
 quick-xml = { version = "0.26", default-features = false }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
 rgb = { version = "0.8" }
-rustix = { version = "0.36", features = ["fs", "termios"] }
+rustix-4e55305914c60c55 = { package = "rustix", version = "0.36", features = ["fs"] }
+rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["termios"] }
 security-framework = { version = "2" }
 security-framework-sys = { version = "2", default-features = false, features = ["OSX_10_9"] }
 signal-hook = { version = "0.3" }
@@ -1486,7 +1488,8 @@ cpp_demangle = { version = "0.4" }
 cpufeatures = { version = "0.2", default-features = false }
 debugid = { version = "0.8", default-features = false }
 encoding_rs = { version = "0.8" }
-errno = { version = "0.2", default-features = false }
+errno-468e82937335b1c9 = { package = "errno", version = "0.3", default-features = false }
+errno-6f8ce4dd05d13bba = { package = "errno", version = "0.2", default-features = false }
 findshlibs = { version = "0.10", default-features = false }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
 inferno = { version = "0.11", default-features = false, features = ["nameattr"] }
@@ -1507,7 +1510,8 @@ protobuf-src = { version = "1", default-features = false }
 quick-xml = { version = "0.26", default-features = false }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
 rgb = { version = "0.8" }
-rustix = { version = "0.36", features = ["fs", "termios"] }
+rustix-4e55305914c60c55 = { package = "rustix", version = "0.36", features = ["fs"] }
+rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["termios"] }
 security-framework = { version = "2" }
 security-framework-sys = { version = "2", default-features = false, features = ["OSX_10_9"] }
 signal-hook = { version = "0.3" }
@@ -1531,7 +1535,8 @@ ipnet = { version = "2" }
 jemalloc-ctl = { version = "0.5" }
 jemalloc-sys = { version = "0.5" }
 libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
-linux-raw-sys = { version = "0.1", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
+linux-raw-sys-468e82937335b1c9 = { package = "linux-raw-sys", version = "0.3", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
+linux-raw-sys-c65f7effa3be6d31 = { package = "linux-raw-sys", version = "0.1", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
 memmap2 = { version = "0.5", default-features = false }
 memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
 mio-ca01ad9e24f5d932 = { package = "mio", version = "0.7", features = ["os-util", "uds"] }
@@ -1545,7 +1550,8 @@ quick-xml = { version = "0.26", default-features = false }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
 raw-cpuid = { version = "10", default-features = false }
 rgb = { version = "0.8" }
-rustix = { version = "0.36", features = ["fs", "termios"] }
+rustix-4e55305914c60c55 = { package = "rustix", version = "0.36", features = ["fs"] }
+rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["termios"] }
 signal-hook = { version = "0.3" }
 signal-hook-mio = { version = "0.2", default-features = false, features = ["support-v0_7", "support-v0_8"] }
 signal-hook-registry = { version = "1", default-features = false }
@@ -1568,7 +1574,8 @@ ipnet = { version = "2" }
 jemalloc-ctl = { version = "0.5" }
 jemalloc-sys = { version = "0.5" }
 libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
-linux-raw-sys = { version = "0.1", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
+linux-raw-sys-468e82937335b1c9 = { package = "linux-raw-sys", version = "0.3", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
+linux-raw-sys-c65f7effa3be6d31 = { package = "linux-raw-sys", version = "0.1", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
 memmap2 = { version = "0.5", default-features = false }
 memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
 mio-ca01ad9e24f5d932 = { package = "mio", version = "0.7", features = ["os-util", "uds"] }
@@ -1583,7 +1590,8 @@ quick-xml = { version = "0.26", default-features = false }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
 raw-cpuid = { version = "10", default-features = false }
 rgb = { version = "0.8" }
-rustix = { version = "0.36", features = ["fs", "termios"] }
+rustix-4e55305914c60c55 = { package = "rustix", version = "0.36", features = ["fs"] }
+rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["termios"] }
 signal-hook = { version = "0.3" }
 signal-hook-mio = { version = "0.2", default-features = false, features = ["support-v0_7", "support-v0_8"] }
 signal-hook-registry = { version = "1", default-features = false }
@@ -1614,8 +1622,11 @@ winapi = { version = "0.3", default-features = false, features = ["basetsd", "cf
 winapi-util = { version = "0.1", default-features = false }
 windows-sys-53888c27b7ba5cf4 = { package = "windows-sys", version = "0.45", features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming"] }
 windows-sys-b32c9ddb6d93a9d2 = { package = "windows-sys", version = "0.42", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse"] }
-windows-targets = { version = "0.42", default-features = false }
-windows_x86_64_msvc = { version = "0.42", default-features = false }
+windows-sys-c8eced492e86ede7 = { package = "windows-sys", version = "0.48", features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_Console"] }
+windows-targets-b32c9ddb6d93a9d2 = { package = "windows-targets", version = "0.42", default-features = false }
+windows-targets-c8eced492e86ede7 = { package = "windows-targets", version = "0.48", default-features = false }
+windows_x86_64_msvc-b32c9ddb6d93a9d2 = { package = "windows_x86_64_msvc", version = "0.42", default-features = false }
+windows_x86_64_msvc-c8eced492e86ede7 = { package = "windows_x86_64_msvc", version = "0.48", default-features = false }
 winreg = { version = "0.10", default-features = false }
 
 [target.x86_64-pc-windows-msvc.build-dependencies]
@@ -1642,8 +1653,11 @@ winapi = { version = "0.3", default-features = false, features = ["basetsd", "cf
 winapi-util = { version = "0.1", default-features = false }
 windows-sys-53888c27b7ba5cf4 = { package = "windows-sys", version = "0.45", features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming"] }
 windows-sys-b32c9ddb6d93a9d2 = { package = "windows-sys", version = "0.42", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse"] }
-windows-targets = { version = "0.42", default-features = false }
-windows_x86_64_msvc = { version = "0.42", default-features = false }
+windows-sys-c8eced492e86ede7 = { package = "windows-sys", version = "0.48", features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_Console"] }
+windows-targets-b32c9ddb6d93a9d2 = { package = "windows-targets", version = "0.42", default-features = false }
+windows-targets-c8eced492e86ede7 = { package = "windows-targets", version = "0.48", default-features = false }
+windows_x86_64_msvc-b32c9ddb6d93a9d2 = { package = "windows_x86_64_msvc", version = "0.42", default-features = false }
+windows_x86_64_msvc-c8eced492e86ede7 = { package = "windows_x86_64_msvc", version = "0.48", default-features = false }
 winreg = { version = "0.10", default-features = false }
 
 ### END HAKARI SECTION


### PR DESCRIPTION
## Description 

Add a cache which caches the account balance and invalidates it whenever coin ownership changes. This prevents background db access when coin ownership has not changed. Most of the interesting changes are in `indexes.rs`. Only when `deleted` and `new` coins for an account are detected, we invalidate the caches.

## Test Plan 

Added tests to ensure caches are returning latest data as expected.
