### PR TITLE
lock down fast path object insertion to clock object

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -103,7 +103,7 @@ use sui_types::{
     object::{Object, ObjectFormatOptions, ObjectRead},
     SUI_SYSTEM_ADDRESS,
 };
-use sui_types::{is_system_package, TypeTag};
+use sui_types::{is_system_package, TypeTag, SUI_CLOCK_OBJECT_ID};
 use typed_store::Map;
 
 use crate::authority::authority_per_epoch_store::{AuthorityPerEpochStore, CertTxGuard};
@@ -679,7 +679,7 @@ impl AuthorityState {
         // this function, in order to prevent a byzantine validator from
         // giving us incorrect effects.
         effects: &VerifiedCertifiedTransactionEffects,
-        objects: &Vec<Object>,
+        objects: Vec<Object>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult {
         assert!(self.is_fullnode(epoch_store));
@@ -696,6 +696,11 @@ impl AuthorityState {
             }
         );
 
+        // Lock this down to 0x6 before we pin child versions in effects
+        let objects = objects
+            .into_iter()
+            .filter(|o| o.id() == SUI_CLOCK_OBJECT_ID)
+            .collect::<Vec<_>>();
         if !objects.is_empty() {
             debug!(
                 "inserting objects to object store before executing a tx: {:?}",
@@ -705,7 +710,7 @@ impl AuthorityState {
                     .collect::<Vec<_>>()
             );
             self.database
-                .fullnode_fast_path_insert_objects_to_object_store_maybe(objects)?;
+                .fullnode_fast_path_insert_objects_to_object_store_maybe(&objects)?;
             self.transaction_manager()
                 .objects_available(objects.iter().map(InputKey::from).collect(), epoch_store);
         }

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -225,7 +225,7 @@ where
                     &self.validator_state,
                     &executable_tx,
                     &effects_cert,
-                    &objects,
+                    objects,
                     &self.metrics,
                 )
                 .await
@@ -270,7 +270,7 @@ where
         validator_state: &Arc<AuthorityState>,
         transaction: &VerifiedExecutableTransaction,
         effects_cert: &VerifiedCertifiedTransactionEffects,
-        objects: &Vec<Object>,
+        objects: Vec<Object>,
         metrics: &TransactionOrchestratorMetrics,
     ) -> SuiResult {
         let epoch_store = validator_state.load_epoch_store_one_call_per_task();
@@ -367,7 +367,7 @@ where
                         &validator_state,
                         &executable_tx,
                         &effects_cert,
-                        &objects,
+                        objects,
                         &metrics,
                     )
                     .await;


### PR DESCRIPTION
## Description 

as title

## Test Plan 

CI
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
lock down fast path object insertion to clock object.