### PR TITLE
[Deepbook] Add commission and rebates into event of OrderFilled

### DIFF
--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0x16b89a6a4d8175b30794b9c2ba8c59dce215082568e905d7af9ac501b8d88e9b"
+            id: "0x394f9cd9d7fee2a0b64b7b8898ea9444248e857225271f408d888d0fc7b526f7"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0x4af8b307d6152a8ee4d732f5edc63d3403dba9ec549650de15f6e1c5e59a99ea"
+      operation_cap_id: "0x7e35983d7cffd4fa3b873645f1a79c4c565703b858acb0cb1584707caa184349"
       gas_price: 1000
       staking_pool:
-        id: "0x71a6e4f734894377867f8993838b7c672bf750889b3bd0d1326ebe672546ba8e"
+        id: "0x0bc101228f5442dc50248938e857501e712b61561f9d5cc2c101b04fa96a59fb"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0x41d377067c52f17e96ae776b1193d247a992b5eec477a399e932adaf3ca7eb4e"
+          id: "0xb18b679c7f78ea4470610d91bb3d5b17cfd135944e2a657beac366543a7b044c"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0x28fa7aa7f35d519c4fe766f8202b31bf3125200a4bcdc5830e6b218ae9f56cee"
+            id: "0x34cf488ffc6a4a7164e38d77479c054f19cec0c29fae442c13c5df1d6a6d0ade"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0x881984318996da0c14ecbe802f2e4a5a265ff68a46e1ea416e00323418578e77"
+          id: "0x36ff0217619b793c9daa3606b8f9c7bfcfc7db68461799513880212e2c844cab"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x637a9663737d3e2ad1a9149d8232311dbd5c4ba5f1909bdfc77507558a32976c"
+      id: "0x98780fa3d8b012b2c87e9f415dc247071288568dab5968edfb1492ddde178ac2"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0xba922e9630c6604f6c2b88df8677e32f57170cf153ca9ff6e5981ed1b976a2bd"
+    id: "0xf7ac16e826d8c1795035dfaa10c7bc28ad521527818439bb8c48c544dafaff14"
     size: 1
   inactive_validators:
-    id: "0x695c5c2a3d0eedf87a1eb2b8009bc70805be3cfb06637a8b2572d2c482095f1a"
+    id: "0x30d5018ead847e7898ad96b388f6e476b99dacccad077d22ced9598121ab016d"
     size: 0
   validator_candidates:
-    id: "0xf8941a01aef0f383b0eb9dd5490003c99e2f1db76208ada0e3b42b24b66907aa"
+    id: "0x0b9f93b0fed1485723f381c902b3d60aa1e57e2e238c70f8e5a3cd297e5e5e28"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0xc7118bd4dfc92fca73a5376463eefdbfc90453f927cb7d694f2ca100136ebe9f"
+      id: "0xdb6f1f71e6c5b57b93ad954e91c69dd15ad4e361cee91113ee780ecdeabd9eb8"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x3977c88baf836c9cfae153790758bddd22e4fd784adbd94373331ea005afe2b7"
+      id: "0x92753a57d00fc615b1af4ba3a6755f63f59c27cce8dd6cb5a223805d8dca6d65"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0x46f6984f564bd596c637789caf1e732c5b69dfd4593593a40e5ac3a5ac824822"
+      id: "0xf3017ec58450c6e5c79534fa01baaa7e39a81e9ebc9ad38868fc143b0dc32db3"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,6 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0xfd507f519a98a153d1dd5f87cf1f694ab9a8849adf57a8cb05eb286a8b332445"
+    id: "0xfe08f018280495462582458bbdcab7c2aa2f91f678dea3d177a21c070ed0d89d"
   size: 0
 

