### PR TITLE
rpc: add ref gas price to epoch

### DIFF
--- a/crates/sui-indexer/src/models/epoch.rs
+++ b/crates/sui-indexer/src/models/epoch.rs
@@ -105,6 +105,7 @@ impl DBEpochInfo {
             first_checkpoint_id: self.first_checkpoint_id as u64,
             epoch_start_timestamp: self.epoch_start_timestamp as u64,
             end_of_epoch_info,
+            reference_gas_price: self.reference_gas_price.map(|v| v as u64),
         })
     }
 }

--- a/crates/sui-json-rpc-types/src/sui_extended.rs
+++ b/crates/sui-json-rpc-types/src/sui_extended.rs
@@ -39,6 +39,7 @@ pub struct EpochInfo {
     #[serde_as(as = "BigInt<u64>")]
     pub epoch_start_timestamp: u64,
     pub end_of_epoch_info: Option<EndOfEpochInfo>,
+    pub reference_gas_price: Option<u64>,
 }
 
 #[serde_as]


### PR DESCRIPTION
## Description 

Per request from FE team, add gas price field to Epoch data rpc type

## Test Plan 

local run to make sure that rpc call of get_epochs will return gas price as well.
```
curl --location --request POST http://127.0.0.1:3030 \
--header 'Content-Type: application/json' \
--data-raw '{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "suix_getEpochs",
    "params": []
}' | jq
...
        "epochTotalTransactions": "0",
        "firstCheckpointId": "9770",
        "epochStartTimestamp": "1682528442321",
        "endOfEpochInfo": null,
        "referenceGasPrice": null
```