### PR TITLE
 [transaction-fuzzer] Add basic p2p transfers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10983,12 +10983,14 @@ name = "transaction-fuzzer"
 version = "0.1.0"
 dependencies = [
  "move-core-types",
+ "once_cell",
  "proptest",
  "proptest-derive",
  "rand 0.8.5",
  "sui-core",
  "sui-protocol-config",
  "sui-types",
+ "test-utils",
  "tokio",
  "tracing",
  "workspace-hack",

--- a/crates/transaction-fuzzer/Cargo.toml
+++ b/crates/transaction-fuzzer/Cargo.toml
@@ -16,6 +16,8 @@ move-core-types.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tracing = "0.1.36"
 
+test-utils = { path = "../test-utils" }
+once_cell = "1.16"
 sui-core = { path = "../sui-core" }
 sui-protocol-config = { path = "../sui-protocol-config" }
 sui-types = { path = "../sui-types", features = ["fuzzing"] }

--- a/crates/transaction-fuzzer/src/account_universe.rs
+++ b/crates/transaction-fuzzer/src/account_universe.rs
@@ -1,0 +1,127 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::executor::{ExecutionResult, Executor};
+use once_cell::sync::Lazy;
+use proptest::prelude::*;
+use std::{fmt, sync::Arc};
+use sui_types::{messages::VerifiedTransaction, storage::ObjectStore};
+
+mod account;
+mod helpers;
+mod transfer_gen;
+mod universe;
+pub use account::*;
+pub use transfer_gen::*;
+pub use universe::*;
+
+static UNIVERSE_SIZE: Lazy<usize> = Lazy::new(|| {
+    use std::{env, process::abort};
+
+    match env::var("UNIVERSE_SIZE") {
+        Ok(s) => match s.parse::<usize>() {
+            Ok(val) => val,
+            Err(err) => {
+                println!("Could not parse universe size, aborting: {:?}", err);
+                // Abort because Lazy with panics causes poisoning and isn't very
+                // helpful overall.
+                abort();
+            }
+        },
+        Err(env::VarError::NotPresent) => 20,
+        Err(err) => {
+            println!(
+                "Could not read universe size from the environment, aborting: {:?}",
+                err
+            );
+            abort();
+        }
+    }
+});
+
+pub fn default_num_accounts() -> usize {
+    *UNIVERSE_SIZE
+}
+
+pub fn default_num_transactions() -> usize {
+    *UNIVERSE_SIZE * 2
+}
+
+/// Represents any sort of transaction that can be done in an account universe.
+pub trait AUTransactionGen: fmt::Debug {
+    /// Applies this transaction onto the universe, updating balances within the universe as
+    /// necessary. Returns a signed transaction that can be run on the VM and the the execution status.
+    fn apply(
+        &self,
+        universe: &mut AccountUniverse,
+        exec: &mut Executor,
+    ) -> (VerifiedTransaction, ExecutionResult);
+
+    /// Creates an arced version of this transaction, suitable for dynamic dispatch.
+    fn arced(self) -> Arc<dyn AUTransactionGen>
+    where
+        Self: 'static + Sized,
+    {
+        Arc::new(self)
+    }
+}
+
+/// Run these transactions and verify the expected output.
+pub fn run_and_assert_universe(
+    universe: AccountUniverseGen,
+    transaction_gens: Vec<impl AUTransactionGen + Clone>,
+) -> Result<(), TestCaseError> {
+    let mut executor = Executor::new();
+    let mut universe = universe.setup(&mut executor);
+    let (transactions, expected_values): (Vec<_>, Vec<_>) = transaction_gens
+        .iter()
+        .map(|transaction_gen| transaction_gen.clone().apply(&mut universe, &mut executor))
+        .unzip();
+    let outputs = executor.execute_transactions(transactions);
+
+    prop_assert_eq!(outputs.len(), expected_values.len());
+
+    for (idx, (output, expected)) in outputs.iter().zip(&expected_values).enumerate() {
+        prop_assert!(
+            output == expected,
+            "unexpected status for transaction {} expected {:#?} but got {:#?}",
+            idx,
+            expected,
+            output
+        );
+    }
+
+    assert_accounts_match(&universe, &executor)
+}
+
+pub fn assert_accounts_match(
+    universe: &AccountUniverse,
+    executor: &Executor,
+) -> Result<(), TestCaseError> {
+    for (idx, account) in universe.accounts().iter().enumerate() {
+        for (balance_idx, acc_object) in account.current_coins.iter().enumerate() {
+            let object = executor
+                .state
+                .db()
+                .get_object(&acc_object.id())
+                .unwrap()
+                .unwrap();
+            let total_sui_value =
+                object.get_total_sui(&executor.state.db()).unwrap() - object.storage_rebate;
+            let account_balance_i = account.current_balances[balance_idx];
+            prop_assert_eq!(
+                account_balance_i,
+                total_sui_value,
+                "account {} should have correct balance {} for object {} but got {}",
+                idx,
+                total_sui_value,
+                acc_object.id(),
+                account_balance_i
+            );
+        }
+    }
+    Ok(())
+}

--- a/crates/transaction-fuzzer/src/account_universe/account.rs
+++ b/crates/transaction-fuzzer/src/account_universe/account.rs
@@ -1,0 +1,123 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use proptest::prelude::*;
+use sui_types::{
+    base_types::{ObjectID, SuiAddress},
+    crypto::{get_key_pair, AccountKeyPair},
+    object::Object,
+};
+
+use crate::executor::Executor;
+
+pub const INITIAL_BALANCE: u64 = 10_000_000_000;
+pub const NUM_GAS_OBJECTS: usize = 1;
+
+#[derive(Debug)]
+pub struct Account {
+    pub address: SuiAddress,
+    pub key: AccountKeyPair,
+}
+
+// `Arc` account since the key pair is non-copyable
+#[derive(Debug, Clone)]
+pub struct AccountData {
+    pub account: Arc<Account>,
+    pub coins: Vec<Object>,
+    pub initial_balances: Vec<u64>,
+    pub balance_creation_amt: u64,
+}
+
+#[derive(Clone, Debug)]
+pub struct AccountCurrent {
+    pub initial_data: AccountData,
+    pub current_balances: Vec<u64>,
+    pub current_coins: Vec<Object>,
+    // Non-coin objects
+    pub current_objects: Vec<ObjectID>,
+}
+
+impl Account {
+    pub fn new_random() -> Self {
+        let (address, key) = get_key_pair();
+        Self { address, key }
+    }
+}
+
+impl AccountData {
+    pub fn new_random() -> Self {
+        let account = Account::new_random();
+        Self::new_with_account_and_balance(Arc::new(account), INITIAL_BALANCE)
+    }
+
+    pub fn new_with_account_and_balance(account: Arc<Account>, initial_balance: u64) -> Self {
+        let coins = (0..NUM_GAS_OBJECTS)
+            .map(|_| {
+                let gas_object_id = ObjectID::random();
+                Object::with_id_owner_gas_for_testing(
+                    gas_object_id,
+                    account.address,
+                    initial_balance,
+                )
+            })
+            .collect();
+        let initial_balances = (0..NUM_GAS_OBJECTS).map(|_| initial_balance).collect();
+        Self {
+            account,
+            coins,
+            initial_balances,
+            balance_creation_amt: initial_balance,
+        }
+    }
+}
+
+impl AccountCurrent {
+    pub fn new(account: AccountData) -> Self {
+        Self {
+            current_balances: account.initial_balances.clone(),
+            current_coins: account.coins.clone(),
+            current_objects: vec![],
+            initial_data: account,
+        }
+    }
+
+    // TODO: Use this to get around the fact that we need to update object refs in the
+    // executor..figure out a better way to do this other than just creating a gas object for each
+    // transaction.
+    pub fn new_gas_object(&mut self, exec: &mut Executor) -> Object {
+        // We just create a new gas object for this transaction
+        let gas_object_id = ObjectID::random();
+        let gas_object = Object::with_id_owner_gas_for_testing(
+            gas_object_id,
+            self.initial_data.account.address,
+            self.initial_data.balance_creation_amt,
+        );
+        exec.add_object(gas_object.clone());
+        self.current_balances
+            .push(self.initial_data.balance_creation_amt);
+        self.current_coins.push(gas_object.clone());
+        gas_object
+    }
+}
+
+impl Arbitrary for Account {
+    type Parameters = ();
+    type Strategy = fn() -> Account;
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        Account::new_random as Self::Strategy
+    }
+}
+
+impl AccountData {
+    /// Returns a [`Strategy`] that creates `AccountData` instances.
+    pub fn strategy(balance_strategy: impl Strategy<Value = u64>) -> impl Strategy<Value = Self> {
+        (any::<Account>(), balance_strategy).prop_map(|(account, balance)| {
+            AccountData::new_with_account_and_balance(Arc::new(account), balance)
+        })
+    }
+}

