### PR TITLE
[framework] Adds vec_set::keys() method

### DIFF
--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0xa5e149ece841dbe3fc93cccdc5367ca3ee1e15d21534fbc6cd43ec42f4eda1fc"
+            id: "0x789c1af0dbd1cfdcfca807f36be10cca91eae028f71b2f6e773ea76b887dd895"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0x55877fdff98c498e4dfd5fc6f4d1c3f03e401667ecd773234d5a3e3b5e00901b"
+      operation_cap_id: "0xff477447e67d847ab819528ff8ade71535a5f062ebd0b20657e1800f74c83b17"
       gas_price: 1000
       staking_pool:
-        id: "0x25d90d51af2667b4ec8db8e0b802996a951196bbeaa876f097c04c4abc4ee6c8"
+        id: "0x3accd43cfbcdc4e565c59b330a9ccaf74483da1fb4b143b877abf204d873b2a8"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0x1694605e48ef03df23a9a38457b2cc89faf2d0b69cc2fa57c22e5b5d8a425e7a"
+          id: "0x0601fb815fb5f60d49176f532747f6e5f9383aeabe92735126e8b0fff1c07f65"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0xb7fc0303e0fa90a0903961189f8e5d9b5d8e32e5687955a381c48b977e0bd02f"
+            id: "0x4f60035ee0b886bba04acfdfb1b95983a363381a4c89334f9f58cfe445976c30"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0xe26133e6c5c1973455c976f5f805e302b5baaeb648527f509f6aa711199835a3"
+          id: "0x5b604dbf67adf03e22633ad340ef58b3a69905ca542d33120ee6b42ca0fc4ca0"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x4add443afc17a76f9518d626341b0b52e337db1c627d5c970a04dbeeeabe979b"
+      id: "0xedbe0265ea6e44916a8209e7fc3f2603d9205224ea8bd8d9cceae550c2fe0504"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0xa7efb5a806756bc0fba1079b5e6ff5789fd4e6292995f09f4ec3ee06f7b381bd"
+    id: "0x8cc606e28b666a64779de21d13a2c7507f6585dee246232f2bd557a541548dcb"
     size: 1
   inactive_validators:
-    id: "0x71aa8b1e084b47702b71966de5a6608dde57a9cf982ce620c4c047ebfb8f2560"
+    id: "0x9f29bc8b784c9a77c2a6191c3f3328435ae6fe810a49a55d75c7b9821f1671f6"
     size: 0
   validator_candidates:
-    id: "0x5fd5a11bf8385661a1a80930cc0306359492a304dde3ad85cf8bfb362e5c5e78"
+    id: "0x8e11fae0e344c78f18559ff9464984f061f887d901e024132d60397ebeaed108"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0x02ee6fc36bd8f5424a3329fbedc3c94bb6408f7c40cac279502c8378455ca11b"
+      id: "0x21d40a83fd9bf40b43904c5a21637ce875e53a577d55f2e958b10816d93a3585"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0xc622519405270cf8d58516792f83f701ac11d1e4bbe0ada08b418896b6acf1b3"
+      id: "0x80bbfefdf61fa4ef709b4744783116d9e27ba8d01168857ca502c17be6d88033"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 10000
   extra_fields:
     id:
-      id: "0xb197c464795cf9c129869461fe8ab91e4e8a94db303e8fe24e1188473aa3e22a"
+      id: "0x610073c9dbcebeec4a8690b4d2d26b33f6e356747023414acae3d799e98f5d6d"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,6 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0x7d6941855882be146a65f62dbb6f7d6a0e7b68a475c7590e9b8360221386c452"
+    id: "0x24430a5d1c319d25b416ab325d8ddaa4efa2c23e9b198329a62cb0de6e95dd6d"
   size: 0
 

