### PR TITLE
Remove unsupported EventFilters for now

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2613,7 +2613,15 @@ impl AuthorityState {
 
         let limit = limit + 1;
         let mut event_keys = match query {
-            EventFilter::All(..) => index_store.all_events(tx_num, event_num, limit, descending)?,
+            EventFilter::All(filters) => {
+                if filters.is_empty() {
+                    index_store.all_events(tx_num, event_num, limit, descending)?
+                } else {
+                    return Err(anyhow!(
+                        "This query type does not currently support filter combinations."
+                    ));
+                }
+            }
             EventFilter::Transaction(digest) => {
                 index_store.events_by_transaction(&digest, tx_num, event_num, limit, descending)?
             }


### PR DESCRIPTION
## Description 

Return error when unimplemented filters are matched
```
curl -X POST -H 'Content-Type: application/json' -d '{
    "jsonrpc":"2.0",
    "method":"suix_queryEvents",
    "params": [
        {
            "All":[
                {"Package":"0x3dcfc5338d8358450b145629c985a9d6cb20f9c0ab6667e328e152cdfd8022cd"}
            ]
        },
        null,
        10,
        false
    ],
    "id":1
}' 127.0.0.1:9000 ; echo
{"jsonrpc":"2.0","error":{"code":-32000,"message":"This query type does not currently support filter combinations."},"id":1}
```

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
