### PR TITLE
[Part 1/2] Delete test utils messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8998,6 +8998,7 @@ dependencies = [
  "sui-protocol-config",
  "sui-sdk",
  "sui-simulator",
+ "sui-test-transaction-builder",
  "sui-types",
  "sysinfo",
  "telemetry-subscribers",
@@ -9151,6 +9152,7 @@ dependencies = [
  "sui-protocol-config",
  "sui-simulator",
  "sui-storage",
+ "sui-test-transaction-builder",
  "sui-types",
  "sui-verifier",
  "tap",
@@ -9184,6 +9186,7 @@ dependencies = [
  "sui-config",
  "sui-core",
  "sui-move-build",
+ "sui-test-transaction-builder",
  "sui-types",
  "test-utils",
  "tokio",
@@ -10068,6 +10071,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sui-test-transaction-builder"
+version = "1.1.0"
+dependencies = [
+ "move-core-types",
+ "shared-crypto",
+ "sui-move-build",
+ "sui-types",
+ "workspace-hack",
+]
+
+[[package]]
 name = "sui-test-validator"
 version = "0.0.0"
 dependencies = [
@@ -10580,6 +10594,7 @@ dependencies = [
  "sui-sdk",
  "sui-simulator",
  "sui-swarm",
+ "sui-test-transaction-builder",
  "sui-types",
  "tempfile",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ members = [
     "crates/sui-surfer",
     "crates/sui-swarm",
     "crates/sui-telemetry",
+    "crates/sui-test-transaction-builder",
     "crates/sui-test-validator",
     "crates/sui-tls",
     "crates/sui-tool",

--- a/crates/sui-benchmark/Cargo.toml
+++ b/crates/sui-benchmark/Cargo.toml
@@ -36,6 +36,7 @@ sui-keys = { path = "../sui-keys" }
 sui-node = { path = "../sui-node" }
 sui-json-rpc-types = { path = "../sui-json-rpc-types" }
 sui-protocol-config = { path = "../sui-protocol-config" }
+sui-test-transaction-builder = { path = "../sui-test-transaction-builder" }
 telemetry-subscribers.workspace = true
 roaring = "0.10.1"
 regex = "1.7.1"

--- a/crates/sui-benchmark/src/util.rs
+++ b/crates/sui-benchmark/src/util.rs
@@ -8,16 +8,13 @@ use sui_types::{base_types::SuiAddress, crypto::SuiKeyPair};
 use crate::ValidatorProxy;
 use std::path::PathBuf;
 use std::sync::Arc;
+use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_types::base_types::ObjectRef;
-use sui_types::messages::{
-    TransactionData, VerifiedTransaction, TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
-    TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
-};
+use sui_types::messages::{TransactionData, VerifiedTransaction, TEST_ONLY_GAS_UNIT_FOR_TRANSFER};
 use sui_types::utils::to_sender_signed_transaction;
 
 use crate::workloads::Gas;
 use sui_types::crypto::{AccountKeyPair, KeypairTraits};
-use test_utils::messages::create_publish_move_package_transaction;
 use test_utils::transaction::parse_package_ref;
 
 // This is the maximum gas we will transfer from primary coin into any gas coin
@@ -64,16 +61,9 @@ pub async fn publish_basics_package(
     keypair: &AccountKeyPair,
     gas_price: u64,
 ) -> ObjectRef {
-    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    path.push("../../sui_programmability/examples/basics");
-    let transaction = create_publish_move_package_transaction(
-        gas,
-        path,
-        sender,
-        keypair,
-        gas_price * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
-        gas_price,
-    );
+    let transaction = TestTransactionBuilder::new(sender, gas, gas_price)
+        .publish_examples("basics")
+        .build_and_sign(keypair);
     let effects = proxy
         .execute_transaction_block(transaction.into())
         .await

--- a/crates/sui-benchmark/src/workloads/shared_counter.rs
+++ b/crates/sui-benchmark/src/workloads/shared_counter.rs
@@ -15,12 +15,12 @@ use async_trait::async_trait;
 use futures::future::join_all;
 use rand::seq::SliceRandom;
 use std::sync::Arc;
+use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_types::crypto::get_key_pair;
 use sui_types::{
     base_types::{ObjectDigest, ObjectID, SequenceNumber},
     messages::VerifiedTransaction,
 };
-use test_utils::messages::{make_counter_create_transaction, make_counter_increment_transaction};
 use tracing::{debug, error, info};
 
 #[derive(Debug)]
@@ -47,18 +47,20 @@ impl Payload for SharedCounterTestPayload {
         self.gas.0 = effects.gas_object().0;
     }
     fn make_transaction(&mut self) -> VerifiedTransaction {
-        make_counter_increment_transaction(
-            self.gas.0,
-            self.package_id,
-            self.counter_id,
-            self.counter_initial_shared_version,
+        TestTransactionBuilder::new(
             self.gas.1,
-            &self.gas.2,
+            self.gas.0,
             self.system_state_observer
                 .state
                 .borrow()
                 .reference_gas_price,
         )
+        .call_counter_increment(
+            self.package_id,
+            self.counter_id,
+            self.counter_initial_shared_version,
+        )
+        .build_and_sign(self.gas.2.as_ref())
     }
 }
 
@@ -196,13 +198,9 @@ impl Workload<dyn Payload> for SharedCounterWorkload {
         }
         let mut futures = vec![];
         for (gas, sender, keypair) in tail.iter() {
-            let transaction = make_counter_create_transaction(
-                *gas,
-                self.basics_package_id.unwrap(),
-                *sender,
-                keypair,
-                gas_price,
-            );
+            let transaction = TestTransactionBuilder::new(*sender, *gas, gas_price)
+                .call_counter_create(self.basics_package_id.unwrap())
+                .build_and_sign(keypair.as_ref());
             let proxy_ref = proxy.clone();
             futures.push(async move {
                 if let Ok(effects) = proxy_ref

--- a/crates/sui-cluster-test/src/lib.rs
+++ b/crates/sui-cluster-test/src/lib.rs
@@ -20,7 +20,6 @@ use sui_types::base_types::TransactionDigest;
 use sui_types::object::Owner;
 use sui_types::quorum_driver_types::ExecuteTransactionRequestType;
 use sui_types::sui_system_state::sui_system_state_summary::SuiSystemStateSummary;
-use test_utils::messages::make_transactions_with_wallet_context;
 
 use shared_crypto::intent::Intent;
 use sui_sdk::SuiClient;
@@ -132,8 +131,10 @@ impl TestContext {
 
     /// See `make_transactions_with_wallet_context` for potential caveats
     /// of this helper function.
-    pub async fn make_transactions(&mut self, max_txn_num: usize) -> Vec<VerifiedTransaction> {
-        make_transactions_with_wallet_context(self.get_wallet_mut(), max_txn_num).await
+    pub async fn make_transactions(&self, max_txn_num: usize) -> Vec<VerifiedTransaction> {
+        self.get_wallet()
+            .batch_make_transfer_transactions(max_txn_num)
+            .await
     }
 
     pub async fn build_transaction_remotely(

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -75,6 +75,7 @@ sui-network = { path = "../sui-network" }
 sui-protocol-config = { path = "../sui-protocol-config" }
 sui-simulator = { path = "../sui-simulator" }
 sui-storage = { path = "../sui-storage" }
+sui-test-transaction-builder = { path = "../sui-test-transaction-builder" }
 sui-types = { path = "../sui-types" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 

--- a/crates/sui-cost/Cargo.toml
+++ b/crates/sui-cost/Cargo.toml
@@ -16,6 +16,7 @@ strum = { version = "0.24", features = ["derive"] }
 strum_macros = "0.24"
 bcs = "0.1.4"
 sui-core = { path = "../sui-core" }
+sui-test-transaction-builder = { path = "../sui-test-transaction-builder" }
 
 [dev-dependencies]
 insta = { version = "1.21.1", features = ["redactions", "json"] }

--- a/crates/sui-sdk/src/wallet_context.rs
+++ b/crates/sui-sdk/src/wallet_context.rs
@@ -5,6 +5,7 @@ use crate::sui_client_config::SuiClientConfig;
 use crate::SuiClient;
 use anyhow::anyhow;
 use colored::Colorize;
+use shared_crypto::intent::Intent;
 use std::collections::BTreeSet;
 use std::path::Path;
 use std::sync::Arc;
@@ -15,8 +16,12 @@ use sui_json_rpc_types::{
 };
 use sui_keys::keystore::AccountKeystore;
 use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
+use sui_types::crypto::{get_key_pair, AccountKeyPair};
 use sui_types::gas_coin::GasCoin;
-use sui_types::messages::VerifiedTransaction;
+use sui_types::messages::TransactionDataAPI;
+use sui_types::messages::{
+    Transaction, TransactionData, VerifiedTransaction, TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+};
 use tokio::sync::RwLock;
 use tracing::warn;
 
@@ -248,6 +253,21 @@ impl WalletContext {
         Ok(gas_price)
     }
 
+    /// Sign a transaction with a key currently managed by the WalletContext
+    pub fn sign_transaction(&self, data: &TransactionData) -> VerifiedTransaction {
+        let sig = self
+            .config
+            .keystore
+            .sign_secure(&data.sender(), data, Intent::sui_transaction())
+            .unwrap();
+        // TODO: To support sponsored transaction, we should also look at the gas owner.
+        VerifiedTransaction::new_unchecked(Transaction::from_data(
+            data.clone(),
+            Intent::sui_transaction(),
+            vec![sig],
+        ))
+    }
+
     pub async fn execute_transaction_block(
         &self,
         tx: VerifiedTransaction,
@@ -267,5 +287,43 @@ impl WalletContext {
                 Some(sui_types::quorum_driver_types::ExecuteTransactionRequestType::WaitForLocalExecution),
             )
             .await?)
+    }
+
+    /// A helper function to make Transactions with controlled accounts in WalletContext.
+    /// Particularly, the wallet needs to own gas objects for transactions.
+    /// However, if this function is called multiple times without any "sync" actions
+    /// on gas object management, txns may fail and objects may be locked.
+    ///
+    /// The param is called `max_txn_num` because it does not always return the exact
+    /// same amount of Transactions, for example when there are not enough gas objects
+    /// controlled by the WalletContext. Caller should rely on the return value to
+    /// check the count.
+    pub async fn batch_make_transfer_transactions(
+        &self,
+        max_txn_num: usize,
+    ) -> Vec<VerifiedTransaction> {
+        let recipient = get_key_pair::<AccountKeyPair>().0;
+        let accounts_and_objs = self.get_all_accounts_and_gas_objects().await.unwrap();
+        let mut res = Vec::with_capacity(max_txn_num);
+
+        let gas_price = self.get_reference_gas_price().await.unwrap();
+        for (address, objs) in accounts_and_objs {
+            for obj in objs {
+                if res.len() >= max_txn_num {
+                    return res;
+                }
+                let data = TransactionData::new_transfer_sui(
+                    recipient,
+                    address,
+                    Some(2),
+                    obj,
+                    gas_price * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+                    gas_price,
+                );
+                let tx = self.sign_transaction(&data);
+                res.push(tx);
+            }
+        }
+        res
     }
 }

--- a/crates/sui-surfer/src/surfer_state.rs
+++ b/crates/sui-surfer/src/surfer_state.rs
@@ -163,7 +163,7 @@ impl SurferState {
             rgp,
         )
         .unwrap();
-        let tx = self.cluster.sign_transaction(&self.address, &tx_data);
+        let tx = self.cluster.wallet.sign_transaction(&tx_data);
         let response = loop {
             match self.cluster.execute_transaction(tx.clone()).await {
                 Ok(effects) => break effects,
@@ -311,7 +311,7 @@ impl SurferState {
             TEST_ONLY_GAS_UNIT_FOR_PUBLISH * rgp,
             rgp,
         );
-        let tx = self.cluster.sign_transaction(&self.address, &tx_data);
+        let tx = self.cluster.wallet.sign_transaction(&tx_data);
         let response = loop {
             match self.cluster.execute_transaction(tx.clone()).await {
                 Ok(response) => {

--- a/crates/sui-test-transaction-builder/Cargo.toml
+++ b/crates/sui-test-transaction-builder/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "sui-test-transaction-builder"
+version.workspace = true
+authors = ["Mysten Labs <build@mystenlabs.com>"]
+license = "Apache-2.0"
+publish = false
+edition = "2021"
+
+[dependencies]
+shared-crypto = { path = "../shared-crypto" }
+sui-move-build = { path = "../sui-move-build" }
+sui-types = { path = "../sui-types" }
+
+move-core-types.workspace = true
+
+workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/crates/sui-test-transaction-builder/src/lib.rs
+++ b/crates/sui-test-transaction-builder/src/lib.rs
@@ -1,0 +1,155 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use move_core_types::ident_str;
+use shared_crypto::intent::Intent;
+use std::path::PathBuf;
+use sui_move_build::BuildConfig;
+use sui_types::base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress};
+use sui_types::crypto::{Signature, Signer};
+use sui_types::messages::{
+    CallArg, ObjectArg, Transaction, TransactionData, VerifiedTransaction,
+    TEST_ONLY_GAS_UNIT_FOR_GENERIC, TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
+};
+use sui_types::TypeTag;
+
+pub struct TestTransactionBuilder {
+    test_data: TestTransactionData,
+    sender: SuiAddress,
+    gas_object: ObjectRef,
+    gas_price: u64,
+}
+
+impl TestTransactionBuilder {
+    pub fn new(sender: SuiAddress, gas_object: ObjectRef, gas_price: u64) -> Self {
+        Self {
+            test_data: TestTransactionData::Empty,
+            sender,
+            gas_object,
+            gas_price,
+        }
+    }
+
+    pub fn move_call(
+        mut self,
+        package_id: ObjectID,
+        module: &'static str,
+        function: &'static str,
+        args: Vec<CallArg>,
+    ) -> Self {
+        assert!(matches!(self.test_data, TestTransactionData::Empty));
+        self.test_data = TestTransactionData::Move(MoveData {
+            package_id,
+            module,
+            function,
+            args,
+            type_args: vec![],
+        });
+        self
+    }
+
+    pub fn call_counter_create(self, package_id: ObjectID) -> Self {
+        self.move_call(package_id, "counter", "create", vec![])
+    }
+
+    pub fn call_counter_increment(
+        self,
+        package_id: ObjectID,
+        counter_id: ObjectID,
+        counter_initial_shared_version: SequenceNumber,
+    ) -> Self {
+        self.move_call(
+            package_id,
+            "counter",
+            "increment",
+            vec![CallArg::Object(ObjectArg::SharedObject {
+                id: counter_id,
+                initial_shared_version: counter_initial_shared_version,
+                mutable: true,
+            })],
+        )
+    }
+
+    pub fn with_type_args(mut self, type_args: Vec<TypeTag>) -> Self {
+        if let TestTransactionData::Move(data) = &mut self.test_data {
+            assert!(data.type_args.is_empty());
+            data.type_args = type_args;
+        } else {
+            panic!("Cannot set type args for non-move call");
+        }
+        self
+    }
+
+    pub fn publish(mut self, path: PathBuf) -> Self {
+        assert!(matches!(self.test_data, TestTransactionData::Empty));
+        self.test_data = TestTransactionData::Publish(PublishData { path });
+        self
+    }
+
+    pub fn publish_examples(self, subpath: &'static str) -> Self {
+        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.extend(["..", "..", "sui_programmability", "examples", subpath]);
+        self.publish(path)
+    }
+
+    pub fn build(self) -> TransactionData {
+        match self.test_data {
+            TestTransactionData::Move(data) => TransactionData::new_move_call(
+                self.sender,
+                data.package_id,
+                ident_str!(data.module).to_owned(),
+                ident_str!(data.function).to_owned(),
+                data.type_args,
+                self.gas_object,
+                data.args,
+                self.gas_price * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+                self.gas_price,
+            )
+            .unwrap(),
+            TestTransactionData::Publish(data) => {
+                let compiled_package = BuildConfig::new_for_testing().build(data.path).unwrap();
+                let all_module_bytes =
+                    compiled_package.get_package_bytes(/* with_unpublished_deps */ false);
+                let dependencies = compiled_package.get_dependency_original_package_ids();
+
+                TransactionData::new_module(
+                    self.sender,
+                    self.gas_object,
+                    all_module_bytes,
+                    dependencies,
+                    self.gas_price * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
+                    self.gas_price,
+                )
+            }
+            TestTransactionData::Empty => {
+                panic!("Cannot build empty transaction");
+            }
+        }
+    }
+
+    pub fn build_and_sign(self, signer: &dyn Signer<Signature>) -> VerifiedTransaction {
+        VerifiedTransaction::new_unchecked(Transaction::from_data_and_signer(
+            self.build(),
+            Intent::sui_transaction(),
+            vec![signer],
+        ))
+    }
+}
+
+enum TestTransactionData {
+    Move(MoveData),
+    Publish(PublishData),
+    Empty,
+}
+
+struct MoveData {
+    package_id: ObjectID,
+    module: &'static str,
+    function: &'static str,
+    args: Vec<CallArg>,
+    type_args: Vec<TypeTag>,
+}
+
+struct PublishData {
+    path: PathBuf,
+}

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1791,6 +1791,7 @@ impl Transaction {
         Self::from_data(data, intent, signatures)
     }
 
+    // TODO: Rename this function and above to make it clearer.
     pub fn from_data(data: TransactionData, intent: Intent, signatures: Vec<Signature>) -> Self {
         Self::from_generic_sig_data(
             data,

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -44,7 +44,6 @@ use sui_types::crypto::{
 };
 use sui_types::error::SuiObjectResponseError;
 use sui_types::{base_types::ObjectID, crypto::get_key_pair, gas_coin::GasCoin};
-use test_utils::messages::make_transactions_with_wallet_context;
 use test_utils::network::TestClusterBuilder;
 
 const TEST_DATA_DIR: &str = "src/unit_tests/data/";
@@ -1825,7 +1824,7 @@ async fn test_signature_flag() -> Result<(), anyhow::Error> {
 async fn test_execute_signed_tx() -> Result<(), anyhow::Error> {
     let mut test_cluster = TestClusterBuilder::new().build().await?;
     let context = &mut test_cluster.wallet;
-    let mut txns = make_transactions_with_wallet_context(context, 1).await;
+    let mut txns = context.batch_make_transfer_transactions(1).await;
     let txn = txns.swap_remove(0);
 
     let (tx_data, signatures) = txn.to_tx_bytes_and_signatures();

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -44,7 +44,6 @@ use sui_types::utils::{
 };
 use sui_types::{SUI_CLOCK_OBJECT_ID, SUI_CLOCK_OBJECT_SHARED_VERSION};
 use test_utils::authority::test_and_configure_authority_configs;
-use test_utils::messages::make_transactions_with_wallet_context;
 use test_utils::messages::make_transfer_object_transaction_with_wallet_context;
 use test_utils::network::{start_fullnode_from_config, TestClusterBuilder};
 use test_utils::transaction::{
@@ -728,7 +727,7 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
         .expect("Fullnode should have transaction orchestrator toggled on.");
 
     let txn_count = 4;
-    let mut txns = make_transactions_with_wallet_context(context, txn_count).await;
+    let mut txns = context.batch_make_transfer_transactions(txn_count).await;
     assert!(
         txns.len() >= txn_count,
         "Expect at least {} txns. Do we generate enough gas objects during genesis?",
@@ -827,7 +826,7 @@ async fn test_execute_tx_with_serialized_signature() -> Result<(), anyhow::Error
     let jsonrpc_client = &test_cluster.fullnode_handle.rpc_client;
 
     let txn_count = 4;
-    let txns = make_transactions_with_wallet_context(context, txn_count).await;
+    let txns = context.batch_make_transfer_transactions(txn_count).await;
     for txn in txns {
         let tx_digest = txn.digest();
         let (tx_bytes, signatures) = txn.to_tx_bytes_and_signatures();
@@ -860,7 +859,7 @@ async fn test_full_node_transaction_orchestrator_rpc_ok() -> Result<(), anyhow::
     let jsonrpc_client = &test_cluster.fullnode_handle.rpc_client;
 
     let txn_count = 4;
-    let mut txns = make_transactions_with_wallet_context(context, txn_count).await;
+    let mut txns = context.batch_make_transfer_transactions(txn_count).await;
     assert!(
         txns.len() >= txn_count,
         "Expect at least {} txns. Do we generate enough gas objects during genesis?",

--- a/crates/sui/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui/tests/transaction_orchestrator_tests.rs
@@ -17,7 +17,6 @@ use test_utils::authority::{
     spawn_fullnode, spawn_test_authorities, test_authority_configs,
     test_authority_configs_with_objects,
 };
-use test_utils::messages::make_transactions_with_wallet_context;
 use test_utils::network::wait_for_nodes_transition_to_epoch;
 use test_utils::network::TestClusterBuilder;
 use test_utils::transaction::wait_for_tx;
@@ -41,7 +40,7 @@ async fn test_blocking_execution() -> Result<(), anyhow::Error> {
     .unwrap();
 
     let txn_count = 4;
-    let mut txns = make_transactions_with_wallet_context(context, txn_count).await;
+    let mut txns = context.batch_make_transfer_transactions(txn_count).await;
     assert!(
         txns.len() >= txn_count,
         "Expect at least {} txns. Do we generate enough gas objects during genesis?",
@@ -108,7 +107,7 @@ async fn test_fullnode_wal_log() -> Result<(), anyhow::Error> {
 
     let txn_count = 2;
     let context = &mut test_cluster.wallet;
-    let mut txns = make_transactions_with_wallet_context(context, txn_count).await;
+    let mut txns = context.batch_make_transfer_transactions(txn_count).await;
     assert!(
         txns.len() >= txn_count,
         "Expect at least {} txns. Do we generate enough gas objects during genesis?",

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -30,6 +30,7 @@ sui-swarm = { path = "../sui-swarm" }
 sui-types = { path = "../sui-types", features = ["test-utils"] }
 sui-keys = { path = "../sui-keys" }
 sui-sdk = { path = "../sui-sdk" }
+sui-test-transaction-builder = { path = "../sui-test-transaction-builder" }
 mysten-metrics = { path = "../mysten-metrics"}
 shared-crypto = { path = "../shared-crypto" }
 

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -16,7 +16,6 @@ use tokio::{task::JoinHandle, time::sleep};
 use tracing::info;
 
 use mysten_metrics::RegistryService;
-use shared_crypto::intent::Intent;
 use sui_config::builder::{ProtocolVersionsConfig, SupportedProtocolVersionsCallback};
 use sui_config::genesis_config::{AccountConfig, GenesisConfig};
 use sui_config::node::DBCheckpointConfig;
@@ -36,7 +35,7 @@ use sui_types::base_types::{AuthorityName, ObjectID, SuiAddress};
 use sui_types::committee::EpochId;
 use sui_types::crypto::KeypairTraits;
 use sui_types::crypto::SuiKeyPair;
-use sui_types::messages::{SenderSignedData, Transaction, TransactionData, VerifiedTransaction};
+use sui_types::messages::VerifiedTransaction;
 use sui_types::object::Object;
 use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait;
 use sui_types::sui_system_state::SuiSystemState;
@@ -108,27 +107,6 @@ impl TestCluster {
             .get(2)
             .cloned()
             .unwrap()
-    }
-
-    // Sign a transaction with a key currently managed by the WalletContext
-    pub fn sign_transaction(
-        &self,
-        signer_address: &SuiAddress,
-        data: &TransactionData,
-    ) -> VerifiedTransaction {
-        let sig = self
-            .wallet
-            .config
-            .keystore
-            .sign_secure(signer_address, data, Intent::sui_transaction())
-            .unwrap();
-        VerifiedTransaction::new_unchecked(Transaction::new(
-            SenderSignedData::new_from_sender_signature(
-                data.clone(),
-                Intent::sui_transaction(),
-                sig,
-            ),
-        ))
     }
 
     pub fn fullnode_config_builder(&self) -> FullnodeConfigBuilder {

--- a/crates/test-utils/src/transaction.rs
+++ b/crates/test-utils/src/transaction.rs
@@ -31,6 +31,7 @@ use sui_types::messages::TEST_ONLY_GAS_UNIT_FOR_PUBLISH;
 use sui_types::messages::TEST_ONLY_GAS_UNIT_FOR_SPLIT_COIN;
 use sui_types::messages::TEST_ONLY_GAS_UNIT_FOR_TRANSFER;
 
+use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents};
 use sui_types::messages::{CallArg, ObjectArg, Transaction, TransactionData, VerifiedTransaction};
 use sui_types::messages_grpc::{
@@ -46,8 +47,7 @@ use tracing::{debug, info};
 
 use crate::authority::get_client;
 use crate::messages::{
-    create_publish_move_package_transaction, make_tx_certs_and_signed_effects,
-    make_tx_certs_and_signed_effects_with_committee,
+    make_tx_certs_and_signed_effects, make_tx_certs_and_signed_effects_with_committee,
 };
 
 pub fn make_publish_package(
@@ -56,14 +56,9 @@ pub fn make_publish_package(
     gas_price: u64,
 ) -> VerifiedTransaction {
     let (sender, keypair) = deterministic_random_account_key();
-    create_publish_move_package_transaction(
-        gas_object,
-        path,
-        sender,
-        &keypair,
-        gas_price * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
-        gas_price,
-    )
+    TestTransactionBuilder::new(sender, gas_object, gas_price)
+        .publish(path)
+        .build_and_sign(&keypair)
 }
 
 pub async fn publish_package(


### PR DESCRIPTION
This PR is the first of two (to avoid the PR growing too big) to remove test-utils/messages eventually.
It makes the following changes:
1. Added a new sui-test-transaction-builder crate that allows us to create all kinds of test transactions. This cannot live inside sui-types because of package publishes, which requires compiling and verifying the package (which needs to depends on sui-move-build). Migrated some of the functions in messages.rs to use it.
2. Moved sign_transaction from TestCluster to WalletContext because it belongs there.