### PR TITLE
wallet-ext: confirmation dialog buttons size

### DIFF
--- a/apps/wallet/src/ui/app/shared/ConfirmationModal.tsx
+++ b/apps/wallet/src/ui/app/shared/ConfirmationModal.tsx
@@ -52,33 +52,31 @@ export function ConfirmationModal({
                 setIsCancelLoading(false);
             }}
             footer={
-                <div className="flex flex-row self-center gap-3">
-                    <div>
-                        <Button
-                            variant={cancelStyle}
-                            text={cancelText}
-                            loading={isCancelLoading}
-                            disabled={isConfirmLoading}
-                            onClick={async () => {
-                                setIsCancelLoading(true);
-                                await onResponse(false);
-                                setIsCancelLoading(false);
-                            }}
-                        />
-                    </div>
-                    <div>
-                        <Button
-                            variant={confirmStyle}
-                            text={confirmText}
-                            loading={isConfirmLoading}
-                            disabled={isCancelLoading}
-                            onClick={async () => {
-                                setIsConfirmLoading(true);
-                                await onResponse(true);
-                                setIsConfirmLoading(false);
-                            }}
-                        />
-                    </div>
+                <div className="flex flex-row self-stretch gap-3">
+                    <Button
+                        variant={cancelStyle}
+                        size="tall"
+                        text={cancelText}
+                        loading={isCancelLoading}
+                        disabled={isConfirmLoading}
+                        onClick={async () => {
+                            setIsCancelLoading(true);
+                            await onResponse(false);
+                            setIsCancelLoading(false);
+                        }}
+                    />
+                    <Button
+                        variant={confirmStyle}
+                        size="tall"
+                        text={confirmText}
+                        loading={isConfirmLoading}
+                        disabled={isCancelLoading}
+                        onClick={async () => {
+                            setIsConfirmLoading(true);
+                            await onResponse(true);
+                            setIsConfirmLoading(false);
+                        }}
+                    />
                 </div>
             }
         />


### PR DESCRIPTION
| before | after |
| - | - |
| <img width="419" alt="Screenshot 2023-04-17 at 18 09 58" src="https://user-images.githubusercontent.com/10210143/232559487-1f80968c-962f-4afe-b06f-73bb948750f9.png"> | <img width="419" alt="Screenshot 2023-04-17 at 18 06 48" src="https://user-images.githubusercontent.com/10210143/232559529-b079f2eb-f96b-4ee6-9dba-64b40cb95ab4.png"> |
| <img width="419" alt="Screenshot 2023-04-17 at 18 11 59" src="https://user-images.githubusercontent.com/10210143/232560022-1d96dc14-2e70-40e7-b628-ecffaaf8b7dc.png"> | <img width="419" alt="Screenshot 2023-04-17 at 18 12 22" src="https://user-images.githubusercontent.com/10210143/232560070-34ec3207-7e0b-4fbc-9b42-0eb46039259f.png"> |


addresses https://github.com/MystenLabs/sui/pull/10355#issuecomment-1502310267