### PR TITLE
[Narwhal] deduplicate missing parents in vote requests

### DIFF
--- a/narwhal/primary/src/metrics.rs
+++ b/narwhal/primary/src/metrics.rs
@@ -320,6 +320,8 @@ pub struct PrimaryMetrics {
     pub header_to_certificate_latency: Histogram,
     /// Millisecs taken to wait for max parent time, when proposing headers.
     pub header_max_parent_wait_ms: IntCounter,
+    /// Counts when the GC loop in synchronizer times out waiting for consensus commit.
+    pub synchronizer_gc_timeout: IntCounter,
 }
 
 impl PrimaryMetrics {
@@ -498,6 +500,11 @@ impl PrimaryMetrics {
             header_max_parent_wait_ms: register_int_counter_with_registry!(
                 "header_max_parent_wait_ms",
                 "Millisecs taken to wait for max parent time, when proposing headers.",
+                registry
+            ).unwrap(),
+            synchronizer_gc_timeout: register_int_counter_with_registry!(
+                "synchronizer_gc_timeout",
+                "Counts when the GC loop in synchronizer times out waiting for consensus commit.",
                 registry
             ).unwrap(),
         }

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -36,7 +36,6 @@ use fastcrypto::{
     signature_service::SignatureService,
     traits::{KeyPair as _, ToFromBytes},
 };
-use futures::{stream::FuturesUnordered, StreamExt};
 use mysten_metrics::{monitored_scope, spawn_monitored_task};
 use mysten_network::{multiaddr::Protocol, Multiaddr};
 use network::{
@@ -44,8 +43,9 @@ use network::{
     epoch_filter::{AllowedEpoch, EPOCH_HEADER_KEY},
 };
 use network::{failpoints::FailpointsMakeCallbackHandler, metrics::MetricsMakeCallbackHandler};
+use parking_lot::Mutex;
 use prometheus::Registry;
-use std::collections::HashMap;
+use std::collections::{btree_map::Entry, BTreeMap, HashMap};
 use std::{
     cmp::Reverse,
     collections::{BTreeSet, BinaryHeap},
@@ -62,13 +62,12 @@ use tokio::{
 };
 use tower::ServiceBuilder;
 use tracing::{debug, error, info, instrument, warn};
-
 use types::{
     ensure,
     error::{DagError, DagResult},
     metered_channel::{channel_with_total, Receiver, Sender},
     now, Certificate, CertificateAPI, CertificateDigest, FetchCertificatesRequest,
-    FetchCertificatesResponse, GetCertificatesRequest, GetCertificatesResponse, HeaderAPI,
+    FetchCertificatesResponse, GetCertificatesRequest, GetCertificatesResponse, Header, HeaderAPI,
     PayloadAvailabilityRequest, PayloadAvailabilityResponse, PreSubscribedBroadcastSender,
     PrimaryToPrimary, PrimaryToPrimaryServer, RequestVoteRequest, RequestVoteResponse, Round,
     SendCertificateRequest, SendCertificateResponse, Vote, VoteInfoAPI, WorkerOthersBatchMessage,
@@ -222,6 +221,7 @@ impl Primary {
             payload_store: payload_store.clone(),
             vote_digest_store,
             rx_narwhal_round_updates,
+            parent_digests: Default::default(),
             metrics: node_metrics.clone(),
         })
         // Allow only one inflight RequestVote RPC at a time per peer.
@@ -648,6 +648,9 @@ struct PrimaryReceiverHandler {
     vote_digest_store: VoteDigestStore,
     /// Get a signal when the round changes.
     rx_narwhal_round_updates: watch::Receiver<Round>,
+    /// Known parent digests that are being fetched from header proposers.
+    /// Values are where the digests are first known from.
+    parent_digests: Arc<Mutex<BTreeMap<(Round, CertificateDigest), AuthorityIdentifier>>>,
     metrics: Arc<PrimaryMetrics>,
 }
 
@@ -682,6 +685,15 @@ impl PrimaryReceiverHandler {
         let committee = self.committee.clone();
         header.validate(&committee, &self.worker_cache)?;
 
+        let num_parents = request.body().parents.len();
+        ensure!(
+            num_parents <= committee.size(),
+            DagError::TooManyParents(num_parents, committee.size())
+        );
+        self.metrics
+            .certificates_in_votes
+            .inc_by(num_parents as u64);
+
         // Vote request must come from the Header's author.
         let peer_id = request
             .peer_id()
@@ -712,71 +724,39 @@ impl PrimaryReceiverHandler {
             header.round()
         );
 
-        // Clone the round updates channel so we can get update notifications specific to
-        // this RPC handler.
-        let mut rx_narwhal_round_updates = self.rx_narwhal_round_updates.clone();
-        // Maximum header age is chosen to strike a balance between allowing for slightly older
-        // certificates to still have a chance to be included in the DAG while not wasting
-        // resources on very old vote requests. This value affects performance but not correctness
-        // of the algorithm.
-        const HEADER_AGE_LIMIT: Round = 3;
-
-        // If requester has provided us with parent certificates, process them all
-        // before proceeding.
-        self.metrics
-            .certificates_in_votes
-            .inc_by(request.body().parents.len() as u64);
-        let mut wait_notifications: FuturesUnordered<_> = request
-            .body()
-            .parents
-            .clone()
-            .into_iter()
-            .map(|cert| self.synchronizer.wait_to_accept_certificate(cert))
-            .collect();
-        loop {
-            tokio::select! {
-                result = wait_notifications.next() => {
-                    match result {
-                        Some(result) => {
-                            result?;
-                            continue;
-                        },
-                        // Waits are done. Missing parents have been accepted.
-                        None => break,
-                    }
-                },
-                result = rx_narwhal_round_updates.changed() => {
-                    if result.is_err() {
-                        return Err(DagError::NetworkError("Node shutting down".to_owned()));
-                    }
-                    let narwhal_round = *rx_narwhal_round_updates.borrow();
-                    ensure!(
-                        narwhal_round.saturating_sub(HEADER_AGE_LIMIT) <= header.round(),
-                        DagError::TooOld(header.digest().into(), header.round(), narwhal_round)
-                    )
-                },
+        // Request missing parent certificates from the header proposer, to reduce voting latency
+        // when some certificates are not broadcasted to many primaries.
+        // This is only a latency optimization, and not required for liveness.
+        let parents = request.body().parents.clone();
+        if parents.is_empty() {
+            // If any parent is still unknown, ask the header proposer to include them with another
+            // vote request.
+            let unknown_digests = self.get_unknown_parent_digests(header).await?;
+            if !unknown_digests.is_empty() {
+                debug!(
+                    "Received vote request for {:?} with unknown parents {:?}",
+                    header, unknown_digests
+                );
+                return Ok(RequestVoteResponse {
+                    vote: None,
+                    missing: unknown_digests,
+                });
             }
+        } else {
+            // If requester has provided parent certificates, try to accept them.
+            // It is ok to not check for additional unknown digests, because certificates can
+            // become available asynchronously from broadcast or certificate fetching.
+            self.try_accept_unknown_parents(header, parents).await?;
         }
 
-        // Ensure we have the parents. If any are missing, the requester should provide them on retry.
-        // This check is necessary for correctness, because it is possible that the list of missing
-        // parents in the request is incomplete, or wait_notifications get notified on shut down
-        // without actually having the parents available.
-        let (parents, missing) = self.synchronizer.get_parents(header)?;
-        if !missing.is_empty() {
-            return Ok(RequestVoteResponse {
-                vote: None,
-                missing,
-            });
-        }
-
-        // Now that we've got all the required certificates, ensure we're voting on a
-        // current Header.
-        let narwhal_round = *rx_narwhal_round_updates.borrow();
-        ensure!(
-            narwhal_round.saturating_sub(HEADER_AGE_LIMIT) <= header.round(),
-            DagError::TooOld(header.digest().into(), header.round(), narwhal_round)
-        );
+        // Ensure the header has all parents accepted. If some are missing, waits until they become
+        // available from broadcast or certificate fetching. If no certificate becomes available
+        // for a digest, this request will time out or get cancelled by the requestor eventually.
+        // This check is necessary for correctness.
+        let parents = self
+            .synchronizer
+            .notify_read_parent_certificates(header)
+            .await?;
 
         // Check the parent certificates. Ensure the parents:
         // - form a quorum
@@ -852,26 +832,29 @@ impl PrimaryReceiverHandler {
             .map_err(DagError::StoreError)?;
 
         if let Some(vote_info) = result {
-            if header.epoch() < vote_info.epoch()
-                || (header.epoch() == vote_info.epoch() && header.round() < vote_info.round())
-            {
-                // Already voted on a newer Header for this publicKey.
-                return Err(DagError::TooOld(
-                    header.digest().into(),
+            ensure!(
+                header.epoch() == vote_info.epoch(),
+                DagError::InvalidEpoch {
+                    expected: header.epoch(),
+                    received: vote_info.epoch()
+                }
+            );
+            ensure!(
+                header.round() >= vote_info.round(),
+                DagError::AlreadyVotedNewerHeader(
+                    header.digest(),
                     header.round(),
-                    narwhal_round,
-                ));
-            }
-            if header.epoch() == vote_info.epoch() && header.round() == vote_info.round() {
+                    vote_info.round(),
+                )
+            );
+            if header.round() == vote_info.round() {
                 // Make sure we don't vote twice for the same authority in the same epoch/round.
-                let temp_vote =
-                    Vote::new(header, &self.authority_id, &self.signature_service).await;
-                if temp_vote.digest() != vote_info.vote_digest() {
-                    info!(
-                        "Authority {} submitted duplicate header for votes at epoch {}, round {}",
+                let vote = Vote::new(header, &self.authority_id, &self.signature_service).await;
+                if vote.digest() != vote_info.vote_digest() {
+                    warn!(
+                        "Authority {} submitted different header {:?} for voting",
                         header.author(),
-                        header.epoch(),
-                        header.round()
+                        header,
                     );
                     self.metrics.votes_dropped_equivocation_protection.inc();
                     return Err(DagError::AlreadyVoted(
@@ -879,6 +862,15 @@ impl PrimaryReceiverHandler {
                         header.round(),
                     ));
                 }
+                debug!(
+                    "Resending vote {vote:?} for {} at round {}",
+                    header,
+                    header.round()
+                );
+                return Ok(RequestVoteResponse {
+                    vote: Some(vote),
+                    missing: Vec::new(),
+                });
             }
         }
 
@@ -897,6 +889,81 @@ impl PrimaryReceiverHandler {
             vote: Some(vote),
             missing: Vec::new(),
         })
+    }
+
+    // Tries to accept certificates if they have been requested from the header author.
+    // The filtering is to avoid overload from unrequested certificates. It is ok that this
+    // filter may result in a certificate never arriving via header proposals, because
+    // liveness is guaranteed by certificate fetching.
+    async fn try_accept_unknown_parents(
+        &self,
+        header: &Header,
+        mut parents: Vec<Certificate>,
+    ) -> DagResult<()> {
+        {
+            let parent_digests = self.parent_digests.lock();
+            parents.retain(|cert| {
+                let Some(from) = parent_digests.get(&(cert.round(), cert.digest())) else {
+                    return false;
+                };
+                // Only process a certificate from the primary where it is first known.
+                *from == header.author()
+            });
+        }
+        for parent in parents {
+            self.synchronizer.try_accept_certificate(parent).await?;
+        }
+        Ok(())
+    }
+
+    /// Gets parent certificate digests not known before, in storage, among suspended certificates,
+    /// or being requested from other header proposers.
+    async fn get_unknown_parent_digests(
+        &self,
+        header: &Header,
+    ) -> DagResult<Vec<CertificateDigest>> {
+        // Get digests not known by the synchronizer, in storage or among suspended certificates.
+        let mut digests = self.synchronizer.get_unknown_parent_digests(header).await?;
+
+        // Maximum header age is chosen to strike a balance between allowing for slightly older
+        // certificates to still have a chance to be included in the DAG while not wasting
+        // resources on very old vote requests. This value affects performance but not correctness
+        // of the algorithm.
+        const HEADER_AGE_LIMIT: Round = 3;
+
+        // Lock to ensure consistency between limit_round and where parent_digests are gc'ed.
+        let mut parent_digests = self.parent_digests.lock();
+
+        // Check that the header is not too old.
+        let narwhal_round = *self.rx_narwhal_round_updates.borrow();
+        let limit_round = narwhal_round.saturating_sub(HEADER_AGE_LIMIT);
+        ensure!(
+            limit_round <= header.round(),
+            DagError::TooOld(header.digest().into(), header.round(), narwhal_round)
+        );
+
+        // Drop old entries from parent_digests.
+        while let Some(((round, _digest), _authority)) = parent_digests.first_key_value() {
+            // Minimum header round is limit_round, so minimum parent round is limit_round - 1.
+            if *round < limit_round.saturating_sub(1) {
+                parent_digests.pop_first();
+            } else {
+                break;
+            }
+        }
+
+        // Filter out digests that are already requested from other header proposers.
+        digests.retain(
+            |digest| match parent_digests.entry((header.round() - 1, *digest)) {
+                Entry::Occupied(_) => false,
+                Entry::Vacant(v) => {
+                    v.insert(header.author());
+                    true
+                }
+            },
+        );
+
+        Ok(digests)
     }
 }
 

--- a/narwhal/primary/src/synchronizer.rs
+++ b/narwhal/primary/src/synchronizer.rs
@@ -30,7 +30,7 @@ use storage::{CertificateStore, PayloadStore};
 use tokio::{
     sync::{broadcast, mpsc, oneshot, watch, MutexGuard},
     task::JoinSet,
-    time::sleep,
+    time::{sleep, timeout},
 };
 use tracing::{debug, error, instrument, trace, warn};
 use types::{
@@ -41,7 +41,10 @@ use types::{
     Round, SendCertificateRequest, SendCertificateResponse, WorkerSynchronizeMessage,
 };
 
-use crate::{aggregators::CertificatesAggregator, metrics::PrimaryMetrics, CHANNEL_CAPACITY};
+use crate::{
+    aggregators::CertificatesAggregator, certificate_fetcher::CertificateFetcherCommand,
+    metrics::PrimaryMetrics, CHANNEL_CAPACITY,
+};
 
 #[cfg(test)]
 #[path = "tests/synchronizer_tests.rs"]
@@ -75,7 +78,7 @@ struct Inner {
     /// or others workers.
     payload_store: PayloadStore,
     /// Send missing certificates to the `CertificateFetcher`.
-    tx_certificate_fetcher: Sender<Certificate>,
+    tx_certificate_fetcher: Sender<CertificateFetcherCommand>,
     /// Send certificates to be accepted into a separate task that runs
     /// `process_certificate_with_lock()` in a loop.
     /// See comment above `process_certificate_with_lock()` for why this is necessary.
@@ -213,6 +216,33 @@ impl Inner {
         Ok(())
     }
 
+    /// Returns parent digests that do no exist either in storage or among suspended.
+    async fn get_unknown_parent_digests(
+        &self,
+        header: &Header,
+    ) -> DagResult<Vec<CertificateDigest>> {
+        if header.round() == 1 {
+            for digest in header.parents() {
+                if !self.genesis.contains_key(digest) {
+                    return Err(DagError::InvalidGenesisParent(*digest));
+                }
+            }
+            return Ok(Vec::new());
+        }
+
+        let mut unknown: Vec<_> = header
+            .parents()
+            .iter()
+            .filter_map(|digest| match self.certificate_store.contains(digest) {
+                Ok(true) => None,
+                _ => Some(*digest),
+            })
+            .collect();
+        let state = self.state.lock().await;
+        unknown.retain(|digest| !state.suspended.contains_key(digest));
+        Ok(unknown)
+    }
+
     /// Tries to get all missing parents of the certificate. If there is any, sends the
     /// certificate to `CertificateFetcher` which will trigger range fetching of missing
     /// certificates.
@@ -237,7 +267,9 @@ impl Inner {
         }
         if !result.is_empty() {
             self.tx_certificate_fetcher
-                .send(certificate.clone())
+                .send(CertificateFetcherCommand::MissingAncestors(
+                    certificate.clone(),
+                ))
                 .await
                 .map_err(|_| DagError::ShuttingDown)?;
         }
@@ -278,7 +310,7 @@ impl Synchronizer {
         client: NetworkClient,
         certificate_store: CertificateStore,
         payload_store: PayloadStore,
-        tx_certificate_fetcher: Sender<Certificate>,
+        tx_certificate_fetcher: Sender<CertificateFetcherCommand>,
         tx_new_certificates: Sender<Certificate>,
         tx_parents: Sender<(Vec<Certificate>, Round, Epoch)>,
         rx_consensus_round_updates: watch::Receiver<ConsensusRound>,
@@ -339,12 +371,28 @@ impl Synchronizer {
             }
         });
 
-        // Start a task to update gc_round and gc in-memory data.
+        // Start a task to update gc_round, gc in-memory data, and trigger certificate catchup
+        // if no gc / commit happened for 10s.
         let weak_inner = Arc::downgrade(&inner);
         spawn_monitored_task!(async move {
+            const FETCH_TRIGGER_TIMEOUT: Duration = Duration::from_secs(30);
             let mut rx_consensus_round_updates = rx_consensus_round_updates.clone();
             loop {
-                let result = rx_consensus_round_updates.changed().await;
+                let Ok(result) = timeout(FETCH_TRIGGER_TIMEOUT, rx_consensus_round_updates.changed()).await else {
+                    // When consensus commit has not happened for 30s, it is possible that no new
+                    // certificate is received by this primary or created in the network, so
+                    // fetching should definitely be started.
+                    // For other reasons of timing out, there is no harm to start fetching either.
+                    let Some(inner) = weak_inner.upgrade() else {
+                        debug!("Synchronizer is shutting down.");
+                        return;
+                    };
+                    if inner.tx_certificate_fetcher.send(CertificateFetcherCommand::Kick).await.is_err() {
+                        debug!("Synchronizer is shutting down.");
+                        return;
+                    }
+                    continue;
+                };
                 if result.is_err() {
                     debug!("Synchronizer is shutting down.");
                     return;
@@ -453,24 +501,6 @@ impl Synchronizer {
         let _scope = monitored_scope("Synchronizer::try_accept_fetched_certificate");
         self.process_certificate_internal(certificate, false, false)
             .await
-    }
-
-    /// Validates the certificate and accepts it into the DAG, if the certificate can be verified
-    /// and has all parents in the certificate store.
-    /// If the certificate has missing parents, wait until all parents are available to accept the
-    /// certificate.
-    /// Otherwise returns an error.
-    pub async fn wait_to_accept_certificate(&self, certificate: Certificate) -> DagResult<()> {
-        match self
-            .process_certificate_internal(certificate, true, true)
-            .await
-        {
-            Err(DagError::Suspended(notify)) => {
-                notify.wait().await;
-                Ok(())
-            }
-            result => result,
-        }
     }
 
     /// Accepts a certificate produced by this primary. This is not expected to fail unless
@@ -635,7 +665,9 @@ impl Synchronizer {
         if highest_processed_round + NEW_CERTIFICATE_ROUND_LIMIT < certificate.round() {
             self.inner
                 .tx_certificate_fetcher
-                .send(certificate.clone())
+                .send(CertificateFetcherCommand::MissingAncestors(
+                    certificate.clone(),
+                ))
                 .await
                 .map_err(|_| DagError::ShuttingDown)?;
             return Err(DagError::TooNew(
@@ -965,27 +997,38 @@ impl Synchronizer {
         }
     }
 
-    /// Returns the parent certificates of the given header, and a list of digests for any
-    /// that are missing.
-    pub fn get_parents(
+    /// Returns the parent certificates of the given header, waits for availability if needed.
+    pub async fn notify_read_parent_certificates(
         &self,
         header: &Header,
-    ) -> DagResult<(Vec<Certificate>, Vec<CertificateDigest>)> {
-        let mut missing = Vec::new();
+    ) -> DagResult<Vec<Certificate>> {
         let mut parents = Vec::new();
-        for digest in header.parents() {
-            let cert = if header.round() == 1 {
-                self.inner.genesis.get(digest).cloned()
-            } else {
-                self.inner.certificate_store.read(*digest)?
-            };
-            match cert {
-                Some(certificate) => parents.push(certificate),
-                None => missing.push(*digest),
-            };
+        if header.round() == 1 {
+            for digest in header.parents() {
+                match self.inner.genesis.get(digest) {
+                    Some(certificate) => parents.push(certificate.clone()),
+                    None => return Err(DagError::InvalidGenesisParent(*digest)),
+                };
+            }
+        } else {
+            let mut cert_notifications: FuturesOrdered<_> = header
+                .parents()
+                .iter()
+                .map(|digest| async { self.inner.certificate_store.notify_read(*digest).await })
+                .collect();
+            while let Some(result) = cert_notifications.next().await {
+                parents.push(result?);
+            }
         }
+        Ok(parents)
+    }
 
-        Ok((parents, missing))
+    /// Returns parent digests that do no exist either in storage or among suspended.
+    pub async fn get_unknown_parent_digests(
+        &self,
+        header: &Header,
+    ) -> DagResult<Vec<CertificateDigest>> {
+        self.inner.get_unknown_parent_digests(header).await
     }
 
     /// Tries to get all missing parents of the certificate. If there is any, sends the

--- a/narwhal/primary/src/tests/synchronizer_tests.rs
+++ b/narwhal/primary/src/tests/synchronizer_tests.rs
@@ -1,9 +1,9 @@
-use crate::certificate_fetcher::CertificateFetcherCommand;
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+
 use crate::{
-    common::create_db_stores, metrics::PrimaryMetrics, synchronizer::Synchronizer,
-    NUM_SHUTDOWN_RECEIVERS,
+    certificate_fetcher::CertificateFetcherCommand, common::create_db_stores,
+    metrics::PrimaryMetrics, synchronizer::Synchronizer, NUM_SHUTDOWN_RECEIVERS,
 };
 use config::Committee;
 use consensus::consensus::ConsensusRound;
@@ -721,7 +721,7 @@ async fn deliver_certificate_using_store() {
     assert!(parents_available);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn deliver_certificate_not_found_parents() {
     let fixture = CommitteeFixture::builder().build();
     let primary = fixture.authorities().next().unwrap();
@@ -784,8 +784,13 @@ async fn deliver_certificate_not_found_parents() {
     // and we should fail
     assert!(!parents_available);
 
-    let CertificateFetcherCommand::MissingAncestors(certificate)  = rx_certificate_fetcher.recv().await.unwrap() else {
-        panic!("Expected CertificateFetcherCommand::MissingAncestors");
+    let CertificateFetcherCommand::Ancestors(certificate)  = rx_certificate_fetcher.recv().await.unwrap() else {
+        panic!("Expected CertificateFetcherCommand::Ancestors");
+    };
+
+    // Be inactive would result in a kick signal from synchronizer to fetcher eventually.
+    let CertificateFetcherCommand::Kick = rx_certificate_fetcher.recv().await.unwrap() else {
+        panic!("Expected CertificateFetcherCommand::Kick");
     };
 
     assert_eq!(certificate, test_certificate);

--- a/narwhal/primary/src/tests/synchronizer_tests.rs
+++ b/narwhal/primary/src/tests/synchronizer_tests.rs
@@ -1,3 +1,4 @@
+use crate::certificate_fetcher::CertificateFetcherCommand;
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
@@ -783,7 +784,9 @@ async fn deliver_certificate_not_found_parents() {
     // and we should fail
     assert!(!parents_available);
 
-    let certificate = rx_certificate_fetcher.recv().await.unwrap();
+    let CertificateFetcherCommand::MissingAncestors(certificate)  = rx_certificate_fetcher.recv().await.unwrap() else {
+        panic!("Expected CertificateFetcherCommand::MissingAncestors");
+    };
 
     assert_eq!(certificate, test_certificate);
 }

--- a/narwhal/types/src/error.rs
+++ b/narwhal/types/src/error.rs
@@ -73,8 +73,11 @@ pub enum DagError {
     #[error("Received unexpected vote for header {0}")]
     UnexpectedVote(HeaderDigest),
 
-    #[error("Already sent a vote with digest {0} for round {1}")]
-    AlreadyVoted(VoteDigest, Round),
+    #[error("Already voted with a different digest {0} at round {2}, for header {1}")]
+    AlreadyVoted(VoteDigest, HeaderDigest, Round),
+
+    #[error("Already voted a newer header for digest {0} round {1} < {2}")]
+    AlreadyVotedNewerHeader(HeaderDigest, Round, Round),
 
     #[error("Could not form a certificate for header {0}")]
     CouldNotFormCertificate(HeaderDigest),
@@ -87,9 +90,6 @@ pub enum DagError {
 
     #[error("Parents of header {0} are not a quorum")]
     HeaderRequiresQuorum(HeaderDigest),
-
-    #[error("Already voted a newer header: digest {0}, round {1} < {2}")]
-    AlreadyVotedNewerHeader(HeaderDigest, Round, Round),
 
     #[error("Too many parents in RequestVoteRequest {0} > {1}")]
     TooManyParents(usize, usize),

--- a/narwhal/types/src/error.rs
+++ b/narwhal/types/src/error.rs
@@ -88,6 +88,12 @@ pub enum DagError {
     #[error("Parents of header {0} are not a quorum")]
     HeaderRequiresQuorum(HeaderDigest),
 
+    #[error("Already voted a newer header: digest {0}, round {1} < {2}")]
+    AlreadyVotedNewerHeader(HeaderDigest, Round, Round),
+
+    #[error("Too many parents in RequestVoteRequest {0} > {1}")]
+    TooManyParents(usize, usize),
+
     #[error("Message {0} (round {1}) too old for GC round {2}")]
     TooOld(Digest<{ crypto::DIGEST_LENGTH }>, Round, Round),
 


### PR DESCRIPTION
## Description 

We have observed correlations among spikes in certificates in votes, send certificate handler p95 latency, and observed average latency when submitting to consensus. This issue can be observed in many validators on testnet and private-testnet too. It seems the logic to request missing parent certificates from header proposer is problematic, where it is easy to cause a surge of certificates and overwhelm Narwhal, e.g. with requests to certificate stores.

In this PR, a limit is added to request a missing parent certificate only from one header proposer. Additional protections against byzantine primaries sending unrequested parent certificates and overwhelming the system have also been added.

This change weakens the guarantee of certificate propagation via header proposal and voting. A missing parent certificate may never get sent by the header proposer because it is down. So to maintain liveness guarantee, certificate fetching is triggered 30s after no consensus commit happens.

## Test Plan 

CI. Deploy to private testnet.
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
