### PR TITLE
[explorer] fix address page double header

### DIFF
--- a/apps/explorer/src/components/transactions/TransactionsForAddress.tsx
+++ b/apps/explorer/src/components/transactions/TransactionsForAddress.tsx
@@ -83,9 +83,6 @@ export function TransactionsForAddress({ address, type }: Props) {
     return (
         <div data-testid="tx">
             <TabGroup size="lg">
-                <TabList>
-                    <Tab>Transaction Blocks</Tab>
-                </TabList>
                 <TabPanels>
                     <TabPanel>
                         <TableCard

--- a/apps/explorer/src/components/transactions/TransactionsForAddress.tsx
+++ b/apps/explorer/src/components/transactions/TransactionsForAddress.tsx
@@ -83,6 +83,9 @@ export function TransactionsForAddress({ address, type }: Props) {
     return (
         <div data-testid="tx">
             <TabGroup size="lg">
+                <TabList>
+                    <Tab>Transaction Blocks</Tab>
+                </TabList>
                 <TabPanels>
                     <TabPanel>
                         <TableCard

--- a/apps/explorer/src/pages/address-result/AddressResult.tsx
+++ b/apps/explorer/src/pages/address-result/AddressResult.tsx
@@ -32,11 +32,6 @@ function AddressResult() {
             </div>
 
             <div>
-                <div className="border-b border-gray-45 pb-5">
-                    <Heading color="gray-90" variant="heading4/semibold">
-                        Transaction Blocks
-                    </Heading>
-                </div>
                 <ErrorBoundary>
                     <div className="mt-2">
                         <TransactionsForAddress


### PR DESCRIPTION
## Description 

before:
<img width="1186" alt="image" src="https://user-images.githubusercontent.com/128089541/232117218-acc9656a-7320-4b38-b94d-48acde2cdf04.png">

after:
<img width="793" alt="image" src="https://user-images.githubusercontent.com/128089541/232117289-a6c78481-cdd3-4bb9-a139-b49698ecf444.png">

## Test Plan 

Locally

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Fixed double transaction block header on address page.