### PR TITLE
[pruner] decrease default batch size

### DIFF
--- a/crates/sui-config/data/fullnode-template-with-path.yaml
+++ b/crates/sui-config/data/fullnode-template-with-path.yaml
@@ -15,7 +15,7 @@ authority-store-pruning-config:
   num-latest-epoch-dbs-to-retain: 3
   epoch-db-pruning-period-secs: 3600
   num-epochs-to-retain: 1
-  max-checkpoints-in-batch: 200
+  max-checkpoints-in-batch: 10
   max-transactions-in-batch: 1000
   use-range-deletion: true
   pruning-run-delay-seconds: 60

--- a/crates/sui-config/data/fullnode-template.yaml
+++ b/crates/sui-config/data/fullnode-template.yaml
@@ -15,7 +15,7 @@ authority-store-pruning-config:
   num-latest-epoch-dbs-to-retain: 3
   epoch-db-pruning-period-secs: 3600
   num-epochs-to-retain: 1
-  max-checkpoints-in-batch: 200
+  max-checkpoints-in-batch: 10
   max-transactions-in-batch: 1000
   use-range-deletion: true
   pruning-run-delay-seconds: 60

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -406,7 +406,7 @@ impl Default for AuthorityStorePruningConfig {
             epoch_db_pruning_period_secs: u64::MAX,
             num_epochs_to_retain: 2,
             pruning_run_delay_seconds: None,
-            max_checkpoints_in_batch: 200,
+            max_checkpoints_in_batch: 10,
             max_transactions_in_batch: 1000,
             use_range_deletion: true,
         }
@@ -420,7 +420,7 @@ impl AuthorityStorePruningConfig {
             epoch_db_pruning_period_secs: 60 * 60,
             num_epochs_to_retain: 2,
             pruning_run_delay_seconds: None,
-            max_checkpoints_in_batch: 200,
+            max_checkpoints_in_batch: 10,
             max_transactions_in_batch: 1000,
             use_range_deletion: true,
         }
@@ -431,7 +431,7 @@ impl AuthorityStorePruningConfig {
             epoch_db_pruning_period_secs: 60 * 60,
             num_epochs_to_retain: 2,
             pruning_run_delay_seconds: None,
-            max_checkpoints_in_batch: 200,
+            max_checkpoints_in_batch: 10,
             max_transactions_in_batch: 1000,
             use_range_deletion: true,
         }

--- a/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -65,7 +65,7 @@ validator_configs:
       num-latest-epoch-dbs-to-retain: 3
       epoch-db-pruning-period-secs: 3600
       num-epochs-to-retain: 2
-      max-checkpoints-in-batch: 200
+      max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000
       use-range-deletion: true
     end-of-epoch-broadcast-channel-capacity: 128
@@ -149,7 +149,7 @@ validator_configs:
       num-latest-epoch-dbs-to-retain: 3
       epoch-db-pruning-period-secs: 3600
       num-epochs-to-retain: 2
-      max-checkpoints-in-batch: 200
+      max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000
       use-range-deletion: true
     end-of-epoch-broadcast-channel-capacity: 128
@@ -233,7 +233,7 @@ validator_configs:
       num-latest-epoch-dbs-to-retain: 3
       epoch-db-pruning-period-secs: 3600
       num-epochs-to-retain: 2
-      max-checkpoints-in-batch: 200
+      max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000
       use-range-deletion: true
     end-of-epoch-broadcast-channel-capacity: 128
@@ -317,7 +317,7 @@ validator_configs:
       num-latest-epoch-dbs-to-retain: 3
       epoch-db-pruning-period-secs: 3600
       num-epochs-to-retain: 2
-      max-checkpoints-in-batch: 200
+      max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000
       use-range-deletion: true
     end-of-epoch-broadcast-channel-capacity: 128
@@ -401,7 +401,7 @@ validator_configs:
       num-latest-epoch-dbs-to-retain: 3
       epoch-db-pruning-period-secs: 3600
       num-epochs-to-retain: 2
-      max-checkpoints-in-batch: 200
+      max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000
       use-range-deletion: true
     end-of-epoch-broadcast-channel-capacity: 128
@@ -485,7 +485,7 @@ validator_configs:
       num-latest-epoch-dbs-to-retain: 3
       epoch-db-pruning-period-secs: 3600
       num-epochs-to-retain: 2
-      max-checkpoints-in-batch: 200
+      max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000
       use-range-deletion: true
     end-of-epoch-broadcast-channel-capacity: 128
@@ -569,7 +569,7 @@ validator_configs:
       num-latest-epoch-dbs-to-retain: 3
       epoch-db-pruning-period-secs: 3600
       num-epochs-to-retain: 2
-      max-checkpoints-in-batch: 200
+      max-checkpoints-in-batch: 10
       max-transactions-in-batch: 1000
       use-range-deletion: true
     end-of-epoch-broadcast-channel-capacity: 128

--- a/crates/sui-tool/src/db_tool/mod.rs
+++ b/crates/sui-tool/src/db_tool/mod.rs
@@ -114,7 +114,7 @@ pub fn reset_db_to_genesis(path: &Path) -> anyhow::Result<()> {
     //   num-latest-epoch-dbs-to-retain: 3
     //   epoch-db-pruning-period-secs: 3600
     //   num-epochs-to-retain: 18446744073709551615
-    //   max-checkpoints-in-batch: 200
+    //   max-checkpoints-in-batch: 10
     //   max-transactions-in-batch: 1000
     //   use-range-deletion: true
     let perpetual_db = AuthorityPerpetualTables::open_tables_read_write(

--- a/nre/config/validator.yaml
+++ b/nre/config/validator.yaml
@@ -51,7 +51,7 @@ authority-store-pruning-config:
   num-latest-epoch-dbs-to-retain: 3
   epoch-db-pruning-period-secs: 3600
   num-epochs-to-retain: 1
-  max-checkpoints-in-batch: 200
+  max-checkpoints-in-batch: 10
   max-transactions-in-batch: 1000
   use-range-deletion: true
 end-of-epoch-broadcast-channel-capacity: 128


### PR DESCRIPTION
with https://github.com/MystenLabs/sui/pull/11121/ we don't perform batching based on number of transactions anymore.
Current default setting is 200 and may cause rocksdb issues for workloads with hight TPS. We perform multi-get for tx_num * checkpoint_num
PR decreases default value to 10