### PR TITLE
move: sui-compatible test suite for move-stdlib

### DIFF
--- a/crates/sui-framework/packages/move-stdlib/tests/ascii_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/ascii_tests.move
@@ -1,0 +1,125 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module std::ascii_tests {
+    use std::ascii;
+    use std::vector;
+    use std::option;
+
+    #[test]
+    fun test_ascii_chars() {
+        let i = 0;
+        let end = 128;
+        let vec = vector::empty();
+
+        while (i < end) {
+            assert!(ascii::is_valid_char(i), 0);
+            vector::push_back(&mut vec, i);
+            i = i + 1;
+        };
+
+        let str = ascii::string(vec);
+        assert!(vector::length(ascii::as_bytes(&str)) == 128, 0);
+        assert!(!ascii::all_characters_printable(&str), 1);
+        assert!(vector::length(&ascii::into_bytes(str)) == 128, 2);
+    }
+
+    #[test]
+    fun test_ascii_push_chars() {
+        let i = 0;
+        let end = 128;
+        let str = ascii::string(vector::empty());
+
+        while (i < end) {
+            ascii::push_char(&mut str, ascii::char(i));
+            i = i + 1;
+        };
+
+        assert!(vector::length(ascii::as_bytes(&str)) == 128, 0);
+        assert!(ascii::length(&str) == 128, 0);
+        assert!(!ascii::all_characters_printable(&str), 1);
+    }
+
+    #[test]
+    fun test_ascii_push_char_pop_char() {
+        let i = 0;
+        let end = 128;
+        let str = ascii::string(vector::empty());
+
+        while (i < end) {
+            ascii::push_char(&mut str, ascii::char(i));
+            i = i + 1;
+        };
+
+        while (i > 0) {
+            let char = ascii::pop_char(&mut str);
+            assert!(ascii::byte(char) == i - 1, 0);
+            i = i - 1;
+        };
+
+        assert!(vector::length(ascii::as_bytes(&str)) == 0, 0);
+        assert!(ascii::length(&str) == 0, 0);
+        assert!(ascii::all_characters_printable(&str), 1);
+    }
+
+    #[test]
+    fun test_printable_chars() {
+        let i = 0x20;
+        let end = 0x7E;
+        let vec = vector::empty();
+
+        while (i <= end) {
+            assert!(ascii::is_printable_char(i), 0);
+            vector::push_back(&mut vec, i);
+            i = i + 1;
+        };
+
+        let str = ascii::string(vec);
+        assert!(ascii::all_characters_printable(&str), 0);
+    }
+
+    #[test]
+    fun printable_chars_dont_allow_tab() {
+        let str = ascii::string(vector::singleton(0x09));
+        assert!(!ascii::all_characters_printable(&str), 0);
+    }
+
+    #[test]
+    fun printable_chars_dont_allow_newline() {
+        let str = ascii::string(vector::singleton(0x0A));
+        assert!(!ascii::all_characters_printable(&str), 0);
+    }
+
+    #[test]
+    fun test_invalid_ascii_characters() {
+        let i = 128u8;
+        let end = 255u8;
+        while (i < end) {
+            let try_str = ascii::try_string(vector::singleton(i));
+            assert!(option::is_none(&try_str), 0);
+            i = i + 1;
+        };
+    }
+
+    #[test]
+    fun test_nonvisible_chars() {
+        let i = 0;
+        let end = 0x09;
+        while (i < end) {
+            let str = ascii::string(vector::singleton(i));
+            assert!(!ascii::all_characters_printable(&str), 0);
+            i = i + 1;
+        };
+
+        let i = 0x0B;
+        let end = 0x0F;
+        while (i <= end) {
+            let str = ascii::string(vector::singleton(i));
+            assert!(!ascii::all_characters_printable(&str), 0);
+            i = i + 1;
+        };
+    }
+}

--- a/crates/sui-framework/packages/move-stdlib/tests/bcs_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/bcs_tests.move
@@ -1,0 +1,108 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module std::bcs_tests {
+    use std::bcs;
+
+    struct Box<T> has copy, drop, store { x: T }
+    struct Box3<T> has copy, drop, store { x: Box<Box<T>> }
+    struct Box7<T> has copy, drop, store { x: Box3<Box3<T>> }
+    struct Box15<T> has copy, drop, store { x: Box7<Box7<T>> }
+    struct Box31<T> has copy, drop, store { x: Box15<Box15<T>> }
+    struct Box63<T> has copy, drop, store { x: Box31<Box31<T>> }
+    struct Box127<T> has copy, drop, store { x: Box63<Box63<T>> }
+
+    #[test]
+    fun bcs_address() {
+        let addr = @0x0000000000000000000000000000000089b9f9d1fadc027cf9532d6f99041522;
+        let expected_output = x"0000000000000000000000000000000089b9f9d1fadc027cf9532d6f99041522";
+        assert!(bcs::to_bytes(&addr) == expected_output, 0);
+    }
+
+    #[test]
+    fun bcs_bool() {
+        let expected_output = x"01";
+        assert!(bcs::to_bytes(&true) == expected_output, 0);
+    }
+
+    #[test]
+    fun bcs_u8() {
+        let expected_output = x"01";
+        assert!(bcs::to_bytes(&1u8) == expected_output, 0);
+    }
+
+    #[test]
+    fun bcs_u16() {
+        let expected_output = x"0100";
+        assert!(bcs::to_bytes(&1u16) == expected_output, 0);
+    }
+
+    #[test]
+    fun bcs_u32() {
+        let expected_output = x"01000000";
+        assert!(bcs::to_bytes(&1u32) == expected_output, 0);
+    }
+
+    #[test]
+    fun bcs_u64() {
+        let expected_output = x"0100000000000000";
+        assert!(bcs::to_bytes(&1) == expected_output, 0);
+    }
+
+    #[test]
+    fun bcs_u128() {
+        let expected_output = x"01000000000000000000000000000000";
+        assert!(bcs::to_bytes(&1u128) == expected_output, 0);
+    }
+
+    #[test]
+    fun bcs_u256() {
+        let expected_output = x"0100000000000000000000000000000000000000000000000000000000000000";
+        assert!(bcs::to_bytes(&1u256) == expected_output, 0);
+    }
+
+    #[test]
+    fun bcs_vec_u8() {
+        let v = x"0f";
+        let expected_output = x"010f";
+        assert!(bcs::to_bytes(&v) == expected_output, 0);
+    }
+
+    fun box3<T>(x: T): Box3<T> {
+        Box3 { x: Box { x: Box { x } } }
+    }
+
+    fun box7<T>(x: T): Box7<T> {
+        Box7 { x: box3(box3(x)) }
+    }
+
+    fun box15<T>(x: T): Box15<T> {
+        Box15 { x: box7(box7(x)) }
+    }
+
+    fun box31<T>(x: T): Box31<T> {
+        Box31 { x: box15(box15(x)) }
+    }
+
+    fun box63<T>(x: T): Box63<T> {
+        Box63 { x: box31(box31(x)) }
+    }
+
+    fun box127<T>(x: T): Box127<T> {
+        Box127 { x: box63(box63(x)) }
+    }
+
+    #[test]
+    fun encode_128() {
+        bcs::to_bytes(&box127(true));
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 453, location = std::bcs)]
+    fun encode_129() {
+        bcs::to_bytes(&Box { x: box127(true) });
+    }
+}

