### PR TITLE
Increase move verifier timeout & add metrics

### DIFF
--- a/crates/sui-adapter/src/adapter.rs
+++ b/crates/sui-adapter/src/adapter.rs
@@ -218,19 +218,19 @@ pub fn run_metered_move_bytecode_verifier_impl(
             ]
             .contains(&e.major_status())
             {
-                metrics.verifier_timeout_metrics.with_label_values(&["move_verifier", "failed"]).inc();
+                metrics.verifier_timeout_metrics.with_label_values(&[BytecodeVerifierMetrics::MOVE_VERIFIER_TAG, BytecodeVerifierMetrics::TIMEOUT_TAG]).inc();
                 return Err(SuiError::ModuleVerificationFailure {
                     error: "Verification timedout".to_string(),
                 });
             };
         } else {
             sui_verify_module_metered(protocol_config, module, &BTreeMap::new(), meter).map_err(|err|{
-                metrics.verifier_timeout_metrics.with_label_values(&["sui_verifier", "failed"]).inc();
+                metrics.verifier_timeout_metrics.with_label_values(&[ BytecodeVerifierMetrics::SUI_VERIFIER_TAG, BytecodeVerifierMetrics::TIMEOUT_TAG]).inc();
                 err
             })?
         }
+        metrics.verifier_timeout_metrics.with_label_values(&[BytecodeVerifierMetrics::OVERALL_TAG, BytecodeVerifierMetrics::SUCCESS_TAG]).inc();
     }
-    metrics.verifier_timeout_metrics.with_label_values(&["overall", "succeeded"]).inc();
     Ok(())
 }
 

--- a/crates/sui-adapter/src/adapter.rs
+++ b/crates/sui-adapter/src/adapter.rs
@@ -14,6 +14,7 @@ use move_vm_runtime::{
     native_extensions::NativeContextExtensions,
     native_functions::NativeFunctionTable,
 };
+use sui_types::metrics::BytecodeVerifierMetrics;
 use tracing::instrument;
 
 use sui_move_natives::{object_runtime::ObjectRuntime, NativesCostTable};
@@ -169,6 +170,7 @@ pub fn run_metered_move_bytecode_verifier(
     protocol_config: &ProtocolConfig,
     metered_verifier_config: &VerifierConfig,
     meter: &mut impl Meter,
+    metrics: &Arc<BytecodeVerifierMetrics>
 ) -> Result<(), SuiError> {
     let modules_stat = module_bytes
         .iter()
@@ -193,6 +195,7 @@ pub fn run_metered_move_bytecode_verifier(
         protocol_config,
         metered_verifier_config,
         meter,
+        metrics,
     )
 }
 
@@ -201,6 +204,7 @@ pub fn run_metered_move_bytecode_verifier_impl(
     protocol_config: &ProtocolConfig,
     verifier_config: &VerifierConfig,
     meter: &mut impl Meter,
+    metrics: &Arc<BytecodeVerifierMetrics>
 ) -> Result<(), SuiError> {
     // run the Move verifier
     for module in modules.iter() {
@@ -214,14 +218,19 @@ pub fn run_metered_move_bytecode_verifier_impl(
             ]
             .contains(&e.major_status())
             {
+                metrics.verifier_timeout_metrics.with_label_values(&["move_verifier", "failed"]).inc();
                 return Err(SuiError::ModuleVerificationFailure {
                     error: "Verification timedout".to_string(),
                 });
             };
         } else {
-            sui_verify_module_metered(protocol_config, module, &BTreeMap::new(), meter)?
+            sui_verify_module_metered(protocol_config, module, &BTreeMap::new(), meter).map_err(|err|{
+                metrics.verifier_timeout_metrics.with_label_values(&["sui_verifier", "failed"]).inc();
+                err
+            })?
         }
     }
+    metrics.verifier_timeout_metrics.with_label_values(&["overall", "succeeded"]).inc();
     Ok(())
 }
 

