### PR TITLE
[refactor] validator to submit with configurable position and delay step

### DIFF
--- a/crates/sui-config/src/builder.rs
+++ b/crates/sui-config/src/builder.rs
@@ -454,7 +454,7 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                     internal_worker_address,
                     max_pending_transactions: None,
                     max_submit_position: None,
-                    max_submit_delay_step_millis: None,
+                    submit_delay_step_millis: None,
                     narwhal_config: ConsensusParameters {
                         network_admin_server: match self.validator_ip_sel {
                             ValidatorIpSelection::Simulator => NetworkAdminServerParameters {

--- a/crates/sui-config/src/builder.rs
+++ b/crates/sui-config/src/builder.rs
@@ -453,6 +453,8 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                     db_path: consensus_db_path,
                     internal_worker_address,
                     max_pending_transactions: None,
+                    max_submit_position: None,
+                    max_submit_delay_step_millis: None,
                     narwhal_config: ConsensusParameters {
                         network_admin_server: match self.validator_ip_sel {
                             ValidatorIpSelection::Simulator => NetworkAdminServerParameters {

--- a/crates/sui-config/src/builder.rs
+++ b/crates/sui-config/src/builder.rs
@@ -454,7 +454,7 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                     internal_worker_address,
                     max_pending_transactions: None,
                     max_submit_position: None,
-                    submit_delay_step_millis: None,
+                    submit_delay_step_override_millis: None,
                     narwhal_config: ConsensusParameters {
                         network_admin_server: match self.validator_ip_sel {
                             ValidatorIpSelection::Simulator => NetworkAdminServerParameters {

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -14,6 +14,7 @@ use serde_with::serde_as;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 use std::usize;
 use sui_keys::keypair_file::{read_authority_keypair_from_file, read_keypair_from_file};
 use sui_protocol_config::SupportedProtocolVersions;
@@ -240,6 +241,15 @@ pub struct ConsensusConfig {
     // Default to 100_000.
     pub max_pending_transactions: Option<usize>,
 
+    /// Dictates the maximum position  from which will submit to consensus. Even if the is elected to
+    /// submit from a higher position than this, it will "reset" to the max_submit_position.
+    pub max_submit_position: Option<usize>,
+
+    /// The maximum submit delay step to consensus defined in milliseconds. When provided it will
+    /// override the current back off logic otherwise the default backoff logic will be applied based
+    /// on consensus latency estimates.
+    pub max_submit_delay_step_millis: Option<u64>,
+
     pub narwhal_config: ConsensusParameters,
 }
 
@@ -254,6 +264,10 @@ impl ConsensusConfig {
 
     pub fn max_pending_transactions(&self) -> usize {
         self.max_pending_transactions.unwrap_or(100_000)
+    }
+
+    pub fn max_submit_delay_step(&self) -> Option<Duration> {
+        self.max_submit_delay_step_millis.map(Duration::from_millis)
     }
 
     pub fn narwhal_config(&self) -> &ConsensusParameters {

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -231,14 +231,14 @@ pub struct ConsensusConfig {
     pub address: Multiaddr,
     pub db_path: PathBuf,
 
-    // Optional alternative address preferentially used by a primary to talk to its own worker.
-    // For example, this could be used to connect to co-located workers over a private LAN address.
+    /// Optional alternative address preferentially used by a primary to talk to its own worker.
+    /// For example, this could be used to connect to co-located workers over a private LAN address.
     pub internal_worker_address: Option<Multiaddr>,
 
-    // Maximum number of pending transactions to submit to consensus, including those
-    // in submission wait.
-    // Assuming 10_000 txn tps * 10 sec consensus latency = 100_000 inflight consensus txns,
-    // Default to 100_000.
+    /// Maximum number of pending transactions to submit to consensus, including those
+    /// in submission wait.
+    /// Assuming 10_000 txn tps * 10 sec consensus latency = 100_000 inflight consensus txns,
+    /// Default to 100_000.
     pub max_pending_transactions: Option<usize>,
 
     /// Dictates the maximum position  from which will submit to consensus. Even if the is elected to

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -241,14 +241,14 @@ pub struct ConsensusConfig {
     /// Default to 100_000.
     pub max_pending_transactions: Option<usize>,
 
-    /// Dictates the maximum position  from which will submit to consensus. Even if the is elected to
-    /// submit from a higher position than this, it will "reset" to the max_submit_position.
+    /// When defined caps the calculated submission position to the max_submit_position. Even if the
+    /// is elected to submit from a higher position than this, it will "reset" to the max_submit_position.
     pub max_submit_position: Option<usize>,
 
     /// The submit delay step to consensus defined in milliseconds. When provided it will
     /// override the current back off logic otherwise the default backoff logic will be applied based
     /// on consensus latency estimates.
-    pub submit_delay_step_millis: Option<u64>,
+    pub submit_delay_step_override_millis: Option<u64>,
 
     pub narwhal_config: ConsensusParameters,
 }
@@ -266,8 +266,9 @@ impl ConsensusConfig {
         self.max_pending_transactions.unwrap_or(100_000)
     }
 
-    pub fn submit_delay_step(&self) -> Option<Duration> {
-        self.submit_delay_step_millis.map(Duration::from_millis)
+    pub fn submit_delay_step_override(&self) -> Option<Duration> {
+        self.submit_delay_step_override_millis
+            .map(Duration::from_millis)
     }
 
     pub fn narwhal_config(&self) -> &ConsensusParameters {

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -245,10 +245,10 @@ pub struct ConsensusConfig {
     /// submit from a higher position than this, it will "reset" to the max_submit_position.
     pub max_submit_position: Option<usize>,
 
-    /// The maximum submit delay step to consensus defined in milliseconds. When provided it will
+    /// The submit delay step to consensus defined in milliseconds. When provided it will
     /// override the current back off logic otherwise the default backoff logic will be applied based
     /// on consensus latency estimates.
-    pub max_submit_delay_step_millis: Option<u64>,
+    pub submit_delay_step_millis: Option<u64>,
 
     pub narwhal_config: ConsensusParameters,
 }
@@ -266,8 +266,8 @@ impl ConsensusConfig {
         self.max_pending_transactions.unwrap_or(100_000)
     }
 
-    pub fn max_submit_delay_step(&self) -> Option<Duration> {
-        self.max_submit_delay_step_millis.map(Duration::from_millis)
+    pub fn submit_delay_step(&self) -> Option<Duration> {
+        self.submit_delay_step_millis.map(Duration::from_millis)
     }
 
     pub fn narwhal_config(&self) -> &ConsensusParameters {

--- a/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -22,7 +22,7 @@ validator_configs:
       internal-worker-address: ""
       max-pending-transactions: ~
       max-submit-position: ~
-      max-submit-delay-step-millis: ~
+      submit-delay-step-millis: ~
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
@@ -108,7 +108,7 @@ validator_configs:
       internal-worker-address: ""
       max-pending-transactions: ~
       max-submit-position: ~
-      max-submit-delay-step-millis: ~
+      submit-delay-step-millis: ~
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
@@ -194,7 +194,7 @@ validator_configs:
       internal-worker-address: ""
       max-pending-transactions: ~
       max-submit-position: ~
-      max-submit-delay-step-millis: ~
+      submit-delay-step-millis: ~
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
@@ -280,7 +280,7 @@ validator_configs:
       internal-worker-address: ""
       max-pending-transactions: ~
       max-submit-position: ~
-      max-submit-delay-step-millis: ~
+      submit-delay-step-millis: ~
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
@@ -366,7 +366,7 @@ validator_configs:
       internal-worker-address: ""
       max-pending-transactions: ~
       max-submit-position: ~
-      max-submit-delay-step-millis: ~
+      submit-delay-step-millis: ~
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
@@ -452,7 +452,7 @@ validator_configs:
       internal-worker-address: ""
       max-pending-transactions: ~
       max-submit-position: ~
-      max-submit-delay-step-millis: ~
+      submit-delay-step-millis: ~
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
@@ -538,7 +538,7 @@ validator_configs:
       internal-worker-address: ""
       max-pending-transactions: ~
       max-submit-position: ~
-      max-submit-delay-step-millis: ~
+      submit-delay-step-millis: ~
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000

--- a/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -22,7 +22,7 @@ validator_configs:
       internal-worker-address: ""
       max-pending-transactions: ~
       max-submit-position: ~
-      submit-delay-step-millis: ~
+      submit-delay-step-override-millis: ~
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
@@ -108,7 +108,7 @@ validator_configs:
       internal-worker-address: ""
       max-pending-transactions: ~
       max-submit-position: ~
-      submit-delay-step-millis: ~
+      submit-delay-step-override-millis: ~
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
@@ -194,7 +194,7 @@ validator_configs:
       internal-worker-address: ""
       max-pending-transactions: ~
       max-submit-position: ~
-      submit-delay-step-millis: ~
+      submit-delay-step-override-millis: ~
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
@@ -280,7 +280,7 @@ validator_configs:
       internal-worker-address: ""
       max-pending-transactions: ~
       max-submit-position: ~
-      submit-delay-step-millis: ~
+      submit-delay-step-override-millis: ~
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
@@ -366,7 +366,7 @@ validator_configs:
       internal-worker-address: ""
       max-pending-transactions: ~
       max-submit-position: ~
-      submit-delay-step-millis: ~
+      submit-delay-step-override-millis: ~
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
@@ -452,7 +452,7 @@ validator_configs:
       internal-worker-address: ""
       max-pending-transactions: ~
       max-submit-position: ~
-      submit-delay-step-millis: ~
+      submit-delay-step-override-millis: ~
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
@@ -538,7 +538,7 @@ validator_configs:
       internal-worker-address: ""
       max-pending-transactions: ~
       max-submit-position: ~
-      submit-delay-step-millis: ~
+      submit-delay-step-override-millis: ~
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000

--- a/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -21,6 +21,8 @@ validator_configs:
       db-path: /tmp/foo/
       internal-worker-address: ""
       max-pending-transactions: ~
+      max-submit-position: ~
+      max-submit-delay-step-millis: ~
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
@@ -105,6 +107,8 @@ validator_configs:
       db-path: /tmp/foo/
       internal-worker-address: ""
       max-pending-transactions: ~
+      max-submit-position: ~
+      max-submit-delay-step-millis: ~
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
@@ -189,6 +193,8 @@ validator_configs:
       db-path: /tmp/foo/
       internal-worker-address: ""
       max-pending-transactions: ~
+      max-submit-position: ~
+      max-submit-delay-step-millis: ~
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
@@ -273,6 +279,8 @@ validator_configs:
       db-path: /tmp/foo/
       internal-worker-address: ""
       max-pending-transactions: ~
+      max-submit-position: ~
+      max-submit-delay-step-millis: ~
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
@@ -357,6 +365,8 @@ validator_configs:
       db-path: /tmp/foo/
       internal-worker-address: ""
       max-pending-transactions: ~
+      max-submit-position: ~
+      max-submit-delay-step-millis: ~
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
@@ -441,6 +451,8 @@ validator_configs:
       db-path: /tmp/foo/
       internal-worker-address: ""
       max-pending-transactions: ~
+      max-submit-position: ~
+      max-submit-delay-step-millis: ~
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000
@@ -525,6 +537,8 @@ validator_configs:
       db-path: /tmp/foo/
       internal-worker-address: ""
       max-pending-transactions: ~
+      max-submit-position: ~
+      max-submit-delay-step-millis: ~
       narwhal-config:
         header_num_of_batches_threshold: 32
         max_header_num_of_batches: 1000

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -91,6 +91,8 @@ impl AuthorityServer {
             Box::new(Arc::new(ConnectionMonitorStatusForTests {})),
             100_000,
             100_000,
+            None,
+            None,
             ConsensusAdapterMetrics::new_test(),
         ));
 

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -274,9 +274,9 @@ pub struct ConsensusAdapter {
     /// Dictates the maximum position  from which will submit to consensus. Even if the is elected to
     /// submit from a higher position than this, it will "reset" to the max_submit_position.
     max_submit_position: Option<usize>,
-    /// The maximum submit delay step to consensus. When provided it will override the current back off
-    /// logic.
-    max_submit_delay_step: Option<Duration>,
+    /// The submit delay step to consensus as constant. When provided it will override the current back off
+    /// logic and be used instead.
+    submit_delay_step: Option<Duration>,
     /// A structure to check the connection statuses populated by the Connection Monitor Listener
     connection_monitor_status: Box<Arc<dyn CheckConnection>>,
     /// A structure to check the reputation scores populated by Consensus
@@ -315,7 +315,7 @@ impl ConsensusAdapter {
         max_pending_transactions: usize,
         max_pending_local_submissions: usize,
         max_submit_position: Option<usize>,
-        max_submit_delay_step: Option<Duration>,
+        submit_delay_step: Option<Duration>,
         metrics: ConsensusAdapterMetrics,
     ) -> Self {
         let num_inflight_transactions = Default::default();
@@ -326,7 +326,7 @@ impl ConsensusAdapter {
             authority,
             max_pending_transactions,
             max_submit_position,
-            max_submit_delay_step,
+            submit_delay_step,
             num_inflight_transactions,
             connection_monitor_status,
             low_scoring_authorities,
@@ -413,7 +413,7 @@ impl ConsensusAdapter {
             position = std::cmp::min(position, max_submit_position);
         }
 
-        let delay_step = self.max_submit_delay_step.unwrap_or(latency * 3 / 2);
+        let delay_step = self.submit_delay_step.unwrap_or(latency * 3 / 2);
 
         self.metrics
             .sequencing_estimated_latency

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -274,9 +274,9 @@ pub struct ConsensusAdapter {
     /// Dictates the maximum position  from which will submit to consensus. Even if the is elected to
     /// submit from a higher position than this, it will "reset" to the max_submit_position.
     max_submit_position: Option<usize>,
-    /// The submit delay step to consensus as constant. When provided it will override the current back off
-    /// logic and be used instead.
-    submit_delay_step: Option<Duration>,
+    /// When provided it will override the current back off logic and will use this value instead
+    /// as delay step.
+    submit_delay_step_override: Option<Duration>,
     /// A structure to check the connection statuses populated by the Connection Monitor Listener
     connection_monitor_status: Box<Arc<dyn CheckConnection>>,
     /// A structure to check the reputation scores populated by Consensus
@@ -315,7 +315,7 @@ impl ConsensusAdapter {
         max_pending_transactions: usize,
         max_pending_local_submissions: usize,
         max_submit_position: Option<usize>,
-        submit_delay_step: Option<Duration>,
+        submit_delay_step_override: Option<Duration>,
         metrics: ConsensusAdapterMetrics,
     ) -> Self {
         let num_inflight_transactions = Default::default();
@@ -326,7 +326,7 @@ impl ConsensusAdapter {
             authority,
             max_pending_transactions,
             max_submit_position,
-            submit_delay_step,
+            submit_delay_step_override,
             num_inflight_transactions,
             connection_monitor_status,
             low_scoring_authorities,
@@ -413,7 +413,7 @@ impl ConsensusAdapter {
             position = std::cmp::min(position, max_submit_position);
         }
 
-        let delay_step = self.submit_delay_step.unwrap_or(latency * 3 / 2);
+        let delay_step = self.submit_delay_step_override.unwrap_or(latency * 3 / 2);
 
         self.metrics
             .sequencing_estimated_latency

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -385,32 +385,41 @@ impl ConsensusAdapter {
     ) -> (impl Future<Output = ()>, usize, bool) {
         let (duration, position, mapped_to_low_scoring) = match &transaction.kind {
             ConsensusTransactionKind::UserTransaction(certificate) => {
-                let tx_digest = certificate.digest();
-                let (mut position, mapped_to_low_scoring) =
-                    self.submission_position(committee, tx_digest);
-
-                const MAX_LATENCY: Duration = Duration::from_secs(5 * 60);
-                const DEFAULT_LATENCY: Duration = Duration::from_secs(5);
-                let latency = self.latency_observer.latency().unwrap_or(DEFAULT_LATENCY);
-                let latency = std::cmp::max(latency, DEFAULT_LATENCY);
-                let latency = std::cmp::min(latency, MAX_LATENCY);
-
-                position = self.max_submit_position.unwrap_or(position);
-                let delay_step = self.max_submit_delay_step.unwrap_or(latency * 3 / 2);
-
-                self.metrics
-                    .sequencing_estimated_latency
-                    .set(latency.as_millis() as i64);
-                (
-                    delay_step * position as u32,
-                    position,
-                    mapped_to_low_scoring,
-                )
+                self.await_submit_delay_user_transaction(committee, certificate.digest())
             }
             _ => (Duration::ZERO, 0, false),
         };
         (
             tokio::time::sleep(duration),
+            position,
+            mapped_to_low_scoring,
+        )
+    }
+
+    fn await_submit_delay_user_transaction(
+        &self,
+        committee: &Committee,
+        tx_digest: &TransactionDigest,
+    ) -> (Duration, usize, bool) {
+        let (mut position, mapped_to_low_scoring) = self.submission_position(committee, tx_digest);
+
+        const MAX_LATENCY: Duration = Duration::from_secs(5 * 60);
+        const DEFAULT_LATENCY: Duration = Duration::from_secs(5);
+        let latency = self.latency_observer.latency().unwrap_or(DEFAULT_LATENCY);
+        let latency = std::cmp::max(latency, DEFAULT_LATENCY);
+        let latency = std::cmp::min(latency, MAX_LATENCY);
+
+        if let Some(max_submit_position) = self.max_submit_position {
+            position = std::cmp::min(position, max_submit_position);
+        }
+
+        let delay_step = self.max_submit_delay_step.unwrap_or(latency * 3 / 2);
+
+        self.metrics
+            .sequencing_estimated_latency
+            .set(latency.as_millis() as i64);
+        (
+            delay_step * position as u32,
             position,
             mapped_to_low_scoring,
         )
@@ -956,35 +965,104 @@ pub fn position_submit_certificate(
 #[cfg(test)]
 mod adapter_tests {
     use super::position_submit_certificate;
+    use crate::consensus_adapter::{
+        ConnectionMonitorStatusForTests, ConsensusAdapter, ConsensusAdapterMetrics,
+        LazyNarwhalClient,
+    };
     use fastcrypto::traits::KeyPair;
-    use rand::{rngs::StdRng, Rng, SeedableRng};
+    use rand::Rng;
+    use rand::{rngs::StdRng, SeedableRng};
+    use std::sync::Arc;
+    use std::time::Duration;
     use sui_types::{
         base_types::TransactionDigest,
         committee::Committee,
         crypto::{get_key_pair_from_rng, AuthorityKeyPair, AuthorityPublicKeyBytes},
     };
 
-    #[test]
-    fn test_position_submit_certificate() {
-        // grab a random committee and a random stake distribution
-        let mut rng = StdRng::from_seed([0; 32]);
-        const COMMITTEE_SIZE: usize = 10; // 3 * 3 + 1;
-        let authorities = (0..COMMITTEE_SIZE)
+    fn test_committee(rng: &mut StdRng, size: usize) -> Committee {
+        let authorities = (0..size)
             .map(|_k| {
                 (
                     AuthorityPublicKeyBytes::from(
-                        get_key_pair_from_rng::<AuthorityKeyPair, _>(&mut rng)
-                            .1
-                            .public(),
+                        get_key_pair_from_rng::<AuthorityKeyPair, _>(rng).1.public(),
                     ),
                     rng.gen_range(0u64..10u64),
                 )
             })
             .collect::<Vec<_>>();
-        let committee = Committee::new_for_testing_with_normalized_voting_power(
+        Committee::new_for_testing_with_normalized_voting_power(
             0,
             authorities.iter().cloned().collect(),
+        )
+    }
+
+    #[test]
+    fn test_await_submit_delay_user_transaction() {
+        // grab a random committee and a random stake distribution
+        let mut rng = StdRng::from_seed([0; 32]);
+        let committee = test_committee(&mut rng, 10);
+
+        // When we define max submit position and delay step
+        let consensus_adapter = ConsensusAdapter::new(
+            Box::new(LazyNarwhalClient::new(
+                "/ip4/127.0.0.1/tcp/0/http".parse().unwrap(),
+            )),
+            *committee.authority_by_index(0).unwrap(),
+            Box::new(Arc::new(ConnectionMonitorStatusForTests {})),
+            100_000,
+            100_000,
+            Some(1),
+            Some(Duration::from_secs(2)),
+            ConsensusAdapterMetrics::new_test(),
         );
+
+        // transaction to submit
+        let tx_digest = TransactionDigest::generate(&mut rng);
+
+        // Ensure that the original position is higher
+        let (position, low_scoring_authority) =
+            consensus_adapter.submission_position(&committee, &tx_digest);
+        assert_eq!(position, 7);
+        assert!(!low_scoring_authority);
+
+        // Make sure that position is set to max value 0
+        let (delay_step, position, low_scoring_authority) =
+            consensus_adapter.await_submit_delay_user_transaction(&committee, &tx_digest);
+
+        assert_eq!(position, 1);
+        assert_eq!(delay_step, Duration::from_secs(2));
+        assert!(!low_scoring_authority);
+
+        // Without submit position and delay step
+        let consensus_adapter = ConsensusAdapter::new(
+            Box::new(LazyNarwhalClient::new(
+                "/ip4/127.0.0.1/tcp/0/http".parse().unwrap(),
+            )),
+            *committee.authority_by_index(0).unwrap(),
+            Box::new(Arc::new(ConnectionMonitorStatusForTests {})),
+            100_000,
+            100_000,
+            None,
+            None,
+            ConsensusAdapterMetrics::new_test(),
+        );
+
+        let (delay_step, position, low_scoring_authority) =
+            consensus_adapter.await_submit_delay_user_transaction(&committee, &tx_digest);
+
+        assert_eq!(position, 7);
+
+        // delay_step * position * 3/2 = 5 * 7 * 3/2 = 52.5
+        assert_eq!(delay_step, Duration::from_millis(52500));
+        assert!(!low_scoring_authority);
+    }
+
+    #[test]
+    fn test_position_submit_certificate() {
+        // grab a random committee and a random stake distribution
+        let mut rng = StdRng::from_seed([0; 32]);
+        let committee = test_committee(&mut rng, 10);
 
         // generate random transaction digests, and account for validator selection
         const NUM_TEST_TRANSACTIONS: usize = 1000;
@@ -993,7 +1071,7 @@ mod adapter_tests {
             let tx_digest = TransactionDigest::generate(&mut rng);
 
             let mut zero_found = false;
-            for (name, _) in authorities.iter() {
+            for (name, _) in committee.members() {
                 let f = position_submit_certificate(&committee, name, &tx_digest);
                 assert!(f < committee.num_members());
                 if f == 0 {

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -376,8 +376,12 @@ impl ConsensusAdapter {
         let (duration, position, mapped_to_low_scoring) = match &transaction.kind {
             ConsensusTransactionKind::UserTransaction(certificate) => {
                 let tx_digest = certificate.digest();
-                let (position, mapped_to_low_scoring) =
-                    self.submission_position(committee, tx_digest);
+                let _ = self.submission_position(committee, tx_digest);
+
+                // TODO: hack-ish way to always make the validator submit to consensus. Assuming we
+                // want to go with that, we'll need to extract this to a config.
+                let (position, mapped_to_low_scoring) = (0, false);
+
                 const DEFAULT_LATENCY: Duration = Duration::from_secs(5);
                 const MAX_LATENCY: Duration = Duration::from_secs(5 * 60);
                 let latency = self.latency_observer.latency().unwrap_or(DEFAULT_LATENCY);

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -139,6 +139,8 @@ async fn submit_transaction_to_consensus_adapter() {
         Box::new(Arc::new(ConnectionMonitorStatusForTests {})),
         100_000,
         100_000,
+        None,
+        None,
         metrics,
     ));
 

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -836,7 +836,7 @@ impl SuiNode {
             consensus_config.max_pending_transactions(),
             consensus_config.max_pending_transactions() * 2 / committee.num_members(),
             consensus_config.max_submit_position,
-            consensus_config.max_submit_delay_step(),
+            consensus_config.submit_delay_step(),
             ca_metrics,
         )
     }

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -835,6 +835,8 @@ impl SuiNode {
             Box::new(connection_monitor_status),
             consensus_config.max_pending_transactions(),
             consensus_config.max_pending_transactions() * 2 / committee.num_members(),
+            consensus_config.max_submit_position,
+            consensus_config.max_submit_delay_step(),
             ca_metrics,
         )
     }

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -836,7 +836,7 @@ impl SuiNode {
             consensus_config.max_pending_transactions(),
             consensus_config.max_pending_transactions() * 2 / committee.num_members(),
             consensus_config.max_submit_position,
-            consensus_config.submit_delay_step(),
+            consensus_config.submit_delay_step_override(),
             ca_metrics,
         )
     }


### PR DESCRIPTION
## Description 

Providing the ability to configure the maximum position (`max_submit_position`) of a validator to submit to consensus. Provided a max position `N`, we guarantee that a validator even if is elected to submit to position `M` , where `M > N`, it will submit on position `N`.

Similar, if the `submit_delay_step_millis` property is set, then we ensure that on the consensus adapter the delay step will get overwritten with this constant value instead of using the latency observer logic.

## Test Plan 

Added unit tests.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
