### PR TITLE
[transactional-tests] Add upgrade-compatibility tests

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/upgrade/constants.exp
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/constants.exp
@@ -1,0 +1,47 @@
+processed 10 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 6-16:
+created: object(1,0), object(1,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 5928000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'upgrade'. lines 18-28:
+created: object(2,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 5928000,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 3 'upgrade'. lines 30-42:
+created: object(3,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 5928000,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 4 'upgrade'. lines 44-54:
+Error: Transaction Effects Status: Invalid package upgrade. New package is incompatible with previous version
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: PackageUpgradeError { upgrade_error: IncompatibleUpgrade }, source: Some(PartialVMError { major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE, sub_status: None, message: None, exec_state: None, indices: [], offsets: [] }), command: Some(1) } }
+
+task 5 'upgrade'. lines 56-68:
+Error: Transaction Effects Status: Invalid package upgrade. New package is incompatible with previous version
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: PackageUpgradeError { upgrade_error: IncompatibleUpgrade }, source: Some(PartialVMError { major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE, sub_status: None, message: None, exec_state: None, indices: [], offsets: [] }), command: Some(1) } }
+
+task 6 'upgrade'. lines 69-87:
+created: object(6,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 6368800,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 7 'upgrade'. lines 88-103:
+created: object(7,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 6292800,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 8 'upgrade'. lines 104-118:
+created: object(8,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 6209200,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 9 'upgrade'. lines 119-132:
+created: object(9,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 6292800,  storage_rebate: 2595780, non_refundable_storage_fee: 26220

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/constants.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/constants.move
@@ -1,0 +1,132 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses V0=0x0 V1=0x0 V2=0x0 V3=0x0 V4=0x0 V5=0x0 V6=0x0 --accounts A
+
+//# publish --upgradeable --sender A
+module V0::base_module {
+
+    const A: u64 = 0;
+
+    struct X {
+        field0: u64,
+        field1: u64,
+    }
+    public fun public_fun(): u64 { A }
+}
+
+//# upgrade --package V0 --upgrade-capability 1,1 --sender A --policy compatible
+module V1::base_module {
+
+    const A: u64 = 1;
+
+    struct X {
+        field0: u64,
+        field1: u64,
+    }
+    public fun public_fun(): u64 { A }
+}
+
+//# upgrade --package V1 --upgrade-capability 1,1 --sender A --policy additive
+module V2::base_module {
+
+    const Y: u64 = 1;
+
+    struct X {
+        field0: u64,
+        field1: u64,
+    }
+    public fun public_fun(): u64 { Y }
+}
+
+// Value of the constant has changed -- this is incompatible in additive and dep_only policies
+
+//# upgrade --package V2 --upgrade-capability 1,1 --sender A --policy additive
+module V3::base_module {
+
+    const Y: u64 = 0;
+
+    struct X {
+        field0: u64,
+        field1: u64,
+    }
+    public fun public_fun(): u64 { Y }
+}
+
+//# upgrade --package V2 --upgrade-capability 1,1 --sender A --policy dep_only
+module V3::base_module {
+
+    const Y: u64 = 0;
+
+    struct X {
+        field0: u64,
+        field1: u64,
+    }
+    public fun public_fun(): u64 { Y }
+}
+
+// Fine to introduce a new constant with the additive policy
+//# upgrade --package V2 --upgrade-capability 1,1 --sender A --policy additive
+module V3::base_module {
+
+
+    const T: u64 = 2;
+    const Y: u64 = 1;
+    const Z: u64 = 0;
+    const A: u64 = 42;
+
+    struct X {
+        field0: u64,
+        field1: u64,
+    }
+    public fun public_fun(): u64 { Y }
+    public fun public_fun2(): u64 { T }
+}
+
+
+// OK to remove constants in additive policy as long as they're unused
+//# upgrade --package V3 --upgrade-capability 1,1 --sender A --policy additive
+module V4::base_module {
+
+    const Y: u64 = 1;
+    const T: u64 = 2;
+    const A: u64 = 42;
+
+    struct X {
+        field0: u64,
+        field1: u64,
+    }
+    public fun public_fun(): u64 { Y }
+    public fun public_fun2(): u64 { T } 
+}
+
+// OK to remove constants in dep_only policy -- if they're unused
+//# upgrade --package V4 --upgrade-capability 1,1 --sender A --policy dep_only
+module V5::base_module {
+
+    const Y: u64 = 1;
+    const T: u64 = 2;
+
+    struct X {
+        field0: u64,
+        field1: u64,
+    }
+    public fun public_fun(): u64 { Y }
+    public fun public_fun2(): u64 { T } 
+}
+
+// Fine to introduce a new constant as long as it's not used in either policy
+//# upgrade --package V5 --upgrade-capability 1,1 --sender A --policy dep_only
+module V6::base_module {
+
+    const R: u64 = 3;
+    const T: u64 = 2;
+    const Y: u64 = 1;
+
+    struct X {
+        field0: u64,
+        field1: u64,
+    }
+    public fun public_fun(): u64 { Y }
+    public fun public_fun2(): u64 { T }
+}

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/friend_fun_changes.exp
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/friend_fun_changes.exp
@@ -1,0 +1,38 @@
+processed 8 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 6-23:
+created: object(1,0), object(1,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 7668400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'upgrade'. lines 24-41:
+created: object(2,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 7683600,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 3 'upgrade'. lines 42-71:
+created: object(3,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 8907200,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 4 'upgrade'. lines 72-99:
+created: object(4,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 9994000,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 5 'run'. lines 101-101:
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 6 'run'. lines 103-103:
+created: object(6,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 2432000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 7 'view-object'. lines 105-105:
+Owner: Account Address ( A )
+Version: 3
+Contents: V0::base_module::Object {id: sui::object::UID {id: sui::object::ID {bytes: fake(6,0)}}, field0: 10u64, field1: 10u64}

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/friend_fun_changes.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/friend_fun_changes.move
@@ -1,0 +1,105 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses V0=0x0 V1=0x0 V2=0x0 V3=0x0 --accounts A
+
+//# publish --upgradeable --sender A
+module V0::base_module {
+    use sui::object::UID;
+    struct Object has key, store { 
+        id: UID,
+        field0: u64,
+        field1: u64,
+    }
+
+    friend V0::friend_module;
+
+    public(friend) entry fun friend_fun(): u64 { 0 }
+}
+module V0::friend_module {
+    public fun call_friend(): u64 { V0::base_module::friend_fun() }
+}
+
+// Change the friend function signature -- should work
+//# upgrade --package V0 --upgrade-capability 1,1 --sender A
+module V1::base_module {
+    use sui::object::UID;
+    struct Object has key, store {
+        id: UID,
+        field0: u64,
+        field1: u64,
+    }
+
+    friend V1::friend_module;
+
+    public(friend) entry fun friend_fun(x: u64): u64 { x }
+}
+module V1::friend_module {
+    public fun call_friend(): u64 { V1::base_module::friend_fun(10) }
+}
+
+// Change the friend entry to a friend -- should work
+//# upgrade --package V1 --upgrade-capability 1,1 --sender A
+module V2::base_module {
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::transfer;
+    struct Object has key, store {
+        id: UID,
+        field0: u64,
+        field1: u64,
+    }
+
+    friend V2::friend_module;
+
+    public fun public_fun(x: u64, recipient: address, ctx: &mut TxContext): u64 { 
+        transfer::public_transfer(
+            Object { id: object::new(ctx), field0: x, field1: x},
+            recipient
+        );
+        x
+    }
+
+    public fun public_fun2(x: u64): u64 { x }
+
+    public(friend) fun friend_fun(x: u64): u64 { x }
+}
+module V2::friend_module {
+    public fun call_friend(): u64 { V1::base_module::friend_fun(10) }
+}
+
+// Remove a friend function -- and replace with a call to a public function at a previous version should also be fine
+//# upgrade --package V2 --upgrade-capability 1,1 --sender A
+module V3::base_module {
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::transfer;
+    struct Object has key, store {
+        id: UID,
+        field0: u64,
+        field1: u64,
+    }
+
+    friend V3::friend_module;
+    public fun public_fun(x: u64, recipient: address, ctx: &mut TxContext): u64 { 
+        transfer::public_transfer(
+            Object { id: object::new(ctx), field0: x, field1: x},
+            recipient
+        );
+        x
+    }
+    public fun public_fun2(x: u64): u64 { x }
+}
+module V3::friend_module {
+    use sui::tx_context::TxContext;
+    public fun call_friend(): u64 { V2::base_module::public_fun2(10) }
+
+    // Cross-version package call
+    public fun call_public(ctx: &mut TxContext): u64 { V2::base_module::public_fun(10, @A, ctx) }
+}
+
+//# run V3::friend_module::call_friend
+
+//# run V3::friend_module::call_public
+
+//# view-object 6,0 

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/large_module_inclusion_checks.exp
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/large_module_inclusion_checks.exp
@@ -1,0 +1,41 @@
+processed 9 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 6-58:
+created: object(1,0), object(1,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 11308800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'upgrade'. lines 59-112:
+Error: Transaction Effects Status: Invalid package upgrade. New package is incompatible with previous version
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: PackageUpgradeError { upgrade_error: IncompatibleUpgrade }, source: Some(PartialVMError { major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE, sub_status: None, message: None, exec_state: None, indices: [], offsets: [] }), command: Some(1) } }
+
+task 3 'upgrade'. lines 113-166:
+Error: Transaction Effects Status: Invalid package upgrade. New package is incompatible with previous version
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: PackageUpgradeError { upgrade_error: IncompatibleUpgrade }, source: Some(PartialVMError { major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE, sub_status: None, message: None, exec_state: None, indices: [], offsets: [] }), command: Some(1) } }
+
+task 4 'upgrade'. lines 167-219:
+created: object(4,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 11308800,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 5 'upgrade'. lines 220-274:
+Error: Transaction Effects Status: Invalid package upgrade. New package is incompatible with previous version
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: PackageUpgradeError { upgrade_error: IncompatibleUpgrade }, source: Some(PartialVMError { major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE, sub_status: None, message: None, exec_state: None, indices: [], offsets: [] }), command: Some(1) } }
+
+task 6 'upgrade'. lines 275-329:
+created: object(6,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 12084000,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 7 'upgrade'. lines 330-384:
+created: object(7,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 12084000,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 8 'upgrade'. lines 385-437:
+created: object(8,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 12084000,  storage_rebate: 2595780, non_refundable_storage_fee: 26220

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/large_module_inclusion_checks.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/large_module_inclusion_checks.move
@@ -1,0 +1,437 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses V0=0x0 V1=0x0 V2=0x0 V3=0x0 V4=0x0 --accounts A
+
+//# publish --upgradeable --sender A
+module V0::ascii {
+    use std::vector;
+    use std::option::{Self, Option};
+    const EINVALID_ASCII_CHARACTER: u64 = 0x10000;
+   struct String has copy, drop, store { bytes: vector<u8>, }
+   struct Char has copy, drop, store { byte: u8, }
+    public fun char(byte: u8): Char {
+        assert!(is_valid_char(byte), EINVALID_ASCII_CHARACTER);
+        Char { byte }
+    }
+    public fun string(bytes: vector<u8>): String {
+       let x = try_string(bytes);
+       assert!(
+            option::is_some(&x),
+            EINVALID_ASCII_CHARACTER
+       );
+       option::destroy_some(x)
+    }
+    public fun try_string(bytes: vector<u8>): Option<String> {
+       let len = vector::length(&bytes);
+       let i = 0;
+       while (i < len) {
+           let possible_byte = *vector::borrow(&bytes, i);
+           if (!is_valid_char(possible_byte)) return option::none();
+           i = i + 1;
+       };
+       option::some(String { bytes })
+    }
+    public fun all_characters_printable(string: &String): bool {
+       let len = vector::length(&string.bytes);
+       let i = 0;
+       while (i < len) {
+           let byte = *vector::borrow(&string.bytes, i);
+           if (!is_printable_char(byte)) return false;
+           i = i + 1;
+       };
+       true
+    }
+    public fun push_char(string: &mut String, char: Char) { vector::push_back(&mut string.bytes, char.byte); }
+    public fun pop_char(string: &mut String): Char { Char { byte: vector::pop_back(&mut string.bytes) } }
+    public fun length(string: &String): u64 { vector::length(as_bytes(string)) }
+    public fun as_bytes(string: &String): &vector<u8> { &string.bytes }
+    public fun into_bytes(string: String): vector<u8> { let String { bytes } = string; bytes }
+    public fun byte(char: Char): u8 { let Char { byte } = char; byte }
+    public fun is_valid_char(b: u8): bool { b <= 0x7F }
+    public fun is_printable_char(byte: u8): bool {
+       byte >= 0x20 && // Disallow metacharacters
+       byte <= 0x7E // Don't allow DEL metacharacter
+    }
+}
+
+// Bytecode has changed so should fail in dep only mode
+//# upgrade --package V0 --upgrade-capability 1,1 --sender A --policy dep_only
+module V1::ascii {
+    use std::vector;
+    use std::option::{Self, Option};
+    const EINVALID_ASCII_CHARACTER: u64 = 0x10000;
+   struct String has copy, drop, store { bytes: vector<u8>, }
+   struct Char has copy, drop, store { byte: u8, }
+    public fun char(byte: u8): Char {
+        assert!(is_valid_char(byte), EINVALID_ASCII_CHARACTER);
+        Char { byte }
+    }
+    public fun string(bytes: vector<u8>): String {
+       let x = try_string(bytes);
+       assert!(
+            option::is_some(&x),
+            EINVALID_ASCII_CHARACTER
+       );
+       option::destroy_some(x)
+    }
+    public fun try_string(bytes: vector<u8>): Option<String> {
+       let len = vector::length(&bytes);
+       let i = 0;
+       while (i < len) {
+           let possible_byte = *vector::borrow(&bytes, i);
+           if (!is_valid_char(possible_byte)) return option::none();
+           i = i + 2; // <<<< CHANGED FROM 1 to 2 here
+       };
+       option::some(String { bytes })
+    }
+    public fun all_characters_printable(string: &String): bool {
+       let len = vector::length(&string.bytes);
+       let i = 0;
+       while (i < len) {
+           let byte = *vector::borrow(&string.bytes, i);
+           if (!is_printable_char(byte)) return false;
+           i = i + 1;
+       };
+       true
+    }
+    public fun push_char(string: &mut String, char: Char) { vector::push_back(&mut string.bytes, char.byte); }
+    public fun pop_char(string: &mut String): Char { Char { byte: vector::pop_back(&mut string.bytes) } }
+    public fun length(string: &String): u64 { vector::length(as_bytes(string)) }
+    public fun as_bytes(string: &String): &vector<u8> { &string.bytes }
+    public fun into_bytes(string: String): vector<u8> { let String { bytes } = string; bytes }
+    public fun byte(char: Char): u8 { let Char { byte } = char; byte }
+    public fun is_valid_char(b: u8): bool { b <= 0x7F }
+    public fun is_printable_char(byte: u8): bool {
+       byte >= 0x20 && // Disallow metacharacters
+       byte <= 0x7E // Don't allow DEL metacharacter
+    }
+}
+
+// NB: the previous upgrade failed, so even though it was in a stricter mode,
+// we can still upgrade in a less strict mode since it wasn't committed.
+//# upgrade --package V0 --upgrade-capability 1,1 --sender A --policy additive
+module V1::ascii {
+    use std::vector;
+    use std::option::{Self, Option};
+    const EINVALID_ASCII_CHARACTER: u64 = 0x10000;
+   struct String has copy, drop, store { bytes: vector<u8>, }
+   struct Char has copy, drop, store { byte: u8, }
+    public fun char(byte: u8): Char {
+        assert!(is_valid_char(byte), EINVALID_ASCII_CHARACTER);
+        Char { byte }
+    }
+    public fun string(bytes: vector<u8>): String {
+       let x = try_string(bytes);
+       assert!(
+            option::is_some(&x),
+            EINVALID_ASCII_CHARACTER
+       );
+       option::destroy_some(x)
+    }
+    public fun try_string(bytes: vector<u8>): Option<String> {
+       // CHANGED: Swapped the order of these two let declarations.
+       let i = 0;
+       let len = vector::length(&bytes);
+       while (i < len) {
+           let possible_byte = *vector::borrow(&bytes, i);
+           if (!is_valid_char(possible_byte)) return option::none();
+           i = i + 1; 
+       };
+       option::some(String { bytes })
+    }
+    public fun all_characters_printable(string: &String): bool {
+       let len = vector::length(&string.bytes);
+       let i = 0;
+       while (i < len) {
+           let byte = *vector::borrow(&string.bytes, i);
+           if (!is_printable_char(byte)) return false;
+           i = i + 1;
+       };
+       true
+    }
+    public fun push_char(string: &mut String, char: Char) { vector::push_back(&mut string.bytes, char.byte); }
+    public fun pop_char(string: &mut String): Char { Char { byte: vector::pop_back(&mut string.bytes) } }
+    public fun length(string: &String): u64 { vector::length(as_bytes(string)) }
+    public fun as_bytes(string: &String): &vector<u8> { &string.bytes }
+    public fun into_bytes(string: String): vector<u8> { let String { bytes } = string; bytes }
+    public fun byte(char: Char): u8 { let Char { byte } = char; byte }
+    public fun is_valid_char(b: u8): bool { b <= 0x7F }
+    public fun is_printable_char(byte: u8): bool {
+       byte >= 0x20 && // Disallow metacharacters
+       byte <= 0x7E // Don't allow DEL metacharacter
+    }
+}
+
+// Shuffle them around -- should succeed
+//# upgrade --package V0 --upgrade-capability 1,1 --sender A --policy additive
+module V1::ascii {
+    use std::vector;
+    use std::option::{Self, Option};
+    const EINVALID_ASCII_CHARACTER: u64 = 0x10000;
+   struct Char has copy, drop, store { byte: u8, }
+   struct String has copy, drop, store { bytes: vector<u8>, }
+    public fun string(bytes: vector<u8>): String {
+       let x = try_string(bytes);
+       assert!(
+            option::is_some(&x),
+            EINVALID_ASCII_CHARACTER
+       );
+       option::destroy_some(x)
+    }
+    public fun char(byte: u8): Char {
+        assert!(is_valid_char(byte), EINVALID_ASCII_CHARACTER);
+        Char { byte }
+    }
+    public fun try_string(bytes: vector<u8>): Option<String> {
+       let len = vector::length(&bytes);
+       let i = 0;
+       while (i < len) {
+           let possible_byte = *vector::borrow(&bytes, i);
+           if (!is_valid_char(possible_byte)) return option::none();
+           i = i + 1;
+       };
+       option::some(String { bytes })
+    }
+    public fun all_characters_printable(string: &String): bool {
+       let len = vector::length(&string.bytes);
+       let i = 0;
+       while (i < len) {
+           let byte = *vector::borrow(&string.bytes, i);
+           if (!is_printable_char(byte)) return false;
+           i = i + 1;
+       };
+       true
+    }
+    public fun pop_char(string: &mut String): Char { Char { byte: vector::pop_back(&mut string.bytes) } }
+    public fun push_char(string: &mut String, char: Char) { vector::push_back(&mut string.bytes, char.byte); }
+    public fun as_bytes(string: &String): &vector<u8> { &string.bytes }
+    public fun length(string: &String): u64 { vector::length(as_bytes(string)) }
+    public fun into_bytes(string: String): vector<u8> { let String { bytes } = string; bytes }
+    public fun byte(char: Char): u8 { let Char { byte } = char; byte }
+    public fun is_printable_char(byte: u8): bool {
+       byte >= 0x20 && // Disallow metacharacters
+       byte <= 0x7E // Don't allow DEL metacharacter
+    }
+    public fun is_valid_char(b: u8): bool { b <= 0x7F }
+}
+
+// Add new things to the module -- the first one should fail in dep_only mode
+//# upgrade --package V1 --upgrade-capability 1,1 --sender A --policy dep_only
+module V2::ascii {
+    use std::vector;
+    use std::option::{Self, Option};
+    const EINVALID_ASCII_CHARACTER: u64 = 0x10000;
+   struct Char has copy, drop, store { byte: u8, }
+   struct NewStruct { }
+   struct String has copy, drop, store { bytes: vector<u8>, }
+    public fun string(bytes: vector<u8>): String {
+       let x = try_string(bytes);
+       assert!(
+            option::is_some(&x),
+            EINVALID_ASCII_CHARACTER
+       );
+       option::destroy_some(x)
+    }
+    public fun char(byte: u8): Char {
+        assert!(is_valid_char(byte), EINVALID_ASCII_CHARACTER);
+        Char { byte }
+    }
+    public fun try_string(bytes: vector<u8>): Option<String> {
+       let len = vector::length(&bytes);
+       let i = 0;
+       while (i < len) {
+           let possible_byte = *vector::borrow(&bytes, i);
+           if (!is_valid_char(possible_byte)) return option::none();
+           i = i + 1;
+       };
+       option::some(String { bytes })
+    }
+    public fun all_characters_printable(string: &String): bool {
+       let len = vector::length(&string.bytes);
+       let i = 0;
+       while (i < len) {
+           let byte = *vector::borrow(&string.bytes, i);
+           if (!is_printable_char(byte)) return false;
+           i = i + 1;
+       };
+       true
+    }
+    public fun pop_char(string: &mut String): Char { Char { byte: vector::pop_back(&mut string.bytes) } }
+    public fun push_char(string: &mut String, char: Char) { vector::push_back(&mut string.bytes, char.byte); }
+    public fun as_bytes(string: &String): &vector<u8> { &string.bytes }
+    public fun new_function(_x: u64) { } // <<<<<< NEW FUNCTION
+    public fun length(string: &String): u64 { vector::length(as_bytes(string)) }
+    public fun into_bytes(string: String): vector<u8> { let String { bytes } = string; bytes }
+    public fun byte(char: Char): u8 { let Char { byte } = char; byte }
+    public fun is_printable_char(byte: u8): bool {
+       byte >= 0x20 && // Disallow metacharacters
+       byte <= 0x7E // Don't allow DEL metacharacter
+    }
+    public fun is_valid_char(b: u8): bool { b <= 0x7F }
+}
+
+// This one should succeed since we're in additive mode
+//# upgrade --package V1 --upgrade-capability 1,1 --sender A --policy additive
+module V2::ascii {
+    use std::vector;
+    use std::option::{Self, Option};
+    const EINVALID_ASCII_CHARACTER: u64 = 0x10000;
+   struct Char has copy, drop, store { byte: u8, }
+   struct NewStruct { } // <<<<<<<<< NEW STRUCT
+   struct String has copy, drop, store { bytes: vector<u8>, }
+    public fun string(bytes: vector<u8>): String {
+       let x = try_string(bytes);
+       assert!(
+            option::is_some(&x),
+            EINVALID_ASCII_CHARACTER
+       );
+       option::destroy_some(x)
+    }
+    public fun char(byte: u8): Char {
+        assert!(is_valid_char(byte), EINVALID_ASCII_CHARACTER);
+        Char { byte }
+    }
+    public fun try_string(bytes: vector<u8>): Option<String> {
+       let len = vector::length(&bytes);
+       let i = 0;
+       while (i < len) {
+           let possible_byte = *vector::borrow(&bytes, i);
+           if (!is_valid_char(possible_byte)) return option::none();
+           i = i + 1;
+       };
+       option::some(String { bytes })
+    }
+    public fun all_characters_printable(string: &String): bool {
+       let len = vector::length(&string.bytes);
+       let i = 0;
+       while (i < len) {
+           let byte = *vector::borrow(&string.bytes, i);
+           if (!is_printable_char(byte)) return false;
+           i = i + 1;
+       };
+       true
+    }
+    public fun pop_char(string: &mut String): Char { Char { byte: vector::pop_back(&mut string.bytes) } }
+    public fun push_char(string: &mut String, char: Char) { vector::push_back(&mut string.bytes, char.byte); }
+    public fun as_bytes(string: &String): &vector<u8> { &string.bytes }
+    public fun new_function(_x: u64) { } // <<<<<< NEW FUNCTION
+    public fun length(string: &String): u64 { vector::length(as_bytes(string)) }
+    public fun into_bytes(string: String): vector<u8> { let String { bytes } = string; bytes }
+    public fun byte(char: Char): u8 { let Char { byte } = char; byte }
+    public fun is_printable_char(byte: u8): bool {
+       byte >= 0x20 && // Disallow metacharacters
+       byte <= 0x7E // Don't allow DEL metacharacter
+    }
+    public fun is_valid_char(b: u8): bool { b <= 0x7F }
+}
+
+// This one should succeed since we just changed it above
+//# upgrade --package V2 --upgrade-capability 1,1 --sender A --policy dep_only
+module V3::ascii {
+    use std::vector;
+    use std::option::{Self, Option};
+    const EINVALID_ASCII_CHARACTER: u64 = 0x10000;
+   struct Char has copy, drop, store { byte: u8, }
+   struct NewStruct { } // <<<<<<<<< NEW STRUCT
+   struct String has copy, drop, store { bytes: vector<u8>, }
+    public fun string(bytes: vector<u8>): String {
+       let x = try_string(bytes);
+       assert!(
+            option::is_some(&x),
+            EINVALID_ASCII_CHARACTER
+       );
+       option::destroy_some(x)
+    }
+    public fun char(byte: u8): Char {
+        assert!(is_valid_char(byte), EINVALID_ASCII_CHARACTER);
+        Char { byte }
+    }
+    public fun try_string(bytes: vector<u8>): Option<String> {
+       let len = vector::length(&bytes);
+       let i = 0;
+       while (i < len) {
+           let possible_byte = *vector::borrow(&bytes, i);
+           if (!is_valid_char(possible_byte)) return option::none();
+           i = i + 1;
+       };
+       option::some(String { bytes })
+    }
+    public fun all_characters_printable(string: &String): bool {
+       let len = vector::length(&string.bytes);
+       let i = 0;
+       while (i < len) {
+           let byte = *vector::borrow(&string.bytes, i);
+           if (!is_printable_char(byte)) return false;
+           i = i + 1;
+       };
+       true
+    }
+    public fun pop_char(string: &mut String): Char { Char { byte: vector::pop_back(&mut string.bytes) } }
+    public fun push_char(string: &mut String, char: Char) { vector::push_back(&mut string.bytes, char.byte); }
+    public fun as_bytes(string: &String): &vector<u8> { &string.bytes }
+    public fun new_function(_x: u64) { } // <<<<<< NEW FUNCTION
+    public fun length(string: &String): u64 { vector::length(as_bytes(string)) }
+    public fun into_bytes(string: String): vector<u8> { let String { bytes } = string; bytes }
+    public fun byte(char: Char): u8 { let Char { byte } = char; byte }
+    public fun is_printable_char(byte: u8): bool {
+       byte >= 0x20 && // Disallow metacharacters
+       byte <= 0x7E // Don't allow DEL metacharacter
+    }
+    public fun is_valid_char(b: u8): bool { b <= 0x7F }
+}
+
+// This should now fail since we succeeded with `dep_only` -- we can no longer go back down the policy ordering.
+//# upgrade --package V3 --upgrade-capability 1,1 --sender A --policy additive
+module V4::ascii {
+    use std::vector;
+    use std::option::{Self, Option};
+    const EINVALID_ASCII_CHARACTER: u64 = 0x10000;
+   struct Char has copy, drop, store { byte: u8, }
+   struct NewStruct { } // <<<<<<<<< NEW STRUCT
+   struct String has copy, drop, store { bytes: vector<u8>, }
+    public fun string(bytes: vector<u8>): String {
+       let x = try_string(bytes);
+       assert!(
+            option::is_some(&x),
+            EINVALID_ASCII_CHARACTER
+       );
+       option::destroy_some(x)
+    }
+    public fun char(byte: u8): Char {
+        assert!(is_valid_char(byte), EINVALID_ASCII_CHARACTER);
+        Char { byte }
+    }
+    public fun try_string(bytes: vector<u8>): Option<String> {
+       let len = vector::length(&bytes);
+       let i = 0;
+       while (i < len) {
+           let possible_byte = *vector::borrow(&bytes, i);
+           if (!is_valid_char(possible_byte)) return option::none();
+           i = i + 1;
+       };
+       option::some(String { bytes })
+    }
+    public fun all_characters_printable(string: &String): bool {
+       let len = vector::length(&string.bytes);
+       let i = 0;
+       while (i < len) {
+           let byte = *vector::borrow(&string.bytes, i);
+           if (!is_printable_char(byte)) return false;
+           i = i + 1;
+       };
+       true
+    }
+    public fun pop_char(string: &mut String): Char { Char { byte: vector::pop_back(&mut string.bytes) } }
+    public fun push_char(string: &mut String, char: Char) { vector::push_back(&mut string.bytes, char.byte); }
+    public fun as_bytes(string: &String): &vector<u8> { &string.bytes }
+    public fun new_function(_x: u64) { } // <<<<<< NEW FUNCTION
+    public fun length(string: &String): u64 { vector::length(as_bytes(string)) }
+    public fun into_bytes(string: String): vector<u8> { let String { bytes } = string; bytes }
+    public fun byte(char: Char): u8 { let Char { byte } = char; byte }
+    public fun is_printable_char(byte: u8): bool {
+       byte >= 0x20 && // Disallow metacharacters
+       byte <= 0x7E // Don't allow DEL metacharacter
+    }
+    public fun is_valid_char(b: u8): bool { b <= 0x7F }
+}

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/modules.exp
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/modules.exp
@@ -1,0 +1,25 @@
+processed 6 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 6-28:
+created: object(1,0), object(1,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 9583600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'upgrade'. lines 29-50:
+Error: Transaction Effects Status: Invalid package upgrade. New package is incompatible with previous version
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: PackageUpgradeError { upgrade_error: IncompatibleUpgrade }, source: None, command: Some(1) } }
+
+task 3 'upgrade'. lines 51-69:
+Error: Transaction Effects Status: Invalid package upgrade. New package is incompatible with previous version
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: PackageUpgradeError { upgrade_error: IncompatibleUpgrade }, source: None, command: Some(1) } }
+
+task 4 'upgrade'. lines 70-89:
+Error: Transaction Effects Status: Invalid package upgrade. New package is incompatible with previous version
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: PackageUpgradeError { upgrade_error: IncompatibleUpgrade }, source: Some("Existing module b not found in next version of package"), command: Some(1) } }
+
+task 5 'upgrade'. lines 90-107:
+Error: Transaction Effects Status: Invalid package upgrade. New package is incompatible with previous version
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: PackageUpgradeError { upgrade_error: IncompatibleUpgrade }, source: Some("Existing module a not found in next version of package"), command: Some(1) } }

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/modules.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/modules.move
@@ -1,0 +1,107 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses V0=0x0 V1=0x0 V2=0x0 V3=0x0 --accounts A
+
+//# publish --upgradeable --sender A
+module V0::base_module {
+    use sui::object::UID;
+    struct Object has key, store { 
+        id: UID,
+        field0: u64,
+        field1: u64,
+    }
+
+    public fun public_fun(): u64 { 0 }
+}
+module V0::a {
+    fun call_friend(): u64 { V0::base_module::public_fun() }
+}
+module V0::b {
+    public fun public_fun(): u64 { 0 }
+}
+module V0::other_module {
+    struct Y { }
+    fun public_fun(): u64 { 0 }
+}
+
+// other_module::Y is missing in V1
+//# upgrade --package V0 --upgrade-capability 1,1 --sender A
+module V1::base_module {
+    use sui::object::UID;
+    struct Object has key, store { 
+        id: UID,
+        field0: u64,
+        field1: u64,
+    }
+
+    public fun public_fun(): u64 { 0 }
+}
+module V1::a {
+    fun call_friend(): u64 { V0::base_module::public_fun() }
+}
+module V1::b {
+    public fun public_fun(): u64 { 0 }
+}
+module V1::other_module {
+    fun public_fun(): u64 { 0 }
+}
+
+// other_module missing in V1
+//# upgrade --package V0 --upgrade-capability 1,1 --sender A
+module V1::base_module {
+    use sui::object::UID;
+    struct Object has key, store { 
+        id: UID,
+        field0: u64,
+        field1: u64,
+    }
+
+    public fun public_fun(): u64 { 0 }
+}
+module V1::a {
+    fun call_friend(): u64 { V0::base_module::public_fun() }
+}
+module V1::b {
+    public fun public_fun(): u64 { 0 }
+}
+
+// `b` missing in V1
+//# upgrade --package V0 --upgrade-capability 1,1 --sender A
+module V1::base_module {
+    use sui::object::UID;
+    struct Object has key, store { 
+        id: UID,
+        field0: u64,
+        field1: u64,
+    }
+
+    public fun public_fun(): u64 { 0 }
+}
+module V1::a {
+    fun call_friend(): u64 { V0::base_module::public_fun() }
+}
+module V1::other_module {
+    struct Y { }
+    fun public_fun(): u64 { 0 }
+}
+
+// `a` missing in V1
+//# upgrade --package V0 --upgrade-capability 1,1 --sender A
+module V0::base_module {
+    use sui::object::UID;
+    struct Object has key, store { 
+        id: UID,
+        field0: u64,
+        field1: u64,
+    }
+
+    public fun public_fun(): u64 { 0 }
+}
+module V0::b {
+    public fun public_fun(): u64 { 0 }
+}
+module V0::other_module {
+    struct Y { }
+    fun public_fun(): u64 { 0 }
+}

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/private_fun_changes.exp
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/private_fun_changes.exp
@@ -1,0 +1,48 @@
+processed 10 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 6-9:
+created: object(1,0), object(1,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 5038800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'upgrade'. lines 11-14:
+created: object(2,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 5054000,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 3 'upgrade'. lines 16-19:
+created: object(3,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 5122400,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 4 'upgrade'. lines 21-24:
+created: object(4,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 5122400,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 5 'upgrade'. lines 26-29:
+created: object(5,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 5122400,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 6 'upgrade'. lines 31-33:
+created: object(6,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 4856400,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 7 'upgrade'. lines 35-38:
+created: object(7,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 5122400,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 8 'upgrade'. lines 40-43:
+created: object(8,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 5122400,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 9 'upgrade'. lines 45-48:
+Error: Transaction Effects Status: Invalid package upgrade. New package is incompatible with previous version
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: PackageUpgradeError { upgrade_error: IncompatibleUpgrade }, source: Some(PartialVMError { major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE, sub_status: None, message: None, exec_state: None, indices: [], offsets: [] }), command: Some(1) } }

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/private_fun_changes.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/private_fun_changes.move
@@ -1,0 +1,48 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses V0=0x0 V1=0x0 V2=0x0 V3=0x0 V4=0x0 V5=0x0 V6=0x0 V7=0x0 V8=0x0 --accounts A
+
+//# publish --upgradeable --sender A
+module V0::base {
+    fun f() { }
+}
+
+//# upgrade --package V0 --upgrade-capability 1,1 --sender A
+module V1::base {
+    fun f(_x: u64) { }
+}
+
+//# upgrade --package V1 --upgrade-capability 1,1 --sender A
+module V2::base {
+    entry fun f(): u64 { 0 }
+}
+
+//# upgrade --package V2 --upgrade-capability 1,1 --sender A
+module V3::base {
+    entry fun f(_f: u64): u64 { 0 }
+}
+
+//# upgrade --package V3 --upgrade-capability 1,1 --sender A
+module V4::base {
+    fun f(_f: u64): u64 { 0 }
+}
+
+//# upgrade --package V4 --upgrade-capability 1,1 --sender A
+module V5::base {
+}
+
+//# upgrade --package V5 --upgrade-capability 1,1 --sender A
+module V6::base {
+    fun f(): u64 { 0 }
+}
+
+//# upgrade --package V6 --upgrade-capability 1,1 --sender A
+module V7::base {
+    public fun f(_f: u64): u64 { 0 }
+}
+
+//# upgrade --package V7 --upgrade-capability 1,1 --sender A
+module V8::base {
+    public fun f(): u64 { 0 }
+}

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/public_fun_changes.exp
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/public_fun_changes.exp
@@ -1,0 +1,43 @@
+processed 10 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 6-9:
+created: object(1,0), object(1,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 5038800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'upgrade'. lines 11-14:
+Error: Transaction Effects Status: Invalid package upgrade. New package is incompatible with previous version
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: PackageUpgradeError { upgrade_error: IncompatibleUpgrade }, source: Some(PartialVMError { major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE, sub_status: None, message: None, exec_state: None, indices: [], offsets: [] }), command: Some(1) } }
+
+task 3 'upgrade'. lines 16-19:
+Error: Transaction Effects Status: Invalid package upgrade. New package is incompatible with previous version
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: PackageUpgradeError { upgrade_error: IncompatibleUpgrade }, source: Some(PartialVMError { major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE, sub_status: None, message: None, exec_state: None, indices: [], offsets: [] }), command: Some(1) } }
+
+task 4 'upgrade'. lines 21-24:
+Error: Transaction Effects Status: Invalid package upgrade. New package is incompatible with previous version
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: PackageUpgradeError { upgrade_error: IncompatibleUpgrade }, source: Some(PartialVMError { major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE, sub_status: None, message: None, exec_state: None, indices: [], offsets: [] }), command: Some(1) } }
+
+task 5 'upgrade'. lines 26-29:
+Error: Transaction Effects Status: Invalid package upgrade. New package is incompatible with previous version
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: PackageUpgradeError { upgrade_error: IncompatibleUpgrade }, source: Some(PartialVMError { major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE, sub_status: None, message: None, exec_state: None, indices: [], offsets: [] }), command: Some(1) } }
+
+task 6 'upgrade'. lines 31-34:
+created: object(6,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 5038800,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 7 'upgrade'. lines 36-39:
+Error: Transaction Effects Status: Invalid package upgrade. New package is incompatible with previous version
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: PackageUpgradeError { upgrade_error: IncompatibleUpgrade }, source: Some(PartialVMError { major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE, sub_status: None, message: None, exec_state: None, indices: [], offsets: [] }), command: Some(1) } }
+
+task 8 'upgrade'. lines 41-44:
+Error: Transaction Effects Status: Invalid package upgrade. New package is incompatible with previous version
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: PackageUpgradeError { upgrade_error: IncompatibleUpgrade }, source: Some(PartialVMError { major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE, sub_status: None, message: None, exec_state: None, indices: [], offsets: [] }), command: Some(1) } }
+
+task 9 'upgrade'. lines 46-49:
+created: object(9,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 5038800,  storage_rebate: 2595780, non_refundable_storage_fee: 26220

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/public_fun_changes.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/public_fun_changes.move
@@ -1,0 +1,49 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses Test_V0=0x0 Test_V1=0x0 Test_V2=0x0 --accounts A
+
+//# publish --upgradeable --sender A
+module Test_V0::base {
+    public fun f() { }
+}
+
+//# upgrade --package Test_V0 --upgrade-capability 1,1 --sender A
+module Test_V0::base {
+    public fun f(_x: u64) { }
+}
+
+//# upgrade --package Test_V0 --upgrade-capability 1,1 --sender A
+module Test_V0::base {
+    public fun f(): u64 { 0 }
+}
+
+//# upgrade --package Test_V0 --upgrade-capability 1,1 --sender A
+module Test_V0::base {
+    fun f() {  }
+}
+
+//# upgrade --package Test_V0 --upgrade-capability 1,1 --sender A
+module Test_V0::base {
+    entry fun f() {  }
+}
+
+//# upgrade --package Test_V0 --upgrade-capability 1,1 --sender A
+module Test_V1::base {
+    public entry fun f() {  }
+}
+
+//# upgrade --package Test_V1 --upgrade-capability 1,1 --sender A
+module Test_V2::base {
+    public entry fun f(_x: u64) {  }
+}
+
+//# upgrade --package Test_V1 --upgrade-capability 1,1 --sender A
+module Test_V2::base {
+    public fun f(_x: u64) {  }
+}
+
+//# upgrade --package Test_V1 --upgrade-capability 1,1 --sender A
+module Test_V2::base {
+    public fun f() {  }
+}

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/structs.exp
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/structs.exp
@@ -1,0 +1,29 @@
+processed 7 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 6-14:
+created: object(1,0), object(1,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 5882400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'upgrade'. lines 16-24:
+Error: Transaction Effects Status: Invalid package upgrade. New package is incompatible with previous version
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: PackageUpgradeError { upgrade_error: IncompatibleUpgrade }, source: None, command: Some(1) } }
+
+task 3 'upgrade'. lines 26-29:
+Error: Transaction Effects Status: Invalid package upgrade. New package is incompatible with previous version
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: PackageUpgradeError { upgrade_error: IncompatibleUpgrade }, source: None, command: Some(1) } }
+
+task 4 'upgrade'. lines 31-39:
+Error: Transaction Effects Status: Invalid package upgrade. New package is incompatible with previous version
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: PackageUpgradeError { upgrade_error: IncompatibleUpgrade }, source: Some(PartialVMError { major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE, sub_status: None, message: None, exec_state: None, indices: [], offsets: [] }), command: Some(1) } }
+
+task 5 'upgrade'. lines 41-49:
+Error: Transaction Effects Status: Invalid package upgrade. New package is incompatible with previous version
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: PackageUpgradeError { upgrade_error: IncompatibleUpgrade }, source: Some(PartialVMError { major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE, sub_status: None, message: None, exec_state: None, indices: [], offsets: [] }), command: Some(1) } }
+
+task 6 'upgrade'. lines 51-60:
+Error: Transaction Effects Status: Invalid package upgrade. New package is incompatible with previous version
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: PackageUpgradeError { upgrade_error: IncompatibleUpgrade }, source: Some(PartialVMError { major_status: BACKWARD_INCOMPATIBLE_MODULE_UPDATE, sub_status: None, message: None, exec_state: None, indices: [], offsets: [] }), command: Some(1) } }

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/structs.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/structs.move
@@ -1,0 +1,60 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses Test_V0=0x0 Test_V1=0x0 --accounts A
+
+//# publish --upgradeable --sender A
+module Test_V0::base_module {
+    struct X {
+        field0: u64,
+        field1: u64,
+    }
+
+    public fun public_fun(): u64 { 0 }
+}
+
+//# upgrade --package Test_V0 --upgrade-capability 1,1 --sender A
+module Test_V1::base_module {
+    struct Y {
+        field0: u64,
+        field1: u64,
+    }
+
+    public fun public_fun(): u64 { 0 }
+}
+
+//# upgrade --package Test_V0 --upgrade-capability 1,1 --sender A
+module Test_V1::base_module {
+    public fun public_fun(): u64 { 0 }
+}
+
+//# upgrade --package Test_V0 --upgrade-capability 1,1 --sender A
+module Test_V1::base_module {
+    struct X {
+        field2: u64,
+        field1: u64,
+    }
+
+    public fun public_fun(): u64 { 0 }
+}
+
+//# upgrade --package Test_V0 --upgrade-capability 1,1 --sender A
+module Test_V1::base_module {
+    struct X {
+        field1: u64,
+        field0: u64,
+    }
+
+    public fun public_fun(): u64 { 0 }
+}
+
+//# upgrade --package Test_V0 --upgrade-capability 1,1 --sender A
+module Test_V1::base_module {
+    struct X {
+        field0: u64,
+        field1: u64,
+        field2: u64,
+    }
+
+    public fun public_fun(): u64 { 0 }
+}

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/upgrade_ratchet.exp
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/upgrade_ratchet.exp
@@ -1,0 +1,64 @@
+processed 15 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 6-13:
+created: object(1,0), object(1,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 5646800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'upgrade'. lines 14-17:
+created: object(2,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 5016000,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 3 'run'. lines 19-21:
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 2622000,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 4 'upgrade'. lines 22-27:
+Error: Transaction Effects Status: Move Runtime Abort. Location: sui::package::authorize_upgrade (function index 21) at offset 24, Abort Code: 1
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("package") }, function: 21, instruction: 24, function_name: Some("authorize_upgrade") }, 1), source: Some(VMError { major_status: ABORTED, sub_status: Some(1), message: Some("sui::package::authorize_upgrade at offset 24"), exec_state: Some(ExecutionState { stack_trace: [] }), location: Module(ModuleId { address: sui, name: Identifier("package") }), indices: [], offsets: [(FunctionDefinitionIndex(21), 24)] }), command: Some(0) } }
+
+task 5 'upgrade'. lines 28-33:
+created: object(5,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 5016000,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 6 'upgrade'. lines 34-37:
+created: object(6,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 5016000,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 7 'run'. lines 39-41:
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 2622000,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 8 'upgrade'. lines 42-47:
+Error: Transaction Effects Status: Move Runtime Abort. Location: sui::package::authorize_upgrade (function index 21) at offset 24, Abort Code: 1
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("package") }, function: 21, instruction: 24, function_name: Some("authorize_upgrade") }, 1), source: Some(VMError { major_status: ABORTED, sub_status: Some(1), message: Some("sui::package::authorize_upgrade at offset 24"), exec_state: Some(ExecutionState { stack_trace: [] }), location: Module(ModuleId { address: sui, name: Identifier("package") }), indices: [], offsets: [(FunctionDefinitionIndex(21), 24)] }), command: Some(0) } }
+
+task 9 'upgrade'. lines 48-53:
+Error: Transaction Effects Status: Move Runtime Abort. Location: sui::package::authorize_upgrade (function index 21) at offset 24, Abort Code: 1
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("package") }, function: 21, instruction: 24, function_name: Some("authorize_upgrade") }, 1), source: Some(VMError { major_status: ABORTED, sub_status: Some(1), message: Some("sui::package::authorize_upgrade at offset 24"), exec_state: Some(ExecutionState { stack_trace: [] }), location: Module(ModuleId { address: sui, name: Identifier("package") }), indices: [], offsets: [(FunctionDefinitionIndex(21), 24)] }), command: Some(0) } }
+
+task 10 'upgrade'. lines 54-59:
+created: object(10,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 5016000,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 11 'run'. lines 60-62:
+Error: Transaction Effects Status: Move Runtime Abort. Location: sui::package::restrict (function index 23) at offset 10, Abort Code: 1
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("package") }, function: 23, instruction: 10, function_name: Some("restrict") }, 1), source: Some(VMError { major_status: ABORTED, sub_status: Some(1), message: Some("sui::package::restrict at offset 10"), exec_state: Some(ExecutionState { stack_trace: [(Some(ModuleId { address: sui, name: Identifier("package") }), FunctionDefinitionIndex(18), 2)] }), location: Module(ModuleId { address: sui, name: Identifier("package") }), indices: [], offsets: [(FunctionDefinitionIndex(23), 10)] }), command: Some(0) } }
+
+task 12 'run'. lines 63-63:
+mutated: object(0,0)
+deleted: object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 13 'view-object'. lines 65-67:
+No object at id 1,1
+
+task 14 'upgrade'. lines 68-71:
+Error: INVALID TEST. Could not load object argument 0xc1a85383fc881013473c67dd4a5881e823f0b533bcd9dc6cac45bf87095c4a47

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/upgrade_ratchet.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/upgrade_ratchet.move
@@ -1,0 +1,71 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses V0=0x0 V1=0x0 V2=0x0 V3=0x0 V4=0x0 V5=0x0 --accounts A
+
+//# publish --upgradeable --sender A
+module V0::M1 {
+    use sui::tx_context::TxContext;
+    fun init(_ctx: &mut TxContext) { }
+    public fun f1() { }
+}
+
+// Compatible -- this is fine
+//# upgrade --package V0 --upgrade-capability 1,1 --sender A
+module V1::M1 {
+    public fun f1() { }
+}
+
+//# run sui::package::only_additive_upgrades --args object(1,1) --sender A
+
+// Fails now since we've updated the package to only allow additive (or more restrictive) upgrades
+//# upgrade --package V1 --upgrade-capability 1,1 --sender A --policy compatible
+module V2::M1 {
+    public fun f1() { }
+}
+
+// additive: this is fine
+//# upgrade --package V1 --upgrade-capability 1,1 --sender A --policy additive
+module V2::M1 {
+    public fun f1() { }
+}
+
+// dep_only: this is fine
+//# upgrade --package V2 --upgrade-capability 1,1 --sender A --policy dep_only
+module V3::M1 {
+    public fun f1() { }
+}
+
+//# run sui::package::only_dep_upgrades --args object(1,1) --sender A
+
+// Fails now since we've updated the package to only allow dep_only  upgrades
+//# upgrade --package V3 --upgrade-capability 1,1 --sender A --policy compatible
+module V4::M1 {
+    public fun f1() { }
+}
+
+// additive: this fails since it's < dep_only
+//# upgrade --package V3 --upgrade-capability 1,1 --sender A --policy additive
+module V4::M1 {
+    public fun f1() { }
+}
+
+// dep_only: this is fine
+//# upgrade --package V3 --upgrade-capability 1,1 --sender A --policy dep_only
+module V4::M1 {
+    public fun f1() { }
+}
+
+// Can't go back to a less restrictive policy
+//# run sui::package::only_additive_upgrades --args object(1,1) --sender A
+
+// Can make it immutable though
+//# run sui::package::make_immutable --args object(1,1) --sender A
+
+//# view-object 1,1
+
+// Can't upgrade now -- upgrade cap is gone
+//# upgrade --package V4 --upgrade-capability 1,1 --sender A --policy dep_only
+module V5::M1 {
+    public fun f1() { }
+}

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -12,6 +12,7 @@ use move_core_types::value::{MoveStruct, MoveValue};
 use move_transactional_test_runner::tasks::SyntaxChoice;
 use sui_types::base_types::SuiAddress;
 use sui_types::messages::{Argument, CallArg, ObjectArg};
