### PR TITLE
Adds support for validator pool ID 

### DIFF
--- a/apps/explorer/src/components/validator/ValidatorMeta.tsx
+++ b/apps/explorer/src/components/validator/ValidatorMeta.tsx
@@ -64,6 +64,11 @@ export function ValidatorMeta({ validatorData }: ValidatorMetaProps) {
                             --
                         </Text>
                     </DescriptionItem>
+                    <DescriptionItem title="Pool Id">
+                        <Text variant="pBody/medium" color="steel-darker">
+                            {validatorData.stakingPoolId}
+                        </Text>
+                    </DescriptionItem>
                     <DescriptionItem title="Address">
                         <AddressLink
                             address={validatorData.suiAddress}

--- a/apps/explorer/src/components/validator/ValidatorMeta.tsx
+++ b/apps/explorer/src/components/validator/ValidatorMeta.tsx
@@ -64,7 +64,7 @@ export function ValidatorMeta({ validatorData }: ValidatorMetaProps) {
                             --
                         </Text>
                     </DescriptionItem>
-                    <DescriptionItem title="Pool Id">
+                    <DescriptionItem title="Pool ID">
                         <Text variant="pBody/medium" color="steel-darker">
                             {validatorData.stakingPoolId}
                         </Text>

--- a/apps/explorer/src/components/validator/ValidatorMeta.tsx
+++ b/apps/explorer/src/components/validator/ValidatorMeta.tsx
@@ -6,6 +6,7 @@ import { type SuiValidatorSummary } from '@mysten/sui.js';
 
 import { StakeButton } from './StakeButton';
 
+import { CopyToClipboard } from '~/ui/CopyToClipboard';
 import { DescriptionList, DescriptionItem } from '~/ui/DescriptionList';
 import { Heading } from '~/ui/Heading';
 import { ImageIcon } from '~/ui/ImageIcon';
@@ -65,15 +66,29 @@ export function ValidatorMeta({ validatorData }: ValidatorMetaProps) {
                         </Text>
                     </DescriptionItem>
                     <DescriptionItem title="Pool ID" align="start">
-                        <Text variant="pBody/medium" color="steel-darker">
-                            {validatorData.stakingPoolId}
-                        </Text>
+                        <div className="flex gap-1">
+                            <Text variant="pBody/medium" color="steel-darker">
+                                {validatorData.stakingPoolId}
+                            </Text>
+                            <CopyToClipboard
+                                size="md"
+                                color="steel"
+                                copyText={validatorData.stakingPoolId}
+                            />
+                        </div>
                     </DescriptionItem>
                     <DescriptionItem title="Address">
-                        <AddressLink
-                            address={validatorData.suiAddress}
-                            noTruncate
-                        />
+                        <div className="flex gap-1">
+                            <AddressLink
+                                address={validatorData.suiAddress}
+                                noTruncate
+                            />
+                            <CopyToClipboard
+                                size="md"
+                                color="steel"
+                                copyText={validatorData.suiAddress}
+                            />
+                        </div>
                     </DescriptionItem>
                     <DescriptionItem title="Public Key" align="start">
                         <Text variant="pBody/medium" color="steel-darker">

--- a/apps/explorer/src/components/validator/ValidatorMeta.tsx
+++ b/apps/explorer/src/components/validator/ValidatorMeta.tsx
@@ -25,7 +25,7 @@ export function ValidatorMeta({ validatorData }: ValidatorMetaProps) {
 
     return (
         <>
-            <div className="flex basis-full gap-5 border-r border-transparent border-r-gray-45 md:mr-7.5 md:basis-1/4">
+            <div className="flex basis-full gap-5 border-r border-transparent border-r-gray-45 md:mr-7.5 md:basis-1/3">
                 <ImageIcon
                     src={logo}
                     label={validatorName}
@@ -54,17 +54,17 @@ export function ValidatorMeta({ validatorData }: ValidatorMetaProps) {
             </div>
             <div className="min-w-0 basis-full break-words md:basis-2/3">
                 <DescriptionList>
-                    <DescriptionItem title="Description">
+                    <DescriptionItem title="Description" align="start">
                         <Text variant="pBody/medium" color="gray-90">
                             {description || '--'}
                         </Text>
                     </DescriptionItem>
-                    <DescriptionItem title="Location">
+                    <DescriptionItem title="Location" align="start">
                         <Text variant="pBody/medium" color="gray-90">
                             --
                         </Text>
                     </DescriptionItem>
-                    <DescriptionItem title="Pool ID">
+                    <DescriptionItem title="Pool ID" align="start">
                         <Text variant="pBody/medium" color="steel-darker">
                             {validatorData.stakingPoolId}
                         </Text>
@@ -75,7 +75,7 @@ export function ValidatorMeta({ validatorData }: ValidatorMetaProps) {
                             noTruncate
                         />
                     </DescriptionItem>
-                    <DescriptionItem title="Public Key">
+                    <DescriptionItem title="Public Key" align="start">
                         <Text variant="pBody/medium" color="steel-darker">
                             {validatorPublicKey}
                         </Text>

--- a/apps/explorer/src/components/validator/ValidatorMeta.tsx
+++ b/apps/explorer/src/components/validator/ValidatorMeta.tsx
@@ -66,7 +66,7 @@ export function ValidatorMeta({ validatorData }: ValidatorMetaProps) {
                         </Text>
                     </DescriptionItem>
                     <DescriptionItem title="Pool ID" align="start">
-                        <div className="flex gap-1">
+                        <div className="flex items-start gap-1 break-all">
                             <Text variant="pBody/medium" color="steel-darker">
                                 {validatorData.stakingPoolId}
                             </Text>
@@ -78,7 +78,7 @@ export function ValidatorMeta({ validatorData }: ValidatorMetaProps) {
                         </div>
                     </DescriptionItem>
                     <DescriptionItem title="Address" align="start">
-                        <div className="flex gap-1">
+                        <div className="flex items-start gap-1">
                             <AddressLink
                                 address={validatorData.suiAddress}
                                 noTruncate

--- a/apps/explorer/src/components/validator/ValidatorMeta.tsx
+++ b/apps/explorer/src/components/validator/ValidatorMeta.tsx
@@ -77,7 +77,7 @@ export function ValidatorMeta({ validatorData }: ValidatorMetaProps) {
                             />
                         </div>
                     </DescriptionItem>
-                    <DescriptionItem title="Address">
+                    <DescriptionItem title="Address" align="start">
                         <div className="flex gap-1">
                             <AddressLink
                                 address={validatorData.suiAddress}

--- a/apps/explorer/src/hooks/useSearch.ts
+++ b/apps/explorer/src/hooks/useSearch.ts
@@ -114,9 +114,12 @@ const getResultsForValidatorByPoolIdOrSuiAddress = async (
     systemStateSummery: SuiSystemStateSummary | null,
     query: string
 ) => {
-    console.log('useSearch', query);
     const normalized = normalizeSuiObjectId(query);
-    if (!normalized || !systemStateSummery) return null;
+    if (
+        (!isValidSuiAddress(normalized) && !isValidSuiObjectId(normalized)) ||
+        !systemStateSummery
+    )
+        return null;
 
     // find validator by pool id or sui address
     const validator = systemStateSummery.activeValidators?.find(

--- a/apps/explorer/src/pages/validator/ValidatorDetails.tsx
+++ b/apps/explorer/src/pages/validator/ValidatorDetails.tsx
@@ -35,7 +35,12 @@ function ValidatorDetails() {
 
     const validatorData = useMemo(() => {
         if (!data) return null;
-        return data.activeValidators.find((av) => av.suiAddress === id) || null;
+        return (
+            data.activeValidators.find(
+                ({ suiAddress, stakingPoolId }) =>
+                    suiAddress === id || stakingPoolId === id
+            ) || null
+        );
     }, [id, data]);
 
     const atRiskRemainingEpochs = getAtRiskRemainingEpochs(data, id);

--- a/apps/explorer/src/pages/validators/Validators.tsx
+++ b/apps/explorer/src/pages/validators/Validators.tsx
@@ -71,7 +71,7 @@ export function validatorsTableData(
                     commission: Number(validator.commissionRate) / 100,
                     img: img,
                     address: validator.suiAddress,
-                    lastReward: lastReward ? Number(lastReward) : null,
+                    lastReward: lastReward ?? null,
                     votingPower: Number(validator.votingPower) / 100,
                     atRisk: isAtRisk
                         ? VALIDATOR_LOW_STAKE_GRACE_PERIOD -
@@ -172,8 +172,8 @@ export function validatorsTableData(
                 accessorKey: 'lastReward',
                 cell: (props: any) => {
                     const lastReward = props.getValue();
-                    return lastReward >= 0 ? (
-                        <StakeColumn stake={lastReward} />
+                    return lastReward !== null ? (
+                        <StakeColumn stake={Number(lastReward)} />
                     ) : (
                         <Text variant="bodySmall/medium" color="steel-darker">
                             --


### PR DESCRIPTION
## Description 

Describe the changes or additions included in this PR.

- Search by validator pool ID, or validator address 
- Get to the validator details page by the Pool ID or Address
- Show `--` for validators with unavailable epoch data/rewards 


## Test Plan 

How did you test the new or updated feature?
<img width="559" alt="Screenshot 2023-05-10 at 3 13 54 PM" src="https://github.com/MystenLabs/sui/assets/126525197/369d6330-6782-4922-8bb8-dc3f4add3006">
<img width="1469" alt="Screenshot 2023-05-11 at 8 32 25 PM" src="https://github.com/MystenLabs/sui/assets/126525197/0cb6fc28-46eb-4acf-b3f4-cdbfc1262d8d">



---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
