### PR TITLE
[refactor] further tune randomized test iterations

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -18,10 +18,10 @@ failure-output = "immediate-final"
 status-level = "skip"
 # Do not cancel the test run on the first failure.
 fail-fast = false
-# Retry failing tests in order to not block builds on flaky tests
-retries = 2
-# Mark tests as slow after 3 hours, kill them right after
-slow-timeout = { period = "3h", terminate-after = 1 }
+# Do not retry failing tests
+retries = 0
+# Mark tests as slow after 4 hours, kill them right after
+slow-timeout = { period = "4h", terminate-after = 1 }
 
 [profile.simtestnightly]
 # Print out output for failing tests as soon as they fail, and also at the end

--- a/narwhal/consensus/src/tests/randomized_tests.rs
+++ b/narwhal/consensus/src/tests/randomized_tests.rs
@@ -78,16 +78,16 @@ async fn bullshark_randomised_tests() {
     // Configuration regarding the randomized tests. The tests will run for different values
     // on the below parameters to increase the different cases we can generate.
 
-    // A range of gc_depth to be used
-    const GC_DEPTH: RangeInclusive<Round> = 7..=10;
+    // gc_depth to be used
+    const GC_DEPTH: [Round; 3] = [6, 7, 10];
     // A the committee size values to be used
     const COMMITTEE_SIZE: [usize; 3] = [4, 7, 10];
-    // A range of rounds for which we will create DAGs
-    const DAG_ROUNDS: RangeInclusive<Round> = 7..=15;
+    // Rounds for which we will create DAGs
+    const DAG_ROUNDS: [Round; 6] = [6, 7, 8, 10, 12, 15];
     // The number of different execution plans to be created and tested against for every generated DAG
     const EXECUTION_PLANS: u64 = 500;
     // The number of DAGs that should be generated and tested against for every set of properties.
-    const DAGS_PER_SETUP: u64 = 500;
+    const DAGS_PER_SETUP: u64 = 400;
     // DAGs will be created for these failure modes
     let failure_modes: Vec<FailureModes> = vec![
         // Some failures


### PR DESCRIPTION
## Description 

Latest run timed out as iterations were too many. This PR is reducing the number of iterations + configuring the nextest run profile so we increase the timeout time and remove entirely the retries.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
