### PR TITLE
Fixed links pointing to content that has moved

### DIFF
--- a/doc/src/build/event_api.md
+++ b/doc/src/build/event_api.md
@@ -18,7 +18,7 @@ A Sui node emits the following types of events:
 
 ## Move event
 
-Move calls emit Move events. You can [define custom events](../explore/move-examples/basics.md#events) in Move contracts.
+Move calls emit Move events. You can [define custom events](https://examples.sui.io/basics/events.html) in Move contracts.
 
 ### Attributes
 

--- a/doc/src/learn/objects.md
+++ b/doc/src/learn/objects.md
@@ -47,7 +47,7 @@ All Sui Move packages are immutable objects: you can't change a Sui Move package
 
 ### Shared
 
-An object can be shared, meaning that anyone can read or write this object. In contrast to mutable owned objects (which are single-writer), shared objects require [consensus](architecture/consensus.md) to sequence reads and writes. For an example of creating and accessing a shared object, see [Shared Object](../explore/move-examples/basics.md#shared-object).
+An object can be shared, meaning that anyone can read or write this object. In contrast to mutable owned objects (which are single-writer), shared objects require [consensus](architecture/consensus.md) to sequence reads and writes. For an example of creating and accessing a shared object, see [Shared Object](https://examples.sui.io/basics/shared-object.html).
 
 In other blockchains, every object is shared. However, Sui programmers often have the choice to implement a particular use-case using shared objects, owned objects, or a combination. This choice can have implications for performance, security, and implementation complexity. The best way to understand these tradeoffs is to look at a few examples of use-cases implemented both ways:
 

--- a/doc/src/learn/why-move.md
+++ b/doc/src/learn/why-move.md
@@ -11,7 +11,7 @@ First, note Move is based upon the well-supported [Rust](https://www.rust-lang.o
  * [Sui Move announcement](https://sui.io/resources-move/why-we-created-sui-move/)
  * [Sui source code](https://github.com/MystenLabs/sui)
  * [`rustdoc` output](../build/install.md#rustdoc)
- * [Sui Move by Example](../explore/move-examples/index.md)
+ * [Sui Move by Example](https://examples.sui.io)
 
 ## Move resources
 


### PR DESCRIPTION
## Description 

Port of examples.io was reversed. Fixing links that were updated on original move but missed when the port was reversed.

## Test Plan 

Local

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
