### PR TITLE
Revert "[execution_driver] Avoid dispatching thread when permit is available immediately (#11269)"

### DIFF
--- a/crates/sui-core/src/execution_driver.rs
+++ b/crates/sui-core/src/execution_driver.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use parking_lot::RwLock;
 use std::{
     sync::{Arc, Weak},
     time::Duration,
@@ -9,15 +8,13 @@ use std::{
 
 use mysten_metrics::{monitored_scope, spawn_monitored_task};
 use sui_types::{digests::TransactionEffectsDigest, messages::VerifiedExecutableTransaction};
-use tokio::sync::mpsc::UnboundedSender;
-use tokio::sync::OwnedSemaphorePermit;
 use tokio::{
     sync::{mpsc::UnboundedReceiver, oneshot, Semaphore},
     time::sleep,
 };
 use tracing::{error, error_span, info, trace, Instrument};
 
-use crate::authority::{AuthorityMetrics, AuthorityState};
+use crate::authority::AuthorityState;
 
 #[cfg(test)]
 #[path = "unit_tests/execution_driver_tests.rs"]
@@ -28,16 +25,6 @@ mod execution_driver_tests;
 pub const EXECUTION_MAX_ATTEMPTS: u32 = 10;
 const EXECUTION_FAILURE_RETRY_INTERVAL: Duration = Duration::from_secs(1);
 
-pub struct ExecutionDispatcher {
-    limit: Arc<Semaphore>,
-    tx_ready_certificates: UnboundedSender<(
-        VerifiedExecutableTransaction,
-        Option<TransactionEffectsDigest>,
-    )>,
-    authority: RwLock<Option<Weak<AuthorityState>>>,
-    metrics: Arc<AuthorityMetrics>,
-}
-
 /// When a notification that a new pending transaction is received we activate
 /// processing the transaction in a loop.
 pub async fn execution_process(
@@ -47,9 +34,11 @@ pub async fn execution_process(
         Option<TransactionEffectsDigest>,
     )>,
     mut rx_execution_shutdown: oneshot::Receiver<()>,
-    limit: Arc<Semaphore>,
 ) {
     info!("Starting pending certificates execution process.");
+
+    // Rate limit concurrent executions to # of cpus.
+    let limit = Arc::new(Semaphore::new(num_cpus::get()));
 
     // Loop whenever there is a signal that a new transactions is ready to process.
     loop {
@@ -83,118 +72,46 @@ pub async fn execution_process(
         };
         authority.metrics.execution_driver_dispatch_queue.dec();
 
+        // TODO: Ideally execution_driver should own a copy of epoch store and recreate each epoch.
+        let epoch_store = authority.load_epoch_store_one_call_per_task();
+
         let digest = *certificate.digest();
         trace!(?digest, "Pending certificate execution activated.");
 
         let limit = limit.clone();
         // hold semaphore permit until task completes. unwrap ok because we never close
         // the semaphore in this context.
-        let permit = {
-            let _scope = monitored_scope("ExecutionDriver::acquire_semaphore");
-            limit.acquire_owned().await.unwrap()
-        };
+        let permit = limit.acquire_owned().await.unwrap();
+
         // Certificate execution can take significant time, so run it in a separate task.
-        spawn_monitored_task!(execution_task(
-            permit,
-            authority,
-            certificate,
-            expected_effects_digest
-        )
-        .instrument(error_span!("execution_driver", tx_digest = ?digest)));
-    }
-}
-
-async fn execution_task(
-    _permit: OwnedSemaphorePermit,
-    authority: Arc<AuthorityState>,
-    certificate: VerifiedExecutableTransaction,
-    expected_effects_digest: Option<TransactionEffectsDigest>,
-) {
-    let digest = *certificate.digest();
-    // TODO: Ideally execution_driver should own a copy of epoch store and recreate each epoch.
-    let epoch_store = authority.load_epoch_store_one_call_per_task();
-    let _scope = monitored_scope("ExecutionDriver::task");
-    if let Ok(true) = authority.is_tx_already_executed(&digest) {
-        return;
-    }
-    let mut attempts = 0;
-    loop {
-        attempts += 1;
-        let res = authority
-            .try_execute_immediately(&certificate, expected_effects_digest, &epoch_store)
-            .await;
-        if let Err(e) = res {
-            if attempts == EXECUTION_MAX_ATTEMPTS {
-                panic!("Failed to execute certified transaction {digest:?} after {attempts} attempts! error={e} certificate={certificate:?}");
-            }
-            // Assume only transient failure can happen. Permanent failure is probably
-            // a bug. There is nothing that can be done to recover from permanent failures.
-            error!(tx_digest=?digest, "Failed to execute certified transaction {digest:?}! attempt {attempts}, {e}");
-            sleep(EXECUTION_FAILURE_RETRY_INTERVAL).await;
-        } else {
-            break;
-        }
-    }
-    authority
-        .metrics
-        .execution_driver_executed_transactions
-        .inc();
-}
-
-impl ExecutionDispatcher {
-    pub fn new(
-        tx_ready_certificates: UnboundedSender<(
-            VerifiedExecutableTransaction,
-            Option<TransactionEffectsDigest>,
-        )>,
-        semaphore: Arc<Semaphore>,
-        metrics: Arc<AuthorityMetrics>,
-    ) -> Self {
-        let authority = RwLock::new(None);
-        Self {
-            limit: semaphore,
-            tx_ready_certificates,
-            authority,
-            metrics,
-        }
-    }
-
-    pub fn dispatch_certificate(
-        &self,
-        certificate: VerifiedExecutableTransaction,
-        expected_effects_digest: Option<TransactionEffectsDigest>,
-    ) {
-        let authority = self.authority.read();
-        let authority = authority.as_ref().and_then(|w| w.upgrade());
-        if let Some(authority) = authority {
-            if let Ok(permit) = self.limit.clone().try_acquire_owned() {
-                // Schedule execution immediately when permit is available
-                // This helps to avoid using single dispatcher thread to dispatch all transactions
-                let digest = *certificate.digest();
-                spawn_monitored_task!(execution_task(
-                    permit,
-                    authority,
-                    certificate,
-                    expected_effects_digest
-                )
-                .instrument(error_span!("execution_driver", tx_digest = ?digest)));
+        spawn_monitored_task!(async move {
+            let _scope = monitored_scope("ExecutionDriver");
+            let _guard = permit;
+            if let Ok(true) = authority.is_tx_already_executed(&digest) {
                 return;
             }
-        }
-        self.metrics.execution_driver_dispatch_queue.inc();
-        self.tx_ready_certificates
-            .send((certificate, expected_effects_digest))
-            .ok();
-    }
-
-    pub fn set_authority(&self, authority: Weak<AuthorityState>) {
-        let mut ptr = self.authority.write();
-        assert!(ptr.is_none());
-        *ptr = Some(authority);
-    }
-
-    #[cfg(test)]
-    pub fn shutdown_execution_for_test(&self) {
-        *self.authority.write() = None;
+            let mut attempts = 0;
+            loop {
+                attempts += 1;
+                let res = authority
+                    .try_execute_immediately(&certificate, expected_effects_digest, &epoch_store)
+                    .await;
+                if let Err(e) = res {
+                    if attempts == EXECUTION_MAX_ATTEMPTS {
+                        panic!("Failed to execute certified transaction {digest:?} after {attempts} attempts! error={e} certificate={certificate:?}");
+                    }
+                    // Assume only transient failure can happen. Permanent failure is probably
+                    // a bug. There is nothing that can be done to recover from permanent failures.
+                    error!(tx_digest=?digest, "Failed to execute certified transaction {digest:?}! attempt {attempts}, {e}");
+                    sleep(EXECUTION_FAILURE_RETRY_INTERVAL).await;
+                } else {
+                    break;
+                }
+            }
+            authority
+                .metrics
+                .execution_driver_executed_transactions
+                .inc();
+        }.instrument(error_span!("execution_driver", tx_digest = ?digest)));
     }
 }

--- a/crates/sui-core/src/unit_tests/transaction_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_manager_tests.rs
@@ -3,8 +3,6 @@
 
 use std::{time::Duration, vec};
 
-use crate::execution_driver::ExecutionDispatcher;
-use std::sync::Arc;
 use sui_types::{
     base_types::ObjectID,
     crypto::deterministic_random_account_key,
@@ -14,7 +12,6 @@ use sui_types::{
     SUI_FRAMEWORK_OBJECT_ID,
 };
 use test_utils::messages::move_transaction;
-use tokio::sync::Semaphore;
 use tokio::{
     sync::mpsc::{unbounded_channel, UnboundedReceiver},
     time::sleep,
@@ -40,17 +37,10 @@ fn make_transaction_manager(
     // Create a new transaction manager instead of reusing the authority's, to examine
     // transaction_manager output from rx_ready_certificates.
     let (tx_ready_certificates, rx_ready_certificates) = unbounded_channel();
-    // no permits so that we don't try to spawn execution tasks in txn manager test
-    let execution_limit = Arc::new(Semaphore::new(0));
-    let execution_dispatcher = Arc::new(ExecutionDispatcher::new(
-        tx_ready_certificates,
-        execution_limit,
-        state.metrics.clone(),
-    ));
     let transaction_manager = TransactionManager::new(
         state.database.clone(),
         &state.epoch_store_for_testing(),
-        execution_dispatcher,
+        tx_ready_certificates,
         state.metrics.clone(),
     );
 


### PR DESCRIPTION
This reverts commit b52e54d98319b754deac442c17f29d97e02515c9.

## Description 

This seems to lower the max throughput of shared object transaction.

## Test Plan 

Deploying to private testnet.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
