### PR TITLE
indexer: revert data trimming on obj & tx data

### DIFF
--- a/crates/sui-indexer/src/models/objects.rs
+++ b/crates/sui-indexer/src/models/objects.rs
@@ -198,11 +198,6 @@ impl Object {
         })?;
         Ok((object_id, (self.version as u64).into(), digest))
     }
-
-    // MUSTFIX(gegaowp): trim data to reduce short-term storage consumption.
-    pub fn trim_data(&mut self) {
-        self.bcs.clear();
-    }
 }
 
 impl TryFrom<Object> for sui_types::object::Object {

--- a/crates/sui-indexer/src/models/transactions.rs
+++ b/crates/sui-indexer/src/models/transactions.rs
@@ -153,22 +153,6 @@ impl TryFrom<TemporaryTransactionBlockResponseStore> for Transaction {
     }
 }
 
-impl Transaction {
-    // MUSTFIX(gegaowp): trim data to reduce short-term storage consumption.
-    pub fn trim_data(&mut self) {
-        self.created.clear();
-        self.mutated.clear();
-        self.unwrapped.clear();
-        self.wrapped.clear();
-        self.move_calls.clear();
-        self.recipients.clear();
-        // trim BCS and JSON data from transaction
-        self.raw_transaction.clear();
-        self.transaction_content.clear();
-        self.transaction_effects_content.clear();
-    }
-}
-
 fn owned_obj_ref_to_obj_id(owned_obj_ref: &OwnedObjectRef) -> String {
     owned_obj_ref.reference.object_id.to_string()
 }

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -1266,17 +1266,9 @@ impl IndexerStore for PgIndexerStore {
         checkpoint: &Checkpoint,
         transactions: &[Transaction],
     ) -> Result<usize, IndexerError> {
-        let trimmed_transactions = transactions
-            .iter()
-            .map(|t| {
-                let mut t = t.clone();
-                t.trim_data();
-                t
-            })
-            .collect::<Vec<_>>();
         transactional_blocking!(&self.blocking_cp, |conn| {
             // Commit indexed transactions
-            for transaction_chunk in trimmed_transactions.chunks(PG_COMMIT_CHUNK_SIZE) {
+            for transaction_chunk in transactions.chunks(PG_COMMIT_CHUNK_SIZE) {
                 diesel::insert_into(transactions::table)
                     .values(transaction_chunk)
                     .on_conflict(transactions::transaction_digest)
@@ -1337,26 +1329,10 @@ WHERE e1.epoch = e2.epoch
                     .collect();
                 let (mutation_count, deletion_count) =
                     (mutated_objects.len(), deleted_objects.len());
-
-                // MUSTFIX(gegaowp): trim data to reduce short-term storage consumption.
-                let trimmed_mutated_objects = mutated_objects
-                    .into_iter()
-                    .map(|mut o| {
-                        o.trim_data();
-                        o
-                    })
-                    .collect::<Vec<Object>>();
-                let trimmed_deleted_objects = deleted_objects
-                    .into_iter()
-                    .map(|mut o| {
-                        o.trim_data();
-                        o
-                    })
-                    .collect::<Vec<Object>>();
                 persist_transaction_object_changes(
                     conn,
-                    trimmed_mutated_objects,
-                    trimmed_deleted_objects,
+                    mutated_objects,
+                    deleted_objects,
                     Some(object_mutation_latency),
                     Some(object_deletion_latency),
                 )?;


### PR DESCRIPTION
## Description 

Before mainnet, I trimmed obj & tx data to temp. reduce storage consumption, but these are needed for new features of address & active address count, thus this PR resumed that.
Also per [DB size dash](https://metrics.sui.io/d/4P9w6d14z/sui-indexer?orgId=1&refresh=1m&from=1683606004118&to=1683649204118&viewPanel=55), current storage is 20GB after a week, and we can at least do 2.5TiB, so this move should be safe.

## Test Plan 

Local run to make sure that tx and object data are indeed populated with full contents.
