### PR TITLE
[sui-core/ gate some util methods]

### DIFF
--- a/crates/sui-core/src/authority/authority_test_utils.rs
+++ b/crates/sui-core/src/authority/authority_test_utils.rs
@@ -5,7 +5,6 @@
 use crate::checkpoints::CheckpointServiceNoop;
 use crate::consensus_handler::SequencedConsensusTransaction;
 use fastcrypto::hash::MultisetHash;
-use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{
     crypto::{AccountKeyPair, AuthorityKeyPair, KeypairTraits},
     messages::VerifiedTransaction,
@@ -161,6 +160,7 @@ pub async fn init_state_with_ids_and_versions<
     state
 }
 
+#[cfg(feature = "test-utils")]
 pub async fn init_state_with_objects<I: IntoIterator<Item = Object>>(
     objects: I,
 ) -> Arc<AuthorityState> {
@@ -173,6 +173,7 @@ pub async fn init_state_with_objects<I: IntoIterator<Item = Object>>(
     init_state_with_objects_and_committee(objects, &genesis, &keypair).await
 }
 
+#[cfg(feature = "test-utils")]
 pub async fn init_state_with_objects_and_committee<I: IntoIterator<Item = Object>>(
     objects: I,
     genesis: &Genesis,
@@ -184,7 +185,7 @@ pub async fn init_state_with_objects_and_committee<I: IntoIterator<Item = Object
     }
     state
 }
-
+#[cfg(feature = "test-utils")]
 pub async fn init_state_with_object_id(
     address: SuiAddress,
     object: ObjectID,
@@ -192,6 +193,7 @@ pub async fn init_state_with_object_id(
     init_state_with_ids(std::iter::once((address, object))).await
 }
 
+#[cfg(feature = "test-utils")]
 pub fn init_transfer_transaction(
     sender: SuiAddress,
     secret: &AccountKeyPair,
@@ -201,6 +203,7 @@ pub fn init_transfer_transaction(
     gas_budget: u64,
     gas_price: u64,
 ) -> VerifiedTransaction {
+    use sui_types::utils::to_sender_signed_transaction;
     let data = TransactionData::new_transfer(
         recipient,
         object_ref,
@@ -212,6 +215,7 @@ pub fn init_transfer_transaction(
     to_sender_signed_transaction(data, secret)
 }
 
+#[cfg(feature = "test-utils")]
 pub fn init_certified_transfer_transaction(
     sender: SuiAddress,
     secret: &AccountKeyPair,


### PR DESCRIPTION
Summary:

* unable to build sui-core due to a cfg gate.
* build error caused by https://github.com/MystenLabs/sui/commit/c9a1414d6860e1a94682f05738eccb812c965a73
* hack in some gates via #[cfg(feature = "test-utils")] to let the rest of the repo build again.

Test Plan:

fixes build error:

```
error[E0432]: unresolved import `sui_types::utils`
  --> crates/sui-core/src/authority/authority_test_utils.rs:12:5
   |
12 |     utils::to_sender_signed_transaction,
   |     ^^^^^ could not find `utils` in `sui_types`

For more information about this error, try `rustc --explain E0432`.
```

This is due to how it's gated in lib.rs:

```
#[cfg(feature = "test-utils")]
#[path = "./unit_tests/utils.rs"]
pub mod utils;
```

cargo build

## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
