### PR TITLE
[RPC] - remove locked_until from rpc layer

### DIFF
--- a/crates/sui-cluster-test/src/test_case/coin_index_test.rs
+++ b/crates/sui-cluster-test/src/test_case/coin_index_test.rs
@@ -6,7 +6,6 @@ use async_trait::async_trait;
 use jsonrpsee::rpc_params;
 use move_core_types::language_storage::StructTag;
 use serde_json::json;
-use std::collections::HashMap;
 use sui_core::test_utils::compile_managed_coin_package;
 use sui_json::SuiJsonValue;
 use sui_json_rpc_types::ObjectChange;
@@ -222,13 +221,11 @@ impl TestCaseImpl for CoinIndexTest {
                 coin_type: sui_type_str.into(),
                 coin_object_count: old_coin_object_count,
                 total_balance,
-                locked_balance: HashMap::new(),
             },
             Balance {
                 coin_type: coin_type_str.clone(),
                 coin_object_count: 1,
                 total_balance: 10000,
-                locked_balance: HashMap::new(),
             },
         ];
         // Comes with asc order.

--- a/crates/sui-json-rpc-types/src/sui_coin.rs
+++ b/crates/sui-json-rpc-types/src/sui_coin.rs
@@ -47,9 +47,6 @@ pub struct Coin {
     #[schemars(with = "BigInt<u64>")]
     #[serde_as(as = "BigInt<u64>")]
     pub balance: u64,
-    #[schemars(with = "Option<BigInt<u64>>")]
-    #[serde_as(as = "Option<BigInt<u64>>")]
-    pub locked_until_epoch: Option<EpochId>,
     pub previous_transaction: TransactionDigest,
 }
 

--- a/crates/sui-json-rpc-types/src/sui_coin.rs
+++ b/crates/sui-json-rpc-types/src/sui_coin.rs
@@ -1,16 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
 use crate::Page;
-use sui_types::base_types::{
-    EpochId, ObjectDigest, ObjectID, ObjectRef, SequenceNumber, TransactionDigest,
-};
+use sui_types::base_types::{ObjectDigest, ObjectID, ObjectRef, SequenceNumber, TransactionDigest};
 use sui_types::coin::CoinMetadata;
 use sui_types::error::SuiError;
 use sui_types::object::Object;
@@ -28,10 +24,6 @@ pub struct Balance {
     #[schemars(with = "BigInt<u128>")]
     #[serde_as(as = "BigInt<u128>")]
     pub total_balance: u128,
-    // TODO: This should be removed
-    #[schemars(with = "HashMap<BigInt<u64>, BigInt<u128>>")]
-    #[serde_as(as = "HashMap<BigInt<u64>, BigInt<u128>>")]
-    pub locked_balance: HashMap<EpochId, u128>,
 }
 
 #[serde_as]

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -65,7 +65,6 @@ impl CoinReadApi {
                         version: coin.version,
                         digest: coin.digest,
                         balance: coin.balance,
-                        locked_until_epoch: None,
                         previous_transaction: coin.previous_transaction,
                     })
                     .collect::<Vec<_>>(),

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -251,8 +251,6 @@ impl CoinReadApiServer for CoinReadApi {
             coin_type: coin_type.to_string(),
             coin_object_count: balance.num_coins as usize,
             total_balance: balance.balance as u128,
-            // note: LockedCoin is deprecated
-            locked_balance: Default::default(),
         })
     }
 
@@ -272,14 +270,10 @@ impl CoinReadApiServer for CoinReadApi {
             })?;
         Ok(all_balance
             .iter()
-            .map(|(coin_type, balance)| {
-                Balance {
-                    coin_type: coin_type.to_string(),
-                    coin_object_count: balance.num_coins as usize,
-                    total_balance: balance.balance as u128,
-                    // note: LockedCoin is deprecated
-                    locked_balance: Default::default(),
-                }
+            .map(|(coin_type, balance)| Balance {
+                coin_type: coin_type.to_string(),
+                coin_object_count: balance.num_coins as usize,
+                total_balance: balance.balance as u128,
             })
             .collect())
     }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -2695,7 +2695,6 @@
         "required": [
           "coinObjectCount",
           "coinType",
-          "lockedBalance",
           "totalBalance"
         ],
         "properties": {
@@ -2706,12 +2705,6 @@
           },
           "coinType": {
             "type": "string"
-          },
-          "lockedBalance": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/BigInt_for_uint128"
-            }
           },
           "totalBalance": {
             "$ref": "#/components/schemas/BigInt_for_uint128"
@@ -2920,17 +2913,6 @@
           },
           "digest": {
             "$ref": "#/components/schemas/ObjectDigest"
-          },
-          "lockedUntilEpoch": {
-            "default": null,
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/BigInt_for_uint64"
-              },
-              {
-                "type": "null"
-              }
-            ]
           },
           "previousTransaction": {
             "$ref": "#/components/schemas/TransactionDigest"

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -271,7 +271,7 @@ pub async fn metadata(
         context
             .client
             .coin_read_api()
-            .select_coins(sender, None, total_amount.into(), None, vec![])
+            .select_coins(sender, None, total_amount.into(), vec![])
             .await
             .ok()
     } else {

--- a/sdk/typescript/src/types/coin.ts
+++ b/sdk/typescript/src/types/coin.ts
@@ -8,7 +8,6 @@ import {
   nullable,
   number,
   object,
-  optional,
   string,
 } from 'superstruct';
 import { ObjectId, TransactionDigest } from './common';
@@ -20,7 +19,6 @@ export const CoinStruct = object({
   version: string(),
   digest: TransactionDigest,
   balance: string(),
-  lockedUntilEpoch: nullable(number()),
   previousTransaction: TransactionDigest,
 });
 
@@ -38,10 +36,6 @@ export const CoinBalance = object({
   coinType: string(),
   coinObjectCount: number(),
   totalBalance: string(),
-  lockedBalance: object({
-    epochId: optional(number()),
-    number: optional(number()),
-  }),
 });
 
 export type CoinBalance = Infer<typeof CoinBalance>;


### PR DESCRIPTION
## Description 

We have removed locked coin from move, locked until is not longer needed 

## Test Plan 

unit tests