### PR TITLE
Start tracking skipped keys during iteration

### DIFF
--- a/crates/typed-store/src/metrics.rs
+++ b/crates/typed-store/src/metrics.rs
@@ -273,7 +273,7 @@ impl OperationMetrics {
             .unwrap(),
             rocksdb_iter_keys: register_histogram_vec_with_registry!(
                 "rocksdb_iter_keys",
-                "Rocksdb iter size in bytes",
+                "Rocksdb iter num keys",
                 &["cf_name"],
                 registry,
             )
@@ -405,6 +405,8 @@ pub struct ReadPerfContextMetrics {
     pub bloom_sst_miss_count: IntCounterVec,
     pub key_lock_wait_time: IntCounterVec,
     pub key_lock_wait_count: IntCounterVec,
+    pub internal_delete_skipped_count: IntCounterVec,
+    pub internal_skipped_count: IntCounterVec,
 }
 
 impl ReadPerfContextMetrics {
@@ -614,6 +616,20 @@ impl ReadPerfContextMetrics {
                 registry,
             )
             .unwrap(),
+            internal_delete_skipped_count: register_int_counter_vec_with_registry!(
+                "internal_delete_skipped_count",
+                "Total number of deleted keys skipped during iteration",
+                &["cf_name"],
+                registry,
+            )
+                .unwrap(),
+            internal_skipped_count: register_int_counter_vec_with_registry!(
+                "internal_skipped_count",
+                "Totall number of internal keys skipped during iteration",
+                &["cf_name"],
+                registry,
+            )
+                .unwrap(),
         }
     }
 
@@ -708,6 +724,12 @@ impl ReadPerfContextMetrics {
             self.key_lock_wait_count
                 .with_label_values(&[cf_name])
                 .inc_by(perf_context.metric(PerfMetric::KeyLockWaitCount));
+            self.internal_delete_skipped_count
+                .with_label_values(&[cf_name])
+                .inc_by(perf_context.metric(PerfMetric::InternalDeleteSkippedCount));
+            self.internal_skipped_count
+                .with_label_values(&[cf_name])
+                .inc_by(perf_context.metric(PerfMetric::InternalKeySkippedCount));
         });
     }
 }


### PR DESCRIPTION
## Description 

RocksDB can tell us the number of tombstones it had to skip during an iteration. A high number of skipped keys is a cause of concern for performance and probably requires compaction. 
 
## Test Plan 

Existing tests
