### PR TITLE
1/n improve sui-json-rpc error codes and handling

### DIFF
--- a/crates/sui-json-rpc/src/logger.rs
+++ b/crates/sui-json-rpc/src/logger.rs
@@ -5,13 +5,27 @@
 macro_rules! with_tracing {
     ($method_name:literal, $future:expr) => {{
         use tracing::{info, error, Instrument, Span};
+        use jsonrpsee::core::{RpcResult, Error as RpcError};
+        use jsonrpsee::types::error::{CallError, INVALID_PARAMS_CODE, CALL_EXECUTION_FAILED_CODE};
+
         async move {
-            let result = $future.await;
+            let result: RpcResult<_> = $future.await;
+
             match &result {
                 Ok(_) => info!("success"),
-                Err(e) => error!(error = ?e, "failed"),
+                Err(e) => {
+                    match e {
+                        RpcError::Call(call_error) => {
+                            let error_code = match call_error {
+                                CallError::InvalidParams(_) => INVALID_PARAMS_CODE,
+                                _ => CALL_EXECUTION_FAILED_CODE
+                            };
+                            error!(error = ?e, error_code = error_code);
+                        }
+                        _ => error!(error = ?e),
+                    }
+                }
             }
-
             result
         }
         .instrument(Span::current())

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -140,11 +140,10 @@ impl ReadApi {
     ) -> Result<Vec<SuiTransactionBlockResponse>, Error> {
         let num_digests = digests.len();
         if num_digests > *QUERY_MAX_RESULT_LIMIT {
-            return Err(anyhow!(UserInputError::SizeLimitExceeded {
+            return Err(Error::UserInputError(UserInputError::SizeLimitExceeded {
                 limit: "multi get transaction input limit".to_string(),
-                value: QUERY_MAX_RESULT_LIMIT.to_string()
-            })
-            .into());
+                value: QUERY_MAX_RESULT_LIMIT.to_string(),
+            }));
         }
         self.metrics
             .get_tx_blocks_limit
@@ -488,9 +487,9 @@ impl ReadApiServer for ReadApi {
                     .inc_by(objects.len() as u64);
                 Ok(objects)
             } else {
-                Err(anyhow!(UserInputError::SizeLimitExceeded {
+                Err(Error::UserInputError(UserInputError::SizeLimitExceeded {
                     limit: "input limit".to_string(),
-                    value: QUERY_MAX_RESULT_LIMIT.to_string()
+                    value: QUERY_MAX_RESULT_LIMIT.to_string(),
                 })
                 .into())
             }
@@ -579,9 +578,9 @@ impl ReadApiServer for ReadApi {
                     Ok(success)
                 }
             } else {
-                Err(anyhow!(UserInputError::SizeLimitExceeded {
+                Err(Error::UserInputError(UserInputError::SizeLimitExceeded {
                     limit: "input limit".to_string(),
-                    value: QUERY_MAX_RESULT_LIMIT.to_string()
+                    value: QUERY_MAX_RESULT_LIMIT.to_string(),
                 })
                 .into())
             }
@@ -758,7 +757,7 @@ impl ReadApiServer for ReadApi {
                     .await
             })
             .await
-            .map_err(|e| anyhow!(e))??)
+            .map_err(Error::from)??)
         })
     }
 


### PR DESCRIPTION
## Description 
Most of the errors we return in `sui-json-rpc` are `anyhow::Error`s that then get converted to `RpcError`. Or, if we keep things in `sui_json_rpc::Error`, there is a catch-all `From` implementation that converts all variants to `CallError::Failed`.

In this PR, the `From` implementation is expanded to map some variants to `RpcError::Call(CallError::InvalidParams` instead, so that we can return different error codes rather than defaulting to `-32000` for everything.

This will help w/ differentiating server from client errors, and we can make use of this for alerting on error logs. 
Start with `UserInputErrors`, which now map to error code `-32602`. Also log error code if available.

In terms of performance, there shouldn't be any impact since we do the same number of conversions. Only, instead of `JoinError` -> `anyhow::Error` -> `RpcError`, or `anyhow::Error` -> `anyhow::Error` -> `RpcError`, we now do `error from inner call` -> `sui_json_rpc::Error` -> `RpcError`.

```
curl --location '127.0.0.1:9000' \
--header 'Content-Type: application/json' \
--data '{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "sui_getTransactionBlock",
  "params": [
    [
      "DwRWCvrkfauz95wTrfJxi3VSWdMZWCEtdPCiaZhcanZh"
    ],
    {
      "showInput": true,
      "showRawInput": false,
      "showEffects": true,
      "showEvents": true,
      "showObjectChanges": false,
      "showBalanceChanges": false
    }
  ]
}'
{"jsonrpc":"2.0","error":{"code":-32602,"message":"invalid type: sequence, expected a string at line 2 column 4"},"id":1}%       
```

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
