### PR TITLE
[rocksdb] more config updates to improve write throughput

### DIFF
--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -429,6 +429,7 @@ fn objects_table_default_config() -> DBOptions {
 fn transactions_table_default_config() -> DBOptions {
     default_db_options()
         .optimize_for_write_throughput()
+        .optimize_for_large_values_no_scan()
         .optimize_for_point_lookup(
             read_size_from_env(ENV_VAR_TRANSACTIONS_BLOCK_CACHE_SIZE).unwrap_or(512),
         )
@@ -437,6 +438,7 @@ fn transactions_table_default_config() -> DBOptions {
 fn effects_table_default_config() -> DBOptions {
     default_db_options()
         .optimize_for_write_throughput()
+        .optimize_for_large_values_no_scan()
         .optimize_for_point_lookup(
             read_size_from_env(ENV_VAR_EFFECTS_BLOCK_CACHE_SIZE).unwrap_or(1024),
         )
@@ -445,6 +447,7 @@ fn effects_table_default_config() -> DBOptions {
 fn events_table_default_config() -> DBOptions {
     default_db_options()
         .optimize_for_write_throughput()
+        .optimize_for_large_values_no_scan()
         .optimize_for_read(read_size_from_env(ENV_VAR_EVENTS_BLOCK_CACHE_SIZE).unwrap_or(1024))
 }
 

--- a/crates/typed-store-derive/src/lib.rs
+++ b/crates/typed-store-derive/src/lib.rs
@@ -416,7 +416,7 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
                     };
                     // Safe to call unwrap because we will have at least one field_name entry in the struct
                     let rwopt_cfs: std::collections::HashMap<String, typed_store::rocks::ReadWriteOptions> = opt_cfs.iter().map(|q| (q.0.as_str().to_string(), q.1.rw_options.clone())).collect();
-                    let opt_cfs: Vec<_> = opt_cfs.iter().map(|q| (q.0.as_str(), &q.1.options)).collect();
+                    let opt_cfs: Vec<_> = opt_cfs.iter().map(|q| (q.0.as_str(), q.1.options.clone())).collect();
                     let db = match (as_secondary_with_path, is_transaction) {
                         (Some(p), _) => typed_store::rocks::open_cf_opts_secondary(path, Some(&p), global_db_options_override, metric_conf, &opt_cfs),
                         (_, true) => typed_store::rocks::open_cf_opts_transactional(path, global_db_options_override, metric_conf, &opt_cfs),
@@ -789,7 +789,7 @@ pub fn derive_sallydb_general(input: TokenStream) -> TokenStream {
                             };
                             // Safe to call unwrap because we will have at least one field_name entry in the struct
                             let rwopt_cfs: std::collections::HashMap<String, typed_store::rocks::ReadWriteOptions> = opt_cfs.iter().map(|q| (q.0.as_str().to_string(), q.1.rw_options.clone())).collect();
-                            let opt_cfs: Vec<_> = opt_cfs.iter().map(|q| (q.0.as_str(), &q.1.options)).collect();
+                            let opt_cfs: Vec<_> = opt_cfs.iter().map(|q| (q.0.as_str(), q.1.options.clone())).collect();
                             let db = match access_type {
                                 RocksDBAccessType::Secondary(Some(p)) => typed_store::rocks::open_cf_opts_secondary(path, Some(&p), global_db_options_override, metric_conf, &opt_cfs),
                                 _ => typed_store::rocks::open_cf_opts(path, global_db_options_override, metric_conf, &opt_cfs)

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -708,7 +708,7 @@ async fn test_transactional() {
     let path = temp_dir();
     let opt = rocksdb::Options::default();
     let rocksdb =
-        open_cf_opts_transactional(path, None, MetricConf::default(), &[("cf", &opt)]).unwrap();
+        open_cf_opts_transactional(path, None, MetricConf::default(), &[("cf", opt)]).unwrap();
     let db = DBMap::<String, String>::reopen(&rocksdb, None, &ReadWriteOptions::default())
         .expect("Failed to re-open storage");
 
@@ -732,7 +732,7 @@ async fn test_transaction_snapshot() {
     let path = temp_dir();
     let opt = rocksdb::Options::default();
     let rocksdb =
-        open_cf_opts_transactional(path, None, MetricConf::default(), &[("cf", &opt)]).unwrap();
+        open_cf_opts_transactional(path, None, MetricConf::default(), &[("cf", opt)]).unwrap();
     let db = DBMap::<String, String>::reopen(&rocksdb, None, &ReadWriteOptions::default())
         .expect("Failed to re-open storage");
 
@@ -819,7 +819,7 @@ async fn test_retry_transaction() {
     let path = temp_dir();
     let opt = rocksdb::Options::default();
     let rocksdb =
-        open_cf_opts_transactional(path, None, MetricConf::default(), &[("cf", &opt)]).unwrap();
+        open_cf_opts_transactional(path, None, MetricConf::default(), &[("cf", opt)]).unwrap();
     let db = DBMap::<String, String>::reopen(&rocksdb, None, &ReadWriteOptions::default())
         .expect("Failed to re-open storage");
 
@@ -879,7 +879,7 @@ async fn test_transaction_read_your_write() {
     let path = temp_dir();
     let opt = rocksdb::Options::default();
     let rocksdb =
-        open_cf_opts_transactional(path, None, MetricConf::default(), &[("cf", &opt)]).unwrap();
+        open_cf_opts_transactional(path, None, MetricConf::default(), &[("cf", opt)]).unwrap();
     let db = DBMap::<String, String>::reopen(&rocksdb, None, &ReadWriteOptions::default())
         .expect("Failed to re-open storage");
     db.insert(&key1.to_string(), &"1".to_string()).unwrap();
@@ -944,7 +944,7 @@ async fn open_as_secondary_test() {
         None,
         None,
         MetricConf::default(),
-        &[("table", &opt)],
+        &[("table", opt)],
     )
     .unwrap();
     let secondary_db = DBMap::<i32, String>::reopen(
@@ -1100,7 +1100,7 @@ fn open_map<P: AsRef<Path>, K, V>(
             path,
             None,
             MetricConf::default(),
-            &[(cf, &default_db_options().options)],
+            &[(cf, default_db_options().options)],
         )
         .map(|db| DBMap::new(db, &ReadWriteOptions::default(), cf))
         .expect("failed to open rocksdb")
@@ -1119,7 +1119,10 @@ fn open_map<P: AsRef<Path>, K, V>(
 fn open_rocksdb<P: AsRef<Path>>(path: P, opt_cfs: &[&str], is_transactional: bool) -> Arc<RocksDB> {
     if is_transactional {
         let options = default_db_options().options;
-        let cfs: Vec<_> = opt_cfs.iter().map(|name| (*name, &options)).collect();
+        let cfs: Vec<_> = opt_cfs
+            .iter()
+            .map(|name| (*name, options.clone()))
+            .collect();
         open_cf_opts_transactional(path, None, MetricConf::default(), &cfs)
             .expect("failed to open rocksdb")
     } else {

--- a/narwhal/storage/src/node_store.rs
+++ b/narwhal/storage/src/node_store.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+
 use crate::payload_store::PayloadStore;
 use crate::proposer_store::ProposerKey;
 use crate::vote_digest_store::VoteDigestStore;
@@ -13,8 +14,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use store::metrics::SamplingInterval;
 use store::reopen;
-use store::rocks::{default_db_options, DBMap};
-use store::rocks::{open_cf, MetricConf, ReadWriteOptions};
+use store::rocks::{default_db_options, open_cf_opts, DBMap, MetricConf, ReadWriteOptions};
 use types::{
     Batch, BatchDigest, Certificate, CertificateDigest, CommittedSubDagShell, ConsensusCommit,
     Header, HeaderDigest, Round, SequenceNumber, VoteInfo,
@@ -62,23 +62,43 @@ impl NodeStorage {
         let db_options = default_db_options().optimize_db_for_write_throughput(2);
         let mut metrics_conf = MetricConf::with_db_name("consensus_epoch");
         metrics_conf.read_sample_interval = SamplingInterval::new(Duration::from_secs(60), 0);
-        let rocksdb = open_cf(
+        let cf_options = db_options.options.clone();
+        let column_family_options = vec![
+            (Self::LAST_PROPOSED_CF, cf_options.clone()),
+            (Self::VOTES_CF, cf_options.clone()),
+            (
+                Self::HEADERS_CF,
+                default_db_options()
+                    .optimize_for_write_throughput()
+                    .optimize_for_large_values_no_scan()
+                    .options,
+            ),
+            (
+                Self::CERTIFICATES_CF,
+                default_db_options()
+                    .optimize_for_write_throughput()
+                    .optimize_for_large_values_no_scan()
+                    .options,
+            ),
+            (Self::CERTIFICATE_DIGEST_BY_ROUND_CF, cf_options.clone()),
+            (Self::CERTIFICATE_DIGEST_BY_ORIGIN_CF, cf_options.clone()),
+            (Self::PAYLOAD_CF, cf_options.clone()),
+            (
+                Self::BATCHES_CF,
+                default_db_options()
+                    .optimize_for_write_throughput()
+                    .optimize_for_large_values_no_scan()
+                    .options,
+            ),
+            (Self::LAST_COMMITTED_CF, cf_options.clone()),
+            (Self::SUB_DAG_INDEX_CF, cf_options.clone()),
+            (Self::COMMITTED_SUB_DAG_INDEX_CF, cf_options),
+        ];
+        let rocksdb = open_cf_opts(
             store_path,
             Some(db_options.options),
             metrics_conf,
-            &[
-                Self::LAST_PROPOSED_CF,
-                Self::VOTES_CF,
-                Self::HEADERS_CF,
-                Self::CERTIFICATES_CF,
-                Self::CERTIFICATE_DIGEST_BY_ROUND_CF,
-                Self::CERTIFICATE_DIGEST_BY_ORIGIN_CF,
-                Self::PAYLOAD_CF,
-                Self::BATCHES_CF,
-                Self::LAST_COMMITTED_CF,
-                Self::SUB_DAG_INDEX_CF,
-                Self::COMMITTED_SUB_DAG_INDEX_CF,
-            ],
+            &column_family_options,
         )
         .expect("Cannot open database");
 


### PR DESCRIPTION
## Description 

### Blob storage for transactions and effects

Sui transactions and effects are 300B and 600B minimum respectively. Narwhal payload minimum size is similar to Sui transactions. Narwhal headers and certificates are 2KB ~ 3KB with 100 nodes. Currently they are stored as values in sst files, which are read and often written again each time the file is compacted, while they are not changing. This behavior can be optimized by using rocksdb blob storage: https://rocksdb.org/blog/2021/05/26/integrated-blob-db.html.

From the blog post above, it seems the additional lookup cost is minimal. Also, transactions and effects are accessed most often when they are recent, when they are still in memtables.

### Increase block size to 16KiB

Default block size is increased from 4KiB to 16KiB, which seems to be the production setting in Facebook. This should help reduce metadata size, but may increase read amplifications and block cache load. For tables optimized for point lookup, block size is still 4KiB.

### Other changes

Default write buffer and base level target sizes are restored to default values, i.e. what they were before 3ca4d305fc8f99085ce8a2981fa33da7c442f89d. They are increased only for tables optimized for write throughput.

## Test Plan 

Verified on private testnet, with shared counter and batch workloads.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
