### PR TITLE
[ts-sdk] Correctly handle input bytes length

### DIFF
--- a/.changeset/khaki-dolphins-argue.md
+++ b/.changeset/khaki-dolphins-argue.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Increase max size of pure inputs

--- a/sdk/typescript/src/builder/Inputs.ts
+++ b/sdk/typescript/src/builder/Inputs.ts
@@ -37,11 +37,17 @@ export type ObjectCallArg = Infer<typeof ObjectCallArg>;
 export const BuilderCallArg = union([PureCallArg, ObjectCallArg]);
 export type BuilderCallArg = Infer<typeof BuilderCallArg>;
 
+const MAX_PURE_ARGUMENT_SIZE = 16 * 1024;
+
 export const Inputs = {
   Pure(data: unknown, type?: string): PureCallArg {
     return {
       Pure: Array.from(
-        data instanceof Uint8Array ? data : builder.ser(type!, data).toBytes(),
+        data instanceof Uint8Array
+          ? data
+          : builder
+              .ser(type!, data, { maxSize: MAX_PURE_ARGUMENT_SIZE })
+              .toBytes(),
       ),
     };
   },


### PR DESCRIPTION
## Description 

The max size for pure arguments was the default, but needs to be set higher.

## Test Plan 

CI