### PR TITLE
[explorer]: Refactor code to use Disclosure + Add Published in Summary view

### DIFF
--- a/apps/core/src/utils/transaction/getObjectChangeSummary.ts
+++ b/apps/core/src/utils/transaction/getObjectChangeSummary.ts
@@ -7,12 +7,14 @@ import {
     SuiObjectChangeTransferred,
     SuiObjectChangeCreated,
     SuiObjectChangeMutated,
+    SuiObjectChangePublished,
 } from '@mysten/sui.js';
 
 export type ObjectChangeSummary = {
     mutated: SuiObjectChangeMutated[];
     created: SuiObjectChangeCreated[];
     transferred: SuiObjectChangeTransferred[];
+    published: SuiObjectChangePublished[];
 };
 
 export const getObjectChangeSummary = (
@@ -37,9 +39,14 @@ export const getObjectChangeSummary = (
         (change) => change.type === 'transferred'
     ) as SuiObjectChangeTransferred[];
 
+    const published = objectChanges.filter(
+        (change) => change.type === 'published'
+    ) as SuiObjectChangePublished[];
+
     return {
         mutated,
         created,
         transferred,
+        published,
     };
 };

--- a/apps/explorer/src/components/GasBreakdown/index.tsx
+++ b/apps/explorer/src/components/GasBreakdown/index.tsx
@@ -12,7 +12,7 @@ import { CopyToClipboard } from '~/ui/CopyToClipboard';
 import { DescriptionItem } from '~/ui/DescriptionList';
 import { Divider } from '~/ui/Divider';
 import { Heading } from '~/ui/Heading';
-import { ObjectLink } from '~/ui/InternalLink';
+import { AddressLink, ObjectLink } from '~/ui/InternalLink';
 import { Text } from '~/ui/Text';
 import {
     TransactionBlockCard,
@@ -122,6 +122,8 @@ export function GasBreakdown({ summary }: GasBreakdownProps) {
     const gasPrice = gasData.price || 1;
     const gasBudget = gasData.budget;
     const totalGas = gasData.totalGas;
+    const owner = gasData.owner;
+    const isSponsored = gasData.isSponsored;
 
     return (
         <TransactionBlockCard
@@ -136,6 +138,15 @@ export function GasBreakdown({ summary }: GasBreakdownProps) {
             }
         >
             <TransactionBlockCardSection>
+                {isSponsored && owner && (
+                    <div className="mb-4 flex items-center gap-2 rounded-xl bg-sui/10 px-3 py-2">
+                        <Text variant="pBody/medium" color="steel-darker">
+                            Paid by
+                        </Text>
+                        <AddressLink address={owner} />
+                    </div>
+                )}
+
                 <div className="flex flex-col gap-3">
                     <Divider />
 

--- a/apps/explorer/src/pages/transaction-result/transaction-summary/BalanceChanges.tsx
+++ b/apps/explorer/src/pages/transaction-result/transaction-summary/BalanceChanges.tsx
@@ -38,7 +38,7 @@ function BalanceChangeEntry({ change }: { change: BalanceChangeSummary }) {
     return (
         <div className="flex flex-col gap-2 py-3 first:pt-0 only:pb-0 only:pt-0">
             <div className="flex flex-col gap-2">
-                <div className="flex justify-between">
+                <div className="flex flex-wrap justify-between">
                     <Text variant="pBody/medium" color="steel-dark">
                         Amount
                     </Text>
@@ -54,11 +54,11 @@ function BalanceChangeEntry({ change }: { change: BalanceChangeSummary }) {
                 </div>
 
                 {recipient && (
-                    <div className="flex justify-between">
+                    <div className="flex flex-wrap items-center justify-between">
                         <Text variant="pBody/medium" color="steel-dark">
                             Recipient
                         </Text>
-                        {recipient}
+                        <AddressLink address={recipient} />
                     </div>
                 )}
             </div>
@@ -90,7 +90,7 @@ function BalanceChangeCard({
             size="sm"
             footer={
                 owner ? (
-                    <div className="flex justify-between">
+                    <div className="flex flex-wrap justify-between">
                         <Text variant="pBody/medium" color="steel-dark">
                             Owner
                         </Text>
@@ -126,7 +126,7 @@ export function BalanceChanges({ changes }: BalanceChangesProps) {
 
     return (
         <>
-            {Object.entries(changesByOwner).map(([owner, changes], index) => (
+            {Object.entries(changesByOwner).map(([owner, changes]) => (
                 <BalanceChangeCard
                     key={owner}
                     changes={changes}

--- a/apps/explorer/src/ui/CoinsStack.tsx
+++ b/apps/explorer/src/ui/CoinsStack.tsx
@@ -28,15 +28,16 @@ function CoinIcon({ coinMetadata }: { coinMetadata?: CoinMetadata | null }) {
 
 export function Coin({ type }: { type: string }) {
     const { data: coinMetadata } = useCoinMetadata(type);
+    const { symbol, iconUrl } = coinMetadata || {};
 
     return (
         <span
             className={clsx(
                 'flex h-5 w-5 items-center justify-center rounded-xl text-white',
-                !coinMetadata &&
+                (!coinMetadata || symbol !== 'SUI') &&
                     'bg-gradient-to-r from-gradient-blue-start to-gradient-blue-end',
-                coinMetadata?.symbol === 'SUI' && 'bg-sui',
-                coinMetadata?.iconUrl && 'bg-gray-40'
+                symbol === 'SUI' && 'bg-sui',
+                iconUrl && 'bg-gray-40'
             )}
         >
             <CoinIcon coinMetadata={coinMetadata} />

--- a/apps/explorer/src/ui/TransactionBlockCard.tsx
+++ b/apps/explorer/src/ui/TransactionBlockCard.tsx
@@ -140,7 +140,7 @@ export function TransactionBlockCard({
     ...cardProps
 }: TransactionBlockCardProps) {
     return (
-        <div className="w-full">
+        <div className="relative w-full">
             <Card
                 rounded="2xl"
                 border="gray45"


### PR DESCRIPTION
## Description 

- Added `Published` module - Slack ref here https://mysten-labs.slack.com/archives/C032676BWGN/p1683072202860129?thread_ts=1683057960.874759&cid=C032676BWGN
- Refactor code to use `Disclosure` for Object open/close panel
- Wrap texts on ipad viewport
- Add `relative` to fix random white space on bottom of txn page
- Address link for recipient

<img width="292" alt="Screenshot 2023-05-03 at 1 36 20 PM" src="https://user-images.githubusercontent.com/127577476/236043803-4e44a657-90ee-44ce-97b6-551520d02b19.png">


## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
