### PR TITLE
indexer: enable indexer to read k8 credentials

### DIFF
--- a/crates/sui-cluster-test/src/cluster.rs
+++ b/crates/sui-cluster-test/src/cluster.rs
@@ -206,7 +206,7 @@ impl Cluster for LocalNewCluster {
         };
         if options.pg_address.is_some() && indexer_address.is_some() {
             let config = IndexerConfig {
-                db_url: options.pg_address.clone().unwrap(),
+                db_url: Some(options.pg_address.clone().unwrap()),
                 rpc_client_url: fullnode_url.clone(),
                 rpc_server_url: indexer_address.as_ref().unwrap().ip().to_string(),
                 rpc_server_port: indexer_address.as_ref().unwrap().port(),

--- a/crates/sui-indexer/src/test_utils.rs
+++ b/crates/sui-indexer/src/test_utils.rs
@@ -17,7 +17,8 @@ use crate::{new_pg_connection_pool, Indexer, IndexerConfig};
 pub async fn start_test_indexer(
     config: IndexerConfig,
 ) -> Result<(PgIndexerStore, JoinHandle<Result<(), IndexerError>>), anyhow::Error> {
-    let (blocking_pool, async_pool) = new_pg_connection_pool(&config.base_connection_url())
+    let parsed_url = config.base_connection_url()?;
+    let (blocking_pool, async_pool) = new_pg_connection_pool(&parsed_url)
         .await
         .map_err(|e| anyhow!("unable to connect to Postgres, is it running? {e}"))?;
     if config.reset_db {


### PR DESCRIPTION
## Description 

title

## Test Plan 

to make sure both one DB_url or composing it by parts work
```
cargo run --bin sui-indexer -- --db-url "postgres://postgres:postgres@localhost:5432/gegao" --rpc-client-url http://nrt-exp-val-00.experiments.sui.io:9000 --client-metric-host "127.0.0.1" --client-metric-port 9184 --rpc-server-port 3030 --reset-db --fullnode-sync-worker

cargo run --bin sui-indexer -- --db-user-name "postgres" --db-password "postgres" --db-host "localhost" --db-port 5432 --db-name "gegao" --rpc-client-url http://nrt-exp-val-00.experiments.sui.io:9000 --client-metric-host "127.0.0.1" --client-metric-port 9184 --rpc-server-port 3030 --reset-db --fullnode-sync-worker
```
