### PR TITLE
Improve collection of metrics in typed-store lib

### DIFF
--- a/crates/typed-store/src/metrics.rs
+++ b/crates/typed-store/src/metrics.rs
@@ -240,6 +240,7 @@ impl ColumnFamilyMetrics {
 pub struct OperationMetrics {
     pub rocksdb_iter_latency_seconds: HistogramVec,
     pub rocksdb_iter_bytes: HistogramVec,
+    pub rocksdb_iter_keys: HistogramVec,
     pub rocksdb_get_latency_seconds: HistogramVec,
     pub rocksdb_get_bytes: HistogramVec,
     pub rocksdb_multiget_latency_seconds: HistogramVec,
@@ -265,6 +266,13 @@ impl OperationMetrics {
             .unwrap(),
             rocksdb_iter_bytes: register_histogram_vec_with_registry!(
                 "rocksdb_iter_bytes",
+                "Rocksdb iter size in bytes",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_iter_keys: register_histogram_vec_with_registry!(
+                "rocksdb_iter_keys",
                 "Rocksdb iter size in bytes",
                 &["cf_name"],
                 registry,

--- a/crates/typed-store/src/rocks/iter.rs
+++ b/crates/typed-store/src/rocks/iter.rs
@@ -1,28 +1,56 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use std::marker::PhantomData;
+use std::sync::Arc;
 
 use bincode::Options;
+use prometheus::{Histogram, HistogramTimer};
 use rocksdb::Direction;
 
 use super::{be_fix_int_ser, errors::TypedStoreError, RocksDBRawIter};
+use crate::metrics::RocksDBPerfContext;
+use crate::DBMetrics;
 use serde::{de::DeserializeOwned, Serialize};
 
 /// An iterator over all key-value pairs in a data map.
 pub struct Iter<'a, K, V> {
+    cf_name: String,
     db_iter: RocksDBRawIter<'a>,
     _phantom: PhantomData<(K, V)>,
     direction: Direction,
     is_initialized: bool,
+    _timer: Option<HistogramTimer>,
+    _perf_ctx: Option<RocksDBPerfContext>,
+    bytes_scanned: Option<Histogram>,
+    keys_scanned: Option<Histogram>,
+    db_metrics: Option<Arc<DBMetrics>>,
+    bytes_scanned_counter: usize,
+    keys_returned_counter: usize,
 }
 
 impl<'a, K: DeserializeOwned, V: DeserializeOwned> Iter<'a, K, V> {
-    pub(super) fn new(db_iter: RocksDBRawIter<'a>) -> Self {
+    pub(super) fn new(
+        cf_name: String,
+        db_iter: RocksDBRawIter<'a>,
+        _timer: Option<HistogramTimer>,
+        _perf_ctx: Option<RocksDBPerfContext>,
+        bytes_scanned: Option<Histogram>,
+        keys_scanned: Option<Histogram>,
+        db_metrics: Option<Arc<DBMetrics>>,
+    ) -> Self {
         Self {
+            cf_name,
             db_iter,
             _phantom: PhantomData,
             direction: Direction::Forward,
             is_initialized: false,
+            _timer,
+            _perf_ctx,
+            bytes_scanned,
+            keys_scanned,
+            db_metrics,
+            bytes_scanned_counter: 0,
+            keys_returned_counter: 0,
         }
     }
 }
@@ -49,6 +77,8 @@ impl<'a, K: DeserializeOwned, V: DeserializeOwned> Iterator for Iter<'a, K, V> {
                 .db_iter
                 .value()
                 .expect("Valid iterator failed to get value");
+            self.bytes_scanned_counter += raw_key.len() + raw_value.len();
+            self.keys_returned_counter += 1;
             let key = config.deserialize(raw_key).ok();
             let value = bcs::from_bytes(raw_value).ok();
             match self.direction {
@@ -58,6 +88,22 @@ impl<'a, K: DeserializeOwned, V: DeserializeOwned> Iterator for Iter<'a, K, V> {
             key.and_then(|k| value.map(|v| (k, v)))
         } else {
             None
+        }
+    }
+}
+
+impl<'a, K, V> Drop for Iter<'a, K, V> {
+    fn drop(&mut self) {
+        if let Some(bytes_scanned) = self.bytes_scanned.take() {
+            bytes_scanned.observe(self.bytes_scanned_counter as f64);
+        }
+        if let Some(keys_scanned) = self.keys_scanned.take() {
+            keys_scanned.observe(self.keys_returned_counter as f64);
+        }
+        if let Some(db_metrics) = self.db_metrics.take() {
+            db_metrics
+                .read_perf_ctx_metrics
+                .report_metrics(&self.cf_name);
         }
     }
 }

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -461,7 +461,14 @@ impl RocksDB {
         delegate_call!(self.set_options_cf(cf, opts))
     }
 
-    pub fn read_sampling_interval(&self) -> SamplingInterval {
+    pub fn get_sampling_interval(&self) -> SamplingInterval {
+        match self {
+            Self::DBWithThreadMode(d) => d.metric_conf.read_sample_interval.clone(),
+            Self::OptimisticTransactionDB(d) => d.metric_conf.read_sample_interval.clone(),
+        }
+    }
+
+    pub fn multiget_sampling_interval(&self) -> SamplingInterval {
         match self {
             Self::DBWithThreadMode(d) => d.metric_conf.read_sample_interval.clone(),
             Self::OptimisticTransactionDB(d) => d.metric_conf.read_sample_interval.clone(),
@@ -475,17 +482,10 @@ impl RocksDB {
         }
     }
 
-    pub fn iter_latency_sampling_interval(&self) -> SamplingInterval {
+    pub fn iter_sampling_interval(&self) -> SamplingInterval {
         match self {
-            Self::DBWithThreadMode(d) => d.metric_conf.iter_latency_sample_interval.clone(),
-            Self::OptimisticTransactionDB(d) => d.metric_conf.iter_latency_sample_interval.clone(),
-        }
-    }
-
-    pub fn iter_bytes_sampling_interval(&self) -> SamplingInterval {
-        match self {
-            Self::DBWithThreadMode(d) => d.metric_conf.iter_bytes_sample_interval.clone(),
-            Self::OptimisticTransactionDB(d) => d.metric_conf.iter_bytes_sample_interval.clone(),
+            Self::DBWithThreadMode(d) => d.metric_conf.iter_sample_interval.clone(),
+            Self::OptimisticTransactionDB(d) => d.metric_conf.iter_sample_interval.clone(),
         }
     }
 
@@ -616,8 +616,7 @@ pub struct MetricConf {
     pub db_name_override: Option<String>,
     pub read_sample_interval: SamplingInterval,
     pub write_sample_interval: SamplingInterval,
-    pub iter_latency_sample_interval: SamplingInterval,
-    pub iter_bytes_sample_interval: SamplingInterval,
+    pub iter_sample_interval: SamplingInterval,
 }
 
 impl MetricConf {
@@ -626,8 +625,7 @@ impl MetricConf {
             db_name_override: Some(db_name.to_string()),
             read_sample_interval: SamplingInterval::default(),
             write_sample_interval: SamplingInterval::default(),
-            iter_latency_sample_interval: SamplingInterval::default(),
-            iter_bytes_sample_interval: SamplingInterval::default(),
+            iter_sample_interval: SamplingInterval::default(),
         }
     }
     pub fn with_sampling(read_interval: SamplingInterval) -> Self {
@@ -635,8 +633,7 @@ impl MetricConf {
             db_name_override: None,
             read_sample_interval: read_interval,
             write_sample_interval: SamplingInterval::default(),
-            iter_latency_sample_interval: SamplingInterval::default(),
-            iter_bytes_sample_interval: SamplingInterval::default(),
+            iter_sample_interval: SamplingInterval::default(),
         }
     }
 }
@@ -652,10 +649,10 @@ pub struct DBMap<K, V> {
     cf: String,
     pub opts: ReadWriteOptions,
     db_metrics: Arc<DBMetrics>,
-    read_sample_interval: SamplingInterval,
+    get_sample_interval: SamplingInterval,
+    multiget_sample_interval: SamplingInterval,
     write_sample_interval: SamplingInterval,
-    iter_latency_sample_interval: SamplingInterval,
-    iter_bytes_sample_interval: SamplingInterval,
+    iter_sample_interval: SamplingInterval,
     _metrics_task_cancel_handle: Arc<oneshot::Sender<()>>,
 }
 
@@ -695,10 +692,10 @@ impl<K, V> DBMap<K, V> {
             cf: opt_cf.to_string(),
             db_metrics: db_metrics_cloned,
             _metrics_task_cancel_handle: Arc::new(sender),
-            read_sample_interval: db.read_sampling_interval(),
+            get_sample_interval: db.get_sampling_interval(),
+            multiget_sample_interval: db.multiget_sampling_interval(),
             write_sample_interval: db.write_sampling_interval(),
-            iter_bytes_sample_interval: db.iter_bytes_sampling_interval(),
-            iter_latency_sample_interval: db.iter_latency_sampling_interval(),
+            iter_sample_interval: db.iter_sampling_interval(),
         }
     }
 
@@ -1350,7 +1347,15 @@ impl<'a> DBTransaction<'a> {
         let db_iter = self
             .transaction
             .raw_iterator_cf_opt(&db.cf(), db.opts.readopts());
-        Iter::new(RocksDBRawIter::OptimisticTransaction(db_iter))
+        Iter::new(
+            db.cf.clone(),
+            RocksDBRawIter::OptimisticTransaction(db_iter),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
     }
 
     pub fn keys<K: DeserializeOwned, V: DeserializeOwned>(
@@ -1492,14 +1497,14 @@ where
 
     #[instrument(level = "trace", skip_all, err)]
     fn get(&self, key: &K) -> Result<Option<V>, TypedStoreError> {
-        let report_metrics = if self.read_sample_interval.sample() {
-            let timer = self
-                .db_metrics
-                .op_metrics
-                .rocksdb_get_latency_seconds
-                .with_label_values(&[&self.cf])
-                .start_timer();
-            Some((timer, RocksDBPerfContext::default()))
+        let _timer = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_get_latency_seconds
+            .with_label_values(&[&self.cf])
+            .start_timer();
+        let perf_ctx = if self.get_sample_interval.sample() {
+            Some(RocksDBPerfContext::default())
         } else {
             None
         };
@@ -1507,12 +1512,12 @@ where
         let res = self
             .rocksdb
             .get_pinned_cf(&self.cf(), &key_buf, &self.opts.readopts())?;
-        if report_metrics.is_some() {
-            self.db_metrics
-                .op_metrics
-                .rocksdb_get_bytes
-                .with_label_values(&[&self.cf])
-                .observe(res.as_ref().map_or(0.0, |v| v.len() as f64));
+        self.db_metrics
+            .op_metrics
+            .rocksdb_get_bytes
+            .with_label_values(&[&self.cf])
+            .observe(res.as_ref().map_or(0.0, |v| v.len() as f64));
+        if perf_ctx.is_some() {
             self.db_metrics
                 .read_perf_ctx_metrics
                 .report_metrics(&self.cf);
@@ -1525,14 +1530,14 @@ where
 
     #[instrument(level = "trace", skip_all, err)]
     fn get_raw_bytes(&self, key: &K) -> Result<Option<Vec<u8>>, TypedStoreError> {
-        let report_metrics = if self.read_sample_interval.sample() {
-            let timer = self
-                .db_metrics
-                .op_metrics
-                .rocksdb_get_latency_seconds
-                .with_label_values(&[&self.cf])
-                .start_timer();
-            Some((timer, RocksDBPerfContext::default()))
+        let _timer = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_get_latency_seconds
+            .with_label_values(&[&self.cf])
+            .start_timer();
+        let perf_ctx = if self.get_sample_interval.sample() {
+            Some(RocksDBPerfContext::default())
         } else {
             None
         };
@@ -1540,12 +1545,12 @@ where
         let res = self
             .rocksdb
             .get_pinned_cf(&self.cf(), &key_buf, &self.opts.readopts())?;
-        if report_metrics.is_some() {
-            self.db_metrics
-                .op_metrics
-                .rocksdb_get_bytes
-                .with_label_values(&[&self.cf])
-                .observe(res.as_ref().map_or(0.0, |v| v.len() as f64));
+        self.db_metrics
+            .op_metrics
+            .rocksdb_get_bytes
+            .with_label_values(&[&self.cf])
+            .observe(res.as_ref().map_or(0.0, |v| v.len() as f64));
+        if perf_ctx.is_some() {
             self.db_metrics
                 .read_perf_ctx_metrics
                 .report_metrics(&self.cf);
@@ -1558,25 +1563,25 @@ where
 
     #[instrument(level = "trace", skip_all, err)]
     fn insert(&self, key: &K, value: &V) -> Result<(), TypedStoreError> {
-        let report_metrics = if self.write_sample_interval.sample() {
-            let timer = self
-                .db_metrics
-                .op_metrics
-                .rocksdb_put_latency_seconds
-                .with_label_values(&[&self.cf])
-                .start_timer();
-            Some((timer, RocksDBPerfContext::default()))
+        let _timer = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_put_latency_seconds
+            .with_label_values(&[&self.cf])
+            .start_timer();
+        let perf_ctx = if self.write_sample_interval.sample() {
+            Some(RocksDBPerfContext::default())
         } else {
             None
         };
         let key_buf = be_fix_int_ser(key)?;
         let value_buf = bcs::to_bytes(value)?;
-        if report_metrics.is_some() {
-            self.db_metrics
-                .op_metrics
-                .rocksdb_put_bytes
-                .with_label_values(&[&self.cf])
-                .observe((key_buf.len() + value_buf.len()) as f64);
+        self.db_metrics
+            .op_metrics
+            .rocksdb_put_bytes
+            .with_label_values(&[&self.cf])
+            .observe((key_buf.len() + value_buf.len()) as f64);
+        if perf_ctx.is_some() {
             self.db_metrics
                 .write_perf_ctx_metrics
                 .report_metrics(&self.cf);
@@ -1588,26 +1593,26 @@ where
 
     #[instrument(level = "trace", skip_all, err)]
     fn remove(&self, key: &K) -> Result<(), TypedStoreError> {
-        let report_metrics = if self.write_sample_interval.sample() {
-            let timer = self
-                .db_metrics
-                .op_metrics
-                .rocksdb_delete_latency_seconds
-                .with_label_values(&[&self.cf])
-                .start_timer();
-            Some((timer, RocksDBPerfContext::default()))
+        let _timer = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_delete_latency_seconds
+            .with_label_values(&[&self.cf])
+            .start_timer();
+        let perf_ctx = if self.write_sample_interval.sample() {
+            Some(RocksDBPerfContext::default())
         } else {
             None
         };
         let key_buf = be_fix_int_ser(key)?;
         self.rocksdb
             .delete_cf(&self.cf(), key_buf, &self.opts.writeopts())?;
-        if report_metrics.is_some() {
-            self.db_metrics
-                .op_metrics
-                .rocksdb_deletes
-                .with_label_values(&[&self.cf])
-                .inc();
+        self.db_metrics
+            .op_metrics
+            .rocksdb_deletes
+            .with_label_values(&[&self.cf])
+            .inc();
+        if perf_ctx.is_some() {
             self.db_metrics
                 .write_perf_ctx_metrics
                 .report_metrics(&self.cf);
@@ -1628,56 +1633,75 @@ where
     }
 
     fn iter(&'a self) -> Self::Iterator {
-        let report_metrics = if self.iter_latency_sample_interval.sample() {
-            let timer = self
-                .db_metrics
-                .op_metrics
-                .rocksdb_iter_latency_seconds
-                .with_label_values(&[&self.cf])
-                .start_timer();
-            Some((timer, RocksDBPerfContext::default()))
+        let _timer = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_iter_latency_seconds
+            .with_label_values(&[&self.cf])
+            .start_timer();
+        let bytes_scanned = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_iter_bytes
+            .with_label_values(&[&self.cf]);
+        let keys_scanned = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_iter_keys
+            .with_label_values(&[&self.cf]);
+        let _perf_ctx = if self.iter_sample_interval.sample() {
+            Some(RocksDBPerfContext::default())
         } else {
             None
         };
         let db_iter = self
             .rocksdb
             .raw_iterator_cf(&self.cf(), self.opts.readopts());
-        if let Some((timer, _perf_ctx)) = report_metrics {
-            timer.stop_and_record();
-            self.db_metrics
-                .read_perf_ctx_metrics
-                .report_metrics(&self.cf);
-        }
-        Iter::new(db_iter)
+        Iter::new(
+            self.cf.clone(),
+            db_iter,
+            Some(_timer),
+            _perf_ctx,
+            Some(bytes_scanned),
+            Some(keys_scanned),
+            Some(self.db_metrics.clone()),
+        )
     }
 
     fn safe_iter(&'a self) -> Self::SafeIterator {
-        let report_metrics = if self.iter_latency_sample_interval.sample() {
-            let timer = self
-                .db_metrics
-                .op_metrics
-                .rocksdb_iter_latency_seconds
-                .with_label_values(&[&self.cf])
-                .start_timer();
-            Some((timer, RocksDBPerfContext::default()))
+        let _timer = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_iter_latency_seconds
+            .with_label_values(&[&self.cf])
+            .start_timer();
+        let _perf_ctx = if self.iter_sample_interval.sample() {
+            Some(RocksDBPerfContext::default())
         } else {
             None
         };
+        let bytes_scanned = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_iter_bytes
+            .with_label_values(&[&self.cf]);
+        let keys_scanned = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_iter_keys
+            .with_label_values(&[&self.cf]);
         let mut db_iter = self
             .rocksdb
             .raw_iterator_cf(&self.cf(), self.opts.readopts());
         db_iter.seek_to_first();
-        if let Some((timer, _perf_ctx)) = report_metrics {
-            timer.stop_and_record();
-            self.db_metrics
-                .read_perf_ctx_metrics
-                .report_metrics(&self.cf);
-        }
         SafeIter::new(
-            db_iter,
             self.cf.clone(),
-            &self.db_metrics,
-            &self.iter_bytes_sample_interval,
+            db_iter,
+            Some(_timer),
+            _perf_ctx,
+            Some(bytes_scanned),
+            Some(keys_scanned),
+            Some(self.db_metrics.clone()),
         )
     }
 
@@ -1688,14 +1712,24 @@ where
         lower_bound: Option<K>,
         upper_bound: Option<K>,
     ) -> Self::Iterator {
-        let report_metrics = if self.iter_latency_sample_interval.sample() {
-            let timer = self
-                .db_metrics
-                .op_metrics
-                .rocksdb_iter_latency_seconds
-                .with_label_values(&[&self.cf])
-                .start_timer();
-            Some((timer, RocksDBPerfContext::default()))
+        let _timer = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_iter_latency_seconds
+            .with_label_values(&[&self.cf])
+            .start_timer();
+        let bytes_scanned = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_iter_bytes
+            .with_label_values(&[&self.cf]);
+        let keys_scanned = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_iter_keys
+            .with_label_values(&[&self.cf]);
+        let _perf_ctx = if self.iter_sample_interval.sample() {
+            Some(RocksDBPerfContext::default())
         } else {
             None
         };
@@ -1709,13 +1743,15 @@ where
             readopts.set_iterate_upper_bound(key_buf);
         }
         let db_iter = self.rocksdb.raw_iterator_cf(&self.cf(), readopts);
-        if let Some((timer, _perf_ctx)) = report_metrics {
-            timer.stop_and_record();
-            self.db_metrics
-                .read_perf_ctx_metrics
-                .report_metrics(&self.cf);
-        }
-        Iter::new(db_iter)
+        Iter::new(
+            self.cf.clone(),
+            db_iter,
+            Some(_timer),
+            _perf_ctx,
+            Some(bytes_scanned),
+            Some(keys_scanned),
+            Some(self.db_metrics.clone()),
+        )
     }
 
     fn keys(&'a self) -> Self::Keys {
@@ -1745,24 +1781,22 @@ where
     where
         J: Borrow<K>,
     {
-        let report_metrics = if self.read_sample_interval.sample() {
-            let timer = self
-                .db_metrics
-                .op_metrics
-                .rocksdb_multiget_latency_seconds
-                .with_label_values(&[&self.cf])
-                .start_timer();
-            Some((timer, RocksDBPerfContext::default()))
+        let _timer = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_multiget_latency_seconds
+            .with_label_values(&[&self.cf])
+            .start_timer();
+        let perf_ctx = if self.multiget_sample_interval.sample() {
+            Some(RocksDBPerfContext::default())
         } else {
             None
         };
         let cf = self.cf();
-
         let keys_bytes: Result<Vec<_>, TypedStoreError> = keys
             .into_iter()
             .map(|k| Ok((&cf, be_fix_int_ser(k.borrow())?)))
             .collect();
-
         let results = self
             .rocksdb
             .multi_get_cf(keys_bytes?, &self.opts.readopts());
@@ -1771,12 +1805,12 @@ where
                 .as_ref()
                 .map_or(0.0, |e| e.as_ref().map_or(0.0, |v| v.len() as f64))
         };
-        if report_metrics.is_some() {
-            self.db_metrics
-                .op_metrics
-                .rocksdb_multiget_bytes
-                .with_label_values(&[&self.cf])
-                .observe(results.iter().map(entry_size).sum());
+        self.db_metrics
+            .op_metrics
+            .rocksdb_multiget_bytes
+            .with_label_values(&[&self.cf])
+            .observe(results.iter().map(entry_size).sum());
+        if perf_ctx.is_some() {
             self.db_metrics
                 .read_perf_ctx_metrics
                 .report_metrics(&self.cf);

--- a/crates/typed-store/src/rocks/safe_iter.rs
+++ b/crates/typed-store/src/rocks/safe_iter.rs
@@ -3,37 +3,51 @@
 use std::{marker::PhantomData, sync::Arc};
 
 use bincode::Options;
+use prometheus::{Histogram, HistogramTimer};
 use rocksdb::Direction;
 
-use crate::metrics::{DBMetrics, SamplingInterval};
+use crate::metrics::{DBMetrics, RocksDBPerfContext};
 
 use super::{be_fix_int_ser, errors::TypedStoreError, RocksDBRawIter};
 use serde::{de::DeserializeOwned, Serialize};
 
 /// An iterator over all key-value pairs in a data map.
 pub struct SafeIter<'a, K, V> {
+    cf_name: String,
     db_iter: RocksDBRawIter<'a>,
     _phantom: PhantomData<(K, V)>,
     direction: Direction,
-    cf: String,
-    db_metrics: Arc<DBMetrics>,
-    iter_bytes_sample_interval: SamplingInterval,
+    _timer: Option<HistogramTimer>,
+    _perf_ctx: Option<RocksDBPerfContext>,
+    bytes_scanned: Option<Histogram>,
+    keys_scanned: Option<Histogram>,
+    db_metrics: Option<Arc<DBMetrics>>,
+    bytes_scanned_counter: usize,
+    keys_returned_counter: usize,
 }
 
 impl<'a, K: DeserializeOwned, V: DeserializeOwned> SafeIter<'a, K, V> {
     pub(super) fn new(
+        cf_name: String,
         db_iter: RocksDBRawIter<'a>,
-        cf: String,
-        db_metrics: &Arc<DBMetrics>,
-        iter_bytes_sample_interval: &SamplingInterval,
+        _timer: Option<HistogramTimer>,
+        _perf_ctx: Option<RocksDBPerfContext>,
+        bytes_scanned: Option<Histogram>,
+        keys_scanned: Option<Histogram>,
+        db_metrics: Option<Arc<DBMetrics>>,
     ) -> Self {
         Self {
+            cf_name,
             db_iter,
             _phantom: PhantomData,
             direction: Direction::Forward,
-            cf,
-            db_metrics: db_metrics.clone(),
-            iter_bytes_sample_interval: iter_bytes_sample_interval.clone(),
+            _timer,
+            _perf_ctx,
+            bytes_scanned,
+            keys_scanned,
+            db_metrics,
+            bytes_scanned_counter: 0,
+            keys_returned_counter: 0,
         }
     }
 }
@@ -54,27 +68,36 @@ impl<'a, K: DeserializeOwned, V: DeserializeOwned> Iterator for SafeIter<'a, K, 
                 .db_iter
                 .value()
                 .expect("Valid iterator failed to get value");
+            self.bytes_scanned_counter += raw_key.len() + raw_value.len();
+            self.keys_returned_counter += 1;
             let key = config.deserialize(raw_key).ok();
             let value = bcs::from_bytes(raw_value).ok();
-            if self.iter_bytes_sample_interval.sample() {
-                let total_bytes_read = (raw_key.len() + raw_value.len()) as f64;
-                self.db_metrics
-                    .op_metrics
-                    .rocksdb_iter_bytes
-                    .with_label_values(&[&self.cf])
-                    .observe(total_bytes_read);
-            }
             match self.direction {
                 Direction::Forward => self.db_iter.next(),
                 Direction::Reverse => self.db_iter.prev(),
             }
-
             key.and_then(|k| value.map(|v| Ok((k, v))))
         } else {
             match self.db_iter.status() {
                 Ok(_) => None,
                 Err(err) => Some(Err(TypedStoreError::RocksDBError(format!("{err}")))),
             }
+        }
+    }
+}
+
+impl<'a, K, V> Drop for SafeIter<'a, K, V> {
+    fn drop(&mut self) {
+        if let Some(bytes_scanned) = self.bytes_scanned.take() {
+            bytes_scanned.observe(self.bytes_scanned_counter as f64);
+        }
+        if let Some(keys_scanned) = self.keys_scanned.take() {
+            keys_scanned.observe(self.keys_returned_counter as f64);
+        }
+        if let Some(db_metrics) = self.db_metrics.take() {
+            db_metrics
+                .read_perf_ctx_metrics
+                .report_metrics(&self.cf_name);
         }
     }
 }


### PR DESCRIPTION
## Description 

There are several problems with how we collect metrics in typed-store lib and this PR tries to address them:
1. We don't know how many keys are retrieved for different tables. We recently had an issue where some iterator calls are scanning the entire table. Having such a metric would be able to catch such scenarios.
2. We don't know total bytes scanned in iterators. Adding that.
3. Operational metrics don't need to be sampled. Perf context metrics are expensive so that should still keep getting sampled
4. Different read endpoints i.e. get and multi-get should have different operational metrics and sampling

## Test Plan 

Existing tests
