### PR TITLE
wallet-ext: mnemonic require password confirmation if not onboarding

### DIFF
--- a/apps/wallet/src/ui/app/components/menu/content/ExportAccount.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/ExportAccount.tsx
@@ -61,6 +61,8 @@ export function ExportAccount() {
             onPasswordVerified={async (password) => {
                 await exportMutation.mutateAsync(password);
             }}
+            background
+            spacing
         />
     );
 }

--- a/apps/wallet/src/ui/app/components/menu/content/ImportPrivateKey.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/ImportPrivateKey.tsx
@@ -86,6 +86,8 @@ export function ImportPrivateKey() {
                 onPasswordVerified={async (password) => {
                     await importMutation.mutateAsync(password);
                 }}
+                background
+                spacing
             />
         </div>
     ) : (

--- a/apps/wallet/src/ui/app/components/menu/content/PasswordInputDialog.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/PasswordInputDialog.tsx
@@ -60,9 +60,15 @@ export function PasswordInputDialog({
         >
             {({ isSubmitting, isValid }) => (
                 <Form className="bg-white px-5 pt-10 flex flex-col flex-nowrap items-center flex-1 gap-7.5">
-                    <Heading variant="heading1" color="gray-90" weight="bold">
-                        {title}
-                    </Heading>
+                    <div className="text-center">
+                        <Heading
+                            variant="heading1"
+                            color="gray-90"
+                            weight="bold"
+                        >
+                            {title}
+                        </Heading>
+                    </div>
                     <div className="self-stretch flex-1">
                         <FieldLabel txt="Enter Wallet Password to Continue">
                             <PasswordInputField name="password" />
@@ -82,7 +88,7 @@ export function PasswordInputDialog({
                             </Text>
                         </div>
                     </div>
-                    <div className="flex flex-col flex-nowrap gap-3.75 self-stretch">
+                    <div className="flex flex-col flex-nowrap gap-3.75 self-stretch pb-2">
                         <Button
                             type="submit"
                             variant="primary"

--- a/apps/wallet/src/ui/app/components/menu/content/PasswordInputDialog.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/PasswordInputDialog.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ArrowRight16 } from '@mysten/icons';
+import classNames from 'classnames';
 import { Formik, Form, ErrorMessage } from 'formik';
 import { toast } from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
@@ -26,12 +27,16 @@ export type PasswordExportDialogProps = {
     showArrowIcon?: boolean;
     onPasswordVerified: (password: string) => Promise<void> | void;
     onBackClicked?: () => void;
+    spacing?: boolean;
+    background?: boolean;
 };
 
 export function PasswordInputDialog({
     title,
     continueLabel = 'Continue',
     showArrowIcon = false,
+    spacing = false,
+    background = false,
     onPasswordVerified,
     onBackClicked,
 }: PasswordExportDialogProps) {
@@ -59,7 +64,12 @@ export function PasswordInputDialog({
             validateOnMount
         >
             {({ isSubmitting, isValid }) => (
-                <Form className="bg-white px-5 pt-10 flex flex-col flex-nowrap items-center flex-1 gap-7.5">
+                <Form
+                    className={classNames(
+                        'flex flex-col flex-nowrap items-center flex-1 gap-7.5',
+                        { 'bg-white': background, 'px-5 pt-10': spacing }
+                    )}
+                >
                     <div className="text-center">
                         <Heading
                             variant="heading1"
@@ -88,7 +98,7 @@ export function PasswordInputDialog({
                             </Text>
                         </div>
                     </div>
-                    <div className="flex flex-col flex-nowrap gap-3.75 self-stretch pb-2">
+                    <div className="flex flex-col flex-nowrap gap-3.75 self-stretch">
                         <Button
                             type="submit"
                             variant="primary"

--- a/apps/wallet/src/ui/app/pages/initialize/backup/index.tsx
+++ b/apps/wallet/src/ui/app/pages/initialize/backup/index.tsx
@@ -3,6 +3,7 @@
 
 import { ArrowLeft16, Check12 } from '@mysten/icons';
 import { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 
 import { Button } from '_app/shared/ButtonUI';
 import { CardLayout } from '_app/shared/card-layout';
@@ -14,6 +15,7 @@ import { useAppDispatch } from '_hooks';
 import { loadEntropyFromKeyring } from '_redux/slices/account';
 import { entropyToMnemonic, toEntropy } from '_shared/utils/bip39';
 import { HideShowDisplayBox } from '_src/ui/app/components/HideShowDisplayBox';
+import { PasswordInputDialog } from '_src/ui/app/components/menu/content/PasswordInputDialog';
 
 export type BackupPageProps = {
     mode?: 'created' | 'imported';
@@ -25,10 +27,18 @@ const BackupPage = ({ mode = 'created' }: BackupPageProps) => {
     const [mnemonic, setLocalMnemonic] = useState<string[] | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [passwordCopied, setPasswordCopied] = useState(false);
+    const { state } = useLocation();
+    const isOnboardingFlow = !!state?.onboarding;
+    const [showPasswordDialog, setShowPasswordDialog] = useState(false);
+    const [passwordConfirmed, setPasswordConfirmed] = useState(false);
     const dispatch = useAppDispatch();
     useEffect(() => {
         (async () => {
-            if (guardsLoading || mode !== 'created') {
+            if (
+                guardsLoading ||
+                mode !== 'created' ||
+                (!isOnboardingFlow && !passwordConfirmed)
+            ) {
                 return;
             }
             setLoading(true);
@@ -49,109 +59,148 @@ const BackupPage = ({ mode = 'created' }: BackupPageProps) => {
                 setLoading(false);
             }
         })();
-    }, [dispatch, mode, guardsLoading]);
+    }, [dispatch, mode, guardsLoading, isOnboardingFlow, passwordConfirmed]);
+    useEffect(() => {
+        if (
+            !guardsLoading &&
+            mode === 'created' &&
+            !isOnboardingFlow &&
+            !passwordConfirmed &&
+            !showPasswordDialog
+        ) {
+            setShowPasswordDialog(true);
+        }
+    }, [
+        guardsLoading,
+        mode,
+        isOnboardingFlow,
+        passwordConfirmed,
+        showPasswordDialog,
+    ]);
     return (
         <Loading loading={guardsLoading}>
-            <CardLayout
-                icon="success"
-                title={
-                    mode === 'imported'
-                        ? 'Wallet Imported Successfully!'
-                        : 'Wallet Created Successfully!'
-                }
-            >
-                <div className="flex flex-col flex-nowrap flex-grow h-full w-full">
-                    {mode === 'created' ? (
-                        <div className="flex flex-col flex-nowrap flex-grow mb-5">
-                            <div className="mb-1 mt-7.5 text-center">
-                                <Text
-                                    variant="caption"
-                                    color="steel-darker"
-                                    weight="bold"
-                                >
-                                    Recovery phrase
-                                </Text>
-                            </div>
-                            <div className="mb-3.5 mt-2 text-center">
-                                <Text
-                                    variant="pBodySmall"
-                                    color="steel-dark"
-                                    weight="normal"
-                                >
-                                    Your recovery phrase makes it easy to back
-                                    up and restore your account.
-                                </Text>
-                            </div>
-                            <Loading loading={loading}>
-                                {mnemonic ? (
-                                    <HideShowDisplayBox
-                                        value={mnemonic}
-                                        hideCopy
-                                    />
-                                ) : (
-                                    <Alert>{error}</Alert>
-                                )}
-                            </Loading>
-                            <div className="mt-3.75 mb-1 text-center">
-                                <Text
-                                    variant="caption"
-                                    color="steel-dark"
-                                    weight="semibold"
-                                >
-                                    Warning
-                                </Text>
-                            </div>
-                            <div className="mb-1 text-center">
-                                <Text
-                                    variant="pBodySmall"
-                                    color="steel-dark"
-                                    weight="normal"
-                                >
-                                    Never disclose your secret recovery phrase.
-                                    Anyone can take over your account with it.
-                                </Text>
-                            </div>
-                            <div className="flex-1" />
-                            <div className="w-full text-left flex mt-5 mb-">
-                                <label className="flex items-center justify-center h-5 mb-0 mr-5 text-sui-dark gap-1.25 relative cursor-pointer">
-                                    <input
-                                        type="checkbox"
-                                        name="agree"
-                                        id="agree"
-                                        className="peer/agree invisible ml-2"
-                                        onChange={() =>
-                                            setPasswordCopied(!passwordCopied)
-                                        }
-                                    />
-                                    <span className="absolute top-0 left-0 h-5 w-5 bg-white peer-checked/agree:bg-success peer-checked/agree:shadow-none border-gray-50 border rounded shadow-button flex justify-center items-center">
-                                        <Check12 className="text-white text-body font-semibold" />
-                                    </span>
-
+            {showPasswordDialog ? (
+                <PasswordInputDialog
+                    title="Backup Recovery Phrase"
+                    onPasswordVerified={() => {
+                        setPasswordConfirmed(true);
+                        setShowPasswordDialog(false);
+                    }}
+                    continueLabel="Confirm"
+                />
+            ) : (
+                <CardLayout
+                    icon="success"
+                    title={
+                        mode === 'imported'
+                            ? 'Wallet Imported Successfully!'
+                            : isOnboardingFlow
+                            ? 'Wallet Created Successfully!'
+                            : 'Backup Recovery Phrase'
+                    }
+                >
+                    <div className="flex flex-col flex-nowrap flex-grow h-full w-full">
+                        {mode === 'created' ? (
+                            <div className="flex flex-col flex-nowrap flex-grow mb-5">
+                                <div className="mb-1 mt-7.5 text-center">
                                     <Text
-                                        variant="bodySmall"
+                                        variant="caption"
+                                        color="steel-darker"
+                                        weight="bold"
+                                    >
+                                        Recovery phrase
+                                    </Text>
+                                </div>
+                                <div className="mb-3.5 mt-2 text-center">
+                                    <Text
+                                        variant="pBodySmall"
                                         color="steel-dark"
                                         weight="normal"
                                     >
-                                        I saved my recovery phrase
+                                        Your recovery phrase makes it easy to
+                                        back up and restore your account.
                                     </Text>
-                                </label>
+                                </div>
+                                <Loading loading={loading}>
+                                    {mnemonic ? (
+                                        <HideShowDisplayBox
+                                            value={mnemonic}
+                                            hideCopy
+                                        />
+                                    ) : (
+                                        <Alert>{error}</Alert>
+                                    )}
+                                </Loading>
+                                <div className="mt-3.75 mb-1 text-center">
+                                    <Text
+                                        variant="caption"
+                                        color="steel-dark"
+                                        weight="semibold"
+                                    >
+                                        Warning
+                                    </Text>
+                                </div>
+                                <div className="mb-1 text-center">
+                                    <Text
+                                        variant="pBodySmall"
+                                        color="steel-dark"
+                                        weight="normal"
+                                    >
+                                        Never disclose your secret recovery
+                                        phrase. Anyone can take over your
+                                        account with it.
+                                    </Text>
+                                </div>
+                                <div className="flex-1" />
+                                {isOnboardingFlow ? (
+                                    <div className="w-full text-left flex mt-5 mb-">
+                                        <label className="flex items-center justify-center h-5 mb-0 mr-5 text-sui-dark gap-1.25 relative cursor-pointer">
+                                            <input
+                                                type="checkbox"
+                                                name="agree"
+                                                id="agree"
+                                                className="peer/agree invisible ml-2"
+                                                onChange={() =>
+                                                    setPasswordCopied(
+                                                        !passwordCopied
+                                                    )
+                                                }
+                                            />
+                                            <span className="absolute top-0 left-0 h-5 w-5 bg-white peer-checked/agree:bg-success peer-checked/agree:shadow-none border-gray-50 border rounded shadow-button flex justify-center items-center">
+                                                <Check12 className="text-white text-body font-semibold" />
+                                            </span>
+
+                                            <Text
+                                                variant="bodySmall"
+                                                color="steel-dark"
+                                                weight="normal"
+                                            >
+                                                I saved my recovery phrase
+                                            </Text>
+                                        </label>
+                                    </div>
+                                ) : null}
                             </div>
-                        </div>
-                    ) : null}
-                    {mode !== 'created' && <div className="flex-1 flex" />}
-                    <Button
-                        type="button"
-                        size="tall"
-                        variant="primary"
-                        disabled={mode === 'created' && !passwordCopied}
-                        to="/"
-                        text="Open Sui Wallet"
-                        after={
-                            <ArrowLeft16 className="text-pBodySmall font-normal rotate-135" />
-                        }
-                    />
-                </div>
-            </CardLayout>
+                        ) : null}
+                        {mode !== 'created' && <div className="flex-1 flex" />}
+                        <Button
+                            type="button"
+                            size="tall"
+                            variant="primary"
+                            disabled={
+                                mode === 'created' &&
+                                !passwordCopied &&
+                                isOnboardingFlow
+                            }
+                            to="/"
+                            text="Open Sui Wallet"
+                            after={
+                                <ArrowLeft16 className="text-pBodySmall font-normal rotate-135" />
+                            }
+                        />
+                    </div>
+                </CardLayout>
+            )}
         </Loading>
     );
 };

--- a/apps/wallet/src/ui/app/pages/initialize/backup/index.tsx
+++ b/apps/wallet/src/ui/app/pages/initialize/backup/index.tsx
@@ -80,17 +80,19 @@ const BackupPage = ({ mode = 'created' }: BackupPageProps) => {
     return (
         <Loading loading={guardsLoading}>
             {showPasswordDialog ? (
-                <PasswordInputDialog
-                    title="Backup Recovery Phrase"
-                    onPasswordVerified={() => {
-                        setPasswordConfirmed(true);
-                        setShowPasswordDialog(false);
-                    }}
-                    continueLabel="Confirm"
-                />
+                <CardLayout>
+                    <PasswordInputDialog
+                        title="Backup Recovery Phrase"
+                        onPasswordVerified={() => {
+                            setPasswordConfirmed(true);
+                            setShowPasswordDialog(false);
+                        }}
+                        continueLabel="Confirm"
+                    />
+                </CardLayout>
             ) : (
                 <CardLayout
-                    icon="success"
+                    icon={isOnboardingFlow ? 'success' : undefined}
                     title={
                         mode === 'imported'
                             ? 'Wallet Imported Successfully!'

--- a/apps/wallet/src/ui/app/pages/initialize/create/index.tsx
+++ b/apps/wallet/src/ui/app/pages/initialize/create/index.tsx
@@ -36,7 +36,7 @@ const CreatePage = () => {
                         await dispatch(
                             createVault({ password: values.password })
                         ).unwrap();
-                        navigate('../backup');
+                        navigate('../backup', { state: { onboarding: true } });
                     } catch (e) {
                         // Do nothing
                     }


### PR DESCRIPTION
* make sure accessing the backup mnemonic view directly prompts for password confirmation
* hide saved checkbox and update title for this case


https://user-images.githubusercontent.com/10210143/235657322-2a551e80-50cb-4702-9ff3-59d82157e46f.mov




closes APPS-883