### PR TITLE
Fix cluster test

### DIFF
--- a/crates/sui-test-transaction-builder/src/lib.rs
+++ b/crates/sui-test-transaction-builder/src/lib.rs
@@ -10,8 +10,7 @@ use sui_types::crypto::{Signature, Signer};
 use sui_types::sui_system_state::SUI_SYSTEM_MODULE_NAME;
 use sui_types::transaction::{
     CallArg, ObjectArg, Transaction, TransactionData, VerifiedTransaction,
-    TEST_ONLY_GAS_UNIT_FOR_GENERIC, TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
-    TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+    TEST_ONLY_GAS_UNIT_FOR_GENERIC, TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
 };
 use sui_types::{TypeTag, SUI_SYSTEM_OBJECT_ID};
 
@@ -194,7 +193,7 @@ impl TestTransactionBuilder {
                     self.gas_object,
                     all_module_bytes,
                     dependencies,
-                    self.gas_price * TEST_ONLY_GAS_UNIT_FOR_PUBLISH,
+                    self.gas_price * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
                     self.gas_price,
                 )
             }

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -40,6 +40,8 @@ use sui_protocol_config::{ProtocolConfig, SupportedProtocolVersions};
 use tap::Pipe;
 use tracing::trace;
 
+// TODO: The following constants appear to be very large.
+// We should revisit them.
 pub const TEST_ONLY_GAS_UNIT_FOR_TRANSFER: u64 = 2_000_000;
 pub const TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS: u64 = 10_000_000;
 pub const TEST_ONLY_GAS_UNIT_FOR_PUBLISH: u64 = 25_000_000;


### PR DESCRIPTION
This is a walk around to lower the gas budget used by publish.
We need to properly fix tests by using the right constant budget in general.