### PR TITLE
3/n improve sui-json-rpc error codes and handling

### DIFF
--- a/.changeset/early-dancers-walk.md
+++ b/.changeset/early-dancers-walk.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Update ts-sdk e2e test to reflect new rpc error language

--- a/crates/sui-json-rpc/src/error.rs
+++ b/crates/sui-json-rpc/src/error.rs
@@ -48,6 +48,9 @@ pub enum Error {
 
     #[error(transparent)]
     SuiObjectResponseError(#[from] SuiObjectResponseError),
+
+    #[error(transparent)]
+    SuiRpcInputError(#[from] SuiRpcInputError),
 }
 
 impl From<Error> for RpcError {
@@ -61,6 +64,9 @@ impl Error {
         match self {
             Error::UserInputError(user_input_error) => {
                 RpcError::Call(CallError::InvalidParams(user_input_error.into()))
+            }
+            Error::SuiRpcInputError(sui_json_rpc_input_error) => {
+                RpcError::Call(CallError::InvalidParams(sui_json_rpc_input_error.into()))
             }
             Error::SuiError(sui_error) => match sui_error {
                 SuiError::TransactionNotFound { .. } | SuiError::TransactionsNotFound { .. } => {
@@ -82,4 +88,28 @@ impl Error {
             _ => RpcError::Call(CallError::Failed(self.into())),
         }
     }
+}
+
+#[derive(Debug, Error)]
+pub enum SuiRpcInputError {
+    #[error("Input contains duplicates")]
+    ContainsDuplicates,
+
+    #[error("Input exceeds limit of {0}")]
+    SizeLimitExceeded(String),
+
+    #[error("{0}")]
+    GenericNotFound(String),
+
+    #[error("{0}")]
+    GenericInvalid(String),
+
+    #[error("request_type` must set to `None` or `WaitForLocalExecution` if effects is required in the response")]
+    InvalidExecuteTransactionRequestType,
+
+    #[error("Unsupported protocol version requested. Min supported: {0}, max supported: {1}")]
+    ProtocolVersionUnsupported(u64, u64),
+
+    #[error("Unable to serialize: {0}")]
+    CannotSerialize(#[from] bcs::Error),
 }

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -38,7 +38,7 @@ use sui_types::crypto::default_hash;
 use sui_types::digests::TransactionEventsDigest;
 use sui_types::display::DisplayVersionUpdatedEvent;
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents};
-use sui_types::error::{SuiObjectResponseError, UserInputError};
+use sui_types::error::SuiObjectResponseError;
 use sui_types::messages_checkpoint::{CheckpointSequenceNumber, CheckpointTimestamp};
 use sui_types::move_package::normalize_modules;
 use sui_types::object::{Data, Object, ObjectRead, PastObjectRead};
@@ -49,7 +49,7 @@ use sui_types::transaction::{TransactionData, VerifiedTransaction};
 use crate::api::JsonRpcMetrics;
 use crate::api::{validate_limit, ReadApiServer};
 use crate::api::{QUERY_MAX_RESULT_LIMIT, QUERY_MAX_RESULT_LIMIT_CHECKPOINTS};
-use crate::error::Error;
+use crate::error::{Error, SuiRpcInputError};
 use crate::with_tracing;
 use crate::{
     get_balance_changes_from_effect, get_object_changes, ObjectProviderCache, SuiRpcModule,
@@ -140,10 +140,9 @@ impl ReadApi {
     ) -> Result<Vec<SuiTransactionBlockResponse>, Error> {
         let num_digests = digests.len();
         if num_digests > *QUERY_MAX_RESULT_LIMIT {
-            return Err(Error::UserInputError(UserInputError::SizeLimitExceeded {
-                limit: "multi get transaction input limit".to_string(),
-                value: QUERY_MAX_RESULT_LIMIT.to_string(),
-            }));
+            return Err(Error::SuiRpcInputError(
+                SuiRpcInputError::SizeLimitExceeded(QUERY_MAX_RESULT_LIMIT.to_string()),
+            ));
         }
         self.metrics
             .get_tx_blocks_limit
@@ -159,15 +158,17 @@ impl ReadApi {
                     .map(|k| (k, IntermediateTransactionResponse::new(*k))),
             );
         if temp_response.len() < num_digests {
-            return Err(anyhow!("The list of digests in the input contain duplicates").into());
+            return Err(Error::SuiRpcInputError(
+                SuiRpcInputError::ContainsDuplicates,
+            ));
         }
 
         if opts.require_input() {
             let state = self.state.clone();
-            let digest_clone = digests.clone();
+            let digests_clone = digests.clone();
             let transactions =
-                state.multi_get_executed_transactions(&digest_clone).tap_err(
-                    |err| debug!(digests=?digest_clone, "Failed to multi get transaction: {:?}", err),
+                state.multi_get_executed_transactions(&digests_clone).tap_err(
+                    |err| debug!(digests=?digests_clone, "Failed to multi get transactions: {:?}", err),
                 )?;
 
             for ((_digest, cache_entry), txn) in
@@ -182,7 +183,7 @@ impl ReadApi {
             let state = self.state.clone();
             let digests_clone = digests.clone();
             let effects_list = state.multi_get_executed_effects(&digests_clone).tap_err(
-                |err| debug!(digests=?digests_clone, "Failed to multi get effects: {:?}", err),
+                |err| debug!(digests=?digests_clone, "Failed to multi get effects for transactions: {:?}", err),
             )?;
             for ((_digest, cache_entry), e) in
                 temp_response.iter_mut().zip(effects_list.into_iter())
@@ -218,8 +219,7 @@ impl ReadApi {
             .state
             .multi_get_checkpoint_by_sequence_number(&unique_checkpoint_numbers)
             .map_err(|e| {
-                error!("Failed to fetch checkpoint summarys by these checkpoint ids: {unique_checkpoint_numbers:?} with error: {e:?}");
-                anyhow!("{e}")
+                Error::UnexpectedError(format!("Failed to fetch checkpoint summaries by these checkpoint ids: {unique_checkpoint_numbers:?} with error: {e:?}"))
             })?
             .into_iter()
             .map(|c| c.map(|checkpoint| checkpoint.timestamp_ms));
@@ -261,8 +261,7 @@ impl ReadApi {
                 .state
                 .multi_get_events(&event_digests_list)
                 .map_err(|e| {
-                    error!("Failed to call multi_get_events for transactions {digests:?} with event digests {event_digests_list:?}");
-                    anyhow!("{e}")
+                    Error::UnexpectedError(format!("Failed to call multi_get_events for transactions {digests:?} with event digests {event_digests_list:?}: {e:?}"))
                 })?
                 .into_iter();
 
@@ -283,7 +282,7 @@ impl ReadApi {
                 if event_digest.is_some() {
                     // safe to unwrap because `is_some` is checked
                     let event_digest = event_digest.as_ref().unwrap();
-                    let events: Option<RpcResult<SuiTransactionBlockEvents>> = event_digest_to_events
+                    let events= event_digest_to_events
                         .get(event_digest)
                         .cloned()
                         .unwrap_or_else(|| panic!("Expect event digest {event_digest:?} to be found in cache for transaction {transaction_digest}"))
@@ -324,7 +323,9 @@ impl ReadApi {
                 results.push(get_balance_changes_from_effect(
                     &object_cache,
                     resp.effects.as_ref().ok_or_else(|| {
-                        anyhow!("unable to derive balance changes because effect is empty")
+                        Error::SuiRpcInputError(SuiRpcInputError::GenericNotFound(
+                            "unable to derive balance changes because effect is empty".to_string(),
+                        ))
                     })?,
                     input_objects,
                     None,
@@ -346,7 +347,9 @@ impl ReadApi {
             let mut results = vec![];
             for resp in temp_response.values() {
                 let effects = resp.effects.as_ref().ok_or_else(|| {
-                    anyhow!("unable to derive object changes because effect is empty")
+                    Error::SuiRpcInputError(SuiRpcInputError::GenericNotFound(
+                        "unable to derive object changes because effect is empty".to_string(),
+                    ))
                 })?;
 
                 results.push(get_object_changes(
@@ -354,7 +357,10 @@ impl ReadApi {
                     resp.transaction
                         .as_ref()
                         .ok_or_else(|| {
-                            anyhow!("unable to derive object changes because effect is empty")
+                            Error::SuiRpcInputError(SuiRpcInputError::GenericNotFound(
+                                "unable to derive object changes because transaction is empty"
+                                    .to_string(),
+                            ))
                         })?
                         .data()
                         .intent_message()
@@ -406,11 +412,11 @@ impl ReadApiServer for ReadApi {
             let object_read = spawn_monitored_task!(async move {
                 state.get_object_read(&object_id).map_err(|e| {
                     warn!(?object_id, "Failed to get object: {:?}", e);
-                    anyhow!("{e}")
+                    Error::from(e)
                 })
             })
             .await
-            .map_err(|e| anyhow!(e))??;
+            .map_err(Error::from)??;
             let options = options.unwrap_or_default();
 
             match object_read {
@@ -487,10 +493,9 @@ impl ReadApiServer for ReadApi {
                     .inc_by(objects.len() as u64);
                 Ok(objects)
             } else {
-                Err(Error::UserInputError(UserInputError::SizeLimitExceeded {
-                    limit: "input limit".to_string(),
-                    value: QUERY_MAX_RESULT_LIMIT.to_string(),
-                })
+                Err(Error::SuiRpcInputError(SuiRpcInputError::SizeLimitExceeded(
+                    QUERY_MAX_RESULT_LIMIT.to_string(),
+                ))
                 .into())
             }
         })
@@ -509,8 +514,8 @@ impl ReadApiServer for ReadApi {
             state.get_past_object_read(&object_id, version)
             .map_err(|e| {
                 error!("Failed to call try_get_past_object for object: {object_id:?} version: {version:?} with error: {e:?}");
-                anyhow!("{e}")
-            })}).await.map_err(|e| anyhow!(e))??;
+                Error::from(e)
+            })}).await.map_err(Error::from)??;
             let options = options.unwrap_or_default();
             match past_read {
                 PastObjectRead::ObjectNotExists(id) => {
@@ -573,15 +578,14 @@ impl ReadApiServer for ReadApi {
                         .map(|e| e.to_string())
                         .collect::<Vec<String>>()
                         .join("; ");
-                    Err(anyhow!("{error_string}").into())
+                    Err(anyhow!("{error_string}").into()) // Collects errors not related to SuiPastObjectResponse variants
                 } else {
                     Ok(success)
                 }
             } else {
-                Err(Error::UserInputError(UserInputError::SizeLimitExceeded {
-                    limit: "input limit".to_string(),
-                    value: QUERY_MAX_RESULT_LIMIT.to_string(),
-                })
+                Err(Error::SuiRpcInputError(SuiRpcInputError::SizeLimitExceeded(
+                    QUERY_MAX_RESULT_LIMIT.to_string(),
+                ))
                 .into())
             }
         })
@@ -611,13 +615,13 @@ impl ReadApiServer for ReadApi {
             // Fetch transaction to determine existence
             let state = self.state.clone();
             let transaction = spawn_monitored_task!(async move {
-                state.get_transaction_block(digest).await.tap_err(
-                    |err| debug!(tx_digest=?digest, "Failed to get transaction: {:?}", err),
-                )
+                state.get_transaction_block(digest).await.map_err(|err| {
+                    debug!(tx_digest=?digest, "Failed to get transaction: {:?}", err);
+                    Error::from(err)
+                })
             })
             .await
-            .map_err(Error::from)?
-            .map_err(Error::from)?;
+            .map_err(Error::from)??;
             let input_objects = transaction
                 .data()
                 .inner()
@@ -636,13 +640,13 @@ impl ReadApiServer for ReadApi {
                 let state = self.state.clone();
                 temp_response.effects = Some(
                     spawn_monitored_task!(async move {
-                        state.get_executed_effects(digest).tap_err(
-                            |err| debug!(tx_digest=?digest, "Failed to get effects: {:?}", err),
-                        )
+                        state.get_executed_effects(digest).map_err(|err| {
+                            debug!(tx_digest=?digest, "Failed to get effects: {:?}", err);
+                            Error::from(err)
+                        })
                     })
                     .await
-                    .map_err(Error::from)?
-                    .map_err(Error::from)?,
+                    .map_err(Error::from)??,
                 );
             }
 
@@ -651,8 +655,8 @@ impl ReadApiServer for ReadApi {
             state.get_transaction_checkpoint_sequence(&digest)
             .map_err(|e| {
                 error!("Failed to retrieve checkpoint sequence for transaction {digest:?} with error: {e:?}");
-                anyhow!("{e}")
-            })}).await.map_err(|e|anyhow!(e))??
+                Error::from(e)
+            })}).await.map_err(Error::from)??
         {
             temp_response.checkpoint_seq = Some(seq);
         }
@@ -666,9 +670,8 @@ impl ReadApiServer for ReadApi {
                 .get_checkpoint_by_sequence_number(checkpoint_seq)
                 .map_err(|e| {
                     error!("Failed to get checkpoint by sequence number: {checkpoint_seq:?} with error: {e:?}");
-                    anyhow!("{e}"
-                )
-                })}).await.map_err(|e|anyhow!(e))??;
+                    Error::from(e)
+                })}).await.map_err(Error::from)??;
                 // TODO(chris): we don't need to fetch the whole checkpoint summary
                 temp_response.timestamp = checkpoint.as_ref().map(|c| c.timestamp_ms);
             }
@@ -686,7 +689,7 @@ impl ReadApiServer for ReadApi {
                         {
                             error!("Failed to call get transaction events for events digest: {event_digest:?} with error {e:?}");
                             Error::from(e)
-                        })}).await.map_err(|e|anyhow!(e))??;
+                        })}).await.map_err(Error::from)??;
                     match to_sui_transaction_events(self, digest, events) {
                         Ok(e) => temp_response.events = Some(e),
                         Err(e) => temp_response.errors.push(e.to_string()),
@@ -800,7 +803,7 @@ impl ReadApiServer for ReadApi {
             vec![]
         };
         Ok(events)
-        }).await.map_err(|e| anyhow!(e))?
+        }).await.map_err(Error::from)?
         })
     }
 
