### PR TITLE
best efforts post quorum cert broadcasting

### DIFF
--- a/crates/sui-benchmark/src/fullnode_reconfig_observer.rs
+++ b/crates/sui-benchmark/src/fullnode_reconfig_observer.rs
@@ -23,7 +23,7 @@ pub struct FullNodeReconfigObserver {
     pub fullnode_client: SuiClient,
     committee_store: Arc<CommitteeStore>,
     safe_client_metrics_base: SafeClientMetricsBase,
-    auth_agg_metrics: AuthAggMetrics,
+    auth_agg_metrics: Arc<AuthAggMetrics>,
 }
 
 impl FullNodeReconfigObserver {
@@ -31,7 +31,7 @@ impl FullNodeReconfigObserver {
         fullnode_rpc_url: &str,
         committee_store: Arc<CommitteeStore>,
         safe_client_metrics_base: SafeClientMetricsBase,
-        auth_agg_metrics: AuthAggMetrics,
+        auth_agg_metrics: Arc<AuthAggMetrics>,
     ) -> Self {
         Self {
             fullnode_client: SuiClientBuilder::default()

--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -227,7 +227,7 @@ pub trait ValidatorProxy {
     /// signature. It should only be used for benchmarks.
     async fn execute_bench_transaction(&self, tx: Transaction) -> anyhow::Result<ExecutionEffects>;
 
-    fn clone_committee(&self) -> Committee;
+    fn clone_committee(&self) -> Arc<Committee>;
 
     fn get_current_epoch(&self) -> EpochId;
 
@@ -590,7 +590,7 @@ impl ValidatorProxy for LocalValidatorAggregatorProxy {
         Ok(effects)
     }
 
-    fn clone_committee(&self) -> Committee {
+    fn clone_committee(&self) -> Arc<Committee> {
         self.qd.clone_committee()
     }
 
@@ -622,7 +622,7 @@ impl ValidatorProxy for LocalValidatorAggregatorProxy {
 
 pub struct FullNodeProxy {
     sui_client: SuiClient,
-    committee: Committee,
+    committee: Arc<Committee>,
 }
 
 impl FullNodeProxy {
@@ -643,7 +643,7 @@ impl FullNodeProxy {
 
         Ok(Self {
             sui_client,
-            committee,
+            committee: Arc::new(committee),
         })
     }
 }
@@ -756,7 +756,7 @@ impl ValidatorProxy for FullNodeProxy {
         self.execute_transaction_block(tx).await
     }
 
-    fn clone_committee(&self) -> Committee {
+    fn clone_committee(&self) -> Arc<Committee> {
         self.committee.clone()
     }
 

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -265,8 +265,6 @@ pub struct AuthorityEpochTables {
     /// Non-empty list of transactions here might result in empty list when we are forming checkpoint.
     /// Because we don't want to create checkpoints with empty content(see CheckpointBuilder::write_checkpoint),
     /// the sequence number of checkpoint does not match height here.
-    ///
-    /// The boolean value indicates whether this is the last checkpoint of the epoch.
     #[default_options_override_fn = "pending_checkpoints_table_default_config"]
     pending_checkpoints: DBMap<CheckpointCommitHeight, PendingCheckpoint>,
 

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -8,8 +8,9 @@ use crate::authority_client::{
 };
 use crate::safe_client::{SafeClient, SafeClientMetrics, SafeClientMetricsBase};
 use fastcrypto::encoding::Encoding;
+use futures::Future;
 use futures::{future::BoxFuture, stream::FuturesUnordered, StreamExt};
-use mysten_metrics::{monitored_future, GaugeGuard};
+use mysten_metrics::{monitored_future, spawn_monitored_task, GaugeGuard};
 use mysten_network::config::Config;
 use std::convert::AsRef;
 use sui_config::genesis::Genesis;
@@ -65,34 +66,20 @@ pub type AsyncResult<'a, T, E> = BoxFuture<'a, Result<T, E>>;
 
 #[derive(Clone)]
 pub struct TimeoutConfig {
-    // Timeout used when making many concurrent requests - ok if it is large because a slow
-    // authority won't block other authorities from being contacted.
-    pub authority_request_timeout: Duration,
     pub pre_quorum_timeout: Duration,
     pub post_quorum_timeout: Duration,
 
-    // Timeout used when making serial requests. Should be smaller, since we wait to hear from each
-    // authority before continuing.
-    pub serial_authority_request_timeout: Duration,
-
     // Timeout used to determine when to start a second "serial" request for
-    // quorum_once_with_timeout. This is a latency optimization that prevents us from having
-    // to wait an entire serial_authority_request_timeout interval before starting a second
-    // request.
-    //
-    // If this is set to zero, then quorum_once_with_timeout becomes completely parallelized - if
-    // it is set to a value greater than serial_authority_request_timeout then it becomes
-    // completely serial.
+    // quorum_once_with_timeout. If this is set to zero, then
+    // quorum_once_with_timeout becomes completely parallelized.
     pub serial_authority_request_interval: Duration,
 }
 
 impl Default for TimeoutConfig {
     fn default() -> Self {
         Self {
-            authority_request_timeout: Duration::from_secs(60),
             pre_quorum_timeout: Duration::from_secs(60),
-            post_quorum_timeout: Duration::from_secs(30),
-            serial_authority_request_timeout: Duration::from_secs(5),
+            post_quorum_timeout: Duration::from_secs(7),
             serial_authority_request_interval: Duration::from_millis(1000),
         }
     }
@@ -111,6 +98,8 @@ pub struct AuthAggMetrics {
     pub inflight_certificates: IntGauge,
     pub inflight_transaction_requests: IntGauge,
     pub inflight_certificate_requests: IntGauge,
+
+    pub cert_broadcasting_post_quorum_timeout: IntCounter,
 }
 
 impl AuthAggMetrics {
@@ -177,6 +166,12 @@ impl AuthAggMetrics {
             inflight_certificate_requests: register_int_gauge_with_registry!(
                 "auth_agg_inflight_certificate_requests",
                 "Inflight handle_certificate requests",
+                registry,
+            )
+            .unwrap(),
+            cert_broadcasting_post_quorum_timeout: register_int_counter_with_registry!(
+                "auth_agg_cert_broadcasting_post_quorum_timeout",
+                "Total number of timeout in cert processing post quorum",
                 registry,
             )
             .unwrap(),
@@ -349,13 +344,13 @@ impl ProcessTransactionResult {
 }
 
 #[derive(Clone)]
-pub struct AuthorityAggregator<A> {
+pub struct AuthorityAggregator<A: Clone> {
     /// Our Sui committee.
-    pub committee: Committee,
+    pub committee: Arc<Committee>,
     /// How to talk to this committee.
-    pub authority_clients: BTreeMap<AuthorityName, SafeClient<A>>,
+    pub authority_clients: Arc<BTreeMap<AuthorityName, Arc<SafeClient<A>>>>,
     /// Metrics
-    pub metrics: AuthAggMetrics,
+    pub metrics: Arc<AuthAggMetrics>,
     /// Metric base for the purpose of creating new safe clients during reconfiguration.
     pub safe_client_metrics_base: SafeClientMetricsBase,
     pub timeouts: TimeoutConfig,
@@ -363,7 +358,7 @@ pub struct AuthorityAggregator<A> {
     pub committee_store: Arc<CommitteeStore>,
 }
 
-impl<A> AuthorityAggregator<A> {
+impl<A: Clone> AuthorityAggregator<A> {
     pub fn new(
         committee: Committee,
         committee_store: Arc<CommitteeStore>,
@@ -388,22 +383,24 @@ impl<A> AuthorityAggregator<A> {
     ) -> Self {
         let safe_client_metrics_base = SafeClientMetricsBase::new(registry);
         Self {
-            committee,
-            authority_clients: authority_clients
-                .into_iter()
-                .map(|(name, api)| {
-                    (
-                        name,
-                        SafeClient::new(
-                            api,
-                            committee_store.clone(),
+            committee: Arc::new(committee),
+            authority_clients: Arc::new(
+                authority_clients
+                    .into_iter()
+                    .map(|(name, api)| {
+                        (
                             name,
-                            SafeClientMetrics::new(&safe_client_metrics_base, name),
-                        ),
-                    )
-                })
-                .collect(),
-            metrics: AuthAggMetrics::new(registry),
+                            Arc::new(SafeClient::new(
+                                api,
+                                committee_store.clone(),
+                                name,
+                                SafeClientMetrics::new(&safe_client_metrics_base, name),
+                            )),
+                        )
+                    })
+                    .collect(),
+            ),
+            metrics: Arc::new(AuthAggMetrics::new(registry)),
             safe_client_metrics_base,
             timeouts,
             committee_store,
@@ -415,24 +412,26 @@ impl<A> AuthorityAggregator<A> {
         committee_store: Arc<CommitteeStore>,
         authority_clients: BTreeMap<AuthorityName, A>,
         safe_client_metrics_base: SafeClientMetricsBase,
-        auth_agg_metrics: AuthAggMetrics,
+        auth_agg_metrics: Arc<AuthAggMetrics>,
     ) -> Self {
         Self {
-            committee,
-            authority_clients: authority_clients
-                .into_iter()
-                .map(|(name, api)| {
-                    (
-                        name,
-                        SafeClient::new(
-                            api,
-                            committee_store.clone(),
+            committee: Arc::new(committee),
+            authority_clients: Arc::new(
+                authority_clients
+                    .into_iter()
+                    .map(|(name, api)| {
+                        (
                             name,
-                            SafeClientMetrics::new(&safe_client_metrics_base, name),
-                        ),
-                    )
-                })
-                .collect(),
+                            Arc::new(SafeClient::new(
+                                api,
+                                committee_store.clone(),
+                                name,
+                                SafeClientMetrics::new(&safe_client_metrics_base, name),
+                            )),
+                        )
+                    })
+                    .collect(),
+            ),
             metrics: auth_agg_metrics,
             safe_client_metrics_base,
             timeouts: Default::default(),
@@ -466,12 +465,12 @@ impl<A> AuthorityAggregator<A> {
             .map(|(name, api)| {
                 (
                     name,
-                    SafeClient::new(
+                    Arc::new(SafeClient::new(
                         api,
                         self.committee_store.clone(),
                         name,
                         SafeClientMetrics::new(&self.safe_client_metrics_base, name),
-                    ),
+                    )),
                 )
             })
             .collect::<BTreeMap<_, _>>();
@@ -497,8 +496,8 @@ impl<A> AuthorityAggregator<A> {
         // store and all of them need to reconfigure.
         let _ = self.committee_store.insert_new_committee(&new_committee);
         Ok(AuthorityAggregator {
-            committee: new_committee,
-            authority_clients: safe_clients,
+            committee: Arc::new(new_committee),
+            authority_clients: Arc::new(safe_clients),
             metrics: self.metrics.clone(),
             timeouts: self.timeouts.clone(),
             safe_client_metrics_base: self.safe_client_metrics_base.clone(),
@@ -506,30 +505,31 @@ impl<A> AuthorityAggregator<A> {
         })
     }
 
-    pub fn get_client(&self, name: &AuthorityName) -> Option<&SafeClient<A>> {
+    pub fn get_client(&self, name: &AuthorityName) -> Option<&Arc<SafeClient<A>>> {
         self.authority_clients.get(name)
     }
 
-    pub fn clone_client(&self, name: &AuthorityName) -> SafeClient<A>
+    pub fn clone_client_test_only(&self, name: &AuthorityName) -> Arc<SafeClient<A>>
     where
         A: Clone,
     {
         self.authority_clients[name].clone()
     }
 
-    pub fn clone_inner_clients(&self) -> BTreeMap<AuthorityName, A>
-    where
-        A: Clone,
-    {
-        let mut clients = BTreeMap::new();
-        for (name, client) in &self.authority_clients {
-            clients.insert(*name, client.authority_client().clone());
-        }
-        clients
-    }
-
     pub fn clone_committee_store(&self) -> Arc<CommitteeStore> {
         self.committee_store.clone()
+    }
+
+    pub fn clone_inner_committee_test_only(&self) -> Committee {
+        (*self.committee).clone()
+    }
+
+    pub fn clone_inner_clients_test_only(&self) -> BTreeMap<AuthorityName, SafeClient<A>> {
+        (*self.authority_clients)
+            .clone()
+            .into_iter()
+            .map(|(k, v)| (k, (*v).clone()))
+            .collect()
     }
 }
 
@@ -549,7 +549,7 @@ impl AuthorityAggregator<NetworkAuthorityClient> {
             sui_system_state.get_current_epoch_committee(),
             committee_store,
             safe_client_metrics_base,
-            auth_agg_metrics,
+            Arc::new(auth_agg_metrics),
         )
     }
 
@@ -557,7 +557,7 @@ impl AuthorityAggregator<NetworkAuthorityClient> {
         committee: CommitteeWithNetworkMetadata,
         committee_store: &Arc<CommitteeStore>,
         safe_client_metrics_base: SafeClientMetricsBase,
-        auth_agg_metrics: AuthAggMetrics,
+        auth_agg_metrics: Arc<AuthAggMetrics>,
     ) -> anyhow::Result<Self> {
         let net_config = default_mysten_network_config();
         let authority_clients =
@@ -598,8 +598,16 @@ where
     /// This function provides a flexible way to communicate with a quorum of authorities, processing and
     /// processing their results into a safe overall result, and also safely allowing operations to continue
     /// past the quorum to ensure all authorities are up to date (up to a timeout).
-    pub(crate) async fn quorum_map_then_reduce_with_timeout<'a, S, V, R, FMap, FReduce>(
-        &'a self,
+    pub(crate) async fn quorum_map_then_reduce_with_timeout<
+        'a,
+        S: 'a,
+        V: 'a,
+        R: 'a,
+        FMap,
+        FReduce,
+    >(
+        committee: Arc<Committee>,
+        authority_clients: Arc<BTreeMap<AuthorityName, Arc<SafeClient<A>>>>,
         // The initial state that will be used to fold in values from authorities.
         initial_state: S,
         // The async function used to apply to each authority. It takes an authority name,
@@ -610,17 +618,27 @@ where
         reduce_result: FReduce,
         // The initial timeout applied to all
         initial_timeout: Duration,
-    ) -> Result<R, S>
+    ) -> Result<
+        (
+            R,
+            FuturesUnordered<impl Future<Output = (AuthorityName, Result<V, SuiError>)> + 'a>,
+        ),
+        S,
+    >
     where
-        FMap: FnOnce(AuthorityName, &'a SafeClient<A>) -> AsyncResult<'a, V, SuiError> + Clone,
+        FMap:
+            FnOnce(AuthorityName, Arc<SafeClient<A>>) -> AsyncResult<'a, V, SuiError> + Clone + 'a,
         FReduce: Fn(
-            S,
-            AuthorityName,
-            StakeUnit,
-            Result<V, SuiError>,
-        ) -> BoxFuture<'a, ReduceOutput<R, S>>,
+                S,
+                AuthorityName,
+                StakeUnit,
+                Result<V, SuiError>,
+            ) -> BoxFuture<'a, ReduceOutput<R, S>>
+            + 'a,
     {
-        self.quorum_map_then_reduce_with_timeout_and_prefs(
+        AuthorityAggregator::quorum_map_then_reduce_with_timeout_and_prefs(
+            committee,
+            authority_clients,
             None,
             initial_state,
             map_each_authority,
@@ -631,15 +649,22 @@ where
     }
 
     pub(crate) async fn quorum_map_then_reduce_with_timeout_and_prefs<'a, S, V, R, FMap, FReduce>(
-        &'a self,
+        committee: Arc<Committee>,
+        authority_clients: Arc<BTreeMap<AuthorityName, Arc<SafeClient<A>>>>,
         authority_preferences: Option<&BTreeSet<AuthorityName>>,
         initial_state: S,
         map_each_authority: FMap,
         reduce_result: FReduce,
         initial_timeout: Duration,
-    ) -> Result<R, S>
+    ) -> Result<
+        (
+            R,
+            FuturesUnordered<impl Future<Output = (AuthorityName, Result<V, SuiError>)>>,
+        ),
+        S,
+    >
     where
-        FMap: FnOnce(AuthorityName, &'a SafeClient<A>) -> AsyncResult<'a, V, SuiError> + Clone,
+        FMap: FnOnce(AuthorityName, Arc<SafeClient<A>>) -> AsyncResult<'a, V, SuiError> + Clone,
         FReduce: Fn(
             S,
             AuthorityName,
@@ -647,18 +672,18 @@ where
             Result<V, SuiError>,
         ) -> BoxFuture<'a, ReduceOutput<R, S>>,
     {
-        let authorities_shuffled = self.committee.shuffle_by_stake(authority_preferences, None);
+        let authorities_shuffled = committee.shuffle_by_stake(authority_preferences, None);
 
         // First, execute in parallel for each authority FMap.
         let mut responses: futures::stream::FuturesUnordered<_> = authorities_shuffled
-            .iter()
+            .into_iter()
             .map(|name| {
-                let client = &self.authority_clients[name];
+                let client = authority_clients[&name].clone();
                 let execute = map_each_authority.clone();
                 monitored_future!(async move {
                     (
-                        *name,
-                        execute(*name, client)
+                        name,
+                        execute(name, client)
                             .instrument(tracing::trace_span!("quorum_map_auth", authority =? name.concise()))
                             .await,
                     )
@@ -672,7 +697,7 @@ where
         while let Ok(Some((authority_name, result))) =
             timeout(current_timeout, responses.next()).await
         {
-            let authority_weight = self.committee.weight(&authority_name);
+            let authority_weight = committee.weight(&authority_name);
             accumulated_state =
                 match reduce_result(accumulated_state, authority_name, authority_weight, result)
                     .await
@@ -689,7 +714,7 @@ where
                     }
                     ReduceOutput::Success(result) => {
                         // The reducer tells us that we have the result needed. Just return it.
-                        return Ok(result);
+                        return Ok((result, responses));
                     }
                 }
         }
@@ -714,7 +739,10 @@ where
         authority_errors: &mut HashMap<AuthorityName, SuiError>,
     ) -> Result<S, SuiError>
     where
-        FMap: Fn(AuthorityName, SafeClient<A>) -> AsyncResult<'a, S, SuiError> + Send + Clone + 'a,
+        FMap: Fn(AuthorityName, Arc<SafeClient<A>>) -> AsyncResult<'a, S, SuiError>
+            + Send
+            + Clone
+            + 'a,
         S: Send,
     {
         let start = tokio::time::Instant::now();
@@ -732,7 +760,7 @@ where
 
             let mut futures = FuturesUnordered::<BoxFuture<'a, Event<S>>>::new();
 
-            let start_req = |name: AuthorityName, client: SafeClient<A>| {
+            let start_req = |name: AuthorityName, client: Arc<SafeClient<A>>| {
                 let map_each_authority = map_each_authority.clone();
                 Box::pin(monitored_future!(async move {
                     trace!(name=?name.concise(), now = ?tokio::time::Instant::now() - start, "new request");
@@ -847,7 +875,10 @@ where
         description: String,
     ) -> Result<S, SuiError>
     where
-        FMap: Fn(AuthorityName, SafeClient<A>) -> AsyncResult<'a, S, SuiError> + Send + Clone + 'a,
+        FMap: Fn(AuthorityName, Arc<SafeClient<A>>) -> AsyncResult<'a, S, SuiError>
+            + Send
+            + Clone
+            + 'a,
         S: Send,
     {
         let mut authority_errors = HashMap::new();
@@ -894,8 +925,9 @@ where
             total_weight: StakeUnit,
         }
         let initial_state = State::default();
-        self
-            .quorum_map_then_reduce_with_timeout(
+        let result = AuthorityAggregator::quorum_map_then_reduce_with_timeout(
+                self.committee.clone(),
+                self.authority_clients.clone(),
                 initial_state,
                 |_name, client| {
                     Box::pin(async move {
@@ -933,10 +965,11 @@ where
                 // A long timeout before we hear back from a quorum
                 self.timeouts.pre_quorum_timeout,
             )
-            .await.map_err(|_state| UserInputError::ObjectNotFound {
+            .await.map_err(|_state| SuiError::from(UserInputError::ObjectNotFound {
                 object_id,
                 version: None,
-            }.into())
+            }))?;
+        Ok(result.0)
     }
 
     /// Get the latest system state object from the authorities.
@@ -951,7 +984,9 @@ where
             total_weight: StakeUnit,
         }
         let initial_state = State::default();
-        self.quorum_map_then_reduce_with_timeout(
+        let result = AuthorityAggregator::quorum_map_then_reduce_with_timeout(
+            self.committee.clone(),
+            self.authority_clients.clone(),
             initial_state,
             |_name, client| Box::pin(async move { client.handle_system_state_object().await }),
             |mut state, name, weight, result| {
@@ -994,7 +1029,8 @@ where
             self.timeouts.pre_quorum_timeout,
         )
         .await
-        .map_err(|_| anyhow::anyhow!("Failed to get latest system state from the authorities"))
+        .map_err(|_| anyhow::anyhow!("Failed to get latest system state from the authorities"))?;
+        Ok(result.0)
     }
 
     /// Submits the transaction to a quorum of validators to make a certificate.
@@ -1012,8 +1048,7 @@ where
             "Transaction data: {:?}",
             transaction.data().intent_message().value
         );
-
-        let committee = Arc::new(self.committee.clone());
+        let committee = self.committee.clone();
         let state = ProcessTransactionState {
             tx_signatures: StakeAggregator::new(committee.clone()),
             effects_map: MultiStakeAggregator::new(committee.clone()),
@@ -1028,8 +1063,9 @@ where
         let transaction_ref = &transaction;
         let validity_threshold = committee.validity_threshold();
         let quorum_threshold = committee.quorum_threshold();
-        let result = self
-            .quorum_map_then_reduce_with_timeout(
+        let result = AuthorityAggregator::quorum_map_then_reduce_with_timeout(
+                committee.clone(),
+                self.authority_clients.clone(),
                 state,
                 |_name, client| {
                     Box::pin(
@@ -1066,7 +1102,7 @@ where
                                     .process_tx_errors
                                     .with_label_values(&[&concise_name.to_string(), err.as_ref()])
                                     .inc();
-                                self.record_rpc_error_maybe(concise_name, &err);
+                                Self::record_rpc_error_maybe(self.metrics.clone(), concise_name, &err);
                                 let (retryable, categorized) = err.is_retryable();
                                 if !categorized {
                                     // TODO: Should minimize possible uncategorized errors here
@@ -1112,7 +1148,7 @@ where
             .await;
 
         match result {
-            Ok(result) => Ok(result),
+            Ok((result, _)) => Ok(result),
             Err(state) => {
                 self.record_process_transaction_metrics(tx_digest, &state);
                 let state = self.record_non_quorum_effects_maybe(tx_digest, state);
@@ -1121,9 +1157,13 @@ where
         }
     }
 
-    fn record_rpc_error_maybe(&self, name: ConciseAuthorityPublicKeyBytesRef, error: &SuiError) {
+    fn record_rpc_error_maybe(
+        metrics: Arc<AuthAggMetrics>,
+        name: ConciseAuthorityPublicKeyBytesRef,
+        error: &SuiError,
+    ) {
         if let SuiError::RpcError(_message, code) = error {
-            self.metrics
+            metrics
                 .total_rpc_err
                 .with_label_values(&[&name.to_string(), code.as_str()])
                 .inc();
@@ -1430,7 +1470,7 @@ where
         AggregatorProcessCertificateError,
     > {
         let state = ProcessCertificateState {
-            effects_map: MultiStakeAggregator::new(Arc::new(self.committee.clone())),
+            effects_map: MultiStakeAggregator::new(self.committee.clone()),
             object_map: HashMap::new(),
             non_retryable_stake: 0,
             non_retryable_errors: vec![],
@@ -1441,7 +1481,7 @@ where
         let tx_digest = *certificate.digest();
         let timeout_after_quorum = self.timeouts.post_quorum_timeout;
 
-        let cert_ref = &certificate;
+        let cert_ref = certificate;
         let threshold = self.committee.quorum_threshold();
         let validity = self.committee.validity_threshold();
 
@@ -1454,18 +1494,23 @@ where
             "Broadcasting certificate to authorities"
         );
         // TODO: We show the below messages for debugging purposes re. incident #267. When this is fixed, we should remove them again.
-        let cert_bytes = fastcrypto::encoding::Base64::encode(bcs::to_bytes(cert_ref).unwrap());
+        let cert_bytes = fastcrypto::encoding::Base64::encode(bcs::to_bytes(&cert_ref).unwrap());
         info!(
             ?tx_digest,
             ?cert_bytes,
             "Broadcasting certificate (serialized) to authorities"
         );
-
-        self.quorum_map_then_reduce_with_timeout(
+        let committee: Arc<Committee> = self.committee.clone();
+        let authority_clients = self.authority_clients.clone();
+        let metrics = self.metrics.clone();
+        let metrics_clone = metrics.clone();
+        let (result, mut remaining_tasks) = AuthorityAggregator::quorum_map_then_reduce_with_timeout(
+            committee.clone(),
+            authority_clients.clone(),
             state,
-            |name, client| {
+            move |name, client| {
                 Box::pin(async move {
-                    let _guard = GaugeGuard::acquire(&self.metrics.inflight_certificate_requests);
+                    let _guard = GaugeGuard::acquire(&metrics_clone.inflight_certificate_requests);
                     client
                         .handle_certificate_v2(cert_ref.clone())
                         .instrument(
@@ -1474,12 +1519,15 @@ where
                         .await
                 })
             },
-            |mut state, name, weight, response| {
+            move |mut state, name, weight, response| {
+                let committee_clone = committee.clone();
+                let metrics = metrics.clone();
                 Box::pin(async move {
                     // We aggregate the effects response, until we have more than 2f
                     // and return.
-                    match self
-                        .handle_process_certificate_response(&tx_digest, &mut state, response, name)
+                    match AuthorityAggregator::<A>::handle_process_certificate_response(
+                        committee_clone,
+                        &tx_digest, &mut state, response, name)
                     {
                         Ok(Some(effects)) => ReduceOutput::Success(effects),
                         Ok(None) => {
@@ -1496,11 +1544,11 @@ where
                         Err(err) => {
                             let concise_name = name.concise();
                             debug!(?tx_digest, name=?concise_name, "Error processing certificate from validator: {:?}", err);
-                            self.metrics
+                            metrics
                                 .process_cert_errors
                                 .with_label_values(&[&concise_name.to_string(), err.as_ref()])
                                 .inc();
-                            self.record_rpc_error_maybe(concise_name, &err);
+                            Self::record_rpc_error_maybe(metrics, concise_name, &err);
                             let (retryable, categorized) = err.is_retryable();
                             if !categorized {
                                 // TODO: Should minimize possible uncategorized errors here
@@ -1559,11 +1607,32 @@ where
                     non_retryable_errors: group_errors(state.non_retryable_errors),
                 }
             }
-        })
+        })?;
+
+        // Use best efforts to send the cert to remaining validators.
+        let metrics = self.metrics.clone();
+        spawn_monitored_task!(async move {
+            let mut timeout = Box::pin(sleep(timeout_after_quorum));
+            loop {
+                tokio::select! {
+                    _ = &mut timeout => {
+                        debug!(?tx_digest, "Timed out in post quorum cert broadcasting: {:?}", timeout_after_quorum);
+                        metrics.cert_broadcasting_post_quorum_timeout.inc();
+                        break;
+                    }
+                    res = remaining_tasks.next() => {
+                        if res.is_none() {
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+        Ok(result)
     }
 
     fn handle_process_certificate_response(
-        &self,
+        committee: Arc<Committee>,
         tx_digest: &TransactionDigest,
         state: &mut ProcessCertificateState,
         response: SuiResult<HandleCertificateResponseV2>,
@@ -1614,7 +1683,7 @@ where
                             signed_effects.into_data(),
                             cert_sig,
                         );
-                        ct.verify(&self.committee).map(|ct| {
+                        ct.verify(&committee).map(|ct| {
                             debug!(?tx_digest, "Got quorum for validators handle_certificate.");
                             let fastpath_input_objects =
                                 state.object_map.remove(&effects_digest).unwrap_or_default();

--- a/crates/sui-core/src/quorum_driver/mod.rs
+++ b/crates/sui-core/src/quorum_driver/mod.rs
@@ -63,7 +63,7 @@ impl Debug for QuorumDriverTask {
     }
 }
 
-pub struct QuorumDriver<A> {
+pub struct QuorumDriver<A: Clone> {
     validators: ArcSwap<AuthorityAggregator<A>>,
     task_sender: Sender<QuorumDriverTask>,
     effects_subscribe_sender: tokio::sync::broadcast::Sender<QuorumDriverEffectsQueueResult>,
@@ -72,7 +72,7 @@ pub struct QuorumDriver<A> {
     max_retry_times: u8,
 }
 
-impl<A> QuorumDriver<A> {
+impl<A: Clone> QuorumDriver<A> {
     pub(crate) fn new(
         validators: ArcSwap<AuthorityAggregator<A>>,
         task_sender: Sender<QuorumDriverTask>,
@@ -95,7 +95,7 @@ impl<A> QuorumDriver<A> {
         &self.validators
     }
 
-    pub fn clone_committee(&self) -> Committee {
+    pub fn clone_committee(&self) -> Arc<Committee> {
         self.validators.load().committee.clone()
     }
 
@@ -526,7 +526,7 @@ where
     }
 }
 
-pub struct QuorumDriverHandler<A> {
+pub struct QuorumDriverHandler<A: Clone> {
     quorum_driver: Arc<QuorumDriver<A>>,
     effects_subscriber: tokio::sync::broadcast::Receiver<QuorumDriverEffectsQueueResult>,
     quorum_driver_metrics: Arc<QuorumDriverMetrics>,
@@ -783,7 +783,7 @@ where
     }
 }
 
-pub struct QuorumDriverHandlerBuilder<A> {
+pub struct QuorumDriverHandlerBuilder<A: Clone> {
     validators: Arc<AuthorityAggregator<A>>,
     metrics: Arc<QuorumDriverMetrics>,
     notifier: Option<Arc<NotifyRead<TransactionDigest, QuorumDriverResult>>>,

--- a/crates/sui-core/src/quorum_driver/reconfig_observer.rs
+++ b/crates/sui-core/src/quorum_driver/reconfig_observer.rs
@@ -18,7 +18,7 @@ use crate::{
 use super::QuorumDriver;
 
 #[async_trait]
-pub trait ReconfigObserver<A> {
+pub trait ReconfigObserver<A: Clone> {
     async fn run(&mut self, quorum_driver: Arc<QuorumDriver<A>>);
     fn clone_boxed(&self) -> Box<dyn ReconfigObserver<A> + Send + Sync>;
 }
@@ -124,7 +124,7 @@ pub struct DummyReconfigObserver;
 #[async_trait]
 impl<A> ReconfigObserver<A> for DummyReconfigObserver
 where
-    A: AuthorityAPI + Send + Sync + 'static,
+    A: AuthorityAPI + Send + Sync + Clone + 'static,
 {
     fn clone_boxed(&self) -> Box<dyn ReconfigObserver<A> + Send + Sync> {
         Box::new(Self {})

--- a/crates/sui-core/src/quorum_driver/tests.rs
+++ b/crates/sui-core/src/quorum_driver/tests.rs
@@ -196,7 +196,9 @@ async fn test_quorum_driver_update_validators_and_max_retry_times() {
     });
 
     // Update authority aggregator with a new epoch number, and let quorum driver know.
-    aggregator.committee.epoch = 10;
+    let mut committee = aggregator.clone_inner_committee_test_only();
+    committee.epoch = 10;
+    aggregator.committee = Arc::new(committee);
     quorum_driver_clone
         .update_validators(Arc::new(aggregator))
         .await;
@@ -250,9 +252,9 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
     let tx = make_tx(&gas, sender, &keypair, rgp);
     let names: Vec<_> = aggregator.authority_clients.keys().clone().collect();
     assert_eq!(names.len(), 4);
-    let client0 = aggregator.clone_client(names[0]);
-    let client1 = aggregator.clone_client(names[1]);
-    let client2 = aggregator.clone_client(names[2]);
+    let client0 = aggregator.clone_client_test_only(names[0]);
+    let client1 = aggregator.clone_client_test_only(names[1]);
+    let client2 = aggregator.clone_client_test_only(names[2]);
 
     println!("Case 0 - two validators lock the object with the same tx");
     assert!(client0.handle_transaction(tx.clone()).await.is_ok());

--- a/crates/sui-core/src/safe_client.rs
+++ b/crates/sui-core/src/safe_client.rs
@@ -151,14 +151,17 @@ impl SafeClientMetrics {
 /// See `SafeClientMetrics::new` for description of each metrics.
 /// The metrics are per validator client.
 #[derive(Clone)]
-pub struct SafeClient<C> {
+pub struct SafeClient<C>
+where
+    C: Clone,
+{
     authority_client: C,
     committee_store: Arc<CommitteeStore>,
     address: AuthorityPublicKeyBytes,
     metrics: SafeClientMetrics,
 }
 
-impl<C> SafeClient<C> {
+impl<C: Clone> SafeClient<C> {
     pub fn new(
         authority_client: C,
         committee_store: Arc<CommitteeStore>,
@@ -174,7 +177,7 @@ impl<C> SafeClient<C> {
     }
 }
 
-impl<C> SafeClient<C> {
+impl<C: Clone> SafeClient<C> {
     pub fn authority_client(&self) -> &C {
         &self.authority_client
     }

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -288,10 +288,8 @@ pub async fn init_local_authorities_with_genesis(
         clients.insert(authority_name, client);
     }
     let timeouts = TimeoutConfig {
-        authority_request_timeout: Duration::from_secs(5),
         pre_quorum_timeout: Duration::from_secs(5),
         post_quorum_timeout: Duration::from_secs(5),
-        serial_authority_request_timeout: Duration::from_secs(1),
         serial_authority_request_interval: Duration::from_secs(1),
     };
     let committee_store = Arc::new(CommitteeStore::new_for_testing(&committee));

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -50,7 +50,7 @@ const LOCAL_EXECUTION_TIMEOUT: Duration = Duration::from_secs(10);
 
 const WAIT_FOR_FINALITY_TIMEOUT: Duration = Duration::from_secs(30);
 
-pub struct TransactiondOrchestrator<A> {
+pub struct TransactiondOrchestrator<A: Clone> {
     quorum_driver_handler: Arc<QuorumDriverHandler<A>>,
     validator_state: Arc<AuthorityState>,
     _local_executor_handle: JoinHandle<()>,

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -483,7 +483,9 @@ async fn test_validator_resign_effects() {
     sleep(Duration::from_secs(10)).await;
     trigger_reconfiguration(&authorities).await;
     // Manually reconfigure the aggregator.
-    net.committee.epoch = 1;
+    let mut committee = net.clone_inner_committee_test_only();
+    committee.epoch = 1;
+    net.committee = Arc::new(committee);
     let (effects1, _, _) = net.process_certificate(cert.into_inner()).await.unwrap();
     // Ensure that we are able to form a new effects cert in the new epoch.
     assert_eq!(effects1.epoch(), 1);


### PR DESCRIPTION
## Description 

We use best efforts to send tx certs to validators post quorum, with the hope that this could reduce the chance of slow validators miss their slot to submit to consensus.

meat is https://github.com/MystenLabs/sui/pull/11548/files#r1181387700

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
