### PR TITLE
[cherry-pick][sui-framework] Clean-ups in test_adapter and base_types (#10944)

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/call/simple.exp
+++ b/crates/sui-adapter-transactional-tests/tests/call/simple.exp
@@ -3,7 +3,7 @@ processed 4 tasks
 task 1 'publish'. lines 6-28:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 6118000,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5570800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 30-30:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/child_count/count_decremented.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/count_decremented.exp
@@ -6,7 +6,7 @@ A: object(0,0), B: object(0,1)
 task 1 'publish'. lines 9-52:
 created: object(1,0)
 mutated: object(0,2)
-gas summary: computation_cost: 1000000, storage_cost: 8063600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 7516400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 54-54:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/child_count/delete_by_wrap.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/delete_by_wrap.exp
@@ -6,7 +6,7 @@ A: object(0,0), B: object(0,1)
 task 1 'publish'. lines 9-38:
 created: object(1,0)
 mutated: object(0,2)
-gas summary: computation_cost: 1000000, storage_cost: 7060400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 6513200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 40-40:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/child_count/delete_by_wrap_one_txn.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/delete_by_wrap_one_txn.exp
@@ -6,7 +6,7 @@ A: object(0,0), B: object(0,1)
 task 1 'publish'. lines 9-32:
 created: object(1,0)
 mutated: object(0,2)
-gas summary: computation_cost: 1000000, storage_cost: 6650000,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 6102800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 34-34:
 created: object(2,0), object(2,1), object(2,2)

--- a/crates/sui-adapter-transactional-tests/tests/child_count/delete_parent_invalid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/delete_parent_invalid.exp
@@ -6,7 +6,7 @@ A: object(0,0), B: object(0,1)
 task 1 'publish'. lines 9-33:
 created: object(1,0)
 mutated: object(0,2)
-gas summary: computation_cost: 1000000, storage_cost: 6574000,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 6026800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 35-35:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/child_count/delete_parent_valid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/delete_parent_valid.exp
@@ -6,7 +6,7 @@ A: object(0,0), B: object(0,1)
 task 1 'publish'. lines 9-58:
 created: object(1,0)
 mutated: object(0,2)
-gas summary: computation_cost: 1000000, storage_cost: 8534800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 7987600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 59-59:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/child_count/delete_parent_valid_one_txn.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/delete_parent_valid_one_txn.exp
@@ -6,7 +6,7 @@ A: object(0,0), B: object(0,1)
 task 1 'publish'. lines 10-70:
 created: object(1,0)
 mutated: object(0,2)
-gas summary: computation_cost: 1000000, storage_cost: 8930000,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 8382800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 72-72:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/child_count/freeze_parent_invalid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/freeze_parent_invalid.exp
@@ -6,7 +6,7 @@ A: object(0,0), B: object(0,1)
 task 1 'publish'. lines 9-62:
 created: object(1,0)
 mutated: object(0,2)
-gas summary: computation_cost: 1000000, storage_cost: 9006000,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 8458800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 64-64:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/child_count/freeze_parent_valid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/freeze_parent_valid.exp
@@ -6,7 +6,7 @@ A: object(0,0), B: object(0,1)
 task 1 'publish'. lines 9-62:
 created: object(1,0)
 mutated: object(0,2)
-gas summary: computation_cost: 1000000, storage_cost: 9006000,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 8458800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 64-64:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/child_count/freeze_parent_valid_one_txn.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/freeze_parent_valid_one_txn.exp
@@ -6,7 +6,7 @@ A: object(0,0), B: object(0,1)
 task 1 'publish'. lines 10-65:
 created: object(1,0)
 mutated: object(0,2)
-gas summary: computation_cost: 1000000, storage_cost: 9158000,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 8610800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 67-67:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/child_count/non_zero_child_count_valid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/non_zero_child_count_valid.exp
@@ -6,7 +6,7 @@ A: object(0,0), B: object(0,1)
 task 1 'publish'. lines 9-46:
 created: object(1,0)
 mutated: object(0,2)
-gas summary: computation_cost: 1000000, storage_cost: 7524000,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 6976800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 48-48:
 created: object(2,0), object(2,1), object(2,2)

--- a/crates/sui-adapter-transactional-tests/tests/child_count/non_zero_child_count_valid_one_txn.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/non_zero_child_count_valid_one_txn.exp
@@ -6,7 +6,7 @@ A: object(0,0), B: object(0,1)
 task 1 'publish'. lines 10-36:
 created: object(1,0)
 mutated: object(0,2)
-gas summary: computation_cost: 1000000, storage_cost: 6498000,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5950800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 38-38:
 created: object(2,0), object(2,1), object(2,2)

--- a/crates/sui-adapter-transactional-tests/tests/child_count/temp_parent_invalid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/temp_parent_invalid.exp
@@ -6,7 +6,7 @@ A: object(0,0), B: object(0,1)
 task 1 'publish'. lines 9-24:
 created: object(1,0)
 mutated: object(0,2)
-gas summary: computation_cost: 1000000, storage_cost: 5814000,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5266800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 26-26:
 created: object(2,0), object(2,1)

--- a/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_never_stored.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_never_stored.exp
@@ -6,7 +6,7 @@ A: object(0,0), B: object(0,1)
 task 1 'publish'. lines 9-39:
 created: object(1,0)
 mutated: object(0,2)
-gas summary: computation_cost: 1000000, storage_cost: 6384000,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5836800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 41-41:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_never_stored_transfer.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_never_stored_transfer.exp
@@ -6,7 +6,7 @@ A: object(0,0), B: object(0,1)
 task 1 'publish'. lines 9-38:
 created: object(1,0)
 mutated: object(0,2)
-gas summary: computation_cost: 1000000, storage_cost: 6619600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 6072400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 40-40:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_then_delete_invalid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_then_delete_invalid.exp
@@ -6,7 +6,7 @@ A: object(0,0), B: object(0,1)
 task 1 'publish'. lines 9-45:
 created: object(1,0)
 mutated: object(0,2)
-gas summary: computation_cost: 1000000, storage_cost: 7235200,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 6688000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 47-47:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/children/child_of_shared_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/children/child_of_shared_object.exp
@@ -6,17 +6,17 @@ A: object(0,0)
 task 1 'publish'. lines 6-21:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 5730400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5183200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'publish'. lines 23-52:
 created: object(2,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 8215600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1000000, storage_cost: 7668400,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 3 'publish'. lines 55-82:
 created: object(3,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 8762800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1000000, storage_cost: 8215600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 4 'run'. lines 84-84:
 created: object(4,0)

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/add_duplicate.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/add_duplicate.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 9-30:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 6414400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5867200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 32-32:
 created: object(2,0), object(2,1)

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/add_duplicate_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/add_duplicate_object.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 10-31:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 6574000,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 6026800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 33-33:
 created: object(2,0), object(2,1), object(2,2)

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/borrow_wrong_type.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/borrow_wrong_type.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 9-34:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 7052800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 6505600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 36-36:
 created: object(2,0), object(2,1)

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/borrow_wrong_type_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/borrow_wrong_type_object.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 10-39:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 7622800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 7075600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 41-41:
 created: object(2,0), object(2,1), object(2,2)

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/dynamic_object_field_swap.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/dynamic_object_field_swap.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 6-62:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 9484800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 8937600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 64-64:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/exhaustive.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/exhaustive.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 9-79:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 12942800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 12395600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 81-81:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/exhaustive_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/exhaustive_object.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 10-104:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 14029600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 13482400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 106-106:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/read_field_from_immutable.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/read_field_from_immutable.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 9-30:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 6680400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 6133200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 32-32:
 created: object(2,0), object(2,1)

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/remove_wrong_type.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/remove_wrong_type.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 9-31:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 6566400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 6019200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 33-33:
 created: object(2,0), object(2,1)

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/remove_wrong_type_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/remove_wrong_type_object.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 10-36:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 7242800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 6695600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 38-38:
 created: object(2,0), object(2,1), object(2,2)

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/transfer_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/transfer_object.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 10-67:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 9864800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 9317600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 69-69:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/unwrap_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/unwrap_object.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-41:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 8025600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 7478400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 43-43:
 created: object(2,0), object(2,1)

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/wrap_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/wrap_object.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-41:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 8025600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 7478400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 43-43:
 created: object(2,0), object(2,1), object(2,2)

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/wrapped_uid_after_delete.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/wrapped_uid_after_delete.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 10-84:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 10776800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 10229600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 86-86:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/ascii.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/ascii.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 6-28:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 6292800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5745600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 30-33:
 mutated: object(0,0)

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/generic_by_ref.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/generic_by_ref.exp
@@ -6,4 +6,4 @@ A: object(0,0)
 task 1 'publish'. lines 6-14:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 4696800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4149600,  storage_rebate: 0, non_refundable_storage_fee: 0

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/imm_txn_context.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/imm_txn_context.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 6-28:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 6581600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 6034400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 30-30:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/missing_type.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/missing_type.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-15:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 4423200,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 3876000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 17-17:
 Error: Transaction Effects Status: Move Bytecode Verification Error. Please run the Bytecode Verifier for more information.

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/no_txn_context.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/no_txn_context.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 6-24:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 6042000,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5494800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 26-26:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-116:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 13193600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 12646400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 118-118:
 mutated: object(0,0)

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-115:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 13999200,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 13452000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 117-117:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/utf8.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/utf8.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 6-27:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 6558800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 6011600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 29-32:
 mutated: object(0,0)

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/wrong_visibility.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/wrong_visibility.exp
@@ -3,7 +3,7 @@ processed 6 tasks
 task 1 'publish'. lines 8-28:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 5069200,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4522000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 30-30:
 Error: Transaction Effects Status: Non Entry Function Invoked. Move Call must start with an entry function

--- a/crates/sui-adapter-transactional-tests/tests/programmable/borrowed_arg_copyable_invalid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/borrowed_arg_copyable_invalid.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-15:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 5008400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4461200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 17-18:
 Error: Transaction Effects Status: Invalid command argument at 1. Invalid usage of value. Mutably borrowed values require unique usage. Immutably borrowed values cannot be taken or borrowed mutably. Taken values cannot be used again.

--- a/crates/sui-adapter-transactional-tests/tests/programmable/borrowed_arg_non_copyable_invalid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/borrowed_arg_non_copyable_invalid.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-24:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 6961600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 6414400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 26-28:
 Error: Transaction Effects Status: Invalid command argument at 1. Invalid usage of value. Mutably borrowed values require unique usage. Immutably borrowed values cannot be taken or borrowed mutably. Taken values cannot be used again.

--- a/crates/sui-adapter-transactional-tests/tests/programmable/borrowed_arg_valid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/borrowed_arg_valid.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-24:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 5935600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5388400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 26-35:
 mutated: object(0,1)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/cannot_call_emit.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/cannot_call_emit.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-12:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 4453600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 3906400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 14-16:
 Error: Transaction Effects Status: Non Entry Function Invoked. Move Call must start with an entry function

--- a/crates/sui-adapter-transactional-tests/tests/programmable/cannot_call_init.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/cannot_call_init.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-11:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 4446000,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 3898800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 13-14:
 Error: Transaction Effects Status: Non Entry Function Invoked. Move Call must start with an entry function

--- a/crates/sui-adapter-transactional-tests/tests/programmable/cannot_call_private.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/cannot_call_private.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-11:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 4446000,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 3898800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 13-14:
 Error: Transaction Effects Status: Non Entry Function Invoked. Move Call must start with an entry function

--- a/crates/sui-adapter-transactional-tests/tests/programmable/coin_negative.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/coin_negative.exp
@@ -7,7 +7,7 @@ task 1 'publish'. lines 8-23:
 events: Event { package_id: test, transaction_module: Identifier("fake"), sender: A, type_: StructTag { address: sui, module: Identifier("coin"), name: Identifier("CurrencyCreated"), type_params: [Struct(StructTag { address: test, module: Identifier("fake"), name: Identifier("FAKE"), type_params: [] })] }, contents: [2] }
 created: object(1,0), object(1,1), object(1,2)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 11164400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 10617200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 25-27:
 created: object(2,0)
@@ -20,4 +20,4 @@ Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { k
 
 task 4 'programmable'. lines 32-33:
 Error: Transaction Effects Status: Insufficient coin balance for operation.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientCoinBalance, source: Some("balance: 199999984463192 required: 18446744073709551615"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientCoinBalance, source: Some("balance: 199999985010392 required: 18446744073709551615"), command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/coin_operations_custom_coin.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/coin_operations_custom_coin.exp
@@ -7,7 +7,7 @@ task 1 'publish'. lines 8-23:
 events: Event { package_id: test, transaction_module: Identifier("fake"), sender: A, type_: StructTag { address: sui, module: Identifier("coin"), name: Identifier("CurrencyCreated"), type_params: [Struct(StructTag { address: test, module: Identifier("fake"), name: Identifier("FAKE"), type_params: [] })] }, contents: [2] }
 created: object(1,0), object(1,1), object(1,2)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 11164400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 10617200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 25-27:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/coin_operations_non_coins.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/coin_operations_non_coins.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-28:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 5441600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4894400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 29-33:
 Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type

--- a/crates/sui-adapter-transactional-tests/tests/programmable/coin_overflow.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/coin_overflow.exp
@@ -7,7 +7,7 @@ task 1 'publish'. lines 8-23:
 events: Event { package_id: test, transaction_module: Identifier("fake"), sender: A, type_: StructTag { address: sui, module: Identifier("coin"), name: Identifier("CurrencyCreated"), type_params: [Struct(StructTag { address: test, module: Identifier("fake"), name: Identifier("FAKE"), type_params: [] })] }, contents: [2] }
 created: object(1,0), object(1,1), object(1,2)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 11164400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 10617200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 25-27:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/delayed_invalid_gas_by_value.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/delayed_invalid_gas_by_value.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-13:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 4529600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 3982400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 15-17:
 Error: Transaction Effects Status: Invalid command argument at 0. Invalid usage of value. Mutably borrowed values require unique usage. Immutably borrowed values cannot be taken or borrowed mutably. Taken values cannot be used again.

--- a/crates/sui-adapter-transactional-tests/tests/programmable/delayed_invalid_object_by_value.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/delayed_invalid_object_by_value.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-32:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 6300400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5753200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 34-35:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/gas_coin_by_reference.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/gas_coin_by_reference.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-24:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 4605600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4058400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 25-26:
 mutated: object(0,0)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/gas_coin_by_value_invalid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/gas_coin_by_value_invalid.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-23:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 4408000,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 3860800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 24-25:
 Error: Transaction Effects Status: Invalid command argument at 0. Invalid taking of the Gas coin. It can only be used by-value with TransferObjects

--- a/crates/sui-adapter-transactional-tests/tests/programmable/generics_substitution.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/generics_substitution.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-26:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 6004000,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5456800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 27-36:
 mutated: object(0,1)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/invalid_option.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/invalid_option.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-17:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 4970400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4423200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 19-20:
 Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type

--- a/crates/sui-adapter-transactional-tests/tests/programmable/invalid_public_function_return.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/invalid_public_function_return.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-16:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 5228800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4681600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 18-19:
 Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 0

--- a/crates/sui-adapter-transactional-tests/tests/programmable/invalid_result_arity.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/invalid_result_arity.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-15:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 5092000,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4544800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 17-19:
 Error: Transaction Effects Status: Invalid command argument at 0. Invalid usage of result 0, expected a single result but found either no return values or multiple.

--- a/crates/sui-adapter-transactional-tests/tests/programmable/make_vec_objects.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/make_vec_objects.exp
@@ -6,7 +6,7 @@ A: object(0,0), B: object(0,1)
 task 1 'publish'. lines 8-47:
 created: object(1,0)
 mutated: object(0,2)
-gas summary: computation_cost: 1000000, storage_cost: 7706400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 7159200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 48-55:
 mutated: object(0,0)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/make_vec_special_validation_invalid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/make_vec_special_validation_invalid.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-31:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 6596800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 6049600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 33-36:
 Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type

--- a/crates/sui-adapter-transactional-tests/tests/programmable/merge_coin_mismatched_coin.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/merge_coin_mismatched_coin.exp
@@ -7,7 +7,7 @@ task 1 'publish'. lines 8-23:
 events: Event { package_id: test, transaction_module: Identifier("fake"), sender: A, type_: StructTag { address: sui, module: Identifier("coin"), name: Identifier("CurrencyCreated"), type_params: [Struct(StructTag { address: test, module: Identifier("fake"), name: Identifier("FAKE"), type_params: [] })] }, contents: [2] }
 created: object(1,0), object(1,1), object(1,2)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 11164400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 10617200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 25-27:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/nested_result_zero_zero.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/nested_result_zero_zero.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-13:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 4590400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4043200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 15-18:
 mutated: object(0,1)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/non_primitive_non_object_arguments.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/non_primitive_non_object_arguments.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-19:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 5206000,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4658800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 21-26:
 mutated: object(0,1)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/out_of_bounds_input.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/out_of_bounds_input.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-15:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 5213600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4666400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 17-18:
 Error: Transaction Effects Status: Invalid command argument at 0. Out of bounds access to input or result vector 0

--- a/crates/sui-adapter-transactional-tests/tests/programmable/out_of_bounds_nested.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/out_of_bounds_nested.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-16:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 5411200,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4864000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 18-20:
 Error: Transaction Effects Status: Invalid command argument at 0. Out of bounds secondary access to result vector 0 at secondary index 2

--- a/crates/sui-adapter-transactional-tests/tests/programmable/out_of_bounds_result.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/out_of_bounds_result.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-16:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 5342800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4795600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 18-19:
 Error: Transaction Effects Status: Invalid command argument at 0. Out of bounds access to input or result vector 0

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_by_ref_input_invalid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_by_ref_input_invalid.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 9-21:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 5601200,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5054000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 23-28:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_by_ref_input_valid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_by_ref_input_valid.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 9-25:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 6049600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5502400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 27-29:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_copied_input_valid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_copied_input_valid.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 9-13:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 4096400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 3549200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 15-17:
 mutated: object(0,1)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_make_move_vec_invalid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_make_move_vec_invalid.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 9-21:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 5950800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5403600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 23-27:
 created: object(2,0), object(2,1), object(2,2)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_make_move_vec_valid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_make_move_vec_valid.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 9-29:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 6794400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 6247200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 31-35:
 created: object(2,0), object(2,1), object(2,2)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_non_pure_input_invalid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_non_pure_input_invalid.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-16:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 4552400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4005200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 17-19:
 Error: Transaction Effects Status: Invalid command argument at 0. Invalid argument to private entry function. These functions cannot take arguments from other Move functions

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_per_argument.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_per_argument.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-18:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 5479600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4932400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 20-23:
 created: object(2,0), object(2,1)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_type_check.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_entry_value_restriction_type_check.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-18:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 5449200,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4902000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 20-22:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_transfer_invalid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_transfer_invalid.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-20:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 5776000,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5228800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 22-24:
 Error: Transaction Effects Status: Non Entry Function Invoked. Move Call must start with an entry function

--- a/crates/sui-adapter-transactional-tests/tests/programmable/private_transfer_valid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/private_transfer_valid.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-15:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 5175600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4628400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 17-19:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_type_change.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_type_change.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-27:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 5874800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5327600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 29-35:
 Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type

--- a/crates/sui-adapter-transactional-tests/tests/programmable/split_coins.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/split_coins.exp
@@ -6,7 +6,7 @@ A: object(0,0), B: object(0,1)
 task 1 'publish'. lines 9-26:
 created: object(1,0)
 mutated: object(0,2)
-gas summary: computation_cost: 1000000, storage_cost: 5874800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5327600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 28-32:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/split_coins_invalid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/split_coins_invalid.exp
@@ -6,7 +6,7 @@ A: object(0,0), B: object(0,1), C: object(0,2)
 task 1 'publish'. lines 9-26:
 created: object(1,0)
 mutated: object(0,3)
-gas summary: computation_cost: 1000000, storage_cost: 6110400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5563200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 28-32:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/transfer_objects.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/transfer_objects.exp
@@ -6,7 +6,7 @@ A: object(0,0), B: object(0,1)
 task 1 'publish'. lines 8-35:
 created: object(1,0)
 mutated: object(0,2)
-gas summary: computation_cost: 1000000, storage_cost: 6551200,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 6004000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 36-38:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/transfer_objects_invalid_address.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/transfer_objects_invalid_address.exp
@@ -6,7 +6,7 @@ A: object(0,0), B: object(0,1)
 task 1 'publish'. lines 8-31:
 created: object(1,0)
 mutated: object(0,2)
-gas summary: computation_cost: 1000000, storage_cost: 6178800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5631600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 32-36:
 Error: Transaction Effects Status: Invalid command argument at 1. The argument cannot be deserialized into a value of the specified type

--- a/crates/sui-adapter-transactional-tests/tests/programmable/transfer_objects_invalid_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/transfer_objects_invalid_object.exp
@@ -6,7 +6,7 @@ A: object(0,0), B: object(0,1)
 task 1 'publish'. lines 8-38:
 created: object(1,0)
 mutated: object(0,2)
-gas summary: computation_cost: 1000000, storage_cost: 6695600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 6148400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 39-42:
 Error: TransferObjects, MergeCoin, and Publish cannot have empty arguments. If MakeMoveVec has empty arguments, it must have a type specified

--- a/crates/sui-adapter-transactional-tests/tests/programmable/unused_values_invalid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/unused_values_invalid.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-27:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 7151600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 6604400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 29-34:
 Error: Transaction Effects Status: Unused result without the drop ability. Command result 2, return value 0

--- a/crates/sui-adapter-transactional-tests/tests/programmable/unused_values_valid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/unused_values_valid.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-33:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 7790000,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 7242800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 34-38:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/coin_limit.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/coin_limit.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 6-28:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 7197200,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 6650000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 29-32:
 created: object(2,0), object(2,1)

--- a/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/make_vec.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/make_vec.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 6-53:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 9256800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 8709600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 55-61:
 mutated: object(0,1)

--- a/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/receipt.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/receipt.exp
@@ -3,7 +3,7 @@ processed 4 tasks
 task 1 'publish'. lines 6-27:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 6771600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 6224400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 29-33:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/publish/init.exp
+++ b/crates/sui-adapter-transactional-tests/tests/publish/init.exp
@@ -3,7 +3,7 @@ processed 4 tasks
 task 1 'publish'. lines 6-23:
 created: object(1,0), object(1,1)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 7189600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 6642400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'view-object'. lines 25-25:
 Owner: Account Address ( _ )

--- a/crates/sui-adapter-transactional-tests/tests/publish/multi_module_publish.exp
+++ b/crates/sui-adapter-transactional-tests/tests/publish/multi_module_publish.exp
@@ -3,7 +3,7 @@ processed 3 tasks
 task 1 'publish'. lines 6-15:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 5593600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5046400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'view-object'. lines 17-17:
 1,0::{M1, M2}

--- a/crates/sui-adapter-transactional-tests/tests/publish/publish_with_upgrade.exp
+++ b/crates/sui-adapter-transactional-tests/tests/publish/publish_with_upgrade.exp
@@ -3,7 +3,7 @@ processed 3 tasks
 task 1 'publish'. lines 6-10:
 created: object(1,0), object(1,1)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 6080000,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5532800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'view-object'. lines 12-12:
 Owner: Account Address ( _ )

--- a/crates/sui-adapter-transactional-tests/tests/runtime_behavior/error_locations.exp
+++ b/crates/sui-adapter-transactional-tests/tests/runtime_behavior/error_locations.exp
@@ -3,7 +3,7 @@ processed 6 tasks
 task 1 'publish'. lines 8-30:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 4879200,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4332000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 32-32:
 Error: Transaction Effects Status: Move Runtime Abort. Location: test::m::abort_ (function index 0) at offset 1, Abort Code: 0

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object.exp
@@ -3,12 +3,12 @@ processed 7 tasks
 task 1 'publish'. lines 8-28:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 5890000,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5342800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'publish'. lines 30-38:
 created: object(2,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 5000800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1000000, storage_cost: 4453600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 3 'run'. lines 41-41:
 created: object(3,0)

--- a/crates/sui-adapter-transactional-tests/tests/shared/upgrade.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/upgrade.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-40:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 7987600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 7440400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 42-42:
 created: object(2,0), object(2,1), object(2,2), object(2,3)

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/deleted_id_limits_tests.exp
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/deleted_id_limits_tests.exp
@@ -3,7 +3,7 @@ processed 11 tasks
 task 1 'publish'. lines 8-35:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 5806400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5259200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 36-38:
 mutated: object(0,0)
@@ -15,7 +15,7 @@ gas summary: computation_cost: 10000000, storage_cost: 13,  storage_rebate: 9880
 
 task 4 'run'. lines 42-44:
 Error: Transaction Effects Status: Insufficient Gas.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: Some(ExecutionState { stack_trace: [(Some(ModuleId { address: sui, name: Identifier("object") }), FunctionDefinitionIndex(10), 1), (Some(ModuleId { address: Test, name: Identifier("M1") }), FunctionDefinitionIndex(0), 10)] }), location: Module(ModuleId { address: sui, name: Identifier("tx_context") }), indices: [], offsets: [(FunctionDefinitionIndex(3), 7)] }), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: Some(ExecutionState { stack_trace: [(Some(ModuleId { address: sui, name: Identifier("object") }), FunctionDefinitionIndex(10), 1), (Some(ModuleId { address: Test, name: Identifier("M1") }), FunctionDefinitionIndex(0), 10)] }), location: Module(ModuleId { address: sui, name: Identifier("tx_context") }), indices: [], offsets: [(FunctionDefinitionIndex(3), 15)] }), command: Some(0) } }
 
 task 5 'run'. lines 45-47:
 mutated: object(0,0)
