### PR TITLE
[refactor] add transaction type to consensus_adapter metrics

### DIFF
--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -415,7 +415,7 @@ impl<T> ConsensusHandler<T> {
     }
 }
 
-fn classify(transaction: &ConsensusTransaction) -> &'static str {
+pub(crate) fn classify(transaction: &ConsensusTransaction) -> &'static str {
     match &transaction.kind {
         ConsensusTransactionKind::UserTransaction(certificate) => {
             if certificate.contains_shared_object() {


### PR DESCRIPTION
## Description 

Getting better visibility to the type of transactions send via consensus adapter. Currently we can't differentiate the volume which in some cases is helpful.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
