### PR TITLE
[explorer]: Switchable split panes orientation

### DIFF
--- a/apps/explorer/src/components/module/PkgModulesWrapper.tsx
+++ b/apps/explorer/src/components/module/PkgModulesWrapper.tsx
@@ -4,6 +4,7 @@
 import { Combobox } from '@headlessui/react';
 import clsx from 'clsx';
 import { useState, useCallback, useEffect } from 'react';
+import { type Direction } from 'react-resizable-panels';
 
 import ModuleView from './ModuleView';
 import { ModuleFunctionsInteraction } from './module-functions-interaction';
@@ -20,7 +21,7 @@ type ModuleType = [moduleName: string, code: string];
 interface Props {
     id?: string;
     modules: ModuleType[];
-    isSplitPaneHorizontal: boolean;
+    splitPanelOrientation: Direction;
 }
 
 interface ModuleViewWrapperProps {
@@ -47,7 +48,7 @@ function ModuleViewWrapper({
     return <ModuleView id={id} name={name} code={code} />;
 }
 
-function PkgModuleViewWrapper({ id, modules, isSplitPaneHorizontal }: Props) {
+function PkgModuleViewWrapper({ id, modules, splitPanelOrientation }: Props) {
     const isMediumOrAbove = useBreakpoint('md');
 
     const modulenames = modules.map(([name]) => name);
@@ -143,7 +144,7 @@ function PkgModuleViewWrapper({ id, modules, isSplitPaneHorizontal }: Props) {
     ];
 
     return (
-        <div className="flex flex-col gap-5 border-y border-gray-45 md:flex-row md:flex-nowrap">
+        <div className="flex flex-col gap-5 border-b border-gray-45 md:flex-row md:flex-nowrap">
             <div className="w-full md:w-1/5">
                 <Combobox value={selectedModule} onChange={onChangeModule}>
                     <div className="mt-2.5 flex w-full justify-between rounded-md border border-gray-50 py-1 pl-3 placeholder-gray-65 shadow-sm">
@@ -218,7 +219,7 @@ function PkgModuleViewWrapper({ id, modules, isSplitPaneHorizontal }: Props) {
             {isMediumOrAbove ? (
                 <div className="w-4/5">
                     <SplitPanes
-                        direction={isSplitPaneHorizontal ? 'horizontal' : 'vertical'}
+                        direction={splitPanelOrientation}
                         defaultSizes={[40, 60]}
                         panels={bytecodeContent}
                     />

--- a/apps/explorer/src/components/module/PkgModulesWrapper.tsx
+++ b/apps/explorer/src/components/module/PkgModulesWrapper.tsx
@@ -20,6 +20,7 @@ type ModuleType = [moduleName: string, code: string];
 interface Props {
     id?: string;
     modules: ModuleType[];
+    isSplitPaneHorizontal: boolean;
 }
 
 interface ModuleViewWrapperProps {
@@ -46,7 +47,7 @@ function ModuleViewWrapper({
     return <ModuleView id={id} name={name} code={code} />;
 }
 
-function PkgModuleViewWrapper({ id, modules }: Props) {
+function PkgModuleViewWrapper({ id, modules, isSplitPaneHorizontal }: Props) {
     const isMediumOrAbove = useBreakpoint('md');
 
     const modulenames = modules.map(([name]) => name);
@@ -217,7 +218,7 @@ function PkgModuleViewWrapper({ id, modules }: Props) {
             {isMediumOrAbove ? (
                 <div className="w-4/5">
                     <SplitPanes
-                        direction="horizontal"
+                        direction={isSplitPaneHorizontal ? 'horizontal' : 'vertical'}
                         defaultSizes={[40, 60]}
                         panels={bytecodeContent}
                     />

--- a/apps/explorer/src/components/module/PkgModulesWrapper.tsx
+++ b/apps/explorer/src/components/module/PkgModulesWrapper.tsx
@@ -98,7 +98,7 @@ function PkgModuleViewWrapper({ id, modules, splitPanelOrientation }: Props) {
     const bytecodeContent = [
         <div
             key="bytecode"
-            className="grow overflow-auto border-gray-45 pt-5 md:pl-7"
+            className="h-full grow overflow-auto border-gray-45 pt-5 md:pl-7"
         >
             <TabGroup size="md">
                 <TabList>
@@ -106,7 +106,14 @@ function PkgModuleViewWrapper({ id, modules, splitPanelOrientation }: Props) {
                 </TabList>
                 <TabPanels>
                     <TabPanel>
-                        <div className="h-verticalListLong overflow-auto">
+                        <div
+                            className={clsx(
+                                'overflow-auto',
+                                (splitPanelOrientation === 'horizontal' ||
+                                    !isMediumOrAbove) &&
+                                    'h-verticalListLong'
+                            )}
+                        >
                             <ModuleViewWrapper
                                 id={id}
                                 modules={modules}
@@ -119,7 +126,7 @@ function PkgModuleViewWrapper({ id, modules, splitPanelOrientation }: Props) {
         </div>,
         <div
             key="execute"
-            className="grow overflow-auto border-gray-45 pt-5 md:pl-7"
+            className="h-full grow overflow-auto border-gray-45 pt-5 md:pl-7"
         >
             <TabGroup size="md">
                 <TabList>
@@ -127,7 +134,14 @@ function PkgModuleViewWrapper({ id, modules, splitPanelOrientation }: Props) {
                 </TabList>
                 <TabPanels>
                     <TabPanel>
-                        <div className="h-verticalListLong overflow-auto">
+                        <div
+                            className={clsx(
+                                'overflow-auto',
+                                (splitPanelOrientation === 'horizontal' ||
+                                    !isMediumOrAbove) &&
+                                    'h-verticalListLong'
+                            )}
+                        >
                             {id && selectedModule ? (
                                 <ModuleFunctionsInteraction
                                     // force recreating everything when we change modules

--- a/apps/explorer/src/pages/object-result/views/PkgView.tsx
+++ b/apps/explorer/src/pages/object-result/views/PkgView.tsx
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { getTransactionSender } from '@mysten/sui.js';
-import {useState} from "react";
+import { useState } from 'react';
+import { type Direction } from 'react-resizable-panels';
 
 import { ErrorBoundary } from '../../../components/error-boundary/ErrorBoundary';
 import PkgModulesWrapper from '../../../components/module/PkgModulesWrapper';
@@ -12,19 +13,24 @@ import { getOwnerStr } from '../../../utils/objectUtils';
 import { trimStdLibPrefix } from '../../../utils/stringUtils';
 import { type DataType } from '../ObjectResultType';
 
-
 import styles from './ObjectView.module.css';
 
-import {Button} from "~/ui/Button";
-import { Heading } from '~/ui/Heading';
 import { AddressLink, ObjectLink } from '~/ui/InternalLink';
 import { LoadingSpinner } from '~/ui/LoadingSpinner';
+import { RadioGroup, RadioOption } from '~/ui/Radio';
 import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '~/ui/Tabs';
 
 const GENESIS_TX_DIGEST = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=';
 
+const splitPanelsOrientation = [
+    { label: 'STACKED', value: 'vertical' },
+    { label: 'SIDE-BY-SIDE', value: 'horizontal' },
+];
+
 function PkgView({ data }: { data: DataType }) {
-    const [isSplitPaneHorizontal, setIsSplitPaneHorizontal] = useState(true);
+    const [selectedSplitPanelOrientation, setSplitPanelOrientation] = useState(
+        splitPanelsOrientation[1].value
+    );
 
     const { data: txnData, isLoading } = useGetTransaction(
         data.data.tx_digest!
@@ -102,18 +108,45 @@ function PkgView({ data }: { data: DataType }) {
                     </TabPanels>
                 </TabGroup>
 
-                <div className="mb-3 mt-16 flex justify-between">
-                    <Heading as="h2" variant="heading4/semibold">
-                        Modules
-                    </Heading>
-                    <div className="flex justify-end gap-5">
-                        <Button variant="outline" size="sm" onClick={() => setIsSplitPaneHorizontal(false)}><div className="uppercase">stacked</div></Button>
-                        <Button variant="outline" size="sm" onClick={() => setIsSplitPaneHorizontal(true)}><div className="uppercase">side-by-side</div></Button>
-                    </div>
-                </div>
-                <ErrorBoundary>
-                    <PkgModulesWrapper id={data.id} modules={properties} isSplitPaneHorizontal={isSplitPaneHorizontal} />
-                </ErrorBoundary>
+                <TabGroup size="lg">
+                    <TabList>
+                        <div className="mt-16 flex w-full justify-between">
+                            <Tab>Modules</Tab>
+                            <div>
+                                <RadioGroup
+                                    className="hidden gap-0.5 md:flex"
+                                    ariaLabel="split-panel-bytecode-viewer"
+                                    value={selectedSplitPanelOrientation}
+                                    onChange={setSplitPanelOrientation}
+                                >
+                                    {splitPanelsOrientation.map(
+                                        ({ value, label }) => (
+                                            <RadioOption
+                                                key={value}
+                                                value={value}
+                                                label={label}
+                                            />
+                                        )
+                                    )}
+                                </RadioGroup>
+                            </div>
+                        </div>
+                    </TabList>
+                    <TabPanels>
+                        <TabPanel noGap>
+                            <ErrorBoundary>
+                                <PkgModulesWrapper
+                                    id={data.id}
+                                    modules={properties}
+                                    splitPanelOrientation={
+                                        selectedSplitPanelOrientation as Direction
+                                    }
+                                />
+                            </ErrorBoundary>
+                        </TabPanel>
+                    </TabPanels>
+                </TabGroup>
+
                 <div className={styles.txsection}>
                     <h2 className={styles.header}>Transaction Blocks</h2>
                     <ErrorBoundary>

--- a/apps/explorer/src/pages/object-result/views/PkgView.tsx
+++ b/apps/explorer/src/pages/object-result/views/PkgView.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { getTransactionSender } from '@mysten/sui.js';
+import {useState} from "react";
 
 import { ErrorBoundary } from '../../../components/error-boundary/ErrorBoundary';
 import PkgModulesWrapper from '../../../components/module/PkgModulesWrapper';
@@ -11,8 +12,10 @@ import { getOwnerStr } from '../../../utils/objectUtils';
 import { trimStdLibPrefix } from '../../../utils/stringUtils';
 import { type DataType } from '../ObjectResultType';
 
+
 import styles from './ObjectView.module.css';
 
+import {Button} from "~/ui/Button";
 import { Heading } from '~/ui/Heading';
 import { AddressLink, ObjectLink } from '~/ui/InternalLink';
 import { LoadingSpinner } from '~/ui/LoadingSpinner';
@@ -21,6 +24,8 @@ import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '~/ui/Tabs';
 const GENESIS_TX_DIGEST = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=';
 
 function PkgView({ data }: { data: DataType }) {
+    const [isSplitPaneHorizontal, setIsSplitPaneHorizontal] = useState(true);
+
     const { data: txnData, isLoading } = useGetTransaction(
         data.data.tx_digest!
     );
@@ -97,13 +102,17 @@ function PkgView({ data }: { data: DataType }) {
                     </TabPanels>
                 </TabGroup>
 
-                <div className="mb-3">
+                <div className="mb-3 mt-16 flex justify-between">
                     <Heading as="h2" variant="heading4/semibold">
                         Modules
                     </Heading>
+                    <div className="flex justify-end gap-5">
+                        <Button variant="outline" size="sm" onClick={() => setIsSplitPaneHorizontal(false)}><div className="uppercase">stacked</div></Button>
+                        <Button variant="outline" size="sm" onClick={() => setIsSplitPaneHorizontal(true)}><div className="uppercase">side-by-side</div></Button>
+                    </div>
                 </div>
                 <ErrorBoundary>
-                    <PkgModulesWrapper id={data.id} modules={properties} />
+                    <PkgModulesWrapper id={data.id} modules={properties} isSplitPaneHorizontal={isSplitPaneHorizontal} />
                 </ErrorBoundary>
                 <div className={styles.txsection}>
                     <h2 className={styles.header}>Transaction Blocks</h2>

--- a/apps/explorer/src/pages/object-result/views/PkgView.tsx
+++ b/apps/explorer/src/pages/object-result/views/PkgView.tsx
@@ -22,7 +22,7 @@ import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '~/ui/Tabs';
 
 const GENESIS_TX_DIGEST = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=';
 
-const splitPanelsOrientation = [
+const splitPanelsOrientation: { label: string; value: Direction }[] = [
     { label: 'STACKED', value: 'vertical' },
     { label: 'SIDE-BY-SIDE', value: 'horizontal' },
 ];
@@ -139,7 +139,7 @@ function PkgView({ data }: { data: DataType }) {
                                     id={data.id}
                                     modules={properties}
                                     splitPanelOrientation={
-                                        selectedSplitPanelOrientation as Direction
+                                        selectedSplitPanelOrientation
                                     }
                                 />
                             </ErrorBoundary>

--- a/apps/explorer/src/ui/Button.tsx
+++ b/apps/explorer/src/ui/Button.tsx
@@ -17,13 +17,9 @@ const buttonStyles = cva(['inline-flex items-center justify-center relative'], {
                 'bg-white border border-steel text-steel-dark hover:text-steel-darker hover:border-steel-dark active:text-steel active:border-steel disabled:border-gray-45 disabled:text-steel-dark',
         },
         size: {
-            sm: 'px-2 py-1 rounded-md text-bodySmall font-semibold',
             md: 'px-3 py-2 rounded-md text-bodySmall font-semibold',
             lg: 'px-4 py-3 rounded-lg text-body font-semibold',
         },
-        noBorder: {
-            true: 'border-transparent',
-        }
     },
     defaultVariants: {
         variant: 'primary',
@@ -46,12 +42,11 @@ export function Button({
     children,
     before,
     after,
-                           noBorder,
     ...props
 }: ButtonProps) {
     return (
         <ButtonOrLink
-            className={buttonStyles({ variant, size, noBorder })}
+            className={buttonStyles({ variant, size })}
             {...props}
             disabled={props.disabled || loading}
         >

--- a/apps/explorer/src/ui/Button.tsx
+++ b/apps/explorer/src/ui/Button.tsx
@@ -17,9 +17,13 @@ const buttonStyles = cva(['inline-flex items-center justify-center relative'], {
                 'bg-white border border-steel text-steel-dark hover:text-steel-darker hover:border-steel-dark active:text-steel active:border-steel disabled:border-gray-45 disabled:text-steel-dark',
         },
         size: {
+            sm: 'px-2 py-1 rounded-md text-bodySmall font-semibold',
             md: 'px-3 py-2 rounded-md text-bodySmall font-semibold',
             lg: 'px-4 py-3 rounded-lg text-body font-semibold',
         },
+        noBorder: {
+            true: 'border-transparent',
+        }
     },
     defaultVariants: {
         variant: 'primary',
@@ -42,11 +46,12 @@ export function Button({
     children,
     before,
     after,
+                           noBorder,
     ...props
 }: ButtonProps) {
     return (
         <ButtonOrLink
-            className={buttonStyles({ variant, size })}
+            className={buttonStyles({ variant, size, noBorder })}
             {...props}
             disabled={props.disabled || loading}
         >

--- a/apps/explorer/src/ui/SplitPanes.tsx
+++ b/apps/explorer/src/ui/SplitPanes.tsx
@@ -20,13 +20,13 @@ function ResizeHandle({ isHorizontal }: { isHorizontal: boolean }) {
 
     return (
         <PanelResizeHandle
-            className={clsx(isHorizontal ? 'px-2' : 'py-2')}
+            className={clsx('group', isHorizontal ? 'px-2' : 'py-2')}
             onDragging={setIsDragging}
         >
             <div
                 data-is-dragging={isDragging}
                 className={clsx(
-                    'bg-gray-45 hover:bg-sui data-[is-dragging=true]:bg-hero',
+                    'bg-gray-45 group-hover:bg-sui data-[is-dragging=true]:bg-hero',
                     isHorizontal ? 'h-full w-px' : 'h-px'
                 )}
             />

--- a/apps/explorer/src/ui/SplitPanes.tsx
+++ b/apps/explorer/src/ui/SplitPanes.tsx
@@ -45,7 +45,11 @@ export function SplitPanes({
         <PanelGroup {...props}>
             {panels.map((panel, index) => (
                 <Fragment key={index}>
-                    <Panel order={index} defaultSize={defaultSizes[index]}>
+                    <Panel
+                        collapsible
+                        order={index}
+                        defaultSize={defaultSizes[index]}
+                    >
                         {panel}
                     </Panel>
                     {index < panels.length - 1 && (

--- a/apps/explorer/src/ui/SplitPanes.tsx
+++ b/apps/explorer/src/ui/SplitPanes.tsx
@@ -10,7 +10,7 @@ import {
     PanelResizeHandle,
 } from 'react-resizable-panels';
 
-export interface SplitPaneProps extends PanelGroupProps {
+export interface SplitPanesProps extends PanelGroupProps {
     panels: ReactNode[];
     defaultSizes?: number[];
 }
@@ -38,18 +38,14 @@ export function SplitPanes({
     panels,
     defaultSizes = [],
     ...props
-}: SplitPaneProps) {
+}: SplitPanesProps) {
     const { direction } = props;
 
     return (
         <PanelGroup {...props}>
             {panels.map((panel, index) => (
                 <Fragment key={index}>
-                    <Panel
-                        collapsible
-                        order={index}
-                        defaultSize={defaultSizes[index]}
-                    >
+                    <Panel order={index} defaultSize={defaultSizes[index]}>
                         {panel}
                     </Panel>
                     {index < panels.length - 1 && (

--- a/apps/explorer/src/ui/stories/SplitPanes.stories.tsx
+++ b/apps/explorer/src/ui/stories/SplitPanes.stories.tsx
@@ -3,7 +3,7 @@
 
 import { type Meta, type StoryObj } from '@storybook/react';
 
-import { SplitPanes, type SplitPaneProps } from '../SplitPanes';
+import { SplitPanes, type SplitPanesProps } from '../SplitPanes';
 
 export default {
     component: SplitPanes,
@@ -25,7 +25,7 @@ const panels = [
     </div>,
 ];
 
-const SplitPanesStory: StoryObj<SplitPaneProps> = {
+const SplitPanesStory: StoryObj<SplitPanesProps> = {
     render: (props) => (
         <div className="h-[500px] w-[1000px]">
             <SplitPanes {...props} panels={panels} />
@@ -33,7 +33,7 @@ const SplitPanesStory: StoryObj<SplitPaneProps> = {
     ),
 };
 
-export const HorizontalSplitPanes: StoryObj<SplitPaneProps> = {
+export const HorizontalSplitPanes: StoryObj<SplitPanesProps> = {
     ...SplitPanesStory,
     args: {
         direction: 'horizontal',
@@ -41,14 +41,14 @@ export const HorizontalSplitPanes: StoryObj<SplitPaneProps> = {
     },
 };
 
-export const VerticalSplitPanes: StoryObj<SplitPaneProps> = {
+export const VerticalSplitPanes: StoryObj<SplitPanesProps> = {
     ...SplitPanesStory,
     args: {
         direction: 'vertical',
     },
 };
 
-export const SplitPanesWithStateSaveOnRefresh: StoryObj<SplitPaneProps> = {
+export const SplitPanesWithStateSaveOnRefresh: StoryObj<SplitPanesProps> = {
     ...SplitPanesStory,
     args: {
         direction: 'horizontal',


### PR DESCRIPTION
## Description 

- Update Toggle split view panels
- Update `Modules` to be a Tab for styling consistency
- Pending on https://github.com/MystenLabs/sui/pull/10771
- https://mysten.atlassian.net/browse/APPS-752

![toggle](https://user-images.githubusercontent.com/127577476/231296141-07f2cbe5-871d-408e-983f-74a6d64156a8.gif)

<img width="1543" alt="Screenshot 2023-04-11 at 4 44 29 PM" src="https://user-images.githubusercontent.com/127577476/231311910-e5d5bbbc-2a31-4f5c-92de-11e14aa83aa0.png">


## Test Plan 


How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
