### PR TITLE
Improve test authority builder

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1748,6 +1748,7 @@ impl AuthorityState {
             rx_execution_shutdown
         ));
 
+        // TODO: This doesn't belong to the constructor of AuthorityState.
         state
             .create_owner_index_if_empty(genesis_objects, &epoch_store)
             .expect("Error indexing genesis objects.");

--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -18,95 +18,93 @@ use sui_config::node::{
     AuthorityStorePruningConfig, DBCheckpointConfig, ExpensiveSafetyCheckConfig,
 };
 use sui_config::transaction_deny_config::TransactionDenyConfig;
+use sui_config::NetworkConfig;
 use sui_macros::nondeterministic;
 use sui_protocol_config::SupportedProtocolVersions;
 use sui_storage::IndexStore;
 use sui_types::base_types::{AuthorityName, ObjectID};
-use sui_types::committee::Committee;
 use sui_types::crypto::AuthorityKeyPair;
 use sui_types::messages::{VerifiedExecutableTransaction, VerifiedTransaction};
-use sui_types::object::Object;
 
-pub struct TestAuthorityBuilder {
-    // TODO: Add more configurable fields.
-    store_base_path: PathBuf,
-    transaction_deny_config: TransactionDenyConfig,
+#[derive(Default)]
+pub struct TestAuthorityBuilder<'a> {
+    store_base_path: Option<PathBuf>,
+    store: Option<Arc<AuthorityStore>>,
+    transaction_deny_config: Option<TransactionDenyConfig>,
+    node_keypair: Option<&'a AuthorityKeyPair>,
+    genesis: Option<&'a Genesis>,
 }
 