--- a/crates/sui-framework/packages/move-stdlib/tests/bit_vector_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/bit_vector_tests.move
@@ -1,0 +1,228 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module std::bit_vector_tests {
+    use std::bit_vector;
+
+    #[test_only]
+    fun test_bitvector_set_unset_of_size(k: u64) {
+        let bitvector = bit_vector::new(k);
+        let index = 0;
+        while (index < k) {
+            bit_vector::set(&mut bitvector, index);
+            assert!(bit_vector::is_index_set(&bitvector, index), 0);
+            index = index + 1;
+            let index_to_right = index;
+            while (index_to_right < k) {
+                assert!(!bit_vector::is_index_set(&bitvector, index_to_right), 1);
+                index_to_right = index_to_right + 1;
+            };
+        };
+        // now go back down unsetting
+        index = 0;
+
+        while (index < k) {
+            bit_vector::unset(&mut bitvector, index);
+            assert!(!bit_vector::is_index_set(&bitvector, index), 0);
+            index = index + 1;
+            let index_to_right = index;
+            while (index_to_right < k) {
+                assert!(bit_vector::is_index_set(&bitvector, index_to_right), 1);
+                index_to_right = index_to_right + 1;
+            };
+        };
+    }
+
+    #[test]
+    #[expected_failure(abort_code = bit_vector::EINDEX)]
+    fun set_bit_out_of_bounds() {
+        let bitvector = bit_vector::new(bit_vector::word_size());
+        bit_vector::set(&mut bitvector, bit_vector::word_size());
+    }
+
+    #[test]
+    #[expected_failure(abort_code = bit_vector::EINDEX)]
+    fun unset_bit_out_of_bounds() {
+        let bitvector = bit_vector::new(bit_vector::word_size());
+        bit_vector::unset(&mut bitvector, bit_vector::word_size());
+    }
+
+    #[test]
+    #[expected_failure(abort_code = bit_vector::EINDEX)]
+    fun index_bit_out_of_bounds() {
+        let bitvector = bit_vector::new(bit_vector::word_size());
+        bit_vector::is_index_set(&mut bitvector, bit_vector::word_size());
+    }
+
+    #[test]
+    fun test_set_bit_and_index_basic() {
+        test_bitvector_set_unset_of_size(8)
+    }
+
+    #[test]
+    fun test_set_bit_and_index_odd_size() {
+        test_bitvector_set_unset_of_size(140)
+    }
+
+    #[test]
+    fun longest_sequence_no_set_zero_index() {
+        let bitvector = bit_vector::new(100);
+        assert!(bit_vector::longest_set_sequence_starting_at(&bitvector, 0) == 0, 0);
+    }
+
+    #[test]
+    fun longest_sequence_one_set_zero_index() {
+        let bitvector = bit_vector::new(100);
+        bit_vector::set(&mut bitvector, 1);
+        assert!(bit_vector::longest_set_sequence_starting_at(&bitvector, 0) == 0, 0);
+    }
+
+    #[test]
+    fun longest_sequence_no_set_nonzero_index() {
+        let bitvector = bit_vector::new(100);
+        assert!(bit_vector::longest_set_sequence_starting_at(&bitvector, 51) == 0, 0);
+    }
+
+    #[test]
+    fun longest_sequence_two_set_nonzero_index() {
+        let bitvector = bit_vector::new(100);
+        bit_vector::set(&mut bitvector, 50);
+        bit_vector::set(&mut bitvector, 52);
+        assert!(bit_vector::longest_set_sequence_starting_at(&bitvector, 51) == 0, 0);
+    }
+
+    #[test]
+    fun longest_sequence_with_break() {
+        let bitvector = bit_vector::new(100);
+        let i = 0;
+        while (i < 20) {
+            bit_vector::set(&mut bitvector, i);
+            i = i + 1;
+        };
+        // create a break in the run
+        i = i + 1;
+        while (i < 100) {
+            bit_vector::set(&mut bitvector, i);
+            i = i + 1;
+        };
+        assert!(bit_vector::longest_set_sequence_starting_at(&bitvector, 0) == 20, 0);
+        assert!(bit_vector::longest_set_sequence_starting_at(&bitvector, 20) == 0, 0);
+        assert!(bit_vector::longest_set_sequence_starting_at(&bitvector, 21) == 100 - 21, 0);
+    }
+
+    #[test]
+    fun test_shift_left() {
+        let bitlen = 97;
+        let bitvector = bit_vector::new(bitlen);
+
+        let i = 0;
+        while (i < bitlen) {
+            bit_vector::set(&mut bitvector, i);
+            i = i + 1;
+        };
+
+        i = bitlen - 1;
+        while (i > 0) {
+            assert!(bit_vector::is_index_set(&bitvector, i), 0);
+            bit_vector::shift_left(&mut bitvector, 1);
+            assert!(!bit_vector::is_index_set(&bitvector,  i), 1);
+            i = i - 1;
+        };
+    }
+
+    #[test]
+    fun test_shift_left_specific_amount() {
+        let bitlen = 300;
+        let shift_amount = 133;
+        let bitvector = bit_vector::new(bitlen);
+
+        bit_vector::set(&mut bitvector, 201);
+        assert!(bit_vector::is_index_set(&bitvector, 201), 0);
+
+        bit_vector::shift_left(&mut bitvector, shift_amount);
+        assert!(bit_vector::is_index_set(&bitvector, 201 - shift_amount), 1);
+        assert!(!bit_vector::is_index_set(&bitvector, 201), 2);
+
+        // Make sure this shift clears all the bits
+        bit_vector::shift_left(&mut bitvector, bitlen  - 1);
+
+        let i = 0;
+        while (i < bitlen) {
+            assert!(!bit_vector::is_index_set(&bitvector, i), 3);
+            i = i + 1;
+        }
+    }
+
+    #[test]
+    fun test_shift_left_specific_amount_to_unset_bit() {
+        let bitlen = 50;
+        let chosen_index = 24;
+        let shift_amount = 3;
+        let bitvector = bit_vector::new(bitlen);
+
+        let i = 0;
+
+        while (i < bitlen) {
+            bit_vector::set(&mut bitvector, i);
+            i = i + 1;
+        };
+
+        bit_vector::unset(&mut bitvector, chosen_index);
+        assert!(!bit_vector::is_index_set(&bitvector, chosen_index), 0);
+
+        bit_vector::shift_left(&mut bitvector, shift_amount);
+
+        i = 0;
+
+        while (i < bitlen) {
+            // only chosen_index - shift_amount and the remaining bits should be BitVector::unset
+            if ((i == chosen_index - shift_amount) || (i >= bitlen - shift_amount)) {
+                assert!(!bit_vector::is_index_set(&bitvector, i), 1);
+            } else {
+                assert!(bit_vector::is_index_set(&bitvector, i), 2);
+            };
+            i = i + 1;
+        }
+    }
+
+    #[test]
+    fun shift_left_at_size() {
+        let bitlen = 133;
+        let bitvector = bit_vector::new(bitlen);
+
+        let i = 0;
+        while (i < bitlen) {
+            bit_vector::set(&mut bitvector, i);
+            i = i + 1;
+        };
+
+        bit_vector::shift_left(&mut bitvector, bitlen - 1);
+        i = bitlen - 1;
+        while (i > 0) {
+            assert!(!bit_vector::is_index_set(&bitvector,  i), 1);
+            i = i - 1;
+        };
+    }
+
+    #[test]
+    fun shift_left_more_than_size() {
+        let bitlen = 133;
+        let bitvector = bit_vector::new(bitlen);
+        bit_vector::shift_left(&mut bitvector, bitlen);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = bit_vector::ELENGTH)]
+    fun empty_bitvector() {
+        bit_vector::new(0);
+    }
+
+    #[test]
+    fun single_bit_bitvector() {
+        let bitvector = bit_vector::new(1);
+        assert!(bit_vector::length(&bitvector) == 1, 0);
+    }
+}

