### PR TITLE
new DynamicFieldNotFound error

### DIFF
--- a/crates/sui-cluster-test/src/helper.rs
+++ b/crates/sui-cluster-test/src/helper.rs
@@ -93,6 +93,18 @@ impl ObjectChecker {
             }
             (
                 None,
+                Some(SuiObjectResponseError::DynamicFieldNotFound {
+                    parent_object_id: object_id,
+                }),
+            ) => {
+                panic!(
+                    "Node can't find dynamic field for {} with client {:?}",
+                    object_id,
+                    client.read_api()
+                )
+            }
+            (
+                None,
                 Some(SuiObjectResponseError::Deleted {
                     object_id,
                     version: _,

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -4638,6 +4638,24 @@
             "type": "object",
             "required": [
               "code",
+              "parent_object_id"
+            ],
+            "properties": {
+              "code": {
+                "type": "string",
+                "enum": [
+                  "dynamicFieldNotFound"
+                ]
+              },
+              "parent_object_id": {
+                "$ref": "#/components/schemas/ObjectID"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "code",
               "digest",
               "object_id",
               "version"

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -201,6 +201,8 @@ pub enum UserInputError {
 pub enum SuiObjectResponseError {
     #[error("Object {:?} does not exist.", object_id)]
     NotExists { object_id: ObjectID },
+    #[error("Cannot find dynamic field for parent object {:?}.", parent_object_id)]
+    DynamicFieldNotFound { parent_object_id: ObjectID },
     #[error(
         "Object has been deleted object_id: {:?} at version: {:?} in digest {:?}",
         object_id,


### PR DESCRIPTION
## Description 
If a DynamicFieldName is not found on a parent object, return SuiObjectResponse error response instead of stock RpcResult error
Previously:
```
curl --location 'http://127.0.0.1:9000' \
--header 'Content-Type: application/json' \
--data '{
    "method": "suix_getDynamicFieldObject",
    "jsonrpc": "2.0",
    "params": [
        "0x12d392ea9753ca2313e3f954fe2deadca0eda906e158e0901bacca21501b0398",
        {
            "type": "address",
            "value": "0x672ed3533decef3721c463b599f934cce4d13c894dd9f14d2f65d773ce604f21"
        }
    ],
    "id": 1
}'
{"jsonrpc":"2.0","error":{"code":-32000,"message":"Cannot find dynamic field [DynamicFieldName { type_: Address, value: String(\"0x672ed3533decef3721c463b599f934cce4d13c894dd9f14d2f65d773ce604f21\") }] for object [0x12d392ea9753ca2313e3f954fe2deadca0eda906e158e0901bacca21501b0398]."},"id":1}%    
```
Now:
```
curl --location 'http://127.0.0.1:9000' \
--header 'Content-Type: application/json' \
--data '{
    "method": "suix_getDynamicFieldObject",
    "jsonrpc": "2.0",
    "params": [
        "0x12d392ea9753ca2313e3f954fe2deadca0eda906e158e0901bacca21501b0398",
        {
            "type": "address",
            "value": "0x672ed3533decef3721c463b599f934cce4d13c894dd9f14d2f65d773ce604f21"
        }
    ],
    "id": 1
}'
{"jsonrpc":"2.0","result":{"error":{"code":"dynamicFieldNotFound","parent_object_id":"0x12d392ea9753ca2313e3f954fe2deadca0eda906e158e0901bacca21501b0398"}},"id":1}%  
```

Note: chose not to include the dynamicFieldName itself as DynamicFieldName.value is a serde_json object that does not appear to `#[derive(Hash)]` which is required by `SuiObjectResponseError`. And it's in the client call anyways.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
