### PR TITLE
[hardening] Reduce non-local asserts on execution path

### DIFF
--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1029,7 +1029,7 @@ pub struct TransactionDataV1 {
 }
 
 impl TransactionData {
-    pub fn new_system_transaction(kind: TransactionKind) -> Self {
+    fn new_system_transaction(kind: TransactionKind) -> Self {
         // assert transaction kind if a system transaction
         assert!(kind.is_system_tx());
         let sender = SuiAddress::default();

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -171,12 +171,15 @@ impl MoveObject {
     pub fn has_public_transfer(&self) -> bool {
         self.has_public_transfer
     }
+
     pub fn id(&self) -> ObjectID {
         Self::id_opt(&self.contents).unwrap()
     }
 
     pub fn id_opt(contents: &[u8]) -> Result<ObjectID, ObjectIDParseError> {
-        // TODO: Ensure safe index to to parse ObjectID. https://github.com/MystenLabs/sui/issues/6278
+        if ID_END_INDEX > contents.len() {
+            return Err(ObjectIDParseError::TryFromSliceError);
+        }
         ObjectID::try_from(&contents[0..ID_END_INDEX])
     }
 


### PR DESCRIPTION
## Description 

- replaced asserts/unwraps with invariant violations where the assert invariant was non-local

## Test Plan 

- Ran existing tests. The asserts are impossible to hit (as far as we know) so not easy to test 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
