### PR TITLE
[framework] Minor fixes in Kiosk

### DIFF
--- a/crates/sui-framework/packages/sui-framework/sources/kiosk/kiosk.move
+++ b/crates/sui-framework/packages/sui-framework/sources/kiosk/kiosk.move
@@ -359,6 +359,13 @@ module sui::kiosk {
         coin::take(&mut self.profits, amount, ctx)
     }
 
+    // === KioskOwnerCap fields access ===
+
+    /// Get the `for` field from the `KioskOwnerCap`.
+    public fun kiosk_cap_for(self: &KioskOwnerCap): ID {
+        self.for
+    }
+
     // === Kiosk fields access ===
 
     /// Check whether the an `item` is present in the `Kiosk`.
@@ -385,7 +392,7 @@ module sui::kiosk {
     }
 
     /// Check whether the `KioskOwnerCap` matches the `Kiosk`.
-    public fun has_access(self: &mut Kiosk, cap: &KioskOwnerCap): bool {
+    public fun has_access(self: &Kiosk, cap: &KioskOwnerCap): bool {
         object::id(self) == cap.for
     }
 


### PR DESCRIPTION
## Description 

While working on examples I've discovered that we don't provide enough getter functions as well as require mutability where it's not needed.

## Test Plan 

---

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

- changes signature in `kiosk::has_access` from `&mut` to just `&`
- adds a getter function `kiosk::
