### PR TITLE
indexer: add warnings when FN returns unexpected results

### DIFF
--- a/crates/sui-indexer/src/errors.rs
+++ b/crates/sui-indexer/src/errors.rs
@@ -17,6 +17,9 @@ pub enum IndexerError {
     #[error("Indexer failed to deserialize event from events table with error: `{0}`")]
     EventDeserializationError(String),
 
+    #[error("Fullnode returns unexpected responses, which may block indexers from proceeding, with error: `{0}`")]
+    UnexpectedFullnodeResponseError(String),
+
     #[error("Indexer failed to read fullnode with error: `{0}`")]
     FullNodeReadingError(String),
 

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -217,6 +217,14 @@ where
                 if let Ok(checkpoint) = download_result {
                     downloaded_checkpoints.push(checkpoint);
                 } else {
+                    if let Err(IndexerError::UnexpectedFullnodeResponseError(fn_e)) =
+                        download_result
+                    {
+                        warn!(
+                            "Unexpected response from fullnode for object checkpoints: {}",
+                            fn_e
+                        );
+                    }
                     break;
                 }
             }
@@ -227,6 +235,7 @@ where
             current_parallel_downloads =
                 std::cmp::min(downloaded_checkpoints.len() + 1, MAX_PARALLEL_DOWNLOADS);
             if downloaded_checkpoints.is_empty() {
+                warn!("No object checkpoints downloaded, retrying in next iteration ...");
                 continue;
             }
 
@@ -292,6 +301,14 @@ where
                 if let Ok(checkpoint) = download_result {
                     downloaded_checkpoints.push(checkpoint);
                 } else {
+                    if let Err(IndexerError::UnexpectedFullnodeResponseError(fn_e)) =
+                        download_result
+                    {
+                        warn!(
+                            "Unexpected response from fullnode for checkpoints: {}",
+                            fn_e
+                        );
+                    }
                     break;
                 }
             }
@@ -303,6 +320,7 @@ where
             current_parallel_downloads =
                 std::cmp::min(downloaded_checkpoints.len() + 1, MAX_PARALLEL_DOWNLOADS);
             if downloaded_checkpoints.is_empty() {
+                warn!("No checkpoints downloaded, retrying in next iteration ...");
                 continue;
             }
 

--- a/crates/sui-indexer/src/utils.rs
+++ b/crates/sui-indexer/src/utils.rs
@@ -109,9 +109,9 @@ pub async fn multi_get_full_transactions(
         .map(CheckpointTransactionBlockResponse::try_from)
         .collect::<Result<Vec<_>, _>>()
         .map_err(|e| {
-            IndexerError::FullNodeReadingError(format!(
-                "Unexpected None value in SuiTransactionBlockFullResponse of digests {:?} with error {:?}",
-                digests, e
+            IndexerError::UnexpectedFullnodeResponseError(format!(
+                "Unexpected None value in SuiTransactionBlockFullResponse with error {:?}",
+                e
             ))
         })?;
     Ok(sui_full_transactions)


### PR DESCRIPTION
## Description 

Unexpected responses from FN could block indexers from moving forward.

## Test Plan 

local run with checkpoint numbers and make sure that warnings pop
```
2023-04-12T17:10:00.913403Z  WARN sui_indexer::handlers::checkpoint_handler: Unexpected response from fullnode for checkpoints: Unexpected None value in SuiTransactionBlockFullResponse with error Transaction is None in SuiTransactionBlockFullResponse of digest TransactionDigest(JBBRdsd4UnrQ8haRYS2RoCkEJFFoUduSATZ78oBSdkhC).
2023-04-12T17:10:00.913435Z  WARN sui_indexer::handlers::checkpoint_handler: No checkpoints downloaded, retrying in next iteration ...
2023-04-12T17:10:00.944678Z  WARN sui_indexer::handlers::checkpoint_handler: Unexpected response from fullnode for object checkpoints: Unexpected None value in SuiTransactionBlockFullResponse with error Transaction is None in SuiTransactionBlockFullResponse of digest TransactionDigest(JBBRdsd4UnrQ8haRYS2RoCkEJFFoUduSATZ78oBSdkhC).
2023-04-12T17:10:00.944710Z  WARN sui_indexer::handlers::checkpoint_handler: No object checkpoints downloaded, retrying in next iteration ...
```