### PR TITLE
[Faucet] Turning off worker thread to clear WAL

### DIFF
--- a/crates/sui-faucet/src/main.rs
+++ b/crates/sui-faucet/src/main.rs
@@ -107,14 +107,14 @@ async fn main() -> Result<(), anyhow::Error> {
                 .into_inner(),
         );
 
-    spawn_monitored_task!(async move {
-        info!("Starting task to clear WAL.");
-        loop {
-            // Every 300 seconds we try to clear the wal coins
-            tokio::time::sleep(Duration::from_secs(wal_retry_interval)).await;
-            app_state.faucet.retry_wal_coins().await.unwrap();
-        }
-    });
+    // spawn_monitored_task!(async move {
+    //     info!("Starting task to clear WAL.");
+    //     loop {
+    //         // Every 300 seconds we try to clear the wal coins
+    //         tokio::time::sleep(Duration::from_secs(wal_retry_interval)).await;
+    //         app_state.faucet.retry_wal_coins().await.unwrap();
+    //     }
+    // });
 
     let addr = SocketAddr::new(IpAddr::V4(host_ip), port);
     info!("listening on {}", addr);

--- a/crates/sui-faucet/src/main.rs
+++ b/crates/sui-faucet/src/main.rs
@@ -59,7 +59,6 @@ async fn main() -> Result<(), anyhow::Error> {
         max_request_per_second,
         wallet_client_timeout_secs,
         ref write_ahead_log,
-        wal_retry_interval,
         ..
     } = config;
 
@@ -107,6 +106,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 .into_inner(),
         );
 
+    // TODO (jian):Investigate this issue later.
     // spawn_monitored_task!(async move {
     //     info!("Starting task to clear WAL.");
     //     loop {


### PR DESCRIPTION
## Description 

The thread in faucet cause some duplicate submissions to the WAL because the same coins were pulled from the WAL.
This seeks to mitigate this issue temporarily.

## Test Plan 

Deployed image to testnet, and tested over the course of the day.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
