### PR TITLE
[rpc] avoid redundant dserialization in show_raw_input

### DIFF
--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -87,7 +87,7 @@ impl TransactionExecutionApi {
         let txn = Transaction::from_generic_sig_data(tx_data, Intent::sui_transaction(), sigs);
         let digest = *txn.digest();
         let raw_transaction = if opts.show_raw_input {
-            bcs::to_bytes(txn.data())?
+            tx_bytes.to_vec()?
         } else {
             vec![]
         };


### PR DESCRIPTION
We already have the base64 of the tx and can use that directly rather than going through BCS

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
