### PR TITLE
[explorer]: fix render for object type

### DIFF
--- a/apps/explorer/src/pages/transaction-result/programmable-transaction-view/InputsCard.tsx
+++ b/apps/explorer/src/pages/transaction-result/programmable-transaction-view/InputsCard.tsx
@@ -62,7 +62,7 @@ export function InputsCard({ inputs }: InputsCardProps) {
                                 {key}
                             </Text>
 
-                            <div className="max-w-[66%] break-all">
+                            <div className="max-w-[66%] break-all text-right">
                                 <Text
                                     variant="pBody/medium"
                                     color="steel-darker"

--- a/apps/explorer/src/pages/transaction-result/transaction-summary/ObjectChanges.tsx
+++ b/apps/explorer/src/pages/transaction-result/transaction-summary/ObjectChanges.tsx
@@ -65,7 +65,12 @@ function Item({
     typeName?: string;
 }) {
     return (
-        <div className="flex items-center justify-between gap-10">
+        <div
+            className={clsx(
+                'flex justify-between gap-10',
+                label === ItemLabels.type ? 'items-start' : 'items-center'
+            )}
+        >
             <Text variant="pBody/medium" color="steel-dark">
                 {label}
             </Text>
@@ -80,9 +85,11 @@ function Item({
                 />
             )}
             {label === ItemLabels.type && (
-                <Text truncate variant="pBody/medium" color="steel-darker">
-                    {typeName}
-                </Text>
+                <div className="break-all text-right">
+                    <Text variant="pBody/medium" color="steel-darker">
+                        {typeName}
+                    </Text>
+                </div>
             )}
         </div>
     );
@@ -141,8 +148,11 @@ function ObjectDetail({
     objectType: string;
     objectId: string;
 }) {
-    const [packageId, moduleName, typeName] =
-        objectType?.split('<')[0]?.split('::') || [];
+    const separator = '::';
+    const objectTypeSplit = objectType?.split(separator) || [];
+    const packageId = objectTypeSplit[0];
+    const moduleName = objectTypeSplit[1];
+    const typeName = objectTypeSplit.slice(2).join(separator);
 
     const objectDetailLabels = [
         ItemLabels.package,


### PR DESCRIPTION
## Description 
- Right alignment for texts 
- Slack for context: https://mysten-labs.slack.com/archives/C032676BWGN/p1683650782815109
- We are getting ObjectType as these format

```
0x2::coin::Coin<0x2::sui::SUI>
```

or 

```
0x6e8afef4fe19f8981ca0b651b2ca4e60191790b7cef2ba8664f0f2e073803f3d::suicat::Global
```

With the original way to split, we will only get `Coin` as the `typeName`

<img width="482" alt="Screenshot 2023-05-10 at 11 15 16 AM" src="https://github.com/MystenLabs/sui/assets/127577476/1751f21f-b6a1-49be-afa4-ee52f1387ba1">


<img width="441" alt="Screenshot 2023-05-09 at 10 50 08 AM" src="https://github.com/MystenLabs/sui/assets/127577476/56c0578a-e0a5-43d0-b73d-33a106056cb5">

<img width="523" alt="Screenshot 2023-05-09 at 4 23 29 PM" src="https://github.com/MystenLabs/sui/assets/127577476/4b4e6a07-e141-4c8e-a6d7-a35e6c85d01b">


## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
