### PR TITLE
keytool: show phrase in command output

### DIFF
--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -170,14 +170,15 @@ impl KeyToolCommand {
                     let file_name = format!("bls-{address}.key");
                     write_authority_keypair_to_file(&keypair, file_name)?;
                 } else {
-                    let (address, kp, scheme, _) =
+                    let (address, kp, scheme, phrase) =
                         generate_new_key(key_scheme, derivation_path, word_length)?;
                     let file = format!("{address}.key");
                     write_keypair_to_file(&kp, &file)?;
                     println!(
-                        "Keypair wrote to file path: {:?} with scheme: {:?}",
+                        "Created new keypair for address wrote to file path {:?} with scheme {:?}: [{address}]",
                         file, scheme
                     );
+                    println!("Secret Recovery Phrase : [{phrase}]");
                 }
             }
             KeyToolCommand::Show { file } => {


### PR DESCRIPTION
## Description 

show output in keytool command to match `sui client new-address`

## Test Plan 

target/debug/sui keytool generate ed25519

Created new keypair for address wrote to file path "0x26526b4396bb01cf6762c3f9d756bb19692e1b30dbd8779579848a5eaf92e9d5.key" with scheme ED25519: [0x26526b4396bb01cf6762c3f9d756bb19692e1b30dbd8779579848a5eaf92e9d5]
Secret Recovery Phrase : [visa enact radio buzz dial helmet enlist speak weapon census million leaf]

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
