### PR TITLE
[sui-system] add constant for max gas price a validator can set

### DIFF
--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0x52bbda89a31815a3345dcfdc46b2d5b9add594b688317a6f8582d61b8da7f4d0"
+            id: "0x0a94c4d674bea213f17013fa13c9cf2b47550e397a8845817e57f4197c1f8913"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0xeb9b625021e63e598c4636eff9ade20cb323eaf266aba5d844ab9b025fe4a72c"
+      operation_cap_id: "0xaf563374e4d0bfb33e0cda157a14ce8ebf7505c27829b5110023fbde6cc4acac"
       gas_price: 1000
       staking_pool:
-        id: "0x0a350268e5ddb13b8ac6763414b58d2568d4a82d839cd93b84a13d7583c4a7b4"
+        id: "0xd7a765a0d7ceec8fd8d310e2138bce0608b610b534931d4b19c79b140c6f3401"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0xbce88588fc81c7b2bd5654ab754c86e30d6c3d262cf0900f165a90e543b9dc6c"
+          id: "0xa2104e83db0365c32b8950097eda03a400a6ccf1c850a844bd7b64c7d1752be9"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0x63f4f5afd2646893b7193e28ee377980cf5961ca37a457279f94b7a0885aa898"
+            id: "0xd9c9bf3931f7b308ea11a0d2115c3c02d343f56e40d77d664c5d3cd03aa93863"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0x312357b89f83a786d6db2f49c8e0a71e0bc84fb1e7776f4f636c0aad22b79db6"
+          id: "0xbc6ba24e6c5a4ab19c53a8e6b1b864f0d35bb46267dc6949df001c6573c703fd"
         size: 0
   pending_active_validators:
     contents:
-      id: "0xd7c142e0058e255b023d352a81a9c2eb7951cc8eaa1d6557d56ac191cd3e64b8"
+      id: "0x1ce534eb7cc4f2e01117eedc09ba6f61d2c1685443411d79c2046471b2104c3e"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0xea14a2d0dd6e925b0e9459fe7bc78ce3dc7c743a1157040383921f10eb919395"
+    id: "0xed29b31bb39757e1f649d918fe893048c976a194d6b21edec77746fb96e33eef"
     size: 1
   inactive_validators:
-    id: "0x7e86f416d2dbe1a6c562c0d43a82167aa34bf0bb015797f0c99d20ba0a2ae87b"
+    id: "0xf92feb7d93c2e9bd9aa4ab4c2a57964a472cce9b279f355056488619c2e94efc"
     size: 0
   validator_candidates:
-    id: "0xff52792319368063ea9387eb0527b12044a15564244a5af5f041af09647f6465"
+    id: "0x03b5dcd2fb3a5a90fa6bf62494352a71067b52efe6e91c2bcf9e958e5c6a06eb"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0xa93bd622ddbc3f0c5f545ff8c891b7e5dd508a769ee6ecd4fd9e836caf92396d"
+      id: "0x122b6b7f2ff8764eea7f9c149902bf4111ff2753d09d2d301e7a1cc8e4823a4d"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x5634202025769355420c45fc2ad617b62f4816058d4f4f10880e3a5113568abd"
+      id: "0x78a4631a43504eabcea0b3c0c7d30a06a5588da934d8395eeb7a07dd35d70341"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 10000
   extra_fields:
     id:
-      id: "0x7af34b009d463115a0525e231d2b7f7b831d959b72331b0686b882ff6fb03404"
+      id: "0xff09a626a04e5e356aeaa152937c2885c2724a49d665e68509ab29c6c0cbefc6"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,6 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0x08ac6dc78547cb853ad09f01182616fc0ebbeab1d9365c8fdbc6f1e7f3dcec4b"
+    id: "0x574fdb978273dfd8df3f4cba2e3fd243a2cd8f87ba69774a3bced440d22c0476"
   size: 0
 

--- a/crates/sui-framework/docs/validator.md
+++ b/crates/sui-framework/docs/validator.md
@@ -485,6 +485,16 @@ Commission rate set by the validator is higher than the threshold
 
 
 
+<a name="0x3_validator_EGasPriceHigherThanThreshold"></a>
+
+Validator trying to set gas price higher than threshold.
+
+
+<pre><code><b>const</b> <a href="validator.md#0x3_validator_EGasPriceHigherThanThreshold">EGasPriceHigherThanThreshold</a>: u64 = 102;
+</code></pre>
+
+
+
 <a name="0x3_validator_EInvalidCap"></a>
 
 Capability code is not valid
@@ -624,6 +634,16 @@ Validator Metadata is too long
 
 
 
