### PR TITLE
[CI] reserve additional disk as swap space

### DIFF
--- a/.github/workflows/nightly-narwhal.yml
+++ b/.github/workflows/nightly-narwhal.yml
@@ -36,6 +36,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
       - uses: taiki-e/install-action@nextest
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 256
       # Enable caching of the 'librocksdb-sys' crate by additionally caching the
       # 'librocksdb-sys' src directory which is managed by cargo
       - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,13 +82,14 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
       - uses: taiki-e/install-action@nextest
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 256
       - name: Install python dependencies
         run: |
           pip install pyopenssl --upgrade
           if [ -f narwhal/benchmark/requirements.txt ]; then pip install -r narwhal/benchmark/requirements.txt; fi
-      - name: External crates tests
-        run: |
-          cargo xtest
       - name: cargo test
         run: |
           cargo nextest run --profile ci
@@ -96,6 +97,9 @@ jobs:
         run: |
           cargo run --package sui-benchmark --bin stress -- --log-path /tmp/stress.log --num-client-threads 10 --num-server-threads 24 --num-transfer-accounts 2 bench --target-qps 100 --num-workers 10  --transfer-object 50 --shared-counter 50 --run-duration 10s --stress-stat-collection
           pushd narwhal/benchmark && fab smoke && popd
+      - name: External crates tests
+        run: |
+          cargo xtest
       - name: doctests
         run: |
           cargo test --doc
@@ -149,6 +153,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
       - uses: taiki-e/install-action@nextest
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 256
       - name: cargo simtest
         run: |
           scripts/simtest/cargo-simtest simtest


### PR DESCRIPTION
## Description 

Increase swap space to accommodate high memory usage during linking. Other strategies are removing debug info from build artifacts, or reducing build and test parallelism which are less ideal.

It is mentioned that github large runners have [2040GB](https://docs.github.com/en/actions/using-github-hosted-runners/using-larger-runners) of disk space but reserving 512GB of swap failed.

## Test Plan 

Build passing at https://github.com/MystenLabs/sui/actions/runs/4842516246/jobs/8629516910#step:7:1719

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
