### PR TITLE
feat: make `total_gas_cost` i64 so it won't panic

### DIFF
--- a/crates/sui-indexer/src/models/checkpoints.rs
+++ b/crates/sui-indexer/src/models/checkpoints.rs
@@ -41,9 +41,9 @@ impl Checkpoint {
     ) -> Result<Self, IndexerError> {
         let total_gas_cost = rpc_checkpoint
             .epoch_rolling_gas_cost_summary
-            .computation_cost
-            + rpc_checkpoint.epoch_rolling_gas_cost_summary.storage_cost
-            - rpc_checkpoint.epoch_rolling_gas_cost_summary.storage_rebate;
+            .computation_cost as i64
+            + rpc_checkpoint.epoch_rolling_gas_cost_summary.storage_cost as i64
+            - rpc_checkpoint.epoch_rolling_gas_cost_summary.storage_rebate as i64;
 
         let checkpoint_transactions: Vec<Option<String>> = rpc_checkpoint
             .transactions
@@ -58,7 +58,7 @@ impl Checkpoint {
             transactions: checkpoint_transactions,
             previous_checkpoint_digest: rpc_checkpoint.previous_digest.map(|d| d.base58_encode()),
             end_of_epoch: rpc_checkpoint.end_of_epoch_data.is_some(),
-            total_gas_cost: total_gas_cost as i64,
+            total_gas_cost,
             total_computation_cost: rpc_checkpoint
                 .epoch_rolling_gas_cost_summary
                 .computation_cost as i64,


### PR DESCRIPTION
## Description 

The `total_gas_cost` results in an overflow in case of -ve value.

