### PR TITLE
[upgrades] Hash module bytes individually to compute digest

### DIFF
--- a/crates/sui-adapter/src/programmable_transactions/execution.rs
+++ b/crates/sui-adapter/src/programmable_transactions/execution.rs
@@ -587,7 +587,11 @@ fn execute_move_upgrade<S: StorageView, Mode: ExecutionMode>(
 
     // Check digest.
     let computed_digest =
-        MovePackage::compute_digest_for_modules_and_deps(&module_bytes, &dep_ids).to_vec();
+        MovePackage::compute_digest_for_modules_and_deps(
+            &module_bytes,
+            &dep_ids,
+            context.protocol_config.package_digest_hash_module(),
+        ).to_vec();
     if computed_digest != upgrade_ticket.digest {
         return Err(ExecutionError::from_kind(
             ExecutionErrorKind::PackageUpgradeError {

--- a/crates/sui-core/src/authority/authority_test_utils.rs
+++ b/crates/sui-core/src/authority/authority_test_utils.rs
@@ -408,8 +408,12 @@ pub async fn upgrade_package_on_single_authority(
 ) -> SuiResult<ObjectID> {
     let package = build_test_modules_with_dep_addr(path, dep_original_addresses, dep_id_mapping);
 
-    let modules = package.get_package_bytes(false);
-    let digest = package.get_package_digest(false).to_vec();
+    let with_unpublished_deps = false;
+    let hash_modules = true;
+    let modules = package.get_package_bytes(with_unpublished_deps);
+    let digest = package
+        .get_package_digest(with_unpublished_deps, hash_modules)
+        .to_vec();
 
     let rgp = state.epoch_store_for_testing().reference_gas_price();
     let data = TransactionData::new_upgrade(

--- a/crates/sui-core/src/unit_tests/move_package_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_tests.rs
@@ -227,8 +227,9 @@ fn test_upgrade_linkage_digest_to_new_dep() {
 
     // Make sure that we compute the package digest off of the update dependencies and not the old
     // dependencies in the linkage table.
+    let hash_modules = true;
     assert_eq!(
-        b_new.digest(),
+        b_new.digest(hash_modules),
         MovePackage::compute_digest_for_modules_and_deps(
             &build_test_modules("B")
                 .iter()
@@ -238,7 +239,8 @@ fn test_upgrade_linkage_digest_to_new_dep() {
                     bytes
                 })
                 .collect::<Vec<_>>(),
-            [&c_id2]
+            [&c_id2],
+            hash_modules,
         )
     )
 }
@@ -333,12 +335,15 @@ fn package_digest_changes_with_dep_upgrades_and_in_sync_with_move_package_digest
 
     let b_v2 = MovePackage::new_initial(&build_test_modules("Bv2"), u64::MAX, [&c_v2]).unwrap();
 
-    let local_v1 = build_test_package("B").get_package_digest(false);
-    let local_v2 = build_test_package("Bv2").get_package_digest(false);
+    let with_unpublished_deps = false;
+    let hash_modules = true;
+    let local_v1 = build_test_package("B").get_package_digest(with_unpublished_deps, hash_modules);
+    let local_v2 =
+        build_test_package("Bv2").get_package_digest(with_unpublished_deps, hash_modules);
 
-    assert_ne!(b_pkg.digest(), b_v2.digest());
-    assert_eq!(b_pkg.digest(), local_v1);
-    assert_eq!(b_v2.digest(), local_v2);
+    assert_ne!(b_pkg.digest(hash_modules), b_v2.digest(hash_modules));
+    assert_eq!(b_pkg.digest(hash_modules), local_v1);
+    assert_eq!(b_v2.digest(hash_modules), local_v2);
     assert_ne!(local_v1, local_v2);
 }
 

--- a/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -44,9 +44,12 @@ fn build_upgrade_test_modules(test_dir: &str) -> (Vec<u8>, Vec<Vec<u8>>) {
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.extend(["src", "unit_tests", "data", "move_upgrade", test_dir]);
     let with_unpublished_deps = false;
+    let hash_modules = true;
     let package = BuildConfig::new_for_testing().build(path).unwrap();
     (
-        package.get_package_digest(with_unpublished_deps).to_vec(),
+        package
+            .get_package_digest(with_unpublished_deps, hash_modules)
+            .to_vec(),
         package.get_package_bytes(with_unpublished_deps),
     )
 }
@@ -60,8 +63,11 @@ pub fn build_upgrade_test_modules_with_dep_addr(
     path.extend(["src", "unit_tests", "data", "move_upgrade", test_dir]);
     let package = build_test_modules_with_dep_addr(path, dep_original_addresses, dep_ids);
     let with_unpublished_deps = false;
+    let hash_modules = true;
     (
-        package.get_package_digest(with_unpublished_deps).to_vec(),
+        package
+            .get_package_digest(with_unpublished_deps, hash_modules)
+            .to_vec(),
         package.get_package_bytes(with_unpublished_deps),
         package.dependency_ids.published.values().cloned().collect(),
     )

--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -323,10 +323,11 @@ impl CompiledPackage {
         ids.into_iter().collect()
     }
 
-    pub fn get_package_digest(&self, with_unpublished_deps: bool) -> [u8; 32] {
+    pub fn get_package_digest(&self, with_unpublished_deps: bool, hash_modules: bool) -> [u8; 32] {
         MovePackage::compute_digest_for_modules_and_deps(
             &self.get_package_bytes(with_unpublished_deps),
             self.dependency_ids.published.values(),
+            hash_modules,
         )
     }
 

--- a/crates/sui-move/src/unit_test.rs
+++ b/crates/sui-move/src/unit_test.rs
@@ -41,9 +41,9 @@ impl Test {
         let rerooted_path = base::reroot_path(path)?;
         // pre build for Sui-specific verifications
         let with_unpublished_deps = false;
+        let legacy_digest = false;
         let dump_bytecode_as_base64 = false;
         let generate_struct_layouts: bool = false;
-        let dump_package_digest = false;
         build::Build::execute_internal(
             rerooted_path.clone(),
             BuildConfig {
@@ -51,9 +51,9 @@ impl Test {
                 ..build_config.clone()
             },
             with_unpublished_deps,
+            legacy_digest,
             dump_bytecode_as_base64,
             generate_struct_layouts,
-            dump_package_digest,
         )?;
         run_move_unit_tests(
             rerooted_path,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -26,7 +26,9 @@ const MAX_PROTOCOL_VERSION: u64 = 7;
 // Version 6: Change to how bytes are charged in the gas meter, increase buffer stake to 0.5f
 // Version 7: Disallow adding new abilities to types during package upgrades,
 //            disable_invariant_violation_check_in_swap_loc,
-//            advance_to_hightest_supported_protocol_version
+//            advance_to_highest_supported_protocol_version,
+//            disable init functions becoming entry,
+//            hash module bytes individually before computing package digest.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -160,6 +162,9 @@ struct FeatureFlags {
     // If true, disallow entry modifiers on entry functions
     #[serde(skip_serializing_if = "is_false")]
     ban_entry_init: bool,
+    // If true, hash module bytes individually when calculating package digests for upgrades
+    #[serde(skip_serializing_if = "is_false")]
+    package_digest_hash_module: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -667,6 +672,10 @@ impl ProtocolConfig {
     pub fn ban_entry_init(&self) -> bool {
         self.feature_flags.ban_entry_init
     }
+
+    pub fn package_digest_hash_module(&self) -> bool {
+        self.feature_flags.package_digest_hash_module
+    }
 }
 
 // Special getters
@@ -1073,6 +1082,7 @@ impl ProtocolConfig {
                 cfg.feature_flags
                     .advance_to_highest_supported_protocol_version = true;
                 cfg.feature_flags.ban_entry_init = true;
+                cfg.feature_flags.package_digest_hash_module = true;
                 cfg
             }
             // Use this template when making changes:

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_7.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_7.snap
@@ -14,6 +14,7 @@ feature_flags:
   disable_invariant_violation_check_in_swap_loc: true
   advance_to_highest_supported_protocol_version: true
   ban_entry_init: true
+  package_digest_hash_module: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-source-validation/src/tests.rs
+++ b/crates/sui-source-validation/src/tests.rs
@@ -607,8 +607,11 @@ async fn upgrade_package(
 ) -> ObjectRef {
     let package = compile_package(package);
     let with_unpublished_deps = false;
+    let hash_modules = true;
     let package_bytes = package.get_package_bytes(with_unpublished_deps);
-    let package_digest = package.get_package_digest(with_unpublished_deps).to_vec();
+    let package_digest = package
+        .get_package_digest(with_unpublished_deps, hash_modules)
+        .to_vec();
     let package_deps = package.dependency_ids.published.into_values().collect();
 
     upgrade_package_with_wallet(

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -800,8 +800,12 @@ impl<'a> SuiTestAdapter<'a> {
 
         SuiValue::Object(upgrade_capability).into_argument(&mut builder, self)?; // Argument::Input(0)
         let upgrade_arg = builder.pure(policy).unwrap();
-        let digest: Vec<u8> =
-            MovePackage::compute_digest_for_modules_and_deps(&modules_bytes, &dependencies).into();
+        let digest: Vec<u8> = MovePackage::compute_digest_for_modules_and_deps(
+            &modules_bytes,
+            &dependencies,
+            /* hash_modules */ true,
+        )
+        .into();
         let digest_arg = builder.pure(digest).unwrap();
 
         let upgrade_ticket = builder.programmable_move_call(

--- a/crates/sui-types/src/move_package.rs
+++ b/crates/sui-types/src/move_package.rs
@@ -231,12 +231,13 @@ impl MovePackage {
         Ok(pkg)
     }
 
-    pub fn digest(&self) -> [u8; 32] {
+    pub fn digest(&self, hash_modules: bool) -> [u8; 32] {
         Self::compute_digest_for_modules_and_deps(
             self.module_map.values(),
             self.linkage_table
                 .values()
                 .map(|UpgradeInfo { upgraded_id, .. }| upgraded_id),
+            hash_modules,
         )
     }
 
@@ -245,18 +246,31 @@ impl MovePackage {
     pub fn compute_digest_for_modules_and_deps<'a>(
         modules: impl IntoIterator<Item = &'a Vec<u8>>,
         object_ids: impl IntoIterator<Item = &'a ObjectID>,
+        hash_modules: bool,
     ) -> [u8; 32] {
-        let mut bytes: Vec<&[u8]> = modules
-            .into_iter()
-            .map(|x| x.as_ref())
-            .chain(object_ids.into_iter().map(|obj_id| obj_id.as_ref()))
-            .collect();
+        let mut module_digests: Vec<[u8; 32]>;
+        let mut components: Vec<&[u8]> = vec![];
+        if !hash_modules {
+            for module in modules {
+                components.push(module.as_ref())
+            }
+        } else {
+            module_digests = vec![];
+            for module in modules {
+                let mut digest = DefaultHash::default();
+                digest.update(module);
+                module_digests.push(digest.finalize().digest);
+            }
+            components.extend(module_digests.iter().map(|d| d.as_ref()))
+        }
+
+        components.extend(object_ids.into_iter().map(|o| o.as_ref()));
         // NB: sorting so the order of the modules and the order of the dependencies does not matter.
-        bytes.sort();
+        components.sort();
 
         let mut digest = DefaultHash::default();
-        for b in bytes {
-            digest.update(b);
+        for c in components {
+            digest.update(c);
         }
         digest.finalize().digest
     }

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -191,6 +191,10 @@ pub enum SuiClientCommands {
         #[clap(long)]
         with_unpublished_dependencies: bool,
 
+        /// Use the legacy digest calculation algorithm
+        #[clap(long)]
+        legacy_digest: bool,
+
         /// Do not sign/submit transaction, output base64-encoded serialized output
         #[clap(long)]
         serialize_output: bool,
@@ -506,6 +510,7 @@ impl SuiClientCommands {
                 gas_budget,
                 skip_dependency_verification,
                 with_unpublished_dependencies,
+                legacy_digest,
                 serialize_output,
             } => {
                 let sender = context.try_get_object_owner(&gas).await?;
@@ -558,8 +563,8 @@ impl SuiClientCommands {
                 // policy at the moment. To change the policy you can call a Move function in the
                 // `package` module to change this policy.
                 let upgrade_policy = upgrade_cap.policy;
-                let package_digest =
-                    compiled_package.get_package_digest(with_unpublished_dependencies);
+                let package_digest = compiled_package
+                    .get_package_digest(with_unpublished_dependencies, !legacy_digest);
 
                 let data = client
                     .transaction_builder()

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -1054,6 +1054,7 @@ async fn test_package_upgrade_command() -> Result<(), anyhow::Error> {
         gas_budget: rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
         skip_dependency_verification: false,
         with_unpublished_dependencies: false,
+        legacy_digest: false,
         serialize_output: false,
     }
     .execute(context)


### PR DESCRIPTION
## Description

Rather than hashing the concatenation of (sorted) module bytes, hash each module's bytes into a 32-byte digest and hash the (sorted) concatenation of those, to prevent hash collisions.

Thanks to @otter-sec (https://osec.io) for the report.

## Test Plan

Existing tests:

```
$ cargo simtest
$ env SUI_SKIP_SIMTESTS=1 cargo nextest run
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [x] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
The algorithm for computing package digests for upgrades will change from protocol version 7 and beyond.  Toolchains built at v0.33.1 and above will compute digests using the new algorithm by default, and can be revert to the old algorithm using the `--legacy-digest` flag (available for `sui move build --dump-bytecode-as-base64` and `sui client upgrade`) if working with networks running older protocol versions.

This PR also removes the `--dump-package-digest` flag on `sui move build`, in favour of incorporating it in the output from `--dump-bytecode-as-base64`.