### PR TITLE
[sui-proxy/increase post body limit to 5 MB]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,13 +596,13 @@ source = "git+https://github.com/mystenmark/async-task?rev=4e45b26e11126b191701b
 
 [[package]]
 name = "async-trait"
-version = "0.1.61"
+version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2 1.0.54",
  "quote 1.0.26",
- "syn 1.0.107",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -1265,9 +1265,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cae3e661676ffbacb30f1a824089a8c9150e71017f7e1e38f2aa32009188d34"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4125,9 +4125,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes",
  "fnv",

--- a/crates/sui-proxy/src/consumer.rs
+++ b/crates/sui-proxy/src/consumer.rs
@@ -11,7 +11,7 @@ use bytes::buf::Reader;
 use fastcrypto::ed25519::Ed25519PublicKey;
 use multiaddr::Multiaddr;
 use once_cell::sync::Lazy;
-use prometheus::proto;
+use prometheus::proto::{self, MetricFamily};
 use prometheus::{register_counter, register_counter_vec, register_histogram_vec};
 use prometheus::{Counter, CounterVec, HistogramVec};
 use prost::Message;
@@ -136,11 +136,11 @@ pub fn populate_labels(
 fn encode_compress(request: &WriteRequest) -> Result<Vec<u8>, (StatusCode, &'static str)> {
     let observe = || {
         let timer = CONSUMER_ENCODE_COMPRESS_DURATION
-        .with_label_values(&["encode_compress"])
-        .start_timer();
-    ||{
-        timer.observe_duration();
-    }
+            .with_label_values(&["encode_compress"])
+            .start_timer();
+        || {
+            timer.observe_duration();
+        }
     }();
     let mut buf = Vec::new();
     buf.reserve(request.encoded_len());
@@ -236,6 +236,37 @@ async fn check_response(
     }
 }
 
+async fn convert(
+    mfs: Vec<MetricFamily>,
+) -> Result<impl Iterator<Item = WriteRequest>, (StatusCode, &'static str)> {
+    let result = match tokio::task::spawn_blocking(|| {
+        let timer = CONSUMER_OPERATION_DURATION
+            .with_label_values(&["convert_to_remote_write_task"])
+            .start_timer();
+        let result = Mimir::from(mfs);
+        timer.observe_duration();
+        result.into_iter()
+    })
+    .await
+    {
+        Ok(v) => v,
+        Err(err) => {
+            error!("unable to convert to remote_write; {err}");
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "DROPPING METRICS; unable to convert to remote_write",
+            ));
+        }
+    };
+    Ok(result)
+}
+
+/// convert_to_remote_write is an expensive method due to the time it takes to submit to mimir.
+/// other operations here are optimized for async, within reason.  The post process uses a single
+/// connection to mimir and thus incurs the seriliaztion delay for each metric family sent. Possible
+/// future optimizations would be to use multiple tcp connections to mimir, within reason. Nevertheless
+/// we await on each post of each metric family so it shouldn't block any other async work in a
+/// significant way.
 pub async fn convert_to_remote_write(
     rc: ReqwestClient,
     node_metric: NodeMetric,
@@ -243,14 +274,24 @@ pub async fn convert_to_remote_write(
     let timer = CONSUMER_OPERATION_DURATION
         .with_label_values(&["convert_to_remote_write"])
         .start_timer();
+
+    let remote_write_protos = match convert(node_metric.data).await {
+        Ok(v) => v,
+        Err(err) => {
+            timer.stop_and_discard();
+            return err;
+        }
+    };
+
     // a counter so we don't iterate the node data 2x
     let mut mf_cnt = 0;
-    for request in Mimir::from(node_metric.data) {
+    for request in remote_write_protos {
         mf_cnt += 1;
         let compressed = match encode_compress(&request) {
             Ok(compressed) => compressed,
             Err(error) => return error,
         };
+
         let response = match rc
             .client
             .post(rc.settings.url.to_owned())
@@ -271,18 +312,19 @@ pub async fn convert_to_remote_write(
                     .with_label_values(&["check_response", "INTERNAL_SERVER_ERROR"])
                     .inc();
                 error!("DROPPING METRICS due to post error: {error}");
-                timer.observe_duration();
+                timer.stop_and_discard();
                 return (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "DROPPING METRICS due to post error",
                 );
             }
         };
+
         match check_response(request, response).await {
             Ok(_) => (),
-            Err(error) => {
-                timer.observe_duration();
-                return error;
+            Err(err) => {
+                timer.stop_and_discard();
+                return err;
             }
         }
     }

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -1381,7 +1381,7 @@ subtle = { version = "2", default-features = false, features = ["i128", "std"] }
 subtle-ng = { version = "2", default-features = false, features = ["std"] }
 syn-3575ec1268b04181 = { package = "syn", version = "0.15", features = ["extra-traits", "full", "visit"] }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
-syn-f595c2ba2a3f28df = { package = "syn", version = "2", features = ["extra-traits", "fold", "full"] }
+syn-f595c2ba2a3f28df = { package = "syn", version = "2", features = ["extra-traits", "fold", "full", "visit-mut"] }
 sync_wrapper = { version = "0.1", default-features = false }
 synstructure = { version = "0.12" }
 sysinfo = { version = "0.27" }


### PR DESCRIPTION
Summary:

* raise the metrics post limit to 5 MB from 2 MB.
* added instrumentation and also an additional header check for content-length
* move the mimir decode/encode to a dedicated spawn blocking pool to prevent (potentially) blocking the async runtime

Test Plan:

local testing and testnet

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
