### PR TITLE
Use coin symbol from metadata

### DIFF
--- a/apps/explorer/src/components/GasPriceCard/index.tsx
+++ b/apps/explorer/src/components/GasPriceCard/index.tsx
@@ -5,11 +5,10 @@ import {
     CoinFormat,
     formatBalance,
     formatDate,
-    useCoinDecimals,
     useGetReferenceGasPrice,
     useRpcClient,
 } from '@mysten/core';
-import { SUI_TYPE_ARG } from '@mysten/sui.js';
+import { SUI_DECIMALS } from '@mysten/sui.js';
 import { useQuery } from '@tanstack/react-query';
 import { ParentSize } from '@visx/responsive';
 import clsx from 'clsx';
@@ -89,11 +88,10 @@ function useGasPriceAverage(totalEpochs: number) {
 }
 
 function useGasPriceFormat(gasPrice: bigint | null, unit: 'MIST' | 'SUI') {
-    const [suiDecimals] = useCoinDecimals(SUI_TYPE_ARG);
     return gasPrice !== null
         ? formatBalance(
               gasPrice,
-              unit === 'MIST' ? 0 : suiDecimals,
+              unit === 'MIST' ? 0 : SUI_DECIMALS,
               CoinFormat.FULL
           )
         : null;

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/PreviewTransfer.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/PreviewTransfer.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useCoinDecimals } from '@mysten/core';
+import { useCoinMetadata } from '@mysten/core';
 
 import { Text } from '_app/shared/text';
 import { TxnAddress } from '_components/receipt-card/TxnAddress';
@@ -26,8 +26,8 @@ export function PreviewTransfer({
     gasBudget,
 }: PreviewTransferProps) {
     const accountAddress = useActiveAddress();
-    const [decimals] = useCoinDecimals(coinType);
-    const amountWithoutDecimals = parseAmount(amount, decimals);
+    const { data: metadata } = useCoinMetadata(coinType);
+    const amountWithoutDecimals = parseAmount(amount, metadata?.decimals ?? 0);
 
     return (
         <div className="divide-y divide-solid divide-steel/20 divide-x-0 flex flex-col px-2.5 w-full">

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/SendTokenForm.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/SendTokenForm.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useCoinDecimals, useFormatCoin, CoinFormat } from '@mysten/core';
+import { useCoinMetadata, useFormatCoin, CoinFormat } from '@mysten/core';
 import { ArrowRight16 } from '@mysten/icons';
 import { SUI_TYPE_ARG, Coin as CoinAPI, type CoinStruct } from '@mysten/sui.js';
 import { Field, Form, useFormikContext, Formik } from 'formik';
@@ -123,7 +123,8 @@ export function SendTokenForm({
     const suiBalance = CoinAPI.totalBalance(suiCoinsData || []);
 
     const coinSymbol = (coinType && CoinAPI.getCoinSymbol(coinType)) || '';
-    const [coinDecimals, coinDecimalsQueryResult] = useCoinDecimals(coinType);
+    const coinMetadata = useCoinMetadata(coinType);
+    const coinDecimals = coinMetadata.data?.decimals ?? 0;
 
     const validationSchemaStepOne = useMemo(
         () =>
@@ -149,7 +150,7 @@ export function SendTokenForm({
         <Loading
             loading={
                 queryResult.isLoading ||
-                coinDecimalsQueryResult.isLoading ||
+                coinMetadata.isLoading ||
                 suiCoinsIsLoading ||
                 coinsIsLoading
             }

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/index.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useCoinDecimals } from '@mysten/core';
+import { useCoinMetadata } from '@mysten/core';
 import { ArrowRight16, ArrowLeft16 } from '@mysten/icons';
 import { getTransactionDigest } from '@mysten/sui.js';
 import * as Sentry from '@sentry/react';
@@ -35,7 +35,7 @@ function TransferCoinPage() {
         useState<boolean>(false);
     const [formData, setFormData] = useState<SubmitProps>();
     const navigate = useNavigate();
-    const [coinDecimals] = useCoinDecimals(coinType);
+    const { data: coinMetadata } = useCoinMetadata(coinType);
     const signer = useSigner();
     const address = useActiveAddress();
     const queryClient = useQueryClient();
@@ -45,10 +45,10 @@ function TransferCoinPage() {
 
         return createTokenTransferTransaction({
             coinType,
-            coinDecimals,
+            coinDecimals: coinMetadata?.decimals ?? 0,
             ...formData,
         });
-    }, [formData, signer, coinType, address, coinDecimals]);
+    }, [formData, signer, coinType, address, coinMetadata?.decimals]);
 
     const executeTransfer = useMutation({
         mutationFn: async () => {

--- a/apps/wallet/src/ui/app/staking/stake/StakeForm.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/StakeForm.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
-    useCoinDecimals,
+    useCoinMetadata,
     useFormatCoin,
     useGetTimeBeforeEpochNumber,
 } from '@mysten/core';
@@ -36,7 +36,8 @@ function StakeForm({
 }: StakeFromProps) {
     const { values, setFieldValue } = useFormikContext<FormValues>();
 
-    const [decimals] = useCoinDecimals(coinType);
+    const { data: metadata } = useCoinMetadata(coinType);
+    const decimals = metadata?.decimals ?? 0;
     const [maxToken, symbol, queryResult] = useFormatCoin(
         coinBalance,
         coinType

--- a/apps/wallet/src/ui/app/staking/stake/StakingCard.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/StakingCard.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useFeatureIsOn } from '@growthbook/growthbook-react';
-import { useCoinDecimals, useGetSystemState } from '@mysten/core';
+import { useCoinMetadata, useGetSystemState } from '@mysten/core';
 import { ArrowLeft16 } from '@mysten/icons';
 import {
     getTransactionDigest,
@@ -91,7 +91,8 @@ function StakingCard() {
 
     const suiEarned = stakeData?.estimatedReward || '0';
 
-    const [coinDecimals] = useCoinDecimals(coinType);
+    const { data: metadata } = useCoinMetadata(coinType);
+    const coinDecimals = metadata?.decimals ?? 0;
     // set minimum stake amount to 1 SUI
     const minimumStake = parseAmount('1', coinDecimals);
 

--- a/sdk/typescript/src/types/objects.ts
+++ b/sdk/typescript/src/types/objects.ts
@@ -107,6 +107,8 @@ export const SuiRawData = union([
 ]);
 export type SuiRawData = Infer<typeof SuiRawData>;
 
+export const SUI_DECIMALS = 9;
+
 export const MIST_PER_SUI = BigInt(1000000000);
 
 export const ObjectDigest = string();


### PR DESCRIPTION
## Description 

Our apps were using a parsed coin symbol from the type name, not from the metadata. This updates to only use the parsed symbol as a fallback, and use the coin metadata when we can. The one side-effect of this is that symbol have a small delay when loading, but they will at least display the correct values now.

## Test Plan 

Ran explorer locally

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
