### PR TITLE
[ts-sdk] Reduce flakiness of test

### DIFF
--- a/sdk/typescript/test/e2e/read-transactions.test.ts
+++ b/sdk/typescript/test/e2e/read-transactions.test.ts
@@ -75,8 +75,8 @@ describe('Transaction Reading API', () => {
         }),
       ).rejects.toThrowError('The operation was aborted due to timeout');
 
-      // Expect it to poll the API at the provided interval
-      expect(spy.mock.calls).toHaveLength(6);
+      // Because JS event loop is somewhat unpredictable, we don't know exactly how long this will take, but we should have _at least_ 2 calls.
+      expect(spy.mock.calls.length).toBeGreaterThan(2);
     });
   });
 


### PR DESCRIPTION
## Description

I noticed this test wasn't perfectly reliable because of JS event loop contention. Loosening the restriction so that it's more just validating that it's called some amount of times, but not the exact amount.

## Test Plan

Ran tests.
