### PR TITLE
record last executed timestamp age v.s. the timestamp itself

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10653,6 +10653,7 @@ dependencies = [
  "move-core-types",
  "move-disassembler",
  "move-ir-types",
+ "mysten-metrics",
  "mysten-network",
  "narwhal-config",
  "narwhal-crypto",

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/metrics.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/metrics.rs
@@ -11,7 +11,6 @@ use std::sync::Arc;
 pub struct CheckpointExecutorMetrics {
     pub checkpoint_exec_sync_tps: IntGauge,
     pub last_executed_checkpoint: IntGauge,
-    pub last_executed_checkpoint_timestamp_ms: IntGauge,
     pub checkpoint_exec_errors: IntCounter,
     pub checkpoint_exec_epoch: IntGauge,
     pub checkpoint_exec_inflight: IntGauge,
@@ -19,6 +18,7 @@ pub struct CheckpointExecutorMetrics {
     pub checkpoint_prepare_latency_us: Histogram,
     pub checkpoint_transaction_count: Histogram,
     pub checkpoint_contents_age_ms: Histogram,
+    pub last_executed_checkpoint_age_ms: Histogram,
     pub accumulator_inconsistent_state: IntGauge,
 }
 
@@ -34,12 +34,6 @@ impl CheckpointExecutorMetrics {
             last_executed_checkpoint: register_int_gauge_with_registry!(
                 "last_executed_checkpoint",
                 "Last executed checkpoint",
-                registry
-            )
-            .unwrap(),
-            last_executed_checkpoint_timestamp_ms: register_int_gauge_with_registry!(
-                "last_executed_checkpoint_timestamp_ms",
-                "Last executed checkpoint timestamp ms",
                 registry
             )
             .unwrap(),
@@ -80,6 +74,11 @@ impl CheckpointExecutorMetrics {
                 "checkpoint_contents_age_ms",
                 "Age of checkpoints when they arrive for execution",
                 registry,
+            ),
+            last_executed_checkpoint_age_ms: Histogram::new_in_registry(
+                "last_executed_checkpoint_age_ms",
+                "Age of the last executed checkpoint",
+                registry
             ),
             accumulator_inconsistent_state: register_int_gauge_with_registry!(
                 "accumulator_inconsistent_state",

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -21,7 +21,7 @@
 use std::{
     collections::HashMap,
     sync::Arc,
-    time::{Duration, Instant, SystemTime},
+    time::{Duration, Instant},
 };
 
 use futures::stream::FuturesOrdered;
@@ -39,7 +39,7 @@ use sui_types::{
     transaction::VerifiedTransaction,
 };
 use sui_types::{error::SuiResult, transaction::TransactionDataAPI};
-use tap::{TapFallible, TapOptional};
+use tap::TapOptional;
 use tokio::{
     sync::broadcast::{self, error::RecvError},
     task::JoinHandle,
@@ -202,12 +202,7 @@ impl CheckpointExecutor {
                             sequence_number = ?checkpoint.sequence_number,
                             "received checkpoint summary from state sync"
                         );
-                        SystemTime::now().duration_since(checkpoint.timestamp())
-                            .map(|latency|
-                                self.metrics.checkpoint_contents_age_ms.report(latency.as_millis() as u64)
-                            )
-                            .tap_err(|err| warn!("unable to compute checkpoint age: {}", err))
-                            .ok();
+                        checkpoint.report_checkpoint_age_ms(&self.metrics.checkpoint_contents_age_ms);
                     },
                     // In this case, messages in the mailbox have been overwritten
                     // as a result of lagging too far behind.
@@ -275,15 +270,7 @@ impl CheckpointExecutor {
             .unwrap();
         self.metrics.last_executed_checkpoint.set(seq as i64);
 
-        SystemTime::now()
-            .duration_since(checkpoint.timestamp())
-            .map(|latency| {
-                self.metrics
-                    .last_executed_checkpoint_age_ms
-                    .report(latency.as_millis() as u64)
-            })
-            .tap_err(|err| warn!("unable to compute checkpoint age: {}", err))
-            .ok();
+        checkpoint.report_checkpoint_age_ms(&self.metrics.last_executed_checkpoint_age_ms);
     }
 
     async fn schedule_synced_checkpoints(

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -236,7 +236,6 @@ impl CheckpointExecutor {
     fn process_executed_checkpoint(&self, checkpoint: &VerifiedCheckpoint) {
         // Ensure that we are not skipping checkpoints at any point
         let seq = *checkpoint.sequence_number();
-        let timestamp_ms = checkpoint.timestamp_ms;
         if let Some(prev_highest) = self
             .checkpoint_store
             .get_highest_executed_checkpoint_seq_number()
@@ -275,9 +274,16 @@ impl CheckpointExecutor {
             .update_highest_executed_checkpoint(checkpoint)
             .unwrap();
         self.metrics.last_executed_checkpoint.set(seq as i64);
-        self.metrics
-            .last_executed_checkpoint_timestamp_ms
-            .set(timestamp_ms as i64);
+
+        SystemTime::now()
+            .duration_since(checkpoint.timestamp())
+            .map(|latency| {
+                self.metrics
+                    .last_executed_checkpoint_age_ms
+                    .report(latency.as_millis() as u64)
+            })
+            .tap_err(|err| warn!("unable to compute checkpoint age: {}", err))
+            .ok();
     }
 
     async fn schedule_synced_checkpoints(

--- a/crates/sui-core/src/checkpoints/metrics.rs
+++ b/crates/sui-core/src/checkpoints/metrics.rs
@@ -22,6 +22,8 @@ pub struct CheckpointMetrics {
     pub last_sent_checkpoint_signature: IntGauge,
     pub highest_accumulated_epoch: IntGauge,
     pub checkpoint_creation_latency_ms: Histogram,
+    pub last_created_checkpoint_age_ms: Histogram,
+    pub last_certified_checkpoint_age_ms: Histogram,
 }
 
 impl CheckpointMetrics {
@@ -39,6 +41,16 @@ impl CheckpointMetrics {
                 registry
             )
             .unwrap(),
+            last_created_checkpoint_age_ms: Histogram::new_in_registry(
+                "last_created_checkpoint_age_ms",
+                "Age of the last created checkpoint",
+                registry
+            ),
+            last_certified_checkpoint_age_ms: Histogram::new_in_registry(
+                "last_certified_checkpoint_age_ms",
+                "Age of the last certified checkpoint",
+                registry
+            ),
             checkpoint_errors: register_int_counter_with_registry!(
                 "checkpoint_errors",
                 "Checkpoints errors count",

--- a/crates/sui-network/src/state_sync/metrics.rs
+++ b/crates/sui-network/src/state_sync/metrics.rs
@@ -4,7 +4,6 @@
 use mysten_metrics::histogram::Histogram;
 use prometheus::{register_int_gauge_with_registry, IntGauge, Registry};
 use std::sync::Arc;
-use std::time::Duration;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use tap::Pipe;
 
@@ -46,12 +45,11 @@ impl Metrics {
         }
     }
 
-    pub fn report_checkpoint_summary_age(&self, age: Duration) {
+    pub fn checkpoint_summary_age_metric(&self) -> Option<&Histogram> {
         if let Some(inner) = &self.0 {
-            inner
-                .checkpoint_summary_age_ms
-                .report(age.as_millis() as u64);
+            return Some(&inner.checkpoint_summary_age_ms);
         }
+        None
     }
 }
 

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -48,6 +48,7 @@ sui-cost-tables = { path = "../sui-cost-tables"}
 sui-protocol-config = { path = "../sui-protocol-config" }
 shared-crypto = { path = "../shared-crypto" }
 mysten-network = { path = "../mysten-network" }
+mysten-metrics = { path = "../mysten-metrics" }
 sui-macros = { path = "../sui-macros" }
 
 fastcrypto = { workspace = true, features = ["copy_key"] }


### PR DESCRIPTION
## Description 

as title

## Test Plan 

CI
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Eecord last executed timestamp age v.s. the timestamp itself