### PR TITLE
wallet-ext: navigate to home after staking (from receipt view)

### DIFF
--- a/apps/wallet/src/ui/app/staking/stake/StakingCard.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/StakingCard.tsx
@@ -237,7 +237,7 @@ function StakingCard() {
                 navigate(
                     `/receipt?${new URLSearchParams({
                         txdigest: txDigest,
-                        from: 'stake',
+                        from: 'tokens',
                     }).toString()}`,
                     { state: { response } }
                 );

--- a/apps/wallet/src/ui/app/staking/useGetDelegatedStake.tsx
+++ b/apps/wallet/src/ui/app/staking/useGetDelegatedStake.tsx
@@ -10,7 +10,9 @@ export function useGetDelegatedStake(
     address: string
 ): UseQueryResult<DelegatedStake[], Error> {
     const rpc = useRpcClient();
-    return useQuery(['validator', address], () =>
-        rpc.getStakes({ owner: address })
+    return useQuery(
+        ['validator', address],
+        () => rpc.getStakes({ owner: address }),
+        { staleTime: 10 * 1000 }
     );
 }


### PR DESCRIPTION
* mitigate the issue that the new stake is not visible in stake home for a few seconds after the tx
* this happens because we don't wait for local execution
* also decreased the stale time for stakes query to allow refetching a bit sooner


https://user-images.githubusercontent.com/10210143/235789907-57dc6cc4-1da1-44f2-b982-aca62409366f.mov

context [here](https://mysten-labs.slack.com/archives/C042YF60NH2/p1683054515330329)