### PR TITLE
[kiosk] Adds extensions API

### DIFF
--- a/crates/sui-framework/packages/sui-framework/sources/kiosk/kiosk.move
+++ b/crates/sui-framework/packages/sui-framework/sources/kiosk/kiosk.move
@@ -142,7 +142,7 @@ module sui::kiosk {
     /// authorizes their usage. Currently supported methods are: `borrow`, `place`
     /// and `lock`.
     ///
-    /// The `action_set` can support up to 16 different "actions" and all their
+    /// The `permissions` can support up to 16 different "actions" and all their
     /// combinations in the future.
     struct Extension<phantom E> has store, copy, drop {}
 
@@ -617,9 +617,9 @@ module sui::kiosk {
     #[test_only]
     /// Test-only version of `add_extension`
     public fun add_extension_for_testing<E: drop>(
-        self: &mut Kiosk, cap: &KioskOwnerCap, action_set: u16
+        self: &mut Kiosk, cap: &KioskOwnerCap, permissions: u16
     ) {
-        add_extension<E>(self, cap, action_set);
+        add_extension<E>(self, cap, permissions);
     }
 }
 

--- a/crates/sui-framework/packages/sui-framework/tests/kiosk/kiosk_extensions_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/kiosk/kiosk_extensions_tests.move
@@ -1,0 +1,100 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+/// Test extensions functionality. Make sure it's not breaking the kiosk as well
+/// as the new extensions functions are working as expected.
+module sui::kiosk_extension_tests {
+    use sui::kiosk;
+    use sui::kiosk_test_utils::{Self as test, Asset};
+
+    struct Ext has drop {}
+
+    #[test]
+    fun ext_test_add_get_remove_extension() {
+        let ctx = test::ctx();
+        let (kiosk, kiosk_cap) = test::get_kiosk(&mut ctx);
+
+        kiosk::add_extension(Ext {}, &mut kiosk, &kiosk_cap, 0);
+        assert!(kiosk::get_extension<Ext>(&kiosk) == 0, 0);
+        kiosk::remove_extension<Ext>(&mut kiosk, &kiosk_cap);
+
+        test::return_kiosk(kiosk, kiosk_cap, &mut ctx);
+    }
+
+    #[test]
+    fun ext_test_all_permissions() {
+        let ctx = test::ctx();
+        let (kiosk, kiosk_cap) = test::get_kiosk(&mut ctx);
+        let (policy, policy_cap) = test::get_policy(&mut ctx);
+
+        // 0111 - mask for all permissions (Place, Borrow, Lock)
+        kiosk::add_extension(Ext {}, &mut kiosk, &kiosk_cap, 0xF);
+        assert!(kiosk::get_extension<Ext>(&kiosk) == 0xF, 0);
+
+        let (asset, item_id) = test::get_asset(&mut ctx);
+
+        // check whether the extension can place the asset
+        kiosk::ext_place(Ext {}, &mut kiosk, asset);
+        kiosk::has_item(&kiosk, item_id);
+
+        // check whether the extension can borrow the asset
+        let _asset: &Asset = kiosk::ext_borrow(Ext {}, &mut kiosk, item_id);
+
+        // take the asset as owner
+        let asset = kiosk::take(&mut kiosk, &kiosk_cap, item_id);
+
+        // check whether the extension can lock the asset
+        kiosk::ext_lock(Ext {}, &mut kiosk, &policy, asset);
+        kiosk::list<Asset>(&mut kiosk, &kiosk_cap, item_id, 0);
+
+        let (asset, req) = kiosk::purchase(&mut kiosk, item_id, test::get_sui(0, &mut ctx));
+        sui::transfer_policy::confirm_request(&policy, req);
+
+        test::return_assets(vector[ asset ]);
+        test::return_policy(policy, policy_cap, &mut ctx);
+        test::return_kiosk(kiosk, kiosk_cap, &mut ctx);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = sui::kiosk::EExtNotPermitted)]
+    fun ext_test_place_fail() {
+        let ctx = test::ctx();
+        let (asset, _) = test::get_asset(&mut ctx);
+        let (kiosk, kiosk_cap) = test::get_kiosk(&mut ctx);
+
+        kiosk::add_extension(Ext {}, &mut kiosk, &kiosk_cap, 0x0);
+        kiosk::ext_place(Ext {}, &mut kiosk, asset);
+
+        abort 1337
+    }
+
+    #[test]
+    #[expected_failure(abort_code = sui::kiosk::EExtNotPermitted)]
+    fun ext_test_borrow_fail() {
+        let ctx = test::ctx();
+        let (asset, item_id) = test::get_asset(&mut ctx);
+        let (kiosk, kiosk_cap) = test::get_kiosk(&mut ctx);
+
+        kiosk::place(&mut kiosk, &kiosk_cap, asset);
+
+        kiosk::add_extension(Ext {}, &mut kiosk, &kiosk_cap, 0x4);
+        let _: &Asset = kiosk::ext_borrow(Ext {}, &kiosk, item_id);
+
+        abort 1337
+    }
+
+    #[test]
+    #[expected_failure(abort_code = sui::kiosk::EExtNotPermitted)]
+    fun ext_test_lock_fail() {
+        let ctx = test::ctx();
+        let (asset, _item_id) = test::get_asset(&mut ctx);
+        let (kiosk, kiosk_cap) = test::get_kiosk(&mut ctx);
+        let (policy, _policy_cap) = test::get_policy(&mut ctx);
+
+        kiosk::add_extension(Ext {}, &mut kiosk, &kiosk_cap, 0x0);
+        kiosk::ext_lock(Ext {}, &mut kiosk, &policy, asset);
+
+        abort 1337
+    }
+}

