### PR TITLE
[checkpoints] Detect checkpoint hard fork early

### DIFF
--- a/crates/sui-core/src/stake_aggregator.rs
+++ b/crates/sui-core/src/stake_aggregator.rs
@@ -51,7 +51,13 @@ impl<S: Clone + Eq, const STRENGTH: bool> StakeAggregator<S, STRENGTH> {
     /// A generic version of inserting arbitrary type of V (e.g. void type).
     /// If V is AuthoritySignInfo, the `insert` function should be used instead since it does extra
     /// checks and aggregations in the end.
-    pub fn insert_generic(&mut self, authority: AuthorityName, s: S) -> InsertResult<()> {
+    /// Returns Map authority -> S, without aggregating it.
+    /// If you want to get an aggregated signature instead, use `StakeAggregator::insert`
+    pub fn insert_generic(
+        &mut self,
+        authority: AuthorityName,
+        s: S,
+    ) -> InsertResult<&HashMap<AuthorityName, S>> {
         match self.data.entry(authority) {
             Entry::Occupied(oc) => {
                 return InsertResult::Failed {
@@ -69,7 +75,7 @@ impl<S: Clone + Eq, const STRENGTH: bool> StakeAggregator<S, STRENGTH> {
         if votes > 0 {
             self.total_votes += votes;
             if self.total_votes >= self.committee.threshold::<STRENGTH>() {
-                InsertResult::QuorumReached(())
+                InsertResult::QuorumReached(&self.data)
             } else {
                 InsertResult::NotEnoughVotes {
                     bad_votes: 0,


### PR DESCRIPTION
This PR detects checkpoints hard fork early in checkpoint builder and panics validator. This is needed to prevent chain from signing certificates on the fast path, reducing potential fork impact.

There is some discussion whether panic is the right response in this case. This PR follows pattern established in the `CheckpointExecutor` and panics on fork. We can revisit both places in a separate PR if we want different response in case of a fork.