--- a/crates/sui-framework/packages/move-stdlib/tests/fixedpoint32_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/fixedpoint32_tests.move
@@ -1,0 +1,114 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module std::fixed_point32_tests {
+    use std::fixed_point32;
+
+    #[test]
+    #[expected_failure(abort_code = fixed_point32::EDENOMINATOR)]
+    fun create_div_zero() {
+        // A denominator of zero should cause an arithmetic error.
+        fixed_point32::create_from_rational(2, 0);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = fixed_point32::ERATIO_OUT_OF_RANGE)]
+    fun create_overflow() {
+        // The maximum value is 2^32 - 1. Check that anything larger aborts
+        // with an overflow.
+        fixed_point32::create_from_rational(4294967296, 1); // 2^32
+    }
+
+    #[test]
+    #[expected_failure(abort_code = fixed_point32::ERATIO_OUT_OF_RANGE)]
+    fun create_underflow() {
+        // The minimum non-zero value is 2^-32. Check that anything smaller
+        // aborts.
+        fixed_point32::create_from_rational(1, 8589934592); // 2^-33
+    }
+
+    #[test]
+    fun create_zero() {
+        let x = fixed_point32::create_from_rational(0, 1);
+        assert!(fixed_point32::is_zero(x), 0);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = fixed_point32::EDIVISION_BY_ZERO)]
+    fun divide_by_zero() {
+        // Dividing by zero should cause an arithmetic error.
+        let f = fixed_point32::create_from_raw_value(0);
+        fixed_point32::divide_u64(1, f);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = fixed_point32::EDIVISION)]
+    fun divide_overflow_small_divisore() {
+        let f = fixed_point32::create_from_raw_value(1); // 0x0.00000001
+        // Divide 2^32 by the minimum fractional value. This should overflow.
+        fixed_point32::divide_u64(4294967296, f);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = fixed_point32::EDIVISION)]
+    fun divide_overflow_large_numerator() {
+        let f = fixed_point32::create_from_rational(1, 2); // 0.5
+        // Divide the maximum u64 value by 0.5. This should overflow.
+        fixed_point32::divide_u64(18446744073709551615, f);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = fixed_point32::EMULTIPLICATION)]
+    fun multiply_overflow_small_multiplier() {
+        let f = fixed_point32::create_from_rational(3, 2); // 1.5
+        // Multiply the maximum u64 value by 1.5. This should overflow.
+        fixed_point32::multiply_u64(18446744073709551615, f);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = fixed_point32::EMULTIPLICATION)]
+    fun multiply_overflow_large_multiplier() {
+        let f = fixed_point32::create_from_raw_value(18446744073709551615);
+        // Multiply 2^33 by the maximum fixed-point value. This should overflow.
+        fixed_point32::multiply_u64(8589934592, f);
+    }
+
+    #[test]
+    fun exact_multiply() {
+        let f = fixed_point32::create_from_rational(3, 4); // 0.75
+        let nine = fixed_point32::multiply_u64(12, f); // 12 * 0.75
+        assert!(nine == 9, 0);
+    }
+
+    #[test]
+    fun exact_divide() {
+        let f = fixed_point32::create_from_rational(3, 4); // 0.75
+        let twelve = fixed_point32::divide_u64(9, f); // 9 / 0.75
+        assert!(twelve == 12, 0);
+    }
+
+    #[test]
+    fun multiply_truncates() {
+        let f = fixed_point32::create_from_rational(1, 3); // 0.333...
+        let not_three = fixed_point32::multiply_u64(9, copy f); // 9 * 0.333...
+        // multiply_u64 does NOT round -- it truncates -- so values that
+        // are not perfectly representable in binary may be off by one.
+        assert!(not_three == 2, 0);
+
+        // Try again with a fraction slightly larger than 1/3.
+        let f = fixed_point32::create_from_raw_value(fixed_point32::get_raw_value(f) + 1);
+        let three = fixed_point32::multiply_u64(9, f);
+        assert!(three == 3, 1);
+    }
+
+    #[test]
+    fun create_from_rational_max_numerator_denominator() {
+        // Test creating a 1.0 fraction from the maximum u64 value.
+        let f = fixed_point32::create_from_rational(18446744073709551615, 18446744073709551615);
+        let one = fixed_point32::get_raw_value(f);
+        assert!(one == 4294967296, 0); // 0x1.00000000
+    }
+}