--- a/crates/sui-framework/packages/sui-framework/tests/kiosk/kiosk_extensions_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/kiosk/kiosk_extensions_tests.move
@@ -6,6 +6,7 @@
 /// as the new extensions functions are working as expected.
 module sui::kiosk_extension_tests {
     use sui::kiosk;
+    // use sui::kiosk_permissions as auth;
     use sui::kiosk_test_utils::{Self as test, Asset};
 
     struct Ext has drop {}
@@ -14,9 +15,10 @@ module sui::kiosk_extension_tests {
     fun ext_test_add_get_remove_extension() {
         let ctx = test::ctx();
         let (kiosk, kiosk_cap) = test::get_kiosk(&mut ctx);
+        let auth = 0;
 
-        kiosk::add_extension(Ext {}, &mut kiosk, &kiosk_cap, 0);
-        assert!(kiosk::get_extension<Ext>(&kiosk) == 0, 0);
+        kiosk::add_extension_for_testing<Ext>(&mut kiosk, &kiosk_cap, auth);
+        assert!(kiosk::get_extension_permissions<Ext>(&kiosk) == 0, 0);
         kiosk::remove_extension<Ext>(&mut kiosk, &kiosk_cap);
 
         test::return_kiosk(kiosk, kiosk_cap, &mut ctx);
@@ -29,23 +31,23 @@ module sui::kiosk_extension_tests {
         let (policy, policy_cap) = test::get_policy(&mut ctx);
 
         // 0111 - mask for all permissions (Place, Borrow, Lock)
-        kiosk::add_extension(Ext {}, &mut kiosk, &kiosk_cap, 0xF);
-        assert!(kiosk::get_extension<Ext>(&kiosk) == 0xF, 0);
+        kiosk::add_extension_for_testing<Ext>(&mut kiosk, &kiosk_cap, 0xF);
+        assert!(kiosk::get_extension_permissions<Ext>(&kiosk) == 0xF, 0);
 
         let (asset, item_id) = test::get_asset(&mut ctx);
 
         // check whether the extension can place the asset
-        kiosk::ext_place(Ext {}, &mut kiosk, asset);
+        kiosk::place_as_extension(Ext {}, &mut kiosk, asset);
         kiosk::has_item(&kiosk, item_id);
 
         // check whether the extension can borrow the asset
-        let _asset: &Asset = kiosk::ext_borrow(Ext {}, &mut kiosk, item_id);
+        let _asset: &Asset = kiosk::borrow_as_extension(Ext {}, &mut kiosk, item_id);
 
         // take the asset as owner
         let asset = kiosk::take(&mut kiosk, &kiosk_cap, item_id);
 
         // check whether the extension can lock the asset
-        kiosk::ext_lock(Ext {}, &mut kiosk, &policy, asset);
+        kiosk::lock_as_extension(Ext {}, &mut kiosk, &policy, asset);
         kiosk::list<Asset>(&mut kiosk, &kiosk_cap, item_id, 0);
 
         let (asset, req) = kiosk::purchase(&mut kiosk, item_id, test::get_sui(0, &mut ctx));
@@ -63,8 +65,8 @@ module sui::kiosk_extension_tests {
         let (asset, _) = test::get_asset(&mut ctx);
         let (kiosk, kiosk_cap) = test::get_kiosk(&mut ctx);
 
-        kiosk::add_extension(Ext {}, &mut kiosk, &kiosk_cap, 0x0);
-        kiosk::ext_place(Ext {}, &mut kiosk, asset);
+        kiosk::add_extension_for_testing<Ext>(&mut kiosk, &kiosk_cap, 0x0);
+        kiosk::place_as_extension(Ext {}, &mut kiosk, asset);
 
         abort 1337
     }
@@ -78,8 +80,8 @@ module sui::kiosk_extension_tests {
 
         kiosk::place(&mut kiosk, &kiosk_cap, asset);
 
-        kiosk::add_extension(Ext {}, &mut kiosk, &kiosk_cap, 0x4);
-        let _: &Asset = kiosk::ext_borrow(Ext {}, &kiosk, item_id);
+        kiosk::add_extension_for_testing<Ext>(&mut kiosk, &kiosk_cap, 0x4);
+        let _: &Asset = kiosk::borrow_as_extension(Ext {}, &kiosk, item_id);
 
         abort 1337
     }
@@ -92,8 +94,8 @@ module sui::kiosk_extension_tests {
         let (kiosk, kiosk_cap) = test::get_kiosk(&mut ctx);
         let (policy, _policy_cap) = test::get_policy(&mut ctx);
 
-        kiosk::add_extension(Ext {}, &mut kiosk, &kiosk_cap, 0x0);
-        kiosk::ext_lock(Ext {}, &mut kiosk, &policy, asset);
+        kiosk::add_extension_for_testing<Ext>(&mut kiosk, &kiosk_cap, 0x0);
+        kiosk::lock_as_extension(Ext {}, &mut kiosk, &policy, asset);
 
         abort 1337
     }


### PR DESCRIPTION
## Description 

Adds "Kiosk Extensions" as a concept to the Kiosk allowing the Kiosk Owner to install "extensions". 

- Each extension gets a set of permissions (any combination of `place`, `borrow` and `borrow_mut`)
- All of the extensions get access to `uid_mut` even when public access is disabled
- Adding an extension is a _private entry_ function to make sure it is an explicit action performed by the K.O.
- Extensions can be removed anytime  

## Questions

- Naming: should we use `ext_<fun>` or `<fun>_as_extension` or `<fun>_as_ext` for functions that are meant to be used by an extension (via the extension authorization). Eg: `place` is for KO, `place_as_extension` requires a Witness.

```
fun place_as_extension(...) {}
fun lock_as_extension(...) {}
fun borrow_as_extension(...) {}
fun borrow_mut_as_extension(...) {}
```
VS
```
fun ext_place() {}
fun ext_lock() {}
fun ext_borrow() {}
fun ext_borrow_mut() {}
```

## Test Plan 

- Every feature is covered with tests

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries) ? 
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

TBD
