### PR TITLE
Gas smashing proptests

### DIFF
--- a/crates/transaction-fuzzer/src/account_universe/transfer_gen.rs
+++ b/crates/transaction-fuzzer/src/account_universe/transfer_gen.rs
@@ -4,6 +4,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::account_universe::AccountCurrent;
 use crate::{
     account_universe::{AUTransactionGen, AccountPair, AccountPairGen, AccountUniverse},
     executor::{ExecutionResult, Executor},
@@ -68,6 +69,22 @@ pub struct P2PTransferGenRandomGasRandomPrice {
     gas_price: u64,
 }
 
+/// Represents a peer-to-peer transaction performed in the account universe with the gas budget,
+/// gas price and number of gas coins randomly selected.
+#[derive(Arbitrary, Clone, Debug)]
+#[proptest(params = "(u64, u64)")]
+pub struct P2PTransferGenRandGasRandPriceRandCoins {
+    sender_receiver: AccountPairGen,
+    #[proptest(strategy = "params.0 ..= params.1")]
+    amount: u64,
+    #[proptest(strategy = "gas_budget_selection_strategy()")]
+    gas: u64,
+    #[proptest(strategy = "gas_price_selection_strategy()")]
+    gas_price: u64,
+    #[proptest(strategy = "gas_coins_selection_strategy()")]
+    gas_coins: u32,
+}
+
 fn p2p_success_gas(gas_price: u64) -> u64 {
     gas_price * P2P_COMPUTE_GAS_USAGE + P2P_SUCCESS_STORAGE_USAGE
 }
@@ -105,6 +122,15 @@ fn gas_budget_selection_strategy() -> impl Strategy<Value = u64> {
     ]
 }
 
