### PR TITLE
[rocksdb iterators] don't perform seek_to_first by default

### DIFF
--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -1276,11 +1276,9 @@ impl<'a> DBTransaction<'a> {
         &'a self,
         db: &DBMap<K, V>,
     ) -> Iter<'a, K, V> {
-        let mut db_iter = self
+        let db_iter = self
             .transaction
             .raw_iterator_cf_opt(&db.cf(), db.opts.readopts());
-        db_iter.seek_to_first();
-
         Iter::new(
             RocksDBRawIter::OptimisticTransaction(db_iter),
             db.cf.clone(),
@@ -1575,10 +1573,9 @@ where
         } else {
             None
         };
-        let mut db_iter = self
+        let db_iter = self
             .rocksdb
             .raw_iterator_cf(&self.cf(), self.opts.readopts());
-        db_iter.seek_to_first();
         if let Some((timer, _perf_ctx)) = report_metrics {
             timer.stop_and_record();
             self.db_metrics


### PR DESCRIPTION
currently in order to fetch the object, we seek twice: [once implicitly](https://github.com/MystenLabs/sui/blob/main/crates/typed-store/src/rocks/mod.rs#L1282) to the start of the table and then again to the actual key.
This PR changes that behavior and only applies seek_to_first to iterators that have an uninitialized starting position