### PR TITLE
[sui verifier] Ban entry on init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9496,6 +9496,7 @@ dependencies = [
  "move-package",
  "move-symbol-pool",
  "serde-reflection",
+ "sui-protocol-config",
  "sui-types",
  "sui-verifier",
  "tempfile",
@@ -10199,6 +10200,7 @@ dependencies = [
  "move-bytecode-utils",
  "move-bytecode-verifier",
  "move-core-types",
+ "sui-protocol-config",
  "sui-types",
  "workspace-hack",
 ]

--- a/crates/sui-adapter-transactional-tests/tests/init/entry_new.exp
+++ b/crates/sui-adapter-transactional-tests/tests/init/entry_new.exp
@@ -1,0 +1,9 @@
+processed 3 tasks
+
+task 1 'publish'. lines 8-13:
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::m. 'init' cannot be 'entry'"), command: Some(0) } }
+
+task 2 'run'. lines 15-15:
+Error: Transaction Effects Status: Move Bytecode Verification Error. Please run the Bytecode Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VMVerificationOrDeserializationError, source: Some(VMError { major_status: LINKER_ERROR, sub_status: None, message: Some("Cannot find link context test in store"), exec_state: None, location: Undefined, indices: [], offsets: [] }), command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/init/entry_new.move
+++ b/crates/sui-adapter-transactional-tests/tests/init/entry_new.move
@@ -1,0 +1,15 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// init with entry is no longer allowed
+
+//# init --addresses test=0x0
+
+//# publish
+module test::m {
+    use sui::tx_context::TxContext;
+    entry fun init(_: &mut TxContext) {
+    }
+}
+
+//# run test::m::init

--- a/crates/sui-adapter-transactional-tests/tests/init/entry_old.exp
+++ b/crates/sui-adapter-transactional-tests/tests/init/entry_old.exp
@@ -1,0 +1,26 @@
+processed 6 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 8-15:
+created: object(1,0), object(1,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 5639200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'run'. lines 17-17:
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'run'. lines 19-21:
+Error: Transaction Effects Status: Non Entry Function Invoked. Move Call must start with an entry function
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: NonEntryFunctionInvoked, source: Some("Cannot call 'init'"), command: Some(0) } }
+
+task 4 'run'. lines 22-22:
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5 'upgrade'. lines 24-31:
+created: object(5,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 5639200,  storage_rebate: 2595780, non_refundable_storage_fee: 26220

--- a/crates/sui-adapter-transactional-tests/tests/init/entry_old.move
+++ b/crates/sui-adapter-transactional-tests/tests/init/entry_old.move
@@ -1,0 +1,31 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// init with entry used to be allowed
+
+//# init --addresses test=0x0 v2=0x0 --protocol_version 6 --accounts A
+
+//# publish --sender A --upgradeable
+module test::m {
+    use sui::tx_context::TxContext;
+    entry fun init(_: &mut TxContext) {
+    }
+
+    public fun foo() {}
+}
+
+//# run test::m::init
+
+//# run test::m::init --protocol-version 7
+
+// m still loads
+//# run test::m::foo --protocol-version 7
+
+//# upgrade --package test  --sender A --upgrade-capability 1,1
+module v2::m {
+    use sui::tx_context::TxContext;
+    fun init(_: &mut TxContext) {
+    }
+
+    public fun foo() {}
+}

--- a/crates/sui-adapter-transactional-tests/tests/programmable/cannot_call_init.exp
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/cannot_call_init.exp
@@ -10,4 +10,4 @@ gas summary: computation_cost: 1000000, storage_cost: 3898800,  storage_rebate: 
 
 task 2 'programmable'. lines 13-14:
 Error: Transaction Effects Status: Non Entry Function Invoked. Move Call must start with an entry function
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: NonEntryFunctionInvoked, source: Some("Can only call `entry` or `public` functions"), command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: NonEntryFunctionInvoked, source: Some("Cannot call 'init'"), command: Some(0) } }

--- a/crates/sui-move-build/Cargo.toml
+++ b/crates/sui-move-build/Cargo.toml
@@ -15,6 +15,7 @@ tempfile = "3.3.0"
 serde-reflection = "0.3.6"
 sui-types = { path = "../sui-types" }
 sui-verifier = { path = "../sui-verifier" }
+sui-protocol-config = { path = "../sui-protocol-config" }
 
 move-binary-format.workspace = true
 move-bytecode-utils.workspace = true

