### PR TITLE
Get fully annotated type from Session

### DIFF
--- a/external-crates/move/move-vm/runtime/src/session.rs
+++ b/external-crates/move/move-vm/runtime/src/session.rs
@@ -285,6 +285,13 @@ impl<'r, 'l, S: MoveResolver> Session<'r, 'l, S> {
             .map_err(|e| e.finish(Location::Undefined))
     }
 
+    pub fn type_to_fully_annotated_layout(&self, ty: &Type) -> VMResult<MoveTypeLayout> {
+        self.runtime
+            .loader()
+            .type_to_fully_annotated_layout(ty)
+            .map_err(|e| e.finish(Location::Undefined))
+    }
+
     pub fn get_type_tag(&self, ty: &Type) -> VMResult<TypeTag> {
         self.runtime
             .loader()


### PR DESCRIPTION
## Description 

Make API on session to get a fully annotated type

## Test Plan 

no plan
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