@@ -23,7 +23,7 @@ gas summary: computation_cost: 50000000, storage_cost: 13,  storage_rebate: 9880
 
 task 6 'run'. lines 48-50:
 Error: Transaction Effects Status: Insufficient Gas.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: Some(ExecutionState { stack_trace: [(Some(ModuleId { address: sui, name: Identifier("object") }), FunctionDefinitionIndex(10), 1), (Some(ModuleId { address: Test, name: Identifier("M1") }), FunctionDefinitionIndex(0), 10)] }), location: Module(ModuleId { address: sui, name: Identifier("tx_context") }), indices: [], offsets: [(FunctionDefinitionIndex(3), 7)] }), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: Some(ExecutionState { stack_trace: [(Some(ModuleId { address: sui, name: Identifier("object") }), FunctionDefinitionIndex(10), 1), (Some(ModuleId { address: Test, name: Identifier("M1") }), FunctionDefinitionIndex(0), 10)] }), location: Module(ModuleId { address: sui, name: Identifier("tx_context") }), indices: [], offsets: [(FunctionDefinitionIndex(3), 15)] }), command: Some(0) } }
 
 task 7 'run'. lines 51-53:
 Error: Transaction Effects Status: Move Primitive Runtime Error. Location: sui::tx_context::derive_id (function index 5) at offset 0. Arithmetic error, stack overflow, max value depth, etc.

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/event_limits_tests.exp
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/event_limits_tests.exp
@@ -3,7 +3,7 @@ processed 13 tasks
 task 1 'publish'. lines 8-57:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 7873600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 7326400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 58-60:
 events: Event { package_id: Test, transaction_module: Identifier("M1"), sender: _, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("NewValueEvent"), type_params: [] }, contents: [3, 9, 9, 9] }
