### PR TITLE
[wallet-kit] Filtering sui accounts

### DIFF
--- a/sdk/wallet-adapter/wallet-kit-core/src/index.ts
+++ b/sdk/wallet-adapter/wallet-kit-core/src/index.ts
@@ -247,9 +247,16 @@ export function createWalletKitCore({
           } catch {}
           // TODO: Rather than using this method, we should just standardize the wallet properties on the adapter itself:
           const accounts = await currentWallet.getAccounts();
+          const suiAccounts = accounts.filter(account => { 
+            if (account.chains[0]) {
+              return account.chains[0].split(':')[0] === 'sui';
+            } else {
+              return false;
+            }
+          });
           // TODO: Implement account selection:
 
-          setState({ accounts, currentAccount: accounts[0] ?? null });
+          setState({ accounts: suiAccounts, currentAccount: suiAccounts[0] ?? null });
         } catch (e) {
           console.log("Wallet connection error", e);
 


### PR DESCRIPTION
## Description 
This PR adds a filtering process that selects only Sui accounts from multi-chain accounts. This is required for support the multi-chain Wallet Standard.

More description 👉🏻 https://github.com/MystenLabs/sui/issues/11457

## Test Plan
Test with existing wallets supporting Wallet Standard and wallets supporting multi-chain Wallet Standard.
1. Connect with those wallet using wallet kit.
2. Check how for Wallet Kit to process the accounts(`WalletAccount[]`) returned from the wallet after connecting to the wallet.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
