### PR TITLE
Some cleanups in GenesisConfig

### DIFF
--- a/crates/sui-cluster-test/src/cluster.rs
+++ b/crates/sui-cluster-test/src/cluster.rs
@@ -186,7 +186,7 @@ impl Cluster for LocalNewCluster {
         let genesis_config = if let Some(config) = genesis_config {
             config
         } else {
-            GenesisConfig::custom_genesis(4, 1, 100)
+            GenesisConfig::custom_genesis(1, 100)
         };
         // TODO: options should contain port instead of address
         let fullnode_port = options.fullnode_address.as_ref().map(|addr| {

--- a/crates/sui-config/src/builder.rs
+++ b/crates/sui-config/src/builder.rs
@@ -11,7 +11,7 @@ use crate::node::{
 use crate::node::{StateDebugDumpConfig, DEFAULT_GRPC_CONCURRENCY_LIMIT};
 use crate::{
     genesis,
-    genesis_config::{GenesisConfig, ValidatorConfigInfo},
+    genesis_config::{GenesisConfig, ValidatorGenesisConfig},
     node::AuthorityStorePruningConfig,
     p2p::P2pConfig,
     utils, ConsensusConfig, NetworkConfig, NodeConfig, ValidatorInfo, AUTHORITIES_DB_NAME,
@@ -38,7 +38,7 @@ use sui_types::object::Object;
 
 pub enum CommitteeConfig {
     Size(NonZeroUsize),
-    Validators(Vec<ValidatorConfigInfo>),
+    Validators(Vec<ValidatorGenesisConfig>),
     AccountKeys(Vec<AccountKeyPair>),
 }
 
@@ -139,7 +139,7 @@ impl<R> ConfigBuilder<R> {
         self
     }
 
-    pub fn with_validators(mut self, validators: Vec<ValidatorConfigInfo>) -> Self {
+    pub fn with_validators(mut self, validators: Vec<ValidatorGenesisConfig>) -> Self {
         self.committee = Some(CommitteeConfig::Validators(validators));
         self
     }
@@ -243,11 +243,11 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                                           protocol_key_pair: AuthorityKeyPair,
                                           account_key_pair: AccountKeyPair,
                                           rng: &mut R|
-         -> ValidatorConfigInfo {
+         -> ValidatorGenesisConfig {
             let (worker_key_pair, network_key_pair): (NetworkKeyPair, NetworkKeyPair) =
                 (get_key_pair_from_rng(rng).1, get_key_pair_from_rng(rng).1);
 
-            ValidatorConfigInfo::new(
+            ValidatorGenesisConfig::new(
                 idx,
                 protocol_key_pair,
                 worker_key_pair,
@@ -297,7 +297,7 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
     fn build_with_validators(
         mut self,
         mut rng: R,
-        validators: Vec<ValidatorConfigInfo>,
+        validators: Vec<ValidatorGenesisConfig>,
     ) -> NetworkConfig {
         self.get_or_init_genesis_config();
         let genesis_config = self.genesis_config.unwrap();
@@ -311,11 +311,11 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
             }
             // Add allocations for each validator
             for validator in &validators {
-                let account_key: PublicKey = validator.genesis_info.account_key_pair.public();
+                let account_key: PublicKey = validator.account_key_pair.public();
                 let address = SuiAddress::from(&account_key);
                 let stake = TokenAllocation {
                     recipient_address: address,
-                    amount_mist: validator.genesis_info.stake,
+                    amount_mist: validator.stake,
                     staked_with_validator: Some(address),
                 };
                 builder.add_allocation(stake);
@@ -330,10 +330,10 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
 
             for (i, validator) in validators.iter().enumerate() {
                 let name = format!("validator-{i}");
-                let validator_info = ValidatorInfo::new(name, &validator.genesis_info);
+                let validator_info = ValidatorInfo::new(name, validator);
                 let pop = generate_proof_of_possession(
-                    &validator.genesis_info.key_pair,
-                    (&validator.genesis_info.account_key_pair.public()).into(),
+                    &validator.key_pair,
+                    (&validator.account_key_pair.public()).into(),
                 );
                 builder = builder.add_validator(validator_info, pop);
             }
@@ -341,7 +341,7 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
             builder = builder.with_token_distribution_schedule(token_distribution_schedule);
 
             for validator in &validators {
-                builder = builder.add_validator_signature(&validator.genesis_info.key_pair);
+                builder = builder.add_validator_signature(&validator.key_pair);
             }
 
             builder.build()
@@ -351,15 +351,14 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
             .into_iter()
             .enumerate()
             .map(|(idx, validator)| {
-                let public_key: AuthorityPublicKeyBytes =
-                    validator.genesis_info.key_pair.public().into();
+                let public_key: AuthorityPublicKeyBytes = validator.key_pair.public().into();
                 let mut key_path = Hex::encode(public_key);
                 key_path.truncate(12);
                 let db_path = self
                     .config_directory
                     .join(AUTHORITIES_DB_NAME)
                     .join(key_path.clone());
-                let network_address = validator.genesis_info.network_address;
+                let network_address = validator.network_address;
                 let consensus_address = validator.consensus_address;
                 let consensus_db_path =
                     self.config_directory.join(CONSENSUS_DB_NAME).join(key_path);
@@ -387,23 +386,20 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                             },
                         },
                         prometheus_metrics: PrometheusMetricsParameters {
-                            socket_addr: validator.genesis_info.narwhal_metrics_address,
+                            socket_addr: validator.narwhal_metrics_address,
                         },
                         ..Default::default()
                     },
                 };
 
                 let p2p_config = P2pConfig {
-                    listen_address: validator.genesis_info.p2p_listen_address.unwrap_or_else(
-                        || {
-                            validator
-                                .genesis_info
-                                .p2p_address
-                                .udp_multiaddr_to_listen_address()
-                                .unwrap()
-                        },
-                    ),
-                    external_address: Some(validator.genesis_info.p2p_address),
+                    listen_address: validator.p2p_listen_address.unwrap_or_else(|| {
+                        validator
+                            .p2p_address
+                            .udp_multiaddr_to_listen_address()
+                            .unwrap()
+                    }),
+                    external_address: Some(validator.p2p_address),
                     ..Default::default()
                 };
 
@@ -414,19 +410,17 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                 };
 
                 NodeConfig {
-                    protocol_key_pair: AuthorityKeyPairWithPath::new(
-                        validator.genesis_info.key_pair,
-                    ),
+                    protocol_key_pair: AuthorityKeyPairWithPath::new(validator.key_pair),
                     network_key_pair: KeyPairWithPath::new(SuiKeyPair::Ed25519(
-                        validator.genesis_info.network_key_pair,
+                        validator.network_key_pair,
                     )),
-                    account_key_pair: KeyPairWithPath::new(validator.genesis_info.account_key_pair),
+                    account_key_pair: KeyPairWithPath::new(validator.account_key_pair),
                     worker_key_pair: KeyPairWithPath::new(SuiKeyPair::Ed25519(
-                        validator.genesis_info.worker_key_pair,
+                        validator.worker_key_pair,
                     )),
                     db_path,
                     network_address,
-                    metrics_address: validator.genesis_info.metrics_address,
+                    metrics_address: validator.metrics_address,
                     // TODO: admin server is hard coded to start on 127.0.0.1 - we should probably
                     // provide the entire socket address here to avoid confusion.
                     admin_interface_port: match self.validator_ip_sel {

--- a/crates/sui-config/src/builder.rs
+++ b/crates/sui-config/src/builder.rs
@@ -3,12 +3,12 @@
 
 use crate::genesis::{TokenAllocation, TokenDistributionScheduleBuilder};
 use crate::genesis_config::AccountConfig;
-use crate::node::StateDebugDumpConfig;
 use crate::node::{
     default_enable_index_processing, default_end_of_epoch_broadcast_channel_capacity,
     AuthorityKeyPairWithPath, DBCheckpointConfig, ExpensiveSafetyCheckConfig, KeyPairWithPath,
     DEFAULT_VALIDATOR_GAS_PRICE,
 };
+use crate::node::{StateDebugDumpConfig, DEFAULT_GRPC_CONCURRENCY_LIMIT};
 use crate::{
     genesis,
     genesis_config::{GenesisConfig, ValidatorConfigInfo},
@@ -438,8 +438,8 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                     enable_event_processing: false,
                     enable_index_processing: default_enable_index_processing(),
                     genesis: crate::node::Genesis::new(genesis.clone()),
-                    grpc_load_shed: genesis_config.grpc_load_shed,
-                    grpc_concurrency_limit: genesis_config.grpc_concurrency_limit,
+                    grpc_load_shed: None,
+                    grpc_concurrency_limit: Some(DEFAULT_GRPC_CONCURRENCY_LIMIT),
                     p2p_config,
                     authority_store_pruning_config: AuthorityStorePruningConfig::validator_config(),
                     end_of_epoch_broadcast_channel_capacity:

--- a/crates/sui-config/src/genesis_config.rs
+++ b/crates/sui-config/src/genesis_config.rs
@@ -262,30 +262,16 @@ impl GenesisConfig {
 
     pub fn for_local_testing() -> Self {
         Self::custom_genesis(
-            DEFAULT_NUMBER_OF_AUTHORITIES,
             DEFAULT_NUMBER_OF_ACCOUNT,
             DEFAULT_NUMBER_OF_OBJECT_PER_ACCOUNT,
         )
     }
 
     pub fn for_local_testing_with_addresses(addresses: Vec<SuiAddress>) -> Self {
-        Self::custom_genesis_with_addresses(
-            DEFAULT_NUMBER_OF_AUTHORITIES,
-            addresses,
-            DEFAULT_NUMBER_OF_OBJECT_PER_ACCOUNT,
-        )
+        Self::custom_genesis_with_addresses(addresses, DEFAULT_NUMBER_OF_OBJECT_PER_ACCOUNT)
     }
 
-    pub fn custom_genesis(
-        num_authorities: usize,
-        num_accounts: usize,
-        num_objects_per_account: usize,
-    ) -> Self {
-        assert!(
-            num_authorities > 0,
-            "num_authorities should be larger than 0"
-        );
-
+    pub fn custom_genesis(num_accounts: usize, num_objects_per_account: usize) -> Self {
         let mut accounts = Vec::new();
         for _ in 0..num_accounts {
             accounts.push(AccountConfig {
@@ -301,15 +287,9 @@ impl GenesisConfig {
     }
 
     pub fn custom_genesis_with_addresses(
-        num_authorities: usize,
         addresses: Vec<SuiAddress>,
         num_objects_per_account: usize,
     ) -> Self {
-        assert!(
-            num_authorities > 0,
-            "num_authorities should be larger than 0"
-        );
-
         let mut accounts = Vec::new();
         for address in addresses {
             accounts.push(AccountConfig {

--- a/crates/sui-config/src/genesis_config.rs
+++ b/crates/sui-config/src/genesis_config.rs
@@ -16,9 +16,7 @@ use sui_types::crypto::{
 };
 
 use crate::genesis::{GenesisCeremonyParameters, TokenAllocation};
-use crate::node::{
-    DEFAULT_COMMISSION_RATE, DEFAULT_GRPC_CONCURRENCY_LIMIT, DEFAULT_VALIDATOR_GAS_PRICE,
-};
+use crate::node::{DEFAULT_COMMISSION_RATE, DEFAULT_VALIDATOR_GAS_PRICE};
 use crate::utils;
 use crate::Config;
 
@@ -86,8 +84,6 @@ pub struct GenesisConfig {
     pub validator_config_info: Option<Vec<ValidatorConfigInfo>>,
     pub parameters: GenesisCeremonyParameters,
     pub committee_size: usize,
-    pub grpc_load_shed: Option<bool>,
-    pub grpc_concurrency_limit: Option<usize>,
     pub accounts: Vec<AccountConfig>,
 }
 
@@ -380,8 +376,6 @@ impl GenesisConfig {
             validator_config_info: Some(validator_config_info),
             parameters,
             committee_size: ips.len(),
-            grpc_load_shed: None,
-            grpc_concurrency_limit: None,
             accounts: vec![account_config],
         }
     }
@@ -411,8 +405,6 @@ impl Default for GenesisConfig {
             validator_config_info: None,
             parameters: Default::default(),
             committee_size: 0, // default value indicates the field is not set
-            grpc_load_shed: None,
-            grpc_concurrency_limit: Some(DEFAULT_GRPC_CONCURRENCY_LIMIT),
             accounts: vec![],
         }
     }

--- a/crates/sui-config/src/genesis_config.rs
+++ b/crates/sui-config/src/genesis_config.rs
@@ -79,11 +79,10 @@ impl ValidatorConfigInfo {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Default)]
 pub struct GenesisConfig {
     pub validator_config_info: Option<Vec<ValidatorConfigInfo>>,
     pub parameters: GenesisCeremonyParameters,
-    pub committee_size: usize,
     pub accounts: Vec<AccountConfig>,
 }
 
@@ -375,7 +374,6 @@ impl GenesisConfig {
         GenesisConfig {
             validator_config_info: Some(validator_config_info),
             parameters,
-            committee_size: ips.len(),
             accounts: vec![account_config],
         }
     }
@@ -396,16 +394,5 @@ impl GenesisConfig {
         (0..quantity)
             .map(|_| ObjectID::random_from_rng(&mut rng))
             .collect()
-    }
-}
-
-impl Default for GenesisConfig {
-    fn default() -> Self {
-        Self {
-            validator_config_info: None,
-            parameters: Default::default(),
-            committee_size: 0, // default value indicates the field is not set
-            accounts: vec![],
-        }
     }
 }

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -3,6 +3,7 @@
 
 use crate::certificate_deny_config::CertificateDenyConfig;
 use crate::genesis;
+use crate::genesis_config::ValidatorGenesisInfo;
 use crate::p2p::P2pConfig;
 use crate::transaction_deny_config::TransactionDenyConfig;
 use crate::Config;
@@ -21,12 +22,12 @@ use sui_keys::keypair_file::{read_authority_keypair_from_file, read_keypair_from
 use sui_protocol_config::SupportedProtocolVersions;
 use sui_storage::object_store::ObjectStoreConfig;
 use sui_types::base_types::{ObjectID, SuiAddress};
-use sui_types::crypto::AuthorityPublicKeyBytes;
 use sui_types::crypto::KeypairTraits;
 use sui_types::crypto::NetworkKeyPair;
 use sui_types::crypto::NetworkPublicKey;
 use sui_types::crypto::SuiKeyPair;
 use sui_types::crypto::{get_key_pair_from_rng, AccountKeyPair, AuthorityKeyPair};
+use sui_types::crypto::{AuthorityPublicKeyBytes, PublicKey};
 use sui_types::multiaddr::Multiaddr;
 
 // Default max number of concurrent requests served
@@ -516,6 +517,31 @@ pub struct ValidatorInfo {
 }
 
 impl ValidatorInfo {
+    pub fn new(name: String, genesis_info: &ValidatorGenesisInfo) -> Self {
+        let protocol_key: AuthorityPublicKeyBytes = genesis_info.key_pair.public().into();
+        let account_key: PublicKey = genesis_info.account_key_pair.public();
+        let network_key: NetworkPublicKey = genesis_info.network_key_pair.public().clone();
+        let worker_key: NetworkPublicKey = genesis_info.worker_key_pair.public().clone();
+        let network_address = genesis_info.network_address.clone();
+
+        Self {
+            name,
+            protocol_key,
+            worker_key,
+            network_key,
+            account_address: SuiAddress::from(&account_key),
+            gas_price: genesis_info.gas_price,
+            commission_rate: genesis_info.commission_rate,
+            network_address,
+            p2p_address: genesis_info.p2p_address.clone(),
+            narwhal_primary_address: genesis_info.narwhal_primary_address.clone(),
+            narwhal_worker_address: genesis_info.narwhal_worker_address.clone(),
+            description: String::new(),
+            image_url: String::new(),
+            project_url: String::new(),
+        }
+    }
+
     pub fn name(&self) -> &str {
         &self.name
     }

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -3,7 +3,7 @@
 
 use crate::certificate_deny_config::CertificateDenyConfig;
 use crate::genesis;
-use crate::genesis_config::ValidatorGenesisInfo;
+use crate::genesis_config::ValidatorGenesisConfig;
 use crate::p2p::P2pConfig;
 use crate::transaction_deny_config::TransactionDenyConfig;
 use crate::Config;
@@ -517,12 +517,12 @@ pub struct ValidatorInfo {
 }
 
 impl ValidatorInfo {
-    pub fn new(name: String, genesis_info: &ValidatorGenesisInfo) -> Self {
-        let protocol_key: AuthorityPublicKeyBytes = genesis_info.key_pair.public().into();
-        let account_key: PublicKey = genesis_info.account_key_pair.public();
-        let network_key: NetworkPublicKey = genesis_info.network_key_pair.public().clone();
-        let worker_key: NetworkPublicKey = genesis_info.worker_key_pair.public().clone();
-        let network_address = genesis_info.network_address.clone();
+    pub fn new(name: String, config: &ValidatorGenesisConfig) -> Self {
+        let protocol_key: AuthorityPublicKeyBytes = config.key_pair.public().into();
+        let account_key: PublicKey = config.account_key_pair.public();
+        let network_key: NetworkPublicKey = config.network_key_pair.public().clone();
+        let worker_key: NetworkPublicKey = config.worker_key_pair.public().clone();
+        let network_address = config.network_address.clone();
 
         Self {
             name,
@@ -530,12 +530,12 @@ impl ValidatorInfo {
             worker_key,
             network_key,
             account_address: SuiAddress::from(&account_key),
-            gas_price: genesis_info.gas_price,
-            commission_rate: genesis_info.commission_rate,
+            gas_price: config.gas_price,
+            commission_rate: config.commission_rate,
             network_address,
-            p2p_address: genesis_info.p2p_address.clone(),
-            narwhal_primary_address: genesis_info.narwhal_primary_address.clone(),
-            narwhal_worker_address: genesis_info.narwhal_worker_address.clone(),
+            p2p_address: config.p2p_address.clone(),
+            narwhal_primary_address: config.narwhal_primary_address.clone(),
+            narwhal_worker_address: config.narwhal_worker_address.clone(),
             description: String::new(),
             image_url: String::new(),
             project_url: String::new(),

--- a/crates/sui-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -13,8 +13,6 @@ parameters:
   stake_subsidy_period_length: 10
   stake_subsidy_decrease_rate: 1000
 committee_size: 0
-grpc_load_shed: ~
-grpc_concurrency_limit: 20000000000
 accounts:
   - address: "0x73a6b3c33e2d63383de5c6786cbaca231ff789f4c853af6d54cb883d8780adc0"
     gas_amounts:

--- a/crates/sui-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -12,7 +12,6 @@ parameters:
   stake_subsidy_initial_distribution_amount: 1000000000000000
   stake_subsidy_period_length: 10
   stake_subsidy_decrease_rate: 1000
-committee_size: 0
 accounts:
   - address: "0x73a6b3c33e2d63383de5c6786cbaca231ff789f4c853af6d54cb883d8780adc0"
     gas_amounts:

--- a/crates/sui-swarm/src/memory/swarm.rs
+++ b/crates/sui-swarm/src/memory/swarm.rs
@@ -15,7 +15,7 @@ use std::{
 use sui_config::builder::{
     CommitteeConfig, ConfigBuilder, ProtocolVersionsConfig, SupportedProtocolVersionsCallback,
 };
-use sui_config::genesis_config::{AccountConfig, GenesisConfig, ValidatorConfigInfo};
+use sui_config::genesis_config::{AccountConfig, GenesisConfig, ValidatorGenesisConfig};
 use sui_config::node::DBCheckpointConfig;
 use sui_config::NetworkConfig;
 use sui_node::SuiNodeHandle;
@@ -90,7 +90,7 @@ impl<R> SwarmBuilder<R> {
         self
     }
 
-    pub fn with_validators(mut self, validators: Vec<ValidatorConfigInfo>) -> Self {
+    pub fn with_validators(mut self, validators: Vec<ValidatorGenesisConfig>) -> Self {
         self.committee = CommitteeConfig::Validators(validators);
         self
     }

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -413,27 +413,13 @@ pub async fn genesis(
         genesis_conf.parameters.epoch_duration_ms = epoch_duration_ms;
     }
     let mut network_config = if let Some(validators) = validator_info {
-        if genesis_conf.committee_size != 0 && genesis_conf.committee_size != validators.len() {
-            bail!(
-                "Committee size {} is different from the number of validators {}!",
-                genesis_conf.committee_size,
-                validators.len()
-            );
-        }
         builder
             .with_genesis_config(genesis_conf)
             .with_validators(validators)
             .build()
     } else {
         builder
-            .committee_size(
-                NonZeroUsize::new(if genesis_conf.committee_size != 0 {
-                    genesis_conf.committee_size
-                } else {
-                    DEFAULT_NUMBER_OF_AUTHORITIES
-                })
-                .unwrap(),
-            )
+            .committee_size(NonZeroUsize::new(DEFAULT_NUMBER_OF_AUTHORITIES).unwrap())
             .with_genesis_config(genesis_conf)
             .build()
     };


### PR DESCRIPTION
This PR makes the following clean ups in genesis configs:
1. Removes grpc related fields from genesis config because they are never set differently other than the default value
2. Remove committee_size from genesis config because it's never used.
3. Merge ValidatorConfigInfo and ValidatorGenesisInfo, rename to ValidatorGenesisConfig.
4. Move some initializers into constructors, for clarity