### PR TITLE
[move/fuzz] Fix up verifier fuzz targets after metering changes

### DIFF
--- a/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/binary_samples.rs
+++ b/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/binary_samples.rs
@@ -8,13 +8,15 @@
 
 use crate::unit_tests::production_config;
 use move_binary_format::{errors::VMResult, CompiledModule};
-use move_bytecode_verifier::verifier;
+use move_bytecode_verifier::{meter::BoundMeter, verifier};
 
 #[allow(unused)]
 fn run_binary_test(name: &str, bytes: &str) -> VMResult<()> {
     let bytes = hex::decode(bytes).expect("invalid hex string");
     let m = CompiledModule::deserialize_with_defaults(&bytes).expect("invalid module");
-    verifier::verify_module_with_config_for_test(name, &production_config(), &m)
+    let config = production_config();
+    let mut meter = BoundMeter::new(&config);
+    verifier::verify_module_with_config_for_test(name, &config, &m, &mut meter)
 }
 
 #[cfg(feature = "address32")]

--- a/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/dependencies_tests.rs
+++ b/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/dependencies_tests.rs
@@ -81,7 +81,7 @@ fn mk_script_function_module() -> CompiledModule {
         function_instantiations: vec![],
         field_instantiations: vec![],
     };
-    move_bytecode_verifier::verify_module(&m).unwrap();
+    move_bytecode_verifier::verify_module_unmetered(&m).unwrap();
     m
 }
 
@@ -173,7 +173,7 @@ fn mk_invoking_module(use_generic: bool, valid: bool) -> CompiledModule {
         struct_def_instantiations: vec![],
         field_instantiations: vec![],
     };
-    move_bytecode_verifier::verify_module(&m).unwrap();
+    move_bytecode_verifier::verify_module_unmetered(&m).unwrap();
     m
 }
 
@@ -237,7 +237,7 @@ fn mk_invoking_script(use_generic: bool) -> CompiledScript {
         constant_pool: vec![],
         metadata: vec![],
     };
-    move_bytecode_verifier::verify_script(&s).unwrap();
+    move_bytecode_verifier::verify_script_unmetered(&s).unwrap();
     s
 }
 

--- a/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/large_type_test.rs
+++ b/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/large_type_test.rs
@@ -7,6 +7,7 @@ use move_binary_format::file_format::{
     IdentifierIndex, ModuleHandleIndex, Signature, SignatureIndex, SignatureToken,
     Visibility::Public,
 };
+use move_bytecode_verifier::meter::BoundMeter;
 use move_core_types::{identifier::Identifier, vm_status::StatusCode};
 
 const NUM_LOCALS: u8 = 64;
@@ -143,10 +144,13 @@ fn test_large_types() {
         code.push(Bytecode::Ret);
     }
 
