### PR TITLE
indexer: address & active address tables

### DIFF
--- a/crates/sui-indexer/benches/indexer_benchmark.rs
+++ b/crates/sui-indexer/benches/indexer_benchmark.rs
@@ -89,6 +89,7 @@ fn create_checkpoint(sequence_number: i64) -> TemporaryCheckpointStore {
             deleted_objects: vec![],
         }],
         addresses: vec![],
+        active_addresses: vec![],
         packages: vec![],
         input_objects: vec![],
         move_calls: vec![],

--- a/crates/sui-indexer/migrations/2022-11-28-204251_addresses/down.sql
+++ b/crates/sui-indexer/migrations/2022-11-28-204251_addresses/down.sql
@@ -1,1 +1,2 @@
 DROP TABLE IF EXISTS addresses;
+DROP TABLE IF EXISTS active_addresses;

--- a/crates/sui-indexer/migrations/2022-11-28-204251_addresses/up.sql
+++ b/crates/sui-indexer/migrations/2022-11-28-204251_addresses/up.sql
@@ -2,12 +2,16 @@ CREATE TABLE addresses
 (
     account_address       address       PRIMARY KEY,
     first_appearance_tx   base58digest  NOT NULL,
-    first_appearance_time BIGINT        NOT NULL
+    first_appearance_time BIGINT        NOT NULL,
+    last_appearance_tx    base58digest  NOT NULL,
+    last_appearance_time  BIGINT        NOT NULL
 );
 
 CREATE TABLE active_addresses
 (
     account_address       address       PRIMARY KEY,
+    first_appearance_tx   base58digest  NOT NULL,
+    first_appearance_time BIGINT        NOT NULL,
     last_appearance_tx    base58digest  NOT NULL,
     last_appearance_time  BIGINT        NOT NULL
 );

--- a/crates/sui-indexer/migrations/2022-11-28-204251_addresses/up.sql
+++ b/crates/sui-indexer/migrations/2022-11-28-204251_addresses/up.sql
@@ -4,4 +4,10 @@ CREATE TABLE addresses
     first_appearance_tx   base58digest  NOT NULL,
     first_appearance_time BIGINT        NOT NULL
 );
-CREATE INDEX addresses_account_address ON addresses (account_address);
+
+CREATE TABLE active_addresses
+(
+    account_address       address       PRIMARY KEY,
+    last_appearance_tx    base58digest  NOT NULL,
+    last_appearance_time  BIGINT        NOT NULL
+);

--- a/crates/sui-indexer/migrations/2022-12-01-034426_objects/up.sql
+++ b/crates/sui-indexer/migrations/2022-12-01-034426_objects/up.sql
@@ -40,34 +40,34 @@ CREATE INDEX objects_owner_address ON objects (owner_type, owner_address);
 CREATE INDEX objects_tx_digest ON objects (previous_transaction);
 
 -- NOTE(gegaowp): remove object history so that it will not be created over DB reset / migration run.
