### PR TITLE
Simplify initialization phase for stress client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8884,6 +8884,7 @@ dependencies = [
  "itertools",
  "move-core-types",
  "move-package",
+ "mysten-metrics",
  "narwhal-node",
  "prometheus",
  "rand 0.8.5",

--- a/crates/sui-benchmark/Cargo.toml
+++ b/crates/sui-benchmark/Cargo.toml
@@ -42,6 +42,7 @@ regex = "1.7.1"
 
 move-core-types.workspace = true
 move-package.workspace = true
+mysten-metrics = { path = "../mysten-metrics" }
 narwhal-node = { path = "../../narwhal/node" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 test-utils = { path = "../test-utils" }

--- a/crates/sui-benchmark/src/bank.rs
+++ b/crates/sui-benchmark/src/bank.rs
@@ -1,48 +1,33 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::util::{make_pay_tx, UpdatedAndNewlyMintedGasCoins};
+use crate::util::UpdatedAndNewlyMintedGasCoins;
 use crate::workloads::payload::Payload;
 use crate::workloads::workload::{Workload, WorkloadBuilder, MAX_BUDGET};
 use crate::workloads::{Gas, GasCoinConfig};
 use crate::ValidatorProxy;
 use anyhow::{Error, Result};
 use itertools::Itertools;
-use move_core_types::language_storage::TypeTag;
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
-use sui_types::base_types::{ObjectRef, SuiAddress};
+use sui_core::test_utils::{make_pay_sui_transaction, make_transfer_sui_transaction};
+use sui_types::base_types::SuiAddress;
 use sui_types::crypto::AccountKeyPair;
-use sui_types::gas_coin::GAS;
-use sui_types::messages::{CallArg, ObjectArg, TransactionData, VerifiedTransaction};
-use sui_types::utils::to_sender_signed_transaction;
-use sui_types::{coin, SUI_FRAMEWORK_OBJECT_ID};
-use tracing::{debug, error};
+use tracing::{debug, info};
 
-/// Bank is used for generating gas for running the benchmark. It is initialized with two gas coins i.e.
-/// `pay_coin` which is split into smaller gas coins and `primary_gas` which is the gas coin used
-/// for executing coin split transactions
+/// Bank is used for generating gas for running the benchmark.
 #[derive(Clone)]
 pub struct BenchmarkBank {
     pub proxy: Arc<dyn ValidatorProxy + Send + Sync>,
-    // Gas to use for execution of gas generation transaction
-    pub primary_gas: Gas,
-    // Coin to use for splitting and generating small gas coins. Can accept
-    // multiple coins in case we no longer have one large coin that will support
-    // generating all coins for the workloads.
-    pub pay_coins: Vec<Gas>,
+    // Coin used for paying for gas & splitting into smaller gas coins
+    pub primary_coin: Gas,
 }
 
 impl BenchmarkBank {
-    pub fn new(
-        proxy: Arc<dyn ValidatorProxy + Send + Sync>,
-        primary_gas: Gas,
-        pay_coins: Vec<Gas>,
-    ) -> Self {
+    pub fn new(proxy: Arc<dyn ValidatorProxy + Send + Sync>, primary_coin: Gas) -> Self {
         BenchmarkBank {
             proxy,
-            primary_gas,
-            pay_coins,
+            primary_coin,
         }
     }
     pub async fn generate(
@@ -65,9 +50,20 @@ impl BenchmarkBank {
 
         let mut new_gas_coins: Vec<Gas> = vec![];
         let chunked_coin_configs = all_coin_configs.chunks(chunk_size as usize);
+
+        // Split off the initlization coin for this workload, to reduce contention
+        // of main gas coin used by other instances of this tool.
+        let total_gas_needed: u64 = all_coin_configs.iter().map(|c| c.amount).sum();
+        let mut init_coin = self
+            .create_init_coin(
+                total_gas_needed + (MAX_BUDGET * chunked_coin_configs.len() as u64),
+                gas_price,
+            )
+            .await?;
+
         debug!("Number of gas requests = {}", chunked_coin_configs.len());
         for chunk in chunked_coin_configs {
-            let gas_coins = self.split_coin_and_pay(chunk, gas_price).await?;
+            let gas_coins = self.pay_sui(chunk, &mut init_coin, gas_price).await?;
             new_gas_coins.extend(gas_coins);
         }
         let mut workloads = vec![];
@@ -99,192 +95,116 @@ impl BenchmarkBank {
         Ok(workloads)
     }
 
-    fn make_split_coin_tx(
-        &self,
-        split_amounts: Vec<u64>,
-        gas_price: u64,
-        keypair: &AccountKeyPair,
-        pay_coin: &Gas,
-    ) -> Result<VerifiedTransaction> {
-        let split_coin = TransactionData::new_move_call(
-            self.primary_gas.1,
-            SUI_FRAMEWORK_OBJECT_ID,
-            coin::PAY_MODULE_NAME.to_owned(),
-            coin::PAY_SPLIT_VEC_FUNC_NAME.to_owned(),
-            vec![TypeTag::Struct(Box::new(GAS::type_()))],
-            self.primary_gas.0,
-            vec![
-                CallArg::Object(ObjectArg::ImmOrOwnedObject(pay_coin.0)),
-                CallArg::Pure(bcs::to_bytes(&split_amounts).unwrap()),
-            ],
-            MAX_BUDGET,
-            gas_price,
-        )?;
-        let verified_tx = to_sender_signed_transaction(split_coin, keypair);
-        Ok(verified_tx)
-    }
-
-    async fn split_coin_and_pay(
+    async fn pay_sui(
         &mut self,
         coin_configs: &[GasCoinConfig],
+        mut init_coin: &mut Gas,
         gas_price: u64,
     ) -> Result<UpdatedAndNewlyMintedGasCoins> {
-        // split one coin into smaller coins of different amounts and send them to recipients
-        let split_amounts: Vec<u64> = coin_configs.iter().map(|c| c.amount).collect();
-        // TODO: Instead of splitting the coin and then using pay tx to transfer it to recipients,
-        // we can do both in one tx with pay_sui which will split the coin out for us before
-        // transferring it to recipients
-        let mut updated_pay_coins = Vec::new();
-        let mut transferred_coins: Result<Vec<Gas>> = Err(Error::msg("Failed to split coin"));
-        debug!(
-            "Splitting {} coin(s) into {} coin(s) of balance {}",
-            self.pay_coins.len(),
-            split_amounts.len(),
-            split_amounts[0],
+        let recipient_addresses: Vec<SuiAddress> = coin_configs.iter().map(|g| g.address).collect();
+        let amounts: Vec<u64> = coin_configs.iter().map(|c| c.amount).collect();
+
+        info!(
+            "Creating {} coin(s) of balance {}...",
+            amounts.len(),
+            amounts[0],
         );
-        for (idx, pay_coin) in self.pay_coins.iter().enumerate() {
-            debug!("Attempting split of coin#{idx}");
-            let verified_tx = self.make_split_coin_tx(
-                split_amounts.clone(),
-                gas_price,
-                &self.primary_gas.2,
-                pay_coin,
-            )?;
-            let effects = self
-                .proxy
-                .execute_transaction_block(verified_tx.into())
-                .await;
 
-            let effects = match effects {
-                Ok(effects) => {
-                    if !effects.is_ok() {
-                        error!("Failed to split coin: {:?}", effects);
-                        // TODO: check effects and make decision on what coin to use
-                        // next based on errors.
-                        let updated_gas = effects
-                            .mutated()
-                            .into_iter()
-                            .find(|(k, _)| k.0 == self.primary_gas.0 .0)
-                            .ok_or("Input gas missing in the effects")
-                            .map_err(Error::msg);
+        let verified_tx = make_pay_sui_transaction(
+            init_coin.0,
+            vec![],
+            recipient_addresses,
+            amounts,
+            init_coin.1,
+            &init_coin.2,
+            gas_price,
+            MAX_BUDGET,
+        );
 
-                        match updated_gas {
-                            Ok(updated_gas) => {
-                                self.primary_gas = (
-                                    updated_gas.0,
-                                    updated_gas.1.get_owner_address()?,
-                                    self.primary_gas.2.clone(),
-                                );
-                            }
-                            Err(e) => {
-                                error!("Failed to get mutated gas: {:?}", e);
-                                continue;
-                            }
-                        };
+        let effects = self
+            .proxy
+            .execute_transaction_block(verified_tx.into())
+            .await?;
 
-                        let updated_coin = effects
-                            .mutated()
-                            .into_iter()
-                            .find(|(k, _)| k.0 == pay_coin.0 .0)
-                            .ok_or("Pay coin missing in the effects")
-                            .map_err(Error::msg);
-
-                        match updated_coin {
-                            Ok(updated_coin) => {
-                                updated_pay_coins.push((
-                                    updated_coin.0,
-                                    updated_coin.1.get_owner_address()?,
-                                    self.primary_gas.2.clone(),
-                                ));
-                                continue;
-                            }
-                            Err(e) => {
-                                error!("Failed to mutated pay coi: {:?}", e);
-                                continue;
-                            }
-                        };
-                    }
-                    effects
-                }
-                Err(e) => {
-                    error!("Failed to split coin: {:?}", e);
-                    continue;
-                }
-            };
-
-            let updated_gas = effects
-                .mutated()
-                .into_iter()
-                .find(|(k, _)| k.0 == self.primary_gas.0 .0)
-                .ok_or("Input gas missing in the effects")
-                .map_err(Error::msg)?;
-            let created_coins: Vec<ObjectRef> =
-                effects.created().into_iter().map(|c| c.0).collect();
-            assert_eq!(created_coins.len(), split_amounts.len());
-            let updated_coin = effects
-                .mutated()
-                .into_iter()
-                .find(|(k, _)| k.0 == pay_coin.0 .0)
-                .ok_or("Input gas missing in the effects")
-                .map_err(Error::msg)?;
-
-            updated_pay_coins.push((
-                updated_coin.0,
-                updated_coin.1.get_owner_address()?,
-                self.primary_gas.2.clone(),
-            ));
-
-            let recipient_addresses: Vec<SuiAddress> =
-                coin_configs.iter().map(|g| g.address).collect();
-            let verified_tx = make_pay_tx(
-                created_coins,
-                self.primary_gas.1,
-                recipient_addresses,
-                split_amounts,
-                updated_gas.0,
-                &self.primary_gas.2,
-                gas_price,
-            )?;
-            let effects = self
-                .proxy
-                .execute_transaction_block(verified_tx.into())
-                .await?;
-            let address_map: HashMap<SuiAddress, Arc<AccountKeyPair>> = coin_configs
-                .iter()
-                .map(|c| (c.address, c.keypair.clone()))
-                .collect();
-            transferred_coins = effects
-                .created()
-                .into_iter()
-                .map(|c| {
-                    let address = c.1.get_owner_address()?;
-                    let keypair = address_map
-                        .get(&address)
-                        .ok_or("Owner address missing in the address map")
-                        .map_err(Error::msg)?;
-                    Ok((c.0, address, keypair.clone()))
-                })
-                .collect();
-            let updated_gas = effects
-                .mutated()
-                .into_iter()
-                .find(|(k, _)| k.0 == self.primary_gas.0 .0)
-                .ok_or("Input gas missing in the effects")
-                .map_err(Error::msg)?;
-
-            self.primary_gas = (
-                updated_gas.0,
-                updated_gas.1.get_owner_address()?,
-                self.primary_gas.2.clone(),
-            );
-
-            let (_, right) = self.pay_coins.split_at_mut(idx + 1);
-            let remaining_pay_coins = right.to_vec();
-            self.pay_coins = updated_pay_coins;
-            self.pay_coins.extend(remaining_pay_coins);
-            break;
+        if !effects.is_ok() {
+            effects.print_gas_summary();
+            panic!("Could not generate coins for workload...");
         }
 
+        let updated_gas = effects
+            .mutated()
+            .into_iter()
+            .find(|(k, _)| k.0 == init_coin.0 .0)
+            .ok_or("Input gas missing in the effects")
+            .map_err(Error::msg)?;
+
+        init_coin.0 = updated_gas.0;
+        init_coin.1 = updated_gas.1.get_owner_address()?;
+        init_coin.2 = self.primary_coin.2.clone();
+
+        let address_map: HashMap<SuiAddress, Arc<AccountKeyPair>> = coin_configs
+            .iter()
+            .map(|c| (c.address, c.keypair.clone()))
+            .collect();
+
+        let transferred_coins: Result<Vec<Gas>> = effects
+            .created()
+            .into_iter()
+            .map(|c| {
+                let address = c.1.get_owner_address()?;
+                let keypair = address_map
+                    .get(&address)
+                    .ok_or("Owner address missing in the address map")
+                    .map_err(Error::msg)?;
+                Ok((c.0, address, keypair.clone()))
+            })
+            .collect();
+
         transferred_coins
+    }
+
+    async fn create_init_coin(&mut self, amount: u64, gas_price: u64) -> Result<Gas> {
+        info!("Creating initilization coin of value {amount}...");
+
+        let verified_tx = make_transfer_sui_transaction(
+            self.primary_coin.0,
+            self.primary_coin.1,
+            Some(amount),
+            self.primary_coin.1,
+            &self.primary_coin.2,
+            gas_price,
+        );
+
+        let effects = self
+            .proxy
+            .execute_transaction_block(verified_tx.into())
+            .await?;
+
+        if !effects.is_ok() {
+            effects.print_gas_summary();
+            panic!("Failed to create initilization coin for workload.");
+        }
+
+        let updated_gas = effects
+            .mutated()
+            .into_iter()
+            .find(|(k, _)| k.0 == self.primary_coin.0 .0)
+            .ok_or("Input gas missing in the effects")
+            .map_err(Error::msg)?;
+
+        self.primary_coin = (
+            updated_gas.0,
+            updated_gas.1.get_owner_address()?,
+            self.primary_coin.2.clone(),
+        );
+
+        match effects.created().get(0) {
+            Some(created_coin) => Ok((
+                created_coin.0,
+                created_coin.1.get_owner_address()?,
+                self.primary_coin.2.clone(),
+            )),
+            None => panic!("Failed to create initilization coin for workload."),
+        }
     }
 }

--- a/crates/sui-benchmark/src/benchmark_setup.rs
+++ b/crates/sui-benchmark/src/benchmark_setup.rs
@@ -8,7 +8,6 @@ use std::sync::Arc;
 use std::thread::JoinHandle;
 use std::time::Duration;
 use sui_config::utils;
-use tracing::debug;
 
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::SuiAddress;
@@ -18,7 +17,7 @@ use tokio::time::sleep;
 use crate::bank::BenchmarkBank;
 use crate::options::Opts;
 use crate::util::get_ed25519_keypair_from_keystore;
-use crate::workloads::workload::MAX_GAS_FOR_TESTING;
+use crate::workloads::workload::MIN_SUI_PER_WORKLOAD;
 use crate::{FullNodeProxy, LocalValidatorAggregatorProxy, ValidatorProxy};
 use sui_types::object::generate_max_test_gas_objects_with_owner;
 use test_utils::authority::test_and_configure_authority_configs_with_objects;
@@ -69,7 +68,6 @@ impl Env {
                     opts.use_fullnode_for_reconfig,
                     opts.use_fullnode_for_execution,
                     opts.fullnode_rpc_addresses.clone(),
-                    opts.gas_request_chunk_size,
                 )
                 .await
             }
@@ -86,7 +84,7 @@ impl Env {
     ) -> Result<BenchmarkSetup> {
         info!("Running benchmark setup in local mode..");
         let (address, keypair): (SuiAddress, AccountKeyPair) = deterministic_random_account_key();
-        let generated_gas = generate_max_test_gas_objects_with_owner(2, address);
+        let generated_gas = generate_max_test_gas_objects_with_owner(1, address);
         let (mut network_config, generated_gas) =
             test_and_configure_authority_configs_with_objects(committee_size, generated_gas);
         let mut metric_port = server_metric_port;
@@ -113,10 +111,6 @@ impl Env {
         let primary_gas = generated_gas
             .get(0)
             .context("No gas found at index 0")?
-            .clone();
-        let pay_coin = generated_gas
-            .get(1)
-            .context("No gas found at index 1")?
             .clone();
         // Make the client runtime wait until we are done creating genesis objects
         let cloned_config = config.clone();
@@ -158,11 +152,10 @@ impl Env {
             address,
             keypair.clone(),
         );
-        let pay_coin = (pay_coin.compute_object_reference(), address, keypair);
         Ok(BenchmarkSetup {
             server_handle: join_handle,
             shutdown_notifier: sender,
-            bank: BenchmarkBank::new(proxy.clone(), primary_gas, vec![pay_coin]),
+            bank: BenchmarkBank::new(proxy.clone(), primary_gas),
             proxies: vec![proxy],
         })
     }
@@ -177,7 +170,6 @@ impl Env {
         use_fullnode_for_reconfig: bool,
         use_fullnode_for_execution: bool,
         fullnode_rpc_address: Vec<String>,
-        chunk_size: u64,
     ) -> Result<BenchmarkSetup> {
         info!("Running benchmark setup in remote mode ..");
         let (sender, recv) = tokio::sync::oneshot::channel::<()>();
@@ -249,14 +241,17 @@ impl Env {
             .await?;
         gas_objects.sort_by_key(|&(gas, _)| std::cmp::Reverse(gas));
 
+        // TODO: Merge all owned gas objects into one and use that as the primary gas object.
         let (balance, primary_gas_obj) = gas_objects
             .iter()
-            .filter(|(balance, _)| balance > &MAX_GAS_FOR_TESTING)
+            .filter(|(balance, _)| *balance > MIN_SUI_PER_WORKLOAD)
             .collect::<Vec<_>>()
             .choose(&mut rand::thread_rng())
-            .context("Failed to choose a random primary gas id")?;
+            .context(format!(
+                "Failed to choose a random primary gas id with atleast {MIN_SUI_PER_WORKLOAD} SUI"
+            ))?;
 
-        debug!(
+        info!(
             "Using primary gas id: {} with balance of {balance}",
             primary_gas_obj.id()
         );
@@ -276,30 +271,7 @@ impl Env {
             &primary_gas_account,
         )?);
 
-        let pay_coin_objs = gas_objects.iter().filter(|(balance, gas_object)| {
-            gas_object != primary_gas_obj && balance > &(MAX_GAS_FOR_TESTING * chunk_size)
-        });
-        let mut pay_coins_total_balance = 0;
-        let pay_coins = pay_coin_objs
-            .map(|(balance, pay_coin)| {
-                pay_coins_total_balance += balance;
-                (
-                    pay_coin.compute_object_reference(),
-                    pay_coin
-                        .owner
-                        .get_owner_address()
-                        .expect("Failed to get owner address"),
-                    keypair.clone(),
-                )
-            })
-            .collect::<Vec<_>>();
-
-        debug!(
-            "Using {} pay coin(s) with balance of {pay_coins_total_balance}",
-            pay_coins.len()
-        );
-
-        let primary_gas = (
+        let primary_coin = (
             primary_gas_obj.compute_object_reference(),
             primary_gas_account,
             keypair,
@@ -308,7 +280,7 @@ impl Env {
         Ok(BenchmarkSetup {
             server_handle: join_handle,
             shutdown_notifier: sender,
-            bank: BenchmarkBank::new(proxy.clone(), primary_gas, pay_coins),
+            bank: BenchmarkBank::new(proxy.clone(), primary_coin),
             proxies,
         })
     }

--- a/crates/sui-benchmark/src/benchmark_setup.rs
+++ b/crates/sui-benchmark/src/benchmark_setup.rs
@@ -147,11 +147,7 @@ impl Env {
             LocalValidatorAggregatorProxy::from_genesis(&config.genesis, registry, None).await,
         );
         let keypair = Arc::new(keypair);
-        let primary_gas = (
-            primary_gas.compute_object_reference(),
-            address,
-            keypair.clone(),
-        );
+        let primary_gas = (primary_gas.compute_object_reference(), address, keypair);
         Ok(BenchmarkSetup {
             server_handle: join_handle,
             shutdown_notifier: sender,

--- a/crates/sui-benchmark/src/bin/stress.rs
+++ b/crates/sui-benchmark/src/bin/stress.rs
@@ -86,6 +86,7 @@ async fn main() -> Result<()> {
             .unwrap(),
     );
     let registry: Registry = registry_service.default_registry();
+    mysten_metrics::init_metrics(&registry);
 
     let barrier = Arc::new(Barrier::new(2));
     let cloned_barrier = barrier.clone();

--- a/crates/sui-benchmark/src/workloads/batch_payment.rs
+++ b/crates/sui-benchmark/src/workloads/batch_payment.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use sui_core::test_utils::make_pay_sui_transaction;
 use sui_types::base_types::{ObjectID, SequenceNumber};
 use sui_types::digests::ObjectDigest;
+use sui_types::gas_coin::MIST_PER_SUI;
 use sui_types::object::Owner;
 use sui_types::{
     base_types::{ObjectRef, SuiAddress},
@@ -25,7 +26,7 @@ use tracing::{debug, error};
 /// Value of each address's "primary coin" in mist. The first transaction gives
 /// each address a coin worth PRIMARY_COIN_VALUE, and all subsequent transfers
 /// send TRANSFER_AMOUNT coins each time
-const PRIMARY_COIN_VALUE: u64 = 100_000_000_000;
+const PRIMARY_COIN_VALUE: u64 = 100 * MIST_PER_SUI;
 
 /// Number of mist sent to each address on each batch transfer
 const BATCH_TRANSFER_AMOUNT: u64 = 1;

--- a/crates/sui-benchmark/src/workloads/delegation.rs
+++ b/crates/sui-benchmark/src/workloads/delegation.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 use sui_core::test_utils::make_transfer_sui_transaction;
 use sui_types::base_types::{ObjectRef, SuiAddress};
 use sui_types::crypto::{get_key_pair, AccountKeyPair};
+use sui_types::gas_coin::MIST_PER_SUI;
 use sui_types::messages::VerifiedTransaction;
 use test_utils::messages::make_staking_transaction;
 use tracing::error;
@@ -69,7 +70,7 @@ impl Payload for DelegationTestPayload {
             None => make_transfer_sui_transaction(
                 self.gas,
                 self.sender,
-                Some(1),
+                Some(MIST_PER_SUI),
                 self.sender,
                 &self.keypair,
                 self.system_state_observer

--- a/crates/sui-benchmark/src/workloads/workload.rs
+++ b/crates/sui-benchmark/src/workloads/workload.rs
@@ -1,22 +1,23 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::system_state_observer::SystemStateObserver;
+use crate::workloads::payload::Payload;
+use crate::workloads::{Gas, GasCoinConfig};
+use crate::ValidatorProxy;
 use async_trait::async_trait;
 use std::sync::Arc;
+use sui_types::gas_coin::MIST_PER_SUI;
 
-use crate::system_state_observer::SystemStateObserver;
-use crate::workloads::{Gas, GasCoinConfig};
-
-use crate::workloads::payload::Payload;
-use crate::ValidatorProxy;
+pub const MIN_SUI_PER_WORKLOAD: u64 = 10_000_000 * MIST_PER_SUI;
 
 // This is the maximum gas we will transfer from primary coin into any gas coin
 // for running the benchmark
-pub const MAX_GAS_FOR_TESTING: u64 = 1_000_000_000_000;
+pub const MAX_GAS_FOR_TESTING: u64 = 1_000 * MIST_PER_SUI;
 
 // TODO: get this information from protocol config
 // This is the maximum budget that can be set for a transaction. 50 SUI.
-pub const MAX_BUDGET: u64 = 50_000_000_000;
+pub const MAX_BUDGET: u64 = 50 * MIST_PER_SUI;
 // (COIN_BYTES_SIZE * STORAGE_PRICE * STORAGE_UNITS_PER_BYTE)
 pub const STORAGE_COST_PER_COIN: u64 = 130 * 76 * 100;
 // (COUNTER_BYTES_SIZE * STORAGE_PRICE * STORAGE_UNITS_PER_BYTE)

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -388,15 +388,13 @@ mod test {
         let ed25519_keypair =
             Arc::new(get_ed25519_keypair_from_keystore(keystore_path, &sender).unwrap());
         let (_, gas) = all_gas.get(0).unwrap();
-        let (_move_struct, pay_coin) = all_gas.get(1).unwrap();
-        let primary_gas = (gas.clone(), sender, ed25519_keypair.clone());
-        let pay_coin = (pay_coin.clone(), sender, ed25519_keypair.clone());
+        let primary_coin = (gas.clone(), sender, ed25519_keypair.clone());
 
         let registry = prometheus::Registry::new();
         let proxy: Arc<dyn ValidatorProxy + Send + Sync> =
             Arc::new(LocalValidatorAggregatorProxy::from_genesis(&genesis, &registry, None).await);
 
-        let bank = BenchmarkBank::new(proxy.clone(), primary_gas, vec![pay_coin]);
+        let bank = BenchmarkBank::new(proxy.clone(), primary_coin);
         let system_state_observer = {
             let mut system_state_observer = SystemStateObserver::new(proxy.clone());
             if let Ok(_) = system_state_observer.state.changed().await {


### PR DESCRIPTION
## Description 

Instead of issuing a split coin + transfer transaction for each gas chunk we will now jut issue one pay_sui transaction which just requires one coin. Also we will split off a coin from the primary gas coin that may have contention from other stress clients to help reduce that contention.

Also fixed the issue with delegation workloads in this PR 

## Test Plan 

benchmark/labnet/private-testnet