### PR TITLE
[move-cli] Update framework branch in sui move new template

### DIFF
--- a/crates/sui-move/src/new.rs
+++ b/crates/sui-move/src/new.rs
@@ -4,12 +4,11 @@
 use clap::Parser;
 use move_cli::base::new;
 use std::path::PathBuf;
-use sui_types::SUI_FRAMEWORK_ADDRESS;
 
 const SUI_PKG_NAME: &str = "Sui";
 
 // Use testnet by default. Probably want to add options to make this configurable later
-const SUI_PKG_PATH: &str = "{ git = \"https://github.com/MystenLabs/sui.git\", subdir = \"crates/sui-framework/packages/sui-framework\", rev = \"testnet\" }";
+const SUI_PKG_PATH: &str = "{ git = \"https://github.com/MystenLabs/sui.git\", subdir = \"crates/sui-framework/packages/sui-framework\", rev = \"framework/testnet\" }";
 
 #[derive(Parser)]
 pub struct New {
@@ -24,13 +23,7 @@ impl New {
             path,
             "0.0.1",
             [(SUI_PKG_NAME, SUI_PKG_PATH)],
-            [
-                (name, "0x0"),
-                (
-                    &SUI_PKG_NAME.to_lowercase(),
-                    &SUI_FRAMEWORK_ADDRESS.to_string(),
-                ),
-            ],
+            [(name, "0x0")],
             "",
         )?;
         Ok(())

--- a/doc/src/build/move/write-package.md
+++ b/doc/src/build/move/write-package.md
@@ -21,7 +21,7 @@ name = "my_first_package"
 version = "0.0.1"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework", rev = "devnet" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/devnet" }
 
 [addresses]
 my_first_package = "0x0"
@@ -106,4 +106,4 @@ The comments in the preceding code highlight different parts of a typical Sui Mo
 
     These functions allow the fields of the module's structs to be read from other modules.
 
-After you save the file, you have a complete Sui Move package. Next, you learn to build and test your package to get it ready for publishing. 
+After you save the file, you have a complete Sui Move package. Next, you learn to build and test your package to get it ready for publishing.

--- a/doc/src/doc-updates/sui-migration-guide.md
+++ b/doc/src/doc-updates/sui-migration-guide.md
@@ -46,7 +46,7 @@ version = "0.0.1"
 published-at = "0x42"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir="crates/sui-framework/packages/sui-framework/", rev = "devnet" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir="crates/sui-framework/packages/sui-framework/", rev = "framework/devnet" }
 
 [addresses]
 example = "0x42"

--- a/external-crates/move/tools/move-cli/src/base/new.rs
+++ b/external-crates/move/tools/move-cli/src/base/new.rs
@@ -76,7 +76,7 @@ version = \"{version}\"
 [addresses]"
         )?;
         for (addr_name, addr_val) in addrs {
-            writeln!(w, "{addr_name} =  \"{addr_val}\"")?;
+            writeln!(w, "{addr_name} = \"{addr_val}\"")?;
         }
         if !custom.is_empty() {
             writeln!(w, "{}", custom)?;

--- a/external-crates/move/tools/move-cli/tests/build_tests/simple_new/args.exp
+++ b/external-crates/move/tools/move-cli/tests/build_tests/simple_new/args.exp
@@ -8,7 +8,7 @@ version = "0.0.0"
 MoveStdlib = { git = "https://github.com/move-language/move.git", subdir = "language/move-stdlib", rev = "main" }
 
 [addresses]
-std =  "0x1"
+std = "0x1"
 Command `new P2 -p other_dir`:
 External Command `cat other_dir/Move.toml`:
 [package]
@@ -19,4 +19,4 @@ version = "0.0.0"
 MoveStdlib = { git = "https://github.com/move-language/move.git", subdir = "language/move-stdlib", rev = "main" }
 
 [addresses]
-std =  "0x1"
+std = "0x1"

--- a/scripts/check-framework-compat.sh
+++ b/scripts/check-framework-compat.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Check whether the version of framework in the repo is compatible
+# with the version on chain, as reported by the currently active
+# environment, using the binary in environment variable $SUI.
+
+set -e
+
+SUI=${SUI:-sui}
+REPO=$(git rev-parse --show-toplevel)
+
+for PACKAGE in "$REPO"/crates/sui-framework/packages/*; do
+    $SUI client verify-source "$PACKAGE"
+done
+


### PR DESCRIPTION
## Description

Differentiate the branch that node operators build their software off of (e.g. `mainnet`) from the branch that Move package developers depend on the framework at (e.g. `framework/mainnet`).

This is to account for the fact that when a protocol version/binary upgrade includes a framework change, there is a period of time between when the tracking branch for node operators (e.g. `mainnet`) is updated and when the network performs the protocol upgrade where an attempt to publish a package that depends on a system package will fail because of dependency source validation.

This PR also introduces some other minor changes to the new package template:

- Remove an extraneous space in the `addresses` output.
- Don't include the address for `sui` because it will be inherited from the `Sui` dependency automatically.

## Test Plan

Test output from `sui move new`

```
crates/sui$ cargo run -- --path /tmp/example example
crates/sui$ cat /tmp/example/Move.toml
[package]
name = "example"
version = "0.0.1"

[dependencies]
Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/testnet" }

[addresses]
example = "0x0"
```

Test script that checks compatibility against localnet:

```
crates/sui$ cargo build
sui$ export SUI=$(git rev-parse --show-toplevel)/target/debug/sui
sui$ $SUI genesis -f && $SUI start

     # In a new terminal session
sui$ export SUI=$(git rev-parse --show-toplevel)/target/debug/sui
sui$ $SUI client switch --env localnet
sui$ ./scripts/check-framework-compat.sh
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
The revision that the framework used by `$NETWORK` is found it is now `framework/$NETWORK` and not just `$NETWORK`.