### PR TITLE
do not fail the request if objects are pruned for object and balance change

### DIFF
--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -702,9 +702,15 @@ impl ReadApiServer for ReadApi {
                         input_objects,
                         None,
                     )
-                    .await
-                    .map_err(Error::SuiError)?;
-                    temp_response.balance_changes = Some(balance_changes);
+                    .await;
+
+                    if let Ok(balance_changes) = balance_changes {
+                        temp_response.balance_changes = Some(balance_changes);
+                    } else {
+                        temp_response
+                            .errors
+                            .push(balance_changes.unwrap_err().to_string());
+                    }
                 }
             }
 
@@ -720,9 +726,15 @@ impl ReadApiServer for ReadApi {
                         effects.all_changed_objects(),
                         effects.all_deleted(),
                     )
-                    .await
-                    .map_err(Error::SuiError)?;
-                    temp_response.object_changes = Some(object_changes);
+                    .await;
+
+                    if let Ok(object_changes) = object_changes {
+                        temp_response.object_changes = Some(object_changes);
+                    } else {
+                        temp_response
+                            .errors
+                            .push(object_changes.unwrap_err().to_string());
+                    }
                 }
             }
             let epoch_store = self.state.load_epoch_store_one_call_per_task();

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -707,9 +707,10 @@ impl ReadApiServer for ReadApi {
                     if let Ok(balance_changes) = balance_changes {
                         temp_response.balance_changes = Some(balance_changes);
                     } else {
-                        temp_response
-                            .errors
-                            .push(balance_changes.unwrap_err().to_string());
+                        temp_response.errors.push(format!(
+                            "Cannot retrieve balance changes: {}",
+                            balance_changes.unwrap_err()
+                        ));
                     }
                 }
             }
@@ -731,9 +732,10 @@ impl ReadApiServer for ReadApi {
                     if let Ok(object_changes) = object_changes {
                         temp_response.object_changes = Some(object_changes);
                     } else {
-                        temp_response
-                            .errors
-                            .push(object_changes.unwrap_err().to_string());
+                        temp_response.errors.push(format!(
+                            "Cannot retrieve object changes: {}",
+                            object_changes.unwrap_err()
+                        ));
                     }
                 }
             }


### PR DESCRIPTION
## Description 

as titled.

Tested on testnet:

request
```
{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "sui_getTransactionBlock",
  "params": ["Cgww1sn7XViCPSdDcAPmVcARueWuexJ8af8zD842Ff43", {"showBalanceChanges": true, "showObjectChanges":true}]
}
```

response:
```
{
    "jsonrpc": "2.0",
    "result": {
        "digest": "Cgww1sn7XViCPSdDcAPmVcARueWuexJ8af8zD842Ff43",
        "timestampMs": "1679936400000",
        "checkpoint": "0",
        "errors": [
            "Cannot retrieve balance changes: Error checking transaction input objects: ObjectNotFound { object_id: 0x0000000000000000000000000000000000000000000000000000000000000002, version: Some(SequenceNumber(1)) }",
            "Cannot retrieve object changes: Error checking transaction input objects: ObjectNotFound { object_id: 0x0000000000000000000000000000000000000000000000000000000000000002, version: Some(SequenceNumber(1)) }"
        ]
    },
    "id": 1
}
```

