### PR TITLE
adding serialization handler to prevent crash on start

### DIFF
--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -41,7 +41,7 @@ pub struct SimpleFaucet {
     active_address: SuiAddress,
     producer: Mutex<Sender<ObjectID>>,
     consumer: Mutex<Receiver<ObjectID>>,
-    metrics: FaucetMetrics,
+    pub metrics: FaucetMetrics,
     wal: Mutex<WriteAheadLog>,
 }
 
@@ -245,18 +245,11 @@ impl SimpleFaucet {
         // Drops the lock early because sign_and_execute_txn requires the lock.
         drop(wal);
 
-        let transfer_results =
-            futures::future::join_all(pending.into_iter().map(|(uuid, recipient, coin_id, tx)| {
-                self.sign_and_execute_txn(uuid, recipient, coin_id, tx)
-            }))
-            .await;
+        futures::future::join_all(pending.into_iter().map(|(uuid, recipient, coin_id, tx)| {
+            self.sign_and_execute_txn(uuid, recipient, coin_id, tx)
+        }))
+        .await;
 
-        for result in transfer_results.into_iter() {
-            if result.is_ok() {
-                self.metrics.total_available_coins.inc();
-                self.metrics.total_discarded_coins.dec();
-            }
-        }
         Ok(())
     }
 
@@ -794,6 +787,9 @@ mod tests {
         .await
         .unwrap();
 
+        let original_available = faucet.metrics.total_available_coins.get();
+        let original_discarded = faucet.metrics.total_discarded_coins.get();
+
         let recipient = SuiAddress::random_for_testing_only();
         let faucet_address = faucet.wallet_mut().active_address().unwrap();
         let uuid = Uuid::new_v4();
@@ -826,6 +822,10 @@ mod tests {
 
         let wal_2 = faucet.wal.lock().await;
         assert!(wal_2.log.is_empty());
+        let total_coins = faucet.metrics.total_available_coins.get();
+        let discarded_coins = faucet.metrics.total_discarded_coins.get();
+        assert_eq!(total_coins, original_available);
+        assert_eq!(discarded_coins, original_discarded);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description 

Adding a serialization handler to prevent crash on start.

## Test Plan 

Old entry causing crash:
![image](https://user-images.githubusercontent.com/123408603/232078293-1a991cdc-f309-402d-9fea-c945f3481c1d.png)

New faucet image restart, but catching the error and not crashing the program.
![image](https://user-images.githubusercontent.com/123408603/232079264-cb66a764-5fba-4c67-9ffc-63660885b216.png)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
