### PR TITLE
[explorer] Quick NFT display fix

### DIFF
--- a/apps/explorer/src/components/displaybox/DisplayBox.module.css
+++ b/apps/explorer/src/components/displaybox/DisplayBox.module.css
@@ -2,6 +2,10 @@ div.imagebox {
     @apply flex h-full w-full items-center justify-center;
 }
 
+.display-container {
+    @apply h-50 w-50;
+}
+
 img.smallimage {
     @apply cursor-pointer rounded-[6px] object-fill;
 }


### PR DESCRIPTION
## Description

This is a quick fix for display box to set a width and height so that NFTs show up consistently. There's a larger refactor of this landing soon so leaving all of the refactoring work to that PR.

## Test Plan

Ran locally.
