### PR TITLE
explorer: gas price graph updates

### DIFF
--- a/apps/explorer/src/components/GasPriceCard/index.tsx
+++ b/apps/explorer/src/components/GasPriceCard/index.tsx
@@ -132,7 +132,7 @@ export function GasPriceCard({
         selectedUnit
     );
     const [selectedGraphDuration, setSelectedGraphsDuration] =
-        useState<GraphDurationsType>('7 EPOCHS');
+        useState<GraphDurationsType>('30 EPOCHS');
     const graphEpochs = useMemo(
         () =>
             historicalData?.slice(


### PR DESCRIPTION
* use epoch number for x axis label
* default to 30 epochs
* update number of tick based on the width of graph (assumes tick length of about 4 digits)



https://user-images.githubusercontent.com/10210143/235868884-6f9992b8-50c7-40b9-8a28-6b5454a102b5.mov



part of APPS-874