### PR TITLE
verifier: CLI show meter ticks used

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9321,6 +9321,7 @@ dependencies = [
  "sui-test-transaction-builder",
  "sui-tool",
  "sui-types",
+ "sui-verifier-latest",
  "tap",
  "telemetry-subscribers",
  "tempfile",

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -46,6 +46,7 @@ sui-move = { path = "../sui-move", features = ["all"] }
 sui-move-build = { path = "../sui-move-build" }
 sui-protocol-config = { path = "../sui-protocol-config" }
 sui-test-transaction-builder = { path = "../sui-test-transaction-builder" }
+sui-verifier = { path = "../../sui-execution/latest/sui-verifier", package = "sui-verifier-latest" }
 shared-crypto = { path = "../shared-crypto" }
 
 fastcrypto.workspace = true

--- a/sui-execution/latest/sui-verifier/src/meter.rs
+++ b/sui-execution/latest/sui-verifier/src/meter.rs
@@ -16,17 +16,17 @@ struct SuiVerifierMeterBounds {
 
 impl SuiVerifierMeterBounds {
     fn add(&mut self, ticks: u128) -> PartialVMResult<()> {
-        if let Some(max_ticks) = self.max_ticks {
-            let new_ticks = self.ticks.saturating_add(ticks);
-            if new_ticks > max_ticks {
-                return Err(PartialVMError::new(StatusCode::CONSTRAINT_NOT_SATISFIED)
+        let max_ticks = self.max_ticks.unwrap_or(u128::MAX);
+
+        let new_ticks = self.ticks.saturating_add(ticks);
+        if new_ticks >= max_ticks {
+            return Err(PartialVMError::new(StatusCode::CONSTRAINT_NOT_SATISFIED)
                     .with_message(format!(
                         "program too complex. Ticks exceeded `{}` will exceed limits: `{} current + {} new > {} max`)",
                         self.name, self.ticks, ticks, max_ticks
                     )));
-            }
-            self.ticks = new_ticks;
         }
+        self.ticks = new_ticks;
         Ok(())
     }
 }


### PR DESCRIPTION
## Description 

As described. Example

`sui client verify-bytecode-meter  crates/sui-framework/packages/sui-framework/`
```
Running bytecode verifier for 41 modules
                |     Module      |    Function    
------------------------------------------------
      Max       |    16000000     |    16000000    
     Used       |     1393870     |      4130    
```

## Test Plan 

Manual
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
