### PR TITLE
[sui-json] Spans for fullnode write paths

### DIFF
--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -28,6 +28,7 @@ use sui_types::quorum_driver_types::{
 use sui_types::signature::GenericSignature;
 use sui_types::sui_serde::BigInt;
 use sui_types::transaction::{Transaction, TransactionData, TransactionDataAPI, TransactionKind};
+use tracing::{error_span, Instrument};
 
 use crate::api::JsonRpcMetrics;
 use crate::api::WriteApiServer;
@@ -217,6 +218,7 @@ impl WriteApiServer for TransactionExecutionApi {
     ) -> RpcResult<SuiTransactionBlockResponse> {
         Ok(self
             .execute_transaction_block(tx_bytes, signatures, opts, request_type)
+            .instrument(error_span!("execute_transaction_block"))
             .await?)
     }
 
@@ -232,6 +234,7 @@ impl WriteApiServer for TransactionExecutionApi {
         Ok(self
             .state
             .dev_inspect_transaction_block(sender_address, tx_kind, gas_price.map(|i| *i))
+            .instrument(error_span!("dev_inspect_transaction_block"))
             .await?)
     }
 
@@ -239,7 +242,10 @@ impl WriteApiServer for TransactionExecutionApi {
         &self,
         tx_bytes: Base64,
     ) -> RpcResult<DryRunTransactionBlockResponse> {
-        Ok(self.dry_run_transaction_block(tx_bytes).await?)
+        Ok(self
+           .dry_run_transaction_block(tx_bytes)
+           .instrument(error_span!("dry_run_transaction_block"))
+           .await?)
     }
 }
 

--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -243,9 +243,9 @@ impl WriteApiServer for TransactionExecutionApi {
         tx_bytes: Base64,
     ) -> RpcResult<DryRunTransactionBlockResponse> {
         Ok(self
-           .dry_run_transaction_block(tx_bytes)
-           .instrument(error_span!("dry_run_transaction_block"))
-           .await?)
+            .dry_run_transaction_block(tx_bytes)
+            .instrument(error_span!("dry_run_transaction_block"))
+            .await?)
     }
 }
 


### PR DESCRIPTION
## Description

Add `error_span!`s to the fullnode write paths to distinguish error messages due to execution, dev-inspect and dry-run.

## Test Plan

Dry run a transaction that would cause an invariant violation, and note that the error that is produced by the fullnode mentions `dev_inspect_transaction_block` in its span:

Test move package:

```move
module example::example {
    use sui::dynamic_object_field as ofield;
    use sui::object::{Self, UID};
    use sui::transfer;
    use sui::tx_context::TxContext;

    struct S has key, store { id: UID  }

    fun init(ctx: &mut TxContext) {
        let parent = S { id: object::new(ctx) };
        let child  = S { id: object::new(ctx) };

        ofield::add(&mut parent.id, 0, child);
        transfer::share_object(parent);
    }

    entry fun f(_s: &S) {}
}
```

JS to dry-run the transaction:

```js
const PACKAGE_ID = /* ... */;
const CHILD = /* ... */;

const tx = new TransactionBlock();
tx.moveCall({
    target: `${PACKAGE_ID}::example::f`,
    arguments: [tx.pure(CHILD)],
});

const provider = new JsonRpcProvider(localnetConnection);
const signer = new RawSigner(keyPair, provider);

const result = await signer.devInspectTransactionBlock({
    transactionBlock: tx,
    options: {
        showEffects: true,
        showObjectChanges: true,
    }
});

console.log(result)
```

Note that the error output from the Sui Node contains the expected error message

```
     # Need to build release because debug builds will panic
sui$ cargo build --bin sui --release
sui$ ~/sui/target/release/sui genesis -f \
  && ~/sui/target/release sui start      \
  |  grep 'INVARIANT VIOLATION!'
2023-05-11T23:30:55.916719Z ERROR node{name=k#84343e5b..}:connection{remote_addr=127.0.0.1:56988 conn_id=4}:dev_inspect_transaction_block: sui_adapter::execution_engine: INVARIANT VIOLATION! Source: Some("ObjectOwner objects cannot be input") kind=InvariantViolation tx_digest=TransactionDigest(5rpcPM1TKWYYLzKDgMq8JCxdYngbMV2uLUWKXVchaMC7)
```