### PR TITLE
Use mist in validator table

### DIFF
--- a/apps/explorer/src/components/top-validators-card/StakeColumn.tsx
+++ b/apps/explorer/src/components/top-validators-card/StakeColumn.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useFormatCoin, CoinFormat } from '@mysten/core';
+import { useFormatCoin, CoinFormat, formatBalance } from '@mysten/core';
 import { SUI_TYPE_ARG } from '@mysten/sui.js';
 
 import { Text } from '~/ui/Text';
@@ -17,15 +17,12 @@ export function StakeColumn({
     hideCoinSymbol,
     inMIST = false,
 }: StakeColumnProps) {
-    const [amount, symbol] = useFormatCoin(
-        stake,
-        SUI_TYPE_ARG,
-        hideCoinSymbol ? CoinFormat.FULL : CoinFormat.ROUNDED
-    );
+    const coinFormat = hideCoinSymbol ? CoinFormat.FULL : CoinFormat.ROUNDED;
+    const [amount, symbol] = useFormatCoin(stake, SUI_TYPE_ARG, coinFormat);
     return (
         <div className="flex items-end gap-0.5">
             <Text variant="bodySmall/medium" color="steel-darker">
-                {inMIST ? stake.toLocaleString() : amount}
+                {inMIST ? formatBalance(stake, 0, coinFormat) : amount}
             </Text>
             {!hideCoinSymbol && (
                 <Text variant="captionSmall/medium" color="steel-dark">

--- a/apps/explorer/src/components/top-validators-card/StakeColumn.tsx
+++ b/apps/explorer/src/components/top-validators-card/StakeColumn.tsx
@@ -9,9 +9,14 @@ import { Text } from '~/ui/Text';
 type StakeColumnProps = {
     stake: bigint | number | string;
     hideCoinSymbol?: boolean;
+    inMIST?: boolean;
 };
 
-export function StakeColumn({ stake, hideCoinSymbol }: StakeColumnProps) {
+export function StakeColumn({
+    stake,
+    hideCoinSymbol,
+    inMIST = false,
+}: StakeColumnProps) {
     const [amount, symbol] = useFormatCoin(
         stake,
         SUI_TYPE_ARG,
@@ -20,11 +25,11 @@ export function StakeColumn({ stake, hideCoinSymbol }: StakeColumnProps) {
     return (
         <div className="flex items-end gap-0.5">
             <Text variant="bodySmall/medium" color="steel-darker">
-                {amount}
+                {inMIST ? stake.toLocaleString() : amount}
             </Text>
             {!hideCoinSymbol && (
                 <Text variant="captionSmall/medium" color="steel-dark">
-                    {symbol}
+                    {inMIST ? 'MIST' : symbol}
                 </Text>
             )}
         </div>

--- a/apps/explorer/src/components/validator/DelegationAmount.tsx
+++ b/apps/explorer/src/components/validator/DelegationAmount.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useFormatCoin } from '@mysten/core';
+import { useFormatCoin, formatBalance, CoinFormat } from '@mysten/core';
 import { SUI_TYPE_ARG } from '@mysten/sui.js';
 
 import { Heading } from '~/ui/Heading';
@@ -19,7 +19,9 @@ export function DelegationAmount({
     inMIST = false,
 }: DelegationAmountProps) {
     const [formattedAmount, symbol] = useFormatCoin(amount, SUI_TYPE_ARG);
-    const delegationAmount = inMIST ? amount.toLocaleString() : formattedAmount;
+    const delegationAmount = inMIST
+        ? formatBalance(amount, 0, CoinFormat.FULL)
+        : formattedAmount;
     const delegationSymbol = inMIST ? 'MIST' : symbol;
     return isStats ? (
         <div className="flex items-end gap-1.5 break-all">

--- a/apps/explorer/src/components/validator/DelegationAmount.tsx
+++ b/apps/explorer/src/components/validator/DelegationAmount.tsx
@@ -10,25 +10,31 @@ import { Text } from '~/ui/Text';
 type DelegationAmountProps = {
     amount: bigint | number | string;
     isStats?: boolean;
+    inMIST?: boolean;
 };
 
-export function DelegationAmount({ amount, isStats }: DelegationAmountProps) {
+export function DelegationAmount({
+    amount,
+    isStats,
+    inMIST = false,
+}: DelegationAmountProps) {
     const [formattedAmount, symbol] = useFormatCoin(amount, SUI_TYPE_ARG);
-
+    const delegationAmount = inMIST ? amount.toLocaleString() : formattedAmount;
+    const delegationSymbol = inMIST ? 'MIST' : symbol;
     return isStats ? (
         <div className="flex items-end gap-1.5 break-all">
             <Heading as="div" variant="heading3/semibold" color="steel-darker">
-                {formattedAmount}
+                {delegationAmount}
             </Heading>
             <Heading variant="heading4/medium" color="steel-darker">
-                {symbol}
+                {delegationSymbol}
             </Heading>
         </div>
     ) : (
         <div className="flex h-full items-center gap-1">
             <div className="flex items-baseline gap-0.5 break-all text-steel-darker">
-                <Text variant="body/medium">{formattedAmount}</Text>
-                <Text variant="subtitleSmall/medium">{symbol}</Text>
+                <Text variant="body/medium">{delegationAmount}</Text>
+                <Text variant="subtitleSmall/medium">{delegationSymbol}</Text>
             </div>
         </div>
     );

--- a/apps/explorer/src/components/validator/ValidatorStats.tsx
+++ b/apps/explorer/src/components/validator/ValidatorStats.tsx
@@ -165,6 +165,7 @@ export function ValidatorStats({
                                     <DelegationAmount
                                         amount={validatorData.nextEpochGasPrice}
                                         isStats
+                                        inMIST
                                     />
                                 </Stats>
                             </div>

--- a/apps/explorer/src/pages/validators/Validators.tsx
+++ b/apps/explorer/src/pages/validators/Validators.tsx
@@ -136,7 +136,9 @@ export function validatorsTableData(
                 header: 'Proposed Next Epoch Gas Price',
                 accessorKey: 'nextEpochGasPrice',
                 enableSorting: true,
-                cell: (props: any) => <StakeColumn stake={props.getValue()} />,
+                cell: (props: any) => (
+                    <StakeColumn stake={props.getValue()} inMIST />
+                ),
             },
             {
                 header: 'APY',


### PR DESCRIPTION
## Description 

Use Mist on validators table

## Test Plan 

How did you test the new or updated feature?
<img width="1176" alt="Screenshot 2023-04-13 at 8 53 30 AM" src="https://user-images.githubusercontent.com/126525197/231764641-1fb8a563-067e-47f9-8450-d9396a61d0bc.png">

<img width="1507" alt="Screenshot 2023-04-13 at 9 01 19 AM" src="https://user-images.githubusercontent.com/126525197/231766758-05d0faa8-6fa4-4386-adc6-fe3f2257a69d.png">


---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
