### PR TITLE
docs: fix value for non-refundable storage share

### DIFF
--- a/doc/src/build/sui-gas-charges.md
+++ b/doc/src/build/sui-gas-charges.md
@@ -63,7 +63,7 @@ The remaining values provide an insight into the storage charges. Each time Sui 
 
 At the end of execution, all created object contribute to `storage_cost` with the following formula: `storage_cost = object_byte * storage_normalizer * storage_price` where, currently, `storage_normalizer = 100` and `storage_price = 76`. The `storage_cost` is saved and tracked by each object, and represents the value of the object in terms of its storage cost.
 
-All deleted objects storage values are added together and refunded to the user (`storage_rebate`), except for a small percentage of the rebate that is charged by the system and goes into the `non_refundable_storage_fee`. That percentage is currently defined to be 0.01%.
+All deleted objects storage values are added together and refunded to the user (`storage_rebate`), except for a small percentage of the rebate that is charged by the system and goes into the `non_refundable_storage_fee`. That percentage is currently defined to be 1%.
 
 ## Out Of Gas Model
 


### PR DESCRIPTION
## Description 

There is currently a discrepancy in the documentation concerning the non-refundable share of the storage fee:
- [learn/tokenomics/gas-in-sui.md](https://github.com/MystenLabs/sui/blob/01cd8598cba72aaafcc8c85194d227b2d760230b/doc/src/learn/tokenomics/gas-in-sui.md?plain=1#L52) (added in #10245) states 1%
- [build/sui-gas-charges.md](https://github.com/MystenLabs/sui/blob/01cd8598cba72aaafcc8c85194d227b2d760230b/doc/src/build/sui-gas-charges.md?plain=1#L66) (added in #10503) states 0.01%

I'm not 100% sure which one of the two is correct, but I guess the first makes more sense. I'm happy to modify the PR otherwise.

## Test Plan 

Only documentation changes, no tests required.
