### PR TITLE
Explorer dynamic field struct update

### DIFF
--- a/apps/explorer/src/components/SyntaxHighlighter/index.tsx
+++ b/apps/explorer/src/components/SyntaxHighlighter/index.tsx
@@ -22,7 +22,7 @@ export function SyntaxHighlighter({ code, language }: Props) {
             >
                 {({ style, tokens, getLineProps, getTokenProps }) => (
                     <pre
-                        className="bg-transparent !p-0 font-medium"
+                        className="overflow-auto bg-transparent !p-0 font-medium"
                         style={style}
                     >
                         {tokens.map((line, i) => (

--- a/apps/explorer/src/components/owned-objects/utils.ts
+++ b/apps/explorer/src/components/owned-objects/utils.ts
@@ -47,13 +47,6 @@ export function extractSerializationType(
     }
 
     if ('Struct' in type) {
-        const theType = type.Struct;
-        const theTypeArgs = theType.typeArguments;
-
-        if (theTypeArgs && theTypeArgs.length > 0) {
-            return extractSerializationType(theTypeArgs[0]);
-        }
-
         return type.Struct;
     }
 
@@ -84,9 +77,20 @@ export function getFieldTypeValue(
         };
     }
 
+    // For nested Structs type.typeArguments  append the typeArguments to the name
+    // Balance<XUS> || Balance<LSP<SUI, USDT>>
     const { address, module, name } = normalizedType;
+    let typeParam = '';
+
+    if (normalizedType.typeArguments?.length) {
+        typeParam = normalizedType.typeArguments
+            .map(
+                (typeArg) => getFieldTypeValue(typeArg, objectType).displayName
+            )
+            .join(', ');
+    }
     return {
-        displayName: normalizedType.name,
+        displayName: normalizedType.name + (typeParam ? `<${typeParam}>` : ''),
         normalizedType: `${address}::${module}::${name}`,
     };
 }

--- a/apps/explorer/src/components/owned-objects/utils.ts
+++ b/apps/explorer/src/components/owned-objects/utils.ts
@@ -91,7 +91,9 @@ export function getFieldTypeValue(
     }
 
     return {
-        displayName: `${normalizedType.name} ${typeParam}`,
+        displayName: `${normalizedType.name}${
+            typeParam === '' ? '' : ` <${typeParam}>`
+        }`,
         normalizedType: `${address}::${module}::${name}`,
     };
 }

--- a/apps/explorer/src/components/owned-objects/utils.ts
+++ b/apps/explorer/src/components/owned-objects/utils.ts
@@ -91,7 +91,7 @@ export function getFieldTypeValue(
     }
 
     return {
-        displayName:`${normalizedType.name} ${typeParam}`,
+        displayName: `${normalizedType.name} ${typeParam}`,
         normalizedType: `${address}::${module}::${name}`,
     };
 }

--- a/apps/explorer/src/components/owned-objects/utils.ts
+++ b/apps/explorer/src/components/owned-objects/utils.ts
@@ -92,7 +92,7 @@ export function getFieldTypeValue(
 
     return {
         displayName: `${normalizedType.name}${
-            typeParam === '' ? '' : ` <${typeParam}>`
+            typeParam === '' ? '' : `<${typeParam}>`
         }`,
         normalizedType: `${address}::${module}::${name}`,
     };

--- a/apps/explorer/src/components/owned-objects/utils.ts
+++ b/apps/explorer/src/components/owned-objects/utils.ts
@@ -83,17 +83,15 @@ export function getFieldTypeValue(
     let typeParam = '';
 
     if (normalizedType.typeArguments?.length) {
-        typeParam = normalizedType.typeArguments
+        typeParam = `<${normalizedType.typeArguments
             .map(
                 (typeArg) => getFieldTypeValue(typeArg, objectType).displayName
             )
-            .join(', ');
+            .join(', ')}>`;
     }
 
     return {
-        displayName: `${normalizedType.name}${
-            typeParam === '' ? '' : `<${typeParam}>`
-        }`,
+        displayName: `${normalizedType.name}${typeParam}`,
         normalizedType: `${address}::${module}::${name}`,
     };
 }

--- a/apps/explorer/src/components/owned-objects/utils.ts
+++ b/apps/explorer/src/components/owned-objects/utils.ts
@@ -89,8 +89,9 @@ export function getFieldTypeValue(
             )
             .join(', ');
     }
+
     return {
-        displayName: normalizedType.name + (typeParam ? `<${typeParam}>` : ''),
+        displayName:`${normalizedType.name} ${typeParam}`,
         normalizedType: `${address}::${module}::${name}`,
     };
 }

--- a/apps/explorer/src/components/owned-objects/views/DynamicFieldsCard.tsx
+++ b/apps/explorer/src/components/owned-objects/views/DynamicFieldsCard.tsx
@@ -51,31 +51,28 @@ export function DynamicFieldsCard({ id }: { id: string }) {
                 </TabList>
                 <TabPanels>
                     <TabPanel>
-                        <div className="mt-4 flex max-h-600 flex-col gap-5 overflow-auto overflow-x-scroll">
+                        <div className="mt-4 flex max-h-600 flex-col gap-5 overflow-auto">
                             {data.pages.map(({ data }) =>
                                 // Show the field name and type is it is not an object
                                 data.map((result) => (
                                     <DisclosureBox
                                         title={
                                             <div className="flex items-center gap-1 truncate break-words text-body font-medium leading-relaxed text-steel-dark">
-                                                {typeof result.name?.value ===
-                                                'object' ? (
-                                                    <div className="block w-8/12 truncate break-words">
-                                                        Struct{' '}
-                                                        {formatAddress(
-                                                            result.objectType
-                                                        )}
-                                                    </div>
-                                                ) : (
-                                                    <div className="block w-8/12 truncate break-words">
-                                                        {result.name?.value
-                                                            ? String(
-                                                                  result.name
-                                                                      .value
-                                                              )
-                                                            : null}
-                                                    </div>
-                                                )}
+                                                <div className="block w-8/12 truncate break-words">
+                                                    {typeof result.name
+                                                        ?.value === 'object' ? (
+                                                        <>
+                                                            Struct{' '}
+                                                            {formatAddress(
+                                                                result.objectType
+                                                            )}
+                                                        </>
+                                                    ) : result.name?.value ? (
+                                                        String(
+                                                            result.name.value
+                                                        )
+                                                    ) : null}
+                                                </div>
                                                 <ObjectLink
                                                     objectId={result.objectId}
                                                 />

--- a/apps/explorer/src/components/owned-objects/views/ObjectFieldsCard.tsx
+++ b/apps/explorer/src/components/owned-objects/views/ObjectFieldsCard.tsx
@@ -149,7 +149,7 @@ export function ObjectFieldsCard({ id }: ObjectFieldsProps) {
                                             ({ name, type }) => (
                                                 <div
                                                     key={name}
-                                                    className="mt-0.5 md:min-w-fit"
+                                                    className="mt-0.5"
                                                 >
                                                     <ListItem
                                                         active={
@@ -162,7 +162,7 @@ export function ObjectFieldsCard({ id }: ObjectFieldsProps) {
                                                             )
                                                         }
                                                     >
-                                                        <div className="flex flex-1 justify-between gap-2 truncate">
+                                                        <div className="flex w-full flex-1 justify-between gap-2 truncate">
                                                             <Text
                                                                 variant="body/medium"
                                                                 color="steel-darker"
@@ -174,6 +174,7 @@ export function ObjectFieldsCard({ id }: ObjectFieldsProps) {
                                                             <Text
                                                                 variant="p3/normal"
                                                                 color="steel"
+                                                                truncate
                                                             >
                                                                 {
                                                                     getFieldTypeValue(

--- a/apps/explorer/src/components/owned-objects/views/ObjectFieldsCard.tsx
+++ b/apps/explorer/src/components/owned-objects/views/ObjectFieldsCard.tsx
@@ -143,7 +143,7 @@ export function ObjectFieldsCard({ id }: ObjectFieldsProps) {
                                         ))}
                                     </Combobox.Options>
                                 </Combobox>
-                                <div className="max-h-600 min-h-full overflow-auto overflow-x-clip overflow-y-scroll py-3">
+                                <div className="max-h-600 min-h-full overflow-y-auto overflow-x-clip py-3">
                                     <VerticalList>
                                         {normalizedStruct?.fields?.map(
                                             ({ name, type }) => (
@@ -193,7 +193,7 @@ export function ObjectFieldsCard({ id }: ObjectFieldsProps) {
                             </div>
 
                             <div className="grow overflow-auto border-gray-45 pt-1 md:w-3/5 md:border-l md:pl-7">
-                                <div className="flex max-h-[600px] flex-col gap-5 overflow-x-scroll pb-5">
+                                <div className="flex max-h-600 flex-col gap-5 overflow-y-auto pb-5">
                                     {normalizedStruct?.fields.map(
                                         ({ name, type }) => (
                                             <ScrollToViewCard

--- a/apps/explorer/src/ui/DisclosureBox.tsx
+++ b/apps/explorer/src/ui/DisclosureBox.tsx
@@ -49,7 +49,7 @@ export function DisclosureBox({
                                 {preview && !open ? preview : null}
                             </div>
 
-                            <ChevronRight12 className="text-caption text-steel ui-open:rotate-90" />
+                            <ChevronRight12 className="ml-1 text-caption text-steel ui-open:rotate-90" />
                         </Disclosure.Button>
                         <Disclosure.Panel className="px-5 pb-3.75">
                             {children}

--- a/apps/explorer/src/ui/DisclosureBox.tsx
+++ b/apps/explorer/src/ui/DisclosureBox.tsx
@@ -42,14 +42,14 @@ export function DisclosureBox({
                     <>
                         <Disclosure.Button
                             as="div"
-                            className="flex cursor-pointer flex-nowrap items-center px-5 py-3.75"
+                            className="flex cursor-pointer flex-nowrap items-center gap-1 px-5 py-3.75"
                         >
                             <div className="flex w-11/12 flex-1 gap-1 text-body font-semibold text-gray-90">
                                 {title}
                                 {preview && !open ? preview : null}
                             </div>
 
-                            <ChevronRight12 className="ml-1 text-caption text-steel ui-open:rotate-90" />
+                            <ChevronRight12 className="text-caption text-steel ui-open:rotate-90" />
                         </Disclosure.Button>
                         <Disclosure.Panel className="px-5 pb-3.75">
                             {children}


### PR DESCRIPTION
## Description 

Describe the changes or additions included in this PR.
This PR adds the nested struct `typeArgument` to the Key type field and UI scroll polish

## Test Plan 

How did you test the new or updated feature?

Before
<img width="1469" alt="Screenshot 2023-04-14 at 1 39 24 PM" src="https://user-images.githubusercontent.com/126525197/232118452-82f17ca5-a9a7-40db-a2bf-8c829f881a17.png">

After
<img width="1482" alt="Screenshot 2023-04-14 at 1 39 41 PM" src="https://user-images.githubusercontent.com/126525197/232118504-6d3e7172-cc12-4f02-b468-eef4b39dc18a.png">

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
