### PR TITLE
Nm/fix nft details

### DIFF
--- a/apps/wallet/src/ui/app/pages/home/nft-details/LabelValueItem.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nft-details/LabelValueItem.tsx
@@ -49,13 +49,8 @@ export function LabelValueItem({
     }
     return display ? (
         <div className="flex flex-row flex-nowrap gap-1">
-            <div className="flex-1 overflow-hidden">
-                <Text
-                    color="steel-dark"
-                    variant="body"
-                    weight="medium"
-                    truncate
-                >
+            <div className="flex-1 truncate">
+                <Text color="steel-dark" variant="p2" weight="medium" truncate>
                     {label}
                 </Text>
             </div>
@@ -76,6 +71,7 @@ export function LabelValueItem({
                     <Text
                         color="steel-darker"
                         weight="medium"
+                        variant="p2"
                         truncate={!multiline}
                     >
                         {display}

--- a/apps/wallet/src/ui/app/pages/home/nft-details/LabelValueItem.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nft-details/LabelValueItem.tsx
@@ -49,15 +49,23 @@ export function LabelValueItem({
     }
     return display ? (
         <div className="flex flex-row flex-nowrap gap-1">
-            <div className="flex-1 truncate">
-                <Text color="steel-dark" variant="p2" weight="medium" truncate>
+            <div className="flex-1 [&>div]:leading-5">
+                <Text
+                    color="steel-dark"
+                    variant="body"
+                    weight="medium"
+                    truncate
+                >
                     {label}
                 </Text>
             </div>
             <div
-                className={cl('max-w-[60%] break-words text-end', {
-                    'pr-px line-clamp-3 hover:line-clamp-none': multiline,
-                })}
+                className={cl(
+                    'max-w-[60%] break-words text-end [&>div]:leading-5',
+                    {
+                        'pr-px line-clamp-3 hover:line-clamp-none': multiline,
+                    }
+                )}
             >
                 {href && display ? (
                     <Link
@@ -71,7 +79,7 @@ export function LabelValueItem({
                     <Text
                         color="steel-darker"
                         weight="medium"
-                        variant="p2"
+                        variant="body"
                         truncate={!multiline}
                     >
                         {display}


### PR DESCRIPTION
## Description 

<img width="332" alt="image" src="https://user-images.githubusercontent.com/128089541/231046625-cdc08c08-0758-44fb-87c6-e6f4272ebbf4.png">

https://mysten.atlassian.net/browse/APPS-307

## Test Plan 

Locally. Seems like the line height is getting clipped for some reason, just giving it a little bit of additional spacing so it doesn't happen.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Fixed NFT details clipping.