### PR TITLE
[explorer] remove home page redesign feature flag

### DIFF
--- a/apps/explorer/src/pages/home/Home.tsx
+++ b/apps/explorer/src/pages/home/Home.tsx
@@ -10,7 +10,6 @@ import { TopValidatorsCard } from '../../components/top-validators-card/TopValid
 
 import { Activity } from '~/components/Activity';
 import { GasPriceCard } from '~/components/GasPriceCard';
-import { HomeMetrics } from '~/components/HomeMetrics';
 import { Checkpoint } from '~/components/HomeMetrics/Checkpoint';
 import { CurrentEpoch } from '~/components/HomeMetrics/CurrentEpoch';
 import { NetworkTPS } from '~/components/HomeMetrics/NetworkTPS';
@@ -24,12 +23,9 @@ const NodeMap = lazy(() => import('../../components/node-map'));
 const TRANSACTIONS_LIMIT = 25;
 
 function Home() {
-    const isHomePageRedesignEnabled = useFeatureIsOn(
-        'explorer-home-page-redesign'
-    );
     const isSuiTokenCardEnabled = useFeatureIsOn('explorer-sui-token-card');
 
-    return isHomePageRedesignEnabled ? (
+    return (
         <div
             data-testid="home-page"
             className={clsx('home-page-grid-container', {
@@ -96,54 +92,6 @@ function Home() {
             {/* TODO: Add the popular packages component here :) */}
             {/* <div style={{ gridArea: 'packages' }} className="mt-5 bg-gray-60">
                 Popular packages
-            </div> */}
-        </div>
-    ) : (
-        <div
-            data-testid="home-page"
-            className="grid grid-cols-1 gap-x-12 gap-y-10 md:grid-cols-2"
-        >
-            <ErrorBoundary>
-                <HomeMetrics />
-            </ErrorBoundary>
-
-            <ErrorBoundary>
-                <Suspense fallback={<Card />}>
-                    <NodeMap minHeight={280} />
-                </Suspense>
-            </ErrorBoundary>
-
-            <ErrorBoundary>
-                <Activity initialLimit={TRANSACTIONS_LIMIT} disablePagination />
-            </ErrorBoundary>
-
-            <div data-testid="validators-table">
-                <TabGroup>
-                    <TabList>
-                        <Tab>Validators</Tab>
-                    </TabList>
-                    <TabPanels>
-                        <TabPanel>
-                            <ErrorBoundary>
-                                <TopValidatorsCard limit={10} showIcon />
-                            </ErrorBoundary>
-                        </TabPanel>
-                    </TabPanels>
-                </TabGroup>
-            </div>
-            {/* <div>
-                    <TabGroup>
-                        <TabList>
-                            <Tab>Recent Packages</Tab>
-                        </TabList>
-                        <TabPanels>
-                            <TabPanel>
-                                <ErrorBoundary>
-                                    <RecentModulesCard />
-                                </ErrorBoundary>
-                            </TabPanel>
-                        </TabPanels>
-                    </TabGroup>
             </div> */}
         </div>
     );


### PR DESCRIPTION
## Description 

Just having this ready if we want to remove the feature flag because it causes a little bit of jank where Growthbook loads after we've already rendered the old UI.

## Test Plan 
- Manual testing

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
N/A
