### PR TITLE
Increase buffer stake to 0.5f, allocate protocol version 6

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -23,7 +23,7 @@ const MAX_PROTOCOL_VERSION: u64 = 6;
 //            length is short.
 // Version 5: Package upgrade compatibility error fix. New gas cost table. New scoring decision
 //            mechanism that includes up to f scoring authorities.
-// Version 6: Change to how bytes are charged in the gas meter.
+// Version 6: Change to how bytes are charged in the gas meter, increase buffer stake to 0.5f
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -1020,6 +1020,7 @@ impl ProtocolConfig {
             6 => {
                 let mut cfg = Self::get_for_version_impl(version - 1);
                 cfg.gas_model_version = Some(5);
+                cfg.buffer_stake_for_protocol_upgrade_bps = Some(5000);
                 cfg
             }
             // Use this template when making changes:

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_6.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_6.snap
@@ -73,7 +73,7 @@ reward_slashing_rate: 10000
 storage_gas_price: 76
 max_transactions_per_checkpoint: 10000
 max_checkpoint_size_bytes: 31457280
-buffer_stake_for_protocol_upgrade_bps: 0
+buffer_stake_for_protocol_upgrade_bps: 5000
 address_from_bytes_cost_base: 52
 address_to_u256_cost_base: 52
 address_from_u256_cost_base: 52


### PR DESCRIPTION
## Description 

Allocates a new protocol version 6, increases buffer stake to 0.5f.

## Test Plan 

cargo simtest

---

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Fullnode operators should upgrade to a binary supporting version 6 as soon as one is released.