### PR TITLE
[wallet-ext] - add support for displaying OriginByte kiosk

### DIFF
--- a/apps/core/src/hooks/useGetOriginByteKioskContents.ts
+++ b/apps/core/src/hooks/useGetOriginByteKioskContents.ts
@@ -1,0 +1,69 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { SuiAddress } from '@mysten/sui.js';
+import { useQuery } from '@tanstack/react-query';
+import { useRpcClient } from '../api/RpcClientContext';
+import { useGetOwnedObjects } from './useGetOwnedObjects';
+
+// OriginByte contract address for mainnet (we only support mainnet)
+const ORIGINBYTE_KIOSK_MODULE =
+    '0x95a441d389b07437d00dd07e0b6f05f513d7659b13fd7c5d3923c7d9d847199b::ob_kiosk';
+const ORIGINBYTE_KIOSK_OWNER_TOKEN = `${ORIGINBYTE_KIOSK_MODULE}::OwnerToken`;
+
+export function useGetOriginByteKioskContents(
+    address?: SuiAddress | null,
+    disable?: boolean
+) {
+    const rpc = useRpcClient();
+    const { data } = useGetOwnedObjects(address, {
+        StructType: ORIGINBYTE_KIOSK_OWNER_TOKEN,
+    });
+
+    return useQuery(
+        ['originbyte-kiosk-contents', address],
+        async () => {
+            // find list of kiosk IDs owned by address
+            const obKioskIds = data!.pages
+                .flatMap((page) => page.data)
+                .map(
+                    (obj) =>
+                        obj.data?.content &&
+                        'fields' in obj.data.content &&
+                        obj.data.content.fields.kiosk
+                );
+
+            if (!obKioskIds.length) return [];
+
+            // fetch the user's kiosks
+            const ownedKiosks = await rpc.multiGetObjects({
+                ids: obKioskIds,
+                options: {
+                    showContent: true,
+                },
+            });
+
+            // find object IDs within a kiosk
+            const kioskObjectIds = await Promise.all(
+                ownedKiosks.map(async (kiosk) => {
+                    if (!kiosk.data?.objectId) return [];
+                    const objects = await rpc.getDynamicFields({
+                        parentId: kiosk.data.objectId,
+                    });
+                    return objects.data.map((obj) => obj.objectId);
+                })
+            );
+
+            // fetch the contents of the objects within a kiosk
+            const kioskContent = await rpc.multiGetObjects({
+                ids: kioskObjectIds.flat(),
+                options: {
+                    showDisplay: true,
+                },
+            });
+
+            return kioskContent;
+        },
+        { enabled: !!data?.pages.length && !disable && !!address }
+    );
+}

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -27,3 +27,4 @@ export * from './utils/transaction';
 export * from './hooks/useOnScreen';
 export * from './hooks/useGetOwnedObjects';
 export * from './hooks/useCopyToClipboard';
+export * from './hooks/useGetOriginByteKioskContents';

--- a/apps/wallet/src/ui/app/hooks/useGetNFTs.ts
+++ b/apps/wallet/src/ui/app/hooks/useGetNFTs.ts
@@ -1,0 +1,66 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+    useGetOwnedObjects,
+    useGetOriginByteKioskContents,
+} from '@mysten/core';
+import {
+    getObjectDisplay,
+    type SuiObjectData,
+    type SuiAddress,
+    type SuiObjectResponse,
+} from '@mysten/sui.js';
+
+import useAppSelector from './useAppSelector';
+
+const hasDisplayData = (obj: SuiObjectResponse) => !!getObjectDisplay(obj).data;
+
+export function useGetNFTs(address?: SuiAddress | null) {
+    const {
+        data,
+        isLoading,
+        error,
+        isError,
+        isFetchingNextPage,
+        hasNextPage,
+        fetchNextPage,
+        isInitialLoading,
+    } = useGetOwnedObjects(
+        address,
+        {
+            MatchNone: [{ StructType: '0x2::coin::Coin' }],
+        },
+        50
+    );
+    const { apiEnv } = useAppSelector((state) => state.app);
+
+    const shouldFetchKioskContents = apiEnv === 'mainnet';
+    const { data: obKioskContents, isLoading: areKioskContentsLoading } =
+        useGetOriginByteKioskContents(address, !shouldFetchKioskContents);
+
+    const filteredKioskContents =
+        obKioskContents
+            ?.filter(hasDisplayData)
+            .map(({ data }) => data as SuiObjectData) || [];
+
+    const nfts = [
+        ...filteredKioskContents,
+        ...(data?.pages
+            .flatMap((page) => page.data)
+            .filter(hasDisplayData)
+            .map(({ data }) => data as SuiObjectData) || []),
+    ];
+
+    return {
+        data: nfts,
+        isInitialLoading,
+        hasNextPage,
+        isFetchingNextPage,
+        fetchNextPage,
+        isLoading:
+            isLoading || (shouldFetchKioskContents && areKioskContentsLoading),
+        isError: isError,
+        error,
+    };
+}

--- a/apps/wallet/src/ui/app/pages/home/nfts/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nfts/index.tsx
@@ -1,8 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useOnScreen, useGetOwnedObjects } from '@mysten/core';
-import { getObjectDisplay, type SuiObjectData } from '@mysten/sui.js';
+import { useOnScreen } from '@mysten/core';
 import { useRef, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 
@@ -12,37 +11,24 @@ import { ErrorBoundary } from '_components/error-boundary';
 import Loading from '_components/loading';
 import LoadingSpinner from '_components/loading/LoadingIndicator';
 import { NFTDisplayCard } from '_components/nft-display';
+import { useGetNFTs } from '_src/ui/app/hooks/useGetNFTs';
 import PageTitle from '_src/ui/app/shared/PageTitle';
-
-const MAX_FETCH_LIMIT = 50;
 
 function NftsPage() {
     const accountAddress = useActiveAddress();
     const {
-        data,
-        isLoading,
-        error,
-        isError,
-        isFetchingNextPage,
+        data: nfts,
         hasNextPage,
-        fetchNextPage,
         isInitialLoading,
-    } = useGetOwnedObjects(
-        accountAddress,
-        {
-            MatchNone: [{ StructType: '0x2::coin::Coin' }],
-        },
-        MAX_FETCH_LIMIT
-    );
+        isFetchingNextPage,
+        error,
+        isLoading,
+        fetchNextPage,
+        isError,
+    } = useGetNFTs(accountAddress);
     const observerElem = useRef<HTMLDivElement | null>(null);
     const { isIntersecting } = useOnScreen(observerElem);
     const isSpinnerVisible = isFetchingNextPage && hasNextPage;
-
-    const nfts =
-        data?.pages
-            .flatMap((page) => page.data)
-            .filter((resp) => !!getObjectDisplay(resp).data)
-            .map(({ data }) => data as SuiObjectData) || [];
 
     useEffect(() => {
         if (isIntersecting && hasNextPage && !isFetchingNextPage) {


### PR DESCRIPTION
## Description 

Adds some rudimentary support for displaying OB Kiosk items on mainnet. There's definitely some improvements we can make here, as we currently have to merge lists of objects with one being a paginated API to `getOwnedObjects` and the other being a series of RPC requests in order to fetch the contents of a kiosk

adapted from #11505 

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
