### PR TITLE
Add certificate deny config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8937,6 +8937,7 @@ dependencies = [
  "move-package",
  "move-vm-runtime",
  "move-vm-types",
+ "once_cell",
  "serde 1.0.152",
  "sui-macros",
  "sui-move-natives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9923,6 +9923,7 @@ dependencies = [
  "move-package",
  "msim",
  "narwhal-network",
+ "sui-adapter",
  "sui-framework",
  "sui-move-build",
  "sui-types",

--- a/crates/sui-adapter/Cargo.toml
+++ b/crates/sui-adapter/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2021"
 anyhow = { version = "1.0.64", features = ["backtrace"] }
 bcs = "0.1.4"
 leb128 = "0.2.5"
+once_cell = "1.16"
 tracing = "0.1.36"
 serde = { version = "1.0.140", features = ["derive"] }
 

--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -73,14 +73,17 @@ use sui_types::{
 /// 5. Unfortunately, we can't remove the transaction digest from this list, because if we do so, any future
 /// node that sync from genesis will fork on this transaction. We may be able to remove it once
 /// we have stable snapshots and the binary has a minimum supported protocol version past the epoch.
-static DENIED_CERTIFICATES: Lazy<HashSet<TransactionDigest>> = Lazy::new(|| HashSet::from([]));
+pub fn get_denied_certificates() -> &'static HashSet<TransactionDigest> {
+    static DENIED_CERTIFICATES: Lazy<HashSet<TransactionDigest>> = Lazy::new(|| HashSet::from([]));
+    Lazy::force(&DENIED_CERTIFICATES)
+}
 
 fn is_certificate_denied(
     transaction_digest: &TransactionDigest,
     certificate_deny_set: &HashSet<TransactionDigest>,
 ) -> bool {
     certificate_deny_set.contains(transaction_digest)
-        || DENIED_CERTIFICATES.contains(transaction_digest)
+        || get_denied_certificates().contains(transaction_digest)
 }
 
 checked_arithmetic! {

--- a/crates/sui-adapter/src/execution_engine.rs
+++ b/crates/sui-adapter/src/execution_engine.rs
@@ -1,13 +1,16 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeSet, sync::Arc};
-
 use crate::execution_mode::{self, ExecutionMode};
 use move_binary_format::access::ModuleAccess;
 use move_binary_format::CompiledModule;
 use move_bytecode_utils::module_cache::GetModule;
 use move_vm_runtime::move_vm::MoveVM;
+use once_cell::sync::Lazy;
+use std::{
+    collections::{BTreeSet, HashSet},
+    sync::Arc,
+};
 use sui_types::balance::{
     BALANCE_CREATE_REWARDS_FUNCTION_NAME, BALANCE_DESTROY_REBATES_FUNCTION_NAME,
     BALANCE_MODULE_NAME,
@@ -53,6 +56,33 @@ use sui_types::{
     SUI_FRAMEWORK_OBJECT_ID, SUI_SYSTEM_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
 };
 
+/// If a transaction digest shows up in this list, when executing such transaction,
+/// we will always return `ExecutionError::CertificateDenied` without executing it (but still do
+/// gas smashing). Because this list is not gated by protocol version, there are a few important
+/// criteria for adding a digest to this list:
+/// 1. The certificate must be causing all validators to either panic or hang forever deterministically.
+/// 2. If we ever ship a fix to make it no longer panic or hang when executing such transaction,
+/// we must make sure the transaction is already in this list. Otherwise nodes running the newer version
+/// without these transactions in the list will generate forked result.
+/// Below is a scenario of when we need to use this list:
+/// 1. We detect that a specific transaction is causing all validators to either panic or hang forever deterministically.
+/// 2. We push a CertificateDenyConfig to deny such transaction to all validators asap.
+/// 3. To make sure that all fullnodes are able to sync to the latest version, we need to add the transaction digest
+/// to this list as well asap, and ship this binary to all fullnodes, so that they can sync past this transaction.
+/// 4. We then can start fixing the issue, and ship the fix to all nodes.
+/// 5. Unfortunately, we can't remove the transaction digest from this list, because if we do so, any future
+/// node that sync from genesis will fork on this transaction. We may be able to remove it once
+/// we have stable snapshots and the binary has a minimum supported protocol version past the epoch.
+static DENIED_CERTIFICATES: Lazy<HashSet<TransactionDigest>> = Lazy::new(|| HashSet::from([]));
+
+fn is_certificate_denied(
+    transaction_digest: &TransactionDigest,
+    certificate_deny_set: &HashSet<TransactionDigest>,
+) -> bool {
+    certificate_deny_set.contains(transaction_digest)
+        || DENIED_CERTIFICATES.contains(transaction_digest)
+}
+
 checked_arithmetic! {
 
 #[instrument(name = "tx_execute_to_effects", level = "debug", skip_all)]
@@ -72,7 +102,8 @@ pub fn execute_transaction_to_effects<
     epoch_data: &EpochData,
     protocol_config: &ProtocolConfig,
     metrics: Arc<LimitsMetrics>,
-    enable_expensive_checks: bool
+    enable_expensive_checks: bool,
+    certificate_deny_set: &HashSet<TransactionDigest>,
 ) -> (
     InnerTemporaryStore,
     TransactionEffects,
@@ -93,7 +124,8 @@ pub fn execute_transaction_to_effects<
         epoch_data.epoch_start_timestamp(),
         protocol_config,
         metrics,
-        enable_expensive_checks
+        enable_expensive_checks,
+        certificate_deny_set,
     )
 }
 
@@ -115,7 +147,8 @@ pub fn execute_transaction_to_effects_impl<
     epoch_timestamp_ms: u64,
     protocol_config: &ProtocolConfig,
     metrics: Arc<LimitsMetrics>,
-    enable_expensive_checks: bool
+    enable_expensive_checks: bool,
+    certificate_deny_set: &HashSet<TransactionDigest>,
 ) -> (
     InnerTemporaryStore,
     TransactionEffects,
@@ -125,6 +158,7 @@ pub fn execute_transaction_to_effects_impl<
 
     let is_epoch_change = matches!(transaction_kind, TransactionKind::ChangeEpoch(_));
 
+    let deny_cert = is_certificate_denied(&transaction_digest, certificate_deny_set);
     let (gas_cost_summary, execution_result) = execute_transaction::<Mode, _>(
         &mut temporary_store,
         transaction_kind,
@@ -134,7 +168,8 @@ pub fn execute_transaction_to_effects_impl<
         gas_status,
         protocol_config,
         metrics,
-        enable_expensive_checks
+        enable_expensive_checks,
+        deny_cert,
     );
 
     let status = if let Err(error) = &execution_result {
@@ -242,7 +277,8 @@ fn execute_transaction<
     mut gas_status: SuiGasStatus,
     protocol_config: &ProtocolConfig,
     metrics: Arc<LimitsMetrics>,
-    enable_expensive_checks: bool
+    enable_expensive_checks: bool,
+    deny_cert: bool,
 ) -> (
     GasCostSummary,
     Result<Mode::ExecutionResults, ExecutionError>,
@@ -266,16 +302,20 @@ fn execute_transaction<
     // we must still ensure an effect is committed and all objects versions incremented
     let result = charge_gas_for_object_read(temporary_store, &mut gas_status);
     let mut result = result.and_then(|()| {
-        let mut execution_result = execution_loop::<Mode, _>(
-            temporary_store,
-            transaction_kind,
-            gas_object_ref.0,
-            tx_ctx,
-            move_vm,
-            &mut gas_status,
-            protocol_config,
-            metrics.clone(),
-        );
+        let mut execution_result = if deny_cert {
+            Err(ExecutionError::new(ExecutionErrorKind::CertificateDenied, None))
+        } else {
+            execution_loop::<Mode, _>(
+                temporary_store,
+                transaction_kind,
+                gas_object_ref.0,
+                tx_ctx,
+                move_vm,
+                &mut gas_status,
+                protocol_config,
+                metrics.clone(),
+            )
+        };
 
         let effects_estimated_size = temporary_store.estimate_effects_size_upperbound();
 

--- a/crates/sui-config/src/builder.rs
+++ b/crates/sui-config/src/builder.rs
@@ -534,6 +534,7 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                     expensive_safety_check_config: Default::default(),
                     name_service_resolver_object_id: None,
                     transaction_deny_config: Default::default(),
+                    certificate_deny_config: Default::default(),
                 }
             })
             .collect();

--- a/crates/sui-config/src/certificate_deny_config.rs
+++ b/crates/sui-config/src/certificate_deny_config.rs
@@ -1,0 +1,62 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use once_cell::sync::OnceCell;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use sui_types::base_types::TransactionDigest;
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct CertificateDenyConfig {
+    /// A list of certificate digests that are known to be either deterministically crashing
+    /// every validator, or causing every validator to hang forever, i.e. there is no way
+    /// for such transaction to execute successfully today.
+    /// Now with this config, a validator will decide that this transaction will always yield
+    /// ExecutionError and charge gas accordingly.
+    /// This config is meant for a fast temporary fix for a known issue, and should be removed
+    /// once the issue is fixed. However, since a certificate once executed will be included
+    /// in checkpoints, all future executions of this transaction through replay must also lead
+    /// to the same result (i.e. ExecutionError). So when we remove this config, we need to make
+    /// sure it's added to the constant certificate deny list in the Rust code (TODO: code link).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    certificate_deny_list: Vec<TransactionDigest>,
+
+    /// In-memory cache for faster lookup of the certificate deny list.
+    #[serde(skip)]
+    certificate_deny_set: OnceCell<HashSet<TransactionDigest>>,
+}
+
+impl CertificateDenyConfig {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn certificate_deny_set(&self) -> &HashSet<TransactionDigest> {
+        self.certificate_deny_set.get_or_init(|| {
+            self.certificate_deny_list
+                .iter()
+                .cloned()
+                .collect::<HashSet<_>>()
+        })
+    }
+}
+
+#[derive(Default)]
+pub struct CertificateDenyConfigBuilder {
+    config: CertificateDenyConfig,
+}
+
+impl CertificateDenyConfigBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn build(self) -> CertificateDenyConfig {
+        self.config
+    }
+
+    pub fn add_certificate_deny(mut self, certificate: TransactionDigest) -> Self {
+        self.config.certificate_deny_list.push(certificate);
+        self
+    }
+}

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -12,7 +12,7 @@ use move_core_types::ident_str;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_with::serde_as;
 use shared_crypto::intent::{Intent, IntentMessage, IntentScope};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::convert::TryInto;
 use std::sync::Arc;
 use std::{fs, path::Path};
