### PR TITLE
[sui-node] Stop and wait sui node runtimes on SIGINT

### DIFF
--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -52,6 +52,7 @@ mod type_param_tests;
 
 pub mod signature_verifier;
 
+pub mod runtime;
 mod transaction_signing_filter;
 
 pub const SUI_CORE_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/sui-core/src/runtime.rs
+++ b/crates/sui-core/src/runtime.rs
@@ -1,0 +1,29 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use sui_config::NodeConfig;
+use tokio::runtime::Runtime;
+
+pub struct SuiRuntimes {
+    // Order in this struct is the order in which runtimes are stopped
+    pub sui_node: Runtime,
+    pub metrics: Runtime,
+    // json_rpc: Runtime,
+}
+
+impl SuiRuntimes {
+    pub fn new(_confg: &NodeConfig) -> Self {
+        let sui_node = tokio::runtime::Builder::new_multi_thread()
+            .thread_name("sui-node-runtime")
+            .enable_all()
+            .build()
+            .unwrap();
+        let metrics = tokio::runtime::Builder::new_multi_thread()
+            .thread_name("metrics-runtime")
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .unwrap();
+        Self { sui_node, metrics }
+    }
+}


### PR DESCRIPTION
This change makes sure we stop all sui node runtimes upon receiving SIGINT. This is needed to make sure rocks db databases are properly closed before existing sui node

