### PR TITLE
[ts-sdk] Add waitForTransactionBlock API

### DIFF
--- a/.changeset/modern-clocks-try.md
+++ b/.changeset/modern-clocks-try.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Add `waitForTransactionBlock` API to wait for a transaction to be available over the API.

--- a/sdk/typescript/src/utils/errors.ts
+++ b/sdk/typescript/src/utils/errors.ts
@@ -19,7 +19,12 @@ export class RPCError extends Error {
     data?: unknown;
     cause?: Error;
   }) {
-    super('RPC Error', { cause: options.cause });
+    super(
+      options.cause
+        ? `RPC Error: ${options.cause.message}`
+        : 'Unknown RPC Error',
+      { cause: options.cause },
+    );
 
     this.req = options.req;
     this.code = options.code;


### PR DESCRIPTION
## Description

This adds a `waitForTransactionBlock` API to the TS SDK, which is the first step to allowing us to make the `executeTransactionBlock` not block waiting for the final transaction. This is currently implemented with polling, but ideally will be re-implemented using events in the future to improve response time.

## Test Plan

Added tests for new API.
