### PR TITLE
[deepbook] Deepbook snapshots patch

### DIFF
--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0xb9283535f1ed8ac593b0573a3ac71a9bd35bc38158e7fda5b1b1af90612e3453"
+            id: "0xa9e18addad3e2dba86212bf9224611725c859ded562b4e60f4dcec2bf26c08cd"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0xf45d13ef977aec29eee2040f969e26602e2872a78869411cf44a38ee23c2c6cc"
+      operation_cap_id: "0x25d879d01d279d572cfb84393f39e7957e25595a8ce91425c5b386f6cd982235"
       gas_price: 1000
       staking_pool:
-        id: "0x4eeb66269389fe040b469e86cc61b1d4810d9b89d69706ff5e3d33edec9ef185"
+        id: "0xbfa8f2a3d3d3beea142e4d0c5816b0ea157c8fcce8c03a41bce8dba84a83eb0b"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0x29a5aa65a694ef03e7625f4ff553d9f8812e6e565cfa77e3d4e844656cef83af"
+          id: "0xcdc918d4d2bd7018a0c8f9fc81c94bf646cf6549701ac88ddd7af27d8836935e"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0x96814c2886cd0d2700b9e350fe2e086d4cbdca148bc0ceeecf2806e318e829a9"
+            id: "0x550e65ca285ad0c4eda1af7c7026b00158d972b4fb2c5f2928358dba7e4999a8"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0x65e03e1435307d6b592f0ba67339330c05edaa9669e9c3350d62e5b6961b5bc8"
+          id: "0x36d9dfd9d67bbf31e60f836bd780d553194780e7f2e9a21be8ba61116042a8d9"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x086497df1cfc9f4b09551cbf31b434e822ad2771085d3b3b078359934246ecbe"
+      id: "0x5cefe212e2815a5e1fb8fdcb0db701ecaca233b6069ff1aecad8424db56da228"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0x7ce40c41d41e96e28daa6cbd19cce0e618210f86f1d6820e68f273d92d6f2f18"
+    id: "0x1a1d90465e2f715a7d7d03662be914e5510705edf8d1de0421f36dbb8974a9d6"
     size: 1
   inactive_validators:
-    id: "0x81964ed4d468092c474c07d7abef14a7ed670bd57e2893b445ca265e23157f2d"
+    id: "0x617d89768164d45f056eb5253506796d86da50455e4de513144e67a052b9d0f1"
     size: 0
   validator_candidates:
-    id: "0xb51aa1ec8dbbc6adc51677a15d4c5d0b075d4bd108d6cf45739b650dfc5b43b6"
+    id: "0x355ba10b89bcce32811860cc05ee410410e5f88a14167cab5ded860c9177a1f2"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0xc20c693e20e5b77f20fb1aa6d726ef67c77ce0f40b80b57ca40e9c02407d9e38"
+      id: "0xae78d28e60d648b65f5d5e7cc77bd66518051651897b0c64aeb21386e513b213"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x9345ef8a986da468961a68b57cc818bd0e7810fac1a3d86d6b8f949533a082b6"
+      id: "0xa5580ab42b7c35dab5c0ad61fe4bc9b7e3e45874e2e14328bfcd32b5bf38eca5"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 10000
   extra_fields:
     id:
-      id: "0x728b427b7702dec9fe6af5a3407650d8e67ef931e0fc6671b940c113b2ec7f34"
+      id: "0xaa09f94bd52fc83da538b27b831539edcd73d0418408b6deb647b8c27b4ceb07"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,6 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0x59dd5547a5504a29d9deb2605d0b442a7909572d6cf5d42f4850847580a965a3"
+    id: "0x9fe7232e21039ba398d073f3cc1c11076b7475748e81e7a1c08a5bdc59f83af9"
   size: 0
 

--- a/crates/sui-framework/docs/clob.md
+++ b/crates/sui-framework/docs/clob.md
@@ -623,16 +623,7 @@ Emitted when a maker order is injected into the order book.
 
 
 
-<pre><code><b>const</b> <a href="clob.md#0xdee9_clob_EInvalidBaseBalance">EInvalidBaseBalance</a>: u64 = 18;
-</code></pre>
-
-
-
-<a name="0xdee9_clob_EInvalidBaseCoin"></a>
-
-
-
-<pre><code><b>const</b> <a href="clob.md#0xdee9_clob_EInvalidBaseCoin">EInvalidBaseCoin</a>: u64 = 19;
+<pre><code><b>const</b> <a href="clob.md#0xdee9_clob_EInvalidBaseBalance">EInvalidBaseBalance</a>: u64 = 17;
 </code></pre>
 
 