+fn gas_coins_selection_strategy() -> impl Strategy<Value = u32> {
+    prop_oneof![
+        2 => Just(1u32),
+        6 => 2u32..PROTOCOL_CONFIG.max_gas_payment_objects(),
+        1 => Just(PROTOCOL_CONFIG.max_gas_payment_objects()),
+        1 => Just(PROTOCOL_CONFIG.max_gas_payment_objects() + 1),
+    ]
+}
+
 impl AUTransactionGen for P2PTransferGenGoodGas {
     fn apply(
         &self,
@@ -136,6 +162,23 @@ impl AUTransactionGen for P2PTransferGenRandomGas {
     }
 }
 
+impl AUTransactionGen for P2PTransferGenRandomGasRandomPrice {
+    fn apply(
+        &self,
+        universe: &mut AccountUniverse,
+        exec: &mut Executor,
+    ) -> (VerifiedTransaction, ExecutionResult) {
+        P2PTransferGenRandGasRandPriceRandCoins {
+            sender_receiver: self.sender_receiver.clone(),
+            amount: self.amount,
+            gas: self.gas,
+            gas_price: self.gas_price,
+            gas_coins: 1,
+        }
+        .apply(universe, exec)
+    }
+}
+
 // Encapsulates information needed to determine the result of a transaction execution.
 #[derive(Debug)]
 struct RunInfo {
@@ -148,10 +191,11 @@ struct RunInfo {
     gas_price_too_high: bool,
     gas_price_too_low: bool,
     gas_units_too_low: bool,
+    too_many_gas_coins: bool,
 }
 
 impl RunInfo {
-    pub fn new(sender_balance: u64, p2p: &P2PTransferGenRandomGasRandomPrice) -> Self {
+    pub fn new(sender_balance: u64, p2p: &P2PTransferGenRandGasRandPriceRandCoins) -> Self {
         let to_deduct = p2p.amount as u128 + p2p.gas as u128;
         let enough_max_gas = sender_balance >= p2p.gas;
         let enough_computation_gas = p2p.gas >= p2p.gas_price * P2P_COMPUTE_GAS_USAGE;
@@ -165,6 +209,7 @@ impl RunInfo {
         let gas_units_too_low = p2p.gas_price > 0
             && p2p.gas / p2p.gas_price < INSUFFICIENT_GAS_UNITS_THRESHOLD
             || gas_price_greater_than_budget;
+        let too_many_gas_coins = p2p.gas_coins >= PROTOCOL_CONFIG.max_gas_payment_objects();
         Self {
             enough_max_gas,
             enough_computation_gas,
@@ -175,11 +220,12 @@ impl RunInfo {
             gas_price_too_high,
             gas_price_too_low,
             gas_units_too_low,
+            too_many_gas_coins,
         }
     }
 }
 
-impl AUTransactionGen for P2PTransferGenRandomGasRandomPrice {
+impl AUTransactionGen for P2PTransferGenRandGasRandPriceRandCoins {
     fn apply(
         &self,
         universe: &mut AccountUniverse,
@@ -191,7 +237,13 @@ impl AUTransactionGen for P2PTransferGenRandomGasRandomPrice {
             ..
         } = self.sender_receiver.pick(universe);
 
-        let gas_object = sender.new_gas_object(exec);
+        // get all the gas coins to smash
+        let mut gas_coin_refs = vec![];
+        for _ in 0..self.gas_coins {
+            let gas_object = sender.new_gas_object(exec);
+            gas_coin_refs.push(gas_object.compute_object_reference());
+        }
+
         // construct a p2p transfer of a random amount of SUI
         let txn = {
             let mut builder = ProgrammableTransactionBuilder::new();
@@ -199,10 +251,10 @@ impl AUTransactionGen for P2PTransferGenRandomGasRandomPrice {
             builder.finish()
         };
         let kind = TransactionKind::ProgrammableTransaction(txn);
-        let tx_data = TransactionData::new(
+        let tx_data = TransactionData::new_with_gas_coins(
             kind,
             sender.initial_data.account.address,
-            gas_object.compute_object_reference(),
+            gas_coin_refs,
             self.gas,
             self.gas_price,
         );
@@ -219,13 +271,20 @@ impl AUTransactionGen for P2PTransferGenRandomGasRandomPrice {
                 gas_price_too_low: false,
                 gas_price_too_high: false,
                 gas_units_too_low: false,
+                too_many_gas_coins: false,
             } => {
-                // Fine to cast to u64 at this point, since otherwise enough_max_gas would be false
-                // since sender_balance is a u64.
-                *sender.current_balances.last_mut().unwrap() -=
-                    self.amount + p2p_success_gas(self.gas_price);
+                self.fix_balance_and_gas_coins(sender, true);
                 Ok(ExecutionStatus::Success)
             }
+            RunInfo {
+                too_many_gas_coins: true,
+                ..
+            } => Err(SuiError::UserInputError {
+                error: UserInputError::SizeLimitExceeded {
+                    limit: "maximum number of gas payment objects".to_string(),
+                    value: "256".to_string(),
+                },
+            }),
             RunInfo {
                 gas_price_too_low: true,
                 ..
@@ -276,8 +335,7 @@ impl AUTransactionGen for P2PTransferGenRandomGasRandomPrice {
                 gas_units_too_low: false,
                 ..
             } => {
-                *sender.current_balances.last_mut().unwrap() -=
-                    std::cmp::min(self.gas, p2p_failure_gas(self.gas_price));
+                self.fix_balance_and_gas_coins(sender, false);
                 Ok(ExecutionStatus::Failure {
                     error: ExecutionFailureStatus::InsufficientCoinBalance,
                     command: Some(0),
@@ -287,8 +345,7 @@ impl AUTransactionGen for P2PTransferGenRandomGasRandomPrice {
                 enough_max_gas: true,
                 ..
             } => {
-                *sender.current_balances.last_mut().unwrap() -=
-                    std::cmp::min(self.gas, p2p_failure_gas(self.gas_price));
+                self.fix_balance_and_gas_coins(sender, false);
                 Ok(ExecutionStatus::Failure {
                     error: ExecutionFailureStatus::InsufficientGas,
                     command: None,
@@ -296,6 +353,30 @@ impl AUTransactionGen for P2PTransferGenRandomGasRandomPrice {
             }
         };
         (signed_txn, status)
+    }
+}
+
+impl P2PTransferGenRandGasRandPriceRandCoins {
+    fn fix_balance_and_gas_coins(&self, sender: &mut AccountCurrent, success: bool) {
+        // collect all the coins smashed and update the balance of the one true gas coin.
+        // Gas objects are all coming from genesis which implies there is no rebate.
+        // In making things simple that does not really exercise an important aspect
+        // of the gas logic
+        let mut smash_balance = 0;
+        for _ in 1..self.gas_coins {
+            sender.current_coins.pop().expect("coin must exist");
+            smash_balance += sender.current_balances.pop().expect("balance must exist");
+        }
+        *sender.current_balances.last_mut().unwrap() += smash_balance;
+        // Fine to cast to u64 at this point, since otherwise enough_max_gas would be false
+        // since sender_balance is a u64.
+        if success {
+            *sender.current_balances.last_mut().unwrap() -=
+                self.amount + p2p_success_gas(self.gas_price);
+        } else {
+            *sender.current_balances.last_mut().unwrap() -=
+                std::cmp::min(self.gas, p2p_failure_gas(self.gas_price));
+        }
     }
 }
 

--- a/crates/transaction-fuzzer/tests/p2p_fuzz.rs
+++ b/crates/transaction-fuzzer/tests/p2p_fuzz.rs
@@ -87,6 +87,18 @@ proptest! {
 
     #[test]
     #[cfg_attr(msim, ignore)]
+    fn fuzz_p2p_rand_gas_budget_price_and_coins(
+        universe in AccountUniverseGen::strategy(
+            2..default_num_accounts(),
+            10_000_000_000u64..1_000_000_000_000,
+            ),
+            transfers in vec(any_with::<P2PTransferGenRandGasRandPriceRandCoins>((1_000_000, 100_000_000)), 0..default_num_transactions()),
+        ) {
+        run_and_assert_universe(universe, transfers).unwrap();
+    }
+
+    #[test]
+    #[cfg_attr(msim, ignore)]
     fn fuzz_p2p_mixed(
         universe in AccountUniverseGen::strategy(
             2..default_num_accounts(),


### PR DESCRIPTION
## Description 

Adding proptest for gas smashing.
Coin objects always coming from genesis makes the scenario not as real as it could and should be. But the fix is for another day

## Test Plan 

This is it

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
