### PR TITLE
[Rosetta] - Use multi_get_transactions

### DIFF
--- a/crates/sui-rosetta/src/state.rs
+++ b/crates/sui-rosetta/src/state.rs
@@ -231,12 +231,12 @@ impl CheckpointBlockProvider {
         let index = checkpoint.sequence_number;
         let hash = checkpoint.digest;
         let mut transactions = vec![];
-        for digest in checkpoint.transactions.iter() {
-            let tx = self
+        for batch in checkpoint.transactions.chunks(50) {
+            let transaction_responses = self
                 .client
                 .read_api()
-                .get_transaction_with_options(
-                    *digest,
+                .multi_get_transactions_with_options(
+                    batch.to_vec(),
                     SuiTransactionBlockResponseOptions::new()
                         .with_input()
                         .with_effects()
@@ -244,12 +244,14 @@ impl CheckpointBlockProvider {
                         .with_events(),
                 )
                 .await?;
-            transactions.push(Transaction {
-                transaction_identifier: TransactionIdentifier { hash: tx.digest },
-                operations: Operations::try_from(tx)?,
-                related_transactions: vec![],
-                metadata: None,
-            })
+            for tx in transaction_responses.into_iter() {
+                transactions.push(Transaction {
+                    transaction_identifier: TransactionIdentifier { hash: tx.digest },
+                    operations: Operations::try_from(tx)?,
+                    related_transactions: vec![],
+                    metadata: None,
+                })
+            }
         }
 
         // previous digest should only be None for genesis block.


### PR DESCRIPTION
## Description 

This PR changes create_block_response() function in state.rs of sui-rosetta to use multi_get_transactions_with_options() instead of get_transaction_with_options().

## Test Plan 

All tests passed succesfully in crates/sui-rosetta

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