@@ -1393,6 +1393,7 @@ fn create_genesis_transaction(
                 protocol_config,
                 metrics,
                 false, // enable_expensive_checks
+                &HashSet::new(),
             );
         assert!(inner_temp_store.objects.is_empty());
         assert!(inner_temp_store.mutable_inputs.is_empty());
@@ -1482,7 +1483,6 @@ fn process_package(
     #[cfg(debug_assertions)]
     {
         use move_core_types::account_address::AccountAddress;
-        use std::collections::HashSet;
         let to_be_published_addresses: HashSet<_> = modules
             .iter()
             .map(|module| *module.self_id().address())
@@ -1965,6 +1965,7 @@ mod test {
                 &protocol_config,
                 metrics,
                 false, // enable_expensive_checks
+                &HashSet::new(),
             );
 
         assert_eq!(effects, genesis.effects);

--- a/crates/sui-config/src/lib.rs
+++ b/crates/sui-config/src/lib.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 use tracing::trace;
 
 pub mod builder;
+pub mod certificate_deny_config;
 pub mod genesis;
 pub mod genesis_config;
 pub mod node;

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::certificate_deny_config::CertificateDenyConfig;
 use crate::genesis;
 use crate::p2p::P2pConfig;
 use crate::transaction_deny_config::TransactionDenyConfig;
@@ -116,6 +117,9 @@ pub struct NodeConfig {
 
     #[serde(default)]
     pub transaction_deny_config: TransactionDenyConfig,
+
+    #[serde(default)]
+    pub certificate_deny_config: CertificateDenyConfig,
 }
 
 fn default_authority_store_pruning_config() -> AuthorityStorePruningConfig {

--- a/crates/sui-config/src/swarm.rs
+++ b/crates/sui-config/src/swarm.rs
@@ -290,6 +290,7 @@ impl<'a> FullnodeConfigBuilder<'a> {
             expensive_safety_check_config: validator_config.expensive_safety_check_config.clone(),
             name_service_resolver_object_id: None,
             transaction_deny_config: Default::default(),
+            certificate_deny_config: Default::default(),
         })
     }
 }

