### PR TITLE
Remove deepbook transaction in simtest

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -3,7 +3,6 @@
 
 #[cfg(msim)]
 mod test {
-    use fastcrypto::ed25519::Ed25519KeyPair;
     use move_core_types::language_storage::StructTag;
     use rand::{distributions::uniform::SampleRange, thread_rng, Rng};
     use std::path::PathBuf;
@@ -26,18 +25,12 @@ mod test {
     use sui_core::authority::framework_injection;
     use sui_core::checkpoints::CheckpointStore;
     use sui_framework::BuiltInFramework;
-    use sui_json_rpc_types::SuiExecutionStatus;
-    use sui_json_rpc_types::SuiObjectDataOptions;
-    use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
     use sui_macros::{register_fail_point_async, register_fail_points, sim_test};
     use sui_protocol_config::{ProtocolVersion, SupportedProtocolVersions};
     use sui_simulator::{configs::*, SimConfig};
     use sui_types::base_types::{ObjectRef, SuiAddress};
     use sui_types::messages_checkpoint::VerifiedCheckpoint;
-    use sui_types::DEEPBOOK_OBJECT_ID;
-    use test_utils::messages::{
-        create_publish_move_package_transaction, get_sui_gas_object_with_wallet_context,
-    };
+    use test_utils::messages::get_sui_gas_object_with_wallet_context;
     use test_utils::network::{TestCluster, TestClusterBuilder};
     use tracing::{error, info};
     use typed_store::traits::Map;
@@ -327,44 +320,10 @@ mod test {
                 }
                 info!("Framework injected");
                 test_cluster
-                    .upgrade_protocol(SupportedProtocolVersions::new_for_testing(
-                        min_ver,
-                        next_version,
-                    ))
-                    .await;
-                // TODO: move these DeepBook-specific checks into their own test or remove them
-                // make sure we can read the DeepBook package
-                assert!(test_cluster
-                    .sui_client()
-                    .read_api()
-                    .get_object_with_options(
-                        DEEPBOOK_OBJECT_ID,
-                        SuiObjectDataOptions::default().with_type()
+                    .update_validator_supported_versions(
+                        SupportedProtocolVersions::new_for_testing(min_ver, next_version),
                     )
-                    .await
-                    .unwrap()
-                    .data
-                    .unwrap()
-                    .type_
-                    .unwrap()
-                    .is_package());
-
-                let keypair = test_init_data.keypair();
-                let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-                path.push("tests/data/deepbook_client");
-                let tx = create_publish_move_package_transaction(
-                    test_init_data.all_gas[1].1,
-                    path,
-                    test_init_data.sender,
-                    &keypair,
-                    1_000_000_000,
-                    1000,
-                );
-                let response = test_cluster.execute_transaction(tx).await.unwrap();
-                assert_eq!(
-                    *response.effects.unwrap().status(),
-                    SuiExecutionStatus::Success
-                );
+                    .await;
             }
             finished_clone.store(true, Ordering::SeqCst);
         });
@@ -424,13 +383,6 @@ mod test {
                     .await,
                 sender,
             }
-        }
-
-        pub fn keypair(&self) -> Arc<Ed25519KeyPair> {
-            Arc::new(
-                get_ed25519_keypair_from_keystore(self.keystore_path.clone(), &self.sender)
-                    .unwrap(),
-            )
         }
     }
 

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -196,7 +196,10 @@ impl TestCluster {
     /// supported versions.
     /// Note that we don't restart the fullnode here, and it is assumed that the fulnode supports
     /// the entire version range.
-    pub async fn upgrade_protocol(&mut self, new_supported_versions: SupportedProtocolVersions) {
+    pub async fn update_validator_supported_versions(
+        &mut self,
+        new_supported_versions: SupportedProtocolVersions,
+    ) {
         for authority in self.get_validator_addresses().into_iter() {
             self.stop_validator(authority);
             tokio::time::sleep(Duration::from_millis(1000)).await;


### PR DESCRIPTION
This is no longer effective since we have already shipped deepbook. And it's causing flakiness now