### PR TITLE
[chore] clippy to run with all features enabled

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -4,7 +4,7 @@
 # configuration file. This is a similar workaround to the ones presented here:
 # <https://github.com/EmbarkStudios/rust-ecosystem/issues/59>
 xclippy = [
-    "clippy", "--all-targets", "--",
+    "clippy", "--all-targets", "--all-features", "--",
     "-Wclippy::all",
     "-Wclippy::disallowed_methods",
 ]

--- a/crates/sui-indexer/tests/integration_tests.rs
+++ b/crates/sui-indexer/tests/integration_tests.rs
@@ -30,7 +30,12 @@ pub mod pg_integration_test {
     use sui_json_rpc::api::ExtendedApiClient;
     use sui_json_rpc::api::IndexerApiClient;
     use sui_json_rpc::api::{ReadApiClient, TransactionBuilderClient, WriteApiClient};
-    use sui_json_rpc_types::{CheckpointId, EventFilter, SuiMoveObject, SuiObjectData, SuiObjectDataFilter, SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery, SuiParsedMoveObject, SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions, SuiTransactionBlockResponseQuery, TransactionBlockBytes, TransactionFilter};
+    use sui_json_rpc_types::{
+        CheckpointId, EventFilter, SuiMoveObject, SuiObjectData, SuiObjectDataFilter,
+        SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery, SuiParsedMoveObject,
+        SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions,
+        SuiTransactionBlockResponseQuery, TransactionBlockBytes, TransactionFilter,
+    };
     use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
     use sui_types::base_types::{ObjectID, SuiAddress};
     use sui_types::digests::{ObjectDigest, TransactionDigest};

--- a/crates/sui-indexer/tests/integration_tests.rs
+++ b/crates/sui-indexer/tests/integration_tests.rs
@@ -30,19 +30,13 @@ pub mod pg_integration_test {
     use sui_json_rpc::api::ExtendedApiClient;
     use sui_json_rpc::api::IndexerApiClient;
     use sui_json_rpc::api::{ReadApiClient, TransactionBuilderClient, WriteApiClient};
-    use sui_json_rpc_types::{
-        CheckpointId, EventFilter, SuiMoveObject, SuiObjectData, SuiObjectDataFilter,
-        SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery, SuiParsedMoveObject,
-        SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions,
-        SuiTransactionBlockResponseQuery, TransactionBlockBytes,
-    };
+    use sui_json_rpc_types::{CheckpointId, EventFilter, SuiMoveObject, SuiObjectData, SuiObjectDataFilter, SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery, SuiParsedMoveObject, SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions, SuiTransactionBlockResponseQuery, TransactionBlockBytes, TransactionFilter};
     use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
     use sui_types::base_types::{ObjectID, SuiAddress};
     use sui_types::digests::{ObjectDigest, TransactionDigest};
     use sui_types::error::SuiObjectResponseError;
     use sui_types::gas_coin::GasCoin;
     use sui_types::object::ObjectFormatOptions;
-    use sui_types::query::TransactionFilter;
     use sui_types::quorum_driver_types::ExecuteTransactionRequestType;
     use sui_types::transaction::TEST_ONLY_GAS_UNIT_FOR_TRANSFER;
     use sui_types::utils::to_sender_signed_transaction;
@@ -884,7 +878,7 @@ pub mod pg_integration_test {
             .get_checkpoint(CheckpointId::SequenceNumber(prev_epoch_last_checkpoint_id))
             .await
             .unwrap();
-        assert_eq!(checkpoint.epoch as u64, current_epoch.epoch - 1);
+        assert_eq!(checkpoint.epoch, current_epoch.epoch - 1);
         assert_eq!(checkpoint.sequence_number, prev_epoch_last_checkpoint_id);
         assert!(checkpoint.end_of_epoch_data.is_some());
 
@@ -965,7 +959,6 @@ pub mod pg_integration_test {
         let mut pg_pool_conn = get_pg_pool_connection(&pg_connection_pool).unwrap();
 
         let lot_of_data = (1..10000)
-            .into_iter()
             .map(|_| Object {
                 epoch: 0,
                 checkpoint: 0,
@@ -1027,7 +1020,6 @@ pub mod pg_integration_test {
         let mut pg_pool_conn = get_pg_pool_connection(&pg_connection_pool).unwrap();
 
         let bulk_data = (1..=10000)
-            .into_iter()
             .map(|_| Object {
                 epoch: 0,
                 checkpoint: 0,
@@ -1206,7 +1198,7 @@ pub mod pg_integration_test {
         // Check if checkpoint validator sig matches
         let fullnode_checkpoint = test_cluster
             .rpc_client()
-            .get_checkpoint((cp as u64).into())
+            .get_checkpoint(cp.into())
             .await
             .unwrap();
 
@@ -1283,7 +1275,7 @@ pub mod pg_integration_test {
         };
 
         let config = IndexerConfig {
-            db_url,
+            db_url: Some(db_url),
             rpc_client_url: test_cluster.rpc_url().to_string(),
             migrated_methods: IndexerConfig::all_implemented_methods(),
             reset_db: true,

--- a/narwhal/node/src/benchmark_client.rs
+++ b/narwhal/node/src/benchmark_client.rs
@@ -70,7 +70,6 @@ async fn main() -> Result<(), eyre::Report> {
     let nodes = matches
         .values_of("nodes")
         .unwrap_or_default()
-        .into_iter()
         .map(|x| x.parse::<Url>())
         .collect::<Result<Vec<_>, _>>()
         .with_context(|| format!("Invalid url format {target_str}"))?;


### PR DESCRIPTION
## Description 

clippy seems to be ignoring files when those depend on features that aren't enabled when it runs. This is leading to build failures (ex [this](https://github.com/MystenLabs/sui/actions/runs/4942463072/jobs/8836005749) and [this](https://github.com/MystenLabs/sui/actions/runs/4910003494)) frequently as our rust CI is passing but when it comes to build CI it fails and mostly goes undetected.

The PR is enabling `--all-features` so we align the rust & build CI. It is also fixing some linter failures.


## Test Plan 

Did run locally

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
