### PR TITLE
indexer stability: epoch commit fix

### DIFF
--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -245,7 +245,8 @@ where
             // Index checkpoint data
             let indexed_checkpoint_epoch_vec = join_all(downloaded_checkpoints.iter().map(
                 |downloaded_checkpoint| async {
-                    self.index_checkpoint(downloaded_checkpoint).await
+                    self.index_checkpoint(downloaded_checkpoint, /* index_epoch */ true)
+                        .await
                 },
             ))
             .await
@@ -259,8 +260,35 @@ where
                 );
                 e
             })?;
-            let (indexed_checkpoints, _indexed_epochs): (Vec<_>, Vec<_>) =
+            let (indexed_checkpoints, indexed_epochs): (Vec<_>, Vec<_>) =
                 indexed_checkpoint_epoch_vec.into_iter().unzip();
+            for epoch in indexed_epochs.into_iter().flatten() {
+                // for the first epoch, we need to store the epoch data first,
+                // otherwise send it to channel to be committed later.
+                if epoch.last_epoch.is_none() {
+                    let epoch_db_guard = self.metrics.epoch_db_commit_latency.start_timer();
+                    info!("Persisting first epoch...");
+                    let mut persist_first_epoch_res = self.state.persist_epoch(&epoch).await;
+                    while persist_first_epoch_res.is_err() {
+                        warn!("Failed to persist first epoch, retrying...");
+                        persist_first_epoch_res = self.state.persist_epoch(&epoch).await;
+                    }
+                    epoch_db_guard.stop_and_record();
+                    self.metrics.total_epoch_committed.inc();
+                    info!("Persisted first epoch");
+                } else {
+                    let epoch_sender_guard = self.epoch_sender.lock().await;
+                    // NOTE: when the channel is full, epoch_sender_guard will wait until the channel has space.
+                    epoch_sender_guard.send(epoch).await.map_err(|e| {
+                        error!(
+                            "Failed to send indexed epoch to epoch commit handler with error {}",
+                            e.to_string()
+                        );
+                        IndexerError::MpscChannelError(e.to_string())
+                    })?;
+                    drop(epoch_sender_guard);
+                }
+            }
 
             let object_sender_guard = self.object_checkpoint_sender.lock().await;
             // NOTE: when the channel is full, checkpoint_sender_guard will wait until the channel has space.
@@ -331,7 +359,8 @@ where
             let index_guard = self.metrics.checkpoint_index_latency.start_timer();
             let indexed_checkpoint_epoch_vec = join_all(downloaded_checkpoints.iter().map(
                 |downloaded_checkpoint| async {
-                    self.index_checkpoint(downloaded_checkpoint).await
+                    self.index_checkpoint(downloaded_checkpoint, /* index_epoch */ false)
+                        .await
                 },
             ))
             .await
@@ -345,7 +374,7 @@ where
                 );
                 e
             })?;
-            let (indexed_checkpoints, indexed_epochs): (Vec<_>, Vec<_>) =
+            let (indexed_checkpoints, _indexed_epochs): (Vec<_>, Vec<_>) =
                 indexed_checkpoint_epoch_vec.into_iter().unzip();
             index_guard.stop_and_record();
 
@@ -362,34 +391,6 @@ where
                 })?;
             }
             drop(checkpoint_sender_guard);
-
-            for epoch in indexed_epochs.into_iter().flatten() {
-                // for the first epoch, we need to store the epoch data first,
-                // otherwise send it to channel to be committed later.
-                if epoch.last_epoch.is_none() {
-                    let epoch_db_guard = self.metrics.epoch_db_commit_latency.start_timer();
-                    info!("Persisting first epoch...");
-                    let mut persist_first_epoch_res = self.state.persist_epoch(&epoch).await;
-                    while persist_first_epoch_res.is_err() {
-                        warn!("Failed to persist first epoch, retrying...");
-                        persist_first_epoch_res = self.state.persist_epoch(&epoch).await;
-                    }
-                    epoch_db_guard.stop_and_record();
-                    self.metrics.total_epoch_committed.inc();
-                    info!("Persisted first epoch");
-                } else {
-                    let epoch_sender_guard = self.epoch_sender.lock().await;
-                    // NOTE: when the channel is full, epoch_sender_guard will wait until the channel has space.
-                    epoch_sender_guard.send(epoch).await.map_err(|e| {
-                        error!(
-                            "Failed to send indexed epoch to epoch commit handler with error {}",
-                            e.to_string()
-                        );
-                        IndexerError::MpscChannelError(e.to_string())
-                    })?;
-                    drop(epoch_sender_guard);
-                }
-            }
 
             // NOTE(gegaowp): today ws processing actually will block next checkpoint download,
             // we can pipeline this as well in the future if needed
