### PR TITLE
[explorer]: Split balances changes by owner

### DIFF
--- a/apps/explorer/src/components/footer/Footer.tsx
+++ b/apps/explorer/src/components/footer/Footer.tsx
@@ -25,7 +25,7 @@ function FooterLinks() {
 
             <ul className="flex justify-center gap-6">
                 {socialLinks.map(({ children, href }) => (
-                    <li key="href">
+                    <li key={href}>
                         <Link variant="text" color="steel-darker" href={href}>
                             <div className="mt-2">{children}</div>
                         </Link>

--- a/apps/explorer/src/pages/transaction-result/TransactionData.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionData.tsx
@@ -25,28 +25,20 @@ import {
     TransactionBlockCardSection,
 } from '~/ui/TransactionBlockCard';
 
-function GasAmount({
-    amount,
-    isHighlighted,
-}: {
-    amount?: bigint | number;
-    isHighlighted?: boolean;
-}) {
+function GasAmount({ amount }: { amount?: bigint | number }) {
     const [formattedAmount, symbol] = useFormatCoin(
         amount,
         SUI_TYPE_ARG,
         CoinFormat.FULL
     );
 
-    const textColor = isHighlighted ? 'success-dark' : 'steel-darker';
-
     return (
         <div className="flex flex-wrap gap-1">
             <div className="flex flex-wrap items-center gap-1">
-                <Text variant="pBody/medium" color={textColor}>
+                <Text variant="pBody/medium" color="steel-darker">
                     {formattedAmount}
                 </Text>
-                <Text variant="subtitleSmall/medium" color={textColor}>
+                <Text variant="subtitleSmall/medium" color="steel-darker">
                     {symbol}
                 </Text>
             </div>
@@ -243,11 +235,11 @@ export function TransactionData({ transaction }: Props) {
                                         />
                                     </DescriptionItem>
 
-                                    <div className="mt-2 flex flex-col gap-2 rounded-xl border border-success px-4 py-2 md:flex-row md:items-center md:gap-4">
+                                    <div className="mt-2 flex flex-col gap-2 rounded-xl border border-dashed border-steel px-4 py-2 md:flex-row md:items-center md:gap-4">
                                         <div className="w-full md:w-40">
                                             <Text
                                                 variant="pBody/semibold"
-                                                color="success-dark"
+                                                color="steel-darker"
                                             >
                                                 Storage Rebate
                                             </Text>
@@ -255,7 +247,6 @@ export function TransactionData({ transaction }: Props) {
 
                                         <div className="ml-0 min-w-0 flex-1 leading-none">
                                             <GasAmount
-                                                isHighlighted
                                                 amount={
                                                     -Number(
                                                         gasUsed?.storageRebate

--- a/apps/explorer/src/pages/transaction-result/transaction-summary/BalanceChanges.tsx
+++ b/apps/explorer/src/pages/transaction-result/transaction-summary/BalanceChanges.tsx
@@ -66,11 +66,13 @@ function BalanceChangeEntry({ change }: { change: BalanceChangeSummary }) {
     );
 }
 
-export function BalanceChanges({ changes }: BalanceChangesProps) {
-    if (!changes?.length) return null;
-
-    const owner = changes[0]?.owner ?? '';
-
+function BalanceChangeCard({
+    changes,
+    owner,
+}: {
+    changes: BalanceChangeSummary[];
+    owner: string;
+}) {
     const coinTypesSet = new Set(changes.map((change) => change.coinType));
 
     return (
@@ -107,5 +109,30 @@ export function BalanceChanges({ changes }: BalanceChangesProps) {
                 ))}
             </div>
         </TransactionBlockCard>
+    );
+}
+
+export function BalanceChanges({ changes }: BalanceChangesProps) {
+    if (!changes?.length) return null;
+
+    const changesByOwner = changes.reduce((acc, change) => {
+        const owner = change.owner ?? '';
+
+        acc[owner] = acc[owner] ?? [];
+        acc[owner].push(change);
+
+        return acc;
+    }, {} as Record<string, BalanceChangeSummary[]>);
+
+    return (
+        <>
+            {Object.entries(changesByOwner).map(([owner, changes], index) => (
+                <BalanceChangeCard
+                    key={owner}
+                    changes={changes}
+                    owner={owner}
+                />
+            ))}
+        </>
     );
 }

--- a/apps/explorer/src/pages/transaction-result/transaction-summary/ObjectChanges.tsx
+++ b/apps/explorer/src/pages/transaction-result/transaction-summary/ObjectChanges.tsx
@@ -191,7 +191,8 @@ function ObjectChangeEntries({
 interface ObjectChangeEntryUpdatedProps extends ObjectChangeEntryBaseProps {
     data:
         | ObjectChangeEntryData<SuiObjectChangeMutated>
-        | ObjectChangeEntryData<SuiObjectChangeTransferred>;
+        | ObjectChangeEntryData<SuiObjectChangeTransferred>
+        | ObjectChangeEntryData<SuiObjectChangeCreated>;
 }
 
 export function ObjectChangeEntryUpdated({
@@ -279,21 +280,12 @@ export function ObjectChanges({ objectSummary }: ObjectChangesProps) {
     return (
         <>
             {objectSummary?.created?.length ? (
-                <TransactionBlockCard shadow title="Changes" size="sm">
-                    <div className="flex flex-col gap-3">
-                        {Object.values(createdChangesByOwner).map(
-                            (data, index) => (
-                                <ObjectChangeEntries
-                                    key={index}
-                                    type="created"
-                                    changeEntries={
-                                        data as unknown as SuiObjectChangeCreated[]
-                                    }
-                                />
-                            )
-                        )}
-                    </div>
-                </TransactionBlockCard>
+                <ObjectChangeEntryUpdated
+                    type="created"
+                    data={
+                        createdChangesByOwner as unknown as ObjectChangeEntryData<SuiObjectChangeCreated>
+                    }
+                />
             ) : null}
 
             {objectSummary.mutated?.length ? (


### PR DESCRIPTION
## Description 

- Split balance changes by owner instead of grouping
- Update Rebate to dash border


<img width="523" alt="Screenshot 2023-05-02 at 6 21 11 PM" src="https://user-images.githubusercontent.com/127577476/235817533-08459da2-5cbe-41ad-818f-f574b377ab02.png">


## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
