### PR TITLE
[docs] Add comments regarding type argument instantiation

### DIFF
--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -4439,7 +4439,7 @@ pub async fn call_dev_inspect(
 }
 
 /// This function creates a transaction that calls a 0x02::object_basics::set_value function.
-/// Usually we need to publish this package first, but in this test files we often don't do that.
+/// Usually we need to publish this package first, but in these test files we often don't do that.
 /// Then the tx would fail with `VMVerificationOrDeserializationError` (Linker error, module not found),
 /// but gas is still charged. Depending on what we want to test, this may be fine.
 #[cfg(test)]

--- a/crates/sui-json/src/lib.rs
+++ b/crates/sui-json/src/lib.rs
@@ -832,7 +832,7 @@ fn resolve_call_args(
         .collect()
 }
 
-/// Resolve a the JSON args of a function into the expected formats to make them usable by Move call
+/// Resolve the JSON args of a function into the expected formats to make them usable by Move call
 /// This is because we have special types which we need to specify in other formats
 pub fn resolve_move_function_args(
     package: &MovePackage,

--- a/crates/sui-types/src/execution_status.rs
+++ b/crates/sui-types/src/execution_status.rs
@@ -93,7 +93,9 @@ pub enum ExecutionFailureStatus {
     MoveAbort(MoveLocation, u64),
     #[error(
         "Move Bytecode Verification Error. \
-        Please run the Bytecode Verifier for more information."
+        Please run the Bytecode Verifier for more information. \
+        If applicable, verify that all entry functions' type arguments have been \
+        specified."
     )]
     VMVerificationOrDeserializationError,
     #[error("MOVE VM INVARIANT VIOLATION.")]

--- a/crates/sui-types/src/execution_status.rs
+++ b/crates/sui-types/src/execution_status.rs
@@ -93,9 +93,7 @@ pub enum ExecutionFailureStatus {
     MoveAbort(MoveLocation, u64),
     #[error(
         "Move Bytecode Verification Error. \
-        Please run the Bytecode Verifier for more information. \
-        If applicable, verify that all entry functions' type arguments have been \
-        specified."
+        Please run the Bytecode Verifier for more information."
     )]
     VMVerificationOrDeserializationError,
     #[error("MOVE VM INVARIANT VIOLATION.")]

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -125,7 +125,8 @@ pub enum SuiClientCommands {
         /// Function name in module
         #[clap(long)]
         function: String,
-        /// Function name in module
+        /// Type arguments to the generic function being called.
+        /// All must be specified, or the call will fail.
         #[clap(
             long,
             value_parser = parse_sui_type_tag,

--- a/doc/src/build/cli-client.md
+++ b/doc/src/build/cli-client.md
@@ -423,17 +423,48 @@ The command parameters include:
   function call
 * `--gas-budget` - a decimal value expressing how much gas you are
   willing to pay for the `transfer` call to be completed to avoid
-  accidental drain of all gas in the gas pay)
+  accidental drainage of all gas in the gas payment
+* `--type-args` - a list of types to let the Sui Move compiler know how to fill
+  in generic type paramenters in the called function.
+  It is not needed above, but it would be if the function being called were generic.
+  See more about this flag below.
 
 Note the third argument to the `transfer` function representing
 `TxContext` does not have to be specified explicitly - it
 is a required argument for all functions callable from Sui and is
 auto-injected by the platform at the point of a function call.
 
-**Important:** If you use a shell that interprets square brackets ([ ]) as special characters (such as the `zsh` shell), you must enclose the brackets in single quotes. For example, instead of `[7,42]` you must use `'[7,42]'`.
+**Important:** 
 
