### PR TITLE
[FN] Fallback to retry in case of an invalid cert signature

### DIFF
--- a/crates/sui-core/src/safe_client.rs
+++ b/crates/sui-core/src/safe_client.rs
@@ -257,7 +257,7 @@ impl<C> SafeClient<C> {
                             .map_err(|e| match e {
                                 // TODO: Remove as well once incident #267 is resolved.
                                 SuiError::InvalidSignature { error } => {
-                                    SuiError::PotentiallyTemporaryInvalidSignature { error }
+                                    SuiError::PotentiallyTemporarilyInvalidSignature { error }
                                 }
                                 _ => e,
                             })?;

--- a/crates/sui-core/src/safe_client.rs
+++ b/crates/sui-core/src/safe_client.rs
@@ -256,7 +256,7 @@ impl<C> SafeClient<C> {
                             })
                             .map_err(|e| match e {
                                 // TODO: Remove as well once incident #267 is resolved.
-                                SuiError::InvalidSignature(error) => {
+                                SuiError::InvalidSignature { error } => {
                                     SuiError::PotentiallyTemporaryInvalidSignature { error }
                                 }
                                 _ => e,

--- a/crates/sui-core/src/safe_client.rs
+++ b/crates/sui-core/src/safe_client.rs
@@ -7,7 +7,10 @@ use crate::epoch::committee_store::CommitteeStore;
 use fastcrypto::encoding::Encoding;
 use mysten_metrics::histogram::{Histogram, HistogramVec};
 use prometheus::core::GenericCounter;
-use prometheus::{register_int_counter_vec_with_registry, IntCounterVec, Registry};
+use prometheus::{
+    register_int_counter_vec_with_registry, register_int_counter_with_registry, IntCounter,
+    IntCounterVec, Registry,
+};
 use std::sync::Arc;
 use sui_types::crypto::AuthorityPublicKeyBytes;
 use sui_types::messages_checkpoint::{
@@ -39,6 +42,7 @@ pub struct SafeClientMetricsBase {
     total_requests_by_address_method: IntCounterVec,
     total_responses_by_address_method: IntCounterVec,
     latency: HistogramVec,
+    potentially_temporarily_invalid_signatures: IntCounter,
 }
 
 impl SafeClientMetricsBase {
@@ -64,6 +68,12 @@ impl SafeClientMetricsBase {
                 &["address", "method"],
                 registry,
             ),
+            potentially_temporarily_invalid_signatures: register_int_counter_with_registry!(
+                "safe_client_potentially_temporarily_invalid_signatures",
+                "Number of PotentiallyTemporarilyInvalidSignature errors",
+                registry,
+            )
+            .unwrap(),
         }
     }
 }

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -275,6 +275,12 @@ pub enum SuiError {
         signer: AuthorityName,
         conflicting_sig: bool,
     },
+    // TODO: Used for distinguishing between different occurrences of invalid signatures, to allow retries in some cases.
+    #[error(
+        "Signature is not valid, but a retry may result in a valid one: {}",
+        error
+    )]
+    PotentiallyTemporaryInvalidSignature { error: String },
 
     // Certificate verification and execution
     #[error(
@@ -637,6 +643,8 @@ impl SuiError {
                     _ => (false, true),
                 }
             }
+
+            SuiError::PotentiallyTemporaryInvalidSignature { .. } => (true, true),
 
             // Overload errors
             SuiError::TooManyTransactionsPendingExecution { .. } => (true, true),

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -280,7 +280,7 @@ pub enum SuiError {
         "Signature is not valid, but a retry may result in a valid one: {}",
         error
     )]
-    PotentiallyTemporaryInvalidSignature { error: String },
+    PotentiallyTemporarilyInvalidSignature { error: String },
 
     // Certificate verification and execution
     #[error(
@@ -644,7 +644,7 @@ impl SuiError {
                 }
             }
 
-            SuiError::PotentiallyTemporaryInvalidSignature { .. } => (true, true),
+            SuiError::PotentiallyTemporarilyInvalidSignature { .. } => (true, true),
 
             // Overload errors
             SuiError::TooManyTransactionsPendingExecution { .. } => (true, true),


### PR DESCRIPTION
## Description 
Full node - Fallback to retry in case we receive an invalid cert signature in `TransactionStatus::Executed`. It's a safe change since:
- if `>f` are indeed byzantine, we would still never accept invalid certs/transactions; the only difference is that we would keep retrying (until we reach the maximal number of retries).
- if `<=f` are byzantine - we will eventually receive `2f+1` good responses anyhow

## Test Plan 
All tests pass
