### PR TITLE
Prune and compact checkpoints before upload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9135,6 +9135,7 @@ dependencies = [
  "tracing",
  "typed-store",
  "typed-store-derive",
+ "url",
  "workspace-hack",
 ]
 

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -458,6 +458,8 @@ pub struct DBCheckpointConfig {
     pub object_store_config: Option<ObjectStoreConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub perform_index_db_checkpoints_at_epoch_end: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prune_and_compact_before_upload: Option<bool>,
 }
 
 /// Publicly known information about a validator

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -39,6 +39,7 @@ tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 tokio-retry = "0.3"
 tokio-stream = { version = "0.1.8", features = ["sync", "net"] }
 tracing = "0.1.36"
+url = "2.3.1"
 
 fastcrypto.workspace = true
 move-binary-format.workspace = true

--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -142,7 +142,7 @@ impl AuthorityStorePruner {
     }
 
     /// Prunes old object versions based on effects from all checkpoints from epochs eligible for pruning
-    async fn prune_objects_for_eligible_epochs(
+    pub async fn prune_objects_for_eligible_epochs(
         perpetual_db: &Arc<AuthorityPerpetualTables>,
         checkpoint_store: &Arc<CheckpointStore>,
         objects_lock_table: &Arc<RwLockTable<ObjectContentDigest>>,

--- a/crates/sui-core/src/db_checkpoint_handler.rs
+++ b/crates/sui-core/src/db_checkpoint_handler.rs
@@ -1,22 +1,32 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::authority::authority_store_pruner::{
+    AuthorityStorePruner, AuthorityStorePruningMetrics,
+};
+use crate::authority::authority_store_tables::AuthorityPerpetualTables;
+use crate::checkpoints::CheckpointStore;
 use anyhow::{anyhow, Context, Result};
 use bytes::Bytes;
 use futures::future::try_join_all;
 use object_store::path::Path;
 use object_store::{DynObjectStore, Error};
 use oneshot::channel;
+use prometheus::Registry;
 use std::collections::BTreeMap;
 use std::collections::Bound::{Included, Unbounded};
 use std::num::NonZeroUsize;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
+use sui_config::node::AuthorityStorePruningConfig;
+use sui_storage::mutex_table::RwLockTable;
 use sui_storage::object_store::util::{copy_recursively, delete_recursively, put};
 use sui_storage::object_store::{ObjectStoreConfig, ObjectStoreType};
 use tokio::sync::oneshot;
 use tokio::sync::oneshot::Sender;
 use tracing::{debug, error, info};
+use url::Url;
 
 pub const SUCCESS_MARKER: &str = "_SUCCESS";
 pub const TEST_MARKER: &str = "_TEST";
@@ -25,12 +35,20 @@ pub const UPLOAD_COMPLETED_MARKER: &str = "_UPLOAD_COMPLETED";
 pub struct DBCheckpointHandler {
     /// Directory on local disk where db checkpoints are stored
     input_object_store: Arc<DynObjectStore>,
+    /// DB checkpoint directory on local filesystem
+    input_root_path: PathBuf,
     /// Bucket on cloud object store where db checkpoints will be copied
     output_object_store: Arc<DynObjectStore>,
     /// Time interval to check for presence of new db checkpoint
     interval: Duration,
     /// File markers which signal that local db checkpoint can be garbage collected
     gc_markers: Vec<String>,
+    /// Checkpoint store
+    checkpoint_store: Arc<CheckpointStore>,
+    /// Boolean flag to enable/disable object pruning and manual compaction before upload
+    prune_and_compact_before_upload: bool,
+    /// Indirect object config for pruner
+    indirect_objects_threshold: usize,
 }
 
 impl DBCheckpointHandler {
@@ -38,6 +56,9 @@ impl DBCheckpointHandler {
         input_path: &std::path::Path,
         output_object_store_config: &ObjectStoreConfig,
         interval_s: u64,
+        checkpoint_store: Arc<CheckpointStore>,
+        prune_and_compact_before_upload: bool,
+        indirect_objects_threshold: usize,
     ) -> Result<Self> {
         let input_store_config = ObjectStoreConfig {
             object_store: Some(ObjectStoreType::File),
@@ -46,21 +67,35 @@ impl DBCheckpointHandler {
         };
         Ok(DBCheckpointHandler {
             input_object_store: input_store_config.make()?,
+            input_root_path: input_path.to_path_buf(),
             output_object_store: output_object_store_config.make()?,
             interval: Duration::from_secs(interval_s),
             gc_markers: vec![UPLOAD_COMPLETED_MARKER.to_string()],
+            checkpoint_store,
+            prune_and_compact_before_upload,
+            indirect_objects_threshold,
         })
     }
     pub fn new_for_test(
         input_object_store_config: &ObjectStoreConfig,
         output_object_store_config: &ObjectStoreConfig,
         interval_s: u64,
+        checkpoint_store: Arc<CheckpointStore>,
+        prune_and_compact_before_upload: bool,
     ) -> Result<Self> {
         Ok(DBCheckpointHandler {
             input_object_store: input_object_store_config.make()?,
+            input_root_path: input_object_store_config
+                .directory
+                .as_ref()
+                .unwrap()
+                .clone(),
             output_object_store: output_object_store_config.make()?,
             interval: Duration::from_secs(interval_s),
             gc_markers: vec![UPLOAD_COMPLETED_MARKER.to_string(), TEST_MARKER.to_string()],
+            checkpoint_store,
+            prune_and_compact_before_upload,
+            indirect_objects_threshold: 0,
         })
     }
     pub fn start(self) -> Sender<()> {
@@ -80,6 +115,34 @@ impl DBCheckpointHandler {
             }
         });
         sender
+    }
+    async fn prune_and_compact(&self, db_path: PathBuf, epoch: u32) -> Result<()> {
+        let perpetual_db = Arc::new(AuthorityPerpetualTables::open(&db_path.join("store"), None));
+        let config = AuthorityStorePruningConfig {
+            num_epochs_to_retain: 0,
+            ..Default::default()
+        };
+        let metrics = AuthorityStorePruningMetrics::new(&Registry::default());
+        let lock_table = Arc::new(RwLockTable::new(1));
+        info!(
+            "Pruning db checkpoint in {:?} for epoch: {epoch}",
+            db_path.display()
+        );
+        AuthorityStorePruner::prune_objects_for_eligible_epochs(
+            &perpetual_db,
+            &self.checkpoint_store,
+            &lock_table,
+            config,
+            metrics,
+            self.indirect_objects_threshold,
+        )
+        .await?;
+        info!(
+            "Compacting db checkpoint in {:?} for epoch: {epoch}",
+            db_path.display()
+        );
+        AuthorityStorePruner::compact(&perpetual_db)?;
+        Ok(())
     }
     async fn upload_db_checkpoint_to_object_store(&self) -> Result<()> {
         let local_checkpoints_by_epoch = self
@@ -117,6 +180,12 @@ impl DBCheckpointHandler {
             .range((Included(next_epoch), Unbounded))
             .next();
         if let Some((epoch, db_path)) = next_db_checkpoint_to_copy {
+            if self.prune_and_compact_before_upload {
+                // Convert `db_path` to the local filesystem path to where db checkpoint is stored
+                let local_db_path = self.path_to_filesystem(db_path)?;
+                // Invoke pruning and compaction on the db checkpoint
+                self.prune_and_compact(local_db_path, *epoch).await?;
+            }
             info!("Copying db checkpoint for epoch: {epoch} to remote storage");
             copy_recursively(
                 db_path,
@@ -205,13 +274,29 @@ impl DBCheckpointHandler {
         }
         Ok(checkpoints_by_epoch)
     }
+    fn path_to_filesystem(&self, location: &Path) -> Result<PathBuf> {
+        // Convert an `object_store::path::Path` to `std::path::PathBuf`
+        let path = std::fs::canonicalize(&self.input_root_path)?;
+        let mut url = Url::from_file_path(&path)
+            .map_err(|_| anyhow!("Failed to parse input path: {}", path.display()))?;
+        url.path_segments_mut()
+            .map_err(|_| anyhow!("Failed to get path segments: {}", path.display()))?
+            .pop_if_empty()
+            .extend(location.parts());
+        let new_path = url
+            .to_file_path()
+            .map_err(|_| anyhow!("Failed to convert url to path: {}", url.as_str()))?;
+        Ok(new_path)
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::checkpoints::CheckpointStore;
     use crate::db_checkpoint_handler::{
         DBCheckpointHandler, SUCCESS_MARKER, TEST_MARKER, UPLOAD_COMPLETED_MARKER,
     };
+    use narwhal_test_utils::temp_dir;
     use std::fs;
     use sui_storage::object_store::{ObjectStoreConfig, ObjectStoreType};
     use tempfile::TempDir;
@@ -245,8 +330,27 @@ mod tests {
             directory: Some(remote_checkpoint_dir_path.to_path_buf()),
             ..Default::default()
         };
-        let db_checkpoint_handler =
-            DBCheckpointHandler::new_for_test(&input_store_config, &output_store_config, 10)?;
+        // Create a temporary checkpoint store to initialize the db checkpoint handler, we are not
+        // actually going to trigger pruning in the test
+        let checkpoint_store = CheckpointStore::new(&temp_dir());
+        let db_checkpoint_handler = DBCheckpointHandler::new_for_test(
+            &input_store_config,
+            &output_store_config,
+            10,
+            checkpoint_store,
+            false,
+        )?;
+        let local_checkpoints_by_epoch = db_checkpoint_handler
+            .read_checkpoint_dir(db_checkpoint_handler.input_object_store.clone())
+            .await?;
+        assert!(!local_checkpoints_by_epoch.is_empty());
+        assert_eq!(*local_checkpoints_by_epoch.first_key_value().unwrap().0, 0);
+        assert_eq!(
+            db_checkpoint_handler
+                .path_to_filesystem(local_checkpoints_by_epoch.first_key_value().unwrap().1)
+                .unwrap(),
+            std::fs::canonicalize(local_epoch0_checkpoint.clone()).unwrap()
+        );
         db_checkpoint_handler
             .upload_db_checkpoint_to_object_store()
             .await?;
@@ -294,8 +398,16 @@ mod tests {
             directory: Some(remote_checkpoint_dir_path.to_path_buf()),
             ..Default::default()
         };
-        let db_checkpoint_handler =
-            DBCheckpointHandler::new_for_test(&input_store_config, &output_store_config, 10)?;
+        // Create a temporary checkpoint store to initialize the db checkpoint handler, we are not
+        // actually going to trigger pruning in the test
+        let checkpoint_store = CheckpointStore::new(&temp_dir());
+        let db_checkpoint_handler = DBCheckpointHandler::new_for_test(
+            &input_store_config,
+            &output_store_config,
+            10,
+            checkpoint_store,
+            false,
+        )?;
 
         fs::create_dir(&local_epoch0_checkpoint)?;
         let file1 = local_epoch0_checkpoint.join("file1");

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -311,8 +311,17 @@ impl SuiNode {
             .as_ref()
             .zip(db_checkpoint_config.object_store_config.as_ref())
         {
-            Some((path, config)) => {
-                let handler = DBCheckpointHandler::new(path, config, 60)?;
+            Some((path, object_store_config)) => {
+                let handler = DBCheckpointHandler::new(
+                    path,
+                    object_store_config,
+                    60,
+                    checkpoint_store.clone(),
+                    db_checkpoint_config
+                        .prune_and_compact_before_upload
+                        .unwrap_or(true),
+                    config.indirect_objects_threshold,
+                )?;
                 Some(handler.start())
             }
             None => None,

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -399,6 +399,7 @@ impl TestClusterBuilder {
             checkpoint_path: None,
             object_store_config: None,
             perform_index_db_checkpoints_at_epoch_end: None,
+            prune_and_compact_before_upload: None,
         };
         self
     }
@@ -409,6 +410,7 @@ impl TestClusterBuilder {
             checkpoint_path: None,
             object_store_config: None,
             perform_index_db_checkpoints_at_epoch_end: None,
+            prune_and_compact_before_upload: None,
         };
         self
     }


### PR DESCRIPTION
## Description 

As title says, we are enabling a config which allows us to prune objects and invoke compaction on the objects table before uploading the snapshot to s3.
## Test Plan 

Enhanced current unit tests.
