### PR TITLE
explorer: remove addresses stat from home screen

### DIFF
--- a/apps/explorer/src/components/HomeMetrics/index.tsx
+++ b/apps/explorer/src/components/HomeMetrics/index.tsx
@@ -124,11 +124,13 @@ export function HomeMetrics() {
                         tooltip="Total transaction blocks counter"
                         amount={transactionCount}
                     />
-                    <FormattedStatsAmount
+                    {/* 
+                        TODO: enable when indexer is healthy
+                        <FormattedStatsAmount
                         label="Addresses"
                         tooltip="Addresses that have participated in at least one transaction since network genesis"
                         amount={networkMetrics?.totalAddresses}
-                    />
+                    /> */}
                 </MetricGroup>
             </div>
         </Card>


### PR DESCRIPTION
* the metric is wrong at the moment - revert when fixed

before

<img width="689" alt="Screenshot 2023-04-12 at 23 17 20" src="https://user-images.githubusercontent.com/10210143/231598353-0b55b0b5-c15d-4081-aa22-0e7dc58f419c.png">

after

<img width="689" alt="Screenshot 2023-04-12 at 23 00 05" src="https://user-images.githubusercontent.com/10210143/231598375-447fae55-eb57-4f0e-b140-73852b8e5e61.png">


addresses https://mysten-labs.slack.com/archives/C032676BWGN/p1681331443312099?thread_ts=1681324937.877989&cid=C032676BWGN
