### PR TITLE
Fix default enable_deep_per_tx_sui_conservation_check field

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -277,6 +277,7 @@ pub struct ExpensiveSafetyCheckConfig {
     /// If enabled, we will check that the total SUI in all input objects of a tx
     /// (both the Move part and the storage rebate) matches the total SUI in all
     /// output objects of the tx + gas fees
+    #[serde(default)]
     enable_deep_per_tx_sui_conservation_check: bool,
 
     /// Disable epoch SUI conservation check even when we are running in debug mode.


### PR DESCRIPTION
The field needs to be serde default otherwise it's not backward compatible