### PR TITLE
Index store search debug util

### DIFF
--- a/crates/sui-tool/src/db_tool/index_search.rs
+++ b/crates/sui-tool/src/db_tool/index_search.rs
@@ -39,7 +39,7 @@ pub fn search_index(
     table_name: String,
     start: String,
     termination: SearchRange<String>,
-) -> Result<BTreeMap<String, String>, anyhow::Error> {
+) -> Result<Vec<(String, String)>, anyhow::Error> {
     let start = start.as_str();
     let db_read_only_handle =
         IndexStoreTables::get_read_only_handle(db_path, None, None, MetricConf::default());
@@ -148,6 +148,7 @@ pub fn search_index(
 #[macro_export]
 macro_rules! get_db_entries {
     ($db_map:expr, $key_converter:expr, $start:expr, $term:expr) => {{
+        $db_map.try_catch_up_with_primary().unwrap();
         let key = $key_converter($start)?;
         let termination = match $term {
             SearchRange::ExclusiveLastKey(last_key) => {
@@ -163,7 +164,7 @@ fn get_entries_to_str<K, V>(
     db_map: &DBMap<K, V>,
     start: K,
     termination: SearchRange<K>,
-) -> Result<BTreeMap<String, String>, anyhow::Error>
+) -> Result<Vec<(String, String)>, anyhow::Error>
 where
     K: Serialize + serde::de::DeserializeOwned + Clone + Debug,
     V: serde::Serialize + DeserializeOwned + Clone + Debug,

--- a/crates/sui-tool/src/db_tool/index_search.rs
+++ b/crates/sui-tool/src/db_tool/index_search.rs
@@ -1,0 +1,296 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::anyhow;
+use serde::{de::DeserializeOwned, Serialize};
+use std::{collections::BTreeMap, path::PathBuf, str::FromStr};
+use sui_types::digests::TransactionDigest;
+use typed_store::rocks::{DBMap, MetricConf};
+use typed_store::traits::Map;
+
+use crate::get_db_entries;
+use std::fmt::Debug;
+use sui_storage::IndexStoreTables;
+use sui_types::{
+    base_types::{ObjectID, SuiAddress, TxSequenceNumber},
+    Identifier, TypeTag,
+};
+
+#[derive(Clone, Debug)]
+pub enum SearchRange<T: Serialize + Clone + Debug> {
+    ExclusiveLastKey(T),
+    EndOffset(u64),
+}
+
+impl<T: Serialize + Clone + Debug + FromStr> FromStr for SearchRange<T>
+where
+    <T as std::str::FromStr>::Err: std::fmt::Debug,
+{
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let last_key = T::from_str(s).map_err(|e| anyhow!("Failed to parse last_key: {:?}", e))?;
+        Ok(SearchRange::ExclusiveLastKey(last_key))
+    }
+}
+
+pub fn search_index(
+    db_path: PathBuf,
+    table_name: String,
+    start: String,
+    termination: SearchRange<String>,
+) -> Result<BTreeMap<String, String>, anyhow::Error> {
+    let start = start.as_str();
+    let db_read_only_handle =
+        IndexStoreTables::get_read_only_handle(db_path, None, None, MetricConf::default());
+    match table_name.as_str() {
+        "transactions_from_addr" => {
+            get_db_entries!(
+                db_read_only_handle.transactions_from_addr,
+                from_addr_seq,
+                start,
+                termination
+            )
+        }
+        "transactions_to_addr" => {
+            get_db_entries!(
+                db_read_only_handle.transactions_to_addr,
+                from_addr_seq,
+                start,
+                termination
+            )
+        }
+        "transactions_by_input_object_id" => {
+            get_db_entries!(
+                db_read_only_handle.transactions_by_input_object_id,
+                from_id_seq,
+                start,
+                termination
+            )
+        }
+        "transactions_by_mutated_object_id" => {
+            get_db_entries!(
+                db_read_only_handle.transactions_by_mutated_object_id,
+                from_id_seq,
+                start,
+                termination
+            )
+        }
+        "transactions_by_move_function" => {
+            get_db_entries!(
+                db_read_only_handle.transactions_by_move_function,
+                from_id_module_function_txseq,
+                start,
+                termination
+            )
+        }
+        "timestamps" => {
+            get_db_entries!(
+                db_read_only_handle.timestamps,
+                TransactionDigest::from_str,
+                start,
+                termination
+            )
+        }
+        "transaction_order" => {
+            get_db_entries!(
+                db_read_only_handle.transaction_order,
+                u64::from_str,
+                start,
+                termination
+            )
+        }
+        "transactions_seq" => {
+            get_db_entries!(
+                db_read_only_handle.transactions_seq,
+                TransactionDigest::from_str,
+                start,
+                termination
+            )
+        }
+        "owner_index" => {
+            get_db_entries!(
+                db_read_only_handle.owner_index,
+                from_addr_oid,
+                start,
+                termination
+            )
+        }
+        "coin_index" => {
+            get_db_entries!(
+                db_read_only_handle.coin_index,
+                from_addr_str_oid,
+                start,
+                termination
+            )
+        }
+        "dynamic_field_index" => {
+            get_db_entries!(
+                db_read_only_handle.dynamic_field_index,
+                from_oid_oid,
+                start,
+                termination
+            )
+        }
+        "loaded_child_object_versions" => {
+            get_db_entries!(
+                db_read_only_handle.loaded_child_object_versions,
+                TransactionDigest::from_str,
+                start,
+                termination
+            )
+        }
+
+        _ => Err(anyhow!("Invalid or unsupported table name: {}", start)),
+    }
+}
+
+#[macro_export]
+macro_rules! get_db_entries {
+    ($db_map:expr, $key_converter:expr, $start:expr, $term:expr) => {{
+        let key = $key_converter($start)?;
+        let termination = match $term {
+            SearchRange::ExclusiveLastKey(last_key) => {
+                SearchRange::ExclusiveLastKey($key_converter(last_key.as_str())?)
+            }
+            SearchRange::EndOffset(offset) => SearchRange::EndOffset(offset),
+        };
+        get_entries_to_str(&$db_map, key, termination)
+    }};
+}
+
+fn get_entries_to_str<K, V>(
+    db_map: &DBMap<K, V>,
+    start: K,
+    termination: SearchRange<K>,
+) -> Result<BTreeMap<String, String>, anyhow::Error>
+where
+    K: Serialize + serde::de::DeserializeOwned + Clone + Debug,
+    V: serde::Serialize + DeserializeOwned + Clone + Debug,
+{
+    get_entries(db_map, start, termination).map(|entries| {
+        entries
+            .into_iter()
+            .map(|(k, v)| (format!("{:?}", k), format!("{:?}", v)))
+            .collect()
+    })
+}
+
+fn get_entries<K, V>(
+    db_map: &DBMap<K, V>,
+    start: K,
+    termination: SearchRange<K>,
+) -> Result<Vec<(K, V)>, anyhow::Error>
+where
+    K: Serialize + serde::de::DeserializeOwned + Clone + std::fmt::Debug,
+    V: serde::Serialize + DeserializeOwned + Clone,
+{
+    let mut entries = Vec::new();
+    match termination {
+        SearchRange::ExclusiveLastKey(exclusive_last_key) => {
+            let iter = db_map.iter_with_bounds(Some(start), Some(exclusive_last_key));
+
+            for (key, value) in iter {
+                entries.push((key.clone(), value.clone()));
+            }
+        }
+        SearchRange::EndOffset(mut end_offset) => {
+            let mut iter = db_map.iter_with_bounds(Some(start), None);
+
+            while end_offset > 0 {
+                if let Some((key, value)) = iter.next() {
+                    entries.push((key.clone(), value.clone()));
+                } else {
+                    break;
+                }
+                end_offset -= 1;
+            }
+        }
+    }
+    Ok(entries)
+}
+
+fn from_addr_seq(s: &str) -> Result<(SuiAddress, TxSequenceNumber), anyhow::Error> {
+    // Remove whitespaces
+    let s = s.trim();
+    let tokens = s.split(',').collect::<Vec<&str>>();
+    if tokens.len() != 2 {
+        return Err(anyhow!("Invalid address, sequence number pair"));
+    }
+    let address = SuiAddress::from_str(tokens[0].trim())?;
+    let sequence_number = TxSequenceNumber::from_str(tokens[1].trim())?;
+
+    Ok((address, sequence_number))
+}
+
+fn from_id_seq(s: &str) -> Result<(ObjectID, TxSequenceNumber), anyhow::Error> {
+    // Remove whitespaces
+    let s = s.trim();
+    let tokens = s.split(',').collect::<Vec<&str>>();
+    if tokens.len() != 2 {
+        return Err(anyhow!("Invalid object id, sequence number pair"));
+    }
+    let oid = ObjectID::from_str(tokens[0].trim())?;
+    let sequence_number = TxSequenceNumber::from_str(tokens[1].trim())?;
+
+    Ok((oid, sequence_number))
+}
+
+fn from_id_module_function_txseq(
+    s: &str,
+) -> Result<(ObjectID, String, String, TxSequenceNumber), anyhow::Error> {
+    // Remove whitespaces
+    let s = s.trim();
+    let tokens = s.split(',').collect::<Vec<&str>>();
+    if tokens.len() != 4 {
+        return Err(anyhow!(
+            "Invalid object id, module name, function name, TX sequence number quad"
+        ));
+    }
+    let pid = ObjectID::from_str(tokens[0].trim())?;
+    let module: Identifier = Identifier::from_str(tokens[1].trim())?;
+    let func: Identifier = Identifier::from_str(tokens[2].trim())?;
+    let seq: TxSequenceNumber = TxSequenceNumber::from_str(tokens[3].trim())?;
+
+    Ok((pid, module.to_string(), func.to_string(), seq))
+}
+
+fn from_addr_oid(s: &str) -> Result<(SuiAddress, ObjectID), anyhow::Error> {
+    // Remove whitespaces
+    let s = s.trim();
+    let tokens = s.split(',').collect::<Vec<&str>>();
+    if tokens.len() != 2 {
+        return Err(anyhow!("Invalid address, object id pair"));
+    }
+    let addr = SuiAddress::from_str(tokens[0].trim())?;
+    let oid = ObjectID::from_str(tokens[1].trim())?;
+
+    Ok((addr, oid))
+}
+
+fn from_addr_str_oid(s: &str) -> Result<(SuiAddress, String, ObjectID), anyhow::Error> {
+    // Remove whitespaces
+    let s = s.trim();
+    let tokens = s.split(',').collect::<Vec<&str>>();
+    if tokens.len() != 3 {
+        return Err(anyhow!("Invalid addr, type tag object id triplet"));
+    }
+    let address = SuiAddress::from_str(tokens[0].trim())?;
+    let tag: TypeTag = TypeTag::from_str(tokens[1].trim())?;
+    let oid: ObjectID = ObjectID::from_str(tokens[2].trim())?;
+
+    Ok((address, tag.to_string(), oid))
+}
+
+fn from_oid_oid(s: &str) -> Result<(ObjectID, ObjectID), anyhow::Error> {
+    // Remove whitespaces
+    let s = s.trim();
+    let tokens = s.split(',').collect::<Vec<&str>>();
+    if tokens.len() != 2 {
+        return Err(anyhow!("Invalid object id, object id triplet"));
+    }
+    let oid1 = ObjectID::from_str(tokens[0].trim())?;
+    let oid2: ObjectID = ObjectID::from_str(tokens[1].trim())?;
+
+    Ok((oid1, oid2))
+}

--- a/crates/sui-tool/src/db_tool/index_search.rs
+++ b/crates/sui-tool/src/db_tool/index_search.rs
@@ -34,6 +34,8 @@ where
     }
 }
 
+/// Until we use a proc macro to auto derive this, we have to make sure to update the
+/// `search_index` function below when adding new tables.
 pub fn search_index(
     db_path: PathBuf,
     table_name: String,
@@ -154,7 +156,7 @@ macro_rules! get_db_entries {
         let termination = match $term {
             SearchRange::ExclusiveLastKey(last_key) => {
                 println!(
-                    "Retrieving al keys up to (but not including) key: {:?}",
+                    "Retrieving all keys up to (but not including) key: {:?}",
                     key
                 );
                 SearchRange::ExclusiveLastKey($key_converter(last_key.as_str())?)

--- a/crates/sui-tool/src/db_tool/mod.rs
+++ b/crates/sui-tool/src/db_tool/mod.rs
@@ -34,7 +34,7 @@ pub struct IndexSearchKeyRangeOptions {
     table_name: String,
     #[clap(long = "start", short = 's')]
     start: String,
-    #[clap(long = "end-key", short = 'e')]
+    #[clap(long = "end", short = 'e')]
     end_key: String,
 }
 
@@ -45,8 +45,8 @@ pub struct IndexSearchCountOptions {
     table_name: String,
     #[clap(long = "start", short = 's')]
     start: String,
-    #[clap(long = "end-offset", short = 'e')]
-    end_offset: u64,
+    #[clap(long = "count", short = 'c')]
+    count: u64,
 }
 
 #[derive(Parser)]
@@ -110,18 +110,13 @@ pub fn execute_db_tool_command(db_path: PathBuf, cmd: DbToolCommand) -> anyhow::
                 db_path,
                 sc.table_name,
                 sc.start,
-                SearchRange::EndOffset(sc.end_offset),
+                SearchRange::Count(sc.count),
             )?;
             for (k, v) in res {
                 println!("{}: {}", k, v);
             }
             Ok(())
-        } // DbToolCommand::IndexSearch(opts) => {
-          //     let res = search_index(db_path, opts.table_name, opts.start, opts.end)?;
-          //     for (k, v) in res {
-          //         println!("{}: {}", k, v);
-          //     }
-          //     Ok(())
+        }
     }
 }
 

--- a/crates/sui-tool/src/db_tool/mod.rs
+++ b/crates/sui-tool/src/db_tool/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use self::db_dump::{dump_table, duplicate_objects_summary, list_tables, table_summary, StoreName};
+use self::index_search::{search_index, SearchRange};
 use crate::db_tool::db_dump::{compact, print_table_metadata};
 use clap::Parser;
 use std::path::{Path, PathBuf};
@@ -9,19 +10,43 @@ use sui_core::authority::authority_store_tables::AuthorityPerpetualTables;
 use sui_core::checkpoints::CheckpointStore;
 use sui_types::base_types::EpochId;
 use typed_store::rocks::MetricConf;
-
 pub mod db_dump;
+mod index_search;
 
 #[derive(Parser)]
 #[clap(rename_all = "kebab-case")]
 pub enum DbToolCommand {
     ListTables,
     Dump(Options),
+    IndexSearchKeyRange(IndexSearchKeyRangeOptions),
+    IndexSearchCount(IndexSearchCountOptions),
     TableSummary(Options),
     DuplicatesSummary,
     ResetDB,
     ListDBMetadata(Options),
     Compact,
+}
+
+#[derive(Parser)]
+#[clap(rename_all = "kebab-case")]
+pub struct IndexSearchKeyRangeOptions {
+    #[clap(long = "table-name", short = 't')]
+    table_name: String,
+    #[clap(long = "start", short = 's')]
+    start: String,
+    #[clap(long = "end-key", short = 'e')]
+    end_key: String,
+}
+
+#[derive(Parser)]
+#[clap(rename_all = "kebab-case")]
+pub struct IndexSearchCountOptions {
+    #[clap(long = "table-name", short = 't')]
+    table_name: String,
+    #[clap(long = "start", short = 's')]
+    start: String,
+    #[clap(long = "end-offset", short = 'e')]
+    end_offset: u64,
 }
 
 #[derive(Parser)]
@@ -68,6 +93,35 @@ pub fn execute_db_tool_command(db_path: PathBuf, cmd: DbToolCommand) -> anyhow::
             print_table_metadata(d.store_name, d.epoch, db_path, &d.table_name)
         }
         DbToolCommand::Compact => compact(db_path),
+        DbToolCommand::IndexSearchKeyRange(rg) => {
+            let res = search_index(
+                db_path,
+                rg.table_name,
+                rg.start,
+                SearchRange::ExclusiveLastKey(rg.end_key),
+            )?;
+            for (k, v) in res {
+                println!("{}: {}", k, v);
+            }
+            Ok(())
+        }
+        DbToolCommand::IndexSearchCount(sc) => {
+            let res = search_index(
+                db_path,
+                sc.table_name,
+                sc.start,
+                SearchRange::EndOffset(sc.end_offset),
+            )?;
+            for (k, v) in res {
+                println!("{}: {}", k, v);
+            }
+            Ok(())
+        } // DbToolCommand::IndexSearch(opts) => {
+          //     let res = search_index(db_path, opts.table_name, opts.start, opts.end)?;
+          //     for (k, v) in res {
+          //         println!("{}: {}", k, v);
+          //     }
+          //     Ok(())
     }
 }
 


