### PR TITLE
with_tracing to instrument info or error logs

### DIFF
--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -32,7 +32,7 @@ use sui_types::sui_system_state::{
 
 use crate::api::{GovernanceReadApiServer, JsonRpcMetrics};
 use crate::error::Error;
-use crate::{ObjectProvider, SuiRpcModule};
+use crate::{with_tracing, ObjectProvider, SuiRpcModule};
 
 pub struct GovernanceReadApi {
     state: Arc<AuthorityState>,
@@ -255,43 +255,49 @@ impl GovernanceReadApiServer for GovernanceReadApi {
         &self,
         staked_sui_ids: Vec<ObjectID>,
     ) -> RpcResult<Vec<DelegatedStake>> {
-        info!("get_stakes_by_ids");
-        Ok(self.get_stakes_by_ids(staked_sui_ids).await?)
+        with_tracing!("get_stakes_by_ids", async move {
+            Ok(self.get_stakes_by_ids(staked_sui_ids).await?)
+        })
     }
 
     #[instrument(skip(self))]
     async fn get_stakes(&self, owner: SuiAddress) -> RpcResult<Vec<DelegatedStake>> {
-        info!("get_stakes");
-        Ok(self.get_stakes(owner).await?)
+        with_tracing!(
+            "get_stakes",
+            async move { Ok(self.get_stakes(owner).await?) }
+        )
     }
 
     #[instrument(skip(self))]
     async fn get_committee_info(&self, epoch: Option<BigInt<u64>>) -> RpcResult<SuiCommittee> {
-        info!("get_committee_info");
-        Ok(self
-            .state
-            .committee_store()
-            .get_or_latest_committee(epoch.map(|e| *e))
-            .map(|committee| committee.into())
-            .map_err(Error::from)?)
+        with_tracing!("get_committee_info", async move {
+            Ok(self
+                .state
+                .committee_store()
+                .get_or_latest_committee(epoch.map(|e| *e))
+                .map(|committee| committee.into())
+                .map_err(Error::from)?)
+        })
     }
 
     #[instrument(skip(self))]
     async fn get_latest_sui_system_state(&self) -> RpcResult<SuiSystemStateSummary> {
-        info!("get_latest_sui_system_state");
-        Ok(self
-            .state
-            .database
-            .get_sui_system_state_object()
-            .map_err(Error::from)?
-            .into_sui_system_state_summary())
+        with_tracing!("get_latest_sui_system_state", async move {
+            Ok(self
+                .state
+                .database
+                .get_sui_system_state_object()
+                .map_err(Error::from)?
+                .into_sui_system_state_summary())
+        })
     }
 
     #[instrument(skip(self))]
     async fn get_reference_gas_price(&self) -> RpcResult<BigInt<u64>> {
-        info!("get_reference_gas_price");
-        let epoch_store = self.state.load_epoch_store_one_call_per_task();
-        Ok(epoch_store.reference_gas_price().into())
+        with_tracing!("get_reference_gas_price", async move {
+            let epoch_store = self.state.load_epoch_store_one_call_per_task();
+            Ok(epoch_store.reference_gas_price().into())
+        })
     }
 }
 

--- a/crates/sui-json-rpc/src/indexer_api.rs
+++ b/crates/sui-json-rpc/src/indexer_api.rs
@@ -353,7 +353,7 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
                 }?;
                 return Ok(Some(addr));
             }
-            return Ok(None);
+            Ok(None)
         })
     }
 

--- a/crates/sui-json-rpc/src/indexer_api.rs
+++ b/crates/sui-json-rpc/src/indexer_api.rs
@@ -14,7 +14,7 @@ use move_bytecode_utils::layout::TypeLayoutBuilder;
 use serde::Serialize;
 use sui_json::SuiJsonValue;
 use sui_types::MOVE_STDLIB_ADDRESS;
-use tracing::{info, instrument, warn};
+use tracing::{instrument, warn};
 
 use move_core_types::language_storage::{StructTag, TypeTag};
 use mysten_metrics::spawn_monitored_task;
@@ -34,6 +34,7 @@ use crate::api::{
     cap_page_limit, validate_limit, IndexerApiServer, JsonRpcMetrics, ReadApiServer,
     QUERY_MAX_RESULT_LIMIT,
 };