--- a/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -87,6 +87,7 @@ validator_configs:
       package_upgrade_disabled: false
       shared_object_disabled: false
       user_transaction_disabled: false
+    certificate-deny-config: {}
   - protocol-key-pair:
       value: avYcyVgYMXTyaUYh9IRwLK0gSzl7YF6ZQDAbrS1Bhvo=
     worker-key-pair:
@@ -171,6 +172,7 @@ validator_configs:
       package_upgrade_disabled: false
       shared_object_disabled: false
       user_transaction_disabled: false
+    certificate-deny-config: {}
   - protocol-key-pair:
       value: OXnx3yM1C/ppgnDMx/o1d49fJs7E05kq11mXNae/O+I=
     worker-key-pair:
@@ -255,6 +257,7 @@ validator_configs:
       package_upgrade_disabled: false
       shared_object_disabled: false
       user_transaction_disabled: false
+    certificate-deny-config: {}
   - protocol-key-pair:
       value: CyNkjqNVr3HrHTH7f/NLs7u5lUHJzuPAw0PqMTD2y2s=
     worker-key-pair:
@@ -339,6 +342,7 @@ validator_configs:
       package_upgrade_disabled: false
       shared_object_disabled: false
       user_transaction_disabled: false
+    certificate-deny-config: {}
   - protocol-key-pair:
       value: X/I/kM+KvHcxAKEf2UU6Sr7SpN3bhiE9nP5CuM/iIY0=
     worker-key-pair:
@@ -423,6 +427,7 @@ validator_configs:
       package_upgrade_disabled: false
       shared_object_disabled: false
       user_transaction_disabled: false
+    certificate-deny-config: {}
   - protocol-key-pair:
       value: N272EiFDyKtxRbDKbyN6ujenJ+skPcRoc/XolpOLGnU=
     worker-key-pair:
@@ -507,6 +512,7 @@ validator_configs:
       package_upgrade_disabled: false
       shared_object_disabled: false
       user_transaction_disabled: false
+    certificate-deny-config: {}
   - protocol-key-pair:
       value: a74f03IOjL8ZFSWFChFVEi+wiMwHNwNCPDGIYkGfgjs=
     worker-key-pair:
@@ -591,6 +597,7 @@ validator_configs:
       package_upgrade_disabled: false
       shared_object_disabled: false
       user_transaction_disabled: false
+    certificate-deny-config: {}
 account_keys:
   - Hloy4pnf8pWEHGP+4OFsXz56bLdIJhkD2O+OdKMqCA4=
   - pvMScjoMR/DaN0M5IOxS2VpGC59N6kv6gDm63ufLQ5w=

--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -13,6 +13,7 @@ use fastcrypto::traits::KeyPair;
 use prometheus::Registry;
 use std::path::PathBuf;
 use std::sync::Arc;
+use sui_config::certificate_deny_config::CertificateDenyConfig;
 use sui_config::genesis::Genesis;
 use sui_config::node::{
     AuthorityStorePruningConfig, DBCheckpointConfig, ExpensiveSafetyCheckConfig,
@@ -32,6 +33,7 @@ pub struct TestAuthorityBuilder<'a> {
     store_base_path: Option<PathBuf>,
     store: Option<Arc<AuthorityStore>>,
     transaction_deny_config: Option<TransactionDenyConfig>,
+    certificate_deny_config: Option<CertificateDenyConfig>,
     protocol_config: Option<ProtocolConfig>,
     reference_gas_price: Option<u64>,
     node_keypair: Option<&'a AuthorityKeyPair>,
@@ -55,6 +57,11 @@ impl<'a> TestAuthorityBuilder<'a> {
 
     pub fn with_transaction_deny_config(mut self, config: TransactionDenyConfig) -> Self {
         assert!(self.transaction_deny_config.replace(config).is_none());
+        self
+    }
+
+    pub fn with_certificate_deny_config(mut self, config: CertificateDenyConfig) -> Self {
+        assert!(self.certificate_deny_config.replace(config).is_none());
         self
     }
 
@@ -170,6 +177,7 @@ impl<'a> TestAuthorityBuilder<'a> {
                 .max_move_identifier_len_as_option(),
         )));
         let transaction_deny_config = self.transaction_deny_config.unwrap_or_default();
