### PR TITLE
[doc] add Sui dev cheat sheet

### DIFF
--- a/doc/src/build/cli-client.md
+++ b/doc/src/build/cli-client.md
@@ -32,7 +32,6 @@ The Sui Client CLI supports the following commands:
 | `pay_all_sui` | Pay all residual SUI coins to the recipient with input coins, after deducting the gas cost. The input coins also include the coin for gas payment, so no extra gas coin is required. |
 | `pay_sui` | Pay SUI coins to recipients following specified amounts, with input coins. Length of recipients must be the same as that of amounts. The input coins also include the coin for gas payment, so no extra gas coin is required. |
 | `publish` | Publish Move modules. |
-| `serialize-transfer-sui` | Serialize a transfer that can be signed. This is useful when user prefers to take the data to sign elsewhere. |
 | `split-coin` | Split a coin object into multiple coins. |
 | `switch` | Switch active address and network (e.g., devnet, local RPC server). |
 | `transfer` | Transfer object. |
@@ -135,8 +134,8 @@ All commands use the active address if you don't specify an `address`.
 
 All Sui transactions require a gas object for gas fees. If you don't specify a gas object, Sui uses a gas object with sufficient SUI to cover the gas fee.
 
-You can't use the same gas object as part of a transaction and to pay for the same transaction. 
-To see how much gas is in an account, use the `gas` command. 
+You can't use the same gas object as part of a transaction and to pay for the same transaction.
+To see how much gas is in an account, use the `gas` command.
 
 ```shell
 sui client gas
@@ -184,13 +183,13 @@ sui client objects
 The response resembles the following:
 
 ```
