### PR TITLE
Update caches instead of invalidating them

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -255,6 +255,7 @@ mod test {
         assert_eq!(expected_checkpoint, pruned);
     }
 
+    #[ignore]
     #[sim_test(config = "test_config()")]
     async fn test_testnet_upgrade_compatibility() {
         // This test is intended to test the compatibility of the latest protocol version with

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -223,8 +223,8 @@ impl CoinReadApiServer for CoinReadApi {
             })?;
         Ok(Balance {
             coin_type: coin_type.to_string(),
-            coin_object_count: balance.num_coins,
-            total_balance: balance.balance,
+            coin_object_count: balance.num_coins as usize,
+            total_balance: balance.balance as u128,
             // note: LockedCoin is deprecated
             locked_balance: Default::default(),
         })
@@ -249,8 +249,8 @@ impl CoinReadApiServer for CoinReadApi {
             .map(|(coin_type, balance)| {
                 Balance {
                     coin_type: coin_type.to_string(),
-                    coin_object_count: balance.num_coins,
-                    total_balance: balance.balance,
+                    coin_object_count: balance.num_coins as usize,
+                    total_balance: balance.balance as u128,
                     // note: LockedCoin is deprecated
                     locked_balance: Default::default(),
                 }

--- a/crates/sui-storage/src/indexes.rs
+++ b/crates/sui-storage/src/indexes.rs
@@ -17,7 +17,9 @@ use move_core_types::language_storage::{ModuleId, StructTag, TypeTag};
 use prometheus::{register_int_counter_with_registry, IntCounter, Registry};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::collections::BTreeMap;
+use tokio::sync::OwnedMutexGuard;
 
+use crate::mutex_table::MutexTable;
 use crate::sharded_lru::ShardedLruCache;
 use sui_json_rpc_types::SuiObjectDataFilter;
 use sui_types::base_types::{
@@ -46,17 +48,19 @@ type CoinIndexKey = (SuiAddress, String, ObjectID);
 type DynamicFieldKey = (ObjectID, ObjectID);
 type EventId = (TxSequenceNumber, usize);
 type EventIndex = (TransactionEventsDigest, TransactionDigest, u64);
+type AllBalance = HashMap<TypeTag, TotalBalance>;
 
 pub const MAX_TX_RANGE_SIZE: u64 = 4096;
 
 pub const MAX_GET_OWNED_OBJECT_SIZE: usize = 256;
 const ENV_VAR_COIN_INDEX_BLOCK_CACHE_SIZE_MB: &str = "COIN_INDEX_BLOCK_CACHE_MB";
 const ENV_VAR_DISABLE_INDEX_CACHE: &str = "DISABLE_INDEX_CACHE";
+const ENV_VAR_INVALIDATE_INSTEAD_OF_UPDATE: &str = "INVALIDATE_INSTEAD_OF_UPDATE";
 
 #[derive(Default, Copy, Clone, Debug, Eq, PartialEq)]
 pub struct TotalBalance {
-    pub balance: u128,
-    pub num_coins: usize,
+    pub balance: i128,
+    pub num_coins: i64,
 }
 
 #[derive(Debug)]
@@ -116,6 +120,14 @@ impl IndexStoreMetrics {
 pub struct IndexStoreCaches {
     per_coin_type_balance: ShardedLruCache<(SuiAddress, TypeTag), SuiResult<TotalBalance>>,
     all_balances: ShardedLruCache<SuiAddress, SuiResult<Arc<HashMap<TypeTag, TotalBalance>>>>,
+    locks: MutexTable<SuiAddress>,
+}
+
+#[derive(Default)]
+pub struct IndexStoreCacheUpdates {
+    _locks: Vec<OwnedMutexGuard<()>>,
+    per_coin_type_balance_changes: Vec<((SuiAddress, TypeTag), SuiResult<TotalBalance>)>,
+    all_balance_changes: Vec<(SuiAddress, SuiResult<Arc<AllBalance>>)>,
 }
 
 #[derive(DBMapUtils)]
@@ -251,6 +263,7 @@ impl IndexStore {
         let caches = IndexStoreCaches {
             per_coin_type_balance: ShardedLruCache::new(1_000_000, 1000),
             all_balances: ShardedLruCache::new(1_000_000, 1000),
+            locks: MutexTable::new(128),
         };
         let next_sequence_number = tables
             .transaction_order
@@ -275,18 +288,32 @@ impl IndexStore {
         batch: &mut DBBatch,
         object_index_changes: &ObjectIndexChanges,
         tx_coins: Option<TxCoins>,
-    ) -> SuiResult<()> {
+    ) -> SuiResult<IndexStoreCacheUpdates> {
         // In production if this code path is hit, we should expect `tx_coins` to not be None.
         // However, in many tests today we do not distinguish validator and/or fullnode, so
         // we gracefully exist here.
         if tx_coins.is_none() {
-            return Ok(());
+            return Ok(IndexStoreCacheUpdates::default());
         }
-
+        // Acquire locks on changed coin owners
+        let mut addresses: HashSet<SuiAddress> = HashSet::new();
+        addresses.extend(
+            object_index_changes
+                .deleted_owners
+                .iter()
+                .map(|(owner, _)| *owner),
+        );
+        addresses.extend(
+            object_index_changes
+                .new_owners
+                .iter()
+                .map(|((owner, _), _)| *owner),
+        );
+        let _locks = self.caches.locks.acquire_locks(addresses.into_iter()).await;
+        let mut balance_changes: HashMap<SuiAddress, HashMap<TypeTag, TotalBalance>> =
+            HashMap::new();
         // Index coin info
         let (input_coins, written_coins) = tx_coins.unwrap();
-        let mut address_coin_type_to_invalidate: HashSet<(SuiAddress, TypeTag)> = HashSet::new();
-        let mut addresses_to_invalidate: HashSet<SuiAddress> = HashSet::new();
         // 1. Delete old owner if the object is deleted or transferred to a new owner,
         // by looking at `object_index_changes.deleted_owners`.
         // Objects in `deleted_owners` must be owned by `Owner::Address` befoer the tx,
@@ -297,15 +324,22 @@ impl IndexStore {
             .iter()
             .filter_map(|(owner, obj_id)| {
                 // If it's not in `input_coins`, then it's not a coin type. Skip.
-                let coin_type_tag = input_coins.get(obj_id)?
-                .coin_type_maybe().unwrap_or_else(|| {
+                let object = input_coins.get(obj_id)?;
+                let coin_type_tag = object.coin_type_maybe().unwrap_or_else(|| {
                     panic!(
                         "object_id: {:?} in input_coins is not a coin type, input_coins: {:?}, tx_digest: {:?}",
                         obj_id, input_coins, digest
                     )
                 });
-                address_coin_type_to_invalidate.insert((*owner, coin_type_tag.clone()));
-                addresses_to_invalidate.insert(*owner);
+                let map = balance_changes.entry(*owner).or_insert(HashMap::new());
+                let entry = map.entry(coin_type_tag.clone()).or_insert(TotalBalance {
+                    num_coins: 0,
+                    balance: 0
+                });
+                if let Ok(Some(coin_info)) = &self.tables.coin_index.get(&(*owner, coin_type_tag.to_string(), *obj_id)) {
+                    entry.num_coins -= 1;
+                    entry.balance -= coin_info.balance as i128;
+                }
                 Some((*owner, coin_type_tag.to_string(), *obj_id))
             }).collect::<Vec<_>>();
         trace!(
@@ -339,8 +373,19 @@ impl IndexStore {
                     obj_id, written_coins, digest
                 )
             });
-            address_coin_type_to_invalidate.insert((*owner, coin_type_tag.clone()));
-            addresses_to_invalidate.insert(*owner);
+            let map = balance_changes.entry(*owner).or_insert(HashMap::new());
+            let entry = map.entry(coin_type_tag.clone()).or_insert(TotalBalance {
+                num_coins: 0,
+                balance: 0
+            });
+            let result = self.tables.coin_index.get(&(*owner, coin_type_tag.to_string(), *obj_id));
+            if let Ok(Some(coin_info)) = &result {
+                entry.balance -= coin_info.balance as i128;
+                entry.balance += coin.balance.value() as i128;
+            } else if let Ok(None) = &result {
+                entry.num_coins += 1;
+                entry.balance += coin.balance.value() as i128;
+            }
             Some(((*owner, coin_type_tag.to_string(), *obj_id), (CoinInfo {version: obj_info.version, digest: obj_info.digest, balance: coin.balance.value(), previous_transaction: *digest})))
         }).collect::<Vec<_>>();
         trace!(
@@ -348,13 +393,35 @@ impl IndexStore {
             "coin_add_keys: {:?}",
             coin_add_keys,
         );
-        batch.insert_batch(&self.tables.coin_index, coin_add_keys.into_iter())?;
-        self.invalidate_per_coin_type_cache(address_coin_type_to_invalidate.into_iter())
-            .await?;
-        self.invalidate_all_balance_cache(addresses_to_invalidate.into_iter())
-            .await?;
 
-        Ok(())
+        batch.insert_batch(&self.tables.coin_index, coin_add_keys.into_iter())?;
+
+        let per_coin_type_balance_changes: Vec<_> = balance_changes
+            .iter()
+            .flat_map(|(address, balance_map)| {
+                balance_map.iter().map(|(type_tag, balance)| {
+                    (
+                        (*address, type_tag.clone()),
+                        Ok::<TotalBalance, SuiError>(*balance),
+                    )
+                })
+            })
+            .collect();
+        let all_balance_changes: Vec<_> = balance_changes
+            .into_iter()
+            .map(|(address, balance_map)| {
+                (
+                    address,
+                    Ok::<Arc<HashMap<TypeTag, TotalBalance>>, SuiError>(Arc::new(balance_map)),
+                )
+            })
+            .collect();
+        let cache_updates = IndexStoreCacheUpdates {
+            _locks,
+            per_coin_type_balance_changes,
+            all_balance_changes,
+        };
+        Ok(cache_updates)
     }
 
     pub async fn index_tx(
@@ -426,7 +493,8 @@ impl IndexStore {
         )?;
 
         // Coin Index
-        self.index_coin(digest, &mut batch, &object_index_changes, tx_coins)
+        let cache_updates = self
+            .index_coin(digest, &mut batch, &object_index_changes, tx_coins)
             .await?;
 
         // Owner index
@@ -509,7 +577,36 @@ impl IndexStore {
             std::iter::once((*digest, loaded_child_objects)),
         )?;
 
+        let invalidate_caches =
+            read_size_from_env(ENV_VAR_INVALIDATE_INSTEAD_OF_UPDATE).unwrap_or(0) > 0;
+
+        if invalidate_caches {
+            // Invalidate cache before writing to db so we always serve latest values
+            self.invalidate_per_coin_type_cache(
+                cache_updates
+                    .per_coin_type_balance_changes
+                    .iter()
+                    .map(|x| x.0.clone()),
+            )
+            .await?;
+            self.invalidate_all_balance_cache(
+                cache_updates.all_balance_changes.iter().map(|x| x.0),
+            )
+            .await?;
+        }
+
         batch.write()?;
+
+        if !invalidate_caches {
+            // We cannot update the cache before updating the db or else on failing to write to db
+            // we will update the cache (when we retry to index this transaction again we would have
+            // updated the cache twice). However, this only means cache is eventually consistent with
+            // the db (within a very short delay)
+            self.update_per_coin_type_cache(cache_updates.per_coin_type_balance_changes)
+                .await?;
+            self.update_all_balance_cache(cache_updates.all_balance_changes)
+                .await?;
+        }
         Ok(sequence)
     }
 
@@ -1277,13 +1374,12 @@ impl IndexStore {
             Self::get_owned_coins_iterator(&coin_index, owner, Some(coin_type_str.clone()))?
                 .map(|(_coin_type, obj_id, coin)| (coin_type_str.clone(), obj_id, coin));
 
-        let mut balance = 0u128;
+        let mut balance = 0i128;
         let mut num_coins = 0;
         for (_coin_type, _obj_id, coin_info) in coins {
-            balance += coin_info.balance as u128;
+            balance += coin_info.balance as i128;
             num_coins += 1;
         }
-
         Ok(TotalBalance { balance, num_coins })
     }
 
@@ -1299,10 +1395,10 @@ impl IndexStore {
             .map(|(coin_type, obj_id, coin)| (coin_type, obj_id, coin))
             .group_by(|(coin_type, _obj_id, _coin)| coin_type.clone());
         for (coin_type, coins) in &coins {
-            let mut total_balance = 0u128;
+            let mut total_balance = 0i128;
             let mut coin_object_count = 0;
             for (_coin_type, _obj_id, coin_info) in coins {
-                total_balance += coin_info.balance as u128;
+                total_balance += coin_info.balance as i128;
                 coin_object_count += 1;
             }
             let coin_type =
@@ -1340,6 +1436,76 @@ impl IndexStore {
     ) -> SuiResult {
         self.caches.all_balances.batch_invalidate(addresses).await;
         Ok(())
+    }
+
+    async fn update_per_coin_type_cache(
+        &self,
+        keys: impl IntoIterator<Item = ((SuiAddress, TypeTag), SuiResult<TotalBalance>)>,
+    ) -> SuiResult {
+        self.caches
+            .per_coin_type_balance
+            .batch_merge(keys, Self::merge_balance)
+            .await;
+        Ok(())
+    }
+
+    fn merge_balance(
+        old_balance: &SuiResult<TotalBalance>,
+        balance_delta: &SuiResult<TotalBalance>,
+    ) -> SuiResult<TotalBalance> {
+        if let Ok(old_balance) = old_balance {
+            if let Ok(balance_delta) = balance_delta {
+                Ok(TotalBalance {
+                    balance: old_balance.balance + balance_delta.balance,
+                    num_coins: old_balance.num_coins + balance_delta.num_coins,
+                })
+            } else {
+                balance_delta.clone()
+            }
+        } else {
+            old_balance.clone()
+        }
+    }
+
+    async fn update_all_balance_cache(
+        &self,
+        keys: impl IntoIterator<Item = (SuiAddress, SuiResult<Arc<HashMap<TypeTag, TotalBalance>>>)>,
+    ) -> SuiResult {
+        self.caches
+            .all_balances
+            .batch_merge(keys, Self::merge_all_balance)
+            .await;
+        Ok(())
+    }
+
+    fn merge_all_balance(
+        old_balance: &SuiResult<Arc<HashMap<TypeTag, TotalBalance>>>,
+        balance_delta: &SuiResult<Arc<HashMap<TypeTag, TotalBalance>>>,
+    ) -> SuiResult<Arc<HashMap<TypeTag, TotalBalance>>> {
+        if let Ok(old_balance) = old_balance {
+            if let Ok(balance_delta) = balance_delta {
+                let mut new_balance = HashMap::new();
+                for (key, value) in old_balance.iter() {
+                    new_balance.insert(key.clone(), *value);
+                }
+                for (key, delta) in balance_delta.iter() {
+                    let old = new_balance.entry(key.clone()).or_insert(TotalBalance {
+                        balance: 0,
+                        num_coins: 0,
+                    });
+                    let new_total = TotalBalance {
+                        balance: old.balance + delta.balance,
+                        num_coins: old.num_coins + delta.num_coins,
+                    };
+                    new_balance.insert(key.clone(), new_total);
+                }
+                Ok(Arc::new(new_balance))
+            } else {
+                balance_delta.clone()
+            }
+        } else {
+            old_balance.clone()
+        }
     }
 }
 
@@ -1473,6 +1639,21 @@ mod tests {
             address,
             GAS::type_tag(),
         )?;
+        let balance = index_store.get_balance(address, GAS::type_tag()).await?;
+        assert_eq!(balance, balance_from_db);
+        assert_eq!(balance.balance, 700);
+        assert_eq!(balance.num_coins, 7);
+        // Invalidate per coin type balance cache and read from all balance cache to ensure
+        // the balance matches
+        index_store
+            .caches
+            .per_coin_type_balance
+            .invalidate(&(address, GAS::type_tag()))
+            .await;
+        let all_balance = index_store.get_all_balance(address).await;
+        let all_balance = all_balance?;
+        assert_eq!(all_balance.get(&GAS::type_tag()).unwrap().balance, 700);
+        assert_eq!(all_balance.get(&GAS::type_tag()).unwrap().num_coins, 7);
         let balance = index_store.get_balance(address, GAS::type_tag()).await?;
         assert_eq!(balance, balance_from_db);
         assert_eq!(balance.balance, 700);


### PR DESCRIPTION
## Description 

As title says, we are going to start updating index caches with account balances instead of invalidating them. The motivation is that going to db is expensive for some accounts which hold tens and hundreds thousand keys, and by keep balance updated in cache we see a p99 of less than 0.01 seconds
## Test Plan 

Enhanced existing tests