@@ -12,7 +12,7 @@ gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 9
 
 task 3 'run'. lines 61-63:
 Error: Transaction Effects Status: Insufficient Gas.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: Some(ExecutionState { stack_trace: [(Some(ModuleId { address: Test, name: Identifier("M1") }), FunctionDefinitionIndex(1), 8)] }), location: Module(ModuleId { address: Test, name: Identifier("M1") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 27)] }), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: Some(ExecutionState { stack_trace: [(Some(ModuleId { address: Test, name: Identifier("M1") }), FunctionDefinitionIndex(1), 8)] }), location: Module(ModuleId { address: Test, name: Identifier("M1") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 32)] }), command: Some(0) } }
 
 task 4 'run'. lines 64-66:
 Error: Transaction Effects Status: Move Primitive Runtime Error. Location: sui::event::emit (function index 0) at offset 0. Arithmetic error, stack overflow, max value depth, etc.
@@ -24,15 +24,15 @@ Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { k
 
 task 6 'run'. lines 70-72:
 Error: Transaction Effects Status: Insufficient Gas.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: Some(ExecutionState { stack_trace: [] }), location: Module(ModuleId { address: Test, name: Identifier("M1") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 26)] }), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: Some(ExecutionState { stack_trace: [] }), location: Module(ModuleId { address: Test, name: Identifier("M1") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 31)] }), command: Some(0) } }
 
 task 7 'run'. lines 73-75:
 Error: Transaction Effects Status: Insufficient Gas.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: Some(ExecutionState { stack_trace: [] }), location: Module(ModuleId { address: Test, name: Identifier("M1") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 26)] }), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: Some(ExecutionState { stack_trace: [] }), location: Module(ModuleId { address: Test, name: Identifier("M1") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 31)] }), command: Some(0) } }
 
 task 8 'run'. lines 76-78:
 Error: Transaction Effects Status: Insufficient Gas.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: Some(ExecutionState { stack_trace: [] }), location: Module(ModuleId { address: Test, name: Identifier("M1") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 26)] }), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: Some(ExecutionState { stack_trace: [] }), location: Module(ModuleId { address: Test, name: Identifier("M1") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 31)] }), command: Some(0) } }
 
 task 9 'run'. lines 79-83:
 Error: Transaction Effects Status: Move Primitive Runtime Error. Location: sui::event::emit (function index 0) at offset 0. Arithmetic error, stack overflow, max value depth, etc.
