### PR TITLE
[wallet] fix can not see all coins when bottom nav is on

### DIFF
--- a/apps/wallet/src/ui/styles/utils/index.scss
+++ b/apps/wallet/src/ui/styles/utils/index.scss
@@ -6,7 +6,7 @@ $main-space-var: v.use(v.$sizing-nav-height-placeholder);
 $main-extra-space: sizing.$main-bottom-space;
 
 @mixin main-extra-space-for-nav() {
-    padding-bottom: calc($main-space-var + $main-extra-space);
+    margin-bottom: calc($main-space-var + $main-extra-space);
 }
 
 @mixin escape-main-sides-space() {


### PR DESCRIPTION
- fix can not see all coins when the bottom nav is on by changing extra space for nav from padding-bottom to margin-bottom

## Description 

Before, the last coin is underlaid at the bottom of the nav.

![Screenshot 2023-04-26 173806](https://user-images.githubusercontent.com/8283616/234552168-4ea9e074-6569-45bf-8a1f-9c2b52b0cd7e.png)

After, now we can see all.

![Screenshot 2023-04-26 173556](https://user-images.githubusercontent.com/8283616/234553042-c19c7b85-ad56-4c47-9a9b-7e35f841d6f5.png)

## Test Plan 

How did you test the new or updated feature? check on the view.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ x ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
- fix can not see all coins when the bottom nav is on