### PR TITLE
[wallet-ext] show only 2 ledger accounts in the import flow

### DIFF
--- a/apps/wallet/src/ui/app/components/ledger/ImportLedgerAccounts.tsx
+++ b/apps/wallet/src/ui/app/components/ledger/ImportLedgerAccounts.tsx
@@ -25,7 +25,7 @@ import { Button } from '_src/ui/app/shared/ButtonUI';
 import { Link } from '_src/ui/app/shared/Link';
 import { Text } from '_src/ui/app/shared/text';
 
-const numLedgerAccountsToDeriveByDefault = 10;
+const numLedgerAccountsToDeriveByDefault = 2;
 
 export function ImportLedgerAccounts() {
     const accountsUrl = useNextMenuUrl(true, `/accounts`);


### PR DESCRIPTION
## Description 

https://mysten-labs.slack.com/archives/C04R8B45QDS/p1681502281725109?thread_ts=1681493666.781589&cid=C04R8B45QDS

TLDR; Ledger wants us to make users confirm every request to `getPublicKey`, so we're only going to show 2 accounts until we work out some improvements to the Sui Ledger app and figure out the best pagination / load more / infinite scrolling UX.


## Test Plan 
- Manual testing

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)
- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
N/A
