### PR TITLE
[DO NOT MERGE] Sample tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8023,6 +8023,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "sample-tool"
+version = "0.1.0"
+dependencies = [
+ "test-utils",
+ "tokio",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ members = [
     "crates/mysten-util-mem",
     "crates/mysten-util-mem-derive",
     "crates/prometheus-closure-metric",
+    "crates/sample-tool",
     "crates/shared-crypto",
     "crates/sui",
     "crates/sui-adapter",

--- a/crates/sample-tool/Cargo.toml
+++ b/crates/sample-tool/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sample-tool"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+test-utils = { path = "../test-utils" }
+
+tokio = { workspace = true, features = ["full", "tracing", "test-util"] }

--- a/crates/sample-tool/src/main.rs
+++ b/crates/sample-tool/src/main.rs
@@ -1,0 +1,8 @@
+use std::time::Duration;
+use test_utils::network::TestClusterBuilder;
+
+#[tokio::main]
+async fn main() {
+    let _cluster = TestClusterBuilder::new().build().await;
+    tokio::time::sleep(Duration::from_secs(3)).await;
+}


### PR DESCRIPTION
Sample tool to demonstrate a panic.
Run:
```
cargo run --bin sample-tool
```

Panic:
```
thread 'tokio-runtime-worker' panicked at 'Cannot drop a runtime in a context where blocking is not allowed. This happens when a runtime is dropped from within an asynchronous context.', /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/blocking/shutdown.rs:51:21
stack backtrace:
   0: rust_begin_unwind
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/std/src/panicking.rs:575:5
   1: core::panicking::panic_fmt
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/core/src/panicking.rs:64:14
   2: tokio::runtime::blocking::shutdown::Receiver::wait
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/blocking/shutdown.rs:51:21
   3: tokio::runtime::blocking::pool::BlockingPool::shutdown
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/blocking/pool.rs:261:12
   4: <tokio::runtime::blocking::pool::BlockingPool as core::ops::drop::Drop>::drop
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/blocking/pool.rs:278:9
   5: core::ptr::drop_in_place<tokio::runtime::blocking::pool::BlockingPool>
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/core/src/ptr/mod.rs:490:1
   6: core::ptr::drop_in_place<tokio::runtime::runtime::Runtime>
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/core/src/ptr/mod.rs:490:1
   7: core::ptr::drop_in_place<<sui_json_rpc::ServerHandle as core::ops::drop::Drop>::drop::{{closure}}>
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/core/src/ptr/mod.rs:490:1
   8: core::ptr::drop_in_place<core::option::Option<<sui_json_rpc::ServerHandle as core::ops::drop::Drop>::drop::{{closure}}>>
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/core/src/ptr/mod.rs:490:1
   9: core::ptr::drop_in_place<tokio::runtime::blocking::task::BlockingTask<<sui_json_rpc::ServerHandle as core::ops::drop::Drop>::drop::{{closure}}>>
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/core/src/ptr/mod.rs:490:1
  10: core::ptr::drop_in_place<tokio::runtime::task::core::Stage<tokio::runtime::blocking::task::BlockingTask<<sui_json_rpc::ServerHandle as core::ops::drop::Drop>::drop::{{closure}}>>>
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/core/src/ptr/mod.rs:490:1
  11: tokio::runtime::task::core::Core<T,S>::set_stage::{{closure}}
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/core.rs:277:41
  12: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/loom/std/unsafe_cell.rs:14:9
  13: tokio::runtime::task::core::Core<T,S>::set_stage
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/core.rs:277:9
  14: tokio::runtime::task::core::Core<T,S>::drop_future_or_output
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/core.rs:242:13
  15: tokio::runtime::task::harness::cancel_task::{{closure}}
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/harness.rs:447:9
  16: core::ops::function::FnOnce::call_once
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/core/src/ops/function.rs:250:5
  17: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/core/src/panic/unwind_safe.rs:271:9
  18: std::panicking::try::do_call
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/std/src/panicking.rs:483:40
  19: ___rust_try
  20: std::panicking::try
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/std/src/panicking.rs:447:19
  21: std::panic::catch_unwind
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/std/src/panic.rs:140:14
  22: tokio::runtime::task::harness::cancel_task
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/harness.rs:446:15
  23: tokio::runtime::task::harness::Harness<T,S>::shutdown
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/harness.rs:241:9
  24: tokio::runtime::task::raw::shutdown
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/raw.rs:295:5
  25: tokio::runtime::task::raw::RawTask::shutdown
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/raw.rs:234:18
  26: tokio::runtime::task::Task<S>::shutdown
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/mod.rs:385:9
  27: tokio::runtime::task::UnownedTask<S>::shutdown
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/mod.rs:437:9
  28: tokio::runtime::blocking::pool::Spawner::spawn_task
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/blocking/pool.rs:397:13
  29: tokio::runtime::blocking::pool::Spawner::spawn_blocking_inner
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/blocking/pool.rs:386:23
  30: tokio::runtime::blocking::pool::Spawner::spawn_blocking
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/blocking/pool.rs:301:17
  31: tokio::runtime::handle::Handle::spawn_blocking
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/handle.rs:180:9
  32: <sui_json_rpc::ServerHandle as core::ops::drop::Drop>::drop
             at ./crates/sui-json-rpc/src/lib.rs:208:13
  33: core::ptr::drop_in_place<sui_json_rpc::ServerHandle>
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/core/src/ptr/mod.rs:490:1
  34: core::ptr::drop_in_place<core::option::Option<sui_json_rpc::ServerHandle>>
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/core/src/ptr/mod.rs:490:1
  35: core::ptr::drop_in_place<sui_node::SuiNode>
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/core/src/ptr/mod.rs:490:1
  36: alloc::sync::Arc<T>::drop_slow
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/alloc/src/sync.rs:1123:18
  37: <alloc::sync::Arc<T> as core::ops::drop::Drop>::drop
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/alloc/src/sync.rs:1745:13
  38: core::ptr::drop_in_place<alloc::sync::Arc<sui_node::SuiNode>>
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/core/src/ptr/mod.rs:490:1
  39: core::ptr::drop_in_place<sui_node::SuiNode::monitor_reconfiguration::{{closure}}>
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/core/src/ptr/mod.rs:894:73
  40: core::ptr::drop_in_place<sui_node::SuiNode::start_async::{{closure}}::{{closure}}::{{closure}}>
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/core/src/ptr/mod.rs:448:84
  41: core::ptr::drop_in_place<sui_node::SuiNode::start_async::{{closure}}::{{closure}}>
             at ./crates/test-utils/src/lib.rs:1:1
  42: core::ptr::drop_in_place<alloc::boxed::Box<sui_node::SuiNode::start_async::{{closure}}::{{closure}}>>
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/core/src/ptr/mod.rs:490:1
  43: core::ptr::drop_in_place<core::pin::Pin<alloc::boxed::Box<sui_node::SuiNode::start_async::{{closure}}::{{closure}}>>>
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/core/src/ptr/mod.rs:490:1
  44: core::ptr::drop_in_place<tokio::runtime::task::core::Stage<core::pin::Pin<alloc::boxed::Box<sui_node::SuiNode::start_async::{{closure}}::{{closure}}>>>>
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/core/src/ptr/mod.rs:490:1
  45: tokio::runtime::task::core::Core<T,S>::set_stage::{{closure}}
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/core.rs:277:41
  46: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/loom/std/unsafe_cell.rs:14:9
  47: tokio::runtime::task::core::Core<T,S>::set_stage
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/core.rs:277:9
  48: tokio::runtime::task::core::Core<T,S>::drop_future_or_output
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/core.rs:242:13
  49: tokio::runtime::task::harness::cancel_task::{{closure}}
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/harness.rs:447:9
  50: core::ops::function::FnOnce::call_once
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/core/src/ops/function.rs:250:5
  51: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/core/src/panic/unwind_safe.rs:271:9
  52: std::panicking::try::do_call
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/std/src/panicking.rs:483:40
  53: ___rust_try
  54: std::panicking::try
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/std/src/panicking.rs:447:19
  55: std::panic::catch_unwind
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/std/src/panic.rs:140:14
  56: tokio::runtime::task::harness::cancel_task
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/harness.rs:446:15
  57: tokio::runtime::task::harness::Harness<T,S>::shutdown
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/harness.rs:241:9
  58: tokio::runtime::task::raw::shutdown
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/raw.rs:295:5
  59: tokio::runtime::task::raw::RawTask::shutdown
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/raw.rs:234:18
  60: tokio::runtime::task::Task<S>::shutdown
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/mod.rs:385:9
  61: tokio::runtime::task::list::OwnedTasks<S>::close_and_shutdown_all
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/list.rs:152:13
  62: tokio::runtime::scheduler::multi_thread::worker::Core::pre_shutdown
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/scheduler/multi_thread/worker.rs:718:9
  63: tokio::runtime::scheduler::multi_thread::worker::Context::run
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/scheduler/multi_thread/worker.rs:444:9
  64: tokio::runtime::scheduler::multi_thread::worker::run::{{closure}}
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/scheduler/multi_thread/worker.rs:406:17
  65: tokio::macros::scoped_tls::ScopedKey<T>::set
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/macros/scoped_tls.rs:61:9
  66: tokio::runtime::scheduler::multi_thread::worker::run
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/scheduler/multi_thread/worker.rs:403:5
  67: tokio::runtime::scheduler::multi_thread::worker::Launch::launch::{{closure}}
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/scheduler/multi_thread/worker.rs:365:45
  68: <tokio::runtime::blocking::task::BlockingTask<T> as core::future::future::Future>::poll
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/blocking/task.rs:42:21
  69: tokio::runtime::task::core::Core<T,S>::poll::{{closure}}
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/core.rs:223:17
  70: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/loom/std/unsafe_cell.rs:14:9
  71: tokio::runtime::task::core::Core<T,S>::poll
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/core.rs:212:13
  72: tokio::runtime::task::harness::poll_future::{{closure}}
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/harness.rs:476:19
  73: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/core/src/panic/unwind_safe.rs:271:9
  74: std::panicking::try::do_call
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/std/src/panicking.rs:483:40
  75: ___rust_try
  76: std::panicking::try
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/std/src/panicking.rs:447:19
  77: std::panic::catch_unwind
             at /rustc/9eb3afe9ebe9c7d2b84b71002d44f4a0edac95e0/library/std/src/panic.rs:140:14
  78: tokio::runtime::task::harness::poll_future
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/harness.rs:464:18
  79: tokio::runtime::task::harness::Harness<T,S>::poll_inner
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/harness.rs:198:27
  80: tokio::runtime::task::harness::Harness<T,S>::poll
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/harness.rs:152:15
  81: tokio::runtime::task::raw::poll
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/raw.rs:255:5
  82: tokio::runtime::task::raw::RawTask::poll
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/raw.rs:200:18
  83: tokio::runtime::task::UnownedTask<S>::run
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/task/mod.rs:431:9
  84: tokio::runtime::blocking::pool::Task::run
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/blocking/pool.rs:159:9
  85: tokio::runtime::blocking::pool::Inner::run
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/blocking/pool.rs:513:17
  86: tokio::runtime::blocking::pool::Spawner::spawn_thread::{{closure}}
             at /Users/xun/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.27.0/src/runtime/blocking/pool.rs:471:13
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```