### PR TITLE
[transaction fuzzer] add generation of random transaction data

### DIFF
--- a/crates/transaction-fuzzer/src/account_universe/transfer_gen.rs
+++ b/crates/transaction-fuzzer/src/account_universe/transfer_gen.rs
@@ -76,7 +76,7 @@ fn p2p_failure_gas(gas_price: u64) -> u64 {
     gas_price * P2P_COMPUTE_GAS_USAGE + P2P_FAILURE_STORAGE_USAGE
 }
 
-fn gas_price_selection_strategy() -> impl Strategy<Value = u64> {
+pub fn gas_price_selection_strategy() -> impl Strategy<Value = u64> {
     prop_oneof![
         Just(0u64),
         1u64..10_000,
@@ -90,7 +90,7 @@ fn gas_price_selection_strategy() -> impl Strategy<Value = u64> {
     ]
 }
 
-fn gas_budget_selection_strategy() -> impl Strategy<Value = u64> {
+pub fn gas_budget_selection_strategy() -> impl Strategy<Value = u64> {
     prop_oneof![
         Just(0u64),
         Just(PROTOCOL_CONFIG.base_tx_cost_fixed() - 1),

--- a/crates/transaction-fuzzer/src/lib.rs
+++ b/crates/transaction-fuzzer/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod account_universe;
 pub mod executor;
+pub mod transaction_data_gen;
 pub mod type_arg_fuzzer;
 
 use proptest::collection::vec;

--- a/crates/transaction-fuzzer/src/transaction_data_gen.rs
+++ b/crates/transaction-fuzzer/src/transaction_data_gen.rs
@@ -1,0 +1,130 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use move_core_types::account_address::AccountAddress;
+use proptest::arbitrary::*;
+use proptest::prelude::*;
+
+use crate::type_arg_fuzzer::{gen_type_tag, pt_for_tags};
+use proptest::collection::vec;
+use sui_types::base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress};
+
+use sui_types::digests::ObjectDigest;
+use sui_types::messages::{
+    GasData, TransactionData, TransactionDataV1, TransactionExpiration, TransactionKind,
+};
+
+use crate::account_universe::{gas_budget_selection_strategy, gas_price_selection_strategy};
+
+const MAX_NUM_GAS_OBJS: usize = 1024_usize;
+
+pub fn gen_transaction_expiration_with_bound(
+    max_epoch: u64,
+) -> impl Strategy<Value = TransactionExpiration> {
+    prop_oneof![
+        Just(TransactionExpiration::None),
+        (0u64..=max_epoch).prop_map(TransactionExpiration::Epoch),
+    ]
+}
+
+pub fn gen_transaction_expiration() -> impl Strategy<Value = TransactionExpiration> {
+    prop_oneof![
+        Just(TransactionExpiration::None),
+        (0u64..=u64::MAX).prop_map(TransactionExpiration::Epoch),
+    ]
+}
+
+pub fn gen_object_ref() -> impl Strategy<Value = ObjectRef> {
+    (
+        any::<AccountAddress>(),
+        any::<SequenceNumber>(),
+        any::<[u8; 32]>(),
+    )
+        .prop_map(move |(addr, seq, seed)| {
+            (ObjectID::from_address(addr), seq, ObjectDigest::new(seed))
+        })
+}
+
+pub fn gen_gas_data(sender: SuiAddress) -> impl Strategy<Value = GasData> {
+    (
+        vec(gen_object_ref(), 0..MAX_NUM_GAS_OBJS),
+        gas_price_selection_strategy(),
+        gas_budget_selection_strategy(),
+    )
+        .prop_map(move |(obj_refs, price, budget)| GasData {
+            payment: obj_refs,
+            owner: sender,
+            price,
+            budget,
+        })
+}
+
+pub fn gen_transaction_kind() -> impl Strategy<Value = TransactionKind> {
+    (vec(gen_type_tag(), 0..10)).prop_map(pt_for_tags)
+}
+
+pub fn transaction_data_gen(sender: SuiAddress) -> impl Strategy<Value = TransactionData> {
+    TransactionDataGenBuilder::new(sender)
+        .kind(gen_transaction_kind())
+        .gas_data(gen_gas_data(sender))
+        .expiration(gen_transaction_expiration())
+        .finish()
+}
+
+pub struct TransactionDataGenBuilder<
+    K: Strategy<Value = TransactionKind>,
+    G: Strategy<Value = GasData>,
+    E: Strategy<Value = TransactionExpiration>,
+> {
+    pub kind: Option<K>,
+    pub sender: SuiAddress,
+    pub gas_data: Option<G>,
+    pub expiration: Option<E>,
+}
+
+impl<
+        K: Strategy<Value = TransactionKind>,
+        G: Strategy<Value = GasData>,
+        E: Strategy<Value = TransactionExpiration>,
+    > TransactionDataGenBuilder<K, G, E>
+{
+    pub fn new(sender: SuiAddress) -> Self {
+        Self {
+            kind: None,
+            sender,
+            gas_data: None,
+            expiration: None,
+        }
+    }
+
+    pub fn kind(mut self, kind: K) -> Self {
+        self.kind = Some(kind);
+        self
+    }
+
+    pub fn gas_data(mut self, gas_data: G) -> Self {
+        self.gas_data = Some(gas_data);
+        self
+    }
+
+    pub fn expiration(mut self, expiration: E) -> Self {
+        self.expiration = Some(expiration);
+        self
+    }
+
+    pub fn finish(self) -> impl Strategy<Value = TransactionData> {
+        (
+            self.kind.expect("kind must be set"),
+            Just(self.sender),
+            self.gas_data.expect("gas_data must be set"),
+            self.expiration.expect("expiration must be set"),
+        )
+            .prop_map(|(kind, sender, gas_data, expiration)| TransactionDataV1 {
+                kind,
+                sender,
+                gas_data,
+                expiration,
+            })
+            .prop_map(TransactionData::V1)
+    }
+}

--- a/crates/transaction-fuzzer/src/type_arg_fuzzer.rs
+++ b/crates/transaction-fuzzer/src/type_arg_fuzzer.rs
@@ -60,26 +60,27 @@ pub fn gen_struct_tag() -> impl Strategy<Value = StructTag> {
         })
 }
 
+pub fn pt_for_tags(type_tags: Vec<TypeTag>) -> TransactionKind {
+    let mut builder = ProgrammableTransactionBuilder::new();
+    builder
+        .move_call(
+            SUI_FRAMEWORK_OBJECT_ID,
+            Identifier::new("random_type_tag_fuzzing").unwrap(),
+            Identifier::new("random_type_tag_fuzzing_fn").unwrap(),
+            type_tags,
+            vec![],
+        )
+        .unwrap();
+    TransactionKind::ProgrammableTransaction(builder.finish())
+}
+
 pub fn run_type_tags(account: &AccountCurrent, exec: &mut Executor, type_tags: Vec<TypeTag>) {
     let gas_object = account
         .current_coins
         .get(0)
         .unwrap()
         .compute_object_reference();
-    let txn = {
-        let mut builder = ProgrammableTransactionBuilder::new();
-        builder
-            .move_call(
-                SUI_FRAMEWORK_OBJECT_ID,
-                Identifier::new("random_type_tag_fuzzing").unwrap(),
-                Identifier::new("random_type_tag_fuzzing_fn").unwrap(),
-                type_tags,
-                vec![],
-            )
-            .unwrap();
-        builder.finish()
-    };
-    let kind = TransactionKind::ProgrammableTransaction(txn);
+    let kind = pt_for_tags(type_tags);
     let tx_data = TransactionData::new(
         kind,
         account.initial_data.account.address,

--- a/crates/transaction-fuzzer/tests/transaction_data_fuzz.rs
+++ b/crates/transaction-fuzzer/tests/transaction_data_fuzz.rs
@@ -1,0 +1,29 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use proptest::prelude::*;
+use sui_types::utils::to_sender_signed_transaction;
+
+use proptest::strategy::ValueTree;
+use transaction_fuzzer::account_universe::AccountCurrent;
+use transaction_fuzzer::account_universe::AccountData;
+
+use transaction_fuzzer::{
+    executor::{assert_is_acceptable_result, Executor},
+    transaction_data_gen::transaction_data_gen,
+};
+
+#[test]
+#[cfg_attr(msim, ignore)]
+fn all_random_transaction_data() {
+    let mut exec = Executor::new();
+    let account = AccountCurrent::new(AccountData::new_random());
+    let strategy = transaction_data_gen(account.initial_data.account.address);
+    let mut runner = proptest::test_runner::TestRunner::deterministic();
+    for _ in 0..1000 {
+        let tx_data = strategy.new_tree(&mut runner).unwrap().current();
+        let signed_txn = to_sender_signed_transaction(tx_data, &account.initial_data.account.key);
+        let result = exec.execute_transaction(signed_txn);
+        assert_is_acceptable_result(&result);
+    }
+}


### PR DESCRIPTION
This adds a builder so we can more easily generate transaction data that we can fuzz with. It also adds a very basic transaction data fuzzing test that generates structurally correct, but random data, and then feeds that into the executor. 