### PR TITLE
[cherry-pick][sdk] Support for upgrade programmable transaction command (#10664)

### DIFF
--- a/.changeset/empty-kiwis-pull.md
+++ b/.changeset/empty-kiwis-pull.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Adding support for the `upgrade` transaction type.

--- a/crates/sui-move/src/build.rs
+++ b/crates/sui-move/src/build.rs
@@ -86,6 +86,7 @@ impl Build {
                 json!({
                     "modules": pkg.get_package_base64(with_unpublished_deps),
                     "dependencies": json!(package_dependencies),
+                    "digest": pkg.get_package_digest(with_unpublished_deps),
                 })
             )
         }

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -242,26 +242,23 @@ import {
   JsonRpcProvider,
   RawSigner,
   TransactionBlock,
-  normalizeSuiObjectId,
 } from '@mysten/sui.js';
 const { execSync } = require('child_process');
 // Generate a new Keypair
 const keypair = new Ed25519Keypair();
 const provider = new JsonRpcProvider();
 const signer = new RawSigner(keypair, provider);
-const compiledModulesAndDeps = JSON.parse(
+const { modules, dependencies } = JSON.parse(
   execSync(
     `${cliPath} move build --dump-bytecode-as-base64 --path ${packagePath}`,
     { encoding: 'utf-8' },
   ),
 );
 const tx = new TransactionBlock();
-const [upgradeCap] = tx.publish(
-  compiledModulesAndDeps.modules.map((m: any) => Array.from(fromB64(m))),
-  compiledModulesAndDeps.dependencies.map((addr: string) =>
-    normalizeSuiObjectId(addr),
-  ),
-);
+const [upgradeCap] = tx.publish({
+  modules,
+  dependencies,
+});
 tx.transferObjects([upgradeCap], tx.pure(await signer.getAddress()));
 const result = await signer.signAndExecuteTransactionBlock({
   transactionBlock: tx,

--- a/sdk/typescript/src/builder/TransactionBlock.ts
+++ b/sdk/typescript/src/builder/TransactionBlock.ts
@@ -327,6 +327,9 @@ export class TransactionBlock {
   publish(...args: Parameters<(typeof Transactions)['Publish']>) {
     return this.add(Transactions.Publish(...args));
   }
+  upgrade(...args: Parameters<(typeof Transactions)['Upgrade']>) {
+    return this.add(Transactions.Upgrade(...args));
+  }
   moveCall(...args: Parameters<(typeof Transactions)['MoveCall']>) {
     return this.add(Transactions.MoveCall(...args));
   }
@@ -655,7 +658,7 @@ export class TransactionBlock {
         });
         if (dryRunResult.effects.status.status !== 'success') {
           throw new Error(
-            'Dry run failed, could not automatically determine a budget',
+            `Dry run failed, could not automatically determine a budget: ${dryRunResult.effects.status.error}`,
             { cause: dryRunResult },
           );
         }

--- a/sdk/typescript/src/builder/bcs.ts
+++ b/sdk/typescript/src/builder/bcs.ts
@@ -49,6 +49,7 @@ export const builder = new BCS(bcs)
     type_arguments: [VECTOR, TYPE_TAG],
     arguments: [VECTOR, ARGUMENT],
   })
+  // Keep this in sync with crates/sui-types/src/messages.rs
   .registerEnumType(TRANSACTION_INNER, {
     /**
      * A Move Call - any public Move function can be called via
@@ -86,6 +87,13 @@ export const builder = new BCS(bcs)
     MakeMoveVec: {
       type: [OPTION, TYPE_TAG],
       objects: [VECTOR, ARGUMENT],
+    },
+    /**  */
+    Upgrade: {
+      modules: [VECTOR, [VECTOR, BCS.U8]],
+      dependencies: [VECTOR, BCS.ADDRESS],
+      packageId: BCS.ADDRESS,
+      ticket: ARGUMENT,
     },
   });
 

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -82,6 +82,9 @@ export const SuiTransaction = union([
   object({ SplitCoins: tuple([SuiArgument, array(SuiArgument)]) }),
   object({ MergeCoins: tuple([SuiArgument, array(SuiArgument)]) }),
   object({ Publish: tuple([SuiMovePackage, array(ObjectId)]) }),
+  object({
+    Upgrade: tuple([SuiMovePackage, array(ObjectId), ObjectId, SuiArgument]),
+  }),
   object({ MakeMoveVec: tuple([nullable(string()), array(SuiArgument)]) }),
 ]);
 

--- a/sdk/typescript/test/e2e/data/serializer_upgrade/Move.toml
+++ b/sdk/typescript/test/e2e/data/serializer_upgrade/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "serializer"
+version = "0.0.2"
+
+[dependencies]
+Sui = { local = "../../../../../../crates/sui-framework/packages/sui-framework" }
+
+[addresses]
+serializer =  "0x0"

--- a/sdk/typescript/test/e2e/data/serializer_upgrade/sources/serializer.move
+++ b/sdk/typescript/test/e2e/data/serializer_upgrade/sources/serializer.move
@@ -35,14 +35,14 @@ module serializer::serializer_tests {
     }
 
     public entry fun value(clock: &MutableShared) {
-        assert!(clock.value > 0, 1);
+        assert!(clock.value > 10, 2);
     }
 
     public entry fun set_value(clock: &mut MutableShared) {
-        clock.value = 10;
+        clock.value = 20;
     }
 
     public fun test_abort() {
-        abort 0
+        abort 1
     }
 }


### PR DESCRIPTION
## Description

Add support to the TypeScript SDK for adding `upgrade` commands into programmable transactions. This enables the creation and use of custom upgrade policies (which require the creation of programmable transactions that call into their custom Move code to authorize and commit upgrades).

## Test Plan

New E2E test exercise upgrades:

```
$ pnpm sdk prepare:e2e # in one shell
$ pnpm sdk test:e2e # in another
```

### Release notes

Incorporate package digest in output from `sui move build --dump-bytecode-as-base64`.