### PR TITLE
[pruner] disable active rocksdb iterator for normal flow

### DIFF
--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -130,9 +130,12 @@ impl AuthorityStorePruner {
         perpetual_db.set_highest_pruned_checkpoint(&mut wb, checkpoint_number)?;
         metrics.last_pruned_checkpoint.set(checkpoint_number as i64);
 
-        let _locks = objects_lock_table
-            .acquire_locks(indirect_objects.into_keys())
-            .await;
+        let mut _locks = vec![];
+        if !indirect_objects.is_empty() {
+            _locks = objects_lock_table
+                .acquire_locks(indirect_objects.into_keys())
+                .await;
+        }
         wb.write()?;
         Ok(())
     }


### PR DESCRIPTION
it'd still be the case for indirect objects, but we have this feature disabled for now
For indirect objects we need a sync version of mutex table  