### PR TITLE
[FN query] Adding event table and event query by package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ yarn-error.log*
 # misc
 *.key
 .env
+fullnode.yaml
+genesis.blob

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2770,6 +2770,13 @@ impl AuthorityState {
                     limit,
                     descending,
                 )?,
+            EventFilter::Package(package_id) => index_store.events_by_event_package(
+                &package_id,
+                tx_num,
+                event_num,
+                limit,
+                descending,
+            )?,
             EventFilter::Sender(sender) => {
                 index_store.events_by_sender(&sender, tx_num, event_num, limit, descending)?
             }


### PR DESCRIPTION
## Description 

Adding a new table to the sui-storage to index by packageId for events

## Test Plan 

How did you test the new or updated feature?

Locally syncing a testnet node and querying against it.
<img width="1063" alt="image" src="https://user-images.githubusercontent.com/123408603/235531311-efeb138c-46ec-4ebd-8ead-4b9c86026532.png">

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
