### PR TITLE
add simple sampling to telemetry_subscribers, instrumenting for trace logging on read_api

### DIFF
--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -27,6 +27,7 @@ use sui_types::sui_system_state::SuiSystemStateTrait;
 use sui_types::sui_system_state::{
     get_validator_from_table, sui_system_state_summary::get_validator_by_pool_id, SuiSystemState,
 };
+use tracing::{info, instrument};
 
 use crate::api::{GovernanceReadApiServer, JsonRpcMetrics};
 use crate::error::Error;
@@ -234,18 +235,24 @@ impl GovernanceReadApi {
 
 #[async_trait]
 impl GovernanceReadApiServer for GovernanceReadApi {
+    #[instrument(skip(self))]
     async fn get_stakes_by_ids(
         &self,
         staked_sui_ids: Vec<ObjectID>,
     ) -> RpcResult<Vec<DelegatedStake>> {
+        info!("get_stakes_by_ids");
         Ok(self.get_stakes_by_ids(staked_sui_ids).await?)
     }
 
+    #[instrument(skip(self))]
     async fn get_stakes(&self, owner: SuiAddress) -> RpcResult<Vec<DelegatedStake>> {
+        info!("get_stakes");
         Ok(self.get_stakes(owner).await?)
     }
 
+    #[instrument(skip(self))]
     async fn get_committee_info(&self, epoch: Option<BigInt<u64>>) -> RpcResult<SuiCommittee> {
+        info!("get_committee_info");
         Ok(self
             .state
             .committee_store()
@@ -254,7 +261,9 @@ impl GovernanceReadApiServer for GovernanceReadApi {
             .map_err(Error::from)?)
     }
 
+    #[instrument(skip(self))]
     async fn get_latest_sui_system_state(&self) -> RpcResult<SuiSystemStateSummary> {
+        info!("get_latest_sui_system_state");
         Ok(self
             .state
             .database
@@ -263,7 +272,9 @@ impl GovernanceReadApiServer for GovernanceReadApi {
             .into_sui_system_state_summary())
     }
 
+    #[instrument(skip(self))]
     async fn get_reference_gas_price(&self) -> RpcResult<BigInt<u64>> {
+        info!("get_reference_gas_price");
         let epoch_store = self.state.load_epoch_store_one_call_per_task();
         Ok(epoch_store.reference_gas_price().into())
     }

--- a/crates/sui-node/src/main.rs
+++ b/crates/sui-node/src/main.rs
@@ -67,6 +67,9 @@ async fn main() -> Result<()> {
 
     // Initialize logging
     let (_guard, filter_handle) = telemetry_subscribers::TelemetryConfig::new()
+        // Set a default
+        .with_sample_nth(10)
+        .with_target_prefix("sui_json_rpc")
         .with_env()
         .with_prom_registry(&prometheus_registry)
         .init();


### PR DESCRIPTION
## Description 

Add a simple sampling layer based on target and sampling rate. Set instrumentation on read_api, and `info!` logs to log method calls with instrumentation.

## Test Plan 

Ran full node locally, verified that we see instrumented logs at expected sampling rate

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
