### PR TITLE
[wallet-ext] display amounts

### DIFF
--- a/.changeset/eighty-spiders-glow.md
+++ b/.changeset/eighty-spiders-glow.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+added constants for `StakingRequestEvent` and `UnstakingRequestEvent`

--- a/apps/core/src/hooks/useGetTransferLabel.ts
+++ b/apps/core/src/hooks/useGetTransferLabel.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+    getTransactionSender,
+    STAKING_REQUEST_EVENT,
+    SuiTransactionBlockResponse,
+    TransactionEvents,
+    UNSTAKING_REQUEST_EVENT,
+} from '@mysten/sui.js';
+
+function getEventType(events: TransactionEvents = []) {
+    return events.find(({ type }) =>
+        [STAKING_REQUEST_EVENT, UNSTAKING_REQUEST_EVENT].includes(type)
+    )?.type;
+}
+
+export function useGetTransferLabel(
+    txn: SuiTransactionBlockResponse,
+    currentAddress: string
+) {
+    const senderAddress = getTransactionSender(txn);
+    const type = getEventType(txn.events);
+
+    switch (type) {
+        case STAKING_REQUEST_EVENT:
+            return 'Staked';
+        case UNSTAKING_REQUEST_EVENT:
+            return 'Unstaked';
+        default:
+            return senderAddress === currentAddress ? 'Sent' : 'Received';
+    }
+}

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -1,11 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-export * from './api/SentryRpcClient';
 export * from './api/RpcClientContext';
+export * from './api/SentryRpcClient';
 export * from './hooks/useFormatCoin';
-export * from './hooks/useTimeAgo';
-export * from './hooks/useGetValidatorsEvents';
 export * from './hooks/useGetRollingAverageApys';
 export * from './utils/formatAmount';
 export * from './utils/roundFloat';
@@ -14,6 +12,11 @@ export * from './hooks/useGetObject';
 export * from './hooks/useGetDynamicFieldObject';
 export * from './hooks/useGetDynamicFields';
 export * from './hooks/useGetNormalizedMoveStruct';
+export * from './hooks/useGetTransferLabel';
+export * from './hooks/useGetValidatorsEvents';
+export * from './hooks/useTimeAgo';
 export * from './PostHogAnalyticsProvider';
+export * from './utils/formatAmount';
 export * from './utils/formatPercentageDisplay';
 export * from './hooks/useGetSystemState';
+export * from './utils/roundFloat';

--- a/apps/wallet/src/ui/app/components/receipt-card/SponsoredTxnGasSummary.tsx
+++ b/apps/wallet/src/ui/app/components/receipt-card/SponsoredTxnGasSummary.tsx
@@ -9,7 +9,7 @@ import { GAS_SYMBOL, GAS_TYPE_ARG } from '_redux/slices/sui-objects/Coin';
 import { Text } from '_src/ui/app/shared/text';
 
 type SponsoredTxnGasSummaryProps = {
-    totalGas: number;
+    totalGas: bigint | number;
     sponsor: SuiAddress;
 };
 

