### PR TITLE
Measure throughput in accumulator bench

### DIFF
--- a/crates/sui-types/benches/accumulator_bench.rs
+++ b/crates/sui-types/benches/accumulator_bench.rs
@@ -1,31 +1,38 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#[macro_use]
-extern crate criterion;
-
 use fastcrypto::hash::MultisetHash;
 use sui_types::accumulator::Accumulator;
 use sui_types::base_types::ObjectDigest;
 
-use criterion::Criterion;
+use criterion::*;
 
 fn accumulator_benchmark(c: &mut Criterion) {
-    let digests: Vec<_> = (0..1_000).map(|_| ObjectDigest::random()).collect();
-    let mut accumulator = Accumulator::default();
-
-    c.bench_function("accumulate_digests", |b| {
-        b.iter(|| accumulator.insert_all(&digests))
-    });
-
-    let mut accumulator = Accumulator::default();
-    let point = {
-        let digest = ObjectDigest::random();
+    {
+        let digests: Vec<_> = (0..1_000).map(|_| ObjectDigest::random()).collect();
         let mut accumulator = Accumulator::default();
-        accumulator.insert(digest);
-        accumulator
-    };
-    c.bench_function("sum_accumulators", |b| b.iter(|| accumulator.union(&point)));
+
+        let mut group = c.benchmark_group("accumulator");
+        group.throughput(Throughput::Elements(digests.len() as u64));
+
+        group.bench_function("accumulate_digests", |b| {
+            b.iter(|| accumulator.insert_all(&digests))
+        });
+    }
+
+    {
+        let mut group = c.benchmark_group("accumulator");
+        group.throughput(Throughput::Elements(1));
+
+        let mut accumulator = Accumulator::default();
+        let point = {
+            let digest = ObjectDigest::random();
+            let mut accumulator = Accumulator::default();
+            accumulator.insert(digest);
+            accumulator
+        };
+        group.bench_function("sum_accumulators", |b| b.iter(|| accumulator.union(&point)));
+    }
 }
 
 criterion_group!(benches, accumulator_benchmark);


### PR DESCRIPTION
Local results:

```
     Running benches/accumulator_bench.rs (/Users/marklogan/dev/sui/target/release/deps/accumulator_bench-431472f3bc9213bf)
Gnuplot not found, using plotters backend
accumulator/accumulate_digests
                        time:   [7.9310 ms 7.9376 ms 7.9452 ms]
                        thrpt:  [125.86 Kelem/s 125.98 Kelem/s 126.09 Kelem/s]
                 change:
                        time:   [-0.0933% +0.0398% +0.1692%] (p = 0.57 > 0.05)
                        thrpt:  [-0.1690% -0.0398% +0.0934%]
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

accumulator/sum_accumulators
                        time:   [126.01 ns 126.11 ns 126.23 ns]
                        thrpt:  [7.9223 Melem/s 7.9295 Melem/s 7.9360 Melem/s]
                 change:
                        time:   [-0.0320% +0.1883% +0.4147%] (p = 0.10 > 0.05)
                        thrpt:  [-0.4130% -0.1879% +0.0320%]
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe

cargo bench  36.99s user 1.70s system 148% cpu 26.112 total
```