### PR TITLE
[Checkpoint] add latency metric and read less effects for creation

### DIFF
--- a/crates/mysten-metrics/src/histogram.rs
+++ b/crates/mysten-metrics/src/histogram.rs
@@ -179,6 +179,10 @@ impl Histogram {
         HistogramVec::new_in_registry(name, desc, &[], registry).with_label_values(&[])
     }
 
+    pub fn observe(&self, v: Point) {
+        self.report(v)
+    }
+
     pub fn report(&self, v: Point) {
         match self.channel.try_send((self.labels.clone(), v)) {
             Ok(()) => {}

--- a/crates/sui-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_output.rs
@@ -67,6 +67,13 @@ impl<T: SubmitToConsensus + ReconfigurationInitiator> CheckpointOutput
     ) -> SuiResult {
         let checkpoint_seq = summary.sequence_number;
         let checkpoint_timestamp = summary.timestamp_ms;
+        self.metrics.checkpoint_creation_latency_ms.observe(
+            summary
+                .timestamp()
+                .elapsed()
+                .unwrap_or_default()
+                .as_millis() as u64,
+        );
         debug!(
             "Sending checkpoint signature at sequence {checkpoint_seq} to consensus, timestamp {checkpoint_timestamp}. 
             {}ms left till end of epoch at timestamp {}",

--- a/crates/sui-core/src/checkpoints/metrics.rs
+++ b/crates/sui-core/src/checkpoints/metrics.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use mysten_metrics::histogram::Histogram;
 use prometheus::{
     register_int_counter_vec_with_registry, register_int_counter_with_registry,
     register_int_gauge_vec_with_registry, register_int_gauge_with_registry, IntCounter,
@@ -20,6 +21,7 @@ pub struct CheckpointMetrics {
     pub last_received_checkpoint_signatures: IntGaugeVec,
     pub last_sent_checkpoint_signature: IntGauge,
     pub highest_accumulated_epoch: IntGauge,
+    pub checkpoint_creation_latency_ms: Histogram,
 }
 
 impl CheckpointMetrics {
@@ -93,6 +95,11 @@ impl CheckpointMetrics {
                 registry
             )
             .unwrap(),
+            checkpoint_creation_latency_ms: Histogram::new_in_registry(
+                "checkpoint_creation_latency_ms",
+                "Latency from consensus commit timstamp to local checkpoint creation in milliseconds",
+                registry,
+            ),
         };
         Arc::new(this)
     }

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -949,6 +949,7 @@ impl CheckpointBuilder {
             let mut pending = HashSet::new();
             for effect in roots {
                 let digest = effect.transaction_digest();
+                // Unnecessary to read effects of a depndency if the effect is already processed.
                 seen.insert(*digest);
                 if self
                     .epoch_store

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -949,6 +949,7 @@ impl CheckpointBuilder {
             let mut pending = HashSet::new();
             for effect in roots {
                 let digest = effect.transaction_digest();
+                seen.insert(*digest);
                 if self
                     .epoch_store
                     .builder_included_transaction_in_checkpoint(digest)?


### PR DESCRIPTION
## Description 

Add a metric to track the latency from Narwhal certificate to finishing checkpoint creation.
Also, try to avoid reading duplicated effects when the effects are already roots previously.

## Test Plan 

CI.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
