### PR TITLE
[fmt] Fix checked_arithmetic suppressed fmt and clippy

### DIFF
--- a/crates/sui-adapter/src/adapter.rs
+++ b/crates/sui-adapter/src/adapter.rs
@@ -70,7 +70,7 @@ pub fn default_verifier_config(
         max_basic_blocks_in_script: None,
         max_per_fun_meter_units,
         max_per_mod_meter_units,
-        max_idenfitier_len: protocol_config.max_move_identifier_len_as_option() // Before protocol version 9, there was no limit
+        max_idenfitier_len: protocol_config.max_move_identifier_len_as_option(), // Before protocol version 9, there was no limit
     }
 }
 
@@ -91,10 +91,10 @@ pub fn new_move_vm(
             runtime_limits_config: VMRuntimeLimitsConfig {
                 vector_len_max: protocol_config.max_move_vector_len(),
             },
-            enable_invariant_violation_check_in_swap_loc:
-                !protocol_config.disable_invariant_violation_check_in_swap_loc(),
-            check_no_extraneous_bytes_during_deserialization:
-                protocol_config.no_extraneous_module_bytes(),
+            enable_invariant_violation_check_in_swap_loc: !protocol_config
+                .disable_invariant_violation_check_in_swap_loc(),
+            check_no_extraneous_bytes_during_deserialization: protocol_config
+                .no_extraneous_module_bytes(),
         },
     )
     .map_err(|_| SuiError::ExecutionInvariantViolation)
@@ -168,7 +168,7 @@ pub fn run_metered_move_bytecode_verifier(
     module_bytes: &[Vec<u8>],
     protocol_config: &ProtocolConfig,
     metered_verifier_config: &VerifierConfig,
-    meter: &mut impl Meter
+    meter: &mut impl Meter,
 ) -> Result<(), SuiError> {
     let modules_stat = module_bytes
         .iter()
@@ -188,14 +188,19 @@ pub fn run_metered_move_bytecode_verifier(
         return Ok(());
     };
 
-    run_metered_move_bytecode_verifier_impl(&modules, protocol_config, metered_verifier_config, meter)
+    run_metered_move_bytecode_verifier_impl(
+        &modules,
+        protocol_config,
+        metered_verifier_config,
+        meter,
+    )
 }
 
 pub fn run_metered_move_bytecode_verifier_impl(
     modules: &[CompiledModule],
     protocol_config: &ProtocolConfig,
     verifier_config: &VerifierConfig,
-    meter: &mut impl Meter
+    meter: &mut impl Meter,
 ) -> Result<(), SuiError> {
     // run the Move verifier
     for module in modules.iter() {
@@ -213,6 +218,7 @@ pub fn run_metered_move_bytecode_verifier_impl(
                     error: "Verification timedout".to_string(),
                 });
             };
+        } else {
             sui_verify_module_metered(protocol_config, module, &BTreeMap::new(), meter)?
         }
     }

--- a/crates/sui-adapter/src/programmable_transactions/linkage_view.rs
+++ b/crates/sui-adapter/src/programmable_transactions/linkage_view.rs
@@ -92,13 +92,13 @@ impl<'state, S: StorageView> LinkageView<'state, S> {
     /// Reset the linkage, but save the context that existed before, if there was one.
     pub fn steal_linkage(&mut self) -> Option<SavedLinkage> {
         if let LinkageInfo::Universal = &self.linkage_info {
-            return None;
-        }
-
-        match std::mem::replace(&mut self.linkage_info, LinkageInfo::Unset) {
-            LinkageInfo::Set(linkage) => Some(SavedLinkage(linkage)),
-            LinkageInfo::Unset => None,
-            LinkageInfo::Universal => unreachable!(),
+            None
+        } else {
+            match std::mem::replace(&mut self.linkage_info, LinkageInfo::Unset) {
+                LinkageInfo::Set(linkage) => Some(SavedLinkage(linkage)),
+                LinkageInfo::Unset => None,
+                LinkageInfo::Universal => unreachable!(),
+            }
         }
     }
 


### PR DESCRIPTION
## Description 

- Fixed formatting and clippy hidden by checked_arithmetic
- Additional if-let-else hardening

## Test Plan 

- nfc

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
