### PR TITLE
[sui-proxy/add debug logging]

### DIFF
--- a/crates/sui-proxy/src/consumer.rs
+++ b/crates/sui-proxy/src/consumer.rs
@@ -101,15 +101,15 @@ impl ProtobufDecoder {
 
 // populate labels in place for our given metric family data
 pub fn populate_labels(
-    name: String,    // host field for grafana agent (from chain data)
-    network: String, // network name from ansible (via config)
-    // TODO use in stderr logging, see below
-    _inventory_hostname: String, // inventory_name from ansible (via config)
+    name: String,               // host field for grafana agent (from chain data)
+    network: String,            // network name from ansible (via config)
+    inventory_hostname: String, // inventory_name from ansible (via config)
     data: Vec<proto::MetricFamily>,
 ) -> Vec<proto::MetricFamily> {
     let timer = CONSUMER_OPERATION_DURATION
         .with_label_values(&["populate_labels"])
         .start_timer();
+    debug!("received metrics from {name} on {inventory_hostname}");
     // proto::LabelPair doesn't have pub fields so we can't use
     // struct literals to construct
     let mut network_label = proto::LabelPair::default();
@@ -119,11 +119,6 @@ pub fn populate_labels(
     let mut host_label = proto::LabelPair::default();
     host_label.set_name("host".into());
     host_label.set_value(name);
-
-    // TODO add this back in via stderr logging only and not in relayed samples
-    // let mut relay_host_label = proto::LabelPair::default();
-    // relay_host_label.set_name("relay_host".into());
-    // relay_host_label.set_value(inventory_hostname);
 
     let labels = vec![network_label, host_label];
 


### PR DESCRIPTION
Description
* add debug logging for the inventory_hostname so we can, if we wish, log what host is hitting what proxy.
* this was previously in the metric labels but caused too many dimensions

Test Plan 
* cargo build/test/fmt/clippy

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
