### PR TITLE
[explorer]: update gas payment section

### DIFF
--- a/apps/core/tailwind.config.ts
+++ b/apps/core/tailwind.config.ts
@@ -160,6 +160,9 @@ export default {
             width: {
                 31.5: '7.5rem',
             },
+            minWidth: {
+                transactionColumn: '31.875rem',
+            },
             transitionTimingFunction: {
                 'ease-in-out-cubic': 'cubic-bezier(0.65, 0, 0.35, 1)',
                 'ease-out-cubic': 'cubic-bezier(0.33, 1, 0.68, 1)',

--- a/apps/explorer/src/components/GasBreakdown/index.tsx
+++ b/apps/explorer/src/components/GasBreakdown/index.tsx
@@ -92,7 +92,7 @@ function TotalGasAmount({ amount }: GasProps) {
 
 function GasPaymentLinks({ objectIds }: { objectIds: string[] }) {
     return (
-        <div className="flex flex-wrap items-center gap-x-4">
+        <div className="flex max-h-20 min-h-[20px] flex-wrap items-center gap-x-4 gap-y-2 overflow-y-auto">
             {objectIds.map((objectId, index) => (
                 <div key={index} className="flex items-center gap-x-1.5">
                     <ObjectLink objectId={objectId} />
@@ -147,12 +147,12 @@ export function GasBreakdown({ summary }: GasBreakdownProps) {
                 <div className="flex flex-col gap-3">
                     <Divider />
 
-                    <DescriptionItem
-                        align="start"
-                        title={
-                            <Text variant="pBody/semibold">Gas Payment</Text>
-                        }
-                    >
+                    <div className="flex flex-col gap-2 md:flex-row md:gap-10">
+                        <div className="w-full flex-shrink-0 md:w-40">
+                            <Text variant="pBody/semibold" color="steel-darker">
+                                Gas Payment
+                            </Text>
+                        </div>
                         {gasPayment?.length ? (
                             <GasPaymentLinks
                                 objectIds={gasPayment.map(
@@ -160,7 +160,7 @@ export function GasBreakdown({ summary }: GasBreakdownProps) {
                                 )}
                             />
                         ) : null}
-                    </DescriptionItem>
+                    </div>
 
                     <DescriptionItem
                         align="start"

--- a/apps/explorer/src/pages/transaction-result/TransactionData.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionData.tsx
@@ -40,7 +40,7 @@ export function TransactionData({ transaction }: Props) {
 
     return (
         <div className="flex flex-wrap gap-6">
-            <section className="flex w-96 min-w-[50%] flex-1 flex-col gap-6">
+            <section className="flex w-96 flex-1 flex-col gap-6 max-md:min-w-[50%]">
                 {transaction.checkpoint && (
                     <TransactionBlockCard>
                         <TransactionBlockCardSection>
@@ -70,7 +70,7 @@ export function TransactionData({ transaction }: Props) {
                 )}
             </section>
 
-            <section className="flex w-96 flex-1 flex-col gap-6">
+            <section className="flex w-96 flex-1 flex-col gap-6 md:min-w-[510px]">
                 {isProgrammableTransaction && (
                     <>
                         <div data-testid="transactions-card">

--- a/apps/explorer/src/pages/transaction-result/TransactionData.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionData.tsx
@@ -70,7 +70,7 @@ export function TransactionData({ transaction }: Props) {
                 )}
             </section>
 
-            <section className="flex w-96 flex-1 flex-col gap-6 md:min-w-[510px]">
+            <section className="flex w-96 flex-1 flex-col gap-6 md:min-w-transactionColumn">
                 {isProgrammableTransaction && (
                     <>
                         <div data-testid="transactions-card">


### PR DESCRIPTION
## Description 

- Update gas payment section so it will always display at least 2 items
- When there are over 10 items, it will become scollable
- https://mysten.atlassian.net/browse/APPS-460
- DEMO: https://explorer-66hwh2ogf-mysten-labs.vercel.app/txblock/J4zaDNsMTAMrpFe5epDPzRwVR9TwNmLQx8mzKBvxvkA9?network=testnet

<img width="441" alt="Screenshot 2023-05-10 at 4 18 27 PM" src="https://github.com/MystenLabs/sui/assets/127577476/14ab40c9-9a0f-49d6-8924-c427f122f0d7">



## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
