### PR TITLE
explorer: gas price card small improvements

### DIFF
--- a/apps/explorer/src/components/GasPriceCard/Graph.tsx
+++ b/apps/explorer/src/components/GasPriceCard/Graph.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AxisBottom } from '@visx/axis';
-import { curveLinear } from '@visx/curve';
+import { curveNatural } from '@visx/curve';
 import { localPoint } from '@visx/event';
 import { scaleTime, scaleLinear } from '@visx/scale';
 import { LinePath } from '@visx/shape';
@@ -35,8 +35,8 @@ export type GraphProps = {
 export function Graph({ data, width, height, onHoverElement }: GraphProps) {
     // remove not defined data (graph displays better and helps with hovering/selecting hovered element)
     const adjData = useMemo(() => data.filter(isDefined), [data]);
-    const graphTop = 5;
-    const graphButton = Math.max(height - 35, 0);
+    const graphTop = 15;
+    const graphButton = Math.max(height - 45, 0);
     const xScale = useMemo(
         () =>
             scaleTime<number>({
@@ -112,7 +112,7 @@ export function Graph({ data, width, height, onHoverElement }: GraphProps) {
                 transform={`translate(${tooltipX})`}
             />
             <LinePath<EpochGasInfo>
-                curve={curveLinear}
+                curve={curveNatural}
                 data={adjData}
                 x={(d) => xScale(d.date!.getTime())}
                 y={(d) => yScale(Number(d.referenceGasPrice!))}

--- a/apps/explorer/src/components/GasPriceCard/index.tsx
+++ b/apps/explorer/src/components/GasPriceCard/index.tsx
@@ -8,6 +8,7 @@ import {
     useGetReferenceGasPrice,
     useRpcClient,
 } from '@mysten/core';
+import { Info12 } from '@mysten/icons';
 import { SUI_DECIMALS } from '@mysten/sui.js';
 import { useQuery } from '@tanstack/react-query';
 import { ParentSize } from '@visx/responsive';
@@ -25,6 +26,7 @@ import { ListboxSelect } from '~/ui/ListboxSelect';
 import { LoadingSpinner } from '~/ui/LoadingSpinner';
 import { Stats } from '~/ui/Stats';
 import { Text } from '~/ui/Text';
+import { Tooltip } from '~/ui/Tooltip';
 
 const UNITS = ['MIST', 'SUI'] as const;
 type UnitsType = (typeof UNITS)[number];
@@ -147,13 +149,16 @@ export function GasPriceCard() {
         <Card spacing="lg" height="full">
             <div className="flex h-full flex-col gap-5">
                 <div className="flex gap-2.5">
-                    <div className="flex-grow">
+                    <div className="flex flex-grow flex-nowrap items-center gap-1 text-steel">
                         <Heading
                             variant="heading4/semibold"
                             color="steel-darker"
                         >
-                            Gas Price
+                            Reference Gas Price
                         </Heading>
+                        <Tooltip tip="Transaction sent at RGP will process promptly during regular network operations">
+                            <Info12 className="h-3.5 w-3.5" />
+                        </Tooltip>
                     </div>
                     <FilterList<UnitsType>
                         lessSpacing

--- a/apps/explorer/src/components/HomeMetrics/index.tsx
+++ b/apps/explorer/src/components/HomeMetrics/index.tsx
@@ -65,8 +65,8 @@ export function HomeMetrics() {
                             : '--'}
                     </StatsWrapper>
                     <StatsWrapper
-                        label="Gas Price"
-                        tooltip="Current gas price"
+                        label="Reference Gas Price"
+                        tooltip="Transaction sent at RGP will process promptly during regular network operations"
                         postfix="MIST"
                     >
                         {gasData ? gasData.toLocaleString() : null}


### PR DESCRIPTION
* rename to Reference Gas Price
* add tooltip
* make graph line more rounded
* also change gas price to Reference Gas Price in home metrics and update tooltip

https://user-images.githubusercontent.com/10210143/235228869-bfa89a14-6b44-4f22-8424-8d5adff6d6e5.mov

<img width="718" alt="Screenshot 2023-04-28 at 21 49 28" src="https://user-images.githubusercontent.com/10210143/235229455-79187494-8faa-4a75-b65c-bf4c72b0b3d9.png">
