### PR TITLE
[explorer] - add additional detail to tx view, fix mobile styling

### DIFF
--- a/apps/core/src/hooks/useTransactionSummary.ts
+++ b/apps/core/src/hooks/useTransactionSummary.ts
@@ -7,6 +7,7 @@ import {
     is,
     getExecutionStatusType,
     getTransactionDigest,
+    getTransactionSender,
 } from '@mysten/sui.js';
 import { useMemo } from 'react';
 
@@ -22,6 +23,12 @@ const getSummary = (
     const objectSummary = getObjectChangeSummary(transaction, currentAddress);
     const balanceChangeSummary = getBalanceChangeSummary(transaction);
 
+    const totalChangeCount =
+        Object.values(objectSummary ?? {}).reduce(
+            (acc, val) => acc + val.length,
+            0
+        ) + (balanceChangeSummary ?? []).length || 0;
+
     const gas = getGasSummary(transaction);
 
     if (is(transaction, DryRunTransactionBlockResponse)) {
@@ -33,11 +40,13 @@ const getSummary = (
     } else {
         return {
             gas,
+            sender: getTransactionSender(transaction),
             balanceChanges: balanceChangeSummary,
             digest: getTransactionDigest(transaction),
             label: getLabel(transaction, currentAddress),
             objectSummary,
             status: getExecutionStatusType(transaction),
+            totalChangeCount: totalChangeCount,
             timestamp: transaction.timestampMs,
         };
     }

--- a/apps/explorer/src/components/Layout/index.tsx
+++ b/apps/explorer/src/components/Layout/index.tsx
@@ -44,32 +44,28 @@ export function Layout() {
                             <NetworkContext.Provider
                                 value={[network, setNetwork]}
                             >
-                                <div className="w-full">
-                                    <Header />
-                                    <main className="relative z-10 min-h-screen bg-offwhite">
-                                        <section className="mx-auto max-w-[1440px] px-5 py-10 lg:px-10 2xl:px-0">
-                                            {networkOutage && (
-                                                <div className="pb-2.5">
-                                                    <Banner
-                                                        variant="warning"
-                                                        border
-                                                        fullWidth
-                                                    >
-                                                        We&rsquo;re sorry that
-                                                        the explorer is running
-                                                        slower than usual.
-                                                        We&rsquo;re working to
-                                                        fix the issue and
-                                                        appreciate your
-                                                        patience.
-                                                    </Banner>
-                                                </div>
-                                            )}
-                                            <Outlet />
-                                        </section>
-                                    </main>
-                                    <Footer />
-                                </div>
+                                <Header />
+                                <main className="relative z-10 min-h-full bg-offwhite">
+                                    <section className="mx-auto max-w-[1440px] px-5 py-10 lg:px-10 2xl:px-0">
+                                        {networkOutage && (
+                                            <div className="pb-2.5">
+                                                <Banner
+                                                    variant="warning"
+                                                    border
+                                                    fullWidth
+                                                >
+                                                    We&rsquo;re sorry that the
+                                                    explorer is running slower
+                                                    than usual. We&rsquo;re
+                                                    working to fix the issue and
+                                                    appreciate your patience.
+                                                </Banner>
+                                            </div>
+                                        )}
+                                        <Outlet />
+                                    </section>
+                                </main>
+                                <Footer />
 
                                 <Toaster
                                     position="bottom-center"

--- a/apps/explorer/src/index.css
+++ b/apps/explorer/src/index.css
@@ -14,6 +14,14 @@
     --steel-dark: theme('colors.steel.dark');
 }
 
+html,
+body,
+#root {
+    height: 100%;
+    width: 100%;
+    position: relative;
+}
+
 @layer base {
     body {
         @apply antialiased;

--- a/apps/explorer/src/pages/transaction-result/TransactionData.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionData.tsx
@@ -9,15 +9,11 @@ import {
     type SuiTransactionBlockResponse,
 } from '@mysten/sui.js';
 
+import { TransactionDetails } from './TransactionDetails';
+
 import { GasBreakdown } from '~/components/GasBreakdown';
 import { InputsCard } from '~/pages/transaction-result/programmable-transaction-view/InputsCard';
 import { TransactionsCard } from '~/pages/transaction-result/programmable-transaction-view/TransactionsCard';
-import { Heading } from '~/ui/Heading';
-import { CheckpointSequenceLink } from '~/ui/InternalLink';
-import {
-    TransactionBlockCard,
-    TransactionBlockCardSection,
-} from '~/ui/TransactionBlockCard';
 
 interface Props {
     transaction: SuiTransactionBlockResponse;
@@ -40,27 +36,14 @@ export function TransactionData({ transaction }: Props) {
 
     return (
         <div className="flex flex-wrap gap-6">
-            <section className="flex w-96 min-w-[50%] flex-1 flex-col gap-6">
+            <section className="flex min-w-[50%] flex-1 flex-col gap-6">
                 {transaction.checkpoint && (
-                    <TransactionBlockCard>
-                        <TransactionBlockCardSection>
-                            <div className="flex flex-col gap-2">
-                                <Heading
-                                    variant="heading4/semibold"
-                                    color="steel-darker"
-                                >
-                                    Checkpoint
-                                </Heading>
-                                <CheckpointSequenceLink
-                                    noTruncate
-                                    label={Number(
-                                        transaction.checkpoint
-                                    ).toLocaleString()}
-                                    sequence={transaction.checkpoint}
-                                />
-                            </div>
-                        </TransactionBlockCardSection>
-                    </TransactionBlockCard>
+                    <TransactionDetails
+                        checkpoint={transaction.checkpoint}
+                        executedEpoch={transaction.effects?.executedEpoch}
+                        sender={summary?.sender}
+                        timestamp={transaction.timestampMs}
+                    />
                 )}
 
                 {isProgrammableTransaction && (
@@ -68,7 +51,7 @@ export function TransactionData({ transaction }: Props) {
                 )}
             </section>
 
-            <section className="flex w-96 flex-1 flex-col gap-6">
+            <section className="flex flex-1 flex-col gap-6">
                 {isProgrammableTransaction && (
                     <>
                         <TransactionsCard

--- a/apps/explorer/src/pages/transaction-result/TransactionDetails.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionDetails.tsx
@@ -1,0 +1,88 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { formatDate } from '@mysten/core';
+import { type ReactNode } from 'react';
+
+import { Heading } from '~/ui/Heading';
+import {
+    AddressLink,
+    CheckpointSequenceLink,
+    EpochLink,
+} from '~/ui/InternalLink';
+import { Text } from '~/ui/Text';
+import {
+    TransactionBlockCard,
+    TransactionBlockCardSection,
+} from '~/ui/TransactionBlockCard';
+
+interface TransactionDetailsProps {
+    sender?: string;
+    checkpoint: string;
+    executedEpoch?: string;
+    timestamp?: string;
+}
+
+export function TransactionDetail({
+    label,
+    value,
+}: {
+    label: string;
+    value: ReactNode | string;
+}) {
+    return (
+        <div className="flex flex-col gap-2 first:pl-0 md:pl-5">
+            <Heading variant="heading4/semibold" color="steel-darker">
+                {label}
+            </Heading>
+            <Text variant="pBody/normal" color="steel-dark">
+                {value}
+            </Text>
+        </div>
+    );
+}
+
+export function TransactionDetails({
+    sender,
+    checkpoint,
+    executedEpoch,
+    timestamp,
+}: TransactionDetailsProps) {
+    return (
+        <TransactionBlockCard>
+            <TransactionBlockCardSection>
+                <div className="flex flex-col gap-6">
+                    {timestamp && (
+                        <Text variant="pBody/medium" color="steel-dark">
+                            {formatDate(Number(timestamp))}
+                        </Text>
+                    )}
+                    <div className="divide flex flex-col flex-wrap gap-5 divide-gray-45 md:flex-row md:divide-x">
+                        {sender && (
+                            <TransactionDetail
+                                label="Sender"
+                                value={<AddressLink address={sender} />}
+                            />
+                        )}
+                        {checkpoint && (
+                            <TransactionDetail
+                                label="Checkpoint"
+                                value={
+                                    <CheckpointSequenceLink
+                                        sequence={checkpoint}
+                                    />
+                                }
+                            />
+                        )}
+                        {executedEpoch && (
+                            <TransactionDetail
+                                label="Epoch"
+                                value={<EpochLink epoch={executedEpoch} />}
+                            />
+                        )}
+                    </div>
+                </div>
+            </TransactionBlockCardSection>
+        </TransactionBlockCard>
+    );
+}

--- a/apps/explorer/src/pages/transaction-result/TransactionView.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionView.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { useTransactionSummary } from '@mysten/core';
 import {
     getExecutionStatusError,
     getExecutionStatusType,
@@ -9,16 +10,8 @@ import {
     getTransactionKindName,
     type SuiTransactionBlockResponse,
 } from '@mysten/sui.js';
-import clsx from 'clsx';
-
-// import {
-//     eventToDisplay,
-//     getAddressesLinks,
-// } from '../../components/events/eventDisplay';
 
 import { Signatures } from './Signatures';
-
-import styles from './TransactionResult.module.css';
 
 import { useBreakpoint } from '~/hooks/useBreakpoint';
 import { TransactionData } from '~/pages/transaction-result/TransactionData';
@@ -34,37 +27,9 @@ export function TransactionView({
     transaction: SuiTransactionBlockResponse;
 }) {
     const isMediumOrAbove = useBreakpoint('md');
-
-    // const txKindData = formatByTransactionKind(txKindName, txnDetails, sender);
-    // const txEventData = transaction.events?.map(eventToDisplay);
-
-    // MUSTFIX(chris): re-enable event display
-    // let eventTitles: [string, string][] = [];
-    // const txEventDisplay = txEventData?.map((ed, index) => {
-    //     if (!ed) return <div />;
-
-    //     let key = ed.top.title + index;
-    //     eventTitles.push([ed.top.title, key]);
-    //     return (
-    //         <div className={styles.txgridcomponent} key={key}>
-    //             <ItemView data={ed.top as TxItemView} />
-    //             {ed.fields && <ItemView data={ed.fields as TxItemView} />}
-    //         </div>
-    //     );
-    // });
-
-    // let eventTitlesDisplay = eventTitles.map(([title, key]) => (
-    //     <div key={key} className={styles.eventtitle}>
-    //         {title}
-    //     </div>
-    // ));
-
-    // MUSTFIX(chris): re-enable event display
-    // const hasEvents = txEventData && txEventData.length > 0;
     const hasEvents = false;
-
     const txError = getExecutionStatusError(transaction);
-
+    const summary = useTransactionSummary({ transaction });
     const transactionKindName = getTransactionKindName(
         getTransactionKind(transaction)!
     );
@@ -74,7 +39,7 @@ export function TransactionView({
 
     const leftPane = {
         panel: (
-            <div className="h-full overflow-y-scroll rounded-2xl border border-transparent bg-gray-40 p-6 md:h-screen md:p-10">
+            <div className="h-full overflow-y-scroll rounded-2xl border border-transparent bg-gray-40 p-6 md:h-full md:max-h-screen md:p-10">
                 <TabGroup size="lg">
                     <TabList>
                         <Tab>Summary</Tab>
@@ -87,18 +52,6 @@ export function TransactionView({
                                 <TransactionSummary transaction={transaction} />
                             </div>
                         </TabPanel>
-                        {/* {hasEvents && (
-                        <TabPanel>
-                            <div className={styles.txevents}>
-                                <div className={styles.txeventsleft}>
-                                    {eventTitlesDisplay}
-                                </div>
-                                <div className={styles.txeventsright}>
-                                    {txEventDisplay}
-                                </div>
-                            </div>
-                        </TabPanel>
-                    )} */}
                         <TabPanel>
                             <Signatures transaction={transaction} />
                         </TabPanel>
@@ -106,7 +59,7 @@ export function TransactionView({
                 </TabGroup>
             </div>
         ),
-        minSize: 35,
+        defaultSize: 35,
         collapsible: true,
         collapsibleButton: true,
         noHoverHidden: isMediumOrAbove,
@@ -123,7 +76,7 @@ export function TransactionView({
     };
 
     return (
-        <div className={clsx(styles.txdetailsbg)}>
+        <div>
             <div className="mb-10">
                 <PageHeader
                     type="Transaction"
@@ -141,12 +94,20 @@ export function TransactionView({
                     </div>
                 )}
             </div>
-            <div className="h-verticalListLong md:h-full">
-                <SplitPanes
-                    splitPanels={[leftPane, rightPane]}
-                    direction={isMediumOrAbove ? 'horizontal' : 'vertical'}
-                />
-            </div>
+
+            {isMediumOrAbove || (summary?.totalChangeCount ?? 0) > 30 ? (
+                <div className="h-screen md:block md:h-full">
+                    <SplitPanes
+                        splitPanels={[leftPane, rightPane]}
+                        direction={isMediumOrAbove ? 'horizontal' : 'vertical'}
+                    />
+                </div>
+            ) : (
+                <div className="flex h-full flex-col gap-6 md:hidden">
+                    {leftPane.panel}
+                    {rightPane.panel}
+                </div>
+            )}
         </div>
     );
 }

--- a/apps/explorer/src/pages/validators/Validators.tsx
+++ b/apps/explorer/src/pages/validators/Validators.tsx
@@ -306,7 +306,7 @@ function ValidatorPageResult() {
 
     return (
         <div>
-            <div className="mt-8 grid gap-5 md:grid-cols-2">
+            <div className="grid gap-5 md:grid-cols-2">
                 <Card spacing="lg">
                     <div className="flex w-full basis-full flex-col gap-8">
                         <Heading


### PR DESCRIPTION
## Description 

Adds some additional useful details to transaction page: 
- Sender
- Timestamp
- Executed Epoch
- Checkpoint


Also fixes up some mobile styling, and disables the split pane view on mobile for transactions with fewer than 30 balance / object changes. I found that the split pane view took up a lot of real estate and is generally easier to just scroll through on a mobile device. Open to suggestions here!


Also addresses some mobile styling issues.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
