### PR TITLE
[part 3][wallet] remove redundant / hacky logic for resetting queries across network selections

### DIFF
--- a/apps/wallet/src/ui/app/ApiProvider.ts
+++ b/apps/wallet/src/ui/app/ApiProvider.ts
@@ -5,7 +5,6 @@ import { SentryRpcClient } from '@mysten/core';
 import { Connection, JsonRpcProvider } from '@mysten/sui.js';
 
 import { BackgroundServiceSigner } from './background-client/BackgroundServiceSigner';
-import { queryClient } from './helpers/queryClient';
 import { growthbook } from '_app/experimentation/feature-gating';
 import {
     AccountType,
@@ -109,10 +108,6 @@ export default class ApiProvider {
         });
 
         this._signerByAddress.clear();
-
-        // We also clear the query client whenever set set a new API provider:
-        queryClient.resetQueries();
-        queryClient.clear();
     }
 
     public get instance() {

--- a/apps/wallet/src/ui/index.tsx
+++ b/apps/wallet/src/ui/index.tsx
@@ -61,16 +61,16 @@ function AppWrapper() {
         <GrowthBookProvider growthbook={growthbook}>
             <HashRouter>
                 <SuiLedgerClientProvider>
-                    {/*
-                     * NOTE: We set a key here to force the entire react tree to be re-created when the network changes so that
-                     * the RPC client instance (api.instance.fullNode) is updated correctly. In the future, we should look into
-                     * making the API provider instance a reactive value and moving it out of the redux-thunk middleware
-                     */}
-                    <Fragment key={network}>
-                        <PersistQueryClientProvider
-                            client={queryClient}
-                            persistOptions={{ persister }}
-                        >
+                    <PersistQueryClientProvider
+                        client={queryClient}
+                        persistOptions={{ persister }}
+                    >
+                        {/*
+                         * NOTE: We set a key here to force the entire react tree to be re-created when the network changes so that
+                         * the RPC client instance (api.instance.fullNode) is updated correctly. In the future, we should look into
+                         * making the API provider instance a reactive value and moving it out of the redux-thunk middleware
+                         */}
+                        <Fragment key={network}>
                             <RpcClientContext.Provider
                                 value={api.instance.fullNode}
                             >
@@ -78,8 +78,8 @@ function AppWrapper() {
                                     <App />
                                 </ErrorBoundary>
                             </RpcClientContext.Provider>
-                        </PersistQueryClientProvider>
-                    </Fragment>
+                        </Fragment>
+                    </PersistQueryClientProvider>
                 </SuiLedgerClientProvider>
             </HashRouter>
         </GrowthBookProvider>


### PR DESCRIPTION
## Description 
This is a follow-up PR to clean up unnecessary logic in Sui Wallet for resetting our query cache upon changing networks via the network selector. We still need to re-render the component tree using a `key` prop since our `api` instance isn't reactive, but we can at least remove logic for manually clearing the query cache.

Part 1 (fixing all of the query dependencies in our apps): https://github.com/MystenLabs/sui/pull/11889
Part 2 (updating Sui Explorer to no longer rely on hacky logic): https://github.com/MystenLabs/sui/pull/11598
Part 3 (updating Sui Wallet to no longer rely on hacky logic): https://github.com/MystenLabs/sui/pull/11890

## Test Plan 
- Verified queries are persisted properly in IDB
- Verified the bug in https://github.com/MystenLabs/sui/pull/7891 doesn't happen
- Verified the network switches properly and queries call to the correct nodes

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
N/A