### PR TITLE
Add TestAuthorityBuilder

### DIFF
--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -1,0 +1,123 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
+use crate::authority::epoch_start_configuration::EpochStartConfiguration;
+use crate::authority::{AuthorityState, AuthorityStore};
+use crate::checkpoints::CheckpointStore;
+use crate::epoch::committee_store::CommitteeStore;
+use crate::epoch::epoch_metrics::EpochMetrics;
+use crate::module_cache_metrics::ResolverMetrics;
+use crate::signature_verifier::SignatureVerifierMetrics;
+use fastcrypto::traits::KeyPair;
+use prometheus::Registry;
+use std::path::PathBuf;
+use std::sync::Arc;
+use sui_config::genesis::Genesis;
+use sui_config::node::{
+    AuthorityStorePruningConfig, DBCheckpointConfig, ExpensiveSafetyCheckConfig,
+};
+use sui_macros::nondeterministic;
+use sui_protocol_config::SupportedProtocolVersions;
+use sui_storage::IndexStore;
+use sui_types::base_types::{AuthorityName, ObjectID};
+use sui_types::committee::Committee;
+use sui_types::crypto::AuthorityKeyPair;
+use sui_types::object::Object;
+
+pub struct TestAuthorityBuilder {
+    // TODO: Add more configurable fields.
+    store_base_path: PathBuf,
+}
+
+impl Default for TestAuthorityBuilder {
+    fn default() -> Self {
+        let dir = std::env::temp_dir();
+        let store_base_path = dir.join(format!("DB_{:?}", nondeterministic!(ObjectID::random())));
+        std::fs::create_dir(&store_base_path).unwrap();
+        Self { store_base_path }
+    }
+}
+
+impl TestAuthorityBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_store_base_path(mut self, path: PathBuf) -> Self {
+        self.store_base_path = path;
+        self
+    }
+
+    // TODO: Figure out why we could not derive genesis_committee from genesis.
+    pub async fn build(
+        self,
+        genesis_committee: Committee,
+        key: &AuthorityKeyPair,
+        genesis: &Genesis,
+    ) -> Arc<AuthorityState> {
+        // unwrap ok - for testing only.
+        let store = AuthorityStore::open_with_committee_for_testing(
+            &self.store_base_path.join("store"),
+            None,
+            &genesis_committee,
+            genesis,
+            0,
+        )
+        .await
+        .unwrap();
+        Self::build_with_store(self, genesis_committee, key, store, &[]).await
+    }
+
+    pub async fn build_with_store(
+        self,
+        genesis_committee: Committee,
+        key: &AuthorityKeyPair,
+        authority_store: Arc<AuthorityStore>,
+        genesis_objects: &[Object],
+    ) -> Arc<AuthorityState> {
+        let secret = Arc::pin(key.copy());
+        let name: AuthorityName = secret.public().into();
+        let path = self.store_base_path;
+        let registry = Registry::new();
+        let cache_metrics = Arc::new(ResolverMetrics::new(&registry));
+        let signature_verifier_metrics = SignatureVerifierMetrics::new(&registry);
+        let epoch_store = AuthorityPerEpochStore::new(
+            name,
+            Arc::new(genesis_committee.clone()),
+            &path.join("store"),
+            None,
+            EpochMetrics::new(&registry),
+            EpochStartConfiguration::new_for_testing(),
+            authority_store.clone(),
+            cache_metrics,
+            signature_verifier_metrics,
+            &ExpensiveSafetyCheckConfig::default(),
+        );
+
+        let committee_store = Arc::new(CommitteeStore::new(
+            path.join("epochs"),
+            &genesis_committee,
+            None,
+        ));
+
+        let checkpoint_store = CheckpointStore::new(&path.join("checkpoints"));
+        let index_store = Some(Arc::new(IndexStore::new(path.join("indexes"))));
+        AuthorityState::new(
+            name,
+            secret,
+            SupportedProtocolVersions::SYSTEM_DEFAULT,
+            authority_store,
+            epoch_store,
+            committee_store,
+            index_store,
+            checkpoint_store,
+            &registry,
+            AuthorityStorePruningConfig::default(),
+            genesis_objects,
+            &DBCheckpointConfig::default(),
+            ExpensiveSafetyCheckConfig::new_enable_all(),
+        )
+        .await
+    }
+}

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -16,6 +16,7 @@ use sui_types::committee::ProtocolVersion;
 use sui_types::messages_checkpoint::{ECMHLiveObjectSetDigest, EndOfEpochData, VerifiedCheckpoint};
 use tokio::{sync::broadcast, time::timeout};
 
