### PR TITLE
[explorer] validator map followup

### DIFF
--- a/apps/explorer/src/components/validator-map/index.tsx
+++ b/apps/explorer/src/components/validator-map/index.tsx
@@ -88,7 +88,8 @@ export default function ValidatorMap({ minHeight }: Props) {
             }),
         {
             // Some validators will come back as null from the location API
-            select: (validators) => validators.filter((validator: ValidatorMapData) => validator),
+            select: (validators) =>
+                validators.filter((validator: ValidatorMapData) => validator),
         }
     );
 
@@ -189,7 +190,7 @@ export default function ValidatorMap({ minHeight }: Props) {
                                     numberFormatter.format(
                                         validatorData.length
                                     )) ||
-                                '--'
+                                    '--'
                             }
                         </NodeStat>
                         <NodeStat title="Nodes">

--- a/apps/explorer/src/components/validator-map/index.tsx
+++ b/apps/explorer/src/components/validator-map/index.tsx
@@ -92,7 +92,7 @@ export default function ValidatorMap({ minHeight }: Props) {
         ).then((res) => {
             const data = res as ValidatorMapData[];
             setValidatorCount(data.length);
-            // Some validators will come back as null from the API
+            // Some validators will come back as null from the location API
             return data.filter((validator) => validator);
         })
     );

--- a/apps/explorer/src/components/validator-map/index.tsx
+++ b/apps/explorer/src/components/validator-map/index.tsx
@@ -82,13 +82,13 @@ export default function ValidatorMap({ minHeight }: Props) {
         isError,
     } = useQuery(
         ['validator-map'],
-        async () =>
+        async (): Promise<ValidatorMapData[]>  =>
             appsBe(`validator-map`, {
                 network: network.toLowerCase(),
-            }).then((res) => res as ValidatorMapData[]),
+            }),
         {
             // Some validators will come back as null from the location API
-            select: (validators) => validators.filter((validator) => validator),
+            select: (validators) => validators.filter((validator: ValidatorMapData) => validator),
         }
     );
 

--- a/apps/explorer/src/components/validator-map/index.tsx
+++ b/apps/explorer/src/components/validator-map/index.tsx
@@ -82,7 +82,7 @@ export default function ValidatorMap({ minHeight }: Props) {
         isError,
     } = useQuery(
         ['validator-map'],
-        async (): Promise<ValidatorMapData[]>  =>
+        (): Promise<ValidatorMapData[]> =>
             appsBe(`validator-map`, {
                 network: network.toLowerCase(),
             }),
@@ -189,7 +189,7 @@ export default function ValidatorMap({ minHeight }: Props) {
                                     numberFormatter.format(
                                         validatorData.length
                                     )) ||
-                                    '--'
+                                '--'
                             }
                         </NodeStat>
                         <NodeStat title="Nodes">

--- a/apps/explorer/src/components/validator-map/index.tsx
+++ b/apps/explorer/src/components/validator-map/index.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { type QueryKey, useQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { ParentSize } from '@visx/responsive';
 import { TooltipWithBounds, useTooltip } from '@visx/tooltip';
 import React, { type ReactNode, useCallback, useMemo } from 'react';
@@ -81,7 +81,7 @@ export default function ValidatorMap({ minHeight }: Props) {
         isLoading,
         isError,
     } = useQuery({
-        queryKey: 'validator-map' as unknown as QueryKey,
+        queryKey: ['validator-map'],
         queryFn: (): Promise<ValidatorMapData[]> =>
             appsBe('validator-map', {
                 network: network.toLowerCase(),

--- a/apps/explorer/src/components/validator-map/index.tsx
+++ b/apps/explorer/src/components/validator-map/index.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useQuery } from '@tanstack/react-query';
+import { type QueryKey, useQuery } from '@tanstack/react-query';
 import { ParentSize } from '@visx/responsive';
 import { TooltipWithBounds, useTooltip } from '@visx/tooltip';
 import React, { type ReactNode, useCallback, useMemo } from 'react';
@@ -80,18 +80,16 @@ export default function ValidatorMap({ minHeight }: Props) {
         data: validatorData,
         isLoading,
         isError,
-    } = useQuery(
-        ['validator-map'],
-        (): Promise<ValidatorMapData[]> =>
+    } = useQuery({
+        queryKey: 'validator-map' as unknown as QueryKey,
+        queryFn: (): Promise<ValidatorMapData[]> =>
             appsBe('validator-map', {
                 network: network.toLowerCase(),
             }),
-        {
+        select: (validators: ValidatorMapData[]) =>
             // Some validators will come back as null from the location API
-            select: (validators) =>
-                validators.filter((validator: ValidatorMapData) => validator),
-        }
-    );
+            validators.filter((validator: ValidatorMapData) => validator),
+    });
 
     const { countryCount, validatorMap } = useMemo<{
         countryCount: number | null;

--- a/apps/explorer/src/components/validator-map/index.tsx
+++ b/apps/explorer/src/components/validator-map/index.tsx
@@ -83,7 +83,7 @@ export default function ValidatorMap({ minHeight }: Props) {
     } = useQuery(
         ['validator-map'],
         (): Promise<ValidatorMapData[]> =>
-            appsBe(`validator-map`, {
+            appsBe('validator-map', {
                 network: network.toLowerCase(),
             }),
         {

--- a/apps/explorer/src/components/validator-map/index.tsx
+++ b/apps/explorer/src/components/validator-map/index.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { useGetSystemState } from '@mysten/core';
 import { useQuery } from '@tanstack/react-query';
 import { ParentSize } from '@visx/responsive';
 import { TooltipWithBounds, useTooltip } from '@visx/tooltip';
@@ -42,6 +43,8 @@ interface Props {
 // NOTE: This component is lazy imported, so it needs to be default exported:
 export default function ValidatorMap({ minHeight }: Props) {
     const [network] = useNetwork();
+    const { data: systemState, isError: systemStateError } =
+        useGetSystemState();
 
     const appsBe = useAppsBackend();
 
@@ -183,10 +186,10 @@ export default function ValidatorMap({ minHeight }: Props) {
                             )}
                             {
                                 // Fetch received response with no errors and the value was not null
-                                (!isError &&
-                                    validatorData &&
+                                (!systemStateError &&
+                                    systemState &&
                                     numberFormatter.format(
-                                        validatorData.length
+                                        systemState.activeValidators.length
                                     )) ||
                                     '--'
                             }


### PR DESCRIPTION
## Description 

removed the useEffect in favor of useQuery

## Test Plan 

Locally

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
