### PR TITLE
[rpc] Fix get_coin_metadata for 0x2::sui::SUI

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -26,7 +26,7 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use sui_config::transaction_deny_config::TransactionDenyConfig;
 use sui_types::metrics::LimitsMetrics;
-use sui_types::TypeTag;
+use sui_types::{is_system_package, TypeTag};
 use tap::{TapFallible, TapOptional};
 use tokio::sync::mpsc::unbounded_channel;
 use tokio::sync::{oneshot, Semaphore};
@@ -2519,6 +2519,31 @@ impl AuthorityState {
                 Base58::encode(digest)
             )),
         }
+    }
+
+    pub fn find_publish_txn_digest(
+        &self,
+        package_id: ObjectID,
+    ) -> Result<TransactionDigest, anyhow::Error> {
+        if is_system_package(package_id) {
+            return Ok(self.find_genesis_txn_digest()?);
+        }
+        Ok(self
+            .get_object_read(&package_id)?
+            .into_object()?
+            .previous_transaction)
+    }
+
+    pub fn find_genesis_txn_digest(&self) -> Result<TransactionDigest, anyhow::Error> {
+        let summary = self
+            .get_verified_checkpoint_by_sequence_number(0)?
+            .into_message();
+        let content = self.get_checkpoint_contents(summary.content_digest)?;
+        let genesis_transaction = content.enumerate_transactions(&summary).next();
+        Ok(genesis_transaction
+            .ok_or(anyhow!("No transactions found in checkpoint content"))?
+            .1
+            .transaction)
     }
 
     pub fn get_verified_checkpoint_by_sequence_number(

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2526,7 +2526,7 @@ impl AuthorityState {
         package_id: ObjectID,
     ) -> Result<TransactionDigest, anyhow::Error> {
         if is_system_package(package_id) {
-            return Ok(self.find_genesis_txn_digest()?);
+            return self.find_genesis_txn_digest();
         }
         Ok(self
             .get_object_read(&package_id)?

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -96,10 +96,7 @@ impl CoinReadApi {
         let package_id = *package_id;
 
         spawn_monitored_task!(async move {
-            let publish_txn_digest = state
-                .get_object_read(&package_id)?
-                .into_object()?
-                .previous_transaction;
+            let publish_txn_digest = state.find_publish_txn_digest(package_id)?;
 
             let (_, effect) = state
                 .get_executed_transaction_and_effects(publish_txn_digest)

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -6,6 +6,8 @@ use std::sync::Arc;
 use anyhow::anyhow;
 
 use async_trait::async_trait;
+use cached::proc_macro::cached;
+use cached::SizedCache;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::RpcModule;
 use move_core_types::language_storage::{StructTag, TypeTag};
@@ -92,46 +94,58 @@ impl CoinReadApi {
         package_id: &ObjectID,
         object_struct_tag: StructTag,
     ) -> Result<Object, Error> {
-        let state = self.state.clone();
-        let package_id = *package_id;
+        let object_id =
+            find_package_object_id(self.state.clone(), *package_id, object_struct_tag).await?;
+        Ok(self.state.get_object_read(&object_id)?.into_object()?)
+    }
+}
 
-        spawn_monitored_task!(async move {
-            let publish_txn_digest = state.find_publish_txn_digest(package_id)?;
+#[cached(
+    type = "SizedCache<String, ObjectID>",
+    create = "{ SizedCache::with_size(10000) }",
+    convert = r#"{ format!("{}{}", package_id, object_struct_tag) }"#,
+    result = true
+)]
+async fn find_package_object_id(
+    state: Arc<AuthorityState>,
+    package_id: ObjectID,
+    object_struct_tag: StructTag,
+) -> Result<ObjectID, Error> {
+    spawn_monitored_task!(async move {
+        let publish_txn_digest = state.find_publish_txn_digest(package_id)?;
 
-            let (_, effect) = state
-                .get_executed_transaction_and_effects(publish_txn_digest)
-                .await?;
+        let (_, effect) = state
+            .get_executed_transaction_and_effects(publish_txn_digest)
+            .await?;
 
-            async fn find_object_with_type(
-                state: &Arc<AuthorityState>,
-                created: &[(ObjectRef, Owner)],
-                object_struct_tag: &StructTag,
-                package_id: &ObjectID,
-            ) -> Result<ObjectID, anyhow::Error> {
-                for ((id, version, _), _) in created {
-                    if let Ok(past_object) = state.get_past_object_read(id, *version) {
-                        if let Ok(object) = past_object.into_object() {
-                            if matches!(object.type_(), Some(type_) if type_.is(object_struct_tag))
-                            {
-                                return Ok(*id);
-                            }
+        async fn find_object_with_type(
+            state: &Arc<AuthorityState>,
+            created: &[(ObjectRef, Owner)],
+            object_struct_tag: &StructTag,
+            package_id: &ObjectID,
+        ) -> Result<ObjectID, anyhow::Error> {
+            for ((id, version, _), _) in created {
+                if let Ok(past_object) = state.get_past_object_read(id, *version) {
+                    if let Ok(object) = past_object.into_object() {
+                        if matches!(object.type_(), Some(type_) if type_.is(object_struct_tag)) {
+                            return Ok(*id);
                         }
                     }
                 }
-                Err(anyhow!(
-                    "Cannot find object [{}] from [{}] package event.",
-                    object_struct_tag,
-                    package_id
-                ))
             }
+            Err(anyhow!(
+                "Cannot find object [{}] from [{}] package event.",
+                object_struct_tag,
+                package_id
+            ))
+        }
 
-            let object_id =
-                find_object_with_type(&state, effect.created(), &object_struct_tag, &package_id)
-                    .await?;
-            Ok(state.get_object_read(&object_id)?.into_object()?)
-        })
-        .await?
-    }
+        let object_id =
+            find_object_with_type(&state, effect.created(), &object_struct_tag, &package_id)
+                .await?;
+        Ok(object_id)
+    })
+    .await?
 }
 
 impl SuiRpcModule for CoinReadApi {


### PR DESCRIPTION
## Description 

we assumed [previous_transaction](https://github.com/MystenLabs/sui/blob/main/crates/sui-json-rpc/src/coin_api.rs#L99-L102) is always the publish transaction for a package, but this assumption has been broken by the package upgrades. For system objects, the package ids can stay unchanged even though their content can be changed by `ChangeEpoch` transaction.

In this case, we can fetch the genesis transaction directly, which is the transaction that creates the coin metadata object for SUI

This PR also adds memoization for the `get_package_object_id` function

## Test Plan 

```
curl --location --request POST 'http://127.0.0.1:9000' \
--header 'Content-Type: application/json' \
--data-raw '{
    "jsonrpc":"2.0",
    "id":1,
    "method":"suix_getCoinMetadata",
    "params":["0x2::sui::SUI"]
}'
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