--- a/crates/sui-core/src/unit_tests/move_package_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_tests.rs
@@ -485,11 +485,13 @@ async fn test_metered_move_bytecode_verifier() {
     metered_verifier_config.max_per_fun_meter_units = Some(10_000);
 
     let mut meter = BoundMeter::new(&metered_verifier_config);
+    let bytecode_verifier_metrics = Arc::new(BytecodeVerifierMetrics::new(registry));
     let r = run_metered_move_bytecode_verifier_impl(
         &compiled_modules_bytes,
         &ProtocolConfig::get_for_max_version(),
         &metered_verifier_config,
         &mut meter,
+        &bytecode_verifier_metrics,
     );
 
     assert!(
@@ -539,6 +541,7 @@ async fn test_metered_move_bytecode_verifier() {
         default_verifier_config(&protocol_config, true /* enable metering */);
     // Check if the same meter is indeed used for all modules
     let mut meter = BoundMeter::new(&metered_verifier_config);
+    let bytecode_verifier_metrics = Arc::new(BytecodeVerifierMetrics::new(registry));
     if let TransactionKind::ProgrammableTransaction(pt) = tx_data.kind() {
         pt.non_system_packages_to_be_published()
             .try_for_each(|q| {
@@ -552,6 +555,7 @@ async fn test_metered_move_bytecode_verifier() {
                     &protocol_config,
                     &metered_verifier_config,
                     &mut meter,
+                    &bytecode_verifier_metrics,
                 );
                 // Check that at least one of the meter values has increased
                 assert!(

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -33,7 +33,7 @@ const MAX_PROTOCOL_VERSION: u64 = 10;
 // Version 9: Limit the length of Move idenfitiers to 128.
 //            Disallow extraneous module bytes,
 //            advance_to_highest_supported_protocol_version,
-// Version 10:
+// Version 10:increase bytecode verifier limits from 6_000_000 to 16_000_000
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -1130,7 +1130,11 @@ impl ProtocolConfig {
                     .advance_to_highest_supported_protocol_version = true;
                 cfg
             }
-            10 => Self::get_for_version_impl(version - 1),
+            10 => {
+                let mut cfg = Self::get_for_version_impl(version - 1);
+                cfg.max_verifier_meter_ticks_per_function = Some(16_000_000);
+                cfg
+            }
             // Use this template when making changes:
             //
             //     // modify an existing constant.

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -33,7 +33,8 @@ const MAX_PROTOCOL_VERSION: u64 = 10;
 // Version 9: Limit the length of Move idenfitiers to 128.
 //            Disallow extraneous module bytes,
 //            advance_to_highest_supported_protocol_version,
-// Version 10:increase bytecode verifier limits from 6_000_000 to 16_000_000
+// Version 10:increase bytecode verifier `max_verifier_meter_ticks_per_function` and
+//            `max_meter_ticks_per_module` limits each from 6_000_000 to 16_000_000
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -1133,6 +1134,7 @@ impl ProtocolConfig {
             10 => {
                 let mut cfg = Self::get_for_version_impl(version - 1);
                 cfg.max_verifier_meter_ticks_per_function = Some(16_000_000);
+                cfg.max_meter_ticks_per_module = Some(16_000_000);
                 cfg
             }
             // Use this template when making changes:

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_10.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_10.snap
@@ -59,8 +59,8 @@ max_move_vector_len: 262144
 max_move_identifier_len: 128
 max_back_edges_per_function: 10000
 max_back_edges_per_module: 10000
-max_verifier_meter_ticks_per_function: 6000000
-max_meter_ticks_per_module: 6000000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
 object_runtime_max_num_cached_objects: 1000
 object_runtime_max_num_cached_objects_system_tx: 16000
 object_runtime_max_num_store_entries: 1000

--- a/crates/sui-types/src/metrics.rs
+++ b/crates/sui-types/src/metrics.rs
@@ -69,3 +69,21 @@ impl LimitsMetrics {
         }
     }
 }
+
+pub struct BytecodeVerifierMetrics {
+    /// Bytecode verifier metrics
+    pub verifier_timeout_metrics: IntCounterVec,
+}
+
+impl BytecodeVerifierMetrics {
+    pub fn new(registry: &prometheus::Registry) -> Self {
+        Self {
+            verifier_timeout_metrics: register_int_counter_vec_with_registry!(
+                "verifier_timeout_metrics",
+                "Number of timeouts in bytecode verifier",
+                &["verifier_meter", "status"],
+                registry,
+            ).unwrap(),
+        }
+    }
+}

--- a/crates/sui-types/src/metrics.rs
+++ b/crates/sui-types/src/metrics.rs
@@ -76,6 +76,11 @@ pub struct BytecodeVerifierMetrics {
 }
 
 impl BytecodeVerifierMetrics {
+    pub const MOVE_VERIFIER_TAG: &'static str = "move_verifier";
+    pub const SUI_VERIFIER_TAG: &'static str = "sui_verifier";
+    pub const OVERALL_TAG: &'static str = "overall";
+    pub const SUCCESS_TAG: &'static str = "success";
+    pub const TIMEOUT_TAG: &'static str = "failed";
     pub fn new(registry: &prometheus::Registry) -> Self {
         Self {
             verifier_timeout_metrics: register_int_counter_vec_with_registry!(
@@ -83,7 +88,8 @@ impl BytecodeVerifierMetrics {
                 "Number of timeouts in bytecode verifier",
                 &["verifier_meter", "status"],
                 registry,
-            ).unwrap(),
+            )
+            .unwrap(),
         }
     }
 }

--- a/sui_programmability/examples/math/sources/ecdsa.move
+++ b/sui_programmability/examples/math/sources/ecdsa.move
@@ -26,7 +26,7 @@ module math::ecdsa_k1 {
     public entry fun keccak256(data: vector<u8>, recipient: address, ctx: &mut TxContext) {
         let hashed = Output {
             id: object::new(ctx),
-            value: ecdsa_k1::keccak256(&data),
+            value: sui::hash::keccak256(&data),
         };
         // Transfer an output data object holding the hashed data to the recipient.
         transfer::public_transfer(hashed, recipient)
@@ -65,7 +65,7 @@ module math::ecdsa_k1 {
         };
 
         // Take the last 20 bytes of the hash of the 64-bytes uncompressed pubkey.
-        let hashed = ecdsa_k1::keccak256(&uncompressed_64);
+        let hashed = sui::hash::keccak256(&uncompressed_64);
         let addr = vector::empty<u8>();
         let i = 12;
         while (i < 32) {

--- a/sui_programmability/examples/utils/sources/immutable_external_resource.move
+++ b/sui_programmability/examples/utils/sources/immutable_external_resource.move
@@ -7,7 +7,6 @@
 /// RFC 2119.
 ///
 module utils::immutable_external_resource {
-    use sui::digest::Sha3256Digest;
     use sui::url::{Url, inner_url};
 
     /// ImmutableExternalResource: An arbitrary, mutable URL plus an immutable digest of the resource.
@@ -23,16 +22,16 @@ module utils::immutable_external_resource {
     /// the result is false, clients SHOULD indicate that to users or ignore the resource.
     struct ImmutableExternalResource has store, copy, drop {
         url: Url,
-        digest: Sha3256Digest,
+        digest: vector<u8>,
     }
 
     /// Create a `ImmutableExternalResource`, and set the immutable hash.
-    public fun new(url: Url, digest: Sha3256Digest): ImmutableExternalResource {
+    public fun new(url: Url, digest: vector<u8>): ImmutableExternalResource {
         ImmutableExternalResource { url, digest }
     }
 
     /// Get the hash of the resource.
-    public fun digest(self: &ImmutableExternalResource): Sha3256Digest {
+    public fun digest(self: &ImmutableExternalResource): vector<u8> {
         self.digest
     }
 


### PR DESCRIPTION
## Description 

Increases the verifier timeout limits, adds test
Adds metrics and metrics tests

## Test Plan 

Unit tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
