### PR TITLE
APY approx update

### DIFF
--- a/apps/core/src/hooks/useGetValidatorsApy.ts
+++ b/apps/core/src/hooks/useGetValidatorsApy.ts
@@ -13,18 +13,44 @@ import { roundFloat } from '../utils/roundFloat';
 const DEFAULT_APY_DECIMALS = 2;
 
 export interface ApyByValidator {
-    [validatorAddress: string]: number;
+    [validatorAddress: string]: {
+        apy: number;
+        isApyApproxZero: boolean;
+    };
 }
+// For small APYs or AYPs before stakeSubsidyStartEpoch, show ~0% instead of 0%
+// If APY falls below 0.001, show ~0% instead of 0% since we round to 2 decimal places
+const MINIMUM_THRESHOLD = 0.001;
 
 export function useGetValidatorsApy() {
     const rpc = useRpcClient();
     return useQuery(
         ['get-rolling-average-apys'],
-        () => rpc.getValidatorsApy(),
+        async () => {
+            const [apy, systemStateResponse] = await Promise.all([
+                rpc.getValidatorsApy(),
+                //TODO: remove the stakeSubsidyStartEpoch check once its past that epoch
+                rpc.getLatestSuiSystemState(),
+            ]);
+
+            // check if stakeSubsidyStartEpoch is greater than current epoch, flag for UI to show ~0% instead of 0%
+            const currentEpoch = Number(systemStateResponse?.epoch);
+            const stakeSubsidyStartEpoch = Number(
+                systemStateResponse?.stakeSubsidyStartEpoch
+            );
+            return {
+                validatorApys: apy,
+                isStakeSubsidyStarted: currentEpoch > stakeSubsidyStartEpoch,
+            };
+        },
         {
-            select: (data) => {
-                return data.apys.reduce((acc, { apy, address }) => {
-                    acc[address] = roundFloat(apy * 100, DEFAULT_APY_DECIMALS);
+            select: ({ validatorApys, isStakeSubsidyStarted }) => {
+                return validatorApys?.apys.reduce((acc, { apy, address }) => {
+                    acc[address] = {
+                        apy: roundFloat(apy * 100, DEFAULT_APY_DECIMALS),
+                        isApyApproxZero:
+                            !isStakeSubsidyStarted || apy < MINIMUM_THRESHOLD,
+                    };
                     return acc;
                 }, {} as ApyByValidator);
             },

--- a/apps/core/src/hooks/useGetValidatorsApy.ts
+++ b/apps/core/src/hooks/useGetValidatorsApy.ts
@@ -19,7 +19,7 @@ export interface ApyByValidator {
         isApyApproxZero: boolean;
     };
 }
-// For small APYs or AYPs before stakeSubsidyStartEpoch, show ~0% instead of 0%
+// For small APY or epoch before stakeSubsidyStartEpoch, show ~0% instead of 0%
 // If APY falls below 0.001, show ~0% instead of 0% since we round to 2 decimal places
 const MINIMUM_THRESHOLD = 0.001;
 

--- a/apps/core/src/utils/formatPercentageDisplay.ts
+++ b/apps/core/src/utils/formatPercentageDisplay.ts
@@ -4,7 +4,8 @@
 // For unavailable %, return '--' else return the APY number
 export function formatPercentageDisplay(
     value: number | null,
-    nullDisplay = '--'
+    nullDisplay = '--',
+    isApyApprox = false
 ) {
-    return value === null ? nullDisplay : `${value}%`;
+    return value === null ? nullDisplay : `${isApyApprox ? '~' : ''}${value}%`;
 }

--- a/apps/explorer/src/components/validator/ValidatorStats.tsx
+++ b/apps/explorer/src/components/validator/ValidatorStats.tsx
@@ -13,7 +13,7 @@ type StatsCardProps = {
     validatorData: SuiValidatorSummary;
     epoch: number | string;
     epochRewards: number | null;
-    apy: number;
+    apy: number | string | null;
     tallyingScore: string | null;
 };
 
@@ -49,7 +49,7 @@ export function ValidatorStats({
                             <Stats
                                 label="Staking APY"
                                 tooltip="This is the Annualized Percentage Yield of the a specific validator’s past operations. Note there is no guarantee this APY will be true in the future."
-                                unavailable={apy <= 0}
+                                unavailable={apy === null}
                             >
                                 {apy}%
                             </Stats>

--- a/apps/explorer/src/pages/validator/ValidatorDetails.tsx
+++ b/apps/explorer/src/pages/validator/ValidatorDetails.tsx
@@ -77,8 +77,8 @@ function ValidatorDetails() {
             </div>
         );
     }
+    const { apy, isApyApproxZero } = rollingAverageApys?.[id] ?? { apy: null };
 
-    const apy = rollingAverageApys?.[id] || 0;
     const tallyingScore =
         validatorEvents?.find(
             ({ parsedJson }) => parsedJson?.validator_address === id
@@ -93,7 +93,7 @@ function ValidatorDetails() {
                     validatorData={validatorData}
                     epoch={data.epoch}
                     epochRewards={validatorRewards}
-                    apy={apy}
+                    apy={isApyApproxZero ? '~0' : apy}
                     tallyingScore={tallyingScore}
                 />
             </div>

--- a/apps/explorer/src/pages/validators/Validators.tsx
+++ b/apps/explorer/src/pages/validators/Validators.tsx
@@ -260,7 +260,10 @@ function ValidatorPageResult() {
             return null;
 
         // if all validators have isApyApproxZero, return ~0
-        if (Object.values(validatorsApy)?.filter((a) => a.isApyApproxZero)) {
+        if (
+            Object.values(validatorsApy)?.filter((a) => a.isApyApproxZero)
+                .length === numberOfValidators
+        ) {
             return '~0';
         }
 
@@ -271,7 +274,7 @@ function ValidatorPageResult() {
         const averageAPY = apys?.reduce((acc, cur) => acc + cur.apy, 0);
         // in case of no apy, return 0
         return apys.length > 0 ? roundFloat(averageAPY / apys.length) : 0;
-    }, [validatorsApy]);
+    }, [numberOfValidators, validatorsApy]);
 
     const lastEpochRewardOnAllValidators = useMemo(() => {
         if (!validatorEvents) return null;

--- a/apps/explorer/src/pages/validators/Validators.tsx
+++ b/apps/explorer/src/pages/validators/Validators.tsx
@@ -55,6 +55,9 @@ export function validatorsTableData(
                 );
                 const isAtRisk = !!atRiskValidator;
                 const lastReward = event?.pool_staking_reward ?? null;
+                const { apy, isApyApproxZero } = rollingAverageApys?.[
+                    validator.suiAddress
+                ] ?? { apy: null };
 
                 return {
                     name: {
@@ -63,7 +66,9 @@ export function validatorsTableData(
                     },
                     stake: totalStake,
                     // show the rolling average apy even if its zero, otherwise show -- for no data
-                    apy: rollingAverageApys?.[validator.suiAddress] ?? null,
+                    apy:
+                        formatPercentageDisplay(apy, '--', isApyApproxZero) ??
+                        null,
                     nextEpochGasPrice: validator.nextEpochGasPrice,
                     commission: Number(validator.commissionRate) / 100,
                     img: img,
@@ -147,7 +152,7 @@ export function validatorsTableData(
                     const apy = props.getValue();
                     return (
                         <Text variant="bodySmall/medium" color="steel-darker">
-                            {formatPercentageDisplay(apy)}
+                            {apy}
                         </Text>
                     );
                 },
@@ -254,9 +259,16 @@ function ValidatorPageResult() {
         if (!validatorsApy || Object.keys(validatorsApy)?.length === 0)
             return null;
 
+        // if all validators have isApyApproxZero, return ~0
+        if (Object.values(validatorsApy)?.filter((a) => a.isApyApproxZero)) {
+            return '~0';
+        }
+
         // exclude validators with no apy
-        const apys = Object.values(validatorsApy)?.filter((a) => a > 0);
-        const averageAPY = apys?.reduce((acc, cur) => acc + cur, 0);
+        const apys = Object.values(validatorsApy)?.filter(
+            (a) => a.apy > 0 && !a.isApyApproxZero
+        );
+        const averageAPY = apys?.reduce((acc, cur) => acc + cur.apy, 0);
         // in case of no apy, return 0
         return apys.length > 0 ? roundFloat(averageAPY / apys.length) : 0;
     }, [validatorsApy]);

--- a/apps/explorer/src/pages/validators/Validators.tsx
+++ b/apps/explorer/src/pages/validators/Validators.tsx
@@ -66,9 +66,7 @@ export function validatorsTableData(
                     },
                     stake: totalStake,
                     // show the rolling average apy even if its zero, otherwise show -- for no data
-                    apy:
-                        formatPercentageDisplay(apy, '--', isApyApproxZero) ??
-                        null,
+                    apy: formatPercentageDisplay(apy, '--', isApyApproxZero),
                     nextEpochGasPrice: validator.nextEpochGasPrice,
                     commission: Number(validator.commissionRate) / 100,
                     img: img,
@@ -261,8 +259,9 @@ function ValidatorPageResult() {
 
         // if all validators have isApyApproxZero, return ~0
         if (
-            Object.values(validatorsApy)?.filter((a) => a.isApyApproxZero)
-                .length === numberOfValidators
+            Object.values(validatorsApy)?.every(
+                ({ isApyApproxZero }) => isApyApproxZero
+            )
         ) {
             return '~0';
         }
@@ -274,7 +273,7 @@ function ValidatorPageResult() {
         const averageAPY = apys?.reduce((acc, cur) => acc + cur.apy, 0);
         // in case of no apy, return 0
         return apys.length > 0 ? roundFloat(averageAPY / apys.length) : 0;
-    }, [numberOfValidators, validatorsApy]);
+    }, [validatorsApy]);
 
     const lastEpochRewardOnAllValidators = useMemo(() => {
         if (!validatorEvents) return null;

--- a/apps/wallet/src/shared/constants.ts
+++ b/apps/wallet/src/shared/constants.ts
@@ -15,4 +15,4 @@ export const DEFAULT_NFT_IMAGE =
 // number of epochs before earning
 // Staking Rewards Redeemable
 export const NUM_OF_EPOCH_BEFORE_STAKING_REWARDS_REDEEMABLE = 2;
-export const NUM_OF_EPOCH_BEFORE_STAKING__REWARDS_STARTS = 1;
+export const NUM_OF_EPOCH_BEFORE_STAKING_REWARDS_STARTS = 1;

--- a/apps/wallet/src/shared/constants.ts
+++ b/apps/wallet/src/shared/constants.ts
@@ -13,4 +13,6 @@ export const DEFAULT_NFT_IMAGE =
     'ipfs://QmZPWWy5Si54R3d26toaqRiqvCH7HkGdXkxwUgCm2oKKM2?filename=img-sq-01.png';
 
 // number of epochs before earning
-export const NUM_OF_EPOCH_BEFORE_EARNING = 2;
+// Staking Rewards Redeemable
+export const NUM_OF_EPOCH_BEFORE_STAKING_REWARDS_REDEEMABLE = 2;
+export const NUM_OF_EPOCH_BEFORE_STAKING__REWARDS_STARTS = 1;

--- a/apps/wallet/src/ui/app/components/receipt-card/StakeTxnCard.tsx
+++ b/apps/wallet/src/ui/app/components/receipt-card/StakeTxnCard.tsx
@@ -13,7 +13,7 @@ import { ValidatorLogo } from '_app/staking/validators/ValidatorLogo';
 import { TxnAmount } from '_components/receipt-card/TxnAmount';
 import {
     NUM_OF_EPOCH_BEFORE_STAKING_REWARDS_REDEEMABLE,
-    NUM_OF_EPOCH_BEFORE_STAKING__REWARDS_STARTS,
+    NUM_OF_EPOCH_BEFORE_STAKING_REWARDS_STARTS,
 } from '_src/shared/constants';
 import { CountDownTimer } from '_src/ui/app/shared/countdown-timer';
 import { Text } from '_src/ui/app/shared/text';
@@ -40,7 +40,7 @@ export function StakeTxnCard({ event }: StakeTxnCardProps) {
     // TODO: Get epochStartTimestampMs/StartDate
     // for staking epoch + NUM_OF_EPOCH_BEFORE_STAKING_REWARDS_REDEEMABLE
     const startEarningRewardsEpoch =
-        Number(stakedEpoch) + NUM_OF_EPOCH_BEFORE_STAKING__REWARDS_STARTS;
+        Number(stakedEpoch) + NUM_OF_EPOCH_BEFORE_STAKING_REWARDS_STARTS;
 
     const redeemableRewardsEpoch =
         Number(stakedEpoch) + NUM_OF_EPOCH_BEFORE_STAKING_REWARDS_REDEEMABLE;

--- a/apps/wallet/src/ui/app/components/receipt-card/StakeTxnCard.tsx
+++ b/apps/wallet/src/ui/app/components/receipt-card/StakeTxnCard.tsx
@@ -11,7 +11,10 @@ import { SUI_TYPE_ARG } from '@mysten/sui.js';
 import { Card } from '../../shared/transaction-summary/Card';
 import { ValidatorLogo } from '_app/staking/validators/ValidatorLogo';
 import { TxnAmount } from '_components/receipt-card/TxnAmount';
-import { NUM_OF_EPOCH_BEFORE_EARNING } from '_src/shared/constants';
+import {
+    NUM_OF_EPOCH_BEFORE_STAKING_REWARDS_REDEEMABLE,
+    NUM_OF_EPOCH_BEFORE_STAKING__REWARDS_STARTS,
+} from '_src/shared/constants';
 import { CountDownTimer } from '_src/ui/app/shared/countdown-timer';
 import { Text } from '_src/ui/app/shared/text';
 import { IconTooltip } from '_src/ui/app/shared/tooltip';
@@ -30,15 +33,24 @@ export function StakeTxnCard({ event }: StakeTxnCardProps) {
 
     const { data: rollingAverageApys } = useGetValidatorsApy();
 
-    const apy = rollingAverageApys?.[validatorAddress] ?? null;
-
+    const { apy, isApyApproxZero } = rollingAverageApys?.[validatorAddress] ?? {
+        apy: null,
+    };
     // Reward will be available after 2 epochs
-    // TODO: Get epochStartTimestampMs/StartDate for staking epoch + NUM_OF_EPOCH_BEFORE_EARNING
-    const startEarningRewardsEpoch = stakedEpoch + NUM_OF_EPOCH_BEFORE_EARNING;
+    // TODO: Get epochStartTimestampMs/StartDate
+    // for staking epoch + NUM_OF_EPOCH_BEFORE_STAKING_REWARDS_REDEEMABLE
+    const startEarningRewardsEpoch =
+        Number(stakedEpoch) + NUM_OF_EPOCH_BEFORE_STAKING__REWARDS_STARTS;
 
-    const { data: timeToEarnStakeRewards } = useGetTimeBeforeEpochNumber(
+    const redeemableRewardsEpoch =
+        Number(stakedEpoch) + NUM_OF_EPOCH_BEFORE_STAKING_REWARDS_REDEEMABLE;
+
+    const { data: timeBeforeStakeRewardsStarts } = useGetTimeBeforeEpochNumber(
         startEarningRewardsEpoch
     );
+
+    const { data: timeBeforeStakeRewardsRedeemable } =
+        useGetTimeBeforeEpochNumber(redeemableRewardsEpoch);
 
     return (
         <Card>
@@ -62,8 +74,8 @@ export function StakeTxnCard({ event }: StakeTxnCardProps) {
                     />
                 )}
                 <div className="flex flex-col">
-                    <div className="flex justify-between w-full pt-3.5">
-                        <div className="flex gap-1 items-baseline text-steel">
+                    <div className="flex justify-between w-full py-3.5">
+                        <div className="flex gap-1 items-baseline justify-center text-steel">
                             <Text
                                 variant="body"
                                 weight="medium"
@@ -78,9 +90,15 @@ export function StakeTxnCard({ event }: StakeTxnCardProps) {
                             weight="medium"
                             color="steel-darker"
                         >
-                            {formatPercentageDisplay(apy)}
+                            {formatPercentageDisplay(
+                                apy,
+                                '--',
+                                isApyApproxZero
+                            )}
                         </Text>
                     </div>
+                </div>
+                <div className="flex flex-col">
                     <div className="flex justify-between w-full py-3.5">
                         <div className="flex gap-1 items-baseline text-steel">
                             <Text
@@ -88,14 +106,15 @@ export function StakeTxnCard({ event }: StakeTxnCardProps) {
                                 weight="medium"
                                 color="steel-darker"
                             >
-                                {timeToEarnStakeRewards > 0
+                                {timeBeforeStakeRewardsStarts > 0
                                     ? 'Staking Rewards Start'
                                     : 'Staking Rewards Started'}
                             </Text>
                         </div>
-                        {timeToEarnStakeRewards > 0 ? (
+
+                        {timeBeforeStakeRewardsStarts > 0 ? (
                             <CountDownTimer
-                                timestamp={timeToEarnStakeRewards}
+                                timestamp={timeBeforeStakeRewardsStarts}
                                 variant="body"
                                 color="steel-darker"
                                 weight="medium"
@@ -111,6 +130,37 @@ export function StakeTxnCard({ event }: StakeTxnCardProps) {
                                 Epoch #{startEarningRewardsEpoch}
                             </Text>
                         )}
+                    </div>
+                    <div className="flex justify-between w-full">
+                        <div className="flex gap-1 flex-1 items-baseline text-steel">
+                            <Text
+                                variant="pBody"
+                                weight="medium"
+                                color="steel-darker"
+                            >
+                                Staking Rewards Redeemable
+                            </Text>
+                        </div>
+                        <div className="flex-1 flex justify-end gap-1 items-center">
+                            {timeBeforeStakeRewardsRedeemable > 0 ? (
+                                <CountDownTimer
+                                    timestamp={timeBeforeStakeRewardsRedeemable}
+                                    variant="body"
+                                    color="steel-darker"
+                                    weight="medium"
+                                    label="in"
+                                    endLabel="--"
+                                />
+                            ) : (
+                                <Text
+                                    variant="body"
+                                    weight="medium"
+                                    color="steel-darker"
+                                >
+                                    Epoch #{redeemableRewardsEpoch}
+                                </Text>
+                            )}
+                        </div>
                     </div>
                 </div>
             </div>

--- a/apps/wallet/src/ui/app/shared/delegated-apy/index.tsx
+++ b/apps/wallet/src/ui/app/shared/delegated-apy/index.tsx
@@ -29,7 +29,7 @@ export function DelegatedAPY({ stakedValidators }: DelegatedAPYProps) {
         let stakedAPYs = 0;
 
         stakedValidators.forEach((validatorAddress) => {
-            stakedAPYs += rollingAverageApys?.[validatorAddress] || 0;
+            stakedAPYs += rollingAverageApys?.[validatorAddress].apy || 0;
         });
 
         const averageAPY = stakedAPYs / stakedValidators.length;

--- a/apps/wallet/src/ui/app/staking/delegation-detail/DelegationDetailCard.tsx
+++ b/apps/wallet/src/ui/app/staking/delegation-detail/DelegationDetailCard.tsx
@@ -64,8 +64,7 @@ export function DelegationDetailCard({
     const suiEarned = BigInt(delegationData?.estimatedReward || 0n);
     const { apy, isApyApproxZero } = rollingAverageApys?.[validatorAddress] ?? {
         apy: 0,
-    };
-    // const apy = rollingAverageApys?.[validatorAddress] || 0;
+    };  
 
     const delegationId =
         delegationData?.status === 'Active' && delegationData?.stakedSuiId;

--- a/apps/wallet/src/ui/app/staking/delegation-detail/DelegationDetailCard.tsx
+++ b/apps/wallet/src/ui/app/staking/delegation-detail/DelegationDetailCard.tsx
@@ -64,7 +64,7 @@ export function DelegationDetailCard({
     const suiEarned = BigInt(delegationData?.estimatedReward || 0n);
     const { apy, isApyApproxZero } = rollingAverageApys?.[validatorAddress] ?? {
         apy: 0,
-    };  
+    };
 
     const delegationId =
         delegationData?.status === 'Active' && delegationData?.stakedSuiId;

--- a/apps/wallet/src/ui/app/staking/delegation-detail/DelegationDetailCard.tsx
+++ b/apps/wallet/src/ui/app/staking/delegation-detail/DelegationDetailCard.tsx
@@ -62,8 +62,10 @@ export function DelegationDetailCard({
     const totalStake = BigInt(delegationData?.principal || 0n);
 
     const suiEarned = BigInt(delegationData?.estimatedReward || 0n);
-
-    const apy = rollingAverageApys?.[validatorAddress] || 0;
+    const { apy, isApyApproxZero } = rollingAverageApys?.[validatorAddress] ?? {
+        apy: 0,
+    };
+    // const apy = rollingAverageApys?.[validatorAddress] || 0;
 
     const delegationId =
         delegationData?.status === 'Active' && delegationData?.stakedSuiId;
@@ -160,6 +162,7 @@ export function DelegationDetailCard({
                                                 color="gray-90"
                                                 leading="none"
                                             >
+                                                {isApyApproxZero ? '~' : ''}
                                                 {apy}
                                             </Heading>
 

--- a/apps/wallet/src/ui/app/staking/home/StakedCard.tsx
+++ b/apps/wallet/src/ui/app/staking/home/StakedCard.tsx
@@ -7,7 +7,7 @@ import { cx, cva, type VariantProps } from 'class-variance-authority';
 import { Link } from 'react-router-dom';
 
 import { ValidatorLogo } from '../validators/ValidatorLogo';
-import { NUM_OF_EPOCH_BEFORE_EARNING } from '_src/shared/constants';
+import { NUM_OF_EPOCH_BEFORE_STAKING_REWARDS_REDEEMABLE } from '_src/shared/constants';
 import { CountDownTimer } from '_src/ui/app/shared/countdown-timer';
 import { Text } from '_src/ui/app/shared/text';
 import { IconTooltip } from '_src/ui/app/shared/tooltip';
@@ -133,7 +133,8 @@ export function StakeCard({
     // For cool down epoch, show Available to withdraw add rewards to principal
     // Reward earning epoch is 2 epochs after stake request epoch
     const earningRewardsEpoch =
-        Number(stakeRequestEpoch) + NUM_OF_EPOCH_BEFORE_EARNING;
+        Number(stakeRequestEpoch) +
+        NUM_OF_EPOCH_BEFORE_STAKING_REWARDS_REDEEMABLE;
     const isEarnedRewards = currentEpoch >= Number(earningRewardsEpoch);
     const delegationState = inactiveValidator
         ? StakeState.IN_ACTIVE

--- a/apps/wallet/src/ui/app/staking/stake/StakeForm.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/StakeForm.tsx
@@ -18,7 +18,7 @@ import { Text } from '_app/shared/text';
 import NumberInput from '_components/number-input';
 import {
     NUM_OF_EPOCH_BEFORE_STAKING_REWARDS_REDEEMABLE,
-    NUM_OF_EPOCH_BEFORE_STAKING__REWARDS_STARTS,
+    NUM_OF_EPOCH_BEFORE_STAKING_REWARDS_STARTS,
 } from '_src/shared/constants';
 import { CountDownTimer } from '_src/ui/app/shared/countdown-timer';
 
@@ -65,7 +65,7 @@ function StakeForm({
 
     // Reward will be available after 2 epochs
     const startEarningRewardsEpoch =
-        Number(epoch || 0) + NUM_OF_EPOCH_BEFORE_STAKING__REWARDS_STARTS;
+        Number(epoch || 0) + NUM_OF_EPOCH_BEFORE_STAKING_REWARDS_STARTS;
 
     const redeemableRewardsEpoch =
         Number(epoch || 0) + NUM_OF_EPOCH_BEFORE_STAKING_REWARDS_REDEEMABLE;

--- a/apps/wallet/src/ui/app/staking/stake/StakeForm.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/StakeForm.tsx
@@ -16,7 +16,10 @@ import { createStakeTransaction } from './utils/transaction';
 import { Card } from '_app/shared/card';
 import { Text } from '_app/shared/text';
 import NumberInput from '_components/number-input';
-import { NUM_OF_EPOCH_BEFORE_EARNING } from '_src/shared/constants';
+import {
+    NUM_OF_EPOCH_BEFORE_STAKING_REWARDS_REDEEMABLE,
+    NUM_OF_EPOCH_BEFORE_STAKING__REWARDS_STARTS,
+} from '_src/shared/constants';
 import { CountDownTimer } from '_src/ui/app/shared/countdown-timer';
 
 const HIDE_MAX = true;
@@ -62,11 +65,17 @@ function StakeForm({
 
     // Reward will be available after 2 epochs
     const startEarningRewardsEpoch =
-        Number(epoch || 0) + NUM_OF_EPOCH_BEFORE_EARNING;
+        Number(epoch || 0) + NUM_OF_EPOCH_BEFORE_STAKING__REWARDS_STARTS;
 
-    const { data: timeToEarnStakeRewards } = useGetTimeBeforeEpochNumber(
+    const redeemableRewardsEpoch =
+        Number(epoch || 0) + NUM_OF_EPOCH_BEFORE_STAKING_REWARDS_REDEEMABLE;
+
+    const { data: timeBeforeStakeRewardsStarts } = useGetTimeBeforeEpochNumber(
         startEarningRewardsEpoch
     );
+
+    const { data: timeBeforeStakeRewardsRedeemable } =
+        useGetTimeBeforeEpochNumber(redeemableRewardsEpoch);
 
     return (
         <Form
@@ -130,9 +139,9 @@ function StakeForm({
                     <Text variant="body" weight="medium" color="steel-darker">
                         Staking Rewards Start
                     </Text>
-                    {timeToEarnStakeRewards > 0 ? (
+                    {timeBeforeStakeRewardsStarts > 0 ? (
                         <CountDownTimer
-                            timestamp={timeToEarnStakeRewards}
+                            timestamp={timeBeforeStakeRewardsStarts}
                             variant="body"
                             color="steel-darker"
                             weight="semibold"
@@ -150,6 +159,39 @@ function StakeForm({
                                 : '--'}
                         </Text>
                     )}
+                </div>
+                <div className="pb-3.75 flex justify-between item-center w-full">
+                    <div className="flex-1">
+                        <Text
+                            variant="pBody"
+                            weight="medium"
+                            color="steel-darker"
+                        >
+                            Staking Rewards Redeemable
+                        </Text>
+                    </div>
+                    <div className="flex-1 flex justify-end gap-1 items-center">
+                        {timeBeforeStakeRewardsRedeemable > 0 ? (
+                            <CountDownTimer
+                                timestamp={timeBeforeStakeRewardsRedeemable}
+                                variant="body"
+                                color="steel-darker"
+                                weight="semibold"
+                                label="in"
+                                endLabel="--"
+                            />
+                        ) : (
+                            <Text
+                                variant="body"
+                                weight="medium"
+                                color="steel-darker"
+                            >
+                                {epoch
+                                    ? `Epoch #${Number(redeemableRewardsEpoch)}`
+                                    : '--'}
+                            </Text>
+                        )}
+                    </div>
                 </div>
             </Card>
         </Form>

--- a/apps/wallet/src/ui/app/staking/stake/ValidatorFormDetail.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/ValidatorFormDetail.tsx
@@ -84,7 +84,9 @@ export function ValidatorFormDetail({
         );
     }, [system, totalValidatorsStake, validatorData]);
 
-    const apy = rollingAverageApys?.[validatorAddress] ?? null;
+    const { apy, isApyApproxZero } = rollingAverageApys?.[validatorAddress] ?? {
+        apy: null,
+    };
 
     if (isLoading || loadingValidators) {
         return (
@@ -157,7 +159,11 @@ export function ValidatorFormDetail({
                                 weight="semibold"
                                 color="gray-90"
                             >
-                                {apy === null ? '--' : `${apy}%`}
+                                {formatPercentageDisplay(
+                                    apy,
+                                    '--',
+                                    isApyApproxZero
+                                )}
                             </Text>
                         </div>
                         <div className="flex gap-2 items-center justify-between">

--- a/apps/wallet/src/ui/app/staking/stake/ValidatorFormDetail.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/ValidatorFormDetail.tsx
@@ -173,9 +173,9 @@ export function ValidatorFormDetail({
                                     weight="medium"
                                     color="steel-darker"
                                 >
-                                    Staking Share
+                                    Stake Share
                                 </Text>
-                                <IconTooltip tip="This is the Annualized Percentage Yield of the a specific validator’s past operations. Note there is no guarantee this APY will be true in the future." />
+                                <IconTooltip tip="The percentage of total stake managed by this validator" />
                             </div>
 
                             <Text

--- a/apps/wallet/src/ui/app/staking/validators/SelectValidatorCard.tsx
+++ b/apps/wallet/src/ui/app/staking/validators/SelectValidatorCard.tsx
@@ -60,15 +60,21 @@ export function SelectValidatorCard() {
         [data?.activeValidators]
     );
     const validatorList = useMemo(() => {
-        const sortedAsc = validatorsRandomOrder.map((validator) => ({
-            name: validator.name,
-            address: validator.suiAddress,
-            apy: rollingAverageApys?.[validator.suiAddress] ?? null,
-            stakeShare: calculateStakeShare(
-                BigInt(validator.stakingPoolSuiBalance),
-                BigInt(totalStake)
-            ),
-        }));
+        const sortedAsc = validatorsRandomOrder.map((validator) => {
+            const { apy, isApyApproxZero } = rollingAverageApys?.[
+                validator.suiAddress
+            ] ?? { apy: null };
+            return {
+                name: validator.name,
+                address: validator.suiAddress,
+                apy,
+                isApyApproxZero,
+                stakeShare: calculateStakeShare(
+                    BigInt(validator.stakingPoolSuiBalance),
+                    BigInt(totalStake)
+                ),
+            };
+        });
         if (sortKey) {
             sortedAsc.sort((a, b) => {
                 if (sortKey === 'name') {
@@ -189,7 +195,8 @@ export function SelectValidatorCard() {
                                         !sortKey || sortKey === 'name'
                                             ? null
                                             : validator[sortKey],
-                                        '-'
+                                        '-',
+                                        validator?.isApyApproxZero
                                     )}
                                 />
                             </div>


### PR DESCRIPTION
## Description 

Describe the changes or additions included in this PR.

Add `~` to APY if `stakeSubsidyStartEpoch` has not started
Add `Staking Rewards Redeemable` to wallet staking flow and receipt page
<img width="360" alt="Screenshot 2023-05-02 at 6 04 26 PM" src="https://user-images.githubusercontent.com/126525197/235795942-e3dc61a8-59f0-4b1d-ab1e-69301f677048.png">
<img width="343" alt="Screenshot 2023-05-02 at 6 24 53 PM" src="https://user-images.githubusercontent.com/126525197/235798775-479ca64d-6fd9-4370-b642-8bf83cf94b55.png">
<img width="371" alt="Screenshot 2023-05-02 at 6 25 00 PM" src="https://user-images.githubusercontent.com/126525197/235798778-3fef765b-d408-4e3c-a783-742bbe4662e6.png">

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
