### PR TITLE
move: improve upgrade transactional test setup for dependencies

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/upgrade/dep_override.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/dep_override.move
@@ -50,7 +50,7 @@ module Test_DepV1::DepM1 {
 
 //# upgrade --package Test_DepV1 --upgrade-capability 4,1 --dependencies Test_DepDepV2 --sender A
 module Test_DepV2::DepM1 {
-    use Test_DepDepV1::DepDepM1;
+    use Test_DepDepV2::DepDepM1;
 
     public fun bar(ctx: &mut sui::tx_context::TxContext) { DepDepM1::foo(ctx)  }
 }
@@ -70,7 +70,7 @@ module Test_V1::M1 {
 
 //# upgrade --package Test_V1 --upgrade-capability 6,1 --dependencies Test_DepV2 Test_DepDepV2 --sender A
 module Test_V2::M1 {
-    use Test_DepV1::DepM1;
+    use Test_DepV2::DepM1;
 
     public entry fun baz(ctx: &mut sui::tx_context::TxContext) { DepM1::bar(ctx) }
 }
@@ -121,7 +121,7 @@ module Test_V4::M1 {
 
 //# upgrade --package Test_V3 --upgrade-capability 6,1 --dependencies Test_DepV2 --sender A
 module Test_V4::M1 {
-    use Test_DepV1::DepM1;
+    use Test_DepV2::DepM1;
     public entry fun baz(ctx: &mut sui::tx_context::TxContext) { DepM1::bar(ctx) }
 }
 
@@ -129,6 +129,6 @@ module Test_V4::M1 {
 
 //# upgrade --package Test_V3 --upgrade-capability 6,1 --dependencies Test_DepV2 Test_DepDepV1 --sender A
 module Test_V4::M1 {
-    use Test_DepV1::DepM1;
+    use Test_DepV2::DepM1;
     public entry fun baz(ctx: &mut sui::tx_context::TxContext) { DepM1::bar(ctx) }
 }

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/linkage.exp
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/linkage.exp
@@ -1,0 +1,24 @@
+processed 5 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 6-12:
+created: object(1,0), object(1,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6216800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'upgrade'. lines 14-24:
+created: object(2,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 6520800,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 3 'publish'. lines 26-32:
+created: object(3,0), object(3,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6201600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4 'upgrade'. lines 34-41:
+created: object(4,0)
+mutated: object(0,0), object(3,1)
+gas summary: computation_cost: 1000000, storage_cost: 6247200,  storage_rebate: 2595780, non_refundable_storage_fee: 26220

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/linkage.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/linkage.move
@@ -1,0 +1,41 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses Test_V2=0x0 Test_V1=0x0 Test_DepV1=0x0 Test_DepV2=0x0 --accounts A
+
+//# publish --upgradeable --sender A
+module Test_DepV1::DepM1 {
+    struct DepObj has key, store { id: sui::object::UID, v: u64 }
+    public fun mod_obj(o: &mut DepObj) {
+        o.v = 0;
+    }
+}
+
+//# upgrade --package Test_DepV1 --upgrade-capability 1,1 --sender A
+module Test_DepV2::DepM1 {
+    struct DepObj has key, store { id: sui::object::UID, v: u64 }
+    public fun mod_obj(o: &mut DepObj) {
+        o.v = 0;
+    }
+
+    public fun only_defined(o: &mut DepObj) {
+        o.v = 1
+    }
+}
+
+//# publish --upgradeable --dependencies Test_DepV1 --sender A
+module Test_V1::M1 {
+    use Test_DepV1::DepM1;
+    public fun mod_dep_obj(o: &mut DepM1::DepObj) {
+        DepM1::mod_obj(o);
+    }
+}
+
+//# upgrade --package Test_V1 --upgrade-capability 3,1 --dependencies Test_DepV2 --sender A
+module Test_V2::M1 {
+    use Test_DepV2::DepM1;
+
+    public fun mod_dep_obj(o: &mut DepM1::DepObj) {
+        DepM1::only_defined(o);
+    }
+}

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/new_types.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/new_types.move
@@ -61,7 +61,7 @@ module Test_V2::M1 {
 
 //# upgrade --package Test_V2 --upgrade-capability 3,1 --dependencies Test_DepV2 --sender A
 module Test_V3::M1 {
-    use Test_DepV1::DepM1;
+    use Test_DepV2::DepM1;
 
     public entry fun bar(ctx: &mut sui::tx_context::TxContext) {
         DepM1::foo(ctx);

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/transitive_linkage.exp
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/transitive_linkage.exp
@@ -1,0 +1,34 @@
+processed 7 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 6-12:
+created: object(1,0), object(1,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6216800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'upgrade'. lines 15-21:
+created: object(2,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 6216800,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 3 'upgrade'. lines 23-33:
+created: object(3,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 6520800,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 4 'publish'. lines 36-42:
+created: object(4,0), object(4,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6201600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5 'upgrade'. lines 44-50:
+created: object(5,0)
+mutated: object(0,0), object(4,1)
+gas summary: computation_cost: 1000000, storage_cost: 6201600,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 6 'upgrade'. lines 52-59:
+created: object(6,0)
+mutated: object(0,0), object(4,1)
+gas summary: computation_cost: 1000000, storage_cost: 6247200,  storage_rebate: 2595780, non_refundable_storage_fee: 26220

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/transitive_linkage.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/transitive_linkage.move
@@ -1,0 +1,60 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses Test_V3=0x0 Test_V2=0x0 Test_V1=0x0 Test_DepV1=0x0 Test_DepV2=0x0 Test_DepV3=0x0 --accounts A
+
+//# publish --upgradeable --sender A
+module Test_DepV1::DepM1 {
+    struct DepObj has key, store { id: sui::object::UID, v: u64 }
+    public fun mod_obj(o: &mut DepObj) {
+        o.v = 0;
+    }
+}
+
+
+//# upgrade --package Test_DepV1 --upgrade-capability 1,1 --sender A
+module Test_DepV2::DepM1 {
+    struct DepObj has key, store { id: sui::object::UID, v: u64 }
+    public fun mod_obj(o: &mut DepObj) {
+        o.v = 0;
+    }
+}
+
+//# upgrade --package Test_DepV2 --upgrade-capability 1,1 --sender A
+module Test_DepV3::DepM1 {
+    struct DepObj has key, store { id: sui::object::UID, v: u64 }
+    public fun mod_obj(o: &mut DepObj) {
+        o.v = 0;
+    }
+
+    public fun only_defined(o: &mut DepObj) {
+        o.v = 1
+    }
+}
+
+
+//# publish --upgradeable --dependencies Test_DepV1 --sender A
+module Test_V1::M1 {
+    use Test_DepV1::DepM1;
+    public fun mod_dep_obj(o: &mut DepM1::DepObj) {
+        DepM1::mod_obj(o);
+    }
+}
+
+//# upgrade --package Test_V1 --upgrade-capability 4,1 --dependencies Test_DepV2 --sender A
+module Test_V2::M1 {
+    use Test_DepV2::DepM1;
+    public fun mod_dep_obj(o: &mut DepM1::DepObj) {
+        DepM1::mod_obj(o);
+    }
+}
+
+//# upgrade --package Test_V2 --upgrade-capability 4,1 --dependencies Test_DepV3 --sender A
+module Test_V3::M1 {
+    use Test_DepV3::DepM1;
+
+    public fun mod_dep_obj(o: &mut DepM1::DepObj) {
+        DepM1::only_defined(o);
+    }
+}
+


### PR DESCRIPTION
## Description 

Implements logic to map the most recent upgraded dependency to the original dependency's address for compilation, then restores dependency addresses when upgrading. We need the logic so that compilation succeeds in test setup (otherwise the compiler shouts about duplicate defined modules).

When a package is upgraded, we store an entry that maps to the original package name for that upgraded package. For those upgraded packages that are later used as dependencies, we substitute the address of the original package before compiling, and restore it after compiling and before upgrading.

## Test Plan 

Ran tests.