### PR TITLE
[sui-verifier] Move helper functions into more foundational crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9317,6 +9317,7 @@ dependencies = [
  "bcs",
  "fastcrypto",
  "move-binary-format",
+ "move-bytecode-utils",
  "move-core-types",
  "once_cell",
  "schemars",
@@ -10196,6 +10197,7 @@ name = "sui-verifier"
 version = "0.1.0"
 dependencies = [
  "move-binary-format",
+ "move-bytecode-utils",
  "move-bytecode-verifier",
  "move-core-types",
  "sui-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9328,7 +9328,6 @@ dependencies = [
  "sui-move-build",
  "sui-protocol-config",
  "sui-types",
- "sui-verifier",
  "test-fuzz",
  "workspace-hack",
 ]

--- a/crates/sui-adapter/src/programmable_transactions/execution.rs
+++ b/crates/sui-adapter/src/programmable_transactions/execution.rs
@@ -29,14 +29,14 @@ use sui_move_natives::object_runtime::ObjectRuntime;
 use sui_protocol_config::ProtocolConfig;
 use sui_types::{
     base_types::{
-        MoveObjectType, ObjectID, SuiAddress, TxContext, TX_CONTEXT_MODULE_NAME,
-        TX_CONTEXT_STRUCT_NAME,
+        MoveObjectType, ObjectID, SuiAddress, TxContext, TxContextKind, RESOLVED_ASCII_STR,
+        RESOLVED_STD_OPTION, RESOLVED_UTF8_STR, TX_CONTEXT_MODULE_NAME, TX_CONTEXT_STRUCT_NAME,
     },
     coin::Coin,
     error::{ExecutionError, ExecutionErrorKind},
     event::Event,
     gas::{SuiGasStatus, SuiGasStatusAPI},
-    id::UID,
+    id::{RESOLVED_SUI_ID, UID},
     messages::{
         Argument, Command, CommandArgumentError, PackageUpgradeError, ProgrammableMoveCall,
         ProgrammableTransaction,
@@ -49,9 +49,6 @@ use sui_types::{
     SUI_FRAMEWORK_ADDRESS,
 };
 use sui_verifier::{
-    entry_points_verifier::{
-        TxContextKind, RESOLVED_ASCII_STR, RESOLVED_STD_OPTION, RESOLVED_SUI_ID, RESOLVED_UTF8_STR,
-    },
     private_generics::{EVENT_MODULE, PRIVATE_TRANSFER_FUNCTIONS, TRANSFER_MODULE},
     INIT_FN_NAME,
 };

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -15,7 +15,9 @@ use move_core_types::{
 };
 
 use sui_types::{
-    error::ExecutionErrorKind, programmable_transaction_builder::ProgrammableTransactionBuilder,
+    base_types::{RESOLVED_ASCII_STR, RESOLVED_STD_OPTION, RESOLVED_UTF8_STR},
+    error::ExecutionErrorKind,
+    programmable_transaction_builder::ProgrammableTransactionBuilder,
     utils::to_sender_signed_transaction,
 };
 
@@ -30,9 +32,6 @@ use sui_types::{
 
 use std::{collections::HashSet, path::PathBuf};
 use std::{env, str::FromStr};
-use sui_verifier::entry_points_verifier::{
-    RESOLVED_ASCII_STR, RESOLVED_STD_OPTION, RESOLVED_UTF8_STR,
-};
 
 #[tokio::test]
 #[cfg_attr(msim, ignore)]

--- a/crates/sui-json/Cargo.toml
+++ b/crates/sui-json/Cargo.toml
@@ -17,7 +17,6 @@ schemars = "0.8.12"
 sui-framework = { path = "../sui-framework" }
 sui-protocol-config = { path = "../sui-protocol-config" }
 sui-types = { path = "../sui-types" }
-sui-verifier = { path = "../sui-verifier" }
 
 move-binary-format.workspace = true
 move-bytecode-utils.workspace = true

--- a/crates/sui-json/Cargo.toml
+++ b/crates/sui-json/Cargo.toml
@@ -20,6 +20,7 @@ sui-types = { path = "../sui-types" }
 sui-verifier = { path = "../sui-verifier" }
 
 move-binary-format.workspace = true
+move-bytecode-utils.workspace = true
 move-core-types.workspace = true
 fastcrypto = { workspace = true }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/crates/sui-json/src/lib.rs
+++ b/crates/sui-json/src/lib.rs
@@ -28,16 +28,13 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Number, Value as JsonValue};
 
 use sui_types::base_types::{
-    ObjectID, SuiAddress, STD_ASCII_MODULE_NAME, STD_ASCII_STRUCT_NAME, STD_OPTION_MODULE_NAME,
+    ObjectID, SuiAddress, TxContext, TxContextKind, RESOLVED_ASCII_STR, RESOLVED_STD_OPTION,
+    RESOLVED_UTF8_STR, STD_ASCII_MODULE_NAME, STD_ASCII_STRUCT_NAME, STD_OPTION_MODULE_NAME,
     STD_OPTION_STRUCT_NAME, STD_UTF8_MODULE_NAME, STD_UTF8_STRUCT_NAME,
 };
-use sui_types::id::ID;
+use sui_types::id::{ID, RESOLVED_SUI_ID};
 use sui_types::move_package::MovePackage;
 use sui_types::MOVE_STDLIB_ADDRESS;
-use sui_verifier::entry_points_verifier::{
-    is_tx_context, TxContextKind, RESOLVED_ASCII_STR, RESOLVED_STD_OPTION, RESOLVED_SUI_ID,
-    RESOLVED_UTF8_STR,
-};
 
 const HEX_PREFIX: &str = "0x";
 
@@ -879,7 +876,7 @@ pub fn resolve_move_function_args(
 
     // Lengths have to match, less one, due to TxContext
     let expected_len = match parameters.last() {
-        Some(param) if is_tx_context(&view, param) != TxContextKind::None => parameters.len() - 1,
+        Some(param) if TxContext::kind(&view, param) != TxContextKind::None => parameters.len() - 1,
         _ => parameters.len(),
     };
     if combined_args_json.len() != expected_len {

--- a/crates/sui-json/src/lib.rs
+++ b/crates/sui-json/src/lib.rs
@@ -11,6 +11,7 @@ use move_binary_format::{
     access::ModuleAccess, binary_views::BinaryIndexedView, file_format::SignatureToken,
     file_format_common::VERSION_MAX,
 };
+use move_bytecode_utils::resolve_struct;
 use move_core_types::account_address::AccountAddress;
 use move_core_types::identifier::IdentStr;
 use move_core_types::u256::U256;
@@ -622,7 +623,7 @@ pub fn primitive_type(
             }
         }
         SignatureToken::Struct(struct_handle_idx) => {
-            let resolved_struct = sui_verifier::resolve_struct(view, *struct_handle_idx);
+            let resolved_struct = resolve_struct(view, *struct_handle_idx);
             if resolved_struct == RESOLVED_ASCII_STR {
                 (
                     true,
@@ -662,7 +663,7 @@ pub fn primitive_type(
             }
         }
         SignatureToken::StructInstantiation(idx, targs) => {
-            let resolved_struct = sui_verifier::resolve_struct(view, *idx);
+            let resolved_struct = resolve_struct(view, *idx);
             // is option of a primitive
             if resolved_struct == RESOLVED_STD_OPTION && targs.len() == 1 {
                 // there is no MoveLayout for this so while we can still report whether a type

--- a/crates/sui-types/src/clock.rs
+++ b/crates/sui-types/src/clock.rs
@@ -1,13 +1,19 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use move_core_types::{ident_str, identifier::IdentStr, language_storage::StructTag};
+use move_binary_format::{binary_views::BinaryIndexedView, file_format::SignatureToken};
+use move_bytecode_utils::resolve_struct;
+use move_core_types::{
+    account_address::AccountAddress, ident_str, identifier::IdentStr, language_storage::StructTag,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::{id::UID, SUI_FRAMEWORK_ADDRESS};
 
 pub const CLOCK_MODULE_NAME: &IdentStr = ident_str!("clock");
 pub const CLOCK_STRUCT_NAME: &IdentStr = ident_str!("Clock");
+pub const RESOLVED_SUI_CLOCK: (&AccountAddress, &IdentStr, &IdentStr) =
+    (&SUI_FRAMEWORK_ADDRESS, CLOCK_MODULE_NAME, CLOCK_STRUCT_NAME);
 pub const CONSENSUS_COMMIT_PROLOGUE_FUNCTION_NAME: &IdentStr =
     ident_str!("consensus_commit_prologue");
 
@@ -24,6 +30,16 @@ impl Clock {
             module: CLOCK_MODULE_NAME.to_owned(),
             name: CLOCK_STRUCT_NAME.to_owned(),
             type_params: vec![],
+        }
+    }
+
+    /// Detects a `&mut sui::clock::Clock` or `sui::clock::Clock` in the signature.
+    pub fn is_mutable(view: &BinaryIndexedView<'_>, s: &SignatureToken) -> bool {
+        use SignatureToken as S;
+        match s {
+            S::MutableReference(inner) => Self::is_mutable(view, inner),
+            S::Struct(idx) => resolve_struct(view, *idx) == RESOLVED_SUI_CLOCK,
+            _ => false,
         }
     }
 }

--- a/crates/sui-types/src/id.rs
+++ b/crates/sui-types/src/id.rs
@@ -3,6 +3,7 @@
 
 use crate::MoveTypeTagTrait;
 use crate::{base_types::ObjectID, SUI_FRAMEWORK_ADDRESS};
+use move_core_types::account_address::AccountAddress;
 use move_core_types::language_storage::TypeTag;
 use move_core_types::{
     ident_str,
@@ -17,6 +18,8 @@ pub const OBJECT_MODULE_NAME_STR: &str = "object";
 pub const OBJECT_MODULE_NAME: &IdentStr = ident_str!(OBJECT_MODULE_NAME_STR);
 pub const UID_STRUCT_NAME: &IdentStr = ident_str!("UID");
 pub const ID_STRUCT_NAME: &IdentStr = ident_str!("ID");
+pub const RESOLVED_SUI_ID: (&AccountAddress, &IdentStr, &IdentStr) =
+    (&SUI_FRAMEWORK_ADDRESS, OBJECT_MODULE_NAME, ID_STRUCT_NAME);
 
 /// Rust version of the Move sui::object::Info type
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Clone, Eq, PartialEq)]

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -7,8 +7,13 @@
     rust_2021_compatibility
 )]
 
-use base_types::{SequenceNumber, SuiAddress};
+use base_types::{SequenceNumber, SuiAddress, RESOLVED_ASCII_STR, RESOLVED_UTF8_STR};
 use messages::{CallArg, ObjectArg};
+use move_binary_format::{
+    binary_views::BinaryIndexedView,
+    file_format::{AbilitySet, SignatureToken},
+};
+use move_bytecode_utils::resolve_struct;
 use move_core_types::{account_address::AccountAddress, language_storage::StructTag};
 pub use move_core_types::{identifier::Identifier, language_storage::TypeTag};
 use object::OBJECT_START_VERSION;
@@ -16,6 +21,8 @@ use object::OBJECT_START_VERSION;
 use base_types::ObjectID;
 
 pub use mysten_network::multiaddr;
+
+use crate::{base_types::RESOLVED_STD_OPTION, id::RESOLVED_SUI_ID};
 
 #[macro_use]
 pub mod error;
@@ -162,5 +169,91 @@ impl MoveTypeTagTrait for ObjectID {
 impl MoveTypeTagTrait for SuiAddress {
     fn get_type_tag() -> TypeTag {
         TypeTag::Address
+    }
+}
+
+pub fn is_primitive(
+    view: &BinaryIndexedView<'_>,
+    function_type_args: &[AbilitySet],
+    s: &SignatureToken,
+) -> bool {
+    use SignatureToken as S;
+    match s {
+        S::Bool | S::U8 | S::U16 | S::U32 | S::U64 | S::U128 | S::U256 | S::Address => true,
+        S::Signer => false,
+        // optimistic, but no primitive has key
+        S::TypeParameter(idx) => !function_type_args[*idx as usize].has_key(),
+
+        S::Struct(idx) => [RESOLVED_SUI_ID, RESOLVED_ASCII_STR, RESOLVED_UTF8_STR]
+            .contains(&resolve_struct(view, *idx)),
+
+        S::StructInstantiation(idx, targs) => {
+            let resolved_struct = resolve_struct(view, *idx);
+            // is option of a primitive
+            resolved_struct == RESOLVED_STD_OPTION
+                && targs.len() == 1
+                && is_primitive(view, function_type_args, &targs[0])
+        }
+
+        S::Vector(inner) => is_primitive(view, function_type_args, inner),
+        S::Reference(_) | S::MutableReference(_) => false,
+    }
+}
+
+pub fn is_object(
+    view: &BinaryIndexedView<'_>,
+    function_type_args: &[AbilitySet],
+    t: &SignatureToken,
+) -> Result<bool, String> {
+    use SignatureToken as S;
+    match t {
+        S::Reference(inner) | S::MutableReference(inner) => {
+            is_object(view, function_type_args, inner)
+        }
+        _ => is_object_struct(view, function_type_args, t),
+    }
+}
+
+pub fn is_object_vector(
+    view: &BinaryIndexedView<'_>,
+    function_type_args: &[AbilitySet],
+    t: &SignatureToken,
+) -> Result<bool, String> {
+    use SignatureToken as S;
+    match t {
+        S::Vector(inner) => is_object_struct(view, function_type_args, inner),
+        _ => is_object_struct(view, function_type_args, t),
+    }
+}
+
+fn is_object_struct(
+    view: &BinaryIndexedView<'_>,
+    function_type_args: &[AbilitySet],
+    s: &SignatureToken,
+) -> Result<bool, String> {
+    use SignatureToken as S;
+    match s {
+        S::Bool
+        | S::U8
+        | S::U16
+        | S::U32
+        | S::U64
+        | S::U128
+        | S::U256
+        | S::Address
+        | S::Signer
+        | S::Vector(_)
+        | S::Reference(_)
+        | S::MutableReference(_) => Ok(false),
+        S::TypeParameter(idx) => Ok(function_type_args
+            .get(*idx as usize)
+            .map(|abs| abs.has_key())
+            .unwrap_or(false)),
+        S::Struct(_) | S::StructInstantiation(_, _) => {
+            let abilities = view
+                .abilities(s, function_type_args)
+                .map_err(|vm_err| vm_err.to_string())?;
+            Ok(abilities.has_key())
+        }
     }
 }

--- a/crates/sui-types/src/move_package.rs
+++ b/crates/sui-types/src/move_package.rs
@@ -565,7 +565,7 @@ impl UpgradeReceipt {
     }
 }
 
-/// Checks if a function is annotated with one of the test-related annotations1
+/// Checks if a function is annotated with one of the test-related annotations
 pub fn is_test_fun(name: &IdentStr, module: &CompiledModule, fn_info_map: &FnInfoMap) -> bool {
     let fn_name = name.to_string();
     let mod_handle = module.self_handle();

--- a/crates/sui-types/src/move_package.rs
+++ b/crates/sui-types/src/move_package.rs
@@ -565,6 +565,18 @@ impl UpgradeReceipt {
     }
 }
 
+/// Checks if a function is annotated with one of the test-related annotations1
+pub fn is_test_fun(name: &IdentStr, module: &CompiledModule, fn_info_map: &FnInfoMap) -> bool {
+    let fn_name = name.to_string();
+    let mod_handle = module.self_handle();
+    let mod_addr = *module.address_identifier_at(mod_handle.address);
+    let fn_info_key = FnInfoKey { fn_name, mod_addr };
+    match fn_info_map.get(&fn_info_key) {
+        Some(fn_info) => fn_info.is_test,
+        None => false,
+    }
+}
+
 pub fn disassemble_modules<'a, I>(modules: I) -> SuiResult<BTreeMap<String, Value>>
 where
     I: Iterator<Item = &'a Vec<u8>>,

--- a/crates/sui-verifier/Cargo.toml
+++ b/crates/sui-verifier/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 
 [dependencies]
 move-binary-format.workspace = true
+move-bytecode-utils.workspace = true
 move-bytecode-verifier.workspace = true
 move-core-types.workspace = true
 

--- a/crates/sui-verifier/src/entry_points_verifier.rs
+++ b/crates/sui-verifier/src/entry_points_verifier.rs
@@ -7,19 +7,14 @@ use move_binary_format::{
     file_format::{AbilitySet, Bytecode, FunctionDefinition, SignatureToken, Visibility},
     CompiledModule,
 };
-use move_bytecode_utils::{format_signature_token, resolve_struct};
-use move_core_types::{account_address::AccountAddress, identifier::IdentStr};
+use move_bytecode_utils::format_signature_token;
 use sui_types::{
-    base_types::{
-        STD_ASCII_MODULE_NAME, STD_ASCII_STRUCT_NAME, STD_OPTION_MODULE_NAME,
-        STD_OPTION_STRUCT_NAME, STD_UTF8_MODULE_NAME, STD_UTF8_STRUCT_NAME, TX_CONTEXT_MODULE_NAME,
-        TX_CONTEXT_STRUCT_NAME,
-    },
-    clock::{CLOCK_MODULE_NAME, CLOCK_STRUCT_NAME},
+    base_types::{TxContext, TxContextKind, TX_CONTEXT_MODULE_NAME, TX_CONTEXT_STRUCT_NAME},
+    clock::Clock,
     error::ExecutionError,
-    id::{ID_STRUCT_NAME, OBJECT_MODULE_NAME},
+    is_object, is_object_vector, is_primitive,
     move_package::{is_test_fun, FnInfoMap},
-    MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS,
+    SUI_FRAMEWORK_ADDRESS,
 };
 
 use crate::{verification_failure, INIT_FN_NAME};
@@ -149,7 +144,7 @@ fn verify_init_function(module: &CompiledModule, fdef: &FunctionDefinition) -> R
     // then the first parameter must be of a one-time witness type and must be passed by value. This
     // is checked by the verifier for pass one-time witness value (one_time_witness_verifier) -
     // please see the description of this pass for additional details.
-    if is_tx_context(view, &parameters[parameters.len() - 1]) != TxContextKind::None {
+    if TxContext::kind(view, &parameters[parameters.len() - 1]) != TxContextKind::None {
         Ok(())
     } else {
         Err(format!(
@@ -174,7 +169,7 @@ fn verify_entry_function_impl(
     let params = view.signature_at(handle.parameters);
 
     let all_non_ctx_params = match params.0.last() {
-        Some(last_param) if is_tx_context(view, last_param) != TxContextKind::None => {
+        Some(last_param) if TxContext::kind(view, last_param) != TxContextKind::None => {
             &params.0[0..params.0.len() - 1]
         }
         _ => &params.0,
@@ -222,7 +217,7 @@ fn verify_param_type(
 ) -> Result<(), String> {
     // Only `sui::sui_system` is allowed to expose entry functions that accept a mutable clock
     // parameter.
-    if is_mutable_clock(view, param) {
+    if Clock::is_mutable(view, param) {
         return Err(format!(
             "Invalid entry point parameter type. Clock must be passed by immutable reference. got: \
              {}",
@@ -240,168 +235,5 @@ fn verify_param_type(
             "Invalid entry point parameter type. Expected primitive or object type. Got: {}",
             format_signature_token(view, param)
         ))
-    }
-}
-
-pub const RESOLVED_SUI_ID: (&AccountAddress, &IdentStr, &IdentStr) =
-    (&SUI_FRAMEWORK_ADDRESS, OBJECT_MODULE_NAME, ID_STRUCT_NAME);
-pub const RESOLVED_SUI_CLOCK: (&AccountAddress, &IdentStr, &IdentStr) =
-    (&SUI_FRAMEWORK_ADDRESS, CLOCK_MODULE_NAME, CLOCK_STRUCT_NAME);
-pub const RESOLVED_STD_OPTION: (&AccountAddress, &IdentStr, &IdentStr) = (
-    &MOVE_STDLIB_ADDRESS,
-    STD_OPTION_MODULE_NAME,
-    STD_OPTION_STRUCT_NAME,
-);
-pub const RESOLVED_ASCII_STR: (&AccountAddress, &IdentStr, &IdentStr) = (
-    &MOVE_STDLIB_ADDRESS,
-    STD_ASCII_MODULE_NAME,
-    STD_ASCII_STRUCT_NAME,
-);
-pub const RESOLVED_UTF8_STR: (&AccountAddress, &IdentStr, &IdentStr) = (
-    &MOVE_STDLIB_ADDRESS,
-    STD_UTF8_MODULE_NAME,
-    STD_UTF8_STRUCT_NAME,
-);
-
-pub fn is_primitive(
-    view: &BinaryIndexedView,
-    function_type_args: &[AbilitySet],
-    s: &SignatureToken,
-) -> bool {
-    match s {
-        SignatureToken::Bool
-        | SignatureToken::U8
-        | SignatureToken::U16
-        | SignatureToken::U32
-        | SignatureToken::U64
-        | SignatureToken::U128
-        | SignatureToken::U256
-        | SignatureToken::Address => true,
-        SignatureToken::Signer => false,
-        // optimistic, but no primitive has key
-        SignatureToken::TypeParameter(idx) => !function_type_args[*idx as usize].has_key(),
-
-        SignatureToken::Struct(idx) => {
-            let resolved_struct = resolve_struct(view, *idx);
-            resolved_struct == RESOLVED_SUI_ID
-                || resolved_struct == RESOLVED_ASCII_STR
-                || resolved_struct == RESOLVED_UTF8_STR
-        }
-
-        SignatureToken::StructInstantiation(idx, targs) => {
-            let resolved_struct = resolve_struct(view, *idx);
-            // is option of a primitive
-            resolved_struct == RESOLVED_STD_OPTION
-                && targs.len() == 1
-                && is_primitive(view, function_type_args, &targs[0])
-        }
-
-        SignatureToken::Vector(inner) => is_primitive(view, function_type_args, inner),
-        SignatureToken::Reference(_) | SignatureToken::MutableReference(_) => false,
-    }
-}
-
-#[derive(PartialEq, Eq, Clone, Copy)]
-pub enum TxContextKind {
-    // No TxContext
-    None,
-    // &mut TxContext
-    Mutable,
-    // &TxContext
-    Immutable,
-}
-
-// Returns Some(kind) if the type is a reference to the TxnContext. kind being Mutable with
-// a MutableReference, and Immutable otherwise.
-// Returns None for all other types
-pub fn is_tx_context(view: &BinaryIndexedView, p: &SignatureToken) -> TxContextKind {
-    match p {
-        SignatureToken::MutableReference(m) | SignatureToken::Reference(m) => match &**m {
-            SignatureToken::Struct(idx) => {
-                let (module_addr, module_name, struct_name) = resolve_struct(view, *idx);
-                let is_tx_context_type = module_name == TX_CONTEXT_MODULE_NAME
-                    && module_addr == &SUI_FRAMEWORK_ADDRESS
-                    && struct_name == TX_CONTEXT_STRUCT_NAME;
-                if is_tx_context_type {
-                    match p {
-                        SignatureToken::MutableReference(_) => TxContextKind::Mutable,
-                        SignatureToken::Reference(_) => TxContextKind::Immutable,
-                        _ => unreachable!(),
-                    }
-                } else {
-                    TxContextKind::None
-                }
-            }
-            _ => TxContextKind::None,
-        },
-        _ => TxContextKind::None,
-    }
-}
-
-/// Detects a `&mut sui::clock::Clock` or `sui::clock::Clock` in the signature.
-pub fn is_mutable_clock(view: &BinaryIndexedView, t: &SignatureToken) -> bool {
-    use SignatureToken as S;
-    match t {
-        S::MutableReference(inner) => is_mutable_clock(view, inner),
-        S::Struct(idx) => resolve_struct(view, *idx) == RESOLVED_SUI_CLOCK,
-        _ => false,
-    }
-}
-
-pub fn is_object(
-    view: &BinaryIndexedView,
-    function_type_args: &[AbilitySet],
-    t: &SignatureToken,
-) -> Result<bool, String> {
-    use SignatureToken as S;
-    match t {
-        S::Reference(inner) | S::MutableReference(inner) => {
-            is_object(view, function_type_args, inner)
-        }
-        _ => is_object_struct(view, function_type_args, t),
-    }
-}
-
-pub fn is_object_vector(
-    view: &BinaryIndexedView,
-    function_type_args: &[AbilitySet],
-    t: &SignatureToken,
-) -> Result<bool, String> {
-    use SignatureToken as S;
-    match t {
-        S::Vector(inner) => is_object_struct(view, function_type_args, inner),
-        _ => is_object_struct(view, function_type_args, t),
-    }
-}
-
-fn is_object_struct(
-    view: &BinaryIndexedView,
-    function_type_args: &[AbilitySet],
-    s: &SignatureToken,
-) -> Result<bool, String> {
-    use SignatureToken as S;
-    match s {
-        S::Bool
-        | S::U8
-        | S::U16
-        | S::U32
-        | S::U64
-        | S::U128
-        | S::U256
-        | S::Address
-        | S::Signer
-        | S::Vector(_)
-        | S::Reference(_)
-        | S::MutableReference(_) => Ok(false),
-        S::TypeParameter(idx) => Ok(function_type_args
-            .get(*idx as usize)
-            .map(|abs| abs.has_key())
-            .unwrap_or(false)),
-        S::Struct(_) | S::StructInstantiation(_, _) => {
-            let abilities = view
-                .abilities(s, function_type_args)
-                .map_err(|vm_err| vm_err.to_string())?;
-            Ok(abilities.has_key())
-        }
     }
 }

--- a/crates/sui-verifier/src/entry_points_verifier.rs
+++ b/crates/sui-verifier/src/entry_points_verifier.rs
@@ -7,6 +7,7 @@ use move_binary_format::{
     file_format::{AbilitySet, Bytecode, FunctionDefinition, SignatureToken, Visibility},
     CompiledModule,
 };
+use move_bytecode_utils::{format_signature_token, resolve_struct};
 use move_core_types::{account_address::AccountAddress, identifier::IdentStr};
 use sui_types::{
     base_types::{
@@ -17,13 +18,11 @@ use sui_types::{
     clock::{CLOCK_MODULE_NAME, CLOCK_STRUCT_NAME},
     error::ExecutionError,
     id::{ID_STRUCT_NAME, OBJECT_MODULE_NAME},
-    move_package::FnInfoMap,
+    move_package::{is_test_fun, FnInfoMap},
     MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS,
 };
 
-use crate::{
-    format_signature_token, is_test_fun, resolve_struct, verification_failure, INIT_FN_NAME,
-};
+use crate::{verification_failure, INIT_FN_NAME};
 
 /// Checks valid rules rules for entry points, both for module initialization and transactions
 ///

--- a/crates/sui-verifier/src/lib.rs
+++ b/crates/sui-verifier/src/lib.rs
@@ -10,102 +10,12 @@ pub mod one_time_witness_verifier;
 pub mod private_generics;
 pub mod struct_with_key_verifier;
 
-use move_binary_format::{
-    access::ModuleAccess,
-    binary_views::BinaryIndexedView,
-    file_format::{SignatureToken, StructHandleIndex},
-    CompiledModule,
-};
-use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr};
-use sui_types::{
-    error::{ExecutionError, ExecutionErrorKind},
-    move_package::{FnInfoKey, FnInfoMap},
-};
+use move_core_types::{ident_str, identifier::IdentStr};
+use sui_types::error::{ExecutionError, ExecutionErrorKind};
 
 pub const INIT_FN_NAME: &IdentStr = ident_str!("init");
 pub const TEST_SCENARIO_MODULE_NAME: &str = "test_scenario";
 
 fn verification_failure(error: String) -> ExecutionError {
     ExecutionError::new_with_source(ExecutionErrorKind::SuiMoveVerificationError, error)
-}
-
-/// Checks if a function is annotated with one of the test-related annotations1
-fn is_test_fun(name: &IdentStr, module: &CompiledModule, fn_info_map: &FnInfoMap) -> bool {
-    let fn_name = name.to_string();
-    let mod_handle = module.self_handle();
-    let mod_addr = *module.address_identifier_at(mod_handle.address);
-    let fn_info_key = FnInfoKey { fn_name, mod_addr };
-    match fn_info_map.get(&fn_info_key) {
-        Some(fn_info) => fn_info.is_test,
-        None => false,
-    }
-}
-
-// TODO move these to move bytecode utils
-pub fn resolve_struct<'a>(
-    view: &'a BinaryIndexedView,
-    sidx: StructHandleIndex,
-) -> (&'a AccountAddress, &'a IdentStr, &'a IdentStr) {
-    let shandle = view.struct_handle_at(sidx);
-    let mhandle = view.module_handle_at(shandle.module);
-    let address = view.address_identifier_at(mhandle.address);
-    let module_name = view.identifier_at(mhandle.name);
-    let struct_name = view.identifier_at(shandle.name);
-    (address, module_name, struct_name)
-}
-
-pub fn format_signature_token(view: &BinaryIndexedView, t: &SignatureToken) -> String {
-    match t {
-        SignatureToken::Bool => "bool".to_string(),
-        SignatureToken::U8 => "u8".to_string(),
-        SignatureToken::U16 => "u16".to_string(),
-        SignatureToken::U32 => "u32".to_string(),
-        SignatureToken::U64 => "u64".to_string(),
-        SignatureToken::U128 => "u128".to_string(),
-        SignatureToken::U256 => "u256".to_string(),
-        SignatureToken::Address => "address".to_string(),
-        SignatureToken::Signer => "signer".to_string(),
-        SignatureToken::Vector(inner) => {
-            format!("vector<{}>", format_signature_token(view, inner))
-        }
-        SignatureToken::Reference(inner) => format!("&{}", format_signature_token(view, inner)),
-        SignatureToken::MutableReference(inner) => {
-            format!("&mut {}", format_signature_token(view, inner))
-        }
-        SignatureToken::TypeParameter(i) => format!("T{}", i),
-
-        SignatureToken::Struct(idx) => format_signature_token_struct(view, *idx, &[]),
-        SignatureToken::StructInstantiation(idx, ty_args) => {
-            format_signature_token_struct(view, *idx, ty_args)
-        }
-    }
-}
-
-pub fn format_signature_token_struct(
-    view: &BinaryIndexedView,
-    sidx: StructHandleIndex,
-    ty_args: &[SignatureToken],
-) -> String {
-    let (address, module_name, struct_name) = resolve_struct(view, sidx);
-    let s;
-    let ty_args_string = if ty_args.is_empty() {
-        ""
-    } else {
-        s = format!(
-            "<{}>",
-            ty_args
-                .iter()
-                .map(|t| format_signature_token(view, t))
-                .collect::<Vec<_>>()
-                .join(", ")
-        );
-        &s
-    };
-    format!(
-        "0x{}::{}::{}{}",
-        address.short_str_lossless(),
-        module_name,
-        struct_name,
-        ty_args_string
-    )
 }

--- a/crates/sui-verifier/src/one_time_witness_verifier.rs
+++ b/crates/sui-verifier/src/one_time_witness_verifier.rs
@@ -27,11 +27,11 @@ use move_core_types::{ident_str, language_storage::ModuleId};
 use sui_types::{
     base_types::{TX_CONTEXT_MODULE_NAME, TX_CONTEXT_STRUCT_NAME},
     error::ExecutionError,
-    move_package::FnInfoMap,
+    move_package::{is_test_fun, FnInfoMap},
     SUI_FRAMEWORK_ADDRESS,
 };
 
-use crate::{is_test_fun, verification_failure, INIT_FN_NAME};
+use crate::{verification_failure, INIT_FN_NAME};
 
 pub fn verify_module(
     module: &CompiledModule,

--- a/crates/sui-verifier/src/private_generics.rs
+++ b/crates/sui-verifier/src/private_generics.rs
@@ -10,10 +10,11 @@ use move_binary_format::{
     },
     CompiledModule,
 };
+use move_bytecode_utils::format_signature_token;
 use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr};
 use sui_types::{error::ExecutionError, SUI_FRAMEWORK_ADDRESS};
 
-use crate::{format_signature_token, verification_failure, TEST_SCENARIO_MODULE_NAME};
+use crate::{verification_failure, TEST_SCENARIO_MODULE_NAME};
 
 pub const TRANSFER_MODULE: &IdentStr = ident_str!("transfer");
 pub const EVENT_MODULE: &IdentStr = ident_str!("event");

--- a/external-crates/move/tools/move-bytecode-utils/src/lib.rs
+++ b/external-crates/move/tools/move-bytecode-utils/src/lib.rs
@@ -7,8 +7,14 @@ pub mod layout;
 pub mod module_cache;
 
 use crate::dependency_graph::DependencyGraph;
-use move_binary_format::{access::ModuleAccess, file_format::{CompiledModule, StructHandleIndex, SignatureToken}, binary_views::BinaryIndexedView};
-use move_core_types::{language_storage::ModuleId, identifier::IdentStr, account_address::AccountAddress};
+use move_binary_format::{
+    access::ModuleAccess,
+    binary_views::BinaryIndexedView,
+    file_format::{CompiledModule, SignatureToken, StructHandleIndex},
+};
+use move_core_types::{
+    account_address::AccountAddress, identifier::IdentStr, language_storage::ModuleId,
+};
 
 use anyhow::{anyhow, Result};
 use std::collections::BTreeMap;

--- a/external-crates/move/tools/move-bytecode-utils/src/lib.rs
+++ b/external-crates/move/tools/move-bytecode-utils/src/lib.rs
@@ -7,8 +7,8 @@ pub mod layout;
 pub mod module_cache;
 
 use crate::dependency_graph::DependencyGraph;
-use move_binary_format::{access::ModuleAccess, file_format::CompiledModule};
-use move_core_types::language_storage::ModuleId;
+use move_binary_format::{access::ModuleAccess, file_format::{CompiledModule, StructHandleIndex, SignatureToken}, binary_views::BinaryIndexedView};
+use move_core_types::{language_storage::ModuleId, identifier::IdentStr, account_address::AccountAddress};
 
 use anyhow::{anyhow, Result};
 use std::collections::BTreeMap;
@@ -93,4 +93,72 @@ impl<'a> Modules<'a> {
         }
         Ok(all_deps)
     }
+}
+
+pub fn resolve_struct<'a>(
+    view: &'a BinaryIndexedView,
+    sidx: StructHandleIndex,
+) -> (&'a AccountAddress, &'a IdentStr, &'a IdentStr) {
+    let shandle = view.struct_handle_at(sidx);
+    let mhandle = view.module_handle_at(shandle.module);
+    let address = view.address_identifier_at(mhandle.address);
+    let module_name = view.identifier_at(mhandle.name);
+    let struct_name = view.identifier_at(shandle.name);
+    (address, module_name, struct_name)
+}
+
+pub fn format_signature_token(view: &BinaryIndexedView, t: &SignatureToken) -> String {
+    match t {
+        SignatureToken::Bool => "bool".to_string(),
+        SignatureToken::U8 => "u8".to_string(),
+        SignatureToken::U16 => "u16".to_string(),
+        SignatureToken::U32 => "u32".to_string(),
+        SignatureToken::U64 => "u64".to_string(),
+        SignatureToken::U128 => "u128".to_string(),
+        SignatureToken::U256 => "u256".to_string(),
+        SignatureToken::Address => "address".to_string(),
+        SignatureToken::Signer => "signer".to_string(),
+        SignatureToken::Vector(inner) => {
+            format!("vector<{}>", format_signature_token(view, inner))
+        }
+        SignatureToken::Reference(inner) => format!("&{}", format_signature_token(view, inner)),
+        SignatureToken::MutableReference(inner) => {
+            format!("&mut {}", format_signature_token(view, inner))
+        }
+        SignatureToken::TypeParameter(i) => format!("T{}", i),
+
+        SignatureToken::Struct(idx) => format_signature_token_struct(view, *idx, &[]),
+        SignatureToken::StructInstantiation(idx, ty_args) => {
+            format_signature_token_struct(view, *idx, ty_args)
+        }
+    }
+}
+
+pub fn format_signature_token_struct(
+    view: &BinaryIndexedView,
+    sidx: StructHandleIndex,
+    ty_args: &[SignatureToken],
+) -> String {
+    let (address, module_name, struct_name) = resolve_struct(view, sidx);
+    let s;
+    let ty_args_string = if ty_args.is_empty() {
+        ""
+    } else {
+        s = format!(
+            "<{}>",
+            ty_args
+                .iter()
+                .map(|t| format_signature_token(view, t))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+        &s
+    };
+    format!(
+        "0x{}::{}::{}{}",
+        address.short_str_lossless(),
+        module_name,
+        struct_name,
+        ty_args_string
+    )
 }


### PR DESCRIPTION
## Description 

`sui-verifier` contained a number of helper functions that were being used by other crates (like `sui-json`).  These helpers don't need to be versioned as part of the execution layer, but `sui-verifier` in general does.  By moving helpers into `sui-types` and `move-bytecode-utils` (which are not versioned), we avoid `sui-json` having to deal with the versioned API.

## Test Plan 

```
$ cargo simtest
$ env SUI_SKIP_SIMTESTS=1 cargo nextest run
```