### PR TITLE
indexer stability: revert diesel-async changes

### DIFF
--- a/crates/sui-indexer/benches/indexer_benchmark.rs
+++ b/crates/sui-indexer/benches/indexer_benchmark.rs
@@ -51,7 +51,7 @@ fn indexer_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("persist_checkpoint", |b| {
-        b.iter(|| rt.block_on(store.persist_all_checkpoint_data(&checkpoints.pop().unwrap())))
+        b.iter(|| store.persist_all_checkpoint_data(&checkpoints.pop().unwrap()))
     });
 
     let mut checkpoints = (20..100).cycle().map(CheckpointId::SequenceNumber);

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -365,14 +365,15 @@ where
                 // otherwise send it to channel to be committed later.
                 if epoch.last_epoch.is_none() {
                     let epoch_db_guard = self.metrics.epoch_db_commit_latency.start_timer();
+                    info!("Persisting first epoch...");
                     let mut persist_first_epoch_res = self.state.persist_epoch(&epoch).await;
                     while persist_first_epoch_res.is_err() {
                         warn!("Failed to persist first epoch, retrying...");
                         persist_first_epoch_res = self.state.persist_epoch(&epoch).await;
                     }
-                    self.state.persist_epoch(&epoch).await?;
                     epoch_db_guard.stop_and_record();
                     self.metrics.total_epoch_committed.inc();
+                    info!("Persisted first epoch");
                 } else {
                     let epoch_sender_guard = self.epoch_sender.lock().await;
                     // NOTE: when the channel is full, epoch_sender_guard will wait until the channel has space.

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -189,7 +189,7 @@ pub trait IndexerStore {
     ) -> Result<usize, IndexerError>;
     // TODO(gegaowp): keep this method in this trait for now for easier reverting,
     // will remove it if it's no longer needed.
-    async fn persist_all_checkpoint_data(
+    fn persist_all_checkpoint_data(
         &self,
         data: &TemporaryCheckpointStore,
     ) -> Result<usize, IndexerError>;

--- a/crates/sui-indexer/src/store/mod.rs
+++ b/crates/sui-indexer/src/store/mod.rs
@@ -21,31 +21,6 @@ mod diesel_marco {
         }};
     }
 
-    macro_rules! read_only {
-        ($pool:expr, $query:expr) => {{
-            let mut pg_pool_conn = crate::get_async_pg_pool_connection($pool).await?;
-            pg_pool_conn
-                .build_transaction()
-                .read_only()
-                .run($query)
-                .await
-                .map_err(|e| IndexerError::PostgresReadError(e.to_string()))
-        }};
-    }
-
-    macro_rules! transactional {
-        ($pool:expr, $query:expr) => {{
-            let mut pg_pool_conn = crate::get_async_pg_pool_connection($pool).await?;
-            pg_pool_conn
-                .build_transaction()
-                .serializable()
-                .read_write()
-                .run($query)
-                .await
-                .map_err(|e| IndexerError::PostgresWriteError(e.to_string()))
-        }};
-    }
-
     macro_rules! transactional_blocking {
         ($pool:expr, $query:expr) => {{
             let mut pg_pool_conn = crate::get_pg_pool_connection($pool)?;
@@ -57,8 +32,6 @@ mod diesel_marco {
                 .map_err(|e| IndexerError::PostgresWriteError(e.to_string()))
         }};
     }
-    pub(crate) use read_only;
     pub(crate) use read_only_blocking;
-    pub(crate) use transactional;
     pub(crate) use transactional_blocking;
 }


### PR DESCRIPTION
## Description 

The reason is that read_only queries will still build tx, see code [pointer](https://github.com/MystenLabs/sui/blob/main/crates/sui-indexer/src/store/mod.rs#L24-L34) and when Diesel gets concurrent tx, it will check if some other tx is in process [here](https://github.com/diesel-rs/diesel/blob/4b2ebca2ddb25f08bf9107869f064f5774efbb83/diesel/src/connection/transaction_manager.rs#L286), if there is another on-going tx, even it is a read-only tx, Diesel will return error AlreadyInTransaction

More context can be found in #sui_testnet_n_inc_307

## Test Plan 

CI 
