### PR TITLE
[bugfix] - object type should not trim leading zero

### DIFF
--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -29,8 +29,8 @@ use crate::multisig::MultiSigPublicKey;
 use crate::object::{Object, Owner};
 use crate::parse_sui_struct_tag;
 use crate::signature::GenericSignature;
-use crate::sui_serde::HexAccountAddress;
 use crate::sui_serde::Readable;
+use crate::sui_serde::{to_sui_struct_tag_string, HexAccountAddress};
 use crate::transaction::Transaction;
 use crate::transaction::VerifiedTransaction;
 use crate::MOVE_STDLIB_ADDRESS;
@@ -53,6 +53,7 @@ use move_core_types::language_storage::StructTag;
 use move_core_types::language_storage::TypeTag;
 use rand::Rng;
 use schemars::JsonSchema;
+use serde::ser::Error;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use shared_crypto::intent::HashingIntentScope;
@@ -1181,7 +1182,11 @@ impl From<SuiAddress> for AccountAddress {
 impl fmt::Display for MoveObjectType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
         let s: StructTag = self.clone().into();
-        write!(f, "{}", s)
+        write!(
+            f,
+            "{}",
+            to_sui_struct_tag_string(&s).map_err(fmt::Error::custom)?
+        )
     }
 }
 

--- a/crates/sui-types/src/sui_serde.rs
+++ b/crates/sui-types/src/sui_serde.rs
@@ -161,7 +161,8 @@ impl SerializeAs<StructTag> for SuiStructTag {
     }
 }
 
-fn to_sui_struct_tag_string(value: &StructTag) -> Result<String, fmt::Error> {
+/// Serialize StructTag as a string, retaining the leading zeros in the address.
+pub fn to_sui_struct_tag_string(value: &StructTag) -> Result<String, fmt::Error> {
     let mut f = String::new();
     write!(
         f,

--- a/crates/sui-types/tests/serde_tests.rs
+++ b/crates/sui-types/tests/serde_tests.rs
@@ -5,6 +5,8 @@ use move_core_types::language_storage::StructTag;
 use serde::Serialize;
 use serde_json::Value;
 use serde_with::serde_as;
+use std::str::FromStr;
+use sui_types::base_types::ObjectType;
 use sui_types::parse_sui_struct_tag;
 use sui_types::sui_serde::SuiStructTag;
 
@@ -22,4 +24,16 @@ fn test_struct_tag_serde() {
 
     let tag2 = parse_sui_struct_tag(&json).unwrap();
     assert_eq!(tag, tag2);
+}
+
+#[test]
+fn test_object_type_to_string() {
+    let object_type = ObjectType::from_str(
+        "0x1a1aa18691be519899bf5187f5ce80af629407dd4f68d4175b99f4dc09497c1::custodian::AccountCap",
+    )
+    .unwrap();
+    assert_eq!(
+        object_type.to_string(),
+        "0x01a1aa18691be519899bf5187f5ce80af629407dd4f68d4175b99f4dc09497c1::custodian::AccountCap"
+    );
 }


### PR DESCRIPTION
## Description 

Object type in get_object api is trimming leading zero. This PR fixes that.

## Test Plan 

Added unit test
