### PR TITLE
Fix uptime metrics

### DIFF
--- a/crates/mysten-metrics/src/lib.rs
+++ b/crates/mysten-metrics/src/lib.rs
@@ -315,7 +315,8 @@ pub fn uptime_metric(
     chain_identifier: &str,
 ) -> Box<dyn prometheus::core::Collector> {
     let opts = prometheus::opts!("uptime", "uptime of the node service in seconds")
-        .variable_label("version");
+        .variable_label("version")
+        .variable_label("chain_identifier");
 
     let start_time = std::time::Instant::now();
     let uptime = move || start_time.elapsed().as_secs();


### PR DESCRIPTION
## Description 

Fix uptime metrics by providing the right label names.

## Test Plan 

Tested locally by starting a node and see it not crash.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Fix uptime metrics by providing the right label names.

