### PR TITLE
[move-package] Hash username when calculating package lock name

### DIFF
--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -3249,6 +3249,7 @@ dependencies = [
  "named-lock",
  "once_cell",
  "petgraph 0.5.1",
+ "proptest",
  "ptree",
  "regex",
  "reqwest",

--- a/external-crates/move/tools/move-package/Cargo.toml
+++ b/external-crates/move/tools/move-package/Cargo.toml
@@ -48,6 +48,7 @@ whoami = { version = "1.2.1" }
 
 [dev-dependencies]
 datatest-stable = "0.1.1"
+proptest = "1.0.0"
 
 [[test]]
 name = "test_runner"

--- a/external-crates/move/tools/move-package/src/package_lock.rs
+++ b/external-crates/move/tools/move-package/src/package_lock.rs
@@ -4,15 +4,21 @@
 
 use named_lock::{NamedLock, NamedLockGuard};
 use once_cell::sync::Lazy;
+use sha2::{Digest, Sha256};
 use std::sync::{Mutex, MutexGuard};
 use whoami::username;
 
 const PACKAGE_LOCK_NAME: &str = "move_pkg_lock";
 static PACKAGE_THREAD_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
-static PACKAGE_PROCESS_MUTEX: Lazy<NamedLock> = Lazy::new(|| {
-    let user_lock_file = format!("{}_{}", PACKAGE_LOCK_NAME, username());
+static PACKAGE_PROCESS_MUTEX: Lazy<NamedLock> = Lazy::new(|| lock_username(username()));
+
+fn lock_username(unsanitized_username: String) -> NamedLock {
+    let hashed_username = format!("{:X}", Sha256::digest(unsanitized_username.as_bytes()));
+    let mut user_lock_file = format!("{}_{}", PACKAGE_LOCK_NAME, hashed_username);
+    // truncate to 255 characters to avoid filname length limit
+    user_lock_file.truncate(255);
     NamedLock::create(user_lock_file.as_str()).unwrap()
-});
+}
 
 /// The package lock is a lock held across threads and processes. This lock is held to ensure that
 /// the Move package manager has a consistent (read: serial) view of the file system. Without this
@@ -33,6 +39,34 @@ impl PackageLock {
         Self {
             _thread_lock: PACKAGE_THREAD_MUTEX.lock().unwrap(),
             _process_lock: PACKAGE_PROCESS_MUTEX.lock().unwrap(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    #[test]
+    fn package_lock_slashes_in_username() {
+        lock_username("user/name".to_string());
+    }
+
+    #[test]
+    fn package_lock_unicode() {
+        lock_username("🦀".to_string());
+    }
+
+    #[test]
+    fn package_lock_unicode_bad() {
+        lock_username("𱍐".to_string());
+    }
+
+    proptest! {
+        #[test]
+        fn package_lock_username_does_not_crash(username in "\\PC*") {
+            lock_username(username);
         }
     }
 }


### PR DESCRIPTION
Hash the username when grabbing a package lock so we don't run unti filename sanitization/length issues.

## Test Plan 

Adds a bunch of test cases and a proptest testing different user names.

