### PR TITLE
Store FullCheckpoint contents in a single db row for faster retrieval.

### DIFF
--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -34,7 +34,7 @@ use sui_types::message_envelope::Message;
 use sui_types::messages::VerifiedExecutableTransaction;
 use sui_types::{
     base_types::{ExecutionDigests, TransactionDigest, TransactionEffectsDigest},
-    messages::{TransactionEffects, TransactionEffectsAPI},
+    messages::{TransactionEffects, TransactionEffectsAPI, VerifiedTransaction},
     messages_checkpoint::{CheckpointSequenceNumber, VerifiedCheckpoint},
 };
 use sui_types::{error::SuiResult, messages::TransactionDataAPI};
@@ -251,6 +251,10 @@ impl CheckpointExecutor {
         }
 
         fail_point!("highest-executed-checkpoint");
+
+        self.checkpoint_store
+            .delete_full_checkpoint_contents(seq)
+            .expect("Failed to delete full checkpoint contents");
 
         self.checkpoint_store
             .update_highest_executed_checkpoint(checkpoint)
@@ -833,6 +837,16 @@ fn get_unexecuted_transactions(
     Vec<(VerifiedExecutableTransaction, TransactionEffectsDigest)>,
 ) {
     let checkpoint_sequence = checkpoint.sequence_number();
+    let full_contents = checkpoint_store
+        .get_full_checkpoint_contents_by_sequence_number(*checkpoint_sequence)
+        .expect("Failed to get checkpoint contents from store")
+        .tap_some(|_| {
+            debug!(
+                "loaded full checkpoint contents in bulk for sequence {}",
+                checkpoint_sequence
+            )
+        });
+
     let mut execution_digests = checkpoint_store
         .get_checkpoint_contents(&checkpoint.content_digest)
         .expect("Failed to get checkpoint contents from store")
@@ -843,6 +857,14 @@ fn get_unexecuted_transactions(
             )
         })
         .into_inner();
