### PR TITLE
[sui-types] Convert `parse_sui_struct_tag` and `parse_sui_type_tag` to use the Move core types parsers instead of the move command line parsers.

### DIFF
--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -9,8 +9,11 @@
 
 use base_types::{SequenceNumber, SuiAddress};
 use messages::{CallArg, ObjectArg};
+use move_core_types::account_address::AccountAddress;
 pub use move_core_types::language_storage::TypeTag;
-use move_core_types::{account_address::AccountAddress, language_storage::StructTag};
+pub use move_core_types::parser::{
+    parse_struct_tag as parse_sui_struct_tag, parse_type_tag as parse_sui_type_tag,
+};
 use object::OBJECT_START_VERSION;
 
 use base_types::ObjectID;
@@ -107,25 +110,6 @@ const fn address_from_single_byte(b: u8) -> AccountAddress {
 
 pub fn sui_framework_address_concat_string(suffix: &str) -> String {
     format!("{}{suffix}", SUI_FRAMEWORK_ADDRESS.to_hex_literal())
-}
-
-pub fn parse_sui_struct_tag(s: &str) -> anyhow::Result<StructTag> {
-    use move_command_line_common::types::ParsedStructType;
-    ParsedStructType::parse(s)?.into_struct_tag(&resolve_address)
-}
-
-pub fn parse_sui_type_tag(s: &str) -> anyhow::Result<TypeTag> {
-    use move_command_line_common::types::ParsedType;
-    ParsedType::parse(s)?.into_type_tag(&resolve_address)
-}
-
-fn resolve_address(addr: &str) -> Option<AccountAddress> {
-    match addr {
-        "std" => Some(MOVE_STDLIB_ADDRESS),
-        "sui" => Some(SUI_FRAMEWORK_ADDRESS),
-        "sui_system" => Some(SUI_SYSTEM_ADDRESS),
-        _ => None,
-    }
 }
 
 pub trait MoveTypeTagTrait {


### PR DESCRIPTION
This switches the parsing of struct tags and type tags to use the more robust Move core parsers for these types instead of the Move command line parsers. This also changes the semantics of the parsers so that no substitution of names addresses is performed if we encounter one when parsing a type/struct tag. From looking at the code and running the tests as far as I can tell we should never hit this situation. 

Also, regarding the previous issue that we had with these parsers and primitive types (as @patrickkuo remembers) this issue has been fixed and a number of tests added on the Move side to make sure we can handle these situations, so switching back to these parsers is fine.

## Test Plan 

Make sure existing tests pass.

