### PR TITLE
Explorer update validators average APY to 2 decimal

### DIFF
--- a/apps/core/src/utils/roundFloat.ts
+++ b/apps/core/src/utils/roundFloat.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-const defaultPrecision = 2;
-export function roundFloat(num: number, precision = defaultPrecision) {
+const DEFAULT_PRECISION = 2;
+export function roundFloat(num: number, precision = DEFAULT_PRECISION) {
     return parseFloat(num.toFixed(precision));
 }

--- a/apps/core/src/utils/roundFloat.ts
+++ b/apps/core/src/utils/roundFloat.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-export function roundFloat(num: number, precision: number) {
+const defaultPrecision = 2;
+export function roundFloat(num: number, precision = defaultPrecision) {
     return parseFloat(num.toFixed(precision));
 }

--- a/apps/explorer/src/pages/validators/Validators.tsx
+++ b/apps/explorer/src/pages/validators/Validators.tsx
@@ -29,7 +29,6 @@ import { Tooltip } from '~/ui/Tooltip';
 import { getValidatorMoveEvent } from '~/utils/getValidatorMoveEvent';
 import { VALIDATOR_LOW_STAKE_GRACE_PERIOD } from '~/utils/validatorConstants';
 
-const APY_DECIMALS = 2;
 
 const NodeMap = lazy(() => import('../../components/node-map'));
 
@@ -249,7 +248,7 @@ function ValidatorPageResult() {
         const averageAPY = apys?.reduce((acc, cur) => acc + cur, 0);
         // exclude validators with no apy
         const numberOfValidatorsWithAPY = apys?.filter((a) => a > 0).length;
-        return roundFloat(averageAPY / numberOfValidatorsWithAPY, APY_DECIMALS);
+        return roundFloat(averageAPY / numberOfValidatorsWithAPY);
     }, [rollingAverageApys]);
 
     const lastEpochRewardOnAllValidators = useMemo(() => {

--- a/apps/explorer/src/pages/validators/Validators.tsx
+++ b/apps/explorer/src/pages/validators/Validators.tsx
@@ -29,7 +29,7 @@ import { Tooltip } from '~/ui/Tooltip';
 import { getValidatorMoveEvent } from '~/utils/getValidatorMoveEvent';
 import { VALIDATOR_LOW_STAKE_GRACE_PERIOD } from '~/utils/validatorConstants';
 
-const APY_DECIMALS = 3;
+const APY_DECIMALS = 2;
 
 const NodeMap = lazy(() => import('../../components/node-map'));
 
@@ -247,7 +247,9 @@ function ValidatorPageResult() {
             return null;
         const apys = Object.values(rollingAverageApys);
         const averageAPY = apys?.reduce((acc, cur) => acc + cur, 0);
-        return roundFloat(averageAPY / apys.length, APY_DECIMALS);
+        // exclude validators with no apy
+        const numberOfValidatorsWithAPY = apys?.filter((a) => a > 0).length;
+        return roundFloat(averageAPY / numberOfValidatorsWithAPY, APY_DECIMALS);
     }, [rollingAverageApys]);
 
     const lastEpochRewardOnAllValidators = useMemo(() => {

--- a/apps/explorer/src/pages/validators/Validators.tsx
+++ b/apps/explorer/src/pages/validators/Validators.tsx
@@ -29,7 +29,6 @@ import { Tooltip } from '~/ui/Tooltip';
 import { getValidatorMoveEvent } from '~/utils/getValidatorMoveEvent';
 import { VALIDATOR_LOW_STAKE_GRACE_PERIOD } from '~/utils/validatorConstants';
 
-
 const NodeMap = lazy(() => import('../../components/node-map'));
 
 export function validatorsTableData(

--- a/apps/explorer/src/pages/validators/Validators.tsx
+++ b/apps/explorer/src/pages/validators/Validators.tsx
@@ -243,11 +243,11 @@ function ValidatorPageResult() {
             Object.keys(rollingAverageApys)?.length === 0
         )
             return null;
-        const apys = Object.values(rollingAverageApys);
-        const averageAPY = apys?.reduce((acc, cur) => acc + cur, 0);
+
         // exclude validators with no apy
-        const numberOfValidatorsWithAPY = apys?.filter((a) => a > 0).length;
-        return roundFloat(averageAPY / numberOfValidatorsWithAPY);
+        const apys = Object.values(rollingAverageApys)?.filter((a) => a > 0);
+        const averageAPY = apys?.reduce((acc, cur) => acc + cur, 0);
+        return roundFloat(averageAPY / apys.length);
     }, [rollingAverageApys]);
 
     const lastEpochRewardOnAllValidators = useMemo(() => {


### PR DESCRIPTION
## Description 

Describe the changes or additions included in this PR.

- Use 2 decimal places for average APY and exclude 0 APY

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
