### PR TITLE
Wait until only fewer than threshold db checkpoints are on disk

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -479,6 +479,8 @@ pub struct DBCheckpointConfig {
     pub perform_index_db_checkpoints_at_epoch_end: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prune_and_compact_before_upload: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_pending_checkpoints: Option<u64>,
 }
 
 /// Publicly known information about a validator

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -108,6 +108,7 @@ use crate::authority::epoch_start_configuration::EpochStartConfigTrait;
 use crate::authority::epoch_start_configuration::EpochStartConfiguration;
 use crate::checkpoints::checkpoint_executor::CheckpointExecutor;
 use crate::checkpoints::CheckpointStore;
+use crate::db_checkpoint_handler::DBCheckpointWaiter;
 use crate::epoch::committee_store::CommitteeStore;
 use crate::event_handler::SubscriptionHandler;
 use crate::execution_driver::execution_process;
@@ -1912,6 +1913,11 @@ impl AuthorityState {
                 .db_checkpoint_config
                 .perform_db_checkpoints_at_epoch_end
             {
+                DBCheckpointWaiter::wait_until_num_pending_is_less_than_threshold(
+                    &self.db_checkpoint_config,
+                )
+                .await
+                .map_err(|e| SuiError::DBCheckpointError(e.to_string()))?;
                 let checkpoint_indexes = self
                     .db_checkpoint_config
                     .perform_index_db_checkpoints_at_epoch_end

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -295,6 +295,10 @@ pub enum SuiError {
     },
     #[error("Signatures in a certificate must form a quorum")]
     CertificateRequiresQuorum,
+
+    #[error("Error while taking db checkpoint at epoch end: {0}")]
+    DBCheckpointError(String),
+
     #[error("Transaction certificate processing failed: {err}")]
     ErrorWhileProcessingCertificate { err: String },
     #[error(

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -400,6 +400,7 @@ impl TestClusterBuilder {
             object_store_config: None,
             perform_index_db_checkpoints_at_epoch_end: None,
             prune_and_compact_before_upload: None,
+            max_pending_checkpoints: None,
         };
         self
     }
@@ -411,6 +412,7 @@ impl TestClusterBuilder {
             object_store_config: None,
             perform_index_db_checkpoints_at_epoch_end: None,
             prune_and_compact_before_upload: None,
+            max_pending_checkpoints: None,
         };
         self
     }


### PR DESCRIPTION


## Description 

Describe the changes or additions included in this PR.

A snapshot FN syncing from genesis is very fast in executing checkpoints and triggering epoch transitions which creates one db checkpoint per epoch. However, pruning and compaction is much slower and causes a build up of checkpoints on disk which eventually causes the node to run out of disk and fail. We want to wait until there are fewer than `threshold` number of checkpoints in db checkpoint directory. Note that db checkpoint directories are garbage collected as soon
as they are done uploading to remote object store.

## Test Plan 

Add unit tests
