### PR TITLE
[fix] fixing failing randomized tests

### DIFF
--- a/narwhal/consensus/src/tests/bullshark_tests.rs
+++ b/narwhal/consensus/src/tests/bullshark_tests.rs
@@ -1170,7 +1170,7 @@ async fn not_enough_support_and_missing_leaders_and_gc() {
                     assert_eq!(sub_dags[1].leader.round(), 6);
 
                     assert_eq!(sub_dags[0].certificates.len(), 4);
-                    assert_eq!(sub_dags[1].certificates.len(), 9);
+                    assert_eq!(sub_dags[1].certificates.len(), 10);
 
                     // And GC has collected everything up to round 5.
                     assert_eq!(state.dag.len(), 5);

--- a/narwhal/consensus/src/tests/randomized_tests.rs
+++ b/narwhal/consensus/src/tests/randomized_tests.rs
@@ -363,6 +363,7 @@ pub fn make_certificates_with_parameters(
                     current_parents.clone(),
                     ids.as_slice(),
                     &mut rand,
+                    committee,
                 );
 
             // We want to ensure that we always refer to "our" certificate of the previous round -
@@ -403,7 +404,11 @@ pub fn make_certificates_with_parameters(
                 parents_digests.insert(0, my_parent_digest);
             }
 
-            assert!(parents_digests.len() >= committee.quorum_threshold() as usize);
+            assert!(
+                parents_digests.len() >= committee.quorum_threshold() as usize,
+                "Failed on seed {}. At least 2f+1 parents are needed.",
+                seed
+            );
 
             let parents_digests: BTreeSet<CertificateDigest> =
                 parents_digests.into_iter().collect();
@@ -432,7 +437,8 @@ pub fn make_certificates_with_parameters(
         // Ensure total stake of the round provides strong quorum
         assert!(
             committee.reached_quorum(total_round_stake),
-            "Strong quorum is needed per round to ensure DAG advance"
+            "Failed on seed {}. Strong quorum is needed per round to ensure DAG advance.",
+            seed
         );
 
         // Ensure each certificate's parents exist from previous processing
@@ -442,7 +448,8 @@ pub fn make_certificates_with_parameters(
             .for_each(|digest| {
                 assert!(
                     certificate_digests.contains(digest),
-                    "Certificate with digest {} should be found in processed certificates",
+                    "Failed on seed {}. Certificate with digest {} should be found in processed certificates.",
+                    seed,
                     digest
                 );
             });

--- a/narwhal/test-utils/src/lib.rs
+++ b/narwhal/test-utils/src/lib.rs
@@ -517,8 +517,13 @@ pub fn make_certificates_with_slow_nodes(
     for round in range {
         next_parents.clear();
         for name in names {
-            let this_cert_parents =
-                this_cert_parents_with_slow_nodes(name, parents.clone(), slow_nodes, &mut rand);
+            let this_cert_parents = this_cert_parents_with_slow_nodes(
+                name,
+                parents.clone(),
+                slow_nodes,
+                &mut rand,
+                committee,
+            );
             let (_, certificate) = mock_certificate(committee, *name, round, this_cert_parents);
             certificates.push_back(certificate.clone());
             next_parents.push(certificate);
@@ -539,9 +544,15 @@ pub fn this_cert_parents_with_slow_nodes(
     ancestors: Vec<Certificate>,
     slow_nodes: &[(AuthorityIdentifier, f64)],
     rand: &mut StdRng,
+    committee: &Committee,
 ) -> BTreeSet<CertificateDigest> {
     let mut parents = BTreeSet::new();
+    let mut not_included = Vec::new();
+    let mut total_stake = 0;
+
     for parent in ancestors {
+        let authority = committee.authority(&parent.origin()).unwrap();
+
         // Identify if the parent is within the slow nodes - and is not the same author as the
         // one we want to create the certificate for.
         if let Some((_, inclusion_probability)) = slow_nodes
@@ -553,12 +564,26 @@ pub fn this_cert_parents_with_slow_nodes(
 
             if should_include {
                 parents.insert(parent.digest());
+                total_stake += authority.stake();
+            } else {
+                not_included.push(parent);
             }
         } else {
             // just add it directly as it is not within the slow nodes or we are the
             // same author.
             parents.insert(parent.digest());
+            total_stake += authority.stake();
         }
+    }
+
+    // ensure we'll have enough parents (2f + 1)
+    while total_stake < committee.quorum_threshold() {
+        let parent = not_included.pop().unwrap();
+        let authority = committee.authority(&parent.origin()).unwrap();
+
+        total_stake += authority.stake();
+
+        parents.insert(parent.digest());
     }
 
     parents

--- a/narwhal/test-utils/src/lib.rs
+++ b/narwhal/test-utils/src/lib.rs
@@ -524,6 +524,7 @@ pub fn make_certificates_with_slow_nodes(
                 &mut rand,
                 committee,
             );
+
             let (_, certificate) = mock_certificate(committee, *name, round, this_cert_parents);
             certificates.push_back(certificate.clone());
             next_parents.push(certificate);
@@ -585,6 +586,13 @@ pub fn this_cert_parents_with_slow_nodes(
 
         parents.insert(parent.digest());
     }
+
+    assert!(
+        committee.reached_quorum(total_stake),
+        "Not enough parents by stake provided. Expected at least {} but instead got {}",
+        committee.quorum_threshold(),
+        total_stake
+    );
 
     parents
 }


### PR DESCRIPTION
## Description 

This PR is fixing an issue on the behaviour of `this_cert_parents_with_slow_nodes` which is used in randomized tests - and in other consensus unit tests as well. The method is picking the parents of a certificate supporting some failure modes (slow nodes). So basically , it does pick a subset of the given parents when slow nodes exist. However, it does not verifying that the parents honour the `2f + 1` requirement by stake. This is now fixed.

Now the randomized tests [should not fail](https://github.com/MystenLabs/sui/actions/runs/4793242232) anymore

## Test Plan 

Existing randomized_tests should not fail.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
