### PR TITLE
[explorer] - add null check to net inflow calculation

### DIFF
--- a/apps/explorer/src/utils/getStorageFundFlow.ts
+++ b/apps/explorer/src/utils/getStorageFundFlow.ts
@@ -15,7 +15,9 @@ export function getEpochStorageFundFlow(endOfEpochInfo: EndOfEpochInfo | null) {
         : null;
 
     const netInflow =
-        fundInflow && fundOutflow ? fundInflow - fundOutflow : null;
+        fundInflow !== null && fundOutflow !== null
+            ? fundInflow - fundOutflow
+            : null;
 
     return { netInflow, fundInflow, fundOutflow };
 }


### PR DESCRIPTION
## Description 

Fixes a bug where calculation was returning null when `fundInflow` was 0n
## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
