### PR TITLE
support getting stakes with pending active pool

### DIFF
--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -125,17 +125,18 @@ impl GovernanceReadApi {
             },
         );
 
-        let system_state: SuiSystemStateSummary =
-            self.get_system_state()?.into_sui_system_state_summary();
+        let system_state = self.get_system_state()?;
+        let system_state_summary: SuiSystemStateSummary =
+            system_state.clone().into_sui_system_state_summary();
         let mut delegated_stakes = vec![];
         for (pool_id, stakes) in pools {
             // Rate table and rate can be null when the pool is not active
             let rate_table = self
-                .get_exchange_rate_table(&system_state, &pool_id)
+                .get_exchange_rate_table(&system_state_summary, &pool_id)
                 .await
                 .ok();
             let current_rate = if let Some(rate_table) = rate_table {
-                self.get_exchange_rate(rate_table, system_state.epoch)
+                self.get_exchange_rate(rate_table, system_state_summary.epoch)
                     .await
                     .ok()
             } else {
@@ -146,7 +147,7 @@ impl GovernanceReadApi {
             for (stake, exists) in stakes {
                 let status = if !exists {
                     StakeStatus::Unstaked
-                } else if system_state.epoch >= stake.activation_epoch() {
+                } else if system_state_summary.epoch >= stake.activation_epoch() {
                     let estimated_reward = if let (Some(rate_table), Some(current_rate)) =
                         (&rate_table, &current_rate)
                     {
@@ -173,8 +174,12 @@ impl GovernanceReadApi {
                     status,
                 })
             }
-            let validator =
-                get_validator_by_pool_id(self.state.db().as_ref(), &system_state, pool_id)?;
+            let validator = get_validator_by_pool_id(
+                self.state.db().as_ref(),
+                &system_state,
+                &system_state_summary,
+                pool_id,
+            )?;
             delegated_stakes.push(DelegatedStake {
                 validator_address: validator.sui_address,
                 staking_pool: pool_id,

--- a/crates/sui-types/src/sui_system_state/simtest_sui_system_state_inner.rs
+++ b/crates/sui-types/src/sui_system_state/simtest_sui_system_state_inner.rs
@@ -6,6 +6,8 @@ use crate::base_types::SuiAddress;
 use crate::collection_types::{Bag, Table};
 use crate::committee::{Committee, CommitteeWithNetworkMetadata, NetworkMetadata};
 use crate::crypto::AuthorityPublicKeyBytes;
+use crate::error::SuiError;
+use crate::storage::ObjectStore;
 use crate::sui_system_state::epoch_start_sui_system_state::{
     EpochStartSystemState, EpochStartValidatorInfoV1,
 };
@@ -182,6 +184,13 @@ impl SuiSystemStateTrait for SimTestSuiSystemStateInnerV1 {
         }
     }
 
+    fn get_pending_active_validators<S: ObjectStore>(
+        &self,
+        _object_store: &S,
+    ) -> Result<Vec<SuiValidatorSummary>, SuiError> {
+        Ok(vec![])
+    }
+
     fn into_epoch_start_state(self) -> EpochStartSystemState {
         EpochStartSystemState::new_v1(
             self.epoch,
@@ -287,6 +296,13 @@ impl SuiSystemStateTrait for SimTestSuiSystemStateInnerShallowV2 {
             committee: Committee::new(self.epoch, voting_rights),
             network_metadata,
         }
+    }
+
+    fn get_pending_active_validators<S: ObjectStore>(
+        &self,
+        _object_store: &S,
+    ) -> Result<Vec<SuiValidatorSummary>, SuiError> {
+        Ok(vec![])
     }
 
     fn into_epoch_start_state(self) -> EpochStartSystemState {
@@ -423,6 +439,13 @@ impl SuiSystemStateTrait for SimTestSuiSystemStateInnerDeepV2 {
             committee: Committee::new(self.epoch, voting_rights),
             network_metadata,
         }
+    }
+
+    fn get_pending_active_validators<S: ObjectStore>(
+        &self,
+        _object_store: &S,
+    ) -> Result<Vec<SuiValidatorSummary>, SuiError> {
+        Ok(vec![])
     }
 
     fn into_epoch_start_state(self) -> EpochStartSystemState {

--- a/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
+++ b/crates/sui-types/src/sui_system_state/sui_system_state_inner_v1.rs
@@ -7,8 +7,10 @@ use crate::collection_types::{Bag, Table, TableVec, VecMap, VecSet};
 use crate::committee::{Committee, CommitteeWithNetworkMetadata, NetworkMetadata};
 use crate::crypto::verify_proof_of_possession;
 use crate::crypto::AuthorityPublicKeyBytes;
+use crate::error::SuiError;
 use crate::id::ID;
 use crate::multiaddr::Multiaddr;
+use crate::storage::ObjectStore;
 use crate::sui_system_state::epoch_start_sui_system_state::EpochStartSystemState;
 use anyhow::Result;
 use fastcrypto::traits::ToFromBytes;
@@ -18,7 +20,7 @@ use std::collections::BTreeMap;
 
 use super::epoch_start_sui_system_state::EpochStartValidatorInfoV1;
 use super::sui_system_state_summary::{SuiSystemStateSummary, SuiValidatorSummary};
-use super::{AdvanceEpochParams, SuiSystemStateTrait};
+use super::{get_validators_from_table_vec, AdvanceEpochParams, SuiSystemStateTrait};
 
 const E_METADATA_INVALID_POP: u64 = 0;
 const E_METADATA_INVALID_PUBKEY: u64 = 1;
@@ -559,6 +561,20 @@ impl SuiSystemStateTrait for SuiSystemStateInnerV1 {
             committee: Committee::new(self.epoch, voting_rights),
             network_metadata,
         }
+    }
+
+    fn get_pending_active_validators<S: ObjectStore>(
+        &self,
+        object_store: &S,
+    ) -> Result<Vec<SuiValidatorSummary>, SuiError> {
+        let table_id = self.validators.pending_active_validators.contents.id;
+        let table_size = self.validators.pending_active_validators.contents.size;
+        let validators: Vec<ValidatorV1> =
+            get_validators_from_table_vec(object_store, table_id, table_size)?;
+        Ok(validators
+            .into_iter()
+            .map(|v| v.into_sui_validator_summary())
+            .collect())
     }
 
     fn into_epoch_start_state(self) -> EpochStartSystemState {


### PR DESCRIPTION
## Description 

Previously `getStakes` would error if one of the stakes is with a pending active validator's pool. This PR fixes that.

## Test Plan 

Added a read in a simtest

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
