### PR TITLE
[wallet-ext] auto-focus the password input on the locked screen

### DIFF
--- a/apps/wallet/src/ui/app/wallet/locked-page/index.tsx
+++ b/apps/wallet/src/ui/app/wallet/locked-page/index.tsx
@@ -82,6 +82,7 @@ export default function LockedPage() {
                                         <PasswordInputField
                                             name="password"
                                             disabled={isSubmitting}
+                                            autoFocus
                                         />
                                         {touched.password && errors.password ? (
                                             <Alert>{errors.password}</Alert>


### PR DESCRIPTION
## Description 
Saw someone ask for this in Discord and thought it would be a nice addition so users can just type in their password after clicking to open the extension! Let me know if there are any objections here @mystie711 😄 

https://user-images.githubusercontent.com/7453188/236563681-4d529934-e9d3-4194-9cbd-d7244e6145c3.mov

## Test Plan 
- Manual testing

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
N/A