--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -40,7 +40,7 @@ use move_package::{
 };
 use move_symbol_pool::Symbol;
 use serde_reflection::Registry;
-use sui_protocol_config::ProtocolConfig;
+use sui_protocol_config::{ProtocolConfig, ProtocolVersion};
 use sui_types::{
     base_types::ObjectID,
     error::{SuiError, SuiResult},
@@ -200,8 +200,9 @@ pub fn build_from_resolution_graph(
                     error: err.to_string(),
                 }
             })?;
+            // TODO make this configurable
             sui_bytecode_verifier::verify_module(
-                &ProtocolConfig::get_for_max_version(),
+                &ProtocolConfig::get_for_version(ProtocolVersion::MAX),
                 m,
                 &fn_info,
             )?;

--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -40,6 +40,7 @@ use move_package::{
 };
 use move_symbol_pool::Symbol;
 use serde_reflection::Registry;
+use sui_protocol_config::ProtocolConfig;
 use sui_types::{
     base_types::ObjectID,
     error::{SuiError, SuiResult},
@@ -199,7 +200,11 @@ pub fn build_from_resolution_graph(
                     error: err.to_string(),
                 }
             })?;
-            sui_bytecode_verifier::verify_module(m, &fn_info)?;
+            sui_bytecode_verifier::verify_module(
+                &ProtocolConfig::get_for_max_version(),
+                m,
+                &fn_info,
+            )?;
         }
         // TODO(https://github.com/MystenLabs/sui/issues/69): Run Move linker
     }

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -157,6 +157,9 @@ struct FeatureFlags {
     // protocol version.
     #[serde(skip_serializing_if = "is_false")]
     advance_to_highest_supported_protocol_version: bool,
+    // If true, disallow entry modifiers on entry functions
+    #[serde(skip_serializing_if = "is_false")]
+    ban_entry_init: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -660,6 +663,10 @@ impl ProtocolConfig {
         self.feature_flags
             .advance_to_highest_supported_protocol_version
     }
+
+    pub fn ban_entry_init(&self) -> bool {
+        self.feature_flags.ban_entry_init
+    }
 }
 
 // Special getters
@@ -1065,6 +1072,7 @@ impl ProtocolConfig {
                     .disable_invariant_violation_check_in_swap_loc = true;
                 cfg.feature_flags
                     .advance_to_highest_supported_protocol_version = true;
+                cfg.feature_flags.ban_entry_init = true;
                 cfg
             }
             // Use this template when making changes:

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_7.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_7.snap
@@ -13,6 +13,7 @@ feature_flags:
   disallow_adding_abilities_on_upgrade: true
   disable_invariant_violation_check_in_swap_loc: true
   advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-verifier/Cargo.toml
+++ b/crates/sui-verifier/Cargo.toml
@@ -15,3 +15,4 @@ move-core-types.workspace = true
 
 sui-types = { path = "../sui-types" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
+sui-protocol-config = { path = "../sui-protocol-config" }

--- a/crates/sui-verifier/src/verifier.rs
+++ b/crates/sui-verifier/src/verifier.rs
@@ -5,6 +5,7 @@
 
 use move_binary_format::file_format::CompiledModule;
 use move_bytecode_verifier::meter::DummyMeter;
+use sui_protocol_config::ProtocolConfig;
 use sui_types::{error::ExecutionError, move_package::FnInfoMap};
 
 use crate::{
@@ -14,6 +15,7 @@ use crate::{
 
 /// Helper for a "canonical" verification of a module.
 pub fn verify_module(
+    config: &ProtocolConfig,
     module: &CompiledModule,
     fn_info_map: &FnInfoMap,
 ) -> Result<(), ExecutionError> {
@@ -21,6 +23,6 @@ pub fn verify_module(
     global_storage_access_verifier::verify_module(module)?;
     id_leak_verifier::verify_module(module, &mut DummyMeter)?;
     private_generics::verify_module(module)?;
-    entry_points_verifier::verify_module(module, fn_info_map)?;
+    entry_points_verifier::verify_module(config, module, fn_info_map)?;
     one_time_witness_verifier::verify_module(module, fn_info_map)
 }


### PR DESCRIPTION
## Description 

- No longer allow entry modifier on init
- `entry` on `init` while not harmful, is a bit confusing as `init` functions are otherwise not callable. For cleanliness, we think it is important to keep it separated as one might expect `init` is only called once
- Thanks @otter-sec (https://osec.io/) for the report! 

## Test Plan 

- New tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
