### PR TITLE
Fix formatAmount prefix bug, not correctly formatting native values

### DIFF
--- a/apps/core/src/utils/formatAmount.ts
+++ b/apps/core/src/utils/formatAmount.ts
@@ -12,20 +12,21 @@ export function formatAmountParts(
 
     let postfix = '';
     let bn = new BigNumber(amount.toString());
+    const bnAbs = bn.abs();
 
     // use absolute value to determine the postfix
-    if (bn.abs().gte(1_000_000_000)) {
+    if (bnAbs.gte(1_000_000_000)) {
         bn = bn.shiftedBy(-9);
         postfix = 'B';
-    } else if (bn.abs().gte(1_000_000)) {
+    } else if (bnAbs.gte(1_000_000)) {
         bn = bn.shiftedBy(-6);
         postfix = 'M';
-    } else if (bn.abs().gte(10_000)) {
+    } else if (bnAbs.gte(10_000)) {
         bn = bn.shiftedBy(-3);
         postfix = 'K';
     }
 
-    if (bn.abs().gte(1)) {
+    if (bnAbs.gte(1)) {
         bn = bn.decimalPlaces(2, BigNumber.ROUND_DOWN);
     }
 

--- a/apps/core/src/utils/formatAmount.ts
+++ b/apps/core/src/utils/formatAmount.ts
@@ -13,18 +13,18 @@ export function formatAmountParts(
     let postfix = '';
     let bn = new BigNumber(amount.toString());
 
-    if (bn.gte(1_000_000_000)) {
+    if (bn.abs().gte(1_000_000_000)) {
         bn = bn.shiftedBy(-9);
         postfix = 'B';
-    } else if (bn.gte(1_000_000)) {
+    } else if (bn.abs().gte(1_000_000)) {
         bn = bn.shiftedBy(-6);
         postfix = 'M';
-    } else if (bn.gte(10_000)) {
+    } else if (bn.abs().gte(10_000)) {
         bn = bn.shiftedBy(-3);
         postfix = 'K';
     }
 
-    if (bn.gte(1)) {
+    if (bn.abs().gte(1)) {
         bn = bn.decimalPlaces(2, BigNumber.ROUND_DOWN);
     }
 

--- a/apps/core/src/utils/formatAmount.ts
+++ b/apps/core/src/utils/formatAmount.ts
@@ -13,6 +13,7 @@ export function formatAmountParts(
     let postfix = '';
     let bn = new BigNumber(amount.toString());
 
+    // use absolute value to determine the postfix
     if (bn.abs().gte(1_000_000_000)) {
         bn = bn.shiftedBy(-9);
         postfix = 'B';


### PR DESCRIPTION
## Description 

Describe the changes or additions included in this PR.
This PR fixes the formatAmount bug by checking against the absolute value 

Before
<img width="686" alt="Screenshot 2023-04-21 at 9 58 00 AM" src="https://user-images.githubusercontent.com/126525197/233655456-c5a88d15-5eee-46dc-9ae1-9a904a878f70.png">

After 
<img width="348" alt="Screenshot 2023-04-21 at 10 02 26 AM" src="https://user-images.githubusercontent.com/126525197/233656042-704c9b7d-adda-4110-911f-6ddbf031ca36.png">
