### PR TITLE
Add with_accounts to swarm and config builder

### DIFF
--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -1900,12 +1900,11 @@ mod test {
 
     #[test]
     fn genesis_transaction() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let builder = crate::builder::ConfigBuilder::new(&dir);
-        let protocol_version = builder.protocol_version;
-        let protocol_config = ProtocolConfig::get_for_version(protocol_version);
+        let builder = crate::builder::ConfigBuilder::new_with_temp_dir();
         let network_config = builder.build();
         let genesis = network_config.genesis;
+        let protocol_version = ProtocolVersion::new(genesis.sui_system_object().protocol_version());
+        let protocol_config = ProtocolConfig::get_for_version(protocol_version);
 
         let genesis_transaction = genesis.transaction.clone();
 

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -420,7 +420,7 @@ async fn genesis(
             );
         }
         builder
-            .initial_accounts_config(genesis_conf)
+            .with_genesis_config(genesis_conf)
             .with_validators(validators)
             .build()
     } else {
@@ -433,7 +433,7 @@ async fn genesis(
                 })
                 .unwrap(),
             )
-            .initial_accounts_config(genesis_conf)
+            .with_genesis_config(genesis_conf)
             .build()
     };
 


### PR DESCRIPTION
This PR adds an API to set up initial coin balance accounts in genesis in tests, by adding a with_accounts API.
Renamed the previously confusing initial_account_config to with_genesis_config. With this change we can start moving some of the tests to use with_accounts to properly set up initial coin objects.