### PR TITLE
[move-stdlib] Avoid dependency on move-compiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5308,7 +5308,6 @@ dependencies = [
  "log",
  "move-binary-format",
  "move-command-line-common",
- "move-compiler",
  "move-core-types",
  "move-docgen",
  "move-errmapgen",

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -3425,7 +3425,6 @@ dependencies = [
  "move-binary-format",
  "move-cli",
  "move-command-line-common",
- "move-compiler",
  "move-core-types",
  "move-docgen",
  "move-errmapgen",

--- a/external-crates/move/move-stdlib/Cargo.toml
+++ b/external-crates/move/move-stdlib/Cargo.toml
@@ -19,7 +19,6 @@ move-vm-types = { path = "../move-vm/types" }
 move-binary-format = { path = "../move-binary-format" }
 move-core-types = { path = "../move-core/types" }
 move-vm-runtime = { path = "../move-vm/runtime" }
-move-compiler = { path = "../move-compiler" }
 log = "0.4.14"
 walkdir = "2.3.1"
 smallvec = "1.6.1"

--- a/external-crates/move/move-stdlib/src/lib.rs
+++ b/external-crates/move/move-stdlib/src/lib.rs
@@ -3,8 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use log::LevelFilter;
-use move_command_line_common::files::{extension_equals, find_filenames, MOVE_EXTENSION};
-use move_compiler::shared::NumericalAddress;
+use move_command_line_common::{
+    address::NumericalAddress,
+    files::{extension_equals, find_filenames, MOVE_EXTENSION},
+};
 use move_core_types::account_address::AccountAddress;
 use std::{collections::BTreeMap, path::PathBuf};
 


### PR DESCRIPTION
## Description

`move-stdlib` contains native functions, so is part of the versioned execution layer.  `move-compiler` is part of the tooling layer, not execution, and ideally we want to keep it out, to avoid having to version it.

## Test Plan

```
sui/external-crates$ sh ./tests.sh
```