--- a/crates/sui-framework/packages/move-stdlib/tests/hash_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/hash_tests.move
@@ -1,0 +1,23 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module std::hash_tests {
+    use std::hash;
+
+    #[test]
+    fun sha2_256_expected_hash() {
+        let input = x"616263";
+        let expected_output = x"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+        assert!(hash::sha2_256(input) == expected_output, 0);
+    }
+
+    #[test]
+    fun sha3_256_expected_hash() {
+        let input = x"616263";
+        let expected_output = x"3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532";
+        assert!(hash::sha3_256(input) == expected_output, 0);
+    }
+}

--- a/crates/sui-framework/packages/move-stdlib/tests/option_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/option_tests.move
@@ -1,0 +1,175 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module std::option_tests {
+    use std::option;
+    use std::vector;
+
+    #[test]
+    fun option_none_is_none() {
+        let none = option::none<u64>();
+        assert!(option::is_none(&none), 0);
+        assert!(!option::is_some(&none), 1);
+    }
+
+    #[test]
+    fun option_some_is_some() {
+        let some = option::some(5);
+        assert!(!option::is_none(&some), 0);
+        assert!(option::is_some(&some), 1);
+    }
+
+    #[test]
+    fun option_contains() {
+        let none = option::none<u64>();
+        let some = option::some(5);
+        let some_other = option::some(6);
+        assert!(option::contains(&some, &5), 0);
+        assert!(option::contains(&some_other, &6), 1);
+        assert!(!option::contains(&none, &5), 2);
+        assert!(!option::contains(&some_other, &5), 3);
+    }
+
+    #[test]
+    fun option_borrow_some() {
+        let some = option::some(5);
+        let some_other = option::some(6);
+        assert!(*option::borrow(&some) == 5, 3);
+        assert!(*option::borrow(&some_other) == 6, 4);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = option::EOPTION_NOT_SET)]
+    fun option_borrow_none() {
+        option::borrow(&option::none<u64>());
+    }
+
+    #[test]
+    fun borrow_mut_some() {
+        let some = option::some(1);
+        let ref = option::borrow_mut(&mut some);
+        *ref = 10;
+        assert!(*option::borrow(&some) == 10, 0);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = option::EOPTION_NOT_SET)]
+    fun borrow_mut_none() {
+        option::borrow_mut(&mut option::none<u64>());
+    }
+
+    #[test]
+    fun borrow_with_default() {
+        let none = option::none<u64>();
+        let some = option::some(5);
+        assert!(*option::borrow_with_default(&some, &7) == 5, 0);
+        assert!(*option::borrow_with_default(&none, &7) == 7, 1);
+    }
+
+    #[test]
+    fun get_with_default() {
+        let none = option::none<u64>();
+        let some = option::some(5);
+        assert!(option::get_with_default(&some, 7) == 5, 0);
+        assert!(option::get_with_default(&none, 7) == 7, 1);
+    }
+
+    #[test]
+    fun extract_some() {
+        let opt = option::some(1);
+        assert!(option::extract(&mut opt) == 1, 0);
+        assert!(option::is_none(&opt), 1);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = option::EOPTION_NOT_SET)]
+    fun extract_none() {
+        option::extract(&mut option::none<u64>());
+    }
+
+    #[test]
+    fun swap_some() {
+        let some = option::some(5);
+        assert!(option::swap(&mut some, 1) == 5, 0);
+        assert!(*option::borrow(&some) == 1, 1);
+    }
+
+    #[test]
+    fun swap_or_fill_some() {
+        let some = option::some(5);
+        assert!(option::swap_or_fill(&mut some, 1) == option::some(5), 0);
+        assert!(*option::borrow(&some) == 1, 1);
+    }
+
+    #[test]
+    fun swap_or_fill_none() {
+        let none = option::none();
+        assert!(option::swap_or_fill(&mut none, 1) == option::none(), 0);
+        assert!(*option::borrow(&none) == 1, 1);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = option::EOPTION_NOT_SET)]
+    fun swap_none() {
+        option::swap(&mut option::none<u64>(), 1);
+    }
+
+    #[test]
+    fun fill_none() {
+        let none = option::none<u64>();
+        option::fill(&mut none, 3);
+        assert!(option::is_some(&none), 0);
+        assert!(*option::borrow(&none) == 3, 1);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = option::EOPTION_IS_SET)]
+    fun fill_some() {
+        option::fill(&mut option::some(3), 0);
+    }
+
+    #[test]
+    fun destroy_with_default() {
+        assert!(option::destroy_with_default(option::none<u64>(), 4) == 4, 0);
+        assert!(option::destroy_with_default(option::some(4), 5) == 4, 1);
+    }
+
+    #[test]
+    fun destroy_some() {
+        assert!(option::destroy_some(option::some(4)) == 4, 0);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = option::EOPTION_NOT_SET)]
+    fun destroy_some_none() {
+        option::destroy_some(option::none<u64>());
+    }
+
+    #[test]
+    fun destroy_none() {
+        option::destroy_none(option::none<u64>());
+    }
+
+    #[test]
+    #[expected_failure(abort_code = option::EOPTION_IS_SET)]
+    fun destroy_none_some() {
+        option::destroy_none(option::some<u64>(0));
+    }
+
+    #[test]
+    fun into_vec_some() {
+        let v = option::to_vec(option::some<u64>(0));
+        assert!(vector::length(&v) == 1, 0);
+        let x = vector::pop_back(&mut v);
+        assert!(x == 0, 1);
+    }
+
+    #[test]
+    fun into_vec_none() {
+        let v: vector<u64> = option::to_vec(option::none());
+        assert!(vector::is_empty(&v), 0);
+    }
+}