@@ -641,7 +632,7 @@ Emitted when a maker order is injected into the order book.
 
 
 
-<pre><code><b>const</b> <a href="clob.md#0xdee9_clob_EInvalidExpireTimestamp">EInvalidExpireTimestamp</a>: u64 = 22;
+<pre><code><b>const</b> <a href="clob.md#0xdee9_clob_EInvalidExpireTimestamp">EInvalidExpireTimestamp</a>: u64 = 19;
 </code></pre>
 
 
@@ -650,16 +641,7 @@ Emitted when a maker order is injected into the order book.
 
 
 
-<pre><code><b>const</b> <a href="clob.md#0xdee9_clob_EInvalidFee">EInvalidFee</a>: u64 = 21;
-</code></pre>
-
-
-
-<a name="0xdee9_clob_EInvalidFeeCoin"></a>
-
-
-
-<pre><code><b>const</b> <a href="clob.md#0xdee9_clob_EInvalidFeeCoin">EInvalidFeeCoin</a>: u64 = 20;
+<pre><code><b>const</b> <a href="clob.md#0xdee9_clob_EInvalidFee">EInvalidFee</a>: u64 = 18;
 </code></pre>
 
 
@@ -686,7 +668,7 @@ Emitted when a maker order is injected into the order book.
 
 
 
-<pre><code><b>const</b> <a href="clob.md#0xdee9_clob_EInvalidPair">EInvalidPair</a>: u64 = 17;
+<pre><code><b>const</b> <a href="clob.md#0xdee9_clob_EInvalidPair">EInvalidPair</a>: u64 = 16;
 </code></pre>
 
 
@@ -713,7 +695,7 @@ Emitted when a maker order is injected into the order book.
 
 
 
-<pre><code><b>const</b> <a href="clob.md#0xdee9_clob_EInvalidRestriction">EInvalidRestriction</a>: u64 = 15;
+<pre><code><b>const</b> <a href="clob.md#0xdee9_clob_EInvalidRestriction">EInvalidRestriction</a>: u64 = 14;
 </code></pre>
 
 
@@ -723,6 +705,15 @@ Emitted when a maker order is injected into the order book.
 
 
 <pre><code><b>const</b> <a href="clob.md#0xdee9_clob_EInvalidTickPrice">EInvalidTickPrice</a>: u64 = 11;
+</code></pre>
+
+
+
+<a name="0xdee9_clob_EInvalidTickSizeLotSize"></a>
+
+
+
+<pre><code><b>const</b> <a href="clob.md#0xdee9_clob_EInvalidTickSizeLotSize">EInvalidTickSizeLotSize</a>: u64 = 20;
 </code></pre>
 
 
@@ -740,7 +731,7 @@ Emitted when a maker order is injected into the order book.
 
 
 
-<pre><code><b>const</b> <a href="clob.md#0xdee9_clob_ELevelNotEmpty">ELevelNotEmpty</a>: u64 = 16;
+<pre><code><b>const</b> <a href="clob.md#0xdee9_clob_ELevelNotEmpty">ELevelNotEmpty</a>: u64 = 15;
 </code></pre>
 
 
