### PR TITLE
use coin name

### DIFF
--- a/apps/wallet/src/ui/app/components/active-coins-card/CoinItem.tsx
+++ b/apps/wallet/src/ui/app/components/active-coins-card/CoinItem.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useFormatCoin } from '@mysten/core';
+import { useFormatCoin, useCoinMetadata } from '@mysten/core';
 
 import { Text } from '_app/shared/text';
 import { CoinIcon } from '_components/coin-icon';
@@ -15,6 +15,7 @@ type CoinItemProps = {
 
 export function CoinItem({ coinType, balance, isActive, usd }: CoinItemProps) {
     const [formatted, symbol] = useFormatCoin(balance, coinType);
+    const { data: metadata } = useCoinMetadata(coinType);
 
     return (
         <div className="flex gap-2.5 w-full justify-center items-center">
@@ -22,7 +23,7 @@ export function CoinItem({ coinType, balance, isActive, usd }: CoinItemProps) {
             <div className="flex flex-1 gap-1.5 justify-between">
                 <div className="flex flex-col gap-1.5">
                     <Text variant="body" color="steel-darker" weight="semibold">
-                        {symbol} {isActive ? 'available' : ''}
+                        {metadata?.name || symbol} {isActive ? 'available' : ''}
                     </Text>
                     {!isActive ? (
                         <Text

--- a/apps/wallet/src/ui/app/pages/home/tokens/TokensDetails.tsx
+++ b/apps/wallet/src/ui/app/pages/home/tokens/TokensDetails.tsx
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useFeatureIsOn } from '@growthbook/growthbook-react';
+import { useCoinMetadata } from '@mysten/core';
 import {
     Info12,
     WalletActionBuy24,
     WalletActionSend24,
     Swap16,
 } from '@mysten/icons';
-import { SUI_TYPE_ARG, Coin } from '@mysten/sui.js';
-import { useMemo } from 'react';
+import { SUI_TYPE_ARG } from '@mysten/sui.js';
 
 import { useOnrampProviders } from '../onramp/useOnrampProviders';
 import { CoinActivitiesCard } from './CoinActivityCard';
@@ -89,11 +89,8 @@ function TokenDetails({ coinType }: TokenDetailsProps) {
     const { providers } = useOnrampProviders();
 
     const tokenBalance = coinBalance?.totalBalance || BigInt(0);
-
-    const coinSymbol = useMemo(
-        () => Coin.getCoinSymbol(activeCoinType),
-        [activeCoinType]
-    );
+    const { data: coinMetadata } = useCoinMetadata(activeCoinType);
+    const coinSymbol = coinMetadata?.symbol;
     // Avoid perpetual loading state when fetching and retry keeps failing add isFetched check
     const isFirstTimeLoading = isLoading && !isFetched;
 

--- a/apps/wallet/src/ui/app/pages/home/tokens/coin-balance/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/tokens/coin-balance/index.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useFormatCoin } from '@mysten/core';
+import { useFormatCoin, useCoinMetadata } from '@mysten/core';
 import cl from 'classnames';
 import { memo, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -19,6 +19,7 @@ export type CoinProps = {
 
 function CoinBalance({ type, balance, mode = 'row-item' }: CoinProps) {
     const [formatted, symbol] = useFormatCoin(balance, type);
+    const { data: metadata } = useCoinMetadata(type);
     const navigate = useNavigate();
 
     // TODO: use a different logic to differentiate between view types
@@ -43,7 +44,7 @@ function CoinBalance({ type, balance, mode = 'row-item' }: CoinProps) {
                     <CoinIcon coinType={type} />
                     <div className={cl(st.coinNameContainer, st[mode])}>
                         <span className={st.coinName}>
-                            {symbol.toLocaleLowerCase()}
+                            {metadata?.name || symbol.toLocaleLowerCase()}
                         </span>
                         <span className={st.coinSymbol}>{symbol}</span>
                     </div>

--- a/apps/wallet/src/ui/app/shared/delegated-apy/index.tsx
+++ b/apps/wallet/src/ui/app/shared/delegated-apy/index.tsx
@@ -29,7 +29,7 @@ export function DelegatedAPY({ stakedValidators }: DelegatedAPYProps) {
         let stakedAPYs = 0;
 
         stakedValidators.forEach((validatorAddress) => {
-            stakedAPYs += rollingAverageApys?.[validatorAddress].apy || 0;
+            stakedAPYs += rollingAverageApys?.[validatorAddress]?.apy || 0;
         });
 
         const averageAPY = stakedAPYs / stakedValidators.length;


### PR DESCRIPTION
## Description 

This PR uses the Coin metadata name as the display name instead of the coin symbol and fixes edge cases where APY is not available for inactive validator 