### PR TITLE
[Deepbook] Minor fix and always use quote for commission

### DIFF
--- a/crates/sui-framework/docs/clob.md
+++ b/crates/sui-framework/docs/clob.md
@@ -6,12 +6,13 @@
 
 
 -  [Struct `PoolCreated`](#0xdee9_clob_PoolCreated)
--  [Struct `OrderPlaced`](#0xdee9_clob_OrderPlaced)
+-  [Struct `OrderPlacedV2`](#0xdee9_clob_OrderPlacedV2)
 -  [Struct `OrderCanceled`](#0xdee9_clob_OrderCanceled)
 -  [Struct `OrderFilled`](#0xdee9_clob_OrderFilled)
 -  [Struct `Order`](#0xdee9_clob_Order)
 -  [Struct `TickLevel`](#0xdee9_clob_TickLevel)
 -  [Resource `Pool`](#0xdee9_clob_Pool)
+-  [Struct `OrderPlaced`](#0xdee9_clob_OrderPlaced)
 -  [Constants](#@Constants_0)
 -  [Function `destroy_empty_level`](#0xdee9_clob_destroy_empty_level)
 -  [Function `create_account`](#0xdee9_clob_create_account)
@@ -126,14 +127,14 @@ Emitted when a new pool is created
 
 </details>
 
-<a name="0xdee9_clob_OrderPlaced"></a>
+<a name="0xdee9_clob_OrderPlacedV2"></a>
 
-## Struct `OrderPlaced`
+## Struct `OrderPlacedV2`
 
 Emitted when a maker order is injected into the order book.
 
 
-<pre><code><b>struct</b> <a href="clob.md#0xdee9_clob_OrderPlaced">OrderPlaced</a>&lt;BaseAsset, QuoteAsset&gt; <b>has</b> <b>copy</b>, drop, store
+<pre><code><b>struct</b> <a href="clob.md#0xdee9_clob_OrderPlacedV2">OrderPlacedV2</a>&lt;BaseAsset, QuoteAsset&gt; <b>has</b> <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -175,6 +176,12 @@ Emitted when a maker order is injected into the order book.
 </dd>
 <dt>
 <code>price: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>expire_timestamp: u64</code>
 </dt>
 <dd>
 
@@ -494,19 +501,77 @@ Emitted only when a maker order is filled.
 <code>creation_fee: <a href="../../../.././build/Sui/docs/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;<a href="../../../.././build/Sui/docs/sui.md#0x2_sui_SUI">sui::SUI</a>&gt;</code>
 </dt>
 <dd>
- Stores the fee paid to create this pool. These funds are not accessible.
+
 </dd>
 <dt>
 <code>base_asset_trading_fees: <a href="../../../.././build/Sui/docs/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;BaseAsset&gt;</code>
 </dt>
 <dd>
- Stores the trading fees paid in <code>BaseAsset</code>. These funds are not accessible.
+
 </dd>
 <dt>
 <code>quote_asset_trading_fees: <a href="../../../.././build/Sui/docs/balance.md#0x2_balance_Balance">balance::Balance</a>&lt;QuoteAsset&gt;</code>
 </dt>
 <dd>
- Stores the trading fees paid in <code>QuoteAsset</code>. These funds are not accessible.
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0xdee9_clob_OrderPlaced"></a>
+
+## Struct `OrderPlaced`
+
+Emitted when a maker order is injected into the order book.
+
+
+<pre><code><b>struct</b> <a href="clob.md#0xdee9_clob_OrderPlaced">OrderPlaced</a>&lt;BaseAsset, QuoteAsset&gt; <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>pool_id: <a href="../../../.././build/Sui/docs/object.md#0x2_object_ID">object::ID</a></code>
+</dt>
+<dd>
+ object ID of the pool the order was placed on
+</dd>
+<dt>
+<code>order_id: u64</code>
+</dt>
+<dd>
+ ID of the order within the pool
+</dd>
+<dt>
+<code>is_bid: bool</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>owner: <a href="../../../.././build/Sui/docs/object.md#0x2_object_ID">object::ID</a></code>
+</dt>
+<dd>
+ object ID of the <code>AccountCap</code> that placed the order
+</dd>
+<dt>
+<code>base_asset_quantity_placed: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>price: u64</code>
+</dt>
+<dd>
+
 </dd>
 </dl>
 
@@ -1007,7 +1072,11 @@ Emitted only when a maker order is filled.
     <a href="../../../.././build/Sui/docs/coin.md#0x2_coin">coin</a>: Coin&lt;BaseAsset&gt;,
     account_cap: &AccountCap
 ) {
-    <a href="custodian.md#0xdee9_custodian_increase_user_available_balance">custodian::increase_user_available_balance</a>(&<b>mut</b> pool.base_custodian, <a href="../../../.././build/Sui/docs/object.md#0x2_object_id">object::id</a>(account_cap), <a href="../../../.././build/Sui/docs/coin.md#0x2_coin_into_balance">coin::into_balance</a>(<a href="../../../.././build/Sui/docs/coin.md#0x2_coin">coin</a>))
+    <a href="custodian.md#0xdee9_custodian_increase_user_available_balance">custodian::increase_user_available_balance</a>(
+        &<b>mut</b> pool.base_custodian,
+        <a href="../../../.././build/Sui/docs/object.md#0x2_object_id">object::id</a>(account_cap),
+        <a href="../../../.././build/Sui/docs/coin.md#0x2_coin_into_balance">coin::into_balance</a>(<a href="../../../.././build/Sui/docs/coin.md#0x2_coin">coin</a>)
+    )
 }
 </code></pre>
 
@@ -1035,7 +1104,11 @@ Emitted only when a maker order is filled.
     <a href="../../../.././build/Sui/docs/coin.md#0x2_coin">coin</a>: Coin&lt;QuoteAsset&gt;,
     account_cap: &AccountCap
 ) {
-    <a href="custodian.md#0xdee9_custodian_increase_user_available_balance">custodian::increase_user_available_balance</a>(&<b>mut</b> pool.quote_custodian, <a href="../../../.././build/Sui/docs/object.md#0x2_object_id">object::id</a>(account_cap), <a href="../../../.././build/Sui/docs/coin.md#0x2_coin_into_balance">coin::into_balance</a>(<a href="../../../.././build/Sui/docs/coin.md#0x2_coin">coin</a>))
+    <a href="custodian.md#0xdee9_custodian_increase_user_available_balance">custodian::increase_user_available_balance</a>(
+        &<b>mut</b> pool.quote_custodian,
+        <a href="../../../.././build/Sui/docs/object.md#0x2_object_id">object::id</a>(account_cap),
+        <a href="../../../.././build/Sui/docs/coin.md#0x2_coin_into_balance">coin::into_balance</a>(<a href="../../../.././build/Sui/docs/coin.md#0x2_coin">coin</a>)
+    )
 }
 </code></pre>
 
@@ -1064,7 +1137,7 @@ Emitted only when a maker order is filled.
     account_cap: &AccountCap,
     ctx: &<b>mut</b> TxContext
 ): Coin&lt;BaseAsset&gt; {
-    <a href="custodian.md#0xdee9_custodian_withdraw_base_asset">custodian::withdraw_base_asset</a>(&<b>mut</b> pool.base_custodian, quantity, account_cap, ctx)
+    <a href="custodian.md#0xdee9_custodian_withdraw_asset">custodian::withdraw_asset</a>(&<b>mut</b> pool.base_custodian, quantity, account_cap, ctx)
 }
 </code></pre>
 
@@ -1093,7 +1166,7 @@ Emitted only when a maker order is filled.
     account_cap: &AccountCap,
     ctx: &<b>mut</b> TxContext
 ): Coin&lt;QuoteAsset&gt; {
-    <a href="custodian.md#0xdee9_custodian_withdraw_quote_asset">custodian::withdraw_quote_asset</a>(&<b>mut</b> pool.quote_custodian, quantity, account_cap, ctx)
+    <a href="custodian.md#0xdee9_custodian_withdraw_asset">custodian::withdraw_asset</a>(&<b>mut</b> pool.quote_custodian, quantity, account_cap, ctx)
 }
 </code></pre>
 
@@ -1205,6 +1278,7 @@ Emitted only when a maker order is filled.
 ): (Balance&lt;BaseAsset&gt;, Balance&lt;QuoteAsset&gt;) {
     // Base <a href="../../../.././build/Sui/docs/balance.md#0x2_balance">balance</a> received by taker, taking into account of taker commission.
     // Need <b>to</b> individually keep track of the remaining base quantity <b>to</b> be filled <b>to</b> avoid infinite <b>loop</b>.
+    <b>let</b> pool_id = *<a href="../../../.././build/Sui/docs/object.md#0x2_object_uid_as_inner">object::uid_as_inner</a>(&pool.id);
     <b>let</b> taker_quote_quantity_remaining = quantity;
     <b>let</b> base_balance_filled = <a href="../../../.././build/Sui/docs/balance.md#0x2_balance_zero">balance::zero</a>&lt;BaseAsset&gt;();
     <b>let</b> quote_balance_left = quote_balance;
@@ -1226,21 +1300,43 @@ Emitted only when a maker order is filled.
             <b>if</b> (maker_order.expire_timestamp &lt;= current_timestamp) {
                 skip_order = <b>true</b>;
                 <a href="custodian.md#0xdee9_custodian_unlock_balance">custodian::unlock_balance</a>(&<b>mut</b> pool.base_custodian, maker_order.owner, maker_order.quantity);
+                <a href="clob.md#0xdee9_clob_emit_order_canceled">emit_order_canceled</a>&lt;BaseAsset, QuoteAsset&gt;(pool_id, maker_order);
             } <b>else</b> {
+                // Calculate how much quote asset (maker_quote_quantity) is required, including the commission, <b>to</b> fill the maker order.
                 <b>let</b> (flag, maker_quote_quantity) = clob_math::mul_round(maker_base_quantity, maker_order.price);
                 <b>if</b> (flag) maker_quote_quantity = maker_quote_quantity + 1;
-                // filled_quote_quantity, subtract from taker total quote remaining in each <b>loop</b>, round up <b>if</b> needed
-                <b>let</b> filled_quote_quantity =
-                    <b>if</b> (taker_quote_quantity_remaining &gt;= maker_quote_quantity) { maker_quote_quantity }
-                    <b>else</b> { taker_quote_quantity_remaining };
-                // filled_base_quantity, subtract from maker locked_base_balance, round up <b>if</b> needed
-                <b>let</b> (flag, filled_base_quantity) = clob_math::div_round(filled_quote_quantity, maker_order.price);
-                <b>if</b> (flag) filled_base_quantity = filled_base_quantity + 1;
-                // rebate_fee <b>to</b> maker, no need <b>to</b> round up
-                <b>let</b> maker_rebate = clob_math::mul(filled_base_quantity, pool.maker_rebate_rate);
-                <b>let</b> (is_round_down, taker_commission) = clob_math::mul_round(filled_base_quantity, pool.taker_fee_rate);
-                <b>if</b> (is_round_down) taker_commission = taker_commission + 1;
+                (flag, maker_quote_quantity) = clob_math::mul_round(
+                    maker_quote_quantity,
+                    <a href="clob.md#0xdee9_clob_FLOAT_SCALING">FLOAT_SCALING</a> + pool.taker_fee_rate
+                );
+                <b>if</b> (flag) maker_quote_quantity = maker_quote_quantity + 1;
 
+                // Total base quantity filled.
+                <b>let</b> filled_base_quantity: u64;
+                // Total quote quantity filled, excluding commission and rebate.
+                <b>let</b> filled_quote_quantity: u64;
+                // Total quote quantity paid by taker.
+                // filled_quote_quantity_without_commission * (<a href="clob.md#0xdee9_clob_FLOAT_SCALING">FLOAT_SCALING</a> + taker_fee_rate) = filled_quote_quantity
+                <b>let</b> filled_quote_quantity_without_commission: u64;
+                <b>if</b> (taker_quote_quantity_remaining &gt;= maker_quote_quantity) {
+                    filled_quote_quantity = maker_quote_quantity;
+                    (_, filled_quote_quantity_without_commission) = clob_math::div_round(
+                        filled_quote_quantity,
+                        <a href="clob.md#0xdee9_clob_FLOAT_SCALING">FLOAT_SCALING</a> + pool.taker_fee_rate
+                    );
+                    filled_base_quantity = maker_base_quantity;
+                } <b>else</b> {
+                    filled_quote_quantity = taker_quote_quantity_remaining;
+                    (_, filled_quote_quantity_without_commission) = clob_math::div_round(
+                        filled_quote_quantity,
+                        <a href="clob.md#0xdee9_clob_FLOAT_SCALING">FLOAT_SCALING</a> + pool.taker_fee_rate
+                    );
+                    (_, filled_base_quantity) = clob_math::div_round(
+                        filled_quote_quantity_without_commission,
+                        maker_order.price
+                    );
+                };
+                <b>let</b> maker_rebate = clob_math::mul(filled_quote_quantity_without_commission, pool.maker_rebate_rate);
                 maker_base_quantity = maker_base_quantity - filled_base_quantity;
 
                 // maker in ask side, decrease maker's locked base asset, increase maker's available quote asset
@@ -1250,29 +1346,24 @@ Emitted only when a maker order is filled.
                     maker_order.owner,
                     filled_base_quantity
                 );
-                <b>let</b> taker_commission_balance = <a href="../../../.././build/Sui/docs/balance.md#0x2_balance_split">balance::split</a>(
-                    &<b>mut</b> locked_base_balance,
-                    taker_commission,
-                );
-                <a href="custodian.md#0xdee9_custodian_increase_user_available_balance">custodian::increase_user_available_balance</a>&lt;BaseAsset&gt;(
-                    &<b>mut</b> pool.base_custodian,
-                    maker_order.owner,
-                    <a href="../../../.././build/Sui/docs/balance.md#0x2_balance_split">balance::split</a>(
-                        &<b>mut</b> taker_commission_balance,
-                        maker_rebate,
-                    ),
-                );
-                <a href="../../../.././build/Sui/docs/balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> pool.base_asset_trading_fees, taker_commission_balance);
-                <a href="../../../.././build/Sui/docs/balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> base_balance_filled, locked_base_balance);
 
+                <b>let</b> quote_balance_filled = <a href="../../../.././build/Sui/docs/balance.md#0x2_balance_split">balance::split</a>(
+                    &<b>mut</b> quote_balance_left,
+                    filled_quote_quantity,
+                );
+                // Send quote asset including rebate <b>to</b> maker.
                 <a href="custodian.md#0xdee9_custodian_increase_user_available_balance">custodian::increase_user_available_balance</a>&lt;QuoteAsset&gt;(
                     &<b>mut</b> pool.quote_custodian,
                     maker_order.owner,
                     <a href="../../../.././build/Sui/docs/balance.md#0x2_balance_split">balance::split</a>(
-                        &<b>mut</b> quote_balance_left,
-                        filled_quote_quantity,
+                        &<b>mut</b> quote_balance_filled,
+                        maker_rebate + filled_quote_quantity_without_commission,
                     ),
                 );
+                // Send remaining of commission - rebate <b>to</b> the protocol.
+                // commission - rebate = filled_quote_quantity_without_commission - filled_quote_quantity - maker_rebate
+                <a href="../../../.././build/Sui/docs/balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> pool.quote_asset_trading_fees, quote_balance_filled);
+                <a href="../../../.././build/Sui/docs/balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> base_balance_filled, locked_base_balance);
 
                 <a href="../../../.././build/Sui/docs/event.md#0x2_event_emit">event::emit</a>(<a href="clob.md#0xdee9_clob_OrderFilled">OrderFilled</a>&lt;BaseAsset, QuoteAsset&gt; {
                     pool_id: *<a href="../../../.././build/Sui/docs/object.md#0x2_object_uid_as_inner">object::uid_as_inner</a>(&pool.id),
@@ -1347,7 +1438,7 @@ Emitted only when a maker order is filled.
     quote_balance: Balance&lt;QuoteAsset&gt;,
 ): (Balance&lt;BaseAsset&gt;, Balance&lt;QuoteAsset&gt;) {
     <b>let</b> pool_id = *<a href="../../../.././build/Sui/docs/object.md#0x2_object_uid_as_inner">object::uid_as_inner</a>(&pool.id);
-    // Base <a href="../../../.././build/Sui/docs/balance.md#0x2_balance">balance</a> received by taker, taking into account of taker commission.
+    // Base <a href="../../../.././build/Sui/docs/balance.md#0x2_balance">balance</a> received by taker.
     // Need <b>to</b> individually keep track of the remaining base quantity <b>to</b> be filled <b>to</b> avoid infinite <b>loop</b>.
     <b>let</b> taker_base_quantity_remaining = quantity;
     <b>let</b> base_balance_filled = <a href="../../../.././build/Sui/docs/balance.md#0x2_balance_zero">balance::zero</a>&lt;BaseAsset&gt;();
@@ -1379,8 +1470,11 @@ Emitted only when a maker order is filled.
                 <b>let</b> filled_quote_quantity = clob_math::mul(filled_base_quantity, maker_order.price);
 
                 // rebate_fee <b>to</b> maker, no need <b>to</b> round up
-                <b>let</b> maker_rebate = clob_math::mul(filled_base_quantity, pool.maker_rebate_rate);
-                <b>let</b> (is_round_down, taker_commission) = clob_math::mul_round(filled_base_quantity, pool.taker_fee_rate);
+                <b>let</b> maker_rebate = clob_math::mul(filled_quote_quantity, pool.maker_rebate_rate);
+                <b>let</b> (is_round_down, taker_commission) = clob_math::mul_round(
+                    filled_quote_quantity,
+                    pool.taker_fee_rate
+                );
                 <b>if</b> (is_round_down) taker_commission = taker_commission + 1;
 
                 maker_base_quantity = maker_base_quantity - filled_base_quantity;
@@ -1393,18 +1487,18 @@ Emitted only when a maker order is filled.
                     filled_base_quantity
                 );
                 <b>let</b> taker_commission_balance = <a href="../../../.././build/Sui/docs/balance.md#0x2_balance_split">balance::split</a>(
-                    &<b>mut</b> locked_base_balance,
+                    &<b>mut</b> quote_balance_left,
                     taker_commission,
                 );
-                <a href="custodian.md#0xdee9_custodian_increase_user_available_balance">custodian::increase_user_available_balance</a>&lt;BaseAsset&gt;(
-                    &<b>mut</b> pool.base_custodian,
+                <a href="custodian.md#0xdee9_custodian_increase_user_available_balance">custodian::increase_user_available_balance</a>&lt;QuoteAsset&gt;(
+                    &<b>mut</b> pool.quote_custodian,
                     maker_order.owner,
                     <a href="../../../.././build/Sui/docs/balance.md#0x2_balance_split">balance::split</a>(
                         &<b>mut</b> taker_commission_balance,
                         maker_rebate,
                     ),
                 );
-                <a href="../../../.././build/Sui/docs/balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> pool.base_asset_trading_fees, taker_commission_balance);
+                <a href="../../../.././build/Sui/docs/balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> pool.quote_asset_trading_fees, taker_commission_balance);
                 <a href="../../../.././build/Sui/docs/balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> base_balance_filled, locked_base_balance);
 
                 <a href="custodian.md#0xdee9_custodian_increase_user_available_balance">custodian::increase_user_available_balance</a>&lt;QuoteAsset&gt;(
@@ -1519,7 +1613,10 @@ Emitted only when a maker order is filled.
 
                 // rebate_fee <b>to</b> maker, no need <b>to</b> round up
                 <b>let</b> maker_rebate = clob_math::mul(filled_quote_quantity, pool.maker_rebate_rate);
-                <b>let</b> (is_round_down, taker_commission) = clob_math::mul_round(filled_quote_quantity, pool.taker_fee_rate);
+                <b>let</b> (is_round_down, taker_commission) = clob_math::mul_round(
+                    filled_quote_quantity,
+                    pool.taker_fee_rate
+                );
                 <b>if</b> (is_round_down) taker_commission = taker_commission + 1;
 
                 maker_base_quantity = maker_base_quantity - filled_base_quantity;
@@ -1645,6 +1742,7 @@ Place a market order to the order book.
     // The inner <b>loop</b> for iterating over the open orders in ascending orders of order id is the same <b>as</b> above.
     // Then iterate over the price levels in descending order until the market order is completely filled.
     <b>assert</b>!(quantity % pool.lot_size == 0, <a href="clob.md#0xdee9_clob_EInvalidQuantity">EInvalidQuantity</a>);
+    <b>assert</b>!(quantity != 0, <a href="clob.md#0xdee9_clob_EInvalidQuantity">EInvalidQuantity</a>);
     <b>if</b> (is_bid) {
         <b>let</b> (base_balance_filled, quote_balance_left) = <a href="clob.md#0xdee9_clob_match_bid">match_bid</a>(
             pool,
@@ -1742,13 +1840,14 @@ Returns the order id.
 
     <b>let</b> tick_level = borrow_mut_leaf_by_index(open_orders, tick_index);
     <a href="../../../.././build/Sui/docs/linked_table.md#0x2_linked_table_push_back">linked_table::push_back</a>(&<b>mut</b> tick_level.open_orders, order_id, order);
-    <a href="../../../.././build/Sui/docs/event.md#0x2_event_emit">event::emit</a>(<a href="clob.md#0xdee9_clob_OrderPlaced">OrderPlaced</a>&lt;BaseAsset, QuoteAsset&gt; {
+    <a href="../../../.././build/Sui/docs/event.md#0x2_event_emit">event::emit</a>(<a href="clob.md#0xdee9_clob_OrderPlacedV2">OrderPlacedV2</a>&lt;BaseAsset, QuoteAsset&gt; {
         pool_id: *<a href="../../../.././build/Sui/docs/object.md#0x2_object_uid_as_inner">object::uid_as_inner</a>(&pool.id),
         order_id,
         is_bid,
         owner: user,
         base_asset_quantity_placed: quantity,
-        price
+        price,
+        expire_timestamp
     });
     <b>if</b> (!contains(&pool.usr_open_orders, user)) {
         add(&<b>mut</b> pool.usr_open_orders, user, <a href="../../../.././build/Sui/docs/linked_table.md#0x2_linked_table_new">linked_table::new</a>(ctx));
@@ -1769,6 +1868,9 @@ Returns the order id.
 
 Place a limit order to the order book.
 Returns (base quantity filled, quote quantity filled, whether a maker order is being placed, order id of the maker order).
+When the limit order is not successfully placed, we return false to indicate that and also returns a meaningless order_id 0.
+When the limit order is successfully placed, we return true to indicate that and also the corresponding order_id.
+So please check that boolean value first before using the order id.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="clob.md#0xdee9_clob_place_limit_order">place_limit_order</a>&lt;BaseAsset, QuoteAsset&gt;(pool: &<b>mut</b> <a href="clob.md#0xdee9_clob_Pool">clob::Pool</a>&lt;BaseAsset, QuoteAsset&gt;, price: u64, quantity: u64, is_bid: bool, expire_timestamp: u64, restriction: u8, <a href="../../../.././build/Sui/docs/clock.md#0x2_clock">clock</a>: &<a href="../../../.././build/Sui/docs/clock.md#0x2_clock_Clock">clock::Clock</a>, account_cap: &<a href="custodian.md#0xdee9_custodian_AccountCap">custodian::AccountCap</a>, ctx: &<b>mut</b> <a href="../../../.././build/Sui/docs/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): (u64, u64, bool, u64)
@@ -1878,16 +1980,19 @@ Returns (base quantity filled, quote quantity filled, whether a maker order is b
         <b>return</b> (base_quantity_filled, quote_quantity_filled, <b>true</b>, order_id)
     } <b>else</b> {
         <b>assert</b>!(restriction == <a href="clob.md#0xdee9_clob_NO_RESTRICTION">NO_RESTRICTION</a>, <a href="clob.md#0xdee9_clob_EInvalidRestriction">EInvalidRestriction</a>);
-        order_id = <a href="clob.md#0xdee9_clob_inject_limit_order">inject_limit_order</a>(
-            pool,
-            price,
-            quantity - base_quantity_filled,
-            is_bid,
-            expire_timestamp,
-            account_cap,
-            ctx
-        );
-        <b>return</b> (base_quantity_filled, quote_quantity_filled, <b>true</b>, order_id)
+        <b>if</b>(quantity &gt; base_quantity_filled){
+            order_id = <a href="clob.md#0xdee9_clob_inject_limit_order">inject_limit_order</a>(
+                pool,
+                price,
+                quantity - base_quantity_filled,
+                is_bid,
+                expire_timestamp,
+                account_cap,
+                ctx
+            );
+            <b>return</b> (base_quantity_filled, quote_quantity_filled, <b>true</b>, order_id)
+        };
+        <b>return</b> (base_quantity_filled, quote_quantity_filled, <b>false</b>, 0)
     }
 }
 </code></pre>
@@ -2071,7 +2176,7 @@ Abort if order_id is invalid or if the order is not submitted by the transaction
 ) {
     <b>let</b> pool_id = *<a href="../../../.././build/Sui/docs/object.md#0x2_object_uid_as_inner">object::uid_as_inner</a>(&pool.id);
     <b>let</b> user = <a href="../../../.././build/Sui/docs/object.md#0x2_object_id">object::id</a>(account_cap);
-    <b>assert</b>!(contains(&pool.usr_open_orders, user), 0);
+    <b>assert</b>!(contains(&pool.usr_open_orders, user), <a href="clob.md#0xdee9_clob_EInvalidUser">EInvalidUser</a>);
     <b>let</b> usr_open_order_ids = <a href="../../../.././build/Sui/docs/table.md#0x2_table_borrow_mut">table::borrow_mut</a>(&<b>mut</b> pool.usr_open_orders, user);
     <b>while</b> (!<a href="../../../.././build/Sui/docs/linked_table.md#0x2_linked_table_is_empty">linked_table::is_empty</a>(usr_open_order_ids)) {
         <b>let</b> order_id = *<a href="_borrow">option::borrow</a>(<a href="../../../.././build/Sui/docs/linked_table.md#0x2_linked_table_back">linked_table::back</a>(usr_open_order_ids));
@@ -2139,8 +2244,7 @@ Grouping order_ids like [0, 2, 1, 3] would make it the most gas efficient.
     <b>let</b> user = <a href="../../../.././build/Sui/docs/object.md#0x2_object_id">object::id</a>(account_cap);
     <b>assert</b>!(contains(&pool.usr_open_orders, user), 0);
     <b>let</b> tick_index: u64 = 0;
-    <b>let</b> _open_orders = <b>if</b> (!<a href="critbit.md#0xdee9_critbit_is_empty">critbit::is_empty</a>(&pool.bids)) { &pool.bids } <b>else</b> { &pool.asks };
-    <b>let</b> tick_price: u64 = borrow_leaf_by_index(_open_orders, tick_index).price;
+    <b>let</b> tick_price: u64 = 0;
     <b>let</b> n_order = <a href="_length">vector::length</a>(&order_ids);
     <b>let</b> i_order = 0;
     <b>let</b> usr_open_orders = borrow_mut(&<b>mut</b> pool.usr_open_orders, user);
@@ -2148,7 +2252,6 @@ Grouping order_ids like [0, 2, 1, 3] would make it the most gas efficient.
         <b>let</b> order_id = *<a href="_borrow">vector::borrow</a>(&order_ids, i_order);
         <b>assert</b>!(<a href="../../../.././build/Sui/docs/linked_table.md#0x2_linked_table_contains">linked_table::contains</a>(usr_open_orders, order_id), <a href="clob.md#0xdee9_clob_EInvalidOrderId">EInvalidOrderId</a>);
         <b>let</b> new_tick_price = *<a href="../../../.././build/Sui/docs/linked_table.md#0x2_linked_table_borrow">linked_table::borrow</a>(usr_open_orders, order_id);
-        // <b>let</b> new_tick_price = order.price;
         <b>let</b> is_bid = <a href="clob.md#0xdee9_clob_order_is_bid">order_is_bid</a>(order_id);
         <b>if</b> (new_tick_price != tick_price) {
             tick_price = new_tick_price;
@@ -2428,7 +2531,9 @@ internal func to retrive single depth of a tick price
     account_cap: &AccountCap
 ): &<a href="clob.md#0xdee9_clob_Order">Order</a> {
     <b>let</b> user = <a href="../../../.././build/Sui/docs/object.md#0x2_object_id">object::id</a>(account_cap);
+    <b>assert</b>!(<a href="../../../.././build/Sui/docs/table.md#0x2_table_contains">table::contains</a>(&pool.usr_open_orders, user), <a href="clob.md#0xdee9_clob_EInvalidUser">EInvalidUser</a>);
     <b>let</b> usr_open_order_ids = <a href="../../../.././build/Sui/docs/table.md#0x2_table_borrow">table::borrow</a>(&pool.usr_open_orders, user);
+    <b>assert</b>!(<a href="../../../.././build/Sui/docs/linked_table.md#0x2_linked_table_contains">linked_table::contains</a>(usr_open_order_ids, order_id), <a href="clob.md#0xdee9_clob_EInvalidOrderId">EInvalidOrderId</a>);
     <b>let</b> order_price = *<a href="../../../.././build/Sui/docs/linked_table.md#0x2_linked_table_borrow">linked_table::borrow</a>(usr_open_order_ids, order_id);
     <b>let</b> open_orders =
         <b>if</b> (order_id &lt; <a href="clob.md#0xdee9_clob_MIN_ASK_ORDER_ID">MIN_ASK_ORDER_ID</a>) { &pool.bids }

--- a/crates/sui-framework/docs/custodian.md
+++ b/crates/sui-framework/docs/custodian.md
@@ -12,8 +12,7 @@
 -  [Function `mint_account_cap`](#0xdee9_custodian_mint_account_cap)
 -  [Function `account_balance`](#0xdee9_custodian_account_balance)
 -  [Function `new`](#0xdee9_custodian_new)
--  [Function `withdraw_base_asset`](#0xdee9_custodian_withdraw_base_asset)
--  [Function `withdraw_quote_asset`](#0xdee9_custodian_withdraw_quote_asset)
+-  [Function `withdraw_asset`](#0xdee9_custodian_withdraw_asset)
 -  [Function `increase_user_available_balance`](#0xdee9_custodian_increase_user_available_balance)
 -  [Function `decrease_user_available_balance`](#0xdee9_custodian_decrease_user_available_balance)
 -  [Function `increase_user_locked_balance`](#0xdee9_custodian_increase_user_locked_balance)
@@ -185,7 +184,7 @@ Create an <code><a href="custodian.md#0xdee9_custodian_AccountCap">AccountCap</a
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="custodian.md#0xdee9_custodian_account_balance">account_balance</a>&lt;Asset&gt;(
     <a href="custodian.md#0xdee9_custodian">custodian</a>: &<a href="custodian.md#0xdee9_custodian_Custodian">Custodian</a>&lt;Asset&gt;,
     user: ID
-): (u64, u64){
+): (u64, u64) {
     <b>let</b> account_balances = <a href="../../../.././build/Sui/docs/table.md#0x2_table_borrow">table::borrow</a>(&<a href="custodian.md#0xdee9_custodian">custodian</a>.account_balances, user);
     <b>let</b> avail_balance = <a href="../../../.././build/Sui/docs/balance.md#0x2_balance_value">balance::value</a>(&account_balances.available_balance);
     <b>let</b> locked_balance = <a href="../../../.././build/Sui/docs/balance.md#0x2_balance_value">balance::value</a>(&account_balances.locked_balance);
@@ -224,13 +223,13 @@ Create an <code><a href="custodian.md#0xdee9_custodian_AccountCap">AccountCap</a
 
 </details>
 
-<a name="0xdee9_custodian_withdraw_base_asset"></a>
+<a name="0xdee9_custodian_withdraw_asset"></a>
 
-## Function `withdraw_base_asset`
+## Function `withdraw_asset`
 
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="custodian.md#0xdee9_custodian_withdraw_base_asset">withdraw_base_asset</a>&lt;BaseAsset&gt;(<a href="custodian.md#0xdee9_custodian">custodian</a>: &<b>mut</b> <a href="custodian.md#0xdee9_custodian_Custodian">custodian::Custodian</a>&lt;BaseAsset&gt;, quantity: u64, account_cap: &<a href="custodian.md#0xdee9_custodian_AccountCap">custodian::AccountCap</a>, ctx: &<b>mut</b> <a href="../../../.././build/Sui/docs/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../../../.././build/Sui/docs/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;BaseAsset&gt;
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="custodian.md#0xdee9_custodian_withdraw_asset">withdraw_asset</a>&lt;Asset&gt;(<a href="custodian.md#0xdee9_custodian">custodian</a>: &<b>mut</b> <a href="custodian.md#0xdee9_custodian_Custodian">custodian::Custodian</a>&lt;Asset&gt;, quantity: u64, account_cap: &<a href="custodian.md#0xdee9_custodian_AccountCap">custodian::AccountCap</a>, ctx: &<b>mut</b> <a href="../../../.././build/Sui/docs/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../../../.././build/Sui/docs/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;Asset&gt;
 </code></pre>
 
 
@@ -239,42 +238,13 @@ Create an <code><a href="custodian.md#0xdee9_custodian_AccountCap">AccountCap</a
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="custodian.md#0xdee9_custodian_withdraw_base_asset">withdraw_base_asset</a>&lt;BaseAsset&gt;(
-    <a href="custodian.md#0xdee9_custodian">custodian</a>: &<b>mut</b> <a href="custodian.md#0xdee9_custodian_Custodian">Custodian</a>&lt;BaseAsset&gt;,
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="custodian.md#0xdee9_custodian_withdraw_asset">withdraw_asset</a>&lt;Asset&gt;(
+    <a href="custodian.md#0xdee9_custodian">custodian</a>: &<b>mut</b> <a href="custodian.md#0xdee9_custodian_Custodian">Custodian</a>&lt;Asset&gt;,
     quantity: u64,
     account_cap: &<a href="custodian.md#0xdee9_custodian_AccountCap">AccountCap</a>,
     ctx: &<b>mut</b> TxContext
-): Coin&lt;BaseAsset&gt; {
-    <a href="../../../.././build/Sui/docs/coin.md#0x2_coin_from_balance">coin::from_balance</a>(<a href="custodian.md#0xdee9_custodian_decrease_user_available_balance">decrease_user_available_balance</a>&lt;BaseAsset&gt;(<a href="custodian.md#0xdee9_custodian">custodian</a>, account_cap, quantity), ctx)
-}
-</code></pre>
-
-
-
-</details>
-
-<a name="0xdee9_custodian_withdraw_quote_asset"></a>
-
-## Function `withdraw_quote_asset`
-
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="custodian.md#0xdee9_custodian_withdraw_quote_asset">withdraw_quote_asset</a>&lt;QuoteAsset&gt;(<a href="custodian.md#0xdee9_custodian">custodian</a>: &<b>mut</b> <a href="custodian.md#0xdee9_custodian_Custodian">custodian::Custodian</a>&lt;QuoteAsset&gt;, quantity: u64, account_cap: &<a href="custodian.md#0xdee9_custodian_AccountCap">custodian::AccountCap</a>, ctx: &<b>mut</b> <a href="../../../.././build/Sui/docs/tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): <a href="../../../.././build/Sui/docs/coin.md#0x2_coin_Coin">coin::Coin</a>&lt;QuoteAsset&gt;
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="custodian.md#0xdee9_custodian_withdraw_quote_asset">withdraw_quote_asset</a>&lt;QuoteAsset&gt;(
-    <a href="custodian.md#0xdee9_custodian">custodian</a>: &<b>mut</b> <a href="custodian.md#0xdee9_custodian_Custodian">Custodian</a>&lt;QuoteAsset&gt;,
-    quantity: u64,
-    account_cap: &<a href="custodian.md#0xdee9_custodian_AccountCap">AccountCap</a>,
-    ctx: &<b>mut</b> TxContext
-): Coin&lt;QuoteAsset&gt; {
-    <a href="../../../.././build/Sui/docs/coin.md#0x2_coin_from_balance">coin::from_balance</a>(<a href="custodian.md#0xdee9_custodian_decrease_user_available_balance">decrease_user_available_balance</a>&lt;QuoteAsset&gt;(<a href="custodian.md#0xdee9_custodian">custodian</a>, account_cap, quantity), ctx)
+): Coin&lt;Asset&gt; {
+    <a href="../../../.././build/Sui/docs/coin.md#0x2_coin_from_balance">coin::from_balance</a>(<a href="custodian.md#0xdee9_custodian_decrease_user_available_balance">decrease_user_available_balance</a>&lt;Asset&gt;(<a href="custodian.md#0xdee9_custodian">custodian</a>, account_cap, quantity), ctx)
 }
 </code></pre>
 

--- a/crates/sui-framework/packages/deepbook/sources/custodian.move
+++ b/crates/sui-framework/packages/deepbook/sources/custodian.move
@@ -10,8 +10,6 @@ module deepbook::custodian {
 
     friend deepbook::clob;
 
-    // Custodian for limit orders.
-
     // <<<<<<<<<<<<<<<<<<<<<<<< Error codes <<<<<<<<<<<<<<<<<<<<<<<<
     const EUserBalanceDoesNotExist: u64 = 1;
     // <<<<<<<<<<<<<<<<<<<<<<<< Error codes <<<<<<<<<<<<<<<<<<<<<<<<
@@ -23,6 +21,7 @@ module deepbook::custodian {
 
     struct AccountCap has key, store { id: UID }
 
+    // Custodian for limit orders.
     struct Custodian<phantom T> has key, store {
         id: UID,
         /// Map from an AccountCap object ID to an Account object
@@ -37,7 +36,7 @@ module deepbook::custodian {
     public(friend) fun account_balance<Asset>(
         custodian: &Custodian<Asset>,
         user: ID
-    ): (u64, u64){
+    ): (u64, u64) {
         let account_balances = table::borrow(&custodian.account_balances, user);
         let avail_balance = balance::value(&account_balances.available_balance);
         let locked_balance = balance::value(&account_balances.locked_balance);
@@ -51,22 +50,13 @@ module deepbook::custodian {
         }
     }
 
-    public(friend) fun withdraw_base_asset<BaseAsset>(
-        custodian: &mut Custodian<BaseAsset>,
+    public(friend) fun withdraw_asset<Asset>(
+        custodian: &mut Custodian<Asset>,
         quantity: u64,
         account_cap: &AccountCap,
         ctx: &mut TxContext
-    ): Coin<BaseAsset> {
-        coin::from_balance(decrease_user_available_balance<BaseAsset>(custodian, account_cap, quantity), ctx)
-    }
-
-    public(friend) fun withdraw_quote_asset<QuoteAsset>(
-        custodian: &mut Custodian<QuoteAsset>,
-        quantity: u64,
-        account_cap: &AccountCap,
-        ctx: &mut TxContext
-    ): Coin<QuoteAsset> {
-        coin::from_balance(decrease_user_available_balance<QuoteAsset>(custodian, account_cap, quantity), ctx)
+    ): Coin<Asset> {
+        coin::from_balance(decrease_user_available_balance<Asset>(custodian, account_cap, quantity), ctx)
     }
 
     public(friend) fun increase_user_available_balance<T>(

--- a/crates/sui-framework/packages/deepbook/tests/clob_tests.move
+++ b/crates/sui-framework/packages/deepbook/tests/clob_tests.move
@@ -266,9 +266,9 @@ module deepbook::clob_test {
                 MAX_PRICE,
                 0,
             );
-            assert!(base_quantity_filled == 1500 - 5 - 3, 0);
+            assert!(base_quantity_filled == 1500, 0);
             // 4500 + 2, 2 from round up
-            assert!(quote_quantity_filled == 4500, 0);
+            assert!(quote_quantity_filled == 4500 + 10 + 13, 0);
             test::return_shared(pool);
         };
 
@@ -1140,7 +1140,7 @@ module deepbook::clob_test {
                 MAX_PRICE,
                 0,
             );
-            assert!(base_quantity_filled == 1492, 0);
+            assert!(base_quantity_filled == 1000 + 495, 0);
             assert!(quote_quantity_filled == 4500, 0);
             test::return_shared(pool);
         };
@@ -1155,14 +1155,18 @@ module deepbook::clob_test {
             // custodian::assert_user_balance<USDC>(&custodian, alice, 0, 10000);
             // custodian::assert_user_balance<WSUI>(&custodian, alice, 8000, 2000);
             // rebate fee in base asset 3
-            custodian::assert_user_balance<USD>(quote_custodian, account_cap_user_alice, 4500, 10000);
-            custodian::assert_user_balance<SUI>(base_custodian, account_cap_user_alice, 8000 + 3, 500);
+            custodian::assert_user_balance<USD>(quote_custodian, account_cap_user_alice, 4500 - 10 - 13 + 5 + 6, 10000);
+            custodian::assert_user_balance<SUI>(base_custodian, account_cap_user_alice, 8000, 500 + 5);
             {
                 let (_, _, _, asks) = get_pool_stat(&pool);
                 clob::check_empty_tick_level(asks, 2 * FLOAT_SCALING);
             };
             {
                 let open_orders = vector::empty<Order>();
+                vector::push_back(
+                    &mut open_orders,
+                    clob::test_construct_order(0, 5 * FLOAT_SCALING, 5, false, account_cap_user_alice)
+                );
                 vector::push_back(
                     &mut open_orders,
                     clob::test_construct_order(1, 5 * FLOAT_SCALING, 500, false, account_cap_user_alice)
@@ -1183,6 +1187,10 @@ module deepbook::clob_test {
 
             let open_orders = list_open_orders(&pool, &account_cap_alice);
             let open_orders_cmp = vector::empty<Order>();
+            vector::push_back(
+                &mut open_orders_cmp,
+                clob::test_construct_order(0, 5 * FLOAT_SCALING, 5, false, account_cap_user_alice)
+            );
             vector::push_back(
                 &mut open_orders_cmp,
                 clob::test_construct_order(1, 5 * FLOAT_SCALING, 500, false, account_cap_user_alice)
@@ -1286,9 +1294,9 @@ module deepbook::clob_test {
                 MAX_PRICE,
                 0,
             );
-            assert!(base_quantity_filled == 1500 - 5 - 3, 0);
-            // 4500 + 2, 2 from round up
-            assert!(quote_quantity_filled == 4500, 0);
+            assert!(base_quantity_filled == 1500, 0);
+            // 4500 + 10 + 13, 13 from round up
+            assert!(quote_quantity_filled == 4500 + 10 + 13, 0);
             test::return_shared(pool);
         };
         next_tx(&mut test, bob);
@@ -1302,8 +1310,8 @@ module deepbook::clob_test {
             // custodian::assert_user_balance<USDC>(&custodian, alice, 0, 10000);
             // custodian::assert_user_balance<WSUI>(&custodian, alice, 8000, 2000);
             // rebate fee in base asset 3
-            custodian::assert_user_balance<USD>(quote_custodian, account_cap_user_alice, 4500, 10000);
-            custodian::assert_user_balance<SUI>(base_custodian, account_cap_user_alice, 8000 + 3, 500);
+            custodian::assert_user_balance<USD>(quote_custodian, account_cap_user_alice, 4500 + 5 + 6, 10000);
+            custodian::assert_user_balance<SUI>(base_custodian, account_cap_user_alice, 8000, 500);
             {
                 let (_, _, _, asks) = get_pool_stat(&pool);
                 clob::check_empty_tick_level(asks, 2 * FLOAT_SCALING);
@@ -1611,13 +1619,13 @@ module deepbook::clob_test {
         next_tx(&mut test, bob);
         {
             let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
-            let (base_quantity_filled, quote_quantity_filled) = clob::test_match_bid(
+            let (base_quantity_filled, quote_quantity_filled) = clob::test_match_bid_with_quote_quantity(
                 &mut pool,
                 4500,
                 MAX_PRICE,
                 1,
             );
-            assert!(base_quantity_filled == 1492, 0);
+            assert!(base_quantity_filled == 1000 + 495, 0);
             // 4500
             assert!(quote_quantity_filled == 4500, 0);
             test::return_shared(pool);
@@ -1629,15 +1637,20 @@ module deepbook::clob_test {
             let account_cap_user = object::id(&account_cap);
             let (base_custodian, quote_custodian) = clob::borrow_custodian(&pool);
             // rebate fee in base asset 3
-            custodian::assert_user_balance<USD>(quote_custodian, account_cap_user, 4500, 10000);
-            custodian::assert_user_balance<SUI>(base_custodian, account_cap_user, 8500 + 3, 0);
+            custodian::assert_user_balance<USD>(quote_custodian, account_cap_user, 4500 - 10 - 13 + 5 + 6, 10000);
+            custodian::assert_user_balance<SUI>(base_custodian, account_cap_user, 8500, 5);
             {
                 let (_, _, _, asks) = get_pool_stat(&pool);
                 clob::check_empty_tick_level(asks, 2 * FLOAT_SCALING);
             };
             {
+                let open_orders = vector::empty<Order>();
+                vector::push_back(
+                    &mut open_orders,
+                    clob::test_construct_order(0, 5 * FLOAT_SCALING, 5, false, account_cap_user)
+                );
                 let (_, _, _, asks) = get_pool_stat(&pool);
-                clob::check_empty_tick_level(asks, 5 * FLOAT_SCALING);
+                clob::check_tick_level(asks, 5 * FLOAT_SCALING, &open_orders);
             };
 
             {
@@ -1798,9 +1811,8 @@ module deepbook::clob_test {
                 MAX_PRICE,
                 1,
             );
-            assert!(base_quantity_filled == 1500 - 5 - 3, 0);
-            // 4500
-            assert!(quote_quantity_filled == 4500, 0);
+            assert!(base_quantity_filled == 1500, 0);
+            assert!(quote_quantity_filled == 4500 + 10 + 13, 0);
             test::return_shared(pool);
         };
         next_tx(&mut test, bob);
@@ -1810,8 +1822,8 @@ module deepbook::clob_test {
             let account_cap_user = object::id(&account_cap);
             let (base_custodian, quote_custodian) = clob::borrow_custodian(&pool);
             // rebate fee in base asset 3
-            custodian::assert_user_balance<USD>(quote_custodian, account_cap_user, 4500, 10000);
-            custodian::assert_user_balance<SUI>(base_custodian, account_cap_user, 8500 + 3, 0);
+            custodian::assert_user_balance<USD>(quote_custodian, account_cap_user, 4500 + 5 + 6, 10000);
+            custodian::assert_user_balance<SUI>(base_custodian, account_cap_user, 8500, 0);
             {
                 let (_, _, _, asks) = get_pool_stat(&pool);
                 clob::check_empty_tick_level(asks, 2 * FLOAT_SCALING);


### PR DESCRIPTION
    ## Description
    
    - emit_order_canceled when match_bid_with_quote_quantity
    - add asserts to get_order_status to avoid crash
    - remove duplicate withdraw function from custodian
    - reject place market order with qty 0
    - fix place limit order with qty 0 in N_RESTRICTIONS case
    - add expire_timestamp in OrderPlaced event
    - always use quote for commission
    - avoid crash when batch cancel
    
    ## Test Plan
   
    cd to deepbook dir and run "sui move test"
    
    ### Type of Change (Check all that apply)
    
    - [ ] user-visible impact
    - [ ] breaking change for a client SDKs
    - [ ] breaking change for FNs (FN binary must upgrade)
    - [ ] breaking change for validators or node operators (must upgrade
    binaries)
    - [ ] breaking change for on-chain data layout
    - [ ] necessitate either a data wipe or data migration
    
    ### Release notes