+use sui_types::move_package::UpgradePolicy;
 use sui_types::object::Owner;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 
@@ -116,6 +117,8 @@ pub struct UpgradePackageCommand {
     pub gas_budget: Option<u64>,
     #[clap(long = "syntax")]
     pub syntax: Option<SyntaxChoice>,
+    #[clap(long = "policy", default_value="compatible", parse(try_from_str = parse_policy))]
+    pub policy: u8,
 }
 
 #[derive(Debug, clap::Parser)]
@@ -304,5 +307,14 @@ fn parse_fake_id(s: &str) -> anyhow::Result<FakeID> {
         u256_bytes.reverse();
         let address: SuiAddress = SuiAddress::from_bytes(&u256_bytes).unwrap();
         FakeID::Known(address.into())
+    })
+}
+
+fn parse_policy(x: &str) -> anyhow::Result<u8> {
+    Ok(match x {
+            "compatible" => UpgradePolicy::COMPATIBLE,
+            "additive" => UpgradePolicy::ADDITIVE,
+            "dep_only" => UpgradePolicy::DEP_ONLY,
+        _ => bail!("Invalid upgrade policy {x}. Policy must be one of 'compatible', 'additive', or 'dep_only'")
     })
 }

--- a/external-crates/move/move-binary-format/src/compatibility.rs
+++ b/external-crates/move/move-binary-format/src/compatibility.rs
@@ -293,12 +293,11 @@ impl InclusionCheck {
         }
 
         // If we're checking exactness we make sure there's an inclusion, and that the size of all
-        // of the tables are the exact same.
+        // of the tables are the exact same except for constants.
         if (self == &Self::Equal)
             && (old_module.structs.len() != new_module.structs.len()
                 || old_module.functions.len() != new_module.functions.len()
-                || old_module.friends.len() != new_module.friends.len()
-                || old_module.constants.len() != new_module.constants.len())
+                || old_module.friends.len() != new_module.friends.len())
         {
             return err;
         }


### PR DESCRIPTION
Adds compatibility tests to the transactional test runner to test different upgrade scenarios and compatibility checking around it. 

This also adds the ability to specify the upgrade policy when upgrading in the transactional test runner, and also relaxes compatibility requirements around constant pools in additive and dep_only modes (constants can be added/removed as long as they are not used, and added and used in additive mode).