### PR TITLE
[Part 1/2] Use TestCluster universally

### DIFF
--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -357,6 +357,13 @@ impl ProcessTransactionResult {
             Self::Executed(..) => panic!("Wrong type"),
         }
     }
+
+    pub fn into_effects_for_testing(self) -> VerifiedCertifiedTransactionEffects {
+        match self {
+            Self::Certified(..) => panic!("Wrong type"),
+            Self::Executed(effects, ..) => effects,
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -584,8 +591,8 @@ impl AuthorityAggregator<NetworkAuthorityClient> {
                 if authority_name.is_err() {
                     return None;
                 }
-                let human_readble_name = s.name;
-                Some((authority_name.unwrap(), human_readble_name))
+                let human_readable_name = s.name;
+                Some((authority_name.unwrap(), human_readable_name))
             })
             .collect();
         Self::new_from_committee(

--- a/crates/sui-sdk/src/wallet_context.rs
+++ b/crates/sui-sdk/src/wallet_context.rs
@@ -200,14 +200,20 @@ impl WalletContext {
         ))
     }
 
-    /// Given an address, return one gas object owned by this address.
-    /// The actual implementation just returns the first one returned by the read api.
-    pub async fn get_one_gas_object_owned_by_address(
+    pub async fn get_all_gas_objects_owned_by_address(
         &self,
         address: SuiAddress,
-    ) -> anyhow::Result<Option<ObjectRef>> {
+    ) -> anyhow::Result<Vec<ObjectRef>> {
+        self.get_gas_objects_owned_by_address(address, None).await
+    }
+
+    pub async fn get_gas_objects_owned_by_address(
+        &self,
+        address: SuiAddress,
+        limit: Option<usize>,
+    ) -> anyhow::Result<Vec<ObjectRef>> {
         let client = self.get_client().await?;
-        let mut response = client
+        let results: Vec<_> = client
             .read_api()
             .get_owned_objects(
                 address,
@@ -216,13 +222,35 @@ impl WalletContext {
                     Some(SuiObjectDataOptions::full_content()),
                 )),
                 None,
-                Some(1),
+                limit,
             )
-            .await?;
-        Ok(response
+            .await?
             .data
-            .pop()
-            .and_then(|r| r.data.map(|o| o.object_ref())))
+            .into_iter()
+            .filter_map(|r| r.data.map(|o| o.object_ref()))
+            .collect();
+        Ok(results)
+    }
+
+    /// Given an address, return one gas object owned by this address.
+    /// The actual implementation just returns the first one returned by the read api.
+    pub async fn get_one_gas_object_owned_by_address(
+        &self,
+        address: SuiAddress,
+    ) -> anyhow::Result<Option<ObjectRef>> {
+        Ok(self
+            .get_gas_objects_owned_by_address(address, Some(1))
+            .await?
+            .pop())
+    }
+
+    /// Returns one address and all gas objects owned by that address.
+    pub async fn get_one_account(&self) -> anyhow::Result<(SuiAddress, Vec<ObjectRef>)> {
+        let address = self.get_addresses().pop().unwrap();
+        Ok((
+            address,
+            self.get_all_gas_objects_owned_by_address(address).await?,
+        ))
     }
 
     /// Return a gas object owned by an arbitrary address managed by the wallet.
@@ -329,6 +357,22 @@ impl WalletContext {
             }
         }
         res
