### PR TITLE
[rocksdb] only store blobs >= 4KiB in blob files

### DIFF
--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -1960,9 +1960,9 @@ impl DBOptions {
         self.options
             .set_blob_compression_type(rocksdb::DBCompressionType::Lz4);
         self.options.set_enable_blob_gc(true);
-        // Not setting a min_blob_size, to avoid additional behavior variance when workload changes.
-        // Most transactions and effects are > 300B, which makes blob storage worthwhile for
-        // saving write cost.
+        // Since each blob can have non-trivial size overhead, and compression does not work across blobs,
+        // set a min blob size to so small transactions and effects are kept in sst files.
+        self.options.set_min_blob_size(4 * 1024); // 4KiB
 
         // Since large blobs are not in sst files, reduce the target file size and base level
         // target size.


### PR DESCRIPTION
## Description 

Each blob has non-trivial size overhead. So only store larger blobs in blob files.

From checking rocksdb logs, increment counter and simple transfers are a few hundred bytes in transactions and effects. Setting the size threshold for storing in blobs to be 4KiB.

## Test Plan 

local fullnode

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
