### PR TITLE
fix flaky validator candidate simtest

### DIFF
--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -490,7 +490,6 @@ async fn test_validator_resign_effects() {
 }
 
 #[sim_test]
-#[ignore]
 async fn test_validator_candidate_pool_read() {
     let new_validator_key = gen_keys(5).pop().unwrap();
     let new_validator_address: SuiAddress = new_validator_key.public().into();
@@ -547,6 +546,10 @@ async fn test_validator_candidate_pool_read() {
         &new_validator_key,
     )
     .await;
+
+    // Trigger reconfiguration so that the candidate adding txn is executed on all authorities.
+    trigger_reconfiguration(&authorities).await;
+
     // Check that the candidate can be found in the candidate table now.
     authorities[0].with(|node| {
         let system_state = node


### PR DESCRIPTION
## Description 

Removing `#[ignore]` from a flaky simtest.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