-                 Object ID                  |  Version   |                    Digest                    |   Owner Type    |               Object Type               
+                 Object ID                  |  Version   |                    Digest                    |   Owner Type    |               Object Type
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------
- 0x1aa482ad8c6240cda3097a4aa13ad5bfb27bf6052133c01f79c8b4ea0aaa0601 |     1      | OpU8HmueEaLzK6hkNSQkcahG8qo73ag4vJPG+g8EQBs= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>     
- 0x3fd0e889ee56152cdbd5fa5b5dab78ddc66d127930f5173ae7b5a9ac3e17dd6d |     1      | lRamSZkLHnfN9mcrkoVzmXwHxE7GnFHNnqe8dzWEUA8= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>     
- 0x51ec7820e82035a5de7b4f3ba2a3813ea099dca1867876f4177a1fa1d1efe022 |     1      | 1NO7XtdmojnOch4gcCsUHDdV1n2bPYv5je83yXd5Suw= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>     
- 0x727b37454ab13d5c1dbb22e8741bff72b145d1e660f71b275c01f24e7860e5e5 |     1      | 9C1lxL45JIxwX35rL69OtAFUf3kz39Dq6jiguVvpCeM= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>     
- 0xe638c76768804cebc0ab43e103999886641b0269a46783f2b454e2f8880b5255 |     1      | idJrGmd6ZkzJVQeKtu8XlUt2dA397GURgCUXJOLQhxI= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>     
+ 0x1aa482ad8c6240cda3097a4aa13ad5bfb27bf6052133c01f79c8b4ea0aaa0601 |     1      | OpU8HmueEaLzK6hkNSQkcahG8qo73ag4vJPG+g8EQBs= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>
+ 0x3fd0e889ee56152cdbd5fa5b5dab78ddc66d127930f5173ae7b5a9ac3e17dd6d |     1      | lRamSZkLHnfN9mcrkoVzmXwHxE7GnFHNnqe8dzWEUA8= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>
+ 0x51ec7820e82035a5de7b4f3ba2a3813ea099dca1867876f4177a1fa1d1efe022 |     1      | 1NO7XtdmojnOch4gcCsUHDdV1n2bPYv5je83yXd5Suw= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>
+ 0x727b37454ab13d5c1dbb22e8741bff72b145d1e660f71b275c01f24e7860e5e5 |     1      | 9C1lxL45JIxwX35rL69OtAFUf3kz39Dq6jiguVvpCeM= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>
+ 0xe638c76768804cebc0ab43e103999886641b0269a46783f2b454e2f8880b5255 |     1      | idJrGmd6ZkzJVQeKtu8XlUt2dA397GURgCUXJOLQhxI= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>
 Showing 5 results.
 ```
 
@@ -260,7 +259,7 @@ You can transfer mutable objects you own to another address using the command be
 sui client transfer [OPTIONS] --to <TO> --object-id <OBJECT_ID> --gas-budget <GAS_BUDGET>
 
 OPTIONS:
-        --object-id <OBJECT_ID> 
+        --object-id <OBJECT_ID>
             Object to transfer, in 32 bytes Hex string
 
         --gas <GAS>
@@ -441,7 +440,7 @@ To include multiple object IDs, enclose the IDs in double quotes. For example,
 
 ## Publish packages
 
-You must publish packages to the Sui [distributed ledger](../learn/how-sui-works.md#architecture) for the code you developed to be available in Sui. To publish packages with the Sui client, use the `publish` command. 
+You must publish packages to the Sui [distributed ledger](../learn/how-sui-works.md#architecture) for the code you developed to be available in Sui. To publish packages with the Sui client, use the `publish` command.
 
 Refer to the [Move developer documentation](move/index.md) for a
 description on how to [write a simple Move code package](move/write-package.md),
@@ -464,7 +463,7 @@ sui client publish $PATH_TO_PACKAGE/my_move_package --gas 0x33e3e1d64f76b71a80ec
 The publish command accepts the path to your package as an optional positional parameter (`$PATH_TO_PACKAGE/my_move_package` in the previous call). If you do not supply the path, the command uses the current working directory as the default path value. The call also provides the following data:
 
  * `--gas` - The Coin object used to pay for gas.
- * `--gas-budget` - Gas budget for running module initializers. 
+ * `--gas-budget` - Gas budget for running module initializers.
 
 When you publish a package, the CLI verifies that the bytecode for dependencies found at their respective published addresses matches the bytecode you get when compiling that dependency from source code. If the bytecode for a dependency does not match, your package does not publish and you receive an error message indicating which package and module the mismatch was found in:
 
@@ -526,7 +525,7 @@ publishing was updated as well.
 
 ## Verify source
 
-Supply a package path to `verify-source` (or run from package root) to have the CLI compile the package and check that all its modules match their on-chain counterparts. 
+Supply a package path to `verify-source` (or run from package root) to have the CLI compile the package and check that all its modules match their on-chain counterparts.
 
 `sui client verify-source ./code/MyPackage`
 
@@ -534,7 +533,7 @@ The default behavior is for the command to verify only the direct source of the 
 
 Running `sui client verify-source --skip-source --verify-deps` does not publish the package, but performs the same dependency verification as `sui client publish`. You could use this command to check dependency verification before attempting to publish, as described in the [previous section](#publish-packages).
 
-The `sui client verify-source` command expects package on-chain addresses to be set in the package manifest. There should not be any unspecified or `0x0` addresses in the package. If you want to verify a seemingly unpublished package against an on-chain address, use the `--address-override` flag to supply the on-chain address to verify against. This flag only supports packages that are truly unpublished, with all modules at address `0x0`. You receive an error if you attempt to use this flag on a published (or somehow partially published) package. 
+The `sui client verify-source` command expects package on-chain addresses to be set in the package manifest. There should not be any unspecified or `0x0` addresses in the package. If you want to verify a seemingly unpublished package against an on-chain address, use the `--address-override` flag to supply the on-chain address to verify against. This flag only supports packages that are truly unpublished, with all modules at address `0x0`. You receive an error if you attempt to use this flag on a published (or somehow partially published) package.
 
 If successful, the command returns a `0` exit code and prints `Source verification succeeded!` to the console. If it fails, it returns a non-zero exit code and prints an error message to the console.
 

--- a/doc/src/build/dev_cheat_sheet.md
+++ b/doc/src/build/dev_cheat_sheet.md
@@ -1,0 +1,43 @@
+# title: Sui Dev Cheat Sheet
+
+Quick reference on best practices for Sui Network developers.
+
+# Move
+
+### General
+
+- Read about [package upgrades](https://docs.sui.io/build/package-upgrades) and write upgrade-friendly code:
+    - Packages are immutable, so buggy package code can be called forever. Add protections at the object level instead.
+    - If you upgrade a package `P` to `P'`, other packages and clients that depend on `P` will continue using `P`, not auto-update to `P'`. Both dependent packages and client code must be explicitly updated to point at `P'`.
+    - `public` functions cannot be deleted or changed, but `public(friend)` functions can. Use `public(friend)` or private visibility liberally unless you are exposing library functions that will live forever.
+    - It is not possible to delete`struct` types, add new fields (though you can add [dynamic fields](https://docs.sui.io/devnet/build/programming-with-objects/ch5-dynamic-fields)), or add new [abilities](https://move-language.github.io/move/abilities.html) via an upgrade. Introduce new types liberally—they will live forever!
+- Use `vector`-backed collections (`vector`, `VecSet`, `VecMap`, `PriorityQueue`) with a **known** maximum size of ≤= 1000 items.
+    - Use dynamic field-backed collections (`Table`, `Bag`, `ObjectBag`, `ObjectTable`, `LinkedTable`) for larger collections, collections that contain an unbounded number of items, or any collection that allows third-party addition.
+    - Sui Move objects have a maximum size of 250KB—any attempt to create a larger object will lead to an aborted transaction. Ensure that your objects do not have an ever-growing `vector`-backed collection.
+    -
+- If your function `f` needs a payment in (e.g.) SUI from the caller, use `fun f(payment: Coin<SUI>)` not `fun f(payment: &mut Coin<SUI>, amount: u64)`. This is safer for callers—they know exactly how much they are paying, and do not need to trust `f` to extract the right amount.
+- Don’t micro-optimize gas usage. Sui computation costs are rounded up to the closest *[bucket](https://docs.sui.io/devnet/learn/tokenomics/gas-in-sui#gas-units)*, so only very drastic changes will make a difference. In particular, if your transaction is already in the lowest cost bucket, it can’t get any cheaper.
+- Follow the [Move coding conventions](https://move-language.github.io/move/coding-conventions.html) for consistent style.
+
+### Composability
+
+- Use the [`display`](https://docs.sui.io/build/sui-object-display) standard to customize how your objects show up in wallets, apps, and explorers
+- Avoid “self-transfers”—whenever possible, instead of writing `transfer::transfer(obj, tx_context::sender(ctx))`, return `obj` from the current function. This allows a caller or [programmable transaction block](https://docs.sui.io/build/prog-trans-ts-sdk) to use `obj`.
+
+### Testing
+
+- Use [`sui::test_scenario`](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/packages/sui-framework/sources/test/test_scenario.move)` to mimic multi-transaction, multi-sender test scenarios
+- Use the [`sui::test_utils`](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/packages/sui-framework/sources/test/test_utils.move#L5)` module for better test error messages via `assert_eq`, debug printing via `print`, and test-only destruction via `destroy`.
+- Use `sui move test --coverage` to compute code coverage information for your tests, and `sui move coverage source --module <name>` to see uncovered lines highlighted in red. Push coverage all the way to 100% if feasible.
+
+# Apps
+
+- Apps should use the wallet's [`signTransactionBlock`](https://sui-wallet-kit.vercel.app/) API, then submit the transaction via a call to [`execute_transactionBlock`](https://docs.sui.io/sui-jsonrpc#sui_executeTransactionBlock) on the app's full node, *not* use the wallet's `signAndExecuteTransactionBlock` API. This ensures read-after-write-consistency--reads from the app's full node will reflect writes from the transaction right away instead of waiting for a checkpoint.
+- Whenever possible, use [programmable transaction blocks](https://www.notion.so/Programmable-Transactions-4264a0fb3034416bba5f8b6dec288b19) to compose existing on-chain functionality rather than publishing new smart contract code.
+- Apps should leave gas budget, gas price, and coin selection to the wallet. This gives wallets more flexibility, and it’s the wallet’s responsibility to dry run a transaction to ensure it doesn't fail.
+
+# Signing
+
+- **Never** sign two concurrent transactions that are touching the same owned object. Either use independent owned objects, or wait for one transaction to conclude before sending the next one. Violating this rule might lead to client [equivocation](https://docs.sui.io/learn/sui-glossary#equivocation), which locks up the owned objects involved in the two transactions until the end of the current epoch.
+- Any `sui client` command that crafts a transaction (e.g., `sui client publish`, `sui client call`) can accept the `--serialize-output` flag to output a base64 transaction to be signed.
+    - Sui supports several [signature schemes](https://docs.sui.io/devnet/learn/cryptography/sui-offline-signing) for transaction signing, including native [multisig](https://docs.sui.io/devnet/learn/cryptography/sui-multisig).

--- a/doc/src/learn/cryptography/sui-offline-signing.md
+++ b/doc/src/learn/cryptography/sui-offline-signing.md
@@ -14,10 +14,12 @@ You must serialize transaction data following [Binary Canonical Serialization](h
 
 The following example demonstrates how to serialize data for a transfer using the Sui CLI. This returns serialized transaction data in Base64. Submit the raw transaction to execute as `tx_bytes`.
 ```shell
-$SUI_BINARY client serialize-transfer-sui --to $ADDRESS --sui-coin-object-id $OBJECT_ID --gas-budget 1000
+$SUI_BINARY client transfer-sui --to $ADDRESS --sui-coin-object-id $OBJECT_ID --gas-budget 1000 --serialize-output
 
 Raw tx_bytes to execute: $TX_BYTES
 ```
+
+**Note:** All other CLI commands that craft a transaction (e.g., `sui client publish`, `sui client call`) also accept the `--serialize-output` flag and you can use them in the same way.
 
 ## Sign the serialized data
 
@@ -41,7 +43,7 @@ To verify a signature against the cryptography library backing Sui when debuggin
 
 ## Execute the signed transaction
 
-After you obtain the serialized signature, you can submit it using the execution transaction command. This command takes `--tx-bytes` as the raw transaction bytes to execute (see output of `$SUI_BINARY client serialize-transfer-sui`) and the serialized signature (Base64 encoded `flag || sig || pk`, see output of `$SUI_BINARY keytool sign`). This executes the signed transaction and returns the certificate and transaction effects if successful.
+After you obtain the serialized signature, you can submit it using the execution transaction command. This command takes `--tx-bytes` as the raw transaction bytes to execute (see output of the `$SUI_BINARY client transfer` command above) and the serialized signature (Base64 encoded `flag || sig || pk`, see output of `$SUI_BINARY keytool sign`). This executes the signed transaction and returns the certificate and transaction effects if successful.
 
 ```shell
 $SUI_BINARY client execute-signed-tx --tx-bytes $TX_BYTES --signatures $SERIALIZED_SIG

--- a/doc/src/navconfig.json
+++ b/doc/src/navconfig.json
@@ -276,6 +276,10 @@
 						"fileName": "build/event_api"
 					}
 				]
+			},
+			{
+				"label": "Developer Cheat Sheet",
+				"filename": "build/dev_cheat_sheet.md"
 			}
 		],
 			"reference": [{


### PR DESCRIPTION
## Description 

A list of useful tips for Sui devs, with links into appropriate parts of the docs.

I also fixed a few outdated docs that mention the now-deleted `serialize-transfer-sui` CLI command after linking to one of them + noticing.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
