### PR TITLE
[not for commit] Gas stats with multiply statuses

### DIFF
--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -73,7 +73,7 @@ sui-network = { path = "../sui-network" }
 sui-protocol-config = { path = "../sui-protocol-config" }
 sui-simulator = { path = "../sui-simulator" }
 sui-storage = { path = "../sui-storage" }
-sui-types = { path = "../sui-types" }
+sui-types = { path = "../sui-types", features = ["test-utils"] }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -62,9 +62,9 @@ use sui_types::crypto::{
 };
 use sui_types::digests::TransactionEventsDigest;
 use sui_types::dynamic_field::{DynamicFieldInfo, DynamicFieldName, DynamicFieldType, Field};
-use sui_types::error::{ExecutionError, UserInputError};
+use sui_types::error::{ExecutionError, ExecutionErrorKind, UserInputError};
 use sui_types::event::{Event, EventID};
-use sui_types::gas::{GasCostSummary, SuiGasStatus};
+use sui_types::gas::{write_gas_stats, GasCostSummary, SuiGasStatus};
 use sui_types::message_envelope::Message;
 use sui_types::messages_checkpoint::{
     CheckpointCommitment, CheckpointContents, CheckpointContentsDigest, CheckpointDigest,
@@ -996,7 +996,7 @@ impl AuthorityState {
         TransactionEffects,
         Option<ExecutionError>,
     )> {
-        let _metrics_guard = self.metrics.prepare_certificate_latency.start_timer();
+        let metrics_guard = self.metrics.prepare_certificate_latency.start_timer();
 
         // check_certificate_input also checks shared object locks when loading the shared objects.
         let (gas_status, input_objects) = transaction_input_checker::check_certificate_input(
@@ -1038,7 +1038,44 @@ impl AuthorityState {
                     .enable_deep_per_tx_sui_conservation_check(),
             );
 
-        Ok((inner_temp_store, effects, execution_error_opt.err()))
+        let time = (metrics_guard.stop_and_record() * 1_000_000_000.0).round() as u64;
+        let shared = effects.shared_objects().len();
+        let created = effects.created().len();
+        let mutated = effects.mutated().len();
+        let unwrapped = effects.unwrapped().len();
+        let deleted = effects.deleted().len();
+        let unwrapped_deleted = effects.unwrapped_then_deleted().len();
+        let wrapped = effects.wrapped().len();
+        let err = execution_error_opt.err();
+        let error = match &err {
+            None => 0,
+            Some(err) => match err.kind() {
+                ExecutionErrorKind::InsufficientGas => 1,
+                ExecutionErrorKind::InvariantViolation
+                | ExecutionErrorKind::VMInvariantViolation => 2,
+                _ => 3,
+            },
+        };
+        write_gas_stats(
+            format!(
+                "{}: time = {}, error = {}, shared = {}, created = {}, \
+                    mutated = {}, unwrapped = {}, deleted = {}, \
+                    unwrapped_deleted = {}, wrapped = {}",
+                *certificate.digest(),
+                time,
+                error,
+                shared,
+                created,
+                mutated,
+                unwrapped,
+                deleted,
+                unwrapped_deleted,
+                wrapped,
+            )
+            .as_str(),
+        );
+
+        Ok((inner_temp_store, effects, err))
     }
 
     pub async fn dry_exec_transaction(
@@ -1231,7 +1268,12 @@ impl AuthorityState {
             transaction_digest,
             protocol_config,
         );
-        let gas_status = SuiGasStatus::new_with_budget(max_tx_gas, gas_price, protocol_config);
+        let gas_status = SuiGasStatus::new_with_budget(
+            max_tx_gas,
+            gas_price,
+            protocol_config,
+            Some(transaction_digest),
+        );
         let move_vm = Arc::new(
             adapter::new_move_vm(
                 epoch_store.native_functions().clone(),

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -9,7 +9,7 @@ use sui_adapter::adapter::run_metered_move_bytecode_verifier;
 use sui_config::transaction_deny_config::TransactionDenyConfig;
 use sui_macros::checked_arithmetic;
 use sui_protocol_config::ProtocolConfig;
-use sui_types::base_types::ObjectRef;
+use sui_types::base_types::{ObjectRef, TransactionDigest};
 use sui_types::error::{UserInputError, UserInputResult};
 use sui_types::messages::{
     TransactionKind, VerifiedExecutableTransaction, VersionedProtocolMessage,
@@ -36,6 +36,7 @@ async fn get_gas_status(
     gas: &[ObjectRef],
     epoch_store: &AuthorityPerEpochStore,
     transaction: &TransactionData,
+    tx_digest: Option<TransactionDigest>,
 ) -> SuiResult<SuiGasStatus> {
     // Get the first coin (possibly the only one) and make it "the gas coin", then
     // keep track of all others that can contribute to gas (gas smashing).
@@ -51,6 +52,7 @@ async fn get_gas_status(
         transaction.gas_budget(),
         transaction.gas_price(),
         transaction.kind(),
+        tx_digest,
     )
     .await
 }
@@ -73,7 +75,8 @@ pub async fn check_transaction_input(
         store,
     )?;
     let objects = store.check_input_objects(&input_objects, epoch_store.protocol_config())?;
-    let gas_status = get_gas_status(&objects, transaction.gas(), epoch_store, transaction).await?;
+    let gas_status =
+        get_gas_status(&objects, transaction.gas(), epoch_store, transaction, None).await?;
     let input_objects = check_objects(transaction, input_objects, objects)?;
     Ok((gas_status, input_objects))
 }
@@ -94,7 +97,8 @@ pub async fn check_transaction_input_with_given_gas(
     input_objects.push(InputObjectKind::ImmOrOwnedMoveObject(gas_object_ref));
     objects.push(gas_object);
 
-    let gas_status = get_gas_status(&objects, &[gas_object_ref], epoch_store, transaction).await?;
+    let gas_status =
+        get_gas_status(&objects, &[gas_object_ref], epoch_store, transaction, None).await?;
     let input_objects = check_objects(transaction, input_objects, objects)?;
     Ok((gas_status, input_objects))
 }
@@ -164,8 +168,14 @@ pub async fn check_certificate_input(
     } else {
         store.check_sequenced_input_objects(cert.digest(), &input_object_kinds, epoch_store)?
     };
-    let gas_status =
-        get_gas_status(&input_object_data, tx_data.gas(), epoch_store, tx_data).await?;
+    let gas_status = get_gas_status(
+        &input_object_data,
+        tx_data.gas(),
+        epoch_store,
+        tx_data,
+        Some(*cert.digest()),
+    )
+    .await?;
     let input_objects = check_objects(tx_data, input_object_kinds, input_object_data)?;
     Ok((gas_status, input_objects))
 }
@@ -181,6 +191,7 @@ async fn check_gas(
     gas_budget: u64,
     gas_price: u64,
     tx_kind: &TransactionKind,
+    tx_digest: Option<TransactionDigest>,
 ) -> SuiResult<SuiGasStatus> {
     let protocol_config = epoch_store.protocol_config();
     if tx_kind.is_system_tx() {
@@ -227,6 +238,7 @@ async fn check_gas(
             gas_budget,
             gas_price,
             protocol_config,
+            tx_digest,
         ))
     }
 }

--- a/crates/sui-cost-tables/src/double_meter.rs
+++ b/crates/sui-cost-tables/src/double_meter.rs
@@ -1,0 +1,668 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Instant;
+
+use move_binary_format::errors::PartialVMResult;
+
+use move_core_types::gas_algebra::{AbstractMemorySize, InternalGas};
+use move_core_types::language_storage::TypeTag;
+
+use move_vm_types::gas::GasMeter;
+use move_vm_types::views::{TypeView, ValueView, ValueVisitor};
+use once_cell::sync::Lazy;
+
+use crate::tier_based::units_types::{CostTable, Gas};
+
+use crate::tier_based::tables as T;
+
+pub use crate::tier_based::tables::initial_cost_schedule_v1;
+pub use crate::tier_based::tables::initial_cost_schedule_v2;
+pub use crate::tier_based::tables::initial_cost_schedule_v3;
+
+pub static ZERO_COST_SCHEDULE: Lazy<CostTable> = Lazy::new(T::zero_cost_schedule);
+
+#[derive(Debug)]
+pub struct GasStatus {
+    pub current: T::GasStatus,
+    pub new: Vec<T::GasStatus>,
+    start_time: Instant,
+}
+
+impl GasStatus {
+    /// Initialize the gas state with metering enabled.
+    ///
+    /// Charge for every operation and fail when there is no more gas to pay for operations.
+    /// This is the instantiation that must be used when executing a user script.
+
+    pub fn new_v2(
+        cost_table: CostTable,
+        budget: u64,
+        gas_price: u64,
+        gas_model_version: u64,
+    ) -> Self {
+        let statuses = vec![
+            T::GasStatus::new_v2(initial_cost_schedule_v1(), u32::MAX as u64, gas_price, 3),
+            T::GasStatus::new_v2(initial_cost_schedule_v2(), u32::MAX as u64, gas_price, 4),
+            T::GasStatus::new_v2(initial_cost_schedule_v2(), u32::MAX as u64, gas_price, 5),
+            T::GasStatus::new_v2(initial_cost_schedule_v3(), u32::MAX as u64, gas_price, 5),
+        ];
+        Self {
+            current: T::GasStatus::new_v2(cost_table, budget, gas_price, gas_model_version),
+            new: statuses,
+            start_time: Instant::now(),
+        }
+    }
+
+    pub fn new(cost_table: CostTable, gas_left: Gas) -> Self {
+        // not sure this will ever work but I am also not sure it is ever called and if
+        // it matters
+        let statuses = vec![
+            T::GasStatus::new(initial_cost_schedule_v1(), gas_left),
+            T::GasStatus::new(initial_cost_schedule_v2(), gas_left),
+            T::GasStatus::new(initial_cost_schedule_v3(), gas_left),
+        ];
+        Self {
+            current: T::GasStatus::new(cost_table, gas_left),
+            new: statuses,
+            start_time: Instant::now(),
+        }
+    }
+
+    /// Initialize the gas state with metering disabled.
+    ///
+    /// It should be used by clients in very specific cases and when executing system
+    /// code that does not have to charge the user.
+    pub fn new_unmetered() -> Self {
+        Self {
+            current: T::GasStatus::new_unmetered(),
+            new: vec![T::GasStatus::new_unmetered()],
+            start_time: Instant::now(),
+        }
+    }
+
+    pub fn get_status_info(&self) -> (u64, u64, u64) {
+        (
+            self.current.instructions_executed,
+            self.current.stack_height_high_water_mark,
+            self.current.stack_size_high_water_mark,
+        )
+    }
+
+    pub fn get_others_info(&self) -> Vec<(u64, u64, u64, u64)> {
+        self.new.iter().map(|status| (
+            status.gas_used_pre_gas_price(),
+            status.instructions_executed,
+            status.stack_height_high_water_mark,
+            status.stack_size_high_water_mark,
+        )).collect()
+    }
+
+    pub fn push_stack(&mut self, pushes: u64) -> PartialVMResult<()> {
+        self.new
+            .iter_mut()
+            .for_each(|status| status.push_stack(pushes).unwrap());
+        self.current.push_stack(pushes)
+    }
+
+    pub fn pop_stack(&mut self, pops: u64) {
+        self.new
+            .iter_mut()
+            .for_each(|status| status.pop_stack(pops));
+        self.current.pop_stack(pops)
+    }
+
+    pub fn increase_instruction_count(&mut self, amount: u64) -> PartialVMResult<()> {
+        self.new
+            .iter_mut()
+            .for_each(|status| status.increase_instruction_count(amount).unwrap());
+        self.current.increase_instruction_count(amount)
+    }
+
+    pub fn increase_stack_size(&mut self, size_amount: u64) -> PartialVMResult<()> {
+        self.new
+            .iter_mut()
+            .for_each(|status| status.increase_stack_size(size_amount).unwrap());
+        self.current.increase_stack_size(size_amount)
+    }
+
+    pub fn decrease_stack_size(&mut self, size_amount: u64) {
+        self.new
+            .iter_mut()
+            .for_each(|status| status.decrease_stack_size(size_amount));
+        self.current.decrease_stack_size(size_amount)
+    }
+
+    /// Given: pushes + pops + increase + decrease in size for an instruction charge for the
+    /// execution of the instruction.
+    pub fn charge(
+        &mut self,
+        num_instructions: u64,
+        pushes: u64,
+        pops: u64,
+        incr_size: u64,
+        decr_size: u64,
+    ) -> PartialVMResult<()> {
+        self.new.iter_mut().for_each(|status| {
+            status
+                .charge(num_instructions, pushes, pops, incr_size, decr_size)
+                .unwrap()
+        });
+        self.current
+            .charge(num_instructions, pushes, pops, incr_size, decr_size)
+    }
+
+    /// Return the `CostTable` behind this `GasStatus`.
+    pub fn cost_table(&self) -> &CostTable {
+        &self.current.cost_table
+    }
+
+    /// Return the gas left.
+    pub fn remaining_gas(&self) -> Gas {
+        self.current.gas_left.to_unit_round_down()
+    }
+
+    /// Charge a given amount of gas and fail if not enough gas units are left.
+    pub fn deduct_gas(&mut self, amount: InternalGas) -> PartialVMResult<()> {
+        self.new
+            .iter_mut()
+            .for_each(|status| status.deduct_gas(amount).unwrap());
+        self.current.deduct_gas(amount)
+    }
+
+    pub fn set_metering(&mut self, enabled: bool) {
+        self.new
+            .iter_mut()
+            .for_each(|status| status.set_metering(enabled));
+        self.current.set_metering(enabled)
+    }
+
+    // The amount of gas used, it does not include the multiplication for the gas price
+    pub fn gas_used_pre_gas_price(&self) -> u64 {
+        self.current.gas_used_pre_gas_price()
+    }
+
+    // Charge the number of bytes with the cost per byte value
+    // As more bytes are read throughout the computation the cost per bytes is increased.
+    pub fn charge_bytes(&mut self, size: usize, cost_per_byte: u64) -> PartialVMResult<()> {
+        self.new
+            .iter_mut()
+            .for_each(|status| status.charge_bytes(size, cost_per_byte).unwrap());
+        self.current.charge_bytes(size, cost_per_byte)
+    }
+
+    pub fn time(&self) -> u128 {
+        self.start_time.elapsed().as_micros()
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct MyVal(pub u64);
+
+#[derive(Debug, Clone)]
+pub struct MyTag(pub TypeTag);
+
+// Ooohhh so hacky but also somewhat wonderful
+impl ValueView for MyVal {
+    fn visit(&self, _visitor: &mut impl ValueVisitor) {
+        std::unimplemented!()
+    }
+
+    fn legacy_abstract_memory_size(&self) -> AbstractMemorySize {
+        AbstractMemorySize::new(self.0)
+    }
+}
+
+impl TypeView for MyTag {
+    fn to_type_tag(&self) -> TypeTag {
+        self.0.clone()
+    }
+}
+
+impl MyVal {
+    pub fn val(x: impl ValueView) -> Self {
+        Self(u64::from(x.legacy_abstract_memory_size()))
+    }
+
+    pub fn ref_(x: &impl ValueView) -> Self {
+        Self(u64::from(x.legacy_abstract_memory_size()))
+    }
+}
+
+impl MyTag {
+    pub fn val(x: impl TypeView) -> Self {
+        Self(x.to_type_tag())
+    }
+
+    pub fn ref_(x: &impl TypeView) -> Self {
+        Self(x.to_type_tag())
+    }
+}
+
+impl GasMeter for GasStatus {
+    fn charge_simple_instr(
+        &mut self,
+        instr: move_vm_types::gas::SimpleInstruction,
+    ) -> PartialVMResult<()> {
+        self.new
+            .iter_mut()
+            .for_each(|status| status.charge_simple_instr(instr).unwrap());
+        self.current.charge_simple_instr(instr)
+    }
+
+    fn charge_pop(
+        &mut self,
+        popped_val: impl move_vm_types::views::ValueView,
+    ) -> PartialVMResult<()> {
+        self.new
+            .iter_mut()
+            .for_each(|status| status.charge_pop(MyVal::ref_(&popped_val)).unwrap());
+        self.current.charge_pop(MyVal::ref_(&popped_val))
+    }
+
+    fn charge_call(
+        &mut self,
+        module_id: &move_core_types::language_storage::ModuleId,
+        func_name: &str,
+        args: impl ExactSizeIterator<Item = impl move_vm_types::views::ValueView>,
+        num_locals: move_core_types::gas_algebra::NumArgs,
+    ) -> PartialVMResult<()> {
+        let args: Vec<_> = args.map(MyVal::val).collect();
+        self.new.iter_mut().for_each(|status| {
+            status
+                .charge_call(module_id, func_name, args.clone().into_iter(), num_locals)
+                .unwrap()
+        });
+        self.current
+            .charge_call(module_id, func_name, args.into_iter(), num_locals)
+    }
+
+    fn charge_call_generic(
+        &mut self,
+        module_id: &move_core_types::language_storage::ModuleId,
+        func_name: &str,
+        ty_args: impl ExactSizeIterator<Item = impl move_vm_types::views::TypeView>,
+        args: impl ExactSizeIterator<Item = impl move_vm_types::views::ValueView>,
+        num_locals: move_core_types::gas_algebra::NumArgs,
+    ) -> PartialVMResult<()> {
+        let ty_args: Vec<_> = ty_args.map(MyTag::val).collect();
+        let args: Vec<_> = args.map(MyVal::val).collect();
+        self.new.iter_mut().for_each(|status| {
+            status
+                .charge_call_generic(
+                    module_id,
+                    func_name,
+                    ty_args.clone().into_iter(),
+                    args.clone().into_iter(),
+                    num_locals,
+                )
+                .unwrap()
+        });
+        self.current.charge_call_generic(
+            module_id,
+            func_name,
+            ty_args.into_iter(),
+            args.into_iter(),
+            num_locals,
+        )
+    }
+
+    fn charge_ld_const(
+        &mut self,
+        size: move_core_types::gas_algebra::NumBytes,
+    ) -> PartialVMResult<()> {
+        self.new
+            .iter_mut()
+            .for_each(|status| status.charge_ld_const(size).unwrap());
+        self.current.charge_ld_const(size)
+    }
+
+    fn charge_ld_const_after_deserialization(
+        &mut self,
+        val: impl move_vm_types::views::ValueView,
+    ) -> PartialVMResult<()> {
+        let val = MyVal::val(val);
+        self.new
+            .iter_mut()
+            .for_each(|status| status.charge_ld_const_after_deserialization(val).unwrap());
+        self.current.charge_ld_const_after_deserialization(val)
+    }
+
+    fn charge_copy_loc(
+        &mut self,
+        val: impl move_vm_types::views::ValueView,
+    ) -> PartialVMResult<()> {
+        let val = MyVal::val(val);
+        self.new
+            .iter_mut()
+            .for_each(|status| status.charge_copy_loc(val).unwrap());
+        self.current.charge_copy_loc(val)
+    }
+
+    fn charge_move_loc(
+        &mut self,
+        val: impl move_vm_types::views::ValueView,
+    ) -> PartialVMResult<()> {
+        let val = MyVal::val(val);
+        self.new
+            .iter_mut()
+            .for_each(|status| status.charge_move_loc(val).unwrap());
+        self.current.charge_move_loc(val)
+    }
+
+    fn charge_store_loc(
+        &mut self,
+        val: impl move_vm_types::views::ValueView,
+    ) -> PartialVMResult<()> {
+        let val = MyVal::val(val);
+        self.new
+            .iter_mut()
+            .for_each(|status| status.charge_store_loc(val).unwrap());
+        self.current.charge_store_loc(val)
+    }
+
+    fn charge_pack(
+        &mut self,
+        is_generic: bool,
+        args: impl ExactSizeIterator<Item = impl move_vm_types::views::ValueView>,
+    ) -> PartialVMResult<()> {
+        let args: Vec<_> = args.map(MyVal::val).collect();
+        self.new.iter_mut().for_each(|status| {
+            status
+                .charge_pack(is_generic, args.clone().into_iter())
+                .unwrap()
+        });
+        self.current.charge_pack(is_generic, args.into_iter())
+    }
+
+    fn charge_unpack(
+        &mut self,
+        is_generic: bool,
+        args: impl ExactSizeIterator<Item = impl move_vm_types::views::ValueView>,
+    ) -> PartialVMResult<()> {
+        let args: Vec<_> = args.map(MyVal::val).collect();
+        self.new.iter_mut().for_each(|status| {
+            status
+                .charge_unpack(is_generic, args.clone().into_iter())
+                .unwrap()
+        });
+        self.current.charge_unpack(is_generic, args.into_iter())
+    }
+
+    fn charge_read_ref(
+        &mut self,
+        val: impl move_vm_types::views::ValueView,
+    ) -> PartialVMResult<()> {
+        let val = MyVal::val(val);
+        self.new
+            .iter_mut()
+            .for_each(|status| status.charge_read_ref(val).unwrap());
+        self.current.charge_read_ref(val)
+    }
+
+    fn charge_write_ref(
+        &mut self,
+        new_val: impl move_vm_types::views::ValueView,
+        old_val: impl move_vm_types::views::ValueView,
+    ) -> PartialVMResult<()> {
+        let new_val = MyVal::val(new_val);
+        let old_val = MyVal::val(old_val);
+        self.new
+            .iter_mut()
+            .for_each(|status| status.charge_write_ref(new_val, old_val).unwrap());
+        self.current.charge_write_ref(new_val, old_val)
+    }
+
+    fn charge_eq(
+        &mut self,
+        lhs: impl move_vm_types::views::ValueView,
+        rhs: impl move_vm_types::views::ValueView,
+    ) -> PartialVMResult<()> {
+        let lhs = MyVal::val(lhs);
+        let rhs = MyVal::val(rhs);
+        self.new
+            .iter_mut()
+            .for_each(|status| status.charge_eq(lhs, rhs).unwrap());
+        self.current.charge_eq(lhs, rhs)
+    }
+
+    fn charge_neq(
+        &mut self,
+        lhs: impl move_vm_types::views::ValueView,
+        rhs: impl move_vm_types::views::ValueView,
+    ) -> PartialVMResult<()> {
+        let lhs = MyVal::val(lhs);
+        let rhs = MyVal::val(rhs);
+        self.new
+            .iter_mut()
+            .for_each(|status| status.charge_neq(lhs, rhs).unwrap());
+        self.current.charge_neq(lhs, rhs)
+    }
+
+    fn charge_borrow_global(
+        &mut self,
+        is_mut: bool,
+        is_generic: bool,
+        ty: impl move_vm_types::views::TypeView,
+        is_success: bool,
+    ) -> PartialVMResult<()> {
+        let ty = MyTag::val(ty);
+        self.new.iter_mut().for_each(|status| {
+            status
+                .charge_borrow_global(is_mut, is_generic, ty.clone(), is_success)
+                .unwrap()
+        });
+        self.current
+            .charge_borrow_global(is_mut, is_generic, ty, is_success)
+    }
+
+    fn charge_exists(
+        &mut self,
+        is_generic: bool,
+        ty: impl move_vm_types::views::TypeView,
+        // TODO(Gas): see if we can get rid of this param
+        exists: bool,
+    ) -> PartialVMResult<()> {
+        let ty = MyTag::val(ty);
+        self.new.iter_mut().for_each(|status| {
+            status
+                .charge_exists(is_generic, ty.clone(), exists)
+                .unwrap()
+        });
+        self.current.charge_exists(is_generic, ty, exists)
+    }
+
+    fn charge_move_from(
+        &mut self,
+        is_generic: bool,
+        ty: impl move_vm_types::views::TypeView,
+        val: Option<impl move_vm_types::views::ValueView>,
+    ) -> PartialVMResult<()> {
+        let ty = MyTag::val(ty);
+        let val = val.map(MyVal::val);
+        self.new.iter_mut().for_each(|status| {
+            status
+                .charge_move_from(is_generic, ty.clone(), val)
+                .unwrap()
+        });
+        self.current.charge_move_from(is_generic, ty, val)
+    }
+
+    fn charge_move_to(
+        &mut self,
+        is_generic: bool,
+        ty: impl move_vm_types::views::TypeView,
+        val: impl move_vm_types::views::ValueView,
+        is_success: bool,
+    ) -> PartialVMResult<()> {
+        let ty = MyTag::val(ty);
+        let val = MyVal::val(val);
+        self.new.iter_mut().for_each(|status| {
+            status
+                .charge_move_to(is_generic, ty.clone(), val, is_success)
+                .unwrap()
+        });
+        self.current.charge_move_to(is_generic, ty, val, is_success)
+    }
+
+    fn charge_vec_pack<'b>(
+        &mut self,
+        ty: impl move_vm_types::views::TypeView + 'b,
+        args: impl ExactSizeIterator<Item = impl move_vm_types::views::ValueView>,
+    ) -> PartialVMResult<()> {
+        let ty = MyTag::val(ty);
+        let args: Vec<_> = args.map(MyVal::val).collect();
+        self.new.iter_mut().for_each(|status| {
+            status
+                .charge_vec_pack(ty.clone(), args.clone().into_iter())
+                .unwrap()
+        });
+        self.current.charge_vec_pack(ty, args.into_iter())
+    }
+
+    fn charge_vec_len(&mut self, ty: impl move_vm_types::views::TypeView) -> PartialVMResult<()> {
+        let ty = MyTag::val(ty);
+        self.new
+            .iter_mut()
+            .for_each(|status| status.charge_vec_len(ty.clone()).unwrap());
+        self.current.charge_vec_len(ty)
+    }
+
+    fn charge_vec_borrow(
+        &mut self,
+        is_mut: bool,
+        ty: impl move_vm_types::views::TypeView,
+        is_success: bool,
+    ) -> PartialVMResult<()> {
+        let ty = MyTag::val(ty);
+        self.new.iter_mut().for_each(|status| {
+            status
+                .charge_vec_borrow(is_mut, ty.clone(), is_success)
+                .unwrap()
+        });
+        self.current.charge_vec_borrow(is_mut, ty, is_success)
+    }
+
+    fn charge_vec_push_back(
+        &mut self,
+        ty: impl move_vm_types::views::TypeView,
+        val: impl move_vm_types::views::ValueView,
+    ) -> PartialVMResult<()> {
+        let ty = MyTag::val(ty);
+        let val = MyVal::val(val);
+        self.new
+            .iter_mut()
+            .for_each(|status| status.charge_vec_push_back(ty.clone(), val).unwrap());
+        self.current.charge_vec_push_back(ty, val)
+    }
+
+    fn charge_vec_pop_back(
+        &mut self,
+        ty: impl move_vm_types::views::TypeView,
+        val: Option<impl move_vm_types::views::ValueView>,
+    ) -> PartialVMResult<()> {
+        let ty = MyTag::val(ty);
+        let val = val.map(MyVal::val);
+        self.new
+            .iter_mut()
+            .for_each(|status| status.charge_vec_pop_back(ty.clone(), val).unwrap());
+        self.current.charge_vec_pop_back(ty, val)
+    }
+
+    fn charge_vec_unpack(
+        &mut self,
+        ty: impl move_vm_types::views::TypeView,
+        expect_num_elements: move_core_types::gas_algebra::NumArgs,
+        elems: impl ExactSizeIterator<Item = impl move_vm_types::views::ValueView>,
+    ) -> PartialVMResult<()> {
+        let ty = MyTag::val(ty);
+        let elems: Vec<_> = elems.map(MyVal::val).collect();
+        self.new.iter_mut().for_each(|status| {
+            status
+                .charge_vec_unpack(ty.clone(), expect_num_elements, elems.clone().into_iter())
+                .unwrap()
+        });
+        self.current
+            .charge_vec_unpack(ty, expect_num_elements, elems.into_iter())
+    }
+
+    fn charge_vec_swap(&mut self, ty: impl move_vm_types::views::TypeView) -> PartialVMResult<()> {
+        let ty = MyTag::val(ty);
+        self.new
+            .iter_mut()
+            .for_each(|status| status.charge_vec_swap(ty.clone()).unwrap());
+        self.current.charge_vec_swap(ty)
+    }
+
+    fn charge_load_resource(
+        &mut self,
+        loaded: Option<(
+            move_core_types::gas_algebra::NumBytes,
+            impl move_vm_types::views::ValueView,
+        )>,
+    ) -> PartialVMResult<()> {
+        let loaded = loaded.map(|(x, y)| (x, MyVal::val(y)));
+        self.new
+            .iter_mut()
+            .for_each(|status| status.charge_load_resource(loaded).unwrap());
+        self.current.charge_load_resource(loaded)
+    }
+
+    fn charge_native_function(
+        &mut self,
+        amount: InternalGas,
+        ret_vals: Option<impl ExactSizeIterator<Item = impl move_vm_types::views::ValueView>>,
+    ) -> PartialVMResult<()> {
+        let ret_vals = ret_vals.map(|x| x.map(MyVal::val).collect::<Vec<_>>());
+        self.new.iter_mut().for_each(|status| {
+            status
+                .charge_native_function(amount, ret_vals.clone().map(|x| x.into_iter()))
+                .unwrap()
+        });
+        self.current
+            .charge_native_function(amount, ret_vals.map(|x| x.into_iter()))
+    }
+
+    fn charge_native_function_before_execution(
+        &mut self,
+        ty_args: impl ExactSizeIterator<Item = impl move_vm_types::views::TypeView>,
+        args: impl ExactSizeIterator<Item = impl move_vm_types::views::ValueView>,
+    ) -> PartialVMResult<()> {
+        let ty_args: Vec<_> = ty_args.map(MyTag::val).collect();
+        let args: Vec<_> = args.map(MyVal::val).collect();
+        self.new.iter_mut().for_each(|status| {
+            status
+                .charge_native_function_before_execution(
+                    ty_args.clone().into_iter(),
+                    args.clone().into_iter(),
+                )
+                .unwrap()
+        });
+        self.current
+            .charge_native_function_before_execution(ty_args.into_iter(), args.into_iter())
+    }
+
+    fn charge_drop_frame(
+        &mut self,
+        locals: impl Iterator<Item = impl move_vm_types::views::ValueView>,
+    ) -> PartialVMResult<()> {
+        let locals: Vec<_> = locals.map(MyVal::val).collect();
+        self.new.iter_mut().for_each(|status| {
+            status
+                .charge_drop_frame(locals.clone().into_iter())
+                .unwrap()
+        });
+        self.current.charge_drop_frame(locals.into_iter())
+    }
+
+    fn remaining_gas(&self) -> InternalGas {
+        // NB: we need to call the trait method and not the struct method
+        InternalGas::new(u64::from(GasMeter::remaining_gas(&self.current)))
+    }
+}
+
+pub static INITIAL_COST_SCHEDULE: Lazy<CostTable> = Lazy::new(T::initial_cost_schedule_v1);
+
+pub fn initial_cost_schedule_for_unit_tests() -> move_vm_test_utils::gas_schedule::CostTable {
+    T::initial_cost_schedule_for_unit_tests()
+}

--- a/crates/sui-cost-tables/src/lib.rs
+++ b/crates/sui-cost-tables/src/lib.rs
@@ -11,8 +11,10 @@ pub use bytecode_based::tables as bytecode_tables;
 pub use bytecode_based::units_types;
 
 #[cfg(feature = "tiered-gas")]
+pub mod double_meter;
+#[cfg(feature = "tiered-gas")]
 pub mod tier_based;
 #[cfg(feature = "tiered-gas")]
-pub use tier_based::tables as bytecode_tables;
+pub use double_meter as bytecode_tables;
 #[cfg(feature = "tiered-gas")]
 pub use tier_based::units_types;

--- a/crates/sui-cost-tables/src/tier_based/tables.rs
+++ b/crates/sui-cost-tables/src/tier_based/tables.rs
@@ -48,28 +48,28 @@ pub static INITIAL_COST_SCHEDULE: Lazy<CostTable> = Lazy::new(initial_cost_sched
 #[derive(Debug)]
 pub struct GasStatus {
     pub gas_model_version: u64,
-    cost_table: CostTable,
-    gas_left: InternalGas,
-    gas_price: u64,
-    initial_budget: InternalGas,
-    charge: bool,
+    pub cost_table: CostTable,
+    pub gas_left: InternalGas,
+    pub gas_price: u64,
+    pub initial_budget: InternalGas,
+    pub charge: bool,
 
     // The current height of the operand stack, and the maximal height that it has reached.
-    stack_height_high_water_mark: u64,
-    stack_height_current: u64,
-    stack_height_next_tier_start: Option<u64>,
-    stack_height_current_tier_mult: u64,
+    pub stack_height_high_water_mark: u64,
+    pub stack_height_current: u64,
+    pub stack_height_next_tier_start: Option<u64>,
+    pub stack_height_current_tier_mult: u64,
 
     // The current (abstract) size  of the operand stack and the maximal size that it has reached.
-    stack_size_high_water_mark: u64,
-    stack_size_current: u64,
-    stack_size_next_tier_start: Option<u64>,
-    stack_size_current_tier_mult: u64,
+    pub stack_size_high_water_mark: u64,
+    pub stack_size_current: u64,
+    pub stack_size_next_tier_start: Option<u64>,
+    pub stack_size_current_tier_mult: u64,
 
     // The total number of bytecode instructions that have been executed in the transaction.
-    instructions_executed: u64,
-    instructions_next_tier_start: Option<u64>,
-    instructions_current_tier_mult: u64,
+    pub instructions_executed: u64,
+    pub instructions_next_tier_start: Option<u64>,
+    pub instructions_current_tier_mult: u64,
 }
 
 impl GasStatus {
@@ -170,14 +170,26 @@ impl GasStatus {
 
     const INTERNAL_UNIT_MULTIPLIER: u64 = 1000;
 
-    fn to_internal_units(val: u64) -> InternalGas {
+    pub(crate) fn to_internal_units(val: u64) -> InternalGas {
         InternalGas::new(val * Self::INTERNAL_UNIT_MULTIPLIER)
     }
 
     #[allow(dead_code)]
-    fn to_mist(&self, val: InternalGas) -> u64 {
+    pub(crate) fn to_mist(&self, val: InternalGas) -> u64 {
         let gas: Gas = InternalGas::to_unit_round_down(val);
         u64::from(gas) * self.gas_price
+    }
+
+    pub fn get_status_info(&self) -> (u64, u64, u64) {
+        (
+            self.instructions_executed,
+            self.stack_height_high_water_mark,
+            self.stack_size_high_water_mark,
+        )
+    }
+
+    pub fn get_others_info(&self) -> Vec<(u64, u64, u64, u64)> {
+        vec![]
     }
 
     pub fn push_stack(&mut self, pushes: u64) -> PartialVMResult<()> {
@@ -322,7 +334,7 @@ impl GasStatus {
     }
 
     // Deduct the amount provided with no conversion, as if it was InternalGasUnit
-    fn deduct_units(&mut self, amount: u64) -> PartialVMResult<()> {
+    pub(crate) fn deduct_units(&mut self, amount: u64) -> PartialVMResult<()> {
         self.deduct_gas(InternalGas::new(amount))
     }
 

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -534,8 +534,12 @@ impl LocalExec {
             .await?;
 
         // Create the gas status
-        let gas_status =
-            SuiGasStatus::new_with_budget(tx_info.gas_budget, tx_info.gas_price, protocol_config);
+        let gas_status = SuiGasStatus::new_with_budget(
+            tx_info.gas_budget,
+            tx_info.gas_price,
+            protocol_config,
+            None,
+        );
 
         // Temp store for data
         let temporary_store =

--- a/crates/sui-types/src/gas.rs
+++ b/crates/sui-types/src/gas.rs
@@ -5,6 +5,7 @@
 use crate::sui_serde::BigInt;
 use crate::sui_serde::Readable;
 use crate::{
+    base_types::TransactionDigest,
     error::{ExecutionError, UserInputError, UserInputResult},
     gas_model::gas_v1::{self, SuiCostTable as SuiCostTableV1, SuiGasStatus as SuiGasStatusV1},
     gas_model::gas_v2::{self, SuiCostTable as SuiCostTableV2, SuiGasStatus as SuiGasStatusV2},
@@ -13,13 +14,34 @@ use crate::{
 };
 use enum_dispatch::enum_dispatch;
 use itertools::MultiUnzip;
+use once_cell::sync::Lazy;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use sui_cost_tables::bytecode_tables::GasStatus;
 use sui_protocol_config::ProtocolConfig;
+use tracing::error;
 
 sui_macros::checked_arithmetic! {
+
+static LOGGING_FILE: Lazy<std::sync::Mutex<std::fs::File>> = Lazy::new(|| {
+    std::sync::Mutex::new(
+        std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .append(true)
+            .open("/Users/dariorussi/tmp/track_gas/stats")
+            .unwrap(),
+    )
+});
+
+pub fn write_gas_stats(stats: &str) {
+    use std::io::Write;
+    let f = &mut *LOGGING_FILE.lock().unwrap();
+    if writeln!(f, "{}", stats).is_err() {
+        error!("cannot write to gas stats tracking file");
+    }
+}
 
 #[enum_dispatch]
 pub trait SuiGasStatusAPI {
@@ -52,7 +74,12 @@ pub enum SuiGasStatus {
 }
 
 impl SuiGasStatus {
-    pub fn new_with_budget(gas_budget: u64, gas_price: u64, config: &ProtocolConfig) -> Self {
+    pub fn new_with_budget(
+        gas_budget: u64,
+        gas_price: u64,
+        config: &ProtocolConfig,
+        tx_digest: Option<TransactionDigest>,
+    ) -> Self {
         match config.gas_model_version() {
             1 => Self::V1(SuiGasStatusV1::new_with_budget(
                 gas_budget,
@@ -63,6 +90,7 @@ impl SuiGasStatus {
                 gas_budget,
                 gas_price,
                 config,
+                tx_digest,
             )),
             _ => panic!("unknown gas model version"),
         }

--- a/crates/sui-types/src/gas_model/gas_v2.rs
+++ b/crates/sui-types/src/gas_model/gas_v2.rs
@@ -3,8 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::error::{UserInputError, UserInputResult};
-use crate::gas::{self, GasCostSummary, SuiGasStatusAPI};
+use crate::gas::{self, write_gas_stats, GasCostSummary, SuiGasStatusAPI};
 use crate::{
+    digests::TransactionDigest,
     error::{ExecutionError, ExecutionErrorKind},
     object::{Object, Owner},
 };
@@ -204,6 +205,8 @@ pub struct SuiGasStatus {
     /// Amount of storage rebate accumulated when we are running in unmetered mode (i.e. system transaction).
     /// This allows us to track how much storage rebate we need to retain in system transactions.
     unmetered_storage_rebate: u64,
+    // transaction digest (for logging purposes)
+    tx_digest: Option<TransactionDigest>,
 }
 
 impl SuiGasStatus {
@@ -215,6 +218,7 @@ impl SuiGasStatus {
         storage_gas_price: u64,
         rebate_rate: u64,
         cost_table: SuiCostTable,
+        tx_digest: Option<TransactionDigest>,
     ) -> SuiGasStatus {
         SuiGasStatus {
             gas_status: move_gas_status,
@@ -228,6 +232,7 @@ impl SuiGasStatus {
             rebate_rate,
             unmetered_storage_rebate: 0,
             cost_table,
+            tx_digest,
         }
     }
 
@@ -235,6 +240,7 @@ impl SuiGasStatus {
         gas_budget: u64,
         gas_price: u64,
         config: &ProtocolConfig,
+        tx_digest: Option<TransactionDigest>,
     ) -> SuiGasStatus {
         let storage_gas_price = config.storage_gas_price();
         let max_computation_budget = config.max_gas_computation_bucket() * gas_price;
@@ -257,6 +263,7 @@ impl SuiGasStatus {
             storage_gas_price,
             config.storage_rebate_rate(),
             sui_cost_table,
+            tx_digest,
         )
     }
 
@@ -287,6 +294,7 @@ impl SuiGasStatus {
             storage_gas_price,
             rebate_rate,
             cost_table,
+            None,
         )
     }
 
@@ -299,7 +307,55 @@ impl SuiGasStatus {
             0,
             0,
             SuiCostTable::unmetered(),
+            None,
         )
+    }
+
+    fn gas_status_stats(&self, summary: &GasCostSummary, digest: TransactionDigest) {
+        let (instr_count, stack_height, stack_size) = self.gas_status.get_status_info();
+        write_gas_stats(
+            format!(
+                "{}: computation_cost = {}, storage_cost = {}, storage_rebate = {}, \
+                non_refundable_storage_fee = {}, instructions = {}, stack_height = {}, \
+                stack_size = {}, gas_used = {}",
+                digest,
+                summary.computation_cost,
+                summary.storage_cost,
+                summary.storage_rebate,
+                summary.non_refundable_storage_fee,
+                instr_count,
+                stack_height,
+                stack_size,
+                self.gas_status.gas_used_pre_gas_price(),
+            )
+            .as_str(),
+        );
+
+        let info = self.gas_status.get_others_info();
+        for (idx, (gas_used, instr_count, stack_height, stack_size)) in info.into_iter().enumerate() {
+            let bucket_cost = get_bucket_cost(&self.cost_table.computation_bucket, gas_used);
+            // charge extra on top of `computation_cost` to make the total computation
+            // cost a bucket value
+            let total_gas_used = bucket_cost * self.gas_price;
+            let computation_cost = if self.gas_budget <= total_gas_used {
+                self.gas_budget
+            } else {
+                total_gas_used
+            };
+            write_gas_stats(
+                format!(
+                    "{}: computation_cost_v{idx} = {}, instructions_v{idx} = {}, \
+                    stack_height_v{idx} = {}, stack_size_v{idx} = {}, gas_used_v{idx} = {}",
+                    digest,
+                    computation_cost,
+                    instr_count,
+                    stack_height,
+                    stack_size,
+                    gas_used,
+                )
+                .as_str(),
+            );
+        }
     }
 }
 
@@ -335,12 +391,16 @@ impl SuiGasStatusAPI for SuiGasStatus {
         let sender_rebate = sender_rebate(self.storage_rebate, self.rebate_rate);
         assert!(sender_rebate <= self.storage_rebate);
         let non_refundable_storage_fee = self.storage_rebate - sender_rebate;
-        GasCostSummary {
+        let summary = GasCostSummary {
             computation_cost: self.computation_cost,
             storage_cost: self.storage_cost,
             storage_rebate: sender_rebate,
             non_refundable_storage_fee,
-        }
+        };
+        if let Some(digest) = self.tx_digest {
+            self.gas_status_stats(&summary, digest);
+        };
+        summary
     }
 
     fn gas_budget(&self) -> u64 {

--- a/crates/sui-types/src/temporary_store.rs
+++ b/crates/sui-types/src/temporary_store.rs
@@ -218,6 +218,10 @@ impl<S> TemporaryStore<S> {
         }
     }
 
+    pub fn tx_digest(&self) -> TransactionDigest {
+        self.tx_digest
+    }
+
     // Helpers to access private fields
     pub fn objects(&self) -> &BTreeMap<ObjectID, Object> {
         &self.input_objects

--- a/scripts/gas_stats/gas_stats.py
+++ b/scripts/gas_stats/gas_stats.py
@@ -1,0 +1,204 @@
+from os import path
+from glob import glob
+from collections import defaultdict
+from pathlib import Path
+
+# Main holder of gas stats. It's a dictionary keyed off the transaction digest.
+# Values are stats related to gas for the given transaction
+gas_stats = defaultdict(dict)
+
+# Parse all stats* files, create and populate gas_stats
+def parse_files():
+    files_path = path.join(Path.home(), "tmp/track_gas/stats*")
+    stats_files = glob(files_path)
+    for file_name in stats_files:
+        file = open(file_name)
+        while True:
+            line = file.readline()
+            if not line:
+                break
+            parse_line(line)
+
+# parse a single line
+def parse_line(line):
+    # print(line)
+    key_value = line.split(':', 1)
+    gas_entry = gas_stats[key_value[0].strip()]
+    process_value(gas_entry, key_value[1].strip())
+
+# parse the values in a line for a given transaction digest
+def process_value(gas_entry, line):
+    idx = 0
+    while idx < len(line) - 1:
+        c = line[idx]
+        if c.isspace() or c == ',':
+            idx += 1
+            continue
+        (key, idx) = get_key(line, idx)
+        # print("key: {} - idx: {}".format(key, idx))
+        if key in ["packages", "modules", "functions"]:
+            (value, idx) = get_values(line, idx)
+        else:
+            (value, idx) = get_value(line, idx)
+        # print("value: {} - idx: {}".format(value, idx))
+        gas_entry[key] = value
+
+# get a key in a list of stats (key, value) pairs
+def get_key(line, start):
+    idx = start
+    key = ""
+    for idx in range(idx, len(line)):
+        c = line[idx]
+        if c.isidentifier():
+            key += c
+        else:
+            break
+    return key, idx
+
+# get an integer value for a gas stat
+def get_value(line, start):
+    # import pdb; pdb.set_trace()
+    idx = start
+    value = ""
+    for idx in range(idx, len(line)):
+        c = line[idx]
+        if c.isspace() or c == '=':
+            continue
+        if c.isnumeric():
+            value += c
+        else:
+            break
+    return int(value), idx
+
+# get an array of key/value pairs for packages, module and functions in a programmable transaction
+def get_values(line, start):
+    # import pdb; pdb.set_trace()
+    idx = start
+
+    # read until '['
+    while idx < len(line):
+        c = line[idx]
+        idx += 1
+        if c.isspace() or c == '=':
+            continue
+        elif c == '[':
+            break
+        else:
+            raise Exception("Unexpected character while look for '['")
+
+    # read values in '[...]'
+    key_value = {}
+    while idx < len(line):
+        c = line[idx]
+        idx += 1
+        if c == ']':
+            break
+        elif c.isspace() or c == ',':
+            continue
+        else:
+            key = c
+            while idx < len(line):
+                c = line[idx]
+                idx += 1
+                if c == '=':
+                    break
+                key += c
+            key = key.strip()
+            (value, idx) = get_value(line, idx)
+            key_value[key] = value
+
+    return key_value, idx
+
+# stats summaries
+def check_transactions():
+    genesis = 0
+    consensus_commit_prologue = 0
+    change_eopch = 0
+    programmable_transaction = 0
+    unknown = 0
+    for values in gas_stats.values():
+        if "genesis" in values:
+            genesis += 1
+        elif "consensus_commit_prologue" in values:
+            consensus_commit_prologue += 1
+        elif "change_epoch" in values:
+            change_eopch += 1
+        elif "programmable_transaction" in values:
+            programmable_transaction += 1
+        else:
+            unknown += 1
+            # raise Exception("unknown transaction type for {}".format(values))
+    print(
+        "genesis = {}, consensus_commit_prologue = {}, change_eopch = {}, programmable_transaction = {}, unknown = {}".format(
+            genesis,
+            consensus_commit_prologue,
+            change_eopch,
+            programmable_transaction,
+            unknown,
+        )
+    )
+
+def print_times():
+    for digest, values in gas_stats.items():
+        if "time" not in values:
+            continue
+        time = values["time"]
+        if "genesis" in values:
+            print("genesis, {}".format(time))
+        elif "consensus_commit_prologue" in values:
+            print("consensus_commit_prologue, {}".format(time))
+        elif "change_epoch" in values:
+            print("change_epoch, {}".format(time))
+        elif "programmable_transaction" in values:
+            print("programmable_transaction, {}".format(time))
+        else:
+            print("unknown, {}".format(time))
+            # raise Exception("unknown transaction type for {} - {}".format(digest, values))
+
+
+def print_programmable_transactions():
+    print("digest, time, error, total_cost, computation_cost, storage_cost, storage_rebate, instructions, stack_height, stack_size, function count, functions, publishes, splits, merges, make_vecs, transfers")
+    for digest, values in gas_stats.items():
+        if "time" not in values:
+            continue
+        if "programmable_transaction" not in values:
+            continue
+        functions = ""
+        if "functions" in values:
+            for function in values["functions"]:
+                functions += function + " - "
+        total_cost = -1
+        if "computation_cost" in values and "storage_cost" in values and "storage_rebate" in values:
+            total_cost = values["computation_cost"] + values["storage_cost"] - values["storage_rebate"]
+        print(
+            "{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}".format(
+                digest,
+                values["time"],
+                values.get("error", -1),
+                total_cost,
+                values.get("computation_cost", -1),
+                values.get("storage_cost", -1),
+                values.get("storage_rebate", -1),
+                values.get("instructions", -1),
+                values.get("stack_height", -1),
+                values.get("stack_size", -1),
+                len(values.get("functions", {})),
+                functions,
+                values.get("publishes", -1),
+                values.get("splits", -1),
+                values.get("merges", -1),
+                values.get("make_vecs", -1),
+                values.get("transfers", -1),
+            )
+        )
+
+
+# main...
+def main():
+    parse_files()
+    # check_transactions()
+    # print_times()
+    print_programmable_transactions()
+
+if __name__ == "__main__":
+   main()

--- a/scripts/gas_stats/plot_stats.py
+++ b/scripts/gas_stats/plot_stats.py
@@ -1,0 +1,59 @@
+import pandas as pd
+import matplotlib.pyplot as plt
+import numpy as np
+import mpld3
+import os
+import glob
+
+
+# use glob to get all the csv files
+# in the folder
+path = os.getcwd()
+csv_files = glob.glob(os.path.join(path, "outputs/*.csv"))
+
+fig, ax = plt.subplots()
+
+ax.grid(color='white', linestyle='solid')
+ax.set_title("Comparison of gas and execution time for old, new (and possibly previous) cost models", size=20)
+ax.set_xlabel("Time (Nanoseconds)", size = 20)
+ax.set_ylabel("Gas", size = 20)
+labels = ["Old Gas Model"]
+
+old = pd.read_csv('outputs/old_gas_model.csv')
+ax.scatter(old.nanos.values,
+           old.gas.values,
+           c='black',
+           label= "Old Gas Model",
+           alpha=0.8)
+tooltip = mpld3.plugins.PointHTMLTooltip(ax.collections[0], labels= ['old {0} (gas: {1}, nanos: {2})'.format(row['name'], row.gas, row.nanos) for _, row in old.iterrows()])
+mpld3.plugins.connect(fig, tooltip)
+
+
+# loop over the list of csv files
+for idx, f in enumerate(csv_files):
+
+    file_name = f.split("/")[-1]
+    labels.append(file_name)
+
+    # read the csv file
+    df = pd.read_csv(f)
+    ax.scatter(df.nanos.values,
+               df.gas.values,
+               label= file_name,
+               alpha=0.8)
+
+    tooltip = mpld3.plugins.PointHTMLTooltip(ax.collections[idx + 1], labels= ['{3} {0} (gas: {1}, nanos: {2})'.format(row['name'], row.gas, row.nanos, file_name) for _, row in df.iterrows()])
+    mpld3.plugins.connect(fig, tooltip)
+
+    # print the location and filename
+    print('Plotting:', f.split("/")[-1])
+
+handles, llabels = ax.get_legend_handles_labels() # return lines and labels
+interactive_legend = mpld3.plugins.InteractiveLegendPlugin(
+    zip(handles, ax.collections), labels, alpha_unsel=0.0, alpha_over=5,
+    start_visible=True)
+
+mpld3.plugins.connect(fig, interactive_legend)
+
+mpld3.save_html(fig, "rough_prelim_results.html")
+mpld3.show()


### PR DESCRIPTION
## Description 

Get this PR to have a full node that saves gas stats in a local file.
A python script is provided to load those stats into python.
Right now the last 4 gas model are run at the same time and produce stats for the different gas models

## Test Plan 

Nothing to test

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
