### PR TITLE
docs: update links to archived narwhal repository

### DIFF
--- a/doc/src/learn/about-sui.md
+++ b/doc/src/learn/about-sui.md
@@ -18,7 +18,7 @@ Sui is backed by a number of state-of-the-art [peer-reviewed works](../contribut
 
 A transaction in Sui is a change to the blockchain. This may be a *simple transaction* affecting only single-owner, single-address objects, such as minting an NFT or transferring an NFT or a different token. These *simple transactions* may bypass the consensus protocol in Sui.
 
-More *complex transactions* affecting objects that are shared or owned by multiple addresses, such as asset management and other DeFi use cases, go through the [Narwhal and Bullshark](https://github.com/MystenLabs/narwhal) DAG-based mempool and efficient Byzantine Fault Tolerant (BFT) consensus.
+More *complex transactions* affecting objects that are shared or owned by multiple addresses, such as asset management and other DeFi use cases, go through the [Narwhal and Bullshark](https://github.com/MystenLabs/sui/tree/main/narwhal) DAG-based mempool and efficient Byzantine Fault Tolerant (BFT) consensus.
 
 ## Parallel agreement - a breakthrough in system design
 

--- a/doc/src/learn/architecture/consensus.md
+++ b/doc/src/learn/architecture/consensus.md
@@ -2,7 +2,7 @@
 title: Narwhal and Bullshark, Sui's Mempool and Consensus Engines
 ---
 
-This is a brief introduction to [Narwhal](https://github.com/MystenLabs/narwhal) and [Bullshark](https://arxiv.org/abs/2209.05633), the high-throughput mempool and consensus engines offered by Mysten Labs. Sui uses Narwhal as the mempool and Bullshark as the consensus engine by default, to sequence transactions that require a total ordering, synchronize transactions between validators and periodically checkpoint the network's state.
+This is a brief introduction to [Narwhal](https://github.com/MystenLabs/sui/tree/main/narwhal), and [Bullshark](https://arxiv.org/abs/2209.05633), the high-throughput mempool and consensus engines offered by Mysten Labs. Sui uses Narwhal as the mempool and Bullshark as the consensus engine by default, to sequence transactions that require a total ordering, synchronize transactions between validators and periodically checkpoint the network's state.
 
 The names highlight that the components split the responsibilities of:
  * ensuring the availability of data submitted to consensus = [Narwhal](https://arxiv.org/abs/2105.11827)

--- a/doc/src/learn/sui-compared.md
+++ b/doc/src/learn/sui-compared.md
@@ -58,7 +58,7 @@ Unlike most existing blockchain systems (and as the reader may have guessed from
 
 [Narwhal and Bullshark](architecture/consensus.md) represent the latest variant of decades of work on multi-proposer, high-throughput consensus algorithms that reaches throughputs more than 130,000 transactions per second on a WAN, with production cryptography, permanent storage, and a scaled-out primary-worker architecture.
 
-The [Narwhal mempool](https://github.com/MystenLabs/narwhal) offers a high-throughput data availability engine and a scaled architecture, splitting the disk I/O and networking requirements across several workers. And Bullshark is a zero-message overhead consensus algorithm, leveraging graph traversals.
+The [Narwhal mempool](https://github.com/MystenLabs/sui/tree/main/narwhal) offers a high-throughput data availability engine and a scaled architecture, splitting the disk I/O and networking requirements across several workers. And Bullshark is a zero-message overhead consensus algorithm, leveraging graph traversals.
 
 ## Where Sui excels
 
@@ -126,4 +126,4 @@ Sui uses the state commitment that arrives upon epoch change. Sui requires a sin
 
 In summary, Sui offers many performance and usability gains at the cost of some complexity in less simple use cases. Direct sender transactions excel in Sui. And complex smart contracts may benefit from shared objects where more than one user can mutate those objects (following smart contract specific rules). In this case, Sui totally orders all transactions involving shared objects using a [consensus](architecture/consensus.md) protocol.
 
-Sui uses a novel peer-reviewed consensus protocol based on [Narwhal and Bullshark](https://github.com/MystenLabs/narwhal), which provides a DAG-based mempool and efficient Byzantine Fault Tolerant (BFT) consensus. This is state-of-the-art in terms of both performance and robustness.
+Sui uses a novel peer-reviewed consensus protocol based on [Narwhal and Bullshark](https://github.com/MystenLabs/sui/tree/main/narwhal), which provides a DAG-based mempool and efficient Byzantine Fault Tolerant (BFT) consensus. This is state-of-the-art in terms of both performance and robustness.

--- a/doc/src/learn/sui-glossary.md
+++ b/doc/src/learn/sui-glossary.md
@@ -96,7 +96,7 @@ For more information, see [Causal order vs total order](sui-compared.md#causal-o
 
 A transaction in Sui is a change to the blockchain. This may be a *simple transaction* affecting only single-writer, single-address objects, such as minting an NFT or transferring an NFT or another token. These transactions may bypass the consensus protocol in Sui.
 
-More *complex transactions* affecting objects that are shared or owned by multiple addresses, such as asset management and other DeFi use cases, go through the [Narwhal and Bullshark](https://github.com/MystenLabs/narwhal) DAG-based mempool and efficient Byzantine Fault Tolerant (BFT) consensus.
+More *complex transactions* affecting objects that are shared or owned by multiple addresses, such as asset management and other DeFi use cases, go through the [Narwhal and Bullshark](https://github.com/MystenLabs/sui/tree/main/narwhal) DAG-based mempool and efficient Byzantine Fault Tolerant (BFT) consensus.
 
 ### Transfer
 

--- a/narwhal/benchmark/README.md
+++ b/narwhal/benchmark/README.md
@@ -8,7 +8,7 @@ When running benchmarks, the codebase is automatically compiled with the feature
 
 ### Parametrize the benchmark
 
-After [cloning the repo and installing all dependencies](https://github.com/mystenlabs/narwhal#quick-start), you can use [Fabric](http://www.fabfile.org/) to run benchmarks on your local machine. Locate the task called `local` in the file [fabfile.py](https://github.com/MystenLabs/sui/blob/main/narwhal/benchmark/fabfile.py):
+After [cloning the repo and installing all dependencies](https://github.com/MystenLabs/sui/tree/main/narwhal#quick-start), you can use [Fabric](http://www.fabfile.org/) to run benchmarks on your local machine. Locate the task called `local` in the file [fabfile.py](https://github.com/MystenLabs/sui/blob/main/narwhal/benchmark/fabfile.py):
 
 ```python
 @task
@@ -184,13 +184,13 @@ The file [settings.json](https://github.com/MystenLabs/sui/blob/main/narwhal/ben
 ```json
 {
   "key": {
-    "name": "aws",
-    "path": "/absolute/key/path"
+    "name": "aws-sui",
+    "path": "/Users/username/.ssh/aws-sui.pem"
   },
   "port": 5000,
   "repo": {
-    "name": "narwhal",
-    "url": "https://github.com/mystenlabs/narwhal.git",
+    "name": "sui",
+    "url": "https://github.com/mystenlabs/sui",
     "branch": "main"
   },
   "instances": {
@@ -229,8 +229,8 @@ The third block (`repo`) contains the information regarding the repository's nam
 
 ```json
 "repo": {
-    "name": "narwhal",
-    "url": "https://github.com/mystenlabs/narwhal.git",
+    "name": "sui",
+    "url": "https://github.com/mystenlabs/sui",
     "branch": "main"
 },
 ```
@@ -291,7 +291,7 @@ The commands `fab stop` and `fab start` respectively stop and start the testbed 
 
 ### Step 5. Run a benchmark
 
-After setting up the testbed, running a benchmark on AWS is similar to running it locally (see [Run Local Benchmarks](https://github.com/mystenlabs/narwhal/tree/main/benchmark#local-benchmarks)). Locate the task `remote` in [fabfile.py](https://github.com/MystenLabs/sui/blob/main/narwhal/benchmark/fabfile.py):
+After setting up the testbed, running a benchmark on AWS is similar to running it locally (see [Run Local Benchmarks](https://github.com/MystenLabs/sui/tree/main/narwhal/benchmark#local-benchmarks)). Locate the task `remote` in [fabfile.py](https://github.com/MystenLabs/sui/blob/main/narwhal/benchmark/fabfile.py):
 
 ```python
 @task
@@ -299,7 +299,7 @@ def remote(ctx):
     ...
 ```
 
-The benchmark parameters are similar to [local benchmarks](https://github.com/mystenlabs/narwhal/tree/main/benchmark#local-benchmarks) but allow you to specify the number of nodes and the input rate as arrays to automate multiple benchmarks with a single command. The parameter `runs` specifies the number of times to repeat each benchmark (to later compute the average and stdev of the results), and the parameter `collocate` specifies whether to collocate all the node's workers and the primary on the same machine. If `collocate` is set to `False`, the script will run one node per data center (AWS region), with its primary and each of its worker running on a dedicated instance.
+The benchmark parameters are similar to [local benchmarks](https://github.com/MystenLabs/sui/tree/main/narwhal/benchmark#local-benchmarks) but allow you to specify the number of nodes and the input rate as arrays to automate multiple benchmarks with a single command. The parameter `runs` specifies the number of times to repeat each benchmark (to later compute the average and stdev of the results), and the parameter `collocate` specifies whether to collocate all the node's workers and the primary on the same machine. If `collocate` is set to `False`, the script will run one node per data center (AWS region), with its primary and each of its worker running on a dedicated instance.
 
 ```python
 bench_params = {


### PR DESCRIPTION
## Description 

I noticed that various places in the documentation still link to the archived [MystenLabs/narwhal](https://github.com/MystenLabs/narwhal) repository. Where applicable, I've updated the link to point towards <https://github.com/MystenLabs/sui/tree/main/narwhal> instead.

## Test Plan 

Only documentation changes, no tests required.