--- CREATE TABLE objects_history
--- (
---     epoch                  BIGINT        NOT NULL,
---     checkpoint             BIGINT        NOT NULL,
---     object_id              address       NOT NULL,
---     version                BIGINT        NOT NULL,
---     object_digest          base58digest  NOT NULL,
---     owner_type             owner_type    NOT NULL,
---     owner_address          address,
---     old_owner_type         owner_type,
---     old_owner_address      address,
---     initial_shared_version BIGINT,
---     previous_transaction   base58digest  NOT NULL,
---     object_type            VARCHAR       NOT NULL,
---     object_status          object_status NOT NULL,
---     has_public_transfer    BOOLEAN       NOT NULL,
---     storage_rebate         BIGINT        NOT NULL,
---     bcs                    bcs_bytes[]   NOT NULL,
---     CONSTRAINT objects_history_pk PRIMARY KEY (object_id, version, checkpoint)
--- ) PARTITION BY RANGE (checkpoint);
--- CREATE INDEX objects_history_checkpoint_index ON objects_history (checkpoint);
--- CREATE INDEX objects_history_id_version_index ON objects_history (object_id, version);
--- CREATE INDEX objects_history_owner_index ON objects_history (owner_type, owner_address);
--- CREATE INDEX objects_history_old_owner_index ON objects_history (old_owner_type, old_owner_address);
--- -- fast-path partition for the most recent objects before checkpoint, range is half-open.
--- -- partition name need to match regex of '.*(_partition_)\d+'.
--- CREATE TABLE objects_history_fast_path_partition_0 PARTITION OF objects_history FOR VALUES FROM (-1) TO (0);
--- CREATE TABLE objects_history_partition_0 PARTITION OF objects_history FOR VALUES FROM (0) TO (MAXVALUE);
+CREATE TABLE objects_history
+(
+    epoch                  BIGINT        NOT NULL,
+    checkpoint             BIGINT        NOT NULL,
+    object_id              address       NOT NULL,
+    version                BIGINT        NOT NULL,
+    object_digest          base58digest  NOT NULL,
+    owner_type             owner_type    NOT NULL,
+    owner_address          address,
+    old_owner_type         owner_type,
+    old_owner_address      address,
+    initial_shared_version BIGINT,
+    previous_transaction   base58digest  NOT NULL,
+    object_type            VARCHAR       NOT NULL,
+    object_status          object_status NOT NULL,
+    has_public_transfer    BOOLEAN       NOT NULL,
+    storage_rebate         BIGINT        NOT NULL,
+    bcs                    bcs_bytes[]   NOT NULL,
+    CONSTRAINT objects_history_pk PRIMARY KEY (object_id, version, checkpoint)
+) PARTITION BY RANGE (checkpoint);
+CREATE INDEX objects_history_checkpoint_index ON objects_history (checkpoint);
+CREATE INDEX objects_history_id_version_index ON objects_history (object_id, version);
+CREATE INDEX objects_history_owner_index ON objects_history (owner_type, owner_address);
+CREATE INDEX objects_history_old_owner_index ON objects_history (old_owner_type, old_owner_address);
+-- fast-path partition for the most recent objects before checkpoint, range is half-open.
+-- partition name need to match regex of '.*(_partition_)\d+'.
+CREATE TABLE objects_history_fast_path_partition_0 PARTITION OF objects_history FOR VALUES FROM (-1) TO (0);
+CREATE TABLE objects_history_partition_0 PARTITION OF objects_history FOR VALUES FROM (0) TO (MAXVALUE);
 
 -- CREATE OR REPLACE FUNCTION objects_modified_func() RETURNS TRIGGER AS
 -- $body$

--- a/crates/sui-indexer/src/models/addresses.rs
+++ b/crates/sui-indexer/src/models/addresses.rs
@@ -3,11 +3,19 @@
 
 use diesel::prelude::*;
 
