### PR TITLE
[cherry-pick][framework] Finish implementation of system package publish (#10953)

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -45,7 +45,7 @@ use sui_config::genesis::Genesis;
 use sui_config::node::{
     AuthorityStorePruningConfig, DBCheckpointConfig, ExpensiveSafetyCheckConfig,
 };
-use sui_framework::BuiltInFramework;
+use sui_framework::{BuiltInFramework, SystemPackage};
 use sui_json_rpc_types::{
     Checkpoint, DevInspectResults, DryRunTransactionBlockResponse, EventFilter, SuiEvent,
     SuiMoveValue, SuiObjectDataFilter, SuiTransactionBlockData, SuiTransactionBlockEvents,
@@ -3124,7 +3124,16 @@ impl AuthorityState {
         max_binary_format_version: u32,
     ) -> Vec<ObjectRef> {
         let mut results = vec![];
-        for system_package in BuiltInFramework::iter_system_packages() {
+
+        let system_packages = BuiltInFramework::iter_system_packages();
+
+        // Add extra framework packages during simtest
+        #[cfg(msim)]
+        let extra_packages = framework_injection::get_extra_packages(self.name);
+        #[cfg(msim)]
+        let system_packages = system_packages.map(|p| p).chain(extra_packages.iter());
+
+        for system_package in system_packages {
             let modules = system_package.modules().to_vec();
             // In simtests, we could override the current built-in framework packages.
             #[cfg(msim)]
@@ -3142,6 +3151,7 @@ impl AuthorityState {
             };
             results.push(obj_ref);
         }
+
         results
     }
 
@@ -3168,21 +3178,33 @@ impl AuthorityState {
 
         let mut res = Vec::with_capacity(system_packages.len());
         for (system_package_ref, object) in system_packages.into_iter().zip(objects.iter()) {
-            let cur_object = object
-                .as_ref()
-                .unwrap_or_else(|| panic!("system package {:?} must exist", system_package_ref.0));
+            let prev_transaction = match object {
+                Some(cur_object) if cur_object.compute_object_reference() == system_package_ref => {
+                    // Skip this one because it doesn't need to be upgraded.
+                    info!("Framework {} does not need updating", system_package_ref.0);
+                    continue;
+                }
 
-            if cur_object.compute_object_reference() == system_package_ref {
-                // Skip this one because it doesn't need to be upgraded.
-                info!("Framework {} does not need updating", system_package_ref.0);
-                continue;
-            }
+                Some(cur_object) => cur_object.previous_transaction,
+                None => TransactionDigest::genesis(),
+            };
 
-            let system_package = BuiltInFramework::get_package_by_id(&system_package_ref.0);
-            let bytes = system_package.bytes().to_vec();
             #[cfg(msim)]
-            let bytes = framework_injection::get_override_bytes(&system_package_ref.0, self.name)
-                .unwrap_or(bytes);
+            let SystemPackage {
+                id: _,
+                bytes,
+                dependencies,
+            } = framework_injection::get_override_system_package(&system_package_ref.0, self.name)
+                .unwrap_or_else(|| {
+                    BuiltInFramework::get_package_by_id(&system_package_ref.0).clone()
+                });
+
+            #[cfg(not(msim))]
+            let SystemPackage {
+                id: _,
+                bytes,
+                dependencies,
+            } = BuiltInFramework::get_package_by_id(&system_package_ref.0).clone();
 
             let modules: Vec<_> = bytes
                 .iter()
@@ -3195,8 +3217,8 @@ impl AuthorityState {
             let new_object = Object::new_system_package(
                 &modules,
                 system_package_ref.1,
-                system_package.dependencies().to_vec(),
-                cur_object.previous_transaction,
+                dependencies.clone(),
+                prev_transaction,
             );
 
             let new_ref = new_object.compute_object_reference();
@@ -3207,11 +3229,7 @@ impl AuthorityState {
                 return None;
             }
 
-            res.push((
-                system_package_ref.1,
-                bytes,
-                system_package.dependencies().to_vec(),
-            ));
+            res.push((system_package_ref.1, bytes, dependencies));
         }
 
         Some(res)
@@ -3633,9 +3651,11 @@ mod tests {
 #[cfg(msim)]
 pub mod framework_injection {
     use move_binary_format::CompiledModule;
-    use std::cell::RefCell;
     use std::collections::BTreeMap;
+    use std::{cell::RefCell, collections::BTreeSet};
+    use sui_framework::{BuiltInFramework, SystemPackage};
     use sui_types::base_types::{AuthorityName, ObjectID};
+    use sui_types::is_system_package;
 
     type FrameworkOverrideConfig = BTreeMap<ObjectID, PackageOverrideConfig>;
 
@@ -3702,5 +3722,44 @@ pub mod framework_injection {
                 PackageOverrideConfig::PerValidator(func) => func(name),
             })
         })
+    }
+
+    pub fn get_override_system_package(
+        package_id: &ObjectID,
+        name: AuthorityName,
+    ) -> Option<SystemPackage> {
+        let bytes = get_override_bytes(package_id, name)?;
+        let dependencies = if is_system_package(*package_id) {
+            BuiltInFramework::get_package_by_id(package_id)
+                .dependencies()
+                .to_vec()
+        } else {
+            // Assume that entirely new injected packages depend on all existing system packages.
+            BuiltInFramework::all_package_ids()
+        };
+        Some(SystemPackage {
+            id: *package_id,
+            bytes,
+            dependencies,
+        })
+    }
+
+    pub fn get_extra_packages(name: AuthorityName) -> Vec<SystemPackage> {
+        let built_in = BTreeSet::from_iter(BuiltInFramework::all_package_ids().into_iter());
+        let extra: Vec<ObjectID> = OVERRIDE.with(|cfg| {
+            cfg.borrow()
+                .keys()
+                .filter_map(|package| (!built_in.contains(package)).then_some(*package))
+                .collect()
+        });
+
+        extra
+            .into_iter()
+            .map(|package| SystemPackage {
+                id: package,
+                bytes: get_override_bytes(&package, name).unwrap(),
+                dependencies: BuiltInFramework::all_package_ids(),
+            })
+            .collect()
     }
 }

--- a/crates/sui-framework/src/lib.rs
+++ b/crates/sui-framework/src/lib.rs
@@ -26,11 +26,11 @@ pub mod natives;
 
 /// Represents a system package in the framework, that's built from the source code inside
 /// sui-framework.
-#[derive(Serialize, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Serialize, PartialEq, Eq, Deserialize)]
 pub struct SystemPackage {
-    id: ObjectID,
-    bytes: Vec<Vec<u8>>,
-    dependencies: Vec<ObjectID>,
+    pub id: ObjectID,
+    pub bytes: Vec<Vec<u8>>,
+    pub dependencies: Vec<ObjectID>,
 }
 
 impl SystemPackage {

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -592,7 +592,9 @@ impl Object {
             previous_transaction,
         );
 
+        #[cfg(not(msim))]
         assert!(ret.is_system_package());
+
         ret
     }
 

--- a/crates/sui/tests/framework_upgrades/extra_package/Move.toml
+++ b/crates/sui/tests/framework_upgrades/extra_package/Move.toml
@@ -1,0 +1,11 @@
+[package]
+name = "SuiExtra"
+version = "0.0.1"
+
+[dependencies]
+SuiSystem = { local = "../../../../sui-framework/packages/sui-system" }
+Sui = { local = "../../../../sui-framework/packages/sui-framework" }
+MoveStdlib = { local = "../../../../sui-framework/packages/move-stdlib" }
+
+[addresses]
+sui_extra = "0x42"

--- a/crates/sui/tests/framework_upgrades/extra_package/sources/modules.move
+++ b/crates/sui/tests/framework_upgrades/extra_package/sources/modules.move
@@ -1,0 +1,20 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module sui_extra::msim_extra_1 {
+    use sui::object::{Self, UID};
+    use sui::transfer;
+    use sui::tx_context::TxContext;
+
+    struct S has key { id: UID }
+    
+    fun init(ctx: &mut TxContext) {
+        transfer::share_object(S {
+            id: object::new(ctx)
+        })
+    }
+
+    public fun canary(): u64 {
+        43
+    }
+}

--- a/crates/sui/tests/protocol_version_tests.rs
+++ b/crates/sui/tests/protocol_version_tests.rs
@@ -66,12 +66,14 @@ mod sim_only_tests {
     use std::sync::Arc;
     use sui_core::authority::framework_injection;
     use sui_framework::BuiltInFramework;
-    use sui_framework_build::compiled_package::BuildConfig;
+    use sui_framework_build::compiled_package::{BuildConfig, CompiledPackage};
     use sui_json_rpc::api::WriteApiClient;
     use sui_macros::*;
     use sui_protocol_config::SupportedProtocolVersions;
     use sui_types::base_types::ObjectID;
     use sui_types::id::ID;
+    use sui_types::messages::{Command, ProgrammableMoveCall, TransactionEffects};
+    use sui_types::object::Owner;
     use sui_types::sui_system_state::{
         epoch_start_sui_system_state::EpochStartSystemStateTrait, get_validator_from_table,
         SuiSystemState, SuiSystemStateTrait, SUI_SYSTEM_STATE_SIM_TEST_DEEP_V2,
@@ -314,7 +316,7 @@ mod sim_only_tests {
         expect_upgrade_succeeded(&cluster).await;
         assert_eq!(call_canary(&cluster).await, 43);
 
-        let (modified_at, mutated_to) = get_framework_upgrade_effects(&cluster).await;
+        let (modified_at, mutated_to) = get_framework_upgrade_versions(&cluster).await;
         assert_eq!(Some(SequenceNumber::from(1)), modified_at);
         assert_eq!(Some(SequenceNumber::from(2)), mutated_to);
     }
@@ -364,6 +366,62 @@ mod sim_only_tests {
         assert_eq!(call_canary(&cluster).await, 42);
     }
 
+    #[sim_test]
+    async fn test_new_framework_package() {
+        ProtocolConfig::poison_get_for_min_version();
+
+        let sui_extra = ObjectID::from_single_byte(0x42);
+        framework_injection::set_override(sui_extra, fixture_modules("extra_package"));
+
+        let cluster = TestClusterBuilder::new()
+            .with_epoch_duration_ms(20000)
+            .with_supported_protocol_versions(SupportedProtocolVersions::new_for_testing(
+                START, FINISH,
+            ))
+            .build()
+            .await
+            .unwrap();
+
+        expect_upgrade_succeeded(&cluster).await;
+
+        // Make sure the epoch change event includes the event from the new package's module
+        // initializer
+        let effects = get_framework_upgrade_effects(&cluster, &sui_extra).await;
+
+        let shared_id = effects
+            .created()
+            .iter()
+            .find_map(|(obj, owner)| {
+                if let Owner::Shared { .. } = owner {
+                    Some(obj.0)
+                } else {
+                    None
+                }
+            })
+            .unwrap();
+
+        let shared = get_object(&cluster, &shared_id).await;
+        let type_ = shared.type_().unwrap();
+        assert_eq!(type_.module().as_str(), "msim_extra_1");
+        assert_eq!(type_.name().as_str(), "S");
+
+        // Call a function from the newly published system package
+        assert_eq!(
+            dev_inspect_call(
+                &cluster,
+                ProgrammableMoveCall {
+                    package: sui_extra,
+                    module: ident_str!("msim_extra_1").to_owned(),
+                    function: ident_str!("canary").to_owned(),
+                    type_arguments: vec![],
+                    arguments: vec![],
+                }
+            )
+            .await,
+            43,
+        );
+    }
+
     async fn run_framework_upgrade(from: &str, to: &str) -> TestCluster {
         ProtocolConfig::poison_get_for_min_version();
 
@@ -380,20 +438,26 @@ mod sim_only_tests {
     }
 
     async fn call_canary(cluster: &TestCluster) -> u64 {
+        dev_inspect_call(
+            cluster,
+            ProgrammableMoveCall {
+                package: SUI_SYSTEM_PACKAGE_ID,
+                module: ident_str!("msim_extra_1").to_owned(),
+                function: ident_str!("canary").to_owned(),
+                type_arguments: vec![],
+                arguments: vec![],
+            },
+        )
+        .await
+    }
+
+    async fn dev_inspect_call(cluster: &TestCluster, call: ProgrammableMoveCall) -> u64 {
         let client = cluster.rpc_client();
         let sender = cluster.accounts.first().cloned().unwrap();
 
         let pt = {
             let mut builder = ProgrammableTransactionBuilder::new();
-            builder
-                .move_call(
-                    SUI_SYSTEM_PACKAGE_ID,
-                    ident_str!("msim_extra_1").to_owned(),
-                    ident_str!("canary").to_owned(),
-                    vec![],
-                    vec![],
-                )
-                .unwrap();
+            builder.command(Command::MoveCall(Box::new(call)));
             builder.finish()
         };
         let txn = TransactionKind::programmable(pt);
@@ -422,26 +486,10 @@ mod sim_only_tests {
         monitor_version_change(&cluster, FINISH /* expected proto version */).await;
     }
 
-    async fn get_framework_upgrade_effects(
+    async fn get_framework_upgrade_versions(
         cluster: &TestCluster,
     ) -> (Option<SequenceNumber>, Option<SequenceNumber>) {
-        let node_handle = cluster
-            .swarm
-            .validators()
-            .next()
-            .unwrap()
-            .get_node_handle()
-            .unwrap();
-
-        let effects = node_handle
-            .with_async(|node| async {
-                let db = node.state().db();
-                let framework = db.get_object(&SUI_SYSTEM_PACKAGE_ID);
-                let digest = framework.unwrap().unwrap().previous_transaction;
-                let effects = db.get_executed_effects(&digest);
-                effects.unwrap().unwrap()
-            })
-            .await;
+        let effects = get_framework_upgrade_effects(cluster, &SUI_SYSTEM_PACKAGE_ID).await;
 
         let modified_at = effects
             .modified_at_versions()
@@ -454,6 +502,43 @@ mod sim_only_tests {
             .find_map(|((id, v, _), _)| (id == &SUI_SYSTEM_PACKAGE_ID).then_some(*v));
 
         (modified_at, mutated_to)
+    }
+
+    async fn get_framework_upgrade_effects(
+        cluster: &TestCluster,
+        package: &ObjectID,
+    ) -> TransactionEffects {
+        let node_handle = cluster
+            .swarm
+            .validators()
+            .next()
+            .unwrap()
+            .get_node_handle()
+            .unwrap();
+
+        node_handle
+            .with_async(|node| async {
+                let db = node.state().db();
+                let framework = db.get_object(package);
+                let digest = framework.unwrap().unwrap().previous_transaction;
+                let effects = db.get_executed_effects(&digest);
+                effects.unwrap().unwrap()
+            })
+            .await
+    }
+
+    async fn get_object(cluster: &TestCluster, package: &ObjectID) -> Object {
+        let node_handle = cluster
+            .swarm
+            .validators()
+            .next()
+            .unwrap()
+            .get_node_handle()
+            .unwrap();
+
+        node_handle
+            .with_async(|node| async { node.state().db().get_object(package).unwrap().unwrap() })
+            .await
     }
 
     #[sim_test]
@@ -750,17 +835,13 @@ mod sim_only_tests {
         framework_injection::set_override_cb(SUI_SYSTEM_PACKAGE_ID, f)
     }
 
-    /// Get compiled modules for Sui Framework, built from fixture `fixture` in the
+    /// Get compiled modules for Sui System, built from fixture `fixture` in the
     /// `framework_upgrades` directory.
     fn sui_system_modules(fixture: &str) -> Vec<CompiledModule> {
-        let mut package = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        package.extend(["tests", "framework_upgrades", fixture]);
-
-        let mut config = BuildConfig::new_for_testing();
-        config.run_bytecode_verifier = true;
-
-        let pkg = config.build(package).unwrap();
-        pkg.get_sui_system_modules().cloned().collect()
+        fixture_package(fixture)
+            .get_sui_system_modules()
+            .cloned()
+            .collect()
     }
 
     /// Like `sui_system_modules`, but package the modules in an `Object`.
@@ -776,5 +857,20 @@ mod sim_only_tests {
             ],
         )
         .unwrap()
+    }
+
+    /// Get root compiled modules, built from fixture `fixture` in the `framework_upgrades`
+    /// directory.
+    fn fixture_modules(fixture: &str) -> Vec<CompiledModule> {
+        fixture_package(fixture).into_modules()
+    }
+
+    fn fixture_package(fixture: &str) -> CompiledPackage {
+        let mut package = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        package.extend(["tests", "framework_upgrades", fixture]);
+
+        let mut config = BuildConfig::new_for_testing();
+        config.run_bytecode_verifier = true;
+        config.build(package).unwrap()
     }
 }


### PR DESCRIPTION
## Description

If the validator binary includes a system package that doesn't exist on-chain, then during the protocol/framework upgrade that introduces it, we shoud run its module initializer. This aligns with the behaviour during genesis (where we already run the module initializer for system packages).

Note that the module init must succeed, or the validator panics (this is also the case when module initializers are run as part of genesis).

## Test Plan

New test for a framework upgrade that introduces a system package with a module initializer.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration