### PR TITLE
[framework] Kiosk, TransferPolicy: post-audit fixes

### DIFF
--- a/crates/sui-framework/docs/kiosk.md
+++ b/crates/sui-framework/docs/kiosk.md
@@ -1177,7 +1177,7 @@ Access the <code>UID</code> using the <code><a href="kiosk.md#0x2_kiosk_KioskOwn
 
 ## Function `set_allow_extensions`
 
-Allow or disallow <code>uid_mut</code> access via the <code>allow_extensions</code> setting.
+Allow or disallow <code>uid</code> and <code>uid_mut</code> access via the <code>allow_extensions</code> setting.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="kiosk.md#0x2_kiosk_set_allow_extensions">set_allow_extensions</a>(self: &<b>mut</b> <a href="kiosk.md#0x2_kiosk_Kiosk">kiosk::Kiosk</a>, cap: &<a href="kiosk.md#0x2_kiosk_KioskOwnerCap">kiosk::KioskOwnerCap</a>, allow_extensions: bool)
@@ -1206,7 +1206,8 @@ Allow or disallow <code>uid_mut</code> access via the <code>allow_extensions</co
 Get the immutable <code>UID</code> for dynamic field access.
 Aborts if <code>allow_extensions</code> set to <code><b>false</b></code>.
 
-Given the &UID can be powerful for
+Given the &UID can be used for reading keys and authorization,
+its access
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="kiosk.md#0x2_kiosk_uid">uid</a>(self: &<a href="kiosk.md#0x2_kiosk_Kiosk">kiosk::Kiosk</a>): &<a href="object.md#0x2_object_UID">object::UID</a>

--- a/crates/sui-framework/docs/kiosk.md
+++ b/crates/sui-framework/docs/kiosk.md
@@ -62,6 +62,7 @@ be used to implement application-specific transfer rules.
 -  [Function `has_access`](#0x2_kiosk_has_access)
 -  [Function `uid_mut_as_owner`](#0x2_kiosk_uid_mut_as_owner)
 -  [Function `set_allow_extensions`](#0x2_kiosk_set_allow_extensions)
+-  [Function `uid`](#0x2_kiosk_uid)
 -  [Function `uid_mut`](#0x2_kiosk_uid_mut)
 -  [Function `owner`](#0x2_kiosk_owner)
 -  [Function `item_count`](#0x2_kiosk_item_count)
@@ -789,6 +790,7 @@ Performs an authorization check to make sure only owner can sell.
     self: &<b>mut</b> <a href="kiosk.md#0x2_kiosk_Kiosk">Kiosk</a>, cap: &<a href="kiosk.md#0x2_kiosk_KioskOwnerCap">KioskOwnerCap</a>, id: ID, price: u64
 ) {
     <b>assert</b>!(<a href="object.md#0x2_object_id">object::id</a>(self) == cap.for, <a href="kiosk.md#0x2_kiosk_ENotOwner">ENotOwner</a>);
+    <b>assert</b>!(<a href="kiosk.md#0x2_kiosk_has_item">has_item</a>(self, id), <a href="kiosk.md#0x2_kiosk_EItemNotFound">EItemNotFound</a>);
     <b>assert</b>!(!<a href="kiosk.md#0x2_kiosk_is_listed_exclusively">is_listed_exclusively</a>(self, id), <a href="kiosk.md#0x2_kiosk_EListedExclusively">EListedExclusively</a>);
 
     df::add(&<b>mut</b> self.id, <a href="kiosk.md#0x2_kiosk_Listing">Listing</a> { id, is_exclusive: <b>false</b> }, price);
@@ -891,6 +893,7 @@ for any price equal or higher than the <code>min_price</code>.
     self: &<b>mut</b> <a href="kiosk.md#0x2_kiosk_Kiosk">Kiosk</a>, cap: &<a href="kiosk.md#0x2_kiosk_KioskOwnerCap">KioskOwnerCap</a>, id: ID, min_price: u64, ctx: &<b>mut</b> TxContext
 ): <a href="kiosk.md#0x2_kiosk_PurchaseCap">PurchaseCap</a>&lt;T&gt; {
     <b>assert</b>!(<a href="object.md#0x2_object_id">object::id</a>(self) == cap.for, <a href="kiosk.md#0x2_kiosk_ENotOwner">ENotOwner</a>);
+    <b>assert</b>!(<a href="kiosk.md#0x2_kiosk_has_item">has_item</a>(self, id), <a href="kiosk.md#0x2_kiosk_EItemNotFound">EItemNotFound</a>);
     <b>assert</b>!(!<a href="kiosk.md#0x2_kiosk_is_listed">is_listed</a>(self, id), <a href="kiosk.md#0x2_kiosk_EAlreadyListed">EAlreadyListed</a>);
 
     <b>let</b> uid = <a href="object.md#0x2_object_new">object::new</a>(ctx);
@@ -1189,6 +1192,35 @@ Allow or disallow <code>uid_mut</code> access via the <code>allow_extensions</co
 <pre><code><b>public</b> <b>fun</b> <a href="kiosk.md#0x2_kiosk_set_allow_extensions">set_allow_extensions</a>(self: &<b>mut</b> <a href="kiosk.md#0x2_kiosk_Kiosk">Kiosk</a>, cap: &<a href="kiosk.md#0x2_kiosk_KioskOwnerCap">KioskOwnerCap</a>, allow_extensions: bool) {
     <b>assert</b>!(<a href="object.md#0x2_object_id">object::id</a>(self) == cap.for, <a href="kiosk.md#0x2_kiosk_ENotOwner">ENotOwner</a>);
     self.allow_extensions = allow_extensions;
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_kiosk_uid"></a>
+
+## Function `uid`
+
+Get the immutable <code>UID</code> for dynamic field access.
+Aborts if <code>allow_extensions</code> set to <code><b>false</b></code>.
+
+Given the &UID can be powerful for
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="kiosk.md#0x2_kiosk_uid">uid</a>(self: &<a href="kiosk.md#0x2_kiosk_Kiosk">kiosk::Kiosk</a>): &<a href="object.md#0x2_object_UID">object::UID</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="kiosk.md#0x2_kiosk_uid">uid</a>(self: &<a href="kiosk.md#0x2_kiosk_Kiosk">Kiosk</a>): &UID {
+    <b>assert</b>!(self.allow_extensions, <a href="kiosk.md#0x2_kiosk_EExtensionsDisabled">EExtensionsDisabled</a>);
+    &self.id
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/kiosk.md
+++ b/crates/sui-framework/docs/kiosk.md
@@ -40,6 +40,7 @@ be used to implement application-specific transfer rules.
 -  [Struct `Listing`](#0x2_kiosk_Listing)
 -  [Struct `Lock`](#0x2_kiosk_Lock)
 -  [Struct `ItemListed`](#0x2_kiosk_ItemListed)
+-  [Struct `ItemPurchased`](#0x2_kiosk_ItemPurchased)
 -  [Constants](#@Constants_0)
 -  [Function `new`](#0x2_kiosk_new)
 -  [Function `close_and_withdraw`](#0x2_kiosk_close_and_withdraw)
@@ -376,6 +377,54 @@ type-indexed which allows for searching for offers of a specific <code>T</code>
 
 
 <pre><code><b>struct</b> <a href="kiosk.md#0x2_kiosk_ItemListed">ItemListed</a>&lt;T: store, key&gt; <b>has</b> <b>copy</b>, drop
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code><a href="kiosk.md#0x2_kiosk">kiosk</a>: <a href="object.md#0x2_object_ID">object::ID</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>id: <a href="object.md#0x2_object_ID">object::ID</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>price: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x2_kiosk_ItemPurchased"></a>
+
+## Struct `ItemPurchased`
+
+Emitted when an item was purchased from the <code><a href="kiosk.md#0x2_kiosk_Kiosk">Kiosk</a></code>. Can be used
+to track finalized sales across the network. The event is emitted
+in both cases: when an item is purchased via the <code><a href="kiosk.md#0x2_kiosk_PurchaseCap">PurchaseCap</a></code> or
+when it's purchased directly (via <code>list</code> + <code>purchase</code>).
+
+The <code>price</code> is also emitted and might differ from the <code>price</code> set
+in the <code><a href="kiosk.md#0x2_kiosk_ItemListed">ItemListed</a></code> event. This is because the <code><a href="kiosk.md#0x2_kiosk_PurchaseCap">PurchaseCap</a></code> only
+sets a minimum price for the item, and the actual price is defined
+by the trading module / extension.
+
+
+<pre><code><b>struct</b> <a href="kiosk.md#0x2_kiosk_ItemPurchased">ItemPurchased</a>&lt;T: store, key&gt; <b>has</b> <b>copy</b>, drop
 </code></pre>
 
 
@@ -863,6 +912,8 @@ finalized.
     <b>assert</b>!(price == <a href="coin.md#0x2_coin_value">coin::value</a>(&payment), <a href="kiosk.md#0x2_kiosk_EIncorrectAmount">EIncorrectAmount</a>);
     <a href="balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> self.profits, <a href="coin.md#0x2_coin_into_balance">coin::into_balance</a>(payment));
     df::remove_if_exists&lt;<a href="kiosk.md#0x2_kiosk_Lock">Lock</a>, bool&gt;(&<b>mut</b> self.id, <a href="kiosk.md#0x2_kiosk_Lock">Lock</a> { id });
+
+    <a href="event.md#0x2_event_emit">event::emit</a>(<a href="kiosk.md#0x2_kiosk_ItemPurchased">ItemPurchased</a>&lt;T&gt; { <a href="kiosk.md#0x2_kiosk">kiosk</a>: <a href="object.md#0x2_object_id">object::id</a>(self), id, price });
 
     (inner, <a href="transfer_policy.md#0x2_transfer_policy_new_request">transfer_policy::new_request</a>(id, price, <a href="object.md#0x2_object_id">object::id</a>(self)))
 }

--- a/crates/sui-framework/docs/transfer_policy.md
+++ b/crates/sui-framework/docs/transfer_policy.md
@@ -679,6 +679,7 @@ Remove the Rule from the <code><a href="transfer_policy.md#0x2_transfer_policy_T
 ) {
     <b>assert</b>!(<a href="object.md#0x2_object_id">object::id</a>(policy) == cap.policy_id, <a href="transfer_policy.md#0x2_transfer_policy_ENotOwner">ENotOwner</a>);
     <b>let</b> _: Config = df::remove(&<b>mut</b> policy.id, <a href="transfer_policy.md#0x2_transfer_policy_RuleKey">RuleKey</a>&lt;Rule&gt; {});
+    <a href="vec_set.md#0x2_vec_set_remove">vec_set::remove</a>(&<b>mut</b> policy.rules, &<a href="_get">type_name::get</a>&lt;Rule&gt;());
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/transfer_policy.md
+++ b/crates/sui-framework/docs/transfer_policy.md
@@ -44,6 +44,7 @@ of the type at once.
 -  [Function `remove_rule`](#0x2_transfer_policy_remove_rule)
 -  [Function `uid`](#0x2_transfer_policy_uid)
 -  [Function `uid_mut_as_owner`](#0x2_transfer_policy_uid_mut_as_owner)
+-  [Function `rules`](#0x2_transfer_policy_rules)
 -  [Function `item`](#0x2_transfer_policy_item)
 -  [Function `paid`](#0x2_transfer_policy_paid)
 -  [Function `from`](#0x2_transfer_policy_from)
@@ -732,6 +733,31 @@ to the <code><a href="transfer_policy.md#0x2_transfer_policy_TransferPolicy">Tra
 ): &<b>mut</b> UID {
     <b>assert</b>!(<a href="object.md#0x2_object_id">object::id</a>(self) == cap.policy_id, <a href="transfer_policy.md#0x2_transfer_policy_ENotOwner">ENotOwner</a>);
     &<b>mut</b> self.id
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_transfer_policy_rules"></a>
+
+## Function `rules`
+
+Read the <code>rules</code> field from the <code><a href="transfer_policy.md#0x2_transfer_policy_TransferPolicy">TransferPolicy</a></code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="transfer_policy.md#0x2_transfer_policy_rules">rules</a>&lt;T&gt;(self: &<a href="transfer_policy.md#0x2_transfer_policy_TransferPolicy">transfer_policy::TransferPolicy</a>&lt;T&gt;): &<a href="vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;<a href="_TypeName">type_name::TypeName</a>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="transfer_policy.md#0x2_transfer_policy_rules">rules</a>&lt;T&gt;(self: &<a href="transfer_policy.md#0x2_transfer_policy_TransferPolicy">TransferPolicy</a>&lt;T&gt;): &VecSet&lt;TypeName&gt; {
+    &self.rules
 }
 </code></pre>
 

--- a/crates/sui-framework/packages/sui-framework/sources/kiosk/transfer_policy.move
+++ b/crates/sui-framework/packages/sui-framework/sources/kiosk/transfer_policy.move
@@ -242,6 +242,7 @@ module sui::transfer_policy {
     ) {
         assert!(object::id(policy) == cap.policy_id, ENotOwner);
         let _: Config = df::remove(&mut policy.id, RuleKey<Rule> {});
+        vec_set::remove(&mut policy.rules, &type_name::get<Rule>());
     }
 
     // === Fields access ===

--- a/crates/sui-framework/packages/sui-framework/sources/kiosk/transfer_policy.move
+++ b/crates/sui-framework/packages/sui-framework/sources/kiosk/transfer_policy.move
@@ -245,7 +245,7 @@ module sui::transfer_policy {
         vec_set::remove(&mut policy.rules, &type_name::get<Rule>());
     }
 
-    // === Fields access ===
+    // === Fields access: TransferPolicy ===
 
     /// Allows reading custom attachments to the `TransferPolicy` if there are any.
     public fun uid<T>(self: &TransferPolicy<T>): &UID { &self.id }
@@ -258,6 +258,13 @@ module sui::transfer_policy {
         assert!(object::id(self) == cap.policy_id, ENotOwner);
         &mut self.id
     }
+
+    /// Read the `rules` field from the `TransferPolicy`.
+    public fun rules<T>(self: &TransferPolicy<T>): &VecSet<TypeName> {
+        &self.rules
+    }
+
+    // === Fields access: TransferRequest ===
 
     /// Get the `item` field of the `TransferRequest`.
     public fun item<T>(self: &TransferRequest<T>): ID { self.item }

--- a/crates/sui-framework/packages/sui-framework/tests/kiosk/kiosk_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/kiosk/kiosk_tests.move
@@ -135,6 +135,30 @@ module sui::kiosk_tests {
     }
 
     #[test]
+    #[expected_failure(abort_code = sui::kiosk::EItemNotFound)]
+    fun test_list_no_item_fail() {
+        let ctx = &mut test::ctx();
+        let (_asset, item_id) = test::get_asset(ctx);
+        let (kiosk, owner_cap) = test::get_kiosk(ctx);
+
+        kiosk::list<Asset>(&mut kiosk, &owner_cap, item_id, AMT);
+
+        abort 1337
+    }
+
+    #[test]
+    #[expected_failure(abort_code = sui::kiosk::EItemNotFound)]
+    fun test_list_with_purchase_cap_no_item_fail() {
+        let ctx = &mut test::ctx();
+        let (_asset, item_id) = test::get_asset(ctx);
+        let (kiosk, owner_cap) = test::get_kiosk(ctx);
+
+        let _purchase_cap = kiosk::list_with_purchase_cap<Asset>(&mut kiosk, &owner_cap, item_id, AMT, ctx);
+
+        abort 1337
+    }
+
+    #[test]
     #[expected_failure(abort_code = sui::kiosk::EAlreadyListed)]
     fun test_purchase_cap_already_listed_fail() {
         let ctx = &mut test::ctx();
@@ -207,13 +231,36 @@ module sui::kiosk_tests {
     }
 
     #[test]
+    fun test_uid_access() {
+        let ctx = &mut test::ctx();
+        let (kiosk, owner_cap) = test::get_kiosk(ctx);
+
+        let uid = kiosk::uid(&kiosk);
+        assert!(sui::object::uid_to_inner(uid) == sui::object::id(&kiosk), 0);
+
+        test::return_kiosk(kiosk, owner_cap, ctx);
+    }
+
+    #[test]
     #[expected_failure(abort_code = sui::kiosk::EExtensionsDisabled)]
-    fun test_disallow_extensions() {
+    fun test_disallow_extensions_uid_mut() {
         let ctx = &mut test::ctx();
         let (kiosk, owner_cap) = test::get_kiosk(ctx);
 
         kiosk::set_allow_extensions(&mut kiosk, &owner_cap, false);
         let _ = kiosk::uid_mut(&mut kiosk);
+
+        abort 1337
+    }
+
+    #[test]
+    #[expected_failure(abort_code = sui::kiosk::EExtensionsDisabled)]
+    fun test_disallow_extensions_uid() {
+        let ctx = &mut test::ctx();
+        let (kiosk, owner_cap) = test::get_kiosk(ctx);
+
+        kiosk::set_allow_extensions(&mut kiosk, &owner_cap, false);
+        let _ = kiosk::uid(&kiosk);
 
         abort 1337
     }

--- a/crates/sui-framework/packages/sui-framework/tests/kiosk/transfer_policy_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/kiosk/transfer_policy_tests.move
@@ -19,6 +19,7 @@ module sui::transfer_policy_tests {
     use sui::object::{Self, ID, UID};
     use sui::dummy_policy;
     use sui::malicious_policy;
+    use sui::vec_set;
     use sui::package;
     use sui::coin;
 
@@ -44,8 +45,11 @@ module sui::transfer_policy_tests {
         let ctx = &mut ctx();
         let (policy, cap) = prepare(ctx);
 
+        assert!(vec_set::size(policy::rules(&policy)) == 0, 0);
         // now require everyone to pay any amount
         dummy_policy::set(&mut policy, &cap);
+
+        assert!(vec_set::size(policy::rules(&policy)) == 1, 1);
 
         let request = policy::new_request(fresh_id(ctx), 10_000, fresh_id(ctx));
 
@@ -63,8 +67,12 @@ module sui::transfer_policy_tests {
         let ctx = &mut ctx();
         let (policy, cap) = prepare(ctx);
 
+        assert!(vec_set::size(policy::rules(&policy)) == 0, 0);
+
         // now require everyone to pay any amount
         dummy_policy::set(&mut policy, &cap);
+
+        assert!(vec_set::size(policy::rules(&policy)) == 1, 0);
 
         let request = policy::new_request(fresh_id(ctx), 10_000, fresh_id(ctx));
         dummy_policy::pay(&mut policy, &mut request, coin::mint_for_testing(10_000, ctx));
@@ -75,6 +83,7 @@ module sui::transfer_policy_tests {
         let request = policy::new_request(fresh_id(ctx), 10_000, fresh_id(ctx));
         policy::confirm_request(&policy, request);
 
+        assert!(vec_set::size(policy::rules(&policy)) == 0, 0);
         assert!(wrapup(policy, cap, ctx) == 10_000, 0);
     }
 


### PR DESCRIPTION
## Description 

- adds check that item exists on `list` and `list_with_purchase_cap`
- fixes broken behavior for `policy::remove_rule`
- adds `kiosk::uid` function to read UID if `allow_extensions` set to true
- adds `transfer_policy::rules` function to read assigned "Rules" 
- adds `kiosk::ItemPurchased` event

## Test Plan 

Includes tests for new behaviors, makes sure that the fixes work.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

- adds check that item exists on `list` and `list_with_purchase_cap`
- fixes broken behavior for `policy::remove_rule`
- adds `kiosk::uid` function to read UID if `allow_extensions` set to true
- adds `transfer_policy::rules` function to read assigned "Rules" 
- adds `kiosk::ItemPurchased` event
