### PR TITLE
remove account key copying from docs

### DIFF
--- a/nre/ansible/roles/sui-node/tasks/sui.yaml
+++ b/nre/ansible/roles/sui-node/tasks/sui.yaml
@@ -41,14 +41,6 @@
     group: "sui"
     mode: 0600
 
-- name: Copy account.key
-  copy:
-    src: "{{ keypair_path }}account.key"
-    dest: /opt/sui/key-pairs/account.key
-    owner: "sui"
-    group: "sui"
-    mode: 0600
-
 - name: Copy network.key
   copy:
     src: "{{ keypair_path }}network.key"

--- a/nre/docker/README.md
+++ b/nre/docker/README.md
@@ -15,8 +15,6 @@ Add the paths to your private keys to validator.yaml. If you chose to put them i
 ```
 protocol-key-pair:
   path: /opt/sui/key-pairs/protocol.key
-account-key-pair: 
-  path: /opt/sui/key-pairs/account.key
 worker-key-pair: 
   path: /opt/sui/key-pairs/worker.key
 network-key-pair: 

--- a/nre/systemd/README.md
+++ b/nre/systemd/README.md
@@ -49,8 +49,6 @@ Add the paths to your private keys to validator.yaml. If you chose to put them i
 ```
 protocol-key-pair: 
   path: /opt/sui/key-pairs/protocol.key
-account-key-pair: 
-  path: /opt/sui/key-pairs/account.key
 worker-key-pair: 
   path: /opt/sui/key-pairs/worker.key
 network-key-pair: 


### PR DESCRIPTION
## Description 

Remove account key copy references from docs - follow up to #10769 