@@ -40,12 +40,12 @@ Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { k
 
 task 10 'run'. lines 84-86:
 Error: Transaction Effects Status: Insufficient Gas.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: Some(ExecutionState { stack_trace: [(Some(ModuleId { address: Test, name: Identifier("M1") }), FunctionDefinitionIndex(1), 8)] }), location: Module(ModuleId { address: Test, name: Identifier("M1") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 27)] }), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: Some(ExecutionState { stack_trace: [(Some(ModuleId { address: Test, name: Identifier("M1") }), FunctionDefinitionIndex(1), 8)] }), location: Module(ModuleId { address: Test, name: Identifier("M1") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 34)] }), command: Some(0) } }
 
 task 11 'run'. lines 87-89:
 Error: Transaction Effects Status: Insufficient Gas.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: Some(ExecutionState { stack_trace: [(Some(ModuleId { address: Test, name: Identifier("M1") }), FunctionDefinitionIndex(1), 8)] }), location: Module(ModuleId { address: Test, name: Identifier("M1") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 27)] }), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: Some(ExecutionState { stack_trace: [(Some(ModuleId { address: Test, name: Identifier("M1") }), FunctionDefinitionIndex(1), 8)] }), location: Module(ModuleId { address: Test, name: Identifier("M1") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 34)] }), command: Some(0) } }
 
 task 12 'run'. lines 90-90:
 Error: Transaction Effects Status: Insufficient Gas.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: Some(ExecutionState { stack_trace: [] }), location: Module(ModuleId { address: Test, name: Identifier("M1") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 26)] }), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: Some(ExecutionState { stack_trace: [] }), location: Module(ModuleId { address: Test, name: Identifier("M1") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 31)] }), command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/move_object_size_limit.exp
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/move_object_size_limit.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-79:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 10510800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 9963600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 80-82:
 Error: Transaction Effects Status: Move object with size 256001 is larger than the maximum object size 256000

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/new_id_limits_tests.exp
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/new_id_limits_tests.exp
@@ -3,7 +3,7 @@ processed 12 tasks
 task 1 'publish'. lines 8-34:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 5806400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5259200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 35-37:
 mutated: object(0,0)

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/object_runtime_limits.exp
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/object_runtime_limits.exp
@@ -6,19 +6,19 @@ A: object(0,0)
 task 1 'publish'. lines 7-28:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 6368800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5821600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 30-30:
 Error: Transaction Effects Status: Insufficient Gas.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: Some(ExecutionState { stack_trace: [(Some(ModuleId { address: sui, name: Identifier("object") }), FunctionDefinitionIndex(10), 1), (Some(ModuleId { address: a, name: Identifier("m") }), FunctionDefinitionIndex(0), 8)] }), location: Module(ModuleId { address: sui, name: Identifier("tx_context") }), indices: [], offsets: [(FunctionDefinitionIndex(3), 16)] }), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: Some(ExecutionState { stack_trace: [] }), location: Module(ModuleId { address: a, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 12)] }), command: Some(0) } }
 
 task 3 'run'. lines 32-32:
 Error: Transaction Effects Status: Insufficient Gas.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: Some(ExecutionState { stack_trace: [(Some(ModuleId { address: sui, name: Identifier("object") }), FunctionDefinitionIndex(10), 1), (Some(ModuleId { address: a, name: Identifier("m") }), FunctionDefinitionIndex(0), 8)] }), location: Module(ModuleId { address: sui, name: Identifier("tx_context") }), indices: [], offsets: [(FunctionDefinitionIndex(3), 16)] }), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: Some(ExecutionState { stack_trace: [] }), location: Module(ModuleId { address: a, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 12)] }), command: Some(0) } }
 
 task 4 'run'. lines 34-34:
 Error: Transaction Effects Status: Insufficient Gas.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: Some(ExecutionState { stack_trace: [(Some(ModuleId { address: sui, name: Identifier("object") }), FunctionDefinitionIndex(10), 1), (Some(ModuleId { address: a, name: Identifier("m") }), FunctionDefinitionIndex(0), 8)] }), location: Module(ModuleId { address: sui, name: Identifier("tx_context") }), indices: [], offsets: [(FunctionDefinitionIndex(3), 16)] }), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: Some(ExecutionState { stack_trace: [] }), location: Module(ModuleId { address: a, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 12)] }), command: Some(0) } }
 
 task 5 'run'. lines 36-36:
 Error: Transaction Effects Status: Move Primitive Runtime Error. Location: sui::dynamic_field::has_child_object (function index 14) at offset 0. Arithmetic error, stack overflow, max value depth, etc.

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/transfered_id_limits_tests.exp
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/transfered_id_limits_tests.exp
@@ -3,7 +3,7 @@ processed 9 tasks
 task 1 'publish'. lines 8-35:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 6125600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5578400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 36-38:
 created: object(2,0)
