### PR TITLE
[sui-types] Move convert_vm_error to sui-adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10116,7 +10116,6 @@ dependencies = [
  "move-core-types",
  "move-disassembler",
  "move-ir-types",
- "move-vm-runtime",
  "mysten-network",
  "narwhal-config",
  "narwhal-crypto",

--- a/crates/sui-adapter/src/error.rs
+++ b/crates/sui-adapter/src/error.rs
@@ -1,0 +1,96 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use move_binary_format::{
+    access::ModuleAccess,
+    errors::{Location, VMError},
+    file_format::FunctionDefinitionIndex,
+};
+use move_core_types::{
+    resolver::MoveResolver,
+    vm_status::{StatusCode, StatusType},
+};
+use move_vm_runtime::move_vm::MoveVM;
+use sui_types::{
+    error::{ExecutionError, SuiError},
+    messages::{ExecutionFailureStatus, MoveLocation, MoveLocationOpt},
+};
+
+pub(crate) fn convert_vm_error<S: MoveResolver<Err = SuiError>>(
+    error: VMError,
+    vm: &MoveVM,
+    state_view: &S,
+) -> ExecutionError {
+    let kind = match (error.major_status(), error.sub_status(), error.location()) {
+        (StatusCode::EXECUTED, _, _) => {
+            // If we have an error the status probably shouldn't ever be Executed
+            debug_assert!(false, "VmError shouldn't ever report successful execution");
+            ExecutionFailureStatus::VMInvariantViolation
+        }
+        (StatusCode::ABORTED, None, _) => {
+            debug_assert!(false, "No abort code");
+            // this is a Move VM invariant violation, the code should always be there
+            ExecutionFailureStatus::VMInvariantViolation
+        }
+        (StatusCode::ABORTED, _, Location::Script) => {
+            debug_assert!(false, "Scripts are not used in Sui");
+            // this is a Move VM invariant violation, in the sense that the location
+            // is malformed
+            ExecutionFailureStatus::VMInvariantViolation
+        }
+        (StatusCode::ABORTED, Some(code), Location::Module(id)) => {
+            let offset = error.offsets().first().copied().map(|(f, i)| (f.0, i));
+            debug_assert!(offset.is_some(), "Move should set the location on aborts");
+            let (function, instruction) = offset.unwrap_or((0, 0));
+            let function_name = vm.load_module(id, state_view).ok().map(|module| {
+                let fdef = module.function_def_at(FunctionDefinitionIndex(function));
+                let fhandle = module.function_handle_at(fdef.function);
+                module.identifier_at(fhandle.name).to_string()
+            });
+            ExecutionFailureStatus::MoveAbort(
+                MoveLocation {
+                    module: id.clone(),
+                    function,
+                    instruction,
+                    function_name,
+                },
+                code,
+            )
+        }
+        (StatusCode::OUT_OF_GAS, _, _) => ExecutionFailureStatus::InsufficientGas,
+        (_, _, location) => match error.major_status().status_type() {
+            StatusType::Execution => {
+                debug_assert!(error.major_status() != StatusCode::ABORTED);
+                let location = match location {
+                    Location::Module(id) => {
+                        let offset = error.offsets().first().copied().map(|(f, i)| (f.0, i));
+                        debug_assert!(
+                            offset.is_some(),
+                            "Move should set the location on all execution errors. Error {error}"
+                        );
+                        let (function, instruction) = offset.unwrap_or((0, 0));
+                        let function_name = vm.load_module(id, state_view).ok().map(|module| {
+                            let fdef = module.function_def_at(FunctionDefinitionIndex(function));
+                            let fhandle = module.function_handle_at(fdef.function);
+                            module.identifier_at(fhandle.name).to_string()
+                        });
+                        Some(MoveLocation {
+                            module: id.clone(),
+                            function,
+                            instruction,
+                            function_name,
+                        })
+                    }
+                    _ => None,
+                };
+                ExecutionFailureStatus::MovePrimitiveRuntimeError(MoveLocationOpt(location))
+            }
+            StatusType::Validation
+            | StatusType::Verification
+            | StatusType::Deserialization
+            | StatusType::Unknown => ExecutionFailureStatus::VMVerificationOrDeserializationError,
+            StatusType::InvariantViolation => ExecutionFailureStatus::VMInvariantViolation,
+        },
+    };
+    ExecutionError::new_with_source(kind, error)
+}

--- a/crates/sui-adapter/src/lib.rs
+++ b/crates/sui-adapter/src/lib.rs
@@ -19,6 +19,7 @@ macro_rules! assert_invariant {
 }
 
 pub mod adapter;
+pub mod error;
 pub mod execution_engine;
 pub mod execution_mode;
 pub mod programmable_transactions;

--- a/crates/sui-adapter/src/programmable_transactions/context.rs
+++ b/crates/sui-adapter/src/programmable_transactions/context.rs
@@ -162,7 +162,7 @@ impl<'vm, 'state, 'a, S: StorageView> ExecutionContext<'vm, 'state, 'a, S> {
         // exist. Plus, Sui Move does not use these changes or events
         let (res, linkage) = tmp_session.finish();
         let (change_set, move_events) =
-            res.map_err(|e| sui_types::error::convert_vm_error(e, vm, &linkage))?;
+            res.map_err(|e| crate::error::convert_vm_error(e, vm, &linkage))?;
         assert_invariant!(change_set.accounts().is_empty(), "Change set must be empty");
         assert_invariant!(move_events.is_empty(), "Events must be empty");
         // make the real session
@@ -503,7 +503,7 @@ impl<'vm, 'state, 'a, S: StorageView> ExecutionContext<'vm, 'state, 'a, S> {
 
     /// Determine the object changes and collect all user events
     pub fn finish<Mode: ExecutionMode>(self) -> Result<ExecutionResults, ExecutionError> {
-        use sui_types::error::convert_vm_error;
+        use crate::error::convert_vm_error;
         let Self {
             protocol_config,
             vm,
@@ -751,7 +751,7 @@ impl<'vm, 'state, 'a, S: StorageView> ExecutionContext<'vm, 'state, 'a, S> {
 
     /// Convert a VM Error to an execution one
     pub fn convert_vm_error(&self, error: VMError) -> ExecutionError {
-        sui_types::error::convert_vm_error(error, self.vm, self.session.get_resolver())
+        crate::error::convert_vm_error(error, self.vm, self.session.get_resolver())
     }
 
     /// Special case errors for type arguments to Move functions
@@ -1160,7 +1160,7 @@ unsafe fn create_written_object<S: StorageView>(
 
     let type_tag = session
         .get_type_tag(&type_)
-        .map_err(|e| sui_types::error::convert_vm_error(e, vm, session.get_resolver()))?;
+        .map_err(|e| crate::error::convert_vm_error(e, vm, session.get_resolver()))?;
 
     let struct_tag = match type_tag {
         TypeTag::Struct(inner) => *inner,

--- a/crates/sui-adapter/src/programmable_transactions/types.rs
+++ b/crates/sui-adapter/src/programmable_transactions/types.rs
@@ -208,7 +208,7 @@ impl ObjectValue {
         };
         let tag: StructTag = type_.into();
         let type_ = load_type(session, &TypeTag::Struct(Box::new(tag)))
-            .map_err(|e| sui_types::error::convert_vm_error(e, vm, session.get_resolver()))?;
+            .map_err(|e| crate::error::convert_vm_error(e, vm, session.get_resolver()))?;
         Ok(Self {
             type_,
             has_public_transfer,

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -40,7 +40,6 @@ move-command-line-common.workspace = true
 move-core-types.workspace = true
 move-disassembler.workspace = true
 move-ir-types.workspace = true
-move-vm-runtime.workspace = true
 
 narwhal-config = { path = "../../narwhal/config" }
 narwhal-crypto = { path = "../../narwhal/crypto" }

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -5,16 +5,10 @@
 use crate::{
     base_types::*,
     committee::{Committee, EpochId, StakeUnit},
-    messages::{CommandIndex, ExecutionFailureStatus, MoveLocation, MoveLocationOpt},
+    messages::{CommandIndex, ExecutionFailureStatus},
     object::Owner,
 };
-use move_binary_format::{access::ModuleAccess, errors::VMError};
-use move_binary_format::{errors::Location, file_format::FunctionDefinitionIndex};
-use move_core_types::{
-    resolver::MoveResolver,
-    vm_status::{StatusCode, StatusType},
-};
-pub use move_vm_runtime::move_vm::MoveVM;
+
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, fmt::Debug};
@@ -763,83 +757,4 @@ impl From<ExecutionErrorKind> for ExecutionError {
     fn from(kind: ExecutionErrorKind) -> Self {
         Self::from_kind(kind)
     }
-}
-
-pub fn convert_vm_error<S: MoveResolver<Err = SuiError>>(
-    error: VMError,
-    vm: &MoveVM,
-    state_view: &S,
-) -> ExecutionError {
-    let kind = match (error.major_status(), error.sub_status(), error.location()) {
-        (StatusCode::EXECUTED, _, _) => {
-            // If we have an error the status probably shouldn't ever be Executed
-            debug_assert!(false, "VmError shouldn't ever report successful execution");
-            ExecutionFailureStatus::VMInvariantViolation
-        }
-        (StatusCode::ABORTED, None, _) => {
-            debug_assert!(false, "No abort code");
-            // this is a Move VM invariant violation, the code should always be there
-            ExecutionFailureStatus::VMInvariantViolation
-        }
-        (StatusCode::ABORTED, _, Location::Script) => {
-            debug_assert!(false, "Scripts are not used in Sui");
-            // this is a Move VM invariant violation, in the sense that the location
-            // is malformed
-            ExecutionFailureStatus::VMInvariantViolation
-        }
-        (StatusCode::ABORTED, Some(code), Location::Module(id)) => {
-            let offset = error.offsets().first().copied().map(|(f, i)| (f.0, i));
-            debug_assert!(offset.is_some(), "Move should set the location on aborts");
-            let (function, instruction) = offset.unwrap_or((0, 0));
-            let function_name = vm.load_module(id, state_view).ok().map(|module| {
-                let fdef = module.function_def_at(FunctionDefinitionIndex(function));
-                let fhandle = module.function_handle_at(fdef.function);
-                module.identifier_at(fhandle.name).to_string()
-            });
-            ExecutionFailureStatus::MoveAbort(
-                MoveLocation {
-                    module: id.clone(),
-                    function,
-                    instruction,
-                    function_name,
-                },
-                code,
-            )
-        }
-        (StatusCode::OUT_OF_GAS, _, _) => ExecutionFailureStatus::InsufficientGas,
-        (_, _, location) => match error.major_status().status_type() {
-            StatusType::Execution => {
-                debug_assert!(error.major_status() != StatusCode::ABORTED);
-                let location = match location {
-                    Location::Module(id) => {
-                        let offset = error.offsets().first().copied().map(|(f, i)| (f.0, i));
-                        debug_assert!(
-                            offset.is_some(),
-                            "Move should set the location on all execution errors. Error {error}"
-                        );
-                        let (function, instruction) = offset.unwrap_or((0, 0));
-                        let function_name = vm.load_module(id, state_view).ok().map(|module| {
-                            let fdef = module.function_def_at(FunctionDefinitionIndex(function));
-                            let fhandle = module.function_handle_at(fdef.function);
-                            module.identifier_at(fhandle.name).to_string()
-                        });
-                        Some(MoveLocation {
-                            module: id.clone(),
-                            function,
-                            instruction,
-                            function_name,
-                        })
-                    }
-                    _ => None,
-                };
-                ExecutionFailureStatus::MovePrimitiveRuntimeError(MoveLocationOpt(location))
-            }
-            StatusType::Validation
-            | StatusType::Verification
-            | StatusType::Deserialization
-            | StatusType::Unknown => ExecutionFailureStatus::VMVerificationOrDeserializationError,
-            StatusType::InvariantViolation => ExecutionFailureStatus::VMInvariantViolation,
-        },
-    };
-    ExecutionError::new_with_source(kind, error)
 }


### PR DESCRIPTION
## Description

`convert_vm_error` is only used within `sui-adapter`, and introduces a dependency on `move-vm-runtime` (which will be versioned with the execution layer) to `sui-types` (which will not).

Moving `convert_vm_error` to `sui-adapter` removes the dependency and brings the function closer to its call-sites which also improves encapsulation.

## Test Plan

```
$ cargo simtest
$ env SUI_SKIP_SIMTESTS=1 cargo nextest run
```