### PR TITLE
[framework tests] Adds sui::clock::share_for_testing

### DIFF
--- a/crates/sui-framework/packages/sui-framework/sources/clock.move
+++ b/crates/sui-framework/packages/sui-framework/sources/clock.move
@@ -70,6 +70,12 @@ module sui::clock {
     }
 
     #[test_only]
+    /// For transactional tests (if a Clock is used as a shared object).
+    public fun share_for_testing(clock: Clock) {
+        transfer::share_object(clock)
+    }
+
+    #[test_only]
     public fun increment_for_testing(clock: &mut Clock, tick: u64) {
         clock.timestamp_ms = clock.timestamp_ms + tick;
     }


### PR DESCRIPTION
## Description 

Recent change #10005 broke compatibility in tests and made it impossible to use Clock as a shared object. This PR adds a new function `share_for_testing` to allow sharing Clock (as a key-only struct)

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Adds a new function share_for_testing to allow sharing Clock (as a key-only struct)