--- a/crates/transaction-fuzzer/src/account_universe/helpers.rs
+++ b/crates/transaction-fuzzer/src/account_universe/helpers.rs
@@ -1,0 +1,76 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use proptest::sample::Index as PropIndex;
+use proptest_derive::Arbitrary;
+use std::{
+    collections::BTreeSet,
+    ops::{Deref, Index as OpsIndex},
+};
+
+/// Given a maximum value `max` and a list of [`Index`](proptest::sample::Index) instances, picks
+/// integers in the range `[0, max)` uniformly randomly and without duplication.
+///
+/// If `indexes_len` is greater than `max`, all indexes will be returned.
+///
+/// This function implements [Robert Floyd's F2
+/// algorithm](https://blog.acolyer.org/2018/01/30/a-sample-of-brilliance/) for sampling without
+/// replacement.
+pub fn pick_idxs<T, P>(max: usize, indexes: &T, indexes_len: usize) -> Vec<usize>
+where
+    T: OpsIndex<usize, Output = P> + ?Sized,
+    P: AsRef<PropIndex>,
+{
+    // See https://blog.acolyer.org/2018/01/30/a-sample-of-brilliance/ (the F2 algorithm)
+    // for a longer explanation. This is a variant that works with zero-indexing.
+    let mut selected = BTreeSet::new();
+    let to_select = indexes_len.min(max);
+    for (iter_idx, choice) in ((max - to_select)..max).enumerate() {
+        // "RandInt(1, J)" in the original algorithm means a number between 1
+        // and choice, both inclusive. `PropIndex::index` picks a number between 0 and
+        // whatever's passed in, with the latter exclusive. Pass in "+1" to ensure the same
+        // range of values is picked from. (This also ensures that if choice is 0 then `index`
+        // doesn't panic.
+        let idx = indexes[iter_idx].as_ref().index(choice + 1);
+        if !selected.insert(idx) {
+            selected.insert(choice);
+        }
+    }
+    selected.into_iter().collect()
+}
+
+/// Given a maximum value `max` and a slice of [`Index`](proptest::sample::Index) instances, picks
+/// integers in the range `[0, max)` uniformly randomly and without duplication.
+///
+/// If the number of `Index` instances is greater than `max`, all indexes will be returned.
+///
+/// This function implements [Robert Floyd's F2
+/// algorithm](https://blog.acolyer.org/2018/01/30/a-sample-of-brilliance/) for sampling without
+/// replacement.
+#[inline]
+pub fn pick_slice_idxs(max: usize, indexes: &[impl AsRef<PropIndex>]) -> Vec<usize> {
+    pick_idxs(max, indexes, indexes.len())
+}
+/// Wrapper for `proptest`'s [`Index`][proptest::sample::Index] that allows `AsRef` to work.
+///
+/// There is no blanket `impl<T> AsRef<T> for T`, so `&[PropIndex]` doesn't work with
+/// `&[impl AsRef<PropIndex>]` (unless an impl gets added upstream). `Index` does.
+#[derive(Arbitrary, Clone, Copy, Debug)]
+pub struct Index(PropIndex);
+
+impl AsRef<PropIndex> for Index {
+    fn as_ref(&self) -> &PropIndex {
+        &self.0
+    }
+}
+
+impl Deref for Index {
+    type Target = PropIndex;
+
+    fn deref(&self) -> &PropIndex {
+        &self.0
+    }
+}

