### PR TITLE
[framework] Finish implementation of system package publish

### DIFF
--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -26,8 +26,8 @@ use sui_types::epoch_data::EpochData;
 use sui_types::error::{ExecutionError, ExecutionErrorKind};
 use sui_types::gas::{GasCostSummary, SuiGasStatusAPI};
 use sui_types::messages::{
-    Argument, ConsensusCommitPrologue, GenesisTransaction, ObjectArg, ProgrammableTransaction,
-    TransactionKind, Command,
+    Argument, Command, ConsensusCommitPrologue, GenesisTransaction, ObjectArg,
+    ProgrammableTransaction, TransactionKind,
 };
 use sui_types::storage::{ChildObjectResolver, ObjectStore, ParentSync, WriteKind};
 use sui_types::sui_system_state::{AdvanceEpochParams, ADVANCE_EPOCH_SAFE_MODE_FUNCTION_NAME};

--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -4,6 +4,7 @@
 use std::{collections::BTreeSet, sync::Arc};
 
 use crate::execution_mode::{self, ExecutionMode};
+use move_binary_format::access::ModuleAccess;
 use move_binary_format::CompiledModule;
 use move_bytecode_utils::module_cache::GetModule;
 use move_vm_runtime::move_vm::MoveVM;
@@ -26,7 +27,7 @@ use sui_types::error::{ExecutionError, ExecutionErrorKind};
 use sui_types::gas::{GasCostSummary, SuiGasStatusAPI};
 use sui_types::messages::{
     Argument, ConsensusCommitPrologue, GenesisTransaction, ObjectArg, ProgrammableTransaction,
-    TransactionKind,
+    TransactionKind, Command,
 };
 use sui_types::storage::{ChildObjectResolver, ObjectStore, ParentSync, WriteKind};
 use sui_types::sui_system_state::{AdvanceEpochParams, ADVANCE_EPOCH_SAFE_MODE_FUNCTION_NAME};
@@ -635,45 +636,53 @@ fn advance_epoch<S: ObjectStore + BackingPackageStore + ParentSync + ChildObject
     }
 
     for (version, modules, dependencies) in change_epoch.system_packages.into_iter() {
-        let modules: Vec<_> = modules
-            .into_iter()
-            .map(|m| {
-                CompiledModule::deserialize_with_max_version(
-                    &m,
-                    protocol_config.move_binary_format_version(),
-                )
-                .unwrap()
-            })
+        let max_format_version = protocol_config.move_binary_format_version();
+        let deserialized_modules: Vec<_> = modules
+            .iter()
+            .map(|m| CompiledModule::deserialize_with_max_version(m, max_format_version).unwrap())
             .collect();
 
-        // Note: every new system package should be created at OBJECT_START_VERSION
-        let mut new_package =
-            Object::new_system_package(&modules, version, dependencies, tx_ctx.digest());
+        if version == OBJECT_START_VERSION {
+            let package_id = deserialized_modules.first().unwrap().address();
+            info!("adding new system package {package_id}");
 
-        let write_kind = if version == OBJECT_START_VERSION {
-            info!(
-                "adding new system package {:?}",
-                new_package.compute_object_reference()
-            );
-            // creation of a new framework module
-            WriteKind::Create
+            let publish_pt = {
+                let mut b = ProgrammableTransactionBuilder::new();
+                b.command(Command::Publish(modules, dependencies));
+                b.finish()
+            };
+
+            programmable_transactions::execution::execute::<_, execution_mode::System>(
+                protocol_config,
+                move_vm,
+                temporary_store,
+                tx_ctx,
+                gas_status,
+                None,
+                publish_pt,
+            )
+            .expect("System Package Publish must succeed");
         } else {
+            let mut new_package = Object::new_system_package(
+                &deserialized_modules, version, dependencies, tx_ctx.digest(),
+            );
+
             info!(
                 "upgraded system package {:?}",
                 new_package.compute_object_reference()
             );
-            // upgrade of a previously existing framework module
-            WriteKind::Mutate
-        };
 
-        // Decrement the version before writing the package so that the store can record the version
-        // growing by one in the effects.
-        new_package
-            .data
-            .try_as_package_mut()
-            .unwrap()
-            .decrement_version();
-        temporary_store.write_object(new_package, write_kind);
+            // Decrement the version before writing the package so that the store can record the
+            // version growing by one in the effects.
+            new_package
+                .data
+                .try_as_package_mut()
+                .unwrap()
+                .decrement_version();
+
+            // upgrade of a previously existing framework module
+            temporary_store.write_object(new_package, WriteKind::Mutate);
+        }
     }
 
     Ok(())

