### PR TITLE
indexer stability: fix package population

### DIFF
--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -195,7 +195,10 @@ where
         info!("Indexer object checkpoint download & index task started...");
         // NOTE: important not to cast i64 to u64 here,
         // because -1 will be returned when checkpoints table is empty.
-        let last_seq_from_db = self.state.get_latest_checkpoint_sequence_number().await?;
+        let last_seq_from_db = self
+            .state
+            .get_latest_object_checkpoint_sequence_number()
+            .await?;
         if last_seq_from_db > 0 {
             info!("Resuming from checkpoint {last_seq_from_db}");
         }

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -467,24 +467,6 @@ where
                 //     }
                 // });
 
-                let packages_handler = self.clone();
-                spawn_monitored_task!(async move {
-                    let mut package_commit_res =
-                        packages_handler.state.persist_packages(&packages).await;
-                    while let Err(e) = package_commit_res {
-                        warn!(
-                            "Indexer package commit failed with error: {:?}, retrying after {:?} milli-secs...",
-                            e, DB_COMMIT_RETRY_INTERVAL_IN_MILLIS
-                        );
-                        tokio::time::sleep(std::time::Duration::from_millis(
-                            DB_COMMIT_RETRY_INTERVAL_IN_MILLIS,
-                        ))
-                        .await;
-                        package_commit_res =
-                            packages_handler.state.persist_packages(&packages).await;
-                    }
-                });
-
                 // MUSTFIX(gegaowp): temp. turn off tx index table commit to reduce short-term storage consumption.
                 // this include recipients, input_objects and move_calls.
                 // let transactions_handler = self.clone();
@@ -570,14 +552,32 @@ where
                     events: _,
                     object_changes: tx_object_changes,
                     addresses: _,
-                    packages: _,
+                    packages,
                     input_objects: _,
                     move_calls: _,
                     recipients: _,
                 } = indexed_checkpoint;
                 let checkpoint_seq = checkpoint.sequence_number;
 
-                // NOTE: commit object changes in the curren task to stick to the original order.
+                let packages_handler = self.clone();
+                spawn_monitored_task!(async move {
+                    let mut package_commit_res =
+                        packages_handler.state.persist_packages(&packages).await;
+                    while let Err(e) = package_commit_res {
+                        warn!(
+                            "Indexer package commit failed with error: {:?}, retrying after {:?} milli-secs...",
+                            e, DB_COMMIT_RETRY_INTERVAL_IN_MILLIS
+                        );
+                        tokio::time::sleep(std::time::Duration::from_millis(
+                            DB_COMMIT_RETRY_INTERVAL_IN_MILLIS,
+                        ))
+                        .await;
+                        package_commit_res =
+                            packages_handler.state.persist_packages(&packages).await;
+                    }
+                });
+
+                // NOTE: commit object changes in the current task to stick to the original order.
                 let object_db_guard = self.metrics.object_db_commit_latency.start_timer();
                 let mut object_changes_commit_res = self
                     .state

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -425,7 +425,7 @@ where
                     events,
                     object_changes: _tx_object_changes,
                     addresses: _,
-                    packages,
+                    packages: _,
                     input_objects: _,
                     move_calls: _,
                     recipients: _,

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -36,6 +36,7 @@ pub trait IndexerStore {
     type ModuleCache;
 
     async fn get_latest_checkpoint_sequence_number(&self) -> Result<i64, IndexerError>;
+    async fn get_latest_object_checkpoint_sequence_number(&self) -> Result<i64, IndexerError>;
     async fn get_checkpoint(&self, id: CheckpointId) -> Result<RpcCheckpoint, IndexerError>;
     async fn get_checkpoint_sequence_number(
         &self,

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -221,6 +221,17 @@ impl IndexerStore for PgIndexerStore {
         .context("Failed reading latest checkpoint sequence number from PostgresDB")
     }
 
+    async fn get_latest_object_checkpoint_sequence_number(&self) -> Result<i64, IndexerError> {
+        read_only_blocking!(&self.blocking_cp, |conn| {
+            objects::dsl::objects
+                .select(max(objects::checkpoint))
+                .first::<Option<i64>>(conn)
+                // -1 to differentiate between no checkpoints and the first checkpoint
+                .map(|o| o.unwrap_or(-1))
+        })
+        .context("Failed reading latest object checkpoint sequence number from PostgresDB")
+    }
+
     async fn get_checkpoint(
         &self,
         id: CheckpointId,


### PR DESCRIPTION
## Description 

After the split, `package` data is actually only available when objects are fetched, thus we need to index package together with objects rather than tx.

## Test Plan 

tested locally and make sure packages can be populated properly
In production, I will 
```
TRUNCATE objects;
```
and then run with a binary with this fix, it will start backfilling for both objects and packages.