### PR TITLE
Make coin metadata nullable

### DIFF
--- a/.changeset/dull-lobsters-leave.md
+++ b/.changeset/dull-lobsters-leave.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Response for `getCoinMetadata` is now nullable, in the event that no metadata can be found.

--- a/crates/sui-indexer/src/apis/coin_api.rs
+++ b/crates/sui-indexer/src/apis/coin_api.rs
@@ -60,7 +60,7 @@ impl CoinReadApiServer for CoinReadApi {
         self.fullnode.get_all_balances(owner).await
     }
 
-    async fn get_coin_metadata(&self, coin_type: String) -> RpcResult<SuiCoinMetadata> {
+    async fn get_coin_metadata(&self, coin_type: String) -> RpcResult<Option<SuiCoinMetadata>> {
         self.fullnode.get_coin_metadata(coin_type).await
     }
 

--- a/crates/sui-json-rpc/src/api/coin.rs
+++ b/crates/sui-json-rpc/src/api/coin.rs
@@ -61,7 +61,7 @@ pub trait CoinReadApi {
         &self,
         /// type name for the coin (e.g., 0x168da5bf1f48dafc111b0a488fa454aca95e0b5e::usdc::USDC)
         coin_type: String,
-    ) -> RpcResult<SuiCoinMetadata>;
+    ) -> RpcResult<Option<SuiCoinMetadata>>;
 
     /// Return total supply for a coin
     #[method(name = "getTotalSupply")]

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -498,7 +498,8 @@ async fn test_get_metadata() -> Result<(), anyhow::Error> {
 
     let result: SuiCoinMetadata = http_client
         .get_coin_metadata(format!("{package_id}::trusted_coin::TRUSTED_COIN"))
-        .await?;
+        .await?
+        .unwrap();
 
     assert_eq!("TRUSTED", result.symbol);
     assert_eq!("Trusted Coin for test", result.description);

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1298,7 +1298,6 @@
       ],
       "result": {
         "name": "SuiCoinMetadata",
-        "required": true,
         "schema": {
           "$ref": "#/components/schemas/SuiCoinMetadata"
         }

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -353,7 +353,10 @@ impl CoinReadApi {
         Ok(self.api.http.get_all_balances(owner).await?)
     }
 
-    pub async fn get_coin_metadata(&self, coin_type: String) -> SuiRpcResult<SuiCoinMetadata> {
+    pub async fn get_coin_metadata(
+        &self,
+        coin_type: String,
+    ) -> SuiRpcResult<Option<SuiCoinMetadata>> {
         Ok(self.api.http.get_coin_metadata(coin_type).await?)
     }
 

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -235,7 +235,9 @@ export class JsonRpcProvider {
   /**
    * Fetch CoinMetadata for a given coin type
    */
-  async getCoinMetadata(input: { coinType: string }): Promise<CoinMetadata> {
+  async getCoinMetadata(input: {
+    coinType: string;
+  }): Promise<CoinMetadata | null> {
     return await this.client.requestWithType(
       'suix_getCoinMetadata',
       [input.coinType],

--- a/sdk/typescript/test/e2e/coin-metadata.test.ts
+++ b/sdk/typescript/test/e2e/coin-metadata.test.ts
@@ -16,9 +16,9 @@ describe('Test Coin Metadata', () => {
   });
 
   it('Test accessing coin metadata', async () => {
-    const coinMetadata = await toolbox.signer.provider.getCoinMetadata({
+    const coinMetadata = (await toolbox.signer.provider.getCoinMetadata({
       coinType: `${packageId}::test::TEST`,
-    });
+    }))!;
     expect(coinMetadata.decimals).to.equal(2);
     expect(coinMetadata.name).to.equal('Test Coin');
     expect(coinMetadata.description).to.equal('Test coin metadata');


### PR DESCRIPTION
## Description 

There are cases where coin metadata fails to load, and these are actually somewhat expected. Rather than making the API hard error on these case, we instead can just make it return `null`. In general I'd like it if more of our APIs did this so that errors were really an actual error vs just "there is no data".

This is technically a breaking change, but I opted to not introduce it gradually because I think this should be fairly non-impacting to the ecosystem

## Test Plan 

Ran locally.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
