### PR TITLE
[Rosetta] - Fix gas budget for dryRunTransaction

### DIFF
--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -220,9 +220,9 @@ pub async fn metadata(
     let (total_required_amount, objects, budget) = match &option.internal_operation {
         InternalOperation::PaySui { amounts, .. } => {
             let amount = amounts.iter().sum::<u64>();
-            (Some(amount), vec![], 5_000_000)
+            (Some(amount), vec![], 1_000_000)
         }
-        InternalOperation::Stake { amount, .. } => (*amount, vec![], 100_000_000),
+        InternalOperation::Stake { amount, .. } => (*amount, vec![], 10_000_000),
         InternalOperation::WithdrawStake { sender, stake_ids } => {
             let stake_ids = if stake_ids.is_empty() {
                 // unstake all
@@ -261,7 +261,7 @@ pub async fn metadata(
                 .collect::<Result<Vec<_>, _>>()
                 .map_err(SuiError::from)?;
 
-            (Some(0), stake_refs, 100_000_000)
+            (Some(0), stake_refs, 10_000_000)
         }
     };
 
@@ -296,6 +296,20 @@ pub async fn metadata(
         .map(|c| c.object_ref())
         .collect::<Vec<_>>();
 
+    let budget = if let Some(amount) = total_required_amount {
+        if (total_coin_value - amount) < 50000000000 {
+            total_coin_value - amount
+        } else {
+            50000000000
+        }
+    } else {
+        if total_coin_value < 50000000000 {
+            total_coin_value
+        } else {
+            50000000000
+        }
+    };
+
     // get gas estimation from dry-run, this will also return any tx error.
     let data = option
         .internal_operation
@@ -305,7 +319,7 @@ pub async fn metadata(
             objects: objects.clone(),
             total_coin_value,
             gas_price,
-            budget: budget * gas_price,
+            budget,
         })?;
 
     let dry_run = context


### PR DESCRIPTION
## Description 

I changed the gasBudget for dryRunTransaction to be the balance of account - the amount he wants to pay/stake. If the balance is higher than the max gasBudget then the gasBudget is set to the max amount.

## Test Plan 

end-to-end tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
