### PR TITLE
[explorer] fix broken transaction block page for failed transactions

### DIFF
--- a/apps/explorer/src/pages/transaction-result/Signatures.tsx
+++ b/apps/explorer/src/pages/transaction-result/Signatures.tsx
@@ -4,12 +4,8 @@
 import {
     toB64,
     fromSerializedSignature,
-    getGasData,
-    getTransactionSender,
-    getTransactionSignature,
     normalizeSuiAddress,
     type SuiAddress,
-    type SuiTransactionBlockResponse,
     type SignaturePubkeyPair,
 } from '@mysten/sui.js';
 
@@ -63,32 +59,22 @@ function getSignatureFromAddress(
 }
 
 interface Props {
-    transaction: SuiTransactionBlockResponse;
+    sender: string;
+    gasOwner: string;
+    signatures: string[];
 }
 
-export function Signatures({ transaction }: Props) {
-    const sender = getTransactionSender(transaction);
-    const gasData = getGasData(transaction);
-    const transactionSignatures = getTransactionSignature(transaction);
-
-    if (!transactionSignatures) return null;
-
-    const isSponsoredTransaction = gasData?.owner !== sender;
-
-    const deserializedTransactionSignatures = transactionSignatures.map(
-        (signature) => fromSerializedSignature(signature)
+export function Signatures({ sender, gasOwner, signatures }: Props) {
+    const isSponsoredTransaction = gasOwner !== sender;
+    const deserializedTransactionSignatures = signatures.map((signature) =>
+        fromSerializedSignature(signature)
     );
-
     const userSignature = getSignatureFromAddress(
         deserializedTransactionSignatures,
-        sender!
+        sender
     );
-
     const sponsorSignature = isSponsoredTransaction
-        ? getSignatureFromAddress(
-              deserializedTransactionSignatures,
-              gasData!.owner
-          )
+        ? getSignatureFromAddress(deserializedTransactionSignatures, gasOwner)
         : null;
 
     return (


### PR DESCRIPTION
## Description 
We make some invalid type assumptions on the Transaction Block page, and so the page breaks when trying to view data for a failed transaction block. The fix here is to remove the non-null type assertions and update the UI accordingly.

## Test Plan 
- Manual testing 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
N/A