--- a/crates/transaction-fuzzer/src/account_universe/transfer_gen.rs
+++ b/crates/transaction-fuzzer/src/account_universe/transfer_gen.rs
@@ -1,0 +1,105 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    account_universe::{AUTransactionGen, AccountPair, AccountPairGen, AccountUniverse},
+    executor::{ExecutionResult, Executor},
+};
+use proptest::prelude::*;
+use proptest_derive::Arbitrary;
+use std::sync::Arc;
+use sui_types::{
+    error::{SuiError, UserInputError},
+    messages::{
+        ExecutionFailureStatus, ExecutionStatus, TransactionData, TransactionKind,
+        VerifiedTransaction,
+    },
+    programmable_transaction_builder::ProgrammableTransactionBuilder,
+    utils::to_sender_signed_transaction,
+};
+
+const GAS_UNIT_PRICE: u64 = 1;
+const P2P_SUCCESS_GAS_USAGE: u64 = 1000 + 1976000;
+const P2P_FAILURE_GAS_USAGE: u64 = 1000 + 988000;
+
+/// Represents a peer-to-peer transaction performed in the account universe.
+///
+/// The parameters are the minimum and maximum balances to transfer.
+#[derive(Arbitrary, Clone, Debug)]
+#[proptest(params = "(u64, u64)")]
+pub struct P2PTransferGen {
+    sender_receiver: AccountPairGen,
+    #[proptest(strategy = "params.0 ..= params.1")]
+    amount: u64,
+}
+
+impl AUTransactionGen for P2PTransferGen {
+    fn apply(
+        &self,
+        universe: &mut AccountUniverse,
+        exec: &mut Executor,
+    ) -> (VerifiedTransaction, ExecutionResult) {
+        let AccountPair {
+            account_1: sender,
+            account_2: recipient,
+            ..
+        } = self.sender_receiver.pick(universe);
+
+        let gas_object = sender.new_gas_object(exec);
+        // construct a p2p transfer of a random amount of SUI
+        let txn = {
+            let mut builder = ProgrammableTransactionBuilder::new();
+            builder.transfer_sui(recipient.initial_data.account.address, Some(self.amount));
+            builder.finish()
+        };
+        let kind = TransactionKind::ProgrammableTransaction(txn);
+        let tx_data = TransactionData::new(
+            kind,
+            sender.initial_data.account.address,
+            gas_object.compute_object_reference(),
+            P2P_SUCCESS_GAS_USAGE,
+            GAS_UNIT_PRICE,
+        );
+        let signed_txn = to_sender_signed_transaction(tx_data, &sender.initial_data.account.key);
+        let gas_amount = P2P_SUCCESS_GAS_USAGE * GAS_UNIT_PRICE;
+        let to_deduct = self.amount + gas_amount;
+        let sender_balance = *sender.current_balances.last().unwrap();
+        // Now determine the state transition
+        let enough_max_gas = sender_balance >= gas_amount;
+        let enough_to_transfer = sender_balance >= self.amount;
+        let enough_to_succeed = sender_balance >= to_deduct;
+        let status = match (enough_max_gas, enough_to_transfer, enough_to_succeed) {
+            (true, true, true) => {
+                *sender.current_balances.last_mut().unwrap() -= to_deduct;
+                Ok(ExecutionStatus::Success)
+            }
+            (true, _, _) => {
+                *sender.current_balances.last_mut().unwrap() -=
+                    P2P_FAILURE_GAS_USAGE * GAS_UNIT_PRICE;
+                Ok(ExecutionStatus::Failure {
+                    error: ExecutionFailureStatus::InsufficientCoinBalance,
+                    command: Some(0),
+                })
+            }
+            (false, _, _) => Err(SuiError::UserInputError {
+                error: UserInputError::GasBalanceTooLow {
+                    gas_balance: sender_balance as u128,
+                    needed_gas_amount: gas_amount as u128,
+                },
+            }),
+        };
+        (signed_txn, status)
+    }
+}
+
+pub fn p2ptransfer_strategy(
+    min: u64,
+    max: u64,
+) -> impl Strategy<Value = Arc<dyn AUTransactionGen + 'static>> {
+    prop_oneof![
+        3 => any_with::<P2PTransferGen>((min, max)).prop_map(P2PTransferGen::arced),
+    ]
+}