+use crate::with_tracing;
 use crate::SuiRpcModule;
 
 const NAME_SERVICE_LOOKUP_KEY: &str = "records";
@@ -60,7 +61,6 @@ where
         };
     });
 }
-
 pub struct IndexerApi<R> {
     state: Arc<AuthorityState>,
     read_api: R,
@@ -94,47 +94,48 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
         cursor: Option<ObjectID>,
         limit: Option<usize>,
     ) -> RpcResult<ObjectsPage> {
-        info!("indexer_get_owned_objects");
-        let limit = validate_limit(limit, *QUERY_MAX_RESULT_LIMIT)?;
-        self.metrics.get_owned_objects_limit.report(limit as u64);
-        let SuiObjectResponseQuery { filter, options } = query.unwrap_or_default();
-        let options = options.unwrap_or_default();
-        let mut objects = self
-            .state
-            .get_owner_objects(address, cursor, limit + 1, filter)
-            .map_err(|e| anyhow!("{e}"))?;
+        with_tracing!("get_owned_objects", async move {
+            let limit = validate_limit(limit, *QUERY_MAX_RESULT_LIMIT)?;
+            self.metrics.get_owned_objects_limit.report(limit as u64);
+            let SuiObjectResponseQuery { filter, options } = query.unwrap_or_default();
+            let options = options.unwrap_or_default();
+            let mut objects = self
+                .state
+                .get_owner_objects(address, cursor, limit + 1, filter)
+                .map_err(|e| anyhow!("{e}"))?;
 
-        // objects here are of size (limit + 1), where the last one is the cursor for the next page
-        let has_next_page = objects.len() > limit;
-        objects.truncate(limit);
-        let next_cursor = objects
-            .last()
-            .cloned()
-            .map_or(cursor, |o_info| Some(o_info.object_id));
+            // objects here are of size (limit + 1), where the last one is the cursor for the next page
+            let has_next_page = objects.len() > limit;
+            objects.truncate(limit);
+            let next_cursor = objects
+                .last()
+                .cloned()
+                .map_or(cursor, |o_info| Some(o_info.object_id));
 
-        let data = match options.is_not_in_object_info() {
-            true => {
-                let object_ids = objects.iter().map(|obj| obj.object_id).collect();
-                self.read_api
-                    .multi_get_objects(object_ids, Some(options))
-                    .await?
-            }
-            false => objects
-                .into_iter()
-                .map(|o_info| SuiObjectResponse::try_from((o_info, options.clone())))
-                .collect::<Result<Vec<SuiObjectResponse>, _>>()?,
-        };
+            let data = match options.is_not_in_object_info() {
+                true => {
+                    let object_ids = objects.iter().map(|obj| obj.object_id).collect();
+                    self.read_api
+                        .multi_get_objects(object_ids, Some(options))
+                        .await?
+                }
+                false => objects
+                    .into_iter()
+                    .map(|o_info| SuiObjectResponse::try_from((o_info, options.clone())))
+                    .collect::<Result<Vec<SuiObjectResponse>, _>>()?,
+            };
 
-        self.metrics
-            .get_owned_objects_result_size
-            .report(data.len() as u64);
-        self.metrics
-            .get_owned_objects_result_size_total
-            .inc_by(data.len() as u64);
-        Ok(Page {
-            data,
-            next_cursor,
-            has_next_page,
+            self.metrics
+                .get_owned_objects_result_size
+                .report(data.len() as u64);
+            self.metrics
+                .get_owned_objects_result_size_total
+                .inc_by(data.len() as u64);
+            Ok(Page {
+                data,
+                next_cursor,
+                has_next_page,
+            })
         })
     }
 
@@ -147,43 +148,44 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
         limit: Option<usize>,
         descending_order: Option<bool>,
     ) -> RpcResult<TransactionBlocksPage> {
-        info!("indexer_query_transaction_blocks");
-        let limit = cap_page_limit(limit);
-        self.metrics.query_tx_blocks_limit.report(limit as u64);
-        let descending = descending_order.unwrap_or_default();
-        let opts = query.options.unwrap_or_default();
+        with_tracing!("query_transaction_blocks", async move {
+            let limit = cap_page_limit(limit);
+            self.metrics.query_tx_blocks_limit.report(limit as u64);
+            let descending = descending_order.unwrap_or_default();
+            let opts = query.options.unwrap_or_default();
 
-        // Retrieve 1 extra item for next cursor
-        let mut digests =
-            self.state
-                .get_transactions(query.filter, cursor, Some(limit + 1), descending)?;
+            // Retrieve 1 extra item for next cursor
+            let mut digests =
+                self.state
+                    .get_transactions(query.filter, cursor, Some(limit + 1), descending)?;
 
-        // extract next cursor
-        let has_next_page = digests.len() > limit;
-        digests.truncate(limit);
-        let next_cursor = digests.last().cloned().map_or(cursor, Some);
+            // extract next cursor
+            let has_next_page = digests.len() > limit;
+            digests.truncate(limit);
+            let next_cursor = digests.last().cloned().map_or(cursor, Some);
 
-        let data: Vec<SuiTransactionBlockResponse> = if opts.only_digest() {
-            digests
-                .into_iter()
-                .map(SuiTransactionBlockResponse::new)
-                .collect()
-        } else {
-            self.read_api
-                .multi_get_transaction_blocks(digests, Some(opts))
-                .await?
-        };
+            let data: Vec<SuiTransactionBlockResponse> = if opts.only_digest() {
+                digests
+                    .into_iter()
+                    .map(SuiTransactionBlockResponse::new)
+                    .collect()
+            } else {
+                self.read_api
+                    .multi_get_transaction_blocks(digests, Some(opts))
+                    .await?
+            };
 
-        self.metrics
-            .query_tx_blocks_result_size
-            .report(data.len() as u64);
-        self.metrics
-            .query_tx_blocks_result_size_total
-            .inc_by(data.len() as u64);
-        Ok(Page {
-            data,
-            next_cursor,
-            has_next_page,
+            self.metrics
+                .query_tx_blocks_result_size
+                .report(data.len() as u64);
+            self.metrics
+                .query_tx_blocks_result_size_total
+                .inc_by(data.len() as u64);
+            Ok(Page {
+                data,
+                next_cursor,
+                has_next_page,
+            })
         })
     }
     #[instrument(skip(self))]
@@ -195,34 +197,37 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
         limit: Option<usize>,
         descending_order: Option<bool>,
     ) -> RpcResult<EventPage> {
-        info!("indexer_query_events");
-        let descending = descending_order.unwrap_or_default();
-        let limit = cap_page_limit(limit);
-        self.metrics.query_events_limit.report(limit as u64);
-        // Retrieve 1 extra item for next cursor
-        let mut data = self
-            .state
-            .query_events(query, cursor.clone(), limit + 1, descending)?;
-        let has_next_page = data.len() > limit;
-        data.truncate(limit);
-        let next_cursor = data.last().map_or(cursor, |e| Some(e.id.clone()));
-        self.metrics
-            .query_events_result_size
-            .report(data.len() as u64);
-        self.metrics
-            .query_events_result_size_total
-            .inc_by(data.len() as u64);
-        Ok(EventPage {
-            data,
-            next_cursor,
-            has_next_page,
+        with_tracing!("query_events", async move {
+            let descending = descending_order.unwrap_or_default();
+            let limit = cap_page_limit(limit);
+            self.metrics.query_events_limit.report(limit as u64);
+            // Retrieve 1 extra item for next cursor
+            let mut data = self
+                .state
+                .query_events(query, cursor.clone(), limit + 1, descending)?;
+            let has_next_page = data.len() > limit;
+            data.truncate(limit);
+            let next_cursor = data.last().map_or(cursor, |e| Some(e.id.clone()));
+            self.metrics
+                .query_events_result_size
+                .report(data.len() as u64);
+            self.metrics
+                .query_events_result_size_total
+                .inc_by(data.len() as u64);
+            Ok(EventPage {
+                data,
+                next_cursor,
+                has_next_page,
+            })
         })
     }
 
+    #[instrument(skip(self))]
     fn subscribe_event(&self, sink: SubscriptionSink, filter: EventFilter) -> SubscriptionResult {
         spawn_subscription(sink, self.state.event_handler.subscribe(filter));
         Ok(())
     }
+
     #[instrument(skip(self))]
     async fn get_dynamic_fields(
         &self,
@@ -231,26 +236,27 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
         cursor: Option<ObjectID>,
         limit: Option<usize>,
     ) -> RpcResult<DynamicFieldPage> {
-        info!("indexer_get_dynamic_fields");
-        let limit = cap_page_limit(limit);
-        self.metrics.get_dynamic_fields_limit.report(limit as u64);
-        let mut data = self
-            .state
-            .get_dynamic_fields(parent_object_id, cursor, limit + 1)
-            .map_err(|e| anyhow!("{e}"))?;
-        let has_next_page = data.len() > limit;
-        data.truncate(limit);
-        let next_cursor = data.last().cloned().map_or(cursor, |c| Some(c.object_id));
-        self.metrics
-            .get_dynamic_fields_result_size
-            .report(data.len() as u64);
-        self.metrics
-            .get_dynamic_fields_result_size_total
-            .inc_by(data.len() as u64);
-        Ok(DynamicFieldPage {
-            data,
-            next_cursor,
-            has_next_page,
+        with_tracing!("get_dynamic_fields", async move {
+            let limit = cap_page_limit(limit);
+            self.metrics.get_dynamic_fields_limit.report(limit as u64);
+            let mut data = self
+                .state
+                .get_dynamic_fields(parent_object_id, cursor, limit + 1)
+                .map_err(|e| anyhow!("{e}"))?;
+            let has_next_page = data.len() > limit;
+            data.truncate(limit);
+            let next_cursor = data.last().cloned().map_or(cursor, |c| Some(c.object_id));
+            self.metrics
+                .get_dynamic_fields_result_size
+                .report(data.len() as u64);
+            self.metrics
+                .get_dynamic_fields_result_size_total
+                .inc_by(data.len() as u64);
+            Ok(DynamicFieldPage {
+                data,
+                next_cursor,
+                has_next_page,
+            })
         })
     }
 
@@ -260,94 +266,95 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
         parent_object_id: ObjectID,
         name: DynamicFieldName,
     ) -> RpcResult<SuiObjectResponse> {
-        info!("indexer_get_dynamic_field_object");
-        let DynamicFieldName {
-            type_: name_type,
-            value,
-        } = name.clone();
-        let layout = TypeLayoutBuilder::build_with_types(&name_type, &self.state.database)?;
-        let sui_json_value = SuiJsonValue::new(value)?;
-        let name_bcs_value = sui_json_value.to_bcs_bytes(&layout)?;
-        let id = self
-            .state
-            .get_dynamic_field_object_id(parent_object_id, name_type, &name_bcs_value)
-            .map_err(|e| anyhow!("{e}"))?
-            .ok_or_else(|| {
-                anyhow!("Cannot find dynamic field [{name:?}] for object [{parent_object_id}].")
-            })?;
-        // TODO(chris): add options to `get_dynamic_field_object` API as well
-        self.read_api
-            .get_object(id, Some(SuiObjectDataOptions::full_content()))
-            .await
+        with_tracing!("get_dynamic_field_object", async move {
+            let DynamicFieldName {
+                type_: name_type,
+                value,
+            } = name.clone();
+            let layout = TypeLayoutBuilder::build_with_types(&name_type, &self.state.database)?;
+            let sui_json_value = SuiJsonValue::new(value)?;
+            let name_bcs_value = sui_json_value.to_bcs_bytes(&layout)?;
+            let id = self
+                .state
+                .get_dynamic_field_object_id(parent_object_id, name_type, &name_bcs_value)
+                .map_err(|e| anyhow!("{e}"))?
+                .ok_or_else(|| {
+                    anyhow!("Cannot find dynamic field [{name:?}] for object [{parent_object_id}].")
+                })?;
+            // TODO(chris): add options to `get_dynamic_field_object` API as well
+            self.read_api
+                .get_object(id, Some(SuiObjectDataOptions::full_content()))
+                .await
+        })
     }
 
     #[instrument(skip(self))]
     async fn resolve_name_service_address(&self, name: String) -> RpcResult<Option<SuiAddress>> {
-        info!("indexer_resolve_name_service_address");
-        let dynamic_field_table_object_id = self
-            .get_name_service_dynamic_field_table_object_id(/* reverse_lookup */ false)
-            .await?;
-        // NOTE: 0x1::string::String is the type tag of fields in dynamic_field_table
-        let name_type_tag = TypeTag::Struct(Box::new(StructTag {
-            address: MOVE_STDLIB_ADDRESS,
-            module: STD_UTF8_MODULE_NAME.to_owned(),
-            name: STD_UTF8_STRUCT_NAME.to_owned(),
-            type_params: vec![],
-        }));
-        let name_bcs_value = bcs::to_bytes(&name).context("Unable to serialize name")?;
-        // record of the input `name`
-        let record_object_id_option = self
-            .state
-            .get_dynamic_field_object_id(
-                dynamic_field_table_object_id,
-                name_type_tag,
-                &name_bcs_value,
-            )
-            .map_err(|e| {
-                anyhow!(
-                    "Read name service dynamic field table failed with error: {:?}",
-                    e
+        with_tracing!("resolve_name_service_address", async move {
+            let dynamic_field_table_object_id = self
+                .get_name_service_dynamic_field_table_object_id(/* reverse_lookup */ false)
+                .await?;
+            // NOTE: 0x1::string::String is the type tag of fields in dynamic_field_table
+            let name_type_tag = TypeTag::Struct(Box::new(StructTag {
+                address: MOVE_STDLIB_ADDRESS,
+                module: STD_UTF8_MODULE_NAME.to_owned(),
+                name: STD_UTF8_STRUCT_NAME.to_owned(),
+                type_params: vec![],
+            }));
+            let name_bcs_value = bcs::to_bytes(&name).context("Unable to serialize name")?;
+            // record of the input `name`
+            let record_object_id_option = self
+                .state
+                .get_dynamic_field_object_id(
+                    dynamic_field_table_object_id,
+                    name_type_tag,
+                    &name_bcs_value,
                 )
-            })?;
-        if let Some(record_object_id) = record_object_id_option {
-            let record_object_read =
-                self.state.get_object_read(&record_object_id).map_err(|e| {
-                    warn!(
-                        "Failed to get object read of name: {:?} with error: {:?}",
-                        record_object_id, e
-                    );
-                    anyhow!("{e}")
-                })?;
-            let record_parsed_move_object =
-                SuiParsedMoveObject::try_from_object_read(record_object_read)?;
-            // NOTE: "value" is the field name to get the address info
-            let address_info_move_value = record_parsed_move_object
-                .read_dynamic_field_value(NAME_SERVICE_VALUE)
-                .ok_or_else(|| anyhow!("Cannot find value field in record Move struct"))?;
-            let address_info_move_struct = match address_info_move_value {
-                SuiMoveValue::Struct(a) => Ok(a),
-                _ => Err(anyhow!("value field is not found.")),
-            }?;
-            // NOTE: "marker" is the field name to get the address
-            let address_str_move_value = address_info_move_struct
-                .read_dynamic_field_value(NAME_SERVICE_MARKER)
-                .ok_or_else(|| {
+                .map_err(|e| {
                     anyhow!(
-                        "Cannot find marker field in address info Move struct: {:?}",
-                        address_info_move_struct
+                        "Read name service dynamic field table failed with error: {:?}",
+                        e
                     )
                 })?;
-            let addr = match address_str_move_value {
-                SuiMoveValue::Address(addr) => Ok(addr),
-                _ => Err(anyhow!(
-                    "No SuiAddress found in: {:?}",
-                    address_str_move_value
-                )),
-            }?;
-            return Ok(Some(addr));
-        } else {
+            if let Some(record_object_id) = record_object_id_option {
+                let record_object_read =
+                    self.state.get_object_read(&record_object_id).map_err(|e| {
+                        warn!(
+                            "Failed to get object read of name: {:?} with error: {:?}",
+                            record_object_id, e
+                        );
+                        anyhow!("{e}")
+                    })?;
+                let record_parsed_move_object =
+                    SuiParsedMoveObject::try_from_object_read(record_object_read)?;
+                // NOTE: "value" is the field name to get the address info
+                let address_info_move_value = record_parsed_move_object
+                    .read_dynamic_field_value(NAME_SERVICE_VALUE)
+                    .ok_or_else(|| anyhow!("Cannot find value field in record Move struct"))?;
+                let address_info_move_struct = match address_info_move_value {
+                    SuiMoveValue::Struct(a) => Ok(a),
+                    _ => Err(anyhow!("value field is not found.")),
+                }?;
+                // NOTE: "marker" is the field name to get the address
+                let address_str_move_value = address_info_move_struct
+                    .read_dynamic_field_value(NAME_SERVICE_MARKER)
+                    .ok_or_else(|| {
+                        anyhow!(
+                            "Cannot find marker field in address info Move struct: {:?}",
+                            address_info_move_struct
+                        )
+                    })?;
+                let addr = match address_str_move_value {
+                    SuiMoveValue::Address(addr) => Ok(addr),
+                    _ => Err(anyhow!(
+                        "No SuiAddress found in: {:?}",
+                        address_str_move_value
+                    )),
+                }?;
+                return Ok(Some(addr));
+            }
             return Ok(None);
-        }
+        })
     }
 
     #[instrument(skip(self))]
@@ -357,49 +364,50 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
         _cursor: Option<ObjectID>,
         _limit: Option<usize>,
     ) -> RpcResult<Page<String, ObjectID>> {
-        info!("indexer_resolve_name_service_names");
-        let dynamic_field_table_object_id = self
-            .get_name_service_dynamic_field_table_object_id(/* reverse_lookup */ true)
-            .await?;
-        let name_type_tag = TypeTag::Address;
-        let name_bcs_value = bcs::to_bytes(&address).context("Unable to serialize address")?;
-        let addr_object_id = self
-            .state
-            .get_dynamic_field_object_id(
-                dynamic_field_table_object_id,
-                name_type_tag,
-                &name_bcs_value,
-            )
-            .map_err(|e| {
-                anyhow!(
-                    "Read name service reverse dynamic field table failed with error: {:?}",
-                    e
+        with_tracing!("resolve_name_service_names", async move {
+            let dynamic_field_table_object_id = self
+                .get_name_service_dynamic_field_table_object_id(/* reverse_lookup */ true)
+                .await?;
+            let name_type_tag = TypeTag::Address;
+            let name_bcs_value = bcs::to_bytes(&address).context("Unable to serialize address")?;
+            let addr_object_id = self
+                .state
+                .get_dynamic_field_object_id(
+                    dynamic_field_table_object_id,
+                    name_type_tag,
+                    &name_bcs_value,
                 )
-            })?
-            .ok_or_else(|| anyhow!("Record not found for address: {:?}", address))?;
-        let addr_object_read = self.state.get_object_read(&addr_object_id).map_err(|e| {
-            warn!(
-                "Failed to get object read of address {:?} with error: {:?}",
-                addr_object_id, e
-            );
-            anyhow!("{e}")
-        })?;
-        let addr_parsed_move_object = SuiParsedMoveObject::try_from_object_read(addr_object_read)?;
-        let address_info_move_value = addr_parsed_move_object
-            .read_dynamic_field_value(NAME_SERVICE_VALUE)
-            .ok_or_else(|| anyhow!("Cannot find value field in record Move struct"))?;
-
-        let primary_name = match address_info_move_value {
-            SuiMoveValue::String(s) => Ok(s),
-            _ => Err(anyhow!(
-                "No string field for primary name is found in {:?}",
-                address_info_move_value
-            )),
-        }?;
-        Ok(Page {
-            data: vec![primary_name],
-            next_cursor: Some(addr_object_id),
-            has_next_page: false,
+                .map_err(|e| {
+                    anyhow!(
+                        "Read name service reverse dynamic field table failed with error: {:?}",
+                        e
+                    )
+                })?
+                .ok_or_else(|| anyhow!("Record not found for address: {:?}", address))?;
+            let addr_object_read = self.state.get_object_read(&addr_object_id).map_err(|e| {
+                warn!(
+                    "Failed to get object read of address {:?} with error: {:?}",
+                    addr_object_id, e
+                );
+                anyhow!("{e}")
+            })?;
+            let addr_parsed_move_object =
+                SuiParsedMoveObject::try_from_object_read(addr_object_read)?;
+            let address_info_move_value = addr_parsed_move_object
+                .read_dynamic_field_value(NAME_SERVICE_VALUE)
+                .ok_or_else(|| anyhow!("Cannot find value field in record Move struct"))?;
+            let primary_name = match address_info_move_value {
+                SuiMoveValue::String(s) => Ok(s),
+                _ => Err(anyhow!(
+                    "No string field for primary name is found in {:?}",
+                    address_info_move_value
+                )),
+            }?;
+            Ok(Page {
+                data: vec![primary_name],
+                next_cursor: Some(addr_object_id),
+                has_next_page: false,
+            })
         })
     }
 }

--- a/crates/sui-json-rpc/src/lib.rs
+++ b/crates/sui-json-rpc/src/lib.rs
@@ -30,6 +30,7 @@ pub mod coin_api;
 pub mod error;
 pub mod governance_api;
 pub mod indexer_api;
+pub mod logger;
 mod metrics;
 pub mod move_utils;
 mod object_changes;

--- a/crates/sui-json-rpc/src/logger.rs
+++ b/crates/sui-json-rpc/src/logger.rs
@@ -1,0 +1,20 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[macro_export]
+macro_rules! with_tracing {
+    ($method_name:literal, $future:expr) => {{
+        use tracing::{info, error, Instrument, Span};
+        async move {
+            let result = $future.await;
+            match &result {
+                Ok(_) => info!("success"),
+                Err(e) => error!(error = ?e, "failed"),
+            }
+
+            result
+        }
+        .instrument(Span::current())
+        .await
+    }};
+}


### PR DESCRIPTION
## Description 

Wrapper function to help instrument info or error logs. info logs are still subject to sampling, but error logs will always log.

```
curl --location 'http://127.0.0.1:9000' \
--header 'Content-Type: application/json' \
--data '{
    "method": "suix_getDynamicFieldObject",
    "jsonrpc": "2.0",
    "params": [
        "0x7d1237b9f8ab28ce64322b1f7b09d18909205a55c0f301f36838abbbfb234516",
        {
            "type": "address",
            "value": "0x82d7715ff1213dbfd740b5761133c6b7b19d5a5d1e1854d74ba6be53b36a9ca0"
        }
    ],
    "id": 1
}'
```
```
2023-04-25T19:55:34.558917Z ERROR connection{remote_addr=127.0.0.1:63470 conn_id=6}:get_dynamic_field_object{parent_object_id=0x7d1237b9f8ab28ce64322b1f7b09d18909205a55c0f301f36838abbbfb234516 name=DynamicFieldName { type_: Address, value: String("0x82d7715ff1213dbfd740b5761133c6b7b19d5a5d1e1854d74ba6be53b36a9ca0") }}: sui_json_rpc::indexer_api: get_dynamic_field_object failed: Call(Failed(Cannot find dynamic field [DynamicFieldName { type_: Address, value: String("0x82d7715ff1213dbfd740b5761133c6b7b19d5a5d1e1854d74ba6be53b36a9ca0") }] for object [0x7d1237b9f8ab28ce64322b1f7b09d18909205a55c0f301f36838abbbfb234516].))
```


```
curl --location 'http://127.0.0.1:9000' \
--header 'Content-Type: application/json' \
--data '{
    "jsonrpc": "2.0",
    "method": "suix_getOwnedObjects",
    "params": [
        "0xadfb89b000e97a30bd485bffbff80f883096a8a98cdce33641ec924393d8fbe8",
        {
            "options": {
                "showType": true,
                "showOwner": false,
                "showPreviousTransaction": false,
                "showDisplay": false,
                "showContent": true,
                "showBcs": false,
                "showStorageRebate": false
            }
        }
    ],
    "id": 1
}'
```

```
2023-04-25T19:56:01.066520Z  INFO connection{remote_addr=127.0.0.1:63477 conn_id=12}:get_owned_objects{address=0xadfb89b000e97a30bd485bffbff80f883096a8a98cdce33641ec924393d8fbe8 query=Some(SuiObjectResponseQuery { filter: None, options: Some(SuiObjectDataOptions { show_type: true, show_owner: false, show_previous_transaction: false, show_display: false, show_content: true, show_bcs: false, show_storage_rebate: false }) }) cursor=None limit=None}:multi_get_objects{object_ids=[] options=Some(SuiObjectDataOptions { show_type: true, show_owner: false, show_previous_transaction: false, show_display: false, show_content: true, show_bcs: false, show_storage_rebate: false })}: sui_json_rpc::read_api: multi_get_objects
```

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
