### PR TITLE
Update a few packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1223,24 +1223,12 @@ dependencies = [
 
 [[package]]
 name = "bitvec"
-version = "0.19.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55f93d0ef3363c364d5976646a38f04cf67cfe1d4c8d160cdea02cab2c116b33"
-dependencies = [
- "funty",
- "radium 0.5.3",
- "tap",
- "wyz",
-]
-
-[[package]]
-name = "bitvec"
 version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
 dependencies = [
  "funty",
- "radium 0.6.2",
+ "radium",
  "tap",
  "wyz",
 ]
@@ -2738,15 +2726,15 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "duration-str"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b301469c4a5e5c5834e5139e2dc208723783f3fd3df7ace3c5801e88f3e3cab9"
+checksum = "f94be4825ff6a563f1bfbdb786ae10c687333c7524fade954e2271170e7f7e6d"
 dependencies = [
- "anyhow",
  "chrono",
- "nom 6.1.2",
+ "nom 7.1.2",
  "rust_decimal",
  "serde 1.0.152",
+ "thiserror",
  "time 0.3.17",
 ]
 
@@ -3220,9 +3208,9 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "fs_extra"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -6123,19 +6111,6 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "6.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
-dependencies = [
- "bitvec 0.19.6",
- "funty",
- "lexical-core",
- "memchr",
- "version_check",
-]
-
-[[package]]
-name = "nom"
 version = "7.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
@@ -6526,7 +6501,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373b1a4c1338d9cd3d1fa53b3a11bdab5ab6bd80a20f7f7becd76953ae2be909"
 dependencies = [
  "arrayvec 0.7.2",
- "bitvec 0.20.4",
+ "bitvec",
  "byte-slice-cast",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
@@ -7371,12 +7346,6 @@ dependencies = [
  "parking_lot 0.12.1",
  "scheduled-thread-pool",
 ]
-
-[[package]]
-name = "radium"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "radium"
@@ -11744,8 +11713,7 @@ dependencies = [
  "bitcoin_hashes",
  "bitflags",
  "bitmaps",
- "bitvec 0.19.6",
- "bitvec 0.20.4",
+ "bitvec",
  "blake2",
  "blake3",
  "block-buffer 0.10.3",
@@ -12111,7 +12079,6 @@ dependencies = [
  "nix 0.24.3",
  "no-std-compat",
  "nom 5.1.2",
- "nom 6.1.2",
  "nom 7.1.2",
  "nonzero_ext",
  "normalize-line-endings",
@@ -12226,8 +12193,7 @@ dependencies = [
  "quote 0.6.13",
  "quote 1.0.26",
  "r2d2",
- "radium 0.5.3",
- "radium 0.6.2",
+ "radium",
  "radix_trie",
  "rand 0.7.3",
  "rand 0.8.5",

--- a/crates/sui-benchmark/Cargo.toml
+++ b/crates/sui-benchmark/Cargo.toml
@@ -22,7 +22,7 @@ clap = { version = "3.1.17", features = ["derive"] }
 prometheus = "0.13.3"
 rand = "0.8.5"
 indicatif = "0.17.2"
-duration-str = "0.4.0"
+duration-str = "0.5.0"
 hdrhistogram = "7.5.1"
 comfy-table = "6.1.3"
 bcs = "0.1.4"

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -81,7 +81,7 @@ shared-crypto = { path = "../shared-crypto" }
 move-symbol-pool.workspace = true
 clap = { version = "3.2.17", features = ["derive"] }
 criterion = { version = "0.4.0" }
-fs_extra = "1.2.0"
+fs_extra = "1.3.0"
 more-asserts="0.3.1"
 serde-reflection = "0.3.6"
 serde_yaml = "0.8.26"

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -69,7 +69,7 @@ jemalloc-ctl = "^0.5"
 tempfile = "3.3.0"
 futures = "0.3.23"
 prometheus = "0.13.3"
-fs_extra = "1.2.0"
+fs_extra = "1.3.0"
 indexmap = "1.9.2"
 
 jsonrpsee = { version = "0.16.2", features = ["jsonrpsee-core"] }

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -81,8 +81,7 @@ bitcoin-private = { version = "0.1" }
 bitcoin_hashes = { version = "0.12", default-features = false }
 bitflags = { version = "1" }
 bitmaps = { version = "2" }
-bitvec-56bd22fc3884b12 = { package = "bitvec", version = "0.20", default-features = false, features = ["std"] }
-bitvec-cdcf2f9584511fe6 = { package = "bitvec", version = "0.19", default-features = false, features = ["std"] }
+bitvec = { version = "0.20", default-features = false, features = ["std"] }
 blake2 = { version = "0.10" }
 blake3 = { version = "1" }
 block-buffer-274715c4dabd11b0 = { package = "block-buffer", version = "0.9", default-features = false, features = ["block-padding"] }
@@ -188,7 +187,7 @@ dirs-sys-next = { version = "0.1", default-features = false }
 dissimilar = { version = "1", default-features = false }
 doc-comment = { version = "0.3", default-features = false }
 downcast = { version = "0.11" }
-duration-str = { version = "0.4" }
+duration-str = { version = "0.5" }
 dyn-clone = { version = "1", default-features = false }
 ecdsa-582f2526e08bb6a0 = { package = "ecdsa", version = "0.14", default-features = false, features = ["der", "sign", "verify"] }
 ecdsa-986da7b5efc2b80e = { package = "ecdsa", version = "0.16", features = ["pkcs8", "signing", "std", "verifying"] }
@@ -381,7 +380,6 @@ nexlint-lints = { git = "https://github.com/nextest-rs/nexlint.git", rev = "94da
 nibble_vec = { version = "0.1", default-features = false }
 no-std-compat = { version = "0.4", default-features = false, features = ["alloc", "std"] }
 nom-15128469a54ed75a = { package = "nom", version = "7" }
-nom-a490c3000a992113 = { package = "nom", version = "6" }
 nom-cdf1610d3e1514e9 = { package = "nom", version = "5" }
 nonzero_ext = { version = "0.3" }
 normalize-line-endings = { version = "0.3", default-features = false }
@@ -464,8 +462,7 @@ quinn-proto = { version = "0.9" }
 quinn-udp = { version = "0.3", default-features = false }
 quote-dff4ba8e3ae991db = { package = "quote", version = "1" }
 r2d2 = { version = "0.8", default-features = false }
-radium-3b31131e45eafb45 = { package = "radium", version = "0.6", default-features = false }
-radium-d8f496e17d97b5cb = { package = "radium", version = "0.5", default-features = false }
+radium = { version = "0.6", default-features = false }
 radix_trie = { version = "0.2", default-features = false }
 rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8", features = ["small_rng"] }
 rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7" }
@@ -749,8 +746,7 @@ bitcoin-private = { version = "0.1" }
 bitcoin_hashes = { version = "0.12", default-features = false }
 bitflags = { version = "1" }
 bitmaps = { version = "2" }
-bitvec-56bd22fc3884b12 = { package = "bitvec", version = "0.20", default-features = false, features = ["std"] }
-bitvec-cdcf2f9584511fe6 = { package = "bitvec", version = "0.19", default-features = false, features = ["std"] }
+bitvec = { version = "0.20", default-features = false, features = ["std"] }
 blake2 = { version = "0.10" }
 blake3 = { version = "1" }
 block-buffer-274715c4dabd11b0 = { package = "block-buffer", version = "0.9", default-features = false, features = ["block-padding"] }
@@ -878,7 +874,7 @@ displaydoc = { version = "0.2" }
 dissimilar = { version = "1", default-features = false }
 doc-comment = { version = "0.3", default-features = false }
 downcast = { version = "0.11" }
-duration-str = { version = "0.4" }
+duration-str = { version = "0.5" }
 dyn-clone = { version = "1", default-features = false }
 ecdsa-582f2526e08bb6a0 = { package = "ecdsa", version = "0.14", default-features = false, features = ["der", "sign", "verify"] }
 ecdsa-986da7b5efc2b80e = { package = "ecdsa", version = "0.16", features = ["pkcs8", "signing", "std", "verifying"] }
@@ -1090,7 +1086,6 @@ nexlint-lints = { git = "https://github.com/nextest-rs/nexlint.git", rev = "94da
 nibble_vec = { version = "0.1", default-features = false }
 no-std-compat = { version = "0.4", default-features = false, features = ["alloc", "std"] }
 nom-15128469a54ed75a = { package = "nom", version = "7" }
-nom-a490c3000a992113 = { package = "nom", version = "6" }
 nom-cdf1610d3e1514e9 = { package = "nom", version = "5" }
 nonzero_ext = { version = "0.3" }
 normalize-line-endings = { version = "0.3", default-features = false }
@@ -1198,8 +1193,7 @@ quinn-udp = { version = "0.3", default-features = false }
 quote-3b31131e45eafb45 = { package = "quote", version = "0.6" }
 quote-dff4ba8e3ae991db = { package = "quote", version = "1" }
 r2d2 = { version = "0.8", default-features = false }
-radium-3b31131e45eafb45 = { package = "radium", version = "0.6", default-features = false }
-radium-d8f496e17d97b5cb = { package = "radium", version = "0.5", default-features = false }
+radium = { version = "0.6", default-features = false }
 radix_trie = { version = "0.2", default-features = false }
 rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8", features = ["small_rng"] }
 rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7" }


### PR DESCRIPTION
## Description 

Remaining deprecation warning: `move-package` -> `ptree` -> `nom v5.1.2`

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