+    let config = production_config();
+    let mut meter = BoundMeter::new(&config);
     let result = move_bytecode_verifier::verify_module_with_config_for_test(
         "test_large_types",
-        &production_config(),
+        &config,
         &m,
+        &mut meter,
     );
     assert_eq!(
         result.unwrap_err().major_status(),

--- a/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/limit_tests.rs
+++ b/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/limit_tests.rs
@@ -4,7 +4,7 @@
 use crate::unit_tests::production_config;
 use move_binary_format::file_format::*;
 use move_bytecode_verifier::{
-    limits::LimitsVerifier, verifier::DEFAULT_MAX_IDENTIFIER_LENGTH,
+    limits::LimitsVerifier, meter::DummyMeter, verifier::DEFAULT_MAX_IDENTIFIER_LENGTH,
     verify_module_with_config_for_test, VerifierConfig,
 };
 use move_core_types::{
@@ -258,6 +258,7 @@ fn big_vec_unpacks() {
             ..Default::default()
         },
         &module,
+        &mut DummyMeter,
     );
     assert_eq!(
         res.unwrap_err().major_status(),

--- a/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/locals.rs
+++ b/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/locals.rs
@@ -7,6 +7,7 @@ use move_binary_format::file_format::{
     IdentifierIndex, ModuleHandleIndex, Signature, SignatureIndex, SignatureToken,
     Visibility::Public,
 };
+use move_bytecode_verifier::meter::BoundMeter;
 use move_core_types::{identifier::Identifier, vm_status::StatusCode};
 
 #[test]
@@ -108,10 +109,13 @@ fn test_locals() {
         code.push(Bytecode::Ret);
     }
 
+    let config = production_config();
+    let mut meter = BoundMeter::new(&config);
     let result = move_bytecode_verifier::verify_module_with_config_for_test(
         "test_locals",
-        &production_config(),
+        &config,
         &m,
+        &mut meter,
     );
     assert_eq!(
         result.unwrap_err().major_status(),

--- a/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/many_back_edges.rs
+++ b/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/many_back_edges.rs
@@ -7,6 +7,7 @@ use move_binary_format::file_format::{
     IdentifierIndex, ModuleHandleIndex, Signature, SignatureIndex, SignatureToken,
     Visibility::Public,
 };
+use move_bytecode_verifier::meter::BoundMeter;
 use move_core_types::{identifier::Identifier, vm_status::StatusCode};
 
 const MAX_BASIC_BLOCKS: u16 = 1024;
@@ -84,10 +85,13 @@ fn many_backedges() {
         code.push(Bytecode::Ret);
     }
 
+    let config = production_config();
+    let mut meter = BoundMeter::new(&config);
     let result = move_bytecode_verifier::verify_module_with_config_for_test(
         "many_backedges",
-        &production_config(),
+        &config,
         &m,
+        &mut meter,
     );
     assert_eq!(
         result.unwrap_err().major_status(),

--- a/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/negative_stack_size_tests.rs
+++ b/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/negative_stack_size_tests.rs
@@ -4,13 +4,14 @@
 
 use crate::support::dummy_procedure_module;
 use move_binary_format::file_format::Bytecode;
+use move_bytecode_verifier::meter::DummyMeter;
 use move_bytecode_verifier::CodeUnitVerifier;
 use move_core_types::vm_status::StatusCode;
 
 #[test]
 fn one_pop_no_push() {
     let module = dummy_procedure_module(vec![Bytecode::Pop, Bytecode::Ret]);
-    let result = CodeUnitVerifier::verify_module(&Default::default(), &module);
+    let result = CodeUnitVerifier::verify_module(&Default::default(), &module, &mut DummyMeter);
     assert_eq!(
         result.unwrap_err().major_status(),
         StatusCode::NEGATIVE_STACK_SIZE_WITHIN_BLOCK
@@ -21,7 +22,7 @@ fn one_pop_no_push() {
 fn one_pop_one_push() {
     // Height: 0 + (-1 + 1) = 0 would have passed original usage verifier
     let module = dummy_procedure_module(vec![Bytecode::ReadRef, Bytecode::Ret]);
-    let result = CodeUnitVerifier::verify_module(&Default::default(), &module);
+    let result = CodeUnitVerifier::verify_module(&Default::default(), &module, &mut DummyMeter);
     assert_eq!(
         result.unwrap_err().major_status(),
         StatusCode::NEGATIVE_STACK_SIZE_WITHIN_BLOCK
@@ -32,7 +33,7 @@ fn one_pop_one_push() {
 fn two_pop_one_push() {
     // Height: 0 + 1 + (-2 + 1) = 0 would have passed original usage verifier
     let module = dummy_procedure_module(vec![Bytecode::LdU64(0), Bytecode::Add, Bytecode::Ret]);
-    let result = CodeUnitVerifier::verify_module(&Default::default(), &module);
+    let result = CodeUnitVerifier::verify_module(&Default::default(), &module, &mut DummyMeter);
     assert_eq!(
         result.unwrap_err().major_status(),
         StatusCode::NEGATIVE_STACK_SIZE_WITHIN_BLOCK
@@ -42,7 +43,7 @@ fn two_pop_one_push() {
 #[test]
 fn two_pop_no_push() {
     let module = dummy_procedure_module(vec![Bytecode::WriteRef, Bytecode::Ret]);
-    let result = CodeUnitVerifier::verify_module(&Default::default(), &module);
+    let result = CodeUnitVerifier::verify_module(&Default::default(), &module, &mut DummyMeter);
     assert_eq!(
         result.unwrap_err().major_status(),
         StatusCode::NEGATIVE_STACK_SIZE_WITHIN_BLOCK

--- a/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/reference_safety_tests.rs
+++ b/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/reference_safety_tests.rs
@@ -8,6 +8,7 @@ use move_binary_format::file_format::{
     IdentifierIndex, ModuleHandleIndex, Signature, SignatureIndex, SignatureToken,
     Visibility::Public,
 };
+use move_bytecode_verifier::meter::BoundMeter;
 use move_core_types::{identifier::Identifier, vm_status::StatusCode};
 
 #[test]
@@ -121,10 +122,13 @@ fn test_bicliques() {
         code.push(Bytecode::Ret);
     }
 
+    let config = production_config();
+    let mut meter = BoundMeter::new(&config);
     let result = move_bytecode_verifier::verify_module_with_config_for_test(
         "test_bicliques",
-        &production_config(),
+        &config,
         &m,
+        &mut meter,
     );
     assert_eq!(
         result.unwrap_err().major_status(),
@@ -240,13 +244,16 @@ fn test_merge_state_large_graph() {
         code.push(Bytecode::Ret);
     }
 
-    let res = move_bytecode_verifier::verify_module_with_config_for_test(
+    let config = production_config();
+    let mut meter = BoundMeter::new(&config);
+    let result = move_bytecode_verifier::verify_module_with_config_for_test(
         "test_merge_state_large_graph",
-        &production_config(),
+        &config,
         &m,
+        &mut meter,
     );
     assert_eq!(
-        res.unwrap_err().major_status(),
+        result.unwrap_err().major_status(),
         StatusCode::CONSTRAINT_NOT_SATISFIED
     );
 }
@@ -328,13 +335,16 @@ fn test_merge_state() {
         code.push(Bytecode::Ret);
     }
 
-    let res = move_bytecode_verifier::verify_module_with_config_for_test(
+    let config = production_config();
+    let mut meter = BoundMeter::new(&config);
+    let result = move_bytecode_verifier::verify_module_with_config_for_test(
         "test_merge_state",
-        &production_config(),
+        &config,
         &m,
+        &mut meter,
     );
     assert_eq!(
-        res.unwrap_err().major_status(),
+        result.unwrap_err().major_status(),
         StatusCode::CONSTRAINT_NOT_SATISFIED
     );
 }
@@ -410,10 +420,13 @@ fn test_copyloc_pop() {
         code.push(Bytecode::Ret);
     }
 
+    let config = production_config();
+    let mut meter = BoundMeter::new(&config);
     let result = move_bytecode_verifier::verify_module_with_config_for_test(
         "test_copyloc_pop",
-        &production_config(),
+        &config,
         &m,
+        &mut meter,
     );
     assert_eq!(
         result.unwrap_err().major_status(),

--- a/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/signature_tests.rs
+++ b/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/signature_tests.rs
@@ -7,7 +7,10 @@ use invalid_mutations::signature::{FieldRefMutation, SignatureRefMutation};
 use move_binary_format::file_format::{
     Bytecode::*, CompiledModule, SignatureToken::*, Visibility::Public, *,
 };
-use move_bytecode_verifier::{verify_module, verify_module_with_config_for_test, SignatureChecker};
+use move_bytecode_verifier::{
+    meter::DummyMeter, verify_module_unmetered, verify_module_with_config_for_test,
+    SignatureChecker,
+};
 use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, vm_status::StatusCode,
 };
@@ -124,7 +127,7 @@ fn no_verify_locals_good() {
             },
         ],
     };
-    assert!(verify_module(&compiled_module_good).is_ok());
+    assert!(verify_module_unmetered(&compiled_module_good).is_ok());
 }
 
 #[test]
@@ -213,8 +216,12 @@ fn big_signature_test() {
     module.serialize(&mut mvbytes).unwrap();
     let module = CompiledModule::deserialize_with_defaults(&mvbytes).unwrap();
 
-    let res =
-        verify_module_with_config_for_test("big_signature_test", &production_config(), &module)
-            .unwrap_err();
+    let res = verify_module_with_config_for_test(
+        "big_signature_test",
+        &production_config(),
+        &module,
+        &mut DummyMeter,
+    )
+    .unwrap_err();
     assert_eq!(res.major_status(), StatusCode::TOO_MANY_TYPE_NODES);
 }

--- a/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/vec_pack_tests.rs
+++ b/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/vec_pack_tests.rs
@@ -6,6 +6,7 @@ use move_binary_format::file_format::{
     empty_module, Bytecode, CodeUnit, FunctionDefinition, FunctionHandle, FunctionHandleIndex,
     IdentifierIndex, ModuleHandleIndex, Signature, SignatureIndex, SignatureToken, Visibility,
 };
+use move_bytecode_verifier::meter::DummyMeter;
 use move_core_types::{identifier::Identifier, vm_status::StatusCode};
 
 fn vec_sig(len: usize) -> SignatureToken {
@@ -63,6 +64,7 @@ fn test_vec_pack() {
         "test_vec_pack",
         &production_config(),
         &m,
+        &mut DummyMeter,
     )
     .unwrap_err();
     assert_eq!(res.major_status(), StatusCode::VALUE_STACK_PUSH_OVERFLOW);

--- a/external-crates/move/move-bytecode-verifier/fuzz/fuzz_targets/code_unit.rs
+++ b/external-crates/move/move-bytecode-verifier/fuzz/fuzz_targets/code_unit.rs
@@ -79,5 +79,5 @@ fuzz_target!(|code_unit: CodeUnit| {
     };
 
     module.function_defs.push(fun_def);
-    let _ = move_bytecode_verifier::verify_module(&module);
+    let _ = move_bytecode_verifier::verify_module_unmetered(&module);
 });

--- a/external-crates/move/move-bytecode-verifier/fuzz/fuzz_targets/compiled_module.rs
+++ b/external-crates/move/move-bytecode-verifier/fuzz/fuzz_targets/compiled_module.rs
@@ -6,5 +6,5 @@ use libfuzzer_sys::fuzz_target;
 use move_binary_format::file_format::CompiledModule;
 
 fuzz_target!(|module: CompiledModule| {
-    let _ = move_bytecode_verifier::verify_module(&module);
+    let _ = move_bytecode_verifier::verify_module_unmetered(&module);
 });

--- a/external-crates/move/move-bytecode-verifier/fuzz/fuzz_targets/mixed.rs
+++ b/external-crates/move/move-bytecode-verifier/fuzz/fuzz_targets/mixed.rs
@@ -93,5 +93,5 @@ fuzz_target!(|mix: Mixed| {
     };
 
     module.function_defs.push(fun_def);
-    let _ = move_bytecode_verifier::verify_module(&module);
+    let _ = move_bytecode_verifier::verify_module_unmetered(&module);
 });

--- a/external-crates/move/move-vm/integration-tests/src/tests/instantiation_tests.rs
+++ b/external-crates/move/move-vm/integration-tests/src/tests/instantiation_tests.rs
@@ -576,7 +576,7 @@ fn make_module(
     };
     // uncomment to see the module generated
     // println!("Module: {:#?}", module);
-    move_bytecode_verifier::verify_module(&module).expect("verification failed");
+    move_bytecode_verifier::verify_module_unmetered(&module).expect("verification failed");
 
     let mut mod_bytes = vec![];
     module

--- a/external-crates/move/move-vm/integration-tests/src/tests/invariant_violation_tests.rs
+++ b/external-crates/move/move-vm/integration-tests/src/tests/invariant_violation_tests.rs
@@ -69,7 +69,7 @@ fn merge_borrow_states_infinite_loop() {
         parameters: SignatureIndex(0),
     };
 
-    move_bytecode_verifier::verify_script(&cs).expect("verify failed");
+    move_bytecode_verifier::verify_script_unmetered(&cs).expect("verify failed");
     let vm = MoveVM::new(vec![]).unwrap();
 
     let storage: InMemoryStorage = InMemoryStorage::new();

--- a/external-crates/move/move-vm/integration-tests/src/tests/leak_tests.rs
+++ b/external-crates/move/move-vm/integration-tests/src/tests/leak_tests.rs
@@ -43,7 +43,7 @@ fn leak_with_abort() {
         parameters: SignatureIndex(0),
     };
 
-    move_bytecode_verifier::verify_script(&cs).expect("verify failed");
+    move_bytecode_verifier::verify_script_unmetered(&cs).expect("verify failed");
     let vm = MoveVM::new(vec![]).unwrap();
 
     let storage: InMemoryStorage = InMemoryStorage::new();


### PR DESCRIPTION
## Description

`verify_module` no longer exists -- fixing the build by using `verify_module_unmetered`.

## Test Plan

This would fail before this change, and now does not:

```
external-crates/move/move-bytecode-verifier/fuzz$ cargo build
```