### PR TITLE
[explorer] - enable retries for home/metrics/epochs table

### DIFF
--- a/apps/explorer/src/components/HomeMetrics/index.tsx
+++ b/apps/explorer/src/components/HomeMetrics/index.tsx
@@ -54,13 +54,13 @@ export function HomeMetrics() {
     const { data: transactionCount } = useQuery(
         ['home', 'transaction-count'],
         () => rpc.getTotalTransactionBlocks(),
-        { cacheTime: 24 * 60 * 60 * 1000, staleTime: Infinity, retry: false }
+        { cacheTime: 24 * 60 * 60 * 1000, staleTime: Infinity, retry: 5 }
     );
 
     const { data: networkMetrics } = useQuery(
         ['home', 'metrics'],
         () => enhancedRpc.getNetworkMetrics(),
-        { cacheTime: 24 * 60 * 60 * 1000, staleTime: Infinity, retry: false }
+        { cacheTime: 24 * 60 * 60 * 1000, staleTime: Infinity, retry: 5 }
     );
 
     return (

--- a/apps/explorer/src/pages/epochs/EpochsTable.tsx
+++ b/apps/explorer/src/pages/epochs/EpochsTable.tsx
@@ -47,9 +47,9 @@ export function EpochsTable({
             }),
         {
             keepPreviousData: true,
+            retry: 5,
             // Disable refetching if not on the first page:
             // refetchInterval: pagination.cursor ? undefined : refetchInterval,
-            retry: false,
             staleTime: Infinity,
             cacheTime: 24 * 60 * 60 * 1000,
         }


### PR DESCRIPTION
## Description 

Enable retries on Home Metrics / Epochs table to mitigate issue with epochs query failing on first attempt.


## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
