### PR TITLE
[move] Ban extraneous module bytes and metadata

### DIFF
--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -690,7 +690,7 @@ fn advance_epoch<S: ObjectStore + BackingPackageStore + ParentSync + ChildObject
         let max_format_version = protocol_config.move_binary_format_version();
         let deserialized_modules: Vec<_> = modules
             .iter()
-            .map(|m| CompiledModule::deserialize_with_max_version(m, max_format_version).unwrap())
+            .map(|m| CompiledModule::deserialize_with_config(m, max_format_version, protocol_config.no_extraneous_module_bytes()).unwrap())
             .collect();
 
         if version == OBJECT_START_VERSION {

--- a/crates/sui-adapter/src/programmable_transactions/execution.rs
+++ b/crates/sui-adapter/src/programmable_transactions/execution.rs
@@ -677,7 +677,7 @@ fn check_compatibility<'a, S: StorageView>(
         ));
     };
 
-    let Ok(current_normalized) = existing_package.normalize(context.protocol_config.move_binary_format_version()) else {
+    let Ok(current_normalized) = existing_package.normalize(context.protocol_config.move_binary_format_version(), context.protocol_config.no_extraneous_module_bytes()) else {
         invariant_violation!("Tried to normalize modules in existing package but failed")
     };
 
@@ -809,9 +809,10 @@ fn deserialize_modules<S: StorageView, Mode: ExecutionMode>(
     let modules = module_bytes
         .iter()
         .map(|b| {
-            CompiledModule::deserialize_with_max_version(
+            CompiledModule::deserialize_with_config(
                 b,
                 context.protocol_config.move_binary_format_version(),
+                context.protocol_config.no_extraneous_module_bytes(),
             )
             .map_err(|e| e.finish(Location::Undefined))
         })

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -889,6 +889,7 @@ impl AuthorityStore {
             events,
             max_binary_format_version: _,
             loaded_child_objects: _,
+            no_extraneous_module_bytes: _,
         } = inner_temporary_store;
         trace!(written =? written.values().map(|((obj_id, ver, _), _, _)| (obj_id, ver)).collect::<Vec<_>>(),
                "batch_update_objects: temp store written");

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -1651,9 +1651,10 @@ async fn test_publish_dependent_module_ok() {
     let gas_payment_object_ref = gas_payment_object.compute_object_reference();
     // create a genesis state that contains the gas object and genesis modules
     let genesis_module = match BuiltInFramework::genesis_objects().next().unwrap().data {
-        Data::Package(m) => {
-            CompiledModule::deserialize(m.serialized_module_map().values().next().unwrap()).unwrap()
-        }
+        Data::Package(m) => CompiledModule::deserialize_with_defaults(
+            m.serialized_module_map().values().next().unwrap(),
+        )
+        .unwrap(),
         _ => unreachable!(),
     };
     // create a module that depends on a genesis module
@@ -1739,9 +1740,10 @@ async fn test_publish_non_existing_dependent_module() {
     let gas_payment_object_ref = gas_payment_object.compute_object_reference();
     // create a genesis state that contains the gas object and genesis modules
     let genesis_module = match BuiltInFramework::genesis_objects().next().unwrap().data {
-        Data::Package(m) => {
-            CompiledModule::deserialize(m.serialized_module_map().values().next().unwrap()).unwrap()
-        }
+        Data::Package(m) => CompiledModule::deserialize_with_defaults(
+            m.serialized_module_map().values().next().unwrap(),
+        )
+        .unwrap(),
         _ => unreachable!(),
     };
     // create a module that depends on a genesis module

--- a/crates/sui-core/src/unit_tests/move_package_publish_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_publish_tests.rs
@@ -391,7 +391,7 @@ async fn test_publish_extraneous_bytes_modules() {
     let gas_object_ref = gas_object.unwrap().compute_object_reference();
     let mut modules = correct_modules.clone();
     let new_bytes = {
-        let mut m = CompiledModule::deserialize(&modules[0]).unwrap();
+        let mut m = CompiledModule::deserialize_with_defaults(&modules[0]).unwrap();
         m.metadata.push(move_core_types::metadata::Metadata {
             key: vec![0],
             value: vec![1],

--- a/crates/sui-core/src/unit_tests/move_package_publish_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_publish_tests.rs
@@ -6,6 +6,7 @@ use crate::authority::{
     move_integration_tests::{build_and_publish_test_package, build_test_package},
 };
 
+use move_binary_format::CompiledModule;
 use sui_types::{
     base_types::ObjectID,
     error::UserInputError,
@@ -299,4 +300,126 @@ async fn test_custom_property_check_unpublished_dependencies() {
         Package dependency "CustomPropertiesInManifestDependencyMissingPublishedAt" does not specify a published address (the Move.toml manifest for "CustomPropertiesInManifestDependencyMissingPublishedAt" does not contain a published-at field).
         If this is intentional, you may use the --with-unpublished-dependencies flag to continue publishing these dependencies as part of your package (they won't be linked against existing packages on-chain)."#]];
     expected.assert_eq(&error)
+}
+
+#[tokio::test]
+#[cfg_attr(msim, ignore)]
+async fn test_publish_extraneous_bytes_modules() {
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let gas = ObjectID::random();
+    let authority = init_state_with_ids(vec![(sender, gas)]).await;
+    let gas_object = authority.get_object(&gas).await.unwrap();
+    let gas_object_ref = gas_object.unwrap().compute_object_reference();
+    let rgp = authority.reference_gas_price_for_testing().unwrap();
+
+    // test valid module bytes
+    let correct_modules =
+        build_test_package("object_owner", /* with_unpublished_deps */ false);
+    assert_eq!(correct_modules.len(), 1);
+    let data = TransactionData::new_module(
+        sender,
+        gas_object_ref,
+        correct_modules.clone(),
+        BuiltInFramework::all_package_ids(),
+        rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
+        rgp,
+    );
+    let transaction = to_sender_signed_transaction(data, &sender_key);
+    let result = send_and_confirm_transaction(&authority, transaction)
+        .await
+        .unwrap()
+        .1;
+    assert_eq!(result.status(), &ExecutionStatus::Success);
+
+    // make the bytes invalid
+    let gas_object = authority.get_object(&gas).await.unwrap();
+    let gas_object_ref = gas_object.unwrap().compute_object_reference();
+    let mut modules = correct_modules.clone();
+    modules[0].push(0);
+    assert_eq!(modules.len(), 1);
+    let data = TransactionData::new_module(
+        sender,
+        gas_object_ref,
+        modules,
+        BuiltInFramework::all_package_ids(),
+        rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
+        rgp,
+    );
+    let transaction = to_sender_signed_transaction(data, &sender_key);
+    let result = send_and_confirm_transaction(&authority, transaction)
+        .await
+        .unwrap()
+        .1;
+    assert_eq!(
+        result.status(),
+        &ExecutionStatus::Failure {
+            error: ExecutionFailureStatus::VMVerificationOrDeserializationError,
+            command: Some(0)
+        }
+    );
+
+    // make the bytes invalid, in a different way
+    let gas_object = authority.get_object(&gas).await.unwrap();
+    let gas_object_ref = gas_object.unwrap().compute_object_reference();
+    let mut modules = correct_modules.clone();
+    let first_module = modules[0].clone();
+    modules[0].extend(first_module);
+    assert_eq!(modules.len(), 1);
+    let data = TransactionData::new_module(
+        sender,
+        gas_object_ref,
+        modules,
+        BuiltInFramework::all_package_ids(),
+        rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
+        rgp,
+    );
+    let transaction = to_sender_signed_transaction(data, &sender_key);
+    let result = send_and_confirm_transaction(&authority, transaction)
+        .await
+        .unwrap()
+        .1;
+    assert_eq!(
+        result.status(),
+        &ExecutionStatus::Failure {
+            error: ExecutionFailureStatus::VMVerificationOrDeserializationError,
+            command: Some(0)
+        }
+    );
+
+    // make the bytes invalid by adding metadata
+    let gas_object = authority.get_object(&gas).await.unwrap();
+    let gas_object_ref = gas_object.unwrap().compute_object_reference();
+    let mut modules = correct_modules.clone();
+    let new_bytes = {
+        let mut m = CompiledModule::deserialize(&modules[0]).unwrap();
+        m.metadata.push(move_core_types::metadata::Metadata {
+            key: vec![0],
+            value: vec![1],
+        });
+        let mut buf = vec![];
+        m.serialize(&mut buf).unwrap();
+        buf
+    };
+    modules[0] = new_bytes;
+    assert_eq!(modules.len(), 1);
+    let data = TransactionData::new_module(
+        sender,
+        gas_object_ref,
+        modules,
+        BuiltInFramework::all_package_ids(),
+        rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
+        rgp,
+    );
+    let transaction = to_sender_signed_transaction(data, &sender_key);
+    let result = send_and_confirm_transaction(&authority, transaction)
+        .await
+        .unwrap()
+        .1;
+    assert_eq!(
+        result.status(),
+        &ExecutionStatus::Failure {
+            error: ExecutionFailureStatus::VMVerificationOrDeserializationError,
+            command: Some(0)
+        }
+    )
 }

--- a/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -269,8 +269,12 @@ async fn test_upgrade_package_happy_path() {
         .get_package(&runner.package.0)
         .unwrap()
         .unwrap();
+    let config = ProtocolConfig::get_for_max_version();
     let normalized_modules = package
-        .normalize(ProtocolConfig::get_for_max_version().move_binary_format_version())
+        .normalize(
+            config.move_binary_format_version(),
+            config.no_extraneous_module_bytes(),
+        )
         .unwrap();
     assert!(normalized_modules.contains_key("new_module"));
     assert!(normalized_modules["new_module"]

--- a/crates/sui-framework-snapshot/tests/compatibility_tests.rs
+++ b/crates/sui-framework-snapshot/tests/compatibility_tests.rs
@@ -13,9 +13,9 @@ mod compatibility_tests {
         // bytecode snapshots.
         for (network, snapshots) in load_bytecode_snapshot_manifest() {
             for (version, _) in snapshots {
-                let max_binary_format_version =
-                    ProtocolConfig::get_for_version(ProtocolVersion::new(version))
-                        .move_binary_format_version();
+                let config = ProtocolConfig::get_for_version(ProtocolVersion::new(version));
+                let max_binary_format_version = config.move_binary_format_version();
+                let no_extraneous_module_bytes = config.no_extraneous_module_bytes();
                 let framework = load_bytecode_snapshot(&network, version).unwrap();
                 let old_framework_store: BTreeMap<_, _> = framework
                     .into_iter()
@@ -28,6 +28,7 @@ mod compatibility_tests {
                         &cur_package.modules(),
                         cur_package.dependencies().to_vec(),
                         max_binary_format_version,
+                        no_extraneous_module_bytes,
                     )
                     .await
                     .is_none()

--- a/crates/sui-framework/src/lib.rs
+++ b/crates/sui-framework/src/lib.rs
@@ -54,7 +54,7 @@ impl SystemPackage {
     pub fn modules(&self) -> Vec<CompiledModule> {
         self.bytes
             .iter()
-            .map(|b| CompiledModule::deserialize(b).unwrap())
+            .map(|b| CompiledModule::deserialize_with_defaults(b).unwrap())
             .collect()
     }
 

--- a/crates/sui-framework/src/lib.rs
+++ b/crates/sui-framework/src/lib.rs
@@ -167,6 +167,7 @@ pub async fn compare_system_package<S: ObjectStore>(
     modules: &[CompiledModule],
     dependencies: Vec<ObjectID>,
     max_binary_format_version: u32,
+    no_extraneous_module_bytes: bool,
 ) -> Option<ObjectRef> {
     let cur_object = match object_store.get_object(id) {
         Ok(Some(cur_object)) => cur_object,
@@ -227,14 +228,17 @@ pub async fn compare_system_package<S: ObjectStore>(
         .try_as_package_mut()
         .expect("Created as package");
 
-    let cur_normalized = match cur_pkg.normalize(max_binary_format_version) {
-        Ok(v) => v,
-        Err(e) => {
-            error!("Could not normalize existing package: {e:?}");
-            return None;
-        }
-    };
-    let mut new_normalized = new_pkg.normalize(max_binary_format_version).ok()?;
+    let cur_normalized =
+        match cur_pkg.normalize(max_binary_format_version, no_extraneous_module_bytes) {
+            Ok(v) => v,
+            Err(e) => {
+                error!("Could not normalize existing package: {e:?}");
+                return None;
+            }
+        };
+    let mut new_normalized = new_pkg
+        .normalize(max_binary_format_version, no_extraneous_module_bytes)
+        .ok()?;
 
     for (name, cur_module) in cur_normalized {
         let Some(new_module) = new_normalized.remove(&name) else {

--- a/crates/sui-json-rpc/src/move_utils.rs
+++ b/crates/sui-json-rpc/src/move_utils.rs
@@ -120,6 +120,7 @@ impl MoveUtilsServer for MoveUtils {
                     normalize_modules(
                         p.serialized_module_map().values(),
                         /* max_binary_format_version */ VERSION_MAX,
+                        /* no_extraneous_module_bytes */ false,
                     )
                     .map_err(|e| anyhow!("{e}"))
                 }

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -1016,6 +1016,7 @@ pub async fn get_move_modules_by_package(
                 normalize_modules(
                     p.serialized_module_map().values(),
                     /* max_binary_format_version */ VERSION_MAX,
+                    /* no_extraneous_module_bytes */ false,
                 )
                 .map_err(|e| {
                     error!("Failed to call get_move_modules_by_package for package: {package:?}");

--- a/crates/sui-json/src/lib.rs
+++ b/crates/sui-json/src/lib.rs
@@ -846,7 +846,7 @@ pub fn resolve_move_function_args(
     allow_arbitrary_function_call: bool,
 ) -> Result<Vec<(ResolvedCallArg, SignatureToken)>, anyhow::Error> {
     // Extract the expected function signature
-    let module = package.deserialize_module(&module_ident, VERSION_MAX)?;
+    let module = package.deserialize_module(&module_ident, VERSION_MAX, true)?;
     let function_str = function.as_ident_str();
     let fdef = module
         .function_defs

--- a/crates/sui-move/src/disassemble.rs
+++ b/crates/sui-move/src/disassemble.rs
@@ -59,7 +59,7 @@ impl Disassemble {
         file.read_to_end(&mut bytes)?;
         // this deserialized a module to the max version of the bytecode but it's OK here because
         // it's not run as part of the deterministic replicated state machine.
-        let module = CompiledModule::deserialize(&bytes)?;
+        let module = CompiledModule::deserialize_with_defaults(&bytes)?;
 
         if self.debug {
             println!("{module:#?}");

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -930,9 +930,9 @@ impl SuiNode {
                 // TODO: without this sleep, the consensus message is not delivered reliably.
                 tokio::time::sleep(Duration::from_millis(1)).await;
 
-                let max_binary_format_version = cur_epoch_store
-                    .protocol_config()
-                    .move_binary_format_version();
+                let config = cur_epoch_store.protocol_config();
+                let max_binary_format_version = config.move_binary_format_version();
+                let no_extraneous_module_bytes = config.no_extraneous_module_bytes();
                 let transaction =
                     ConsensusTransaction::new_capability_notification(AuthorityCapabilities::new(
                         self.state.name,
@@ -940,7 +940,10 @@ impl SuiNode {
                             .supported_protocol_versions
                             .expect("Supported versions should be populated"),
                         self.state
-                            .get_available_system_packages(max_binary_format_version)
+                            .get_available_system_packages(
+                                max_binary_format_version,
+                                no_extraneous_module_bytes,
+                            )
                             .await,
                     ));
                 info!(?transaction, "submitting capabilities to consensus");

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -32,6 +32,7 @@ const MAX_PROTOCOL_VERSION: u64 = 9;
 // Version 8: Disallow changing abilities and type constraints for type parameters in structs
 //            during upgrades.
 // Version 9: Limit the length of Move idenfitiers to 128.
+//            Disallow extraneous module bytes.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -1119,13 +1120,13 @@ impl ProtocolConfig {
                 let mut cfg = Self::get_for_version_impl(version - 1);
                 cfg.feature_flags
                     .disallow_change_struct_type_params_on_upgrade = true;
-                cfg.feature_flags.no_extraneous_module_bytes = true;
                 cfg
             }
             9 => {
                 let mut cfg = Self::get_for_version_impl(version - 1);
                 // Limits the length of a Move identifier
                 cfg.max_move_identifier_len = Some(128);
+                cfg.feature_flags.no_extraneous_module_bytes = true;
                 cfg
             }
             // Use this template when making changes:

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -171,6 +171,9 @@ struct FeatureFlags {
     // If true, disallow changing struct type parameters during package upgrades
     #[serde(skip_serializing_if = "is_false")]
     disallow_change_struct_type_params_on_upgrade: bool,
+    // If true, checks no extra bytes in a compiled module
+    #[serde(skip_serializing_if = "is_false")]
+    no_extraneous_module_bytes: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -690,6 +693,10 @@ impl ProtocolConfig {
         self.feature_flags
             .disallow_change_struct_type_params_on_upgrade
     }
+
+    pub fn no_extraneous_module_bytes(&self) -> bool {
+        self.feature_flags.no_extraneous_module_bytes
+    }
 }
 
 // Special getters
@@ -1112,6 +1119,7 @@ impl ProtocolConfig {
                 let mut cfg = Self::get_for_version_impl(version - 1);
                 cfg.feature_flags
                     .disallow_change_struct_type_params_on_upgrade = true;
+                cfg.feature_flags.no_extraneous_module_bytes = true;
                 cfg
             }
             9 => {

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_8.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_8.snap
@@ -16,6 +16,7 @@ feature_flags:
   ban_entry_init: true
   package_digest_hash_module: true
   disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_8.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_8.snap
@@ -16,7 +16,6 @@ feature_flags:
   ban_entry_init: true
   package_digest_hash_module: true
   disallow_change_struct_type_params_on_upgrade: true
-  no_extraneous_module_bytes: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_9.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_9.snap
@@ -16,6 +16,7 @@ feature_flags:
   ban_entry_init: true
   package_digest_hash_module: true
   disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-source-validation/src/lib.rs
+++ b/crates/sui-source-validation/src/lib.rs
@@ -277,7 +277,7 @@ impl<'a> BytecodeSourceVerifier<'a> {
         for (storage_id, pkg) in addresses.zip(resp) {
             let SuiRawMovePackage { module_map, .. } = pkg?;
             for (name, bytes) in module_map {
-                let Ok(module) = CompiledModule::deserialize(&bytes) else {
+                let Ok(module) = CompiledModule::deserialize_with_defaults(&bytes) else {
                     err.push(SourceVerificationError::OnChainDependencyDeserializationError {
                         address: storage_id,
                         module: name.into(),

--- a/crates/sui-surfer/src/surfer_state.rs
+++ b/crates/sui-surfer/src/surfer_state.rs
@@ -250,10 +250,12 @@ impl SurferState {
     async fn discover_entry_functions(&self, package: Object) {
         let package_id = package.id();
         let move_package = package.data.try_into_package().unwrap();
-        let move_binary_format_version =
-            ProtocolConfig::get_for_max_version().move_binary_format_version();
+        let config = ProtocolConfig::get_for_max_version();
         let entry_functions: Vec<_> = move_package
-            .normalize(move_binary_format_version)
+            .normalize(
+                config.move_binary_format_version(),
+                config.no_extraneous_module_bytes(),
+            )
             .unwrap()
             .into_iter()
             .flat_map(|(module_name, module)| {

--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -413,7 +413,7 @@ impl<Mode: ExecutionMode> TransactionBuilder<Mode> {
                 }
             })
         }
-        let compiled_module = package.deserialize_module(module, VERSION_MAX)?;
+        let compiled_module = package.deserialize_module(module, VERSION_MAX, true)?;
 
         // TODO set the Mode from outside?
         resolve_and_type_check::<Mode>(

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -459,7 +459,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
             .map(|(_, published_module_bytes)| {
                 (
                     named_addr_opt,
-                    CompiledModule::deserialize(published_module_bytes).unwrap(),
+                    CompiledModule::deserialize_with_defaults(published_module_bytes).unwrap(),
                 )
             })
             .collect();

--- a/crates/sui-types/src/move_package.rs
+++ b/crates/sui-types/src/move_package.rs
@@ -492,7 +492,7 @@ impl MovePackage {
     /// `MovePackage::id()` in the case of package upgrades).
     pub fn original_package_id(&self) -> ObjectID {
         let bytes = self.module_map.values().next().expect("Empty module map");
-        let module = CompiledModule::deserialize(bytes)
+        let module = CompiledModule::deserialize_with_defaults(bytes)
             .expect("A Move package contains a module that cannot be deserialized");
         (*module.address()).into()
     }
@@ -610,7 +610,7 @@ where
     for bytecode in modules {
         // this function is only from JSON RPC - it is OK to deserialize with max Move binary
         // version
-        let module = CompiledModule::deserialize(bytecode).map_err(|error| {
+        let module = CompiledModule::deserialize_with_defaults(bytecode).map_err(|error| {
             SuiError::ModuleDeserializationFailure {
                 error: error.to_string(),
             }

--- a/crates/sui-types/src/move_package.rs
+++ b/crates/sui-types/src/move_package.rs
@@ -501,6 +501,7 @@ impl MovePackage {
         &self,
         module: &Identifier,
         max_binary_format_version: u32,
+        check_no_bytes_remaining: bool,
     ) -> SuiResult<CompiledModule> {
         // TODO use the session's cache
         let bytes = self
@@ -509,11 +510,14 @@ impl MovePackage {
             .ok_or_else(|| SuiError::ModuleNotFound {
                 module_name: module.to_string(),
             })?;
-        CompiledModule::deserialize_with_max_version(bytes, max_binary_format_version).map_err(
-            |error| SuiError::ModuleDeserializationFailure {
-                error: error.to_string(),
-            },
+        CompiledModule::deserialize_with_config(
+            bytes,
+            max_binary_format_version,
+            check_no_bytes_remaining,
         )
+        .map_err(|error| SuiError::ModuleDeserializationFailure {
+            error: error.to_string(),
+        })
     }
 
     pub fn disassemble(&self) -> SuiResult<BTreeMap<String, Value>> {
@@ -523,8 +527,13 @@ impl MovePackage {
     pub fn normalize(
         &self,
         max_binary_format_version: u32,
+        check_no_bytes_remaining: bool,
     ) -> SuiResult<BTreeMap<String, normalized::Module>> {
-        normalize_modules(self.module_map.values(), max_binary_format_version)
+        normalize_modules(
+            self.module_map.values(),
+            max_binary_format_version,
+            check_no_bytes_remaining,
+        )
     }
 }
 
@@ -625,17 +634,21 @@ where
 pub fn normalize_modules<'a, I>(
     modules: I,
     max_binary_format_version: u32,
+    check_no_bytes_remaining: bool,
 ) -> SuiResult<BTreeMap<String, normalized::Module>>
 where
     I: Iterator<Item = &'a Vec<u8>>,
 {
     let mut normalized_modules = BTreeMap::new();
     for bytecode in modules {
-        let module =
-            CompiledModule::deserialize_with_max_version(bytecode, max_binary_format_version)
-                .map_err(|error| SuiError::ModuleDeserializationFailure {
-                    error: error.to_string(),
-                })?;
+        let module = CompiledModule::deserialize_with_config(
+            bytecode,
+            max_binary_format_version,
+            check_no_bytes_remaining,
+        )
+        .map_err(|error| SuiError::ModuleDeserializationFailure {
+            error: error.to_string(),
+        })?;
         let normalized_module = normalized::Module::new(&module);
         normalized_modules.insert(normalized_module.name.to_string(), normalized_module);
     }

--- a/crates/sui-types/src/storage.rs
+++ b/crates/sui-types/src/storage.rs
@@ -174,7 +174,8 @@ pub fn get_module_by_id<S: BackingPackageStore>(
     store: S,
     id: &ModuleId,
 ) -> anyhow::Result<Option<CompiledModule>, SuiError> {
-    Ok(get_module(store, id)?.map(|bytes| CompiledModule::deserialize(&bytes).unwrap()))
+    Ok(get_module(store, id)?
+        .map(|bytes| CompiledModule::deserialize_with_defaults(&bytes).unwrap()))
 }
 
 pub trait ParentSync {

--- a/crates/sui-types/src/temporary_store.rs
+++ b/crates/sui-types/src/temporary_store.rs
@@ -53,6 +53,7 @@ pub struct InnerTemporaryStore {
     pub loaded_child_objects: BTreeMap<ObjectID, SequenceNumber>,
     pub events: TransactionEvents,
     pub max_binary_format_version: u32,
+    pub no_extraneous_module_bytes: bool,
 }
 
 impl InnerTemporaryStore {
@@ -124,6 +125,7 @@ where
                 return Ok(Some(Arc::new(p.deserialize_module(
                     &id.name().into(),
                     self.temp_store.max_binary_format_version,
+                    self.temp_store.no_extraneous_module_bytes,
                 )?)));
             }
         }
@@ -286,6 +288,7 @@ impl<S> TemporaryStore<S> {
             events: TransactionEvents { data: self.events },
             max_binary_format_version: self.protocol_config.move_binary_format_version(),
             loaded_child_objects: self.loaded_child_objects,
+            no_extraneous_module_bytes: self.protocol_config.no_extraneous_module_bytes(),
         }
     }
 
@@ -1586,6 +1589,7 @@ impl<S: GetModule<Error = SuiError, Item = CompiledModule>> GetModule for Tempor
                     .deserialize_module(
                         &module_id.name().to_owned(),
                         self.protocol_config.move_binary_format_version(),
+                        self.protocol_config.no_extraneous_module_bytes(),
                     )?,
             ))
         } else {

--- a/external-crates/move/move-binary-format/serializer-tests/tests/serializer_tests.rs
+++ b/external-crates/move/move-binary-format/serializer-tests/tests/serializer_tests.rs
@@ -11,7 +11,7 @@ proptest! {
         let mut serialized = Vec::with_capacity(2048);
         module.serialize(&mut serialized).expect("serialization should work");
 
-        let deserialized_module = CompiledModule::deserialize(&serialized)
+        let deserialized_module = CompiledModule::deserialize_with_defaults(&serialized)
             .expect("deserialization should work");
 
         prop_assert_eq!(module, deserialized_module);

--- a/external-crates/move/move-binary-format/src/deserializer.rs
+++ b/external-crates/move/move-binary-format/src/deserializer.rs
@@ -35,15 +35,26 @@ impl CompiledScript {
 impl CompiledModule {
     /// Deserialize a &[u8] slice into a `CompiledModule` instance.
     pub fn deserialize(binary: &[u8]) -> BinaryLoaderResult<Self> {
-        Self::deserialize_with_max_version(binary, VERSION_MAX)
+        Self::deserialize_with_config(
+            binary,
+            VERSION_MAX,
+            /* check_no_extraneous_bytes */ false,
+        )
     }
 
-    /// Deserialize a &[u8] slice into a `CompiledModule` instance, up to the specified version.
-    pub fn deserialize_with_max_version(
+    /// Deserialize a &[u8] slice into a `CompiledModule` instance with settings
+    /// - Can specify up to the specified version.
+    /// - Can specify if the deserializer should error on trailing bytes
+    pub fn deserialize_with_config(
         binary: &[u8],
         max_binary_format_version: u32,
+        check_no_extraneous_bytes: bool,
     ) -> BinaryLoaderResult<Self> {
-        let module = deserialize_compiled_module(binary, max_binary_format_version)?;
+        let module = deserialize_compiled_module(
+            binary,
+            max_binary_format_version,
+            check_no_extraneous_bytes,
+        )?;
         BoundsChecker::verify_module(&module)?;
         Ok(module)
     }
@@ -51,7 +62,7 @@ impl CompiledModule {
     // exposed as a public function to enable testing the deserializer
     #[doc(hidden)]
     pub fn deserialize_no_check_bounds(binary: &[u8]) -> BinaryLoaderResult<Self> {
-        deserialize_compiled_module(binary, VERSION_MAX)
+        deserialize_compiled_module(binary, VERSION_MAX, false)
     }
 }
 
@@ -304,7 +315,7 @@ fn deserialize_compiled_script(
     max_binary_format_version: u32,
 ) -> BinaryLoaderResult<CompiledScript> {
     let binary_len = binary.len();
-    let mut cursor = VersionedCursor::new(binary, max_binary_format_version)?;
+    let mut cursor = VersionedCursor::new(binary, max_binary_format_version, false)?;
     let table_count = load_table_count(&mut cursor)?;
     let mut tables: Vec<Table> = Vec::new();
     read_tables(&mut cursor, table_count, &mut tables)?;
@@ -336,9 +347,11 @@ fn deserialize_compiled_script(
 fn deserialize_compiled_module(
     binary: &[u8],
     max_binary_format_version: u32,
+    check_no_extraneous_bytes: bool,
 ) -> BinaryLoaderResult<CompiledModule> {
     let binary_len = binary.len();
-    let mut cursor = VersionedCursor::new(binary, max_binary_format_version)?;
+    let mut cursor =
+        VersionedCursor::new(binary, max_binary_format_version, check_no_extraneous_bytes)?;
     let table_count = load_table_count(&mut cursor)?;
     let mut tables: Vec<Table> = Vec::new();
     read_tables(&mut cursor, table_count, &mut tables)?;
@@ -359,6 +372,11 @@ fn deserialize_compiled_module(
 
     build_compiled_module(&mut module, &table_contents, &tables)?;
 
+    let end_pos = cursor.position();
+    let had_remaining_bytes = end_pos < (binary.len() as u64);
+    if check_no_extraneous_bytes && had_remaining_bytes {
+        return Err(PartialVMError::new(StatusCode::TRAILING_BYTES));
+    }
     Ok(module)
 }
 
@@ -572,7 +590,7 @@ fn build_common_tables(
                 load_constant_pool(binary, table, common.get_constant_pool())?;
             }
             TableType::METADATA => {
-                if binary.version() < VERSION_5 {
+                if binary.check_no_extraneous_bytes() || binary.version() < VERSION_5 {
                     return Err(
                         PartialVMError::new(StatusCode::MALFORMED).with_message(format!(
                             "metadata declarations not applicable in bytecode version {}",

--- a/external-crates/move/move-binary-format/src/deserializer.rs
+++ b/external-crates/move/move-binary-format/src/deserializer.rs
@@ -34,7 +34,7 @@ impl CompiledScript {
 
 impl CompiledModule {
     /// Deserialize a &[u8] slice into a `CompiledModule` instance.
-    pub fn deserialize(binary: &[u8]) -> BinaryLoaderResult<Self> {
+    pub fn deserialize_with_defaults(binary: &[u8]) -> BinaryLoaderResult<Self> {
         Self::deserialize_with_config(
             binary,
             VERSION_MAX,

--- a/external-crates/move/move-binary-format/src/unit_tests/deserializer_tests.rs
+++ b/external-crates/move/move-binary-format/src/unit_tests/deserializer_tests.rs
@@ -46,7 +46,7 @@ fn malformed_simple_versioned_test(version: u32) {
     let mut binary = BinaryConstants::MOVE_MAGIC.to_vec();
     binary.extend(version.to_le_bytes()); // version
     binary.push(0); // table count
-    let res = CompiledModule::deserialize(&binary);
+    let res = CompiledModule::deserialize_with_defaults(&binary);
     assert_eq!(
         res.expect_err("Expected no table count").major_status(),
         StatusCode::MALFORMED
@@ -56,7 +56,7 @@ fn malformed_simple_versioned_test(version: u32) {
     let mut binary = BinaryConstants::MOVE_MAGIC.to_vec();
     binary.extend(version.to_le_bytes()); // version
     binary.push(10); // table count
-    let res = CompiledModule::deserialize(&binary);
+    let res = CompiledModule::deserialize_with_defaults(&binary);
     assert_eq!(
         res.expect_err("Expected no table header").major_status(),
         StatusCode::MALFORMED
@@ -82,7 +82,7 @@ fn malformed_simple_versioned_test(version: u32) {
     binary.push(1); // table type
     binary.push(100); // bad table offset
     binary.push(10); // table length
-    let res = CompiledModule::deserialize(&binary);
+    let res = CompiledModule::deserialize_with_defaults(&binary);
     assert_eq!(
         res.expect_err("Expected bad table offset").major_status(),
         StatusCode::BAD_HEADER_TABLE
@@ -99,7 +99,7 @@ fn malformed_simple_versioned_test(version: u32) {
     binary.push(100); // bad table offset
     binary.push(10); // table length
     binary.resize(binary.len() + 5000, 0);
-    let res = CompiledModule::deserialize(&binary);
+    let res = CompiledModule::deserialize_with_defaults(&binary);
     assert_eq!(
         res.expect_err("Expected bad table offset").major_status(),
         StatusCode::BAD_HEADER_TABLE
@@ -127,7 +127,7 @@ fn malformed_simple_versioned_test(version: u32) {
     binary.push(0); // table offset
     binary.push(10); // table length
     binary.resize(binary.len() + 10, 0);
-    let res = CompiledModule::deserialize(&binary);
+    let res = CompiledModule::deserialize_with_defaults(&binary);
     assert_eq!(
         res.expect_err("Expected unknown table").major_status(),
         StatusCode::UNKNOWN_TABLE_TYPE

--- a/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/binary_samples.rs
+++ b/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/binary_samples.rs
@@ -13,7 +13,7 @@ use move_bytecode_verifier::verifier;
 #[allow(unused)]
 fn run_binary_test(name: &str, bytes: &str) -> VMResult<()> {
     let bytes = hex::decode(bytes).expect("invalid hex string");
-    let m = CompiledModule::deserialize(&bytes).expect("invalid module");
+    let m = CompiledModule::deserialize_with_defaults(&bytes).expect("invalid module");
     verifier::verify_module_with_config_for_test(name, &production_config(), &m)
 }
 

--- a/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/limit_tests.rs
+++ b/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/limit_tests.rs
@@ -245,7 +245,7 @@ fn big_vec_unpacks() {
     // save module and verify that it can ser/de
     let mut mvbytes = vec![];
     module.serialize(&mut mvbytes).unwrap();
-    let module = CompiledModule::deserialize(&mvbytes).unwrap();
+    let module = CompiledModule::deserialize_with_defaults(&mvbytes).unwrap();
 
     let res = verify_module_with_config_for_test(
         "big_vec_unpacks",

--- a/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/signature_tests.rs
+++ b/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/signature_tests.rs
@@ -211,7 +211,7 @@ fn big_signature_test() {
     // save module and verify that it can ser/de
     let mut mvbytes = vec![];
     module.serialize(&mut mvbytes).unwrap();
-    let module = CompiledModule::deserialize(&mvbytes).unwrap();
+    let module = CompiledModule::deserialize_with_defaults(&mvbytes).unwrap();
 
     let res =
         verify_module_with_config_for_test("big_signature_test", &production_config(), &module)

--- a/external-crates/move/move-compiler/src/interface_generator.rs
+++ b/external-crates/move/move-compiler/src/interface_generator.rs
@@ -35,7 +35,7 @@ pub fn write_file_to_string(
     compiled_module_file_input_path: &str,
 ) -> Result<(ModuleId, String)> {
     let file_contents = fs::read(compiled_module_file_input_path)?;
-    let module = CompiledModule::deserialize(&file_contents).map_err(|e| {
+    let module = CompiledModule::deserialize_with_defaults(&file_contents).map_err(|e| {
         anyhow!(
             "Unable to deserialize module at '{}': {}",
             compiled_module_file_input_path,

--- a/external-crates/move/move-core/types/src/vm_status.rs
+++ b/external-crates/move/move-core/types/src/vm_status.rs
@@ -666,6 +666,7 @@ pub enum StatusCode {
     VALUE_DESERIALIZATION_ERROR = 3023,
     CODE_DESERIALIZATION_ERROR = 3024,
     INVALID_FLAG_BITS = 3025,
+    TRAILING_BYTES = 3026,
 
     // Errors that can arise at runtime
     // Runtime Errors: 4000-4999

--- a/external-crates/move/move-ir-compiler/src/main.rs
+++ b/external-crates/move/move-ir-compiler/src/main.rs
@@ -116,7 +116,7 @@ fn main() {
             deps_list
                 .into_iter()
                 .map(|module_bytes| {
-                    let module = CompiledModule::deserialize(module_bytes.as_slice())
+                    let module = CompiledModule::deserialize_with_defaults(module_bytes.as_slice())
                         .expect("Downloaded module blob can't be deserialized");
                     verify_module(&module).expect("Downloaded module blob failed verifier");
                     module

--- a/external-crates/move/move-ir-compiler/src/unit_tests/testutils.rs
+++ b/external-crates/move/move-ir-compiler/src/unit_tests/testutils.rs
@@ -54,7 +54,7 @@ fn compile_module_string_impl(
 
     let mut serialized_module = Vec::<u8>::new();
     compiled_module.serialize(&mut serialized_module)?;
-    let deserialized_module = CompiledModule::deserialize(&serialized_module)
+    let deserialized_module = CompiledModule::deserialize_with_defaults(&serialized_module)
         .map_err(|e| e.finish(Location::Undefined).into_vm_status())?;
     assert_eq!(compiled_module, deserialized_module);
 

--- a/external-crates/move/move-vm/runtime/src/config.rs
+++ b/external-crates/move/move-vm/runtime/src/config.rs
@@ -14,6 +14,9 @@ pub struct VMConfig {
     pub runtime_limits_config: VMRuntimeLimitsConfig,
     // When this flag is set to true, MoveVM will check invariant violation in swap_loc
     pub enable_invariant_violation_check_in_swap_loc: bool,
+    // When this flag is set to true, MoveVM will check that there are no trailing bytes after
+    // deserializing and check for no metadata bytes
+    pub check_no_extraneous_bytes_during_deserialization: bool,
 }
 
 impl Default for VMConfig {
@@ -24,6 +27,7 @@ impl Default for VMConfig {
             paranoid_type_checks: false,
             runtime_limits_config: VMRuntimeLimitsConfig::default(),
             enable_invariant_violation_check_in_swap_loc: true,
+            check_no_extraneous_bytes_during_deserialization: false,
         }
     }
 }

--- a/external-crates/move/move-vm/runtime/src/loader.rs
+++ b/external-crates/move/move-vm/runtime/src/loader.rs
@@ -981,9 +981,11 @@ impl Loader {
 
         // for bytes obtained from the data store, they should always deserialize and verify.
         // It is an invariant violation if they don't.
-        let module = CompiledModule::deserialize_with_max_version(
+        let module = CompiledModule::deserialize_with_config(
             &bytes,
             self.vm_config.max_binary_format_version,
+            self.vm_config()
+                .check_no_extraneous_bytes_during_deserialization,
         )
         .map_err(|err| {
             let msg = format!("Deserialization error: {:?}", err);

--- a/external-crates/move/move-vm/runtime/src/runtime.rs
+++ b/external-crates/move/move-vm/runtime/src/runtime.rs
@@ -78,9 +78,12 @@ impl VMRuntime {
         let compiled_modules = match modules
             .iter()
             .map(|blob| {
-                CompiledModule::deserialize_with_max_version(
+                CompiledModule::deserialize_with_config(
                     blob,
                     self.loader.vm_config().max_binary_format_version,
+                    self.loader
+                        .vm_config()
+                        .check_no_extraneous_bytes_during_deserialization,
                 )
             })
             .collect::<PartialVMResult<Vec<_>>>()

--- a/external-crates/move/tools/move-bytecode-utils/src/module_cache.rs
+++ b/external-crates/move/tools/move-bytecode-utils/src/module_cache.rs
@@ -57,7 +57,7 @@ impl<R: ModuleResolver> GetModule for ModuleCache<R> {
                     .get_module(id)
                     .map_err(|_| anyhow!("Failed to get module {:?}", id))?
                     .ok_or_else(|| anyhow!("Module {:?} doesn't exist", id))?;
-                let module = CompiledModule::deserialize(&module_bytes)
+                let module = CompiledModule::deserialize_with_defaults(&module_bytes)
                     .map_err(|_| anyhow!("Failure deserializing module {:?}", id))?;
                 entry.insert(module.clone());
                 module
@@ -75,7 +75,7 @@ impl<R: ModuleResolver> GetModule for &R {
         Ok(self
             .get_module(id)
             .unwrap()
-            .map(|bytes| CompiledModule::deserialize(&bytes).unwrap()))
+            .map(|bytes| CompiledModule::deserialize_with_defaults(&bytes).unwrap()))
     }
 }
 
@@ -87,7 +87,7 @@ impl<R: ModuleResolver> GetModule for &mut R {
         Ok(self
             .get_module(id)
             .unwrap()
-            .map(|bytes| CompiledModule::deserialize(&bytes).unwrap()))
+            .map(|bytes| CompiledModule::deserialize_with_defaults(&bytes).unwrap()))
     }
 }
 
@@ -138,7 +138,7 @@ impl<R: ModuleResolver> GetModule for SyncModuleCache<R> {
             .map_err(|_| anyhow!("Failed to get module {:?}", id))?
         {
             let module = Arc::new(
-                CompiledModule::deserialize(&module_bytes)
+                CompiledModule::deserialize_with_defaults(&module_bytes)
                     .map_err(|_| anyhow!("Failure deserializing module {:?}", id))?,
             );
 

--- a/external-crates/move/tools/move-bytecode-viewer/src/lib.rs
+++ b/external-crates/move/tools/move-bytecode-viewer/src/lib.rs
@@ -51,7 +51,7 @@ impl BytecodeViewerConfig {
     pub fn start_viewer(&self) {
         let bytecode_bytes =
             fs::read(&self.module_binary_path).expect("Unable to read bytecode file");
-        let compiled_module = CompiledModule::deserialize(&bytecode_bytes)
+        let compiled_module = CompiledModule::deserialize_with_defaults(&bytecode_bytes)
             .expect("Module blob can't be deserialized");
 
         let source_map = source_map_from_file(&self.module_sourcemap_path).unwrap();

--- a/external-crates/move/tools/move-cli/src/experimental/commands/read_writeset_analysis.rs
+++ b/external-crates/move/tools/move-cli/src/experimental/commands/read_writeset_analysis.rs
@@ -26,7 +26,7 @@ pub fn analyze_read_write_set(
     concretize: ConcretizeMode,
     verbose: bool,
 ) -> Result<()> {
-    let module_id = CompiledModule::deserialize(&fs::read(module_file)?)
+    let module_id = CompiledModule::deserialize_with_defaults(&fs::read(module_file)?)
         .map_err(|e| anyhow!("Error deserializing module: {:?}", e))?
         .self_id();
     let fun_id = Identifier::new(function.to_string())?;

--- a/external-crates/move/tools/move-cli/src/sandbox/commands/run.rs
+++ b/external-crates/move/tools/move-cli/src/sandbox/commands/run.rs
@@ -99,7 +99,7 @@ move run` must be applied to a module inside `storage/`",
     let res = match script_name_opt {
         Some(script_name) => {
             // script fun. parse module, extract script ID to pass to VM
-            let module = CompiledModule::deserialize(&bytecode)
+            let module = CompiledModule::deserialize_with_defaults(&bytecode)
                 .map_err(|e| anyhow!("Error deserializing module: {:?}", e))?;
             session.execute_entry_function(
                 &module.self_id(),

--- a/external-crates/move/tools/move-cli/src/sandbox/utils/mod.rs
+++ b/external-crates/move/tools/move-cli/src/sandbox/utils/mod.rs
@@ -577,7 +577,7 @@ pub(crate) fn is_bytecode_file(path: &Path) -> bool {
 pub(crate) fn contains_module(path: &Path) -> bool {
     is_bytecode_file(path)
         && match fs::read(path) {
-            Ok(bytes) => CompiledModule::deserialize(&bytes).is_ok(),
+            Ok(bytes) => CompiledModule::deserialize_with_defaults(&bytes).is_ok(),
             Err(_) => false,
         }
 }

--- a/external-crates/move/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
+++ b/external-crates/move/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
@@ -249,7 +249,7 @@ impl OnDiskStateView {
                 let module: CompiledModule;
                 let script: CompiledScript;
                 let view = if is_module {
-                    module = CompiledModule::deserialize(&bytes)
+                    module = CompiledModule::deserialize_with_defaults(&bytes)
                         .map_err(|e| anyhow!("Failure deserializing module: {:?}", e))?;
                     BinaryIndexedView::Module(&module)
                 } else {
@@ -393,7 +393,7 @@ impl OnDiskStateView {
     pub fn get_all_modules(&self) -> Result<Vec<CompiledModule>> {
         self.module_paths()
             .map(|path| {
-                CompiledModule::deserialize(&Self::get_bytes(&path)?.unwrap())
+                CompiledModule::deserialize_with_defaults(&Self::get_bytes(&path)?.unwrap())
                     .map_err(|e| anyhow!("Failed to deserialized module: {:?}", e))
             })
             .collect::<Result<Vec<CompiledModule>>>()

--- a/external-crates/move/tools/move-coverage/src/bin/coverage-summaries.rs
+++ b/external-crates/move/tools/move-coverage/src/bin/coverage-summaries.rs
@@ -55,14 +55,15 @@ fn get_modules(args: &Args) -> Vec<CompiledModule> {
     if let Some(stdlib_path) = &args.stdlib_path {
         let stdlib_modules = fs::read_dir(stdlib_path).unwrap().map(|file| {
             let bytes = fs::read(file.unwrap().path()).unwrap();
-            CompiledModule::deserialize(&bytes).expect("Module blob can't be deserialized")
+            CompiledModule::deserialize_with_defaults(&bytes)
+                .expect("Module blob can't be deserialized")
         });
         modules.extend(stdlib_modules);
     }
 
     if let Some(module_binary_path) = &args.module_binary_path {
         let bytecode_bytes = fs::read(module_binary_path).expect("Unable to read bytecode file");
-        let compiled_module = CompiledModule::deserialize(&bytecode_bytes)
+        let compiled_module = CompiledModule::deserialize_with_defaults(&bytecode_bytes)
             .expect("Module blob can't be deserialized");
         modules.push(compiled_module);
     }

--- a/external-crates/move/tools/move-coverage/src/bin/source-coverage.rs
+++ b/external-crates/move/tools/move-coverage/src/bin/source-coverage.rs
@@ -51,8 +51,8 @@ fn main() {
     };
 
     let bytecode_bytes = fs::read(&args.module_binary_path).expect("Unable to read bytecode file");
-    let compiled_module =
-        CompiledModule::deserialize(&bytecode_bytes).expect("Module blob can't be deserialized");
+    let compiled_module = CompiledModule::deserialize_with_defaults(&bytecode_bytes)
+        .expect("Module blob can't be deserialized");
 
     let source_map = source_map_from_file(
         &Path::new(&args.module_binary_path).with_extension(source_map_extension),

--- a/external-crates/move/tools/move-disassembler/src/main.rs
+++ b/external-crates/move/tools/move-disassembler/src/main.rs
@@ -95,7 +95,7 @@ fn main() {
             .expect("Script blob can't be deserialized");
         BinaryIndexedView::Script(&script)
     } else {
-        module = CompiledModule::deserialize(&bytecode_bytes)
+        module = CompiledModule::deserialize_with_defaults(&bytecode_bytes)
             .expect("Module blob can't be deserialized");
         BinaryIndexedView::Module(&module)
     };

--- a/external-crates/move/tools/move-package/src/compilation/compiled_package.rs
+++ b/external-crates/move/tools/move-package/src/compilation/compiled_package.rs
@@ -250,7 +250,7 @@ impl OnDiskCompiledPackage {
                 Ok(CompiledUnitWithSource { unit, source_path })
             }
             Err(_) => {
-                let module = CompiledModule::deserialize(&bytecode_bytes)?;
+                let module = CompiledModule::deserialize_with_defaults(&bytecode_bytes)?;
                 let (address_bytes, module_name) = {
                     let id = module.self_id();
                     let parsed_addr = NumericalAddress::new(

--- a/external-crates/move/tools/move-resource-viewer/src/resolver.rs
+++ b/external-crates/move/tools/move-resource-viewer/src/resolver.rs
@@ -43,13 +43,14 @@ impl<'a, T: MoveResolver + ?Sized> GetModule for Resolver<'a, T> {
             .get_module(module_id)
             .map_err(|e| anyhow!("Error retrieving module {:?}: {:?}", module_id, e))?
             .ok_or_else(|| anyhow!("Module {:?} can't be found", module_id))?;
-        let compiled_module = CompiledModule::deserialize(&blob).map_err(|status| {
-            anyhow!(
-                "Module {:?} deserialize with error code {:?}",
-                module_id,
-                status
-            )
-        })?;
+        let compiled_module =
+            CompiledModule::deserialize_with_defaults(&blob).map_err(|status| {
+                anyhow!(
+                    "Module {:?} deserialize with error code {:?}",
+                    module_id,
+                    status
+                )
+            })?;
         Ok(Some(self.cache.insert(module_id.clone(), compiled_module)))
     }
 }


### PR DESCRIPTION
## Description 

- Ban extraneous module bytes
- Ban metadata

## Test Plan 

- New tests 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
