### PR TITLE
[rpc doc] - fix get_events example bug

### DIFF
--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -143,12 +143,12 @@
           "params": [
             {
               "name": "tx_bytes",
-              "value": "AAACACB7qR3cfnF89wjJNwYPBASHNuwz+xdG2Zml5YzVxnftgAEAT4LxyFh7mNZMAL+0bDhDvYv2zPp8ZahhOGmM0f3Kw9wCAAAAAAAAACCxDABG4pPAjOwPQHg9msS/SrtNf4IGR/2F0ZGD3ufH/wEBAQEBAAEAAGH7tbTzQqQL2/h/5KlGueONGM+P/HsAALl1F1x7apV2AejYx86GPzE9o9vZKoPvJtEouI/ma/JuDg0Jza9yfR2EAgAAAAAAAAAgzMqpegLMOpgEFnDhYJ23FOmFjJbp5GmFXxzzv9+X6GVh+7W080KkC9v4f+SpRrnjjRjPj/x7AAC5dRdce2qVdgoAAAAAAAAAAC0xAQAAAAAA"
+              "value": "AAACACBqEB6aOvXIBwES+Ahkizbvv43uihqC3kbZUE6WoRCKFwEAjvdvVsOZYzousxC8qRJOXy84znOeqsu2YAaIgE4HhEgCAAAAAAAAACB9w3+ufZMpihJFwxtCBojBaGy00TVtFxgN2C6TpIPFqwEBAQEBAAEAAAS0l6kWtGVmCaf6gnoJGE1vR2gdO6dM4NejbGSysfiHAZ+Q9/hmzCnfsdpjc86U+dldylpA9OF2mRjuv5+64AvTAgAAAAAAAAAgjleHL0UiRGjh/BfIFHCJ3EMY/dQA22c2TvNQyVJnbYUEtJepFrRlZgmn+oJ6CRhNb0doHTunTODXo2xksrH4hwoAAAAAAAAAAC0xAQAAAAAA"
             },
             {
               "name": "signatures",
               "value": [
-                "AGLsaLe6fSvGG/YgrxirjhKqE21kVCcveOW9h0IiCZ1Ei/oAOmu95EnKjoBhLHcS2/2Ga2Ljw0BVnGrY6reYkwVDij1TvBYKLcfLNo8fq6GASb9yfo6uvuwNUBGkTf54wQ=="
+                "AEZc4UMAoxzWtp+i1dvyOgmy+Eeb/5ZNwO5dpHBqX5Rt36+HhYnBby8asFU4b0i7TjQZGgLahT8w3NQUfk0NUQnqvbuA0Q1Bqu4RHV3JPpqmH+C527hWJGUBOZN1j9sg8w=="
               ]
             },
             {
@@ -170,7 +170,7 @@
           "result": {
             "name": "Result",
             "value": {
-              "digest": "Gm54bTY5F9KjiCw3kfKpkXPaEE3kx8ToJkYqTsuQDZ7q",
+              "digest": "BgSFSEFYbCrVUJJtHFeoLmLJi8jDf1CpC2o8S33HjeDJ",
               "transaction": {
                 "data": {
                   "messageVersion": "v1",
@@ -180,14 +180,14 @@
                       {
                         "type": "pure",
                         "valueType": "address",
-                        "value": "0x7ba91ddc7e717cf708c937060f04048736ec33fb1746d999a5e58cd5c677ed80"
+                        "value": "0x6a101e9a3af5c8070112f808648b36efbf8dee8a1a82de46d9504e96a1108a17"
                       },
                       {
                         "type": "object",
                         "objectType": "immOrOwnedObject",
-                        "objectId": "0x4f82f1c8587b98d64c00bfb46c3843bd8bf6ccfa7c65a86138698cd1fdcac3dc",
+                        "objectId": "0x8ef76f56c399633a2eb310bca9124e5f2f38ce739eaacbb6600688804e078448",
                         "version": "2",
-                        "digest": "Cv7n2YaM7Am1ssZGu4khsFkcKHnpgVhwFCSs4kLjrtLW"
+                        "digest": "9Tvs1pGrMbNv7kkr1PoKLsWamyQpaFz5UWbL2AQ1ezk2"
                       }
                     ],
                     "transactions": [
@@ -205,25 +205,25 @@
                       }
                     ]
                   },
-                  "sender": "0x61fbb5b4f342a40bdbf87fe4a946b9e38d18cf8ffc7b0000b975175c7b6a9576",
+                  "sender": "0x04b497a916b4656609a7fa827a09184d6f47681d3ba74ce0d7a36c64b2b1f887",
                   "gasData": {
                     "payment": [
                       {
-                        "objectId": "0xe8d8c7ce863f313da3dbd92a83ef26d128b88fe66bf26e0e0d09cdaf727d1d84",
+                        "objectId": "0x9f90f7f866cc29dfb1da6373ce94f9d95dca5a40f4e1769918eebf9fbae00bd3",
                         "version": 2,
-                        "digest": "EnRQXe1hDGAJCFyF2ds2GmPHdvf9V6yxf24LisEsDkYt"
+                        "digest": "AaeJbTYkUuyromsivxzkoxSkHt7pCESTyQG7xz6nbQ2G"
                       }
                     ],
-                    "owner": "0x61fbb5b4f342a40bdbf87fe4a946b9e38d18cf8ffc7b0000b975175c7b6a9576",
+                    "owner": "0x04b497a916b4656609a7fa827a09184d6f47681d3ba74ce0d7a36c64b2b1f887",
                     "price": "10",
                     "budget": "20000000"
                   }
                 },
                 "txSignatures": [
-                  "AGLsaLe6fSvGG/YgrxirjhKqE21kVCcveOW9h0IiCZ1Ei/oAOmu95EnKjoBhLHcS2/2Ga2Ljw0BVnGrY6reYkwVDij1TvBYKLcfLNo8fq6GASb9yfo6uvuwNUBGkTf54wQ=="
+                  "AEZc4UMAoxzWtp+i1dvyOgmy+Eeb/5ZNwO5dpHBqX5Rt36+HhYnBby8asFU4b0i7TjQZGgLahT8w3NQUfk0NUQnqvbuA0Q1Bqu4RHV3JPpqmH+C527hWJGUBOZN1j9sg8w=="
                 ]
               },
-              "rawTransaction": "AQAAAAAAAgAge6kd3H5xfPcIyTcGDwQEhzbsM/sXRtmZpeWM1cZ37YABAE+C8chYe5jWTAC/tGw4Q72L9sz6fGWoYThpjNH9ysPcAgAAAAAAAAAgsQwARuKTwIzsD0B4PZrEv0q7TX+CBkf9hdGRg97nx/8BAQEBAQABAABh+7W080KkC9v4f+SpRrnjjRjPj/x7AAC5dRdce2qVdgHo2MfOhj8xPaPb2SqD7ybRKLiP5mvybg4NCc2vcn0dhAIAAAAAAAAAIMzKqXoCzDqYBBZw4WCdtxTphYyW6eRphV8c87/fl+hlYfu1tPNCpAvb+H/kqUa5440Yz4/8ewAAuXUXXHtqlXYKAAAAAAAAAAAtMQEAAAAAAAFhAGLsaLe6fSvGG/YgrxirjhKqE21kVCcveOW9h0IiCZ1Ei/oAOmu95EnKjoBhLHcS2/2Ga2Ljw0BVnGrY6reYkwVDij1TvBYKLcfLNo8fq6GASb9yfo6uvuwNUBGkTf54wQ==",
+              "rawTransaction": "AQAAAAAAAgAgahAemjr1yAcBEvgIZIs277+N7ooagt5G2VBOlqEQihcBAI73b1bDmWM6LrMQvKkSTl8vOM5znqrLtmAGiIBOB4RIAgAAAAAAAAAgfcN/rn2TKYoSRcMbQgaIwWhstNE1bRcYDdguk6SDxasBAQEBAQABAAAEtJepFrRlZgmn+oJ6CRhNb0doHTunTODXo2xksrH4hwGfkPf4Zswp37HaY3POlPnZXcpaQPThdpkY7r+fuuAL0wIAAAAAAAAAII5Xhy9FIkRo4fwXyBRwidxDGP3UANtnNk7zUMlSZ22FBLSXqRa0ZWYJp/qCegkYTW9HaB07p0zg16NsZLKx+IcKAAAAAAAAAAAtMQEAAAAAAAFhAEZc4UMAoxzWtp+i1dvyOgmy+Eeb/5ZNwO5dpHBqX5Rt36+HhYnBby8asFU4b0i7TjQZGgLahT8w3NQUfk0NUQnqvbuA0Q1Bqu4RHV3JPpqmH+C527hWJGUBOZN1j9sg8w==",
               "effects": {
                 "messageVersion": "v1",
                 "status": {
@@ -236,52 +236,52 @@
                   "storageRebate": "10",
                   "nonRefundableStorageFee": "0"
                 },
-                "transactionDigest": "8UExPV121BEfWkbymSPDYhh23rVNh3MSWtC5juJ9JGMJ",
+                "transactionDigest": "9agZ3azEMgMqxrDVG8P4GddELfWag2HhimEkpjixHhGE",
                 "mutated": [
                   {
                     "owner": {
-                      "AddressOwner": "0x61fbb5b4f342a40bdbf87fe4a946b9e38d18cf8ffc7b0000b975175c7b6a9576"
+                      "AddressOwner": "0x04b497a916b4656609a7fa827a09184d6f47681d3ba74ce0d7a36c64b2b1f887"
                     },
                     "reference": {
-                      "objectId": "0xe8d8c7ce863f313da3dbd92a83ef26d128b88fe66bf26e0e0d09cdaf727d1d84",
+                      "objectId": "0x9f90f7f866cc29dfb1da6373ce94f9d95dca5a40f4e1769918eebf9fbae00bd3",
                       "version": 2,
-                      "digest": "EnRQXe1hDGAJCFyF2ds2GmPHdvf9V6yxf24LisEsDkYt"
+                      "digest": "AaeJbTYkUuyromsivxzkoxSkHt7pCESTyQG7xz6nbQ2G"
                     }
                   },
                   {
                     "owner": {
-                      "AddressOwner": "0x7ba91ddc7e717cf708c937060f04048736ec33fb1746d999a5e58cd5c677ed80"
+                      "AddressOwner": "0x6a101e9a3af5c8070112f808648b36efbf8dee8a1a82de46d9504e96a1108a17"
                     },
                     "reference": {
-                      "objectId": "0x4f82f1c8587b98d64c00bfb46c3843bd8bf6ccfa7c65a86138698cd1fdcac3dc",
+                      "objectId": "0x8ef76f56c399633a2eb310bca9124e5f2f38ce739eaacbb6600688804e078448",
                       "version": 2,
-                      "digest": "Cv7n2YaM7Am1ssZGu4khsFkcKHnpgVhwFCSs4kLjrtLW"
+                      "digest": "9Tvs1pGrMbNv7kkr1PoKLsWamyQpaFz5UWbL2AQ1ezk2"
                     }
                   }
                 ],
                 "gasObject": {
                   "owner": {
-                    "ObjectOwner": "0x61fbb5b4f342a40bdbf87fe4a946b9e38d18cf8ffc7b0000b975175c7b6a9576"
+                    "ObjectOwner": "0x04b497a916b4656609a7fa827a09184d6f47681d3ba74ce0d7a36c64b2b1f887"
                   },
                   "reference": {
-                    "objectId": "0xe8d8c7ce863f313da3dbd92a83ef26d128b88fe66bf26e0e0d09cdaf727d1d84",
+                    "objectId": "0x9f90f7f866cc29dfb1da6373ce94f9d95dca5a40f4e1769918eebf9fbae00bd3",
                     "version": 2,
-                    "digest": "EnRQXe1hDGAJCFyF2ds2GmPHdvf9V6yxf24LisEsDkYt"
+                    "digest": "AaeJbTYkUuyromsivxzkoxSkHt7pCESTyQG7xz6nbQ2G"
                   }
                 },
-                "eventsDigest": "55TNn3v5vpuXjQfjqamw76P9GZD522pumo4NuT7RYeFB"
+                "eventsDigest": "816hEv4WAW2reK9xkf11PeHiaZJrp7PQT9oGJZhdf9TN"
               },
               "objectChanges": [
                 {
                   "type": "transferred",
-                  "sender": "0x61fbb5b4f342a40bdbf87fe4a946b9e38d18cf8ffc7b0000b975175c7b6a9576",
+                  "sender": "0x04b497a916b4656609a7fa827a09184d6f47681d3ba74ce0d7a36c64b2b1f887",
                   "recipient": {
-                    "AddressOwner": "0x7ba91ddc7e717cf708c937060f04048736ec33fb1746d999a5e58cd5c677ed80"
+                    "AddressOwner": "0x6a101e9a3af5c8070112f808648b36efbf8dee8a1a82de46d9504e96a1108a17"
                   },
                   "objectType": "0x2::example::Object",
-                  "objectId": "0x4f82f1c8587b98d64c00bfb46c3843bd8bf6ccfa7c65a86138698cd1fdcac3dc",
+                  "objectId": "0x8ef76f56c399633a2eb310bca9124e5f2f38ce739eaacbb6600688804e078448",
                   "version": "2",
-                  "digest": "B3xLC8EbyvTxy5pgiwTNUzHLa6kS7uwD6sZdErKB8F8f"
+                  "digest": "7PsBHpUW6yfGNov2WrbVafLjgT9nYziQ3gVDbRq6zTbF"
                 }
               ]
             }
