### PR TITLE
[RFC] Add PackageObjectCache

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -135,6 +135,7 @@ pub mod authority_store_pruner;
 pub mod authority_store_tables;
 pub mod authority_store_types;
 pub mod epoch_start_configuration;
+pub mod package_object_cache;
 
 pub(crate) mod authority_notify_read;
 pub(crate) mod authority_store;
@@ -955,6 +956,7 @@ impl AuthorityState {
         // check_certificate_input also checks shared object locks when loading the shared objects.
         let (gas_status, input_objects) = transaction_input_checker::check_certificate_input(
             &self.database,
+            &epoch_store.move_package_object_cache,
             epoch_store,
             certificate,
         )

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -554,11 +554,12 @@ impl AuthorityStore {
     ///
     /// Before this function is invoked, TransactionManager must ensure all depended
     /// objects are present. Thus any missing object will panic.
-    pub fn check_sequenced_input_objects(
+    pub fn check_sequenced_input_objects<S: BackingPackageStore>(
         &self,
         digest: &TransactionDigest,
         objects: &[InputObjectKind],
         epoch_store: &AuthorityPerEpochStore,
+        package_store: &Arc<S>,
     ) -> Result<Vec<Object>, SuiError> {
         let shared_locks_cell: OnceCell<HashMap<_, _>> = OnceCell::new();
 
@@ -584,7 +585,7 @@ impl AuthorityStore {
                         panic!("All dependencies of tx {:?} should have been executed now, but Shared Object id: {}, version: {} is absent", digest, *id, *version);
                     })
                 }
-                InputObjectKind::MovePackage(id) => self.get_object(id)?.unwrap_or_else(|| {
+                InputObjectKind::MovePackage(id) => package_store.get_package_object(id)?.unwrap_or_else(|| {
                     panic!("All dependencies of tx {:?} should have been executed now, but Move Package id: {} is absent", digest, id);
                 }),
                 InputObjectKind::ImmOrOwnedMoveObject(objref) => {

--- a/crates/sui-core/src/authority/package_object_cache.rs
+++ b/crates/sui-core/src/authority/package_object_cache.rs
@@ -1,0 +1,46 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use parking_lot::RwLock;
+use std::collections::HashMap;
+use std::sync::Arc;
+use sui_types::base_types::ObjectID;
+use sui_types::error::{SuiError, SuiResult, UserInputError};
+use sui_types::object::Object;
+use sui_types::storage::{BackingPackageStore, ObjectStore};
+
+pub struct PackageObjectCache<S> {
+    cache: RwLock<HashMap<ObjectID, Object>>,
+    store: Arc<S>,
+}
+
+impl<S> PackageObjectCache<S> {
+    pub fn new(store: Arc<S>) -> Arc<Self> {
+        Arc::new(Self {
+            cache: RwLock::new(HashMap::new()),
+            store,
+        })
+    }
+}
+
+impl<S: ObjectStore> BackingPackageStore for PackageObjectCache<S> {
+    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<Object>> {
+        if let Some(p) = self.cache.read().get(package_id) {
+            return Ok(Some(p.clone()));
+        }
+        if let Some(p) = self.store.get_object(package_id)? {
+            if p.is_package() {
+                self.cache.write().insert(*package_id, p.clone());
+                Ok(Some(p))
+            } else {
+                Err(SuiError::UserInputError {
+                    error: UserInputError::MoveObjectAsPackage {
+                        object_id: *package_id,
+                    },
+                })
+            }
+        } else {
+            Ok(None)
+        }
+    }
+}


### PR DESCRIPTION
Adds a package object cache for transaction/certificate input object checking. It's a straightforward change that could avoid most of the package reads during input checking.
TODO: This PR only uses it for cert input checking atm, but should be easy to use it in transaction input checking as well.

This is a separate cache from the Move VM's module cache. Ideally we should use a single one, but it's unclear to me if we could/should modify Move VM module cache data structure.