### PR DESCRIPTION
## Description 

Enables searching DB by key and range
Example
This searches the `transactions_from_addr` index for 3 items starting from key `(0x0, 0)`
```
sui-tool db-tool --db-path $INDEX_STORE_PATH index-search-count -t "transactions_from_addr" -s " 0x0000000000000000000000000000000000000000000000000000000000000000  , 0 "  -c 3

(0x0000000000000000000000000000000000000000000000000000000000000000, 0): TransactionDigest(Cgww1sn7XViCPSdDcAPmVcARueWuexJ8af8zD842Ff43)
(0x0000000000000000000000000000000000000000000000000000000000000000, 1): TransactionDigest(ENSA1UVsdNfa66Hifs8YmELAPMUraTkMLnb5vBma7yjG)
(0x0000000000000000000000000000000000000000000000000000000000000000, 2): TransactionDigest(6JrvQmai4CfoepqArnJYa4sRQbRAY4bSXc5tY7ub4HzJ)
```

While this searches the `transactions_from_addr` index for all keys in range [start, end)
where
start = `(0x0000002a71724c656e54172366d1496adc7e7a96e7703f8eba56c771334f1652 , 0)`
end = `(0x000008c4eeb482d337eabdce6d8d362c930d2778cb6169c5ed5bbf6359e49cc0, 0)`
```
sui-tool db-tool --db-path $INDEX_STORE_PATH index-search-key-range -t "transactions_from_addr" -s " 0x0000002a71724c656e54172366d1496adc7e7a96e7703f8eba56c771334f1652 , 0 "  -e "0x000008c4eeb482d337eabdce6d8d362c930d2778cb6169c5ed5bbf6359e49cc0, 0"

(0x0000002a71724c656e54172366d1496adc7e7a96e7703f8eba56c771334f1652, 199901503): TransactionDigest(p6pdecwK6xFV94gW3hEDJC7nXiEMkXT7qBcLmwa4zqt)
(0x000001ec0b8dc49b0554336403df1e2ada04fdb57419b771c8eb630e9b3ca04b, 178533636): TransactionDigest(2y6CdZ6a2vgXgN47VUwPnR38dyg7uF6VJYChUyEiCqiA)
(0x000001ec0b8dc49b0554336403df1e2ada04fdb57419b771c8eb630e9b3ca04b, 179965983): TransactionDigest(GNUZ9RdVcwqR3UB6B1CAZt54szrbxB9ibTqZNuqgz93z)
(0x000001ec0b8dc49b0554336403df1e2ada04fdb57419b771c8eb630e9b3ca04b, 211941432): TransactionDigest(52BvMgFVfTPmNHZLUKxvAW7aBCyMnLT6tLFvQAiKBhz7)
(0x000001ec0b8dc49b0554336403df1e2ada04fdb57419b771c8eb630e9b3ca04b, 226460529): TransactionDigest(aSHK7cDyRScPXkQCsjYa3yHqvLMA9yejwTWcwQLcC5o)
(0x000001ec0b8dc49b0554336403df1e2ada04fdb57419b771c8eb630e9b3ca04b, 229949905): TransactionDigest(napYj2jRXURtDFPWMqMhFMGhD7ZyY3mRT4z95MtU9mj)
(0x000001ec0b8dc49b0554336403df1e2ada04fdb57419b771c8eb630e9b3ca04b, 241586260): TransactionDigest(3exq8i5CnkFng8tdkPD7SkfUTHSEQyaty3BR6fjNgzSV)
(0x000001ec0b8dc49b0554336403df1e2ada04fdb57419b771c8eb630e9b3ca04b, 247068758): TransactionDigest(BFdWNnkunrDL6tzCcyFKSauvMs4z7Kb4gNuxytbRaVkE)
(0x000001ec0b8dc49b0554336403df1e2ada04fdb57419b771c8eb630e9b3ca04b, 262296597): TransactionDigest(9JcoEYnLEXhig9VfZAJJVwTYKnukd1H66wYL3trtdJee)
(0x000001ec0b8dc49b0554336403df1e2ada04fdb57419b771c8eb630e9b3ca04b, 267627735): TransactionDigest(8xNDcr1AwbrEqb2u23itmifTgqMrgPtvfAhVh18AsXRZ)
(0x000001ec0b8dc49b0554336403df1e2ada04fdb57419b771c8eb630e9b3ca04b, 271524485): TransactionDigest(3DrULVDahoZBzDQgPzLQYXnDTwLQQgqxoEvhPMxxtQo2)
(0x000001ec0b8dc49b0554336403df1e2ada04fdb57419b771c8eb630e9b3ca04b, 314070917): TransactionDigest(J2YDEhftnRRPhVCjQd5i8DEC2bFPXUeTHpkAC7Nm7Dvp)
(0x000006711d82cfef20f556c7f70ed9fbd90802934831f32c5dddd1dd428477ec, 113151128): TransactionDigest(5UEyecqJBqsmpxpxmjycty6ZZSS2aj2ryYLUL5CuSCpS)
(0x000006711d82cfef20f556c7f70ed9fbd90802934831f32c5dddd1dd428477ec, 140330634): TransactionDigest(9EE8xVh78HKn6R99vPg8sV9Bw1HKw1nbrvmu2Ff4gPNo)
(0x000006711d82cfef20f556c7f70ed9fbd90802934831f32c5dddd1dd428477ec, 183838323): TransactionDigest(5qvFw1xwfpejf5kLzs5ecrqFDsF3AecwhbdiCztVJJ1L)
(0x000006711d82cfef20f556c7f70ed9fbd90802934831f32c5dddd1dd428477ec, 183856691): TransactionDigest(EnzmKUKhMH7Q2HmxJfPkkJD4vvR72UndmXerxQhw1k5T)
(0x000006711d82cfef20f556c7f70ed9fbd90802934831f32c5dddd1dd428477ec, 237505827): TransactionDigest(BXGYqePT88AvvN7ZvbN1Etb3Q1Wabjc9c9tdqEY1ohND)


```

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
