### PR TITLE
Show input tx sui tool

### DIFF
--- a/crates/sui-rpc-loadgen/Cargo.toml
+++ b/crates/sui-rpc-loadgen/Cargo.toml
@@ -37,7 +37,7 @@ shellexpand = "3.0.0"
 sui = { path = "../sui" }
 sui-node = { path = "../sui-node" }
 sui-json-rpc-types= { path = "../sui-json-rpc-types" }
-sui-types = { path = "../sui-types" }
+sui-types = { path = "../sui-types", features = ["test-utils"]}
 sui-config = { path = "../sui-config" }
 sui-keys = { path = "../sui-keys" }
 sui-sdk = { path = "../sui-sdk" }

--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -79,6 +79,7 @@ pub enum ToolCommand {
         concise_no_header: bool,
     },
 
+    /// Fetch the effects association with transaction `digest`
     #[clap(name = "fetch-transaction")]
     FetchTransaction {
         #[clap(long = "genesis")]
@@ -86,6 +87,10 @@ pub enum ToolCommand {
 
         #[clap(long, help = "The transaction ID to fetch")]
         digest: TransactionDigest,
+
+        /// If true, show the input transaction as well as the effects
+        #[clap(long = "show-tx")]
+        show_input_tx: bool,
     },
 
     /// Tool to read validator & node db.
@@ -224,8 +229,15 @@ impl ToolCommand {
                     }
                 }
             }
-            ToolCommand::FetchTransaction { genesis, digest } => {
-                print!("{}", get_transaction_block(digest, genesis).await?);
+            ToolCommand::FetchTransaction {
+                genesis,
+                digest,
+                show_input_tx,
+            } => {
+                print!(
+                    "{}",
+                    get_transaction_block(digest, genesis, show_input_tx).await?
+                );
             }
             ToolCommand::DbTool { db_path, cmd } => {
                 let path = PathBuf::from(db_path);


### PR DESCRIPTION
## Description 

This would have been useful in a recent incident for where the RPC layer was crashing while trying to convert the input tx to JSON. `sui-tool` doesn't go through the RPC layer, so this option is a nice way to see the tx that is causing us to crash + attempt a repro

## Test Plan 

`cargo run --bin sui-tool -- fetch-transaction --digest Gd4CvyUK57backuDmwZg2WL3cSk4iPAzr67s7kYR1qGD --genesis ~/sui/genesis.blob --show-tx`, the input tx now shows up.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
