### PR TITLE
[ts-sdk] Change gas budget calculation

### DIFF
--- a/.changeset/grumpy-trees-happen.md
+++ b/.changeset/grumpy-trees-happen.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Change the default gas budgeting to take storage rebates into account.

--- a/sdk/typescript/src/builder/TransactionBlock.ts
+++ b/sdk/typescript/src/builder/TransactionBlock.ts
@@ -103,10 +103,10 @@ const TRANSACTION_BRAND = Symbol.for('@mysten/transaction');
 const MAX_GAS_OBJECTS = 256;
 
 // The maximum gas that is allowed.
-const MAX_GAS = 1000000000;
+const MAX_GAS = 50_000_000_000;
 
-// A guess about how much overhead each coin provides for gas calculations.
-const GAS_OVERHEAD_PER_COIN = 10n;
+// An amount of gas (in gas units) that is added to transactions as an overhead to ensure transactions do not fail.
+const GAS_SAFE_OVERHEAD = 1000n;
 
 interface BuildOptions {
   provider?: JsonRpcProvider;
@@ -663,15 +663,22 @@ export class TransactionBlock {
           );
         }
 
-        const coinOverhead =
-          GAS_OVERHEAD_PER_COIN *
-          BigInt(this.blockData.gasConfig.payment?.length || 0n) *
-          BigInt(this.blockData.gasConfig.price || 1n);
+        const safeOverhead =
+          GAS_SAFE_OVERHEAD * BigInt(this.blockData.gasConfig.price || 1n);
 
+        const baseComputationCostWithOverhead =
+          BigInt(dryRunResult.effects.gasUsed.computationCost) + safeOverhead;
+
+        const gasBudget =
+          baseComputationCostWithOverhead +
+          BigInt(dryRunResult.effects.gasUsed.storageCost) -
+          BigInt(dryRunResult.effects.gasUsed.storageRebate);
+
+        // Set the budget to max(computation, computation + storage - rebate)
         this.setGasBudget(
-          BigInt(dryRunResult.effects.gasUsed.computationCost) +
-            BigInt(dryRunResult.effects.gasUsed.storageCost) +
-            coinOverhead,
+          gasBudget > baseComputationCostWithOverhead
+            ? gasBudget
+            : baseComputationCostWithOverhead,
         );
       }
     }


### PR DESCRIPTION
## Description

This changes gas budget calculation from `computation + storage` to `max(computation, computation + storage - rebate)`. I also removed the per-coin overhead cost, and moved to a flat overhead cost that's added just for safety.

## Test Plan

Tests should continue to pass.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
