### PR TITLE
[explorer] - checkpoints table - make sequence number a link

### DIFF
--- a/apps/explorer/src/components/checkpoints/utils.tsx
+++ b/apps/explorer/src/components/checkpoints/utils.tsx
@@ -6,7 +6,7 @@ import { type CheckpointPage } from '@mysten/sui.js/src/types/checkpoints';
 import { TxTableCol } from '../transactions/TxCardUtils';
 import { TxTimeType } from '../tx-time/TxTimeType';
 
-import { CheckpointLink } from '~/ui/InternalLink';
+import { CheckpointLink, CheckpointSequenceLink } from '~/ui/InternalLink';
 import { Text } from '~/ui/Text';
 
 // Generate table data from the checkpoints data
@@ -24,9 +24,7 @@ export const genTableDataFromCheckpointsData = (data: CheckpointPage) => ({
         ),
         sequenceNumber: (
             <TxTableCol>
-                <Text variant="bodySmall/medium" color="steel-darker">
-                    {checkpoint.sequenceNumber}
-                </Text>
+                <CheckpointSequenceLink sequence={checkpoint.sequenceNumber} />
             </TxTableCol>
         ),
         transactionBlockCount: (


### PR DESCRIPTION
## Description 

Use a link for Checkpoint Sequence number in the Epochs table. As requested by @mystie711 

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
