### PR TITLE
move more functions from test util to wallet context

### DIFF
--- a/crates/sui-cluster-test/src/test_case/shared_object_test.rs
+++ b/crates/sui-cluster-test/src/test_case/shared_object_test.rs
@@ -6,7 +6,6 @@ use async_trait::async_trait;
 use sui_json_rpc_types::{SuiExecutionStatus, SuiTransactionBlockEffectsAPI};
 use sui_sdk::wallet_context::WalletContext;
 use sui_types::object::Owner;
-use test_utils::transaction::{increment_counter, publish_basics_package_and_make_counter};
 use tracing::info;
 
 pub struct SharedCounterTest;
@@ -29,10 +28,18 @@ impl TestCaseImpl for SharedCounterTest {
 
         let wallet_context: &WalletContext = ctx.get_wallet();
         let address = ctx.get_wallet_address();
-        let (package_ref, (counter_id, initial_counter_version, _)) =
-            publish_basics_package_and_make_counter(wallet_context, address).await;
-        let response =
-            increment_counter(wallet_context, address, None, package_ref.0, counter_id).await;
+        let (package_ref, (counter_id, initial_counter_version, _)) = wallet_context
+            .publish_basics_package_and_make_counter()
+            .await;
+        let response = wallet_context
+            .increment_counter(
+                address,
+                None,
+                package_ref.0,
+                counter_id,
+                initial_counter_version,
+            )
+            .await;
         assert_eq!(
             *response.effects.as_ref().unwrap().status(),
             SuiExecutionStatus::Success,

--- a/crates/sui-core/src/unit_tests/transaction_deny_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_deny_tests.rs
@@ -30,7 +30,6 @@ use sui_types::transaction::{
 use sui_types::utils::{
     to_sender_signed_transaction, to_sender_signed_transaction_with_multi_signers,
 };
-use test_utils::transaction::make_publish_package;
 
 const ACCOUNT_NUM: usize = 5;
 const GAS_OBJECT_COUNT: usize = 15;
@@ -240,7 +239,10 @@ async fn test_package_publish_disabled() {
     let rgp = state.reference_gas_price_for_testing().unwrap();
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push("src/unit_tests/data/object_basics");
-    let tx = make_publish_package(accounts[0].2[0], path, rgp);
+    let (sender, keypair, gas_object) = (accounts[0].0, &accounts[0].1, accounts[0].2[0]);
+    let tx = TestTransactionBuilder::new(sender, gas_object, rgp)
+        .publish(path)
+        .build_and_sign(keypair);
     let result = state
         .handle_transaction(&state.epoch_store_for_testing(), tx)
         .await;

--- a/crates/sui-cost/tests/empirical_transaction_cost.rs
+++ b/crates/sui-cost/tests/empirical_transaction_cost.rs
@@ -19,7 +19,6 @@ use sui_types::{
     transaction::{CallArg, ObjectArg},
 };
 use test_utils::authority::spawn_test_authorities;
-use test_utils::transaction::make_publish_package;
 use test_utils::{
     authority::test_authority_configs_with_objects,
     transaction::{
@@ -119,11 +118,13 @@ async fn create_txes(
     //
     let mut package_path = PathBuf::from(TEST_DATA_DIR);
     package_path.push("dummy_modules_publish");
-    let publish_tx = make_publish_package(
+    let publish_tx = TestTransactionBuilder::new(
+        sender,
         gas_objects.pop().unwrap().compute_object_reference(),
-        package_path,
         gas_price,
-    );
+    )
+    .publish(package_path)
+    .build_and_sign(keypair);
     ret.insert(CommonTransactionCosts::Publish, publish_tx);
 
     //

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -24,7 +24,7 @@ use sui_node::SuiNode;
 use sui_sdk::wallet_context::WalletContext;
 use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_tool::restore_from_db_checkpoint;
-use sui_types::base_types::ObjectID;
+use sui_types::base_types::{ObjectID, SuiAddress, TransactionDigest};
 use sui_types::base_types::{ObjectRef, SequenceNumber};
 use sui_types::crypto::{get_key_pair, SuiKeyPair};
 use sui_types::event::{Event, EventID};
@@ -46,9 +46,6 @@ use sui_types::utils::{
 use sui_types::SUI_CLOCK_OBJECT_ID;
 use test_utils::authority::test_and_configure_authority_configs;
 use test_utils::network::{start_fullnode_from_config, TestClusterBuilder};
-use test_utils::transaction::{
-    increment_counter, publish_basics_package_and_make_counter, transfer_coin,
-};
 use test_utils::transaction::{wait_for_all_txes, wait_for_tx};
 use tokio::sync::Mutex;
 use tokio::time::timeout;
@@ -66,7 +63,7 @@ async fn test_full_node_follows_txes() -> Result<(), anyhow::Error> {
     // merged we should be able to root out the flakiness.
     sleep(Duration::from_millis(10)).await;
 
-    let (transferred_object, _, receiver, digest, _, _) = transfer_coin(context).await?;
+    let (transferred_object, _, receiver, digest, _) = transfer_coin(context).await?;
 
     wait_for_tx(digest, node.state().clone()).await;
 
@@ -94,9 +91,11 @@ async fn test_full_node_shared_objects() -> Result<(), anyhow::Error> {
     let context = &mut test_cluster.wallet;
 
     let sender = context.config.keystore.addresses().get(0).cloned().unwrap();
-    let (package_ref, counter_ref) = publish_basics_package_and_make_counter(context, sender).await;
+    let (package_ref, counter_ref) = context.publish_basics_package_and_make_counter().await;
 
-    let response = increment_counter(context, sender, None, package_ref.0, counter_ref.0).await;
+    let response = context
+        .increment_counter(sender, None, package_ref.0, counter_ref.0, counter_ref.1)
+        .await;
     let digest = response.digest;
     wait_for_tx(digest, node.state().clone()).await;
 
@@ -116,7 +115,7 @@ async fn test_sponsored_transaction() -> Result<(), anyhow::Error> {
 
     // This makes sender send one coin to sponsor.
     // The sent coin is used as sponsor gas in the following sponsored tx.
-    let (sent_coin, sender_, receiver, _, object_ref, _) = transfer_coin(context).await.unwrap();
+    let (sent_coin, sender_, receiver, _, object_ref) = transfer_coin(context).await.unwrap();
     assert_eq!(sender, sender_);
     assert_eq!(sponsor, receiver);
     let context: &WalletContext = &test_cluster.wallet;
@@ -165,8 +164,10 @@ async fn test_full_node_move_function_index() -> Result<(), anyhow::Error> {
     let sender = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
 
-    let (package_ref, counter_ref) = publish_basics_package_and_make_counter(context, sender).await;
-    let response = increment_counter(context, sender, None, package_ref.0, counter_ref.0).await;
+    let (package_ref, counter_ref) = context.publish_basics_package_and_make_counter().await;
+    let response = context
+        .increment_counter(sender, None, package_ref.0, counter_ref.0, counter_ref.1)
+        .await;
     let digest = response.digest;
 
     wait_for_tx(digest, node.state().clone()).await;
@@ -228,7 +229,7 @@ async fn test_full_node_indexes() -> Result<(), anyhow::Error> {
     let node = &test_cluster.fullnode_handle.sui_node;
     let context = &mut test_cluster.wallet;
 
-    let (transferred_object, sender, receiver, digest, _, _) = transfer_coin(context).await?;
+    let (transferred_object, sender, receiver, digest, _) = transfer_coin(context).await?;
 
     wait_for_tx(digest, node.state().clone()).await;
 
@@ -464,13 +465,11 @@ async fn test_full_node_sync_flood() -> Result<(), anyhow::Error> {
     // Start a new fullnode that is not on the write path
     let node = test_cluster.start_fullnode().await.unwrap().sui_node;
 
-    let sender = test_cluster.get_address_0();
     let context = test_cluster.wallet;
 
     let mut futures = Vec::new();
 
-    let (package_ref, counter_ref) =
-        publish_basics_package_and_make_counter(&context, sender).await;
+    let (package_ref, counter_ref) = context.publish_basics_package_and_make_counter().await;
 
     let context = Arc::new(Mutex::new(context));
 
@@ -519,15 +518,16 @@ async fn test_full_node_sync_flood() -> Result<(), anyhow::Error> {
 
                 let context = &context.lock().await;
                 shared_tx_digest = Some(
-                    increment_counter(
-                        context,
-                        sender,
-                        Some(gas_object_id),
-                        package_ref.0,
-                        counter_ref.0,
-                    )
-                    .await
-                    .digest,
+                    context
+                        .increment_counter(
+                            sender,
+                            Some(gas_object_id),
+                            package_ref.0,
+                            counter_ref.0,
+                            counter_ref.1,
+                        )
+                        .await
+                        .digest,
                 );
             }
             tx.send((owned_tx_digest.unwrap(), shared_tx_digest.unwrap()))
@@ -669,7 +669,7 @@ async fn test_full_node_event_read_api_ok() {
 
     let (package_id, gas_id_1, _) = context.publish_nfts_package().await;
 
-    let (transferred_object, _, _, digest, _, _) = transfer_coin(context).await.unwrap();
+    let (transferred_object, _, _, digest, _) = transfer_coin(context).await.unwrap();
 
     wait_for_tx(digest, node.state().clone()).await;
 
@@ -1161,4 +1161,31 @@ async fn test_pass_back_clock_object() -> Result<(), anyhow::Error> {
     ) = rx.recv().await.unwrap().unwrap();
     assert!(objects.iter().any(|o| o.id() == SUI_CLOCK_OBJECT_ID));
     Ok(())
+}
+
+async fn transfer_coin(
+    context: &mut WalletContext,
+) -> Result<
+    (
+        ObjectID,
+        SuiAddress,
+        SuiAddress,
+        TransactionDigest,
+        ObjectRef,
+    ),
+    anyhow::Error,
+> {
+    let gas_price = context.get_reference_gas_price().await?;
+    let accounts_and_objs = context.get_all_accounts_and_gas_objects().await.unwrap();
+    let sender = accounts_and_objs[0].0;
+    let receiver = accounts_and_objs[1].0;
+    let gas_object = accounts_and_objs[0].1[0];
+    let object_to_send = accounts_and_objs[0].1[1];
+    let txn = context.sign_transaction(
+        &TestTransactionBuilder::new(sender, gas_object, gas_price)
+            .transfer(object_to_send, receiver)
+            .build(),
+    );
+    let resp = context.execute_transaction_block(txn).await?;
+    Ok((object_to_send.0, sender, receiver, resp.digest, gas_object))
 }

--- a/crates/sui/tests/simulator_tests.rs
+++ b/crates/sui/tests/simulator_tests.rs
@@ -15,10 +15,7 @@ use tokio::time::{sleep, Duration, Instant};
 use tracing::{debug, trace};
 
 use sui_macros::*;
-use test_utils::{
-    network::TestClusterBuilder,
-    transaction::{transfer_coin, wait_for_tx},
-};
+use test_utils::{network::TestClusterBuilder, transaction::wait_for_tx};
 
 async fn make_fut(i: usize) -> usize {
     let count_dist = Uniform::from(1..5);
@@ -130,7 +127,8 @@ async fn test_net_determinism() {
     let mut test_cluster = TestClusterBuilder::new().build().await.unwrap();
     let context = &mut test_cluster.wallet;
 
-    let (_transferred_object, _, _, digest, _, _) = transfer_coin(context).await.unwrap();
+    let txn = context.make_transfer_sui_transaction(None, None).await;
+    let digest = context.execute_transaction_block(txn).await.unwrap().digest;
 
     sleep(Duration::from_millis(1000)).await;
 

--- a/crates/test-utils/src/transaction.rs
+++ b/crates/test-utils/src/transaction.rs
@@ -1,43 +1,25 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use serde_json::json;
-use shared_crypto::intent::Intent;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
-use sui::client_commands::{SuiClientCommandResult, SuiClientCommands};
 use sui_core::authority_client::AuthorityAPI;
 pub use sui_core::test_utils::{wait_for_all_txes, wait_for_tx};
-use sui_json_rpc_types::SuiData;
-use sui_json_rpc_types::SuiObjectResponse;
-use sui_json_rpc_types::{
-    SuiObjectDataOptions, SuiObjectResponseQuery, SuiTransactionBlockDataAPI,
-    SuiTransactionBlockEffectsAPI, SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions,
-};
-use sui_keys::keystore::AccountKeystore;
-use sui_sdk::json::SuiJsonValue;
-use sui_sdk::wallet_context::WalletContext;
+use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_types::base_types::ObjectRef;
-use sui_types::base_types::{ObjectID, SuiAddress, TransactionDigest};
 use sui_types::committee::Committee;
 use sui_types::crypto::{deterministic_random_account_key, AuthorityKeyPair};
+use sui_types::effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents};
 use sui_types::error::SuiResult;
 use sui_types::message_envelope::Message;
-use sui_types::transaction::TEST_ONLY_GAS_UNIT_FOR_TRANSFER;
-use sui_types::transaction::{CertifiedTransaction, TEST_ONLY_GAS_UNIT_FOR_GENERIC};
-
-use sui_test_transaction_builder::TestTransactionBuilder;
-use sui_types::effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents};
 use sui_types::messages_grpc::HandleCertificateResponseV2;
 use sui_types::multiaddr::Multiaddr;
 use sui_types::object::{Object, Owner};
-use sui_types::quorum_driver_types::ExecuteTransactionRequestType;
-use sui_types::transaction::{Transaction, VerifiedTransaction};
-use tracing::{debug, info};
+use sui_types::transaction::{CertifiedTransaction, VerifiedTransaction};
 
 use crate::authority::get_client;
 
-pub fn make_publish_package(
+fn make_publish_package(
     gas_object: ObjectRef,
     path: PathBuf,
     gas_price: u64,
@@ -81,204 +63,6 @@ pub async fn publish_counter_package(
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push("../../sui_programmability/examples/basics");
     publish_package(gas_object, path, net_addresses, gas_price).await
-}
-
-/// A helper function to submit a move transaction
-async fn submit_move_transaction(
-    context: &WalletContext,
-    module: &'static str,
-    function: &'static str,
-    package_id: ObjectID,
-    arguments: Vec<SuiJsonValue>,
-    sender: SuiAddress,
-    gas_object: Option<ObjectID>,
-) -> SuiTransactionBlockResponse {
-    debug!(?package_id, ?arguments, "move_transaction");
-    let client = context.get_client().await.unwrap();
-    let gas_price = context.get_reference_gas_price().await.unwrap();
-    let data = client
-        .transaction_builder()
-        .move_call(
-            sender,
-            package_id,
-            module,
-            function,
-            vec![], // type_args
-            arguments,
-            gas_object,
-            TEST_ONLY_GAS_UNIT_FOR_GENERIC * gas_price,
-        )
-        .await
-        .unwrap();
-
-    let signature = context
-        .config
-        .keystore
-        .sign_secure(&sender, &data, Intent::sui_transaction())
-        .unwrap();
-
-    let tx = Transaction::from_data(data, Intent::sui_transaction(), vec![signature])
-        .verify()
-        .unwrap();
-    let tx_digest = tx.digest();
-    debug!(?tx_digest, "submitting move transaction");
-
-    let resp = client
-        .quorum_driver_api()
-        .execute_transaction_block(
-            tx,
-            SuiTransactionBlockResponseOptions::full_content(),
-            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
-        )
-        .await
-        .unwrap();
-    assert!(resp.confirmed_local_execution.unwrap());
-    resp
-}
-
-/// A helper function to publish the basics package and make counter objects
-pub async fn publish_basics_package_and_make_counter(
-    context: &WalletContext,
-    sender: SuiAddress,
-) -> (ObjectRef, ObjectRef) {
-    let package_ref = context.publish_basics_package().await;
-
-    debug!(?package_ref);
-
-    let response = submit_move_transaction(
-        context,
-        "counter",
-        "create",
-        package_ref.0,
-        vec![],
-        sender,
-        None,
-    )
-    .await;
-
-    let counter_ref = response
-        .effects
-        .unwrap()
-        .created()
-        .iter()
-        .find(|obj_ref| matches!(obj_ref.owner, Owner::Shared { .. }))
-        .unwrap()
-        .reference
-        .to_object_ref();
-    debug!(?counter_ref);
-    (package_ref, counter_ref)
-}
-
-pub async fn increment_counter(
-    context: &WalletContext,
-    sender: SuiAddress,
-    gas_object: Option<ObjectID>,
-    package_id: ObjectID,
-    counter_id: ObjectID,
-) -> SuiTransactionBlockResponse {
-    submit_move_transaction(
-        context,
-        "counter",
-        "increment",
-        package_id,
-        vec![SuiJsonValue::new(json!(counter_id.to_hex_literal())).unwrap()],
-        sender,
-        gas_object,
-    )
-    .await
-}
-
-pub async fn transfer_coin(
-    context: &mut WalletContext,
-) -> Result<
-    (
-        ObjectID,
-        SuiAddress,
-        SuiAddress,
-        TransactionDigest,
-        ObjectRef,
-        u64,
-    ),
-    anyhow::Error,
-> {
-    let gas_price = context.get_reference_gas_price().await?;
-    let sender = context.config.keystore.addresses().get(0).cloned().unwrap();
-    let receiver = context.config.keystore.addresses().get(1).cloned().unwrap();
-    let client = context.get_client().await.unwrap();
-    let object_refs: Vec<SuiObjectResponse> = client
-        .read_api()
-        .get_owned_objects(
-            sender,
-            Some(SuiObjectResponseQuery::new_with_options(
-                SuiObjectDataOptions::full_content().with_bcs(),
-            )),
-            None,
-            None,
-        )
-        .await?
-        .data;
-    let object_to_send: ObjectID = object_refs
-        .iter()
-        .find(|resp| {
-            resp.data
-                .as_ref()
-                .unwrap()
-                .bcs
-                .as_ref()
-                .unwrap()
-                .try_as_move()
-                .map(|m| m.has_public_transfer)
-                .unwrap_or(false)
-        })
-        .unwrap()
-        .data
-        .as_ref()
-        .unwrap()
-        .object_id;
-
-    // Send an object
-    info!(
-        "transferring coin {:?} from {:?} -> {:?}",
-        object_to_send, sender, receiver
-    );
-    let res = SuiClientCommands::Transfer {
-        to: receiver,
-        object_id: object_to_send,
-        gas: None,
-        gas_budget: TEST_ONLY_GAS_UNIT_FOR_TRANSFER * gas_price,
-        serialize_unsigned_transaction: false,
-        serialize_signed_transaction: false,
-    }
-    .execute(context)
-    .await?;
-
-    let (digest, gas, gas_used) = if let SuiClientCommandResult::Transfer(response) = res {
-        let effects = response.effects.unwrap();
-        assert!(effects.status().is_ok());
-        let gas_used = effects.gas_cost_summary();
-        (
-            response.digest,
-            response
-                .transaction
-                .unwrap()
-                .data
-                .gas_data()
-                .payment
-                .clone(),
-            gas_used.computation_cost + gas_used.storage_cost - gas_used.storage_rebate,
-        )
-    } else {
-        panic!("transfer command did not return WalletCommandResult::Transfer");
-    };
-
-    Ok((
-        object_to_send,
-        sender,
-        receiver,
-        digest,
-        gas[0].to_object_ref(),
-        gas_used,
-    ))
 }
 
 /// Submit a certificate containing only owned-objects to all authorities.


### PR DESCRIPTION
## Description 

This PR moves all the tests in test-utils/transaction that use `WalletContext` to elsewhere.


---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
