### PR TITLE
Transaction Orchestrator uses deny config

### DIFF
--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -378,6 +378,7 @@ impl SuiNode {
                     end_of_epoch_receiver,
                     &config.db_path(),
                     &prometheus_registry,
+                    config.transaction_deny_config.clone(),
                 )
                 .await?,
             ))

--- a/crates/sui-types/src/quorum_driver_types.rs
+++ b/crates/sui-types/src/quorum_driver_types.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeMap;
 use crate::base_types::{AuthorityName, ObjectRef, TransactionDigest};
 use crate::committee::StakeUnit;
 use crate::crypto::ConciseAuthorityPublicKeyBytes;
-use crate::error::SuiError;
+use crate::error::{SuiError, UserInputError};
 pub use crate::messages::QuorumDriverResponse;
 use crate::messages::VerifiedTransaction;
 use serde::{Deserialize, Serialize};
@@ -27,6 +27,10 @@ pub enum QuorumDriverError {
     QuorumDriverInternalError(SuiError),
     #[error("Invalid user signature: {0:?}.")]
     InvalidUserSignature(SuiError),
+    #[error("Transaction is denied by the submitting fullnode: {0:?}.")]
+    TransactionDeniedByFullNode(SuiError),
+    #[error("UserInput Error {0:?}.")]
+    UserInputError(UserInputError),
     #[error(
         "Failed to sign transaction by a quorum of validators because of locked objects: {:?}, retried a conflicting transaction {:?}, success: {:?}",
         conflicting_txes,

--- a/crates/sui/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui/tests/transaction_orchestrator_tests.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use prometheus::Registry;
+use sui_config::transaction_deny_config::TransactionDenyConfig;
 use sui_core::authority_client::NetworkAuthorityClient;
 use sui_core::transaction_orchestrator::TransactiondOrchestrator;
 use sui_macros::sim_test;
@@ -36,6 +37,7 @@ async fn test_blocking_execution() -> Result<(), anyhow::Error> {
         reconfig_channel,
         temp_dir.path(),
         &Registry::new(),
+        TransactionDenyConfig::default(),
     )
     .await
     .unwrap();
@@ -102,6 +104,7 @@ async fn test_fullnode_wal_log() -> Result<(), anyhow::Error> {
         reconfig_channel,
         temp_dir.path(),
         &Registry::new(),
+        TransactionDenyConfig::default(),
     )
     .await
     .unwrap();


### PR DESCRIPTION
## Description 

Reuse the deny config in Transaction Orchestrator

## Test Plan 

tested with a local cluster

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
