### PR TITLE
Remove testnet specific logic in replay

### DIFF
--- a/crates/sui-replay/src/types.rs
+++ b/crates/sui-replay/src/types.rs
@@ -19,10 +19,6 @@ use thiserror::Error;
 use tokio::time::Duration;
 use tracing::error;
 
-// These are very testnet specific
-pub(crate) const TESTNET_GENESIX_TX_DIGEST: &str = "Cgww1sn7XViCPSdDcAPmVcARueWuexJ8af8zD842Ff43";
-pub(crate) const SAFE_MODE_TX_1_DIGEST: &str = "AGBCaUGj4iGpGYyQvto9Bke1EwouY8LGMoTzzuPMx4nd";
-
 // TODO: make these configurable
 pub(crate) const RPC_TIMEOUT_ERR_SLEEP_RETRY_PERIOD: Duration = Duration::from_millis(10_000);
 pub(crate) const RPC_TIMEOUT_ERR_NUM_RETRIES: u32 = 3;


### PR DESCRIPTION
## Description 

Since we reset testnet, no need for testnet-specific logic we had to get around the epoch speedrun during safemode.

## Test Plan 

Manual

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
