### PR TITLE
[rust sdk] removing check for gas_object in deleted changes

### DIFF
--- a/crates/sui-json-rpc/src/object_changes.rs
+++ b/crates/sui-json-rpc/src/object_changes.rs
@@ -68,23 +68,21 @@ pub async fn get_object_changes<P: ObjectProvider<Error = E>, E>(
             .await?;
         if let Some(o) = o {
             if let Some(type_) = o.type_() {
-                if !type_.is_coin() {
-                    let object_type = type_.clone().into();
-                    match kind {
-                        DeleteKind::Normal => object_changes.push(ObjectChange::Deleted {
-                            sender,
-                            object_type,
-                            object_id: *id,
-                            version: *version,
-                        }),
-                        DeleteKind::Wrap => object_changes.push(ObjectChange::Wrapped {
-                            sender,
-                            object_type,
-                            object_id: *id,
-                            version: *version,
-                        }),
-                        _ => {}
-                    }
+                let object_type = type_.clone().into();
+                match kind {
+                    DeleteKind::Normal => object_changes.push(ObjectChange::Deleted {
+                        sender,
+                        object_type,
+                        object_id: *id,
+                        version: *version,
+                    }),
+                    DeleteKind::Wrap => object_changes.push(ObjectChange::Wrapped {
+                        sender,
+                        object_type,
+                        object_id: *id,
+                        version: *version,
+                    }),
+                    _ => {}
                 }
             }
         };


### PR DESCRIPTION
## Description 

Changed the object changes to include deleted coins that got smashed

## Test Plan 

Tested locally via CLI with merge coins, and checked that the txn block showed the deleted object.

```
./target/debug/sui client merge-coin --primary-coin 0x249599bdcfb8265a46eed80d209455210cd2b72770b5a41eb3e8bf3191a76ca9 --coin-to-merge 0x55fcd3b88c26b80672f7f9e25a7d2fb9a892fc21228e90a8c8123efae79481e8 --gas-budget 100000000
```

coin object returned deleted in API call:
![image](https://user-images.githubusercontent.com/123408603/231794007-ec0feea9-88fb-4362-91b8-08d439b192c1.png)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
