### PR TITLE
[explorer] do some last-minute fixing to the home page for the redesign

### DIFF
--- a/apps/explorer/src/components/GasPriceCard/index.tsx
+++ b/apps/explorer/src/components/GasPriceCard/index.tsx
@@ -168,7 +168,7 @@ export function GasPriceCard() {
                         onChange={setSelectedUnit}
                     />
                 </div>
-                <div className="flex gap-6">
+                <div className="flex gap-6 lg:max-xl:gap-12">
                     <Stats label="Current" postfix={selectedUnit}>
                         {formattedCurrentGasPrice}
                     </Stats>

--- a/apps/explorer/src/components/HomeMetrics/OnTheNetwork.tsx
+++ b/apps/explorer/src/components/HomeMetrics/OnTheNetwork.tsx
@@ -19,7 +19,7 @@ export function OnTheNetwork() {
                 On the Network
             </Heading>
             <div className="-mb-3 -mr-8 mt-8 flex gap-8 overflow-x-auto pb-3">
-                <div className="flex gap-8">
+                <div className="flex gap-8 lg:max-xl:gap-12">
                     <div className="flex flex-shrink-0 gap-1">
                         <Svg3D32 className="h-8 w-8 font-normal text-steel-dark" />
                         <FormattedStatsAmount

--- a/apps/explorer/src/components/HomeMetrics/OnTheNetwork.tsx
+++ b/apps/explorer/src/components/HomeMetrics/OnTheNetwork.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useGetTotalTransactionBlocks } from '@mysten/core';
-import { Svg3D32, Nft232, Wallet32, Staking32 } from '@mysten/icons';
+import { Svg3D32, Nft232, Staking32 } from '@mysten/icons';
 
 import { FormattedStatsAmount } from './FormattedStatsAmount';
 

--- a/apps/explorer/src/components/HomeMetrics/OnTheNetwork.tsx
+++ b/apps/explorer/src/components/HomeMetrics/OnTheNetwork.tsx
@@ -38,7 +38,8 @@ export function OnTheNetwork() {
                             size="sm"
                         />
                     </div>
-                    <div className="flex flex-shrink-0 gap-1">
+                    {/* TODO: Comment this out once addresses are available post-mainnet */}
+                    {/* <div className="flex flex-shrink-0 gap-1">
                         <Wallet32 className="h-8 w-8 text-steel-dark" />
                         <FormattedStatsAmount
                             label="Addresses"
@@ -46,7 +47,7 @@ export function OnTheNetwork() {
                             amount={networkMetrics?.totalAddresses}
                             size="sm"
                         />
-                    </div>
+                    </div> */}
                     <div className="flex flex-shrink-0 gap-1 pr-2">
                         <Staking32 className="h-8 w-8 text-steel-dark" />
                         <FormattedStatsAmount

--- a/apps/explorer/src/index.css
+++ b/apps/explorer/src/index.css
@@ -26,8 +26,8 @@
         @apply grid grid-cols-1 gap-4;
         grid-template-areas:
             'tps'
-            'network'
             'epoch'
+            'network'
             'checkpoint'
             'gas-price'
             'node-map'
@@ -40,8 +40,8 @@
         grid-template-areas:
             'tps'
             'sui-token'
-            'network'
             'epoch'
+            'network'
             'checkpoint'
             'gas-price'
             'node-map'


### PR DESCRIPTION
## Description 
Implementing some last-minute changes before we roll this out:
 - Tweaked the spacing for the `lg` breakpoint on some cards
 - Switched the order of the "Current Epoch" and "On The Network" cards on the `xs` breakpoint
     - We're going to tackle the logical order <> visual order accessibility issue as a follow-up
 - I removed "addresses" from the "On The Network" card because it won't be ready for mainnet

## Test Plan 
- Manual testing

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
N/A
