### PR TITLE
Add bounds for iterators in rocksdb

### DIFF
--- a/crates/sui-storage/src/indexes.rs
+++ b/crates/sui-storage/src/indexes.rs
@@ -753,10 +753,12 @@ impl IndexStore {
         cursor: Option<ObjectID>,
     ) -> SuiResult<impl Iterator<Item = DynamicFieldInfo> + '_> {
         debug!(?object, "get_dynamic_fields");
+        let iter_lower_bound = (object, ObjectID::ZERO);
+        let iter_upper_bound = (object, ObjectID::MAX);
         Ok(self
             .tables
             .dynamic_field_index
-            .iter()
+            .iter_with_bounds(Some(iter_lower_bound), Some(iter_upper_bound))
             // The object id 0 is the smallest possible
             .skip_to(&(object, cursor.unwrap_or(ObjectID::ZERO)))?
             // skip an extra b/c the cursor is exclusive

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -1588,6 +1588,48 @@ where
         )
     }
 
+    /// Returns an iterator visiting each key-value pair in the map. By proving bounds of the
+    /// scan range, RocksDB scan avoid unnecessary scans
+    fn iter_with_bounds(
+        &'a self,
+        lower_bound: Option<K>,
+        upper_bound: Option<K>,
+    ) -> Self::Iterator {
+        let report_metrics = if self.iter_latency_sample_interval.sample() {
+            let timer = self
+                .db_metrics
+                .op_metrics
+                .rocksdb_iter_latency_seconds
+                .with_label_values(&[&self.cf])
+                .start_timer();
+            Some((timer, RocksDBPerfContext::default()))
+        } else {
+            None
+        };
+        let mut readopts = ReadOptions::default();
+        if let Some(lower_bound) = lower_bound {
+            let key_buf = be_fix_int_ser(&lower_bound).unwrap();
+            readopts.set_iterate_lower_bound(key_buf);
+        }
+        if let Some(upper_bound) = upper_bound {
+            let key_buf = be_fix_int_ser(&upper_bound).unwrap();
+            readopts.set_iterate_upper_bound(key_buf);
+        }
+        let db_iter = self.rocksdb.raw_iterator_cf(&self.cf(), readopts);
+        if let Some((timer, _perf_ctx)) = report_metrics {
+            timer.stop_and_record();
+            self.db_metrics
+                .read_perf_ctx_metrics
+                .report_metrics(&self.cf);
+        }
+        Iter::new(
+            db_iter,
+            self.cf.clone(),
+            &self.db_metrics,
+            &self.iter_bytes_sample_interval,
+        )
+    }
+
     fn keys(&'a self) -> Self::Keys {
         let mut db_iter = self
             .rocksdb

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -530,6 +530,59 @@ async fn test_clear() {
     assert_eq!(db.safe_iter().count(), 0);
 }
 
+#[rstest]
+#[tokio::test]
+async fn test_iter_with_bounds(#[values(true, false)] is_transactional: bool) {
+    let db = open_map(temp_dir(), None, is_transactional);
+
+    // Add [1, 50) and (50, 100) in the db
+    for i in 1..100 {
+        if i != 50 {
+            db.insert(&i, &i.to_string()).unwrap();
+        }
+    }
+
+    // Skip prior to will return an iterator starting with an "unexpected" key if the sought one is not in the table
+    let db_iter = db
+        .iter_with_bounds(Some(1), Some(100))
+        .skip_prior_to(&50)
+        .unwrap();
+
+    assert_eq!(
+        (49..50)
+            .chain(51..100)
+            .map(|i| (i, i.to_string()))
+            .collect::<Vec<_>>(),
+        db_iter.collect::<Vec<_>>()
+    );
+
+    // Same logic in the keys iterator
+    let db_iter = db.keys().skip_prior_to(&50).unwrap();
+
+    assert_eq!(
+        (49..50).chain(51..100).map(Ok).collect::<Vec<_>>(),
+        db_iter.collect::<Vec<_>>()
+    );
+
+    // Skip to a key which is not within the bounds (bound is [1, 50))
+    let db_iter = db.iter_with_bounds(Some(1), Some(50)).skip_to(&50).unwrap();
+    assert_eq!(Vec::<(i32, String)>::new(), db_iter.collect::<Vec<_>>());
+
+    // Skip to first key in the bound (bound is [1, 50))
+    let db_iter = db.iter_with_bounds(Some(1), Some(50)).skip_to(&1).unwrap();
+    assert_eq!(
+        (1..50).map(|i| (i, i.to_string())).collect::<Vec<_>>(),
+        db_iter.collect::<Vec<_>>()
+    );
+
+    // Skip to a key which is not within the bounds (bound is [1, 50))
+    let db_iter = db
+        .iter_with_bounds(Some(1), Some(50))
+        .skip_prior_to(&50)
+        .unwrap();
+    assert_eq!(vec![(49, "49".to_string())], db_iter.collect::<Vec<_>>());
+}
+
 #[tokio::test]
 async fn test_is_empty() {
     let db = DBMap::<i32, String>::open(

--- a/crates/typed-store/src/test_db.rs
+++ b/crates/typed-store/src/test_db.rs
@@ -270,7 +270,15 @@ where
     }
 
     fn iter(&'a self) -> Self::Iterator {
-        unimplemented!("deprecated API");
+        unimplemented!("umplemented API");
+    }
+
+    fn iter_with_bounds(
+        &'a self,
+        _lower_bound: Option<K>,
+        _upper_bound: Option<K>,
+    ) -> Self::Iterator {
+        unimplemented!("umplemented API");
     }
 
     fn safe_iter(&'a self) -> Self::SafeIterator {

--- a/crates/typed-store/src/traits.rs
+++ b/crates/typed-store/src/traits.rs
@@ -57,6 +57,10 @@ where
     /// Returns an iterator visiting each key-value pair in the map.
     fn iter(&'a self) -> Self::Iterator;
 
+    /// Returns an iterator visiting each key-value pair in the map.
+    fn iter_with_bounds(&'a self, lower_bound: Option<K>, upper_bound: Option<K>)
+        -> Self::Iterator;
+
     /// Same as `iter` but performs status check
     fn safe_iter(&'a self) -> Self::SafeIterator;
 


### PR DESCRIPTION
## Description 

This PR allows the caller to pass iterator lower and upper bounds upfront (when creating the iterator) which can be useful for db in preventing unneeded key scans. Also, start using bounds for `get_dynamic_fields_iterator()` which was the cause for recent incident. We will add this to more callsites with composite keys i.e. (ObjectID, ..) for example
 
## Test Plan 

Added tests
