### PR TITLE
best efforts post quorum cert broadcasting (#11548)

### DIFF
--- a/crates/sui-benchmark/src/fullnode_reconfig_observer.rs
+++ b/crates/sui-benchmark/src/fullnode_reconfig_observer.rs
@@ -23,7 +23,7 @@ pub struct FullNodeReconfigObserver {
     pub fullnode_client: SuiClient,
     committee_store: Arc<CommitteeStore>,
     safe_client_metrics_base: SafeClientMetricsBase,
-    auth_agg_metrics: AuthAggMetrics,
+    auth_agg_metrics: Arc<AuthAggMetrics>,
 }
 
 impl FullNodeReconfigObserver {
@@ -31,7 +31,7 @@ impl FullNodeReconfigObserver {
         fullnode_rpc_url: &str,
         committee_store: Arc<CommitteeStore>,
         safe_client_metrics_base: SafeClientMetricsBase,
-        auth_agg_metrics: AuthAggMetrics,
+        auth_agg_metrics: Arc<AuthAggMetrics>,
     ) -> Self {
         Self {
             fullnode_client: SuiClientBuilder::default()

--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -227,7 +227,7 @@ pub trait ValidatorProxy {
     /// signature. It should only be used for benchmarks.
     async fn execute_bench_transaction(&self, tx: Transaction) -> anyhow::Result<ExecutionEffects>;
 
-    fn clone_committee(&self) -> Committee;
+    fn clone_committee(&self) -> Arc<Committee>;
 
     fn get_current_epoch(&self) -> EpochId;
 
@@ -590,7 +590,7 @@ impl ValidatorProxy for LocalValidatorAggregatorProxy {
         Ok(effects)
     }
 
-    fn clone_committee(&self) -> Committee {
+    fn clone_committee(&self) -> Arc<Committee> {
         self.qd.clone_committee()
     }
 
@@ -622,7 +622,7 @@ impl ValidatorProxy for LocalValidatorAggregatorProxy {
 
 pub struct FullNodeProxy {
     sui_client: SuiClient,
-    committee: Committee,
+    committee: Arc<Committee>,
 }
 
 impl FullNodeProxy {
@@ -643,7 +643,7 @@ impl FullNodeProxy {
 
         Ok(Self {
             sui_client,
-            committee,
+            committee: Arc::new(committee),
         })
     }
 }
@@ -756,7 +756,7 @@ impl ValidatorProxy for FullNodeProxy {
         self.execute_transaction_block(tx).await
     }
 
-    fn clone_committee(&self) -> Committee {
+    fn clone_committee(&self) -> Arc<Committee> {
         self.committee.clone()
     }
 

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -265,8 +265,6 @@ pub struct AuthorityEpochTables {
     /// Non-empty list of transactions here might result in empty list when we are forming checkpoint.
     /// Because we don't want to create checkpoints with empty content(see CheckpointBuilder::write_checkpoint),
     /// the sequence number of checkpoint does not match height here.
-    ///
-    /// The boolean value indicates whether this is the last checkpoint of the epoch.
     #[default_options_override_fn = "pending_checkpoints_table_default_config"]
     pending_checkpoints: DBMap<CheckpointCommitHeight, PendingCheckpoint>,
 

--- a/crates/sui-core/src/quorum_driver/mod.rs
+++ b/crates/sui-core/src/quorum_driver/mod.rs
@@ -63,7 +63,7 @@ impl Debug for QuorumDriverTask {
     }
 }
 
-pub struct QuorumDriver<A> {
+pub struct QuorumDriver<A: Clone> {
     validators: ArcSwap<AuthorityAggregator<A>>,
     task_sender: Sender<QuorumDriverTask>,
     effects_subscribe_sender: tokio::sync::broadcast::Sender<QuorumDriverEffectsQueueResult>,
@@ -72,7 +72,7 @@ pub struct QuorumDriver<A> {
     max_retry_times: u8,
 }
 
-impl<A> QuorumDriver<A> {
+impl<A: Clone> QuorumDriver<A> {
     pub(crate) fn new(
         validators: ArcSwap<AuthorityAggregator<A>>,
         task_sender: Sender<QuorumDriverTask>,
@@ -95,7 +95,7 @@ impl<A> QuorumDriver<A> {
         &self.validators
     }
 
-    pub fn clone_committee(&self) -> Committee {
+    pub fn clone_committee(&self) -> Arc<Committee> {
         self.validators.load().committee.clone()
     }
 
@@ -526,7 +526,7 @@ where
     }
 }
 
-pub struct QuorumDriverHandler<A> {
+pub struct QuorumDriverHandler<A: Clone> {
     quorum_driver: Arc<QuorumDriver<A>>,
     effects_subscriber: tokio::sync::broadcast::Receiver<QuorumDriverEffectsQueueResult>,
     quorum_driver_metrics: Arc<QuorumDriverMetrics>,
@@ -783,7 +783,7 @@ where
     }
 }
 
-pub struct QuorumDriverHandlerBuilder<A> {
+pub struct QuorumDriverHandlerBuilder<A: Clone> {
     validators: Arc<AuthorityAggregator<A>>,
     metrics: Arc<QuorumDriverMetrics>,
     notifier: Option<Arc<NotifyRead<TransactionDigest, QuorumDriverResult>>>,

--- a/crates/sui-core/src/quorum_driver/reconfig_observer.rs
+++ b/crates/sui-core/src/quorum_driver/reconfig_observer.rs
@@ -18,7 +18,7 @@ use crate::{
 use super::QuorumDriver;
 
 #[async_trait]
-pub trait ReconfigObserver<A> {
+pub trait ReconfigObserver<A: Clone> {
     async fn run(&mut self, quorum_driver: Arc<QuorumDriver<A>>);
     fn clone_boxed(&self) -> Box<dyn ReconfigObserver<A> + Send + Sync>;
 }
@@ -124,7 +124,7 @@ pub struct DummyReconfigObserver;
 #[async_trait]
 impl<A> ReconfigObserver<A> for DummyReconfigObserver
 where
-    A: AuthorityAPI + Send + Sync + 'static,
+    A: AuthorityAPI + Send + Sync + Clone + 'static,
 {
     fn clone_boxed(&self) -> Box<dyn ReconfigObserver<A> + Send + Sync> {
         Box::new(Self {})

--- a/crates/sui-core/src/quorum_driver/tests.rs
+++ b/crates/sui-core/src/quorum_driver/tests.rs
@@ -196,7 +196,9 @@ async fn test_quorum_driver_update_validators_and_max_retry_times() {
     });
 
     // Update authority aggregator with a new epoch number, and let quorum driver know.
-    aggregator.committee.epoch = 10;
+    let mut committee = aggregator.clone_inner_committee_test_only();
+    committee.epoch = 10;
+    aggregator.committee = Arc::new(committee);
     quorum_driver_clone
         .update_validators(Arc::new(aggregator))
         .await;
@@ -250,9 +252,9 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
     let tx = make_tx(&gas, sender, &keypair, rgp);
     let names: Vec<_> = aggregator.authority_clients.keys().clone().collect();
     assert_eq!(names.len(), 4);
-    let client0 = aggregator.clone_client(names[0]);
-    let client1 = aggregator.clone_client(names[1]);
-    let client2 = aggregator.clone_client(names[2]);
+    let client0 = aggregator.clone_client_test_only(names[0]);
+    let client1 = aggregator.clone_client_test_only(names[1]);
+    let client2 = aggregator.clone_client_test_only(names[2]);
 
     println!("Case 0 - two validators lock the object with the same tx");
     assert!(client0.handle_transaction(tx.clone()).await.is_ok());

--- a/crates/sui-core/src/safe_client.rs
+++ b/crates/sui-core/src/safe_client.rs
@@ -151,14 +151,17 @@ impl SafeClientMetrics {
 /// See `SafeClientMetrics::new` for description of each metrics.
 /// The metrics are per validator client.
 #[derive(Clone)]
-pub struct SafeClient<C> {
+pub struct SafeClient<C>
+where
+    C: Clone,
+{
     authority_client: C,
     committee_store: Arc<CommitteeStore>,
     address: AuthorityPublicKeyBytes,
     metrics: SafeClientMetrics,
 }
 
-impl<C> SafeClient<C> {
+impl<C: Clone> SafeClient<C> {
     pub fn new(
         authority_client: C,
         committee_store: Arc<CommitteeStore>,
@@ -174,7 +177,7 @@ impl<C> SafeClient<C> {
     }
 }
 
-impl<C> SafeClient<C> {
+impl<C: Clone> SafeClient<C> {
     pub fn authority_client(&self) -> &C {
         &self.authority_client
     }

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -288,10 +288,8 @@ pub async fn init_local_authorities_with_genesis(
         clients.insert(authority_name, client);
     }
     let timeouts = TimeoutConfig {
-        authority_request_timeout: Duration::from_secs(5),
         pre_quorum_timeout: Duration::from_secs(5),
         post_quorum_timeout: Duration::from_secs(5),
-        serial_authority_request_timeout: Duration::from_secs(1),
         serial_authority_request_interval: Duration::from_secs(1),
     };
     let committee_store = Arc::new(CommitteeStore::new_for_testing(&committee));

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -50,7 +50,7 @@ const LOCAL_EXECUTION_TIMEOUT: Duration = Duration::from_secs(10);
 
 const WAIT_FOR_FINALITY_TIMEOUT: Duration = Duration::from_secs(30);
 
-pub struct TransactiondOrchestrator<A> {
+pub struct TransactiondOrchestrator<A: Clone> {
     quorum_driver_handler: Arc<QuorumDriverHandler<A>>,
     validator_state: Arc<AuthorityState>,
     _local_executor_handle: JoinHandle<()>,

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -483,7 +483,9 @@ async fn test_validator_resign_effects() {
     sleep(Duration::from_secs(10)).await;
     trigger_reconfiguration(&authorities).await;
     // Manually reconfigure the aggregator.
-    net.committee.epoch = 1;
+    let mut committee = net.clone_inner_committee_test_only();
+    committee.epoch = 1;
+    net.committee = Arc::new(committee);
     let (effects1, _, _) = net.process_certificate(cert.into_inner()).await.unwrap();
     // Ensure that we are able to form a new effects cert in the new epoch.
     assert_eq!(effects1.epoch(), 1);


### PR DESCRIPTION
## Description 

We use best efforts to send tx certs to validators post quorum, with the hope that this could reduce the chance of slow validators miss their slot to submit to consensus.

meat is https://github.com/MystenLabs/sui/pull/11548/files#r1181387700

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