--- a/crates/sui-framework/src/lib.rs
+++ b/crates/sui-framework/src/lib.rs
@@ -34,12 +34,20 @@ pub struct SystemPackage {
 }
 
 impl SystemPackage {
-    pub fn new(id: ObjectID, raw_bytes: &'static [u8], dependencies: &[ObjectID]) -> Self {
+    pub fn from_bcs(id: ObjectID, raw_bytes: &'static [u8], dependencies: &[ObjectID]) -> Self {
         let bytes: Vec<Vec<u8>> = bcs::from_bytes(raw_bytes).unwrap();
         Self {
             id,
             bytes,
             dependencies: dependencies.to_vec(),
+        }
+    }
+
+    pub fn new(id: ObjectID, bytes: Vec<Vec<u8>>, dependencies: Vec<ObjectID>) -> Self {
+        Self {
+            id,
+            bytes,
+            dependencies,
         }
     }
 
@@ -93,7 +101,7 @@ macro_rules! define_system_packages {
     ([$(($id:expr, $path:expr, $deps:expr)),* $(,)?]) => {{
         static PACKAGES: Lazy<Vec<SystemPackage>> = Lazy::new(|| {
             vec![
-                $(SystemPackage::new(
+                $(SystemPackage::from_bcs(
                     $id,
                     include_bytes!(concat!(env!("OUT_DIR"), "/", $path)),
                     &$deps,

--- a/crates/sui-framework/src/lib.rs
+++ b/crates/sui-framework/src/lib.rs
@@ -26,28 +26,20 @@ pub mod natives;
 
 /// Represents a system package in the framework, that's built from the source code inside
 /// sui-framework.
-#[derive(Serialize, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Serialize, PartialEq, Eq, Deserialize)]
 pub struct SystemPackage {
-    id: ObjectID,
-    bytes: Vec<Vec<u8>>,
-    dependencies: Vec<ObjectID>,
+    pub id: ObjectID,
+    pub bytes: Vec<Vec<u8>>,
+    pub dependencies: Vec<ObjectID>,
 }
 
 impl SystemPackage {
-    pub fn from_bcs(id: ObjectID, raw_bytes: &'static [u8], dependencies: &[ObjectID]) -> Self {
+    pub fn new(id: ObjectID, raw_bytes: &'static [u8], dependencies: &[ObjectID]) -> Self {
         let bytes: Vec<Vec<u8>> = bcs::from_bytes(raw_bytes).unwrap();
         Self {
             id,
             bytes,
             dependencies: dependencies.to_vec(),
-        }
-    }
-
-    pub fn new(id: ObjectID, bytes: Vec<Vec<u8>>, dependencies: Vec<ObjectID>) -> Self {
-        Self {
-            id,
-            bytes,
-            dependencies,
         }
     }
 
@@ -101,7 +93,7 @@ macro_rules! define_system_packages {
     ([$(($id:expr, $path:expr, $deps:expr)),* $(,)?]) => {{
         static PACKAGES: Lazy<Vec<SystemPackage>> = Lazy::new(|| {
             vec![
-                $(SystemPackage::from_bcs(
+                $(SystemPackage::new(
                     $id,
                     include_bytes!(concat!(env!("OUT_DIR"), "/", $path)),
                     &$deps,

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -592,7 +592,9 @@ impl Object {
             previous_transaction,
         );
 
+        #[cfg(not(msim))]
         assert!(ret.is_system_package());
+
         ret
     }
 

--- a/crates/sui/tests/framework_upgrades/extra_package/Move.toml
+++ b/crates/sui/tests/framework_upgrades/extra_package/Move.toml
@@ -1,0 +1,11 @@
+[package]
+name = "SuiExtra"
+version = "0.0.1"
+
+[dependencies]
+SuiSystem = { local = "../../../../sui-framework/packages/sui-system" }
+Sui = { local = "../../../../sui-framework/packages/sui-framework" }
+MoveStdlib = { local = "../../../../sui-framework/packages/move-stdlib" }
+
+[addresses]
+sui_extra = "0x42"

--- a/crates/sui/tests/framework_upgrades/extra_package/sources/modules.move
+++ b/crates/sui/tests/framework_upgrades/extra_package/sources/modules.move
@@ -1,0 +1,20 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui_extra::msim_extra_1 {
+    use sui::object::{Self, UID};
+    use sui::transfer;
+    use sui::tx_context::TxContext;
+
+    struct S has key { id: UID }
+    
+    fun init(ctx: &mut TxContext) {
+        transfer::share_object(S {
+            id: object::new(ctx)
+        })
+    }
+
+    public fun canary(): u64 {
+        43
+    }
+}

--- a/crates/sui/tests/protocol_version_tests.rs
+++ b/crates/sui/tests/protocol_version_tests.rs
@@ -66,12 +66,14 @@ mod sim_only_tests {
     use std::sync::Arc;
     use sui_core::authority::framework_injection;
     use sui_framework::BuiltInFramework;
-    use sui_framework_build::compiled_package::BuildConfig;
+    use sui_framework_build::compiled_package::{BuildConfig, CompiledPackage};
     use sui_json_rpc::api::WriteApiClient;
     use sui_macros::*;
     use sui_protocol_config::SupportedProtocolVersions;
     use sui_types::base_types::ObjectID;
     use sui_types::id::ID;
+    use sui_types::messages::{Command, ProgrammableMoveCall, TransactionEffects};
+    use sui_types::object::Owner;
     use sui_types::sui_system_state::{
         epoch_start_sui_system_state::EpochStartSystemStateTrait, get_validator_from_table,
         SuiSystemState, SuiSystemStateTrait, SUI_SYSTEM_STATE_SIM_TEST_DEEP_V2,
@@ -314,7 +316,7 @@ mod sim_only_tests {
         expect_upgrade_succeeded(&cluster).await;
         assert_eq!(call_canary(&cluster).await, 43);
 
-        let (modified_at, mutated_to) = get_framework_upgrade_effects(&cluster).await;
+        let (modified_at, mutated_to) = get_framework_upgrade_versions(&cluster).await;
         assert_eq!(Some(SequenceNumber::from(1)), modified_at);
         assert_eq!(Some(SequenceNumber::from(2)), mutated_to);
     }
@@ -364,6 +366,62 @@ mod sim_only_tests {
         assert_eq!(call_canary(&cluster).await, 42);
     }
 
+    #[sim_test]
+    async fn test_new_framework_package() {
+        ProtocolConfig::poison_get_for_min_version();
+
+        let sui_extra = ObjectID::from_single_byte(0x42);
+        framework_injection::set_override(sui_extra, fixture_modules("extra_package"));
+
+        let cluster = TestClusterBuilder::new()
+            .with_epoch_duration_ms(20000)
+            .with_supported_protocol_versions(SupportedProtocolVersions::new_for_testing(
+                START, FINISH,
+            ))
+            .build()
+            .await
+            .unwrap();
+
+        expect_upgrade_succeeded(&cluster).await;
+
+        // Make sure the epoch change event includes the event from the new package's module
+        // initializer
+        let effects = get_framework_upgrade_effects(&cluster, &sui_extra).await;
+
+        let shared_id = effects
+            .created()
+            .iter()
+            .find_map(|(obj, owner)| {
+                if let Owner::Shared { .. } = owner {
+                    Some(obj.0)
+                } else {
+                    None
+                }
+            })
+            .unwrap();
+
+        let shared = get_object(&cluster, &shared_id).await;
+        let type_ = shared.type_().unwrap();
+        assert_eq!(type_.module().as_str(), "msim_extra_1");
+        assert_eq!(type_.name().as_str(), "S");
+
+        // Call a function from the newly published system package
+        assert_eq!(
+            dev_inspect_call(
+                &cluster,
+                ProgrammableMoveCall {
+                    package: sui_extra,
+                    module: ident_str!("msim_extra_1").to_owned(),
+                    function: ident_str!("canary").to_owned(),
+                    type_arguments: vec![],
+                    arguments: vec![],
+                }
+            )
+            .await,
+            43,
+        );
+    }
+
     async fn run_framework_upgrade(from: &str, to: &str) -> TestCluster {
         ProtocolConfig::poison_get_for_min_version();
 
@@ -380,20 +438,26 @@ mod sim_only_tests {
     }
 
     async fn call_canary(cluster: &TestCluster) -> u64 {
+        dev_inspect_call(
+            cluster,
+            ProgrammableMoveCall {
+                package: SUI_SYSTEM_PACKAGE_ID,
+                module: ident_str!("msim_extra_1").to_owned(),
+                function: ident_str!("canary").to_owned(),
+                type_arguments: vec![],
+                arguments: vec![],
+            },
+        )
+        .await
+    }
+
+    async fn dev_inspect_call(cluster: &TestCluster, call: ProgrammableMoveCall) -> u64 {
         let client = cluster.rpc_client();
         let sender = cluster.accounts.first().cloned().unwrap();
 
         let pt = {
             let mut builder = ProgrammableTransactionBuilder::new();
-            builder
-                .move_call(
-                    SUI_SYSTEM_PACKAGE_ID,
-                    ident_str!("msim_extra_1").to_owned(),
-                    ident_str!("canary").to_owned(),
-                    vec![],
-                    vec![],
-                )
-                .unwrap();
+            builder.command(Command::MoveCall(Box::new(call)));
             builder.finish()
         };
         let txn = TransactionKind::programmable(pt);
@@ -422,26 +486,10 @@ mod sim_only_tests {
         monitor_version_change(&cluster, FINISH /* expected proto version */).await;
     }
 
-    async fn get_framework_upgrade_effects(
+    async fn get_framework_upgrade_versions(
         cluster: &TestCluster,
     ) -> (Option<SequenceNumber>, Option<SequenceNumber>) {
-        let node_handle = cluster
-            .swarm
-            .validators()
-            .next()
-            .unwrap()
-            .get_node_handle()
-            .unwrap();
-
-        let effects = node_handle
-            .with_async(|node| async {
-                let db = node.state().db();
-                let framework = db.get_object(&SUI_SYSTEM_PACKAGE_ID);
-                let digest = framework.unwrap().unwrap().previous_transaction;
-                let effects = db.get_executed_effects(&digest);
-                effects.unwrap().unwrap()
-            })
-            .await;
+        let effects = get_framework_upgrade_effects(cluster, &SUI_SYSTEM_PACKAGE_ID).await;
 
         let modified_at = effects
             .modified_at_versions()
@@ -454,6 +502,43 @@ mod sim_only_tests {
             .find_map(|((id, v, _), _)| (id == &SUI_SYSTEM_PACKAGE_ID).then_some(*v));
 
         (modified_at, mutated_to)
+    }
+
+    async fn get_framework_upgrade_effects(
+        cluster: &TestCluster,
+        package: &ObjectID,
+    ) -> TransactionEffects {
+        let node_handle = cluster
+            .swarm
+            .validators()
+            .next()
+            .unwrap()
+            .get_node_handle()
+            .unwrap();
+
+        node_handle
+            .with_async(|node| async {
+                let db = node.state().db();
+                let framework = db.get_object(package);
+                let digest = framework.unwrap().unwrap().previous_transaction;
+                let effects = db.get_executed_effects(&digest);
+                effects.unwrap().unwrap()
+            })
+            .await
+    }
+
+    async fn get_object(cluster: &TestCluster, package: &ObjectID) -> Object {
+        let node_handle = cluster
+            .swarm
+            .validators()
+            .next()
+            .unwrap()
+            .get_node_handle()
+            .unwrap();
+
+        node_handle
+            .with_async(|node| async { node.state().db().get_object(package).unwrap().unwrap() })
+            .await
     }
 
     #[sim_test]
@@ -750,17 +835,13 @@ mod sim_only_tests {
         framework_injection::set_override_cb(SUI_SYSTEM_PACKAGE_ID, f)
     }
 
-    /// Get compiled modules for Sui Framework, built from fixture `fixture` in the
+    /// Get compiled modules for Sui System, built from fixture `fixture` in the
     /// `framework_upgrades` directory.
     fn sui_system_modules(fixture: &str) -> Vec<CompiledModule> {
-        let mut package = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        package.extend(["tests", "framework_upgrades", fixture]);
-
-        let mut config = BuildConfig::new_for_testing();
-        config.run_bytecode_verifier = true;
-
-        let pkg = config.build(package).unwrap();
-        pkg.get_sui_system_modules().cloned().collect()
+        fixture_package(fixture)
+            .get_sui_system_modules()
+            .cloned()
+            .collect()
     }
 
     /// Like `sui_system_modules`, but package the modules in an `Object`.
@@ -776,5 +857,20 @@ mod sim_only_tests {
             ],
         )
         .unwrap()
+    }
+
+    /// Get root compiled modules, built from fixture `fixture` in the `framework_upgrades`
+    /// directory.
+    fn fixture_modules(fixture: &str) -> Vec<CompiledModule> {
+        fixture_package(fixture).into_modules()
+    }
+
+    fn fixture_package(fixture: &str) -> CompiledPackage {
+        let mut package = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        package.extend(["tests", "framework_upgrades", fixture]);
+
+        let mut config = BuildConfig::new_for_testing();
+        config.run_bytecode_verifier = true;
+        config.build(package).unwrap()
     }
 }


### PR DESCRIPTION
## Description

If the validator binary includes a system package that doesn't exist on-chain, then during the protocol/framework upgrade that introduces it, we shoud run its module initializer.  This aligns with the behaviour during genesis (where we already run the module initializer for system packages).

Note that the module init must succeed, or the validator panics (this is also the case when module initializers are run as part of genesis).

## Test Plan

New test for a framework upgrade that introduces a system package with a module initializer.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration
