### PR TITLE
[sui] Fix version output by CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10692,7 +10692,7 @@ dependencies = [
 
 [[package]]
 name = "sui-types"
-version = "0.1.0"
+version = "1.2.0"
 dependencies = [
  "anemo",
  "anyhow",

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sui-types"
-version = "0.1.0"
+version.workspace = true
 authors = ["Mysten Labs <build@mystenlabs.com>"]
 license = "Apache-2.0"
 publish = false


### PR DESCRIPTION
## Description

The `VERSION` constant that populates the output from `sui -V` was recently moved to crate `sui-types` (with fixed version `0.1.0`), from crate `sui` which inherited its version from the workspace (which gets bumped to match the release version).

Have `sui-types` inherit version from workspace as well, to fix the version output.

## Test Plan

```
sui$ cargo run --bin sui -- -V
sui 1.2.0-f6494ee216-dirty
```

Where previously it was:

```
sui 0.1.0-f6494ee216
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Fix the output from `sui -V`, which was incorrectly reporting version `0.1.0`.