+        let certificate_deny_config = self.certificate_deny_config.unwrap_or_default();
         let state = AuthorityState::new(
             name,
             secret,
@@ -185,6 +193,7 @@ impl<'a> TestAuthorityBuilder<'a> {
             &DBCheckpointConfig::default(),
             ExpensiveSafetyCheckConfig::new_enable_all(),
             transaction_deny_config,
+            certificate_deny_config,
             usize::MAX,
         )
         .await;

--- a/crates/sui-core/src/unit_tests/transaction_deny_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_deny_tests.rs
@@ -9,16 +9,21 @@ use crate::authority::authority_test_utils::{
 };
 use crate::authority::test_authority_builder::TestAuthorityBuilder;
 use crate::authority::AuthorityState;
+use crate::test_utils::make_transfer_sui_transaction;
 use fastcrypto::ed25519::Ed25519KeyPair;
 use fastcrypto::traits::KeyPair;
 use move_core_types::ident_str;
+use sui_config::certificate_deny_config::CertificateDenyConfigBuilder;
 use sui_config::genesis_config::{AccountConfig, DEFAULT_GAS_AMOUNT};
 use sui_config::transaction_deny_config::{TransactionDenyConfig, TransactionDenyConfigBuilder};
 use sui_config::NetworkConfig;
 use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
 use sui_types::error::{SuiError, SuiResult, UserInputError};
+use sui_types::execution_status::{ExecutionFailureStatus, ExecutionStatus};
+use sui_types::messages::TransactionEffectsAPI;
 use sui_types::messages::{
-    CallArg, HandleTransactionResponse, TransactionData, TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+    CallArg, CertifiedTransaction, HandleTransactionResponse, TransactionData, VerifiedCertificate,
+    TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
 };
 use sui_types::utils::{
     to_sender_signed_transaction, to_sender_signed_transaction_with_multi_signers,
@@ -391,7 +396,49 @@ async fn test_package_denied() {
     )
     .await;
     assert!(result.is_ok());
+}
 
-    // TODO: We will need to upgrade c to c', and publish a new package b' that depends on c'.
-    // Then we could test that calling c' and b' would both succeed.
+#[tokio::test]
+async fn test_certificate_deny() {
+    let (network_config, state) = setup_test(TransactionDenyConfig::default()).await;
+    let (sender, key, gas_objects) = get_accounts_and_coins(&network_config, &state)
+        .pop()
+        .unwrap();
+    let tx = make_transfer_sui_transaction(
+        gas_objects[0],
+        sender,
+        None,
+        sender,
+        &key,
+        state.reference_gas_price_for_testing().unwrap(),
+    );
+    let digest = *tx.digest();
+    let state = TestAuthorityBuilder::new()
+        .with_network_config(&network_config)
+        .with_certificate_deny_config(
+            CertificateDenyConfigBuilder::new()
+                .add_certificate_deny(digest)
+                .build(),
+        )
+        .build()
+        .await;
+    let epoch_store = state.epoch_store_for_testing();
+    let signature = state
+        .handle_transaction(&epoch_store, tx.clone())
+        .await
+        .unwrap()
+        .status
+        .into_signed_for_testing();
+    let cert = VerifiedCertificate::new_unchecked(
+        CertifiedTransaction::new(tx.into_message(), vec![signature], epoch_store.committee())
+            .unwrap(),
+    );
+    let (effects, _) = state.try_execute_for_test(&cert).await.unwrap();
+    assert!(matches!(
+        effects.status(),
+        &ExecutionStatus::Failure {
+            error: ExecutionFailureStatus::CertificateDenied,
+            ..
+        }
+    ));
 }

--- a/crates/sui-core/src/unit_tests/transaction_deny_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_deny_tests.rs
@@ -18,9 +18,9 @@ use sui_config::genesis_config::{AccountConfig, DEFAULT_GAS_AMOUNT};
 use sui_config::transaction_deny_config::{TransactionDenyConfig, TransactionDenyConfigBuilder};
 use sui_config::NetworkConfig;
 use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
+use sui_types::effects::TransactionEffectsAPI;
 use sui_types::error::{SuiError, SuiResult, UserInputError};
 use sui_types::execution_status::{ExecutionFailureStatus, ExecutionStatus};
-use sui_types::messages::TransactionEffectsAPI;
 use sui_types::messages::{
     CallArg, CertifiedTransaction, HandleTransactionResponse, TransactionData, VerifiedCertificate,
     TEST_ONLY_GAS_UNIT_FOR_TRANSFER,

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -354,6 +354,8 @@ ExecutionFailureStatus:
         STRUCT:
           - current_size: U64
           - max_size: U64
+    29:
+      CertificateDenied: UNIT
 ExecutionStatus:
   ENUM:
     0:

--- a/crates/sui-framework/src/lib.rs
+++ b/crates/sui-framework/src/lib.rs
@@ -96,7 +96,7 @@ macro_rules! define_system_packages {
                 )),*
             ]
         });