@@ -12,19 +12,19 @@ gas summary: computation_cost: 1000000, storage_cost: 2219200,  storage_rebate: 
 
 task 3 'run'. lines 39-41:
 Error: Transaction Effects Status: Insufficient Gas.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: sui, name: Identifier("tx_context") }), indices: [], offsets: [(FunctionDefinitionIndex(5), 0)] }), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: Some(ExecutionState { stack_trace: [(Some(ModuleId { address: sui, name: Identifier("object") }), FunctionDefinitionIndex(10), 1), (Some(ModuleId { address: Test, name: Identifier("M1") }), FunctionDefinitionIndex(0), 8)] }), location: Module(ModuleId { address: sui, name: Identifier("tx_context") }), indices: [], offsets: [(FunctionDefinitionIndex(3), 16)] }), command: Some(0) } }
 
 task 4 'run'. lines 42-44:
 Error: Transaction Effects Status: Insufficient Gas.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: sui, name: Identifier("tx_context") }), indices: [], offsets: [(FunctionDefinitionIndex(5), 0)] }), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: Some(ExecutionState { stack_trace: [(Some(ModuleId { address: sui, name: Identifier("object") }), FunctionDefinitionIndex(10), 1), (Some(ModuleId { address: Test, name: Identifier("M1") }), FunctionDefinitionIndex(0), 8)] }), location: Module(ModuleId { address: sui, name: Identifier("tx_context") }), indices: [], offsets: [(FunctionDefinitionIndex(3), 16)] }), command: Some(0) } }
 
 task 5 'run'. lines 45-47:
 Error: Transaction Effects Status: Insufficient Gas.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: sui, name: Identifier("tx_context") }), indices: [], offsets: [(FunctionDefinitionIndex(5), 0)] }), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: Some(ExecutionState { stack_trace: [(Some(ModuleId { address: sui, name: Identifier("object") }), FunctionDefinitionIndex(10), 1), (Some(ModuleId { address: Test, name: Identifier("M1") }), FunctionDefinitionIndex(0), 8)] }), location: Module(ModuleId { address: sui, name: Identifier("tx_context") }), indices: [], offsets: [(FunctionDefinitionIndex(3), 16)] }), command: Some(0) } }
 
 task 6 'run'. lines 48-50:
 Error: Transaction Effects Status: Insufficient Gas.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: sui, name: Identifier("tx_context") }), indices: [], offsets: [(FunctionDefinitionIndex(5), 0)] }), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: Some(VMError { major_status: OUT_OF_GAS, sub_status: None, message: None, exec_state: Some(ExecutionState { stack_trace: [(Some(ModuleId { address: sui, name: Identifier("object") }), FunctionDefinitionIndex(10), 1), (Some(ModuleId { address: Test, name: Identifier("M1") }), FunctionDefinitionIndex(0), 8)] }), location: Module(ModuleId { address: sui, name: Identifier("tx_context") }), indices: [], offsets: [(FunctionDefinitionIndex(3), 16)] }), command: Some(0) } }
 
 task 7 'run'. lines 51-53:
 Error: Transaction Effects Status: Move Primitive Runtime Error. Location: sui::tx_context::derive_id (function index 5) at offset 0. Arithmetic error, stack overflow, max value depth, etc.

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/vector_len_limits.exp
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/vector_len_limits.exp
@@ -3,7 +3,7 @@ processed 10 tasks
 task 1 'publish'. lines 8-30:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 4864000,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4316800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 31-33:
 mutated: object(0,0)
