### PR TITLE
[rocksdb] specify blob size threshold per column family

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -303,25 +303,25 @@ pub struct AuthorityEpochTables {
 fn signed_transactions_table_default_config() -> DBOptions {
     default_db_options()
         .optimize_for_write_throughput()
-        .optimize_for_large_values_no_scan()
+        .optimize_for_large_values_no_scan(1 << 10)
 }
 
 fn pending_execution_table_default_config() -> DBOptions {
     default_db_options()
         .optimize_for_write_throughput()
-        .optimize_for_large_values_no_scan()
+        .optimize_for_large_values_no_scan(1 << 10)
 }
 
 fn pending_consensus_transactions_table_default_config() -> DBOptions {
     default_db_options()
         .optimize_for_write_throughput()
-        .optimize_for_large_values_no_scan()
+        .optimize_for_large_values_no_scan(1 << 10)
 }
 
 fn pending_checkpoints_table_default_config() -> DBOptions {
     default_db_options()
         .optimize_for_write_throughput()
-        .optimize_for_large_values_no_scan()
+        .optimize_for_large_values_no_scan(1 << 10)
 }
 
 impl AuthorityEpochTables {

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -431,7 +431,7 @@ fn objects_table_default_config() -> DBOptions {
 fn transactions_table_default_config() -> DBOptions {
     default_db_options()
         .optimize_for_write_throughput()
-        .optimize_for_large_values_no_scan()
+        .optimize_for_large_values_no_scan(4 << 10)
         .optimize_for_point_lookup(
             read_size_from_env(ENV_VAR_TRANSACTIONS_BLOCK_CACHE_SIZE).unwrap_or(512),
         )
@@ -440,7 +440,7 @@ fn transactions_table_default_config() -> DBOptions {
 fn effects_table_default_config() -> DBOptions {
     default_db_options()
         .optimize_for_write_throughput()
-        .optimize_for_large_values_no_scan()
+        .optimize_for_large_values_no_scan(4 << 10)
         .optimize_for_point_lookup(
             read_size_from_env(ENV_VAR_EFFECTS_BLOCK_CACHE_SIZE).unwrap_or(1024),
         )
@@ -449,7 +449,7 @@ fn effects_table_default_config() -> DBOptions {
 fn events_table_default_config() -> DBOptions {
     default_db_options()
         .optimize_for_write_throughput()
-        .optimize_for_large_values_no_scan()
+        .optimize_for_large_values_no_scan(4 << 10)
         .optimize_for_read(read_size_from_env(ENV_VAR_EVENTS_BLOCK_CACHE_SIZE).unwrap_or(1024))
 }
 

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -1983,7 +1983,7 @@ impl DBOptions {
     // Optimize write and lookup perf for tables which are rarely scanned, and have large values.
     // https://rocksdb.org/blog/2021/05/26/integrated-blob-db.html
     // REQUIRED: table must set optimize_for_write_throughput() earlier.
-    pub fn optimize_for_large_values_no_scan(mut self) -> DBOptions {
+    pub fn optimize_for_large_values_no_scan(mut self, min_blob_size: u64) -> DBOptions {
         if env::var(ENV_VAR_DISABLE_BLOB_STORAGE).is_ok() {
             info!("Large value blob storage optimization is disabled via env var.");
             return self;
@@ -1995,8 +1995,8 @@ impl DBOptions {
             .set_blob_compression_type(rocksdb::DBCompressionType::Lz4);
         self.options.set_enable_blob_gc(true);
         // Since each blob can have non-trivial size overhead, and compression does not work across blobs,
-        // set a min blob size to so small transactions and effects are kept in sst files.
-        self.options.set_min_blob_size(4 * 1024); // 4KiB
+        // set a min blob size in bytes to so small transactions and effects are kept in sst files.
+        self.options.set_min_blob_size(min_blob_size);
 
         // Since large blobs are not in sst files, reduce the target file size and base level
         // target size.

--- a/narwhal/storage/src/node_store.rs
+++ b/narwhal/storage/src/node_store.rs
@@ -70,14 +70,14 @@ impl NodeStorage {
                 Self::HEADERS_CF,
                 default_db_options()
                     .optimize_for_write_throughput()
-                    .optimize_for_large_values_no_scan()
+                    .optimize_for_large_values_no_scan(1 << 10)
                     .options,
             ),
             (
                 Self::CERTIFICATES_CF,
                 default_db_options()
                     .optimize_for_write_throughput()
-                    .optimize_for_large_values_no_scan()
+                    .optimize_for_large_values_no_scan(1 << 10)
                     .options,
             ),
             (Self::CERTIFICATE_DIGEST_BY_ROUND_CF, cf_options.clone()),
@@ -87,7 +87,7 @@ impl NodeStorage {
                 Self::BATCHES_CF,
                 default_db_options()
                     .optimize_for_write_throughput()
-                    .optimize_for_large_values_no_scan()
+                    .optimize_for_large_values_no_scan(1 << 10)
                     .options,
             ),
             (Self::LAST_COMMITTED_CF, cf_options.clone()),


### PR DESCRIPTION
## Description 

Allow specifying different blob size threshold per column family. Column families in per-epoch databases have less issue with per-blob size overhead and can use a lower blob size threshold.

Also increase the write buffer size inside the `optimize_for_large_values_no_scan()` function, so the function does not require calling `optimize_for_write_throughput()` before. 

## Test Plan 

CI. Deployed to private testnet.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
