### PR TITLE
Bump soft message size limit for sui network to 32 MiB

### DIFF
--- a/crates/sui-config/src/p2p.rs
+++ b/crates/sui-config/src/p2p.rs
@@ -54,7 +54,7 @@ impl Default for P2pConfig {
 
 impl P2pConfig {
     pub fn excessive_message_size(&self) -> usize {
-        const EXCESSIVE_MESSAGE_SIZE: usize = 8 << 20;
+        const EXCESSIVE_MESSAGE_SIZE: usize = 32 << 20;
 
         self.excessive_message_size
             .unwrap_or(EXCESSIVE_MESSAGE_SIZE)


### PR DESCRIPTION
## Description 

We expect state sync messages to reach this size sometimes due to max checkpoint size limit of 30M.

## Test Plan 

Manually inspect metrics/log output