### PR TITLE
[explorer] - fix in progress epoch logic

### DIFF
--- a/apps/explorer/src/components/Table/SuiAmount.tsx
+++ b/apps/explorer/src/components/Table/SuiAmount.tsx
@@ -1,22 +1,30 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useFormatCoin } from '@mysten/core';
+import { CoinFormat, useFormatCoin } from '@mysten/core';
 import { SUI_TYPE_ARG } from '@mysten/sui.js';
 
 import { Text } from '~/ui/Text';
 
 export function SuiAmount({
     amount,
+    full = false,
 }: {
     amount?: bigint | number | string | null;
+    full?: boolean;
 }) {
-    const [formattedAmount, coinType] = useFormatCoin(amount, SUI_TYPE_ARG);
+    const [formattedAmount, coinType] = useFormatCoin(
+        amount,
+        SUI_TYPE_ARG,
+        full ? CoinFormat.FULL : CoinFormat.ROUNDED
+    );
     if (!amount) return <Text variant="bodySmall/medium">--</Text>;
 
     return (
         <div className="leading-1 flex items-end gap-0.5">
-            <Text variant="bodySmall/medium">{formattedAmount}</Text>
+            <Text variant="bodySmall/medium" color="steel-darker">
+                {formattedAmount}
+            </Text>
             <Text variant="captionSmall/normal" color="steel-dark">
                 {coinType}
             </Text>

--- a/apps/explorer/src/pages/checkpoints/CheckpointDetail.tsx
+++ b/apps/explorer/src/pages/checkpoints/CheckpointDetail.tsx
@@ -7,6 +7,7 @@ import { useParams } from 'react-router-dom';
 
 import { CheckpointTransactionBlocks } from './CheckpointTransactionBlocks';
 
+import { SuiAmount } from '~/components/Table/SuiAmount';
 import { Banner } from '~/ui/Banner';
 import { DescriptionList, DescriptionItem } from '~/ui/DescriptionList';
 import { EpochLink } from '~/ui/InternalLink';
@@ -106,33 +107,36 @@ export default function CheckpointDetail() {
                 </TabGroup>
                 <TabGroup as="div" size="lg">
                     <TabList>
-                        <Tab>Gas & Storage Fee</Tab>
+                        <Tab>Gas & Storage Fees</Tab>
                     </TabList>
                     <TabPanels>
                         <DescriptionList>
                             <DescriptionItem title="Computation Fee">
-                                <Text variant="p1/medium" color="steel-darker">
-                                    {
+                                <SuiAmount
+                                    full
+                                    amount={
                                         data.epochRollingGasCostSummary
                                             .computationCost
                                     }
-                                </Text>
+                                />
                             </DescriptionItem>
                             <DescriptionItem title="Storage Fee">
-                                <Text variant="p1/medium" color="steel-darker">
-                                    {
+                                <SuiAmount
+                                    full
+                                    amount={
                                         data.epochRollingGasCostSummary
                                             .storageCost
                                     }
-                                </Text>
+                                />
                             </DescriptionItem>
                             <DescriptionItem title="Storage Rebate">
-                                <Text variant="p1/medium" color="steel-darker">
-                                    {
+                                <SuiAmount
+                                    full
+                                    amount={
                                         data.epochRollingGasCostSummary
                                             .storageRebate
                                     }
-                                </Text>
+                                />
                             </DescriptionItem>
                         </DescriptionList>
                     </TabPanels>

--- a/apps/explorer/src/pages/epochs/EpochDetail.tsx
+++ b/apps/explorer/src/pages/epochs/EpochDetail.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useFormatCoin } from '@mysten/core';
+import { useFormatCoin, useGetSystemState } from '@mysten/core';
 import { SUI_TYPE_ARG } from '@mysten/sui.js';
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
@@ -30,7 +30,7 @@ function SuiStats({
     const [formattedAmount, symbol] = useFormatCoin(amount, SUI_TYPE_ARG);
 
     return (
-        <Stats postfix={symbol} {...props}>
+        <Stats postfix={formattedAmount && symbol} {...props}>
             {formattedAmount || '--'}
         </Stats>
     );
@@ -39,6 +39,7 @@ function SuiStats({
 export default function EpochDetail() {
     const { id } = useParams();
     const enhancedRpc = useEnhancedRpcClient();
+    const { data: systemState } = useGetSystemState();
     const { data, isLoading, isError } = useQuery(['epoch', id], async () =>
         enhancedRpc.getEpochs({
             // todo: endpoint returns no data for epoch 0
@@ -48,7 +49,10 @@ export default function EpochDetail() {
     );
 
     const [epochData] = data?.data ?? [];
-    const isCurrentEpoch = !epochData?.endOfEpochInfo;
+    const isCurrentEpoch = useMemo(
+        () => systemState?.epoch === epochData?.epoch,
+        [systemState, epochData]
+    );
 
     const validatorsTable = useMemo(() => {
         if (!epochData?.validators) return null;

--- a/apps/explorer/src/pages/transaction-result/TransactionView.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionView.tsx
@@ -84,7 +84,7 @@ function GasAmount({
 
     return (
         <div className="flex h-full items-center gap-1">
-            <div className="flex items-baseline gap-0.5 text-gray-90">
+            <div className="flex items-baseline gap-1 text-steel-darker">
                 <Text variant="body/medium">{formattedAmount}</Text>
                 <Text variant="subtitleSmall/medium">{symbol}</Text>
             </div>


### PR DESCRIPTION
## Description 

Changes the logic for determining whether or not an Epoch is in progress as we can't rely on `endOfEpochInfo` to be populated, even when an epoch has ended.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
