### PR TITLE
Revert (#11002, ##11110) Improve perf of get_dynamic_field_object_id

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -24,7 +24,6 @@ use prometheus::{
 };
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use sui_types::TypeTag;
 use tap::TapFallible;
 use tokio::sync::mpsc::unbounded_channel;
 use tokio::sync::oneshot;
@@ -2272,11 +2271,10 @@ impl AuthorityState {
     pub fn get_dynamic_field_object_id(
         &self,
         owner: ObjectID,
-        name_type: TypeTag,
-        name_bcs_bytes: &[u8],
+        name: &DynamicFieldName,
     ) -> SuiResult<Option<ObjectID>> {
         if let Some(indexes) = &self.indexes {
-            indexes.get_dynamic_field_object_id(owner, name_type, name_bcs_bytes)
+            indexes.get_dynamic_field_object_id(owner, name)
         } else {
             Err(SuiError::IndexStoreNotAvailable)
         }

--- a/crates/sui-json-rpc/src/indexer_api.rs
+++ b/crates/sui-json-rpc/src/indexer_api.rs
@@ -1,22 +1,20 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::str::FromStr;
 use std::sync::Arc;
 
-use anyhow::{anyhow, Context};
+use anyhow::anyhow;
 use async_trait::async_trait;
 use futures::Stream;
 use jsonrpsee::core::error::SubscriptionClosed;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::types::SubscriptionResult;
 use jsonrpsee::{RpcModule, SubscriptionSink};
-use move_bytecode_utils::layout::TypeLayoutBuilder;
 use serde::Serialize;
-use sui_json::SuiJsonValue;
-use sui_types::MOVE_STDLIB_ADDRESS;
 use tracing::{debug, warn};
 
-use move_core_types::language_storage::{StructTag, TypeTag};
+use move_core_types::language_storage::TypeTag;
 use mysten_metrics::spawn_monitored_task;
 use sui_core::authority::AuthorityState;
 use sui_json_rpc_types::{
@@ -25,7 +23,7 @@ use sui_json_rpc_types::{
     SuiTransactionBlockResponse, SuiTransactionBlockResponseQuery, TransactionBlocksPage,
 };
 use sui_open_rpc::Module;
-use sui_types::base_types::{ObjectID, SuiAddress, STD_UTF8_MODULE_NAME, STD_UTF8_STRUCT_NAME};
+use sui_types::base_types::{ObjectID, SuiAddress};
 use sui_types::digests::TransactionDigest;
 use sui_types::dynamic_field::DynamicFieldName;
 use sui_types::event::EventID;
@@ -41,6 +39,7 @@ const NAME_SERVICE_REVERSE_LOOKUP_KEY: &str = "reverse";
 const NAME_SERVICE_VALUE: &str = "value";
 const NAME_SERVICE_ID: &str = "id";
 const NAME_SERVICE_MARKER: &str = "marker";
+const STRING_TYPE_TAG: &str = "0x1::string::String";
 
 pub fn spawn_subscription<S, T>(mut sink: SubscriptionSink, rx: S)
 where
@@ -256,16 +255,9 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
         parent_object_id: ObjectID,
         name: DynamicFieldName,
     ) -> RpcResult<SuiObjectResponse> {
-        let DynamicFieldName {
-            type_: name_type,
-            value,
-        } = name.clone();
-        let layout = TypeLayoutBuilder::build_with_types(&name_type, &self.state.database)?;
-        let sui_json_value = SuiJsonValue::new(value)?;
-        let name_bcs_value = sui_json_value.to_bcs_bytes(&layout)?;
         let id = self
             .state
-            .get_dynamic_field_object_id(parent_object_id, name_type, &name_bcs_value)
+            .get_dynamic_field_object_id(parent_object_id, &name)
             .map_err(|e| anyhow!("{e}"))?
             .ok_or_else(|| {
                 anyhow!("Cannot find dynamic field [{name:?}] for object [{parent_object_id}].")
@@ -278,22 +270,16 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
     async fn resolve_name_service_address(&self, name: String) -> RpcResult<SuiAddress> {
         let dynmaic_field_table_object_id =
             self.get_name_service_dynamic_field_table_object_id(/* reverse_lookup */ false)?;
-        // NOTE: 0x1::string::String is the type tag of fields in dynamic_field_table
-        let name_type_tag = TypeTag::Struct(Box::new(StructTag {
-            address: MOVE_STDLIB_ADDRESS,
-            module: STD_UTF8_MODULE_NAME.to_owned(),
-            name: STD_UTF8_STRUCT_NAME.to_owned(),
-            type_params: vec![],
-        }));
-        let name_bcs_value = bcs::to_bytes(&name).context("Unable to serialize name")?;
+        // NOTE: 0x1::string::String is the type tag of fields in dynmaic_field_table
+        let ns_type_tag = TypeTag::from_str(STRING_TYPE_TAG)?;
+        let ns_dynamic_field_name = DynamicFieldName {
+            type_: ns_type_tag,
+            value: name.clone().into(),
+        };
         // record of the input `name`
         let record_object_id = self
             .state
-            .get_dynamic_field_object_id(
-                dynmaic_field_table_object_id,
-                name_type_tag,
-                &name_bcs_value,
-            )
+            .get_dynamic_field_object_id(dynmaic_field_table_object_id, &ns_dynamic_field_name)
             .map_err(|e| {
                 anyhow!(
                     "Read name service dynamic field table failed with error: {:?}",
@@ -345,15 +331,15 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
     ) -> RpcResult<Page<String, ObjectID>> {
         let dynmaic_field_table_object_id =
             self.get_name_service_dynamic_field_table_object_id(/* reverse_lookup */ true)?;
-        let name_type_tag = TypeTag::Address;
-        let name_bcs_value = bcs::to_bytes(&address).context("Unable to serialize address")?;
+        let addr_type_tag = TypeTag::Address;
+        let ns_dynamic_field_name = DynamicFieldName {
+            type_: addr_type_tag,
+            value: address.to_string().into(),
+        };
+
         let addr_object_id = self
             .state
-            .get_dynamic_field_object_id(
-                dynmaic_field_table_object_id,
-                name_type_tag,
-                &name_bcs_value,
-            )
+            .get_dynamic_field_object_id(dynmaic_field_table_object_id, &ns_dynamic_field_name)
             .map_err(|e| {
                 anyhow!(
                     "Read name service reverse dynamic field table failed with error: {:?}",

--- a/crates/sui-storage/src/indexes.rs
+++ b/crates/sui-storage/src/indexes.rs
@@ -996,17 +996,12 @@ impl IndexStore {
                 },
             )?;
 
-        if let Some(info) = self
+        if self
             .tables
             .dynamic_field_index
-            .get(&(object, dynamic_field_id))?
+            .contains_key(&(object, dynamic_field_id))?
         {
-            // info.object_id != dynamic_field_id ==> is_wrapper
-            debug_assert!(
-                info.object_id == dynamic_field_id
-                    || matches!(name_type, TypeTag::Struct(tag) if DynamicFieldInfo::is_dynamic_object_field_wrapper(&tag))
-            );
-            return Ok(Some(info.object_id));
+            return Ok(Some(dynamic_field_id));
         }
 
         let dynamic_object_field_struct = DynamicFieldInfo::dynamic_object_field_wrapper(name_type);

--- a/crates/sui-storage/src/indexes.rs
+++ b/crates/sui-storage/src/indexes.rs
@@ -25,7 +25,7 @@ use sui_types::base_types::{
 };
 use sui_types::base_types::{ObjectInfo, ObjectRef};
 use sui_types::digests::TransactionEventsDigest;
-use sui_types::dynamic_field::{self, DynamicFieldInfo};
+use sui_types::dynamic_field::{DynamicFieldInfo, DynamicFieldName};
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::messages::TransactionEvents;
 use sui_types::object::Owner;
@@ -983,48 +983,21 @@ impl IndexStore {
     pub fn get_dynamic_field_object_id(
         &self,
         object: ObjectID,
-        name_type: TypeTag,
-        name_bcs_bytes: &[u8],
+        name: &DynamicFieldName,
     ) -> SuiResult<Option<ObjectID>> {
         debug!(?object, "get_dynamic_field_object_id");
-        let dynamic_field_id =
-            dynamic_field::derive_dynamic_field_id(object, &name_type, name_bcs_bytes).map_err(
-                |e| {
-                    SuiError::Unknown(format!(
-                        "Unable to generate dynamic field id. Got error: {e:?}"
-                    ))
-                },
-            )?;
-
-        if self
+        Ok(self
             .tables
             .dynamic_field_index
-            .contains_key(&(object, dynamic_field_id))?
-        {
-            return Ok(Some(dynamic_field_id));
-        }
-
-        let dynamic_object_field_struct = DynamicFieldInfo::dynamic_object_field_wrapper(name_type);
-        let dynamic_object_field_type = TypeTag::Struct(Box::new(dynamic_object_field_struct));
-        let dynamic_object_field_id = dynamic_field::derive_dynamic_field_id(
-            object,
-            &dynamic_object_field_type,
-            name_bcs_bytes,
-        )
-        .map_err(|e| {
-            SuiError::Unknown(format!(
-                "Unable to generate dynamic field id. Got error: {e:?}"
-            ))
-        })?;
-        if let Some(info) = self
-            .tables
-            .dynamic_field_index
-            .get(&(object, dynamic_object_field_id))?
-        {
-            return Ok(Some(info.object_id));
-        }
-
-        Ok(None)
+            .iter()
+            // The object id 0 is the smallest possible
+            .skip_to(&(object, ObjectID::ZERO))?
+            .find(|((object_owner, _), info)| {
+                object_owner == &object
+                    && info.name.type_ == name.type_
+                    && info.name.value == name.value
+            })
+            .map(|(_, object_info)| object_info.object_id))
     }
 
     pub fn get_owner_objects(

--- a/crates/sui-types/src/dynamic_field.rs
+++ b/crates/sui-types/src/dynamic_field.rs
@@ -30,9 +30,6 @@ use std::fmt::{Display, Formatter};
 const DYNAMIC_FIELD_MODULE_NAME: &IdentStr = ident_str!("dynamic_field");
 const DYNAMIC_FIELD_FIELD_STRUCT_NAME: &IdentStr = ident_str!("Field");
 
-const DYNAMIC_OBJECT_FIELD_MODULE_NAME: &IdentStr = ident_str!("dynamic_object_field");
-const DYNAMIC_OBJECT_FIELD_WRAPPER_STRUCT_NAME: &IdentStr = ident_str!("Wrapper");
-
 /// Rust version of the Move sui::dynamic_field::Field type
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Field<N, V> {
@@ -96,15 +93,6 @@ impl DynamicFieldInfo {
             name: DYNAMIC_FIELD_FIELD_STRUCT_NAME.to_owned(),
             module: DYNAMIC_FIELD_MODULE_NAME.to_owned(),
             type_params: vec![key, value],
-        }
-    }
-
-    pub fn dynamic_object_field_wrapper(key: TypeTag) -> StructTag {
-        StructTag {
-            address: SUI_FRAMEWORK_ADDRESS,
-            name: DYNAMIC_OBJECT_FIELD_MODULE_NAME.to_owned(),
-            module: DYNAMIC_OBJECT_FIELD_WRAPPER_STRUCT_NAME.to_owned(),
-            type_params: vec![key],
         }
     }
 
@@ -229,8 +217,8 @@ pub fn is_dynamic_object(move_struct: &MoveStruct) -> bool {
     match move_struct {
         MoveStruct::WithTypes { type_, .. } => {
             matches!(&type_.type_params[0], TypeTag::Struct(tag) if tag.address == SUI_FRAMEWORK_ADDRESS
-        && tag.module.as_ident_str() == DYNAMIC_OBJECT_FIELD_MODULE_NAME
-        && tag.name.as_ident_str() == DYNAMIC_OBJECT_FIELD_WRAPPER_STRUCT_NAME)
+        && tag.module.as_str() == "dynamic_object_field"
+        && tag.name.as_str() == "Wrapper")
         }
         _ => false,
     }

--- a/crates/sui-types/src/dynamic_field.rs
+++ b/crates/sui-types/src/dynamic_field.rs
@@ -90,12 +90,6 @@ impl DynamicFieldInfo {
             && tag.name.as_ident_str() == DYNAMIC_FIELD_FIELD_STRUCT_NAME
     }
 
-    pub fn is_dynamic_object_field_wrapper(tag: &StructTag) -> bool {
-        tag.address == SUI_FRAMEWORK_ADDRESS
-            && tag.module.as_ident_str() == DYNAMIC_OBJECT_FIELD_MODULE_NAME
-            && tag.name.as_ident_str() == DYNAMIC_OBJECT_FIELD_WRAPPER_STRUCT_NAME
-    }
-
     pub fn dynamic_field_type(key: TypeTag, value: TypeTag) -> StructTag {
         StructTag {
             address: SUI_FRAMEWORK_ADDRESS,
@@ -108,8 +102,8 @@ impl DynamicFieldInfo {
     pub fn dynamic_object_field_wrapper(key: TypeTag) -> StructTag {
         StructTag {
             address: SUI_FRAMEWORK_ADDRESS,
-            module: DYNAMIC_OBJECT_FIELD_MODULE_NAME.to_owned(),
-            name: DYNAMIC_OBJECT_FIELD_WRAPPER_STRUCT_NAME.to_owned(),
+            name: DYNAMIC_OBJECT_FIELD_MODULE_NAME.to_owned(),
+            module: DYNAMIC_OBJECT_FIELD_WRAPPER_STRUCT_NAME.to_owned(),
             type_params: vec![key],
         }
     }
@@ -234,10 +228,9 @@ fn extract_id_value(id_value: &MoveValue) -> Option<ObjectID> {
 pub fn is_dynamic_object(move_struct: &MoveStruct) -> bool {
     match move_struct {
         MoveStruct::WithTypes { type_, .. } => {
-            matches!(
-                &type_.type_params[0],
-                TypeTag::Struct(tag) if DynamicFieldInfo::is_dynamic_object_field_wrapper(tag)
-            )
+            matches!(&type_.type_params[0], TypeTag::Struct(tag) if tag.address == SUI_FRAMEWORK_ADDRESS
+        && tag.module.as_ident_str() == DYNAMIC_OBJECT_FIELD_MODULE_NAME
+        && tag.name.as_ident_str() == DYNAMIC_OBJECT_FIELD_WRAPPER_STRUCT_NAME)
         }
         _ => false,
     }

--- a/sdk/typescript/test/e2e/dynamic-fields.test.ts
+++ b/sdk/typescript/test/e2e/dynamic-fields.test.ts
@@ -58,15 +58,16 @@ describe('Dynamic Fields Reading API', () => {
     const dynamicFields = await toolbox.provider.getDynamicFields({
       parentId: parentObjectId,
     });
-    for (const data of dynamicFields.data) {
-      const objName = data.name;
 
-      const object = await toolbox.provider.getDynamicFieldObject({
-        parentId: parentObjectId,
-        name: objName,
-      });
+    const objDofName = dynamicFields.data.find(
+      (field) => field.type === 'DynamicField',
+    )!.name;
 
-      expect(object.data?.objectId).toEqual(data.objectId);
-    }
+    const dynamicObjectField = await toolbox.provider.getDynamicFieldObject({
+      parentId: parentObjectId,
+      name: objDofName,
+    });
+
+    expect(dynamicObjectField).not.toEqual({});
   });
 });


### PR DESCRIPTION
## Description 

...and "Fix dynamic object field lookup" -- the new, more efficient look-up does not support serializing struct-based dynamic field names which is breaking downstream flows, (e.g. in `SuiFrens`).

## Test Plan 

CI + Localnet Tests + `simtest` + `nextest run`.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [X] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Re-enable support for looking up dynamic object fields by name that are structs (not primitive types).