### PR TITLE
[faucet] Adding Retry Logic for WAL

### DIFF
--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -307,8 +307,11 @@ impl SimpleFaucet {
                 // retries this transactions will attempt to try again.
                 if let Err(err) = self.wal.lock().await.set_in_flight(coin_id, false) {
                     error!(
+                        ?recipient,
                         ?coin_id,
-                        "Failed to set coin in flight status in WAL: {:?}", err
+                        ?uuid,
+                        "Failed to set coin in flight status in WAL: {:?}",
+                        err
                     );
                 }
 

--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -453,7 +453,7 @@ impl SimpleFaucet {
             .execute_transaction_block(
                 tx.clone(),
                 SuiTransactionBlockResponseOptions::new().with_effects(),
-                Some(ExecuteTransactionRequestType::WaitForEffectsCert),
+                Some(ExecuteTransactionRequestType::WaitForLocalExecution),
             )
             .await
             .tap_err(|e| {

--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -305,9 +305,12 @@ impl SimpleFaucet {
 
                 // We set the inflight status to false so that the async thread that
                 // retries this transactions will attempt to try again.
-                if self.wal.lock().await.set_in_flight(coin_id, false).is_err() {
-                    error!(?coin_id, "Failed to set coin in flight status in WAL");
-                };
+                if let Err(err) = self.wal.lock().await.set_in_flight(coin_id, false) {
+                    error!(
+                        ?coin_id,
+                        "Failed to set coin in flight status in WAL: {:?}", err
+                    );
+                }
 
                 Err(FaucetError::Transfer(
                     "could not complete transfer within timeout".into(),
@@ -618,8 +621,6 @@ mod tests {
     use sui_json_rpc_types::SuiExecutionStatus;
     use sui_sdk::wallet_context::WalletContext;
     use test_utils::network::TestClusterBuilder;
-
-    use crate::faucet;
 
     use super::*;
 

--- a/crates/sui-faucet/src/faucet/write_ahead_log.rs
+++ b/crates/sui-faucet/src/faucet/write_ahead_log.rs
@@ -10,6 +10,7 @@ use typed_store::rocks::{DBMap, TypedStoreError};
 use typed_store::traits::{TableSummary, TypedStoreDebug};
 use typed_store::Map;
 
+use tracing::info;
 use typed_store_derive::DBMapUtils;
 use uuid::Uuid;
 
@@ -114,6 +115,11 @@ impl WriteAheadLog {
         if let Some(mut entry) = self.log.get(&coin)? {
             entry.in_flight = bool;
             self.log.insert(&coin, &entry)?;
+        } else {
+            info!(
+                ?coin,
+                "Attempted to set inflight a coin that was not in the WAL."
+            );
         }
         Ok(())
     }

--- a/crates/sui-faucet/src/faucet/write_ahead_log.rs
+++ b/crates/sui-faucet/src/faucet/write_ahead_log.rs
@@ -120,6 +120,10 @@ impl WriteAheadLog {
                 ?coin,
                 "Attempted to set inflight a coin that was not in the WAL."
             );
+
+            return Err(TypedStoreError::RocksDBError(format!(
+                "Coin object {coin:?} not found in WAL."
+            )));
         }
         Ok(())
     }

--- a/crates/sui-faucet/src/faucet/write_ahead_log.rs
+++ b/crates/sui-faucet/src/faucet/write_ahead_log.rs
@@ -31,6 +31,7 @@ pub struct Entry {
     pub recipient: SuiAddress,
     pub tx: TransactionData,
     pub retry_count: u64,
+    pub in_flight: bool,
 }
 
 impl WriteAheadLog {
@@ -68,6 +69,7 @@ impl WriteAheadLog {
                 recipient,
                 tx,
                 retry_count: 0,
+                in_flight: true,
             },
         )
     }
@@ -99,6 +101,18 @@ impl WriteAheadLog {
     pub(crate) fn increment_retry_count(&mut self, coin: ObjectID) -> Result<(), TypedStoreError> {
         if let Some(mut entry) = self.log.get(&coin)? {
             entry.retry_count += 1;
+            self.log.insert(&coin, &entry)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn set_in_flight(
+        &mut self,
+        coin: ObjectID,
+        bool: bool,
+    ) -> Result<(), TypedStoreError> {
+        if let Some(mut entry) = self.log.get(&coin)? {
+            entry.in_flight = bool;
             self.log.insert(&coin, &entry)?;
         }
         Ok(())

--- a/crates/sui-faucet/src/main.rs
+++ b/crates/sui-faucet/src/main.rs
@@ -110,7 +110,7 @@ async fn main() -> Result<(), anyhow::Error> {
     spawn_monitored_task!(async move {
         info!("Starting task to clear WAL.");
         loop {
-            // Every 300 seconds we try to clear the wal coins
+            // Every config.wal_retry_interval (Default: 300 seconds) we try to clear the wal coins
             tokio::time::sleep(Duration::from_secs(wal_retry_interval)).await;
             app_state.faucet.retry_wal_coins().await.unwrap();
         }

--- a/crates/sui-faucet/src/main.rs
+++ b/crates/sui-faucet/src/main.rs
@@ -59,6 +59,7 @@ async fn main() -> Result<(), anyhow::Error> {
         max_request_per_second,
         wallet_client_timeout_secs,
         ref write_ahead_log,
+        wal_retry_interval,
         ..
     } = config;
 
@@ -106,15 +107,14 @@ async fn main() -> Result<(), anyhow::Error> {
                 .into_inner(),
         );
 
-    // TODO (jian):Investigate this issue later.
-    // spawn_monitored_task!(async move {
-    //     info!("Starting task to clear WAL.");
-    //     loop {
-    //         // Every 300 seconds we try to clear the wal coins
-    //         tokio::time::sleep(Duration::from_secs(wal_retry_interval)).await;
-    //         app_state.faucet.retry_wal_coins().await.unwrap();
-    //     }
-    // });
+    spawn_monitored_task!(async move {
+        info!("Starting task to clear WAL.");
+        loop {
+            // Every 300 seconds we try to clear the wal coins
+            tokio::time::sleep(Duration::from_secs(wal_retry_interval)).await;
+            app_state.faucet.retry_wal_coins().await.unwrap();
+        }
+    });
 
     let addr = SocketAddr::new(IpAddr::V4(host_ip), port);
     info!("listening on {}", addr);


### PR DESCRIPTION
## Description 

Turning back on WAL retry logic with a flag that checks that its already an in_flight request. This way the separate worker thread will never attempt to try the same requests that are already inflight and resulting in a corrupted WAL.

Proof: 
<img width="1128" alt="image" src="https://github.com/MystenLabs/sui/assets/123408603/57f6a2ba-daca-4ff4-80d3-7366d679aa91">


## Test Plan 

How did you test the new or updated feature?

Unit testing + CI/CD
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