--- a/crates/transaction-fuzzer/src/account_universe/universe.rs
+++ b/crates/transaction-fuzzer/src/account_universe/universe.rs
@@ -1,0 +1,265 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    account_universe::{
+        account::{AccountCurrent, AccountData},
+        default_num_accounts, default_num_transactions,
+        helpers::{pick_slice_idxs, Index},
+    },
+    executor::Executor,
+};
+
+use proptest::{
+    collection::{vec, SizeRange},
+    prelude::*,
+};
+use proptest_derive::Arbitrary;
+
+/// A set of accounts which can be used to construct an initial state.
+#[derive(Debug)]
+pub struct AccountUniverseGen {
+    accounts: Vec<AccountData>,
+    pick_style: AccountPickStyle,
+}
+
+/// A set of accounts that has been set up and can now be used to conduct transactions on.
+#[derive(Clone, Debug)]
+pub struct AccountUniverse {
+    accounts: Vec<AccountCurrent>,
+    picker: AccountPicker,
+    /// Whether to ignore any new accounts that transactions add to the universe.
+    ignore_new_accounts: bool,
+}
+
+/// Allows pairs of accounts to be uniformly randomly selected from an account universe.
+#[derive(Arbitrary, Clone, Debug)]
+pub struct AccountPairGen {
+    pair: [Index; 2],
+    // The pick_slice_idx method used by this struct returns values in order, so use this flag
+    // to determine whether to reverse it.
+    reverse: bool,
+}
+
+/// Determines the sampling algorithm used to pick accounts from the universe.
+#[derive(Clone, Debug)]
+pub enum AccountPickStyle {
+    /// An account may be picked as many times as possible.
+    Unlimited,
+    /// An account may only be picked these many times.
+    Limited(usize),
+}
+
+#[derive(Clone, Debug)]
+enum AccountPicker {
+    Unlimited(usize),
+    // Vector of (index, times remaining).
+    Limited(Vec<(usize, usize)>),
+}
+
+impl AccountUniverseGen {
+    /// Returns a [`Strategy`] that generates a universe of accounts with pre-populated initial
+    /// balances.
+    pub fn strategy(
+        num_accounts: impl Into<SizeRange>,
+        balance_strategy: impl Strategy<Value = u64>,
+    ) -> impl Strategy<Value = Self> {
+        // Pick a sequence number in a smaller range so that valid transactions can be generated.
+        // XXX should we also test edge cases around large sequence numbers?
+        // Note that using a function as a strategy directly means that shrinking will not occur,
+        // but that should be fine because there's nothing to really shrink within accounts anyway.
+        vec(AccountData::strategy(balance_strategy), num_accounts).prop_map(|accounts| Self {
+            accounts,
+            pick_style: AccountPickStyle::Unlimited,
+        })
+    }
+
+    /// Returns a [`Strategy`] that generates a universe of accounts that's guaranteed to succeed,
+    /// assuming that any transfers out of accounts will be 100_000 or below.
+    pub fn success_strategy(min_accounts: usize) -> impl Strategy<Value = Self> {
+        // Set the minimum balance to be 5x possible transfers out to handle potential gas cost
+        // issues.
+        let min_balance = (100_000 * (default_num_transactions()) * 5) as u64;
+        let max_balance = min_balance * 10;
+        Self::strategy(
+            min_accounts..default_num_accounts(),
+            min_balance..max_balance,
+        )
+    }
+
+    /// Sets the pick style used by this account universe.
+    pub fn set_pick_style(&mut self, pick_style: AccountPickStyle) -> &mut Self {
+        self.pick_style = pick_style;
+        self
+    }
+
+    /// Returns the number of accounts in this account universe.
+    pub fn num_accounts(&self) -> usize {
+        self.accounts.len()
+    }
+
+    /// Returns an [`AccountUniverse`] with the initial state generated in this universe.
+    pub fn setup(self, executor: &mut Executor) -> AccountUniverse {
+        for account_data in &self.accounts {
+            for coin in &account_data.coins {
+                executor.add_object(coin.clone())
+            }
+        }
+
+        AccountUniverse::new(self.accounts, self.pick_style, false)
+    }
+}
+
+impl AccountUniverse {
+    fn new(
+        accounts: Vec<AccountData>,
+        pick_style: AccountPickStyle,
+        ignore_new_accounts: bool,
+    ) -> Self {
+        let accounts: Vec<_> = accounts.into_iter().map(AccountCurrent::new).collect();
+        let picker = AccountPicker::new(pick_style, accounts.len());
+
+        Self {
+            accounts,
+            picker,
+            ignore_new_accounts,
+        }
+    }
+
+    /// Returns the number of accounts currently in this universe.
+    ///
+    /// Some transactions might cause new accounts to be created. The return value of this method
+    /// will include those new accounts.
+    pub fn num_accounts(&self) -> usize {
+        self.accounts.len()
+    }
+
+    /// Returns the accounts currently in this universe.
+    ///
+    /// Some transactions might cause new accounts to be created. The return value of this method
+    /// will include those new accounts.
+    pub fn accounts(&self) -> &[AccountCurrent] {
+        &self.accounts
+    }
+
+    /// Adds an account to the universe so that future transactions can be made out of this account.
+    ///
+    /// This is ignored if the universe was configured to be in gas-cost-stability mode.
+    pub fn add_account(&mut self, account_data: AccountData) {
+        if !self.ignore_new_accounts {
+            self.accounts.push(AccountCurrent::new(account_data));
+        }
+    }
+
+    /// Picks an account using the provided `Index` as a source of randomness.
+    pub fn pick(&mut self, index: Index) -> (usize, &mut AccountCurrent) {
+        let idx = self.picker.pick(index);
+        (idx, &mut self.accounts[idx])
+    }
+}
+
+impl AccountPicker {
+    fn new(pick_style: AccountPickStyle, num_accounts: usize) -> Self {
+        match pick_style {
+            AccountPickStyle::Unlimited => AccountPicker::Unlimited(num_accounts),
+            AccountPickStyle::Limited(limit) => {
+                let remaining = (0..num_accounts).map(|idx| (idx, limit)).collect();
+                AccountPicker::Limited(remaining)
+            }
+        }
+    }
+
+    fn pick(&mut self, index: Index) -> usize {
+        match self {
+            AccountPicker::Unlimited(num_accounts) => index.index(*num_accounts),
+            AccountPicker::Limited(remaining) => {
+                let remaining_idx = index.index(remaining.len());
+                Self::pick_limited(remaining, remaining_idx)
+            }
+        }
+    }
+
+    fn pick_pair(&mut self, indexes: &[Index; 2]) -> [usize; 2] {
+        match self {
+            AccountPicker::Unlimited(num_accounts) => Self::pick_pair_impl(*num_accounts, indexes),
+            AccountPicker::Limited(remaining) => {
+                let [remaining_idx_1, remaining_idx_2] =
+                    Self::pick_pair_impl(remaining.len(), indexes);
+                // Use the later index first to avoid invalidating indexes.
+                let account_idx_2 = Self::pick_limited(remaining, remaining_idx_2);
+                let account_idx_1 = Self::pick_limited(remaining, remaining_idx_1);
+
+                [account_idx_1, account_idx_2]
+            }
+        }
+    }
+
+    fn pick_pair_impl(max: usize, indexes: &[Index; 2]) -> [usize; 2] {
+        let idxs = pick_slice_idxs(max, indexes);
+        assert_eq!(idxs.len(), 2);
+        let idxs = [idxs[0], idxs[1]];
+        assert!(
+            idxs[0] < idxs[1],
+            "pick_slice_idxs should return sorted order"
+        );
+        idxs
+    }
+
+    fn pick_limited(remaining: &mut Vec<(usize, usize)>, remaining_idx: usize) -> usize {
+        let (account_idx, times_remaining) = {
+            let (account_idx, times_remaining) = &mut remaining[remaining_idx];
+            *times_remaining -= 1;
+            (*account_idx, *times_remaining)
+        };
+
+        if times_remaining == 0 {
+            // Remove the account from further consideration.
+            remaining.remove(remaining_idx);
+        }
+
+        account_idx
+    }
+}
+
+impl AccountPairGen {
+    /// Picks two accounts uniformly randomly from this universe and returns mutable references to
+    /// them.
+    pub fn pick<'a>(&self, universe: &'a mut AccountUniverse) -> AccountPair<'a> {
+        let [low_idx, high_idx] = universe.picker.pick_pair(&self.pair);
+        // Need to use `split_at_mut` because you can't have multiple mutable references to items
+        // from a single slice at any given time.
+        let (head, tail) = universe.accounts.split_at_mut(low_idx + 1);
+        let (low_account, high_account) = (&mut head[low_idx], &mut tail[high_idx - low_idx - 1]);
+
+        if self.reverse {
+            AccountPair {
+                idx_1: high_idx,
+                idx_2: low_idx,
+                account_1: high_account,
+                account_2: low_account,
+            }
+        } else {
+            AccountPair {
+                idx_1: low_idx,
+                idx_2: high_idx,
+                account_1: low_account,
+                account_2: high_account,
+            }
+        }
+    }
+}
+
+/// Mutable references to a pair of distinct accounts picked from a universe.
+pub struct AccountPair<'a> {
+    /// The index of the first account picked.
+    pub idx_1: usize,
+    /// The index of the second account picked.
+    pub idx_2: usize,
+    /// A mutable reference to the first account picked.
+    pub account_1: &'a mut AccountCurrent,
+    /// A mutable reference to the second account picked.
+    pub account_2: &'a mut AccountCurrent,
+}

