### PR TITLE
[fix] failing build due to missing import

### DIFF
--- a/narwhal/consensus/benches/process_certificates.rs
+++ b/narwhal/consensus/benches/process_certificates.rs
@@ -15,7 +15,7 @@ use pprof::criterion::{Output, PProfProfiler};
 use prometheus::Registry;
 use std::{collections::BTreeSet, sync::Arc};
 use storage::NodeStorage;
-use test_utils::{make_consensus_store, make_optimal_certificates, temp_dir, CommitteeFixture};
+use test_utils::{make_optimal_certificates, temp_dir, CommitteeFixture};
 use tokio::time::Instant;
 use types::{Certificate, Round};
 


### PR DESCRIPTION
## Description 

`make_consensus_store` doesn't exist anymore and is making build fail https://github.com/MystenLabs/sui/actions/runs/4910003494

## Test Plan 


---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
