### PR TITLE
[execution_driver] Avoid dispatching thread when permit is available immediately

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -29,7 +29,7 @@ use sui_types::metrics::LimitsMetrics;
 use sui_types::TypeTag;
 use tap::TapFallible;
 use tokio::sync::mpsc::unbounded_channel;
-use tokio::sync::oneshot;
+use tokio::sync::{oneshot, Semaphore};
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
 use tracing::{debug, error, info, instrument, trace, warn, Instrument};
 
@@ -104,7 +104,7 @@ use crate::checkpoints::checkpoint_executor::CheckpointExecutor;
 use crate::checkpoints::CheckpointStore;
 use crate::epoch::committee_store::CommitteeStore;
 use crate::event_handler::EventHandler;
-use crate::execution_driver::execution_process;
+use crate::execution_driver::{execution_process, ExecutionDispatcher};
 use crate::module_cache_metrics::ResolverMetrics;
 use crate::stake_aggregator::StakeAggregator;
 use crate::state_accumulator::StateAccumulator;
@@ -1710,10 +1710,16 @@ impl AuthorityState {
 
         let metrics = Arc::new(AuthorityMetrics::new(prometheus_registry));
         let (tx_ready_certificates, rx_ready_certificates) = unbounded_channel();
+        let execution_limit = Arc::new(Semaphore::new(num_cpus::get() * 2));
+        let execution_dispatcher = Arc::new(ExecutionDispatcher::new(
+            tx_ready_certificates,
+            execution_limit.clone(),
+            metrics.clone(),
+        ));
         let transaction_manager = Arc::new(TransactionManager::new(
             store.clone(),
             &epoch_store,
-            tx_ready_certificates,
+            execution_dispatcher.clone(),
             metrics.clone(),
         ));
         let (tx_execution_shutdown, rx_execution_shutdown) = oneshot::channel();
@@ -1749,10 +1755,12 @@ impl AuthorityState {
 
         // Start a task to execute ready certificates.
         let authority_state = Arc::downgrade(&state);
+        execution_dispatcher.set_authority(authority_state.clone());
         spawn_monitored_task!(execution_process(
             authority_state,
             rx_ready_certificates,
-            rx_execution_shutdown
+            rx_execution_shutdown,
+            execution_limit
         ));
 
         // TODO: This doesn't belong to the constructor of AuthorityState.
@@ -3513,6 +3521,9 @@ impl AuthorityState {
             .unwrap()
             .send(())
             .unwrap();
+        self.transaction_manager
+            .execution_dispatcher
+            .shutdown_execution_for_test();
     }
 }
 

--- a/crates/sui-core/src/execution_driver.rs
+++ b/crates/sui-core/src/execution_driver.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use parking_lot::RwLock;
 use std::{
     sync::{Arc, Weak},
     time::Duration,
@@ -8,13 +9,15 @@ use std::{
 
 use mysten_metrics::{monitored_scope, spawn_monitored_task};
 use sui_types::{digests::TransactionEffectsDigest, messages::VerifiedExecutableTransaction};
+use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::OwnedSemaphorePermit;
 use tokio::{
     sync::{mpsc::UnboundedReceiver, oneshot, Semaphore},
     time::sleep,
 };
 use tracing::{error, error_span, info, trace, Instrument};
 
-use crate::authority::AuthorityState;
+use crate::authority::{AuthorityMetrics, AuthorityState};
 
 #[cfg(test)]
 #[path = "unit_tests/execution_driver_tests.rs"]
@@ -25,6 +28,16 @@ mod execution_driver_tests;
 pub const EXECUTION_MAX_ATTEMPTS: u32 = 10;
 const EXECUTION_FAILURE_RETRY_INTERVAL: Duration = Duration::from_secs(1);
 
+pub struct ExecutionDispatcher {
+    limit: Arc<Semaphore>,
+    tx_ready_certificates: UnboundedSender<(
+        VerifiedExecutableTransaction,
+        Option<TransactionEffectsDigest>,
+    )>,
+    authority: RwLock<Option<Weak<AuthorityState>>>,
+    metrics: Arc<AuthorityMetrics>,
+}
+
 /// When a notification that a new pending transaction is received we activate
 /// processing the transaction in a loop.
 pub async fn execution_process(
@@ -34,11 +47,9 @@ pub async fn execution_process(
         Option<TransactionEffectsDigest>,
     )>,
     mut rx_execution_shutdown: oneshot::Receiver<()>,
+    limit: Arc<Semaphore>,
 ) {
     info!("Starting pending certificates execution process.");
-
-    // Rate limit concurrent executions to # of cpus.
-    let limit = Arc::new(Semaphore::new(num_cpus::get()));
 
     // Loop whenever there is a signal that a new transactions is ready to process.
     loop {
@@ -72,46 +83,118 @@ pub async fn execution_process(
         };
         authority.metrics.execution_driver_dispatch_queue.dec();
 
-        // TODO: Ideally execution_driver should own a copy of epoch store and recreate each epoch.
-        let epoch_store = authority.load_epoch_store_one_call_per_task();
-
         let digest = *certificate.digest();
         trace!(?digest, "Pending certificate execution activated.");
 
         let limit = limit.clone();
         // hold semaphore permit until task completes. unwrap ok because we never close
         // the semaphore in this context.
-        let permit = limit.acquire_owned().await.unwrap();
-
+        let permit = {
+            let _scope = monitored_scope("ExecutionDriver::acquire_semaphore");
+            limit.acquire_owned().await.unwrap()
+        };
         // Certificate execution can take significant time, so run it in a separate task.
-        spawn_monitored_task!(async move {
-            let _scope = monitored_scope("ExecutionDriver");
-            let _guard = permit;
-            if let Ok(true) = authority.is_tx_already_executed(&digest) {
+        spawn_monitored_task!(execution_task(
+            permit,
+            authority,
+            certificate,
+            expected_effects_digest
+        )
+        .instrument(error_span!("execution_driver", tx_digest = ?digest)));
+    }
+}
+
+async fn execution_task(
+    _permit: OwnedSemaphorePermit,
+    authority: Arc<AuthorityState>,
+    certificate: VerifiedExecutableTransaction,
+    expected_effects_digest: Option<TransactionEffectsDigest>,
+) {
+    let digest = *certificate.digest();
+    // TODO: Ideally execution_driver should own a copy of epoch store and recreate each epoch.
+    let epoch_store = authority.load_epoch_store_one_call_per_task();
+    let _scope = monitored_scope("ExecutionDriver::task");
+    if let Ok(true) = authority.is_tx_already_executed(&digest) {
+        return;
+    }
+    let mut attempts = 0;
+    loop {
+        attempts += 1;
+        let res = authority
+            .try_execute_immediately(&certificate, expected_effects_digest, &epoch_store)
+            .await;
+        if let Err(e) = res {
+            if attempts == EXECUTION_MAX_ATTEMPTS {
+                panic!("Failed to execute certified transaction {digest:?} after {attempts} attempts! error={e} certificate={certificate:?}");
+            }
+            // Assume only transient failure can happen. Permanent failure is probably
+            // a bug. There is nothing that can be done to recover from permanent failures.
+            error!(tx_digest=?digest, "Failed to execute certified transaction {digest:?}! attempt {attempts}, {e}");
+            sleep(EXECUTION_FAILURE_RETRY_INTERVAL).await;
+        } else {
+            break;
+        }
+    }
+    authority
+        .metrics
+        .execution_driver_executed_transactions
+        .inc();
+}
+
+impl ExecutionDispatcher {
+    pub fn new(
+        tx_ready_certificates: UnboundedSender<(
+            VerifiedExecutableTransaction,
+            Option<TransactionEffectsDigest>,
+        )>,
+        semaphore: Arc<Semaphore>,
+        metrics: Arc<AuthorityMetrics>,
+    ) -> Self {
+        let authority = RwLock::new(None);
+        Self {
+            limit: semaphore,
+            tx_ready_certificates,
+            authority,
+            metrics,
+        }
+    }
+
+    pub fn dispatch_certificate(
+        &self,
+        certificate: VerifiedExecutableTransaction,
+        expected_effects_digest: Option<TransactionEffectsDigest>,
+    ) {
+        let authority = self.authority.read();
+        let authority = authority.as_ref().and_then(|w| w.upgrade());
+        if let Some(authority) = authority {
+            if let Ok(permit) = self.limit.clone().try_acquire_owned() {
+                // Schedule execution immediately when permit is available
+                // This helps to avoid using single dispatcher thread to dispatch all transactions
+                let digest = *certificate.digest();
+                spawn_monitored_task!(execution_task(
+                    permit,
+                    authority,
+                    certificate,
+                    expected_effects_digest
+                )
+                .instrument(error_span!("execution_driver", tx_digest = ?digest)));
                 return;
             }
-            let mut attempts = 0;
-            loop {
-                attempts += 1;
-                let res = authority
-                    .try_execute_immediately(&certificate, expected_effects_digest, &epoch_store)
-                    .await;
-                if let Err(e) = res {
-                    if attempts == EXECUTION_MAX_ATTEMPTS {
-                        panic!("Failed to execute certified transaction {digest:?} after {attempts} attempts! error={e} certificate={certificate:?}");
-                    }
-                    // Assume only transient failure can happen. Permanent failure is probably
-                    // a bug. There is nothing that can be done to recover from permanent failures.
-                    error!(tx_digest=?digest, "Failed to execute certified transaction {digest:?}! attempt {attempts}, {e}");
-                    sleep(EXECUTION_FAILURE_RETRY_INTERVAL).await;
-                } else {
-                    break;
-                }
-            }
-            authority
-                .metrics
-                .execution_driver_executed_transactions
-                .inc();
-        }.instrument(error_span!("execution_driver", tx_digest = ?digest)));
+        }
+        self.metrics.execution_driver_dispatch_queue.inc();
+        self.tx_ready_certificates
+            .send((certificate, expected_effects_digest))
+            .ok();
+    }
+
+    pub fn set_authority(&self, authority: Weak<AuthorityState>) {
+        let mut ptr = self.authority.write();
+        assert!(ptr.is_none());
+        *ptr = Some(authority);
+    }
+
+    #[cfg(test)]
+    pub fn shutdown_execution_for_test(&self) {
+        *self.authority.write() = None;
     }
 }


### PR DESCRIPTION
Under high load we see that execution queue has a lot of certificates, while execution tasks are not fully utilized. It is possible that we are maxing out on execution dispatch task throughput, this change avoids it by spawning tasks directly when possible