--- a/crates/sui-framework/docs/clob.md
+++ b/crates/sui-framework/docs/clob.md
@@ -8,11 +8,12 @@
 -  [Struct `PoolCreated`](#0xdee9_clob_PoolCreated)
 -  [Struct `OrderPlacedV2`](#0xdee9_clob_OrderPlacedV2)
 -  [Struct `OrderCanceled`](#0xdee9_clob_OrderCanceled)
--  [Struct `OrderFilled`](#0xdee9_clob_OrderFilled)
+-  [Struct `OrderFilledV2`](#0xdee9_clob_OrderFilledV2)
 -  [Struct `Order`](#0xdee9_clob_Order)
 -  [Struct `TickLevel`](#0xdee9_clob_TickLevel)
 -  [Resource `Pool`](#0xdee9_clob_Pool)
 -  [Struct `OrderPlaced`](#0xdee9_clob_OrderPlaced)
+-  [Struct `OrderFilled`](#0xdee9_clob_OrderFilled)
 -  [Constants](#@Constants_0)
 -  [Function `destroy_empty_level`](#0xdee9_clob_destroy_empty_level)
 -  [Function `create_account`](#0xdee9_clob_create_account)
@@ -32,6 +33,7 @@
 -  [Function `place_limit_order`](#0xdee9_clob_place_limit_order)
 -  [Function `order_is_bid`](#0xdee9_clob_order_is_bid)
 -  [Function `emit_order_canceled`](#0xdee9_clob_emit_order_canceled)
+-  [Function `emit_order_filled`](#0xdee9_clob_emit_order_filled)
 -  [Function `cancel_order`](#0xdee9_clob_cancel_order)
 -  [Function `remove_order`](#0xdee9_clob_remove_order)
 -  [Function `cancel_all_orders`](#0xdee9_clob_cancel_all_orders)
@@ -249,14 +251,14 @@ Emitted when a maker order is canceled.
 
 </details>
 
-<a name="0xdee9_clob_OrderFilled"></a>
+<a name="0xdee9_clob_OrderFilledV2"></a>
 
-## Struct `OrderFilled`
+## Struct `OrderFilledV2`
 
 Emitted only when a maker order is filled.
 
 
-<pre><code><b>struct</b> <a href="clob.md#0xdee9_clob_OrderFilled">OrderFilled</a>&lt;BaseAsset, QuoteAsset&gt; <b>has</b> <b>copy</b>, drop, store
+<pre><code><b>struct</b> <a href="clob.md#0xdee9_clob_OrderFilledV2">OrderFilledV2</a>&lt;BaseAsset, QuoteAsset&gt; <b>has</b> <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -310,6 +312,18 @@ Emitted only when a maker order is filled.
 </dd>
 <dt>
 <code>price: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>taker_commission: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>maker_rebates: u64</code>
 </dt>
 <dd>
 
@@ -563,6 +577,76 @@ Deprecated since v1.0.0, use <code><a href="clob.md#0xdee9_clob_OrderPlacedV2">O
 </dd>
 <dt>
 <code>base_asset_quantity_placed: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>price: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0xdee9_clob_OrderFilled"></a>
+
+## Struct `OrderFilled`
+
+Deprecated since v1.0.0, use <code><a href="clob.md#0xdee9_clob_OrderFilledV2">OrderFilledV2</a></code> instead.
+
+
+<pre><code><b>struct</b> <a href="clob.md#0xdee9_clob_OrderFilled">OrderFilled</a>&lt;BaseAsset, QuoteAsset&gt; <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>pool_id: <a href="../../../.././build/Sui/docs/object.md#0x2_object_ID">object::ID</a></code>
+</dt>
+<dd>
+ object ID of the pool the order was placed on
+</dd>
+<dt>
+<code>order_id: u64</code>
+</dt>
+<dd>
+ ID of the order within the pool
+</dd>
+<dt>
+<code>is_bid: bool</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>owner: <a href="../../../.././build/Sui/docs/object.md#0x2_object_ID">object::ID</a></code>
+</dt>
+<dd>
+ object ID of the <code>AccountCap</code> that placed the order
+</dd>
+<dt>
+<code>total_quantity: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>base_asset_quantity_filled: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>base_asset_quantity_remaining: u64</code>
 </dt>
 <dd>
 
@@ -1396,16 +1480,15 @@ Deprecated since v1.0.0, use <code><a href="clob.md#0xdee9_clob_OrderPlacedV2">O
                 <a href="../../../.././build/Sui/docs/balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> pool.quote_asset_trading_fees, quote_balance_filled);
                 <a href="../../../.././build/Sui/docs/balance.md#0x2_balance_join">balance::join</a>(&<b>mut</b> base_balance_filled, locked_base_balance);
 
-                <a href="../../../.././build/Sui/docs/event.md#0x2_event_emit">event::emit</a>(<a href="clob.md#0xdee9_clob_OrderFilled">OrderFilled</a>&lt;BaseAsset, QuoteAsset&gt; {
-                    pool_id: *<a href="../../../.././build/Sui/docs/object.md#0x2_object_uid_as_inner">object::uid_as_inner</a>(&pool.id),
-                    order_id: maker_order.order_id,
-                    is_bid: <b>false</b>,
-                    owner: maker_order.owner,
-                    total_quantity: maker_order.quantity,
-                    base_asset_quantity_filled: filled_base_quantity,
-                    base_asset_quantity_remaining: maker_base_quantity,
-                    price: maker_order.price
-                })
+                <a href="clob.md#0xdee9_clob_emit_order_filled">emit_order_filled</a>&lt;BaseAsset, QuoteAsset&gt;(
+                    *<a href="../../../.././build/Sui/docs/object.md#0x2_object_uid_as_inner">object::uid_as_inner</a>(&pool.id),
+                    maker_order,
+                    filled_base_quantity,
+                    // taker_commission = filled_quote_quantity - filled_quote_quantity_without_commission
+                    // This guarantees that the subtraction will not underflow
+                    filled_quote_quantity - filled_quote_quantity_without_commission,
+                    maker_rebate
+                )
             };
 
             <b>if</b> (skip_order || maker_base_quantity == 0) {
@@ -1543,16 +1626,13 @@ Deprecated since v1.0.0, use <code><a href="clob.md#0xdee9_clob_OrderPlacedV2">O
                     ),
                 );
 
-                <a href="../../../.././build/Sui/docs/event.md#0x2_event_emit">event::emit</a>(<a href="clob.md#0xdee9_clob_OrderFilled">OrderFilled</a>&lt;BaseAsset, QuoteAsset&gt; {
-                    pool_id,
-                    order_id: maker_order.order_id,
-                    is_bid: <b>false</b>,
-                    owner: maker_order.owner,
-                    total_quantity: maker_order.quantity,
-                    base_asset_quantity_filled: filled_base_quantity,
-                    base_asset_quantity_remaining: maker_base_quantity,
-                    price: maker_order.price
-                })
+                <a href="clob.md#0xdee9_clob_emit_order_filled">emit_order_filled</a>&lt;BaseAsset, QuoteAsset&gt;(
+                    *<a href="../../../.././build/Sui/docs/object.md#0x2_object_uid_as_inner">object::uid_as_inner</a>(&pool.id),
+                    maker_order,
+                    filled_base_quantity,
+                    taker_commission,
+                    maker_rebate
+                );
             };
 
             <b>if</b> (skip_order || maker_base_quantity == 0) {
@@ -1685,16 +1765,13 @@ Deprecated since v1.0.0, use <code><a href="clob.md#0xdee9_clob_OrderPlacedV2">O
                     ),
                 );
 
-                <a href="../../../.././build/Sui/docs/event.md#0x2_event_emit">event::emit</a>(<a href="clob.md#0xdee9_clob_OrderFilled">OrderFilled</a>&lt;BaseAsset, QuoteAsset&gt; {
-                    pool_id: *<a href="../../../.././build/Sui/docs/object.md#0x2_object_uid_as_inner">object::uid_as_inner</a>(&pool.id),
-                    order_id: maker_order.order_id,
-                    is_bid: <b>true</b>,
-                    owner: maker_order.owner,
-                    total_quantity: maker_order.quantity,
-                    base_asset_quantity_filled: filled_base_quantity,
-                    base_asset_quantity_remaining: maker_base_quantity,
-                    price: maker_order.price
-                })
+                <a href="clob.md#0xdee9_clob_emit_order_filled">emit_order_filled</a>&lt;BaseAsset, QuoteAsset&gt;(
+                    *<a href="../../../.././build/Sui/docs/object.md#0x2_object_uid_as_inner">object::uid_as_inner</a>(&pool.id),
+                    maker_order,
+                    filled_base_quantity,
+                    taker_commission,
+                    maker_rebate
+                );
             };
 
             <b>if</b> (skip_order || maker_base_quantity == 0) {
@@ -2087,6 +2164,49 @@ So please check that boolean value first before using the order id.
         owner: order.owner,
         base_asset_quantity_canceled: order.quantity,
         price: order.price
+    })
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0xdee9_clob_emit_order_filled"></a>
+
+## Function `emit_order_filled`
+
+
+
+<pre><code><b>fun</b> <a href="clob.md#0xdee9_clob_emit_order_filled">emit_order_filled</a>&lt;BaseAsset, QuoteAsset&gt;(pool_id: <a href="../../../.././build/Sui/docs/object.md#0x2_object_ID">object::ID</a>, order: &<a href="clob.md#0xdee9_clob_Order">clob::Order</a>, base_asset_quantity_filled: u64, taker_commission: u64, maker_rebates: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="clob.md#0xdee9_clob_emit_order_filled">emit_order_filled</a>&lt;BaseAsset, QuoteAsset&gt;(
+    pool_id: ID,
+    order: &<a href="clob.md#0xdee9_clob_Order">Order</a>,
+    base_asset_quantity_filled: u64,
+    taker_commission: u64,
+    maker_rebates: u64
+) {
+    <a href="../../../.././build/Sui/docs/event.md#0x2_event_emit">event::emit</a>(<a href="clob.md#0xdee9_clob_OrderFilledV2">OrderFilledV2</a>&lt;BaseAsset, QuoteAsset&gt; {
+        pool_id,
+        order_id: order.order_id,
+        is_bid: order.is_bid,
+        owner: order.owner,
+        total_quantity: order.quantity,
+        base_asset_quantity_filled,
+        // order.quantity = base_asset_quantity_filled + base_asset_quantity_remaining
+        // This guarantees that the subtraction will not underflow
+        base_asset_quantity_remaining: order.quantity - base_asset_quantity_filled,
+        price: order.price,
+        taker_commission,
+        maker_rebates
     })
 }
 </code></pre>


### PR DESCRIPTION
## Description

Add taker_commission and maker_rebate into OrderFilled events

## Test Plan

cd to deepbook dir and run "sui move test"

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

---------

## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