--- a/crates/sui-framework/docs/vec_set.md
+++ b/crates/sui-framework/docs/vec_set.md
@@ -15,6 +15,7 @@
 -  [Function `size`](#0x2_vec_set_size)
 -  [Function `is_empty`](#0x2_vec_set_is_empty)
 -  [Function `into_keys`](#0x2_vec_set_into_keys)
+-  [Function `keys`](#0x2_vec_set_keys)
 -  [Function `get_idx_opt`](#0x2_vec_set_get_idx_opt)
 -  [Function `get_idx`](#0x2_vec_set_get_idx)
 
@@ -29,10 +30,11 @@
 
 ## Struct `VecSet`
 
-A set data structure backed by a vector. The set is guaranteed not to contain duplicate keys.
-All operations are O(N) in the size of the set--the intention of this data structure is only to provide
-the convenience of programming against a set API.
-Sets that need sorted iteration rather than insertion order iteration should be handwritten.
+A set data structure backed by a vector. The set is guaranteed not to
+contain duplicate keys. All operations are O(N) in the size of the set
+- the intention of this data structure is only to provide the convenience
+of programming against a set API. Sets that need sorted iteration rather
+than insertion order iteration should be handwritten.
 
 
 <pre><code><b>struct</b> <a href="vec_set.md#0x2_vec_set_VecSet">VecSet</a>&lt;K: <b>copy</b>, drop&gt; <b>has</b> <b>copy</b>, drop, store
@@ -279,6 +281,33 @@ The output keys are stored in insertion order, *not* sorted.
 <pre><code><b>public</b> <b>fun</b> <a href="vec_set.md#0x2_vec_set_into_keys">into_keys</a>&lt;K: <b>copy</b> + drop&gt;(self: <a href="vec_set.md#0x2_vec_set_VecSet">VecSet</a>&lt;K&gt;): <a href="">vector</a>&lt;K&gt; {
     <b>let</b> <a href="vec_set.md#0x2_vec_set_VecSet">VecSet</a> { contents } = self;
     contents
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_vec_set_keys"></a>
+
+## Function `keys`
+
+Borrow the <code>contents</code> of the <code><a href="vec_set.md#0x2_vec_set_VecSet">VecSet</a></code> to access content by index
+without unpacking. The contents are stored in insertion order,
+*not* sorted.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_set.md#0x2_vec_set_keys">keys</a>&lt;K: <b>copy</b>, drop&gt;(self: &<a href="vec_set.md#0x2_vec_set_VecSet">vec_set::VecSet</a>&lt;K&gt;): &<a href="">vector</a>&lt;K&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vec_set.md#0x2_vec_set_keys">keys</a>&lt;K: <b>copy</b> + drop&gt;(self: &<a href="vec_set.md#0x2_vec_set_VecSet">VecSet</a>&lt;K&gt;): &<a href="">vector</a>&lt;K&gt; {
+    &self.contents
 }
 </code></pre>
 

--- a/crates/sui-framework/packages/sui-framework/sources/vec_set.move
+++ b/crates/sui-framework/packages/sui-framework/sources/vec_set.move
@@ -11,10 +11,11 @@ module sui::vec_set {
     /// This key does not exist in the map
     const EKeyDoesNotExist: u64 = 1;
 
-    /// A set data structure backed by a vector. The set is guaranteed not to contain duplicate keys.
-    /// All operations are O(N) in the size of the set--the intention of this data structure is only to provide
-    /// the convenience of programming against a set API.
-    /// Sets that need sorted iteration rather than insertion order iteration should be handwritten.
+    /// A set data structure backed by a vector. The set is guaranteed not to
+    /// contain duplicate keys. All operations are O(N) in the size of the set
+    /// - the intention of this data structure is only to provide the convenience
+    /// of programming against a set API. Sets that need sorted iteration rather
+    /// than insertion order iteration should be handwritten.
     struct VecSet<K: copy + drop> has copy, drop, store {
         contents: vector<K>,
     }
@@ -62,6 +63,13 @@ module sui::vec_set {
     public fun into_keys<K: copy + drop>(self: VecSet<K>): vector<K> {
         let VecSet { contents } = self;
         contents
+    }
+
+    /// Borrow the `contents` of the `VecSet` to access content by index
+    /// without unpacking. The contents are stored in insertion order,
+    /// *not* sorted.
+    public fun keys<K: copy + drop>(self: &VecSet<K>): &vector<K> {
+        &self.contents
     }
 
     // == Helper functions ==

--- a/crates/sui-framework/packages/sui-framework/tests/vec_set_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/vec_set_tests.move
@@ -58,4 +58,14 @@ module sui::vec_set_tests {
         }
     }
 
+    #[test]
+    fun test_keys() {
+        let m = vec_set::empty();
+        vec_set::insert(&mut m, 1);
+        vec_set::insert(&mut m, 2);
+        vec_set::insert(&mut m, 3);
+
+        assert!(vec_set::size(&m) == 3, 0);
+        assert!(vec_set::keys(&m) == &vector[1, 2, 3], 1);
+    }
 }


### PR DESCRIPTION
## Description 

Adds `vec_set::keys<K>(): &vector<K>`.

Sometimes we need to read or iterate over the contents of a vec_set. While providing a decent API for uniqueness, grabbing a random value from a VecSet is currently impossible without copying and unpacking (`vec_set::into_keys<K>(): vector<K>`).

## Test Plan 

Features test for the added function.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

- adds `vec_set::keys<K>(): &vector<K>` to read the contents vector without unpacking the VecSet.