### PR TITLE
fn: remove object IDs from transactions_to_addr index

### DIFF
--- a/crates/sui-storage/src/indexes.rs
+++ b/crates/sui-storage/src/indexes.rs
@@ -481,7 +481,7 @@ impl IndexStore {
             &self.tables.transactions_to_addr,
             mutated_objects.filter_map(|(_, owner)| {
                 owner
-                    .get_owner_address()
+                    .get_address_owner_address()
                     .ok()
                     .map(|addr| ((addr, sequence), digest))
             }),

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -488,6 +488,19 @@ pub enum Owner {
 }
 
 impl Owner {
+    // NOTE: only return address of AddressOwner, otherwise return error,
+    // ObjectOwner's address is converted from object id, thus we will skip it.
+    pub fn get_address_owner_address(&self) -> SuiResult<SuiAddress> {
+        match self {
+            Self::AddressOwner(address) => Ok(*address),
+            Self::Shared { .. } | Self::Immutable | Self::ObjectOwner(_) => {
+                Err(SuiError::UnexpectedOwnerType)
+            }
+        }
+    }
+
+    // NOTE: this function will return address of both AddressOwner and ObjectOwner,
+    // address of ObjectOwner is converted from object id, even though the type is SuiAddress.
     pub fn get_owner_address(&self) -> SuiResult<SuiAddress> {
         match self {
             Self::AddressOwner(address) | Self::ObjectOwner(address) => Ok(*address),


### PR DESCRIPTION
## Description 

transactions_to_addr now includes both address and object IDs.
Related posts are 
https://mysten-labs.slack.com/archives/C04FG4Q7YJ3/p1682369162080879
https://mysten-labs.slack.com/archives/C04HS54LHUM/p1682039873458439

## Test Plan 

CI test
run local FN + Explorer and make sure 0x5 is not showing as address any more.