### PR TITLE
Start taking db checkpoint of indexes

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -440,6 +440,8 @@ pub struct DBCheckpointConfig {
     pub checkpoint_path: Option<PathBuf>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub object_store_config: Option<ObjectStoreConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub perform_index_db_checkpoints_at_epoch_end: Option<bool>,
 }
 
 /// Publicly known information about a validator

--- a/crates/sui-storage/src/indexes.rs
+++ b/crates/sui-storage/src/indexes.rs
@@ -5,7 +5,7 @@
 //! The main user of this data is the explorer.
 
 use std::cmp::{max, min};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use anyhow::anyhow;
@@ -844,5 +844,13 @@ impl IndexStore {
 
     pub fn is_empty(&self) -> bool {
         self.tables.owner_index.is_empty()
+    }
+
+    pub fn checkpoint_db(&self, path: &Path) -> SuiResult {
+        // We are checkpointing the whole db
+        self.tables
+            .transactions_from_addr
+            .checkpoint_db(path)
+            .map_err(SuiError::StorageError)
     }
 }

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -356,6 +356,7 @@ impl TestClusterBuilder {
             perform_db_checkpoints_at_epoch_end: true,
             checkpoint_path: None,
             object_store_config: None,
+            perform_index_db_checkpoints_at_epoch_end: None,
         };
         self
     }
@@ -365,6 +366,7 @@ impl TestClusterBuilder {
             perform_db_checkpoints_at_epoch_end: true,
             checkpoint_path: None,
             object_store_config: None,
+            perform_index_db_checkpoints_at_epoch_end: None,
         };
         self
     }


### PR DESCRIPTION
## Description 

As title says, we need to be able to restore indexes from snapshot too so FNs don't start indexing from genesis.

## Test Plan 

Existing tests