### PR TITLE
[transaction-fuzzer] Add withdraw stake, solve some trait issues, and generalize a bit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11084,12 +11084,18 @@ dependencies = [
 name = "transaction-fuzzer"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "indexmap",
  "move-core-types",
  "once_cell",
+ "prometheus",
  "proptest",
  "proptest-derive",
  "rand 0.8.5",
  "sui-core",
+ "sui-node",
  "sui-protocol-config",
  "sui-types",
  "test-utils",

--- a/crates/transaction-fuzzer/Cargo.toml
+++ b/crates/transaction-fuzzer/Cargo.toml
@@ -15,13 +15,18 @@ rand = "0.8.5"
 move-core-types.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tracing = "0.1.36"
+async-trait = "0.1.61"
+prometheus = "0.13.3"
+anyhow = { version = "1.0.64", features = ["backtrace"] }
 
 test-utils = { path = "../test-utils" }
 once_cell = "1.16"
 sui-core = { path = "../sui-core" }
 sui-protocol-config = { path = "../sui-protocol-config" }
 sui-types = { path = "../sui-types", features = ["fuzzing"] }
-
+indexmap = "1.9.2"
+futures = "0.3.23"
+sui-node = { path = "../sui-node" }
 
 [dev-dependencies]
 sui-core = { path = "../sui-core", features = ["test-utils"] }

--- a/crates/transaction-fuzzer/src/lib.rs
+++ b/crates/transaction-fuzzer/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod account_universe;
 mod executor;
+pub mod transaction_fuzzer;
 
 use proptest::collection::vec;
 use sui_protocol_config::ProtocolConfig;

--- a/crates/transaction-fuzzer/src/transaction_fuzzer/account_info.rs
+++ b/crates/transaction-fuzzer/src/transaction_fuzzer/account_info.rs
@@ -1,0 +1,69 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use indexmap::{IndexMap, IndexSet};
+use sui_types::{
+    base_types::{ObjectID, SuiAddress},
+    crypto::{get_key_pair, AccountKeyPair},
+};
+
+pub struct AccountInfo {
+    pub addr: SuiAddress,
+    pub key: AccountKeyPair,
+    pub gas_object_id: ObjectID,
+    // address to stakedSui IDs
+    pub staked_with: IndexMap<SuiAddress, IndexSet<ObjectID>>,
+    pub staking_info: BTreeMap<ObjectID, (u64, u64)>,
+    pub objects: BTreeSet<ObjectID>,
+}
+
+impl Default for AccountInfo {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AccountInfo {
+    pub fn new() -> Self {
+        let (addr, key): (_, AccountKeyPair) = get_key_pair();
+        let gas_object_id = ObjectID::random();
+        Self {
+            addr,
+            key,
+            gas_object_id,
+            staked_with: IndexMap::new(),
+            staking_info: BTreeMap::new(),
+            objects: BTreeSet::new(),
+        }
+    }
+
+    pub fn add_stake(
+        &mut self,
+        staked_with: SuiAddress,
+        stake_id: ObjectID,
+        stake_amount: u64,
+        current_epoch: u64,
+    ) {
+        let stakes = self
+            .staked_with
+            .entry(staked_with)
+            .or_insert_with(IndexSet::new);
+        stakes.insert(stake_id);
+        self.staking_info
+            .insert(stake_id, (stake_amount, current_epoch));
+        self.objects.insert(stake_id);
+    }
+
+    pub fn remove_stake(&mut self, staked_with: SuiAddress, stake_id: ObjectID) {
+        let stakes_with_validator = self.staked_with.get_mut(&staked_with).unwrap();
+        self.objects.remove(&stake_id);
+        stakes_with_validator.remove(&stake_id);
+        // should we remove this? Seems like it would be nice to keep it. But it could grow large.
+        // self.staking_info.remove(&stake_id);
+        if stakes_with_validator.is_empty() {
+            self.staked_with.remove(&staked_with);
+        }
+    }
+}

--- a/crates/transaction-fuzzer/src/transaction_fuzzer/add_stake.rs
+++ b/crates/transaction-fuzzer/src/transaction_fuzzer/add_stake.rs
@@ -1,0 +1,85 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use crate::*;
+
+pub struct RequestAddStakeGen;
+
+pub struct RequestAddStake {
+    sender: SuiAddress,
+    stake_amount: u64,
+    staked_with: SuiAddress,
+}
+
+impl GenStateChange for RequestAddStakeGen {
+    fn create(&self, runner: &mut FuzzTestRunner) -> Option<Box<dyn StatePredicate>> {
+        let stake_amount = runner
+            .rng
+            .gen_range(MIN_DELEGATION_AMOUNT..=MAX_DELEGATION_AMOUNT);
+        let staked_with = runner.pick_random_active_validator().sui_address;
+        let sender = runner.pick_random_sender();
+        Some(Box::new(RequestAddStake {
+            sender,
+            stake_amount,
+            staked_with,
+        }))
+    }
+}
+
+#[async_trait]
+impl StatePredicate for RequestAddStake {
+    async fn run(&mut self, runner: &mut FuzzTestRunner) -> Result<TransactionEffects> {
+        println!("REQUEST ADD STAKE");
+        let pt = {
+            let mut builder = ProgrammableTransactionBuilder::new();
+            builder
+                .obj(ObjectArg::SharedObject {
+                    id: SUI_SYSTEM_STATE_OBJECT_ID,
+                    initial_shared_version: SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
+                    mutable: true,
+                })
+                .unwrap();
+            builder.pure(self.staked_with).unwrap();
+            let coin = FuzzTestRunner::split_off(&mut builder, self.stake_amount);
+            move_call! {
+                builder,
+                (SUI_SYSTEM_OBJECT_ID)::sui_system::request_add_stake(Argument::Input(0), coin, Argument::Input(1))
+            };
+            builder.finish()
+        };
+        let effects = runner.sign_and_run_txn(self.sender, pt).await;
+
+        Ok(effects)
+    }
+
+    async fn pre_epoch_post_condition(
+        &mut self,
+        runner: &mut FuzzTestRunner,
+        effects: &TransactionEffects,
+    ) {
+        // Adding stake should always succeed since we're above the staking threshold
+        assert!(effects.status().is_ok());
+        // Assert that a `StakedSui` object matching the amount delegated is created.
+        // Assert that this staked sui
+        let object = runner
+            .get_created_object_of_type_name(effects, "StakedSui")
+            .await
+            .unwrap();
+        let epoch = runner.system_state().epoch;
+        runner.accounts.get_mut(&self.sender).unwrap().add_stake(
+            self.staked_with,
+            object.id(),
+            self.stake_amount,
+            epoch,
+        );
+        println!("Staked: {}", object.id());
+        let staked_amount =
+            object.get_total_sui(&runner.db().await).unwrap() - object.storage_rebate;
+        assert_eq!(staked_amount, self.stake_amount);
+        assert_eq!(object.owner.get_owner_address().unwrap(), self.sender);
+        runner.display_effects(effects);
+    }
+
+    async fn post_epoch_post_condition(&mut self, _runner: &mut FuzzTestRunner) {}
+}

--- a/crates/transaction-fuzzer/src/transaction_fuzzer/utils.rs
+++ b/crates/transaction-fuzzer/src/transaction_fuzzer/utils.rs
@@ -1,0 +1,17 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+
+// TODO: actually calculate the rewards here
+pub fn calculate_rewards(
+    _initial_amount: u64,
+    start_epoch: u64,
+    end_epoch: u64,
+    _system_states: &BTreeMap<u64, SuiSystemStateSummary>,
+) -> Option<u64> {
+    if start_epoch >= end_epoch {
+        return None;
+    }
+    std::todo!()
+}

--- a/crates/transaction-fuzzer/src/transaction_fuzzer/withdraw_stake.rs
+++ b/crates/transaction-fuzzer/src/transaction_fuzzer/withdraw_stake.rs
@@ -1,0 +1,102 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use crate::*;
+
+pub struct RequestWithdrawStakeGen;
+
+pub struct RequestWithdrawStake {
+    pub sender: SuiAddress,
+    pub stake_id: ObjectID,
+    pub staked_with: SuiAddress,
+}
+
+impl GenStateChange for RequestWithdrawStakeGen {
+    fn create(&self, runner: &mut FuzzTestRunner) -> Option<Box<dyn StatePredicate>> {
+        let sender = runner.pick_random_sender();
+        let account = runner.accounts.get(&sender).unwrap();
+        if account.staked_with.is_empty() {
+            return None;
+        }
+        let (staked_with, stakes) = account
+            .staked_with
+            .get_index(runner.rng.gen_range(0..account.staked_with.len()))
+            .unwrap();
+        assert!(!stakes.is_empty());
+        let stake_id = stakes[runner.rng.gen_range(0..stakes.len())];
+        Some(Box::new(RequestWithdrawStake {
+            sender,
+            stake_id,
+            staked_with: *staked_with,
+        }))
+    }
+}
+
+#[async_trait]
+impl StatePredicate for RequestWithdrawStake {
+    async fn run(&mut self, runner: &mut FuzzTestRunner) -> Result<TransactionEffects> {
+        println!("REQUEST WITHDRAW STAKE {}", self.stake_id);
+        let pt = {
+            let mut builder = ProgrammableTransactionBuilder::new();
+            builder
+                .obj(ObjectArg::SharedObject {
+                    id: SUI_SYSTEM_STATE_OBJECT_ID,
+                    initial_shared_version: SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
+                    mutable: true,
+                })
+                .unwrap();
+            builder
+                .obj(ObjectArg::ImmOrOwnedObject(
+                    runner.object_reference_for_id(self.stake_id).await,
+                ))
+                .unwrap();
+            move_call! {
+                builder,
+                (SUI_SYSTEM_OBJECT_ID)::sui_system::request_withdraw_stake(Argument::Input(0), Argument::Input(1))
+            };
+            builder.finish()
+        };
+        let effects = runner.sign_and_run_txn(self.sender, pt).await;
+
+        Ok(effects)
+    }
+
+    async fn pre_epoch_post_condition(
+        &mut self,
+        runner: &mut FuzzTestRunner,
+        effects: &TransactionEffects,
+    ) {
+        if effects.status().is_ok() {
+            let (stake_amount, _staking_epoch) = {
+                let account = runner.accounts.get_mut(&self.sender).unwrap();
+                account.remove_stake(self.staked_with, self.stake_id);
+                let (stake_amount, staking_epoch) =
+                    account.staking_info.get(&self.stake_id).unwrap();
+                (*stake_amount, *staking_epoch)
+            };
+            let object = runner
+                .get_created_object_of_type_name(effects, "Coin")
+                .await
+                .unwrap();
+            let return_amount =
+                object.get_total_sui(&runner.db().await).unwrap() - object.storage_rebate;
+            println!("STAKED: {}, returned: {}", stake_amount, return_amount);
+            // assert_eq!(
+            //     utils::calculate_rewards(
+            //         stake_amount,
+            //         staking_epoch,
+            //         runner.system_state().epoch,
+            //         &runner.pre_reconfiguration_states
+            //     )
+            //     .unwrap(),
+            //     return_amount
+            // );
+        } else {
+            println!("STATUS: {:#?}", effects.status());
+        }
+        runner.display_effects(effects);
+    }
+
+    async fn post_epoch_post_condition(&mut self, _runner: &mut FuzzTestRunner) {}
+}

--- a/crates/transaction-fuzzer/tests/dynamic_committee_fuzz.rs
+++ b/crates/transaction-fuzzer/tests/dynamic_committee_fuzz.rs
@@ -1,0 +1,30 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use transaction_fuzzer::transaction_fuzzer::{
+    add_stake, withdraw_stake, FuzzTestRunner, GenStateChange,
+};
+
+#[tokio::test]
+async fn fuzz_dynamic_committee() {
+    let num_operations = 10;
+
+    // Add more actions here as we create them
+    let actions: Vec<Box<dyn GenStateChange>> = vec![
+        Box::new(add_stake::RequestAddStakeGen),
+        Box::new(withdraw_stake::RequestWithdrawStakeGen),
+    ];
+
+    let mut runner = FuzzTestRunner::new().await;
+
+    for i in 0..num_operations {
+        if i % 5 == 0 {
+            println!("Changing epoch");
+            runner.change_epoch().await;
+            continue;
+        }
+        let mut task = runner.select_next_operation(actions.as_slice());
+        let effects = task.run(&mut runner).await.unwrap();
+        task.pre_epoch_post_condition(&mut runner, &effects).await;
+    }
+}


### PR DESCRIPTION
Generalizes the transaction fuzzer that we built for dynamic committee testing to be more general and moves it to the `transaction-fuzzer` crate.

This also adds a new command for withdrawing stake. New commands can be added in a similar way to the existing commands. 