@@ -609,7 +610,7 @@ where
                 let mut object_changes_commit_res = self
                     .state
                     .persist_object_changes(
-                        checkpoint_seq,
+                        &checkpoint,
                         &tx_object_changes,
                         self.metrics.object_mutation_db_commit_latency.clone(),
                         self.metrics.object_deletion_db_commit_latency.clone(),
@@ -627,7 +628,7 @@ where
                     object_changes_commit_res = self
                         .state
                         .persist_object_changes(
-                            checkpoint_seq,
+                            &checkpoint,
                             &tx_object_changes,
                             self.metrics.object_mutation_db_commit_latency.clone(),
                             self.metrics.object_deletion_db_commit_latency.clone(),
@@ -778,6 +779,7 @@ where
     async fn index_checkpoint(
         &self,
         data: &CheckpointData,
+        index_epoch: bool,
     ) -> Result<(TemporaryCheckpointStore, Option<TemporaryEpochStore>), IndexerError> {
         let CheckpointData {
             checkpoint,
@@ -867,129 +869,139 @@ where
         //     })
         //     .collect();
 
-        // Index epoch
-        let epoch_index = if checkpoint.epoch == 0 && checkpoint.sequence_number == 0 {
-            // very first epoch
-            let system_state: SuiSystemStateSummary = self
-                .http_client
-                .get_latest_sui_system_state()
-                .await
-                .map_err(|e| {
-                    IndexerError::FullNodeReadingError(format!(
-                        "Failed to get latest system state with error {:?}",
-                        e
-                    ))
-                })?;
-            let validators = system_state
-                .active_validators
-                .iter()
-                .map(|v| (system_state.epoch, v.clone()).into())
-                .collect();
+        // NOTE: Index epoch when object checkpoint index has reached the same checkpoint,
+        // because epoch info is based on the latest system state object by the current checkpoint.
+        let mut epoch_index = None;
+        if index_epoch {
+            epoch_index = if checkpoint.epoch == 0 && checkpoint.sequence_number == 0 {
+                // very first epoch
+                // NOTE: tmp. using latest system state to save storage on indexer.
+                // let system_state = get_sui_system_state(data)?;
+                // let system_state: SuiSystemStateSummary = system_state.into_sui_system_state_summary();
+                let system_state: SuiSystemStateSummary = self
+                    .http_client
+                    .get_latest_sui_system_state()
+                    .await
+                    .map_err(|e| {
+                        IndexerError::FullNodeReadingError(format!(
+                            "Failed to get latest system state with error {:?}",
+                            e
+                        ))
+                    })?;
+                let validators = system_state
+                    .active_validators
+                    .iter()
+                    .map(|v| (system_state.epoch, v.clone()).into())
+                    .collect();
 
-            Some(TemporaryEpochStore {
-                last_epoch: None,
-                new_epoch: DBEpochInfo {
-                    epoch: 0,
-                    first_checkpoint_id: 0,
-                    epoch_start_timestamp: system_state.epoch_start_timestamp_ms as i64,
-                    ..Default::default()
-                },
-                system_state: system_state.into(),
-                validators,
-            })
-        } else if let Some(end_of_epoch_data) = &checkpoint.end_of_epoch_data {
-            // Find system state object
-            let system_state: SuiSystemStateSummary = self
-                .http_client
-                .get_latest_sui_system_state()
-                .await
-                .map_err(|e| {
-                    IndexerError::FullNodeReadingError(format!(
-                        "Failed to get latest system state with error {:?}",
-                        e
-                    ))
-                })?;
-
-            let epoch_event = transactions.iter().find_map(|tx| {
-                tx.events.data.iter().find(|ev| {
-                    ev.type_.address == SUI_SYSTEM_ADDRESS
-                        && ev.type_.module.as_ident_str() == ident_str!("sui_system_state_inner")
-                        && ev.type_.name.as_ident_str() == ident_str!("SystemEpochInfoEvent")
-                })
-            });
-
-            let event = epoch_event
-                .map(|e| bcs::from_bytes::<SystemEpochInfoEvent>(&e.bcs))
-                .transpose()?;
-
-            let validators = system_state
-                .active_validators
-                .iter()
-                .map(|v| (system_state.epoch, v.clone()).into())
-                .collect();
-
-            let epoch_commitments = end_of_epoch_data
-                .epoch_commitments
-                .iter()
-                .map(|c| match c {
-                    CheckpointCommitment::ECMHLiveObjectSetDigest(d) => {
-                        Some(d.digest.into_inner().to_vec())
-                    }
-                })
-                .collect();
-
-            let (next_epoch_committee, next_epoch_committee_stake) =
-                end_of_epoch_data.next_epoch_committee.iter().fold(
-                    (vec![], vec![]),
-                    |(mut names, mut stakes), (name, stake)| {
-                        names.push(Some(name.as_bytes().to_vec()));
-                        stakes.push(Some(*stake as i64));
-                        (names, stakes)
+                Some(TemporaryEpochStore {
+                    last_epoch: None,
+                    new_epoch: DBEpochInfo {
+                        epoch: 0,
+                        first_checkpoint_id: 0,
+                        epoch_start_timestamp: system_state.epoch_start_timestamp_ms as i64,
+                        ..Default::default()
                     },
-                );
+                    system_state: system_state.into(),
+                    validators,
+                })
+            } else if let Some(end_of_epoch_data) = &checkpoint.end_of_epoch_data {
+                // Find system state object
+                // NOTE: tmp. using latest system state to save storage on indexer.
+                // let system_state = get_sui_system_state(data)?;
+                // let system_state: SuiSystemStateSummary = system_state.into_sui_system_state_summary();
+                let system_state: SuiSystemStateSummary = self
+                    .http_client
+                    .get_latest_sui_system_state()
+                    .await
+                    .map_err(|e| {
+                        IndexerError::FullNodeReadingError(format!(
+                            "Failed to get latest system state with error {:?}",
+                            e
+                        ))
+                    })?;
 
-            let event = event.as_ref();
+                let epoch_event = transactions.iter().find_map(|tx| {
+                    tx.events.data.iter().find(|ev| {
+                        ev.type_.address == SUI_SYSTEM_ADDRESS
+                            && ev.type_.module.as_ident_str()
+                                == ident_str!("sui_system_state_inner")
+                            && ev.type_.name.as_ident_str() == ident_str!("SystemEpochInfoEvent")
+                    })
+                });
 
-            Some(TemporaryEpochStore {
-                last_epoch: Some(DBEpochInfo {
-                    epoch: system_state.epoch as i64 - 1,
-                    first_checkpoint_id: 0,
-                    last_checkpoint_id: Some(checkpoint.sequence_number as i64),
-                    epoch_start_timestamp: 0,
-                    epoch_end_timestamp: Some(checkpoint.timestamp_ms as i64),
-                    epoch_total_transactions: 0,
-                    next_epoch_version: Some(
-                        end_of_epoch_data.next_epoch_protocol_version.as_u64() as i64,
-                    ),
-                    next_epoch_committee,
-                    next_epoch_committee_stake,
-                    stake_subsidy_amount: event.map(|e| e.stake_subsidy_amount),
-                    reference_gas_price: event.map(|e| e.reference_gas_price),
-                    storage_fund_balance: event.map(|e| e.storage_fund_balance),
-                    total_gas_fees: event.map(|e| e.total_gas_fees),
-                    total_stake_rewards_distributed: event
-                        .map(|e| e.total_stake_rewards_distributed),
-                    total_stake: event.map(|e| e.total_stake),
-                    storage_fund_reinvestment: event.map(|e| e.storage_fund_reinvestment),
-                    storage_charge: event.map(|e| e.storage_charge),
-                    protocol_version: event.map(|e| e.protocol_version),
-                    storage_rebate: event.map(|e| e.storage_rebate),
-                    leftover_storage_fund_inflow: event.map(|e| e.leftover_storage_fund_inflow),
-                    epoch_commitments,
-                }),
-                new_epoch: DBEpochInfo {
-                    epoch: system_state.epoch as i64,
-                    first_checkpoint_id: checkpoint.sequence_number as i64 + 1,
-                    epoch_start_timestamp: system_state.epoch_start_timestamp_ms as i64,
-                    ..Default::default()
-                },
-                system_state: system_state.into(),
-                validators,
-            })
-        } else {
-            None
-        };
+                let event = epoch_event
+                    .map(|e| bcs::from_bytes::<SystemEpochInfoEvent>(&e.bcs))
+                    .transpose()?;
 
+                let validators = system_state
+                    .active_validators
+                    .iter()
+                    .map(|v| (system_state.epoch, v.clone()).into())
+                    .collect();
+
+                let epoch_commitments = end_of_epoch_data
+                    .epoch_commitments
+                    .iter()
+                    .map(|c| match c {
+                        CheckpointCommitment::ECMHLiveObjectSetDigest(d) => {
+                            Some(d.digest.into_inner().to_vec())
+                        }
+                    })
+                    .collect();
+
+                let (next_epoch_committee, next_epoch_committee_stake) =
+                    end_of_epoch_data.next_epoch_committee.iter().fold(
+                        (vec![], vec![]),
+                        |(mut names, mut stakes), (name, stake)| {
+                            names.push(Some(name.as_bytes().to_vec()));
+                            stakes.push(Some(*stake as i64));
+                            (names, stakes)
+                        },
+                    );
+
+                let event = event.as_ref();
+
+                Some(TemporaryEpochStore {
+                    last_epoch: Some(DBEpochInfo {
+                        epoch: system_state.epoch as i64 - 1,
+                        first_checkpoint_id: 0,
+                        last_checkpoint_id: Some(checkpoint.sequence_number as i64),
+                        epoch_start_timestamp: 0,
+                        epoch_end_timestamp: Some(checkpoint.timestamp_ms as i64),
+                        epoch_total_transactions: 0,
+                        next_epoch_version: Some(
+                            end_of_epoch_data.next_epoch_protocol_version.as_u64() as i64,
+                        ),
+                        next_epoch_committee,
+                        next_epoch_committee_stake,
+                        stake_subsidy_amount: event.map(|e| e.stake_subsidy_amount),
+                        reference_gas_price: event.map(|e| e.reference_gas_price),
+                        storage_fund_balance: event.map(|e| e.storage_fund_balance),
+                        total_gas_fees: event.map(|e| e.total_gas_fees),
+                        total_stake_rewards_distributed: event
+                            .map(|e| e.total_stake_rewards_distributed),
+                        total_stake: event.map(|e| e.total_stake),
+                        storage_fund_reinvestment: event.map(|e| e.storage_fund_reinvestment),
+                        storage_charge: event.map(|e| e.storage_charge),
+                        protocol_version: event.map(|e| e.protocol_version),
+                        storage_rebate: event.map(|e| e.storage_rebate),
+                        leftover_storage_fund_inflow: event.map(|e| e.leftover_storage_fund_inflow),
+                        epoch_commitments,
+                    }),
+                    new_epoch: DBEpochInfo {
+                        epoch: system_state.epoch as i64,
+                        first_checkpoint_id: checkpoint.sequence_number as i64 + 1,
+                        epoch_start_timestamp: system_state.epoch_start_timestamp_ms as i64,
+                        ..Default::default()
+                    },
+                    system_state: system_state.into(),
+                    validators,
+                })
+            } else {
+                None
+            };
+        }
         let total_transactions = db_transactions.iter().map(|t| t.transaction_count).sum();
 
         Ok((

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -201,7 +201,7 @@ pub trait IndexerStore {
     ) -> Result<usize, IndexerError>;
     async fn persist_object_changes(
         &self,
-        checkpoint_seq: i64,
+        checkpoint: &Checkpoint,
         tx_object_changes: &[TransactionObjectChanges],
         object_mutation_latency: Histogram,
         object_deletion_latency: Histogram,


### PR DESCRIPTION
## Description 

- move epoch commit from tx to obj commit
- move epoch tx count from checkpoint handling to obj

## Test Plan 

This has been used to backfill mainnnet data and worked well;
Also tested locally
