### PR TITLE
[verifier] add prom histogram metrics for verifier

### DIFF
--- a/crates/sui-adapter/src/adapter.rs
+++ b/crates/sui-adapter/src/adapter.rs
@@ -208,7 +208,7 @@ pub fn run_metered_move_bytecode_verifier_impl(
 ) -> Result<(), SuiError> {
     // run the Move verifier
     for module in modules.iter() {
-        let per_module_mater_verifier_timer = metrics.verifier_runtime_per_module_success_latency.start_timer();
+        let per_module_meter_verifier_timer = metrics.verifier_runtime_per_module_success_latency.start_timer();
 
         if let Err(e) = verify_module_with_config_metered(verifier_config, module, meter) {
             // Check that the status indicates mtering timeout
@@ -221,7 +221,7 @@ pub fn run_metered_move_bytecode_verifier_impl(
             .contains(&e.major_status())
             {
                 // Discard success timer, but record timeout/failure timer
-                metrics.verifier_runtime_per_module_timeout_latency.observe(per_module_mater_verifier_timer.stop_and_discard());
+                metrics.verifier_runtime_per_module_timeout_latency.observe(per_module_meter_verifier_timer.stop_and_discard());
                 metrics.verifier_timeout_metrics.with_label_values(&[BytecodeVerifierMetrics::MOVE_VERIFIER_TAG, BytecodeVerifierMetrics::TIMEOUT_TAG]).inc();
                 return Err(SuiError::ModuleVerificationFailure {
                     error: "Verification timedout".to_string(),
@@ -229,12 +229,12 @@ pub fn run_metered_move_bytecode_verifier_impl(
             };
         } else if let Err(err) = sui_verify_module_metered(protocol_config, module, &BTreeMap::new(), meter) {
                 // Discard success timer, but record timeout/failure timer
-                metrics.verifier_runtime_per_module_timeout_latency.observe(per_module_mater_verifier_timer.stop_and_discard());
+                metrics.verifier_runtime_per_module_timeout_latency.observe(per_module_meter_verifier_timer.stop_and_discard());
                 metrics.verifier_timeout_metrics.with_label_values(&[ BytecodeVerifierMetrics::SUI_VERIFIER_TAG, BytecodeVerifierMetrics::TIMEOUT_TAG]).inc();
                 return Err(err.into());
         } else {
             // Save the success timer
-            per_module_mater_verifier_timer.stop_and_record();
+            per_module_meter_verifier_timer.stop_and_record();
             metrics.verifier_timeout_metrics.with_label_values(&[BytecodeVerifierMetrics::OVERALL_TAG, BytecodeVerifierMetrics::SUCCESS_TAG]).inc();
         }
     }

--- a/crates/sui-adapter/src/adapter.rs
+++ b/crates/sui-adapter/src/adapter.rs
@@ -208,6 +208,8 @@ pub fn run_metered_move_bytecode_verifier_impl(
 ) -> Result<(), SuiError> {
     // run the Move verifier
     for module in modules.iter() {
+        let per_module_mater_verifier_timer = metrics.verifier_runtime_per_module_success_latency.start_timer();
+
         if let Err(e) = verify_module_with_config_metered(verifier_config, module, meter) {
             // Check that the status indicates mtering timeout
             // TODO: currently the Move verifier emits `CONSTRAINT_NOT_SATISFIED` for various failures including metering timeout
@@ -218,18 +220,23 @@ pub fn run_metered_move_bytecode_verifier_impl(
             ]
             .contains(&e.major_status())
             {
+                // Discard success timer, but record timeout/failure timer
+                metrics.verifier_runtime_per_module_timeout_latency.observe(per_module_mater_verifier_timer.stop_and_discard());
                 metrics.verifier_timeout_metrics.with_label_values(&[BytecodeVerifierMetrics::MOVE_VERIFIER_TAG, BytecodeVerifierMetrics::TIMEOUT_TAG]).inc();
                 return Err(SuiError::ModuleVerificationFailure {
                     error: "Verification timedout".to_string(),
                 });
             };
-        } else {
-            sui_verify_module_metered(protocol_config, module, &BTreeMap::new(), meter).map_err(|err|{
+        } else if let Err(err) = sui_verify_module_metered(protocol_config, module, &BTreeMap::new(), meter) {
+                // Discard success timer, but record timeout/failure timer
+                metrics.verifier_runtime_per_module_timeout_latency.observe(per_module_mater_verifier_timer.stop_and_discard());
                 metrics.verifier_timeout_metrics.with_label_values(&[ BytecodeVerifierMetrics::SUI_VERIFIER_TAG, BytecodeVerifierMetrics::TIMEOUT_TAG]).inc();
-                err
-            })?
+                return Err(err.into());
+        } else {
+            // Save the success timer
+            per_module_mater_verifier_timer.stop_and_record();
+            metrics.verifier_timeout_metrics.with_label_values(&[BytecodeVerifierMetrics::OVERALL_TAG, BytecodeVerifierMetrics::SUCCESS_TAG]).inc();
         }
-        metrics.verifier_timeout_metrics.with_label_values(&[BytecodeVerifierMetrics::OVERALL_TAG, BytecodeVerifierMetrics::SUCCESS_TAG]).inc();
     }
     Ok(())
 }

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -415,9 +415,23 @@ pub fn check_non_system_packages_to_be_published(
         // Use the same meter for all packages
         let mut meter = BoundMeter::new(&metered_verifier_config);
         if let TransactionKind::ProgrammableTransaction(pt) = transaction.kind() {
-            pt.non_system_packages_to_be_published()
-            .try_for_each(|q| run_metered_move_bytecode_verifier(q, protocol_config, &metered_verifier_config, &mut meter, metrics))
-            .map_err(|e| UserInputError::PackageVerificationTimedout { err: e.to_string() })?;
+            // Measure time for verifying all packages in the PTB
+            let shared_mater_verifier_timer = metrics.verifier_runtime_per_ptb_success_latency.start_timer();
+            let verifier_status = pt.non_system_packages_to_be_published()
+                .try_for_each(|q| run_metered_move_bytecode_verifier(q, protocol_config, &metered_verifier_config, &mut meter, metrics))
+                .map_err(|e| UserInputError::PackageVerificationTimedout { err: e.to_string() });
+
+            match verifier_status {
+                Ok(_) => {
+                    // Success: stop and record the success timer
+                    shared_mater_verifier_timer.stop_and_record(); },
+                Err(err) => {
+                    // Failure: redirect the success timers output to the failure timer and
+                    // discard the success timer
+                    metrics.verifier_runtime_per_ptb_timeout_latency.observe(shared_mater_verifier_timer.stop_and_discard());
+                    return Err(err);
+                }
+            };
         }
     }
 

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -416,7 +416,7 @@ pub fn check_non_system_packages_to_be_published(
         let mut meter = BoundMeter::new(&metered_verifier_config);
         if let TransactionKind::ProgrammableTransaction(pt) = transaction.kind() {
             // Measure time for verifying all packages in the PTB
-            let shared_mater_verifier_timer = metrics.verifier_runtime_per_ptb_success_latency.start_timer();
+            let shared_meter_verifier_timer = metrics.verifier_runtime_per_ptb_success_latency.start_timer();
             let verifier_status = pt.non_system_packages_to_be_published()
                 .try_for_each(|q| run_metered_move_bytecode_verifier(q, protocol_config, &metered_verifier_config, &mut meter, metrics))
                 .map_err(|e| UserInputError::PackageVerificationTimedout { err: e.to_string() });
@@ -424,11 +424,12 @@ pub fn check_non_system_packages_to_be_published(
             match verifier_status {
                 Ok(_) => {
                     // Success: stop and record the success timer
-                    shared_mater_verifier_timer.stop_and_record(); },
+                    shared_meter_verifier_timer.stop_and_record();
+                },
                 Err(err) => {
                     // Failure: redirect the success timers output to the failure timer and
                     // discard the success timer
-                    metrics.verifier_runtime_per_ptb_timeout_latency.observe(shared_mater_verifier_timer.stop_and_discard());
+                    metrics.verifier_runtime_per_ptb_timeout_latency.observe(shared_meter_verifier_timer.stop_and_discard());
                     return Err(err);
                 }
             };

--- a/crates/sui-types/src/metrics.rs
+++ b/crates/sui-types/src/metrics.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use prometheus::{register_int_counter_vec_with_registry, IntCounterVec};
+use prometheus::{
+    register_histogram_with_registry, register_int_counter_vec_with_registry, Histogram,
+    IntCounterVec,
+};
 
 pub struct LimitsMetrics {
     /// Execution limits metrics
@@ -71,8 +74,16 @@ impl LimitsMetrics {
 }
 
 pub struct BytecodeVerifierMetrics {
-    /// Bytecode verifier metrics
+    /// Bytecode verifier metrics timeout counter
     pub verifier_timeout_metrics: IntCounterVec,
+    /// Bytecode verifier runtime latency for each module successfully verified
+    pub verifier_runtime_per_module_success_latency: Histogram,
+    /// Bytecode verifier runtime latency for each programmable transaction block successfully verified
+    pub verifier_runtime_per_ptb_success_latency: Histogram,
+    /// Bytecode verifier runtime latency for each module which timed out
+    pub verifier_runtime_per_module_timeout_latency: Histogram,
+    /// Bytecode verifier runtime latency for each programmable transaction block which timed out
+    pub verifier_runtime_per_ptb_timeout_latency: Histogram,
 }
 
 impl BytecodeVerifierMetrics {
@@ -81,6 +92,12 @@ impl BytecodeVerifierMetrics {
     pub const OVERALL_TAG: &'static str = "overall";
     pub const SUCCESS_TAG: &'static str = "success";
     pub const TIMEOUT_TAG: &'static str = "failed";
+    const LATENCY_SEC_BUCKETS: &[f64] = &[
+        0.000_010, 0.000_025, 0.000_050, 0.000_100, /* sub 100 micros */
+        0.000_250, 0.000_500, 0.001_000, 0.002_500, 0.005_000, 0.010_000, /* sub 10 ms: p99 */
+        0.025_000, 0.050_000, 0.100_000, 0.250_000, 0.500_000, 1.000_000, /* sub 1 s */
+        10.000_000, 20.000_000, 50.000_000, 100.0, /* We should almost never get here */
+    ];
     pub fn new(registry: &prometheus::Registry) -> Self {
         Self {
             verifier_timeout_metrics: register_int_counter_vec_with_registry!(
@@ -90,6 +107,32 @@ impl BytecodeVerifierMetrics {
                 registry,
             )
             .unwrap(),
+            verifier_runtime_per_module_success_latency: register_histogram_with_registry!(
+                "verifier_runtime_per_module_success_latency",
+                "Time spent running bytecode verifier to completion at `run_metered_move_bytecode_verifier_impl`",
+                Self::LATENCY_SEC_BUCKETS.to_vec(),
+                registry
+            )
+            .unwrap(),
+            verifier_runtime_per_ptb_success_latency: register_histogram_with_registry!(
+                "verifier_runtime_per_ptb_success_latency",
+                "Time spent running bytecode verifier to completion over the entire PTB at `transaction_input_checker::check_non_system_packages_to_be_published`",
+                Self::LATENCY_SEC_BUCKETS.to_vec(),
+                registry
+            ).unwrap(),
+            verifier_runtime_per_module_timeout_latency:  register_histogram_with_registry!(
+                "verifier_runtime_per_module_timeout_latency",
+                "Time spent running bytecode verifier to timeout at `run_metered_move_bytecode_verifier_impl`",
+                Self::LATENCY_SEC_BUCKETS.to_vec(),
+                registry
+            )
+            .unwrap(),
+            verifier_runtime_per_ptb_timeout_latency: register_histogram_with_registry!(
+                "verifier_runtime_per_ptb_timeout_latency",
+                "Time spent running bytecode verifier to timeout over the entire PTB at `transaction_input_checker::check_non_system_packages_to_be_published`",
+                Self::LATENCY_SEC_BUCKETS.to_vec(),
+                registry
+            ).unwrap(),
         }
     }
 }


### PR DESCRIPTION
## Description 

Adds timer histogram metrics for success and timeout scenarios, for both PTB level and module level verificaiton.
[do we want package level too?] 

## Test Plan 

Unit tests
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
