### PR TITLE
[ConsensusAdapter] reduce the min expected consensus latency

### DIFF
--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -404,7 +404,7 @@ impl ConsensusAdapter {
         let (mut position, mapped_to_low_scoring) = self.submission_position(committee, tx_digest);
 
         const MAX_LATENCY: Duration = Duration::from_secs(5 * 60);
-        const DEFAULT_LATENCY: Duration = Duration::from_secs(5);
+        const DEFAULT_LATENCY: Duration = Duration::from_secs(3); // > p50 consensus latency with global deployment
         let latency = self.latency_observer.latency().unwrap_or(DEFAULT_LATENCY);
         let latency = std::cmp::max(latency, DEFAULT_LATENCY);
         let latency = std::cmp::min(latency, MAX_LATENCY);
@@ -413,7 +413,7 @@ impl ConsensusAdapter {
             position = std::cmp::min(position, max_submit_position);
         }
 
-        let delay_step = self.submit_delay_step_override.unwrap_or(latency * 3 / 2);
+        let delay_step = self.submit_delay_step_override.unwrap_or(latency * 2);
 
         self.metrics
             .sequencing_estimated_latency
@@ -1053,8 +1053,8 @@ mod adapter_tests {
 
         assert_eq!(position, 7);
 
-        // delay_step * position * 3/2 = 5 * 7 * 3/2 = 52.5
-        assert_eq!(delay_step, Duration::from_millis(52500));
+        // delay_step * position = 3 * 2 * 7 = 42
+        assert_eq!(delay_step, Duration::from_secs(42));
         assert!(!low_scoring_authority);
     }
 


### PR DESCRIPTION
## Description 

p50 consensus latency is < 2s on testnet, so min resubmission latency should be lower, e.g. 2s * 1.5 ~ 3s, instead of 5s * 1.5 ~ 7.5s. If the p50 latency increases for various reasons, we rely on `LatencyObserver` to provide a more accurate value.

## Test Plan 

CI. Private testnet.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
