### PR TITLE
add mainnetConnection

### DIFF
--- a/sdk/typescript/src/rpc/connection.ts
+++ b/sdk/typescript/src/rpc/connection.ts
@@ -43,3 +43,8 @@ export const testnetConnection = new Connection({
   fullnode: 'https://fullnode.testnet.sui.io:443/',
   faucet: 'https://faucet.testnet.sui.io/gas',
 });
+
+export const mainnetConnection = new Connection({
+  fullnode: 'https://fullnode.mainnet.sui.io:443/',
+  faucet: '',
+});


### PR DESCRIPTION
add mainnetConnection.

## Description 

Now sui is on mainet. So we need mainnetConnection item to communicate. Also the rpc url is the offical one :  
https://fullnode.mainnet.sui.io:443/

## Test Plan 

I test the rpc node url in another project. 
https://github.com/v1xingyue/sui-todo/blob/1d7a76f11d3e46af4b7e852cd839274fe21d95f7/src/pages/index.tsx#L13 