@@ -811,7 +814,9 @@ impl ReadApiServer for ReadApi {
                 .state
                 .get_latest_checkpoint_sequence_number()
                 .map_err(|e| {
-                    anyhow!("Latest checkpoint sequence number was not found with error :{e}")
+                    Error::SuiRpcInputError(SuiRpcInputError::GenericNotFound(format!(
+                        "Latest checkpoint sequence number was not found with error :{e}"
+                    )))
                 })?
                 .into())
         })
@@ -915,11 +920,12 @@ impl ReadApiServer for ReadApi {
         with_tracing!(async move {
             Ok(version
                 .map(|v| {
-                    ProtocolConfig::get_for_version_if_supported((*v).into()).ok_or(anyhow!(
-                    "Unsupported protocol version requested. Min supported: {}, max supported: {}",
-                    ProtocolVersion::MIN.as_u64(),
-                    ProtocolVersion::MAX.as_u64()
-                ))
+                    ProtocolConfig::get_for_version_if_supported((*v).into()).ok_or(
+                        Error::SuiRpcInputError(SuiRpcInputError::ProtocolVersionUnsupported(
+                            ProtocolVersion::MIN.as_u64(),
+                            ProtocolVersion::MAX.as_u64(),
+                        )),
+                    )
                 })
                 .unwrap_or(Ok(self
                     .state
@@ -945,7 +951,7 @@ fn to_sui_transaction_events(
     fullnode_api: &ReadApi,
     tx_digest: TransactionDigest,
     events: TransactionEvents,
-) -> RpcResult<SuiTransactionBlockEvents> {
+) -> Result<SuiTransactionBlockEvents, Error> {
     Ok(SuiTransactionBlockEvents::try_from(
         events,
         tx_digest,
@@ -960,15 +966,14 @@ fn to_sui_transaction_events(
             .load_epoch_store_one_call_per_task()
             .module_cache()
             .as_ref(),
-    )
-    .map_err(Error::SuiError)?)
+    )?)
 }
 
 fn get_display_fields(
     fullnode_api: &ReadApi,
     original_object: &Object,
     original_layout: &Option<MoveStructLayout>,
-) -> RpcResult<DisplayFieldsResponse> {
+) -> Result<DisplayFieldsResponse, Error> {
     let Some((object_type, layout)) = get_object_type_and_struct(original_object, original_layout)? else {
         return Ok(DisplayFieldsResponse { data: None, error: None });
     };
@@ -985,22 +990,19 @@ fn get_display_object_by_type(
     fullnode_api: &ReadApi,
     object_type: &StructTag,
     // TODO: add query version support
-) -> RpcResult<Option<DisplayVersionUpdatedEvent>> {
-    let mut events = fullnode_api
-        .state
-        .query_events(
-            EventFilter::MoveEventType(DisplayVersionUpdatedEvent::type_(object_type)),
-            None,
-            1,
-            true,
-        )
-        .map_err(Error::from)?;
+) -> Result<Option<DisplayVersionUpdatedEvent>, Error> {
+    let mut events = fullnode_api.state.query_events(
+        EventFilter::MoveEventType(DisplayVersionUpdatedEvent::type_(object_type)),
+        None,
+        1,
+        true,
+    )?;
 
     // If there's any recent version of Display, give it to the client.
     // TODO: add support for version query.
     if let Some(event) = events.pop() {
         let display: DisplayVersionUpdatedEvent = bcs::from_bytes(&event.bcs[..])
-            .map_err(|e| anyhow!("Failed to deserialize 'VersionUpdatedEvent': {e}"))?;
+            .map_err(|e| anyhow!("Failed to deserialize 'VersionUpdatedEvent': {e}"))?; // TODO: currently, this is called on a value returned from state. Is this a client or server error?
 
         Ok(Some(display))
     } else {
@@ -1011,7 +1013,7 @@ fn get_display_object_by_type(
 fn get_object_type_and_struct(
     o: &Object,
     layout: &Option<MoveStructLayout>,
-) -> RpcResult<Option<(StructTag, MoveStruct)>> {
+) -> Result<Option<(StructTag, MoveStruct)>, Error> {
     if let Some(object_type) = o.type_() {
         let move_struct = get_move_struct(o, layout)?;
         Ok(Some((object_type.clone().into(), move_struct)))
@@ -1020,39 +1022,46 @@ fn get_object_type_and_struct(
     }
 }
 
-fn get_move_struct(o: &Object, layout: &Option<MoveStructLayout>) -> RpcResult<MoveStruct> {
-    let layout = layout
-        .as_ref()
-        .ok_or_else(|| anyhow!("Failed to extract layout"))?;
+fn get_move_struct(o: &Object, layout: &Option<MoveStructLayout>) -> Result<MoveStruct, Error> {
+    let layout = layout.as_ref().ok_or_else(|| {
+        Error::SuiRpcInputError(SuiRpcInputError::GenericNotFound(
+            "Failed to extract layout".to_string(),
+        ))
+    })?;
     Ok(o.data
         .try_as_move()
-        .ok_or_else(|| anyhow!("Failed to extract Move object"))?
-        .to_move_struct(layout)
-        .map_err(|err| anyhow!("{err}"))?)
+        .ok_or_else(|| {
+            Error::SuiRpcInputError(SuiRpcInputError::GenericNotFound(
+                "Failed to extract Move object".to_string(),
+            ))
+        })?
+        .to_move_struct(layout)?)
 }
 
 pub async fn get_move_module(
     state: &AuthorityState,
     package: ObjectID,
     module_name: String,
-) -> RpcResult<NormalizedModule> {
+) -> Result<NormalizedModule, Error> {
     let normalized = get_move_modules_by_package(state, package).await?;
     Ok(match normalized.get(&module_name) {
         Some(module) => Ok(module.clone()),
-        None => Err(anyhow!("No module found with module name {}", module_name)),
+        None => Err(SuiRpcInputError::GenericNotFound(format!(
+            "No module found with module name {}",
+            module_name
+        ))),
     }?)
 }
 
 pub async fn get_move_modules_by_package(
     state: &AuthorityState,
     package: ObjectID,
-) -> RpcResult<BTreeMap<String, NormalizedModule>> {
-    let object_read = state.get_object_read(&package).map_err(|e| {
+) -> Result<BTreeMap<String, NormalizedModule>, Error> {
+    let object_read = state.get_object_read(&package).tap_err(|_| {
         warn!("Failed to call get_move_modules_by_package for package: {package:?}");
-        anyhow!("{e}")
     })?;
 
-    Ok(match object_read {
+    match object_read {
         ObjectRead::Exists(_obj_ref, object, _layout) => match object.data {
             Data::Package(p) => {
                 // we are on the read path - it's OK to use VERSION_MAX of the supported Move
@@ -1064,20 +1073,24 @@ pub async fn get_move_modules_by_package(
                 )
                 .map_err(|e| {
                     error!("Failed to call get_move_modules_by_package for package: {package:?}");
-                    anyhow!("{e}")
+                    Error::from(e)
                 })
             }
-            _ => Err(anyhow!("Object is not a package with ID {}", package)),
+            _ => Err(Error::SuiRpcInputError(SuiRpcInputError::GenericInvalid(
+                format!("Object is not a package with ID {}", package),
+            ))),
         },
-        _ => Err(anyhow!("Package object does not exist with ID {}", package)),
-    }?)
+        _ => Err(Error::SuiRpcInputError(SuiRpcInputError::GenericNotFound(
+            format!("Package object does not exist with ID {}", package),
+        ))),
+    }
 }
 
 pub fn get_transaction_data_and_digest(
     tx_bytes: Base64,
-) -> RpcResult<(TransactionData, TransactionDigest)> {
+) -> Result<(TransactionData, TransactionDigest), Error> {
     let tx_data =
-        bcs::from_bytes(&tx_bytes.to_vec().map_err(|e| anyhow!(e))?).map_err(|e| anyhow!(e))?;
+        bcs::from_bytes(&tx_bytes.to_vec().map_err(|e| anyhow!(e))?).map_err(Error::from)?; // TODO: is this a client or server error? Only used by dry_run_transaction_block
     let intent_msg = IntentMessage::new(
         Intent {
             version: IntentVersion::V0,
@@ -1093,7 +1106,7 @@ pub fn get_transaction_data_and_digest(
 pub fn get_rendered_fields(
     fields: VecMap<String, String>,
     move_struct: &MoveStruct,
-) -> RpcResult<DisplayFieldsResponse> {
+) -> Result<DisplayFieldsResponse, Error> {
     let sui_move_value: SuiMoveValue = MoveValue::Struct(move_struct.clone()).into();
     if let SuiMoveValue::Struct(move_struct) = sui_move_value {
         let fields =
@@ -1125,10 +1138,12 @@ pub fn get_rendered_fields(
             error,
         });
     }
-    Err(anyhow!("Failed to parse move struct"))?
+    Err(SuiRpcInputError::GenericInvalid(
+        "Failed to parse move struct".to_string(),
+    ))?
 }
 
-fn parse_template(template: &str, move_struct: &SuiMoveStruct) -> RpcResult<String> {
+fn parse_template(template: &str, move_struct: &SuiMoveStruct) -> Result<String, Error> {
     let mut output = template.to_string();
     let mut var_name = String::new();
     let mut in_braces = false;
@@ -1162,7 +1177,10 @@ fn parse_template(template: &str, move_struct: &SuiMoveStruct) -> RpcResult<Stri
     Ok(output.replace('\\', ""))
 }
 
-fn get_value_from_move_struct(move_struct: &SuiMoveStruct, var_name: &str) -> RpcResult<String> {
+fn get_value_from_move_struct(
+    move_struct: &SuiMoveStruct,
+    var_name: &str,
+) -> Result<String, Error> {
     let parts: Vec<&str> = var_name.split('.').collect();
     if parts.is_empty() {
         return Err(anyhow!("Display template value cannot be empty"))?;
@@ -1190,13 +1208,18 @@ fn get_value_from_move_struct(move_struct: &SuiMoveStruct, var_name: &str) -> Rp
                         ))?;
                     }
                 } else {
-                    return Err(anyhow!(
+                    return Err(Error::UnexpectedError(format!(
                         "Unexpected move struct type for field {}",
                         var_name
-                    ))?;
+                    )))?;
                 }
             }
-            _ => return Err(anyhow!("Unexpected move value type for field {}", var_name))?,
+            _ => {
+                return Err(Error::UnexpectedError(format!(
+                    "Unexpected move value type for field {}",
+                    var_name
+                )))?
+            }
         }
     }
 
@@ -1225,7 +1248,7 @@ fn convert_to_response(
     if opts.show_raw_input && cache.transaction.is_some() {
         let sender_signed_data = cache.transaction.as_ref().unwrap().data();
         let raw_tx = bcs::to_bytes(sender_signed_data)
-            .map_err(|e| anyhow!("Failed to serialize raw transaction with error: {}", e))?;
+            .map_err(|e| anyhow!("Failed to serialize raw transaction with error: {}", e))?; // TODO: is this a client or server error?
         response.raw_transaction = raw_tx;
     }
 
@@ -1238,6 +1261,7 @@ fn convert_to_response(
     if opts.show_effects && cache.effects.is_some() {
         let effects = cache.effects.unwrap().try_into().map_err(|e| {
             anyhow!(
+                // TODO: is this a client or server error?
                 "Failed to convert transaction block effects with error: {}",
                 e
             )

--- a/sdk/typescript/test/e2e/object-display-standard.test.ts
+++ b/sdk/typescript/test/e2e/object-display-standard.test.ts
@@ -31,7 +31,7 @@ describe('Test Object Display Standard', () => {
         options: { showDisplay: true },
       }),
     );
-    expect(display).toEqual({
+    const expectedData = {
       data: {
         age: '10',
         buyer: toolbox.address(),
@@ -44,12 +44,14 @@ describe('Test Object Display Standard', () => {
         full_url: 'https://get-a-boar.fullurl.com/',
         escape_syntax: '{name}',
       },
-      error: {
-        code: 'displayError',
-        error:
-          'RPC call failed: Field value idd cannot be found in struct; RPC call failed: Field value namee cannot be found in struct',
-      },
-    });
+    };
+    expect(display).toEqual(expect.objectContaining(expectedData));
+    const errorMessage1 =
+      'RPC call failed: Field value idd cannot be found in struct; RPC call failed: Field value namee cannot be found in struct';
+    const errorMessage2 =
+      'Field value idd cannot be found in struct; Field value namee cannot be found in struct';
+
+    expect([errorMessage1, errorMessage2]).toContain(display.error?.error);
   });
 
   it('Test getting Display fields for object that has no display object', async () => {


### PR DESCRIPTION
## Description 

Replace anyhow errors with Error enum on sui-json-rpc where possible

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
[API behavioral changes] - rpc methods that result in errors of variant `UserInputError`, `SuiRpcInputError`, `SuiError::TransactionNotFound` or `SuiError::TransactionsNotFound` now return error code `-32602` instead of `-32000`. 
