### PR TITLE
[metrics/add snappy compression to sui-node/sui-proxy]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10025,6 +10025,7 @@ dependencies = [
  "prometheus",
  "reqwest",
  "serde 1.0.152",
+ "snap",
  "sui-config",
  "sui-core",
  "sui-json-rpc",

--- a/crates/sui-node/Cargo.toml
+++ b/crates/sui-node/Cargo.toml
@@ -23,6 +23,7 @@ const-str = "0.5.3"
 reqwest = { version = "0.11.13", default_features= false, features = ["blocking", "json", "rustls-tls"] }
 tap = "1.0.1"
 serde = { version = "1.0.144", features = ["derive"] }
+snap = "1.1.0"
 
 sui-tls = { path = "../sui-tls" }
 sui-macros = { path = "../sui-macros" }


### PR DESCRIPTION
Summary:

* add snappy encoding to the sui-node/proxy

Test Plan:

data suggests that it would be worthwhile compressing this for transport between the sui-node and sui-proxy


---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