--- a/crates/transaction-fuzzer/src/executor.rs
+++ b/crates/transaction-fuzzer/src/executor.rs
@@ -1,0 +1,57 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+use sui_core::{
+    authority::AuthorityState,
+    test_utils::{init_state, send_and_confirm_transaction},
+};
+use sui_types::{
+    error::SuiError,
+    messages::{ExecutionStatus, TransactionEffectsAPI, VerifiedTransaction},
+    object::Object,
+};
+use tokio::runtime::Runtime;
+
+pub type ExecutionResult = Result<ExecutionStatus, SuiError>;
+
+pub struct Executor {
+    pub state: Arc<AuthorityState>,
+    pub rt: Runtime,
+}
+
+impl Default for Executor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Executor {
+    pub fn new() -> Self {
+        let rt = Runtime::new().unwrap();
+        let state = rt.block_on(init_state());
+        Self { state, rt }
+    }
+
+    pub fn add_object(&mut self, object: Object) {
+        self.rt.block_on(self.state.insert_genesis_object(object));
+    }
+
+    pub fn execute_transaction(&mut self, txn: VerifiedTransaction) -> ExecutionResult {
+        self.rt
+            .block_on(send_and_confirm_transaction(&self.state, None, txn))
+            .map(|(_, effects)| effects.into_data().status().clone())
+    }
+
+    pub fn execute_transactions(
+        &mut self,
+        txn: impl IntoIterator<Item = VerifiedTransaction>,
+    ) -> Vec<ExecutionResult> {
+        txn.into_iter()
+            .map(|txn| self.execute_transaction(txn))
+            .collect()
+    }
+}