--- a/crates/sui-framework/packages/move-stdlib/tests/string_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/string_tests.move
@@ -1,0 +1,83 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module std::string_tests {
+    use std::string;
+
+    #[test]
+    fun test_valid_utf8() {
+        let sparkle_heart = vector[240, 159, 146, 150];
+        let s = string::utf8(sparkle_heart);
+        assert!(string::length(&s) == 4, 22);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = string::EINVALID_UTF8)]
+    fun test_invalid_utf8() {
+        let no_sparkle_heart = vector[0, 159, 146, 150];
+        let s = string::utf8(no_sparkle_heart);
+        assert!(string::length(&s) == 1, 22);
+    }
+
+    #[test]
+    fun test_sub_string() {
+        let s = string::utf8(b"abcd");
+        let sub = string::sub_string(&s, 2, 4);
+        assert!(sub == string::utf8(b"cd"), 22)
+    }
+
+    #[test]
+    #[expected_failure(abort_code = string::EINVALID_INDEX)]
+    fun test_sub_string_invalid_boundary() {
+        let sparkle_heart = vector[240, 159, 146, 150];
+        let s = string::utf8(sparkle_heart);
+        let _sub = string::sub_string(&s, 1, 4);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = string::EINVALID_INDEX)]
+    fun test_sub_string_invalid_index() {
+        let s = string::utf8(b"abcd");
+        let _sub = string::sub_string(&s, 4, 5);
+    }
+
+    #[test]
+    fun test_sub_string_empty() {
+        let s = string::utf8(b"abcd");
+        let sub = string::sub_string(&s, 4, 4);
+        assert!(string::is_empty(&sub), 22)
+    }
+
+    #[test]
+    fun test_index_of() {
+        let s = string::utf8(b"abcd");
+        let r = string::utf8(b"bc");
+        let p = string::index_of(&s, &r);
+        assert!(p == 1, 22)
+    }
+
+    #[test]
+    fun test_index_of_fail() {
+        let s = string::utf8(b"abcd");
+        let r = string::utf8(b"bce");
+        let p = string::index_of(&s, &r);
+        assert!(p == 4, 22)
+    }
+
+    #[test]
+    fun test_append() {
+        let s = string::utf8(b"abcd");
+        string::append(&mut s, string::utf8(b"ef"));
+        assert!(s == string::utf8(b"abcdef"), 22)
+    }
+
+    #[test]
+    fun test_insert() {
+        let s = string::utf8(b"abcd");
+        string::insert(&mut s, 1, string::utf8(b"xy"));
+        assert!(s == string::utf8(b"axybcd"), 22)
+    }
+}

--- a/crates/sui-framework/packages/move-stdlib/tests/type_name_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/type_name_tests.move
@@ -1,0 +1,52 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// note: intentionally using 0xa here to test non-0x1 module addresses
+module 0xA::type_name_tests {
+    #[test_only]
+    use std::type_name::{get, into_string};
+    #[test_only]
+    use std::ascii::string;
+
+    struct TestStruct {}
+
+    struct TestGenerics<phantom T> { }
+
+    struct TestMultiGenerics<phantom T1, phantom T2, phantom T3> { }
+
+    #[test]
+    fun test_ground_types() {
+        assert!(into_string(get<u8>()) == string(b"u8"), 0);
+        assert!(into_string(get<u64>()) == string(b"u64"), 0);
+        assert!(into_string(get<u128>()) == string(b"u128"), 0);
+        assert!(into_string(get<address>()) == string(b"address"), 0);
+        assert!(into_string(get<signer>()) == string(b"signer"), 0);
+        assert!(into_string(get<vector<u8>>()) == string(b"vector<u8>"), 0)
+    }
+
+    // Note: these tests assume a 32 byte address length
+    #[test]
+    fun test_structs() {
+        assert!(into_string(get<TestStruct>()) == string(b"000000000000000000000000000000000000000000000000000000000000000a::type_name_tests::TestStruct"), 0);
+        assert!(into_string(get<std::ascii::String>()) == string(b"0000000000000000000000000000000000000000000000000000000000000001::ascii::String"), 0);
+        assert!(into_string(get<std::option::Option<u64>>()) == string(b"0000000000000000000000000000000000000000000000000000000000000001::option::Option<u64>"), 0);
+        assert!(into_string(get<std::string::String>()) == string(b"0000000000000000000000000000000000000000000000000000000000000001::string::String"), 0);
+    }
+
+    // Note: these tests assume a 32 byte address length
+    #[test]
+    fun test_generics() {
+        assert!(into_string(get<TestGenerics<std::string::String>>()) == string(b"000000000000000000000000000000000000000000000000000000000000000a::type_name_tests::TestGenerics<0000000000000000000000000000000000000000000000000000000000000001::string::String>"), 0);
+        assert!(into_string(get<vector<TestGenerics<u64>>>()) == string(b"vector<000000000000000000000000000000000000000000000000000000000000000a::type_name_tests::TestGenerics<u64>>"), 0);
+        assert!(into_string(get<std::option::Option<TestGenerics<u8>>>()) == string(b"0000000000000000000000000000000000000000000000000000000000000001::option::Option<000000000000000000000000000000000000000000000000000000000000000a::type_name_tests::TestGenerics<u8>>"), 0);
+    }
+
+    // Note: these tests assume a 32 byte address length
+    #[test]
+    fun test_multi_generics() {
+        assert!(into_string(get<TestMultiGenerics<bool, u64, u128>>()) == string(b"000000000000000000000000000000000000000000000000000000000000000a::type_name_tests::TestMultiGenerics<bool,u64,u128>"), 0);
+        assert!(into_string(get<TestMultiGenerics<bool, vector<u64>, TestGenerics<u128>>>()) == string(b"000000000000000000000000000000000000000000000000000000000000000a::type_name_tests::TestMultiGenerics<bool,vector<u64>,000000000000000000000000000000000000000000000000000000000000000a::type_name_tests::TestGenerics<u128>>"), 0);
+    }
+}

