### PR TITLE
changing max concurrency option in faucet build

### DIFF
--- a/crates/sui-cluster-test/src/cluster.rs
+++ b/crates/sui-cluster-test/src/cluster.rs
@@ -318,7 +318,7 @@ pub async fn new_wallet_context_from_cluster(
         wallet_config_path
     );
 
-    WalletContext::new(&wallet_config_path, None)
+    WalletContext::new(&wallet_config_path, None, None)
         .await
         .unwrap_or_else(|e| {
             panic!(

--- a/crates/sui-faucet/src/bin/merge_coins.rs
+++ b/crates/sui-faucet/src/bin/merge_coins.rs
@@ -76,5 +76,5 @@ async fn main() -> Result<(), anyhow::Error> {
 pub async fn create_wallet_context(timeout_secs: u64) -> Result<WalletContext, anyhow::Error> {
     let wallet_conf = sui_config_dir()?.join(SUI_CLIENT_CONFIG);
     info!("Initialize wallet from config path: {:?}", wallet_conf);
-    WalletContext::new(&wallet_conf, Some(Duration::from_secs(timeout_secs))).await
+    WalletContext::new(&wallet_conf, Some(Duration::from_secs(timeout_secs)), None).await
 }

--- a/crates/sui-faucet/src/main.rs
+++ b/crates/sui-faucet/src/main.rs
@@ -173,7 +173,12 @@ async fn request_gas(
 async fn create_wallet_context(timeout_secs: u64) -> Result<WalletContext, anyhow::Error> {
     let wallet_conf = sui_config_dir()?.join(SUI_CLIENT_CONFIG);
     info!("Initialize wallet from config path: {:?}", wallet_conf);
-    WalletContext::new(&wallet_conf, Some(Duration::from_secs(timeout_secs))).await
+    WalletContext::new(
+        &wallet_conf,
+        Some(Duration::from_secs(timeout_secs)),
+        Some(1000),
+    )
+    .await
 }
 
 async fn handle_error(error: BoxError) -> impl IntoResponse {

--- a/crates/sui-sdk/src/sui_client_config.rs
+++ b/crates/sui-sdk/src/sui_client_config.rs
@@ -71,6 +71,7 @@ impl SuiEnv {
     pub async fn create_rpc_client(
         &self,
         request_timeout: Option<std::time::Duration>,
+        max_concurrent_requests: Option<u64>,
     ) -> Result<SuiClient, anyhow::Error> {
         let mut builder = SuiClientBuilder::default();
         if let Some(request_timeout) = request_timeout {
@@ -78,6 +79,10 @@ impl SuiEnv {
         }
         if let Some(ws_url) = &self.ws {
             builder = builder.ws_url(ws_url);
+        }
+
+        if let Some(max_concurrent_requests) = max_concurrent_requests {
+            builder = builder.max_concurrent_requests(max_concurrent_requests as usize);
         }
         Ok(builder.build(&self.rpc).await?)
     }

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1154,7 +1154,7 @@ impl SuiClientCommands {
                 let env = SuiEnv { alias, rpc, ws };
 
                 // Check urls are valid and server is reachable
-                env.create_rpc_client(None).await?;
+                env.create_rpc_client(None, None).await?;
                 context.config.envs.push(env.clone());
                 context.config.save()?;
                 SuiClientCommandResult::NewEnv(env)

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -257,7 +257,7 @@ impl SuiCommand {
             SuiCommand::Console { config } => {
                 let config = config.unwrap_or(sui_config_dir()?.join(SUI_CLIENT_CONFIG));
                 prompt_if_no_config(&config, false).await?;
-                let context = WalletContext::new(&config, None).await?;
+                let context = WalletContext::new(&config, None, None).await?;
                 start_console(context, &mut stdout(), &mut stderr()).await
             }
             SuiCommand::Client {
@@ -268,7 +268,7 @@ impl SuiCommand {
             } => {
                 let config_path = config.unwrap_or(sui_config_dir()?.join(SUI_CLIENT_CONFIG));
                 prompt_if_no_config(&config_path, accept_defaults).await?;
-                let mut context = WalletContext::new(&config_path, None).await?;
+                let mut context = WalletContext::new(&config_path, None, None).await?;
                 if let Some(cmd) = cmd {
                     cmd.execute(&mut context).await?.print(!json);
                 } else {
@@ -287,7 +287,7 @@ impl SuiCommand {
             } => {
                 let config_path = config.unwrap_or(sui_config_dir()?.join(SUI_CLIENT_CONFIG));
                 prompt_if_no_config(&config_path, accept_defaults).await?;
-                let mut context = WalletContext::new(&config_path, None).await?;
+                let mut context = WalletContext::new(&config_path, None, None).await?;
                 if let Some(cmd) = cmd {
                     cmd.execute(&mut context).await?.print(!json);
                 } else {

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -507,7 +507,7 @@ impl TestClusterBuilder {
             .save()?;
 
         let wallet_conf = swarm.dir().join(SUI_CLIENT_CONFIG);
-        let wallet = WalletContext::new(&wallet_conf, None).await?;
+        let wallet = WalletContext::new(&wallet_conf, None, None).await?;
 
         Ok(TestCluster {
             swarm,


### PR DESCRIPTION
## Description 

Adding max_concurrency as a client option on the faucet.

## Test Plan 

CI/CD
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
