### PR TITLE
[not for commit] Gas info for replay tool

### DIFF
--- a/crates/sui-cost-tables/src/tier_based/tables.rs
+++ b/crates/sui-cost-tables/src/tier_based/tables.rs
@@ -342,6 +342,7 @@ impl GasStatus {
     // Charge the number of bytes with the cost per byte value
     // As more bytes are read throughout the computation the cost per bytes is increased.
     pub fn charge_bytes(&mut self, size: usize, cost_per_byte: u64) -> PartialVMResult<()> {
+        println!("GAS BYTES: {}", size);
         let computation_cost = if self.gas_model_version == 4 {
             self.increase_stack_size(size as u64)?;
             self.stack_size_current_tier_mult * size as u64 * cost_per_byte

--- a/crates/sui-types/src/gas.rs
+++ b/crates/sui-types/src/gas.rs
@@ -46,6 +46,7 @@ pub trait SuiGasStatusAPI {
 }
 
 #[enum_dispatch(SuiGasStatusAPI)]
+#[derive(Debug)]
 pub enum SuiGasStatus {
     V1(SuiGasStatusV1),
     V2(SuiGasStatusV2),

--- a/crates/sui-types/src/temporary_store.rs
+++ b/crates/sui-types/src/temporary_store.rs
@@ -991,6 +991,7 @@ impl<S: ObjectStore> TemporaryStore<S> {
                     *execution_result = Err(err);
                 }
             }
+            println!("GAS BUCKETIZE: {:#?}", gas_status);
 
             // On error we need to dump writes, deletes, etc before charging storage gas
             if execution_result.is_err() {
@@ -1010,6 +1011,7 @@ impl<S: ObjectStore> TemporaryStore<S> {
                 self.handle_storage_and_rebate_v2(gas, gas_object_id, gas_status, execution_result)
             }
 
+            println!("GAS SUMMARY: {:#?}", gas_status);
             let cost_summary = gas_status.summary();
             let gas_used = cost_summary.net_gas_usage();
 
@@ -1033,6 +1035,7 @@ impl<S: ObjectStore> TemporaryStore<S> {
         execution_result: &mut Result<T, ExecutionError>,
     ) {
         if let Err(err) = gas_status.charge_storage_and_rebate() {
+            println!("GAS STORAGE OOG: {:#?}", gas_status);
             self.reset(gas, gas_status);
             gas_status.adjust_computation_on_out_of_gas();
             self.ensure_gas_and_input_mutated(Some(gas_object_id));
@@ -1051,6 +1054,7 @@ impl<S: ObjectStore> TemporaryStore<S> {
         execution_result: &mut Result<T, ExecutionError>,
     ) {
         if let Err(err) = gas_status.charge_storage_and_rebate() {
+            println!("GAS STORAGE OOG: {:#?}", gas_status);
             // we run out of gas charging storage, reset and try charging for storage again.
             // Input objects are touched and so they have a storage cost
             self.reset(gas, gas_status);


### PR DESCRIPTION
## Description 

`println` added to check gas status in forking nodes.
Add this to a fullnode code and run the fork again with a failing and "possibly" a working node.
This should give you a bit more details on what the gas status is. Specifically it will print the gas status the VM is using and allow a comparison that is very detailed.
Look for instruction executed, stack hight and size and the memory charged. That should tell us exactly what differences we are seeing

## Test Plan 

not for commit

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