--- a/apps/wallet/src/ui/app/components/receipt-card/TxnAmount.tsx
+++ b/apps/wallet/src/ui/app/components/receipt-card/TxnAmount.tsx
@@ -7,7 +7,7 @@ import { Heading } from '_src/ui/app/shared/heading';
 import { Text } from '_src/ui/app/shared/text';
 
 type TxnAmountProps = {
-    amount: string | number;
+    amount: bigint | number;
     coinType: string;
     label: string;
     approximation?: boolean;
@@ -21,11 +21,9 @@ export function TxnAmount({
     label,
     approximation,
 }: TxnAmountProps) {
-    const [formatAmount, symbol] = useFormatCoin(
-        Math.abs(Number(amount)),
-        coinType
-    );
-    return Number(amount) !== 0 ? (
+    const [formatAmount, symbol] = useFormatCoin(amount, coinType);
+    if (!amount) return null;
+    return (
         <div className="flex justify-between w-full items-center py-3.5 first:pt-0">
             <Text variant="body" weight="medium" color="steel-darker">
                 {label}
@@ -40,5 +38,5 @@ export function TxnAmount({
                 </Text>
             </div>
         </div>
-    ) : null;
+    );
 }

--- a/apps/wallet/src/ui/app/components/receipt-card/TxnGasSummary.tsx
+++ b/apps/wallet/src/ui/app/components/receipt-card/TxnGasSummary.tsx
@@ -10,18 +10,17 @@ import type { GasCostSummary } from '@mysten/sui.js';
 
 type TxnGasSummaryProps = {
     gasSummary?: GasCostSummary;
-    totalGas: number;
-    transferAmount: number | null;
+    totalGas: bigint;
+    transferAmount: bigint;
 };
 
 //TODO add gas breakdown
 export function TxnGasSummary({
-    gasSummary,
     totalGas,
     transferAmount,
 }: TxnGasSummaryProps) {
     const [totalAmount, totalAmountSymbol] = useFormatCoin(
-        totalGas + (transferAmount || 0),
+        totalGas + transferAmount,
         GAS_TYPE_ARG
     );
     const [gas, symbol] = useFormatCoin(totalGas, GAS_TYPE_ARG);

--- a/apps/wallet/src/ui/app/components/transactions-card/index.tsx
+++ b/apps/wallet/src/ui/app/components/transactions-card/index.tsx
@@ -1,14 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { useGetTransferLabel, useGetTransferAmount } from '@mysten/core';
 import {
-    getExecutionStatusError,
     getExecutionStatusType,
     getTransactionDigest,
-    getTransactionKindName,
-    getTransactionKind,
     getTransactionSender,
-    SUI_TYPE_ARG,
+    getExecutionStatusError,
+    Coin,
 } from '@mysten/sui.js';
 import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
@@ -18,7 +17,7 @@ import { TxnIcon } from './TxnIcon';
 import { CoinBalance } from '_app/shared/coin-balance';
 import { DateCard } from '_app/shared/date-card';
 import { Text } from '_app/shared/text';
-import { useGetTransferAmount, useGetTxnRecipientAddress } from '_hooks';
+import { useGetTxnRecipientAddress } from '_hooks';
 
 import type {
     SuiAddress,
@@ -48,42 +47,15 @@ export function TransactionCard({
     txn: SuiTransactionBlockResponse;
     address: SuiAddress;
 }) {
-    const transaction = getTransactionKind(txn)!;
     const executionStatus = getExecutionStatusType(txn);
-    getTransactionKindName(transaction);
 
     // const objectId = useMemo(() => {
     //     return getTxnEffectsEventID(txn.events!, address)[0];
     // }, [address, txn.events]);
 
-    const transfer = useGetTransferAmount({
-        txn,
-        activeAddress: address,
-    });
+    const { amount, coinType } = useGetTransferAmount(txn, address);
 
-    // we only show Sui Transfer amount or the first non-Sui transfer amount
-    const transferAmount = useMemo(() => {
-        // Find SUI transfer amount
-        const amountTransfersSui = transfer?.find(
-            ({ coinType }) => coinType === SUI_TYPE_ARG
-        );
-
-        // Find non-SUI transfer amount
-        const amountTransfersNonSui = transfer?.find(
-            ({ coinType }) => coinType !== SUI_TYPE_ARG
-        );
-
-        return {
-            amount:
-                amountTransfersSui?.amount ||
-                amountTransfersNonSui?.amount ||
-                null,
-            coinType:
-                amountTransfersSui?.coinType ||
-                amountTransfersNonSui?.coinType ||
-                null,
-        };
-    }, [transfer]);
+    const symbol = useMemo(() => Coin.getCoinSymbol(coinType), [coinType]);
 
     const recipientAddress = useGetTxnRecipientAddress({ txn, address });
 
@@ -95,22 +67,7 @@ export function TransactionCard({
     // Epoch change without amount is delegation object
     // Special case for staking and unstaking move call transaction,
     // For other transaction show Sent or Received
-    const txnLabel = useMemo(() => {
-        return isSender ? 'Sent' : 'Received';
-    }, [/*txnKind,transferAmount.amount,*/ isSender]);
-
-    // TODO: Support programmable tx:
-    // Show sui symbol only if transfer transferAmount coinType is SUI_TYPE_ARG, staking or unstaking
-    const showSuiSymbol = false;
-
-    const transferAmountComponent = transferAmount.coinType &&
-        transferAmount.amount && (
-            <CoinBalance
-                amount={Math.abs(transferAmount.amount)}
-                coinType={transferAmount.coinType}
-            />
-        );
-
+    const txnLabel = useGetTransferLabel(txn, address);
     const timestamp = txn.timestampMs;
 
     return (
@@ -146,7 +103,7 @@ export function TransactionCard({
                                     </Text>
                                 </div>
                             </div>
-                            {transferAmountComponent}
+                            <CoinBalance amount={amount} coinType={coinType} />
                         </div>
                     ) : (
                         <>
@@ -155,17 +112,19 @@ export function TransactionCard({
                                     <Text color="gray-90" weight="semibold">
                                         {txnLabel}
                                     </Text>
-                                    {showSuiSymbol && (
-                                        <Text
-                                            color="gray-90"
-                                            weight="normal"
-                                            variant="subtitleSmall"
-                                        >
-                                            SUI
-                                        </Text>
-                                    )}
+
+                                    <Text
+                                        color="gray-90"
+                                        weight="normal"
+                                        variant="subtitleSmall"
+                                    >
+                                        {symbol}
+                                    </Text>
                                 </div>
-                                {transferAmountComponent}
+                                <CoinBalance
+                                    amount={amount}
+                                    coinType={coinType}
+                                />
                             </div>
 
                             {/* TODO: Support programmable tx: */}

--- a/apps/wallet/src/ui/app/hooks/useQueryTransactionsByAddress.ts
+++ b/apps/wallet/src/ui/app/hooks/useQueryTransactionsByAddress.ts
@@ -21,6 +21,7 @@ export function useQueryTransactionsByAddress(address: SuiAddress | null) {
                         ToAddress: address!,
                     },
                     options: {
+                        showBalanceChanges: true,
                         showInput: true,
                         showEffects: true,
                         showEvents: true,

--- a/apps/wallet/src/ui/app/pages/home/receipt/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/receipt/index.tsx
@@ -30,6 +30,7 @@ function ReceiptPage() {
             return rpc.getTransactionBlock({
                 digest: transactionId!,
                 options: {
+                    showBalanceChanges: true,
                     showObjectChanges: true,
                     showInput: true,
                     showEffects: true,

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/PreviewTransfer.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/PreviewTransfer.tsx
@@ -38,7 +38,7 @@ export function PreviewTransfer({
     return (
         <div className="divide-y divide-solid divide-steel/20 divide-x-0 flex flex-col px-2.5 w-full">
             <TxnAmount
-                amount={amountWithoutDecimals.toString()}
+                amount={amountWithoutDecimals}
                 label="Sending"
                 coinType={coinType}
                 approximation={approximation}

--- a/apps/wallet/src/ui/app/staking/stake/StakingCard.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/StakingCard.tsx
@@ -288,7 +288,7 @@ function StakingCard() {
                                         stakedSuiId={stakeSuiIdParams!}
                                         coinBalance={totalTokenBalance}
                                         coinType={coinType}
-                                        stakingReward={suiEarned}
+                                        stakingReward={BigInt(suiEarned)}
                                         epoch={Number(system?.epoch || 0)}
                                     />
                                 ) : (

--- a/apps/wallet/src/ui/app/staking/stake/UnstakeForm.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/UnstakeForm.tsx
@@ -19,7 +19,7 @@ export type StakeFromProps = {
     stakedSuiId: string;
     coinBalance: bigint;
     coinType: string;
-    stakingReward?: string;
+    stakingReward?: bigint;
     epoch: number;
 };
 

--- a/sdk/typescript/src/framework/framework.ts
+++ b/sdk/typescript/src/framework/framework.ts
@@ -26,7 +26,8 @@ export const ID_STRUCT_NAME = 'ID';
 export const SUI_TYPE_ARG = `${SUI_FRAMEWORK_ADDRESS}::sui::SUI`;
 export const VALIDATORS_EVENTS_QUERY =
   '0x3::validator_set::ValidatorEpochInfoEvent';
-
+export const STAKING_REQUEST_EVENT = '0x3::validator::StakingRequestEvent';
+export const UNSTAKING_REQUEST_EVENT = '0x3::validator::UnstakingRequestEvent';
 export const SUI_CLOCK_OBJECT_ID = normalizeSuiObjectId('0x6');
 
 // `sui::pay` module is used for Coin management (split, join, join_and_transfer etc);


### PR DESCRIPTION
## Description 

- Adds amounts back to Activity feed / Receipt pages and should mimic the previous behavior / logic
- Planning to tackle Transaction Summary in a follow-up PR which will provide us with a more appropriate display of balance changes and effects

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