+    }
+
+    pub async fn make_transfer_sui_transaction(
+        &self,
+        recipient: Option<SuiAddress>,
+        amount: Option<u64>,
+    ) -> VerifiedTransaction {
+        let accounts_and_objs = self.get_all_accounts_and_gas_objects().await.unwrap();
+        let sender = accounts_and_objs[0].0;
+        let gas_object = accounts_and_objs[0].1[0];
+        let gas_price = self.get_reference_gas_price().await.unwrap();
+        self.sign_transaction(
+            &TestTransactionBuilder::new(sender, gas_object, gas_price)
+                .transfer_sui(amount, recipient.unwrap_or(sender))
+                .build(),
+        )
     }
 
     pub async fn make_staking_transaction(

--- a/crates/sui/tests/checkpoint_tests.rs
+++ b/crates/sui/tests/checkpoint_tests.rs
@@ -1,69 +1,28 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use prometheus::Registry;
-
 use std::time::Duration;
-
-use sui_core::authority_aggregator::{AuthAggMetrics, AuthorityAggregator};
-
-use sui_core::safe_client::SafeClientMetricsBase;
-use sui_core::test_utils::make_transfer_sui_transaction;
 use sui_macros::sim_test;
-
-use sui_types::crypto::get_account_key_pair;
-
-use sui_types::object::Object;
-use test_utils::authority::{spawn_test_authorities, test_authority_configs_with_objects};
+use test_utils::network::TestClusterBuilder;
 
 #[sim_test]
 async fn basic_checkpoints_integration_test() {
-    let (sender, keypair) = get_account_key_pair();
-    let gas1 = Object::with_owner_for_testing(sender);
-    let (configs, mut objects) = test_authority_configs_with_objects([gas1]);
-    let gas1 = objects.pop().expect("Should contain a single gas object");
-    let authorities = spawn_test_authorities(&configs).await;
-    let registry = Registry::new();
-
-    let rgp = authorities
-        .get(0)
-        .unwrap()
-        .with(|sui_node| sui_node.state().reference_gas_price_for_testing())
-        .unwrap();
-
-    // gas1 transaction is committed
-    let tx = make_transfer_sui_transaction(
-        gas1.compute_object_reference(),
-        sender,
-        None,
-        sender,
-        &keypair,
-        rgp,
-    );
-    let net = AuthorityAggregator::new_from_local_system_state(
-        &authorities[0].with(|node| node.state().db()),
-        &authorities[0].with(|node| node.state().committee_store().clone()),
-        SafeClientMetricsBase::new(&registry),
-        AuthAggMetrics::new(&registry),
-    )
-    .unwrap();
-    let cert = net
-        .process_transaction(tx.clone())
-        .await
-        .unwrap()
-        .into_cert_for_testing();
-    let _effects = net
-        .process_certificate(cert.clone().into_inner())
-        .await
-        .unwrap();
+    let test_cluster = TestClusterBuilder::new().build().await.unwrap();
+    let tx = test_cluster
+        .wallet
+        .make_transfer_sui_transaction(None, None)
+        .await;
+    let digest = *tx.digest();
+    test_cluster.execute_transaction(tx).await.unwrap();
 
     for _ in 0..600 {
-        let all_included = authorities.iter().all(|handle| {
-            handle.with(|node| {
-                node.is_transaction_executed_in_checkpoint(tx.digest())
-                    .unwrap()
-            })
-        });
+        let all_included = test_cluster
+            .swarm
+            .validator_node_handles()
+            .into_iter()
+            .all(|handle| {
+                handle.with(|node| node.is_transaction_executed_in_checkpoint(&digest).unwrap())
+            });
         if all_included {
             // success
             return;

--- a/crates/sui/tests/onsite_reconfig_observer_tests.rs
+++ b/crates/sui/tests/onsite_reconfig_observer_tests.rs
@@ -1,14 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(clippy::async_yields_async)]
 use prometheus::Registry;
 use sui_core::authority_aggregator::AuthAggMetrics;
 use sui_core::quorum_driver::reconfig_observer::OnsiteReconfigObserver;
 use sui_core::quorum_driver::reconfig_observer::ReconfigObserver;
 use sui_core::safe_client::SafeClientMetricsBase;
-use test_utils::authority::{spawn_fullnode, spawn_test_authorities, test_authority_configs};
-use test_utils::network::wait_for_nodes_transition_to_epoch;
+use test_utils::network::TestClusterBuilder;
 use tracing::info;
 
 use sui_macros::sim_test;
@@ -16,52 +14,48 @@ use sui_macros::sim_test;
 #[sim_test]
 async fn test_onsite_reconfig_observer_basic() {
     telemetry_subscribers::init_for_testing();
-    let config = test_authority_configs();
-    let authorities = spawn_test_authorities(&config).await;
-    let fullnode = spawn_fullnode(&config, None).await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_epoch_duration_ms(10000)
+        .build()
+        .await
+        .unwrap();
 
-    let _observer_handle = fullnode
-        .with_async(|node| async {
-            let qd = node
-                .transaction_orchestrator()
-                .unwrap()
-                .clone_quorum_driver();
-            assert_eq!(qd.current_epoch(), 0);
-            let rx = node.subscribe_to_epoch_change();
-            let registry = Registry::new();
-            let mut observer = OnsiteReconfigObserver::new(
-                rx,
-                node.clone_authority_store(),
-                node.clone_committee_store(),
-                SafeClientMetricsBase::new(&registry),
-                AuthAggMetrics::new(&registry),
-            );
-            let qd_clone = qd.clone_quorum_driver();
-            tokio::task::spawn(async move { observer.run(qd_clone).await })
-        })
-        .await;
-    info!("Shutting down epoch 0");
-    for handle in &authorities {
-        handle
-            .with_async(|node| async { node.close_epoch_for_testing().await.unwrap() })
-            .await;
-    }
+    let fullnode = &test_cluster.fullnode_handle.sui_node;
+
+    let qd = fullnode
+        .transaction_orchestrator()
+        .unwrap()
+        .clone_quorum_driver();
+    assert_eq!(qd.current_epoch(), 0);
+    let rx = fullnode.subscribe_to_epoch_change();
+    let registry = Registry::new();
+    let mut observer = OnsiteReconfigObserver::new(
+        rx,
+        fullnode.clone_authority_store(),
+        fullnode.clone_committee_store(),
+        SafeClientMetricsBase::new(&registry),
+        AuthAggMetrics::new(&registry),
+    );
+    let qd_clone = qd.clone_quorum_driver();
+    let _observer_handle = tokio::task::spawn(async move { observer.run(qd_clone).await });
+
     // Wait for all nodes to reach the next epoch.
     info!("Waiting for nodes to advance to epoch 1");
-    wait_for_nodes_transition_to_epoch(authorities.iter().chain(std::iter::once(&fullnode)), 1)
-        .await;
+    test_cluster.wait_for_epoch(Some(1)).await;
 
     // Give it some time for the update to happen
     tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
-    fullnode.with(|node| {
-        let qd = node
-            .transaction_orchestrator()
+    let qd = fullnode
+        .transaction_orchestrator()
+        .unwrap()
+        .clone_quorum_driver();
+    assert_eq!(qd.current_epoch(), 1);
+    assert_eq!(
+        fullnode
+            .clone_authority_aggregator()
             .unwrap()
-            .clone_quorum_driver();
-        assert_eq!(qd.current_epoch(), 1);
-        assert_eq!(
-            node.clone_authority_aggregator().unwrap().committee.epoch,
-            1
-        );
-    });
+            .committee
+            .epoch,
+        1
+    );
 }

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -11,7 +11,7 @@ use jsonrpsee::ws_client::WsClient;
 use jsonrpsee::ws_client::WsClientBuilder;
 use prometheus::Registry;
 use rand::{distributions::*, rngs::OsRng, seq::SliceRandom};
-use tokio::time::timeout;
+use tokio::time::{timeout, Instant};
 use tokio::{task::JoinHandle, time::sleep};
 use tracing::info;
 
@@ -199,6 +199,64 @@ impl TestCluster {
         })
         .await
         .expect("Timed out waiting for cluster to target epoch")
+    }
+
+    /// Ask 2f+1 validators to close epoch actively, and wait for the entire network to reach the next
+    /// epoch. This requires waiting for both the fullnode and all validators to reach the next epoch.
+    pub async fn trigger_reconfiguration(&self) {
+        info!("Starting reconfiguration");
+        let start = Instant::now();
+
+        // Close epoch on 2f+1 validators.
+        let cur_committee = self
+            .fullnode_handle
+            .sui_node
+            .state()
+            .clone_committee_for_testing();
+        let mut cur_stake = 0;
+        for handle in self.swarm.validator_node_handles() {
+            handle
+                .with_async(|node| async {
+                    node.close_epoch_for_testing().await.unwrap();
+                    cur_stake += cur_committee.weight(&node.state().name);
+                })
+                .await;
+            if cur_stake >= cur_committee.quorum_threshold() {
+                break;
+            }
+        }
+        info!("close_epoch complete after {:?}", start.elapsed());
+
+        self.wait_for_epoch(Some(cur_committee.epoch + 1)).await;
+        self.wait_for_epoch_all_validators(cur_committee.epoch + 1)
+            .await;
+
+        info!("reconfiguration complete after {:?}", start.elapsed());
+    }
+
+    pub async fn wait_for_epoch_all_validators(&self, target_epoch: EpochId) {
+        let handles = self.swarm.validator_node_handles();
+        let tasks: Vec<_> = handles.iter()
+            .map(|handle| {
+                handle.with_async(|node| async {
+                    let mut retries = 0;
+                    loop {
+                        if node.state().epoch_store_for_testing().epoch() == target_epoch {
+                            break;
+                        }
+                        tokio::time::sleep(Duration::from_secs(1)).await;
+                        retries += 1;
+                        if retries % 5 == 0 {
+                            tracing::warn!(validator=?node.state().name.concise(), "Waiting for {:?} seconds for epoch change", retries);
+                        }
+                    }
+                })
+            })
+            .collect();
+
+        timeout(Duration::from_secs(40), join_all(tasks))
+            .await
+            .expect("timed out waiting for reconfiguration to complete");
     }
 
     /// Upgrade the network protocol version, by restarting every validator with a new


### PR DESCRIPTION
A lot of tests spawn authority nodes individually. This is redundant to the functionality of TestCluster.
This PR replaces a large number of those tests to use TestCluster insdead.

There are two categories that are not update in this PR:
1. Dynamic committee change tests: these types of tests requires some careful crafting of validator set and their keys. I need to figure out a systematic way for integrating them into TestCluster.
2. Many of the shared object tests heavily depend on transactions.rs, which is currently being cleaned up. Leaving that part along to avoid merge conflicts.