### PR TITLE
periodic compaction of sst files

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -416,6 +416,11 @@ pub struct AuthorityStorePruningConfig {
     /// pruner deletion method. If set to `true`, range deletion is utilized (recommended).
     /// Use `false` for point deletes.
     pub use_range_deletion: bool,
+    /// enables periodic background compaction for old SST files whose last modified time is
+    /// older than `periodic_compaction_threshold_days` days.
+    /// That ensures that all sst files eventually go through the compaction process
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub periodic_compaction_threshold_days: Option<usize>,
 }
 
 impl Default for AuthorityStorePruningConfig {
@@ -431,6 +436,7 @@ impl Default for AuthorityStorePruningConfig {
             max_checkpoints_in_batch: 10,
             max_transactions_in_batch: 1000,
             use_range_deletion: true,
+            periodic_compaction_threshold_days: None,
         }
     }
 }
@@ -448,6 +454,7 @@ impl AuthorityStorePruningConfig {
             max_checkpoints_in_batch: 10,
             max_transactions_in_batch: 1000,
             use_range_deletion: true,
+            periodic_compaction_threshold_days: None,
         }
     }
     pub fn fullnode_config() -> Self {
@@ -462,6 +469,7 @@ impl AuthorityStorePruningConfig {
             max_checkpoints_in_batch: 10,
             max_transactions_in_batch: 1000,
             use_range_deletion: true,
+            periodic_compaction_threshold_days: None,
         }
     }
 }


### PR DESCRIPTION
PR adds an option to enable periodic background compactions for the objects table, ensuring that all SST files periodically go through the compaction process. This feature helps address the issue where we observe a large number of L4 SST files consisting mostly of range deletes but not undergoing the compaction process due to internal RocksDB heuristics.

This approach is intended to be used as a complement to aggressive pruning and is disabled by default. 
It is somewhat equivalent to RocksDB's `periodic_compaction_seconds` setting, but the latter is not very flexible and can cause dramatic resource consumption once enabled. The approach implemented in the PR processes one SST file at a time