+
+    let full_contents_txns = full_contents.map(|c| {
+        c.transactions
+            .into_iter()
+            .zip(execution_digests.iter())
+            .map(|(txn, digests)| (digests.transaction, txn))
+            .collect::<HashMap<_, _>>()
+    });
 
     // Remove the change epoch transaction so that we can special case its execution.
     checkpoint.end_of_epoch_data.as_ref().tap_some(|_| {
@@ -894,31 +916,49 @@ fn get_unexecuted_transactions(
             .unzip();
 
     // read remaining unexecuted transactions from store
-    let executable_txns: Vec<_> = authority_store
-        .multi_get_transaction_blocks(&unexecuted_txns)
-        .expect("Failed to get checkpoint txes from store")
-        .into_iter()
-        .zip(expected_effects_digests.into_iter())
-        .enumerate()
-        .map(|(i, (tx, expected_effects_digest))| {
-            let tx = tx.unwrap_or_else(||
-                panic!(
-                    "state-sync should have ensured that transaction with digest {:?} exists for checkpoint: {checkpoint:?}",
-                    unexecuted_txns[i]
+    let executable_txns: Vec<_> = if let Some(full_contents_txns) = full_contents_txns {
+        unexecuted_txns
+            .into_iter()
+            .zip(expected_effects_digests.into_iter())
+            .map(|(tx_digest, expected_effects_digest)| {
+                let tx = &full_contents_txns.get(&tx_digest).unwrap().transaction;
+                (
+                    VerifiedExecutableTransaction::new_from_checkpoint(
+                        VerifiedTransaction::new_unchecked(tx.clone()),
+                        epoch_store.epoch(),
+                        *checkpoint_sequence,
+                    ),
+                    expected_effects_digest,
                 )
-            );
-            // change epoch tx is handled specially in check_epoch_last_checkpoint
-            assert!(!tx.data().intent_message().value.is_change_epoch_tx());
-            (
-                VerifiedExecutableTransaction::new_from_checkpoint(
-                    tx,
-                    epoch_store.epoch(),
-                    *checkpoint_sequence,
-                ),
-                expected_effects_digest
-            )
-        })
-        .collect();
+            })
+            .collect()
+    } else {
+        authority_store
+            .multi_get_transaction_blocks(&unexecuted_txns)
+            .expect("Failed to get checkpoint txes from store")
+            .into_iter()
+            .zip(expected_effects_digests.into_iter())
+            .enumerate()
+            .map(|(i, (tx, expected_effects_digest))| {
+                let tx = tx.unwrap_or_else(||
+                    panic!(
+                        "state-sync should have ensured that transaction with digest {:?} exists for checkpoint: {checkpoint:?}",
+                        unexecuted_txns[i]
+                    )
+                );
+                // change epoch tx is handled specially in check_epoch_last_checkpoint
+                assert!(!tx.data().intent_message().value.is_change_epoch_tx());
+                (
+                    VerifiedExecutableTransaction::new_from_checkpoint(
+                        tx,
+                        epoch_store.epoch(),
+                        *checkpoint_sequence,
+                    ),
+                    expected_effects_digest
+                )
+            })
+            .collect()
+    };
 
     (execution_digests, all_tx_digests, executable_txns)
 }

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -841,10 +841,7 @@ fn get_unexecuted_transactions(
         .get_full_checkpoint_contents_by_sequence_number(*checkpoint_sequence)
         .expect("Failed to get checkpoint contents from store")
         .tap_some(|_| {
-            debug!(
-                "loaded full checkpoint contents in bulk for sequence {}",
-                checkpoint_sequence
-            )
+            debug!("loaded full checkpoint contents in bulk for sequence {checkpoint_sequence}")
         });
 
     let mut execution_digests = checkpoint_store
@@ -859,8 +856,7 @@ fn get_unexecuted_transactions(
         .into_inner();
 
     let full_contents_txns = full_contents.map(|c| {
-        c.transactions
-            .into_iter()
+        c.into_iter()
             .zip(execution_digests.iter())
             .map(|(txn, digests)| (digests.transaction, txn))
             .collect::<HashMap<_, _>>()

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -42,7 +42,7 @@ use sui_types::messages_checkpoint::SignedCheckpointSummary;
 use sui_types::messages_checkpoint::{
     CertifiedCheckpointSummary, CheckpointContents, CheckpointSequenceNumber,
     CheckpointSignatureMessage, CheckpointSummary, CheckpointTimestamp, EndOfEpochData,
-    TrustedCheckpoint, VerifiedCheckpoint,
+    FullCheckpointContents, TrustedCheckpoint, VerifiedCheckpoint, VerifiedCheckpointContents,
 };
 use sui_types::signature::GenericSignature;
 use sui_types::sui_system_state::{SuiSystemState, SuiSystemStateTrait};
@@ -89,6 +89,11 @@ pub struct BuilderCheckpointSummary {
 pub struct CheckpointStore {
     /// Maps checkpoint contents digest to checkpoint contents
     checkpoint_content: DBMap<CheckpointContentsDigest, CheckpointContents>,
+
+    /// Stores entire checkpoint contents from state sync, indexed by sequence number, for
+    /// efficient reads of full checkpoints. Entries from this table are deleted after state
+    /// accumulation has completed.
+    full_checkpoint_content: DBMap<CheckpointSequenceNumber, FullCheckpointContents>,
 
     /// Stores certified checkpoints
     pub(crate) certified_checkpoints: DBMap<CheckpointSequenceNumber, TrustedCheckpoint>,
@@ -272,6 +277,13 @@ impl CheckpointStore {
         self.checkpoint_content.get(digest)
     }
 
+    pub fn get_full_checkpoint_contents_by_sequence_number(
+        &self,
+        seq: CheckpointSequenceNumber,
+    ) -> Result<Option<FullCheckpointContents>, TypedStoreError> {
+        self.full_checkpoint_content.get(&seq)
+    }
+
     pub fn insert_certified_checkpoint(
         &self,
         checkpoint: &VerifiedCheckpoint,
@@ -343,6 +355,18 @@ impl CheckpointStore {
         &self,
         contents: CheckpointContents,
     ) -> Result<(), TypedStoreError> {
+        self.checkpoint_content.insert(contents.digest(), &contents)
+    }
+
+    pub fn insert_verified_checkpoint_contents(
+        &self,
+        checkpoint: &VerifiedCheckpoint,
+        full_contents: VerifiedCheckpointContents,
+    ) -> Result<(), TypedStoreError> {
+        let full_contents = full_contents.into_inner();
+        self.full_checkpoint_content
+            .insert(checkpoint.sequence_number(), &full_contents)?;
+        let contents = full_contents.into_checkpoint_contents();
         self.checkpoint_content.insert(contents.digest(), &contents)
     }
 

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -367,7 +367,7 @@ impl CheckpointStore {
         self.full_checkpoint_content
             .insert(checkpoint.sequence_number(), &full_contents)?;
         let contents = full_contents.into_checkpoint_contents();
-        self.checkpoint_content.insert(contents.digest(), &contents)
+        self.insert_checkpoint_contents(contents)
     }
 
     pub fn delete_full_checkpoint_contents(

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -370,6 +370,13 @@ impl CheckpointStore {
         self.checkpoint_content.insert(contents.digest(), &contents)
     }
 
+    pub fn delete_full_checkpoint_contents(
+        &self,
+        seq: CheckpointSequenceNumber,
+    ) -> Result<(), TypedStoreError> {
+        self.full_checkpoint_content.remove(&seq)
+    }
+
     pub fn get_epoch_last_checkpoint(
         &self,
         epoch_id: EpochId,

--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -81,6 +81,14 @@ impl ReadStore for RocksDbStore {
             })
     }
 
+    fn get_full_checkpoint_contents_by_sequence_number(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> Result<Option<FullCheckpointContents>, Self::Error> {
+        self.checkpoint_store
+            .get_full_checkpoint_contents_by_sequence_number(sequence_number)
+    }
+
     fn get_full_checkpoint_contents(
         &self,
         digest: &CheckpointContentsDigest,
@@ -143,12 +151,13 @@ impl WriteStore for RocksDbStore {
 
     fn insert_checkpoint_contents(
         &self,
+        checkpoint: &VerifiedCheckpoint,
         contents: VerifiedCheckpointContents,
     ) -> Result<(), Self::Error> {
         self.authority_store
             .multi_insert_transaction_and_effects(contents.iter())?;
         self.checkpoint_store
-            .insert_checkpoint_contents(contents.into_inner().into_checkpoint_contents())
+            .insert_verified_checkpoint_contents(checkpoint, contents)
     }
 
     fn insert_committee(&self, new_committee: Committee) -> Result<(), Self::Error> {

--- a/crates/sui-network/src/state_sync/tests.rs
+++ b/crates/sui-network/src/state_sync/tests.rs
@@ -303,12 +303,11 @@ async fn sync_with_checkpoints_being_inserted() {
 
     // Inject one checkpoint and verify that it was shared with the other node
     let mut checkpoint_iter = ordered_checkpoints.clone().into_iter().skip(1);
+    let checkpoint = checkpoint_iter.next().unwrap();
     store_1
-        .insert_checkpoint_contents(empty_contents())
+        .insert_checkpoint_contents(&checkpoint, empty_contents())
         .unwrap();
-    handle_1
-        .send_checkpoint(checkpoint_iter.next().unwrap())
-        .await;
+    handle_1.send_checkpoint(checkpoint).await;
 
     timeout(Duration::from_secs(1), async {
         assert_eq!(

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -395,11 +395,11 @@ impl CheckpointContents {
 // CheckpointBuilder::split_checkpoint_chunks should also be updated accordingly.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FullCheckpointContents {
-    pub transactions: Vec<ExecutionData>,
+    transactions: Vec<ExecutionData>,
     /// This field 'pins' user signatures for the checkpoint
     /// The length of this vector is same as length of transactions vector
     /// System transactions has empty signatures
-    pub user_signatures: Vec<Vec<GenericSignature>>,
+    user_signatures: Vec<Vec<GenericSignature>>,
 }
 
 impl FullCheckpointContents {
@@ -488,6 +488,15 @@ impl FullCheckpointContents {
 
     pub fn size(&self) -> usize {
         self.transactions.len()
+    }
+}
+
+impl IntoIterator for FullCheckpointContents {
+    type Item = ExecutionData;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.transactions.into_iter()
     }
 }
 

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -395,11 +395,11 @@ impl CheckpointContents {
 // CheckpointBuilder::split_checkpoint_chunks should also be updated accordingly.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FullCheckpointContents {
-    transactions: Vec<ExecutionData>,
+    pub transactions: Vec<ExecutionData>,
     /// This field 'pins' user signatures for the checkpoint
     /// The length of this vector is same as length of transactions vector
     /// System transactions has empty signatures
-    user_signatures: Vec<Vec<GenericSignature>>,
+    pub user_signatures: Vec<Vec<GenericSignature>>,
 }
 
 impl FullCheckpointContents {

--- a/crates/sui-types/src/storage.rs
+++ b/crates/sui-types/src/storage.rs
@@ -234,6 +234,11 @@ pub trait ReadStore {
 
     fn get_highest_synced_checkpoint(&self) -> Result<VerifiedCheckpoint, Self::Error>;
 
+    fn get_full_checkpoint_contents_by_sequence_number(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> Result<Option<FullCheckpointContents>, Self::Error>;
+
     fn get_full_checkpoint_contents(
         &self,
         digest: &CheckpointContentsDigest,
@@ -282,6 +287,13 @@ impl<T: ReadStore> ReadStore for &T {
         ReadStore::get_highest_synced_checkpoint(*self)
     }
 
+    fn get_full_checkpoint_contents_by_sequence_number(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> Result<Option<FullCheckpointContents>, Self::Error> {
+        ReadStore::get_full_checkpoint_contents_by_sequence_number(*self, sequence_number)
+    }
+
     fn get_full_checkpoint_contents(
         &self,
         digest: &CheckpointContentsDigest,
@@ -323,6 +335,7 @@ pub trait WriteStore: ReadStore {
     ) -> Result<(), Self::Error>;
     fn insert_checkpoint_contents(
         &self,
+        checkpoint: &VerifiedCheckpoint,
         contents: VerifiedCheckpointContents,
     ) -> Result<(), Self::Error>;
 
@@ -343,9 +356,10 @@ impl<T: WriteStore> WriteStore for &T {
 
     fn insert_checkpoint_contents(
         &self,
+        checkpoint: &VerifiedCheckpoint,
         contents: VerifiedCheckpointContents,
     ) -> Result<(), Self::Error> {
-        WriteStore::insert_checkpoint_contents(*self, contents)
+        WriteStore::insert_checkpoint_contents(*self, checkpoint, contents)
     }
 
     fn insert_committee(&self, new_committee: Committee) -> Result<(), Self::Error> {
@@ -358,6 +372,7 @@ pub struct InMemoryStore {
     highest_verified_checkpoint: Option<(CheckpointSequenceNumber, CheckpointDigest)>,
     highest_synced_checkpoint: Option<(CheckpointSequenceNumber, CheckpointDigest)>,
     checkpoints: HashMap<CheckpointDigest, VerifiedCheckpoint>,
+    full_checkpoint_contents: HashMap<CheckpointSequenceNumber, FullCheckpointContents>,
     sequence_number_to_digest: HashMap<CheckpointSequenceNumber, CheckpointDigest>,
     checkpoint_contents: HashMap<CheckpointContentsDigest, CheckpointContents>,
     transactions: HashMap<TransactionDigest, VerifiedTransaction>,
@@ -376,7 +391,7 @@ impl InMemoryStore {
     ) {
         self.insert_committee(committee);
         self.insert_checkpoint(checkpoint.clone());
-        self.insert_checkpoint_contents(contents);
+        self.insert_checkpoint_contents(&checkpoint, contents);
         self.update_highest_synced_checkpoint(&checkpoint);
     }
 
@@ -415,7 +430,11 @@ impl InMemoryStore {
         self.checkpoint_contents.get(digest)
     }
 
-    pub fn insert_checkpoint_contents(&mut self, contents: VerifiedCheckpointContents) {
+    pub fn insert_checkpoint_contents(
+        &mut self,
+        _checkpoint: &VerifiedCheckpoint,
+        contents: VerifiedCheckpointContents,
+    ) {
         for tx in contents.iter() {
             self.transactions
                 .insert(*tx.transaction.digest(), tx.transaction.to_owned());
@@ -562,6 +581,17 @@ impl ReadStore for SharedInMemoryStore {
             .pipe(Ok)
     }
 
+    fn get_full_checkpoint_contents_by_sequence_number(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> Result<Option<FullCheckpointContents>, Self::Error> {
+        Ok(self
+            .inner()
+            .full_checkpoint_contents
+            .get(&sequence_number)
+            .cloned())
+    }
+
     fn get_full_checkpoint_contents(
         &self,
         digest: &CheckpointContentsDigest,
@@ -628,9 +658,11 @@ impl WriteStore for SharedInMemoryStore {
 
     fn insert_checkpoint_contents(
         &self,
+        checkpoint: &VerifiedCheckpoint,
         contents: VerifiedCheckpointContents,
     ) -> Result<(), Self::Error> {
-        self.inner_mut().insert_checkpoint_contents(contents);
+        self.inner_mut()
+            .insert_checkpoint_contents(checkpoint, contents);
         Ok(())
     }
 

--- a/crates/sui-types/src/storage.rs
+++ b/crates/sui-types/src/storage.rs
@@ -432,7 +432,7 @@ impl InMemoryStore {
 
     pub fn insert_checkpoint_contents(
         &mut self,
-        _checkpoint: &VerifiedCheckpoint,
+        checkpoint: &VerifiedCheckpoint,
         contents: VerifiedCheckpointContents,
     ) {
         for tx in contents.iter() {
@@ -441,7 +441,10 @@ impl InMemoryStore {
             self.effects
                 .insert(tx.effects.digest(), tx.effects.to_owned());
         }
-        let contents = contents.into_inner().into_checkpoint_contents();
+        let contents = contents.into_inner();
+        self.full_checkpoint_contents
+            .insert(*checkpoint.sequence_number(), contents.clone());
+        let contents = contents.into_checkpoint_contents();
         self.checkpoint_contents
             .insert(*contents.digest(), contents);
     }


### PR DESCRIPTION
This attempts to lessen the fan-out/fan-in that presently happens on fullnodes, in which state sync writes checkpoint data to random keys (i.e. digests), and then checkpoint executor does uncached reads of those same random keys.