### PR TITLE
Fix anemo dependency commit id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,7 +123,7 @@ dependencies = [
 [[package]]
 name = "anemo"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=05322deb1795a5d482630740bc938fa7f067c58f#05322deb1795a5d482630740bc938fa7f067c58f"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=03ca780e31a734ca1493aefc68cab539cad3a53b#03ca780e31a734ca1493aefc68cab539cad3a53b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -156,7 +156,7 @@ dependencies = [
 [[package]]
 name = "anemo-build"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=05322deb1795a5d482630740bc938fa7f067c58f#05322deb1795a5d482630740bc938fa7f067c58f"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=03ca780e31a734ca1493aefc68cab539cad3a53b#03ca780e31a734ca1493aefc68cab539cad3a53b"
 dependencies = [
  "prettyplease",
  "proc-macro2 1.0.54",
@@ -167,7 +167,7 @@ dependencies = [
 [[package]]
 name = "anemo-cli"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=05322deb1795a5d482630740bc938fa7f067c58f#05322deb1795a5d482630740bc938fa7f067c58f"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=03ca780e31a734ca1493aefc68cab539cad3a53b#03ca780e31a734ca1493aefc68cab539cad3a53b"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -183,7 +183,7 @@ dependencies = [
 [[package]]
 name = "anemo-tower"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=05322deb1795a5d482630740bc938fa7f067c58f#05322deb1795a5d482630740bc938fa7f067c58f"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=03ca780e31a734ca1493aefc68cab539cad3a53b#03ca780e31a734ca1493aefc68cab539cad3a53b"
 dependencies = [
  "anemo",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,10 +205,10 @@ fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "19540b85
 fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "19540b8550685173f4998ae64d0291ddbdc93868", package = "fastcrypto-zkp" }
 
 # anemo dependencies
-anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "05322deb1795a5d482630740bc938fa7f067c58f" }
-anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "05322deb1795a5d482630740bc938fa7f067c58f" }
-anemo-cli = { git = "https://github.com/mystenlabs/anemo.git", rev = "05322deb1795a5d482630740bc938fa7f067c58f"}
-anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "05322deb1795a5d482630740bc938fa7f067c58f"}
+anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "03ca780e31a734ca1493aefc68cab539cad3a53b" }
+anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "03ca780e31a734ca1493aefc68cab539cad3a53b" }
+anemo-cli = { git = "https://github.com/mystenlabs/anemo.git", rev = "03ca780e31a734ca1493aefc68cab539cad3a53b"}
+anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "03ca780e31a734ca1493aefc68cab539cad3a53b"}
 
 # Use the same workspace-hack across crates.
 workspace-hack = { path = "crates/workspace-hack" }

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -26,9 +26,9 @@ aho-corasick = { version = "0.7" }
 aliasable = { version = "0.1" }
 alloc-no-stdlib = { version = "2", default-features = false }
 alloc-stdlib = { version = "0.2", default-features = false }
-anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "05322deb1795a5d482630740bc938fa7f067c58f", default-features = false }
-anemo-cli = { git = "https://github.com/mystenlabs/anemo.git", rev = "05322deb1795a5d482630740bc938fa7f067c58f", default-features = false }
-anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "05322deb1795a5d482630740bc938fa7f067c58f", default-features = false }
+anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "03ca780e31a734ca1493aefc68cab539cad3a53b", default-features = false }
+anemo-cli = { git = "https://github.com/mystenlabs/anemo.git", rev = "03ca780e31a734ca1493aefc68cab539cad3a53b", default-features = false }
+anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "03ca780e31a734ca1493aefc68cab539cad3a53b", default-features = false }
 anes = { version = "0.1" }
 ansi_term = { version = "0.12", default-features = false }
 anyhow = { version = "1", features = ["backtrace"] }
@@ -681,10 +681,10 @@ aho-corasick = { version = "0.7" }
 aliasable = { version = "0.1" }
 alloc-no-stdlib = { version = "2", default-features = false }
 alloc-stdlib = { version = "0.2", default-features = false }
-anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "05322deb1795a5d482630740bc938fa7f067c58f", default-features = false }
-anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "05322deb1795a5d482630740bc938fa7f067c58f", default-features = false }
-anemo-cli = { git = "https://github.com/mystenlabs/anemo.git", rev = "05322deb1795a5d482630740bc938fa7f067c58f", default-features = false }
-anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "05322deb1795a5d482630740bc938fa7f067c58f", default-features = false }
+anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "03ca780e31a734ca1493aefc68cab539cad3a53b", default-features = false }
+anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "03ca780e31a734ca1493aefc68cab539cad3a53b", default-features = false }
+anemo-cli = { git = "https://github.com/mystenlabs/anemo.git", rev = "03ca780e31a734ca1493aefc68cab539cad3a53b", default-features = false }
+anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "03ca780e31a734ca1493aefc68cab539cad3a53b", default-features = false }
 anes = { version = "0.1" }
 ansi_term = { version = "0.12", default-features = false }
 anyhow = { version = "1", features = ["backtrace"] }


### PR DESCRIPTION
## Description 

Fix anemo dependency commit id:
https://github.com/MystenLabs/anemo/commit/05322deb1795a5d482630740bc938fa7f067c58f -> https://github.com/MystenLabs/anemo/commit/03ca780e31a734ca1493aefc68cab539cad3a53b

## Test Plan 

It compiles successfully after the modification.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
