### PR TITLE
Hide gas versioning behind gas status

### DIFF
--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -300,7 +300,7 @@ fn execute_transaction<
         execution_result
     });
 
-    if protocol_config.gas_model_version() > 1 {
+    if !gas_status.is_legacy_gas() {
         // We always go through the gas charging process, but for system transaction, we don't pass
         // the gas object ID since it's not a valid object.
         // TODO: Ideally we should make gas object ref None in the first place.

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -31,7 +31,7 @@ use sui_types::storage::{
     get_module_by_id, BackingPackageStore, ChildObjectResolver, DeleteKind, ObjectKey, ObjectStore,
 };
 use sui_types::sui_system_state::get_sui_system_state;
-use sui_types::{base_types::SequenceNumber, fp_bail, fp_ensure, storage::ParentSync};
+use sui_types::{base_types::SequenceNumber, fp_bail, fp_ensure, gas, storage::ParentSync};
 use typed_store::rocks::{DBBatch, TypedStoreError};
 use typed_store::traits::Map;
 
@@ -1464,7 +1464,7 @@ impl AuthorityStore {
                 .protocol_version(),
         );
         // Prior to gas model v2, SUI conservation is not guaranteed.
-        if ProtocolConfig::get_for_version(protocol_version).gas_model_version() <= 1 {
+        if gas::is_legacy_gas(&ProtocolConfig::get_for_version(protocol_version)) {
             return Ok(());
         }
 


### PR DESCRIPTION
## Description 

@lxfind @tzakian take a look and see if this is what you had in mind and how it can look.
For me, this is likely better than before, but I also want to see legacy mode to disappear and change things even more and with a much cleaner plate.
Let me know your thoughts though

## Test Plan 

Existing tests
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
