### PR TITLE
[Narwhal] do not request certificates when voting on headers

### DIFF
--- a/narwhal/types/src/primary.rs
+++ b/narwhal/types/src/primary.rs
@@ -1160,6 +1160,7 @@ pub struct RequestVoteRequest {
 
     // Optional parent certificates provided by the requester, in case this primary doesn't yet
     // have them and requires them in order to offer a vote.
+    // TODO: remove the unused field below.
     pub parents: Vec<Certificate>,
 }
 
@@ -1169,6 +1170,7 @@ pub struct RequestVoteResponse {
     pub vote: Option<Vote>,
 
     // Indicates digests of missing certificates without which a vote cannot be provided.
+    // TODO: remove the unused field below.
     pub missing: Vec<CertificateDigest>,
 }
 


### PR DESCRIPTION
## Description 

After checking data in private testnet, number of certificates in votes (as parents) correlates strongly with the number of calls to `Synchronizer::process_certificate_internal()`, and latency spikes in `send_certificate()` handler. The latency spikes may come from contentions, e.g. on certificate store or synchronizer.

To mitigate the issue, I came to the conclusion that the logic to request missing parent certificates from header proposer should be removed.
- For liveness, infinite retries when broadcasting latest certificate is sufficient to trigger certificate catchup. A separate certificate catchup mechanism via header proposal and voting seems unnecessary.
- For e2e voting latency, I believe it should be rare to receive missing certificates via RequestVoteRequest instead of certificate broadcast or fetching. We can add metrics to compare and keep monitoring p95 latencies. Also, only 2f+1 votes are needed to certify a header, so header to certificate latency should not be affected by missing parents unless there are significant issues with certificate broadcast.

An obvious alternative to mitigate latency spikes from processing large number of parent certificates in RequestVoteRequest, is to limit the times a certificate digest can be requested via RequestVoteResponse, and limit the total number of certificates a RequestVoteRequest can contain. But this will add significant complexity, considering that this requires synchronization across RequestVote handlers, and a parent certificate digest may not exist at all.

## Test Plan 

CI. Deploy to private testnet.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
