### PR TITLE
[refactor] configure scoring parameters

### DIFF
--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -164,6 +164,7 @@ impl<T: ParentSync + Send + Sync> ExecutionState for ConsensusHandler<T> {
             consensus_output.sub_dag.reputation_score.clone(),
             self.authority_names_to_hostnames.clone(),
             &self.metrics,
+            self.epoch_store.protocol_config(),
         );
 
         self.metrics

--- a/crates/sui-core/src/scoring_decision.rs
+++ b/crates/sui-core/src/scoring_decision.rs
@@ -49,7 +49,7 @@ pub fn update_low_scoring_authorities(
     metrics: &Arc<AuthorityMetrics>,
     protocol_config: &ProtocolConfig,
 ) {
-    if protocol_config.scoring_decision_with_no_disable() {
+    if protocol_config.scoring_decision_with_validity_cutoff() {
         update_low_scoring_authorities_with_no_disable_mechanism(
             low_scoring_authorities,
             committee,

--- a/crates/sui-core/src/scoring_decision.rs
+++ b/crates/sui-core/src/scoring_decision.rs
@@ -249,10 +249,6 @@ fn update_low_scoring_authorities_with_no_disable_mechanism(
 
     // report new scores
     let len_low_scoring = low_scoring.len();
-    metrics
-        .consensus_handler_num_low_scoring_authorities
-        .set(len_low_scoring as i64);
-
     info!("{:?} low scoring authorities calculated", len_low_scoring);
 
     // Do not disable the scoring mechanism when more than f validators are excluded. Just keep
@@ -282,6 +278,11 @@ fn update_low_scoring_authorities_with_no_disable_mechanism(
             );
         }
     }
+
+    // Report the actual flagged final low scoring authorities
+    metrics
+        .consensus_handler_num_low_scoring_authorities
+        .set(final_low_scoring_map.len() as i64);
 
     low_scoring_authorities.swap(Arc::new(final_low_scoring_map));
 }

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -569,6 +569,12 @@ pub struct ProtocolConfig {
     hmac_hmac_sha3_256_cost_base: Option<u64>,
     hmac_hmac_sha3_256_input_cost_per_byte: Option<u64>,
     hmac_hmac_sha3_256_input_cost_per_block: Option<u64>,
+
+    // Const params for consensus scoring decision
+    // The scaling factor property for the MED outlier detection
+    scoring_decision_mad_divisor: Option<f64>,
+    // The cutoff value for the MED outlier detection
+    scoring_decision_cutoff_value: Option<f64>,
 }
 
 // feature flags
@@ -963,6 +969,10 @@ impl ProtocolConfig {
                 max_size_written_objects: None,
                 max_size_written_objects_system_tx: None,
 
+                // Const params for consensus scoring decision
+                scoring_decision_mad_divisor: None,
+                scoring_decision_cutoff_value: None,
+
                 // When adding a new constant, set it to None in the earliest version, like this:
                 // new_constant: None,
             },
@@ -1002,6 +1012,8 @@ impl ProtocolConfig {
                 cfg.feature_flags.missing_type_is_compatibility_error = true;
                 cfg.gas_model_version = Some(4);
                 cfg.feature_flags.scoring_decision_with_no_disable = true;
+                cfg.scoring_decision_mad_divisor = Some(2.3);
+                cfg.scoring_decision_cutoff_value = Some(2.5);
                 cfg
             }
             // Use this template when making changes:

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -139,7 +139,7 @@ struct FeatureFlags {
     // If true, then the scoring decision mechanism will not get disabled when we do have more than
     // f low scoring authorities, but it will simply flag as low scoring only up to f authorities.
     #[serde(skip_serializing_if = "is_false")]
-    scoring_decision_with_no_disable: bool,
+    scoring_decision_with_validity_cutoff: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -622,8 +622,8 @@ impl ProtocolConfig {
         self.feature_flags.missing_type_is_compatibility_error
     }
 
-    pub fn scoring_decision_with_no_disable(&self) -> bool {
-        self.feature_flags.scoring_decision_with_no_disable
+    pub fn scoring_decision_with_validity_cutoff(&self) -> bool {
+        self.feature_flags.scoring_decision_with_validity_cutoff
     }
 }
 
@@ -1011,7 +1011,7 @@ impl ProtocolConfig {
                 let mut cfg = Self::get_for_version_impl(version - 1);
                 cfg.feature_flags.missing_type_is_compatibility_error = true;
                 cfg.gas_model_version = Some(4);
-                cfg.feature_flags.scoring_decision_with_no_disable = true;
+                cfg.feature_flags.scoring_decision_with_validity_cutoff = true;
                 cfg.scoring_decision_mad_divisor = Some(2.3);
                 cfg.scoring_decision_cutoff_value = Some(2.5);
                 cfg

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_5.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_5.snap
@@ -8,7 +8,7 @@ feature_flags:
   advance_epoch_start_time_in_safe_mode: true
   loaded_child_objects_fixed: true
   missing_type_is_compatibility_error: true
-  scoring_decision_with_no_disable: true
+  scoring_decision_with_validity_cutoff: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_5.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_5.snap
@@ -165,4 +165,6 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
+scoring_decision_mad_divisor: 2.3
+scoring_decision_cutoff_value: 2.5
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_5.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_5.snap
@@ -8,6 +8,7 @@ feature_flags:
   advance_epoch_start_time_in_safe_mode: true
   loaded_child_objects_fixed: true
   missing_type_is_compatibility_error: true
+  scoring_decision_with_no_disable: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000


### PR DESCRIPTION
## Description 

In testnet we have observed the phenomenon where the consensus scores get distributed to the full range of values between 0..300 which eventually makes the MED approach with the current configuration not flag any authority as low scoring , which is somewhat expected. However, we have good reasons to still exclude validators with low scoring (especially the cases < 10) . 

To further tune the parameters we pulled the reported scores of testnet via Grafana (we could equally get them via a validator's db, but that would require more effort) and introduced a test mainly for automation purposes to parse the scores (via a CSV file) , run the algorithm and study the output according to the newly tuned parameters. That allow us to play a little bit with the parameters and based on actual prod data get an idea of how aggressive the pruning is.

The PR is doing the following:
* tuning the scoring parameters to new values to better detected the spread values.
* introducing a slightly different implementation that doesn't disable the scoring mechanism when more than `f` low scoring authorities are detected. Now up to `f` authorities will flagged as low scoring, but no more.
* introducing a protocol config feature flag to enable the new low scoring detection mechanism
* introducing as protocol config the low scoring detection mechanism constants 

The output for the CSV input attached on this PR and the proposed parameters is the following:
```
"ANodes"                      36	28	--	--	--	42	--	--	--	--	23	29	--	--	--	53	--	--	54	76	37	--	--	29	42	40	63	--	39	--	--	--	--	
"Ankr"                        --	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	31	--	--	--	--	--	--	--	--	--	--	--	--	
"B-Harvest"                   --	--	49	--	30	--	--	--	30	56	--	--	--	--	--	37	--	--	--	35	--	--	--	--	56	--	--	35	--	--	41	--	--	
"BACKBONE"                    00	00	00	00	00	00	00	00	00	00	00	00	00	00	00	00	00	00	00	00	00	00	00	00	00	00	00	00	00	00	00	00	00	
"BLRD"                        10	--	48	--	44	18	35	17	33	22	--	48	17	31	--	--	--	63	47	29	--	11	--	--	29	--	55	31	17	30	--	37	--	
"BiXinKelePool"               36	45	45	26	28	--	--	--	30	50	--	--	24	31	--	--	44	33	46	34	--	--	--	23	58	44	56	36	33	47	37	--	07	
"BlockEden.xyz"               --	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	52	--	--	--	--	--	--	--	--	--	
"BlockVision"                 45	26	--	22	--	36	--	--	58	--	--	--	--	41	--	--	--	17	--	43	--	--	--	--	--	--	--	--	--	--	--	--	--	
"Blockdaemon"                 41	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	37	--	--	--	--	--	--	--	40	44	--	--	--	--	--	--	
"Brightlystake"               41	--	28	--	--	44	--	--	47	34	--	31	14	17	--	38	--	30	33	62	--	--	18	--	42	41	58	--	13	46	21	17	38	
"BwareLabs"                   --	53	--	10	--	39	--	--	41	25	--	35	--	--	--	--	--	39	67	36	33	--	--	53	59	--	45	14	--	--	--	--	--	
"Chainbase"                   --	30	23	--	28	32	30	--	21	24	23	19	18	25	21	11	19	51	31	43	44	26	--	35	19	30	40	--	--	31	--	20	--	
"ComingChat"                  08	--	--	02	--	54	17	--	--	--	--	40	--	--	--	--	--	04	--	--	14	--	--	31	43	38	23	41	--	--	22	--	01	
"DSRV"                        37	--	40	--	--	55	21	23	41	37	--	26	--	31	--	36	--	35	34	46	22	--	--	--	--	--	--	--	--	--	--	--	32	
"Flipside"                    --	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	02	--	--	--	--	--	--	--	--	--	--	
"Forbole"                     22	29	38	--	--	26	--	--	33	--	--	--	--	22	--	40	--	46	--	37	--	--	--	--	54	--	58	--	--	42	--	--	--	
"Gaucho"                      --	49	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	37	--	--	--	--	52	--	--	--	--	--	--	--	40	
"H2O Nodes"                   --	--	--	--	--	--	--	--	--	46	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	
"HashQuark"                   27	35	48	17	50	23	--	--	38	56	--	--	--	26	21	51	--	--	57	50	--	--	20	--	43	--	40	--	--	--	--	--	--	
"Imperator"                   --	--	--	--	--	50	--	--	34	--	--	--	--	--	--	--	--	59	62	52	--	--	--	32	25	39	--	--	29	20	50	--	17	
"KingSuper"                   36	29	35	--	37	26	--	--	--	44	21	32	--	36	--	--	--	37	33	49	48	--	29	25	57	--	62	33	--	--	--	--	40	
"Moonlet"                     --	--	--	--	--	58	--	--	19	--	--	06	--	--	--	--	--	18	42	--	--	--	--	--	33	--	56	--	--	14	--	--	06	
"MoveFuns DAO"                --	--	--	28	50	45	--	--	41	44	24	43	23	34	--	--	22	31	66	24	--	--	--	--	23	--	63	--	25	44	33	17	--	
"Neuler"                      --	49	51	--	--	--	--	--	--	--	--	--	24	34	--	--	--	47	42	50	--	--	--	38	23	--	--	--	--	--	--	--	46	
"NodeReal"                    --	51	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	
"OKXEarn"                     41	59	35	22	--	10	31	--	26	44	--	--	--	22	16	34	42	48	29	34	39	25	--	32	35	14	28	15	24	28	--	21	28	
"ONBUFF"                      --	42	50	--	--	39	22	--	--	--	--	40	--	--	--	38	--	--	53	--	--	--	--	--	--	--	32	--	--	--	--	--	49	
"Overclock"                   --	51	39	--	--	--	--	--	--	--	15	--	21	--	--	--	--	--	--	--	--	--	--	51	40	--	--	--	31	--	--	--	--	
"Parasol"                     --	--	31	--	--	54	--	--	36	32	--	--	--	39	--	18	37	21	20	26	40	--	--	44	45	--	33	--	--	37	--	--	29	
"Qredo"                       --	46	--	--	--	59	--	11	43	40	--	12	--	37	--	33	03	27	--	--	44	--	--	35	00	00	00	--	--	--	14	--	--	
"SenseiNode"                  14	12	06	10	13	08	11	07	08	16	09	15	22	11	21	10	14	08	10	10	06	06	05	08	04	08	10	09	20	16	21	16	15	
"SpartanLabs"                 22	44	--	--	--	--	39	--	31	33	--	--	--	46	--	32	--	20	48	36	45	--	--	--	--	--	38	34	22	--	--	--	34	
"Stakin"                      --	54	--	--	--	54	--	--	23	--	--	--	--	--	--	53	37	28	46	--	--	--	--	--	33	37	--	--	--	18	--	35	--	
"XPRV"                        45	61	--	--	--	49	--	--	--	48	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	56	--	--	--	--	--	--	
"gumi"                        --	32	--	--	41	--	--	--	50	--	29	--	--	--	--	32	43	49	34	--	19	20	--	50	--	35	53	42	--	--	--	--	--	
"n1stake"                     00	00	00	00	00	00	00	00	00	43	--	28	00	00	21	--	09	57	--	--	--	--	--	--	--	--	--	--	--	--	09	--	--	
"staked"                      45	50	--	--	28	37	--	--	27	61	31	--	--	--	--	11	18	22	59	23	--	--	33	33	63	--	33	30	21	30	45	--	38	
---------------
Total                         18	23	17	10	12	24	10	06	23	20	09	15	10	18	06	17	12	25	22	22	14	06	07	17	24	13	23	12	12	14	11	08	16
```

where each line represents a host and it's corresponding score value . Each column represents the score values per host for each run of the algorithm for the given scores. It has to be mentioned that the provided CSV file contains on its first row the host names, and on every other line the validators scores snapshoted on the corresponding time instance.

Basically the above output can help us observe how many validators we prune on each "run" and for each host monitor their scores on the evolution of time . When no score value is present `--` , that means that the node has not been picked for pruning, thus we don't render the score.

## Test Plan 

CSV file of scores for a time window of ~1.5 hours as those are exported [by the metric](https://metrics.sui.io/d/FaNbUhene/sui-validators-narwhal-public-testnet-new?orgId=1&from=1681339104273&to=1681342704274&viewPanel=233)  

File [authority_scores.csv](https://github.com/MystenLabs/sui/files/11216856/authority_scores.csv)


---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
