### PR TITLE
explorer: gas price graph hover line only above starting date

### DIFF
--- a/apps/explorer/src/components/GasPriceCard/Graph.tsx
+++ b/apps/explorer/src/components/GasPriceCard/Graph.tsx
@@ -71,7 +71,7 @@ export function Graph({ data, width, height, onHoverElement }: GraphProps) {
             const xDate = xScale.invert(x);
             const epochIndex = bisectDate(adjData, xDate, 0);
             const selectedEpoch = adjData[epochIndex];
-            setTooltipX(x);
+            setTooltipX(selectedEpoch.date ? xScale(selectedEpoch.date) : x);
             setHoveredElement(selectedEpoch);
             setIsTooltipVisible(true);
         },
@@ -105,7 +105,7 @@ export function Graph({ data, width, height, onHoverElement }: GraphProps) {
                 x2={0}
                 y2={graphButton + 10}
                 className={clsx(
-                    'stroke-gray-60 transition-opacity duration-75',
+                    'stroke-gray-60 transition-all ease-ease-out-cubic',
                     isTooltipVisible ? 'opacity-100' : 'opacity-0'
                 )}
                 strokeWidth="1"


### PR DESCRIPTION
* make sure we hover only above actual values


https://user-images.githubusercontent.com/10210143/235444532-38fe92df-6156-41fa-bf8f-73dde2bf91cb.mov

Addresses https://github.com/MystenLabs/sui/pull/11472#issuecomment-1528194577