### PR TITLE
[tiny] Return &Arc<Committee> from per epoch store

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1946,7 +1946,7 @@ impl AuthorityState {
     }
 
     pub fn clone_committee_for_testing(&self) -> Committee {
-        self.epoch_store_for_testing().committee().clone()
+        Committee::clone(self.epoch_store_for_testing().committee())
     }
 
     pub async fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -465,7 +465,7 @@ impl AuthorityPerEpochStore {
         )
     }
 
-    pub fn committee(&self) -> &Committee {
+    pub fn committee(&self) -> &Arc<Committee> {
         &self.committee
     }
 

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -1004,9 +1004,7 @@ impl CheckpointAggregator {
                     next_index: 0,
                     digest: summary.digest(),
                     summary,
-                    signatures: StakeAggregator::new(Arc::new(
-                        self.epoch_store.committee().clone(),
-                    )),
+                    signatures: StakeAggregator::new(self.epoch_store.committee().clone()),
                 });
                 self.current.as_mut().unwrap()
             };

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -3063,7 +3063,10 @@ async fn test_genesis_sui_system_state_object() {
         .unwrap();
     assert_eq!(
         &sui_system_state.get_current_epoch_committee().committee,
-        authority_state.epoch_store_for_testing().committee()
+        authority_state
+            .epoch_store_for_testing()
+            .committee()
+            .as_ref()
     );
 }
 


### PR DESCRIPTION
This avoids cloning committee on every checkpoint

