### PR TITLE
[tx-fuzzer] use one AuthorityState throughout test cases

### DIFF
--- a/crates/transaction-fuzzer/src/account_universe.rs
+++ b/crates/transaction-fuzzer/src/account_universe.rs
@@ -100,15 +100,14 @@ pub fn log_balance_strategy(min_balance: u64, max_balance: u64) -> impl Strategy
 pub fn run_and_assert_universe(
     universe: AccountUniverseGen,
     transaction_gens: Vec<impl AUTransactionGen + Clone>,
+    executor: &mut Executor,
 ) -> Result<(), TestCaseError> {
-    let mut executor = Executor::new();
-    let mut universe = universe.setup(&mut executor);
+    let mut universe = universe.setup(executor);
     let (transactions, expected_values): (Vec<_>, Vec<_>) = transaction_gens
         .iter()
-        .map(|transaction_gen| transaction_gen.clone().apply(&mut universe, &mut executor))
+        .map(|transaction_gen| transaction_gen.clone().apply(&mut universe, executor))
         .unzip();
     let outputs = executor.execute_transactions(transactions);
-
     prop_assert_eq!(outputs.len(), expected_values.len());
 
     for (idx, (output, expected)) in outputs.iter().zip(&expected_values).enumerate() {
@@ -120,8 +119,7 @@ pub fn run_and_assert_universe(
             output
         );
     }
-
-    assert_accounts_match(&universe, &executor)
+    assert_accounts_match(&universe, executor)
 }
 
 pub fn assert_accounts_match(

--- a/crates/transaction-fuzzer/src/account_universe/universe.rs
+++ b/crates/transaction-fuzzer/src/account_universe/universe.rs
@@ -104,9 +104,7 @@ impl AccountUniverseGen {
     /// Returns an [`AccountUniverse`] with the initial state generated in this universe.
     pub fn setup(self, executor: &mut Executor) -> AccountUniverse {
         for account_data in &self.accounts {
-            for coin in &account_data.coins {
-                executor.add_object(coin.clone())
-            }
+            executor.add_objects(&account_data.coins);
         }
 
         AccountUniverse::new(self.accounts, self.pick_style, false)

--- a/crates/transaction-fuzzer/tests/gas_data_tests.rs
+++ b/crates/transaction-fuzzer/tests/gas_data_tests.rs
@@ -1,84 +1,60 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
-
 use proptest::arbitrary::*;
-use sui_core::authority::AuthorityState;
-use sui_core::test_utils::send_and_confirm_transaction;
+use proptest::test_runner::TestCaseError;
 use sui_types::base_types::dbg_addr;
 use sui_types::crypto::KeypairTraits;
 use sui_types::messages::TransactionData;
 use sui_types::messages::TransactionKind;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::utils::to_sender_signed_transaction;
-use tokio::runtime::Runtime;
 use tracing::debug;
+use transaction_fuzzer::executor::Executor;
 use transaction_fuzzer::run_proptest;
 use transaction_fuzzer::GasDataGenConfig;
 use transaction_fuzzer::GasDataWithObjects;
 
 /// Send transfer sui txn with provided random gas data and gas objects to an authority.
-async fn test_with_random_gas_data(
+fn test_with_random_gas_data(
     gas_data_test: GasDataWithObjects,
-    authority_state: Arc<AuthorityState>,
-) {
+    executor: &mut Executor,
+) -> Result<(), TestCaseError> {
     let gas_data = gas_data_test.gas_data;
     let objects = gas_data_test.objects;
     let sender = gas_data_test.sender_key.public().into();
 
     // Insert the random gas objects into genesis.
-    authority_state.insert_genesis_objects(&objects).await;
+    executor.add_objects(&objects);
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        let recipient = dbg_addr(2);
+        builder.transfer_sui(recipient, None);
         builder.finish()
     };
     let kind = TransactionKind::ProgrammableTransaction(pt);
     let tx_data = TransactionData::new_with_gas_data(kind, sender, gas_data);
     let tx = to_sender_signed_transaction(tx_data, &gas_data_test.sender_key);
 
-    let result = send_and_confirm_transaction(&authority_state, None, tx).await;
+    let result = executor.execute_transaction(tx);
     debug!("result: {:?}", result);
+    Ok(())
 }
 
 #[test]
+#[cfg_attr(msim, ignore)]
 fn test_gas_data_owned_or_immut() {
     let strategy = any_with::<GasDataWithObjects>(GasDataGenConfig::owned_by_sender_or_immut());
-    run_proptest(2000, strategy, |gas_data_test, authority_state| {
-        let rt = Runtime::new().unwrap();
-        let future = test_with_random_gas_data(gas_data_test, authority_state);
-        rt.block_on(future);
+    run_proptest(1000, strategy, |gas_data_test, mut executor| {
+        test_with_random_gas_data(gas_data_test, &mut executor)
     });
 }
 
 #[test]
+#[cfg_attr(msim, ignore)]
 fn test_gas_data_any_owner() {
     let strategy = any_with::<GasDataWithObjects>(GasDataGenConfig::any_owner());
-    run_proptest(2000, strategy, |gas_data_test, authority_state| {
-        let rt = Runtime::new().unwrap();
-        let future = test_with_random_gas_data(gas_data_test, authority_state);
-        rt.block_on(future);
+    run_proptest(1000, strategy, |gas_data_test, mut executor| {
+        test_with_random_gas_data(gas_data_test, &mut executor)
     });
 }
-
-// proptest! {
-//     // Stops after 20 test cases.
-//     #![proptest_config(ProptestConfig::with_cases(20))]
-//     #[test]
-//     #[cfg_attr(msim, ignore)]
-//     fn test_gas_data(gas_data_test in any_with::<GasDataWithObjects>(GasDataGenConfig::owned_by_sender_or_immut())) {
-//         let rt = Runtime::new().unwrap();
-
-//         let future = test_with_random_gas_data(gas_data_test);
-//         rt.block_on(future);
-
-//     }
-
-//     #[test]
-//     #[cfg_attr(msim, ignore)]
-//     fn test_gas_data_any_owner(gas_data_test in any_with::<GasDataWithObjects>(GasDataGenConfig::any_owner())) {
-//         let rt = Runtime::new().unwrap();
-
-//         let future = test_with_random_gas_data(gas_data_test);
-//         rt.block_on(future);
-
-//     }
-// }

--- a/crates/transaction-fuzzer/tests/gas_data_tests.rs
+++ b/crates/transaction-fuzzer/tests/gas_data_tests.rs
@@ -1,10 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
 use proptest::arbitrary::*;
-use proptest::prelude::*;
-use proptest::proptest;
-use sui_core::authority::test_authority_builder::TestAuthorityBuilder;
+use sui_core::authority::AuthorityState;
 use sui_core::test_utils::send_and_confirm_transaction;
 use sui_types::base_types::dbg_addr;
 use sui_types::crypto::KeypairTraits;
@@ -14,22 +14,21 @@ use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::utils::to_sender_signed_transaction;
 use tokio::runtime::Runtime;
 use tracing::debug;
+use transaction_fuzzer::run_proptest;
 use transaction_fuzzer::GasDataGenConfig;
 use transaction_fuzzer::GasDataWithObjects;
 
 /// Send transfer sui txn with provided random gas data and gas objects to an authority.
-async fn test_with_random_gas_data(gas_data_test: GasDataWithObjects) {
+async fn test_with_random_gas_data(
+    gas_data_test: GasDataWithObjects,
+    authority_state: Arc<AuthorityState>,
+) {
     let gas_data = gas_data_test.gas_data;
     let objects = gas_data_test.objects;
     let sender = gas_data_test.sender_key.public().into();
 
-    let authority_state = TestAuthorityBuilder::new().build().await;
     // Insert the random gas objects into genesis.
     authority_state.insert_genesis_objects(&objects).await;
-    let pt = {
-        let mut builder = ProgrammableTransactionBuilder::new();
-        let recipient = dbg_addr(2);
-        builder.transfer_sui(recipient, None);
         builder.finish()
     };
     let kind = TransactionKind::ProgrammableTransaction(pt);
@@ -40,26 +39,46 @@ async fn test_with_random_gas_data(gas_data_test: GasDataWithObjects) {
     debug!("result: {:?}", result);
 }
 
-proptest! {
-    // Stops after 20 test cases.
-    #![proptest_config(ProptestConfig::with_cases(20))]
-    #[test]
-    #[cfg_attr(msim, ignore)]
-    fn test_gas_data(gas_data_test in any_with::<GasDataWithObjects>(GasDataGenConfig::owned_by_sender_or_immut())) {
+#[test]
+fn test_gas_data_owned_or_immut() {
+    let strategy = any_with::<GasDataWithObjects>(GasDataGenConfig::owned_by_sender_or_immut());
+    run_proptest(2000, strategy, |gas_data_test, authority_state| {
         let rt = Runtime::new().unwrap();
-
-        let future = test_with_random_gas_data(gas_data_test);
+        let future = test_with_random_gas_data(gas_data_test, authority_state);
         rt.block_on(future);
-
-    }
-
-    #[test]
-    #[cfg_attr(msim, ignore)]
-    fn test_gas_data_any_owner(gas_data_test in any_with::<GasDataWithObjects>(GasDataGenConfig::any_owner())) {
-        let rt = Runtime::new().unwrap();
-
-        let future = test_with_random_gas_data(gas_data_test);
-        rt.block_on(future);
-
-    }
+    });
 }
+
+#[test]
+fn test_gas_data_any_owner() {
+    let strategy = any_with::<GasDataWithObjects>(GasDataGenConfig::any_owner());
+    run_proptest(2000, strategy, |gas_data_test, authority_state| {
+        let rt = Runtime::new().unwrap();
+        let future = test_with_random_gas_data(gas_data_test, authority_state);
+        rt.block_on(future);
+    });
+}
+
+// proptest! {
+//     // Stops after 20 test cases.
+//     #![proptest_config(ProptestConfig::with_cases(20))]
+//     #[test]
+//     #[cfg_attr(msim, ignore)]
+//     fn test_gas_data(gas_data_test in any_with::<GasDataWithObjects>(GasDataGenConfig::owned_by_sender_or_immut())) {
+//         let rt = Runtime::new().unwrap();
+
+//         let future = test_with_random_gas_data(gas_data_test);
+//         rt.block_on(future);
+
+//     }
+
+//     #[test]
+//     #[cfg_attr(msim, ignore)]
+//     fn test_gas_data_any_owner(gas_data_test in any_with::<GasDataWithObjects>(GasDataGenConfig::any_owner())) {
+//         let rt = Runtime::new().unwrap();
+
+//         let future = test_with_random_gas_data(gas_data_test);
+//         rt.block_on(future);
+
+//     }
+// }

--- a/crates/transaction-fuzzer/tests/p2p_fuzz.rs
+++ b/crates/transaction-fuzzer/tests/p2p_fuzz.rs
@@ -7,105 +7,135 @@
 use proptest::arbitrary::*;
 use proptest::collection::vec;
 use proptest::prelude::*;
-use proptest::proptest;
 use transaction_fuzzer::account_universe::*;
+use transaction_fuzzer::run_proptest;
 
-proptest! {
-    #![proptest_config(ProptestConfig::with_cases(15))]
+#[test]
+#[cfg_attr(msim, ignore)]
+fn fuzz_p2p_low_balance() {
+    let universe =
+        AccountUniverseGen::strategy(2..default_num_accounts(), 1_000_000u64..10_000_000);
+    let transfers = vec(
+        any_with::<P2PTransferGenGoodGas>((1_000_000, 100_000_000)),
+        0..default_num_transactions(),
+    );
+    let strategy = (universe, transfers).boxed();
+    run_proptest(20, strategy, |(universe, transfers), mut executor| {
+        run_and_assert_universe(universe, transfers, &mut executor)
+    });
+}
 
-    #[test]
-    #[cfg_attr(msim, ignore)]
-    fn fuzz_p2p_low_balance(
-        universe in AccountUniverseGen::strategy(
-            2..default_num_accounts(),
-            1_000_000u64..10_000_000,
-            ),
-            transfers in vec(any_with::<P2PTransferGenGoodGas>((1_000_000, 100_000_000)), 0..default_num_transactions()),
-        ) {
-        run_and_assert_universe(universe, transfers).unwrap();
-    }
+#[test]
+#[cfg_attr(msim, ignore)]
+fn fuzz_p2p_high_balance() {
+    let universe = AccountUniverseGen::strategy(
+        2..default_num_accounts(),
+        1_000_000_000_000u64..10_000_000_000_000,
+    );
+    let transfers = vec(
+        any_with::<P2PTransferGenGoodGas>((1, 10_000)),
+        0..default_num_transactions(),
+    );
+    let strategy = (universe, transfers).boxed();
+    run_proptest(20, strategy, |(universe, transfers), mut executor| {
+        run_and_assert_universe(universe, transfers, &mut executor)
+    });
+}
 
-    #[test]
-    #[cfg_attr(msim, ignore)]
-    fn fuzz_p2p_high_balance(
-        universe in AccountUniverseGen::strategy(
-            2..default_num_accounts(),
-            1_000_000_000_000u64..10_000_000_000_000,
-            ),
-            transfers in vec(any_with::<P2PTransferGenGoodGas>((1, 10_000)), 0..default_num_transactions()),
-        ) {
-        run_and_assert_universe(universe, transfers).unwrap();
-    }
+#[test]
+#[cfg_attr(msim, ignore)]
+fn fuzz_p2p_random_gas_budget_high_balance() {
+    let universe = AccountUniverseGen::strategy(
+        2..default_num_accounts(),
+        1_000_000_000_000u64..10_000_000_000_000,
+    );
+    let transfers = vec(
+        any_with::<P2PTransferGenRandomGas>((1, 10_000)),
+        0..default_num_transactions(),
+    );
+    let strategy = (universe, transfers).boxed();
+    run_proptest(20, strategy, |(universe, transfers), mut executor| {
+        run_and_assert_universe(universe, transfers, &mut executor)
+    });
+}
 
-    #[test]
-    #[cfg_attr(msim, ignore)]
-    fn fuzz_p2p_random_gas_budget_high_balance(
-        universe in AccountUniverseGen::strategy(
-            2..default_num_accounts(),
-            1_000_000_000_000u64..10_000_000_000_000,
-            ),
-            transfers in vec(any_with::<P2PTransferGenRandomGas>((1, 10_000)), 0..default_num_transactions()),
-        ) {
-        run_and_assert_universe(universe, transfers).unwrap();
-    }
+#[test]
+#[cfg_attr(msim, ignore)]
+fn fuzz_p2p_random_gas_budget_low_balance() {
+    let universe =
+        AccountUniverseGen::strategy(2..default_num_accounts(), 1_000_000u64..10_000_000);
+    let transfers = vec(
+        any_with::<P2PTransferGenRandomGas>((1_000_000, 100_000_000)),
+        0..default_num_transactions(),
+    );
+    let strategy = (universe, transfers).boxed();
+    run_proptest(20, strategy, |(universe, transfers), mut executor| {
+        run_and_assert_universe(universe, transfers, &mut executor)
+    });
+}
 
-    #[test]
-    #[cfg_attr(msim, ignore)]
-    fn fuzz_p2p_random_gas_budget_low_balance(
-        universe in AccountUniverseGen::strategy(
-            2..default_num_accounts(),
-            1_000_000u64..10_000_000,
-            ),
-            transfers in vec(any_with::<P2PTransferGenRandomGas>((1_000_000, 100_000_000)), 0..default_num_transactions()),
-        ) {
-        run_and_assert_universe(universe, transfers).unwrap();
-    }
+#[test]
+#[cfg_attr(msim, ignore)]
+fn fuzz_p2p_random_gas_budget_and_price_high_balance() {
+    let universe = AccountUniverseGen::strategy(
+        2..default_num_accounts(),
+        1_000_000_000_000u64..10_000_000_000_000,
+    );
+    let transfers = vec(
+        any_with::<P2PTransferGenRandomGasRandomPrice>((1, 10_000)),
+        0..default_num_transactions(),
+    );
+    let strategy = (universe, transfers).boxed();
+    run_proptest(20, strategy, |(universe, transfers), mut executor| {
+        run_and_assert_universe(universe, transfers, &mut executor)
+    });
+}
 
-    #[test]
-    #[cfg_attr(msim, ignore)]
-    fn fuzz_p2p_random_gas_budget_and_price_high_balance(
-        universe in AccountUniverseGen::strategy(
-            2..default_num_accounts(),
-            1_000_000_000_000u64..10_000_000_000_000,
-            ),
-            transfers in vec(any_with::<P2PTransferGenRandomGasRandomPrice>((1, 10_000)), 0..default_num_transactions()),
-        ) {
-        run_and_assert_universe(universe, transfers).unwrap();
-    }
+#[test]
+#[cfg_attr(msim, ignore)]
+fn fuzz_p2p_random_gas_budget_and_price_low_balance() {
+    let universe =
+        AccountUniverseGen::strategy(2..default_num_accounts(), 1_000_000u64..10_000_000);
+    let transfers = vec(
+        any_with::<P2PTransferGenRandomGasRandomPrice>((1_000_000, 100_000_000)),
+        0..default_num_transactions(),
+    );
+    let strategy = (universe, transfers).boxed();
+    run_proptest(20, strategy, |(universe, transfers), mut executor| {
+        run_and_assert_universe(universe, transfers, &mut executor)
+    });
+}
 
-    #[test]
-    #[cfg_attr(msim, ignore)]
-    fn fuzz_p2p_random_gas_budget_and_price_low_balance(
-        universe in AccountUniverseGen::strategy(
-            2..default_num_accounts(),
-            1_000_000u64..10_000_000,
-            ),
-            transfers in vec(any_with::<P2PTransferGenRandomGasRandomPrice>((1_000_000, 100_000_000)), 0..default_num_transactions()),
-        ) {
-        run_and_assert_universe(universe, transfers).unwrap();
-    }
+#[test]
+#[cfg_attr(msim, ignore)]
+fn fuzz_p2p_rand_gas_budget_price_and_coins() {
+    let universe = AccountUniverseGen::strategy(
+        2..default_num_accounts(),
+        10_000_000_000u64..1_000_000_000_000,
+    );
+    let transfers = vec(
+        any_with::<P2PTransferGenRandGasRandPriceRandCoins>((1_000_000, 100_000_000)),
+        0..default_num_transactions(),
+    );
+    let strategy = (universe, transfers).boxed();
+    run_proptest(5, strategy, |(universe, transfers), mut executor| {
+        run_and_assert_universe(universe, transfers, &mut executor)
+    });
+}
 
-    #[test]
-    #[cfg_attr(msim, ignore)]
-    fn fuzz_p2p_rand_gas_budget_price_and_coins(
-        universe in AccountUniverseGen::strategy(
-            2..default_num_accounts(),
-            10_000_000_000u64..1_000_000_000_000,
-            ),
-            transfers in vec(any_with::<P2PTransferGenRandGasRandPriceRandCoins>((1_000_000, 100_000_000)), 0..default_num_transactions()),
-        ) {
-        run_and_assert_universe(universe, transfers).unwrap();
-    }
-
-    #[test]
-    #[cfg_attr(msim, ignore)]
-    fn fuzz_p2p_mixed(
-        universe in AccountUniverseGen::strategy(
-            2..default_num_accounts(),
-            log_balance_strategy(1_000_000, 1_000_000_000_000),
-            ),
-            transfers in vec(p2p_transfer_strategy(1, 1_000_000), 0..default_num_transactions()),
-        ) {
-        run_and_assert_universe(universe, transfers).unwrap();
-    }
+#[test]
+#[cfg_attr(msim, ignore)]
+fn fuzz_p2p_mixed() {
+    let universe = AccountUniverseGen::strategy(
+        2..default_num_accounts(),
+        log_balance_strategy(1_000_000, 1_000_000_000_000),
+    );
+    let transfers = vec(
+        p2p_transfer_strategy(1, 1_000_000),
+        0..default_num_transactions(),
+    );
+    let strategy = (universe, transfers).boxed();
+    run_proptest(20, strategy, |(universe, transfers), mut executor| {
+        run_and_assert_universe(universe, transfers, &mut executor)
+    });
 }


### PR DESCRIPTION
## Description 

This PR adds a `run_proptest` function that runs a provided test case, with given number of times, and input generated with the provided strategy. This attempts to do what `proptest` macro does but with the same initialized `AuthorityState` throughout. `gas_data_tests` has been changed to use this function.
  
## Test Plan 

It's all tests.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
