### PR TITLE
add an admin endpoint to print node config

### DIFF
--- a/crates/sui-node/src/admin.rs
+++ b/crates/sui-node/src/admin.rs
@@ -33,6 +33,10 @@ use tracing::info;
 // View current all capabilities from all authorities that have been received by this node:
 //
 //   $ curl 'http://127.0.0.1:1337/capabilities'
+//
+// View the node config (private keys will be masked):
+//
+//   $ curl 'http://127.0.0.1:1337/node-config'
 
 const LOGGING_ROUTE: &str = "/logging";
 const SET_BUFFER_STAKE_ROUTE: &str = "/set-override-buffer-stake";
@@ -118,6 +122,7 @@ async fn capabilities(State(state): State<Arc<AppState>>) -> (StatusCode, String
 async fn node_config(State(state): State<Arc<AppState>>) -> (StatusCode, String) {
     let node_config = &state.node.config;
 
+    // Note private keys will be masked
     (StatusCode::OK, format!("{:#?}\n", node_config))
 }
 

--- a/crates/sui-node/src/admin.rs
+++ b/crates/sui-node/src/admin.rs
@@ -39,6 +39,7 @@ const SET_BUFFER_STAKE_ROUTE: &str = "/set-override-buffer-stake";
 const CLEAR_BUFFER_STAKE_ROUTE: &str = "/clear-override-buffer-stake";
 const FORCE_CLOSE_EPOCH: &str = "/force-close-epoch";
 const CAPABILITIES: &str = "/capabilities";
+const NODE_CONFIG: &str = "/node-config";
 
 struct AppState {
     node: Arc<SuiNode>,
@@ -56,6 +57,7 @@ pub async fn run_admin_server(node: Arc<SuiNode>, port: u16, filter_handle: Filt
     let app = Router::new()
         .route(LOGGING_ROUTE, get(get_filter))
         .route(CAPABILITIES, get(capabilities))
+        .route(NODE_CONFIG, get(node_config))
         .route(LOGGING_ROUTE, post(set_filter))
         .route(
             SET_BUFFER_STAKE_ROUTE,
@@ -111,6 +113,12 @@ async fn capabilities(State(state): State<Arc<AppState>>) -> (StatusCode, String
     }
 
     (StatusCode::OK, output)
+}
+
+async fn node_config(State(state): State<Arc<AppState>>) -> (StatusCode, String) {
+    let node_config = &state.node.config;
+
+    (StatusCode::OK, format!("{:#?}\n", node_config))
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
## Description 

As title 

## Test Plan 

tested locally

```
curl 127.0.0.1:49932/node-config | grep package_deny_list
```
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
