### PR TITLE
Add tx, package scope. Use Sui meter for verifier

### DIFF
--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -79,6 +79,7 @@ sui-simulator = { path = "../sui-simulator" }
 sui-storage = { path = "../sui-storage" }
 sui-test-transaction-builder = { path = "../sui-test-transaction-builder" }
 sui-types = { path = "../sui-types" }
+sui-verifier = { path = "../../sui-execution/latest/sui-verifier", package = "sui-verifier-latest" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -4,7 +4,6 @@
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use crate::authority::AuthorityStore;
 use crate::transaction_signing_filter;
-use move_bytecode_verifier::meter::BoundMeter;
 use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
 use sui_adapter::adapter::default_verifier_config;
@@ -28,6 +27,7 @@ use sui_types::{
     object::{Object, Owner},
 };
 use sui_types::{SUI_CLOCK_OBJECT_ID, SUI_CLOCK_OBJECT_SHARED_VERSION};
+use sui_verifier::meter::SuiVerifierMeter;
 use tracing::instrument;
 
 checked_arithmetic! {
@@ -415,7 +415,7 @@ pub fn check_non_system_packages_to_be_published(
         let metered_verifier_config =
             default_verifier_config(protocol_config, true /* enable metering */);
         // Use the same meter for all packages
-        let mut meter = BoundMeter::new(&metered_verifier_config);
+        let mut meter = SuiVerifierMeter::new(&metered_verifier_config);
         if let TransactionKind::ProgrammableTransaction(pt) = transaction.kind() {
             // Measure time for verifying all packages in the PTB
             let shared_meter_verifier_timer = metrics.verifier_runtime_per_ptb_success_latency.start_timer();

--- a/crates/sui-core/src/unit_tests/move_package_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_tests.rs
@@ -3,7 +3,7 @@
 
 use move_binary_format::file_format::CompiledModule;
 
-use move_bytecode_verifier::meter::{BoundMeter, Scope};
+use move_bytecode_verifier::meter::Scope;
 use prometheus::Registry;
 use std::{collections::BTreeMap, path::PathBuf, sync::Arc, time::Instant};
 use sui_adapter::adapter::{
@@ -25,6 +25,7 @@ use sui_types::{
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     transaction::{Command, TransactionData, TransactionDataAPI, TransactionKind},
 };
+use sui_verifier::meter::SuiVerifierMeter;
 
 macro_rules! type_origin_table {
     {} => { Vec::new() };
@@ -471,7 +472,7 @@ async fn test_metered_move_bytecode_verifier() {
     );
     let registry = &Registry::new();
     let bytecode_verifier_metrics = Arc::new(BytecodeVerifierMetrics::new(registry));
-    let mut meter = BoundMeter::new(&metered_verifier_config);
+    let mut meter = SuiVerifierMeter::new(&metered_verifier_config);
     let timer_start = Instant::now();
     // Default case should pass
     let r = run_metered_move_bytecode_verifier_impl(
@@ -567,7 +568,7 @@ async fn test_metered_move_bytecode_verifier() {
     metered_verifier_config.max_per_mod_meter_units = Some(10_000);
     metered_verifier_config.max_per_fun_meter_units = Some(10_000);
 
-    let mut meter = BoundMeter::new(&metered_verifier_config);
+    let mut meter = SuiVerifierMeter::new(&metered_verifier_config);
     let timer_start = Instant::now();
     let r = run_metered_move_bytecode_verifier_impl(
         &compiled_modules_bytes,
@@ -704,7 +705,7 @@ async fn test_metered_move_bytecode_verifier() {
     let metered_verifier_config =
         default_verifier_config(&protocol_config, true /* enable metering */);
     // Check if the same meter is indeed used for all modules
-    let mut meter = BoundMeter::new(&metered_verifier_config);
+    let mut meter = SuiVerifierMeter::new(&metered_verifier_config);
     if let TransactionKind::ProgrammableTransaction(pt) = tx_data.kind() {
         pt.non_system_packages_to_be_published()
             .try_for_each(|q| {
@@ -742,7 +743,7 @@ async fn test_meter_system_packages() {
     );
     let registry = &Registry::new();
     let bytecode_verifier_metrics = Arc::new(BytecodeVerifierMetrics::new(registry));
-    let mut meter = BoundMeter::new(&metered_verifier_config);
+    let mut meter = SuiVerifierMeter::new(&metered_verifier_config);
     for system_package in BuiltInFramework::iter_system_packages() {
         run_metered_move_bytecode_verifier_impl(
             &system_package.modules(),
@@ -827,7 +828,7 @@ async fn test_build_and_verify_programmability_examples() {
             .unwrap()
             .into_modules();
 
-        let mut meter = BoundMeter::new(&metered_verifier_config);
+        let mut meter = SuiVerifierMeter::new(&metered_verifier_config);
         run_metered_move_bytecode_verifier_impl(
             &modules,
             &ProtocolConfig::get_for_max_version(),

--- a/external-crates/move/move-bytecode-verifier/src/meter.rs
+++ b/external-crates/move/move-bytecode-verifier/src/meter.rs
@@ -9,6 +9,10 @@ use std::ops::Mul;
 /// Scope of meterinng
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Scope {
+    // Metering is for transaction level
+    Transaction,
+    // Metering is for package level
+    Package,
     // Metering is for module level
     Module,
     // Metering is for function level

--- a/sui-execution/latest/sui-verifier/src/lib.rs
+++ b/sui-execution/latest/sui-verifier/src/lib.rs
@@ -6,6 +6,7 @@ pub mod verifier;
 pub mod entry_points_verifier;
 pub mod global_storage_access_verifier;
 pub mod id_leak_verifier;
+pub mod meter;
 pub mod one_time_witness_verifier;
 pub mod private_generics;
 pub mod struct_with_key_verifier;

--- a/sui-execution/latest/sui-verifier/src/meter.rs
+++ b/sui-execution/latest/sui-verifier/src/meter.rs
@@ -1,0 +1,111 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use move_binary_format::errors::{PartialVMError, PartialVMResult};
+use move_bytecode_verifier::{
+    meter::{Meter, Scope},
+    VerifierConfig,
+};
+use move_core_types::vm_status::StatusCode;
+
+struct SuiVerifierMeterBounds {
+    name: String,
+    ticks: u128,
+    max_ticks: Option<u128>,
+}
+
+impl SuiVerifierMeterBounds {
+    fn add(&mut self, ticks: u128) -> PartialVMResult<()> {
+        if let Some(max_ticks) = self.max_ticks {
+            let new_ticks = self.ticks.saturating_add(ticks);
+            if new_ticks > max_ticks {
+                return Err(PartialVMError::new(StatusCode::CONSTRAINT_NOT_SATISFIED)
+                    .with_message(format!(
+                        "program too complex. Ticks exceeded `{}` will exceed limits: `{} current + {} new > {} max`)",
+                        self.name, self.ticks, ticks, max_ticks
+                    )));
+            }
+            self.ticks = new_ticks;
+        }
+        Ok(())
+    }
+}
+
+pub struct SuiVerifierMeter {
+    transaction_bounds: SuiVerifierMeterBounds,
+    package_bounds: SuiVerifierMeterBounds,
+    module_bounds: SuiVerifierMeterBounds,
+    function_bounds: SuiVerifierMeterBounds,
+}
+
+impl SuiVerifierMeter {
+    pub fn new(config: &VerifierConfig) -> Self {
+        Self {
+            transaction_bounds: SuiVerifierMeterBounds {
+                name: "<unknown>".to_string(),
+                ticks: 0,
+                max_ticks: None,
+            },
+
+            // Not used for now to keep backward compat
+            package_bounds: SuiVerifierMeterBounds {
+                name: "<unknown>".to_string(),
+                ticks: 0,
+                max_ticks: None,
+            },
+            module_bounds: SuiVerifierMeterBounds {
+                name: "<unknown>".to_string(),
+                ticks: 0,
+                max_ticks: config.max_per_mod_meter_units,
+            },
+            function_bounds: SuiVerifierMeterBounds {
+                name: "<unknown>".to_string(),
+                ticks: 0,
+                max_ticks: config.max_per_fun_meter_units,
+            },
+        }
+    }
+
+    fn get_bounds_mut(&mut self, scope: Scope) -> &mut SuiVerifierMeterBounds {
+        match scope {
+            Scope::Transaction => &mut self.transaction_bounds,
+            Scope::Package => &mut self.package_bounds,
+            Scope::Module => &mut self.module_bounds,
+            Scope::Function => &mut self.function_bounds,
+        }
+    }
+
+    fn get_bounds(&self, scope: Scope) -> &SuiVerifierMeterBounds {
+        match scope {
+            Scope::Transaction => &self.transaction_bounds,
+            Scope::Package => &self.package_bounds,
+            Scope::Module => &self.module_bounds,
+            Scope::Function => &self.function_bounds,
+        }
+    }
+
+    pub fn get_usage(&self, scope: Scope) -> u128 {
+        self.get_bounds(scope).ticks
+    }
+
+    pub fn get_limit(&self, scope: Scope) -> Option<u128> {
+        self.get_bounds(scope).max_ticks
+    }
+}
+
+impl Meter for SuiVerifierMeter {
+    fn enter_scope(&mut self, name: &str, scope: Scope) {
+        let bounds = self.get_bounds_mut(scope);
+        bounds.name = name.into();
+        bounds.ticks = 0;
+    }
+
+    fn transfer(&mut self, from: Scope, to: Scope, factor: f32) -> PartialVMResult<()> {
+        let ticks = (self.get_bounds_mut(from).ticks as f32 * factor) as u128;
+        self.add(to, ticks)
+    }
+
+    fn add(&mut self, scope: Scope, ticks: u128) -> PartialVMResult<()> {
+        self.get_bounds_mut(scope).add(ticks)
+    }
+}


### PR DESCRIPTION
## Description 

* Add `Package` and `Transaction` metering scope. Not used yet though to keep functionality same. Will iterate on this in subsequent PR.
* Implement our own meter in Sui so we can fine-tune, log, etc as needed.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
