### PR TITLE
[explorer] show non-FDV market cap on the token card

### DIFF
--- a/apps/explorer/src/components/SuiTokenCard.tsx
+++ b/apps/explorer/src/components/SuiTokenCard.tsx
@@ -17,7 +17,7 @@ export function SuiTokenCard() {
         // priceChangePercentageOver24H,
         currentPrice,
         totalSupply,
-        fullyDilutedMarketCap,
+        marketCap,
     } = data || {};
 
     // const isPriceChangePositive = Number(priceChangePercentageOver24H) > 0;
@@ -71,7 +71,7 @@ export function SuiTokenCard() {
                         postfix="USD"
                         unavailable={isLoading}
                     >
-                        {formatAmount(fullyDilutedMarketCap)}
+                        {formatAmount(marketCap)}
                     </StatsWrapper>
                     <StatsWrapper
                         label="Total Supply"


### PR DESCRIPTION
## Description 

<img width="493" alt="image" src="https://user-images.githubusercontent.com/7453188/235963471-5473f9fc-31f1-4844-a09d-b3fcb2a3cb09.png">

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
