### PR TITLE
[explorer]: update link fonts

### DIFF
--- a/apps/explorer/src/components/GasBreakdown/index.tsx
+++ b/apps/explorer/src/components/GasBreakdown/index.tsx
@@ -23,10 +23,7 @@ interface GasProps {
     amount?: bigint | number | string;
 }
 
-function GasAmount({
-    amount,
-    isHighlighted,
-}: GasProps & { isHighlighted?: boolean }) {
+function GasAmount({ amount }: GasProps) {
     const [formattedAmount, symbol] = useFormatCoin(
         amount,
         SUI_TYPE_ARG,
@@ -151,6 +148,7 @@ export function GasBreakdown({ summary }: GasBreakdownProps) {
                     <Divider />
 
                     <DescriptionItem
+                        align="start"
                         title={
                             <Text variant="pBody/semibold">Gas Payment</Text>
                         }
@@ -165,6 +163,7 @@ export function GasBreakdown({ summary }: GasBreakdownProps) {
                     </DescriptionItem>
 
                     <DescriptionItem
+                        align="start"
                         title={<Text variant="pBody/semibold">Gas Budget</Text>}
                     >
                         {gasBudget ? (
@@ -177,11 +176,13 @@ export function GasBreakdown({ summary }: GasBreakdownProps) {
                     <Divider />
 
                     <DescriptionItem
+                        align="start"
                         title={<Text variant="pBody/semibold">Gas Price</Text>}
                     >
                         <GasAmount amount={BigInt(gasPrice)} />
                     </DescriptionItem>
                     <DescriptionItem
+                        align="start"
                         title={
                             <Text variant="pBody/semibold">
                                 Computation Fee
@@ -192,6 +193,7 @@ export function GasBreakdown({ summary }: GasBreakdownProps) {
                     </DescriptionItem>
 
                     <DescriptionItem
+                        align="start"
                         title={
                             <Text variant="pBody/semibold">Storage Fee</Text>
                         }
@@ -208,7 +210,6 @@ export function GasBreakdown({ summary }: GasBreakdownProps) {
 
                         <div className="ml-0 min-w-0 flex-1 leading-none">
                             <GasAmount
-                                isHighlighted
                                 amount={-Number(gasUsed?.storageRebate)}
                             />
                         </div>

--- a/apps/explorer/src/ui/DescriptionList.tsx
+++ b/apps/explorer/src/ui/DescriptionList.tsx
@@ -1,16 +1,39 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { cva, type VariantProps } from 'class-variance-authority';
+
 import type { ReactNode } from 'react';
 
-export interface DescriptionItemProps {
+const DescriptionItemStyles = cva(
+    ['flex flex-col gap-2 md:flex-row md:gap-10'],
+    {
+        variants: {
+            align: {
+                start: 'md:items-start',
+                center: 'md:items-center',
+            },
+        },
+        defaultVariants: {
+            align: 'center',
+        },
+    }
+);
+
+type DescriptionItemStylesProps = VariantProps<typeof DescriptionItemStyles>;
+
+export interface DescriptionItemProps extends DescriptionItemStylesProps {
     title: string | ReactNode;
     children: ReactNode;
 }
 
-export function DescriptionItem({ title, children }: DescriptionItemProps) {
+export function DescriptionItem({
+    title,
+    align,
+    children,
+}: DescriptionItemProps) {
     return (
-        <div className="flex flex-col gap-2 md:flex-row md:items-center md:gap-10">
+        <div className={DescriptionItemStyles({ align })}>
             <dt className="w-full flex-shrink-0 text-pBody font-medium text-steel-darker md:w-40">
                 {title}
             </dt>

--- a/apps/explorer/src/ui/Link.tsx
+++ b/apps/explorer/src/ui/Link.tsx
@@ -10,7 +10,7 @@ const linkStyles = cva([], {
     variants: {
         variant: {
             text: 'text-body font-semibold text-steel-dark hover:text-steel-darker active:text-steel disabled:text-gray-60',
-            mono: 'font-mono text-bodySmall font-medium text-hero-dark hover:text-hero-darkest break-all',
+            mono: 'font-mono text-body font-medium text-hero-dark hover:text-hero-darkest break-all',
             textHeroDark:
                 'text-pBody font-medium text-hero-dark hover:text-hero-darkest',
         },

--- a/apps/explorer/src/ui/TransactionBlockCard.tsx
+++ b/apps/explorer/src/ui/TransactionBlockCard.tsx
@@ -34,8 +34,8 @@ function TransactionBlockCardHeader({
         <div
             className={clsx(
                 'flex w-full justify-between',
-                open && size === 'md' && 'mb-6',
-                open && size === 'sm' && 'mb-4.5'
+                open && size === 'md' && 'pb-6',
+                open && size === 'sm' && 'pb-4.5'
             )}
         >
             {typeof title === 'string' ? (
@@ -66,7 +66,7 @@ function TransactionBlockCardHeader({
 
     if (collapsible) {
         return (
-            <Disclosure.Button as="div" className="w-full cursor-pointer">
+            <Disclosure.Button as="div" className="cursor-pointer">
                 {headerContent}
             </Disclosure.Button>
         );

--- a/apps/explorer/src/ui/stories/SplitPanes.stories.tsx
+++ b/apps/explorer/src/ui/stories/SplitPanes.stories.tsx
@@ -34,7 +34,7 @@ const splitPanels = [
     },
     {
         panel: (
-            <div key={3} className="h-full w-[1000px] w-full bg-sui">
+            <div key={3} className="h-full w-[1000px] bg-sui">
                 Third
             </div>
         ),


### PR DESCRIPTION
## Description 

- Update link fonts to `body`, requested by @mystie711 
- Update alignment for Gas card

<img width="480" alt="Screenshot 2023-05-05 at 2 14 48 PM" src="https://user-images.githubusercontent.com/127577476/236570492-4f748057-5501-4981-a9a8-caa8e3ba9119.png">


<img width="485" alt="Screenshot 2023-05-05 at 2 32 45 PM" src="https://user-images.githubusercontent.com/127577476/236572394-d59de728-00a7-4d17-bbe7-1e7a16990b89.png">

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