-use crate::schema::addresses;
+use crate::schema::{active_addresses, addresses};
 
 #[derive(Queryable, Insertable, Debug)]
 #[diesel(table_name = addresses, primary_key(account_address))]
 pub struct Address {
+    pub account_address: String,
+    pub first_appearance_tx: String,
+    pub first_appearance_time: i64,
+}
+
+#[derive(Queryable, Insertable, Debug)]
+#[diesel(table_name = active_addresses, primary_key(account_address))]
+pub struct ActiveAddress {
     pub account_address: String,
     pub first_appearance_tx: String,
     pub first_appearance_time: i64,

--- a/crates/sui-indexer/src/models/addresses.rs
+++ b/crates/sui-indexer/src/models/addresses.rs
@@ -1,9 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
+
 use diesel::prelude::*;
 
 use crate::schema::{active_addresses, addresses};
+use crate::types::AddressData;
 
 #[derive(Queryable, Insertable, Debug)]
 #[diesel(table_name = addresses, primary_key(account_address))]
@@ -11,6 +14,8 @@ pub struct Address {
     pub account_address: String,
     pub first_appearance_tx: String,
     pub first_appearance_time: i64,
+    pub last_appearance_tx: String,
+    pub last_appearance_time: i64,
 }
 
 #[derive(Queryable, Insertable, Debug)]
@@ -19,4 +24,62 @@ pub struct ActiveAddress {
     pub account_address: String,
     pub first_appearance_tx: String,
     pub first_appearance_time: i64,
+    pub last_appearance_tx: String,
+    pub last_appearance_time: i64,
+}
+
+pub fn dedup_from_and_to_addresses(addrs: Vec<AddressData>) -> Vec<Address> {
+    let addr_map = addrs.into_iter().fold(HashMap::new(), |mut acc, addr| {
+        let key = addr.account_address.clone();
+        let value = Address {
+            account_address: addr.account_address,
+            first_appearance_tx: addr.transaction_digest.clone(),
+            first_appearance_time: addr.timestamp_ms,
+            last_appearance_tx: addr.transaction_digest,
+            last_appearance_time: addr.timestamp_ms,
+        };
+        acc.entry(key)
+            .and_modify(|v: &mut Address| {
+                if v.first_appearance_time > value.first_appearance_time {
+                    v.first_appearance_time = value.first_appearance_time;
+                    v.first_appearance_tx = value.first_appearance_tx.clone();
+                }
+                if v.last_appearance_time < value.last_appearance_time {
+                    v.last_appearance_time = value.last_appearance_time;
+                    v.last_appearance_tx = value.last_appearance_tx.clone();
+                }
+            })
+            .or_insert(value);
+        acc
+    });
+    addr_map.into_values().collect()
+}
+
+pub fn dedup_from_addresses(from_addrs: Vec<AddressData>) -> Vec<ActiveAddress> {
+    let active_addr_map = from_addrs
+        .into_iter()
+        .fold(HashMap::new(), |mut acc, addr| {
+            let key = addr.account_address.clone();
+            let value = ActiveAddress {
+                account_address: addr.account_address,
+                first_appearance_tx: addr.transaction_digest.clone(),
+                first_appearance_time: addr.timestamp_ms,
+                last_appearance_tx: addr.transaction_digest,
+                last_appearance_time: addr.timestamp_ms,
+            };
+            acc.entry(key)
+                .and_modify(|v: &mut ActiveAddress| {
+                    if v.first_appearance_time > value.first_appearance_time {
+                        v.first_appearance_time = value.first_appearance_time;
+                        v.first_appearance_tx = value.first_appearance_tx.clone();
+                    }
+                    if v.last_appearance_time < value.last_appearance_time {
+                        v.last_appearance_time = value.last_appearance_time;
+                        v.last_appearance_tx = value.last_appearance_tx.clone();
+                    }
+                })
+                .or_insert(value);
+            acc
+        });
+    active_addr_map.into_values().collect()
 }

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -17,6 +17,14 @@ pub mod sql_types {
 }
 
 diesel::table! {
+    active_addresses (account_address) {
+        account_address -> Varchar,
+        last_appearance_tx -> Varchar,
+        last_appearance_time -> Int8,
+    }
+}
+
+diesel::table! {
     addresses (account_address) {
         account_address -> Varchar,
         first_appearance_tx -> Varchar,
@@ -296,6 +304,7 @@ diesel::table! {
 }
 
 diesel::allow_tables_to_appear_in_same_query!(
+    active_addresses,
     addresses,
     at_risk_validators,
     checkpoints,

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -19,6 +19,8 @@ pub mod sql_types {
 diesel::table! {
     active_addresses (account_address) {
         account_address -> Varchar,
+        first_appearance_tx -> Varchar,
+        first_appearance_time -> Int8,
         last_appearance_tx -> Varchar,
         last_appearance_time -> Int8,
     }
@@ -29,6 +31,8 @@ diesel::table! {
         account_address -> Varchar,
         first_appearance_tx -> Varchar,
         first_appearance_time -> Int8,
+        last_appearance_tx -> Varchar,
+        last_appearance_time -> Int8,
     }
 }
 

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -207,7 +207,11 @@ pub trait IndexerStore {
         object_deletion_latency: Histogram,
     ) -> Result<(), IndexerError>;
     async fn persist_events(&self, events: &[Event]) -> Result<(), IndexerError>;
-    async fn persist_addresses(&self, addresses: &[Address]) -> Result<(), IndexerError>;
+    async fn persist_addresses(
+        &self,
+        addresses: &[Address],
+        active_addresses: &[Address],
+    ) -> Result<(), IndexerError>;
     async fn persist_packages(&self, packages: &[Package]) -> Result<(), IndexerError>;
     // NOTE: these tables are for tx query performance optimization
     async fn persist_transaction_index_tables(
@@ -282,6 +286,7 @@ pub struct TemporaryCheckpointStore {
     pub events: Vec<Event>,
     pub object_changes: Vec<TransactionObjectChanges>,
     pub addresses: Vec<Address>,
+    pub active_addresses: Vec<Address>,
     pub packages: Vec<Package>,
     pub input_objects: Vec<InputObject>,
     pub move_calls: Vec<MoveCall>,

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -20,7 +20,7 @@ use sui_types::storage::ObjectStore;
 
 use crate::errors::IndexerError;
 use crate::metrics::IndexerMetrics;
-use crate::models::addresses::Address;
+use crate::models::addresses::{ActiveAddress, Address};
 use crate::models::checkpoints::Checkpoint;
 use crate::models::epoch::DBEpochInfo;
 use crate::models::events::Event;
@@ -210,7 +210,7 @@ pub trait IndexerStore {
     async fn persist_addresses(
         &self,
         addresses: &[Address],
-        active_addresses: &[Address],
+        active_addresses: &[ActiveAddress],
     ) -> Result<(), IndexerError>;
     async fn persist_packages(&self, packages: &[Package]) -> Result<(), IndexerError>;
     // NOTE: these tables are for tx query performance optimization
@@ -286,7 +286,7 @@ pub struct TemporaryCheckpointStore {
     pub events: Vec<Event>,
     pub object_changes: Vec<TransactionObjectChanges>,
     pub addresses: Vec<Address>,
-    pub active_addresses: Vec<Address>,
+    pub active_addresses: Vec<ActiveAddress>,
     pub packages: Vec<Package>,
     pub input_objects: Vec<InputObject>,
     pub move_calls: Vec<MoveCall>,

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -45,7 +45,7 @@ use sui_types::object::ObjectRead;
 
 use crate::errors::{Context, IndexerError};
 use crate::metrics::IndexerMetrics;
-use crate::models::addresses::Address;
+use crate::models::addresses::{ActiveAddress, Address};
 use crate::models::checkpoints::Checkpoint;
 use crate::models::epoch::DBEpochInfo;
 use crate::models::events::Event;
@@ -1149,6 +1149,7 @@ impl IndexerStore for PgIndexerStore {
             events,
             object_changes: tx_object_changes,
             addresses,
+            active_addresses,
             packages,
             input_objects,
             move_calls,
@@ -1199,15 +1200,48 @@ impl IndexerStore for PgIndexerStore {
                 .collect();
             persist_transaction_object_changes(conn, mutated_objects, deleted_objects, None, None)?;
 
-            // Commit indexed addresses
-            for addresses_chunk in addresses.chunks(PG_COMMIT_CHUNK_SIZE) {
+            // TODO(gegaowp): refactor to consolidate commit blocks
+            // Commit indexed addresses & active addresses
+            for address_chunk in addresses.chunks(PG_COMMIT_CHUNK_SIZE) {
                 diesel::insert_into(addresses::table)
-                    .values(addresses_chunk)
+                    .values(address_chunk)
                     .on_conflict(addresses::account_address)
-                    .do_nothing()
+                    .do_update()
+                    .set((
+                        addresses::last_appearance_time
+                            .eq(excluded(addresses::last_appearance_time)),
+                        addresses::last_appearance_tx.eq(excluded(addresses::last_appearance_tx)),
+                    ))
                     .execute(conn)
                     .map_err(IndexerError::from)
-                    .context("Failed writing addresses to PostgresDB")?;
+                    .context(
+                        format!(
+                            "Failed writing addresses to PostgresDB with tx {}",
+                            address_chunk[0].last_appearance_tx
+                        )
+                        .as_str(),
+                    )?;
+            }
+            for active_address_chunk in active_addresses.chunks(PG_COMMIT_CHUNK_SIZE) {
+                diesel::insert_into(active_addresses::table)
+                    .values(active_address_chunk)
+                    .on_conflict(active_addresses::account_address)
+                    .do_update()
+                    .set((
+                        active_addresses::last_appearance_time
+                            .eq(excluded(active_addresses::last_appearance_time)),
+                        active_addresses::last_appearance_tx
+                            .eq(excluded(active_addresses::last_appearance_tx)),
+                    ))
+                    .execute(conn)
+                    .map_err(IndexerError::from)
+                    .context(
+                        format!(
+                            "Failed writing active addresses to PostgresDB with tx {}",
+                            active_address_chunk[0].last_appearance_tx
+                        )
+                        .as_str(),
+                    )?;
             }
 
             // Commit indexed packages
@@ -1367,26 +1401,49 @@ WHERE e1.epoch = e2.epoch
     async fn persist_addresses(
         &self,
         addresses: &[Address],
-        active_addresses: &[Address],
+        active_addresses: &[ActiveAddress],
     ) -> Result<(), IndexerError> {
         transactional_blocking!(&self.blocking_cp, |conn| {
             for address_chunk in addresses.chunks(PG_COMMIT_CHUNK_SIZE) {
                 diesel::insert_into(addresses::table)
                     .values(address_chunk)
                     .on_conflict(addresses::account_address)
-                    .do_nothing()
+                    .do_update()
+                    .set((
+                        addresses::last_appearance_time
+                            .eq(excluded(addresses::last_appearance_time)),
+                        addresses::last_appearance_tx.eq(excluded(addresses::last_appearance_tx)),
+                    ))
                     .execute(conn)
                     .map_err(IndexerError::from)
-                    .context("Failed writing addresses to PostgresDB")?;
+                    .context(
+                        format!(
+                            "Failed writing addresses to PostgresDB with tx {}",
+                            address_chunk[0].last_appearance_tx
+                        )
+                        .as_str(),
+                    )?;
             }
             for active_address_chunk in active_addresses.chunks(PG_COMMIT_CHUNK_SIZE) {
                 diesel::insert_into(active_addresses::table)
                     .values(active_address_chunk)
                     .on_conflict(active_addresses::account_address)
                     .do_update()
+                    .set((
+                        active_addresses::last_appearance_time
+                            .eq(excluded(active_addresses::last_appearance_time)),
+                        active_addresses::last_appearance_tx
+                            .eq(excluded(active_addresses::last_appearance_tx)),
+                    ))
                     .execute(conn)
                     .map_err(IndexerError::from)
-                    .context("Failed writing active addresses to PostgresDB")?;
+                    .context(
+                        format!(
+                            "Failed writing active addresses to PostgresDB with tx {}",
+                            active_address_chunk[0].last_appearance_tx
+                        )
+                        .as_str(),
+                    )?;
             }
             Ok::<(), IndexerError>(())
         })?;

--- a/crates/sui-indexer/src/types.rs
+++ b/crates/sui-indexer/src/types.rs
@@ -282,6 +282,14 @@ impl CheckpointTransactionBlockResponse {
             })
             .collect::<Vec<Address>>()
     }
+
+    pub fn get_active_address(&self) -> Address {
+        Address {
+            account_address: self.transaction.data.sender().to_string(),
+            first_appearance_tx: self.digest.to_string(),
+            first_appearance_time: self.timestamp_ms as i64,
+        }
+    }
 }
 
 pub struct TemporaryTransactionBlockResponseStore {

--- a/crates/sui-indexer/src/types.rs
+++ b/crates/sui-indexer/src/types.rs
@@ -12,7 +12,6 @@ use sui_types::object::Owner;
 use sui_types::transaction::{SenderSignedData, TransactionDataAPI};
 
 use crate::errors::IndexerError;
-use crate::models::addresses::Address;
 use crate::models::transaction_index::{InputObject, MoveCall, Recipient};
 
 pub struct FastPathTransactionBlockResponse {
@@ -183,6 +182,12 @@ impl TryFrom<SuiTransactionBlockResponse> for CheckpointTransactionBlockResponse
     }
 }
 
+pub struct AddressData {
+    pub account_address: String,
+    pub transaction_digest: String,
+    pub timestamp_ms: i64,
+}
+
 impl CheckpointTransactionBlockResponse {
     pub fn get_input_objects(&self, epoch: u64) -> Result<Vec<InputObject>, IndexerError> {
         let raw_tx = self.raw_transaction.clone();
@@ -266,7 +271,7 @@ impl CheckpointTransactionBlockResponse {
             .collect()
     }
 
-    pub fn get_addresses(&self, epoch: u64, checkpoint: u64) -> Vec<Address> {
+    pub fn get_from_and_to_addresses(&self, epoch: u64, checkpoint: u64) -> Vec<AddressData> {
         let mut addresses = self
             .get_recipients(epoch, checkpoint)
             .into_iter()
@@ -275,19 +280,19 @@ impl CheckpointTransactionBlockResponse {
         addresses.push(self.transaction.data.sender().to_string());
         addresses
             .into_iter()
-            .map(|r| Address {
+            .map(|r| AddressData {
                 account_address: r,
-                first_appearance_tx: self.digest.to_string(),
-                first_appearance_time: self.timestamp_ms as i64,
+                transaction_digest: self.digest.to_string(),
+                timestamp_ms: self.timestamp_ms as i64,
             })
-            .collect::<Vec<Address>>()
+            .collect::<Vec<AddressData>>()
     }
 
-    pub fn get_active_address(&self) -> Address {
-        Address {
+    pub fn get_from_address(&self) -> AddressData {
+        AddressData {
             account_address: self.transaction.data.sender().to_string(),
-            first_appearance_tx: self.digest.to_string(),
-            first_appearance_time: self.timestamp_ms as i64,
+            transaction_digest: self.digest.to_string(),
+            timestamp_ms: self.timestamp_ms as i64,
         }
     }
 }


### PR DESCRIPTION
For feature requests of `addresses` and `active_addresses` tables, also logging he first and last tx & timestamp for daily active address later.

## Test

run locally to make sure that 
- addresses table and active_addresses table can be populated properly
- last_appearance_tx|time is updated but first_appearance_tx|time is static