### PR TITLE
Optimize transaction construction, especially for stake transactions

### DIFF
--- a/apps/wallet/src/ui/app/staking/stake/utils/transaction.ts
+++ b/apps/wallet/src/ui/app/staking/stake/utils/transaction.ts
@@ -9,9 +9,13 @@ export function createStakeTransaction(amount: bigint, validator: string) {
     tx.moveCall({
         target: '0x3::sui_system::request_add_stake',
         arguments: [
-            tx.object(SUI_SYSTEM_STATE_OBJECT_ID),
+            tx.sharedObjectRef({
+                objectId: SUI_SYSTEM_STATE_OBJECT_ID,
+                initialSharedVersion: 1,
+                mutable: true,
+            }),
             stakeCoin,
-            tx.pure(validator),
+            tx.pure(validator, 'address'),
         ],
     });
     return tx;

--- a/sdk/typescript/src/builder/TransactionBlock.ts
+++ b/sdk/typescript/src/builder/TransactionBlock.ts
@@ -378,7 +378,12 @@ export class TransactionBlock {
   }
 
   // The current default is just picking _all_ coins we can which may not be ideal.
-  async #selectGasPayment(provider?: JsonRpcProvider) {
+  async #prepareGasPayment({ provider, onlyTransactionKind }: BuildOptions) {
+    // Early return if the payment is already set:
+    if (onlyTransactionKind || this.#blockData.gasConfig.payment) {
+      return;
+    }
+
     const gasOwner = this.#blockData.gasConfig.owner ?? this.#blockData.sender;
 
     const coins = await expectProvider(provider).getCoins({
@@ -414,18 +419,18 @@ export class TransactionBlock {
       throw new Error('No valid gas coins found for the transaction.');
     }
 
-    return paymentCoins;
+    this.setGasPayment(paymentCoins);
   }
 
-  /**
-   * Prepare the transaction by valdiating the transaction data and resolving all inputs
-   * so that it can be built into bytes.
-   */
-  async #prepare({ provider, onlyTransactionKind }: BuildOptions) {
-    if (!onlyTransactionKind && !this.#blockData.sender) {
-      throw new Error('Missing transaction sender');
+  async #prepareGasPrice({ provider, onlyTransactionKind }: BuildOptions) {
+    if (onlyTransactionKind || this.#blockData.gasConfig.price) {
+      return;
     }
 
+    this.setGasPrice(await expectProvider(provider).getReferenceGasPrice());
+  }
+
+  async #prepareTransactions(provider?: JsonRpcProvider) {
     const { inputs, transactions } = this.#blockData;
 
     const moveModulesToResolve: MoveCallTransaction[] = [];
@@ -632,18 +637,26 @@ export class TransactionBlock {
         }
       });
     }
+  }
+
+  /**
+   * Prepare the transaction by valdiating the transaction data and resolving all inputs
+   * so that it can be built into bytes.
+   */
+  async #prepare({ provider, onlyTransactionKind }: BuildOptions) {
+    if (!onlyTransactionKind && !this.#blockData.sender) {
+      throw new Error('Missing transaction sender');
+    }
+
+    await Promise.all([
+      this.#prepareGasPrice({ provider, onlyTransactionKind }),
+      this.#prepareTransactions(provider),
+    ]);
 
     if (!onlyTransactionKind) {
-      if (!this.#blockData.gasConfig.price) {
-        this.setGasPrice(await expectProvider(provider).getReferenceGasPrice());
-      }
+      await this.#prepareGasPayment({ provider, onlyTransactionKind });
 
-      if (!this.#blockData.gasConfig.payment) {
-        this.#blockData.gasConfig.payment = await this.#selectGasPayment(
-          provider,
-        );
-      }
-      if (!this.blockData.gasConfig.budget) {
+      if (!this.#blockData.gasConfig.budget) {
         const dryRunResult = await expectProvider(
           provider,
         ).dryRunTransactionBlock({


### PR DESCRIPTION
## Description 

This does two things primarily:
- Reorganize some of the logic around data fetching when building transactions so that we fetch slightly more concurrently. There's still more optimization opportunity here but it's diminishing returns for increased effort.
- Optimize stake requests in the wallet, which removes 2 serialized API calls that were required to serialize the transaction to BCS. In testing this removes up to 1s of latency in the stake flow.

## Test Plan 

Ran locally.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
