### PR TITLE
[wallet-ext] add loading state to the "Verify Ledger Connection" flow

### DIFF
--- a/apps/wallet/src/ui/app/components/menu/content/VerifyLedgerConnectionStatus.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/VerifyLedgerConnectionStatus.tsx
@@ -27,7 +27,7 @@ enum VerificationStatus {
 }
 
 const resetVerificationStatusDelay = 5000;
-const loadingStateDelay = 400;
+const loadingStateDelay = 200;
 
 export function VerifyLedgerConnectionStatus({
     accountAddress,


### PR DESCRIPTION
## Description 
We modified how the "Verify Ledger Connection" flow works last Friday (you now have to confirm a prompt on the Ledger device itself), so now we need to add a loading state. The one tricky thing here is that the verification operation can fail super quickly, to combat a janky loading state we'll only show the loading state after 200 milliseconds.

<img width="342" alt="image" src="https://user-images.githubusercontent.com/7453188/234080383-8a97d4fe-d8b5-4cb5-879d-86a1dc1e616d.png">

## Test Plan 
- Manual testing

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
N/A
