### PR TITLE
[CompatibilityChecker] Fix rpc request in light of protocol change

### DIFF
--- a/scripts/compatibility/monitor_synced.py
+++ b/scripts/compatibility/monitor_synced.py
@@ -28,7 +28,7 @@ def get_current_network_epoch(env='testnet'):
     for i in range(NUM_RETRIES):
         cmd = ['curl', '--location', '--request', 'POST', f'https://explorer-rpc.{env}.sui.io/',
                '--header', 'Content-Type: application/json', '--data-raw',
-               '{"jsonrpc":"2.0", "method":"suix_getEpochs", "params":[null, "1", true], "id":1}']
+               '{"jsonrpc":"2.0", "method":"suix_getCurrentEpoch", "params":[], "id":1}']
         try:
             result = subprocess.check_output(cmd, stderr=subprocess.PIPE)
         except subprocess.CalledProcessError as e:
@@ -39,12 +39,13 @@ def get_current_network_epoch(env='testnet'):
         try:
             result = json.loads(result)
             if 'error' in result:
-                print(f'suix_getEpochs rpc request failed: {result["error"]}')
+                print(
+                    f'suix_getCurrentEpoch rpc request failed: {result["error"]}')
                 time.sleep(3)
                 continue
-            return int(result['result']['data'][0]['epoch'])
+            return int(result['result']['epoch'])
         except (KeyError, IndexError, json.JSONDecodeError):
-            print(f'suix_getEpochs rpc request failed: {result}')
+            print(f'suix_getCurrentEpoch rpc request failed: {result}')
             time.sleep(RETRY_BASE_TIME_SEC * 2**i)  # exponential backoff
             continue
     print(f"Failed to get current network epoch after {NUM_RETRIES} tries")


### PR DESCRIPTION
## Description 

The `suix_getEpochs` api [introduced a breaking change](https://github.com/MystenLabs/sui/blob/c219e74707c500a4fc35df77f65ac5aee5c83d5d/sdk/typescript/src/providers/json-rpc-provider.ts#L782) in `0.32.0` which changed an input type: 

This resulted in the initial rpc request at script kickoff (meant to determine the current network epoch) to fail with

```
suix_getEpochs rpc request failed: {'code': -32602, 'message': 'invalid type: string "1", expected usize at line 1 column 4'}
```

Because the job runs multiple shards at different epochs, we would need to handle both protocol versions if we decide to continue using this api. Instead, this PR moves to using a different api call that is not affected by the protocol config. Bonus points that the replacement api call is also cheaper.

## Test Plan 

Ran the script locally and ensured that it works

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
