### PR TITLE
[easy] allow short commands for db dump

### DIFF
--- a/crates/sui-tool/src/db_tool/mod.rs
+++ b/crates/sui-tool/src/db_tool/mod.rs
@@ -28,23 +28,23 @@ pub enum DbToolCommand {
 #[clap(rename_all = "kebab-case")]
 pub struct Options {
     /// The type of store to dump
-    #[clap(long = "store", value_enum)]
+    #[clap(long = "store", short = 's', value_enum)]
     store_name: StoreName,
     /// The name of the table to dump
-    #[clap(long = "table-name")]
+    #[clap(long = "table-name", short = 't')]
     table_name: String,
     /// The size of page to dump. This is a u16
-    #[clap(long = "page-size")]
+    #[clap(long = "page-size", short = 'p')]
     page_size: u16,
     /// The page number to dump
-    #[clap(long = "page-num")]
+    #[clap(long = "page-num", short = 'n')]
     page_number: usize,
 
     // TODO: We should load this automatically from the system object in AuthorityPerpetualTables.
     // This is very difficult to do right now because you can't share code between
     // AuthorityPerpetualTables and AuthorityEpochTablesReadonly.
     /// The epoch to use when loading AuthorityEpochTables.
-    #[clap(long = "epoch")]
+    #[clap(long = "epoch", short = 'e')]
     epoch: Option<EpochId>,
 }
 


### PR DESCRIPTION
## Description 

Enables short form of options to make commands less verbose.
```
Usage: sui-tool db-tool --db-path <DB_PATH> dump [OPTIONS] --store <STORE_NAME> --table-name <TABLE_NAME> --page-size <PAGE_SIZE> --page-num <PAGE_NUMBER>

Options:
  -s, --store <STORE_NAME>       The type of store to dump [possible values: validator, index, epoch]
  -t, --table-name <TABLE_NAME>  The name of the table to dump
  -p, --page-size <PAGE_SIZE>    The size of page to dump. This is a u16
  -n, --page-num <PAGE_NUMBER>   The page number to dump
  -e, --epoch <EPOCH>            The epoch to use when loading AuthorityEpochTables
  -h, --help                     Print help

```

## Test Plan 

Manual test

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
