### PR TITLE
[indexer] - use 30 checkpoints moving average instead of sum of 10 checkpoints / 10

### DIFF
--- a/crates/sui-indexer/migrations/2023-03-20-041133_epoch/up.sql
+++ b/crates/sui-indexer/migrations/2023-03-20-041133_epoch/up.sql
@@ -1,9 +1,11 @@
-CREATE MATERIALIZED VIEW epoch_network_metrics AS
-SELECT (SELECT MAX(t1.count)::float8 / 10
-        FROM (SELECT SUM(total_transactions) count
-              FROM checkpoints
-              WHERE timestamp_ms / 10000 > (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - '30 days'::INTERVAL)) / 10)::BIGINT
-              GROUP BY (timestamp_ms / 10000)) t1) AS tps_30_days;
+CREATE MATERIALIZED VIEW epoch_network_metrics as
+SELECT MAX(tps_30_days) as tps_30_days
+FROM (SELECT (((SUM(total_transactions) OVER w) - (FIRST_VALUE(total_transactions) OVER w))::float8 /
+              ((MAX(timestamp_ms) OVER w - MIN(timestamp_ms) OVER w)) *
+              1000) AS tps_30_days
+      FROM checkpoints
+      WHERE timestamp_ms / 1000 > (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - '30 days'::INTERVAL)))::BIGINT
+      WINDOW w AS (ORDER BY timestamp_ms ROWS BETWEEN 14 PRECEDING AND 15 FOLLOWING)) t1;
 
 CREATE TABLE epochs
 (


### PR DESCRIPTION
## Description 

Current indexer 30 days TPS is a bit off because it assume each checkpoint last for 1 sec, changing the query to calculate the 30 checkpoints moving average to get a more "accurate" tps