### PR TITLE
[chore] fix rpc loadgen build

### DIFF
--- a/crates/sui-rpc-loadgen/Cargo.toml
+++ b/crates/sui-rpc-loadgen/Cargo.toml
@@ -37,7 +37,7 @@ shellexpand = "3.0.0"
 sui = { path = "../sui" }
 sui-node = { path = "../sui-node" }
 sui-json-rpc-types= { path = "../sui-json-rpc-types" }
-sui-types = { path = "../sui-types" }
+sui-types = { path = "../sui-types", features = ["test-utils"]}
 sui-config = { path = "../sui-config" }
 sui-keys = { path = "../sui-keys" }
 sui-sdk = { path = "../sui-sdk" }


### PR DESCRIPTION
Not sure why how this made it through CI, but was failing with

```
error[E0599]: no function or associated item named `random_for_testing_only` found for struct `SuiAddress` in the current scope
  --> crates/sui-rpc-loadgen/src/payload/pay_sui.rs:26:37
   |
26 |         let recipient = SuiAddress::random_for_testing_only();
   |                                     ^^^^^^^^^^^^^^^^^^^^^^^ function or associated item not found in `SuiAddress`
```
for me
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
