### PR TITLE
[Compatibility] Fix clean mode default value

### DIFF
--- a/.github/workflows/compatibility_checker.yml
+++ b/.github/workflows/compatibility_checker.yml
@@ -5,7 +5,7 @@ concurrency:
 
 on:
   schedule:
-    - cron: "0 9 * * *" # UTC timing is every day at 1am PST
+    - cron: "0 6 * * *" # UTC timing is every day at 10pm PST
   workflow_dispatch:
     inputs:
       verbose:
@@ -13,15 +13,15 @@ on:
         required: false
         description: "Run with verbose logging"
         default: false
-      clean:
+      preserve-state:
         type: boolean
         required: false
-        description: "Run from clean database state"
+        description: "Preserve database state of previous run"
         default: true
 
 jobs:
   genesis-sync-test:
-    timeout-minutes: 480
+    timeout-minutes: 720
     permissions:
       # The "id-token: write" permission is required or Machine ID will not be
       # able to authenticate with the cluster.
@@ -44,7 +44,7 @@ jobs:
           token: fullnode-compat-test
           # Specify the length of time that the generated credentials should be
           # valid for. This is optional and defaults to "1h"
-          certificate-ttl: 6h
+          certificate-ttl: 12h
 
       # Cargo clean and git restore on any left over files from git checkout
       - name: Environment clean
@@ -53,7 +53,7 @@ jobs:
 
       # Wipe database from previous runs
       - name: Wipe SuiDB
-        if: ${{ github.event.inputs.clean == true }}
+        if: ${{ github.event.inputs.preserve-state == false }}
         run: |
           tsh -i ${{ steps.auth.outputs.identity-file }} --ttl 5 ssh ubuntu@fullnode-compat-test-01 "sudo rm -rf /var/lib/sui/suidb || true"
 
@@ -69,7 +69,7 @@ jobs:
 
       - name: Run sync script
         run: |
-          tsh -i ${{ steps.auth.outputs.identity-file }} --ttl 480 ssh ubuntu@fullnode-compat-test-01 "source ~/.bashrc && source ~/.cargo/env && cd ~/sui && CARGO_TERM_COLOR=always ./scripts/fullnode-sync.sh -p ./target/release/sui-node -n testnet ${{ github.event.inputs.verbose == true && '-v' || '' }}"
+          tsh -i ${{ steps.auth.outputs.identity-file }} --ttl 720 ssh ubuntu@fullnode-compat-test-01 "source ~/.bashrc && source ~/.cargo/env && cd ~/sui && CARGO_TERM_COLOR=always ./scripts/fullnode-sync.sh -p ./target/release/sui-node -n testnet ${{ github.event.inputs.verbose == true && '-v' || '' }}"
 
   notify:
     name: Notify


### PR DESCRIPTION
## Description 

[Most recent run](https://github.com/MystenLabs/sui/actions/runs/4687467829/jobs/8306807903) of the workflow failed due to disk being full from previous runs. The job is supposed to wipe the sui db as a step unless explicitly specified. But this step was skipped.

I think this is because I introduced that conditional argument (`clean`) only under `workflow_dispatch`, so for a scheduled run, the boolean is undefined, and probably evaluates to false in that case.

The fix here is to invert the logic of the boolean so that if true it will not be wiped, and it will be true only when explicitly set (in dispatch mode).

## Test Plan 

Added `pull_request:` dispatch mode temporarily, without input arguments, pushed commit, and verified that db wipe step was not skipped:

![Screenshot 2023-04-13 at 7 45 51 AM](https://user-images.githubusercontent.com/11576329/231798029-147249ac-85a5-4793-b51c-d72f095b3b52.png)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