+<a name="0x3_validator_MAX_VALIDATOR_GAS_PRICE"></a>
+
+Max gas price a validator can set is 100K MIST.
+
+
+<pre><code><b>const</b> <a href="validator.md#0x3_validator_MAX_VALIDATOR_GAS_PRICE">MAX_VALIDATOR_GAS_PRICE</a>: u64 = 100000;
+</code></pre>
+
+
+
 <a name="0x3_validator_MAX_VALIDATOR_METADATA_LENGTH"></a>
 
 
@@ -741,6 +761,7 @@ Validator Metadata is too long
         <a href="validator.md#0x3_validator_EValidatorMetadataExceedingLengthLimit">EValidatorMetadataExceedingLengthLimit</a>
     );
     <b>assert</b>!(<a href="validator.md#0x3_validator_commission_rate">commission_rate</a> &lt;= <a href="validator.md#0x3_validator_MAX_COMMISSION_RATE">MAX_COMMISSION_RATE</a>, <a href="validator.md#0x3_validator_ECommissionRateTooHigh">ECommissionRateTooHigh</a>);
+    <b>assert</b>!(<a href="validator.md#0x3_validator_gas_price">gas_price</a> &lt; <a href="validator.md#0x3_validator_MAX_VALIDATOR_GAS_PRICE">MAX_VALIDATOR_GAS_PRICE</a>, <a href="validator.md#0x3_validator_EGasPriceHigherThanThreshold">EGasPriceHigherThanThreshold</a>);
 
     <b>let</b> metadata = <a href="validator.md#0x3_validator_new_metadata">new_metadata</a>(
         sui_address,
@@ -1010,6 +1031,7 @@ Need to present a <code>ValidatorOperationCap</code>.
     verified_cap: ValidatorOperationCap,
     new_price: u64,
 ) {
+    <b>assert</b>!(new_price &lt; <a href="validator.md#0x3_validator_MAX_VALIDATOR_GAS_PRICE">MAX_VALIDATOR_GAS_PRICE</a>, <a href="validator.md#0x3_validator_EGasPriceHigherThanThreshold">EGasPriceHigherThanThreshold</a>);
     <b>let</b> validator_address = *<a href="validator_cap.md#0x3_validator_cap_verified_operation_cap_address">validator_cap::verified_operation_cap_address</a>(&verified_cap);
     <b>assert</b>!(validator_address == self.metadata.sui_address, <a href="validator.md#0x3_validator_EInvalidCap">EInvalidCap</a>);
     self.next_epoch_gas_price = new_price;
@@ -1042,6 +1064,7 @@ Set new gas price for the candidate validator.
     new_price: u64
 ) {
     <b>assert</b>!(<a href="validator.md#0x3_validator_is_preactive">is_preactive</a>(self), <a href="validator.md#0x3_validator_ENotValidatorCandidate">ENotValidatorCandidate</a>);
+    <b>assert</b>!(new_price &lt; <a href="validator.md#0x3_validator_MAX_VALIDATOR_GAS_PRICE">MAX_VALIDATOR_GAS_PRICE</a>, <a href="validator.md#0x3_validator_EGasPriceHigherThanThreshold">EGasPriceHigherThanThreshold</a>);
     <b>let</b> validator_address = *<a href="validator_cap.md#0x3_validator_cap_verified_operation_cap_address">validator_cap::verified_operation_cap_address</a>(&verified_cap);
     <b>assert</b>!(validator_address == self.metadata.sui_address, <a href="validator.md#0x3_validator_EInvalidCap">EInvalidCap</a>);
     self.next_epoch_gas_price = new_price;

--- a/crates/sui-framework/packages/sui-system/tests/sui_system_tests.move
+++ b/crates/sui-framework/packages/sui-system/tests/sui_system_tests.move
@@ -185,6 +185,19 @@ module sui_system::sui_system_tests {
     }
 
     #[test]
+    #[expected_failure(abort_code = validator::EGasPriceHigherThanThreshold)]
+    fun test_set_gas_price_failure() {
+        let scenario_val = test_scenario::begin(@0x0);
+        let scenario = &mut scenario_val;
+        set_up_sui_system_state(vector[@0x1, @0x2]);
+
+        // Fails here since the gas price is too high.
+        set_gas_price_helper(@0x1, 100_001, scenario);
+
+        test_scenario::end(scenario_val);
+    }
+
+    #[test]
     #[expected_failure(abort_code = sui_system_state_inner::ENotValidator)]
     fun test_report_non_validator_failure() {
         let scenario_val = test_scenario::begin(@0x0);


### PR DESCRIPTION
## Description 

Right now the reference gas price can be set to whatever the validators want. If it's higher than the `max_gas_price` than no transaction will go through. This PR adds asserts to make sure the gas price set by validators is not greater than the max gas price.

## Test Plan 

Added a test.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
