### PR TITLE
[cherry-pick][rpc] remove usage of block_on on fullnodes (#10986)

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2156,7 +2156,7 @@ impl AuthorityState {
     /// Depending on the object pruning policies that will be enforced in the
     /// future there is no software-level guarantee/SLA to retrieve an object
     /// with an old version even if it exists/existed.
-    pub async fn get_past_object_read(
+    pub fn get_past_object_read(
         &self,
         object_id: &ObjectID,
         version: SequenceNumber,

--- a/crates/sui-indexer/src/apis/read_api.rs
+++ b/crates/sui-indexer/src/apis/read_api.rs
@@ -226,7 +226,7 @@ where
         )?)
     }
 
-    async fn try_get_past_object(
+    fn try_get_past_object(
         &self,
         object_id: ObjectID,
         version: SequenceNumber,
@@ -237,10 +237,10 @@ where
             .indexer_metrics()
             .try_get_past_object_latency
             .start_timer();
-        let past_obj_resp = self
-            .fullnode
-            .try_get_past_object(object_id, version, options)
-            .await;
+        let past_obj_resp = block_on(
+            self.fullnode
+                .try_get_past_object(object_id, version, options),
+        );
         past_obj_guard.stop_and_record();
         past_obj_resp
     }

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -1856,20 +1856,26 @@ async fn get_network_metrics_cached(
 #[async_trait]
 impl ObjectProvider for PgIndexerStore {
     type Error = IndexerError;
-    async fn get_object(
+    fn get_object(
         &self,
-        id: &ObjectID,
-        version: &SequenceNumber,
+        _id: &ObjectID,
+        _version: &SequenceNumber,
     ) -> Result<sui_types::object::Object, Self::Error> {
-        self.get_sui_types_object(id, version).await
+        Err(IndexerError::NotSupportedError(
+            "Object cache is not supported".to_string(),
+        ))
+        // self.get_sui_types_object(id, version)
     }
 
-    async fn find_object_lt_or_eq_version(
+    fn find_object_lt_or_eq_version(
         &self,
-        id: &ObjectID,
-        version: &SequenceNumber,
+        _id: &ObjectID,
+        _version: &SequenceNumber,
     ) -> Result<Option<sui_types::object::Object>, Self::Error> {
-        self.find_sui_types_object_lt_or_eq_version(id, version)
-            .await
+        Err(IndexerError::NotSupportedError(
+            "find_object_lt_or_eq_version is not supported".to_string(),
+        ))
+        // self.find_sui_types_object_lt_or_eq_version(id, version)
+        //     .await
     }
 }

--- a/crates/sui-indexer/src/utils.rs
+++ b/crates/sui-indexer/src/utils.rs
@@ -149,7 +149,7 @@ pub async fn get_balance_changes_from_effect<P: ObjectProvider<Error = E>, E>(
         .into_iter()
         .map(|(id, version)| (id, version, None))
         .collect();
-    get_balance_changes(object_provider, &modified_at_versions, &all_mutated).await
+    get_balance_changes(object_provider, &modified_at_versions, &all_mutated)
 }
 
 pub async fn get_object_changes<P: ObjectProvider<Error = E>, E>(
@@ -199,5 +199,4 @@ pub async fn get_object_changes<P: ObjectProvider<Error = E>, E>(
         all_changed_objects,
         all_deleted_objects,
     )
-    .await
 }

--- a/crates/sui-json-rpc/src/api/read.rs
+++ b/crates/sui-json-rpc/src/api/read.rs
@@ -62,8 +62,8 @@ pub trait ReadApi {
     /// can be retrieved by this API, even if the object and version exists/existed.
     /// The result may vary across nodes depending on their pruning policies.
     /// Return the object information for a specified version
-    #[method(name = "tryGetPastObject")]
-    async fn try_get_past_object(
+    #[method(name = "tryGetPastObject", blocking)]
+    fn try_get_past_object(
         &self,
         /// the ID of the queried object
         object_id: ObjectID,

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -148,7 +148,7 @@ impl CoinReadApi {
 
         let object_id = async {
             for ((id, version, _), _) in created {
-                if let Ok(past_object) = self.state.get_past_object_read(id, *version).await {
+                if let Ok(past_object) = self.state.get_past_object_read(id, *version) {
                     if let Ok(object) = past_object.into_object() {
                         if matches!(object.type_(), Some(type_) if type_.is(&object_struct_tag)) {
                             return Ok(*id);

--- a/crates/sui-json-rpc/src/object_changes.rs
+++ b/crates/sui-json-rpc/src/object_changes.rs
@@ -10,7 +10,7 @@ use sui_types::storage::{DeleteKind, WriteKind};
 
 use crate::ObjectProvider;
 
-pub async fn get_object_changes<P: ObjectProvider<Error = E>, E>(
+pub fn get_object_changes<P: ObjectProvider<Error = E>, E>(
     object_provider: &P,
     sender: SuiAddress,
     modified_at_versions: &[(ObjectID, SequenceNumber)],
@@ -25,7 +25,7 @@ pub async fn get_object_changes<P: ObjectProvider<Error = E>, E>(
         .collect::<BTreeMap<_, _>>();
 
     for ((id, version, digest), owner, kind) in all_changed_objects {
-        let o = object_provider.get_object(id, version).await?;
+        let o = object_provider.get_object(id, version)?;
         if let Some(type_) = o.type_() {
             let object_type = type_.clone().into();
 
@@ -63,9 +63,7 @@ pub async fn get_object_changes<P: ObjectProvider<Error = E>, E>(
     }
 
     for ((id, version, _), kind) in all_deleted {
-        let o = object_provider
-            .find_object_lt_or_eq_version(id, version)
-            .await?;
+        let o = object_provider.find_object_lt_or_eq_version(id, version)?;
         if let Some(o) = o {
             if let Some(type_) = o.type_() {
                 let object_type = type_.clone().into();

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -7,8 +7,6 @@ use std::sync::Arc;
 use anyhow::anyhow;
 use async_trait::async_trait;
 use fastcrypto::encoding::Base64;
-use futures::executor::block_on;
-use futures::future::join_all;
 use itertools::Itertools;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::RpcModule;
@@ -131,7 +129,7 @@ impl ReadApi {
         })
     }
 
-    async fn multi_get_transaction_blocks_internal(
+    fn multi_get_transaction_blocks_internal(
         &self,
         digests: Vec<TransactionDigest>,
         opts: Option<SuiTransactionBlockResponseOptions>,
@@ -302,7 +300,7 @@ impl ReadApi {
 
         let object_cache = ObjectProviderCache::new(self.state.clone());
         if opts.show_balance_changes {
-            let mut futures = vec![];
+            let mut results = vec![];
             for resp in temp_response.values() {
                 let input_objects = if let Some(tx) = resp.transaction() {
                     tx.data()
@@ -315,7 +313,7 @@ impl ReadApi {
                     // don't have the input tx, so not much we can do. perhaps this is an Err?
                     Vec::new()
                 };
-                futures.push(get_balance_changes_from_effect(
+                results.push(get_balance_changes_from_effect(
                     &object_cache,
                     resp.effects.as_ref().ok_or_else(|| {
                         anyhow!("unable to derive balance changes because effect is empty")
@@ -324,7 +322,6 @@ impl ReadApi {
                     None,
                 ));
             }
-            let results = join_all(futures).await;
             for (result, entry) in results.into_iter().zip(temp_response.iter_mut()) {
                 match result {
                     Ok(balance_changes) => entry.1.balance_changes = Some(balance_changes),
@@ -337,13 +334,13 @@ impl ReadApi {
         }
 
         if opts.show_object_changes {
-            let mut futures = vec![];
+            let mut results = vec![];
             for resp in temp_response.values() {
                 let effects = resp.effects.as_ref().ok_or_else(|| {
                     anyhow!("unable to derive object changes because effect is empty")
                 })?;
 
-                futures.push(get_object_changes(
+                results.push(get_object_changes(
                     &object_cache,
                     resp.transaction
                         .as_ref()
@@ -359,7 +356,6 @@ impl ReadApi {
                     effects.all_deleted(),
                 ));
             }
-            let results = join_all(futures).await;
             for (result, entry) in results.into_iter().zip(temp_response.iter_mut()) {
                 match result {
                     Ok(object_changes) => entry.1.object_changes = Some(object_changes),
@@ -477,7 +473,7 @@ impl ReadApiServer for ReadApi {
         }
     }
 
-    async fn try_get_past_object(
+    fn try_get_past_object(
         &self,
         object_id: ObjectID,
         version: SequenceNumber,
@@ -486,7 +482,6 @@ impl ReadApiServer for ReadApi {
         let past_read = self
             .state
             .get_past_object_read(&object_id, version)
-            .await
             .map_err(|e| {
                 error!("Failed to call try_get_past_object for object: {object_id:?} version: {version:?} with error: {e:?}");
                 anyhow!("{e}")
@@ -529,17 +524,16 @@ impl ReadApiServer for ReadApi {
         options: Option<SuiObjectDataOptions>,
     ) -> RpcResult<Vec<SuiPastObjectResponse>> {
         if past_objects.len() <= QUERY_MAX_RESULT_LIMIT {
-            let results = block_on(async {
-                let mut futures = vec![];
-                for past_object in past_objects {
-                    futures.push(self.try_get_past_object(
+            let results: Vec<_> = past_objects
+                .iter()
+                .map(|past_object| {
+                    self.try_get_past_object(
                         past_object.object_id,
                         past_object.version,
                         options.clone(),
-                    ));
-                }
-                join_all(futures).await
-            });
+                    )
+                })
+                .collect();
             let (oks, errs): (Vec<_>, Vec<_>) = results.into_iter().partition(Result::is_ok);
             let success = oks.into_iter().filter_map(Result::ok).collect();
             let errors: Vec<_> = errs.into_iter().filter_map(Result::err).collect();
@@ -652,7 +646,6 @@ impl ReadApiServer for ReadApi {
             if let Some(effects) = &temp_response.effects {
                 let balance_changes =
                     get_balance_changes_from_effect(&object_cache, effects, input_objects, None)
-                        .await
                         .map_err(Error::SuiError)?;
                 temp_response.balance_changes = Some(balance_changes);
             }
@@ -670,7 +663,6 @@ impl ReadApiServer for ReadApi {
                     effects.all_changed_objects(),
                     effects.all_deleted(),
                 )
-                .await
                 .map_err(Error::SuiError)?;
                 temp_response.object_changes = Some(object_changes);
             }
@@ -688,9 +680,7 @@ impl ReadApiServer for ReadApi {
         digests: Vec<TransactionDigest>,
         opts: Option<SuiTransactionBlockResponseOptions>,
     ) -> RpcResult<Vec<SuiTransactionBlockResponse>> {
-        Ok(block_on(
-            self.multi_get_transaction_blocks_internal(digests, opts),
-        )?)
+        Ok(self.multi_get_transaction_blocks_internal(digests, opts)?)
     }
 
     fn get_events(&self, transaction_digest: TransactionDigest) -> RpcResult<Vec<SuiEvent>> {

--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -125,29 +125,23 @@ impl TransactionExecutionApi {
 
                 let object_cache = ObjectProviderCache::new(self.state.clone());
                 let balance_changes = if opts.show_balance_changes {
-                    Some(
-                        get_balance_changes_from_effect(
-                            &object_cache,
-                            &effects.effects,
-                            input_objs,
-                            None,
-                        )
-                        .await?,
-                    )
+                    Some(get_balance_changes_from_effect(
+                        &object_cache,
+                        &effects.effects,
+                        input_objs,
+                        None,
+                    )?)
                 } else {
                     None
                 };
                 let object_changes = if opts.show_object_changes {
-                    Some(
-                        get_object_changes(
-                            &object_cache,
-                            sender,
-                            effects.effects.modified_at_versions(),
-                            effects.effects.all_changed_objects(),
-                            effects.effects.all_deleted(),
-                        )
-                        .await?,
-                    )
+                    Some(get_object_changes(
+                        &object_cache,
+                        sender,
+                        effects.effects.modified_at_versions(),
+                        effects.effects.all_changed_objects(),
+                        effects.effects.all_deleted(),
+                    )?)
                 } else {
                     None
                 };
@@ -186,16 +180,14 @@ impl TransactionExecutionApi {
             &transaction_effects,
             input_objs,
             mock_gas,
-        )
-        .await?;
+        )?;
         let object_changes = get_object_changes(
             &object_cache,
             sender,
             transaction_effects.modified_at_versions(),
             transaction_effects.all_changed_objects(),
             transaction_effects.all_deleted(),
-        )
-        .await?;
+        )?;
 
         Ok(DryRunTransactionBlockResponse {
             effects: resp.effects,

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -927,10 +927,8 @@ async fn get_past_obj_read_from_node(
     object_id: ObjectID,
     seq_num: SequenceNumber,
 ) -> Result<(ObjectRef, Object, Option<MoveStructLayout>), anyhow::Error> {
-    if let PastObjectRead::VersionFound(obj_ref, object, layout) = node
-        .state()
-        .get_past_object_read(&object_id, seq_num)
-        .await?
+    if let PastObjectRead::VersionFound(obj_ref, object, layout) =
+        node.state().get_past_object_read(&object_id, seq_num)?
     {
         Ok((obj_ref, object, layout))
     } else {
@@ -998,8 +996,7 @@ async fn test_get_objects_read() -> Result<(), anyhow::Error> {
 
     let read_ref_v3 = match node
         .state()
-        .get_past_object_read(&object_id, object_ref_v3.1)
-        .await?
+        .get_past_object_read(&object_id, object_ref_v3.1)?
     {
         PastObjectRead::ObjectDeleted(obj_ref) => obj_ref,
         other => anyhow::bail!("Expect object {object_id:?} deleted but got {other:?}."),
@@ -1022,8 +1019,7 @@ async fn test_get_objects_read() -> Result<(), anyhow::Error> {
 
     match node
         .state()
-        .get_past_object_read(&object_id, too_high_version)
-        .await?
+        .get_past_object_read(&object_id, too_high_version)?
     {
         PastObjectRead::VersionTooHigh {
             object_id: obj_id,


### PR DESCRIPTION
## Description 

While @patrickkuo is experimenting with the removal of `spawn_blocking`, this PR removes the usage of `block_on`, which is expected to cause deadlock when using on the current run time

## Test Plan 

Tested on explorer and wallet traffic

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
