### PR TITLE
Fix: Return None instead of passing Error

### DIFF
--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -115,33 +115,33 @@ impl TransactionExecutionApi {
                         .load_epoch_store_one_call_per_task()
                         .module_cache()
                         .clone();
-                    events = Some(SuiTransactionBlockEvents::try_from(
+                    events = SuiTransactionBlockEvents::try_from(
                         transaction_events,
                         digest,
                         None,
                         module_cache.as_ref(),
-                    )?);
+                    ).ok();
                 }
 
                 let object_cache = ObjectProviderCache::new(self.state.clone());
                 let balance_changes = if opts.show_balance_changes {
-                    Some(get_balance_changes_from_effect(
+                    get_balance_changes_from_effect(
                         &object_cache,
                         &effects.effects,
                         input_objs,
                         None,
-                    )?)
+                    ).ok()
                 } else {
                     None
                 };
                 let object_changes = if opts.show_object_changes {
-                    Some(get_object_changes(
+                    get_object_changes(
                         &object_cache,
                         sender,
                         effects.effects.modified_at_versions(),
                         effects.effects.all_changed_objects(),
                         effects.effects.all_deleted(),
-                    )?)
+                    ).ok()
                 } else {
                     None
                 };


### PR DESCRIPTION
## Description 

Fix https://github.com/MystenLabs/sui/issues/10974

`trace`:
```txt
sui/crates/sui-json-rpc/src/transaction_execution_api.rs
    -> execute_transaction_block
    -> get_balance_changes_from_effect
    -> get_balance_changes
    -> fetch_coins
    -> get_object
    -> get_past_object_read
```

`root cause`: the state on the chain has changed, but the database has not been updated.


## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
