### PR TITLE
Make getTransactionBlock optional

### DIFF
--- a/crates/sui-json-rpc/src/api/read.rs
+++ b/crates/sui-json-rpc/src/api/read.rs
@@ -18,6 +18,16 @@ use sui_types::sui_serde::BigInt;
 #[rpc(server, client, namespace = "sui")]
 pub trait ReadApi {
     /// Return the transaction response object.
+    #[method(name = "getTransactionBlock", version <= "0.32")]
+    async fn get_transaction_block_non_option(
+        &self,
+        /// the digest of the queried transaction
+        digest: TransactionDigest,
+        /// options for specifying the content to be returned
+        options: Option<SuiTransactionBlockResponseOptions>,
+    ) -> RpcResult<SuiTransactionBlockResponse>;
+
+    /// Return the transaction response object.
     #[method(name = "getTransactionBlock")]
     async fn get_transaction_block(
         &self,
@@ -25,7 +35,7 @@ pub trait ReadApi {
         digest: TransactionDigest,
         /// options for specifying the content to be returned
         options: Option<SuiTransactionBlockResponseOptions>,
-    ) -> RpcResult<SuiTransactionBlockResponse>;
+    ) -> RpcResult<Option<SuiTransactionBlockResponse>>;
 
     /// Returns an ordered list of transaction responses
     /// The method will throw an error if the input contains any duplicate or

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -565,8 +565,19 @@ impl ReadApiServer for ReadApi {
         &self,
         digest: TransactionDigest,
         opts: Option<SuiTransactionBlockResponseOptions>,
+    ) -> RpcResult<Option<SuiTransactionBlockResponse>> {
+        Ok(self
+            .get_transaction_block_non_option(digest, opts)
+            .await
+            .ok())
+    }
+
+    async fn get_transaction_block_non_option(
+        &self,
+        digest: TransactionDigest,
+        opts: Option<SuiTransactionBlockResponseOptions>,
     ) -> RpcResult<SuiTransactionBlockResponse> {
-        let opts = opts.unwrap_or_default();
+        let opts: SuiTransactionBlockResponseOptions = opts.unwrap_or_default();
         let mut temp_response = IntermediateTransactionResponse::new(digest);
 
         // Fetch transaction to determine existence

--- a/crates/sui-json-rpc/src/unit_tests/transaction_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/transaction_tests.rs
@@ -319,6 +319,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
             .read_api()
             .get_transaction_with_options(tx_resp.digest, SuiTransactionBlockResponseOptions::new())
             .await
+            .unwrap()
             .unwrap();
         assert!(tx_responses
             .iter()

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -814,7 +814,6 @@
       ],
       "result": {
         "name": "SuiTransactionBlockResponse",
-        "required": true,
         "schema": {
           "$ref": "#/components/schemas/TransactionBlockResponse"
         }

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -905,7 +905,10 @@ impl LocalExec {
             .read_api()
             .get_transaction_with_options(epoch_change_tx, tx_fetch_opts)
             .await
-            .map_err(LocalExecError::from)?;
+            .map_err(LocalExecError::from)?
+            .ok_or(LocalExecError::GeneralError {
+                err: format!("Unable to find transaction {}", epoch_change_tx),
+            })?;
 
         let orig_tx: SenderSignedData = bcs::from_bytes(&tx_info.raw_transaction).unwrap();
         let tx_kind_orig = orig_tx.transaction_data().kind();
@@ -932,7 +935,10 @@ impl LocalExec {
             .read_api()
             .get_transaction_with_options(*tx_digest, tx_fetch_opts)
             .await
-            .map_err(LocalExecError::from)?;
+            .map_err(LocalExecError::from)?
+            .ok_or(LocalExecError::GeneralError {
+                err: format!("Unable to find transaction {}", tx_digest),
+            })?;
         let sender = match tx_info.clone().transaction.unwrap().data {
             sui_json_rpc_types::SuiTransactionBlockData::V1(tx) => tx.sender,
         };

--- a/crates/sui-rosetta/src/block.rs
+++ b/crates/sui-rosetta/src/block.rs
@@ -54,7 +54,8 @@ pub async fn transaction(
                 .with_effects()
                 .with_balance_changes(),
         )
-        .await?;
+        .await?
+        .ok_or(Error::MissingTransaction)?;
     let hash = response.digest;
 
     let operations = response.try_into()?;

--- a/crates/sui-rosetta/src/errors.rs
+++ b/crates/sui-rosetta/src/errors.rs
@@ -78,6 +78,8 @@ pub enum Error {
     DBError(#[from] TypedStoreError),
     #[error(transparent)]
     JsonExtractorRejection(#[from] JsonRejection),
+    #[error("Missing transaction")]
+    MissingTransaction,
 }
 
 impl Serialize for ErrorType {

--- a/crates/sui-rosetta/src/state.rs
+++ b/crates/sui-rosetta/src/state.rs
@@ -243,7 +243,8 @@ impl CheckpointBlockProvider {
                         .with_balance_changes()
                         .with_events(),
                 )
-                .await?;
+                .await?
+                .ok_or(Error::MissingTransaction)?;
             transactions.push(Transaction {
                 transaction_identifier: TransactionIdentifier { hash: tx.digest },
                 operations: Operations::try_from(tx)?,

--- a/crates/sui-rosetta/tests/end_to_end_tests.rs
+++ b/crates/sui-rosetta/tests/end_to_end_tests.rs
@@ -167,6 +167,7 @@ async fn test_stake() {
                 .with_events(),
         )
         .await
+        .unwrap()
         .unwrap();
 
     println!("Sui TX: {tx:?}");
@@ -230,6 +231,7 @@ async fn test_stake_all() {
                 .with_events(),
         )
         .await
+        .unwrap()
         .unwrap();
 
     println!("Sui TX: {tx:?}");
@@ -299,6 +301,7 @@ async fn test_withdraw_stake() {
                 .with_events(),
         )
         .await
+        .unwrap()
         .unwrap();
 
     println!("Sui TX: {tx:?}");
@@ -349,6 +352,7 @@ async fn test_withdraw_stake() {
                 .with_events(),
         )
         .await
+        .unwrap()
         .unwrap();
 
     assert_eq!(
@@ -419,6 +423,7 @@ async fn test_pay_sui() {
                 .with_events(),
         )
         .await
+        .unwrap()
         .unwrap();
 
     assert_eq!(
@@ -480,6 +485,7 @@ async fn test_pay_sui_multiple_times() {
                     .with_events(),
             )
             .await
+            .unwrap()
             .unwrap();
         println!("Sui TX: {tx:?}");
         assert_eq!(

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -127,7 +127,7 @@ impl ReadApi {
         &self,
         digest: TransactionDigest,
         options: SuiTransactionBlockResponseOptions,
-    ) -> SuiRpcResult<SuiTransactionBlockResponse> {
+    ) -> SuiRpcResult<Option<SuiTransactionBlockResponse>> {
         Ok(self
             .api
             .http

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -653,7 +653,8 @@ impl SuiClientCommands {
                         digest,
                         SuiTransactionBlockResponseOptions::full_content(),
                     )
-                    .await?;
+                    .await?
+                    .ok_or_else(|| anyhow!("Transaction block not found"))?;
                 SuiClientCommandResult::TransactionBlock(tx_read)
             }
 


### PR DESCRIPTION
## Description

This updates `getTransactionBlock` for the next release to make it return an option instead of throwing an error on missing transactions. Gated on the next version release.

## Test Plan

Ran locally.