@@ -974,6 +965,7 @@ Emitted when a maker order is injected into the order book.
     creation_fee: Balance&lt;SUI&gt;,
     ctx: &<b>mut</b> TxContext,
 ) {
+    <b>assert</b>!(clob_math::mul(lot_size, tick_size) &gt; 0, <a href="clob.md#0xdee9_clob_EInvalidTickSizeLotSize">EInvalidTickSizeLotSize</a>);
     <b>let</b> base_type_name = <a href="_get">type_name::get</a>&lt;BaseAsset&gt;();
     <b>let</b> quote_type_name = <a href="_get">type_name::get</a>&lt;QuoteAsset&gt;();
     <b>assert</b>!(base_type_name != quote_type_name, <a href="clob.md#0xdee9_clob_EInvalidPair">EInvalidPair</a>);
@@ -1072,6 +1064,7 @@ Emitted when a maker order is injected into the order book.
     <a href="../../../.././build/Sui/docs/coin.md#0x2_coin">coin</a>: Coin&lt;BaseAsset&gt;,
     account_cap: &AccountCap
 ) {
+    <b>assert</b>!(<a href="../../../.././build/Sui/docs/coin.md#0x2_coin_value">coin::value</a>(&<a href="../../../.././build/Sui/docs/coin.md#0x2_coin">coin</a>) != 0, <a href="clob.md#0xdee9_clob_EInsufficientBaseCoin">EInsufficientBaseCoin</a>);
     <a href="custodian.md#0xdee9_custodian_increase_user_available_balance">custodian::increase_user_available_balance</a>(
         &<b>mut</b> pool.base_custodian,
         <a href="../../../.././build/Sui/docs/object.md#0x2_object_id">object::id</a>(account_cap),
@@ -1104,6 +1097,7 @@ Emitted when a maker order is injected into the order book.
     <a href="../../../.././build/Sui/docs/coin.md#0x2_coin">coin</a>: Coin&lt;QuoteAsset&gt;,
     account_cap: &AccountCap
 ) {
+    <b>assert</b>!(<a href="../../../.././build/Sui/docs/coin.md#0x2_coin_value">coin::value</a>(&<a href="../../../.././build/Sui/docs/coin.md#0x2_coin">coin</a>) != 0, <a href="clob.md#0xdee9_clob_EInsufficientQuoteCoin">EInsufficientQuoteCoin</a>);
     <a href="custodian.md#0xdee9_custodian_increase_user_available_balance">custodian::increase_user_available_balance</a>(
         &<b>mut</b> pool.quote_custodian,
         <a href="../../../.././build/Sui/docs/object.md#0x2_object_id">object::id</a>(account_cap),
@@ -1137,6 +1131,7 @@ Emitted when a maker order is injected into the order book.
     account_cap: &AccountCap,
     ctx: &<b>mut</b> TxContext
 ): Coin&lt;BaseAsset&gt; {
+    <b>assert</b>!(quantity &gt; 0, <a href="clob.md#0xdee9_clob_EInvalidQuantity">EInvalidQuantity</a>);
     <a href="custodian.md#0xdee9_custodian_withdraw_asset">custodian::withdraw_asset</a>(&<b>mut</b> pool.base_custodian, quantity, account_cap, ctx)
 }
 </code></pre>
@@ -1166,6 +1161,7 @@ Emitted when a maker order is injected into the order book.
     account_cap: &AccountCap,
     ctx: &<b>mut</b> TxContext
 ): Coin&lt;QuoteAsset&gt; {
+    <b>assert</b>!(quantity &gt; 0, <a href="clob.md#0xdee9_clob_EInvalidQuantity">EInvalidQuantity</a>);
     <a href="custodian.md#0xdee9_custodian_withdraw_asset">custodian::withdraw_asset</a>(&<b>mut</b> pool.quote_custodian, quantity, account_cap, ctx)
 }
 </code></pre>
@@ -1197,6 +1193,7 @@ Emitted when a maker order is injected into the order book.
     <a href="../../../.././build/Sui/docs/clock.md#0x2_clock">clock</a>: &Clock,
     ctx: &<b>mut</b> TxContext,
 ): (Coin&lt;BaseAsset&gt;, Coin&lt;QuoteAsset&gt;, u64) {
+    <b>assert</b>!(<a href="../../../.././build/Sui/docs/coin.md#0x2_coin_value">coin::value</a>(&base_coin) &gt;= quantity, <a href="clob.md#0xdee9_clob_EInsufficientBaseCoin">EInsufficientBaseCoin</a>);
     <b>let</b> original_val = <a href="../../../.././build/Sui/docs/coin.md#0x2_coin_value">coin::value</a>(&quote_coin);
     <b>let</b> (ret_base_coin, ret_quote_coin) = <a href="clob.md#0xdee9_clob_place_market_order">place_market_order</a>(
         pool,
@@ -1238,6 +1235,7 @@ Emitted when a maker order is injected into the order book.
     quote_coin: Coin&lt;QuoteAsset&gt;,
     ctx: &<b>mut</b> TxContext,
 ): (Coin&lt;BaseAsset&gt;, Coin&lt;QuoteAsset&gt;, u64) {
+    <b>assert</b>!(<a href="../../../.././build/Sui/docs/coin.md#0x2_coin_value">coin::value</a>(&quote_coin) &gt;= quantity, <a href="clob.md#0xdee9_clob_EInsufficientQuoteCoin">EInsufficientQuoteCoin</a>);
     <b>let</b> (base_asset_balance, quote_asset_balance) = <a href="clob.md#0xdee9_clob_match_bid_with_quote_quantity">match_bid_with_quote_quantity</a>(
         pool,
         quantity,
@@ -1287,6 +1285,7 @@ Emitted when a maker order is injected into the order book.
         <b>return</b> (base_balance_filled, quote_balance_left)
     };
     <b>let</b> (tick_price, tick_index) = min_leaf(all_open_orders);
+    <b>let</b> terminate_loop = <b>false</b>;
 
     <b>while</b> (!is_empty&lt;<a href="clob.md#0xdee9_clob_TickLevel">TickLevel</a>&gt;(all_open_orders) && tick_price &lt;= price_limit) {
         <b>let</b> tick_level = borrow_mut_leaf_by_index(all_open_orders, tick_index);
@@ -1326,21 +1325,38 @@ Emitted when a maker order is injected into the order book.
                     );
                     filled_base_quantity = maker_base_quantity;
                 } <b>else</b> {
-                    filled_quote_quantity = taker_quote_quantity_remaining;
+                    terminate_loop = <b>true</b>;
                     (_, filled_quote_quantity_without_commission) = clob_math::div_round(
-                        filled_quote_quantity,
+                        taker_quote_quantity_remaining,
                         <a href="clob.md#0xdee9_clob_FLOAT_SCALING">FLOAT_SCALING</a> + pool.taker_fee_rate
                     );
                     (_, filled_base_quantity) = clob_math::div_round(
                         filled_quote_quantity_without_commission,
                         maker_order.price
                     );
+                    <b>let</b> filled_base_lot = filled_base_quantity / pool.lot_size;
+                    filled_base_quantity = filled_base_lot * pool.lot_size;
+                    filled_quote_quantity_without_commission = clob_math::mul(
+                        filled_base_quantity,
+                        maker_order.price
+                    );
+                    <b>let</b> (round_down, taker_commission) = clob_math::mul_round(
+                        filled_quote_quantity_without_commission,
+                        pool.taker_fee_rate
+                    );
+                    <b>if</b> (round_down) {
+                        taker_commission = taker_commission + 1;
+                    };
+                    filled_quote_quantity = filled_quote_quantity_without_commission + taker_commission;
                 };
                 <b>let</b> maker_rebate = clob_math::mul(filled_quote_quantity_without_commission, pool.maker_rebate_rate);
                 maker_base_quantity = maker_base_quantity - filled_base_quantity;
 
                 // maker in ask side, decrease maker's locked base asset, increase maker's available quote asset
                 taker_quote_quantity_remaining = taker_quote_quantity_remaining - filled_quote_quantity;
+                <b>if</b> (taker_quote_quantity_remaining == 0) {
+                    terminate_loop = <b>true</b>;
+                };
                 <b>let</b> locked_base_balance = <a href="custodian.md#0xdee9_custodian_decrease_user_locked_balance">custodian::decrease_user_locked_balance</a>&lt;BaseAsset&gt;(
                     &<b>mut</b> pool.base_custodian,
                     maker_order.owner,
@@ -1394,7 +1410,7 @@ Emitted when a maker order is injected into the order book.
                     order_id);
                 maker_order_mut.quantity = maker_base_quantity;
             };
