### PR TITLE
[DbTool] add a few commands to modify database with minimal safety checks

### DIFF
--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -294,7 +294,12 @@ impl AuthorityPerpetualTables {
         Ok(objects)
     }
 
-    pub fn remove_executed_effects_and_outputs(
+    /// Removes executed effects and outputs for a transaction,
+    /// and tries to ensure the transaction is replayable.
+    ///
+    /// WARNING: This method is very subtle and can corrupt the database if used incorrectly.
+    /// It should only be used in one-off cases or tests after fully understanding the risk.
+    pub fn remove_executed_effects_and_outputs_subtle(
         &self,
         digest: &TransactionDigest,
         objects: &[ObjectKey],
@@ -322,7 +327,11 @@ impl AuthorityPerpetualTables {
             .is_some()
     }
 
-    pub fn remove_object_lock(&self, object: &ObjectKey) -> SuiResult<ObjectRef> {
+    /// Removes owned object locks and set the lock to the previous version of the object.
+    ///
+    /// WARNING: This method is very subtle and can corrupt the database if used incorrectly.
+    /// It should only be used in one-off cases or tests after fully understanding the risk.
+    pub fn remove_object_lock_subtle(&self, object: &ObjectKey) -> SuiResult<ObjectRef> {
         let mut wb = self.objects.batch();
         let object_ref = self.remove_object_lock_batch(&mut wb, object)?;
         wb.write()?;

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -302,7 +302,9 @@ impl AuthorityPerpetualTables {
         let mut wb = self.objects.batch();
         for object in objects {
             wb.delete_batch(&self.objects, [object])?;
-            self.remove_object_lock_batch(&mut wb, object)?;
+            if self.has_object_lock(object) {
+                self.remove_object_lock_batch(&mut wb, object)?;
+            }
         }
         wb.delete_batch(&self.executed_transactions_to_checkpoint, [digest])?;
         wb.delete_batch(&self.executed_effects, [digest])?;

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -359,24 +359,33 @@ impl CheckpointStore {
         &self,
         checkpoint: &VerifiedCheckpoint,
     ) -> Result<(), TypedStoreError> {
-        match self.get_highest_executed_checkpoint_seq_number()? {
-            Some(seq_number) if seq_number > *checkpoint.sequence_number() => Ok(()),
-            _ => self.watermarks.insert(
-                &CheckpointWatermark::HighestExecuted,
-                &(*checkpoint.sequence_number(), *checkpoint.digest()),
-            ),
+        if let Some(seq_number) = self.get_highest_executed_checkpoint_seq_number()? {
+            if seq_number >= *checkpoint.sequence_number() {
+                return Ok(());
+            }
+            assert_eq!(seq_number + 1, *checkpoint.sequence_number(),
+            "Cannot update highest executed checkpoint to {} when current highest executed checkpoint is {}",
+            checkpoint.sequence_number(),
+            seq_number);
         }
+        self.watermarks.insert(
+            &CheckpointWatermark::HighestExecuted,
+            &(*checkpoint.sequence_number(), *checkpoint.digest()),
+        )
     }
 
-    pub fn set_highest_executed_checkpoint(
+    /// Sets highest executed checkpoint to any value.
+    ///
+    /// WARNING: This method is very subtle and can corrupt the database if used incorrectly.
+    /// It should only be used in one-off cases or tests after fully understanding the risk.
+    pub fn set_highest_executed_checkpoint_subtle(
         &self,
         checkpoint: &VerifiedCheckpoint,
     ) -> Result<(), TypedStoreError> {
         self.watermarks.insert(
             &CheckpointWatermark::HighestExecuted,
             &(*checkpoint.sequence_number(), *checkpoint.digest()),
-        )?;
-        Ok(())
+        )
     }
 
     pub fn insert_checkpoint_contents(

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -368,6 +368,17 @@ impl CheckpointStore {
         }
     }
 
+    pub fn set_highest_executed_checkpoint(
+        &self,
+        checkpoint: &VerifiedCheckpoint,
+    ) -> Result<(), TypedStoreError> {
+        self.watermarks.insert(
+            &CheckpointWatermark::HighestExecuted,
+            &(*checkpoint.sequence_number(), *checkpoint.digest()),
+        )?;
+        Ok(())
+    }
+
     pub fn insert_checkpoint_contents(
         &self,
         contents: CheckpointContents,

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -90,6 +90,10 @@ impl SequenceNumber {
             Some(SequenceNumber(self.0 - 1))
         }
     }
+
+    pub fn next(&self) -> SequenceNumber {
+        SequenceNumber(self.0 + 1)
+    }
 }
 
 pub type TxSequenceNumber = u64;

--- a/crates/typed-store-derive/src/lib.rs
+++ b/crates/typed-store-derive/src/lib.rs
@@ -423,7 +423,7 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
                         _ => typed_store::rocks::open_cf_opts(path, global_db_options_override, metric_conf, &opt_cfs)
                     };
                     db.map(|d| (d, rwopt_cfs))
-                }.expect("Cannot open DB.");
+                }.expect(&format!("Cannot open DB at {:?}", path));
                 let (
                         #(
                             #field_names
@@ -795,7 +795,7 @@ pub fn derive_sallydb_general(input: TokenStream) -> TokenStream {
                                 _ => typed_store::rocks::open_cf_opts(path, global_db_options_override, metric_conf, &opt_cfs)
                             };
                             db.map(|d| (d, rwopt_cfs))
-                        }.expect("Cannot open DB.");
+                        }.expect(&format!("Cannot open DB at {:?}", path));
                         let (
                             #(
                                 #field_names

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -1706,7 +1706,8 @@ where
     }
 
     /// Returns an iterator visiting each key-value pair in the map. By proving bounds of the
-    /// scan range, RocksDB scan avoid unnecessary scans
+    /// scan range, RocksDB scan avoid unnecessary scans.
+    /// Lower bound is inclusive, while upper bound is exclusive.
     fn iter_with_bounds(
         &'a self,
         lower_bound: Option<K>,


### PR DESCRIPTION
## Description 

There are needs to repair corrupted databases sometimes. Adding a few commands to remove transaction and its outputs, and remove lock.

## Test Plan 

Tested on fullnodes.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