-impl Default for TestAuthorityBuilder {
-    fn default() -> Self {
-        let dir = std::env::temp_dir();
-        let store_base_path = dir.join(format!("DB_{:?}", nondeterministic!(ObjectID::random())));
-        std::fs::create_dir(&store_base_path).unwrap();
-        Self {
-            store_base_path,
-            transaction_deny_config: TransactionDenyConfig::default(),
-        }
-    }
-}
-
-impl TestAuthorityBuilder {
+impl<'a> TestAuthorityBuilder<'a> {
     pub fn new() -> Self {
         Self::default()
     }
 
     pub fn with_store_base_path(mut self, path: PathBuf) -> Self {
-        self.store_base_path = path;
+        assert!(self.store_base_path.replace(path).is_none());
+        self
+    }
+
+    pub fn with_store(mut self, store: Arc<AuthorityStore>) -> Self {
+        assert!(self.store.replace(store).is_none());
         self
     }
 
     pub fn with_transaction_deny_config(mut self, config: TransactionDenyConfig) -> Self {
-        self.transaction_deny_config = config;
+        assert!(self.transaction_deny_config.replace(config).is_none());
         self
     }
 
-    // TODO: Figure out why we could not derive genesis_committee from genesis.
-    pub async fn build(
-        self,
-        genesis_committee: Committee,
-        key: &AuthorityKeyPair,
-        genesis: &Genesis,
-    ) -> Arc<AuthorityState> {
-        // unwrap ok - for testing only.
-        let store = AuthorityStore::open_with_committee_for_testing(
-            &self.store_base_path.join("store"),
-            None,
-            &genesis_committee,
-            genesis,
-            0,
-        )
-        .await
-        .unwrap();
-        let state = Self::build_with_store(self, genesis_committee, key, store, &[]).await;
-        // For any type of local testing that does not actually spawn a node, the checkpoint executor
-        // won't be started, which means we won't actually execute the genesis transaction. In that case,
-        // the genesis objects (e.g. all the genesis test coins) won't be accessible. Executing it
-        // explicitly makes sure all genesis objects are ready for use.
-        state
-            .try_execute_immediately(
-                &VerifiedExecutableTransaction::new_from_checkpoint(
-                    VerifiedTransaction::new_unchecked(genesis.transaction().clone()),
-                    genesis.epoch(),
-                    genesis.checkpoint().sequence_number,
-                ),
-                None,
-                &state.epoch_store_for_testing(),
-            )
-            .await
-            .unwrap();
-        state
+    pub fn with_genesis_and_keypair(
+        mut self,
+        genesis: &'a Genesis,
+        keypair: &'a AuthorityKeyPair,
+    ) -> Self {
+        assert!(self.genesis.replace(genesis).is_none());
+        assert!(self.node_keypair.replace(keypair).is_none());
+        self
     }
 
-    pub async fn build_with_store(
-        self,
-        genesis_committee: Committee,
-        key: &AuthorityKeyPair,
-        authority_store: Arc<AuthorityStore>,
-        genesis_objects: &[Object],
-    ) -> Arc<AuthorityState> {
-        let secret = Arc::pin(key.copy());
+    /// When providing a network config, we will use the first validator's
+    /// key as the keypair for the new node.
+    pub fn with_network_config(self, config: &'a NetworkConfig) -> Self {
+        self.with_genesis_and_keypair(
+            &config.genesis,
+            config.validator_configs()[0].protocol_key_pair(),
+        )
+    }
+
+    pub async fn build(self) -> Arc<AuthorityState> {
+        let local_network_config = sui_config::builder::ConfigBuilder::new_with_temp_dir().build();
+        let genesis = &self.genesis.unwrap_or(&local_network_config.genesis);
+        let genesis_committee = genesis.committee().unwrap();
+        let path = self.store_base_path.unwrap_or_else(|| {
+            let dir = std::env::temp_dir();
+            let store_base_path =
+                dir.join(format!("DB_{:?}", nondeterministic!(ObjectID::random())));
+            std::fs::create_dir(&store_base_path).unwrap();
+            store_base_path
+        });
+        let authority_store = match self.store {
+            Some(store) => store,
+            None => {
+                // unwrap ok - for testing only.
+                AuthorityStore::open_with_committee_for_testing(
+                    &path.join("store"),
+                    None,
+                    &genesis_committee,
+                    genesis,
+                    0,
+                )
+                .await
+                .unwrap()
+            }
+        };
+        let keypair = self
+            .node_keypair
+            .unwrap_or_else(|| local_network_config.validator_configs()[0].protocol_key_pair());
+        let secret = Arc::pin(keypair.copy());
         let name: AuthorityName = secret.public().into();
-        let path = self.store_base_path;
         let registry = Registry::new();
         let cache_metrics = Arc::new(ResolverMetrics::new(&registry));
         let signature_verifier_metrics = SignatureVerifierMetrics::new(&registry);
@@ -131,7 +129,8 @@ impl TestAuthorityBuilder {
 
         let checkpoint_store = CheckpointStore::new(&path.join("checkpoints"));
         let index_store = Some(Arc::new(IndexStore::new(path.join("indexes"), &registry)));
-        AuthorityState::new(
+        let transaction_deny_config = self.transaction_deny_config.unwrap_or_default();
+        let state = AuthorityState::new(
             name,
             secret,
             SupportedProtocolVersions::SYSTEM_DEFAULT,
@@ -142,11 +141,28 @@ impl TestAuthorityBuilder {
             checkpoint_store,
             &registry,
             AuthorityStorePruningConfig::default(),
-            genesis_objects,
+            genesis.objects(),
             &DBCheckpointConfig::default(),
             ExpensiveSafetyCheckConfig::new_enable_all(),
-            self.transaction_deny_config,
+            transaction_deny_config,
         )
-        .await
+        .await;
+        // For any type of local testing that does not actually spawn a node, the checkpoint executor
+        // won't be started, which means we won't actually execute the genesis transaction. In that case,
+        // the genesis objects (e.g. all the genesis test coins) won't be accessible. Executing it
+        // explicitly makes sure all genesis objects are ready for use.
+        state
+            .try_execute_immediately(
+                &VerifiedExecutableTransaction::new_from_checkpoint(
+                    VerifiedTransaction::new_unchecked(genesis.transaction().clone()),
+                    genesis.epoch(),
+                    genesis.checkpoint().sequence_number,
+                ),
+                None,
+                &state.epoch_store_for_testing(),
+            )
+            .await
+            .unwrap();
+        state
     }
 }

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use fastcrypto::traits::KeyPair;
 use sui_config::node::ExpensiveSafetyCheckConfig;
 use sui_types::gas::GasCostSummary;
 use tempfile::tempdir;
@@ -386,15 +385,10 @@ async fn init_executor_test(
     Sender<VerifiedCheckpoint>,
     CommitteeFixture,
 ) {
-    let dir = tempfile::TempDir::new().unwrap();
-    let network_config = sui_config::builder::ConfigBuilder::new(&dir).build();
-    let genesis = network_config.genesis;
-    let committee = CommitteeFixture::generate(rand::rngs::OsRng, 0, 4);
-    let keypair = network_config.validator_configs[0]
-        .protocol_key_pair()
-        .copy();
+    let network_config = sui_config::builder::ConfigBuilder::new_with_temp_dir().build();
     let state = TestAuthorityBuilder::new()
-        .build(committee.committee().clone(), &keypair, &genesis)
+        .with_network_config(&network_config)
+        .build()
         .await;
 
     let (checkpoint_sender, _): (Sender<VerifiedCheckpoint>, Receiver<VerifiedCheckpoint>) =
@@ -410,7 +404,13 @@ async fn init_executor_test(
         state.transaction_manager().clone(),
         accumulator.clone(),
     );
-    (state, executor, accumulator, checkpoint_sender, committee)
+    (
+        state,
+        executor,
+        accumulator,
+        checkpoint_sender,
+        CommitteeFixture::from_network_config(&network_config),
+    )
 }
 
 /// Creates and simulates syncing of a new checkpoint by StateSync, i.e. new

--- a/crates/sui-core/src/consensus_validator.rs
+++ b/crates/sui-core/src/consensus_validator.rs
@@ -144,20 +144,18 @@ impl SuiTxValidatorMetrics {
 #[cfg(test)]
 mod tests {
     use crate::{
-        authority::authority_tests::init_state_with_objects_and_committee,
         consensus_adapter::consensus_tests::{test_certificates, test_gas_objects},
         consensus_validator::{SuiTxValidator, SuiTxValidatorMetrics},
     };
-    use fastcrypto::traits::KeyPair;
     use narwhal_types::Batch;
     use narwhal_worker::TransactionValidator;
-    use sui_types::{
-        base_types::AuthorityName, messages::ConsensusTransaction, signature::GenericSignature,
-    };
+    use sui_types::{messages::ConsensusTransaction, signature::GenericSignature};
 
+    use crate::authority::test_authority_builder::TestAuthorityBuilder;
     use sui_macros::sim_test;
     use sui_types::crypto::Ed25519SuiSignature;
     use sui_types::object::Object;
+
     #[sim_test]
     async fn accept_valid_transaction() {
         // Initialize an authority with a (owned) gas object and a shared object; then
@@ -165,18 +163,15 @@ mod tests {
         let mut objects = test_gas_objects();
         objects.push(Object::shared_for_testing());
 
-        let dir = tempfile::TempDir::new().unwrap();
-        let network_config = sui_config::builder::ConfigBuilder::new(&dir)
+        let network_config = sui_config::builder::ConfigBuilder::new_with_temp_dir()
             .with_objects(objects.clone())
             .build();
-        let genesis = network_config.genesis;
 
-        let sec1 = network_config.validator_configs[0]
-            .protocol_key_pair()
-            .copy();
-        let name1: AuthorityName = sec1.public().into();
-
-        let state = init_state_with_objects_and_committee(objects, &genesis, &sec1).await;
+        let state = TestAuthorityBuilder::new()
+            .with_network_config(&network_config)
+            .build()
+            .await;
+        let name1 = state.name;
         let certificates = test_certificates(&state).await;
 
         let first_transaction = certificates[0].clone();

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -15,7 +15,6 @@ use sui_config::genesis::Genesis;
 use sui_types::messages::TransactionEvents;
 use sui_types::sui_system_state::SuiSystemState;
 use sui_types::{
-    committee::Committee,
     crypto::AuthorityKeyPair,
     error::SuiError,
     messages::{
@@ -114,9 +113,10 @@ impl AuthorityAPI for LocalAuthorityClient {
 }
 
 impl LocalAuthorityClient {
-    pub async fn new(committee: Committee, secret: AuthorityKeyPair, genesis: &Genesis) -> Self {
+    pub async fn new(secret: AuthorityKeyPair, genesis: &Genesis) -> Self {
         let state = TestAuthorityBuilder::new()
-            .build(committee, &secret, genesis)
+            .with_genesis_and_keypair(genesis, &secret)
+            .build()
             .await;
         Self {
             state,

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::authority::test_authority_builder::TestAuthorityBuilder;
 use crate::authority::{AuthorityState, EffectsNotifyRead};
 use crate::authority_aggregator::{AuthorityAggregator, TimeoutConfig};
 use crate::epoch::committee_store::CommitteeStore;
@@ -49,18 +48,6 @@ use tokio::time::timeout;
 use tracing::{info, warn};
 
 const WAIT_FOR_TX_TIMEOUT: Duration = Duration::from_secs(15);
-
-pub async fn init_state() -> Arc<AuthorityState> {
-    let dir = tempfile::TempDir::new().unwrap();
-    let network_config = sui_config::builder::ConfigBuilder::new(&dir).build();
-    let genesis = network_config.genesis;
-    let keypair = network_config.validator_configs[0]
-        .protocol_key_pair()
-        .copy();
-    TestAuthorityBuilder::new()
-        .build(genesis.committee().unwrap(), &keypair, &genesis)
-        .await
-}
 
 pub async fn send_and_confirm_transaction(
     authority: &AuthorityState,
@@ -295,7 +282,7 @@ pub async fn init_local_authorities_with_genesis(
     let mut clients = BTreeMap::new();
     let mut states = Vec::new();
     for (authority_name, secret) in key_pairs {
-        let client = LocalAuthorityClient::new(committee.clone(), secret, genesis).await;
+        let client = LocalAuthorityClient::new(secret, genesis).await;
         states.push(client.state.clone());
         clients.insert(authority_name, client);
     }

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -52,6 +52,12 @@ pub async fn test_certificates(authority: &AuthorityState) -> Vec<CertifiedTrans
         mutable: true,
     };
     for gas_object in test_gas_objects() {
+        // Object digest may be different in genesis than originally generated.
+        let gas_object = authority
+            .get_object(&gas_object.id())
+            .await
+            .unwrap()
+            .unwrap();
         // Make a sample transaction.
         let module = "object_basics";
         let function = "create";

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -5,7 +5,8 @@ use super::*;
 
 use super::authority_tests::{init_state_with_ids, send_and_confirm_transaction};
 use super::move_integration_tests::build_and_try_publish_test_package;
-use crate::authority::authority_tests::{init_state, init_state_with_ids_and_object_basics};
+use crate::authority::authority_tests::init_state_with_ids_and_object_basics;
+use crate::authority::test_authority_builder::TestAuthorityBuilder;
 use move_core_types::account_address::AccountAddress;
 use move_core_types::ident_str;
 use once_cell::sync::Lazy;
@@ -126,7 +127,7 @@ where
     const GAS_AMOUNT: u64 = 10_000_000_000;
     let gas_coins = make_gas_coins(sender, GAS_AMOUNT, coin_num);
     let gas_coin_ids: Vec<_> = gas_coins.iter().map(|obj| obj.id()).collect();
-    let authority_state = init_state().await;
+    let authority_state = TestAuthorityBuilder::new().build().await;
     for obj in gas_coins {
         authority_state.insert_genesis_object(obj).await;
     }
@@ -510,7 +511,7 @@ async fn test_transfer_sui_insufficient_gas() {
     let gas_object_id = ObjectID::random();
     let gas_object = Object::with_id_owner_gas_for_testing(gas_object_id, sender, *MIN_GAS_BUDGET);
     let gas_object_ref = gas_object.compute_object_reference();
-    let authority_state = init_state().await;
+    let authority_state = TestAuthorityBuilder::new().build().await;
     authority_state.insert_genesis_object(gas_object).await;
 
     let pt = {
@@ -541,7 +542,7 @@ async fn test_transfer_sui_insufficient_gas() {
 #[tokio::test]
 async fn test_invalid_gas_owners() {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
-    let authority_state = init_state().await;
+    let authority_state = TestAuthorityBuilder::new().build().await;
 
     let init_object = |o: Object| async {
         let obj_ref = o.compute_object_reference();

--- a/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -21,11 +21,11 @@ use sui_types::{
 
 use std::{collections::BTreeSet, path::PathBuf, str::FromStr, sync::Arc};
 
+use crate::authority::test_authority_builder::TestAuthorityBuilder;
 use crate::authority::{
     authority_test_utils::build_test_modules_with_dep_addr,
-    authority_tests::{execute_programmable_transaction, init_state},
-    move_integration_tests::build_and_publish_test_package_with_upgrade_cap,
-    AuthorityState,
+    authority_tests::execute_programmable_transaction,
+    move_integration_tests::build_and_publish_test_package_with_upgrade_cap, AuthorityState,
 };
 
 macro_rules! move_call {
@@ -114,7 +114,7 @@ impl UpgradeStateRunner {
         let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
         let gas_object_id = ObjectID::random();
         let gas_object = Object::with_id_owner_for_testing(gas_object_id, sender);
-        let authority_state = init_state().await;
+        let authority_state = TestAuthorityBuilder::new().build().await;
         authority_state.insert_genesis_object(gas_object).await;
 
         let (package, upgrade_cap) = build_and_publish_test_package_with_upgrade_cap(

--- a/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
@@ -96,10 +96,10 @@ async fn test_narwhal_manager() {
         let registry_service = RegistryService::new(Registry::new());
         let secret = Arc::pin(config.protocol_key_pair().copy());
         let genesis = config.genesis().unwrap();
-        let genesis_committee = genesis.committee().unwrap();
 
         let state = TestAuthorityBuilder::new()
-            .build(genesis_committee, &secret, genesis)
+            .with_genesis_and_keypair(genesis, &secret)
+            .build()
             .await;
 
         let system_state = state

--- a/crates/sui-core/src/unit_tests/pay_sui_tests.rs
+++ b/crates/sui-core/src/unit_tests/pay_sui_tests.rs
@@ -1,9 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::authority::authority_tests::{
-    init_state, init_state_with_committee, send_and_confirm_transaction,
-};
+use crate::authority::authority_tests::{init_state_with_committee, send_and_confirm_transaction};
+use crate::authority::test_authority_builder::TestAuthorityBuilder;
 use crate::authority::AuthorityState;
 use futures::future::join_all;
 use std::collections::HashMap;
@@ -391,7 +390,7 @@ async fn execute_pay_sui(
     sender_key: AccountKeyPair,
     gas_budget: u64,
 ) -> PaySuiTransactionBlockExecutionResult {
-    let authority_state = init_state().await;
+    let authority_state = TestAuthorityBuilder::new().build().await;
 
     let input_coin_refs: Vec<ObjectRef> = input_coin_objects
         .iter()

--- a/crates/sui-core/src/unit_tests/transaction_deny_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_deny_tests.rs
@@ -39,11 +39,10 @@ async fn setup_test(deny_config: TransactionDenyConfig) -> (NetworkConfig, Arc<A
             ACCOUNT_NUM
         ])
         .build();
-    let genesis = &network_config.genesis;
-    let keypair = network_config.validator_configs[0].protocol_key_pair();
     let state = TestAuthorityBuilder::new()
         .with_transaction_deny_config(deny_config)
-        .build(genesis.committee().unwrap(), keypair, genesis)
+        .with_network_config(&network_config)
+        .build()
         .await;
     (network_config, state)
 }
@@ -55,12 +54,9 @@ async fn reload_state_with_new_deny_config(
 ) -> Arc<AuthorityState> {
     TestAuthorityBuilder::new()
         .with_transaction_deny_config(config)
-        .build_with_store(
-            network_config.genesis.committee().unwrap(),
-            network_config.validator_configs[0].protocol_key_pair(),
-            state.db(),
-            &[],
-        )
+        .with_network_config(network_config)
+        .with_store(state.db())
+        .build()
         .await
 }
 

--- a/crates/sui-network/src/state_sync/test_utils.rs
+++ b/crates/sui-network/src/state_sync/test_utils.rs
@@ -3,6 +3,7 @@
 
 use shared_crypto::intent::{Intent, IntentMessage, IntentScope};
 use std::collections::HashMap;
+use sui_config::NetworkConfig;
 use sui_types::{
     base_types::AuthorityName,
     committee::{Committee, EpochId, StakeUnit},
@@ -43,6 +44,32 @@ impl CommitteeFixture {
         Self {
             epoch,
             validators,
+            committee,
+        }
+    }
+
+    pub fn from_network_config(network_config: &NetworkConfig) -> Self {
+        let committee = network_config.genesis.committee().unwrap();
+        Self {
+            epoch: committee.epoch,
+            validators: committee
+                .members()
+                .map(|(name, stake)| {
+                    (
+                        *name,
+                        (
+                            network_config
+                                .validator_configs()
+                                .iter()
+                                .find(|config| config.protocol_public_key() == *name)
+                                .unwrap()
+                                .protocol_key_pair()
+                                .copy(),
+                            *stake,
+                        ),
+                    )
+                })
+                .collect(),
             committee,
         }
     }

--- a/crates/transaction-fuzzer/src/executor.rs
+++ b/crates/transaction-fuzzer/src/executor.rs
@@ -5,10 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::sync::Arc;
-use sui_core::{
-    authority::AuthorityState,
-    test_utils::{init_state, send_and_confirm_transaction},
-};
+use sui_core::authority::test_authority_builder::TestAuthorityBuilder;
+use sui_core::{authority::AuthorityState, test_utils::send_and_confirm_transaction};
 use sui_types::{
     error::SuiError,
     messages::{ExecutionStatus, TransactionEffectsAPI, VerifiedTransaction},
@@ -32,7 +30,7 @@ impl Default for Executor {
 impl Executor {
     pub fn new() -> Self {
         let rt = Runtime::new().unwrap();
-        let state = rt.block_on(init_state());
+        let state = rt.block_on(TestAuthorityBuilder::new().build());
         Self { state, rt }
     }
 

--- a/crates/transaction-fuzzer/tests/gas_data_tests.rs
+++ b/crates/transaction-fuzzer/tests/gas_data_tests.rs
@@ -4,7 +4,8 @@
 use proptest::arbitrary::*;
 use proptest::prelude::*;
 use proptest::proptest;
-use sui_core::test_utils::{init_state, send_and_confirm_transaction};
+use sui_core::authority::test_authority_builder::TestAuthorityBuilder;
+use sui_core::test_utils::send_and_confirm_transaction;
 use sui_types::base_types::dbg_addr;
 use sui_types::crypto::KeypairTraits;
 use sui_types::messages::TransactionData;
@@ -22,7 +23,7 @@ async fn test_with_random_gas_data(gas_data_test: GasDataWithObjects) {
     let objects = gas_data_test.objects;
     let sender = gas_data_test.sender_key.public().into();
 
-    let authority_state = init_state().await;
+    let authority_state = TestAuthorityBuilder::new().build().await;
     // Insert the random gas objects into genesis.
     authority_state.insert_genesis_objects(&objects).await;
     let pt = {


### PR DESCRIPTION
This PR allows TestAuthorityBuilder to generate default network config in order to derive the genesis and node private keypair. It also allows a test to explicitly specify the genesis and private keypair if needed.
This allows us to get rid of a lot of similar boiler plate code.
There are a lot more to clean up, though. But the PR is already large enough that I am stopping here.
In the next PRs I will make TestAuthorityBuilder to be able to take in genesis objects and initial accounts.