@@ -15,7 +15,7 @@ gas summary: computation_cost: 5000000, storage_cost: 13,  storage_rebate: 13, n
 
 task 4 'run'. lines 37-39:
 mutated: object(0,0)
-gas summary: computation_cost: 2100352000, storage_cost: 13,  storage_rebate: 13, non_refundable_storage_fee: 0
+gas summary: computation_cost: 2100351000, storage_cost: 13,  storage_rebate: 13, non_refundable_storage_fee: 0
 
 task 5 'run'. lines 40-44:
 Error: Transaction Effects Status: Move Primitive Runtime Error. Location: Test::M1::push_n_items (function index 0) at offset 11. Arithmetic error, stack overflow, max value depth, etc.
@@ -31,7 +31,7 @@ gas summary: computation_cost: 5000000, storage_cost: 13,  storage_rebate: 13, n
 
 task 8 'run'. lines 51-53:
 mutated: object(0,0)
-gas summary: computation_cost: 2100352000, storage_cost: 13,  storage_rebate: 13, non_refundable_storage_fee: 0
+gas summary: computation_cost: 2100351000, storage_cost: 13,  storage_rebate: 13, non_refundable_storage_fee: 0
 
 task 9 'run'. lines 54-54:
 Error: Transaction Effects Status: Move Primitive Runtime Error. Location: Test::M1::push_n_items (function index 0) at offset 11. Arithmetic error, stack overflow, max value depth, etc.

--- a/crates/sui-adapter-transactional-tests/tests/sui/coin_in_vec.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/coin_in_vec.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 6-32:
 created: object(1,0), object(1,1)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 8474000,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 7926800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'programmable'. lines 34-36:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/sui/freeze.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/freeze.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-70:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 9788800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 9241600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 72-72:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/sui/move_call_args_type_mismatch.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/move_call_args_type_mismatch.exp
@@ -3,7 +3,7 @@ processed 4 tasks
 task 1 'publish'. lines 6-13:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 3967200,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 3420000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 14-16:
 Error: Transaction Effects Status: Arity mismatch for Move function. The number of arguments does not match the number of parameters

--- a/crates/sui-adapter-transactional-tests/tests/sui/move_call_incorrect_function.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/move_call_incorrect_function.exp
@@ -3,7 +3,7 @@ processed 4 tasks
 task 1 'publish'. lines 8-15:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 3967200,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 3420000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 16-18:
 Error: Transaction Effects Status: Move Bytecode Verification Error. Please run the Bytecode Verifier for more information.

--- a/crates/sui-adapter-transactional-tests/tests/sui/object_basics.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/object_basics.exp
@@ -6,7 +6,7 @@ A: object(0,0), B: object(0,1)
 task 1 'publish'. lines 8-70:
 created: object(1,0)
 mutated: object(0,2)
-gas summary: computation_cost: 1000000, storage_cost: 9788800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 9241600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 72-72:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/sui/unwrap.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/unwrap.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 9-71:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 9621600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 9074400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 73-73:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/sui/unwrap_then_freeze.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/unwrap_then_freeze.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 9-42:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 7493600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 6946400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 44-44:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/does_not_have_store.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/does_not_have_store.exp
@@ -6,7 +6,7 @@ A: object(0,0), B: object(0,1)
 task 1 'publish'. lines 8-29:
 created: object(1,0)
 mutated: object(0,2)
-gas summary: computation_cost: 1000000, storage_cost: 6330800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5783600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 31-31:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/has_store.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/has_store.exp
@@ -6,7 +6,7 @@ A: object(0,0), B: object(0,1)
 task 1 'publish'. lines 8-29:
 created: object(1,0)
 mutated: object(0,2)
-gas summary: computation_cost: 1000000, storage_cost: 6452400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5905200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 31-31:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/immutable.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/immutable.exp
@@ -6,7 +6,7 @@ A: object(0,0), B: object(0,1)
 task 1 'publish'. lines 8-22:
 created: object(1,0)
 mutated: object(0,2)
-gas summary: computation_cost: 1000000, storage_cost: 5912800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5365600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 24-24:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/package.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/package.exp
@@ -6,7 +6,7 @@ A: object(0,0), B: object(0,1)
 task 1 'publish'. lines 8-10:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 3724000,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 3176800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'view-object'. lines 13-13:
 1,0::m

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/quasi_shared.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/quasi_shared.exp
@@ -6,7 +6,7 @@ A: object(0,0), B: object(0,1)
 task 1 'publish'. lines 8-27:
 created: object(1,0)
 mutated: object(0,2)
-gas summary: computation_cost: 1000000, storage_cost: 6695600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 6148400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 29-29:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/shared.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/shared.exp
@@ -6,7 +6,7 @@ A: object(0,0), B: object(0,1)
 task 1 'publish'. lines 8-21:
 created: object(1,0)
 mutated: object(0,2)
