### PR TITLE
[CLI] add `serialize-output` option for all tx types

### DIFF
--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -730,6 +730,7 @@ mod tests {
             input_coins: vec![*bad_gas.id()],
             recipient: SuiAddress::random_for_testing_only(),
             gas_budget: 2_000_000,
+            serialize_output: false,
         }
         .execute(faucet.wallet_mut())
         .await
@@ -846,6 +847,7 @@ mod tests {
             gas_budget: 50000000,
             gas: None,
             count: None,
+            serialize_output: false,
         }
         .execute(&mut context)
         .await;

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -387,6 +387,7 @@ async fn test_gas_command() -> Result<(), anyhow::Error> {
         object_id: object_to_send,
         gas: Some(object_id),
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+        serialize_output: false,
     }
     .execute(context)
     .await?;
@@ -516,6 +517,7 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
         args,
         gas: None,
         gas_budget: TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS * rgp,
+        serialize_output: false,
     }
     .execute(context)
     .await?;
@@ -553,6 +555,7 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
         args: args.to_vec(),
         gas: Some(gas),
         gas_budget: TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS * rgp,
+        serialize_output: false,
     }
     .execute(context)
     .await;
@@ -577,6 +580,7 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
         args: args.to_vec(),
         gas: Some(gas),
         gas_budget: TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS * rgp,
+        serialize_output: false,
     }
     .execute(context)
     .await;
@@ -603,6 +607,7 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
         args: args.to_vec(),
         gas: Some(gas),
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS,
+        serialize_output: false,
     }
     .execute(context)
     .await?;
@@ -1049,6 +1054,7 @@ async fn test_package_upgrade_command() -> Result<(), anyhow::Error> {
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
         skip_dependency_verification: false,
         with_unpublished_dependencies: false,
+        serialize_output: false,
     }
     .execute(context)
     .await?;
@@ -1109,6 +1115,7 @@ async fn test_native_transfer() -> Result<(), anyhow::Error> {
         to: recipient,
         object_id: obj_id,
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+        serialize_output: false,
     }
     .execute(context)
     .await?;
@@ -1212,6 +1219,7 @@ async fn test_native_transfer() -> Result<(), anyhow::Error> {
         to: recipient,
         object_id: obj_id,
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+        serialize_output: false,
     }
     .execute(context)
     .await?;
@@ -1499,6 +1507,7 @@ async fn test_merge_coin() -> Result<(), anyhow::Error> {
         coin_to_merge,
         gas: Some(gas),
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+        serialize_output: false,
     }
     .execute(context)
     .await?;
@@ -1552,6 +1561,7 @@ async fn test_merge_coin() -> Result<(), anyhow::Error> {
         coin_to_merge,
         gas: None,
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+        serialize_output: false,
     }
     .execute(context)
     .await?;
@@ -1616,6 +1626,7 @@ async fn test_split_coin() -> Result<(), anyhow::Error> {
         coin_id: coin,
         amounts: Some(vec![1000, 10]),
         count: None,
+        serialize_output: false,
     }
     .execute(context)
     .await?;
@@ -1682,6 +1693,7 @@ async fn test_split_coin() -> Result<(), anyhow::Error> {
         coin_id: coin,
         amounts: None,
         count: Some(3),
+        serialize_output: false,
     }
     .execute(context)
     .await?;
@@ -1751,6 +1763,7 @@ async fn test_split_coin() -> Result<(), anyhow::Error> {
         coin_id: coin,
         amounts: Some(vec![1000, 10]),
         count: None,
+        serialize_output: false,
     }
     .execute(context)
     .await?;
@@ -1848,11 +1861,12 @@ async fn test_serialize_tx() -> Result<(), anyhow::Error> {
         .data;
     let coin = object_refs.get(1).unwrap().object().unwrap().object_id;
 
-    SuiClientCommands::SerializeTransferSui {
+    SuiClientCommands::TransferSui {
         to: address1,
         sui_coin_object_id: coin,
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
         amount: Some(1),
+        serialize_output: true,
     }
     .execute(context)
     .await?;

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -498,6 +498,7 @@ async fn test_full_node_sync_flood() -> Result<(), anyhow::Error> {
                         coin_id: object_to_split.0,
                         gas: Some(gas_object_id),
                         gas_budget: 50000,
+                        serialize_output: false,
                     }
                     .execute(context)
                     .await

--- a/crates/test-utils/src/transaction.rs
+++ b/crates/test-utils/src/transaction.rs
@@ -411,6 +411,7 @@ pub async fn create_devnet_nft(
         args,
         gas: Some(*gas_object),
         gas_budget: TEST_ONLY_GAS_UNIT_FOR_GENERIC * gas_price,
+        serialize_output: false,
     }
     .execute(context)
     .await?;
@@ -458,6 +459,7 @@ pub async fn transfer_sui(
         amount: None,
         sui_coin_object_id: gas_ref.0,
         gas_budget: TEST_ONLY_GAS_UNIT_FOR_TRANSFER * gas_price,
+        serialize_output: false,
     }
     .execute(context)
     .await?;
@@ -529,6 +531,7 @@ pub async fn transfer_coin(
         object_id: object_to_send,
         gas: None,
         gas_budget: TEST_ONLY_GAS_UNIT_FOR_TRANSFER * gas_price,
+        serialize_output: false,
     }
     .execute(context)
     .await?;
@@ -570,6 +573,7 @@ pub async fn split_coin_with_wallet_context(context: &mut WalletContext, coin_id
         count: Some(2),
         gas: None,
         gas_budget: TEST_ONLY_GAS_UNIT_FOR_SPLIT_COIN * gas_price,
+        serialize_output: false,
     }
     .execute(context)
     .await


### PR DESCRIPTION
- Every kind of tx the CLI can craft now supports `--serialize-output` to allow signing elsewhere (e.g., via a multi-sig not managed by the CLI).
- Eliminate some existing `Serialize` commands that are now redundant

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
