### PR TITLE
[Faucet] Adding merge/ split coin functions from rust script

### DIFF
--- a/crates/sui-faucet/src/bin/merge_coins.rs
+++ b/crates/sui-faucet/src/bin/merge_coins.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-async fn split_coins_equally(
+async fn _split_coins_equally(
     gas_coin: &str,
     mut wallet: WalletContext,
     count: u64,
@@ -72,7 +72,7 @@ async fn split_coins_equally(
     Ok(())
 }
 
-async fn merge_coins(gas_coin: &str, mut wallet: WalletContext) -> Result<(), anyhow::Error> {
+async fn _merge_coins(gas_coin: &str, mut wallet: WalletContext) -> Result<(), anyhow::Error> {
     let active_address = wallet
         .active_address()
         .map_err(|err| FaucetError::Wallet(err.to_string()))?;
@@ -115,7 +115,7 @@ async fn merge_coins(gas_coin: &str, mut wallet: WalletContext) -> Result<(), an
         let tx = Transaction::from_data(tx_data, Intent::sui_transaction(), vec![signature])
             .verify()
             .unwrap();
-        let resp = client
+        client
             .quorum_driver_api()
             .execute_transaction_block(
                 tx.clone(),


### PR DESCRIPTION
## Description 

Added a script to do merge/split coins instead of having to use CLI

## Test Plan 

![](https://media2.giphy.com/media/x0npYExCGOZeo/giphy.gif?cid=ecf05e47ds44alb30295vmyjy8xcvl84ozjsv51qfv0rmhnp&rid=giphy.gif&ct=g)
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
