### PR TITLE
Add more logs to Narwhal worker startup

### DIFF
--- a/narwhal/worker/src/worker.rs
+++ b/narwhal/worker/src/worker.rs
@@ -438,6 +438,8 @@ impl Worker {
         client: NetworkClient,
         network: anemo::Network,
     ) -> Vec<JoinHandle<()>> {
+        info!("Starting handler for transactions");
+
         let (tx_batch_maker, rx_batch_maker) = channel_with_total(
             CHANNEL_CAPACITY,
             &channel_metrics.tx_batch_maker,


### PR DESCRIPTION
## Description 

We have observed validators crashing on restart, because Narwhal worker did not finished starting up in 30s. Adding a bit more logs to help locate the root cause.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
