### PR TITLE
Get blob file sizes from rocksdb

### DIFF
--- a/crates/typed-store/src/metrics.rs
+++ b/crates/typed-store/src/metrics.rs
@@ -73,6 +73,7 @@ impl SamplingInterval {
 #[derive(Debug)]
 pub struct ColumnFamilyMetrics {
     pub rocksdb_total_sst_files_size: IntGaugeVec,
+    pub rocksdb_total_blob_files_size: IntGaugeVec,
     pub rocksdb_size_all_mem_tables: IntGaugeVec,
     pub rocksdb_num_snapshots: IntGaugeVec,
     pub rocksdb_oldest_snapshot_time: IntGaugeVec,
@@ -96,7 +97,14 @@ impl ColumnFamilyMetrics {
         ColumnFamilyMetrics {
             rocksdb_total_sst_files_size: register_int_gauge_vec_with_registry!(
                 "rocksdb_total_sst_files_size",
-                "The storage size occupied by the column family",
+                "The storage size occupied by the sst files in the column family",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_total_blob_files_size: register_int_gauge_vec_with_registry!(
+                "rocksdb_total_blob_files_size",
+                "The storage size occupied by the blob files in the column family",
                 &["cf_name"],
                 registry,
             )


### PR DESCRIPTION
## Description 

This property is not yet available from the `rocksdb` crate, so using a workaround.

## Test Plan 

TODO: Local fullnode

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