--- a/crates/transaction-fuzzer/src/lib.rs
+++ b/crates/transaction-fuzzer/src/lib.rs
@@ -1,6 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod account_universe;
+mod executor;
+
 use proptest::collection::vec;
 use sui_protocol_config::ProtocolConfig;
 use sui_types::base_types::{ObjectID, SuiAddress};

--- a/crates/transaction-fuzzer/tests/p2p_fuzz.rs
+++ b/crates/transaction-fuzzer/tests/p2p_fuzz.rs
@@ -1,0 +1,40 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use proptest::arbitrary::*;
+use proptest::collection::vec;
+use proptest::prelude::*;
+use proptest::proptest;
+use transaction_fuzzer::account_universe::*;
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(15))]
+
+    #[test]
+    #[cfg_attr(msim, ignore)]
+    fn fuzz_p2p_low_balance(
+        universe in AccountUniverseGen::strategy(
+            2..default_num_accounts(),
+            1_000_000u64..10_000_000,
+            ),
+            transfers in vec(any_with::<P2PTransferGen>((1_000_000, 100_000_000)), 0..default_num_transactions()),
+        ) {
+        run_and_assert_universe(universe, transfers).unwrap();
+    }
+
+    #[test]
+    #[cfg_attr(msim, ignore)]
+    fn fuzz_p2p_high_balance(
+        universe in AccountUniverseGen::strategy(
+            2..default_num_accounts(),
+            1_000_000_000_000u64..10_000_000_000_000,
+            ),
+            transfers in vec(any_with::<P2PTransferGen>((1, 10_000)), 0..default_num_transactions()),
+        ) {
+        run_and_assert_universe(universe, transfers).unwrap();
+    }
+
+}


### PR DESCRIPTION
Adds proptests to generate an account universe and then uses this to generate a number of successful (and unsuccessful) SUI transfers.

Currently, we only use a gas coin once, and then add a new gas coin for each transaction to make dealing with gas usage and determining object refs easier. But this will be updated in a future PR most likely. But for now, this gets us to the point where we can have a bunch of transactions running in sequence and we're checking that state is changing the way we would expect.