### PR TITLE
Create a LayoutResolver to compute layout from VM types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11635,6 +11635,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rand 0.8.5",
+ "sui-adapter",
  "sui-core",
  "sui-move-build",
  "sui-protocol-config",

--- a/crates/sui-adapter/src/lib.rs
+++ b/crates/sui-adapter/src/lib.rs
@@ -1,25 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-macro_rules! invariant_violation {
-    ($msg:expr) => {{
-        if cfg!(debug_assertions) {
-            panic!("{}", $msg)
-        }
-        return Err(sui_types::error::ExecutionError::invariant_violation($msg).into());
-    }};
-}
-
-macro_rules! assert_invariant {
-    ($cond:expr, $msg:expr) => {{
-        if !$cond {
-            invariant_violation!($msg)
-        }
-    }};
-}
+#[macro_use]
+extern crate sui_types;
 
 pub mod adapter;
 pub mod error;
 pub mod execution_engine;
 pub mod execution_mode;
 pub mod programmable_transactions;
+pub mod type_layout_resolver;

--- a/crates/sui-adapter/src/type_layout_resolver.rs
+++ b/crates/sui-adapter/src/type_layout_resolver.rs
@@ -1,0 +1,110 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::programmable_transactions::context::new_session_for_linkage;
+use crate::programmable_transactions::{
+    context::load_type,
+    linkage_view::{LinkageInfo, LinkageView},
+};
+use move_core_types::account_address::AccountAddress;
+use move_core_types::language_storage::{ModuleId, StructTag, TypeTag};
+use move_core_types::resolver::{ModuleResolver, ResourceResolver};
+use move_core_types::value::{MoveStructLayout, MoveTypeLayout};
+use move_vm_runtime::{move_vm::MoveVM, session::Session};
+use sui_types::base_types::ObjectID;
+use sui_types::error::SuiResult;
+use sui_types::object::Object;
+use sui_types::storage::BackingPackageStore;
+use sui_types::{
+    error::SuiError,
+    layout_resolver::LayoutResolver,
+    object::{MoveObject, ObjectFormatOptions},
+};
+
+/// Retrieve a `MoveStructLayout` from a `Type`.
+/// Invocation into the `Session` to leverage the `LinkageView` implementation
+/// common to the runtime.
+pub struct TypeLayoutResolver<
+    'state,
+    'vm,
+    S: BackingPackageStore + ModuleResolver<Error = SuiError>,
+> {
+    session: Session<'state, 'vm, LinkageView<NullSuiResolver<S>>>,
+}
+
+/// Implements SuiResolver traits by providing null implementations for module and resource
+/// resolution and delegating backing package resolution to the wrapped type.
+struct NullSuiResolver<S: BackingPackageStore + ModuleResolver<Error = SuiError>>(S);
+
+impl<'state, 'vm, S: BackingPackageStore + ModuleResolver<Error = SuiError>>
+    TypeLayoutResolver<'state, 'vm, S>
+{
+    pub fn new(vm: &'vm MoveVM, state_view: S) -> Self {
+        let session = new_session_for_linkage(
+            vm,
+            LinkageView::new(NullSuiResolver(state_view), LinkageInfo::Unset),
+        );
+        Self { session }
+    }
+}
+
+impl<'state, 'vm, S: BackingPackageStore + ModuleResolver<Error = SuiError>> LayoutResolver
+    for TypeLayoutResolver<'state, 'vm, S>
+{
+    fn get_layout(
+        &mut self,
+        object: &MoveObject,
+        format: ObjectFormatOptions,
+    ) -> Result<MoveStructLayout, SuiError> {
+        let struct_tag: StructTag = object.type_().clone().into();
+        let type_tag: TypeTag = TypeTag::from(struct_tag.clone());
+        let Ok(ty) = load_type(&mut self.session, &type_tag) else {
+            return Err(SuiError::FailObjectLayout {
+                st: format!("{}", struct_tag),
+            });
+        };
+        let layout = if format.include_types() {
+            self.session.type_to_fully_annotated_layout(&ty)
+        } else {
+            self.session.type_to_type_layout(&ty)
+        };
+        let Ok(MoveTypeLayout::Struct(layout)) = layout else {
+            return Err(SuiError::FailObjectLayout {
+                st: format!("{}", struct_tag),
+            })
+        };
+        Ok(layout)
+    }
+}
+
+impl<S: BackingPackageStore + ModuleResolver<Error = SuiError>> BackingPackageStore
+    for NullSuiResolver<S>
+{
+    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<Object>> {
+        self.0.get_package_object(package_id)
+    }
+}
+
+impl<S: BackingPackageStore + ModuleResolver<Error = SuiError>> ModuleResolver
+    for NullSuiResolver<S>
+{
+    type Error = SuiError;
+
+    fn get_module(&self, id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
+        self.0.get_module(id)
+    }
+}
+
+impl<S: BackingPackageStore + ModuleResolver<Error = SuiError>> ResourceResolver
+    for NullSuiResolver<S>
+{
+    type Error = SuiError;
+
+    fn get_resource(
+        &self,
+        _address: &AccountAddress,
+        _typ: &StructTag,
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        Ok(None)
+    }
+}

--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
+use crate::authority::authority_store_tables::AuthorityPerpetualTables;
 use crate::authority::epoch_start_configuration::EpochStartConfiguration;
 use crate::authority::{AuthorityState, AuthorityStore};
 use crate::checkpoints::CheckpointStore;
