### PR TITLE
TransactionManager optimizations:

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -794,8 +794,10 @@ impl AuthorityState {
             );
             self.database
                 .fullnode_fast_path_insert_objects_to_object_store_maybe(&objects)?;
-            self.transaction_manager()
-                .objects_available(objects.iter().map(InputKey::from).collect(), epoch_store);
+            self.transaction_manager().fastpath_objects_available(
+                objects.iter().map(InputKey::from).collect(),
+                epoch_store,
+            );
         }
 
         if transaction.contains_shared_object() {

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -210,9 +210,11 @@ pub struct AuthorityMetrics {
     pub(crate) transaction_manager_num_pending_certificates: IntGauge,
     pub(crate) transaction_manager_num_executing_certificates: IntGauge,
     pub(crate) transaction_manager_num_ready: IntGauge,
+    pub(crate) transaction_manager_object_cache_size: IntGauge,
     pub(crate) transaction_manager_object_cache_hits: IntCounter,
     pub(crate) transaction_manager_object_cache_misses: IntCounter,
     pub(crate) transaction_manager_object_cache_evictions: IntCounter,
+    pub(crate) transaction_manager_package_cache_size: IntGauge,
     pub(crate) transaction_manager_package_cache_hits: IntCounter,
     pub(crate) transaction_manager_package_cache_misses: IntCounter,
     pub(crate) transaction_manager_package_cache_evictions: IntCounter,
@@ -413,6 +415,12 @@ impl AuthorityMetrics {
                 registry,
             )
             .unwrap(),
+            transaction_manager_object_cache_size: register_int_gauge_with_registry!(
+                "transaction_manager_object_cache_size",
+                "Current size of object-availability cache in TransactionManager",
+                registry,
+            )
+            .unwrap(),
             transaction_manager_object_cache_hits: register_int_counter_with_registry!(
                 "transaction_manager_object_cache_hits",
                 "Number of object-availability cache hits in TransactionManager",
@@ -428,6 +436,12 @@ impl AuthorityMetrics {
             transaction_manager_object_cache_evictions: register_int_counter_with_registry!(
                 "transaction_manager_object_cache_evictions",
                 "Number of object-availability cache evictions in TransactionManager",
+                registry,
+            )
+            .unwrap(),
+            transaction_manager_package_cache_size: register_int_gauge_with_registry!(
+                "transaction_manager_package_cache_size",
+                "Current size of package-availability cache in TransactionManager",
                 registry,
             )
             .unwrap(),

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -210,6 +210,12 @@ pub struct AuthorityMetrics {
     pub(crate) transaction_manager_num_pending_certificates: IntGauge,
     pub(crate) transaction_manager_num_executing_certificates: IntGauge,
     pub(crate) transaction_manager_num_ready: IntGauge,
+    pub(crate) transaction_manager_object_cache_hits: IntCounter,
+    pub(crate) transaction_manager_object_cache_misses: IntCounter,
+    pub(crate) transaction_manager_object_cache_evictions: IntCounter,
+    pub(crate) transaction_manager_package_cache_hits: IntCounter,
+    pub(crate) transaction_manager_package_cache_misses: IntCounter,
+    pub(crate) transaction_manager_package_cache_evictions: IntCounter,
 
     pub(crate) execution_driver_executed_transactions: IntCounter,
     pub(crate) execution_driver_dispatch_queue: IntGauge,
@@ -404,6 +410,42 @@ impl AuthorityMetrics {
             transaction_manager_num_ready: register_int_gauge_with_registry!(
                 "transaction_manager_num_ready",
                 "Number of ready transactions in TransactionManager",
+                registry,
+            )
+            .unwrap(),
+            transaction_manager_object_cache_hits: register_int_counter_with_registry!(
+                "transaction_manager_object_cache_hits",
+                "Number of object-availability cache hits in TransactionManager",
+                registry,
+            )
+            .unwrap(),
+            transaction_manager_object_cache_misses: register_int_counter_with_registry!(
+                "transaction_manager_object_cache_misses",
+                "Number of object-availability cache misses in TransactionManager",
+                registry,
+            )
+            .unwrap(),
+            transaction_manager_object_cache_evictions: register_int_counter_with_registry!(
+                "transaction_manager_object_cache_evictions",
+                "Number of object-availability cache evictions in TransactionManager",
+                registry,
+            )
+            .unwrap(),
+            transaction_manager_package_cache_hits: register_int_counter_with_registry!(
+                "transaction_manager_package_cache_hits",
+                "Number of package-availability cache hits in TransactionManager",
+                registry,
+            )
+            .unwrap(),
+            transaction_manager_package_cache_misses: register_int_counter_with_registry!(
+                "transaction_manager_package_cache_misses",
+                "Number of package-availability cache misses in TransactionManager",
+                registry,
+            )
+            .unwrap(),
+            transaction_manager_package_cache_evictions: register_int_counter_with_registry!(
+                "transaction_manager_package_cache_evictions",
+                "Number of package-availability cache evictions in TransactionManager",
                 registry,
             )
             .unwrap(),

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -617,6 +617,47 @@ impl AuthorityStore {
         }
     }
 
+    /// Checks if the input object identified by the InputKey exists, with support for non-system
+    /// packages i.e. when version is None.
+    pub fn input_object_multi_exists(
+        &self,
+        keys: impl Iterator<Item = InputKey> + Clone,
+    ) -> Result<Vec<bool>, SuiError> {
+        let (keys_with_version, keys_without_version): (Vec<_>, Vec<_>) =
+            keys.enumerate().partition(|(_, key)| key.1.is_some());
+
+        let versioned_results = keys_with_version.iter().map(|(idx, _)| *idx).zip(
+            self.perpetual_tables
+                .objects
+                .multi_get(
+                    keys_with_version
+                        .iter()
+                        .map(|(_, k)| ObjectKey(k.0, k.1.unwrap())),
+                )?
+                .into_iter()
+                .map(|o| o.is_some()),
+        );
+
+        let unversioned_results = keys_without_version.into_iter().map(|(idx, key)| {
+            (
+                idx,
+                match self
+                    .get_object_or_tombstone(key.0)
+                    .expect("read cannot fail")
+                {
+                    None => false,
+                    Some(entry) => entry.2.is_alive(),
+                },
+            )
+        });
+
+        let mut results = versioned_results
+            .chain(unversioned_results)
+            .collect::<Vec<_>>();
+        results.sort_by_key(|(idx, _)| *idx);
+        Ok(results.into_iter().map(|(_, result)| result).collect())
+    }
+
     /// Attempts to acquire execution lock for an executable transaction.
     /// Returns the lock if the transaction is matching current executed epoch
     /// Returns None otherwise

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -604,22 +604,7 @@ impl AuthorityStore {
 
     /// Checks if the input object identified by the InputKey exists, with support for non-system
     /// packages i.e. when version is None.
-    pub fn input_object_exists(&self, key: &InputKey) -> Result<bool, SuiError> {
-        match key.1 {
-            Some(version) => Ok(self
-                .perpetual_tables
-                .objects
-                .contains_key(&ObjectKey(key.0, version))?),
-            None => match self.get_object_or_tombstone(key.0)? {
-                None => Ok(false),
-                Some(entry) => Ok(entry.2.is_alive()),
-            },
-        }
-    }
-
-    /// Checks if the input object identified by the InputKey exists, with support for non-system
-    /// packages i.e. when version is None.
-    pub fn input_object_multi_exists(
+    pub fn multi_input_objects_exist(
         &self,
         keys: impl Iterator<Item = InputKey> + Clone,
     ) -> Result<Vec<bool>, SuiError> {

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -665,7 +665,6 @@ impl TransactionManager {
     /// Notifies TransactionManager that the given objects are available in the objects table.
     /// Useful when transactions associated with the objects are not known, e.g. after checking
     /// object availability from storage, or for testing.
-    #[cfg(test)]
     pub(crate) fn objects_available(
         &self,
         input_keys: Vec<InputKey>,

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -465,18 +465,7 @@ impl TransactionManager {
         {
             let mut inner = self.inner.write();
             for (key, value) in object_availability.iter_mut() {
-                if inner.input_objects.get(&key.0).cloned().unwrap_or(0) > 0 {
-                    // Objects that are already being awaited on by other transactions are known to
-                    // not be available.
-                    *value = Some(false);
-                    if key.1.is_some() {
-                        self.metrics.transaction_manager_object_cache_hits.inc();
-                    } else {
-                        self.metrics.transaction_manager_package_cache_hits.inc();
-                    }
-                } else if let Some(available) =
-                    inner.available_objects_cache.is_object_available(key)
-                {
+                if let Some(available) = inner.available_objects_cache.is_object_available(key) {
                     *value = Some(available);
                 }
             }

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -738,6 +738,9 @@ impl TransactionManager {
                 warn!("Ignoring committed certificate from wrong epoch. Expected={} Actual={} CertificateDigest={:?}", inner.epoch, epoch_store.epoch(), digest);
                 return;
             }
+
+            self.objects_available_locked(&mut inner, epoch_store, output_object_keys);
+
             let Some(acquired_locks) = inner.executing_certificates.remove(digest) else {
                 trace!("{:?} not found in executing certificates, likely because it is a system transaction", digest);
                 return;
@@ -761,8 +764,6 @@ impl TransactionManager {
             self.metrics
                 .transaction_manager_num_executing_certificates
                 .set(inner.executing_certificates.len() as i64);
-
-            self.objects_available_locked(&mut inner, epoch_store, output_object_keys);
 
             inner.maybe_shrink_capacity();
         }


### PR DESCRIPTION
- Cache available and unavailable objects in TransactionManager.
- ~~Use existing missing object information as additional cache~~ this turned out to cause a subtle race since we temporarily release the lock while reading from the db.
- Simplify and optimize enqueue
- Use multi-get when hitting the db, when possible.