--- a/crates/sui-framework/packages/move-stdlib/tests/vector_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/vector_tests.move
@@ -1,0 +1,574 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module std::vector_tests {
+    use std::vector as V;
+
+    struct R has store { }
+    struct Droppable has drop {}
+    struct NotDroppable {}
+
+    #[test]
+    fun test_singleton_contains() {
+        assert!(*V::borrow(&V::singleton(0), 0) == 0, 0);
+        assert!(*V::borrow(&V::singleton(true), 0) == true, 0);
+        assert!(*V::borrow(&V::singleton(@0x1), 0) == @0x1, 0);
+    }
+
+    #[test]
+    fun test_singleton_len() {
+        assert!(V::length(&V::singleton(0)) == 1, 0);
+        assert!(V::length(&V::singleton(true)) == 1, 0);
+        assert!(V::length(&V::singleton(@0x1)) == 1, 0);
+    }
+
+    #[test]
+    fun test_empty_is_empty() {
+        assert!(V::is_empty(&V::empty<u64>()), 0);
+    }
+
+    #[test]
+    fun append_empties_is_empty() {
+        let v1 = V::empty<u64>();
+        let v2 = V::empty<u64>();
+        V::append(&mut v1, v2);
+        assert!(V::is_empty(&v1), 0);
+    }
+
+    #[test]
+    fun append_respects_order_empty_lhs() {
+        let v1 = V::empty();
+        let v2 = V::empty();
+        V::push_back(&mut v2, 0);
+        V::push_back(&mut v2, 1);
+        V::push_back(&mut v2, 2);
+        V::push_back(&mut v2, 3);
+        V::append(&mut v1, v2);
+        assert!(!V::is_empty(&v1), 0);
+        assert!(V::length(&v1) == 4, 1);
+        assert!(*V::borrow(&v1, 0) == 0, 2);
+        assert!(*V::borrow(&v1, 1) == 1, 3);
+        assert!(*V::borrow(&v1, 2) == 2, 4);
+        assert!(*V::borrow(&v1, 3) == 3, 5);
+    }
+
+    #[test]
+    fun append_respects_order_empty_rhs() {
+        let v1 = V::empty();
+        let v2 = V::empty();
+        V::push_back(&mut v1, 0);
+        V::push_back(&mut v1, 1);
+        V::push_back(&mut v1, 2);
+        V::push_back(&mut v1, 3);
+        V::append(&mut v1, v2);
+        assert!(!V::is_empty(&v1), 0);
+        assert!(V::length(&v1) == 4, 1);
+        assert!(*V::borrow(&v1, 0) == 0, 2);
+        assert!(*V::borrow(&v1, 1) == 1, 3);
+        assert!(*V::borrow(&v1, 2) == 2, 4);
+        assert!(*V::borrow(&v1, 3) == 3, 5);
+    }
+
+    #[test]
+    fun append_respects_order_nonempty_rhs_lhs() {
+        let v1 = V::empty();
+        let v2 = V::empty();
+        V::push_back(&mut v1, 0);
+        V::push_back(&mut v1, 1);
+        V::push_back(&mut v1, 2);
+        V::push_back(&mut v1, 3);
+        V::push_back(&mut v2, 4);
+        V::push_back(&mut v2, 5);
+        V::push_back(&mut v2, 6);
+        V::push_back(&mut v2, 7);
+        V::append(&mut v1, v2);
+        assert!(!V::is_empty(&v1), 0);
+        assert!(V::length(&v1) == 8, 1);
+        let i = 0;
+        while (i < 8) {
+            assert!(*V::borrow(&v1, i) == i, i);
+            i = i + 1;
+        }
+    }
+
+    #[test]
+    #[expected_failure(vector_error, minor_status = 1, location = Self)]
+    fun borrow_out_of_range() {
+        let v = V::empty();
+        V::push_back(&mut v, 7);
+        V::borrow(&v, 1);
+    }
+
+    #[test]
+    fun vector_contains() {
+        let vec = V::empty();
+        assert!(!V::contains(&vec, &0), 1);
+
+        V::push_back(&mut vec, 0);
+        assert!(V::contains(&vec, &0), 2);
+        assert!(!V::contains(&vec, &1), 3);
+
+        V::push_back(&mut vec, 1);
+        assert!(V::contains(&vec, &0), 4);
+        assert!(V::contains(&vec, &1), 5);
+        assert!(!V::contains(&vec, &2), 6);
+
+        V::push_back(&mut vec, 2);
+        assert!(V::contains(&vec, &0), 7);
+        assert!(V::contains(&vec, &1), 8);
+        assert!(V::contains(&vec, &2), 9);
+        assert!(!V::contains(&vec, &3), 10);
+    }
+
+    #[test]
+    fun destroy_empty() {
+        V::destroy_empty(V::empty<u64>());
+        V::destroy_empty(V::empty<R>());
+    }
+
+    #[test]
+    fun destroy_empty_with_pops() {
+        let v = V::empty();
+        V::push_back(&mut v, 42);
+        V::pop_back(&mut v);
+        V::destroy_empty(v);
+    }
+
+    #[test]
+    #[expected_failure(vector_error, minor_status = 3, location = Self)]
+    fun destroy_non_empty() {
+        let v = V::empty();
+        V::push_back(&mut v, 42);
+        V::destroy_empty(v);
+    }
+
+    #[test]
+    fun get_set_work() {
+        let vec = V::empty();
+        V::push_back(&mut vec, 0);
+        V::push_back(&mut vec, 1);
+        assert!(*V::borrow(&vec, 1) == 1, 0);
+        assert!(*V::borrow(&vec, 0) == 0, 1);
+
+        *V::borrow_mut(&mut vec, 0) = 17;
+        assert!(*V::borrow(&vec, 1) == 1, 0);
+        assert!(*V::borrow(&vec, 0) == 17, 0);
+    }
+
+    #[test]
+    #[expected_failure(vector_error, minor_status = 2, location = Self)]
+    fun pop_out_of_range() {
+        let v = V::empty<u64>();
+        V::pop_back(&mut v);
+    }
+
+    #[test]
+    fun swap_different_indices() {
+        let vec = V::empty();
+        V::push_back(&mut vec, 0);
+        V::push_back(&mut vec, 1);
+        V::push_back(&mut vec, 2);
+        V::push_back(&mut vec, 3);
+        V::swap(&mut vec, 0, 3);
+        V::swap(&mut vec, 1, 2);
+        assert!(*V::borrow(&vec, 0) == 3, 0);
+        assert!(*V::borrow(&vec, 1) == 2, 0);
+        assert!(*V::borrow(&vec, 2) == 1, 0);
+        assert!(*V::borrow(&vec, 3) == 0, 0);
+    }
+
+    #[test]
+    fun swap_same_index() {
+        let vec = V::empty();
+        V::push_back(&mut vec, 0);
+        V::push_back(&mut vec, 1);
+        V::push_back(&mut vec, 2);
+        V::push_back(&mut vec, 3);
+        V::swap(&mut vec, 1, 1);
+        assert!(*V::borrow(&vec, 0) == 0, 0);
+        assert!(*V::borrow(&vec, 1) == 1, 0);
+        assert!(*V::borrow(&vec, 2) == 2, 0);
+        assert!(*V::borrow(&vec, 3) == 3, 0);
+    }
+
+    #[test]
+    fun remove_singleton_vector() {
+        let v = V::empty();
+        V::push_back(&mut v, 0);
+        assert!(V::remove(&mut v, 0) == 0, 0);
+        assert!(V::length(&v) == 0, 0);
+    }
+
+    #[test]
+    fun remove_nonsingleton_vector() {
+        let v = V::empty();
+        V::push_back(&mut v, 0);
+        V::push_back(&mut v, 1);
+        V::push_back(&mut v, 2);
+        V::push_back(&mut v, 3);
+
+        assert!(V::remove(&mut v, 1) == 1, 0);
+        assert!(V::length(&v) == 3, 0);
+        assert!(*V::borrow(&v, 0) == 0, 0);
+        assert!(*V::borrow(&v, 1) == 2, 0);
+        assert!(*V::borrow(&v, 2) == 3, 0);
+    }
+
+    #[test]
+    fun remove_nonsingleton_vector_last_elem() {
+        let v = V::empty();
+        V::push_back(&mut v, 0);
+        V::push_back(&mut v, 1);
+        V::push_back(&mut v, 2);
+        V::push_back(&mut v, 3);
+
+        assert!(V::remove(&mut v, 3) == 3, 0);
+        assert!(V::length(&v) == 3, 0);
+        assert!(*V::borrow(&v, 0) == 0, 0);
+        assert!(*V::borrow(&v, 1) == 1, 0);
+        assert!(*V::borrow(&v, 2) == 2, 0);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = V::EINDEX_OUT_OF_BOUNDS)]
+    fun remove_empty_vector() {
+        let v = V::empty<u64>();
+        V::remove(&mut v, 0);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = V::EINDEX_OUT_OF_BOUNDS)]
+    fun remove_out_of_bound_index() {
+        let v = V::empty<u64>();
+        V::push_back(&mut v, 0);
+        V::remove(&mut v, 1);
+    }
+
+    #[test]
+    fun reverse_vector_empty() {
+        let v = V::empty<u64>();
+        let is_empty = V::is_empty(&v);
+        V::reverse(&mut v);
+        assert!(is_empty == V::is_empty(&v), 0);
+    }
+
+    #[test]
+    fun reverse_singleton_vector() {
+        let v = V::empty();
+        V::push_back(&mut v, 0);
+        assert!(*V::borrow(&v, 0) == 0, 1);
+        V::reverse(&mut v);
+        assert!(*V::borrow(&v, 0) == 0, 2);
+    }
+
+    #[test]
+    fun reverse_vector_nonempty_even_length() {
+        let v = V::empty();
+        V::push_back(&mut v, 0);
+        V::push_back(&mut v, 1);
+        V::push_back(&mut v, 2);
+        V::push_back(&mut v, 3);
+
+        assert!(*V::borrow(&v, 0) == 0, 1);
+        assert!(*V::borrow(&v, 1) == 1, 2);
+        assert!(*V::borrow(&v, 2) == 2, 3);
+        assert!(*V::borrow(&v, 3) == 3, 4);
+
+        V::reverse(&mut v);
+
+        assert!(*V::borrow(&v, 3) == 0, 5);
+        assert!(*V::borrow(&v, 2) == 1, 6);
+        assert!(*V::borrow(&v, 1) == 2, 7);
+        assert!(*V::borrow(&v, 0) == 3, 8);
+    }
+
+    #[test]
+    fun reverse_vector_nonempty_odd_length_non_singleton() {
+        let v = V::empty();
+        V::push_back(&mut v, 0);
+        V::push_back(&mut v, 1);
+        V::push_back(&mut v, 2);
+
+        assert!(*V::borrow(&v, 0) == 0, 1);
+        assert!(*V::borrow(&v, 1) == 1, 2);
+        assert!(*V::borrow(&v, 2) == 2, 3);
+
+        V::reverse(&mut v);
+
+        assert!(*V::borrow(&v, 2) == 0, 4);
+        assert!(*V::borrow(&v, 1) == 1, 5);
+        assert!(*V::borrow(&v, 0) == 2, 6);
+    }
+
+    #[test]
+    #[expected_failure(vector_error, minor_status = 1, location = Self)]
+    fun swap_empty() {
+        let v = V::empty<u64>();
+        V::swap(&mut v, 0, 0);
+    }
+
+    #[test]
+    #[expected_failure(vector_error, minor_status = 1, location = Self)]
+    fun swap_out_of_range() {
+        let v = V::empty<u64>();
+
+        V::push_back(&mut v, 0);
+        V::push_back(&mut v, 1);
+        V::push_back(&mut v, 2);
+        V::push_back(&mut v, 3);
+
+        V::swap(&mut v, 1, 10);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = V::EINDEX_OUT_OF_BOUNDS)]
+    fun swap_remove_empty() {
+        let v = V::empty<u64>();
+        V::swap_remove(&mut v, 0);
+    }
+
+    #[test]
+    fun swap_remove_singleton() {
+        let v = V::empty<u64>();
+        V::push_back(&mut v, 0);
+        assert!(V::swap_remove(&mut v, 0) == 0, 0);
+        assert!(V::is_empty(&v), 1);
+    }
+
+    #[test]
+    fun swap_remove_inside_vector() {
+        let v = V::empty();
+        V::push_back(&mut v, 0);
+        V::push_back(&mut v, 1);
+        V::push_back(&mut v, 2);
+        V::push_back(&mut v, 3);
+
+        assert!(*V::borrow(&v, 0) == 0, 1);
+        assert!(*V::borrow(&v, 1) == 1, 2);
+        assert!(*V::borrow(&v, 2) == 2, 3);
+        assert!(*V::borrow(&v, 3) == 3, 4);
+
+        assert!(V::swap_remove(&mut v, 1) == 1, 5);
+        assert!(V::length(&v) == 3, 6);
+
+        assert!(*V::borrow(&v, 0) == 0, 7);
+        assert!(*V::borrow(&v, 1) == 3, 8);
+        assert!(*V::borrow(&v, 2) == 2, 9);
+
+    }
+
+    #[test]
+    fun swap_remove_end_of_vector() {
+        let v = V::empty();
+        V::push_back(&mut v, 0);
+        V::push_back(&mut v, 1);
+        V::push_back(&mut v, 2);
+        V::push_back(&mut v, 3);
+
+        assert!(*V::borrow(&v, 0) == 0, 1);
+        assert!(*V::borrow(&v, 1) == 1, 2);
+        assert!(*V::borrow(&v, 2) == 2, 3);
+        assert!(*V::borrow(&v, 3) == 3, 4);
+
+        assert!(V::swap_remove(&mut v, 3) == 3, 5);
+        assert!(V::length(&v) == 3, 6);
+
+        assert!(*V::borrow(&v, 0) == 0, 7);
+        assert!(*V::borrow(&v, 1) == 1, 8);
+        assert!(*V::borrow(&v, 2) == 2, 9);
+    }
+
+    #[test]
+    #[expected_failure(vector_error, minor_status = 1, location = std::vector)]
+    fun swap_remove_out_of_range() {
+        let v = V::empty();
+        V::push_back(&mut v, 0);
+        V::swap_remove(&mut v, 1);
+    }
+
+    #[test]
+    fun push_back_and_borrow() {
+        let v = V::empty();
+        V::push_back(&mut v, 7);
+        assert!(!V::is_empty(&v), 0);
+        assert!(V::length(&v) == 1, 1);
+        assert!(*V::borrow(&v, 0) == 7, 2);
+
+        V::push_back(&mut v, 8);
+        assert!(V::length(&v) == 2, 3);
+        assert!(*V::borrow(&v, 0) == 7, 4);
+        assert!(*V::borrow(&v, 1) == 8, 5);
+    }
+
+    #[test]
+    fun index_of_empty_not_has() {
+        let v = V::empty();
+        let (has, index) = V::index_of(&v, &true);
+        assert!(!has, 0);
+        assert!(index == 0, 1);
+    }
+
+    #[test]
+    fun index_of_nonempty_not_has() {
+        let v = V::empty();
+        V::push_back(&mut v, false);
+        let (has, index) = V::index_of(&v, &true);
+        assert!(!has, 0);
+        assert!(index == 0, 1);
+    }
+
+    #[test]
+    fun index_of_nonempty_has() {
+        let v = V::empty();
+        V::push_back(&mut v, false);
+        V::push_back(&mut v, true);
+        let (has, index) = V::index_of(&v, &true);
+        assert!(has, 0);
+        assert!(index == 1, 1);
+    }
+
+    // index_of will return the index first occurence that is equal
+    #[test]
+    fun index_of_nonempty_has_multiple_occurences() {
+        let v = V::empty();
+        V::push_back(&mut v, false);
+        V::push_back(&mut v, true);
+        V::push_back(&mut v, true);
+        let (has, index) = V::index_of(&v, &true);
+        assert!(has, 0);
+        assert!(index == 1, 1);
+    }
+
+    #[test]
+    fun length() {
+        let empty = V::empty();
+        assert!(V::length(&empty) == 0, 0);
+        let i = 0;
+        let max_len = 42;
+        while (i < max_len) {
+            V::push_back(&mut empty, i);
+            assert!(V::length(&empty) == i + 1, i);
+            i = i + 1;
+        }
+    }
+
+    #[test]
+    fun pop_push_back() {
+        let v = V::empty();
+        let i = 0;
+        let max_len = 42;
+
+        while (i < max_len) {
+            V::push_back(&mut v, i);
+            i = i + 1;
+        };
+
+        while (i > 0) {
+            assert!(V::pop_back(&mut v) == i - 1, i);
+            i = i - 1;
+        };
+    }
+
+    #[test_only]
+    fun test_natives_with_type<T>(x1: T, x2: T): (T, T) {
+        let v = V::empty();
+        assert!(V::length(&v) == 0, 0);
+        V::push_back(&mut v, x1);
+        assert!(V::length(&v) == 1, 1);
+        V::push_back(&mut v, x2);
+        assert!(V::length(&v) == 2, 2);
+        V::swap(&mut v, 0, 1);
+        x1 = V::pop_back(&mut v);
+        assert!(V::length(&v) == 1, 3);
+        x2 = V::pop_back(&mut v);
+        assert!(V::length(&v) == 0, 4);
+        V::destroy_empty(v);
+        (x1, x2)
+    }
+
+    #[test]
+    fun test_natives_with_different_instantiations() {
+        test_natives_with_type<u8>(1u8, 2u8);
+        test_natives_with_type<u16>(45356u16, 25345u16);
+        test_natives_with_type<u32>(45356u32, 28768867u32);
+        test_natives_with_type<u64>(1u64, 2u64);
+        test_natives_with_type<u128>(1u128, 2u128);
+        test_natives_with_type<u256>(45356u256, 253458768867u256);
+        test_natives_with_type<bool>(true, false);
+        test_natives_with_type<address>(@0x1, @0x2);
+
+        test_natives_with_type<vector<u8>>(V::empty(), V::empty());
+
+        test_natives_with_type<Droppable>(Droppable{}, Droppable{});
+        (NotDroppable {}, NotDroppable {}) = test_natives_with_type<NotDroppable>(
+            NotDroppable {},
+            NotDroppable {}
+        );
+    }
+
+    #[test]
+    fun test_insert() {
+        let v = vector[7];
+        V::insert(&mut v, 6, 0);
+        assert!(v == vector[6, 7], 0);
+
+        let v = vector[7, 9];
+        V::insert(&mut v, 8, 1);
+        assert!(v == vector[7, 8, 9], 0);
+
+        let v = vector[6, 7];
+        V::insert(&mut v, 5, 0);
+        assert!(v == vector[5, 6, 7], 0);
+
+        let v = vector[5, 6, 8];
+        V::insert(&mut v, 7, 2);
+        assert!(v == vector[5, 6, 7, 8], 0);
+    }
+
+    #[test]
+    fun insert_at_end() {
+        let v = vector[];
+        V::insert(&mut v, 6, 0);
+        assert!(v == vector[6], 0);
+
+        V::insert(&mut v, 7, 1);
+        assert!(v == vector[6, 7], 0);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = V::EINDEX_OUT_OF_BOUNDS)]
+    fun insert_out_of_range() {
+        let v = vector[7];
+        V::insert(&mut v, 6, 2);
+    }
+
+    #[test]
+    fun size_limit_ok() {
+        let v = V::empty();
+        let i = 0;
+        // Limit is currently 1024 * 54
+        let max_len = 1024 * 53;
+
+        while (i < max_len) {
+            V::push_back(&mut v, i);
+            i = i + 1;
+        };
+    }
+
+    #[test]
+    #[expected_failure(out_of_gas, location = Self)]
+    fun size_limit_fail() {
+        let v = V::empty();
+        let i = 0;
+        // Choose value beyond limit
+        let max_len = 1024 * 1024;
+
+        while (i < max_len) {
+            V::push_back(&mut v, i);
+            i = i + 1;
+        };
+    }
+}


### PR DESCRIPTION
## Description 

The `move-stdlib` test suite in `external-crates/move/move-stdlib` doesn't run against the `move-stdlib` dependency we use and publish for sui in `crates/sui-framework/packages/move-stdlib`. That suite currently also fails against `crates/sui-framework/packages/move-stdlib` for two reasons:

- address length
- gas limits / boundaries that affect test outcomes

We want to track test coverage for sui's `move-stdlib`, which means the test suite needs to pass for sui's `move-stdlib`. This PR copies the test suite from `external-crates/move` and updates it to pass on sui's move-stdlib (see second commit for fix ups). We can leave the test suite in `external-crates/move` alone and have that continue to run in CI against core move like it currently does, since I don't expect those tests will be updated soon (and, if we should update or add to `move-stdlib` tests, it is best done in the now sui-compatible test suite).

## Test Plan 

```
cd crates/sui-framework/packages/move-stdlib && sui move test
```