### PR TITLE
expose chain identifier as a metric

### DIFF
--- a/crates/mysten-metrics/src/lib.rs
+++ b/crates/mysten-metrics/src/lib.rs
@@ -309,8 +309,11 @@ impl RegistryService {
 
 /// Create a metric that measures the uptime from when this metric was constructed.
 /// The metric is labeled with the provided 'version' label (this should generally be of the
-/// format: 'semver-gitrevision').
-pub fn uptime_metric(version: &'static str) -> Box<dyn prometheus::core::Collector> {
+/// format: 'semver-gitrevision') and the provided 'chain_identifier' label.
+pub fn uptime_metric(
+    version: &'static str,
+    chain_identifier: &str,
+) -> Box<dyn prometheus::core::Collector> {
     let opts = prometheus::opts!("uptime", "uptime of the node service in seconds")
         .variable_label("version");
 
@@ -320,7 +323,7 @@ pub fn uptime_metric(version: &'static str) -> Box<dyn prometheus::core::Collect
         opts,
         prometheus_closure_metric::ValueType::Counter,
         uptime,
-        &[version],
+        &[version, chain_identifier],
     )
     .unwrap();
 

--- a/crates/sui-proxy/src/main.rs
+++ b/crates/sui-proxy/src/main.rs
@@ -64,7 +64,7 @@ async fn main() -> Result<()> {
     let registry_service = metrics::start_prometheus_server(metrics_listener);
     let prometheus_registry = registry_service.default_registry();
     prometheus_registry
-        .register(mysten_metrics::uptime_metric(VERSION))
+        .register(mysten_metrics::uptime_metric(VERSION, "sui-proxy"))
         .unwrap();
     let app = app(
         Labels {


### PR DESCRIPTION
## Description 

As title. This will be a useful thing to watch during testnet wipe

## Test Plan 

tested locally

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Expose chain identifier as a metric
