### PR TITLE
Simply Signing With KMS

### DIFF
--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -79,7 +79,7 @@ pub enum KeyToolCommand {
     },
     /// Creates a signature by leveraging AWS KMS. Pass in a key-id to leverage Amazon
     /// KMS to sign a message and the base64 pubkey.
-    /// Generate PubKey from pem using https://github.com/MystenLabs/base64pemkey
+    /// Generate PubKey from pem using MystenLabs/base64pemkey
     /// Any signature commits to a [struct IntentMessage] consisting of the Base64 encoded
     /// of the BCS serialized transaction bytes itself (the result of
     /// [transaction builder API](https://docs.sui.io/sui-jsonrpc) and its intent. If


### PR DESCRIPTION
## Description 

Follow up to #11283 This PR simplifies the SignKMS function by adding an option to pass the sui secp256k1 publickey in base64 as a parameter. Previously we were signing a digest with AWS KMS and recovered the public key from the signature but leads to unwanted side effects such as occasionally recovering the wrong public key/ incorrect serialized_signature.
The pem pubkey from aws can be converted with this helper [program](https://github.com/MystenLabs/base64pemkey).

Since the user has to know their publickey/address in order to figure out the object_id it would be best to pass the publickey as a parameter and leverage it rather than going down the path of ecrecover. 

Ideal usage would be 
`sui keytool sign-kms --data $TX_BYTES --keyid $KMS_KEY_ID --base64pk $pubkey_b64`

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Remove SignatureRecovery to Obtain PubKey for AWS KMS Signing.