### PR TITLE
[sui-framework-build] Use ObjectIDs to distinguish system packages

### DIFF
--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -44,7 +44,7 @@ use sui_types::{
 };
 use sui_types::{
     is_system_package, SUI_CLOCK_OBJECT_ID, SUI_CLOCK_OBJECT_SHARED_VERSION,
-    SUI_FRAMEWORK_OBJECT_ID, SUI_SYSTEM_PACKAGE_ID, SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
+    SUI_FRAMEWORK_OBJECT_ID, SUI_SYSTEM_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
 };
 
 use sui_types::temporary_store::TemporaryStore;
@@ -539,7 +539,7 @@ pub fn construct_advance_epoch_pt(
     );
 
     let storage_rebates = builder.programmable_move_call(
-        SUI_SYSTEM_PACKAGE_ID,
+        SUI_SYSTEM_OBJECT_ID,
         SUI_SYSTEM_MODULE_NAME.to_owned(),
         ADVANCE_EPOCH_FUNCTION_NAME.to_owned(),
         vec![],
@@ -605,7 +605,7 @@ pub fn construct_advance_epoch_safe_mode_pt(
     );
 
     builder.programmable_move_call(
-        SUI_SYSTEM_PACKAGE_ID,
+        SUI_SYSTEM_OBJECT_ID,
         SUI_SYSTEM_MODULE_NAME.to_owned(),
         ADVANCE_EPOCH_SAFE_MODE_FUNCTION_NAME.to_owned(),
         vec![],

--- a/crates/sui-framework-build/src/compiled_package.rs
+++ b/crates/sui-framework-build/src/compiled_package.rs
@@ -43,12 +43,11 @@ use serde_reflection::Registry;
 use sui_types::{
     base_types::ObjectID,
     error::{SuiError, SuiResult},
+    is_system_package,
     move_package::{FnInfo, FnInfoKey, FnInfoMap, MovePackage},
     DEEPBOOK_ADDRESS, MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS, SUI_SYSTEM_ADDRESS,
 };
 use sui_verifier::verifier as sui_bytecode_verifier;
-
-use crate::{MOVE_STDLIB_PACKAGE_NAME, SUI_PACKAGE_NAME, SUI_SYSTEM_PACKAGE_NAME};
 
 /// Wrapper around the core Move `CompiledPackage` with some Sui-specific traits and info
 #[derive(Debug)]
@@ -440,10 +439,11 @@ impl CompiledPackage {
 
     /// Checks whether this package corresponds to a built-in framework
     pub fn is_system_package(&self) -> bool {
-        let package_name = self.package.compiled_package_info.package_name.as_str();
-        package_name == SUI_SYSTEM_PACKAGE_NAME
-            || package_name == SUI_PACKAGE_NAME
-            || package_name == MOVE_STDLIB_PACKAGE_NAME
+        let Ok(published_at) = self.published_at else {
+            return false
+        };
+
+        is_system_package(published_at)
     }
 
     /// Checks for root modules with non-zero package addresses.  Returns an arbitrary one, if one

--- a/crates/sui-framework-build/src/lib.rs
+++ b/crates/sui-framework-build/src/lib.rs
@@ -6,7 +6,3 @@ pub mod compiled_package;
 #[cfg(test)]
 #[path = "unit_tests/build_tests.rs"]
 mod build_tests;
-
-const SUI_SYSTEM_PACKAGE_NAME: &str = "SuiSystem";
-const SUI_PACKAGE_NAME: &str = "Sui";
-const MOVE_STDLIB_PACKAGE_NAME: &str = "MoveStdlib";

--- a/crates/sui-framework-build/src/unit_tests/build_tests.rs
+++ b/crates/sui-framework-build/src/unit_tests/build_tests.rs
@@ -14,7 +14,7 @@ fn generate_struct_layouts() {
         .to_path_buf()
         .join("sui-framework")
         .join("packages")
-        .join("sui-system");
+        .join("sui-framework");
     let pkg = BuildConfig::new_for_testing().build(path).unwrap();
     let registry = pkg.generate_struct_layouts();
     // check for a couple of types that aren't likely to go away

--- a/crates/sui-framework/src/lib.rs
+++ b/crates/sui-framework/src/lib.rs
@@ -15,7 +15,7 @@ use sui_types::{
     digests::TransactionDigest,
     move_package::MovePackage,
     object::{Object, OBJECT_START_VERSION},
-    MOVE_STDLIB_OBJECT_ID, SUI_FRAMEWORK_OBJECT_ID, SUI_SYSTEM_PACKAGE_ID,
+    MOVE_STDLIB_OBJECT_ID, SUI_FRAMEWORK_OBJECT_ID, SUI_SYSTEM_OBJECT_ID,
 };
 use tracing::error;
 
@@ -115,7 +115,7 @@ impl BuiltInFramework {
                 [MOVE_STDLIB_OBJECT_ID]
             ),
             (
-                SUI_SYSTEM_PACKAGE_ID,
+                SUI_SYSTEM_OBJECT_ID,
                 "sui-system",
                 [MOVE_STDLIB_OBJECT_ID, SUI_FRAMEWORK_OBJECT_ID]
             ),

--- a/crates/sui-rosetta/src/operations.rs
+++ b/crates/sui-rosetta/src/operations.rs
@@ -27,7 +27,7 @@ use sui_types::governance::{ADD_STAKE_FUN_NAME, WITHDRAW_STAKE_FUN_NAME};
 use sui_types::messages::TransactionData;
 use sui_types::object::Owner;
 use sui_types::sui_system_state::SUI_SYSTEM_MODULE_NAME;
-use sui_types::{SUI_SYSTEM_ADDRESS, SUI_SYSTEM_PACKAGE_ID};
+use sui_types::{SUI_SYSTEM_ADDRESS, SUI_SYSTEM_OBJECT_ID};
 
 use crate::types::{
     AccountIdentifier, Amount, CoinAction, CoinChange, CoinID, CoinIdentifier, InternalOperation,
@@ -440,13 +440,13 @@ impl Operations {
     }
 
     fn is_stake_call(tx: &SuiProgrammableMoveCall) -> bool {
-        tx.package == SUI_SYSTEM_PACKAGE_ID
+        tx.package == SUI_SYSTEM_OBJECT_ID
             && tx.module == SUI_SYSTEM_MODULE_NAME.as_str()
             && tx.function == ADD_STAKE_FUN_NAME.as_str()
     }
 
     fn is_unstake_call(tx: &SuiProgrammableMoveCall) -> bool {
-        tx.package == SUI_SYSTEM_PACKAGE_ID
+        tx.package == SUI_SYSTEM_OBJECT_ID
             && tx.module == SUI_SYSTEM_MODULE_NAME.as_str()
             && tx.function == WITHDRAW_STAKE_FUN_NAME.as_str()
     }

--- a/crates/sui-rosetta/src/types.rs
+++ b/crates/sui-rosetta/src/types.rs
@@ -25,7 +25,7 @@ use sui_types::messages_checkpoint::CheckpointDigest;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::sui_system_state::SUI_SYSTEM_MODULE_NAME;
 use sui_types::{
-    SUI_SYSTEM_PACKAGE_ID, SUI_SYSTEM_STATE_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
+    SUI_SYSTEM_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
 };
 
 use crate::errors::{Error, ErrorType};
@@ -904,7 +904,7 @@ impl InternalOperation {
                 let arguments = vec![system_state, coin, validator];
 
                 builder.command(Command::move_call(
-                    SUI_SYSTEM_PACKAGE_ID,
+                    SUI_SYSTEM_OBJECT_ID,
                     SUI_SYSTEM_MODULE_NAME.to_owned(),
                     ADD_STAKE_FUN_NAME.to_owned(),
                     vec![],
@@ -935,7 +935,7 @@ impl InternalOperation {
 
                     let arguments = vec![system_state, id];
                     builder.command(Command::move_call(
-                        SUI_SYSTEM_PACKAGE_ID,
+                        SUI_SYSTEM_OBJECT_ID,
                         SUI_SYSTEM_MODULE_NAME.to_owned(),
                         WITHDRAW_STAKE_FUN_NAME.to_owned(),
                         vec![],

--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -35,7 +35,7 @@ use sui_types::object::{Object, Owner};
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::sui_system_state::SUI_SYSTEM_MODULE_NAME;
 use sui_types::{
-    coin, fp_ensure, SUI_FRAMEWORK_OBJECT_ID, SUI_SYSTEM_PACKAGE_ID, SUI_SYSTEM_STATE_OBJECT_ID,
+    coin, fp_ensure, SUI_FRAMEWORK_OBJECT_ID, SUI_SYSTEM_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_ID,
     SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
 };
 
@@ -730,7 +730,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
                     .unwrap(),
             ];
             builder.command(Command::move_call(
-                SUI_SYSTEM_PACKAGE_ID,
+                SUI_SYSTEM_OBJECT_ID,
                 SUI_SYSTEM_MODULE_NAME.to_owned(),
                 ADD_STAKE_MUL_COIN_FUN_NAME.to_owned(),
                 vec![],
@@ -761,7 +761,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
             .await?;
         TransactionData::new_move_call(
             signer,
-            SUI_SYSTEM_PACKAGE_ID,
+            SUI_SYSTEM_OBJECT_ID,
             SUI_SYSTEM_MODULE_NAME.to_owned(),
             WITHDRAW_STAKE_FUN_NAME.to_owned(),
             vec![],

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -74,7 +74,7 @@ use sui_types::{
 use sui_types::{
     programmable_transaction_builder::ProgrammableTransactionBuilder, SUI_FRAMEWORK_OBJECT_ID,
 };
-use sui_types::{utils::to_sender_signed_transaction, SUI_SYSTEM_PACKAGE_ID};
+use sui_types::{utils::to_sender_signed_transaction, SUI_SYSTEM_OBJECT_ID};
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub enum FakeID {
@@ -86,7 +86,7 @@ const WELL_KNOWN_OBJECTS: &[ObjectID] = &[
     MOVE_STDLIB_OBJECT_ID,
     DEEPBOOK_OBJECT_ID,
     SUI_FRAMEWORK_OBJECT_ID,
-    SUI_SYSTEM_PACKAGE_ID,
+    SUI_SYSTEM_OBJECT_ID,
     SUI_SYSTEM_STATE_OBJECT_ID,
     SUI_CLOCK_OBJECT_ID,
 ];

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -74,7 +74,7 @@ pub const SUI_FRAMEWORK_OBJECT_ID: ObjectID = ObjectID::from_address(SUI_FRAMEWO
 /// 0x3-- account address where sui system modules are stored
 /// Same as the ObjectID
 pub const SUI_SYSTEM_ADDRESS: AccountAddress = address_from_single_byte(3);
-pub const SUI_SYSTEM_PACKAGE_ID: ObjectID = ObjectID::from_address(SUI_SYSTEM_ADDRESS);
+pub const SUI_SYSTEM_OBJECT_ID: ObjectID = ObjectID::from_address(SUI_SYSTEM_ADDRESS);
 
 /// 0xdee9-- account address where DeepBook modules are stored
 /// Same as the ObjectID
@@ -100,10 +100,7 @@ pub const SUI_CLOCK_OBJECT_SHARED_VERSION: SequenceNumber = OBJECT_START_VERSION
 pub fn is_system_package(id: ObjectID) -> bool {
     matches!(
         id,
-        MOVE_STDLIB_OBJECT_ID
-            | SUI_FRAMEWORK_OBJECT_ID
-            | SUI_SYSTEM_PACKAGE_ID
-            | DEEPBOOK_OBJECT_ID
+        MOVE_STDLIB_OBJECT_ID | SUI_FRAMEWORK_OBJECT_ID | SUI_SYSTEM_OBJECT_ID | DEEPBOOK_OBJECT_ID
     )
 }
 

--- a/crates/sui/src/fire_drill.rs
+++ b/crates/sui/src/fire_drill.rs
@@ -30,7 +30,7 @@ use sui_types::messages::{
     CallArg, ObjectArg, Transaction, TransactionData, TEST_ONLY_GAS_UNIT_FOR_GENERIC,
 };
 use sui_types::multiaddr::{Multiaddr, Protocol};
-use sui_types::{committee::EpochId, crypto::get_authority_key_pair, SUI_SYSTEM_PACKAGE_ID};
+use sui_types::{committee::EpochId, crypto::get_authority_key_pair, SUI_SYSTEM_OBJECT_ID};
 use sui_types::{SUI_SYSTEM_STATE_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION};
 use tracing::info;
 
@@ -321,7 +321,7 @@ async fn update_metadata_on_chain(
     args.extend(call_args);
     let tx_data = TransactionData::new_move_call(
         sui_address,
-        SUI_SYSTEM_PACKAGE_ID,
+        SUI_SYSTEM_OBJECT_ID,
         ident_str!("sui_system").to_owned(),
         ident_str!(function).to_owned(),
         vec![],

--- a/crates/sui/src/validator_commands.rs
+++ b/crates/sui/src/validator_commands.rs
@@ -20,7 +20,7 @@ use sui_types::{
         sui_system_state_inner_v1::{UnverifiedValidatorOperationCapV1, ValidatorV1},
         sui_system_state_summary::{SuiSystemStateSummary, SuiValidatorSummary},
     },
-    SUI_SYSTEM_PACKAGE_ID,
+    SUI_SYSTEM_OBJECT_ID,
 };
 use tap::tap::TapOptional;
 
@@ -564,7 +564,7 @@ async fn call_0x5(
     let gas_obj_ref = get_gas_obj_ref(sender, &sui_client, gas_budget).await?;
     let tx_data = TransactionData::new_move_call(
         sender,
-        SUI_SYSTEM_PACKAGE_ID,
+        SUI_SYSTEM_OBJECT_ID,
         ident_str!("sui_system").to_owned(),
         ident_str!(function).to_owned(),
         vec![],

--- a/crates/sui/tests/dynamic_committee_tests.rs
+++ b/crates/sui/tests/dynamic_committee_tests.rs
@@ -35,7 +35,7 @@ use sui_types::{
         SuiSystemStateTrait,
     },
     utils::to_sender_signed_transaction,
-    SUI_SYSTEM_PACKAGE_ID, SUI_SYSTEM_STATE_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
+    SUI_SYSTEM_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
 };
 use test_utils::authority::spawn_test_authorities;
 use test_utils::authority::test_authority_configs_with_objects;
@@ -390,7 +390,7 @@ mod add_stake {
                 let coin = StressTestRunner::split_off(&mut builder, self.stake_amount);
                 move_call! {
                     builder,
-                    (SUI_SYSTEM_PACKAGE_ID)::sui_system::request_add_stake(Argument::Input(0), coin, Argument::Input(1))
+                    (SUI_SYSTEM_OBJECT_ID)::sui_system::request_add_stake(Argument::Input(0), coin, Argument::Input(1))
                 };
                 builder.finish()
             };

--- a/crates/sui/tests/protocol_version_tests.rs
+++ b/crates/sui/tests/protocol_version_tests.rs
@@ -86,7 +86,7 @@ mod sim_only_tests {
         object::Object,
         programmable_transaction_builder::ProgrammableTransactionBuilder,
         storage::ObjectStore,
-        MOVE_STDLIB_OBJECT_ID, SUI_FRAMEWORK_OBJECT_ID, SUI_SYSTEM_PACKAGE_ID,
+        MOVE_STDLIB_OBJECT_ID, SUI_FRAMEWORK_OBJECT_ID, SUI_SYSTEM_OBJECT_ID,
     };
     use test_utils::network::{TestCluster, TestClusterBuilder};
     use tokio::time::{sleep, Duration};
@@ -441,7 +441,7 @@ mod sim_only_tests {
         dev_inspect_call(
             cluster,
             ProgrammableMoveCall {
-                package: SUI_SYSTEM_PACKAGE_ID,
+                package: SUI_SYSTEM_OBJECT_ID,
                 module: ident_str!("msim_extra_1").to_owned(),
                 function: ident_str!("canary").to_owned(),
                 type_arguments: vec![],
@@ -489,17 +489,17 @@ mod sim_only_tests {
     async fn get_framework_upgrade_versions(
         cluster: &TestCluster,
     ) -> (Option<SequenceNumber>, Option<SequenceNumber>) {
-        let effects = get_framework_upgrade_effects(cluster, &SUI_SYSTEM_PACKAGE_ID).await;
+        let effects = get_framework_upgrade_effects(cluster, &SUI_SYSTEM_OBJECT_ID).await;
 
         let modified_at = effects
             .modified_at_versions()
             .iter()
-            .find_map(|(id, v)| (id == &SUI_SYSTEM_PACKAGE_ID).then_some(*v));
+            .find_map(|(id, v)| (id == &SUI_SYSTEM_OBJECT_ID).then_some(*v));
 
         let mutated_to = effects
             .mutated()
             .iter()
-            .find_map(|((id, v, _), _)| (id == &SUI_SYSTEM_PACKAGE_ID).then_some(*v));
+            .find_map(|((id, v, _), _)| (id == &SUI_SYSTEM_OBJECT_ID).then_some(*v));
 
         (modified_at, mutated_to)
     }
@@ -828,11 +828,11 @@ mod sim_only_tests {
     }
 
     fn override_sui_system_modules(path: &str) {
-        framework_injection::set_override(SUI_SYSTEM_PACKAGE_ID, sui_system_modules(path));
+        framework_injection::set_override(SUI_SYSTEM_OBJECT_ID, sui_system_modules(path));
     }
 
     fn override_sui_system_modules_cb(f: framework_injection::PackageUpgradeCallback) {
-        framework_injection::set_override_cb(SUI_SYSTEM_PACKAGE_ID, f)
+        framework_injection::set_override_cb(SUI_SYSTEM_OBJECT_ID, f)
     }
 
     /// Get compiled modules for Sui System, built from fixture `fixture` in the

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -42,7 +42,7 @@ use sui_types::sui_system_state::{
 };
 use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{
-    SUI_SYSTEM_PACKAGE_ID, SUI_SYSTEM_STATE_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
+    SUI_SYSTEM_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
 };
 use test_utils::authority::start_node;
 use test_utils::{
@@ -623,7 +623,7 @@ async fn test_inactive_validator_pool_read() {
 
     let tx_data = TransactionData::new_move_call(
         address,
-        SUI_SYSTEM_PACKAGE_ID,
+        SUI_SYSTEM_OBJECT_ID,
         ident_str!("sui_system").to_owned(),
         ident_str!("request_remove_validator").to_owned(),
         vec![],
@@ -1172,7 +1172,7 @@ async fn execute_add_validator_candidate_tx(
         .unwrap();
     let candidate_tx_data = TransactionData::new_move_call(
         sender,
-        SUI_SYSTEM_PACKAGE_ID,
+        SUI_SYSTEM_OBJECT_ID,
         ident_str!("sui_system").to_owned(),
         ident_str!("request_add_validator_candidate").to_owned(),
         vec![],
@@ -1239,7 +1239,7 @@ async fn execute_join_committee_txes(
     // Step 2: Give the candidate enough stake.
     let stake_tx_data = TransactionData::new_move_call(
         sender,
-        SUI_SYSTEM_PACKAGE_ID,
+        SUI_SYSTEM_OBJECT_ID,
         ident_str!("sui_system").to_owned(),
         ident_str!("request_add_stake").to_owned(),
         vec![],
@@ -1268,7 +1268,7 @@ async fn execute_join_committee_txes(
     // Step 3: Convert the candidate to an active valdiator.
     let activation_tx_data = TransactionData::new_move_call(
         sender,
-        SUI_SYSTEM_PACKAGE_ID,
+        SUI_SYSTEM_OBJECT_ID,
         ident_str!("sui_system").to_owned(),
         ident_str!("request_add_validator").to_owned(),
         vec![],
@@ -1303,7 +1303,7 @@ async fn execute_leave_committee_tx(
         .unwrap();
     let tx_data = TransactionData::new_move_call(
         sui_address,
-        SUI_SYSTEM_PACKAGE_ID,
+        SUI_SYSTEM_OBJECT_ID,
         ident_str!("sui_system").to_owned(),
         ident_str!("request_remove_validator").to_owned(),
         vec![],

--- a/crates/test-utils/src/messages.rs
+++ b/crates/test-utils/src/messages.rs
@@ -33,7 +33,7 @@ use sui_types::parse_sui_struct_tag;
 use sui_types::sui_system_state::SUI_SYSTEM_MODULE_NAME;
 use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{
-    SUI_FRAMEWORK_OBJECT_ID, SUI_SYSTEM_PACKAGE_ID, SUI_SYSTEM_STATE_OBJECT_ID,
+    SUI_FRAMEWORK_OBJECT_ID, SUI_SYSTEM_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_ID,
     SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
 };
 
@@ -387,7 +387,7 @@ pub fn make_staking_transaction(
 ) -> VerifiedTransaction {
     let data = TransactionData::new_move_call(
         sender,
-        SUI_SYSTEM_PACKAGE_ID,
+        SUI_SYSTEM_OBJECT_ID,
         SUI_SYSTEM_MODULE_NAME.to_owned(),
         "request_add_stake".parse().unwrap(),
         vec![],

--- a/crates/test-utils/tests/network_tests.rs
+++ b/crates/test-utils/tests/network_tests.rs
@@ -7,7 +7,7 @@ use sui_json_rpc::api::ReadApiClient;
 use sui_json_rpc_types::SuiObjectResponse;
 use sui_types::{
     base_types::ObjectID, digests::TransactionDigest, object::Object, MOVE_STDLIB_OBJECT_ID,
-    SUI_FRAMEWORK_OBJECT_ID, SUI_SYSTEM_ADDRESS, SUI_SYSTEM_PACKAGE_ID,
+    SUI_FRAMEWORK_OBJECT_ID, SUI_SYSTEM_ADDRESS, SUI_SYSTEM_OBJECT_ID,
 };
 use test_utils::network::TestClusterBuilder;
 
@@ -34,10 +34,7 @@ async fn test_package_override() {
     let framework_ref = {
         let default_cluster = TestClusterBuilder::new().build().await.unwrap();
         let client = default_cluster.rpc_client();
-        let obj = client
-            .get_object(SUI_SYSTEM_PACKAGE_ID, None)
-            .await
-            .unwrap();
+        let obj = client.get_object(SUI_SYSTEM_OBJECT_ID, None).await.unwrap();
 
         if let Some(obj) = obj.data {
             obj.object_ref()
@@ -47,7 +44,7 @@ async fn test_package_override() {
     };
 
     let modified_ref = {
-        let mut framework_modules = BuiltInFramework::get_package_by_id(&SUI_SYSTEM_PACKAGE_ID)
+        let mut framework_modules = BuiltInFramework::get_package_by_id(&SUI_SYSTEM_OBJECT_ID)
             .modules()
             .to_vec();
 
@@ -78,10 +75,7 @@ async fn test_package_override() {
             .unwrap();
 
         let client = modified_cluster.rpc_client();
-        let obj = client
-            .get_object(SUI_SYSTEM_PACKAGE_ID, None)
-            .await
-            .unwrap();
+        let obj = client.get_object(SUI_SYSTEM_OBJECT_ID, None).await.unwrap();
 
         if let Some(obj) = obj.data {
             obj.object_ref()


### PR DESCRIPTION
## Description

...rather than their package names, this allows getting rid of package names declared in `sui-framework-build/lib.rs`, the last vestige of framework-specific code from `sui-framework-build`.

Also rename `SUI_SYSTEM_PACKAGE_ID` to `SUI_SYSTEM_OBJECT_ID` for consistency with the rest of the system package ID constants.

In a follow-up PR, we will then rename `sui-framework-build` to `sui-move-build` and consolidate it down to one module, because that is what it is for (not just for building the framework).

## Test Plan

```
$ cargo simtest
$ env SUI_SKIP_SIMTESTS=1 cargo nextest run
```