### PR TITLE
Enable expensive checks by default in default network config

### DIFF
--- a/crates/sui-config/src/builder.rs
+++ b/crates/sui-config/src/builder.rs
@@ -5,7 +5,8 @@ use crate::genesis::{TokenAllocation, TokenDistributionScheduleBuilder};
 use crate::genesis_config::AccountConfig;
 use crate::node::{
     default_enable_index_processing, default_end_of_epoch_broadcast_channel_capacity,
-    AuthorityKeyPairWithPath, DBCheckpointConfig, KeyPairWithPath, DEFAULT_VALIDATOR_GAS_PRICE,
+    AuthorityKeyPairWithPath, DBCheckpointConfig, ExpensiveSafetyCheckConfig, KeyPairWithPath,
+    DEFAULT_VALIDATOR_GAS_PRICE,
 };
 use crate::{
     genesis,
@@ -531,7 +532,7 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                     supported_protocol_versions: Some(supported_protocol_versions),
                     db_checkpoint_config: self.db_checkpoint_config.clone(),
                     indirect_objects_threshold: usize::MAX,
-                    expensive_safety_check_config: Default::default(),
+                    expensive_safety_check_config: ExpensiveSafetyCheckConfig::new_enable_all(),
                     name_service_resolver_object_id: None,
                     transaction_deny_config: Default::default(),
                 }

--- a/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -76,12 +76,12 @@ validator_configs:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
     expensive-safety-check-config:
-      enable-epoch-sui-conservation-check: false
-      enable-deep-per-tx-sui-conservation-check: false
+      enable-epoch-sui-conservation-check: true
+      enable-deep-per-tx-sui-conservation-check: true
       force-disable-epoch-sui-conservation-check: false
-      enable-state-consistency-check: false
+      enable-state-consistency-check: true
       force-disable-state-consistency-check: false
-      enable-move-vm-paranoid-checks: false
+      enable-move-vm-paranoid-checks: true
     transaction-deny-config:
       package_publish_disabled: false
       package_upgrade_disabled: false
@@ -160,12 +160,12 @@ validator_configs:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
     expensive-safety-check-config:
-      enable-epoch-sui-conservation-check: false
-      enable-deep-per-tx-sui-conservation-check: false
+      enable-epoch-sui-conservation-check: true
+      enable-deep-per-tx-sui-conservation-check: true
       force-disable-epoch-sui-conservation-check: false
-      enable-state-consistency-check: false
+      enable-state-consistency-check: true
       force-disable-state-consistency-check: false
-      enable-move-vm-paranoid-checks: false
+      enable-move-vm-paranoid-checks: true
     transaction-deny-config:
       package_publish_disabled: false
       package_upgrade_disabled: false
@@ -244,12 +244,12 @@ validator_configs:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
     expensive-safety-check-config:
-      enable-epoch-sui-conservation-check: false
-      enable-deep-per-tx-sui-conservation-check: false
+      enable-epoch-sui-conservation-check: true
+      enable-deep-per-tx-sui-conservation-check: true
       force-disable-epoch-sui-conservation-check: false
-      enable-state-consistency-check: false
+      enable-state-consistency-check: true
       force-disable-state-consistency-check: false
-      enable-move-vm-paranoid-checks: false
+      enable-move-vm-paranoid-checks: true
     transaction-deny-config:
       package_publish_disabled: false
       package_upgrade_disabled: false
@@ -328,12 +328,12 @@ validator_configs:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
     expensive-safety-check-config:
-      enable-epoch-sui-conservation-check: false
-      enable-deep-per-tx-sui-conservation-check: false
+      enable-epoch-sui-conservation-check: true
+      enable-deep-per-tx-sui-conservation-check: true
       force-disable-epoch-sui-conservation-check: false
-      enable-state-consistency-check: false
+      enable-state-consistency-check: true
       force-disable-state-consistency-check: false
-      enable-move-vm-paranoid-checks: false
+      enable-move-vm-paranoid-checks: true
     transaction-deny-config:
       package_publish_disabled: false
       package_upgrade_disabled: false
@@ -412,12 +412,12 @@ validator_configs:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
     expensive-safety-check-config:
-      enable-epoch-sui-conservation-check: false
-      enable-deep-per-tx-sui-conservation-check: false
+      enable-epoch-sui-conservation-check: true
+      enable-deep-per-tx-sui-conservation-check: true
       force-disable-epoch-sui-conservation-check: false
-      enable-state-consistency-check: false
+      enable-state-consistency-check: true
       force-disable-state-consistency-check: false
-      enable-move-vm-paranoid-checks: false
+      enable-move-vm-paranoid-checks: true
     transaction-deny-config:
       package_publish_disabled: false
       package_upgrade_disabled: false
@@ -496,12 +496,12 @@ validator_configs:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
     expensive-safety-check-config:
-      enable-epoch-sui-conservation-check: false
-      enable-deep-per-tx-sui-conservation-check: false
+      enable-epoch-sui-conservation-check: true
+      enable-deep-per-tx-sui-conservation-check: true
       force-disable-epoch-sui-conservation-check: false
-      enable-state-consistency-check: false
+      enable-state-consistency-check: true
       force-disable-state-consistency-check: false
-      enable-move-vm-paranoid-checks: false
+      enable-move-vm-paranoid-checks: true
     transaction-deny-config:
       package_publish_disabled: false
       package_upgrade_disabled: false
@@ -580,12 +580,12 @@ validator_configs:
       perform-db-checkpoints-at-epoch-end: false
     indirect-objects-threshold: 18446744073709551615
     expensive-safety-check-config:
-      enable-epoch-sui-conservation-check: false
-      enable-deep-per-tx-sui-conservation-check: false
+      enable-epoch-sui-conservation-check: true
+      enable-deep-per-tx-sui-conservation-check: true
       force-disable-epoch-sui-conservation-check: false
-      enable-state-consistency-check: false
+      enable-state-consistency-check: true
       force-disable-state-consistency-check: false
-      enable-move-vm-paranoid-checks: false
+      enable-move-vm-paranoid-checks: true
     transaction-deny-config:
       package_publish_disabled: false
       package_upgrade_disabled: false

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -89,7 +89,7 @@ pub async fn test_checkpoint_executor_crash_recovery() {
     let epoch_store = state.epoch_store_for_testing().clone();
     let executor_handle =
         spawn_monitored_task!(async move { executor.run_epoch(epoch_store).await });
-    tokio::time::sleep(Duration::from_secs(5)).await;
+    tokio::time::sleep(Duration::from_secs(15)).await;
 
     let highest_executed = checkpoint_store
         .get_highest_executed_checkpoint_seq_number()


### PR DESCRIPTION
Today expensive checks are already enabled by default in tests. But not if say, we are running a release version of sui swarm locally.
This change enables it by default whenever we use network config builder (which is either tests or local tools)