### PR TITLE
[checkpoints] Disable InMemoryCheckpointRoots

### DIFF
--- a/crates/sui-core/src/authority/epoch_start_configuration.rs
+++ b/crates/sui-core/src/authority/epoch_start_configuration.rs
@@ -147,7 +147,9 @@ impl EpochStartConfigTrait for EpochStartConfigurationV2 {
 
 impl EpochFlag {
     pub fn default_flags_for_new_epoch() -> Vec<Self> {
-        vec![EpochFlag::InMemoryCheckpointRoots]
+        vec![]
+        // todo - enable after switching to single DBBatch in consensus handler
+        // vec![EpochFlag::InMemoryCheckpointRoots]
     }
 }
 


### PR DESCRIPTION
I think there is an issue with how InMemoryCheckpointRoots works in some edge cases. Switching to single DBBatch will resolve the issue, but until then this feature needs to be disabled