-        &Lazy::force(&PACKAGES)
+        Lazy::force(&PACKAGES)
     }}
 }
 

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -344,6 +344,7 @@ impl SuiNode {
             &db_checkpoint_config,
             config.expensive_safety_check_config.clone(),
             config.transaction_deny_config.clone(),
+            config.certificate_deny_config.clone(),
             config.indirect_objects_threshold,
         )
         .await;

--- a/crates/sui-proc-macros/src/lib.rs
+++ b/crates/sui-proc-macros/src/lib.rs
@@ -37,6 +37,7 @@ pub fn init_static_initializers(_args: TokenStream, item: TokenStream) -> TokenS
             std::thread::spawn(|| {
                 use sui_protocol_config::ProtocolConfig;
                 ::sui_simulator::telemetry_subscribers::init_for_testing();
+                ::sui_simulator::sui_adapter::execution_engine::get_denied_certificates();
                 ::sui_simulator::sui_framework::BuiltInFramework::all_package_ids();
                 ::sui_simulator::sui_types::gas::SuiGasStatus::new_unmetered(
                     &ProtocolConfig::get_for_min_version(),

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -12,7 +12,7 @@ use move_core_types::language_storage::{ModuleId, StructTag};
 use move_core_types::parser::parse_struct_tag;
 use move_core_types::resolver::{ModuleResolver, ResourceResolver};
 use similar::{ChangeTag, TextDiff};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use sui_adapter::adapter;
@@ -505,6 +505,7 @@ impl LocalExec {
             protocol_config,
             metrics,
             true,
+            &HashSet::new(),
         );
 
         let SuiTransactionBlockEffects::V1(new_effects) = res.1.try_into().unwrap();
@@ -606,7 +607,7 @@ impl LocalExec {
         let (mut start_epoch, mut start_protocol_version, mut start_checkpoint) = (0, 1, 0u64);
 
         // Exception for incident: Protocol version 2 started epoch 742
-        // But this was in safe mode so no events emmitted
+        // But this was in safe mode so no events emitted
         // So we need to manually add this range
         let (mut curr_epoch, mut curr_protocol_version) = (742, 2);
         let mut curr_checkpoint = self
@@ -1355,7 +1356,7 @@ impl GetModule for LocalExec {
     }
 }
 
-// <--------------------- Util funcitons ----------------------->
+// <--------------------- Util functions ----------------------->
 
 pub fn get_vm(
     protocol_config: &ProtocolConfig,

--- a/crates/sui-simulator/Cargo.toml
+++ b/crates/sui-simulator/Cargo.toml
@@ -9,6 +9,8 @@ edition = "2021"
 [dependencies]
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 move-package.workspace = true
+
+sui-adapter = { path = "../sui-adapter" }
 sui-framework = { path = "../sui-framework" }
 sui-move-build = { path = "../sui-move-build" }
 sui-types = { path = "../sui-types" }

--- a/crates/sui-simulator/src/lib.rs
+++ b/crates/sui-simulator/src/lib.rs
@@ -11,6 +11,7 @@ pub use fastcrypto;
 pub use lru;
 pub use move_package;
 pub use narwhal_network;
+pub use sui_adapter;
 pub use sui_framework;
 pub use sui_move_build;
 pub use sui_types;

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -32,6 +32,7 @@ use move_transactional_test_runner::{
 use move_vm_runtime::{move_vm::MoveVM, session::SerializedReturnValues};
 use once_cell::sync::Lazy;
 use rand::{rngs::StdRng, Rng, SeedableRng};
+use std::collections::HashSet;
 use std::fmt::{self, Write};
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -1004,6 +1005,7 @@ impl<'a> SuiTestAdapter<'a> {
             &self.protocol_config,
             self.metrics.clone(),
             false, // enable_expensive_checks
+            &HashSet::new(),
         );
         let mut created_ids: Vec<_> = effects
             .created()

--- a/crates/sui-types/src/execution_status.rs
+++ b/crates/sui-types/src/execution_status.rs
@@ -169,6 +169,9 @@ pub enum ExecutionFailureStatus {
     Limit is {max_size} bytes"
     )]
     WrittenObjectsTooLarge { current_size: u64, max_size: u64 },
+
+    #[error("Certificate is on the deny list")]
+    CertificateDenied,
     // NOTE: if you want to add a new enum,
     // please add it at the end for Rust SDK backward compatibility.
 }


### PR DESCRIPTION
Add ability for validators to immediately execute a cert to execution error without actually executing it, based on either a config or a hardcoded list.