### PR TITLE
Use saved `FullCheckpointContents` for state sync

### DIFF
--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -255,7 +255,7 @@ impl CheckpointExecutor {
         // We store a fixed number of additional FullCheckpointContents after execution is complete
         // for use in state sync.
         const NUM_SAVED_FULL_CHECKPOINT_CONTENTS: u64 = 5_000;
-        if seq > NUM_SAVED_FULL_CHECKPOINT_CONTENTS {
+        if seq >= NUM_SAVED_FULL_CHECKPOINT_CONTENTS {
             let prune_seq = seq - NUM_SAVED_FULL_CHECKPOINT_CONTENTS;
             let prune_checkpoint = self
                 .checkpoint_store

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -252,9 +252,23 @@ impl CheckpointExecutor {
 
         fail_point!("highest-executed-checkpoint");
 
-        self.checkpoint_store
-            .delete_full_checkpoint_contents(seq)
-            .expect("Failed to delete full checkpoint contents");
+        // We store a fixed number of additional FullCheckpointContents after execution is complete
+        // for use in state sync.
+        const NUM_SAVED_FULL_CHECKPOINT_CONTENTS: u64 = 5_000;
+        if seq > NUM_SAVED_FULL_CHECKPOINT_CONTENTS {
+            let prune_seq = seq - NUM_SAVED_FULL_CHECKPOINT_CONTENTS;
+            let prune_checkpoint = self
+                .checkpoint_store
+                .get_checkpoint_by_sequence_number(prune_seq)
+                .expect("Failed to fetch checkpoint")
+                .expect("Failed to retrieve earlier checkpoint by sequence number");
+            self.checkpoint_store
+                .delete_full_checkpoint_contents(prune_seq)
+                .expect("Failed to delete full checkpoint contents");
+            self.checkpoint_store
+                .delete_contents_digest_sequence_number_mapping(&prune_checkpoint.content_digest)
+                .expect("Failed to delete contents digest -> sequence number mapping");
+        }
 
         self.checkpoint_store
             .update_highest_executed_checkpoint(checkpoint)

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -90,6 +90,10 @@ pub struct CheckpointStore {
     /// Maps checkpoint contents digest to checkpoint contents
     checkpoint_content: DBMap<CheckpointContentsDigest, CheckpointContents>,
 
+    /// Maps checkpoint contents digest to checkpoint sequence number
+    checkpoint_sequence_by_contents_digest:
+        DBMap<CheckpointContentsDigest, CheckpointSequenceNumber>,
+
     /// Stores entire checkpoint contents from state sync, indexed by sequence number, for
     /// efficient reads of full checkpoints. Entries from this table are deleted after state
     /// accumulation has completed.
@@ -178,6 +182,20 @@ impl CheckpointStore {
         self.certified_checkpoints
             .get(&sequence_number)
             .map(|maybe_checkpoint| maybe_checkpoint.map(|c| c.into()))
+    }
+
+    pub fn get_sequence_number_by_contents_digest(
+        &self,
+        digest: &CheckpointContentsDigest,
+    ) -> Result<Option<CheckpointSequenceNumber>, TypedStoreError> {
+        self.checkpoint_sequence_by_contents_digest.get(digest)
+    }
+
+    pub fn delete_contents_digest_sequence_number_mapping(
+        &self,
+        digest: &CheckpointContentsDigest,
+    ) -> Result<(), TypedStoreError> {
+        self.checkpoint_sequence_by_contents_digest.remove(digest)
     }
 
     pub fn get_latest_certified_checkpoint(&self) -> Option<VerifiedCheckpoint> {
@@ -363,6 +381,8 @@ impl CheckpointStore {
         checkpoint: &VerifiedCheckpoint,
         full_contents: VerifiedCheckpointContents,
     ) -> Result<(), TypedStoreError> {
+        self.checkpoint_sequence_by_contents_digest
+            .insert(&checkpoint.content_digest, checkpoint.sequence_number())?;
         let full_contents = full_contents.into_inner();
         self.full_checkpoint_content
             .insert(checkpoint.sequence_number(), &full_contents)?;


### PR DESCRIPTION
## Description 

- Modifies deletion logic to keep last 5000 `FullCheckpointContents`
- Adds CheckpointContentsDigest->CheckpointSequenceNumber index

## Test Plan 

Manually test on testnet