### PR TITLE
[ts-sdk] Fix type definition for MakeMoveVec

### DIFF
--- a/.changeset/young-seals-mix.md
+++ b/.changeset/young-seals-mix.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Fix `type` field in MakeMoveVec

--- a/apps/wallet/src/ui/app/pages/approval-request/transaction-request/TransactionDetails/Command.tsx
+++ b/apps/wallet/src/ui/app/pages/approval-request/transaction-request/TransactionDetails/Command.tsx
@@ -10,6 +10,8 @@ import {
     type MakeMoveVecTransaction,
     type PublishTransaction,
     toB64,
+    TypeTagSerializer,
+    type TypeTag,
 } from '@mysten/sui.js';
 import { useState } from 'react';
 
@@ -35,6 +37,10 @@ function convertCommandArgumentToString(
     }
 
     if (typeof arg === 'object' && 'Some' in arg) {
+        if (typeof arg.Some === 'object') {
+            // MakeMoveVecTransaction['type'] is TypeTag type
+            return TypeTagSerializer.tagToString(arg.Some as TypeTag);
+        }
         return arg.Some;
     }
 

--- a/sdk/typescript/test/e2e/object-vector.test.ts
+++ b/sdk/typescript/test/e2e/object-vector.test.ts
@@ -33,9 +33,12 @@ describe('Test Move call with a vector of objects as input', () => {
     return getCreatedObjects(result)![0].reference.objectId;
   }
 
-  async function destroyObjects(objects: ObjectId[]) {
+  async function destroyObjects(objects: ObjectId[], withType = false) {
     const tx = new TransactionBlock();
-    const vec = tx.makeMoveVec({ objects: objects.map((id) => tx.object(id)) });
+    const vec = tx.makeMoveVec({
+      objects: objects.map((id) => tx.object(id)),
+      type: withType ? `${packageId}::entry_point_vector::Obj` : undefined,
+    });
     tx.moveCall({
       target: `${packageId}::entry_point_vector::two_obj_vec_destroy`,
       arguments: [vec],
@@ -58,7 +61,17 @@ describe('Test Move call with a vector of objects as input', () => {
   });
 
   it('Test object vector', async () => {
-    await destroyObjects([await mintObject(7), await mintObject(42)]);
+    await destroyObjects(
+      [await mintObject(7), await mintObject(42)],
+      /* withType */ false,
+    );
+  });
+
+  it('Test object vector with type hint', async () => {
+    await destroyObjects(
+      [await mintObject(7), await mintObject(42)],
+      /* withType */ true,
+    );
   });
 
   it('Test regular arg mixed with object vector arg', async () => {


### PR DESCRIPTION
## Description 

Fix a bug where there is a type mismatch in the user input and BCS schema

## Test Plan 

Added an e2e test to add `type` hint for `makeMoveVec`, without the changes in this PR the test will fail with the following error

```
 FAIL  test/e2e/object-vector.test.ts > Test Move call with a vector of objects as input > Test object vector
Error: Incorrect data passed into enum "TypeTag", expected object with properties: "bool | u8 | u64 | u128 | address | signer | vector | struct | u16 | u32 | u256".
Received: ""0x60c831c44574dab69122c964cedc03bf18a23680a713c3ea41240b066187e26d::entry_point_vector::Obj""
 ❯ _BCS.encodeEnum ../bcs/src/index.ts:1269:17
    1267|         }
    1268|         if (typeof data !== "object") {
    1269|           throw new Error(
       |                 ^
    1270|             `Incorrect data passed into enum "$…
    1271|               " | "
```

After this PR, the test will pass


---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
