### PR TITLE
rename send to transaction

### DIFF
--- a/apps/core/src/hooks/useTransactionSummary.ts
+++ b/apps/core/src/hooks/useTransactionSummary.ts
@@ -35,7 +35,7 @@ const getSummary = (
             gas,
             balanceChanges: balanceChangeSummary,
             digest: getTransactionDigest(transaction),
-            label: getLabel(transaction),
+            label: getLabel(transaction, currentAddress),
             objectSummary,
             status: getExecutionStatusType(transaction),
             timestamp: transaction.timestampMs,

--- a/apps/core/src/utils/transaction/getLabel.ts
+++ b/apps/core/src/utils/transaction/getLabel.ts
@@ -3,11 +3,15 @@
 import {
     SuiTransactionBlockResponse,
     getTransactionSender,
+    type SuiAddress,
 } from '@mysten/sui.js';
 
 // todo: add more logic for deriving transaction label
-export const getLabel = (transaction: SuiTransactionBlockResponse) => {
-    const isSender = getTransactionSender(transaction);
-
-    return isSender ? 'Send' : 'Receive';
+export const getLabel = (
+    transaction: SuiTransactionBlockResponse,
+    currentAddress?: SuiAddress
+) => {
+    const isSender = getTransactionSender(transaction) === currentAddress;
+    // Rename to "Send" to Transaction
+    return isSender ? 'Transaction' : 'Receive';
 };


### PR DESCRIPTION
## Description 

Rename wallet activities `send` -> `Transaction`
fix minor bug