-gas summary: computation_cost: 1000000, storage_cost: 5449200,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4902000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 23-23:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/wrap_unwrap.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/wrap_unwrap.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 8-41:
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 6771600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 6224400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'run'. lines 43-43:
 created: object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/basic.exp
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/basic.exp
@@ -6,7 +6,7 @@ A: object(0,0)
 task 1 'publish'. lines 6-11:
 created: object(1,0), object(1,1)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 6194000,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5646800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'upgrade'. lines 13-17:
 Error: Transaction Effects Status: Invalid package upgrade. New package is incompatible with previous version

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/multi_version.exp
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/multi_version.exp
@@ -6,12 +6,12 @@ A: object(0,0)
 task 1 'publish'. lines 6-10:
 created: object(1,0), object(1,1)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 6080000,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5532800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'upgrade'. lines 12-17:
 created: object(2,0)
 mutated: object(0,0), object(1,1)
-gas summary: computation_cost: 1000000, storage_cost: 6194000,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+gas summary: computation_cost: 1000000, storage_cost: 5646800,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
 
 task 3 'upgrade'. lines 19-23:
 Error: Transaction Effects Status: Invalid package upgrade. New package is incompatible with previous version

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -395,32 +395,20 @@ impl ObjectInfo {
 const PACKAGE: &str = "package";
 impl ObjectType {
     pub fn is_gas_coin(&self) -> bool {
-        match self {
-            ObjectType::Struct(s) => s.is_gas_coin(),
-            ObjectType::Package => false,
-        }
+        matches!(self, ObjectType::Struct(s) if s.is_gas_coin())
     }
 
     pub fn is_coin(&self) -> bool {
-        match self {
-            ObjectType::Struct(s) => s.is_coin(),
-            ObjectType::Package => false,
-        }
+        matches!(self, ObjectType::Struct(s) if s.is_coin())
     }
 
     /// Return true if `self` is `0x2::coin::Coin<t>`
     pub fn is_coin_t(&self, t: &TypeTag) -> bool {
-        match self {
-            ObjectType::Struct(s) => s.is_coin_t(t),
-            ObjectType::Package => false,
-        }
+        matches!(self, ObjectType::Struct(s) if s.is_coin_t(t))
     }
 
     pub fn is_package(&self) -> bool {
-        match self {
-            ObjectType::Struct(_) => false,
-            ObjectType::Package => true,
-        }
+        matches!(self, ObjectType::Package)
     }
 }
 

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/clock_ref.exp
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/clock_ref.exp
@@ -3,4 +3,4 @@ processed 1 task
 task 0 'publish'. lines 6-14:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 4499200,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 3952000,  storage_rebate: 0, non_refundable_storage_fee: 0

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/generic_and_generic_object_params.exp
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/generic_and_generic_object_params.exp
@@ -3,4 +3,4 @@ processed 1 task
 task 0 'publish'. lines 4-16:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 5145200,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4598000,  storage_rebate: 0, non_refundable_storage_fee: 0

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/generic_param_after_primitive.exp
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/generic_param_after_primitive.exp
@@ -3,4 +3,4 @@ processed 1 task
 task 0 'publish'. lines 4-16:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 5107200,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4560000,  storage_rebate: 0, non_refundable_storage_fee: 0

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/generic_with_key_valid.exp
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/generic_with_key_valid.exp
@@ -3,4 +3,4 @@ processed 1 task
 task 0 'publish'. lines 6-16:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 4879200,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4332000,  storage_rebate: 0, non_refundable_storage_fee: 0

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/id.exp
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/id.exp
@@ -3,4 +3,4 @@ processed 1 task
 task 0 'publish'. lines 6-21:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 4696800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4149600,  storage_rebate: 0, non_refundable_storage_fee: 0

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/nested_generic_vector_param.exp
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/nested_generic_vector_param.exp
@@ -3,4 +3,4 @@ processed 1 task
 task 0 'publish'. lines 4-13:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 4529600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 3982400,  storage_rebate: 0, non_refundable_storage_fee: 0

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/non_key_struct_generic_valid.exp
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/non_key_struct_generic_valid.exp
@@ -3,4 +3,4 @@ processed 1 task
 task 0 'publish'. lines 6-18:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 5114800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4567600,  storage_rebate: 0, non_refundable_storage_fee: 0

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/ok.exp
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/ok.exp
@@ -3,9 +3,9 @@ processed 2 tasks
 task 0 'publish'. lines 4-11:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 4476400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 3929200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 1 'publish'. lines 13-20:
 created: object(2,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 4476400,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1000000, storage_cost: 3929200,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/option.exp
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/option.exp
@@ -3,4 +3,4 @@ processed 1 task
 task 0 'publish'. lines 6-23:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 5137600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4590400,  storage_rebate: 0, non_refundable_storage_fee: 0

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/optional_txn_context.exp
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/optional_txn_context.exp
@@ -3,9 +3,9 @@ processed 2 tasks
 task 0 'publish'. lines 4-11:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 4316800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 3769600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 1 'publish'. lines 14-23:
 created: object(2,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 4940000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1000000, storage_cost: 4392800,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/return_values.exp
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/return_values.exp
@@ -3,24 +3,24 @@ processed 5 tasks
 task 0 'publish'. lines 6-13:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 4506800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 3959600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 1 'publish'. lines 15-22:
 created: object(2,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 4514400,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1000000, storage_cost: 3967200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 2 'publish'. lines 24-31:
 created: object(3,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 4514400,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1000000, storage_cost: 3967200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 3 'publish'. lines 33-41:
 created: object(4,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 5054000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1000000, storage_cost: 4506800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 4 'publish'. lines 43-51:
 created: object(5,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 5069200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1000000, storage_cost: 4522000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/single_generic_vector_param.exp
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/single_generic_vector_param.exp
@@ -3,4 +3,4 @@ processed 1 task
 task 0 'publish'. lines 4-13:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 4522000,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 3974800,  storage_rebate: 0, non_refundable_storage_fee: 0

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/single_type_param.exp
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/single_type_param.exp
@@ -3,4 +3,4 @@ processed 1 task
 task 0 'publish'. lines 4-13:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 4514400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 3967200,  storage_rebate: 0, non_refundable_storage_fee: 0

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/single_type_param_generic_object.exp
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/single_type_param_generic_object.exp
@@ -3,4 +3,4 @@ processed 1 task
 task 0 'publish'. lines 4-16:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 5122400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4575200,  storage_rebate: 0, non_refundable_storage_fee: 0

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/single_type_param_key.exp
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/single_type_param_key.exp
@@ -3,4 +3,4 @@ processed 1 task
 task 0 'publish'. lines 4-13:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 4514400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 3967200,  storage_rebate: 0, non_refundable_storage_fee: 0

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/string.exp
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/string.exp
@@ -3,4 +3,4 @@ processed 1 task
 task 0 'publish'. lines 6-31:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 5441600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4894400,  storage_rebate: 0, non_refundable_storage_fee: 0

--- a/crates/sui-verifier-transactional-tests/tests/id_immutable/mut_borrow_generic_key_struct_id_field.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_immutable/mut_borrow_generic_key_struct_id_field.exp
@@ -3,4 +3,4 @@ processed 1 task
 task 0 'publish'. lines 4-18:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 5008400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4461200,  storage_rebate: 0, non_refundable_storage_fee: 0

--- a/crates/sui-verifier-transactional-tests/tests/id_immutable/mut_borrow_key_struct_id_field.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_immutable/mut_borrow_key_struct_id_field.exp
@@ -3,4 +3,4 @@ processed 1 task
 task 0 'publish'. lines 4-18:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 4917200,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4370000,  storage_rebate: 0, non_refundable_storage_fee: 0

--- a/crates/sui-verifier-transactional-tests/tests/id_immutable/mut_borrow_key_struct_non_id_field.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_immutable/mut_borrow_key_struct_non_id_field.exp
@@ -3,4 +3,4 @@ processed 1 task
 task 0 'publish'. lines 4-19:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 4985600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4438400,  storage_rebate: 0, non_refundable_storage_fee: 0

--- a/crates/sui-verifier-transactional-tests/tests/id_immutable/mut_borrow_non_key_struct_id_field.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_immutable/mut_borrow_non_key_struct_id_field.exp
@@ -3,4 +3,4 @@ processed 1 task
 task 0 'publish'. lines 4-18:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 4917200,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4370000,  storage_rebate: 0, non_refundable_storage_fee: 0

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/direct_leak_through_call.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/direct_leak_through_call.exp
@@ -3,4 +3,4 @@ processed 1 task
 task 0 'publish'. lines 4-26:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 5137600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4590400,  storage_rebate: 0, non_refundable_storage_fee: 0

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/indirect_leak_through_call.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/indirect_leak_through_call.exp
@@ -7,4 +7,4 @@ Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { k
 task 1 'publish'. lines 28-50:
 created: object(2,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 5137600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1000000, storage_cost: 4590400,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/loop.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/loop.exp
@@ -3,4 +3,4 @@ processed 1 task
 task 0 'publish'. lines 4-34:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 6178800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 5631600,  storage_rebate: 0, non_refundable_storage_fee: 0

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/through_direct_return.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/through_direct_return.exp
@@ -3,4 +3,4 @@ processed 1 task
 task 0 'publish'. lines 4-20:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 4841200,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4294000,  storage_rebate: 0, non_refundable_storage_fee: 0

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/through_pack.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/through_pack.exp
@@ -7,4 +7,4 @@ Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { k
 task 1 'publish'. lines 39-62:
 created: object(2,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 5449200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1000000, storage_cost: 4902000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/through_vector.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/through_vector.exp
@@ -3,4 +3,4 @@ processed 1 task
 task 0 'publish'. lines 4-21:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 4909600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4362400,  storage_rebate: 0, non_refundable_storage_fee: 0

--- a/crates/sui-verifier-transactional-tests/tests/one_time_witness/bool_field.exp
+++ b/crates/sui-verifier-transactional-tests/tests/one_time_witness/bool_field.exp
@@ -3,4 +3,4 @@ processed 2 tasks
 task 1 'publish'. lines 8-15:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 4909600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4362400,  storage_rebate: 0, non_refundable_storage_fee: 0

--- a/crates/sui-verifier-transactional-tests/tests/one_time_witness/no_field.exp
+++ b/crates/sui-verifier-transactional-tests/tests/one_time_witness/no_field.exp
@@ -3,4 +3,4 @@ processed 2 tasks
 task 1 'publish'. lines 8-15:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 4917200,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4370000,  storage_rebate: 0, non_refundable_storage_fee: 0

--- a/crates/sui-verifier-transactional-tests/tests/one_time_witness/other_mod_def.exp
+++ b/crates/sui-verifier-transactional-tests/tests/one_time_witness/other_mod_def.exp
@@ -3,7 +3,7 @@ processed 3 tasks
 task 1 'publish'. lines 8-12:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 4202800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 3655600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'publish'. lines 14-19:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.

--- a/crates/sui-verifier-transactional-tests/tests/one_time_witness/wrong_field_type.exp
+++ b/crates/sui-verifier-transactional-tests/tests/one_time_witness/wrong_field_type.exp
@@ -3,4 +3,4 @@ processed 2 tasks
 task 1 'publish'. lines 8-20:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 5160400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4613200,  storage_rebate: 0, non_refundable_storage_fee: 0

--- a/crates/sui-verifier-transactional-tests/tests/private_generics/no_public_transfer.exp
+++ b/crates/sui-verifier-transactional-tests/tests/private_generics/no_public_transfer.exp
@@ -3,7 +3,7 @@ processed 5 tasks
 task 1 'publish'. lines 8-11:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 4514400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 3967200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'publish'. lines 13-18:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.

--- a/crates/sui-verifier-transactional-tests/tests/private_generics/no_public_transfer_store.exp
+++ b/crates/sui-verifier-transactional-tests/tests/private_generics/no_public_transfer_store.exp
@@ -3,7 +3,7 @@ processed 5 tasks
 task 1 'publish'. lines 8-11:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 4514400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 3967200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'publish'. lines 13-18:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.

--- a/crates/sui-verifier-transactional-tests/tests/private_generics/private_event_emit.exp
+++ b/crates/sui-verifier-transactional-tests/tests/private_generics/private_event_emit.exp
@@ -3,7 +3,7 @@ processed 6 tasks
 task 1 'publish'. lines 8-11:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 4202800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 3655600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'publish'. lines 13-18:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.

--- a/crates/sui-verifier-transactional-tests/tests/private_generics/public_transfer_with_store.exp
+++ b/crates/sui-verifier-transactional-tests/tests/private_generics/public_transfer_with_store.exp
@@ -3,19 +3,19 @@ processed 5 tasks
 task 1 'publish'. lines 9-12:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 4514400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 3967200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'publish'. lines 14-19:
 created: object(2,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 5707600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1000000, storage_cost: 5160400,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 3 'publish'. lines 21-26:
 created: object(3,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 5434000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1000000, storage_cost: 4886800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 4 'publish'. lines 28-33:
 created: object(4,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 5426400,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1000000, storage_cost: 4879200,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-verifier-transactional-tests/tests/private_generics/public_transfer_with_store_generic.exp
+++ b/crates/sui-verifier-transactional-tests/tests/private_generics/public_transfer_with_store_generic.exp
@@ -3,19 +3,19 @@ processed 5 tasks
 task 1 'publish'. lines 9-12:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 4567600,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4020400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2 'publish'. lines 14-22:
 created: object(2,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 5966000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1000000, storage_cost: 5418800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 3 'publish'. lines 24-32:
 created: object(3,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 5654400,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1000000, storage_cost: 5107200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 4 'publish'. lines 34-42:
 created: object(4,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 5646800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1000000, storage_cost: 5099600,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-verifier-transactional-tests/tests/struct_with_key/key_struct_id_field_valid.exp
+++ b/crates/sui-verifier-transactional-tests/tests/struct_with_key/key_struct_id_field_valid.exp
@@ -3,4 +3,4 @@ processed 1 task
 task 0 'publish'. lines 4-10:
 created: object(1,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1000000, storage_cost: 4514400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 3967200,  storage_rebate: 0, non_refundable_storage_fee: 0


### PR DESCRIPTION
## Description

As in title -- went in to handle a TODO from the deepbook integration PR, came out with some more changes. All changes to transactional tests come from the TODO change which reduces the size of published packages by removing a (redundant) linkage table entry.

## Test Plan

```
$ cargo simtest
$ env SUI_SKIP_SIMTESTS=1 cargo nextest run
```