### PR TITLE
allow some sui tool commands to take a fullnode-rpc arg and use the latest committee

### DIFF
--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -54,14 +54,14 @@ pub enum ToolCommand {
         )]
         validator: Option<AuthorityName>,
 
-        // At least one of genesis or fullnode_rpc must be provided
+        // At least one of genesis or fullnode_rpc_url must be provided
         #[clap(long = "genesis")]
         genesis: Option<PathBuf>,
 
-        // At least one of genesis or fullnode_rpc must be provided
+        // At least one of genesis or fullnode_rpc_url must be provided
         // RPC address to provide the up-to-date committee info
-        #[clap(long = "fullnode-rpc")]
-        fullnode_rpc: Option<String>,
+        #[clap(long = "fullnode-rpc-url")]
+        fullnode_rpc_url: Option<String>,
 
         /// Concise mode groups responses by results.
         /// prints tabular output suitable for processing with unix tools. For
@@ -69,7 +69,7 @@ pub enum ToolCommand {
         /// ```text
         /// $ sui-tool fetch-object --id 0x260efde76ebccf57f4c5e951157f5c361cde822c \
         ///      --genesis $HOME/.sui/sui_config/genesis.blob \
-        ///      --history --verbosity concise --concise-no-header
+        ///      --verbosity concise --concise-no-header
         /// ```
         #[clap(
             value_enum,
@@ -89,14 +89,14 @@ pub enum ToolCommand {
     /// Fetch the effects association with transaction `digest`
     #[clap(name = "fetch-transaction")]
     FetchTransaction {
-        // At least one of genesis or fullnode_rpc must be provided
+        // At least one of genesis or fullnode_rpc_url must be provided
         #[clap(long = "genesis")]
         genesis: Option<PathBuf>,
 
-        // At least one of genesis or fullnode_rpc must be provided
+        // At least one of genesis or fullnode_rpc_url must be provided
         // RPC address to provide the up-to-date committee info
-        #[clap(long = "fullnode-rpc")]
-        fullnode_rpc: Option<String>,
+        #[clap(long = "fullnode-rpc-url")]
+        fullnode_rpc_url: Option<String>,
 
         #[clap(long, help = "The transaction ID to fetch")]
         digest: TransactionDigest,
@@ -138,14 +138,14 @@ pub enum ToolCommand {
     /// If sequence number is not specified, get the latest authenticated checkpoint.
     #[clap(name = "fetch-checkpoint")]
     FetchCheckpoint {
-        // At least one of genesis or fullnode_rpc must be provided
+        // At least one of genesis or fullnode_rpc_url must be provided
         #[clap(long = "genesis")]
         genesis: Option<PathBuf>,
 
-        // At least one of genesis or fullnode_rpc must be provided
+        // At least one of genesis or fullnode_rpc_url must be provided
         // RPC address to provide the up-to-date committee info
-        #[clap(long = "fullnode-rpc")]
-        fullnode_rpc: Option<String>,
+        #[clap(long = "fullnode-rpc-url")]
+        fullnode_rpc_url: Option<String>,
 
         #[clap(long, help = "Fetch checkpoint at a specific sequence number")]
         sequence_number: Option<CheckpointSequenceNumber>,
@@ -253,11 +253,11 @@ impl ToolCommand {
                 validator,
                 genesis,
                 version,
-                fullnode_rpc,
+                fullnode_rpc_url,
                 verbosity,
                 concise_no_header,
             } => {
-                let output = get_object(id, version, validator, genesis, fullnode_rpc).await?;
+                let output = get_object(id, version, validator, genesis, fullnode_rpc_url).await?;
 
                 match verbosity {
                     Verbosity::Grouped => {
@@ -278,11 +278,11 @@ impl ToolCommand {
                 genesis,
                 digest,
                 show_input_tx,
-                fullnode_rpc,
+                fullnode_rpc_url,
             } => {
                 print!(
                     "{}",
-                    get_transaction_block(digest, genesis, show_input_tx, fullnode_rpc).await?
+                    get_transaction_block(digest, genesis, show_input_tx, fullnode_rpc_url).await?
                 );
             }
             ToolCommand::DbTool { db_path, cmd } => {
@@ -317,9 +317,9 @@ impl ToolCommand {
             ToolCommand::FetchCheckpoint {
                 genesis,
                 sequence_number,
-                fullnode_rpc,
+                fullnode_rpc_url,
             } => {
-                let clients = make_clients(genesis, fullnode_rpc).await?;
+                let clients = make_clients(genesis, fullnode_rpc_url).await?;
 
                 for (name, (_, client)) in clients {
                     let resp = client

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use fastcrypto::traits::ToFromBytes;
 use futures::future::join_all;
 use itertools::Itertools;
 use std::collections::BTreeMap;
@@ -12,6 +13,8 @@ use std::{fs, io};
 use sui_config::{genesis::Genesis, NodeConfig};
 use sui_core::authority_client::{AuthorityAPI, NetworkAuthorityClient};
 use sui_network::default_mysten_network_config;
+use sui_sdk::SuiClientBuilder;
+use sui_types::crypto::AuthorityPublicKeyBytes;
 use sui_types::multiaddr::Multiaddr;
 use sui_types::object::ObjectFormatOptions;
 use sui_types::{base_types::*, object::Owner};
@@ -26,23 +29,46 @@ use sui_types::messages_grpc::{
 pub mod commands;
 pub mod db_tool;
 
-fn make_clients(
-    genesis: PathBuf,
+// This functions requires at least one of genesis or fullnode_rpc to be `Some`.
+async fn make_clients(
+    genesis: Option<PathBuf>,
+    fullnode_rpc: Option<String>,
 ) -> Result<BTreeMap<AuthorityName, (Multiaddr, NetworkAuthorityClient)>> {
     let net_config = default_mysten_network_config();
-
-    let genesis = Genesis::load(genesis)?;
-
     let mut authority_clients = BTreeMap::new();
 
-    for validator in genesis.validator_set_for_tooling() {
-        let metadata = validator.verified_metadata();
-        let channel = net_config
-            .connect_lazy(&metadata.net_address)
-            .map_err(|err| anyhow!(err.to_string()))?;
-        let client = NetworkAuthorityClient::new(channel);
-        let public_key_bytes = metadata.sui_pubkey_bytes();
-        authority_clients.insert(public_key_bytes, (metadata.net_address.clone(), client));
+    if let Some(fullnode_rpc) = fullnode_rpc {
+        let sui_client = SuiClientBuilder::default().build(fullnode_rpc).await?;
+        let active_validators = sui_client
+            .governance_api()
+            .get_latest_sui_system_state()
+            .await?
+            .active_validators;
+
+        for validator in active_validators {
+            let net_addr = Multiaddr::try_from(validator.net_address).unwrap();
+            let channel = net_config
+                .connect_lazy(&net_addr)
+                .map_err(|err| anyhow!(err.to_string()))?;
+            let client = NetworkAuthorityClient::new(channel);
+            let public_key_bytes =
+                AuthorityPublicKeyBytes::from_bytes(&validator.protocol_pubkey_bytes)?;
+            authority_clients.insert(public_key_bytes, (net_addr.clone(), client));
+        }
+    } else {
+        if genesis.is_none() {
+            return Err(anyhow!("Either genesis or fullnode_rpc must be specified"));
+        }
+        let genesis = Genesis::load(genesis.unwrap())?;
+        for validator in genesis.validator_set_for_tooling() {
+            let metadata = validator.verified_metadata();
+            let channel = net_config
+                .connect_lazy(&metadata.net_address)
+                .map_err(|err| anyhow!(err.to_string()))?;
+            let client = NetworkAuthorityClient::new(channel);
+            let public_key_bytes = metadata.sui_pubkey_bytes();
+            authority_clients.insert(public_key_bytes, (metadata.net_address.clone(), client));
+        }
     }
 
     Ok(authority_clients)
@@ -149,29 +175,30 @@ impl std::fmt::Display for GroupedObjectOutput {
                         for (i, (name, multiaddr, _, _, timespent)) in group.enumerate() {
                             writeln!(
                                 f,
-                                "        {:<4} {:<66} {:<56} (using {:.3} seconds)",
+                                "        {:<4} {:<20} {:<56} ({:.3}s)",
                                 i,
-                                name,
+                                name.concise(),
                                 format!("{}", multiaddr),
                                 timespent
                             )?;
                         }
                     }
                     None => {
-                        writeln!(f, " error")?;
+                        writeln!(f, "ERROR")?;
                         for (i, (name, multiaddr, _, resp, timespent)) in group.enumerate() {
                             writeln!(
                                 f,
-                                "        {:<4} {:<66} {:<56} (using {:.3} seconds) {:?}",
+                                "        {:<4} {:<20} {:<56} ({:.3}s) {:?}",
                                 i,
-                                name,
+                                name.concise(),
                                 format!("{}", multiaddr),
                                 timespent,
                                 resp
                             )?;
                         }
                     }
-                }
+                };
+                writeln!(f, "{:<100}\n", "-".repeat(100))?;
             }
         }
         Ok(())
@@ -183,7 +210,7 @@ struct ConciseObjectOutput(ObjectData);
 impl ConciseObjectOutput {
     fn header() -> String {
         format!(
-            "{:<66} {:<8} {:<66} {:<45} {}",
+            "{:<20} {:<8} {:<66} {:<45} {}",
             "validator", "version", "digest", "parent_cert", "owner"
         )
     }
@@ -195,8 +222,8 @@ impl std::fmt::Display for ConciseObjectOutput {
             for (version, resp, _time_elapsed) in versions {
                 write!(
                     f,
-                    "{:<66} {:<8}",
-                    format!("{:?}", name),
+                    "{:<20} {:<8}",
+                    format!("{:?}", name.concise()),
                     version.map(|s| s.value()).opt_debug("-")
                 )?;
                 match resp {
@@ -226,12 +253,12 @@ impl std::fmt::Display for VerboseObjectOutput {
         writeln!(f, "Object: {}", self.0.requested_id)?;
 
         for (name, multiaddr, versions) in &self.0.responses {
-            writeln!(f, "validator: {:?}, addr: {:?}", name, multiaddr)?;
+            writeln!(f, "validator: {:?}, addr: {:?}", name.concise(), multiaddr)?;
 
             for (version, resp, timespent) in versions {
                 writeln!(
                     f,
-                    "-- version: {} (using {:.3} seconds)",
+                    "-- version: {} ({:.3}s)",
                     version.opt_debug("<version not available>"),
                     timespent,
                 )?;
@@ -276,10 +303,10 @@ pub async fn get_object(
     obj_id: ObjectID,
     version: Option<u64>,
     validator: Option<AuthorityName>,
-    genesis: PathBuf,
-    history: bool,
+    genesis: Option<PathBuf>,
+    fullnode_rpc: Option<String>,
 ) -> Result<ObjectData> {
-    let clients = make_clients(genesis)?;
+    let clients = make_clients(genesis, fullnode_rpc).await?;
 
     let responses = join_all(
         clients
@@ -292,7 +319,7 @@ pub async fn get_object(
                 }
             })
             .map(|(name, (address, client))| async {
-                let object_versions = get_object_impl(client, obj_id, version, history).await;
+                let object_versions = get_object_impl(client, obj_id, version).await;
                 (*name, address.clone(), object_versions)
             }),
     )
@@ -306,10 +333,11 @@ pub async fn get_object(
 
 pub async fn get_transaction_block(
     tx_digest: TransactionDigest,
-    genesis: PathBuf,
+    genesis: Option<PathBuf>,
     show_input_tx: bool,
+    fullnode_rpc: Option<String>,
 ) -> Result<String> {
-    let clients = make_clients(genesis)?;
+    let clients = make_clients(genesis, fullnode_rpc).await?;
     let timer = Instant::now();
     let responses = join_all(clients.iter().map(|(name, (address, client))| async {
         let result = client
@@ -377,59 +405,43 @@ pub async fn get_transaction_block(
         for (j, (_, res)) in group.enumerate() {
             writeln!(
                 &mut s,
-                "        {:<4} {:<66} {:<56} (using {:.3} seconds)",
+                "        {:<4} {:<20} {:<56} ({:.3}s)",
                 j,
-                res.0,
+                res.0.concise(),
                 format!("{}", res.1),
                 res.3
             )?;
         }
-        writeln!(&mut s)?;
+        writeln!(&mut s, "{:<100}\n", "-".repeat(100))?;
     }
     Ok(s)
 }
 
+// Keep the return types a vector in case we need support for lamport versions in the near future
 async fn get_object_impl(
     client: &NetworkAuthorityClient,
     id: ObjectID,
     start_version: Option<u64>,
-    full_history: bool,
 ) -> Vec<(Option<SequenceNumber>, Result<ObjectInfoResponse>, f64)> {
     let mut ret = Vec::new();
-    let mut version = start_version;
+    let version = start_version;
 
-    loop {
-        let start = Instant::now();
-        let resp = client
-            .handle_object_info_request(ObjectInfoRequest {
-                object_id: id,
-                object_format_options: Some(ObjectFormatOptions::default()),
-                request_kind: match version {
-                    None => ObjectInfoRequestKind::LatestObjectInfo,
-                    Some(v) => {
-                        ObjectInfoRequestKind::PastObjectInfoDebug(SequenceNumber::from_u64(v))
-                    }
-                },
-            })
-            .await
-            .map_err(anyhow::Error::from);
-        let elapsed = start.elapsed().as_secs_f64();
+    let start = Instant::now();
+    let resp = client
+        .handle_object_info_request(ObjectInfoRequest {
+            object_id: id,
+            object_format_options: Some(ObjectFormatOptions::default()),
+            request_kind: match version {
+                None => ObjectInfoRequestKind::LatestObjectInfo,
+                Some(v) => ObjectInfoRequestKind::PastObjectInfoDebug(SequenceNumber::from_u64(v)),
+            },
+        })
+        .await
+        .map_err(anyhow::Error::from);
+    let elapsed = start.elapsed().as_secs_f64();
 
-        let resp_version = resp.as_ref().ok().map(|r| r.object.version().value());
-        ret.push((resp_version.map(SequenceNumber::from), resp, elapsed));
-
-        version = match (version, resp_version) {
-            (Some(v), _) | (None, Some(v)) => {
-                if v == 1 || !full_history {
-                    break;
-                } else {
-                    // TODO: With lamport versioning, this is very inefficient.
-                    Some(v - 1)
-                }
-            }
-            _ => break,
-        };
-    }
+    let resp_version = resp.as_ref().ok().map(|r| r.object.version().value());
+    ret.push((resp_version.map(SequenceNumber::from), resp, elapsed));
 
     ret
 }

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -444,14 +444,13 @@ pub async fn get_transaction_block(
     Ok(s)
 }
 
-// Keep the return types a vector in case we need support for lamport versions in the near future
+// Keep the return type a vector in case we need support for lamport versions in the near future
 async fn get_object_impl(
     client: &NetworkAuthorityClient,
     id: ObjectID,
-    start_version: Option<u64>,
+    version: Option<u64>,
 ) -> Vec<(Option<SequenceNumber>, Result<ObjectInfoResponse>, f64)> {
     let mut ret = Vec::new();
-    let version = start_version;
 
     let start = Instant::now();
     let resp = client

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -688,6 +688,18 @@ impl SuiError {
     }
 }
 
+impl Ord for SuiError {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        Ord::cmp(self.as_ref(), other.as_ref())
+    }
+}
+
+impl PartialOrd for SuiError {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 pub type ExecutionErrorKind = ExecutionFailureStatus;

--- a/crates/typed-store/src/rocks/errors.rs
+++ b/crates/typed-store/src/rocks/errors.rs
@@ -9,7 +9,7 @@ use std::{fmt, fmt::Display};
 use thiserror::Error;
 
 #[non_exhaustive]
-#[derive(Error, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+#[derive(Error, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone, Ord, PartialOrd)]
 pub enum TypedStoreError {
     #[error("rocksdb error: {0}")]
     RocksDBError(String),


### PR DESCRIPTION
## Description 

As title. Also remove some stale implementations and use concise keys.

Example:
```
./sui-tool fetch-object --id 0xa577f89fcadd5805f2a9ae0b12670d3051d938e34c702484d2a5b15dd92bc057   --fullnode-rpc https://rpc.mainnet.sui.io:443
```

## Test Plan 

locally tested sui-tool

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Allow some sui tool commands to take a fullnode-rpc arg and use the latest committee. Also remove some stale implementations and use concise keys.
