### PR TITLE
[ts-sdk] Fix makeMoveVec none type

### DIFF
--- a/.changeset/mean-bears-sniff.md
+++ b/.changeset/mean-bears-sniff.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Bugfix for makeMoveVec when not providing type arguments.

--- a/sdk/typescript/src/builder/Transactions.ts
+++ b/sdk/typescript/src/builder/Transactions.ts
@@ -21,7 +21,10 @@ import { ObjectId, normalizeSuiObjectId } from '../types/common';
 import { TRANSACTION_TYPE, WellKnownEncoding, create } from './utils';
 
 const option = <T extends Struct<any, any>>(some: T) =>
-  union([object({ None: literal(null) }), object({ Some: some })]);
+  union([
+    object({ None: union([literal(true), literal(null)]) }),
+    object({ Some: some }),
+  ]);
 
 export const TransactionBlockInput = object({
   kind: literal('Input'),


### PR DESCRIPTION
## Description 

Fixes an issue where `makeMoveVec` uses `None: true` instead of the expected `None: null`. Updated support for both in the superstruct defs.

## Test Plan 

Ran locally.
