### PR TITLE
Missed checked arithmetic in gas_v2

### DIFF
--- a/crates/sui-types/src/gas_model/gas_v2.rs
+++ b/crates/sui-types/src/gas_model/gas_v2.rs
@@ -27,6 +27,8 @@ macro_rules! ok_or_gas_balance_error {
     };
 }
 
+sui_macros::checked_arithmetic! {
+
 /// A bucket defines a range of units that will be priced the same.
 /// After execution a call to `GasStatus::bucketize` will round the computation
 /// cost to `cost` for the bucket ([`min`, `max`]) the gas used falls into.
@@ -462,4 +464,6 @@ pub fn deduct_gas(gas_object: &mut Object, charge_or_rebate: i64) {
         balance - charge_or_rebate as u64
     };
     gas_coin.set_coin_value_unsafe(new_balance)
+}
+
 }


### PR DESCRIPTION
## Description 

Add `checked_arithmetic` on a gas file that was missing it

## Test Plan 

this is it
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