@@ -328,9 +328,9 @@
             "value": {
               "epoch": "5000",
               "sequenceNumber": "1000",
-              "digest": "GMkZ4a6i2fffTRY1K8PpKt275xuk9SmYykpLhAgMLekq",
+              "digest": "AbKbyf26XFmbBt9eg5KJ9tHtgsTysbsTe7Wpy6QKQfJG",
               "networkTotalTransactions": "792385",
-              "previousDigest": "5toSLTmiTe8VRSUbHxuW9w5JXVxjjE1MyajzG5tb52UQ",
+              "previousDigest": "CAbHZCsbX6vsqtCqjhfNdT8XJFcuYkHVGz2hXg54goQk",
               "epochRollingGasCostSummary": {
                 "computationCost": "0",
                 "storageCost": "0",
@@ -339,7 +339,7 @@
               },
               "timestampMs": "1676911928",
               "transactions": [
-                "3bpzHaSLTQ6p4trLDk2euZxzQ6XqLeWDmUNTAdEXXL2c"
+                "4oDBSrdDb2UM59Td5EyPhYP1h1TSphnjfSpoLnWKaM5o"
               ],
               "checkpointCommitments": [],
               "validatorSignature": "wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
@@ -413,9 +413,9 @@
                 {
                   "epoch": "5000",
                   "sequenceNumber": "1005",
-                  "digest": "BuwtTiJoYef2Po6mYmmWNwMKY3scn3AXPixX17JSj7ec",
+                  "digest": "styH61ffb69JzKQYs1u6GS6e6aeyybqcq6VPRumYGFe",
                   "networkTotalTransactions": "792385",
-                  "previousDigest": "27kMxoKi7ZQp6fV1GinA8cdbe6x9iuEuSoXCf9diWpg4",
+                  "previousDigest": "7QHLXheBaMGoygNFs39Fnd2jFxxNefABpZmEceVHmWkC",
                   "epochRollingGasCostSummary": {
                     "computationCost": "0",
                     "storageCost": "0",
@@ -424,7 +424,7 @@
                   },
                   "timestampMs": "1676911928",
                   "transactions": [
-                    "E7FY3GzZHyb9YrXc1G5TWgwxSf11o59BxQ3uq9XRUzi8"
+                    "A1NZtyS73EN5N4jBA8Q7fMcvmJ3voaGkUEuFnjyXA5HC"
                   ],
                   "checkpointCommitments": [],
                   "validatorSignature": "wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
@@ -432,9 +432,9 @@
                 {
                   "epoch": "5000",
                   "sequenceNumber": "1006",
-                  "digest": "Gn3CQbNsDT7pxQQqjs2u344FPVgjy8PVV3N1kRP9jhWa",
+                  "digest": "Gn2vgirgUYdYi27A5s6HfhTVbCoZGeDewUhJDWGTkbg5",
                   "networkTotalTransactions": "792385",
-                  "previousDigest": "GsPDh3rJZzPJ8977gZEf9a5QZo2h7eup7v2ioNk9kvZX",
+                  "previousDigest": "64QD1k3u8x1Jo86PftHbKo6sdnbB2WBtv7p4RGUtQ93N",
                   "epochRollingGasCostSummary": {
                     "computationCost": "0",
                     "storageCost": "0",
@@ -443,7 +443,7 @@
                   },
                   "timestampMs": "1676911928",
                   "transactions": [
-                    "AthhkECez6HHQoSts5tqCNi6GsWQbmqr8gPZh5EqfcHP"
+                    "86BWNNkDbt3nspEopq2dZocBBGbYzkWnUZGgV6x4TaLf"
                   ],
                   "checkpointCommitments": [],
                   "validatorSignature": "wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
@@ -451,9 +451,9 @@
                 {
                   "epoch": "5000",
                   "sequenceNumber": "1007",
-                  "digest": "26ci3tkYanGG4EnTYky3pRjTajscESPvvJtusfd9MACb",
+                  "digest": "5Y6qoLUtnzD5wkruAbZ2pQb58SSwDQmo1sFVHfpZLKqf",
                   "networkTotalTransactions": "792385",
-                  "previousDigest": "HsE5ovGGAMCvQT53ykzTosVvcbr3qNQi2ic5RPyCyANn",
+                  "previousDigest": "8LbMGFpmDF2w59sJxMQefQqSvNh33AaHvZM21dpJ8f8f",
                   "epochRollingGasCostSummary": {
                     "computationCost": "0",
                     "storageCost": "0",
@@ -462,7 +462,7 @@
                   },
                   "timestampMs": "1676911928",
                   "transactions": [
-                    "6MQ4CZ7MQQ6svRfnqR58oSLWQbYznqGFuEzhw1n3oZKq"
+                    "9QSSuYoovaF46KykXtKncXdjHptf5f2ZQXjcd1i6CczX"
                   ],
                   "checkpointCommitments": [],
                   "validatorSignature": "wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
@@ -470,9 +470,9 @@
                 {
                   "epoch": "5000",
                   "sequenceNumber": "1008",
-                  "digest": "FLu28Qbjp9dApF1cujWXNS9RoTcmEFzr4LK7VBw6i5Yx",
+                  "digest": "8mjZb81hqCXxgn4dcdiSZY8SJa8dibsv63nckprhxXTy",
                   "networkTotalTransactions": "792385",
-                  "previousDigest": "EscNSizxsxqh71PsvWbLWSxmhqSfcmXNYd1MFhJ1hEZz",
+                  "previousDigest": "AoM3zdrp12i4Hq6uwPGd5AvkbUnYHxrZgQz5J3oWunpg",
                   "epochRollingGasCostSummary": {
                     "computationCost": "0",
                     "storageCost": "0",
@@ -481,7 +481,7 @@
                   },
                   "timestampMs": "1676911928",
                   "transactions": [
-                    "6ecApRqbEcBv8pwemff6njmj4HBcC2etu3RYWmdQfrZ"
+                    "7egeSqNr6tNeSexCABFpQhTohKXdwb25xTKVt2PQ7XEm"
                   ],
                   "checkpointCommitments": [],
                   "validatorSignature": "wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
@@ -528,7 +528,7 @@
           "params": [
             {
               "name": "transaction_digest",
-              "value": "AfLBXHTTyHM5FV4FwJDUfdUPEPpLaJzJ1Z4o48YdS6ii"
+              "value": "11a72GCQ5hGNpWGh2QhQkkusTEGS6EDqifJqxr7nSYX"
             }
           ],
           "result": {
@@ -540,9 +540,9 @@
                     "txDigest": "11a72GCQ5hGNpWGh2QhQkkusTEGS6EDqifJqxr7nSYX",
                     "eventSeq": "0"
                   },
-                  "packageId": "0x7f7e625ea319aa0a1848666ffed2291ae24a3f8177353a05220d765ca9c421a3",
+                  "packageId": "0xc54ab30a3d9adc07c1429c4d6bbecaf9457c9af77a91f631760853934d383634",
                   "transactionModule": "test_module",
-                  "sender": "0x68083f18fe472f39557dc42aaefeeb8c154d7ddc456b8aeaa3132c7403531dc9",
+                  "sender": "0xbcf7c32655009a61f1de0eae420a2e4ae1bb772ab2dd5d5a7dfa949c0ef06908",
                   "type": "0x9::test::TestEvent",
                   "parsedJson": {
                     "test": "example value"
@@ -862,7 +862,7 @@
                   "type": "0x2::coin::Coin<0x2::sui::SUI>",
                   "hasPublicTransfer": true,
                   "fields": {
-                    "balance": "10000",
+                    "balance": "100000000",
                     "id": {
                       "id": "0x53e4567ccafa5f36ce84c80aa8bc9be64e0d5ae796884274aef3005ae6733809"
                     }
@@ -1112,7 +1112,161 @@
             "$ref": "#/components/schemas/SuiObjectResponse"
           }
         }
-      }
+      },
+      "examples": [
+        {
+          "name": "Get objects by IDs.",
+          "params": [
+            {
+              "name": "object_ids",
+              "value": [
+                "0x63f69f47ae954dec65295231e0d2c7c86867fcc63161269c5c0c73b02229486b",
+                "0xb3bc9237ba6fca019438a9737cf156ae6d907beaa3a49db57bdfdb3557e6d405",
+                "0x869ecbccf96ef8bab1b6d79fbfa88548f44d295a385dc3544d211411b865e8bc",
+                "0x5e43f21e9e57f4abe3c702649d3a7dd0d4f062dbcfc3bf73f5861945592222ff",
+                "0x54a448a78d3a56220f798398dde66eab0a52124e2d53af3bef7959609efa5176"
+              ]
+            },
+            {
+              "name": "options",
+              "value": {
+                "showType": true,
+                "showOwner": true,
+                "showPreviousTransaction": true,
+                "showDisplay": false,
+                "showContent": true,
+                "showBcs": false,
+                "showStorageRebate": true
+              }
+            }
+          ],
+          "result": {
+            "name": "Result",
+            "value": [
+              {
+                "data": {
+                  "objectId": "0x63f69f47ae954dec65295231e0d2c7c86867fcc63161269c5c0c73b02229486b",
+                  "version": "1",
+                  "digest": "3pySHS3Cwy3urMWUPp6N5MVLnt96ajN69vG7vpBjzmFh",
+                  "type": "0x2::coin::Coin<0x2::sui::SUI>",
+                  "owner": {
+                    "AddressOwner": "0xbaff319209dfb8299ced3b860903799749b09c3bfb031aca53e7ddf1dba61bb6"
+                  },
+                  "previousTransaction": "21nFLRUHV4KvcGyCP7saQXHoAJq8yGT4UoHk9RG2B7RB",
+                  "storageRebate": "100",
+                  "content": {
+                    "dataType": "moveObject",
+                    "type": "0x2::coin::Coin<0x2::sui::SUI>",
+                    "hasPublicTransfer": true,
+                    "fields": {
+                      "balance": "100000000",
+                      "id": {
+                        "id": "0x63f69f47ae954dec65295231e0d2c7c86867fcc63161269c5c0c73b02229486b"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "data": {
+                  "objectId": "0xb3bc9237ba6fca019438a9737cf156ae6d907beaa3a49db57bdfdb3557e6d405",
+                  "version": "1",
+                  "digest": "6RWpimPbn7MiimtAiwMoNpzPgJAdcFgEYU76tNR3nPzd",
+                  "type": "0x2::coin::Coin<0x2::sui::SUI>",
+                  "owner": {
+                    "AddressOwner": "0xcbf01c293a53e01457d65e92b5d8dd68d62ca040aba24f862a763851c54908cd"
+                  },
+                  "previousTransaction": "3qBJk6w86rePdymYuWhFudpqS2i2TsydYWYstrSCRxSz",
+                  "storageRebate": "100",
+                  "content": {
+                    "dataType": "moveObject",
+                    "type": "0x2::coin::Coin<0x2::sui::SUI>",
+                    "hasPublicTransfer": true,
+                    "fields": {
+                      "balance": "100000000",
+                      "id": {
+                        "id": "0xb3bc9237ba6fca019438a9737cf156ae6d907beaa3a49db57bdfdb3557e6d405"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "data": {
+                  "objectId": "0x869ecbccf96ef8bab1b6d79fbfa88548f44d295a385dc3544d211411b865e8bc",
+                  "version": "1",
+                  "digest": "2x77QMNgAtYA3vfUG2MRCh46pn6FgAw3P531F1zvZqGw",
+                  "type": "0x2::coin::Coin<0x2::sui::SUI>",
+                  "owner": {
+                    "AddressOwner": "0x4f01f49186970c7cf61e1cc829cc0be747dfa99496428c65b2054ad7db1872b8"
+                  },
+                  "previousTransaction": "9cRMGV4fXXwwMyeNndbXX9GXJ28Q37NaFjo9pPAkPkkz",
+                  "storageRebate": "100",
+                  "content": {
+                    "dataType": "moveObject",
+                    "type": "0x2::coin::Coin<0x2::sui::SUI>",
+                    "hasPublicTransfer": true,
+                    "fields": {
+                      "balance": "100000000",
+                      "id": {
+                        "id": "0x869ecbccf96ef8bab1b6d79fbfa88548f44d295a385dc3544d211411b865e8bc"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "data": {
+                  "objectId": "0x5e43f21e9e57f4abe3c702649d3a7dd0d4f062dbcfc3bf73f5861945592222ff",
+                  "version": "1",
+                  "digest": "B9Nt57ooVUPUfVLneWKR6yXsgUdeKCZ7swTmemXSSsun",
+                  "type": "0x2::coin::Coin<0x2::sui::SUI>",
+                  "owner": {
+                    "AddressOwner": "0x7b090ac21c8a3cf840abdc5b743da778808f8071df7c48ea3cc4ecc349c766ab"
+                  },
+                  "previousTransaction": "9esVvbmQ3pH6GDVJ9wRouewBzxGSctVn5h9Jj8K6c1Mr",
+                  "storageRebate": "100",
+                  "content": {
+                    "dataType": "moveObject",
+                    "type": "0x2::coin::Coin<0x2::sui::SUI>",
+                    "hasPublicTransfer": true,
+                    "fields": {
+                      "balance": "100000000",
+                      "id": {
+                        "id": "0x5e43f21e9e57f4abe3c702649d3a7dd0d4f062dbcfc3bf73f5861945592222ff"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "data": {
+                  "objectId": "0x54a448a78d3a56220f798398dde66eab0a52124e2d53af3bef7959609efa5176",
+                  "version": "1",
+                  "digest": "Hpv3QPqbwvUZ3u82nsBvn2Zc5JJj2d27WuzSWmjFYN7t",
+                  "type": "0x2::coin::Coin<0x2::sui::SUI>",
+                  "owner": {
+                    "AddressOwner": "0x1ad155441a1b73bdaeecce7c56488b137d42c99fc38511ba4813dc57feb3f00e"
+                  },
+                  "previousTransaction": "AFsN32bnEYBPYd4ui5wAExJEqLUmhs4f4cnjo17c91uq",
+                  "storageRebate": "100",
+                  "content": {
+                    "dataType": "moveObject",
+                    "type": "0x2::coin::Coin<0x2::sui::SUI>",
+                    "hasPublicTransfer": true,
+                    "fields": {
+                      "balance": "100000000",
+                      "id": {
+                        "id": "0x54a448a78d3a56220f798398dde66eab0a52124e2d53af3bef7959609efa5176"
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "name": "sui_multiGetTransactionBlocks",
@@ -1151,7 +1305,386 @@
             "$ref": "#/components/schemas/TransactionBlockResponse"
           }
         }
-      }
+      },
+      "examples": [
+        {
+          "name": "Return the transaction data for specified digest.",
+          "params": [
+            {
+              "name": "digests",
+              "value": [
+                "DwRWCvrkfauz95wTrfJxi3VSWdMZWCEtdPCiaZhcanZh",
+                "DKbnodvxQShMzRBopBhmFkjWDesbfxFzPPzxZGAjLdww",
+                "5geoz1TrEnV2pAA7B5ajgvLo6hHapfki3dJHRJEFBNfc"
+              ]
+            },
+            {
+              "name": "options",
+              "value": {
+                "showInput": true,
+                "showRawInput": false,
+                "showEffects": true,
+                "showEvents": true,
+                "showObjectChanges": false,
+                "showBalanceChanges": false
+              }
+            }
+          ],
+          "result": {
+            "name": "Result",
+            "value": [
+              {
+                "digest": "DwRWCvrkfauz95wTrfJxi3VSWdMZWCEtdPCiaZhcanZh",
+                "transaction": {
+                  "data": {
+                    "messageVersion": "v1",
+                    "transaction": {
+                      "kind": "ProgrammableTransaction",
+                      "inputs": [
+                        {
+                          "type": "pure",
+                          "valueType": "address",
+                          "value": "0xd6e4c0ad5ec4de2449c41ac819f9c162d4af78db04f5789cd4fca497d9d14703"
+                        },
+                        {
+                          "type": "object",
+                          "objectType": "immOrOwnedObject",
+                          "objectId": "0x6b5ad50597c5faf4842f454b9b09c7524afb8e30e88e2f84077773b9572d766c",
+                          "version": "2",
+                          "digest": "3FiwvBCr7vJUrSa1wDuapfczD218uxymBACSz625vojt"
+                        }
+                      ],
+                      "transactions": [
+                        {
+                          "TransferObjects": [
+                            [
+                              {
+                                "Input": 1
+                              }
+                            ],
+                            {
+                              "Input": 0
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "sender": "0xcdf1c97cb1a97f6a467db2b32dc8deab001db44968eb4d513b5e96a26a8d3f99",
+                    "gasData": {
+                      "payment": [
+                        {
+                          "objectId": "0x2fb30e765422178a6c146d85e49b53a4ac09b42e9036dd49b9c46a42692b1f20",
+                          "version": 2,
+                          "digest": "4SUrH3e9PNYtorid9WYHST4ExtYziAWF2qNfbcQGXyfc"
+                        }
+                      ],
+                      "owner": "0xcdf1c97cb1a97f6a467db2b32dc8deab001db44968eb4d513b5e96a26a8d3f99",
+                      "price": "10",
+                      "budget": "20000000"
+                    }
+                  },
+                  "txSignatures": [
+                    "AEazvDbLghnbt6IgSnagyNcGOWxRBpMmB5b1nEAyFcG3ioR5yBxEn+HhLlFKcMhxcjoAd6ldsl16RG1r3N1Ifgaku/znSjrM4o7ihNslFlaGkCFdY5WcpqFauUzmNJpmlA=="
+                  ]
+                },
+                "rawTransaction": "AQAAAAAAAgAg1uTArV7E3iRJxBrIGfnBYtSveNsE9Xic1Pykl9nRRwMBAGta1QWXxfr0hC9FS5sJx1JK+44w6I4vhAd3c7lXLXZsAgAAAAAAAAAgIXzvQ5XzESdQhO9bBUGBdH3e2Dz8VIeuIDYvsaXYmxcBAQEBAQABAADN8cl8sal/akZ9srMtyN6rAB20SWjrTVE7Xpaiao0/mQEvsw52VCIXimwUbYXkm1OkrAm0LpA23Um5xGpCaSsfIAIAAAAAAAAAIDMaEhXcN76CmPpK4+nh+poFmTacjKerqTBdxSWWpZ5fzfHJfLGpf2pGfbKzLcjeqwAdtElo601RO16WomqNP5kKAAAAAAAAAAAtMQEAAAAAAAFhAEazvDbLghnbt6IgSnagyNcGOWxRBpMmB5b1nEAyFcG3ioR5yBxEn+HhLlFKcMhxcjoAd6ldsl16RG1r3N1Ifgaku/znSjrM4o7ihNslFlaGkCFdY5WcpqFauUzmNJpmlA==",
+                "effects": {
+                  "messageVersion": "v1",
+                  "status": {
+                    "status": "success"
+                  },
+                  "executedEpoch": "0",
+                  "gasUsed": {
+                    "computationCost": "100",
+                    "storageCost": "100",
+                    "storageRebate": "10",
+                    "nonRefundableStorageFee": "0"
+                  },
+                  "transactionDigest": "6wYAncei61SbsXjfJuREYWFJcwMvTt8vnZh7jECYgMu",
+                  "mutated": [
+                    {
+                      "owner": {
+                        "AddressOwner": "0xcdf1c97cb1a97f6a467db2b32dc8deab001db44968eb4d513b5e96a26a8d3f99"
+                      },
+                      "reference": {
+                        "objectId": "0x2fb30e765422178a6c146d85e49b53a4ac09b42e9036dd49b9c46a42692b1f20",
+                        "version": 2,
+                        "digest": "4SUrH3e9PNYtorid9WYHST4ExtYziAWF2qNfbcQGXyfc"
+                      }
+                    },
+                    {
+                      "owner": {
+                        "AddressOwner": "0xd6e4c0ad5ec4de2449c41ac819f9c162d4af78db04f5789cd4fca497d9d14703"
+                      },
+                      "reference": {
+                        "objectId": "0x6b5ad50597c5faf4842f454b9b09c7524afb8e30e88e2f84077773b9572d766c",
+                        "version": 2,
+                        "digest": "3FiwvBCr7vJUrSa1wDuapfczD218uxymBACSz625vojt"
+                      }
+                    }
+                  ],
+                  "gasObject": {
+                    "owner": {
+                      "ObjectOwner": "0xcdf1c97cb1a97f6a467db2b32dc8deab001db44968eb4d513b5e96a26a8d3f99"
+                    },
+                    "reference": {
+                      "objectId": "0x2fb30e765422178a6c146d85e49b53a4ac09b42e9036dd49b9c46a42692b1f20",
+                      "version": 2,
+                      "digest": "4SUrH3e9PNYtorid9WYHST4ExtYziAWF2qNfbcQGXyfc"
+                    }
+                  },
+                  "eventsDigest": "CnLsjCisnSFWkuWp9qqTkoSQkfhS9F6xQGV2LHMeEBDv"
+                },
+                "objectChanges": [
+                  {
+                    "type": "transferred",
+                    "sender": "0xcdf1c97cb1a97f6a467db2b32dc8deab001db44968eb4d513b5e96a26a8d3f99",
+                    "recipient": {
+                      "AddressOwner": "0xd6e4c0ad5ec4de2449c41ac819f9c162d4af78db04f5789cd4fca497d9d14703"
+                    },
+                    "objectType": "0x2::example::Object",
+                    "objectId": "0x6b5ad50597c5faf4842f454b9b09c7524afb8e30e88e2f84077773b9572d766c",
+                    "version": "2",
+                    "digest": "66Bhgq1W6nBRNNjS3DuWXuZyNJHBrUcwxQz4zUc9tkxZ"
+                  }
+                ]
+              },
+              {
+                "digest": "DKbnodvxQShMzRBopBhmFkjWDesbfxFzPPzxZGAjLdww",
+                "transaction": {
+                  "data": {
+                    "messageVersion": "v1",
+                    "transaction": {
+                      "kind": "ProgrammableTransaction",
+                      "inputs": [
+                        {
+                          "type": "pure",
+                          "valueType": "address",
+                          "value": "0x92e30e8e1dc5061bbf38c199f22627e75ff9bf8c469ff03d000b917ca77792c4"
+                        },
+                        {
+                          "type": "object",
+                          "objectType": "immOrOwnedObject",
+                          "objectId": "0x2209ab55b0202608150d2aaba7d0b2cc03df659954b577bd64996511a63b3292",
+                          "version": "2",
+                          "digest": "4DR9gcLsEacb1vX9D3ZxaZyME146pWTEgieKMcqHGbYC"
+                        }
+                      ],
+                      "transactions": [
+                        {
+                          "TransferObjects": [
+                            [
+                              {
+                                "Input": 1
+                              }
+                            ],
+                            {
+                              "Input": 0
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "sender": "0x793e52965a70e089d4cb66487db3f129a1c180b168957d02cf24c6e36940e49f",
+                    "gasData": {
+                      "payment": [
+                        {
+                          "objectId": "0x9c9996406a6494afc93a8d44f19f048a85e4c7d60ec80a18bf158911a8315dea",
+                          "version": 2,
+                          "digest": "CJEJosr8ywVetzSgmN2QHfbCXg4E32dy5UJLwoR7c931"
+                        }
+                      ],
+                      "owner": "0x793e52965a70e089d4cb66487db3f129a1c180b168957d02cf24c6e36940e49f",
+                      "price": "10",
+                      "budget": "20000000"
+                    }
+                  },
+                  "txSignatures": [
+                    "AID+evodBiU8SGY3IsUCK7fshQx+HD+HDAUgvuBbJTLTKq1fXxZvQLw/W3oIC/8LfYYHxanGQ8qXE9enumwCvgzAFJHipsemTEqF6eQduAyoQ0S1hIdH/l+Rsvd+d4xqxg=="
+                  ]
+                },
+                "rawTransaction": "AQAAAAAAAgAgkuMOjh3FBhu/OMGZ8iYn51/5v4xGn/A9AAuRfKd3ksQBACIJq1WwICYIFQ0qq6fQsswD32WZVLV3vWSZZRGmOzKSAgAAAAAAAAAgL8FWLoAPo0W+hQGqCfrmP0cKZjNiTUaGrqsg3CN4+fEBAQEBAQABAAB5PlKWWnDgidTLZkh9s/EpocGAsWiVfQLPJMbjaUDknwGcmZZAamSUr8k6jUTxnwSKheTH1g7IChi/FYkRqDFd6gIAAAAAAAAAIKfaeewxbjqtwnttIcL/HCfQwmycF0OOhro1ogyopcHseT5Sllpw4InUy2ZIfbPxKaHBgLFolX0CzyTG42lA5J8KAAAAAAAAAAAtMQEAAAAAAAFhAID+evodBiU8SGY3IsUCK7fshQx+HD+HDAUgvuBbJTLTKq1fXxZvQLw/W3oIC/8LfYYHxanGQ8qXE9enumwCvgzAFJHipsemTEqF6eQduAyoQ0S1hIdH/l+Rsvd+d4xqxg==",
+                "effects": {
+                  "messageVersion": "v1",
+                  "status": {
+                    "status": "success"
+                  },
+                  "executedEpoch": "0",
+                  "gasUsed": {
+                    "computationCost": "100",
+                    "storageCost": "100",
+                    "storageRebate": "10",
+                    "nonRefundableStorageFee": "0"
+                  },
+                  "transactionDigest": "6w12UGCyhcAAMhQqqh3X7Q4hHVsJewrB9NhjbziGxrQ7",
+                  "mutated": [
+                    {
+                      "owner": {
+                        "AddressOwner": "0x793e52965a70e089d4cb66487db3f129a1c180b168957d02cf24c6e36940e49f"
+                      },
+                      "reference": {
+                        "objectId": "0x9c9996406a6494afc93a8d44f19f048a85e4c7d60ec80a18bf158911a8315dea",
+                        "version": 2,
+                        "digest": "CJEJosr8ywVetzSgmN2QHfbCXg4E32dy5UJLwoR7c931"
+                      }
+                    },
+                    {
+                      "owner": {
+                        "AddressOwner": "0x92e30e8e1dc5061bbf38c199f22627e75ff9bf8c469ff03d000b917ca77792c4"
+                      },
+                      "reference": {
+                        "objectId": "0x2209ab55b0202608150d2aaba7d0b2cc03df659954b577bd64996511a63b3292",
+                        "version": 2,
+                        "digest": "4DR9gcLsEacb1vX9D3ZxaZyME146pWTEgieKMcqHGbYC"
+                      }
+                    }
+                  ],
+                  "gasObject": {
+                    "owner": {
+                      "ObjectOwner": "0x793e52965a70e089d4cb66487db3f129a1c180b168957d02cf24c6e36940e49f"
+                    },
+                    "reference": {
+                      "objectId": "0x9c9996406a6494afc93a8d44f19f048a85e4c7d60ec80a18bf158911a8315dea",
+                      "version": 2,
+                      "digest": "CJEJosr8ywVetzSgmN2QHfbCXg4E32dy5UJLwoR7c931"
+                    }
+                  },
+                  "eventsDigest": "GJkjmkBDtig9ahD2WTZhfxFdfCfJyBV4RauindRNrsGG"
+                },
+                "objectChanges": [
+                  {
+                    "type": "transferred",
+                    "sender": "0x793e52965a70e089d4cb66487db3f129a1c180b168957d02cf24c6e36940e49f",
+                    "recipient": {
+                      "AddressOwner": "0x92e30e8e1dc5061bbf38c199f22627e75ff9bf8c469ff03d000b917ca77792c4"
+                    },
+                    "objectType": "0x2::example::Object",
+                    "objectId": "0x2209ab55b0202608150d2aaba7d0b2cc03df659954b577bd64996511a63b3292",
+                    "version": "2",
+                    "digest": "6kwvRMKGTDfX4DH4FFGCiQBh1acaiEpWqNYVFu8Fo9bD"
+                  }
+                ]
+              },
+              {
+                "digest": "5geoz1TrEnV2pAA7B5ajgvLo6hHapfki3dJHRJEFBNfc",
+                "transaction": {
+                  "data": {
+                    "messageVersion": "v1",
+                    "transaction": {
+                      "kind": "ProgrammableTransaction",
+                      "inputs": [
+                        {
+                          "type": "pure",
+                          "valueType": "address",
+                          "value": "0xc1c1d32a27103fcd457cd60a94838b84d41b7344f39832dd4f5fb5bdc06fc4e2"
+                        },
+                        {
+                          "type": "object",
+                          "objectType": "immOrOwnedObject",
+                          "objectId": "0xa7b675e9b2f5749415c55996bb9d64a48cf227cd51ebf714d6a33167f44e88d3",
+                          "version": "2",
+                          "digest": "6rQmuiBBfgYwziNwTJd8C6XHFpqdCh3HpFNawCfNffoX"
+                        }
+                      ],
+                      "transactions": [
+                        {
+                          "TransferObjects": [
+                            [
+                              {
+                                "Input": 1
+                              }
+                            ],
+                            {
+                              "Input": 0
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "sender": "0x27313743d21c6125cddc574110e5297a4c78012deecdd81fdf8b7e86c6b939b1",
+                    "gasData": {
+                      "payment": [
+                        {
+                          "objectId": "0x1323c206efc6f6beecf319500fa168a183ae34acbb98b7536dc35648dbd2f26f",
+                          "version": 2,
+                          "digest": "9tyDfaDfToVfN5nYGFExM6KdxtMw387tNatuPkyTCL8S"
+                        }
+                      ],
+                      "owner": "0x27313743d21c6125cddc574110e5297a4c78012deecdd81fdf8b7e86c6b939b1",
+                      "price": "10",
+                      "budget": "20000000"
+                    }
+                  },
+                  "txSignatures": [
+                    "AM16QCzgNVlStYUgmttSacx9QzvEj1vSkC8sAdcFnbVrGQmHyjnHm6T/jOerM58jYw0inlIYXheHiugGyNx3jgMRulg7b73nUu3TRprbA5crjA2GNVy82lz1LzuQuUiKDQ=="
+                  ]
+                },
+                "rawTransaction": "AQAAAAAAAgAgwcHTKicQP81FfNYKlIOLhNQbc0TzmDLdT1+1vcBvxOIBAKe2demy9XSUFcVZlrudZKSM8ifNUev3FNajMWf0TojTAgAAAAAAAAAgVvLGpL5vBY4meq444IJgx9UZ2GQYl0kMnE62dpyotqIBAQEBAQABAAAnMTdD0hxhJc3cV0EQ5Sl6THgBLe7N2B/fi36Gxrk5sQETI8IG78b2vuzzGVAPoWihg640rLuYt1Ntw1ZI29LybwIAAAAAAAAAIIQtrte5sP80Osiq8/2nUcNoV06i2LsUK6CnsQj1AjtzJzE3Q9IcYSXN3FdBEOUpekx4AS3uzdgf34t+hsa5ObEKAAAAAAAAAAAtMQEAAAAAAAFhAM16QCzgNVlStYUgmttSacx9QzvEj1vSkC8sAdcFnbVrGQmHyjnHm6T/jOerM58jYw0inlIYXheHiugGyNx3jgMRulg7b73nUu3TRprbA5crjA2GNVy82lz1LzuQuUiKDQ==",
+                "effects": {
+                  "messageVersion": "v1",
+                  "status": {
+                    "status": "success"
+                  },
+                  "executedEpoch": "0",
+                  "gasUsed": {
+                    "computationCost": "100",
+                    "storageCost": "100",
+                    "storageRebate": "10",
+                    "nonRefundableStorageFee": "0"
+                  },
+                  "transactionDigest": "4vj52Sy63v8ZBX2WuoC389yxa7Q5ZDiBxke1oobEgETW",
+                  "mutated": [
+                    {
+                      "owner": {
+                        "AddressOwner": "0x27313743d21c6125cddc574110e5297a4c78012deecdd81fdf8b7e86c6b939b1"
+                      },
+                      "reference": {
+                        "objectId": "0x1323c206efc6f6beecf319500fa168a183ae34acbb98b7536dc35648dbd2f26f",
+                        "version": 2,
+                        "digest": "9tyDfaDfToVfN5nYGFExM6KdxtMw387tNatuPkyTCL8S"
+                      }
+                    },
+                    {
+                      "owner": {
+                        "AddressOwner": "0xc1c1d32a27103fcd457cd60a94838b84d41b7344f39832dd4f5fb5bdc06fc4e2"
+                      },
+                      "reference": {
+                        "objectId": "0xa7b675e9b2f5749415c55996bb9d64a48cf227cd51ebf714d6a33167f44e88d3",
+                        "version": 2,
+                        "digest": "6rQmuiBBfgYwziNwTJd8C6XHFpqdCh3HpFNawCfNffoX"
+                      }
+                    }
+                  ],
+                  "gasObject": {
+                    "owner": {
+                      "ObjectOwner": "0x27313743d21c6125cddc574110e5297a4c78012deecdd81fdf8b7e86c6b939b1"
+                    },
+                    "reference": {
+                      "objectId": "0x1323c206efc6f6beecf319500fa168a183ae34acbb98b7536dc35648dbd2f26f",
+                      "version": 2,
+                      "digest": "9tyDfaDfToVfN5nYGFExM6KdxtMw387tNatuPkyTCL8S"
+                    }
+                  },
+                  "eventsDigest": "25HeYrYtey4ToAyrxCkjrnfa7rWesCj6J8bawy2MMTth"
+                },
+                "objectChanges": [
+                  {
+                    "type": "transferred",
+                    "sender": "0x27313743d21c6125cddc574110e5297a4c78012deecdd81fdf8b7e86c6b939b1",
+                    "recipient": {
+                      "AddressOwner": "0xc1c1d32a27103fcd457cd60a94838b84d41b7344f39832dd4f5fb5bdc06fc4e2"
+                    },
+                    "objectType": "0x2::example::Object",
+                    "objectId": "0xa7b675e9b2f5749415c55996bb9d64a48cf227cd51ebf714d6a33167f44e88d3",
+                    "version": "2",
+                    "digest": "5EuYqa54WcsyEaPLGqsw5cPtx5H2PibfLCdzPzHiSokr"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "name": "sui_tryGetPastObject",
@@ -1322,7 +1855,7 @@
           "params": [
             {
               "name": "owner",
-              "value": "0xe4a25ab1250e8d40d270f1bdfb076e697da3d7064ffd121168fea245f41987bb"
+              "value": "0xa74fdb6fdbea46a3ebc7779c45e3e1415579352c128b4d1a2f42fdfbc9c5a73a"
             }
           ],
           "result": {
@@ -1386,11 +1919,11 @@
           "params": [
             {
               "name": "owner",
-              "value": "0x8ed5999079e1d0bc50201d79d05c061f8dde264724ab51a21c752e81c51b2063"
+              "value": "0x441193e99ab6cc2a92f7d37948898292d70420418b84502e506794227f897237"
             },
             {
               "name": "cursor",
-              "value": "0x57d828266c36b53865bb5fe48a1f388f5a97d0d8dfe64f09f709f06c32088994"
+              "value": "0x764dde8d79a01ab2104bf742a277a2abe035ca41c556b722878b9ae6b4c693a4"
             },
             {
               "name": "limit",
@@ -1403,30 +1936,30 @@
               "data": [
                 {
                   "coinType": "0x2::sui::SUI",
-                  "coinObjectId": "0x0294cbba1d4980fbaf0a4dbfbcc39033d817566297f9de95703e326f7b6c5bb0",
+                  "coinObjectId": "0x7623b91b0c1f72234f841e8ea76be9ec0b5d72879b091d6d6d8f832ef94830cb",
                   "version": "103626",
-                  "digest": "8R7nCaCDaZPiEvCHkJQBYDFH95q4WspBaXdWTaZ95AHu",
+                  "digest": "AZbu9haHHhVg4FAkTVpAagF635BKdMMyT8Kq1nCadtbt",
                   "balance": "200000000",
-                  "previousTransaction": "An1pV7rG2hm1mmoN5ELhebHJh2YXYLhybwyKLHi4pMHW"
+                  "previousTransaction": "2mufpk8aTSSSRGLYkrpv8EJzW7pXpkPqzW4FYAQu1Z95"
                 },
                 {
                   "coinType": "0x2::sui::SUI",
-                  "coinObjectId": "0x0ed513f80254082f1fadc9347718cef986a866efa6db5c1bd60446af9ce59a85",
+                  "coinObjectId": "0xec4c5c752302b12d01726cfaa9bca5c15f8790856802af59971ef9615b01d73d",
                   "version": "103626",
-                  "digest": "EocxbiEndjvydxtyuq2BrmYG3LS3pTYvncJmKCT3sTkY",
+                  "digest": "23LwBmJXAYK7fwPLbn5GAKVCJjTMb3ky91rfuQYMmYVW",
                   "balance": "200000000",
-                  "previousTransaction": "BRzotf9VWtzyCjpwvWbXgzLhxJFyk8LGTcxjqwnPJjCT"
+                  "previousTransaction": "84rbocBNV2Bnz5wx3o9CWaFStR8Tq282ym2f7sShW5bw"
                 },
                 {
                   "coinType": "0x2::sui::SUI",
-                  "coinObjectId": "0x6c527fab7c2d096141f5975e3c6bd5c95f041a8493ad7e9934be26e69152d2c2",
+                  "coinObjectId": "0x1c752e81c51b206357d828266c36b53865bb5fe48a1f388f5a97d0d8dfe64f09",
                   "version": "103626",
-                  "digest": "GeJTxsrX8DHxsrwVVy9DED612NnMf9mVbDCPw5A5BqyR",
+                  "digest": "HdLVWgeNCudDMEJZ2mN7c5G9LJge15fKHa13pDSQdYA2",
                   "balance": "200000000",
-                  "previousTransaction": "BBpGBYzv2CfqqxnHvH2koFrA8fUcerJKWVfaCh74DMoL"
+                  "previousTransaction": "9AwB9e3Z6uuRFuvFgzQyHYSKHRTiXRwTfc5DVWVrwzL4"
                 }
               ],
-              "nextCursor": "0x9230e672044bb2b0954ae5935392c72fa08e0e5dfd566e977968fa81937919da",
+              "nextCursor": "0x640ee862b96bef84fa98d2fceeb4b9585767750716f58847dd9c66a2024b544c",
               "hasNextPage": true
             }
           }
@@ -1471,7 +2004,7 @@
           "params": [
             {
               "name": "owner",
-              "value": "0xad43a9870a2e587891825debff541cf4e08b5c5f7296ff9840e6f0b185af9398"
+              "value": "0x703e326f7b6c5bb06e2f69ccf4411308e79595034b7c56ae03d69bab88bbb091"
             },
             {
               "name": "coin_type",
@@ -1527,7 +2060,7 @@
             "name": "Result",
             "value": {
               "id": {
-                "id": "0x4cde8cf3870302c062944303fab7b475b723f72ea7072ddb502e90be432231b6"
+                "id": "0x7cfa772baf3e837891413e94b1915b08fb41181bc952002a71ea08ffdb2fd0ea"
               },
               "decimals": 9,
               "name": "Usdc",
@@ -1593,7 +2126,7 @@
           "params": [
             {
               "name": "owner",
-              "value": "0xdee1af33100f0e6f7e769678d059761bff8a8f3944642e4c33a6e4fb0b55f8fa"
+              "value": "0x41696ca3ea204b350ed513f80254082f1fadc9347718cef986a866efa6db5c1b"
             },
             {
               "name": "coin_type",
@@ -1601,7 +2134,7 @@
             },
             {
               "name": "cursor",
-              "value": "0xd4a2083747b76856a5a8e30db5a798a7354340b6ea78a66f50921841ab5359ec"
+              "value": "0x1d83b6efc4dd779f0890ca3b1f6ba997850aa1ca641faf47cb518d49c1cf182f"
             },
             {
               "name": "limit",
@@ -1614,30 +2147,30 @@
               "data": [
                 {
                   "coinType": "0x2::sui::SUI",
-                  "coinObjectId": "0xce36fadaa22f2a0d48a53f22e2e901ea2a5bf44fdd5bb94a1d83b6efc4dd779f",
+                  "coinObjectId": "0xd60446af9ce59a85cd194e4715701e55e66b092d67b54aea5028bed04c46a29b",
                   "version": "103626",
-                  "digest": "aSKFBbCJzVnkvRfM8s4SFRb8nXy1koRJy81BPkmVycs",
+                  "digest": "F4YWin8YQvSgGBQ6VqyfS7usNCqw3e6D4VR3GK6MBK2j",
                   "balance": "200000000",
-                  "previousTransaction": "GEuMBLKybrmn5b85BoCrJjUcJvJbvX2wXvnR7HWjn6o5"
+                  "previousTransaction": "FRkCdGVJM1tiFJUNPJ4DJhJL9tWNDzQazS8rmUNtgURv"
                 },
                 {
                   "coinType": "0x2::sui::SUI",
-                  "coinObjectId": "0x65295231e0d2c7c86867fcc63161269c5c0c73b02229486bbaff319209dfb829",
+                  "coinObjectId": "0x34be26e69152d2c2e86d8a9bdbd242b32564cd31a71cf9833609b111436d8f0f",
                   "version": "103626",
-                  "digest": "BZaQotH3DMRWtK1o2VGnwrXD5cAycfjThBPjNfZnXY2Y",
+                  "digest": "5pxep8QRzhoCeXVtPTDwz9nhHPff4SQoVRxHRG6pg6a9",
                   "balance": "200000000",
-                  "previousTransaction": "DHhRSwt5SM3cnsMmzZYqejMBU6iUsSXJP4VibrFiGgSb"
+                  "previousTransaction": "5cY4D5G8zdGteAjqXaVtTJ8gFnxMYCjo5gJvcJDsSLCf"
                 },
                 {
                   "coinType": "0x2::sui::SUI",
-                  "coinObjectId": "0xd1ec22c06f1ee4e451ceab2edc89f74730e683ebee65578cb3bc9237ba6fca01",
+                  "coinObjectId": "0x40e6f0b185af93984cde8cf3870302c062944303fab7b475b723f72ea7072ddb",
                   "version": "103626",
-                  "digest": "AybTBN63S6bCc4Ta1Gm2boT6J2SkJNprNwhXXCqxvR23",
+                  "digest": "6PzoK9qekAmiWGK3YV3JskCsTQB4U6uWb7JUGZCeRnaF",
                   "balance": "200000000",
-                  "previousTransaction": "6ut4RrYN5WcG2oPQP6AMTLpMAmxoProJUEDTAZP3V7TQ"
+                  "previousTransaction": "4UdPuQUQQmBU6aQknQA6RJ93DD2ZbkpkkjJrZXWNxXM3"
                 }
               ],
-              "nextCursor": "0xd1ec22c06f1ee4e451ceab2edc89f74730e683ebee65578cb3bc9237ba6fca01",
+              "nextCursor": "0x40e6f0b185af93984cde8cf3870302c062944303fab7b475b723f72ea7072ddb",
               "hasNextPage": true
             }
           }
@@ -1963,7 +2496,7 @@
           "params": [
             {
               "name": "coin_type",
-              "value": "0x7a3dc01f282420ae0d4dc2f8623f7e6956c4b75a738cf80e869ecbccf96ef8ba::acoin::ACOIN"
+              "value": "0xcf8ecceac97dd580e26f0b5bf17fbc86a323d541ba5cf9e34919d2644cda38a2::acoin::ACOIN"
             }
           ],
           "result": {
@@ -1990,7 +2523,33 @@
         "schema": {
           "$ref": "#/components/schemas/ValidatorApys"
         }
-      }
+      },
+      "examples": [
+        {
+          "name": "Get the APY for all validators.",
+          "params": [],
+          "result": {
+            "name": "Result",
+            "value": {
+              "apys": [
+                {
+                  "address": "0xca6d9eb1258bfd1ad92af329a07781ee71e60065e00f2de961630d3505f8905a",
+                  "apy": 0.06
+                },
+                {
+                  "address": "0x0f4d42c6ff39a78a6ba2b28f68a3299ec3417bbabc6717dcc95b9e341bc3aba1",
+                  "apy": 0.02
+                },
+                {
+                  "address": "0x654bdbad707dcd773bd6309363447ef3fe58a960de92aa9377b3482580ee8d5b",
+                  "apy": 0.05
+                }
+              ],
+              "epoch": "420"
+            }
+          }
+        }
+      ]
     },
     {
       "name": "suix_queryEvents",

--- a/crates/sui-open-rpc/src/lib.rs
+++ b/crates/sui-open-rpc/src/lib.rs
@@ -101,6 +101,8 @@ impl Project {
                 }
 
                 method.examples = examples
+            } else {
+                println!("No example found for method: {}", method.name);
             }
         }
     }


### PR DESCRIPTION
## Description 

* fix get_events example bug
* added examples for multi_get_objects, multi_get_transaction and get_validators_apy

the following methods example are missing, will be adding them in a few subsequence PRs
```
sui_devInspectTransactionBlock
sui_dryRunTransactionBlock
sui_getLoadedChildObjects
sui_getMoveFunctionArgTypes
sui_getNormalizedMoveFunction
sui_getNormalizedMoveModule
sui_getNormalizedMoveModulesByPackage
sui_getNormalizedMoveStruct
sui_tryMultiGetPastObjects
suix_getDynamicFieldObject
suix_getDynamicFields
suix_getLatestSuiSystemState
suix_getOwnedObjects
suix_getStakes
suix_getStakesByIds
suix_queryEvents
suix_resolveNameServiceAddress
suix_resolveNameServiceNames
suix_subscribeEvent
suix_subscribeTransaction
unsafe_batchTransaction
unsafe_mergeCoins
unsafe_moveCall
unsafe_pay
unsafe_payAllSui
unsafe_paySui
unsafe_publish
unsafe_requestAddStake
unsafe_requestWithdrawStake
unsafe_splitCoin
unsafe_splitCoinEqual
unsafe_transferObject
unsafe_transferSui
```