### PR TITLE
Increase number of pending certificates buffered at synchronizer

### DIFF
--- a/narwhal/primary/src/synchronizer.rs
+++ b/narwhal/primary/src/synchronizer.rs
@@ -49,7 +49,8 @@ pub mod synchronizer_tests;
 
 /// Only try to accept or suspend a certificate, if it is within this limit above the
 /// locally highest processed round.
-const NEW_CERTIFICATE_ROUND_LIMIT: Round = 100;
+/// Expected max memory usage with 100 nodes: 100 nodes * 1000 rounds * 3.3KB per certificate = 330MB.
+const NEW_CERTIFICATE_ROUND_LIMIT: Round = 1000;
 
 struct Inner {
     /// The id of this primary.

--- a/narwhal/primary/src/tests/synchronizer_tests.rs
+++ b/narwhal/primary/src/tests/synchronizer_tests.rs
@@ -208,11 +208,11 @@ async fn accept_suspended_certificates() {
         }
     }
 
-    // Create a certificate > 100 rounds above the highest local round.
+    // Create a certificate > 1000 rounds above the highest local round.
     let (_digest, cert) = mock_signed_certificate(
         keys.as_slice(),
         certificates.last().cloned().unwrap().origin(),
-        200,
+        2000,
         next_parents,
         &committee,
     );


### PR DESCRIPTION
## Description 

We have observed nodes being a few hundred rounds behind and having a hard time catching up. Increase the number of rounds of certificates to buffer, which should still be acceptable in memory usage, and hopefully help with catching up when the node is only a few hundred rounds behind.

## Test Plan 

Deploy to private testnet

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