-To include multiple object IDs, enclose the IDs in double quotes. For example,
-`'["0x33e3e1d64f76b71a80ec4f332f4d1a6742c537f2bb32473b01b1dcb1caac9427","0x11af4b844ff94b3fbef6e36b518da3ad4c5856fa686464524a876b463d129760"]'`
+1. If you use a shell that interprets square brackets ([ ]) as special
+   characters (such as the `zsh` shell), you must enclose the brackets in single
+   quotes. For example, instead of `[7,42]` you must use `'[7,42]'`.
+
+  To include multiple object IDs, enclose the IDs in double quotes. For example,
+  `'["0x33e3e1d64f76b71a80ec4f332f4d1a6742c537f2bb32473b01b1dcb1caac9427","0x11af4b844ff94b3fbef6e36b518da3ad4c5856fa686464524a876b463d129760"]'`
+
+2. The `--type-args` flag is used if the entry function being called is
+  generic, i.e. its signature is similar to
+  ```
+  public entry fun generic<T_1: ..., T_2: ..., ..., T_N: ...>(...) {...}
+  ```
+  In this case, the flag `--type-args` would need to be used like this:
+  ```bash
+  --type-args <type_for_t_1> <type_for_t_2> ... <type_for_t_n>
+  ```
+  where each of the types above can be among the following non-exhaustive list:
+  - a primitive type, such as `u8, bool, address`
+  - a composition of primitive types, like `vector<(u32, u8)>`
+  - a type or struct defined in a published, public Sui Move package, specified thusly:
+  `<package_id>::<module_identifier>::<struct_identifier>`
+
+  When, upon calling `sui client call`, an error similar to
+  ```
+  Error calling module: Failure {
+    error: "VMVerificationOrDeserializationError in command 0",
+  }
+  ```
+  occurs, it may help to check if `--type-args` has all the types the function needs.
 
 ## Publish packages
 

--- a/doc/src/build/cli-client.md
+++ b/doc/src/build/cli-client.md
@@ -453,10 +453,16 @@ auto-injected by the platform at the point of a function call.
   --type-args <type_for_t_1> <type_for_t_2> ... <type_for_t_n>
   ```
   where each of the types above can be among the following non-exhaustive list:
-  - a primitive type, such as `u8, bool, address`
-  - a composition of primitive types, like `vector<(u32, u8)>`
-  - a type or struct defined in a published, public Sui Move package, specified thusly:
-  `<package_id>::<module_identifier>::<struct_identifier>`
+  - a primitive type, such as `u8`, `bool`, `address`
+  - a composition of primitive types, like `vector<u8>`
+  - a non-generic type or struct defined in a published, public Sui Move package, specified thusly:
+  `[package-id]::[module-identifier]::[Struct]`.
+  An example of such a type would be `0x1234::xy::Zzy`
+  - generic types with arbitrarily nested parameters, in the form
+  `[package-id]::[module]::[Struct]<T_1, ..., T_n>`, where `T_1`, ..., `T_n` are fully
+  qualified, fully instantiated types, and `[package-id]::[module]::[Struct]` is a generic type
+  with `n` parameters.
+  An example of such a type would be `vector<0x123::foo::Bar<u32, bool>>`
 
   When, upon calling `sui client call`, an error similar to
   ```

--- a/doc/src/build/cli-client.md
+++ b/doc/src/build/cli-client.md
@@ -425,7 +425,7 @@ The command parameters include:
   willing to pay for the `transfer` call to be completed to avoid
   accidental drainage of all gas in the gas payment
 * `--type-args` - a list of types to let the Sui Move compiler know how to fill
-  in generic type paramenters in the called function.
+  in generic type parameters in the called function.
   It is not needed above, but it would be if the function being called were generic.
   See more about this flag below.
 
@@ -434,7 +434,7 @@ Note the third argument to the `transfer` function representing
 is a required argument for all functions callable from Sui and is
 auto-injected by the platform at the point of a function call.
 
-**Important:** 
+**Important:**
 
 1. If you use a shell that interprets square brackets ([ ]) as special
    characters (such as the `zsh` shell), you must enclose the brackets in single


### PR DESCRIPTION
## Description 

This PR adds a comment regarding the necessity of providing type arguments to Move calls.

I ran into this issue while testing the examples provided in the example [Defi](https://github.com/MystenLabs/sui/blob/main/sui_programmability/examples/defi/sources/escrow.move) package:

 * calling the `create` entry function, via `sui client call`, without instantiating both of its type arguments resulted in
  ```
  Error calling module: Failure {
      error: "VMVerificationOrDeserializationError in command 0",
  }
  ```

Adding the required type arguments fixes the issue.

## Test Plan 

Since this very small PR consists of comments only, I believe no tests are needed.

---

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
