### PR TITLE
[ts-sdk] add try get past object support

### DIFF
--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -45,6 +45,7 @@ import {
   SuiObjectResponseQuery,
   ValidatorsApy,
   MoveCallMetrics,
+  ObjectRead,
 } from '../types';
 import { DynamicFieldName, DynamicFieldPage } from '../types/dynamic_fields';
 import {
@@ -391,6 +392,18 @@ export class JsonRpcProvider {
       'sui_getObject',
       [input.id, input.options],
       SuiObjectResponse,
+    );
+  }
+
+  async tryGetPastObject(input: {
+    id: ObjectId;
+    version: number;
+    options?: SuiObjectDataOptions;
+  }): Promise<ObjectRead> {
+    return await this.client.requestWithType(
+      'sui_tryGetPastObject',
+      [input.id, input.version, input.options],
+      ObjectRead,
     );
   }
 

--- a/sdk/typescript/src/types/objects.ts
+++ b/sdk/typescript/src/types/objects.ts
@@ -16,6 +16,7 @@ import {
   union,
   is,
   nullable,
+  tuple,
 } from 'superstruct';
 import {
   ObjectId,
@@ -474,3 +475,31 @@ export type SuiObjectResponseQuery = {
   filter?: SuiObjectDataFilter;
   options?: SuiObjectDataOptions;
 };
+
+export const ObjectRead = union([
+  object({
+    details: SuiObjectData,
+    status: literal('VersionFound'),
+  }),
+  object({
+    details: ObjectId,
+    status: literal('ObjectNotExists'),
+  }),
+  object({
+    details: SuiObjectRef,
+    status: literal('ObjectDeleted'),
+  }),
+  object({
+    details: tuple([ObjectId, number()]),
+    status: literal('VersionNotFound'),
+  }),
+  object({
+    details: object({
+      asked_version: number(),
+      latest_version: number(),
+      object_id: ObjectId,
+    }),
+    status: literal('VersionTooHigh'),
+  }),
+]);
+export type ObjectRead = Infer<typeof ObjectRead>;

--- a/sdk/typescript/test/e2e/objects.test.ts
+++ b/sdk/typescript/test/e2e/objects.test.ts
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, beforeAll } from 'vitest';
-import { getObjectType, SuiObjectData } from '../../src';
+import {
+  getObjectType,
+  normalizeSuiAddress,
+  SUI_TYPE_ARG,
+  SuiObjectData,
+  TransactionBlock,
+} from '../../src';
 import { setup, TestToolbox } from './utils/setup';
 
 describe('Object Reading API', () => {
@@ -59,5 +65,80 @@ describe('Object Reading API', () => {
         '0x2::coin::Coin<0x2::sui::SUI>',
       ),
     );
+  });
+
+  it('handles trying to get non-existent old objects', async () => {
+    const res = await toolbox.provider.tryGetPastObject({
+      id: normalizeSuiAddress('0x9999'),
+      version: 0,
+    });
+
+    expect(res.status).toBe('ObjectNotExists');
+  });
+
+  it('can read live versions', async () => {
+    const { data } = await toolbox.provider.getCoins({
+      owner: toolbox.address(),
+      coinType: SUI_TYPE_ARG,
+    });
+
+    const res = await toolbox.provider.tryGetPastObject({
+      id: data[0].coinObjectId,
+      version: Number(data[0].version),
+    });
+
+    expect(res.status).toBe('VersionFound');
+  });
+
+  it('handles trying to get a newer version than the latest version', async () => {
+    const { data } = await toolbox.provider.getCoins({
+      owner: toolbox.address(),
+      coinType: SUI_TYPE_ARG,
+    });
+
+    const res = await toolbox.provider.tryGetPastObject({
+      id: data[0].coinObjectId,
+      version: Number(data[0].version) + 1,
+    });
+
+    expect(res.status).toBe('VersionTooHigh');
+  });
+
+  it('handles fetching versions that do not exist', async () => {
+    const { data } = await toolbox.provider.getCoins({
+      owner: toolbox.address(),
+      coinType: SUI_TYPE_ARG,
+    });
+
+    const res = await toolbox.provider.tryGetPastObject({
+      id: data[0].coinObjectId,
+      // NOTE: This works because we know that this is a fresh coin that hasn't been modified:
+      version: Number(data[0].version) - 1,
+    });
+
+    expect(res.status).toBe('VersionNotFound');
+  });
+
+  it('can find old versions of objects', async () => {
+    const { data } = await toolbox.provider.getCoins({
+      owner: toolbox.address(),
+      coinType: SUI_TYPE_ARG,
+    });
+
+    const tx = new TransactionBlock();
+    // Transfer the entire gas object:
+    tx.transferObjects([tx.gas], tx.pure(normalizeSuiAddress('0x2')));
+
+    await toolbox.signer.signAndExecuteTransactionBlock({
+      transactionBlock: tx,
+    });
+
+    const res = await toolbox.provider.tryGetPastObject({
+      id: data[0].coinObjectId,
+      // NOTE: This works because we know that this is a fresh coin that hasn't been modified:
+      version: Number(data[0].version),
+    });
+
+    expect(res.status).toBe('VersionFound');
   });
 });


### PR DESCRIPTION
## Description 

Adds `tryGetPastObject` to the TS SDK

## Test Plan
 
Added tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