-            <b>if</b> (taker_quote_quantity_remaining == 0) {
+            <b>if</b> (terminate_loop) {
                 <b>break</b>
             };
         };
@@ -1403,7 +1419,7 @@ Emitted when a maker order is injected into the order book.
             <a href="clob.md#0xdee9_clob_destroy_empty_level">destroy_empty_level</a>(remove_leaf_by_index(all_open_orders, tick_index));
             (_, tick_index) = find_leaf(all_open_orders, tick_price);
         };
-        <b>if</b> (taker_quote_quantity_remaining == 0) {
+        <b>if</b> (terminate_loop) {
             <b>break</b>
         };
     };
@@ -1725,7 +1741,7 @@ Place a market order to the order book.
     <a href="../../../.././build/Sui/docs/clock.md#0x2_clock">clock</a>: &Clock,
     ctx: &<b>mut</b> TxContext,
 ): (Coin&lt;BaseAsset&gt;, Coin&lt;QuoteAsset&gt;) {
-    // If market bid order, match against the open ask orders. Otherwise, match against the open ask orders.
+    // If market bid order, match against the open ask orders. Otherwise, match against the open bid orders.
     // Take market bid order for example.
     // We first retrieve the PriceLevel <b>with</b> the lowest price by calling min_leaf on the asks Critbit Tree.
     // We then match the market order by iterating through open orders on that price level in ascending order of the order id.
@@ -1757,7 +1773,7 @@ Place a market order to the order book.
         );
         quote_coin = <a href="../../../.././build/Sui/docs/coin.md#0x2_coin_from_balance">coin::from_balance</a>(quote_balance_left, ctx);
     } <b>else</b> {
-        <b>assert</b>!(quantity &lt;= <a href="../../../.././build/Sui/docs/coin.md#0x2_coin_value">coin::value</a>(&base_coin), <a href="clob.md#0xdee9_clob_EInvalidBaseCoin">EInvalidBaseCoin</a>);
+        <b>assert</b>!(quantity &lt;= <a href="../../../.././build/Sui/docs/coin.md#0x2_coin_value">coin::value</a>(&base_coin), <a href="clob.md#0xdee9_clob_EInsufficientBaseCoin">EInsufficientBaseCoin</a>);
         <b>let</b> (base_balance_left, quote_balance_filled) = <a href="clob.md#0xdee9_clob_match_ask">match_ask</a>(
             pool,
             <a href="clob.md#0xdee9_clob_MIN_PRICE">MIN_PRICE</a>,
@@ -1901,6 +1917,7 @@ So please check that boolean value first before using the order id.
     // If the bid order is not completely filled, inject the remaining quantity <b>to</b> the bids Critbit Tree according <b>to</b> the input price and order id.
     // If limit ask order, vice versa.
     <b>assert</b>!(quantity &gt; 0, <a href="clob.md#0xdee9_clob_EInvalidQuantity">EInvalidQuantity</a>);
+    <b>assert</b>!(price &gt; 0, <a href="clob.md#0xdee9_clob_EInvalidPrice">EInvalidPrice</a>);
     <b>assert</b>!(price % pool.tick_size == 0, <a href="clob.md#0xdee9_clob_EInvalidPrice">EInvalidPrice</a>);
     <b>assert</b>!(quantity % pool.lot_size == 0, <a href="clob.md#0xdee9_clob_EInvalidQuantity">EInvalidQuantity</a>);
     <b>assert</b>!(expire_timestamp &gt; <a href="../../../.././build/Sui/docs/clock.md#0x2_clock_timestamp_ms">clock::timestamp_ms</a>(<a href="../../../.././build/Sui/docs/clock.md#0x2_clock">clock</a>), <a href="clob.md#0xdee9_clob_EInvalidExpireTimestamp">EInvalidExpireTimestamp</a>);
@@ -1980,7 +1997,7 @@ So please check that boolean value first before using the order id.
         <b>return</b> (base_quantity_filled, quote_quantity_filled, <b>true</b>, order_id)
     } <b>else</b> {
         <b>assert</b>!(restriction == <a href="clob.md#0xdee9_clob_NO_RESTRICTION">NO_RESTRICTION</a>, <a href="clob.md#0xdee9_clob_EInvalidRestriction">EInvalidRestriction</a>);
-        <b>if</b>(quantity &gt; base_quantity_filled){
+        <b>if</b> (quantity &gt; base_quantity_filled) {
             order_id = <a href="clob.md#0xdee9_clob_inject_limit_order">inject_limit_order</a>(
                 pool,
                 price,

--- a/crates/sui-framework/packages/deepbook/sources/math.move
+++ b/crates/sui-framework/packages/deepbook/sources/math.move
@@ -3,8 +3,8 @@
 
 module deepbook::math {
     /// scaling setting for float
-    const FLOAT_SCALING: u64 = 1000000000;
-    const FLOAT_SCALING_U128: u128 = 1000000000;
+    const FLOAT_SCALING: u64 = 1_000_000_000;
+    const FLOAT_SCALING_U128: u128 = 1_000_000_000;
 
     public fun mul(x: u64, y: u64): u64 {
         let x = (x as u128);


### PR DESCRIPTION
## Description 

Replaces #11550, adds snapshots.

## Test Plan 

-

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
