### PR TITLE
Add Documentation for Security releases

### DIFF
--- a/nre/download_private.sh
+++ b/nre/download_private.sh
@@ -22,16 +22,12 @@ cosign verify-blob --insecure-ignore-tlog --key $pub_key --signature $url/sui-in
 
 echo "[+] Downloading sui binaries for $randomstring ..."
 curl $url/sui -o sui
-curl $url/sui-faucet -o sui-faucet
 curl $url/sui-indexer -o sui-indexer
 curl $url/sui-node -o sui-node
 curl $url/sui-tool -o sui-tool
-curl $url/sui-proxy -o sui-proxy
 
 echo "[+] Verifying sui binaries for $randomstring ..."
 cosign verify-blob --insecure-ignore-tlog --key $pub_key --signature $url/sui.sig sui
-cosign verify-blob --insecure-ignore-tlog --key $pub_key --signature $url/sui-faucet.sig sui-faucet
 cosign verify-blob --insecure-ignore-tlog --key $pub_key --signature $url/sui-indexer.sig sui-indexer
 cosign verify-blob --insecure-ignore-tlog --key $pub_key --signature $url/sui-node.sig sui-node
-cosign verify-blob --insecure-ignore-tlog --key $pub_key --signature $url/sui-proxy.sig sui-proxy
 

--- a/nre/download_private.sh
+++ b/nre/download_private.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
-# Copyright (c) 2023, Mysten Labs, Inc.
+#!/bin/bash
+# Copyright (c) Mysten Labs, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 if ! cosign version &> /dev/null

--- a/nre/download_private.sh
+++ b/nre/download_private.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# Copyright (c) 2023, Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 if ! cosign version &> /dev/null
 then
     echo "cosign in not installed, Please install cosign for binary verification."

--- a/nre/download_private.sh
+++ b/nre/download_private.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+if ! cosign version &> /dev/null
+then
+    echo "cosign in not installed, Please install cosign for binary verification."
+    echo "https://docs.sigstore.dev/cosign/installation"
+    exit
+fi
+
+randomstring=$1
+pub_key=https://sui-private.s3.us-west-2.amazonaws.com/sui_security_release.pem
+url=https://sui-private.s3.us-west-2.amazonaws.com/$randomstring
+
+echo "[+] Downloading docker artifacts for $randomstring ..."
+curl $url/sui-node-docker.tar -o sui-node-docker.tar
+curl $url/sui-tools-docker.tar -o sui-tools-docker.tar
+curl $url/sui-indexer-docker.tar -o sui-indexer-docker.tar
+
+echo "[+] Verifying docker artifacts for $randomstring ..."
+cosign verify-blob --insecure-ignore-tlog --key $pub_key --signature $url/sui-node-docker.tar.sig sui-node-docker.tar
+cosign verify-blob --insecure-ignore-tlog --key $pub_key --signature $url/sui-tools-docker.tar.sig sui-tools-docker.tar
+cosign verify-blob --insecure-ignore-tlog --key $pub_key --signature $url/sui-indexer-docker.tar.sig sui-indexer-docker.tar
+
+echo "[+] Downloading sui binaries for $randomstring ..."
+curl $url/sui -o sui
+curl $url/sui-faucet -o sui-faucet
+curl $url/sui-indexer -o sui-indexer
+curl $url/sui-node -o sui-node
+curl $url/sui-tool -o sui-tool
+curl $url/sui-proxy -o sui-proxy
+
+echo "[+] Verifying sui binaries for $randomstring ..."
+cosign verify-blob --insecure-ignore-tlog --key $pub_key --signature $url/sui.sig sui
+cosign verify-blob --insecure-ignore-tlog --key $pub_key --signature $url/sui-faucet.sig sui-faucet
+cosign verify-blob --insecure-ignore-tlog --key $pub_key --signature $url/sui-indexer.sig sui-indexer
+cosign verify-blob --insecure-ignore-tlog --key $pub_key --signature $url/sui-node.sig sui-node
+cosign verify-blob --insecure-ignore-tlog --key $pub_key --signature $url/sui-proxy.sig sui-proxy
+

--- a/nre/sui_for_node_operators.md
+++ b/nre/sui_for_node_operators.md
@@ -18,6 +18,7 @@ This document is focused on running the Sui Node software as a Validator.
 - [Software Updates](#software-updates)
 - [State Sync](#state-sync)
 - [Chain Operations](#chain-operations)
+- [Private Security Fixes](#security-fixes)
 
 ## Deployment
 
@@ -309,3 +310,15 @@ sui client call --package 0x2 --module sui_system --function request_remove_vali
 ```
 
 After the validator is removed at the next epoch change, the staking pool will become inactive and stakes can only be withdrawn from an inactive pool.
+
+## Private Security Fixes
+
+There may be instances where urgent security fixes need to be rolled out before publicly announcing it's presence (Issues affecting liveliness, invariants such as SUI supply, governance etc). In order to not be actively exploited MystenLabs will release signed security binaries incorporating such fixes with a delay in publishing the source code until a large % of our validators have patched the vulnerability.
+
+This release process will be different and we expect us to announce the directory to announce such binaries out of band.
+Our public key to verify these binaries would be stored [here](https://sui-private.s3.us-west-2.amazonaws.com/sui_security_release.pem)
+
+We will also release a script that downloads all the necessary signed binaries and docker artifacts incorporating the security fixes.
+
+Usage
+```./download_private.sh <directory-name>```


### PR DESCRIPTION
## Description 

Adds documentation pointing to security fix releases.
Includes a bash helper script that downloads signed binaries and verifies signatures.
