### PR TITLE
[transaction fuzzer] Fuzz with valid type tags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11128,6 +11128,7 @@ dependencies = [
  "proptest-derive",
  "rand 0.8.5",
  "sui-core",
+ "sui-move-build",
  "sui-protocol-config",
  "sui-types",
  "test-utils",

--- a/crates/transaction-fuzzer/Cargo.toml
+++ b/crates/transaction-fuzzer/Cargo.toml
@@ -22,6 +22,7 @@ once_cell = "1.16"
 sui-core = { path = "../sui-core" }
 sui-protocol-config = { path = "../sui-protocol-config" }
 sui-types = { path = "../sui-types", features = ["fuzzing"] }
+sui-move-build = { path = "../sui-move-build" }
 
 
 [dev-dependencies]

--- a/crates/transaction-fuzzer/data/type_factory/Move.toml
+++ b/crates/transaction-fuzzer/data/type_factory/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "type_factory"
+version = "0.0.1"
+
+[addresses]
+typer =  "0x0"

--- a/crates/transaction-fuzzer/data/type_factory/sources/type_factory.move
+++ b/crates/transaction-fuzzer/data/type_factory/sources/type_factory.move
@@ -1,0 +1,73 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module typer::type_factory {
+    struct A {}
+    struct B {}
+    struct C {}
+    struct D {}
+    struct E {}
+    struct F {}
+    struct G {}
+    struct H {}
+    struct I {}
+    struct J {}
+    struct K {}
+    struct L {}
+    struct M {}
+    struct N {}
+    struct O {}
+    struct P {}
+    struct Q {}
+    struct R {}
+    struct S {}
+    struct T {}
+    struct U {}
+    struct V {}
+    struct W {}
+    struct X {}
+    struct Y {}
+    struct Z {}
+    struct AA<phantom T> {}
+    struct BB<phantom T> {}
+    struct CC<phantom T> {}
+    struct DD<phantom T> {}
+    struct EE<phantom T> {}
+    struct FF<phantom T> {}
+    struct GG<phantom T> {}
+    struct HH<phantom T> {}
+    struct II<phantom T> {}
+    struct JJ<phantom T> {}
+    struct KK<phantom T> {}
+    struct LL<phantom T> {}
+    struct MM<phantom T> {}
+    struct NN<phantom T> {}
+    struct OO<phantom T> {}
+    struct PP<phantom T> {}
+    struct QQ<phantom T> {}
+    struct RR<phantom T> {}
+    struct SS<phantom T> {}
+    struct TT<phantom T> {}
+    struct UU<phantom T> {}
+    struct VV<phantom T> {}
+    struct WW<phantom T> {}
+    struct XX<phantom T> {}
+    struct YY<phantom T> {}
+    struct ZZ<phantom T> {}
+
+    public fun type_tags0() { }
+    public fun type_tags1<T1>() { }
+    public fun type_tags2<T1, T2>() { }
+    public fun type_tags3<T1, T2, T3>() { }
+    public fun type_tags4<T1, T2, T3, T4>() { }
+    public fun type_tags5<T1, T2, T3, T4, T5>() { }
+    public fun type_tags6<T1, T2, T3, T4, T5, T6>() { }
+    public fun type_tags7<T1, T2, T3, T4, T5, T6, T7>() { }
+    public fun type_tags8<T1, T2, T3, T4, T5, T6, T7, T8>() { }
+    public fun type_tags9<T1, T2, T3, T4, T5, T6, T7, T8, T9>() { }
+    public fun type_tags10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>() { }
+    public fun type_tags11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>() { }
+    public fun type_tags12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>() { }
+    public fun type_tags13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>() { }
+    public fun type_tags14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>() { }
+}

--- a/crates/transaction-fuzzer/src/executor.rs
+++ b/crates/transaction-fuzzer/src/executor.rs
@@ -7,6 +7,10 @@
 use std::{fmt::Debug, sync::Arc};
 use sui_core::authority::test_authority_builder::TestAuthorityBuilder;
 use sui_core::{authority::AuthorityState, test_utils::send_and_confirm_transaction};
+use sui_types::base_types::ObjectRef;
+use sui_types::messages::TransactionData;
+use sui_types::object::Owner;
+use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{
     error::SuiError,
     messages::{
@@ -16,7 +20,26 @@ use sui_types::{
 };
 use tokio::runtime::Runtime;
 
+use crate::account_universe::{AccountCurrent, INITIAL_BALANCE};
+
+use std::path::PathBuf;
+use sui_move_build::BuildConfig;
+
 pub type ExecutionResult = Result<ExecutionStatus, SuiError>;
+
+fn build_test_modules(test_dir: &str) -> (Vec<u8>, Vec<Vec<u8>>) {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.extend(["data", test_dir]);
+    let with_unpublished_deps = false;
+    let hash_modules = true;
+    let package = BuildConfig::new_for_testing().build(path).unwrap();
+    (
+        package
+            .get_package_digest(with_unpublished_deps, hash_modules)
+            .to_vec(),
+        package.get_package_bytes(with_unpublished_deps),
+    )
+}
 
 // We want to look for either panics (in which case we won't hit this) or invariant violations in
 // which case we want to panic.
@@ -72,6 +95,51 @@ impl Executor {
         self.rt
             .block_on(send_and_confirm_transaction(&self.state, None, txn))
             .map(|(_, effects)| effects.into_data().status().clone())
+    }
+
+    pub fn publish(
+        &mut self,
+        package_name: &str,
+        account: &mut AccountCurrent,
+    ) -> (ObjectRef, ObjectRef) {
+        let (_, modules) = build_test_modules(package_name);
+        // let gas_obj_ref = account.current_coins.last().unwrap().compute_object_reference();
+        let gas_object = account.new_gas_object(self);
+        let data = TransactionData::new_module(
+            account.initial_data.account.address,
+            gas_object.compute_object_reference(),
+            modules,
+            vec![],
+            INITIAL_BALANCE,
+            1,
+        );
+        let txn = to_sender_signed_transaction(data, &account.initial_data.account.key);
+        let effects = self
+            .rt
+            .block_on(send_and_confirm_transaction(&self.state, None, txn))
+            .unwrap()
+            .1
+            .into_data();
+
+        println!("PUBLISH STATUS: {:#?}", effects.status());
+        assert!(
+            matches!(effects.status(), ExecutionStatus::Success { .. }),
+            "{:?}",
+            effects.status()
+        );
+
+        let package = effects
+            .created()
+            .iter()
+            .find(|(_, owner)| matches!(owner, Owner::Immutable))
+            .unwrap();
+        let upgrade_cap = effects
+            .created()
+            .iter()
+            .find(|(_, owner)| matches!(owner, Owner::AddressOwner(_)))
+            .unwrap();
+
+        (package.0, upgrade_cap.0)
     }
 
     pub fn execute_transactions(

--- a/crates/transaction-fuzzer/src/transaction_data_gen.rs
+++ b/crates/transaction-fuzzer/src/transaction_data_gen.rs
@@ -60,7 +60,9 @@ pub fn gen_gas_data(sender: SuiAddress) -> impl Strategy<Value = GasData> {
 }
 
 pub fn gen_transaction_kind() -> impl Strategy<Value = TransactionKind> {
-    (vec(gen_type_tag(), 0..10)).prop_map(pt_for_tags)
+    (vec(gen_type_tag(), 0..10))
+        .prop_map(pt_for_tags)
+        .prop_map(TransactionKind::ProgrammableTransaction)
 }
 
 pub fn transaction_data_gen(sender: SuiAddress) -> impl Strategy<Value = TransactionData> {

--- a/crates/transaction-fuzzer/src/type_arg_fuzzer.rs
+++ b/crates/transaction-fuzzer/src/type_arg_fuzzer.rs
@@ -6,7 +6,8 @@ use move_core_types::{account_address::AccountAddress, identifier::Identifier};
 use proptest::arbitrary::*;
 use proptest::prelude::*;
 
-use sui_types::messages::{TransactionData, TransactionKind};
+use sui_types::base_types::ObjectID;
+use sui_types::messages::{ProgrammableTransaction, TransactionData, TransactionKind};
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{TypeTag, SUI_FRAMEWORK_OBJECT_ID};
@@ -60,7 +61,76 @@ pub fn gen_struct_tag() -> impl Strategy<Value = StructTag> {
         })
 }
 
-pub fn pt_for_tags(type_tags: Vec<TypeTag>) -> TransactionKind {
+pub fn generate_valid_type_factory_tags(
+    type_factory_addr: ObjectID,
+) -> impl Strategy<Value = TypeTag> {
+    let leaf = prop_oneof![
+        base_type_factory_tag_gen(type_factory_addr),
+        nested_type_factory_tag_gen(type_factory_addr),
+    ];
+
+    leaf.prop_recursive(8, 6, 10, move |inner| {
+        prop_oneof![inner.prop_map(|x| TypeTag::Vector(Box::new(x))),]
+    })
+}
+
+pub fn generate_valid_and_invalid_type_factory_tags(
+    type_factory_addr: ObjectID,
+) -> impl Strategy<Value = TypeTag> {
+    let leaf = prop_oneof![
+        any::<TypeTag>(),
+        base_type_factory_tag_gen(type_factory_addr),
+        nested_type_factory_tag_gen(type_factory_addr),
+    ];
+
+    leaf.prop_recursive(8, 6, 10, move |inner| {
+        prop_oneof![inner.prop_map(|x| TypeTag::Vector(Box::new(x))),]
+    })
+}
+
+pub fn base_type_factory_tag_gen(addr: ObjectID) -> impl Strategy<Value = TypeTag> {
+    "[A-Z]".prop_map(move |name| {
+        TypeTag::Struct(Box::new(StructTag {
+            address: AccountAddress::from(addr),
+            module: Identifier::new("type_factory").unwrap(),
+            name: Identifier::new(name).unwrap(),
+            type_params: vec![],
+        }))
+    })
+}
+
+pub fn nested_type_factory_tag_gen(addr: ObjectID) -> impl Strategy<Value = TypeTag> {
+    base_type_factory_tag_gen(addr).prop_recursive(20, 256, 10, move |inner| {
+        (inner, "[A-Z]").prop_map(move |(instantiation, name)| {
+            TypeTag::Struct(Box::new(StructTag {
+                address: AccountAddress::from(addr),
+                module: Identifier::new("type_factory").unwrap(),
+                name: Identifier::new(name.to_string() + &name).unwrap(),
+                type_params: vec![instantiation],
+            }))
+        })
+    })
+}
+
+pub fn type_factory_pt_for_tags(
+    package_id: ObjectID,
+    type_tags: Vec<TypeTag>,
+    len: usize,
+) -> ProgrammableTransaction {
+    let mut builder = ProgrammableTransactionBuilder::new();
+    builder
+        .move_call(
+            package_id,
+            Identifier::new("type_factory").unwrap(),
+            Identifier::new(format!("type_tags{}", len)).unwrap(),
+            type_tags,
+            vec![],
+        )
+        .unwrap();
+    builder.finish()
+}
+
+pub fn pt_for_tags(type_tags: Vec<TypeTag>) -> ProgrammableTransaction {
     let mut builder = ProgrammableTransactionBuilder::new();
     builder
         .move_call(
@@ -71,20 +141,17 @@ pub fn pt_for_tags(type_tags: Vec<TypeTag>) -> TransactionKind {
             vec![],
         )
         .unwrap();
-    TransactionKind::ProgrammableTransaction(builder.finish())
+    builder.finish()
 }
 
-pub fn run_type_tags(account: &AccountCurrent, exec: &mut Executor, type_tags: Vec<TypeTag>) {
-    let gas_object = account
-        .current_coins
-        .get(0)
-        .unwrap()
-        .compute_object_reference();
-    let kind = pt_for_tags(type_tags);
+pub fn run_pt(account: &mut AccountCurrent, exec: &mut Executor, pt: ProgrammableTransaction) {
+    let gas_object = account.new_gas_object(exec);
+    let gas_object_ref = gas_object.compute_object_reference();
+    let kind = TransactionKind::ProgrammableTransaction(pt);
     let tx_data = TransactionData::new(
         kind,
         account.initial_data.account.address,
-        gas_object,
+        gas_object_ref,
         GAS,
         GAS_PRICE,
     );

--- a/crates/transaction-fuzzer/tests/type_arg_fuzzer.rs
+++ b/crates/transaction-fuzzer/tests/type_arg_fuzzer.rs
@@ -7,8 +7,26 @@ use proptest::prelude::*;
 use proptest::strategy::ValueTree;
 use transaction_fuzzer::account_universe::AccountCurrent;
 use transaction_fuzzer::account_universe::AccountData;
-use transaction_fuzzer::type_arg_fuzzer::run_type_tags;
+use transaction_fuzzer::type_arg_fuzzer::generate_valid_and_invalid_type_factory_tags;
+use transaction_fuzzer::type_arg_fuzzer::generate_valid_type_factory_tags;
+use transaction_fuzzer::type_arg_fuzzer::pt_for_tags;
+use transaction_fuzzer::type_arg_fuzzer::run_pt;
+use transaction_fuzzer::type_arg_fuzzer::type_factory_pt_for_tags;
 use transaction_fuzzer::{executor::Executor, type_arg_fuzzer::gen_type_tag};
+
+fn _all_valid_type_tag_fuzzing(add_sub: isize) {
+    let mut exec = Executor::new();
+    let mut runner = proptest::test_runner::TestRunner::deterministic();
+    let mut account = AccountCurrent::new(AccountData::new_random());
+    let (package_id, _) = exec.publish("type_factory", &mut account);
+    let strategy = vec(generate_valid_type_factory_tags(package_id.0), 1..10);
+    for _ in 0..500 {
+        let tys = strategy.new_tree(&mut runner).unwrap().current();
+        let len = tys.len();
+        let pt = type_factory_pt_for_tags(package_id.0, tys, (len as isize + add_sub) as usize);
+        run_pt(&mut account, &mut exec, pt)
+    }
+}
 
 #[test]
 #[cfg_attr(msim, ignore)]
@@ -16,9 +34,41 @@ fn all_random_single_type_tag_fuzzing() {
     let mut exec = Executor::new();
     let strategy = vec(gen_type_tag(), 1..10);
     let mut runner = proptest::test_runner::TestRunner::deterministic();
-    let account = AccountCurrent::new(AccountData::new_random());
-    for _ in 0..2000 {
+    let mut account = AccountCurrent::new(AccountData::new_random());
+    for _ in 0..1000 {
         let tys = strategy.new_tree(&mut runner).unwrap().current();
-        run_type_tags(&account, &mut exec, tys)
+        run_pt(&mut account, &mut exec, pt_for_tags(tys))
+    }
+}
+
+#[test]
+#[cfg_attr(msim, ignore)]
+fn all_valid_type_tag_fuzzing() {
+    _all_valid_type_tag_fuzzing(0)
+}
+
+#[test]
+#[cfg_attr(msim, ignore)]
+fn all_valid_type_tag_incorrect_number_fuzzing() {
+    _all_valid_type_tag_fuzzing(-1);
+    _all_valid_type_tag_fuzzing(1);
+}
+
+#[test]
+#[cfg_attr(msim, ignore)]
+fn interesting_invalid_type_tags_fuzzing() {
+    let mut exec = Executor::new();
+    let mut runner = proptest::test_runner::TestRunner::deterministic();
+    let mut account = AccountCurrent::new(AccountData::new_random());
+    let (package_id, _) = exec.publish("type_factory", &mut account);
+    let strategy = vec(
+        generate_valid_and_invalid_type_factory_tags(package_id.0),
+        1..10,
+    );
+    for _ in 0..500 {
+        let tys = strategy.new_tree(&mut runner).unwrap().current();
+        let len = tys.len();
+        let pt = type_factory_pt_for_tags(package_id.0, tys, len);
+        run_pt(&mut account, &mut exec, pt)
     }
 }


### PR DESCRIPTION
Adds a fuzzer generating random valid type tags, one that uses valid type tags but an invalid number of type arguments, and another that generates almost wholly-correct typetags but possibly with some invalid type tags. 