### PR TITLE
2/n improve sui-json-rpc error codes and handling

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2690,16 +2690,15 @@ impl AuthorityState {
     pub fn get_checkpoint_summary_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
-    ) -> Result<CheckpointSummary, anyhow::Error> {
+    ) -> SuiResult<CheckpointSummary> {
         let verified_checkpoint = self
             .get_checkpoint_store()
             .get_checkpoint_by_sequence_number(sequence_number)?;
         match verified_checkpoint {
             Some(verified_checkpoint) => Ok(verified_checkpoint.into_inner().into_data()),
-            None => Err(anyhow!(
-                "Verified checkpoint not found for sequence number {}",
-                sequence_number
-            )),
+            None => Err(SuiError::UserInputError {
+                error: UserInputError::VerifiedCheckpointNotFound(sequence_number),
+            }),
         }
     }
 
@@ -2747,16 +2746,15 @@ impl AuthorityState {
     pub fn get_verified_checkpoint_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
-    ) -> Result<VerifiedCheckpoint, anyhow::Error> {
+    ) -> SuiResult<VerifiedCheckpoint> {
         let verified_checkpoint = self
             .get_checkpoint_store()
             .get_checkpoint_by_sequence_number(sequence_number)?;
         match verified_checkpoint {
             Some(verified_checkpoint) => Ok(verified_checkpoint),
-            None => Err(anyhow!(
-                "Verified checkpoint not found for sequence number {}",
-                sequence_number
-            )),
+            None => Err(SuiError::UserInputError {
+                error: UserInputError::VerifiedCheckpointNotFound(sequence_number),
+            }),
         }
     }
 

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2659,7 +2659,7 @@ impl AuthorityState {
         cursor: Option<TransactionDigest>,
         limit: Option<usize>,
         reverse: bool,
-    ) -> Result<Vec<TransactionDigest>, anyhow::Error> {
+    ) -> SuiResult<Vec<TransactionDigest>> {
         if let Some(TransactionFilter::Checkpoint(sequence_number)) = filter {
             let checkpoint_contents =
                 self.get_checkpoint_contents_by_sequence_number(sequence_number)?;

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1321,10 +1321,12 @@ impl AuthorityState {
         sender: SuiAddress,
         transaction_kind: TransactionKind,
         gas_price: Option<u64>,
-    ) -> Result<DevInspectResults, anyhow::Error> {
+    ) -> SuiResult<DevInspectResults> {
         let epoch_store = self.load_epoch_store_one_call_per_task();
         if !self.is_fullnode(&epoch_store) {
-            return Err(anyhow!("dev-inspect is only supported on fullnodes"));
+            return Err(SuiError::UnsupportedFeatureError {
+                error: "dev-inspect is only supported on fullnodes".to_string(),
+            });
         }
 
         transaction_kind.check_version_supported(epoch_store.protocol_config())?;

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2872,7 +2872,7 @@ impl AuthorityState {
         cursor: Option<EventID>,
         limit: usize,
         descending: bool,
-    ) -> Result<Vec<SuiEvent>, anyhow::Error> {
+    ) -> SuiResult<Vec<SuiEvent>> {
         let index_store = self.get_indexes()?;
 
         //Get the tx_num from tx_digest
@@ -2895,9 +2895,12 @@ impl AuthorityState {
                 if filters.is_empty() {
                     index_store.all_events(tx_num, event_num, limit, descending)?
                 } else {
-                    return Err(anyhow!(
-                        "This query type does not currently support filter combinations."
-                    ));
+                    return Err(SuiError::UserInputError {
+                        error: UserInputError::Unsupported(
+                            "This query type does not currently support filter combinations"
+                                .to_string(),
+                        ),
+                    });
                 }
             }
             EventFilter::Transaction(digest) => {
@@ -2924,9 +2927,11 @@ impl AuthorityState {
             } => index_store
                 .event_iterator(start_time, end_time, tx_num, event_num, limit, descending)?,
             _ => {
-                return Err(anyhow!(
-                    "This query type is not supported by the full node."
-                ))
+                return Err(SuiError::UserInputError {
+                    error: UserInputError::Unsupported(
+                        "This query type is not supported by the full node.".to_string(),
+                    ),
+                })
             }
         };
 

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2581,40 +2581,40 @@ impl AuthorityState {
         digest: TransactionDigest,
     ) -> SuiResult<VerifiedTransaction> {
         let transaction = self.database.get_transaction_block(&digest)?;
-        transaction.ok_or_else(|| SuiError::TransactionNotFound { digest })
+        transaction.ok_or(SuiError::TransactionNotFound { digest })
     }
 
     pub fn get_executed_effects(&self, digest: TransactionDigest) -> SuiResult<TransactionEffects> {
         let effects = self.database.get_executed_effects(&digest)?;
-        effects.ok_or_else(|| SuiError::TransactionNotFound { digest })
+        effects.ok_or(SuiError::TransactionNotFound { digest })
     }
 
     pub fn multi_get_executed_transactions(
         &self,
         digests: &[TransactionDigest],
     ) -> SuiResult<Vec<Option<VerifiedTransaction>>> {
-        Ok(self.database.multi_get_transaction_blocks(digests)?)
+        self.database.multi_get_transaction_blocks(digests)
     }
 
     pub fn multi_get_executed_effects(
         &self,
         digests: &[TransactionDigest],
     ) -> SuiResult<Vec<Option<TransactionEffects>>> {
-        Ok(self.database.multi_get_executed_effects(digests)?)
+        self.database.multi_get_executed_effects(digests)
     }
 
     pub fn multi_get_transaction_checkpoint(
         &self,
         digests: &[TransactionDigest],
     ) -> SuiResult<Vec<Option<(EpochId, CheckpointSequenceNumber)>>> {
-        Ok(self.database.multi_get_transaction_checkpoint(digests)?)
+        self.database.multi_get_transaction_checkpoint(digests)
     }
 
     pub fn multi_get_events(
         &self,
         digests: &[TransactionEventsDigest],
     ) -> SuiResult<Vec<Option<TransactionEvents>>> {
-        Ok(self.database.multi_get_events(digests)?)
+        self.database.multi_get_events(digests)
     }
 
     pub fn multi_get_checkpoint_by_sequence_number(
@@ -2688,7 +2688,7 @@ impl AuthorityState {
     pub fn get_latest_checkpoint_sequence_number(&self) -> SuiResult<CheckpointSequenceNumber> {
         self.get_checkpoint_store()
             .get_highest_executed_checkpoint_seq_number()?
-            .ok_or_else(|| SuiError::UserInputError {
+            .ok_or(SuiError::UserInputError {
                 error: UserInputError::LatestCheckpointSequenceNumberNotFound,
             })
     }
@@ -2783,7 +2783,7 @@ impl AuthorityState {
     ) -> SuiResult<CheckpointContents> {
         self.get_checkpoint_store()
             .get_checkpoint_contents(&digest)?
-            .ok_or_else(|| SuiError::UserInputError {
+            .ok_or(SuiError::UserInputError {
                 error: UserInputError::CheckpointContentsNotFound(digest),
             })
     }
@@ -2812,7 +2812,7 @@ impl AuthorityState {
         cursor: Option<CheckpointSequenceNumber>,
         limit: u64,
         descending_order: bool,
-    ) -> Result<Vec<Checkpoint>, anyhow::Error> {
+    ) -> SuiResult<Vec<Checkpoint>> {
         let max_checkpoint = self.get_latest_checkpoint_sequence_number()?;
         let checkpoint_numbers =
             calculate_checkpoint_numbers(cursor, limit, descending_order, max_checkpoint);
@@ -2862,7 +2862,7 @@ impl AuthorityState {
     }
 
     pub async fn get_timestamp_ms(&self, digest: &TransactionDigest) -> SuiResult<Option<u64>> {
-        Ok(self.get_indexes()?.get_timestamp_ms(digest)?)
+        self.get_indexes()?.get_timestamp_ms(digest)
     }
 
     pub fn query_events(

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1464,7 +1464,7 @@ impl AuthorityStore {
     pub fn multi_get_transaction_blocks(
         &self,
         tx_digests: &[TransactionDigest],
-    ) -> Result<Vec<Option<VerifiedTransaction>>, SuiError> {
+    ) -> SuiResult<Vec<Option<VerifiedTransaction>>> {
         Ok(self
             .perpetual_tables
             .transactions

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -113,7 +113,7 @@ pub(crate) async fn check_dev_inspect_input(
     config: &ProtocolConfig,
     kind: &TransactionKind,
     gas_object: Object,
-) -> Result<(ObjectRef, InputObjects), anyhow::Error> {
+) -> SuiResult<(ObjectRef, InputObjects)> {
     let gas_object_ref = gas_object.compute_object_reference();
     kind.validity_check(config)?;
     match kind {
@@ -121,7 +121,7 @@ pub(crate) async fn check_dev_inspect_input(
         TransactionKind::ChangeEpoch(_)
         | TransactionKind::Genesis(_)
         | TransactionKind::ConsensusCommitPrologue(_) => {
-            anyhow::bail!("Transaction kind {} is not supported in dev-inspect", kind)
+            return Err(UserInputError::Unsupported(format!("Transaction kind {} is not supported in dev-inspect", kind)).into())
         }
     }
     let mut input_objects = kind.input_objects()?;

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -4287,7 +4287,7 @@ pub async fn call_dev_inspect(
     function: &str,
     type_arguments: Vec<TypeTag>,
     test_args: Vec<TestCallArg>,
-) -> Result<DevInspectResults, anyhow::Error> {
+) -> SuiResult<DevInspectResults> {
     let mut builder = ProgrammableTransactionBuilder::new();
     let mut arguments = Vec::with_capacity(test_args.len());
     for a in test_args {

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -24,7 +24,7 @@ use sui_types::base_types::{
 };
 use sui_types::digests::{ObjectDigest, TransactionEventsDigest};
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents};
-use sui_types::error::{ExecutionError, SuiError};
+use sui_types::error::{ExecutionError, SuiError, SuiResult};
 use sui_types::execution_status::ExecutionStatus;
 use sui_types::gas::GasCostSummary;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
@@ -706,7 +706,7 @@ impl SuiTransactionBlockEvents {
         tx_digest: TransactionDigest,
         timestamp_ms: Option<u64>,
         resolver: &impl GetModule,
-    ) -> Result<Self, SuiError> {
+    ) -> SuiResult<Self> {
         Ok(Self {
             data: events
                 .data
@@ -761,7 +761,7 @@ impl DevInspectResults {
         events: TransactionEvents,
         return_values: Result<Vec<ExecutionResult>, ExecutionError>,
         resolver: &impl GetModule,
-    ) -> Result<Self, anyhow::Error> {
+    ) -> SuiResult<Self> {
         let tx_digest = *effects.transaction_digest();
         let mut error = None;
         let mut results = None;

--- a/crates/sui-json-rpc/src/indexer_api.rs
+++ b/crates/sui-json-rpc/src/indexer_api.rs
@@ -208,7 +208,8 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
             // Retrieve 1 extra item for next cursor
             let mut data = self
                 .state
-                .query_events(query, cursor.clone(), limit + 1, descending)?;
+                .query_events(query, cursor.clone(), limit + 1, descending)
+                .map_err(Error::from)?;
             let has_next_page = data.len() > limit;
             data.truncate(limit);
             let next_cursor = data.last().map_or(cursor, |e| Some(e.id.clone()));

--- a/crates/sui-json-rpc/src/indexer_api.rs
+++ b/crates/sui-json-rpc/src/indexer_api.rs
@@ -36,6 +36,7 @@ use crate::api::{
     cap_page_limit, validate_limit, IndexerApiServer, JsonRpcMetrics, ReadApiServer,
     QUERY_MAX_RESULT_LIMIT,
 };
+use crate::error::Error;
 use crate::with_tracing;
 use crate::SuiRpcModule;
 
@@ -157,9 +158,10 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
             let opts = query.options.unwrap_or_default();
 
             // Retrieve 1 extra item for next cursor
-            let mut digests =
-                self.state
-                    .get_transactions(query.filter, cursor, Some(limit + 1), descending)?;
+            let mut digests = self
+                .state
+                .get_transactions(query.filter, cursor, Some(limit + 1), descending)
+                .map_err(Error::from)?;
 
             // extract next cursor
             let has_next_page = digests.len() > limit;

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -987,12 +987,15 @@ fn get_display_object_by_type(
     object_type: &StructTag,
     // TODO: add query version support
 ) -> RpcResult<Option<DisplayVersionUpdatedEvent>> {
-    let mut events = fullnode_api.state.query_events(
-        EventFilter::MoveEventType(DisplayVersionUpdatedEvent::type_(object_type)),
-        None,
-        1,
-        true,
-    )?;
+    let mut events = fullnode_api
+        .state
+        .query_events(
+            EventFilter::MoveEventType(DisplayVersionUpdatedEvent::type_(object_type)),
+            None,
+            1,
+            true,
+        )
+        .map_err(Error::from)?;
 
     // If there's any recent version of Display, give it to the client.
     // TODO: add support for version query.

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -843,7 +843,8 @@ impl ReadApiServer for ReadApi {
                 state.get_checkpoints(cursor.map(|s| *s), limit as u64 + 1, descending_order)
             })
             .await
-            .map_err(|e| anyhow!(e))??;
+            .map_err(Error::from)?
+            .map_err(Error::from)?;
 
             let has_next_page = data.len() > limit;
             data.truncate(limit);

--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -234,8 +234,9 @@ impl WriteApiServer for TransactionExecutionApi {
         Ok(self
             .state
             .dev_inspect_transaction_block(sender_address, tx_kind, gas_price.map(|i| *i))
-            .instrument(error_span!("dev_inspect_transaction_block"))
-            .await?)
+            .instrument(error_span!("dev_inspect_transaction_block"))            
+            .await
+            .map_err(Error::from)?)
     }
 
     async fn dry_run_transaction_block(

--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -234,7 +234,7 @@ impl WriteApiServer for TransactionExecutionApi {
         Ok(self
             .state
             .dev_inspect_transaction_block(sender_address, tx_kind, gas_price.map(|i| *i))
-            .instrument(error_span!("dev_inspect_transaction_block"))            
+            .instrument(error_span!("dev_inspect_transaction_block"))
             .await
             .map_err(Error::from)?)
     }

--- a/crates/sui-storage/src/indexes.rs
+++ b/crates/sui-storage/src/indexes.rs
@@ -10,7 +10,6 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
-use anyhow::anyhow;
 use itertools::Itertools;
 use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::{ModuleId, StructTag, TypeTag};
@@ -626,7 +625,7 @@ impl IndexStore {
         let cursor = if let Some(cursor) = cursor {
             Some(
                 self.get_transaction_seq(&cursor)?
-                    .ok_or_else(|| SuiError::TransactionNotFound { digest: cursor })?,
+                    .ok_or(SuiError::TransactionNotFound { digest: cursor })?,
             )
         } else {
             None

--- a/crates/sui-storage/src/indexes.rs
+++ b/crates/sui-storage/src/indexes.rs
@@ -626,7 +626,7 @@ impl IndexStore {
         let cursor = if let Some(cursor) = cursor {
             Some(
                 self.get_transaction_seq(&cursor)?
-                    .ok_or_else(|| anyhow!("Transaction [{cursor:?}] not found."))?,
+                    .ok_or_else(|| anyhow!("Transaction [{cursor:?}] not found."))?, // over here
             )
         } else {
             None
@@ -653,7 +653,7 @@ impl IndexStore {
             }
             // NOTE: filter via checkpoint sequence number is implemented in
             // `get_transactions` of authority.rs.
-            Some(_) => Err(anyhow!("Unsupported filter: {:?}", filter)),
+            Some(_) => Err(anyhow!("Unsupported filter: {:?}", filter)), // over here
             None => {
                 let iter = self.tables.transaction_order.iter();
 

--- a/crates/sui-storage/src/indexes.rs
+++ b/crates/sui-storage/src/indexes.rs
@@ -621,12 +621,12 @@ impl IndexStore {
         cursor: Option<TransactionDigest>,
         limit: Option<usize>,
         reverse: bool,
-    ) -> Result<Vec<TransactionDigest>, anyhow::Error> {
+    ) -> SuiResult<Vec<TransactionDigest>> {
         // Lookup TransactionDigest sequence number,
         let cursor = if let Some(cursor) = cursor {
             Some(
                 self.get_transaction_seq(&cursor)?
-                    .ok_or_else(|| anyhow!("Transaction [{cursor:?}] not found."))?, // over here
+                    .ok_or_else(|| SuiError::TransactionNotFound { digest: cursor })?,
             )
         } else {
             None
@@ -653,7 +653,9 @@ impl IndexStore {
             }
             // NOTE: filter via checkpoint sequence number is implemented in
             // `get_transactions` of authority.rs.
-            Some(_) => Err(anyhow!("Unsupported filter: {:?}", filter)), // over here
+            Some(_) => Err(SuiError::UserInputError {
+                error: UserInputError::Unsupported(format!("{:?}", filter)),
+            }),
             None => {
                 let iter = self.tables.transaction_order.iter();
 

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -208,7 +208,7 @@ pub enum UserInputError {
     #[error("Transaction is denied: {}", error)]
     TransactionDenied { error: String },
 
-    #[error("Feature is not yet supported: {0}")]
+    #[error("Feature is not supported: {0}")]
     Unsupported(String),
 
     #[error("Query transactions with move function input error: {0}")]

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -5,7 +5,7 @@
 use crate::{
     base_types::*,
     committee::{Committee, EpochId, StakeUnit},
-    digests::CheckpointDigest,
+    digests::CheckpointContentsDigest,
     messages_checkpoint::CheckpointSequenceNumber,
     object::Owner,
 };
@@ -218,7 +218,16 @@ pub enum UserInputError {
     VerifiedCheckpointNotFound(CheckpointSequenceNumber),
 
     #[error("Verified checkpoint not found for digest: {0}")]
-    VerifiedCheckpointDigestNotFound(CheckpointDigest),
+    VerifiedCheckpointDigestNotFound(String),
+
+    #[error("Latest checkpoint sequence number not found")]
+    LatestCheckpointSequenceNumberNotFound,
+
+    #[error("Checkpoint contents not found for digest: {0}")]
+    CheckpointContentsNotFound(CheckpointContentsDigest),
+
+    #[error("Genesis transaction not found")]
+    GenesisTransactionNotFound,
 }
 
 #[derive(

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -5,6 +5,8 @@
 use crate::{
     base_types::*,
     committee::{Committee, EpochId, StakeUnit},
+    digests::CheckpointDigest,
+    messages_checkpoint::CheckpointSequenceNumber,
     object::Owner,
 };
 
@@ -211,6 +213,12 @@ pub enum UserInputError {
 
     #[error("Query transactions with move function input error: {0}")]
     MoveFunctionInputError(String),
+
+    #[error("Verified checkpoint not found for sequence number: {0}")]
+    VerifiedCheckpointNotFound(CheckpointSequenceNumber),
+
+    #[error("Verified checkpoint not found for digest: {0}")]
+    VerifiedCheckpointDigestNotFound(CheckpointDigest),
 }
 
 #[derive(

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -228,6 +228,9 @@ pub enum UserInputError {
 
     #[error("Genesis transaction not found")]
     GenesisTransactionNotFound,
+
+    #[error("Transaction {0} not found")]
+    TransactionCursorNotFound(u64),
 }
 
 #[derive(


### PR DESCRIPTION
## Description 

Update `authority.rs` to use `SuiResult` instead of `anyhow::Error`. Some places that depended on `anyhow::Error` needed to be updated. Most noticeably, previously, because of `anyhow::Error`, there's no need to convert the underlying `SuiError` into `Error` (`SuiJsonRpcError`) where Rust can then do the conversion into `Error` (`RpcError`), as RpcError supports `from anyhow::Error`. Now though, we need to explicitly convert into the intermediary, causing instances where we have `.map_err(Error::from)?.map_err(Error::from)?`. One thought is to have an `_internal()` fn for all methods that rely on calls to state and other services.

## Test Plan 

Existing unit + integration tests. Manually call each api endpoint and verify that success and error responses are as expected

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
