### PR TITLE
Gate indexes processing behind a config

### DIFF
--- a/crates/sui-config/src/builder.rs
+++ b/crates/sui-config/src/builder.rs
@@ -3,8 +3,8 @@
 
 use crate::genesis::{TokenAllocation, TokenDistributionScheduleBuilder};
 use crate::node::{
-    default_end_of_epoch_broadcast_channel_capacity, AuthorityKeyPairWithPath, DBCheckpointConfig,
-    KeyPairWithPath,
+    default_enable_index_processing, default_end_of_epoch_broadcast_channel_capacity,
+    AuthorityKeyPairWithPath, DBCheckpointConfig, KeyPairWithPath,
 };
 use crate::{
     genesis,
@@ -500,6 +500,7 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                     json_rpc_address: utils::available_local_socket_address(),
                     consensus_config: Some(consensus_config),
                     enable_event_processing: false,
+                    enable_index_processing: default_enable_index_processing(),
                     genesis: crate::node::Genesis::new(genesis.clone()),
                     grpc_load_shed: initial_accounts_config.grpc_load_shed,
                     grpc_concurrency_limit: initial_accounts_config.grpc_concurrency_limit,

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -62,8 +62,12 @@ pub struct NodeConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub consensus_config: Option<ConsensusConfig>,
 
+    // TODO: Remove this as it's no longer used.
     #[serde(default)]
     pub enable_event_processing: bool,
+
+    #[serde(default = "default_enable_index_processing")]
+    pub enable_index_processing: bool,
 
     #[serde(default)]
     pub grpc_load_shed: Option<bool>,
@@ -112,6 +116,10 @@ pub struct NodeConfig {
 
 fn default_authority_store_pruning_config() -> AuthorityStorePruningConfig {
     AuthorityStorePruningConfig::default()
+}
+
+pub fn default_enable_index_processing() -> bool {
+    true
 }
 
 fn default_grpc_address() -> Multiaddr {

--- a/crates/sui-config/src/swarm.rs
+++ b/crates/sui-config/src/swarm.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::node::AuthorityStorePruningConfig;
+use crate::node::{default_enable_index_processing, AuthorityStorePruningConfig};
 use crate::node::{
     default_end_of_epoch_broadcast_channel_capacity, AuthorityKeyPairWithPath, DBCheckpointConfig,
     KeyPairWithPath,
@@ -273,6 +273,7 @@ impl<'a> FullnodeConfigBuilder<'a> {
             json_rpc_address,
             consensus_config: None,
             enable_event_processing: self.enable_event_store,
+            enable_index_processing: default_enable_index_processing(),
             genesis: validator_config.genesis.clone(),
             grpc_load_shed: None,
             grpc_concurrency_limit: None,

--- a/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -54,6 +54,7 @@ validator_configs:
           report_batch_rate_limit: ~
           request_batch_rate_limit: ~
     enable-event-processing: false
+    enable-index-processing: true
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:
@@ -132,6 +133,7 @@ validator_configs:
           report_batch_rate_limit: ~
           request_batch_rate_limit: ~
     enable-event-processing: false
+    enable-index-processing: true
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:
@@ -210,6 +212,7 @@ validator_configs:
           report_batch_rate_limit: ~
           request_batch_rate_limit: ~
     enable-event-processing: false
+    enable-index-processing: true
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:
@@ -288,6 +291,7 @@ validator_configs:
           report_batch_rate_limit: ~
           request_batch_rate_limit: ~
     enable-event-processing: false
+    enable-index-processing: true
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:
@@ -366,6 +370,7 @@ validator_configs:
           report_batch_rate_limit: ~
           request_batch_rate_limit: ~
     enable-event-processing: false
+    enable-index-processing: true
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:
@@ -444,6 +449,7 @@ validator_configs:
           report_batch_rate_limit: ~
           request_batch_rate_limit: ~
     enable-event-processing: false
+    enable-index-processing: true
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:
@@ -522,6 +528,7 @@ validator_configs:
           report_batch_rate_limit: ~
           request_batch_rate_limit: ~
     enable-event-processing: false
+    enable-index-processing: true
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
     p2p-config:

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -244,10 +244,10 @@ impl SuiNode {
             checkpoint_store.clone(),
         );
 
-        let index_store = if is_validator {
-            None
-        } else {
+        let index_store = if is_full_node && config.enable_index_processing {
             Some(Arc::new(IndexStore::new(config.db_path().join("indexes"))))
+        } else {
+            None
         };
 
         // Create network


### PR DESCRIPTION
Adds a new config flag to gate indexes processing.
Default to true to make sure all existing fullnodes still have it enabled.