### PR TITLE
docs-sdk: fixed typo in README splitCoins example

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -169,7 +169,7 @@ const keypair = new Ed25519Keypair();
 const provider = new JsonRpcProvider();
 const signer = new RawSigner(keypair, provider);
 const tx = new TransactionBlock();
-const [coin] = tx.splitCoins(tx.gas, tx.pure(1000));
+const [coin] = tx.splitCoins(tx.gas, [tx.pure(1000)]);
 tx.transferObjects([coin], tx.pure(keypair.getPublicKey().toSuiAddress()));
 const result = await signer.signAndExecuteTransactionBlock({
   transactionBlock: tx,


### PR DESCRIPTION
## Description 

There was a typo in the [`Transfer SUI`](https://github.com/coccoinomane/sui/blob/1090c2d487c574b7f5b58c8775a3b0060c4dee19/sdk/typescript/README.md#transfer-sui) section of the README of the SDK.

The error prevented the example code to work properly, resulting in the following error:

```
StructError: At path: amounts -- Expected an array value, but received: [object Object]
```

The error was reported by several users on Discord, e.g. https://discord.com/channels/916379725201563759/955861929346355290/1098875792873762857
