### PR TITLE
Revert "[wallet-ext] change header logo link to point to the network"

### DIFF
--- a/apps/wallet/src/ui/app/shared/header/Header.tsx
+++ b/apps/wallet/src/ui/app/shared/header/Header.tsx
@@ -5,7 +5,6 @@ import { type ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 
 import Logo from '../../components/logo';
-import { useNextMenuUrl } from '../../components/menu/hooks';
 import { type API_ENV } from '_src/shared/api-env';
 
 type HeaderProps = {
@@ -23,15 +22,10 @@ export function Header({
     middleContent,
     rightContent,
 }: HeaderProps) {
-    const networkSwitchUrl = useNextMenuUrl(true, '/network');
-
     return (
         <header className="grid grid-cols-header items-center gap-3 px-3 py-1">
             <div>
-                <Link
-                    to={networkSwitchUrl}
-                    className="no-underline text-gray-90"
-                >
+                <Link to="/" className="no-underline text-gray-90">
                     <Logo networkName={networkName} />
                 </Link>
             </div>


### PR DESCRIPTION
## Description 

This reverts commit b3e2ce12464027b6268445ed917a318b15d98b37. I think there's some internal discussion on whether or not we actually want to do this according to @Jordan-Mysten 

## Test Plan 
N/A

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
N/A
