### PR TITLE
[ts-sdk] use template string types for Ed25519 and Secp256k1 paths

### DIFF
--- a/.changeset/lucky-dancers-call.md
+++ b/.changeset/lucky-dancers-call.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Use template string types for Ed25519 and Secp256k1 paths

--- a/apps/wallet/src/background/keyring/DerivedAccount.ts
+++ b/apps/wallet/src/background/keyring/DerivedAccount.ts
@@ -1,28 +1,35 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { type Keypair, type SuiAddress } from '@mysten/sui.js';
+import {
+    type HardenedEd25519Path,
+    type Secp256k1Path,
+    type Keypair,
+    type SuiAddress,
+} from '@mysten/sui.js';
 
 import { type Account, AccountType } from './Account';
 import { AccountKeypair } from './AccountKeypair';
 
+type DerivedAccountPath = HardenedEd25519Path | Secp256k1Path;
+
 export type SerializedDerivedAccount = {
     type: AccountType.DERIVED;
     address: SuiAddress;
-    derivationPath: string;
+    derivationPath: DerivedAccountPath;
 };
 
 export class DerivedAccount implements Account {
     readonly accountKeypair: AccountKeypair;
     readonly type: AccountType;
     readonly address: SuiAddress;
-    readonly derivationPath: string;
+    readonly derivationPath: DerivedAccountPath;
 
     constructor({
         derivationPath,
         keypair,
     }: {
-        derivationPath: string;
+        derivationPath: DerivedAccountPath;
         keypair: Keypair;
     }) {
         this.type = AccountType.IMPORTED;

--- a/apps/wallet/src/background/keyring/LedgerAccount.ts
+++ b/apps/wallet/src/background/keyring/LedgerAccount.ts
@@ -1,27 +1,31 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { normalizeSuiAddress, type SuiAddress } from '@mysten/sui.js';
+import {
+    normalizeSuiAddress,
+    type SuiAddress,
+    type HardenedEd25519Path,
+} from '@mysten/sui.js';
 
 import { type Account, AccountType } from './Account';
 
 export type SerializedLedgerAccount = {
     type: AccountType.LEDGER;
     address: SuiAddress;
-    derivationPath: string;
+    derivationPath: HardenedEd25519Path;
 };
 
 export class LedgerAccount implements Account {
     readonly type: AccountType;
     readonly address: SuiAddress;
-    readonly derivationPath: string;
+    readonly derivationPath: HardenedEd25519Path;
 
     constructor({
         address,
         derivationPath,
     }: {
         address: SuiAddress;
-        derivationPath: string;
+        derivationPath: HardenedEd25519Path;
     }) {
         this.type = AccountType.LEDGER;
         this.address = normalizeSuiAddress(address);

--- a/apps/wallet/src/background/keyring/index.ts
+++ b/apps/wallet/src/background/keyring/index.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Ed25519Keypair, fromB64 } from '@mysten/sui.js';
+import {
+    Ed25519Keypair,
+    fromB64,
+    type HardenedEd25519Path,
+} from '@mysten/sui.js';
 import mitt from 'mitt';
 import { throttle } from 'throttle-debounce';
 
@@ -506,8 +510,7 @@ export class Keyring {
         );
     }
 
-    private makeDerivationPath(index: number) {
-        // currently returns only Ed25519 path
+    private makeDerivationPath(index: number): HardenedEd25519Path {
         return `m/44'/784'/${index}'/0'/0'`;
     }
 

--- a/apps/wallet/src/ui/app/LedgerSigner.ts
+++ b/apps/wallet/src/ui/app/LedgerSigner.ts
@@ -9,6 +9,7 @@ import {
     type SuiAddress,
     toSerializedSignature,
     type JsonRpcProvider,
+    type HardenedEd25519Path,
 } from '@mysten/sui.js';
 
 import type SuiLedgerClient from '@mysten/ledgerjs-hw-app-sui';
@@ -16,12 +17,12 @@ import type SuiLedgerClient from '@mysten/ledgerjs-hw-app-sui';
 export class LedgerSigner extends SignerWithProvider {
     #suiLedgerClient: SuiLedgerClient | null;
     readonly #connectToLedger: () => Promise<SuiLedgerClient>;
-    readonly #derivationPath: string;
+    readonly #derivationPath: HardenedEd25519Path;
     readonly #signatureScheme: SignatureScheme = 'ED25519';
 
     constructor(
         connectToLedger: () => Promise<SuiLedgerClient>,
-        derivationPath: string,
+        derivationPath: HardenedEd25519Path,
         provider: JsonRpcProvider
     ) {
         super(provider);

--- a/apps/wallet/src/ui/app/components/ledger/useDeriveLedgerAccounts.ts
+++ b/apps/wallet/src/ui/app/components/ledger/useDeriveLedgerAccounts.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Ed25519PublicKey } from '@mysten/sui.js';
+import { Ed25519PublicKey, type HardenedEd25519Path } from '@mysten/sui.js';
 import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
 
 import { useSuiLedgerClient } from './SuiLedgerClientProvider';
@@ -73,5 +73,5 @@ async function deriveAccountsFromLedger(
 function getDerivationPathsForLedger(numDerivations: number) {
     return Array.from({
         length: numDerivations,
-    }).map((_, index) => `m/44'/784'/${index}'/0'/0'`);
+    }).map<HardenedEd25519Path>((_, index) => `m/44'/784'/${index}'/0'/0'`);
 }

--- a/apps/wallet/src/ui/app/components/menu/content/VerifyLedgerConnectionStatus.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/VerifyLedgerConnectionStatus.tsx
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Check12, X12 } from '@mysten/icons';
-import { Ed25519PublicKey, type SuiAddress } from '@mysten/sui.js';
+import {
+    Ed25519PublicKey,
+    type SuiAddress,
+    type HardenedEd25519Path,
+} from '@mysten/sui.js';
 import { useState } from 'react';
 import toast from 'react-hot-toast';
 
@@ -17,7 +21,7 @@ import { Text } from '_src/ui/app/shared/text';
 
 export type VerifyLedgerConnectionLinkProps = {
     accountAddress: SuiAddress;
-    derivationPath: string;
+    derivationPath: HardenedEd25519Path;
 };
 
 enum VerificationStatus {

--- a/sdk/typescript/src/cryptography/ed25519-keypair.ts
+++ b/sdk/typescript/src/cryptography/ed25519-keypair.ts
@@ -4,7 +4,7 @@
 import nacl from 'tweetnacl';
 import { ExportedKeypair, Keypair, PRIVATE_KEY_SIZE } from './keypair';
 import { Ed25519PublicKey } from './ed25519-publickey';
-import { mnemonicToSeedHex } from './mnemonics';
+import { isValidHardenedPath, mnemonicToSeedHex } from './mnemonics';
 import { derivePath } from '../utils/ed25519-hd-key';
 import { toB64 } from '@mysten/bcs';
 import { SignatureScheme } from './signature';
@@ -126,6 +126,10 @@ export class Ed25519Keypair implements Keypair {
     mnemonics: string,
     path: HardenedEd25519Path = DEFAULT_ED25519_DERIVATION_PATH,
   ): Ed25519Keypair {
+    if (!isValidHardenedPath(path)) {
+      throw new Error('Invalid derivation path');
+    }
+
     const { key } = derivePath(path, mnemonicToSeedHex(mnemonics));
     return Ed25519Keypair.fromSecretKey(key);
   }

--- a/sdk/typescript/src/cryptography/ed25519-keypair.ts
+++ b/sdk/typescript/src/cryptography/ed25519-keypair.ts
@@ -4,10 +4,12 @@
 import nacl from 'tweetnacl';
 import { ExportedKeypair, Keypair, PRIVATE_KEY_SIZE } from './keypair';
 import { Ed25519PublicKey } from './ed25519-publickey';
-import { isValidHardenedPath, mnemonicToSeedHex } from './mnemonics';
+import { mnemonicToSeedHex } from './mnemonics';
 import { derivePath } from '../utils/ed25519-hd-key';
 import { toB64 } from '@mysten/bcs';
 import { SignatureScheme } from './signature';
+
+export type HardenedEd25519Path = `m/44'/784'/${number}'/${number}'/${number}'`;
 
 export const DEFAULT_ED25519_DERIVATION_PATH = "m/44'/784'/0'/0'/0'";
 
@@ -120,15 +122,11 @@ export class Ed25519Keypair implements Keypair {
    * If path is none, it will default to m/44'/784'/0'/0'/0', otherwise the path must
    * be compliant to SLIP-0010 in form m/44'/784'/{account_index}'/{change_index}'/{address_index}'.
    */
-  static deriveKeypair(mnemonics: string, path?: string): Ed25519Keypair {
-    if (path == null) {
-      path = DEFAULT_ED25519_DERIVATION_PATH;
-    }
-    if (!isValidHardenedPath(path)) {
-      throw new Error('Invalid derivation path');
-    }
+  static deriveKeypair(
+    mnemonics: string,
+    path: HardenedEd25519Path = DEFAULT_ED25519_DERIVATION_PATH,
+  ): Ed25519Keypair {
     const { key } = derivePath(path, mnemonicToSeedHex(mnemonics));
-
     return Ed25519Keypair.fromSecretKey(key);
   }
 

--- a/sdk/typescript/src/cryptography/mnemonics.ts
+++ b/sdk/typescript/src/cryptography/mnemonics.ts
@@ -4,33 +4,6 @@ import { toHEX } from '@mysten/bcs';
 import { mnemonicToSeedSync as bip39MnemonicToSeedSync } from '@scure/bip39';
 
 /**
- * Parse and validate a path that is compliant to SLIP-0010 in form m/44'/784'/{account_index}'/{change_index}'/{address_index}'.
- *
- * @param path path string (e.g. `m/44'/784'/0'/0'/0'`).
- */
-export function isValidHardenedPath(path: string): boolean {
-  if (
-    !new RegExp("^m\\/44'\\/784'\\/[0-9]+'\\/[0-9]+'\\/[0-9]+'+$").test(path)
-  ) {
-    return false;
-  }
-  return true;
-}
-
-/**
- * Parse and validate a path that is compliant to BIP-32 in form m/54'/784'/{account_index}'/{change_index}/{address_index}.
- * Note that the purpose for Secp256k1 is registered as 54, to differentiate from Ed25519 with purpose 44.
- *
- * @param path path string (e.g. `m/54'/784'/0'/0/0`).
- */
-export function isValidBIP32Path(path: string): boolean {
-  if (!new RegExp("^m\\/54'\\/784'\\/[0-9]+'\\/[0-9]+\\/[0-9]+$").test(path)) {
-    return false;
-  }
-  return true;
-}
-
-/**
  * Uses KDF to derive 64 bytes of key data from mnemonic with empty password.
  *
  * @param mnemonics 12 words string split by spaces.

--- a/sdk/typescript/src/cryptography/mnemonics.ts
+++ b/sdk/typescript/src/cryptography/mnemonics.ts
@@ -2,6 +2,29 @@
 // SPDX-License-Identifier: Apache-2.0
 import { toHEX } from '@mysten/bcs';
 import { mnemonicToSeedSync as bip39MnemonicToSeedSync } from '@scure/bip39';
+import { HardenedEd25519Path } from './ed25519-keypair';
+import { Secp256k1Path } from './secp256k1-keypair';
+
+/**
+ * Parse and validate a path that is compliant to SLIP-0010 in form m/44'/784'/{account_index}'/{change_index}'/{address_index}'.
+ *
+ * @param path path string (e.g. `m/44'/784'/0'/0'/0'`).
+ */
+export function isValidHardenedPath(path: string): path is HardenedEd25519Path {
+  return new RegExp("^m\\/44'\\/784'\\/[0-9]+'\\/[0-9]+'\\/[0-9]+'+$").test(
+    path,
+  );
+}
+
+/**
+ * Parse and validate a path that is compliant to BIP-32 in form m/54'/784'/{account_index}'/{change_index}/{address_index}.
+ * Note that the purpose for Secp256k1 is registered as 54, to differentiate from Ed25519 with purpose 44.
+ *
+ * @param path path string (e.g. `m/54'/784'/0'/0/0`).
+ */
+export function isValidBIP32Path(path: string): path is Secp256k1Path {
+  return new RegExp("^m\\/54'\\/784'\\/[0-9]+'\\/[0-9]+\\/[0-9]+$").test(path);
+}
 
 /**
  * Uses KDF to derive 64 bytes of key data from mnemonic with empty password.

--- a/sdk/typescript/src/cryptography/secp256k1-keypair.ts
+++ b/sdk/typescript/src/cryptography/secp256k1-keypair.ts
@@ -6,12 +6,14 @@ import { PublicKey } from './publickey';
 import { sha256 } from '@noble/hashes/sha256';
 import { Secp256k1PublicKey } from './secp256k1-publickey';
 import { secp256k1 } from '@noble/curves/secp256k1';
-import { isValidBIP32Path, mnemonicToSeed } from './mnemonics';
+import { mnemonicToSeed } from './mnemonics';
 import { HDKey } from '@scure/bip32';
 import { toB64 } from '@mysten/bcs';
 import { SignatureScheme } from './signature';
 import { bytesToHex } from '@noble/hashes/utils';
 import { blake2b } from '@noble/hashes/blake2b';
+
+export type Secp256k1Path = `m/54'/784'/${number}'/${number}/${number}`;
 
 export const DEFAULT_SECP256K1_DERIVATION_PATH = "m/54'/784'/0'/0/0";
 
@@ -125,13 +127,10 @@ export class Secp256k1Keypair implements Keypair {
    * If path is none, it will default to m/54'/784'/0'/0/0, otherwise the path must
    * be compliant to BIP-32 in form m/54'/784'/{account_index}'/{change_index}/{address_index}.
    */
-  static deriveKeypair(mnemonics: string, path?: string): Secp256k1Keypair {
-    if (path == null) {
-      path = DEFAULT_SECP256K1_DERIVATION_PATH;
-    }
-    if (!isValidBIP32Path(path)) {
-      throw new Error('Invalid derivation path');
-    }
+  static deriveKeypair(
+    mnemonics: string,
+    path: Secp256k1Path = DEFAULT_SECP256K1_DERIVATION_PATH,
+  ): Secp256k1Keypair {
     const key = HDKey.fromMasterSeed(mnemonicToSeed(mnemonics)).derive(path);
     if (key.publicKey == null || key.privateKey == null) {
       throw new Error('Invalid key');

--- a/sdk/typescript/src/cryptography/secp256k1-keypair.ts
+++ b/sdk/typescript/src/cryptography/secp256k1-keypair.ts
@@ -6,7 +6,7 @@ import { PublicKey } from './publickey';
 import { sha256 } from '@noble/hashes/sha256';
 import { Secp256k1PublicKey } from './secp256k1-publickey';
 import { secp256k1 } from '@noble/curves/secp256k1';
-import { mnemonicToSeed } from './mnemonics';
+import { isValidBIP32Path, mnemonicToSeed } from './mnemonics';
 import { HDKey } from '@scure/bip32';
 import { toB64 } from '@mysten/bcs';
 import { SignatureScheme } from './signature';
@@ -131,6 +131,10 @@ export class Secp256k1Keypair implements Keypair {
     mnemonics: string,
     path: Secp256k1Path = DEFAULT_SECP256K1_DERIVATION_PATH,
   ): Secp256k1Keypair {
+    if (!isValidBIP32Path(path)) {
+      throw new Error('Invalid derivation path');
+    }
+
     const key = HDKey.fromMasterSeed(mnemonicToSeed(mnemonics)).derive(path);
     if (key.publicKey == null || key.privateKey == null) {
       throw new Error('Invalid key');

--- a/sdk/typescript/src/utils/ed25519-hd-key.ts
+++ b/sdk/typescript/src/utils/ed25519-hd-key.ts
@@ -8,9 +8,9 @@ import { sha512 } from '@noble/hashes/sha512';
 import { hmac } from '@noble/hashes/hmac';
 import nacl from 'tweetnacl';
 import { fromHEX } from '@mysten/bcs';
+import { type HardenedEd25519Path } from '../cryptography/ed25519-keypair';
 
 type Hex = string;
-type Path = string;
 
 type Keys = {
   key: Uint8Array;
@@ -19,8 +19,6 @@ type Keys = {
 
 const ED25519_CURVE = 'ed25519 seed';
 const HARDENED_OFFSET = 0x80000000;
-
-export const pathRegex = new RegExp("^m(\\/[0-9]+')+$");
 
 export const replaceDerive = (val: string): string => val.replace("'", '');
 
@@ -69,26 +67,11 @@ export const getPublicKey = (
   return withZeroByte ? newArr : signPk;
 };
 
-export const isValidPath = (path: string): boolean => {
-  if (!pathRegex.test(path)) {
-    return false;
-  }
-  return !path
-    .split('/')
-    .slice(1)
-    .map(replaceDerive)
-    .some(isNaN as any /* ts T_T*/);
-};
-
 export const derivePath = (
-  path: Path,
+  path: HardenedEd25519Path,
   seed: Hex,
   offset = HARDENED_OFFSET,
 ): Keys => {
-  if (!isValidPath(path)) {
-    throw new Error('Invalid derivation path');
-  }
-
   const { key, chainCode } = getMasterKeyFromSeed(seed);
   const segments = path
     .split('/')

--- a/sdk/typescript/test/unit/cryptography/ed25519-keypair.test.ts
+++ b/sdk/typescript/test/unit/cryptography/ed25519-keypair.test.ts
@@ -86,8 +86,12 @@ describe('ed25519-keypair', () => {
     expect(isValid).toBeTruthy();
   });
 
-  it('valid mnemonic to derive ed25519 keypair', () => {
-    const keypair = Ed25519Keypair.deriveKeypair(TEST_MNEMONIC);
+  it('incorrect coin type node for ed25519 derivation path', () => {
+    const keypair = Ed25519Keypair.deriveKeypair(
+      TEST_MNEMONIC,
+      `m/44'/784'/0'/0'/0'`,
+    );
+
     const signData = new TextEncoder().encode('hello world');
     const signature = keypair.signData(signData);
     const isValid = nacl.sign.detached.verify(
@@ -98,7 +102,21 @@ describe('ed25519-keypair', () => {
     expect(isValid).toBeTruthy();
   });
 
-  it('invalid mnemonic to derive ed25519 keypair', () => {
+  it('incorrect coin type node for ed25519 derivation path', () => {
+    expect(() => {
+      // @ts-expect-error
+      Ed25519Keypair.deriveKeypair(TEST_MNEMONIC, `m/44'/0'/0'/0'/0'`);
+    }).toThrow('Invalid derivation path');
+  });
+
+  it('incorrect purpose node for ed25519 derivation path', () => {
+    expect(() => {
+      // @ts-expect-error
+      Ed25519Keypair.deriveKeypair(TEST_MNEMONIC, `m/54'/784'/0'/0'/0'`);
+    }).toThrow('Invalid derivation path');
+  });
+
+  it('invalid mnemonics to derive ed25519 keypair', () => {
     expect(() => {
       Ed25519Keypair.deriveKeypair('aaa');
     }).toThrow('Invalid mnemonic');

--- a/sdk/typescript/test/unit/cryptography/ed25519-keypair.test.ts
+++ b/sdk/typescript/test/unit/cryptography/ed25519-keypair.test.ts
@@ -98,7 +98,7 @@ describe('ed25519-keypair', () => {
     expect(isValid).toBeTruthy();
   });
 
-  it('invalid mnemonics to derive ed25519 keypair', () => {
+  it('invalid mnemonic to derive ed25519 keypair', () => {
     expect(() => {
       Ed25519Keypair.deriveKeypair('aaa');
     }).toThrow('Invalid mnemonic');

--- a/sdk/typescript/test/unit/cryptography/ed25519-keypair.test.ts
+++ b/sdk/typescript/test/unit/cryptography/ed25519-keypair.test.ts
@@ -86,12 +86,8 @@ describe('ed25519-keypair', () => {
     expect(isValid).toBeTruthy();
   });
 
-  it('incorrect coin type node for ed25519 derivation path', () => {
-    const keypair = Ed25519Keypair.deriveKeypair(
-      TEST_MNEMONIC,
-      `m/44'/784'/0'/0'/0'`,
-    );
-
+  it('valid mnemonic to derive ed25519 keypair', () => {
+    const keypair = Ed25519Keypair.deriveKeypair(TEST_MNEMONIC);
     const signData = new TextEncoder().encode('hello world');
     const signature = keypair.signData(signData);
     const isValid = nacl.sign.detached.verify(
@@ -100,18 +96,6 @@ describe('ed25519-keypair', () => {
       keypair.getPublicKey().toBytes(),
     );
     expect(isValid).toBeTruthy();
-  });
-
-  it('incorrect coin type node for ed25519 derivation path', () => {
-    expect(() => {
-      Ed25519Keypair.deriveKeypair(TEST_MNEMONIC, `m/44'/0'/0'/0'/0'`);
-    }).toThrow('Invalid derivation path');
-  });
-
-  it('incorrect purpose node for ed25519 derivation path', () => {
-    expect(() => {
-      Ed25519Keypair.deriveKeypair(TEST_MNEMONIC, `m/54'/784'/0'/0'/0'`);
-    }).toThrow('Invalid derivation path');
   });
 
   it('invalid mnemonics to derive ed25519 keypair', () => {

--- a/sdk/typescript/test/unit/cryptography/secp256k1-keypair.test.ts
+++ b/sdk/typescript/test/unit/cryptography/secp256k1-keypair.test.ts
@@ -52,6 +52,9 @@ const TEST_CASES = [
   ],
 ];
 
+const TEST_MNEMONIC =
+  'result crisp session latin must fruit genuine question prevent start coconut brave speak student dismiss';
+
 describe('secp256k1-keypair', () => {
   it('new keypair', () => {
     const keypair = new Secp256k1Keypair();
@@ -147,5 +150,19 @@ describe('secp256k1-keypair', () => {
       const exported = imported.export();
       expect(exported.privateKey).toEqual(toB64(raw.slice(1)));
     }
+  });
+
+  it('incorrect purpose node for secp256k1 derivation path', () => {
+    expect(() => {
+      // @ts-expect-error
+      Secp256k1Keypair.deriveKeypair(TEST_MNEMONIC, `m/44'/784'/0'/0'/0'`);
+    }).toThrow('Invalid derivation path');
+  });
+
+  it('incorrect hardened path for secp256k1 key derivation', () => {
+    expect(() => {
+      // @ts-expect-error
+      Secp256k1Keypair.deriveKeypair(TEST_MNEMONIC, `m/54'/784'/0'/0'/0'`);
+    }).toThrow('Invalid derivation path');
   });
 });

--- a/sdk/typescript/test/unit/cryptography/secp256k1-keypair.test.ts
+++ b/sdk/typescript/test/unit/cryptography/secp256k1-keypair.test.ts
@@ -52,9 +52,6 @@ const TEST_CASES = [
   ],
 ];
 
-const TEST_MNEMONIC =
-  'result crisp session latin must fruit genuine question prevent start coconut brave speak student dismiss';
-
 describe('secp256k1-keypair', () => {
   it('new keypair', () => {
     const keypair = new Secp256k1Keypair();
@@ -150,17 +147,5 @@ describe('secp256k1-keypair', () => {
       const exported = imported.export();
       expect(exported.privateKey).toEqual(toB64(raw.slice(1)));
     }
-  });
-
-  it('incorrect purpose node for secp256k1 derivation path', () => {
-    expect(() => {
-      Secp256k1Keypair.deriveKeypair(TEST_MNEMONIC, `m/44'/784'/0'/0'/0'`);
-    }).toThrow('Invalid derivation path');
-  });
-
-  it('incorrect hardened path for secp256k1 key derivation', () => {
-    expect(() => {
-      Secp256k1Keypair.deriveKeypair(TEST_MNEMONIC, `m/54'/784'/0'/0'/0'`);
-    }).toThrow('Invalid derivation path');
   });
 });


### PR DESCRIPTION
## Description 

This is a small improvement to our type safety regarding derivation paths. I think this generally improves the explicitness of what a derivation path could potentially be which is useful in our wallet for derived accounts and Ledger accounts 😄

## Test Plan 
- All tests pass

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
N/A
