### PR TITLE
Refactor checkpoint contents download flow in state sync

### DIFF
--- a/crates/sui-config/src/p2p.rs
+++ b/crates/sui-config/src/p2p.rs
@@ -102,6 +102,14 @@ pub struct StateSyncConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub checkpoint_content_download_concurrency: Option<usize>,
 
+    /// Set the upper bound on the number of individual transactions contained in checkpoint
+    /// contents to be downloaded concurrently. If both this value and
+    /// `checkpoint_content_download_concurrency` are set, the lower of the two will apply.
+    ///
+    /// If unspecified, this will default to `50,000`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checkpoint_content_download_tx_concurrency: Option<u32>,
+
     /// Set the timeout that should be used when sending most state-sync RPC requests.
     ///
     /// If unspecified, this will default to `10,000` milliseconds.
@@ -178,6 +186,13 @@ impl StateSyncConfig {
 
         self.checkpoint_content_download_concurrency
             .unwrap_or(CHECKPOINT_CONTENT_DOWNLOAD_CONCURRENCY)
+    }
+
+    pub fn checkpoint_content_download_tx_concurrency(&self) -> u32 {
+        const CHECKPOINT_CONTENT_DOWNLOAD_TX_CONCURRENCY: u32 = 50_000;
+
+        self.checkpoint_content_download_tx_concurrency
+            .unwrap_or(CHECKPOINT_CONTENT_DOWNLOAD_TX_CONCURRENCY)
     }
 
     pub fn timeout(&self) -> Duration {

--- a/crates/sui-config/src/p2p.rs
+++ b/crates/sui-config/src/p2p.rs
@@ -108,7 +108,7 @@ pub struct StateSyncConfig {
     ///
     /// If unspecified, this will default to `50,000`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub checkpoint_content_download_tx_concurrency: Option<u32>,
+    pub checkpoint_content_download_tx_concurrency: Option<u64>,
 
     /// Set the timeout that should be used when sending most state-sync RPC requests.
     ///
@@ -188,8 +188,8 @@ impl StateSyncConfig {
             .unwrap_or(CHECKPOINT_CONTENT_DOWNLOAD_CONCURRENCY)
     }
 
-    pub fn checkpoint_content_download_tx_concurrency(&self) -> u32 {
-        const CHECKPOINT_CONTENT_DOWNLOAD_TX_CONCURRENCY: u32 = 50_000;
+    pub fn checkpoint_content_download_tx_concurrency(&self) -> u64 {
+        const CHECKPOINT_CONTENT_DOWNLOAD_TX_CONCURRENCY: u64 = 50_000;
 
         self.checkpoint_content_download_tx_concurrency
             .unwrap_or(CHECKPOINT_CONTENT_DOWNLOAD_TX_CONCURRENCY)


### PR DESCRIPTION
## Description 

- Adds tx concurrency limit to complement checkpoint count concurrency limit.
- Continuously starts new `GetCheckpointContents` requests up to the limit instead of doing this in chunked batches.

## Test Plan 

Unit tests