### PR TITLE
tune down the max multi-get limit to 50

### DIFF
--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -48,7 +48,7 @@ use crate::IndexerConfig;
 const MAX_PARALLEL_DOWNLOADS: usize = 24;
 const DOWNLOAD_RETRY_INTERVAL_IN_SECS: u64 = 10;
 const DB_COMMIT_RETRY_INTERVAL_IN_MILLIS: u64 = 100;
-const MULTI_GET_CHUNK_SIZE: usize = 200;
+const MULTI_GET_CHUNK_SIZE: usize = 50;
 const CHECKPOINT_QUEUE_LIMIT: usize = 24;
 const EPOCH_QUEUE_LIMIT: usize = 2;
 

--- a/crates/sui-json-rpc/src/api/mod.rs
+++ b/crates/sui-json-rpc/src/api/mod.rs
@@ -39,15 +39,11 @@ mod read;
 mod transaction_builder;
 mod write;
 
-/// Maximum number of events returned in an event query.
-/// This is equivalent to EVENT_QUERY_MAX_LIMIT in `sui-storage` crate.
-/// To avoid unnecessary dependency on that crate, we have a reference here
-/// for document purposes.
-pub const QUERY_MAX_RESULT_LIMIT: usize = 1000;
+pub const QUERY_MAX_RESULT_LIMIT: usize = 50;
 // TODOD(chris): make this configurable
 pub const QUERY_MAX_RESULT_LIMIT_CHECKPOINTS: usize = 100;
 
-pub const QUERY_MAX_RESULT_LIMIT_OBJECTS: usize = 256;
+pub const QUERY_MAX_RESULT_LIMIT_OBJECTS: usize = 50;
 
 pub fn cap_page_limit(limit: Option<usize>) -> usize {
     let limit = limit.unwrap_or_default();


### PR DESCRIPTION
## Description 

Limit the max multi-get return number. This helps reduce the load on system for each request and risk of resources starvation. 

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
