### PR TITLE
indexer fix: handle first epoch commit

### DIFF
--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -1483,9 +1483,14 @@ WHERE e1.epoch = e2.epoch
         // } else {
         //     self.get_current_epoch().await?.first_checkpoint_id as i64
         // };
-        // self.partition_manager
-        //     .advance_epoch(&data.new_epoch, last_epoch_cp_id)
-        //     .await?;
+        if data.last_epoch.is_none() {
+            let last_epoch_cp_id = 0;
+            self.partition_manager
+                .advance_epoch(&data.new_epoch, last_epoch_cp_id)
+                .await?;
+        }
+        let epoch = data.new_epoch.epoch;
+        info!("Persisting epoch {}", epoch);
 
         transactional!(&self.cp, |conn| async {
             if let Some(last_epoch) = &data.last_epoch {
@@ -1538,6 +1543,7 @@ WHERE e1.epoch = e2.epoch
                 .await
         }
         .scope_boxed())?;
+        info!("Persisted epoch {}", epoch);
         Ok(())
     }
 


### PR DESCRIPTION
## Description 

handle first epoch:
- advance epoch on first epoch
- retry on epoch DB commit, this is more likely to happen when read & write is on the same DB.

## Test Plan 

Tested locally with http://ewr-dnt-rpc-05.devnet.sui.io:9000

make sure explorer APIs work:

```
curl --location --request POST http://127.0.0.1:3030 \
--header 'Content-Type: application/json' \
--data-raw '{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "suix_getNetworkMetrics",
    "params": []
}'
{"jsonrpc":"2.0","result":{"currentTps":6.4,"tps30Days":1.2,"totalPackages":"0","totalAddresses":"0","totalObjects":"8364","currentEpoch":"0","currentCheckpoint":"4823"},"id":1}%       

curl --location --request POST http://127.0.0.1:3030 \
--header 'Content-Type: application/json' \
--data-raw '{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "suix_getEpochs",
    "params": []
}'
```
