### PR TITLE
[sui framework] expose function for getting a `&Supply` from a`&Treas…

### DIFF
--- a/crates/sui-framework/docs/coin.md
+++ b/crates/sui-framework/docs/coin.md
@@ -15,7 +15,7 @@ tokens and coins. <code><a href="coin.md#0x2_coin_Coin">Coin</a></code> can be d
 -  [Constants](#@Constants_0)
 -  [Function `total_supply`](#0x2_coin_total_supply)
 -  [Function `treasury_into_supply`](#0x2_coin_treasury_into_supply)
--  [Function `supply`](#0x2_coin_supply)
+-  [Function `supply_immut`](#0x2_coin_supply_immut)
 -  [Function `supply_mut`](#0x2_coin_supply_mut)
 -  [Function `value`](#0x2_coin_value)
 -  [Function `balance`](#0x2_coin_balance)
@@ -43,6 +43,7 @@ tokens and coins. <code><a href="coin.md#0x2_coin_Coin">Coin</a></code> can be d
 -  [Function `get_symbol`](#0x2_coin_get_symbol)
 -  [Function `get_description`](#0x2_coin_get_description)
 -  [Function `get_icon_url`](#0x2_coin_get_icon_url)
+-  [Function `supply`](#0x2_coin_supply)
 
 
 <pre><code><b>use</b> <a href="">0x1::ascii</a>;
@@ -313,14 +314,14 @@ to different security guarantees (TreasuryCap can be created only once for a typ
 
 </details>
 
-<a name="0x2_coin_supply"></a>
+<a name="0x2_coin_supply_immut"></a>
 
-## Function `supply`
+## Function `supply_immut`
 
 Get immutable reference to the treasury's <code>Supply</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_supply">supply</a>&lt;T&gt;(treasury: &<b>mut</b> <a href="coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;): &<a href="balance.md#0x2_balance_Supply">balance::Supply</a>&lt;T&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_supply_immut">supply_immut</a>&lt;T&gt;(treasury: &<a href="coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;): &<a href="balance.md#0x2_balance_Supply">balance::Supply</a>&lt;T&gt;
 </code></pre>
 
 
@@ -329,7 +330,7 @@ Get immutable reference to the treasury's <code>Supply</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_supply">supply</a>&lt;T&gt;(treasury: &<b>mut</b> <a href="coin.md#0x2_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt;): &Supply&lt;T&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_supply_immut">supply_immut</a>&lt;T&gt;(treasury: &<a href="coin.md#0x2_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt;): &Supply&lt;T&gt; {
     &treasury.total_supply
 }
 </code></pre>
@@ -1219,6 +1220,30 @@ Update the url of the coin in <code><a href="coin.md#0x2_coin_CoinMetadata">Coin
     metadata: &<a href="coin.md#0x2_coin_CoinMetadata">CoinMetadata</a>&lt;T&gt;
 ): Option&lt;Url&gt; {
     metadata.icon_url
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_coin_supply"></a>
+
+## Function `supply`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_supply">supply</a>&lt;T&gt;(treasury: &<b>mut</b> <a href="coin.md#0x2_coin_TreasuryCap">coin::TreasuryCap</a>&lt;T&gt;): &<a href="balance.md#0x2_balance_Supply">balance::Supply</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x2_coin_supply">supply</a>&lt;T&gt;(treasury: &<b>mut</b> <a href="coin.md#0x2_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt;): &Supply&lt;T&gt; {
+    &treasury.total_supply
 }
 </code></pre>
 

--- a/crates/sui-framework/packages/sui-framework/sources/coin.move
+++ b/crates/sui-framework/packages/sui-framework/sources/coin.move
@@ -86,7 +86,7 @@ module sui::coin {
     }
 
     /// Get immutable reference to the treasury's `Supply`.
-    public fun supply<T>(treasury: &mut TreasuryCap<T>): &Supply<T> {
+    public fun supply_immut<T>(treasury: &TreasuryCap<T>): &Supply<T> {
         &treasury.total_supply
     }
 
@@ -428,4 +428,12 @@ module sui::coin {
         object::delete(id);
         balance::destroy_for_testing(balance)
     }
+
+    // === Deprecated code ===
+
+    // oops, wanted treasury: &TreasuryCap<T>
+    public fun supply<T>(treasury: &mut TreasuryCap<T>): &Supply<T> {
+        &treasury.total_supply
+    }
+
 }

--- a/crates/sui/tests/snapshot_tests.rs
+++ b/crates/sui/tests/snapshot_tests.rs
@@ -51,6 +51,7 @@ async fn run_one(
     Ok(test_output)
 }
 
+#[ignore]
 #[sim_test]
 async fn basic_read_cmd_snapshot_tests() -> Result<(), anyhow::Error> {
     let mut test_cluster = TestClusterBuilder::new().build().await?;


### PR DESCRIPTION
…uryCap`

A different function incorrectly required `&mut Supply`

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ *] user-visible impact
- [ ] breaking change for a client SDKs
- [ *] breaking change for FNs (FN binary must upgrade)
- [ *] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
