### PR TITLE
[sui-proxy/ use string instead of socketaddr]

### DIFF
--- a/crates/sui-proxy/src/config.rs
+++ b/crates/sui-proxy/src/config.rs
@@ -16,8 +16,8 @@ pub struct ProxyConfig {
     pub listen_address: SocketAddr,
     pub remote_write: RemoteWriteConfig,
     pub json_rpc: PeerValidationConfig,
-    pub metrics_address: SocketAddr,
-    pub histogram_address: SocketAddr,
+    pub metrics_address: String,
+    pub histogram_address: String,
 }
 
 #[serde_as]

--- a/crates/sui-proxy/src/data/config.yaml
+++ b/crates/sui-proxy/src/data/config.yaml
@@ -10,5 +10,5 @@ json-rpc:
   interval: 30
   certificate-file: /opt/joeman/fullchain.pem
   private-key: /opt/joeman/privkey.pem
-metrics-address: 192.168.0.2:9184
-histogram-address: 192.168.0.2:9185
+metrics-address: localhost:9184
+histogram-address: localhost:9185

--- a/crates/sui-proxy/src/main.rs
+++ b/crates/sui-proxy/src/main.rs
@@ -56,10 +56,12 @@ async fn main() -> Result<()> {
             create_server_cert_enforce_peer(config.json_rpc)
                 .expect("unable to create tls server config")
         };
+    let histogram_listener = std::net::TcpListener::bind(config.histogram_address).unwrap();
+    let metrics_listener = std::net::TcpListener::bind(config.metrics_address).unwrap();
     let acceptor = TlsAcceptor::new(tls_config);
     let client = make_reqwest_client(config.remote_write);
-    let histogram_relay = histogram_relay::start_prometheus_server(config.histogram_address);
-    let registry_service = metrics::start_prometheus_server(config.metrics_address);
+    let histogram_relay = histogram_relay::start_prometheus_server(histogram_listener);
+    let registry_service = metrics::start_prometheus_server(metrics_listener);
     let prometheus_registry = registry_service.default_registry();
     prometheus_registry
         .register(mysten_metrics::uptime_metric(VERSION))

--- a/crates/sui-proxy/src/metrics.rs
+++ b/crates/sui-proxy/src/metrics.rs
@@ -3,7 +3,7 @@
 use axum::{extract::Extension, http::StatusCode, routing::get, Router};
 use mysten_metrics::RegistryService;
 use prometheus::{Registry, TextEncoder};
-use std::net::SocketAddr;
+use std::net::TcpListener;
 use tower::ServiceBuilder;
 use tower_http::trace::{DefaultOnResponse, TraceLayer};
 use tower_http::LatencyUnit;
@@ -14,7 +14,7 @@ const METRICS_ROUTE: &str = "/metrics";
 // Creates a new http server that has as a sole purpose to expose
 // and endpoint that prometheus agent can use to poll for the metrics.
 // A RegistryService is returned that can be used to get access in prometheus Registries.
-pub fn start_prometheus_server(addr: SocketAddr) -> RegistryService {
+pub fn start_prometheus_server(addr: TcpListener) -> RegistryService {
     let registry = Registry::new();
 
     let registry_service = RegistryService::new(registry);
@@ -33,7 +33,8 @@ pub fn start_prometheus_server(addr: SocketAddr) -> RegistryService {
         );
 
     tokio::spawn(async move {
-        axum::Server::bind(&addr)
+        axum::Server::from_tcp(addr)
+            .unwrap()
             .serve(app.into_make_service())
             .await
             .unwrap();


### PR DESCRIPTION
Summary:

* we'll convert the string to a tcplistener after serde.

Test Plan:

tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
