### PR TITLE
add get validators apy endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1441,9 +1441,9 @@ dependencies = [
 
 [[package]]
 name = "cached"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5877db5d1af7fae60d06b5db9430b68056a69b3582a0be8e3691e87654aeb6"
+checksum = "bc2fafddf188d13788e7099295a59b99e99b2148ab2195cae454e754cc099925"
 dependencies = [
  "async-trait",
  "async_once",
@@ -9337,6 +9337,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bcs",
+ "cached",
  "eyre",
  "fastcrypto",
  "futures",
@@ -9371,6 +9372,7 @@ dependencies = [
  "sui-protocol-config",
  "sui-sdk",
  "sui-simulator",
+ "sui-storage",
  "sui-transaction-builder",
  "sui-types",
  "tap",

--- a/crates/sui-indexer/Cargo.toml
+++ b/crates/sui-indexer/Cargo.toml
@@ -52,7 +52,7 @@ move-core-types.workspace = true
 move-bytecode-utils.workspace = true
 
 diesel_migrations = { version = "2.0.0" }
-cached = "0.42.0"
+cached = "0.43.0"
 
 [features]
 pg_integration = []

--- a/crates/sui-indexer/src/apis/governance_api.rs
+++ b/crates/sui-indexer/src/apis/governance_api.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeMap;
+
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::http_client::HttpClient;
@@ -49,6 +51,10 @@ impl GovernanceReadApiServer for GovernanceReadApi {
 
     async fn get_reference_gas_price(&self) -> RpcResult<BigInt<u64>> {
         self.fullnode.get_reference_gas_price().await
+    }
+
+    async fn get_validators_apy(&self) -> RpcResult<BTreeMap<SuiAddress, f64>> {
+        self.fullnode.get_validators_apy().await
     }
 }
 

--- a/crates/sui-indexer/src/apis/governance_api.rs
+++ b/crates/sui-indexer/src/apis/governance_api.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeMap;
-
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::http_client::HttpClient;
@@ -10,8 +8,8 @@ use jsonrpsee::RpcModule;
 
 use sui_json_rpc::api::{GovernanceReadApiClient, GovernanceReadApiServer};
 use sui_json_rpc::SuiRpcModule;
-use sui_json_rpc_types::DelegatedStake;
 use sui_json_rpc_types::SuiCommittee;
+use sui_json_rpc_types::{DelegatedStake, ValidatorApys};
 use sui_open_rpc::Module;
 use sui_types::base_types::{ObjectID, SuiAddress};
 use sui_types::sui_serde::BigInt;
@@ -53,7 +51,7 @@ impl GovernanceReadApiServer for GovernanceReadApi {
         self.fullnode.get_reference_gas_price().await
     }
 
-    async fn get_validators_apy(&self) -> RpcResult<BTreeMap<SuiAddress, f64>> {
+    async fn get_validators_apy(&self) -> RpcResult<ValidatorApys> {
         self.fullnode.get_validators_apy().await
     }
 }

--- a/crates/sui-json-rpc-types/src/sui_governance.rs
+++ b/crates/sui-json-rpc-types/src/sui_governance.rs
@@ -72,3 +72,19 @@ pub struct Stake {
     #[serde(flatten)]
     pub status: StakeStatus,
 }
+
+#[serde_as]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+pub struct ValidatorApys {
+    pub apys: Vec<ValidatorApy>,
+    #[schemars(with = "BigInt<u64>")]
+    #[serde_as(as = "BigInt<u64>")]
+    pub epoch: EpochId,
+}
+
+#[serde_as]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+pub struct ValidatorApy {
+    pub address: SuiAddress,
+    pub apy: f64,
+}

--- a/crates/sui-json-rpc/Cargo.toml
+++ b/crates/sui-json-rpc/Cargo.toml
@@ -37,6 +37,7 @@ tap = "1.0"
 
 sui-adapter = { path = "../sui-adapter" }
 sui-core = { path = "../sui-core" }
+sui-storage = {path = "../sui-storage" }
 sui-types = { path = "../sui-types" }
 sui-json = { path = "../sui-json" }
 sui-open-rpc = { path = "../sui-open-rpc" }
@@ -48,6 +49,7 @@ mysten-metrics = { path = "../mysten-metrics" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 shared-crypto = { path = "../shared-crypto" }
 typed-store.workspace = true
+cached = "0.43.0"
 
 [dev-dependencies]
 sui-config = { path = "../sui-config" }

--- a/crates/sui-json-rpc/src/api/governance.rs
+++ b/crates/sui-json-rpc/src/api/governance.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeMap;
+
 use jsonrpsee::core::RpcResult;
 use jsonrpsee_proc_macros::rpc;
 
@@ -39,4 +41,8 @@ pub trait GovernanceReadApi {
     /// Return the reference gas price for the network
     #[method(name = "getReferenceGasPrice")]
     async fn get_reference_gas_price(&self) -> RpcResult<BigInt<u64>>;
+
+    /// Return the validator APY
+    #[method(name = "getValidatorsApy")]
+    async fn get_validators_apy(&self) -> RpcResult<BTreeMap<SuiAddress, f64>>;
 }

--- a/crates/sui-json-rpc/src/api/governance.rs
+++ b/crates/sui-json-rpc/src/api/governance.rs
@@ -1,12 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeMap;
-
 use jsonrpsee::core::RpcResult;
 use jsonrpsee_proc_macros::rpc;
 
-use sui_json_rpc_types::{DelegatedStake, SuiCommittee};
+use sui_json_rpc_types::{DelegatedStake, SuiCommittee, ValidatorApys};
 use sui_open_rpc_macros::open_rpc;
 use sui_types::base_types::{ObjectID, SuiAddress};
 use sui_types::sui_serde::BigInt;
@@ -44,5 +42,5 @@ pub trait GovernanceReadApi {
 
     /// Return the validator APY
     #[method(name = "getValidatorsApy")]
-    async fn get_validators_apy(&self) -> RpcResult<BTreeMap<SuiAddress, f64>>;
+    async fn get_validators_apy(&self) -> RpcResult<ValidatorApys>;
 }

--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -259,13 +259,13 @@ impl GovernanceReadApiServer for GovernanceReadApi {
 
         for rates in exchange_rate_table.into_iter().filter(|r| r.active) {
             let apy = if let Some((_, latest_rate)) = rates.rates.first() {
-                let (n, rates_n) = if rates.rates.len() < 30 {
+                let (n, rates_n) = if rates.rates.len() < 29 {
                     (rates.rates.len() as f64, rates.rates.last())
                 } else {
-                    (30.0, rates.rates.get(30))
+                    (29.0, rates.rates.get(29))
                 };
                 if let Some((_, rate_n_days)) = rates_n {
-                    (rate_n_days.rate() / latest_rate.rate()).powf(360.0 / n) - 1.0
+                    (rate_n_days.rate() / latest_rate.rate()).powf(360.0 / (n + 1.0)) - 1.0
                 } else {
                     0.0
                 }

--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -10,15 +10,17 @@ use jsonrpsee::core::RpcResult;
 use jsonrpsee::RpcModule;
 use tracing::{info, instrument};
 
+use cached::proc_macro::cached;
+use cached::SizedCache;
 use mysten_metrics::spawn_monitored_task;
 use sui_core::authority::AuthorityState;
-use sui_json_rpc_types::SuiCommittee;
 use sui_json_rpc_types::{DelegatedStake, Stake, StakeStatus};
+use sui_json_rpc_types::{SuiCommittee, ValidatorApy, ValidatorApys};
 use sui_open_rpc::Module;
 use sui_types::base_types::{MoveObjectType, ObjectID, SuiAddress};
 use sui_types::committee::EpochId;
 use sui_types::dynamic_field::get_dynamic_field_from_store;
-use sui_types::error::{SuiError, UserInputError};
+use sui_types::error::{SuiError, SuiResult, UserInputError};
 use sui_types::governance::StakedSui;
 use sui_types::id::ID;
 use sui_types::object::ObjectRead;
@@ -26,9 +28,7 @@ use sui_types::sui_serde::BigInt;
 use sui_types::sui_system_state::sui_system_state_summary::SuiSystemStateSummary;
 use sui_types::sui_system_state::PoolTokenExchangeRate;
 use sui_types::sui_system_state::SuiSystemStateTrait;
-use sui_types::sui_system_state::{
-    get_validator_from_table, sui_system_state_summary::get_validator_by_pool_id, SuiSystemState,
-};
+use sui_types::sui_system_state::{get_validator_from_table, SuiSystemState};
 
 use crate::api::{GovernanceReadApiServer, JsonRpcMetrics};
 use crate::error::Error;
@@ -138,32 +138,33 @@ impl GovernanceReadApi {
         let system_state = self.get_system_state()?;
         let system_state_summary: SuiSystemStateSummary =
             system_state.clone().into_sui_system_state_summary();
+
+        let mut rates = exchange_rates(&self.state, system_state_summary.epoch)
+            .await?
+            .into_iter();
+
         let mut delegated_stakes = vec![];
         for (pool_id, stakes) in pools {
             // Rate table and rate can be null when the pool is not active
-            let rate_table = self
-                .get_exchange_rate_table(&system_state_summary, &pool_id)
-                .await
-                .ok();
-            let current_rate = if let Some(rate_table) = rate_table {
-                self.get_exchange_rate(rate_table, system_state_summary.epoch)
-                    .await
-                    .ok()
-            } else {
-                None
-            };
+            let Some(rate_table) = rates.find(|r| r.pool_id == pool_id) else { continue; };
+            let current_rate = rate_table.rates.first().map(|(_, rate)| rate);
 
             let mut delegations = vec![];
             for (stake, exists) in stakes {
                 let status = if !exists {
                     StakeStatus::Unstaked
                 } else if system_state_summary.epoch >= stake.activation_epoch() {
-                    let estimated_reward = if let (Some(rate_table), Some(current_rate)) =
-                        (&rate_table, &current_rate)
-                    {
-                        let stake_rate = self
-                            .get_exchange_rate(*rate_table, stake.activation_epoch())
-                            .await
+                    let estimated_reward = if let Some(current_rate) = current_rate {
+                        let stake_rate = rate_table
+                            .rates
+                            .iter()
+                            .find_map(|(epoch, rate)| {
+                                if *epoch == stake.activation_epoch() {
+                                    Some(rate.clone())
+                                } else {
+                                    None
+                                }
+                            })
                             .unwrap_or_default();
                         let estimated_reward = ((stake_rate.rate() / current_rate.rate()) - 1.0)
                             * stake.principal() as f64;
@@ -184,14 +185,8 @@ impl GovernanceReadApi {
                     status,
                 })
             }
-            let validator = get_validator_by_pool_id(
-                self.state.db().as_ref(),
-                &system_state,
-                &system_state_summary,
-                pool_id,
-            )?;
             delegated_stakes.push(DelegatedStake {
-                validator_address: validator.sui_address,
+                validator_address: rate_table.address,
                 staking_pool: pool_id,
                 stakes: delegations,
             })
@@ -201,49 +196,6 @@ impl GovernanceReadApi {
 
     fn get_system_state(&self) -> Result<SuiSystemState, Error> {
         Ok(self.state.database.get_sui_system_state_object()?)
-    }
-
-    async fn get_exchange_rate_table(
-        &self,
-        system_state: &SuiSystemStateSummary,
-        pool_id: &ObjectID,
-    ) -> Result<ObjectID, Error> {
-        let active_rate = system_state.active_validators.iter().find_map(|v| {
-            if &v.staking_pool_id == pool_id {
-                Some(v.exchange_rates_id)
-            } else {
-                None
-            }
-        });
-
-        if let Some(active_rate) = active_rate {
-            Ok(active_rate)
-        } else {
-            // try find from inactive pool
-            let validator = get_validator_from_table(
-                self.state.db().as_ref(),
-                system_state.inactive_pools_id,
-                &ID::new(*pool_id),
-            )?;
-
-            Ok(validator.exchange_rates_id)
-        }
-    }
-
-    async fn get_exchange_rate(
-        &self,
-        table: ObjectID,
-        epoch: EpochId,
-    ) -> Result<PoolTokenExchangeRate, Error> {
-        let exchange_rate: PoolTokenExchangeRate = get_dynamic_field_from_store(
-            self.state.db().as_ref(),
-            table,
-            &epoch,
-        )
-        .map_err(|err| {
-            SuiError::SuiSystemStateReadError(format!("Failed to get exchange rate: {:?}", err))
-        })?;
-        Ok(exchange_rate)
     }
 }
 
@@ -294,30 +246,128 @@ impl GovernanceReadApiServer for GovernanceReadApi {
     }
 
     #[instrument(skip(self))]
-    async fn get_validators_apy(&self) -> RpcResult<BTreeMap<SuiAddress, f64>> {
+    async fn get_validators_apy(&self) -> RpcResult<ValidatorApys> {
         info!("get_validator_apy");
         let system_state_summary: SuiSystemStateSummary =
             self.get_latest_sui_system_state().await?;
 
-        let validators = system_state_summary
-            .active_validators
-            .iter()
-            .map(|v| (v.sui_address, v.exchange_rates_id))
-            .collect::<Vec<_>>();
+        let exchange_rate_table = exchange_rates(&self.state, system_state_summary.epoch)
+            .await
+            .map_err(Error::from)?;
 
-        let mut apys = BTreeMap::new();
-        for (validator, rate_table_id) in validators {
-            let current_rate = self
-                .get_exchange_rate(rate_table_id, system_state_summary.epoch)
-                .await?;
-            let rate_30_days = self
-                .get_exchange_rate(rate_table_id, max(system_state_summary.epoch - 30, 0))
-                .await?;
-            let apy = (current_rate.rate() / rate_30_days.rate()).powf(12.0) - 1.0;
-            apys.insert(validator, apy);
+        let mut apys = vec![];
+
+        for rates in exchange_rate_table.into_iter().filter(|r| r.active) {
+            let apy = if let Some((_, latest_rate)) = rates.rates.first() {
+                let (n, rates_n) = if rates.rates.len() < 30 {
+                    (rates.rates.len() as f64, rates.rates.last())
+                } else {
+                    (30.0, rates.rates.get(30))
+                };
+                if let Some((_, rate_n_days)) = rates_n {
+                    (rate_n_days.rate() / latest_rate.rate()).powf(360.0 / n) - 1.0
+                } else {
+                    0.0
+                }
+            } else {
+                0.0
+            };
+            apys.push(ValidatorApy {
+                address: rates.address,
+                apy,
+            });
         }
-        Ok(apys)
+        Ok(ValidatorApys {
+            apys,
+            epoch: system_state_summary.epoch,
+        })
     }
+}
+
+/// Cached exchange rates for validators for the given epoch, the cache size is 1, it will be cleared when the epoch changes.
+#[cached(
+    type = "SizedCache<EpochId, Vec<ValidatorExchangeRates>>",
+    create = "{ SizedCache::with_size(1) }",
+    convert = "{ _current_epoch }",
+    result = true
+)]
+async fn exchange_rates(
+    state: &Arc<AuthorityState>,
+    _current_epoch: EpochId,
+) -> SuiResult<Vec<ValidatorExchangeRates>> {
+    let system_state = state.database.get_sui_system_state_object()?;
+    let system_state_summary: SuiSystemStateSummary = system_state.into_sui_system_state_summary();
+
+    // Get validator rate tables
+    let mut tables = vec![];
+
+    for validator in system_state_summary.active_validators {
+        tables.push((
+            validator.sui_address,
+            validator.exchange_rates_id,
+            validator.exchange_rates_size,
+            true,
+        ));
+    }
+    for df in state.get_dynamic_fields(
+        system_state_summary.inactive_pools_id,
+        None,
+        system_state_summary.inactive_pools_size as usize,
+    )? {
+        let pool_id: ID =
+            bcs::from_bytes(&df.bcs_name).map_err(|e| SuiError::ObjectDeserializationError {
+                error: e.to_string(),
+            })?;
+        let validator = get_validator_from_table(
+            state.database.as_ref(),
+            system_state_summary.inactive_pools_id,
+            &pool_id,
+        )?;
+        tables.push((
+            validator.sui_address,
+            validator.exchange_rates_id,
+            validator.exchange_rates_size,
+            false,
+        ));
+    }
+
+    let mut exchange_rates = vec![];
+    for (address, exchange_rates_id, exchange_rates_size, active) in tables {
+        let mut rates = state
+            .get_dynamic_fields(exchange_rates_id, None, exchange_rates_size as usize)?
+            .into_iter()
+            .map(|df| {
+                let epoch: EpochId = bcs::from_bytes(&df.bcs_name).map_err(|e| {
+                    SuiError::ObjectDeserializationError {
+                        error: e.to_string(),
+                    }
+                })?;
+
+                let exchange_rate: PoolTokenExchangeRate =
+                    get_dynamic_field_from_store(state.db().as_ref(), exchange_rates_id, &epoch)?;
+
+                Ok::<_, SuiError>((epoch, exchange_rate))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        rates.sort_by(|(a, _), (b, _)| a.cmp(b).reverse());
+
+        exchange_rates.push(ValidatorExchangeRates {
+            address,
+            pool_id: exchange_rates_id,
+            active,
+            rates,
+        });
+    }
+    Ok(exchange_rates)
+}
+
+#[derive(Clone, Debug)]
+pub struct ValidatorExchangeRates {
+    address: SuiAddress,
+    pool_id: ObjectID,
+    active: bool,
+    rates: Vec<(EpochId, PoolTokenExchangeRate)>,
 }
 
 impl SuiRpcModule for GovernanceReadApi {

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1631,14 +1631,10 @@
       "description": "Return the validator APY",
       "params": [],
       "result": {
-        "name": "BTreeMap<SuiAddress,f64>",
+        "name": "ValidatorApys",
         "required": true,
         "schema": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "number",
-            "format": "double"
-          }
+          "$ref": "#/components/schemas/ValidatorApys"
         }
       }
     },
@@ -7654,6 +7650,40 @@
                 "$ref": "#/components/schemas/SequenceNumber"
               }
             ]
+          }
+        }
+      },
+      "ValidatorApy": {
+        "type": "object",
+        "required": [
+          "address",
+          "apy"
+        ],
+        "properties": {
+          "address": {
+            "$ref": "#/components/schemas/SuiAddress"
+          },
+          "apy": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "ValidatorApys": {
+        "type": "object",
+        "required": [
+          "apys",
+          "epoch"
+        ],
+        "properties": {
+          "apys": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ValidatorApy"
+            }
+          },
+          "epoch": {
+            "$ref": "#/components/schemas/BigInt_for_uint64"
           }
         }
       }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1622,6 +1622,27 @@
       }
     },
     {
+      "name": "suix_getValidatorsApy",
+      "tags": [
+        {
+          "name": "Governance Read API"
+        }
+      ],
+      "description": "Return the validator APY",
+      "params": [],
+      "result": {
+        "name": "BTreeMap<SuiAddress,f64>",
+        "required": true,
+        "schema": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      }
+    },
+    {
       "name": "suix_queryEvents",
       "tags": [
         {

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -101,7 +101,7 @@ bytemuck = { version = "1", default-features = false }
 byteorder = { version = "1", features = ["i128"] }
 bytes = { version = "1", features = ["serde"] }
 bzip2-sys = { version = "0.1", default-features = false, features = ["static"] }
-cached = { version = "0.42" }
+cached = { version = "0.43" }
 cached_proc_macro_types = { version = "0.1", default-features = false }
 camino = { version = "1", default-features = false, features = ["serde1"] }
 cargo-platform = { version = "0.1", default-features = false }
@@ -769,7 +769,7 @@ bytemuck = { version = "1", default-features = false }
 byteorder = { version = "1", features = ["i128"] }
 bytes = { version = "1", features = ["serde"] }
 bzip2-sys = { version = "0.1", default-features = false, features = ["static"] }
-cached = { version = "0.42" }
+cached = { version = "0.43" }
 cached_proc_macro = { version = "0.16", default-features = false }
 cached_proc_macro_types = { version = "0.1", default-features = false }
 camino = { version = "1", default-features = false, features = ["serde1"] }


### PR DESCRIPTION
## Description 

Added a new endpoint `suix_getValidatorsApy` to get the list of APY for all active validators.
the APY is calculated using the current staking pool and 30 days staking pool exchange rate

this PR also added cache for validator exchange rate, which will be repopulated when epoch change, `get_states` method will be using this cache instead of resolving the rate from move tables to improve the read performance.

## Test Plan 

Tested manually on testnet
```
{
    "jsonrpc": "2.0",
    "result": {
        "apys": [
            {
                "address": "0x44b1b319e23495995fc837dafd28fc6af8b645edddff0fc1467f1ad631362c23",
                "apy": 0.03927171044129407
            },
            {
                "address": "0x3d618b03660f4e8b4ec99c52af08a814f5248154937782d22b5a8f2e44ba15fc",
                "apy": 0.03927182250212513
            },
            {
                "address": "0x24e8511a01aa7ab06eb8ce61d6c002ac5b8b7e0fde809554ca3662fb184ce257",
                "apy": 0.03927171891132608
            },
            {
                "address": "0x4ce8d9d329879f3b361c9515f48acc0f91b283a7305f6c9c789b0c8d1ebf43f2",
                "apy": 0.039271936185637735
            },
            {
                "address": "0x4c05f4f76ed81d210e9a29ac0756c7a3129e4b9ecacbbb9fc1579505947630cf",
                "apy": 0.039272011483796776
            },
            {
                "address": "0x6881875df60daf5528d66a62b66dc5710bf06b220fa9266ffdfeeb9cd8d6ed94",
                "apy": 0.039271851914000955
            },
            {
                "address": "0xab4fb3eeaa7b0ab4f91eedab33adf140c6750e60ca5e44b3df82491937d7bab4",
                "apy": 0.039271687290090895
            },
            {
                "address": "0x2079cb58f32c868deb0f4f20f509b7f034c7bea84c964cb1316f77fc987445b8",
                "apy": 0.03927190475122777
            },
            {
                "address": "0xaaec0462f9286f2aa9db25143eaa428cc6527b1ef669772b40b011983837de77",
                "apy": 0.03927179016703497
            },
            {
                "address": "0xf941ae3cbe5645dccc15da8346b533f7f91f202089a5521653c062b2ff10b304",
                "apy": 0.03927192198581797
            },
            {
                "address": "0x2622b55585033f26b0a86b378de1a6284c2dda531e52ef30ea87a8df81f4630a",
                "apy": 0.03927168099244316
            },
            {
                "address": "0x43ff72d09170ab4712d7bf26f0475d7f94f60f7076d5da9ebcfe7dde87faf2a7",
                "apy": 0.039271755979213285
            },
            {
                "address": "0x9062fc51d91056246dc31f2b818a4ddb113a044ec22c8dd0674616bbe56f7192",
                "apy": 0.039271682672775476
            },
...
```