+use crate::authority::test_authority_builder::TestAuthorityBuilder;
 use crate::{
     authority::AuthorityState, checkpoints::CheckpointStore, state_accumulator::StateAccumulator,
 };
@@ -392,9 +393,9 @@ async fn init_executor_test(
     let keypair = network_config.validator_configs[0]
         .protocol_key_pair()
         .copy();
-    let state =
-        AuthorityState::new_for_testing(committee.committee().clone(), &keypair, None, &genesis)
-            .await;
+    let state = TestAuthorityBuilder::new()
+        .build(committee.committee().clone(), &keypair, &genesis)
+        .await;
 
     let (checkpoint_sender, _): (Sender<VerifiedCheckpoint>, Receiver<VerifiedCheckpoint>) =
         broadcast::channel(buffer_size);

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -1303,6 +1303,7 @@ impl PendingCheckpoint {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::authority::test_authority_builder::TestAuthorityBuilder;
     use crate::state_accumulator::StateAccumulator;
     use async_trait::async_trait;
     use fastcrypto::traits::KeyPair;
@@ -1326,8 +1327,9 @@ mod tests {
         let keypair = network_config.validator_configs[0]
             .protocol_key_pair()
             .copy();
-        let state =
-            AuthorityState::new_for_testing(committee.clone(), &keypair, None, &genesis).await;
+        let state = TestAuthorityBuilder::new()
+            .build(committee.clone(), &keypair, &genesis)
+            .await;
 
         let dummy_tx = VerifiedTransaction::new_genesis_transaction(vec![]);
         let dummy_tx_with_data =

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -7,6 +7,7 @@ use std::{
     time::Duration,
 };
 
+use crate::authority::test_authority_builder::TestAuthorityBuilder;
 use crate::{authority::AuthorityState, authority_client::AuthorityAPI};
 use async_trait::async_trait;
 use mysten_metrics::spawn_monitored_task;
@@ -114,7 +115,9 @@ impl AuthorityAPI for LocalAuthorityClient {
 
 impl LocalAuthorityClient {
     pub async fn new(committee: Committee, secret: AuthorityKeyPair, genesis: &Genesis) -> Self {
-        let state = AuthorityState::new_for_testing(committee, &secret, None, genesis).await;
+        let state = TestAuthorityBuilder::new()
+            .build(committee, &secret, genesis)
+            .await;
         Self {
             state,
             fault_config: LocalAuthorityClientFaultConfig::default(),

--- a/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::authority::AuthorityState;
+use crate::authority::test_authority_builder::TestAuthorityBuilder;
 use crate::narwhal_manager::{NarwhalConfiguration, NarwhalManager, NarwhalManagerMetrics};
 use bytes::Bytes;
 use fastcrypto::bls12381;
@@ -98,8 +98,9 @@ async fn test_narwhal_manager() {
         let genesis = config.genesis().unwrap();
         let genesis_committee = genesis.committee().unwrap();
 
-        let state =
-            AuthorityState::new_for_testing(genesis_committee, &secret, None, genesis).await;
+        let state = TestAuthorityBuilder::new()
+            .build(genesis_committee, &secret, genesis)
+            .await;
 
         let system_state = state
             .get_sui_system_state_object_for_testing()


### PR DESCRIPTION
This PR adds a test utility to help construct AuthorityState with different configs.
This will make it a lot of convenient to test various different configs in Authority.
Cleaned up existing tests.