### PR TITLE
fix flaky safe mode reconfig test

### DIFF
--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -654,7 +654,7 @@ fn advance_epoch<S: ObjectStore + BackingPackageStore + ParentSync + ChildObject
     );
 
     #[cfg(msim)]
-    let result = maybe_modify_result(result);
+    let result = maybe_modify_result(result, change_epoch.epoch);
 
     if result.is_err() {
         tracing::error!(


### PR DESCRIPTION
## Description 

Change the override to take in a start and end epoch instead.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
