### PR TITLE
[wallet-ext] - fix border styles

### DIFF
--- a/apps/wallet/src/ui/app/components/DAppInfoCard.tsx
+++ b/apps/wallet/src/ui/app/components/DAppInfoCard.tsx
@@ -34,6 +34,8 @@ export function DAppInfoCard({
     }, [url]);
     return (
         <SummaryCard
+            minimalPadding
+            noBorder
             showDivider
             body={
                 <>

--- a/apps/wallet/src/ui/app/components/SummaryCard.tsx
+++ b/apps/wallet/src/ui/app/components/SummaryCard.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { cx } from 'class-variance-authority';
+import clsx from 'classnames';
 
 import { Text } from '../shared/text';
 
@@ -13,6 +13,7 @@ export type SummaryCardProps = {
     footer?: ReactNode;
     minimalPadding?: boolean;
     showDivider?: boolean;
+    noBorder?: boolean;
 };
 
 export function SummaryCard({
@@ -21,11 +22,17 @@ export function SummaryCard({
     footer,
     minimalPadding,
     showDivider = false,
+    noBorder = false,
 }: SummaryCardProps) {
     return (
-        <div className="bg-white flex flex-col flex-nowrap rounded-t-xl">
+        <div
+            className={clsx(
+                { 'border border-solid border-gray-45': !noBorder },
+                'bg-white flex flex-col flex-nowrap rounded-2xl'
+            )}
+        >
             {header ? (
-                <div className="flex flex-row flex-nowrap items-center justify-center uppercase bg-gray-40 px-6 py-2.5 rounded-t-2xl">
+                <div className="flex flex-row flex-nowrap items-center justify-center uppercase bg-gray-40 px-3.75 py-2.5 rounded-t-2xl">
                     <Text
                         variant="captionSmall"
                         weight="bold"
@@ -37,8 +44,8 @@ export function SummaryCard({
                 </div>
             ) : null}
             <div
-                className={cx(
-                    'flex-1 flex flex-col items-stretch flex-nowrap px-6',
+                className={clsx(
+                    'flex-1 flex flex-col items-stretch flex-nowrap px-4',
                     minimalPadding ? 'py-2' : 'py-4',
                     showDivider
                         ? 'divide-x-0 divide-y divide-gray-40 divide-solid'

--- a/apps/wallet/src/ui/app/components/user-approve-container/UserApproveContainer.module.scss
+++ b/apps/wallet/src/ui/app/components/user-approve-container/UserApproveContainer.module.scss
@@ -10,7 +10,7 @@
 
 .scroll-body {
     flex: 1;
-    padding: 30px 20px;
+    padding: 24px;
     padding-bottom: 0;
     display: flex;
     flex-flow: column;


### PR DESCRIPTION
## Description 

Uses some of the existing props to make the summary card work in the Connect Account / Approve Tx screens

<img width="388" alt="image" src="https://user-images.githubusercontent.com/122397493/235499806-03ae43a2-5fa6-4337-be5a-1e0f5c669feb.png">



## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
