### PR TITLE
[wallet-ext] fix tooltips being hidden behind overlay screens

### DIFF
--- a/apps/wallet/src/ui/app/shared/tooltip/index.tsx
+++ b/apps/wallet/src/ui/app/shared/tooltip/index.tsx
@@ -106,7 +106,7 @@ export function Tooltip({ tip, children, placement = 'top' }: TooltipProps) {
                 <AnimatePresence>
                     {open ? (
                         <motion.div
-                            className="pointer-events-none left-0 top-0 z-50 text-subtitleSmall font-semibold text-white leading-130"
+                            className="pointer-events-none left-0 top-0 z-[99999] text-subtitleSmall font-semibold text-white leading-130"
                             initial={{
                                 opacity: 0,
                                 scale: 0,
@@ -135,7 +135,7 @@ export function Tooltip({ tip, children, placement = 'top' }: TooltipProps) {
                             }}
                             {...getFloatingProps({ ref: floating })}
                         >
-                            <div className="flex flex-col flex-nowrap gap-px rounded-md bg-gray-100 p-2 z-50">
+                            <div className="flex flex-col flex-nowrap gap-px rounded-md bg-gray-100 p-2">
                                 {tip}
                             </div>
                             <div


### PR DESCRIPTION
## Description 
Tooltips in the wallet are portaled to the body, and the tooltips started getting hidden after the recent changes to the layout of the Overlay component. This PR just increments the z-index to `99999` to match that of the `Toaster` (the Overlay uses `9999`). We probably need to do some better z-index management in the future to prevent issues like this one from happening, but that will be for another day :)

<img width="362" alt="image" src="https://user-images.githubusercontent.com/7453188/233657695-d03a26b0-dfd2-4fcc-9ca3-51566d10cc18.png">


## Test Plan 
- Manual testing

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
N/A
