### PR TITLE
[Narwhal] improve batch maker throughput by avoiding yielding per txn

### DIFF
--- a/narwhal/types/src/metered_channel.rs
+++ b/narwhal/types/src/metered_channel.rs
@@ -80,7 +80,7 @@ impl<T> Receiver<T> {
     }
 
     /// Polls to receive the next message on this channel.
-    ///  Decrements the gauge in case of a successful `poll_recv`.
+    /// Decrements the gauge in case of a successful `poll_recv`.
     pub fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
         match self.inner.poll_recv(cx) {
             res @ Poll::Ready(Some(_)) => {


### PR DESCRIPTION
## Description 

Currently batch maker yields to tokio runtime each time a transaction is added into the batch. This seems to limit batch maker throughput, especially when a few nodes have larger stakes and are responsible for more transaction submissions. Not yielding from batch maker can at most take up one thread.

In private testnet, after the change tx_batch_maker queue length is reduced significantly.

Also, switch to VecDeque for the free pool queue in benchmark client.

## Test Plan 

CI. Private testnet.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
