### PR TITLE
traceId middleware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9356,6 +9356,7 @@ dependencies = [
  "tower",
  "tower-http 0.3.5",
  "tracing",
+ "uuid",
  "workspace-hack",
 ]
 
@@ -11388,9 +11389,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.2.2"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
+checksum = "5b55a3fef2a1e3b3a00ce878640918820d3c51081576ac657d23af9fc7928fdb"
 dependencies = [
  "getrandom 0.2.8",
  "rand 0.8.5",

--- a/crates/sui-json-rpc/Cargo.toml
+++ b/crates/sui-json-rpc/Cargo.toml
@@ -45,6 +45,7 @@ sui-transaction-builder = { path = "../sui-transaction-builder" }
 mysten-metrics = { path = "../mysten-metrics" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 shared-crypto = { path = "../shared-crypto" }
+uuid = "1.3.1"
 
 [dev-dependencies]
 sui-config = { path = "../sui-config" }

--- a/crates/sui-json-rpc/src/lib.rs
+++ b/crates/sui-json-rpc/src/lib.rs
@@ -23,6 +23,7 @@ use sui_open_rpc::{Module, Project};
 use crate::error::Error;
 use crate::metrics::MetricsLogger;
 use crate::routing_layer::RoutingLayer;
+use crate::tracing_layer::TraceIdLayer;
 
 pub mod api;
 mod balance_changes;
@@ -35,6 +36,7 @@ pub mod move_utils;
 mod object_changes;
 pub mod read_api;
 mod routing_layer;
+mod tracing_layer;
 pub mod transaction_builder_api;
 pub mod transaction_execution_api;
 
@@ -148,7 +150,8 @@ impl JsonRpcServerBuilder {
 
         let middleware = tower::ServiceBuilder::new()
             .layer(cors)
-            .layer(routing_layer);
+            .layer(routing_layer)
+            .layer(TraceIdLayer);
 
         let server = ServerBuilder::default()
             .batch_requests_supported(false)

--- a/crates/sui-json-rpc/src/lib.rs
+++ b/crates/sui-json-rpc/src/lib.rs
@@ -152,6 +152,7 @@ impl JsonRpcServerBuilder {
             .layer(cors)
             .layer(routing_layer)
             .layer(TraceIdLayer);
+        // .service(TraceIdMiddleware::new(self.module));
 
         let server = ServerBuilder::default()
             .batch_requests_supported(false)

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -16,7 +16,7 @@ use move_bytecode_utils::module_cache::GetModule;
 use move_core_types::language_storage::StructTag;
 use move_core_types::value::{MoveStruct, MoveStructLayout, MoveValue};
 use tap::TapFallible;
-use tracing::{debug, error, warn};
+use tracing::{debug, error, info, warn};
 
 use shared_crypto::intent::{AppId, Intent, IntentMessage, IntentScope, IntentVersion};
 use sui_core::authority::AuthorityState;
@@ -566,6 +566,8 @@ impl ReadApiServer for ReadApi {
         digest: TransactionDigest,
         opts: Option<SuiTransactionBlockResponseOptions>,
     ) -> RpcResult<SuiTransactionBlockResponse> {
+        // TODO: just to test logging
+        info!(tx_digest=?digest, "Get transaction block");
         let opts = opts.unwrap_or_default();
         let mut temp_response = IntermediateTransactionResponse::new(digest);
 

--- a/crates/sui-json-rpc/src/tracing_layer.rs
+++ b/crates/sui-json-rpc/src/tracing_layer.rs
@@ -1,0 +1,55 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use hyper::{header::HeaderValue, Request, Response};
+use std::task::{Context, Poll};
+use tower::Layer;
+use tower::Service;
+use uuid::Uuid;
+
+#[derive(Debug, Clone)]
+pub struct TraceIdLayer;
+
+impl<S> Layer<S> for TraceIdLayer {
+    type Service = TraceIdMiddleware<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        TraceIdMiddleware::new(inner)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TraceIdMiddleware<S> {
+    inner: S,
+}
+
+impl<S> TraceIdMiddleware<S> {
+    pub fn new(inner: S) -> Self {
+        TraceIdMiddleware { inner }
+    }
+}
+
+impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for TraceIdMiddleware<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
+    ReqBody: Send + 'static,
+    ResBody: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
+        let trace_id = Uuid::new_v4();
+        req.headers_mut().insert(
+            "x-trace-id",
+            HeaderValue::from_str(&trace_id.to_string()).unwrap(),
+        );
+
+        self.inner.call(req)
+    }
+}

--- a/crates/sui-json-rpc/src/tracing_layer.rs
+++ b/crates/sui-json-rpc/src/tracing_layer.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use hyper::{header::HeaderValue, Request, Response};
+use hyper::{Request, Response};
 use std::task::{Context, Poll};
 use tower::Layer;
 use tower::Service;
@@ -43,13 +43,10 @@ where
         self.inner.poll_ready(cx)
     }
 
-    fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
         let trace_id = Uuid::new_v4();
-        req.headers_mut().insert(
-            "x-trace-id",
-            HeaderValue::from_str(&trace_id.to_string()).unwrap(),
-        );
-
+        let span = tracing::info_span!("jsonrpc_request", trace_id = %trace_id);
+        let _enter = span.enter();
         self.inner.call(req)
     }
 }


### PR DESCRIPTION
## Description 

Not sure if I should follow cors and routing_layer, or set it directly on jsonrpsee with `.set_middleware(...)`. The thing is with the latter, I'd need to rewrite cors and routing_layer to also be implemented on jsonrpsee?  All we do is add `x-trace-id` to the request header, which should avoid the (de)serialization costs that led Patrick to moving the logger to `.set_logger(...)`
## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
