### PR TITLE
Cluster test fix for changing faucet coin values

### DIFF
--- a/crates/sui-cluster-test/src/test_case/coin_merge_split_test.rs
+++ b/crates/sui-cluster-test/src/test_case/coin_merge_split_test.rs
@@ -27,7 +27,9 @@ impl TestCaseImpl for CoinMergeSplitTest {
         let gas_obj = sui_objs.swap_remove(0);
 
         let signer = ctx.get_wallet_address();
-        let primary_coin = sui_objs.swap_remove(0);
+        let mut sui_objs_2 = ctx.get_sui_from_faucet(Some(1)).await;
+
+        let primary_coin = sui_objs_2.swap_remove(0);
         let primary_coin_id = *primary_coin.id();
         let original_value = primary_coin.value();
 

--- a/crates/sui-cluster-test/src/test_case/native_transfer_test.rs
+++ b/crates/sui-cluster-test/src/test_case/native_transfer_test.rs
@@ -32,11 +32,12 @@ impl TestCaseImpl for NativeTransferTest {
     async fn run(&self, ctx: &mut TestContext) -> Result<(), anyhow::Error> {
         info!("Testing gas coin transfer");
         let mut sui_objs = ctx.get_sui_from_faucet(Some(1)).await;
-        let gas_obj = sui_objs.swap_remove(0);
+        let gas_obj = ctx.get_sui_from_faucet(Some(1)).await.swap_remove(0);
+
         let signer = ctx.get_wallet_address();
         let (recipient_addr, _): (_, AccountKeyPair) = get_key_pair();
         // Test transfer object
-        let obj_to_transfer = *sui_objs.swap_remove(0).id();
+        let obj_to_transfer: ObjectID = *sui_objs.swap_remove(0).id();
         let params = rpc_params![
             signer,
             obj_to_transfer,
@@ -51,11 +52,12 @@ impl TestCaseImpl for NativeTransferTest {
 
         Self::examine_response(ctx, &mut response, signer, recipient_addr, obj_to_transfer).await;
 
+        let mut sui_objs_2 = ctx.get_sui_from_faucet(Some(1)).await;
         // Test transfer sui
-        let obj_to_transfer = *sui_objs.swap_remove(0).id();
+        let obj_to_transfer_2 = *sui_objs_2.swap_remove(0).id();
         let params = rpc_params![
             signer,
-            obj_to_transfer,
+            obj_to_transfer_2,
             (2_000_000).to_string(),
             recipient_addr,
             None::<u64>


### PR DESCRIPTION
## Description 

Fixing cluster tests given that faucet sends one coin.

Oh basically faucet only gives one coin object, and previously the tests are expecting 5 objects from faucet.

## Test Plan 

Works locally
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
