### PR TITLE
for errors that consist of vectors of errors, return all errors as an object array so downstream clients can handle as desired

### DIFF
--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -109,7 +109,8 @@ impl TransactionExecutionApi {
                 request_type,
             }
         ))
-        .await??;
+        .await?
+        .map_err(Error::from)?;
         drop(orch_timer);
 
         let _post_orch_timer = self.metrics.post_orchestrator_latency_ms.start_timer();

--- a/crates/sui-sdk/src/error.rs
+++ b/crates/sui-sdk/src/error.rs
@@ -12,7 +12,7 @@ pub enum Error {
     #[error(transparent)]
     RpcError(#[from] jsonrpsee::core::Error),
     #[error(transparent)]
-    PcsSerialisationError(#[from] bcs::Error),
+    BcsSerialisationError(#[from] bcs::Error),
     #[error(transparent)]
     UserInputError(#[from] UserInputError),
     #[error("Subscription error : {0}")]


### PR DESCRIPTION
## Description 

Today, when we make an executeTransactionBlock call, we get an rpc error that looks like 

```{"jsonrpc":"2.0","error":{"code":-32000,"message":"Transaction has non recoverable errors from at least 1/3 of validators: [(UserInputError { error: ObjectNotFound { object_id: 0x8ef76f56c399633a2eb310bca9124e5f2f38ce739eaacbb6600688804e078448, version: Some(SequenceNumber(2)) } }, 7500, [k#8dcff6d1.., k#99f25ef6.., k#addeef94..])]."},"id":1}%```
                             
This is difficult to work with: for example, if in the faucet, we want to stop retrying if we receive a `ObjectVersionUnavailableForConsumption` error, we'd need to parse it from the message string.

The source of this comes from transaction orchestrator https://github.com/MystenLabs/sui/blob/main/crates/sui-core/src/transaction_orchestrator.rs#L155 returning QuorumDriverError, specifically,
```
    #[error("Transaction has non recoverable errors from at least 1/3 of validators: {errors:?}.")]
    NonRecoverableTransactionError { errors: GroupedErrors },
```
where GroupedErrors is
`pub type GroupedErrors = Vec<(SuiError, StakeUnit, Vec<ConciseAuthorityPublicKeyBytes>)>;`

In this PR, we modify the error response such that we return
```
{"jsonrpc":"2.0","error":{"code":-32000,"message":"Transaction has non recoverable errors from at least 1/3 of validators","data":[[{"UserInputError":{"error":{"ObjectNotFound":{"object_id":"0x8ef76f56c399633a2eb310bca9124e5f2f38ce739eaacbb6600688804e078448","version":2}}}},7500,["mfJe9h+AMrkUY2RgmCxcxvE07x3a52ZX8sv+wev8jQlzdAgN9vzw3Li8Sw2OCvXYDrv/K0xZn1T0LWMS38MUJ2B4wcw0fru+xRmL4lhRPzhrkw0CwnSagD4jMJVevRoQ","rd7vlNiYyI5A297/kcXxBfnPLHR/tvK8N+wD1ske2y4aV4z1RL6LCTHiXyQ9WbDDDZihbOO6HWzx1/UEJpkusK2zE0sFW+gUDS218l+wDYP45CIr8B/WrJOh/0152ljy","jc/20VUECmVvSBmxMRG1LFdGqGunLzlfuv4uw4R9HoFA5iSnUf32tfIFC8cgXPnTAATJCwx0Cv/TJs5nPMKyOi0k1T4q/rKG38Zo/UBgCJ1tKxe3md02+Q0zLlSnozjU"]]]},"id":1}%                
```  
## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
