### PR TITLE
owned object scan fix

### DIFF
--- a/crates/sui-storage/src/indexes.rs
+++ b/crates/sui-storage/src/indexes.rs
@@ -1117,6 +1117,7 @@ impl IndexStore {
             // The object id 0 is the smallest possible
             .skip_to(&(owner, starting_object_id))?
             .skip(usize::from(starting_object_id != ObjectID::ZERO))
+            .take_while(move |((address_owner, _), _)| address_owner == &owner)
             .filter(move |(_, o)| {
                 if let Some(filter) = filter.as_ref() {
                     filter.matches(o)
@@ -1124,7 +1125,6 @@ impl IndexStore {
                     true
                 }
             })
-            .take_while(move |((address_owner, _), _)| address_owner == &owner)
             .map(|(_, object_info)| object_info))
     }
 


### PR DESCRIPTION
## Description 

Swapping the order of the operations so that owned_objects won't try to do a full scan of the entire DB and at most the number of objects owned by an address.

## Test Plan 

Locally

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
