### PR TITLE
wallet-ext: show success icon when importing mnemonic

### DIFF
--- a/apps/wallet/src/ui/app/pages/initialize/backup/index.tsx
+++ b/apps/wallet/src/ui/app/pages/initialize/backup/index.tsx
@@ -92,7 +92,11 @@ const BackupPage = ({ mode = 'created' }: BackupPageProps) => {
                 </CardLayout>
             ) : (
                 <CardLayout
-                    icon={isOnboardingFlow ? 'success' : undefined}
+                    icon={
+                        isOnboardingFlow || mode === 'imported'
+                            ? 'success'
+                            : undefined
+                    }
                     title={
                         mode === 'imported'
                             ? 'Wallet Imported Successfully!'


### PR DESCRIPTION
| before | after |
| - | - |
| <img width="366" alt="Screenshot 2023-05-03 at 12 01 57" src="https://user-images.githubusercontent.com/10210143/235875644-f6a79702-39da-454d-bf24-5e2865a617f8.png"> | <img width="366" alt="Screenshot 2023-05-03 at 12 01 44" src="https://user-images.githubusercontent.com/10210143/235875705-d3a62c69-ac8e-48f5-a544-304d886fcfb4.png"> |

