### PR TITLE
[sui-replay] Remove extra newline in diff output

### DIFF
--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -1384,7 +1384,7 @@ fn extract_epoch_and_version(ev: SuiEvent) -> Result<(u64, u64), LocalExecError>
     Err(LocalExecError::UnexpectedEventFormat { event: ev })
 }
 
-/// Utility ti diff effects in a human readable format
+/// Utility to diff effects in a human readable format
 fn diff_effects(
     eff1: &SuiTransactionBlockEffectsV1,
     eff2: &SuiTransactionBlockEffectsV1,
@@ -1404,5 +1404,5 @@ fn diff_effects(
         res.push(format!("{}{}", sign, change));
     }
 
-    res.join("\n")
+    res.join("")
 }


### PR DESCRIPTION
## Description

Remove the extra newline being added after each line in the diff output.

## Test Plan

Output from this command (which forks due to lack of historical objects) is no longer output on every other line:

```
crates/sui-tool$ cargo run replay            \
  --rpc https://fullnode.testnet.sui.io:443  \
  tx -t Fr9hm2fYGAz7tTxTVUrbDPR1esH9NUzijoQA2DhHKj9q
```

Outputs:

```
On-chain vs local diff
EffectsForked: Effects for digest Fr9hm2fYGAz7tTxTVUrbDPR1esH9NUzijoQA2DhHKj9q forked with diff
   SuiTransactionBlockEffectsV1 {
       status: Success,
       executed_epoch: 767,
       gas_used: GasCostSummary {
           computation_cost: 1000000,
           storage_cost: 4218000,
...[snip]...
```

And not:

```
On-chain vs local diff
EffectsForked: Effects for digest Fr9hm2fYGAz7tTxTVUrbDPR1esH9NUzijoQA2DhHKj9q forked with diff
   SuiTransactionBlockEffectsV1 {

       status: Success,

       executed_epoch: 767,

       gas_used: GasCostSummary {

           computation_cost: 1000000,

           storage_cost: 4218000,

...[snip]...
```