### PR TITLE
wallet-ext: update tabs url matching to account for locked page

### DIFF
--- a/apps/wallet/src/background/Tabs.ts
+++ b/apps/wallet/src/background/Tabs.ts
@@ -155,7 +155,18 @@ class Tabs {
         return this._onActiveOrigin.asObservable();
     }
 
-    public async highlight(option: { url: string } | { tabID: number }) {
+    public async highlight(
+        option: { windowID?: number } & (
+            | {
+                  url: string;
+                  match?: (values: {
+                      url: string;
+                      inAppRedirectUrl?: string;
+                  }) => boolean;
+              }
+            | { tabID: number }
+        )
+    ) {
         let tabToHighlight: BrowserTabs.Tab | null = null;
         if ('tabID' in option) {
             try {
@@ -163,14 +174,39 @@ class Tabs {
             } catch (e) {
                 //Do nothing
             }
-        }
-        if ('url' in option) {
-            const url = option.url.split('#')[0];
+        } else {
+            const inAppUrlToMatch = option.url.split('#')[1] || '';
             const tabs = (
                 await Browser.tabs.query({
-                    url,
+                    url: option.url.split('#')[0],
+                    windowId: option.windowID,
                 })
-            ).filter((aTab) => aTab.url === option.url);
+            ).filter((aTab) => {
+                let inAppRedirectUrl: string | undefined = undefined;
+                if (aTab.url === option.url) {
+                    return true;
+                }
+                try {
+                    const tabURL = new URL(aTab.url || '');
+                    if (tabURL.hash.startsWith('#/locked?url=')) {
+                        inAppRedirectUrl = decodeURIComponent(
+                            tabURL.hash.replace('#/locked?url=', '')
+                        );
+                        if (inAppRedirectUrl === inAppUrlToMatch) {
+                            return true;
+                        }
+                    }
+                } catch (e) {
+                    // do nothing
+                }
+                if (
+                    option.match &&
+                    option.match({ url: aTab.url || '', inAppRedirectUrl })
+                ) {
+                    return true;
+                }
+                return false;
+            });
             if (tabs.length) {
                 tabToHighlight = tabs[0];
             }


### PR DESCRIPTION
* fixes cases when opening a permission request window when another one is already open and the wallet is locked
* also support optional extra function for custom matching (multiple pages etc)

Before


https://user-images.githubusercontent.com/10210143/233782283-8c83917f-f2ba-48c5-9c82-c83c431f9234.mov



After



https://user-images.githubusercontent.com/10210143/233782321-09a90066-dfd0-4b19-87bf-93dd1006ef8e.mov