@@ -142,10 +143,11 @@ impl<'a> TestAuthorityBuilder<'a> {
         let authority_store = match self.store {
             Some(store) => store,
             None => {
+                let perpetual_tables =
+                    Arc::new(AuthorityPerpetualTables::open(&path.join("store"), None));
                 // unwrap ok - for testing only.
                 AuthorityStore::open_with_committee_for_testing(
-                    &path.join("store"),
-                    None,
+                    perpetual_tables,
                     &genesis_committee,
                     genesis,
                     0,

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -54,6 +54,7 @@ use sui_types::{
     SUI_SYSTEM_STATE_OBJECT_ID,
 };
 
+use crate::authority::authority_store_tables::AuthorityPerpetualTables;
 use crate::authority::move_integration_tests::build_and_publish_test_package_with_upgrade_cap;
 use crate::authority::test_authority_builder::TestAuthorityBuilder;
 use crate::{
@@ -2788,9 +2789,10 @@ async fn test_authority_persist() {
     let path = dir.join(format!("DB_{:?}", ObjectID::random()));
     fs::create_dir(&path).unwrap();
 
+    let perpetual_tables = Arc::new(AuthorityPerpetualTables::open(&path, None));
     // Create an authority
     let store =
-        AuthorityStore::open_with_committee_for_testing(&path, None, &committee, &genesis, 0)
+        AuthorityStore::open_with_committee_for_testing(perpetual_tables, &committee, &genesis, 0)
             .await
             .unwrap();
     let authority = init_state(&genesis, authority_key, store).await;
@@ -2814,8 +2816,9 @@ async fn test_authority_persist() {
     let seed = [1u8; 32];
     let (genesis, authority_key) = init_state_parameters_from_rng(&mut StdRng::from_seed(seed));
     let committee = genesis.committee().unwrap();
+    let perpetual_tables = Arc::new(AuthorityPerpetualTables::open(&path, None));
     let store =
-        AuthorityStore::open_with_committee_for_testing(&path, None, &committee, &genesis, 0)
+        AuthorityStore::open_with_committee_for_testing(perpetual_tables, &committee, &genesis, 0)
             .await
             .unwrap();
     let authority2 = init_state(&genesis, authority_key, store).await;

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/object_cross_module_ref/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/object_cross_module_ref/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "object_cross_module_ref"
+version = "0.0.1"
+
+[dependencies]
+Sui = { local = "../../../../../../sui-framework/packages/sui-framework" }
+
+[addresses]
+base_addr =  "0x0"

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/object_cross_module_ref/sources/base.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/object_cross_module_ref/sources/base.move
@@ -1,0 +1,45 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module base_addr::base {
+    use sui::object::{Self, UID};
+    use sui::tx_context::{Self, TxContext};
+    use sui::transfer;
+    use base_addr::friend_module::{Self, X};
+
+    struct A has store, drop {
+        v: u16,
+    }
+
+    struct B has key {
+        id: UID,
+        field1: u32,
+        field2: A,
+    }
+
+    struct C has key {
+        id: UID,
+        field1: u64,
+        field2: X,
+    }
+
+    entry fun make_objs(ctx: &mut TxContext) {
+        let field2 = A { v: 128 };
+        transfer::transfer(
+            B { id: object::new(ctx), field1: 256, field2 },
+            tx_context::sender(ctx),
+        );
+        let field2 = friend_module::make_x(true);
+        transfer::transfer(
+            C { id: object::new(ctx), field1: 0, field2 },
+            tx_context::sender(ctx),
+        );
+    }
+
+    entry fun destroy_objs(b: B, c: C) {
+        let B { id, field1: _, field2: _ }  = b;
+        object::delete(id);
+        let C { id, field1: _, field2: _ }  = c;
+        object::delete(id);
+    }
+}

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/object_cross_module_ref/sources/friend_module.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/object_cross_module_ref/sources/friend_module.move
@@ -1,0 +1,21 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module base_addr::friend_module {
+
+    struct X has store, drop {
+        v: bool,
+    }
+
+    struct Y has store, drop {
+        v: u64,
+    }
+
+    public fun make_x(v: bool): X {
+        X { v }
+    }
+
+    public fun make_y(v: u64): Y {
+        Y { v }
+    }
+}

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/object_cross_module_ref1/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/object_cross_module_ref1/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "object_cross_module_ref1"
+version = "0.0.1"
+
+[dependencies]
+Sui = { local = "../../../../../../sui-framework/packages/sui-framework" }
+
+[addresses]
+base_addr =  "0x0"

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/object_cross_module_ref1/sources/base.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/object_cross_module_ref1/sources/base.move
@@ -1,0 +1,74 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module base_addr::base {
+    use sui::object::{Self, UID};
+    use sui::tx_context::{Self, TxContext};
+    use sui::transfer;
+    use base_addr::friend_module::{Self, X, Z};
+
+    struct A has store, drop {
+        v: u16,
+    }
+
+    struct B has key {
+        id: UID,
+        field1: u32,
+        field2: A,
+    }
+
+    struct C has key {
+        id: UID,
+        field1: u64,
+        field2: X,
+    }
+
+    struct D has key {
+        id: UID,
+        field1: u64,
+        field2: A,
+    }
+
+    struct E has key {
+        id: UID,
+        field1: u64,
+        field2: X,
+    }
+
+    struct F has key {
+        id: UID,
+        field1: u64,
+        field2: Z,
+    }
+
+    entry fun make_objs(ctx: &mut TxContext) {
+        let field2 = A { v: 128 };
+        transfer::transfer(
+            B { id: object::new(ctx), field1: 256, field2 },
+            tx_context::sender(ctx),
+        );
+        let field2 = friend_module::make_x(true);
+        transfer::transfer(
+            C { id: object::new(ctx), field1: 0, field2 },
+            tx_context::sender(ctx),
+        );
+    }
+
+    entry fun make_objs_v2(ctx: &mut TxContext) {
+        let field2 = A { v: 128 };
+        transfer::transfer(
+            D { id: object::new(ctx), field1: 256, field2 },
+            tx_context::sender(ctx),
+        );
+        let field2 = friend_module::make_x(true);
+        transfer::transfer(
+            E { id: object::new(ctx), field1: 0, field2 },
+            tx_context::sender(ctx),
+        );
+        let field2 = friend_module::make_z(true);
+        transfer::transfer(
+            F { id: object::new(ctx), field1: 0, field2 },
+            tx_context::sender(ctx),
+        );
+    }
+}

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/object_cross_module_ref1/sources/friend_module.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/object_cross_module_ref1/sources/friend_module.move
@@ -1,0 +1,30 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module base_addr::friend_module {
+
+    struct X has store, drop {
+        v: bool,
+    }
+
+    struct Y has store, drop {
+        v: u64,
+    }
+
+    struct Z has store, drop {
+        x: X,
+    }
+
+    public fun make_x(v: bool): X {
+        X { v }
+    }
+
+    public fun make_y(v: u64): Y {
+        Y { v }
+    }
+
+    public fun make_z(v: bool): Z {
+        let x = X { v };
+        Z { x }
+    }
+}

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/object_cross_module_ref2/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/object_cross_module_ref2/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "object_cross_module_ref2"
+version = "0.0.1"
+
+[dependencies]
+Sui = { local = "../../../../../../sui-framework/packages/sui-framework" }
+
+[addresses]
+base_addr =  "0x0"

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/object_cross_module_ref2/sources/base.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/object_cross_module_ref2/sources/base.move
@@ -1,0 +1,88 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module base_addr::base {
+    use sui::object::{Self, UID};
+    use sui::tx_context::{Self, TxContext};
+    use sui::transfer;
+    use base_addr::friend_module::{Self, X, Y, Z};
+
+    struct A has store, drop {
+        v: u16,
+    }
+
+    struct B has key {
+        id: UID,
+        field1: u32,
+        field2: A,
+    }
+
+    struct C has key {
+        id: UID,
+        field1: u64,
+        field2: X,
+    }
+
+    struct D has key {
+        id: UID,
+        field1: u64,
+        field2: A,
+    }
+
+    struct E has key {
+        id: UID,
+        field1: u64,
+        field2: X,
+    }
+
+    struct F has key {
+        id: UID,
+        field1: u64,
+        field2: Z,
+    }
+
+    struct G has key {
+        id: UID,
+        field1: bool,
+        field2: Y,
+    }
+
+    entry fun make_objs(ctx: &mut TxContext) {
+        let field2 = A { v: 128 };
+        transfer::transfer(
+            B { id: object::new(ctx), field1: 256, field2 },
+            tx_context::sender(ctx),
+        );
+        let field2 = friend_module::make_x(true);
+        transfer::transfer(
+            C { id: object::new(ctx), field1: 0, field2 },
+            tx_context::sender(ctx),
+        );
+    }
+
+    entry fun make_objs_v2(ctx: &mut TxContext) {
+        let field2 = A { v: 128 };
+        transfer::transfer(
+            D { id: object::new(ctx), field1: 256, field2 },
+            tx_context::sender(ctx),
+        );
+        let field2 = friend_module::make_x(true);
+        transfer::transfer(
+            E { id: object::new(ctx), field1: 0, field2 },
+            tx_context::sender(ctx),
+        );
+        let field2 = friend_module::make_z(true);
+        transfer::transfer(
+            F { id: object::new(ctx), field1: 0, field2 },
+            tx_context::sender(ctx),
+        );
+    }
+
+    entry fun make_objs_v3(ctx: &mut TxContext) {
+        let field2 = friend_module::make_y(100000000);
+        transfer::transfer(
+            G { id: object::new(ctx), field1: false, field2 },
+            tx_context::sender(ctx),
+        );
+    }
+}

--- a/crates/sui-core/src/unit_tests/data/move_upgrade/object_cross_module_ref2/sources/friend_module.move
+++ b/crates/sui-core/src/unit_tests/data/move_upgrade/object_cross_module_ref2/sources/friend_module.move
@@ -1,0 +1,30 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module base_addr::friend_module {
+
+    struct X has store, drop {
+        v: bool,
+    }
+
+    struct Y has store, drop {
+        v: u64,
+    }
+
+    struct Z has store, drop {
+        x: X,
+    }
+
+    public fun make_x(v: bool): X {
+        X { v }
+    }
+
+    public fun make_y(v: u64): Y {
+        Y { v }
+    }
+
+    public fun make_z(v: bool): Z {
+        let x = X { v };
+        Z { x }
+    }
+}

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -43,6 +43,7 @@ use sui_config::node::DBCheckpointConfig;
 use sui_config::node_config_metrics::NodeConfigMetrics;
 use sui_config::{ConsensusConfig, NodeConfig};
 use sui_core::authority::authority_per_epoch_store::AuthorityPerEpochStore;
+use sui_core::authority::authority_store_tables::AuthorityPerpetualTables;
 use sui_core::authority::epoch_start_configuration::EpochStartConfigTrait;
 use sui_core::authority::epoch_start_configuration::EpochStartConfiguration;
 use sui_core::authority_aggregator::AuthorityAggregator;
@@ -212,9 +213,15 @@ impl SuiNode {
         ));
 
         let perpetual_options = default_db_options().optimize_db_for_write_throughput(4);
-        let store = AuthorityStore::open(
+        let perpetual_tables = Arc::new(AuthorityPerpetualTables::open(
             &config.db_path().join("store"),
             Some(perpetual_options.options),
+        ));
+        let is_genesis = perpetual_tables
+            .database_is_empty()
+            .expect("Database read should not fail at init.");
+        let store = AuthorityStore::open(
+            perpetual_tables,
             genesis,
             &committee_store,
             config.indirect_objects_threshold,
@@ -247,6 +254,17 @@ impl SuiNode {
             signature_verifier_metrics,
             &config.expensive_safety_check_config,
         );
+
+        // the database is empty at genesis time
+        if is_genesis {
+            // When we are opening the db table, the only time when it's safe to
+            // check SUI conservation is at genesis. Otherwise we may be in the middle of
+            // an epoch and the SUI conservation check will fail. This also initialize
+            // the expected_network_sui_amount table.
+            store
+                .expensive_check_sui_conservation(epoch_store.move_vm())
+                .expect("SUI conservation check cannot fail at genesis");
+        }
 
         let effective_buffer_stake = epoch_store.get_effective_buffer_stake_bps();
         let default_buffer_stake = epoch_store

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -52,6 +52,32 @@ macro_rules! exit_main {
     };
 }
 
+#[macro_export]
+macro_rules! make_invariant_violation {
+    ($($args:expr),* $(,)?) => {{
+        if cfg!(debug_assertions) {
+            panic!($($args),*)
+        }
+        ExecutionError::invariant_violation(format!($($args),*))
+    }}
+}
+
+#[macro_export]
+macro_rules! invariant_violation {
+    ($($args:expr),* $(,)?) => {
+        return Err(make_invariant_violation!($($args),*).into())
+    };
+}
+
+#[macro_export]
+macro_rules! assert_invariant {
+    ($cond:expr, $($args:expr),*) => {{
+        if !$cond {
+            invariant_violation!($($args),*)
+        }
+    }};
+}
+
 #[derive(
     Eq, PartialEq, Clone, Debug, Serialize, Deserialize, Error, Hash, AsRefStr, IntoStaticStr,
 )]
@@ -366,6 +392,8 @@ pub enum SuiError {
     TransactionAlreadyExecuted { digest: TransactionDigest },
     #[error("Object ID did not have the expected type")]
     BadObjectType { error: String },
+    #[error("Fail to retrieve Object layout for {st}")]
+    FailObjectLayout { st: String },
 
     #[error("Execution invariant violated")]
     ExecutionInvariantViolation,

--- a/crates/sui-types/src/layout_resolver.rs
+++ b/crates/sui-types/src/layout_resolver.rs
@@ -1,0 +1,16 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    error::SuiError,
+    object::{MoveObject, ObjectFormatOptions},
+};
+use move_core_types::value::MoveStructLayout;
+
+pub trait LayoutResolver {
+    fn get_layout(
+        &mut self,
+        object: &MoveObject,
+        format: ObjectFormatOptions,
+    ) -> Result<MoveStructLayout, SuiError>;
+}

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -46,6 +46,7 @@ pub mod gas_model;
 pub mod governance;
 pub mod id;
 pub mod in_memory_storage;
+pub mod layout_resolver;
 pub mod message_envelope;
 pub mod messages_checkpoint;
 pub mod messages_consensus;

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -23,6 +23,7 @@ use crate::error::{ExecutionError, ExecutionErrorKind, UserInputError, UserInput
 use crate::error::{SuiError, SuiResult};
 use crate::gas_coin::TOTAL_SUPPLY_MIST;
 use crate::is_system_package;
+use crate::layout_resolver::LayoutResolver;
 use crate::move_package::MovePackage;
 use crate::{
     base_types::{
@@ -69,6 +70,10 @@ impl ObjectFormatOptions {
         ObjectFormatOptions {
             include_types: true,
         }
+    }
+
+    pub fn include_types(&self) -> bool {
+        self.include_types
     }
 }
 
@@ -349,7 +354,10 @@ impl MoveObject {
     }
 
     /// Get the total amount of SUI embedded in `self`. Intended for testing purposes
-    pub fn get_total_sui(&self, resolver: &impl GetModule) -> Result<u64, SuiError> {
+    pub fn get_total_sui(
+        &self,
+        layout_resolver: &mut impl LayoutResolver,
+    ) -> Result<u64, SuiError> {
         if self.type_.is_gas_coin() {
             // Fast path without deserialization.
             return Ok(self.get_coin_value_unsafe());
@@ -358,7 +366,7 @@ impl MoveObject {
         if self.type_.is_coin() {
             return Ok(0);
         }
-        let layout = self.get_layout(ObjectFormatOptions::with_types(), resolver)?;
+        let layout = layout_resolver.get_layout(self, ObjectFormatOptions::with_types())?;
         let move_struct = self.to_move_struct(&layout)?;
         Ok(Self::get_total_sui_in_struct(&move_struct, 0))
     }
@@ -811,10 +819,13 @@ impl Object {
 // Testing-related APIs.
 impl Object {
     /// Get the total amount of SUI embedded in `self`, including both Move objects and the storage rebate
-    pub fn get_total_sui(&self, resolver: &impl GetModule) -> Result<u64, SuiError> {
+    pub fn get_total_sui(
+        &self,
+        layout_resolver: &mut impl LayoutResolver,
+    ) -> Result<u64, SuiError> {
         Ok(self.storage_rebate
             + match &self.data {
-                Data::Move(m) => m.get_total_sui(resolver)?,
+                Data::Move(m) => m.get_total_sui(layout_resolver)?,
                 Data::Package(_) => 0,
             })
     }

--- a/crates/sui-types/src/temporary_store.rs
+++ b/crates/sui-types/src/temporary_store.rs
@@ -5,7 +5,7 @@ use move_binary_format::CompiledModule;
 use move_bytecode_utils::module_cache::GetModule;
 use move_core_types::account_address::AccountAddress;
 use move_core_types::language_storage::{ModuleId, StructTag};
-use move_core_types::resolver::{LinkageResolver, ModuleResolver, ResourceResolver};
+use move_core_types::resolver::{ModuleResolver, ResourceResolver};
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -17,6 +17,7 @@ use tracing::trace;
 use crate::committee::EpochId;
 use crate::effects::{TransactionEffects, TransactionEvents};
 use crate::execution_status::ExecutionStatus;
+use crate::layout_resolver::LayoutResolver;
 use crate::storage::ObjectStore;
 use crate::sui_system_state::{
     get_sui_system_state, get_sui_system_state_wrapper, AdvanceEpochParams, SuiSystemState,
@@ -1236,17 +1237,25 @@ impl<S: GetModule + ObjectStore + BackingPackageStore> TemporaryStore<S> {
         &self,
         id: &ObjectID,
         expected_version: SequenceNumber,
+        layout_resolver: &mut impl LayoutResolver,
         do_expensive_checks: bool,
     ) -> Result<(u64, u64), ExecutionError> {
         if let Some(obj) = self.input_objects.get(id) {
             // the assumption here is that if it is in the input objects must be the right one
             if obj.version() != expected_version {
-                return Err(ExecutionError::invariant_violation(format!("Version mismatching when resolving input object to check conservation--expected {}, got {}", expected_version, obj.version())));
+                invariant_violation!(
+                    "Version mismatching when resolving input object to check conservation--\
+                     expected {}, got {}",
+                    expected_version,
+                    obj.version(),
+                );
             }
             let input_sui = if do_expensive_checks {
-                obj.get_total_sui(&self).map_err(|_e| {
-                    ExecutionError::invariant_violation(
-                        "Failed looking up output SUI in SUI conservation checking",
+                obj.get_total_sui(layout_resolver).map_err(|e| {
+                    make_invariant_violation!(
+                        "Failed looking up input SUI in SUI conservation checking for input with \
+                         type {:?}: {e:#?}",
+                        obj.struct_tag(),
                     )
                 })?
             } else {
@@ -1256,26 +1265,25 @@ impl<S: GetModule + ObjectStore + BackingPackageStore> TemporaryStore<S> {
         } else {
             // not in input objects, must be a dynamic field
             if self.protocol_config.gas_model_version() < 2 {
-                let obj = self
-                    .store
-                    .get_object(id)
-                    .map_err(|_e| {
-                        ExecutionError::invariant_violation(
-                            "Failed looking up input object in SUI conservation checking",
-                        )
-                    })?
-                    .ok_or_else(|| {
-                        ExecutionError::invariant_violation(
-                            "Failed looking up input object in SUI conservation checking",
-                        )
-                    })?;
+                let Ok(Some(obj)) = self.store.get_object(id) else {
+                    invariant_violation!(
+                        "Failed looking up dynamic field {id} in SUI conservation checking"
+                    );
+                };
                 if obj.version() != expected_version {
-                    return Err(ExecutionError::invariant_violation(format!("Version mismatching when resolving dynamic field to check conservation--expected {}, got {}", expected_version, obj.version())));
+                    invariant_violation!(
+                        "Version mismatching when resolving dynamic field to check conservation--\
+                         expected {}, got {}",
+                        expected_version,
+                        obj.version(),
+                    );
                 }
                 let input_sui = if do_expensive_checks {
-                    obj.get_total_sui(&self).map_err(|_e| {
-                        ExecutionError::invariant_violation(
-                            "Failed looking up output SUI in SUI conservation checking",
+                    obj.get_total_sui(layout_resolver).map_err(|e| {
+                        make_invariant_violation!(
+                            "Failed looking up input SUI in SUI conservation checking for type \
+                             {:?}: {e:#?}",
+                            obj.struct_tag(),
                         )
                     })?
                 } else {
@@ -1283,23 +1291,17 @@ impl<S: GetModule + ObjectStore + BackingPackageStore> TemporaryStore<S> {
                 };
                 Ok((input_sui, obj.storage_rebate))
             } else {
-                let obj = self
-                    .store
-                    .get_object_by_key(id, expected_version)
-                    .map_err(|_e| {
-                        ExecutionError::invariant_violation(
-                            "Failed looking up input object in SUI conservation checking",
-                        )
-                    })?
-                    .ok_or_else(|| {
-                        ExecutionError::invariant_violation(
-                            "Failed looking up input object in SUI conservation checking",
-                        )
-                    })?;
+                let Ok(Some(obj))= self.store.get_object_by_key(id, expected_version) else {
+                    invariant_violation!(
+                        "Failed looking up dynamic field {id} in SUI conservation checking"
+                    );
+                };
                 let input_sui = if do_expensive_checks {
-                    obj.get_total_sui(&self).map_err(|_e| {
-                        ExecutionError::invariant_violation(
-                            "Failed looking up output SUI in SUI conservation checking",
+                    obj.get_total_sui(layout_resolver).map_err(|e| {
+                        make_invariant_violation!(
+                            "Failed looking up input SUI in SUI conservation checking for type \
+                             {:?}: {e:#?}",
+                            obj.struct_tag(),
                         )
                     })?
                 } else {
@@ -1310,22 +1312,32 @@ impl<S: GetModule + ObjectStore + BackingPackageStore> TemporaryStore<S> {
         }
     }
 
-    /// Check that this transaction neither creates nor destroys SUI. This should hold for all txes except
-    /// the epoch change tx, which mints staking rewards equal to the gas fees burned in the previous epoch.
-    /// Specifically, this checks two key invariants about storage fees and storage rebate:
-    /// 1. all SUI in storage rebate fields of input objects should flow either to the transaction storage rebate, or the transaction non-refundable storage rebate
-    /// 2. all SUI charged for storage should flow into the storage rebate field of some output object
+    /// Check that this transaction neither creates nor destroys SUI. This should hold for all txes
+    /// except the epoch change tx, which mints staking rewards equal to the gas fees burned in the
+    /// previous epoch.  Specifically, this checks two key invariants about storage fees and storage
+    /// rebate:
+    ///
+    /// 1. all SUI in storage rebate fields of input objects should flow either to the transaction
+    ///    storage rebate, or the transaction non-refundable storage rebate
+    /// 2. all SUI charged for storage should flow into the storage rebate field of some output
+    ///    object
+    ///
     /// If `do_expensive_checks` is true, this will also check a third invariant:
-    /// 3. all SUI in input objects (including coins etc in the Move part of an object) should flow either to an output object, or be burned as part of computation fees or non-refundable storage rebate
-    /// This function is intended to be called *after* we have charged for gas + applied the storage rebate to the gas object,
-    /// but *before* we have updated object versions.
-    /// if `do_expensive_checks` is false, this function will only check conservation of object storage rea
-    /// `epoch_fees` and `epoch_rebates` are only set for advance epoch transactions.
-    /// The advance epoch transaction would mint `epoch_fees` amount of SUI, and burn
-    /// `epoch_rebates` amount of SUI. We need these information for conservation check.
+    ///
+    /// 3. all SUI in input objects (including coins etc in the Move part of an object) should flow
+    ///    either to an output object, or be burned as part of computation fees or non-refundable
+    ///    storage rebate
+    ///
+    /// This function is intended to be called *after* we have charged for gas + applied the storage
+    /// rebate to the gas object, but *before* we have updated object versions.  If
+    /// `do_expensive_checks` is false, this function will only check conservation of object storage
+    /// rea `epoch_fees` and `epoch_rebates` are only set for advance epoch transactions.  The
+    /// advance epoch transaction would mint `epoch_fees` amount of SUI, and burn `epoch_rebates`
+    /// amount of SUI. We need these information for conservation check.
     pub fn check_sui_conserved(
         &self,
         advance_epoch_gas_summary: Option<(u64, u64)>,
+        layout_resolver: &mut impl LayoutResolver,
         do_expensive_checks: bool,
     ) -> Result<(), ExecutionError> {
         // total amount of SUI in input objects, including both coins and storage rebates
@@ -1342,15 +1354,22 @@ impl<S: GetModule + ObjectStore + BackingPackageStore> TemporaryStore<S> {
                     // note: output_obj.version has not yet been increased by the tx, so output_obj.version
                     // is the object version at tx input
                     let input_version = output_obj.version();
-                    let (input_sui, input_storage_rebate) =
-                        self.get_input_sui(id, input_version, do_expensive_checks)?;
+                    let (input_sui, input_storage_rebate) = self.get_input_sui(
+                        id,
+                        input_version,
+                        layout_resolver,
+                        do_expensive_checks,
+                    )?;
                     total_input_sui += input_sui;
                     if do_expensive_checks {
-                        total_output_sui += output_obj.get_total_sui(&self).map_err(|_e| {
-                            ExecutionError::invariant_violation(
-                                "Failed looking up output SUI in SUI conservation checking",
-                            )
-                        })?;
+                        total_output_sui +=
+                            output_obj.get_total_sui(layout_resolver).map_err(|e| {
+                                make_invariant_violation!(
+                                    "Failed looking up output SUI in SUI conservation checking for \
+                                     mutated type {:?}: {e:#?}",
+                                    output_obj.struct_tag(),
+                                )
+                            })?;
                     }
                     total_input_rebate += input_storage_rebate;
                     total_output_rebate += output_obj.storage_rebate;
@@ -1358,11 +1377,14 @@ impl<S: GetModule + ObjectStore + BackingPackageStore> TemporaryStore<S> {
                 WriteKind::Create => {
                     // created objects did not exist at input, and thus contribute 0 to input SUI
                     if do_expensive_checks {
-                        total_output_sui += output_obj.get_total_sui(&self).map_err(|_e| {
-                            ExecutionError::invariant_violation(
-                                "Failed looking up output SUI in SUI conservation checking",
-                            )
-                        })?;
+                        total_output_sui +=
+                            output_obj.get_total_sui(layout_resolver).map_err(|e| {
+                                make_invariant_violation!(
+                                    "Failed looking up output SUI in SUI conservation checking for \
+                                     created type {:?}: {e:#?}",
+                                    output_obj.struct_tag()
+                                )
+                            })?;
                     }
                     total_output_rebate += output_obj.storage_rebate;
                 }
@@ -1372,11 +1394,14 @@ impl<S: GetModule + ObjectStore + BackingPackageStore> TemporaryStore<S> {
                     // 2. wrapped in a dynamic field A, or itself a dynamic field
                     // in both cases, its contribution to input SUI will be captured by looking at A
                     if do_expensive_checks {
-                        total_output_sui += output_obj.get_total_sui(&self).map_err(|_e| {
-                            ExecutionError::invariant_violation(
-                                "Failed looking up output SUI in SUI conservation checking",
-                            )
-                        })?;
+                        total_output_sui +=
+                            output_obj.get_total_sui(layout_resolver).map_err(|e| {
+                                make_invariant_violation!(
+                                    "Failed looking up output SUI in SUI conservation checking for \
+                                     unwrapped type {:?}: {e:#?}",
+                                    output_obj.struct_tag(),
+                                )
+                            })?;
                     }
                     total_output_rebate += output_obj.storage_rebate;
                 }
@@ -1385,16 +1410,24 @@ impl<S: GetModule + ObjectStore + BackingPackageStore> TemporaryStore<S> {
         for (id, (input_version, kind)) in &self.deleted {
             match kind {
                 DeleteKind::Normal => {
-                    let (input_sui, input_storage_rebate) =
-                        self.get_input_sui(id, *input_version, do_expensive_checks)?;
+                    let (input_sui, input_storage_rebate) = self.get_input_sui(
+                        id,
+                        *input_version,
+                        layout_resolver,
+                        do_expensive_checks,
+                    )?;
                     total_input_sui += input_sui;
                     total_input_rebate += input_storage_rebate;
                 }
                 DeleteKind::Wrap => {
                     // wrapped object was a tx input or dynamic field--need to account for it in input SUI
                     // note: if an object is created by the tx, then wrapped, it will not appear here
-                    let (input_sui, input_storage_rebate) =
-                        self.get_input_sui(id, *input_version, do_expensive_checks)?;
+                    let (input_sui, input_storage_rebate) = self.get_input_sui(
+                        id,
+                        *input_version,
+                        layout_resolver,
+                        do_expensive_checks,
+                    )?;
                     total_input_sui += input_sui;
                     total_input_rebate += input_storage_rebate;
                     // else, the wrapped object was either:
@@ -1499,25 +1532,24 @@ impl<S: ChildObjectResolver> Storage for TemporaryStore<S> {
     }
 }
 
-impl<S: BackingPackageStore> BackingPackageStore for TemporaryStore<S> {
+impl<S: BackingPackageStore> BackingPackageStore for &TemporaryStore<S> {
     fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<Object>> {
-        self.store.get_package_object(package_id).map(|obj| {
-            // Track object but leave unchanged
-            if let Some(v) = obj.clone() {
-                // Can this lock ever block execution?
-                self.runtime_read_objects.write().insert(*package_id, v);
-            }
-            obj
-        })
+        if let Some((obj, _)) = self.written.get(package_id) {
+            Ok(Some(obj.clone()))
+        } else {
+            self.store.get_package_object(package_id).map(|obj| {
+                // Track object but leave unchanged
+                if let Some(v) = obj.clone() {
+                    // Can this lock ever block execution?
+                    self.runtime_read_objects.write().insert(*package_id, v);
+                }
+                obj
+            })
+        }
     }
 }
 
-/// TODO: Proper implementation of re-linking (currently the default implementation does nothing).
-impl<S> LinkageResolver for TemporaryStore<S> {
-    type Error = SuiError;
-}
-
-impl<S: BackingPackageStore> ModuleResolver for TemporaryStore<S> {
+impl<S: BackingPackageStore> ModuleResolver for &TemporaryStore<S> {
     type Error = SuiError;
     fn get_module(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
         let package_id = &ObjectID::from(*module_id.address());
@@ -1546,7 +1578,7 @@ impl<S: BackingPackageStore> ModuleResolver for TemporaryStore<S> {
     }
 }
 
-impl<S> ResourceResolver for TemporaryStore<S> {
+impl<S> ResourceResolver for &TemporaryStore<S> {
     type Error = SuiError;
 
     fn get_resource(

--- a/crates/sui/tests/dynamic_committee_tests.rs
+++ b/crates/sui/tests/dynamic_committee_tests.rs
@@ -20,6 +20,8 @@ use sui_core::{
 };
 use sui_node::SuiNodeHandle;
 
+use sui_adapter::type_layout_resolver::TypeLayoutResolver;
+use sui_core::authority::AuthorityState;
 use sui_types::effects::{CertifiedTransactionEffects, TransactionEffects, TransactionEffectsAPI};
 use sui_types::{
     base_types::{ObjectID, ObjectRef, SuiAddress},
@@ -246,6 +248,9 @@ impl StressTestRunner {
         println!("CREATED:");
         self.nodes[0].with(|node| {
             let state = node.state();
+            let epoch_store = state.load_epoch_store_one_call_per_task();
+            let move_vm = epoch_store.move_vm();
+            let mut layout_resolver = TypeLayoutResolver::new(move_vm, state.database.as_ref());
             for (obj_ref, _) in &effects.created {
                 let object_opt = state
                     .database
@@ -254,7 +259,7 @@ impl StressTestRunner {
                 let Some(object) = object_opt else { continue };
                 let struct_tag = object.struct_tag().unwrap();
                 let total_sui =
-                    object.get_total_sui(&state.database).unwrap() - object.storage_rebate;
+                    object.get_total_sui(&mut layout_resolver).unwrap() - object.storage_rebate;
                 println!(">> {struct_tag} TOTAL_SUI: {total_sui}");
             }
 
@@ -267,7 +272,7 @@ impl StressTestRunner {
                     .unwrap();
                 let struct_tag = object.struct_tag().unwrap();
                 let total_sui =
-                    object.get_total_sui(&state.database).unwrap() - object.storage_rebate;
+                    object.get_total_sui(&mut layout_resolver).unwrap() - object.storage_rebate;
                 println!(">> {struct_tag} TOTAL_SUI: {total_sui}");
             }
 
@@ -280,7 +285,7 @@ impl StressTestRunner {
                     .unwrap();
                 let struct_tag = object.struct_tag().unwrap();
                 let total_sui =
-                    object.get_total_sui(&state.database).unwrap() - object.storage_rebate;
+                    object.get_total_sui(&mut layout_resolver).unwrap() - object.storage_rebate;
                 println!(">> {struct_tag} TOTAL_SUI: {total_sui}");
             }
         })
@@ -288,6 +293,10 @@ impl StressTestRunner {
 
     pub async fn db(&self) -> Arc<AuthorityStore> {
         self.nodes[0].with(|node| node.state().db())
+    }
+
+    pub async fn state(&self) -> Arc<AuthorityState> {
+        self.nodes[0].with(|node| node.state())
     }
 
     pub async fn change_epoch(&mut self) {
@@ -405,8 +414,13 @@ mod add_stake {
                 .get_created_object_of_type_name(effects, "StakedSui")
                 .await
                 .unwrap();
+            let store = runner.db().await;
+            let state = runner.state().await;
+            let epoch_store = state.load_epoch_store_one_call_per_task();
+            let move_vm = epoch_store.move_vm();
+            let mut layout_resolver = TypeLayoutResolver::new(move_vm, store.as_ref());
             let staked_amount =
-                object.get_total_sui(&runner.db().await).unwrap() - object.storage_rebate;
+                object.get_total_sui(&mut layout_resolver).unwrap() - object.storage_rebate;
             assert_eq!(staked_amount, self.stake_amount);
             assert_eq!(object.owner.get_owner_address().unwrap(), self.sender);
             runner.display_effects(effects);

--- a/crates/transaction-fuzzer/Cargo.toml
+++ b/crates/transaction-fuzzer/Cargo.toml
@@ -19,6 +19,7 @@ tracing = "0.1.36"
 
 test-utils = { path = "../test-utils" }
 once_cell = "1.16"
+sui-adapter = { path = "../sui-adapter" }
 sui-core = { path = "../sui-core" }
 sui-protocol-config = { path = "../sui-protocol-config" }
 sui-types = { path = "../sui-types", features = ["fuzzing"] }

--- a/external-crates/move/move-core/types/src/resolver.rs
+++ b/external-crates/move/move-core/types/src/resolver.rs
@@ -8,6 +8,7 @@ use crate::{
     language_storage::{ModuleId, StructTag},
 };
 use std::fmt::Debug;
+use std::sync::Arc;
 
 /// Traits for resolving Move modules and resources from persistent storage
 
@@ -108,6 +109,13 @@ impl<T: ResourceResolver + ?Sized> ResourceResolver for &T {
 }
 
 impl<T: ModuleResolver + ?Sized> ModuleResolver for &T {
+    type Error = T::Error;
+    fn get_module(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
+        (**self).get_module(module_id)
+    }
+}
+
+impl<T: ModuleResolver + ?Sized> ModuleResolver for Arc<T> {
     type Error = T::Error;
     fn get_module(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
         (**self).get_module(module_id)


### PR DESCRIPTION
## Description 

- Move expensive_check_sui_conservation to node init
- Expose a layout resolver based on a VM session
- Decouple MoveResolver traits from Storage traits

In some of the places where we want to use the layout resolver, we
don't have access to all the information to implement `StorageView`,
but we only need to use the `BackingPackageStore`.

To support these cases, we need to provide a state view to
`LinkageView` that can serve packages, and then shim the Module and
Resource resolution functions.

This requires that `LinkageView` no longer accept a reference
parameter, but a value (so we can inject state into it) -- similar to
the trick we pulled to allow `Session` to own a `LinkageView`.  Then
implementors (like `TemporaryStore`) that only need to be passed by
reference can be passed by explicit reference,

i.e. `LinkageView<'state, TemporaryStore>` becomes
`LinkageView<&'state TemporaryStore>`.

However, we cannot impose a `&'state S: StorageView` bound, because
some APIs in `StorageView` require a mutable reference, so we needed
to decouple the resolution traits (now `SuiResolver`) and the storage
traits, to impose twin constraints:

```
fn ...<'state, S>
where
  S: StorageView
  &'state S: SuiResolver
```

- Logging improvements
- Bring `invariant_violation!` macro into `sui-types`.
- Create a variant of it -- `make_invariant_violation!` -- that
  creates the error, but does not wrap it in a result of return it.
- Add `format!` string support to these macros
- Use this macro for invariant violations within conservation checking
  with extra context on what is failing (what stage, what type is
  involved)
- Enable telemetry_subscription in the `move_package_upgrade_tests` to
  see the logs from authorities during tests.
- (Temporary) Print the IDs of published/upgraded packages in the
  failing test, for context.

## Test Plan 

Existing tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
