### PR TITLE
[explorer] fix object view transaction fetching

### DIFF
--- a/apps/explorer/src/components/TransactionBlocksForAddress/TransactionBlocksForAddress.tsx
+++ b/apps/explorer/src/components/TransactionBlocksForAddress/TransactionBlocksForAddress.tsx
@@ -94,7 +94,7 @@ function TransactionBlocksForAddress({
             setFilterValue(FILTER_VALUES.CHANGED);
         }
     }, [isObject]);
-   
+
     const {
         data,
         isLoading,

--- a/apps/explorer/src/components/TransactionBlocksForAddress/TransactionBlocksForAddress.tsx
+++ b/apps/explorer/src/components/TransactionBlocksForAddress/TransactionBlocksForAddress.tsx
@@ -94,7 +94,7 @@ function TransactionBlocksForAddress({
             setFilterValue(FILTER_VALUES.CHANGED);
         }
     }, [isObject]);
-   
+
     const {
         data,
         isLoading,
@@ -102,7 +102,7 @@ function TransactionBlocksForAddress({
         isFetchingNextPage,
         fetchNextPage,
         hasNextPage,
-        refetch
+        refetch,
     } = useGetTransactionBlocksForAddress(
         address,
         filterValue !== FILTER_VALUES.UNFILTERED
@@ -113,7 +113,7 @@ function TransactionBlocksForAddress({
     );
 
     useEffect(() => {
-        refetch()
+        refetch();
     }, [filterValue, refetch]);
 
     const generateTableCard = (

--- a/apps/explorer/src/components/TransactionBlocksForAddress/TransactionBlocksForAddress.tsx
+++ b/apps/explorer/src/components/TransactionBlocksForAddress/TransactionBlocksForAddress.tsx
@@ -94,7 +94,7 @@ function TransactionBlocksForAddress({
             setFilterValue(FILTER_VALUES.CHANGED);
         }
     }, [isObject]);
-
+   
     const {
         data,
         isLoading,
@@ -102,7 +102,6 @@ function TransactionBlocksForAddress({
         isFetchingNextPage,
         fetchNextPage,
         hasNextPage,
-        refetch,
     } = useGetTransactionBlocksForAddress(
         address,
         filterValue !== FILTER_VALUES.UNFILTERED
@@ -111,10 +110,6 @@ function TransactionBlocksForAddress({
               } as TransactionFilter)
             : undefined
     );
-
-    useEffect(() => {
-        refetch();
-    }, [filterValue, refetch]);
 
     const generateTableCard = (
         currentPage: number,

--- a/apps/explorer/src/components/TransactionBlocksForAddress/TransactionBlocksForAddress.tsx
+++ b/apps/explorer/src/components/TransactionBlocksForAddress/TransactionBlocksForAddress.tsx
@@ -94,7 +94,7 @@ function TransactionBlocksForAddress({
             setFilterValue(FILTER_VALUES.CHANGED);
         }
     }, [isObject]);
-
+   
     const {
         data,
         isLoading,
@@ -102,6 +102,7 @@ function TransactionBlocksForAddress({
         isFetchingNextPage,
         fetchNextPage,
         hasNextPage,
+        refetch
     } = useGetTransactionBlocksForAddress(
         address,
         filterValue !== FILTER_VALUES.UNFILTERED
@@ -110,6 +111,10 @@ function TransactionBlocksForAddress({
               } as TransactionFilter)
             : undefined
     );
+
+    useEffect(() => {
+        refetch()
+    }, [filterValue, refetch]);
 
     const generateTableCard = (
         currentPage: number,

--- a/apps/explorer/src/hooks/useGetTransactionBlocksForAddress.ts
+++ b/apps/explorer/src/hooks/useGetTransactionBlocksForAddress.ts
@@ -16,7 +16,7 @@ export function useGetTransactionBlocksForAddress(
 ) {
     const rpc = useRpcClient();
     return useInfiniteQuery(
-        ['get-transaction-blocks', address],
+        ['get-transaction-blocks', address, filter],
         async ({ pageParam }) =>
             await rpc.queryTransactionBlocks({
                 filter,


### PR DESCRIPTION
## Description 

Ensuring refetching of transaction data when filter value is changed for transaction block query.

## Test Plan 

Locally with https://explorer.sui.io/object/0x01e18c0d4893adc2ee97d4dd469d7bc32afbdde2a5e70b13600abf02d7e64558?network=testnet

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Fixed object view transaction blocks bug