### PR TITLE
Re-enable InMemoryCheckpointRoots

### DIFF
--- a/crates/sui-core/src/authority/epoch_start_configuration.rs
+++ b/crates/sui-core/src/authority/epoch_start_configuration.rs
@@ -147,9 +147,7 @@ impl EpochStartConfigTrait for EpochStartConfigurationV2 {
 
 impl EpochFlag {
     pub fn default_flags_for_new_epoch() -> Vec<Self> {
-        vec![]
-        // todo - enable after switching to single DBBatch in consensus handler
-        // vec![EpochFlag::InMemoryCheckpointRoots]
+        vec![EpochFlag::InMemoryCheckpointRoots]
     }
 }
 


### PR DESCRIPTION
This reverts commit bd28fd72ce0ce8195fef3e86da350558be4e9775.


This is safe now that we are on protocol version 6 that reorders `EndOfEpoch` messages to the end of the commit