### PR TITLE
[1/x] move some test util functions to wallet context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10366,6 +10366,7 @@ dependencies = [
  "move-symbol-pool",
  "rand 0.8.5",
  "sui",
+ "sui-json-rpc-types",
  "sui-move-build",
  "sui-sdk",
  "sui-types",

--- a/crates/sui-benchmark/src/workloads/adversarial.rs
+++ b/crates/sui-benchmark/src/workloads/adversarial.rs
@@ -242,7 +242,7 @@ impl AdversarialTestPayload {
                 let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
                 path.push("src/workloads/data/max_package");
                 TestTransactionBuilder::new(self.sender, account.gas, gas_price)
-                    .publish(path)
+                    .publish(path, false)
                     .build_and_sign(account.key())
             }
             _ => self.state.move_call_pt(
@@ -462,7 +462,7 @@ impl Workload<dyn Payload> for AdversarialWorkload {
         let protocol_config = protocol_config.unwrap();
         let gas_budget = protocol_config.max_tx_gas();
         let transaction = TestTransactionBuilder::new(gas.1, gas.0, reference_gas_price)
-            .publish(path)
+            .publish(path, false)
             .build_and_sign(gas.2.as_ref());
         let effects = proxy
             .execute_transaction_block(transaction.into())

--- a/crates/sui-benchmark/src/workloads/adversarial.rs
+++ b/crates/sui-benchmark/src/workloads/adversarial.rs
@@ -242,7 +242,7 @@ impl AdversarialTestPayload {
                 let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
                 path.push("src/workloads/data/max_package");
                 TestTransactionBuilder::new(self.sender, account.gas, gas_price)
-                    .publish(path, false)
+                    .publish(path)
                     .build_and_sign(account.key())
             }
             _ => self.state.move_call_pt(
@@ -462,7 +462,7 @@ impl Workload<dyn Payload> for AdversarialWorkload {
         let protocol_config = protocol_config.unwrap();
         let gas_budget = protocol_config.max_tx_gas();
         let transaction = TestTransactionBuilder::new(gas.1, gas.0, reference_gas_price)
-            .publish(path, false)
+            .publish(path)
             .build_and_sign(gas.2.as_ref());
         let effects = proxy
             .execute_transaction_block(transaction.into())

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -261,7 +261,17 @@ mod test {
         // to the latest protocol version.
         let max_ver = ProtocolVersion::MAX.as_u64();
         let min_ver = max_ver - 1;
-        test_protocol_upgrade_compatibility_impl(min_ver, "testnet").await;
+        let timeout = tokio::time::timeout(
+            Duration::from_secs(1000),
+            test_protocol_upgrade_compatibility_impl(min_ver, "testnet"),
+        )
+        .await;
+        match timeout {
+            Ok(_) => {}
+            Err(_) => {
+                panic!("testnet upgrade compatibility test timed out");
+            }
+        }
     }
 
     #[sim_test(config = "test_config()")]

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -183,10 +183,6 @@ pub fn compile_basics_package() -> CompiledPackage {
     compile_example_package("../../sui_programmability/examples/basics")
 }
 
-pub fn compile_nfts_package() -> CompiledPackage {
-    compile_example_package("../../sui_programmability/examples/nfts")
-}
-
 pub fn compile_managed_coin_package() -> CompiledPackage {
     compile_example_package("../../crates/sui-core/src/unit_tests/data/managed_coin")
 }

--- a/crates/sui-json-rpc/tests/subscription_tests.rs
+++ b/crates/sui-json-rpc/tests/subscription_tests.rs
@@ -12,18 +12,17 @@ use sui_json_rpc_types::{
     SuiTransactionBlockEffects, SuiTransactionBlockEffectsAPI, TransactionFilter,
 };
 use test_utils::network::TestClusterBuilder;
-use test_utils::transaction::{create_devnet_nft, publish_nfts_package};
 
 #[tokio::test]
 async fn test_subscribe_transaction() -> Result<(), anyhow::Error> {
     let cluster = TestClusterBuilder::new().build().await.unwrap();
 
     let address = &cluster.accounts[0];
-    let mut wallet = cluster.wallet;
+    let wallet = cluster.wallet;
 
     let ws_client = cluster.fullnode_handle.ws_client;
 
-    let package_id = publish_nfts_package(&mut wallet).await.0;
+    let package_id = wallet.publish_nfts_package().await.0;
 
     let mut sub: Subscription<SuiTransactionBlockEffects> = ws_client
         .subscribe(
@@ -34,7 +33,7 @@ async fn test_subscribe_transaction() -> Result<(), anyhow::Error> {
         .await
         .unwrap();
 
-    let (_, _, digest) = create_devnet_nft(&mut wallet, package_id).await?;
+    let (_, _, digest) = wallet.create_devnet_nft(package_id).await;
     wait_for_tx(digest, cluster.fullnode_handle.sui_node.state().clone()).await;
 
     // Wait for streaming

--- a/crates/sui-sdk/src/wallet_context.rs
+++ b/crates/sui-sdk/src/wallet_context.rs
@@ -353,9 +353,7 @@ impl WalletContext {
         path: PathBuf,
         with_unpublished_deps: bool,
     ) -> VerifiedTransaction {
-        let accounts_and_objs = self.get_all_accounts_and_gas_objects().await.unwrap();
-        let sender = accounts_and_objs[0].0;
-        let gas_object = accounts_and_objs[0].1[0];
+        let (sender, gas_object) = self.get_one_gas_object().await.unwrap().unwrap();
         let gas_price = self.get_reference_gas_price().await.unwrap();
         self.sign_transaction(
             &TestTransactionBuilder::new(sender, gas_object, gas_price)
@@ -366,9 +364,7 @@ impl WalletContext {
 
     /// Executed a transaction to publish the `basics` package and returns the package object ref.
     pub async fn publish_basics_package(&self) -> ObjectRef {
-        let accounts_and_objs = self.get_all_accounts_and_gas_objects().await.unwrap();
-        let sender = accounts_and_objs[0].0;
-        let gas_object = accounts_and_objs[0].1[0];
+        let (sender, gas_object) = self.get_one_gas_object().await.unwrap().unwrap();
         let gas_price = self.get_reference_gas_price().await.unwrap();
         let txn = self.sign_transaction(
             &TestTransactionBuilder::new(sender, gas_object, gas_price)
@@ -381,9 +377,7 @@ impl WalletContext {
 
     /// Executes a transaction to publish the `nfts` package and returns the package id, id of the gas object used, and the digest of the transaction.
     pub async fn publish_nfts_package(&self) -> (ObjectID, ObjectID, TransactionDigest) {
-        let accounts_and_objs = self.get_all_accounts_and_gas_objects().await.unwrap();
-        let sender = accounts_and_objs[0].0;
-        let gas_object = accounts_and_objs[0].1[0];
+        let (sender, gas_object) = self.get_one_gas_object().await.unwrap().unwrap();
         let gas_id = gas_object.0;
         let gas_price = self.get_reference_gas_price().await.unwrap();
         let txn = self.sign_transaction(
@@ -402,9 +396,7 @@ impl WalletContext {
         &self,
         package_id: ObjectID,
     ) -> (SuiAddress, ObjectID, TransactionDigest) {
-        let accounts_and_objs = self.get_all_accounts_and_gas_objects().await.unwrap();
-        let sender = accounts_and_objs[0].0;
-        let gas_object = accounts_and_objs[0].1[0];
+        let (sender, gas_object) = self.get_one_gas_object().await.unwrap().unwrap();
         let rgp = self.get_reference_gas_price().await.unwrap();
 
         let txn = self.sign_transaction(

--- a/crates/sui-sdk/src/wallet_context.rs
+++ b/crates/sui-sdk/src/wallet_context.rs
@@ -348,16 +348,22 @@ impl WalletContext {
         )
     }
 
-    pub async fn make_publish_transaction(
-        &self,
-        path: PathBuf,
-        with_unpublished_deps: bool,
-    ) -> VerifiedTransaction {
+    pub async fn make_publish_transaction(&self, path: PathBuf) -> VerifiedTransaction {
         let (sender, gas_object) = self.get_one_gas_object().await.unwrap().unwrap();
         let gas_price = self.get_reference_gas_price().await.unwrap();
         self.sign_transaction(
             &TestTransactionBuilder::new(sender, gas_object, gas_price)
-                .publish(path, with_unpublished_deps)
+                .publish(path)
+                .build(),
+        )
+    }
+
+    pub async fn make_publish_transaction_with_deps(&self, path: PathBuf) -> VerifiedTransaction {
+        let (sender, gas_object) = self.get_one_gas_object().await.unwrap().unwrap();
+        let gas_price = self.get_reference_gas_price().await.unwrap();
+        self.sign_transaction(
+            &TestTransactionBuilder::new(sender, gas_object, gas_price)
+                .publish_with_deps(path)
                 .build(),
         )
     }

--- a/crates/sui-source-validation/Cargo.toml
+++ b/crates/sui-source-validation/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = { version = "1.0.64", features = ["backtrace"] }
 thiserror = "1.0.34"
 futures = "0.3.25"
 
+sui-json-rpc-types = { path = "../sui-json-rpc-types" }
 sui-types = { path = "../sui-types" }
 sui-sdk = { path = "../../crates/sui-sdk" }
 sui-move-build = { path = "../../crates/sui-move-build" }

--- a/crates/sui-source-validation/src/tests.rs
+++ b/crates/sui-source-validation/src/tests.rs
@@ -580,7 +580,7 @@ fn sanitize_id(mut message: String, m: &HashMap<SuiAddress, &str>) -> String {
 
 /// Compile and publish package at absolute path `package` to chain.
 async fn publish_package(context: &WalletContext, package: PathBuf) -> (ObjectRef, ObjectRef) {
-    let txn = context.make_publish_transaction(package, false).await;
+    let txn = context.make_publish_transaction(package).await;
     let response = context.execute_transaction_block(txn).await.unwrap();
     let package = get_new_package_obj_from_response(&response).unwrap();
     let cap = get_new_package_upgrade_cap_from_response(&response).unwrap();
@@ -617,7 +617,7 @@ async fn upgrade_package(
 /// Compile and publish package at absolute path `package` to chain, along with its unpublished
 /// dependencies.
 async fn publish_package_and_deps(context: &WalletContext, package: PathBuf) -> ObjectRef {
-    let txn = context.make_publish_transaction(package, true).await;
+    let txn = context.make_publish_transaction_with_deps(package).await;
     let response = context.execute_transaction_block(txn).await.unwrap();
     get_new_package_obj_from_response(&response).unwrap()
 }

--- a/crates/sui-test-transaction-builder/src/lib.rs
+++ b/crates/sui-test-transaction-builder/src/lib.rs
@@ -74,6 +74,30 @@ impl TestTransactionBuilder {
         )
     }
 
+    pub fn call_nft_create(self, package_id: ObjectID) -> Self {
+        self.move_call(
+            package_id,
+            "devnet_nft",
+            "mint",
+            vec![
+                CallArg::Pure(bcs::to_bytes("example_nft_name").unwrap()),
+                CallArg::Pure(bcs::to_bytes("example_nft_description").unwrap()),
+                CallArg::Pure(
+                    bcs::to_bytes("https://sui.io/_nuxt/img/sui-logo.8d3c44e.svg").unwrap(),
+                ),
+            ],
+        )
+    }
+
+    pub fn call_nft_delete(self, package_id: ObjectID, nft_to_delete: ObjectRef) -> Self {
+        self.move_call(
+            package_id,
+            "devnet_nft",
+            "burn",
+            vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(nft_to_delete))],
+        )
+    }
+
     pub fn call_staking(self, stake_coin: ObjectRef, validator: SuiAddress) -> Self {
         self.move_call(
             SUI_SYSTEM_OBJECT_ID,
@@ -106,16 +130,19 @@ impl TestTransactionBuilder {
         self
     }
 
-    pub fn publish(mut self, path: PathBuf) -> Self {
+    pub fn publish(mut self, path: PathBuf, with_unpublished_deps: bool) -> Self {
         assert!(matches!(self.test_data, TestTransactionData::Empty));
-        self.test_data = TestTransactionData::Publish(PublishData { path });
+        self.test_data = TestTransactionData::Publish(PublishData {
+            path,
+            with_unpublished_deps,
+        });
         self
     }
 
     pub fn publish_examples(self, subpath: &'static str) -> Self {
         let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         path.extend(["..", "..", "sui_programmability", "examples", subpath]);
-        self.publish(path)
+        self.publish(path, false)
     }
 
     pub fn build(self) -> TransactionData {
@@ -143,7 +170,7 @@ impl TestTransactionBuilder {
             TestTransactionData::Publish(data) => {
                 let compiled_package = BuildConfig::new_for_testing().build(data.path).unwrap();
                 let all_module_bytes =
-                    compiled_package.get_package_bytes(/* with_unpublished_deps */ false);
+                    compiled_package.get_package_bytes(data.with_unpublished_deps);
                 let dependencies = compiled_package.get_dependency_original_package_ids();
 
                 TransactionData::new_module(
@@ -187,6 +214,8 @@ struct MoveData {
 
 struct PublishData {
     path: PathBuf,
+    /// Whether to publish unpublished dependencies in the same transaction or not.
+    with_unpublished_deps: bool,
 }
 
 struct TransferData {

--- a/crates/sui-test-transaction-builder/src/lib.rs
+++ b/crates/sui-test-transaction-builder/src/lib.rs
@@ -130,11 +130,20 @@ impl TestTransactionBuilder {
         self
     }
 
-    pub fn publish(mut self, path: PathBuf, with_unpublished_deps: bool) -> Self {
+    pub fn publish(mut self, path: PathBuf) -> Self {
         assert!(matches!(self.test_data, TestTransactionData::Empty));
         self.test_data = TestTransactionData::Publish(PublishData {
             path,
-            with_unpublished_deps,
+            with_unpublished_deps: false,
+        });
+        self
+    }
+
+    pub fn publish_with_deps(mut self, path: PathBuf) -> Self {
+        assert!(matches!(self.test_data, TestTransactionData::Empty));
+        self.test_data = TestTransactionData::Publish(PublishData {
+            path,
+            with_unpublished_deps: true,
         });
         self
     }
@@ -142,7 +151,7 @@ impl TestTransactionBuilder {
     pub fn publish_examples(self, subpath: &'static str) -> Self {
         let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         path.extend(["..", "..", "sui_programmability", "examples", subpath]);
-        self.publish(path, false)
+        self.publish(path)
     }
 
     pub fn build(self) -> TransactionData {

--- a/crates/test-utils/src/transaction.rs
+++ b/crates/test-utils/src/transaction.rs
@@ -44,7 +44,7 @@ pub fn make_publish_package(
 ) -> VerifiedTransaction {
     let (sender, keypair) = deterministic_random_account_key();
     TestTransactionBuilder::new(sender, gas_object, gas_price)
-        .publish(path, false)
+        .publish(path)
         .build_and_sign(&keypair)
 }
 

--- a/sui_programmability/examples/nfts/sources/devnet_nft.move
+++ b/sui_programmability/examples/nfts/sources/devnet_nft.move
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+// TODO: consider renaming this to `example_nft`
 /// A minimalist example to demonstrate how to create an NFT like object
 /// on Sui.
 module nfts::devnet_nft {


### PR DESCRIPTION
## Description 

First step towards moving functions in `test-utils/transaction` to places where they belong better. This PR deals with some of functions that take in a `WalletContext`. Some of them are moved to `wallet_context.rs` and a few are moved to the caller site. More wallet context functions will be moved in following PRs.

## Test Plan 

It's all tests.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
