### PR TITLE
[checkpoints] do not assert InMemoryCheckpointRoots on full nodes

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -411,9 +411,12 @@ impl AuthorityPerEpochStore {
         );
         let signature_verifier =
             SignatureVerifier::new(committee.clone(), signature_verifier_metrics);
-        assert!(epoch_start_configuration
-            .flags()
-            .contains(&EpochFlag::InMemoryCheckpointRoots));
+        let is_validator = committee.authority_index(&name).is_some();
+        if is_validator {
+            assert!(epoch_start_configuration
+                .flags()
+                .contains(&EpochFlag::InMemoryCheckpointRoots));
+        }
         let s = Arc::new(Self {
             committee,
             protocol_config,


### PR DESCRIPTION
Full node might restore from some old snapshot - this is fine and does not need to check for InMemoryCheckpointRoots flags

