### PR TITLE
[sui-proxy/increase mimir timeout]

### DIFF
--- a/crates/sui-proxy/src/admin.rs
+++ b/crates/sui-proxy/src/admin.rs
@@ -5,6 +5,7 @@ use crate::handlers::publish_metrics;
 use crate::histogram_relay::HistogramRelay;
 use crate::middleware::{expect_mysten_proxy_header, expect_valid_public_key};
 use crate::peers::SuiNodeProvider;
+use crate::var;
 use anyhow::Result;
 
 use axum::routing::post as axum_post;
@@ -97,7 +98,7 @@ pub fn make_reqwest_client(settings: RemoteWriteConfig) -> ReqwestClient {
         client: reqwest::Client::builder()
             .user_agent(APP_USER_AGENT)
             .pool_max_idle_per_host(settings.pool_max_idle_per_host)
-            .timeout(Duration::from_secs(15))
+            .timeout(Duration::from_secs(var!("MIMIR_CLIENT_TIMEOUT", 30)))
             .build()
             .expect("cannot create reqwest client"),
         settings,


### PR DESCRIPTION
Summary:

* mimir is getting close to 15 seconds for posting in the p95 graphs.
* bump this timeout to 30 to buy us time to root cause

Test Plan:

locally & cargo build

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
