### PR TITLE
[indexer] Support ipv6 on sui-indexer's RPC server

### DIFF
--- a/crates/sui-indexer/src/lib.rs
+++ b/crates/sui-indexer/src/lib.rs
@@ -4,8 +4,7 @@
 
 use std::collections::HashMap;
 use std::env;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::str::FromStr;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::SystemTime;
 

--- a/crates/sui-indexer/src/lib.rs
+++ b/crates/sui-indexer/src/lib.rs
@@ -388,7 +388,7 @@ pub async fn build_json_rpc_server<S: IndexerStore + Sync + Send + 'static + Clo
     builder.register_module(MoveUtilsApi::new(http_client))?;
     let default_socket_addr = SocketAddr::new(
         // unwrap() here is safe b/c the address is a static config.
-        IpAddr::V4(Ipv4Addr::from_str(config.rpc_server_url.as_str()).unwrap()),
+        config.rpc_server_url.as_str().parse().unwrap(),
         config.rpc_server_port,
     );
     Ok(builder.start(default_socket_addr).await?)


### PR DESCRIPTION
## Description 

Support ipv6 for sui-indexer's RPC server

## Test Plan 

Run sui-indexer with sub args `--rpc-server-url "::"`
Ex. 
full command
```bash
cargo run --package sui-indexer --bin sui-indexer -- --db-url "postgres://postgres:password@127.0.0.1:5432/sui-indexer" --rpc-client-url "https://fullnode.devnet.sui.io:443" --rpc-server-worker --rpc-server-url "::"
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
