### PR TITLE
wallet-ext: update accounts in permissions when they change

### DIFF
--- a/apps/wallet/src/background/index.ts
+++ b/apps/wallet/src/background/index.ts
@@ -84,6 +84,10 @@ Keyring.on('lockedStatusUpdate', keyringStatusCallback);
 Keyring.on('accountsChanged', keyringStatusCallback);
 Keyring.on('activeAccountChanged', keyringStatusCallback);
 
+Keyring.on('accountsChanged', async (accounts) => {
+    await Permissions.ensurePermissionAccountsUpdated(accounts);
+});
+
 Browser.alarms.onAlarm.addListener((alarm) => {
     if (alarm.name === LOCK_ALARM_NAME) {
         Keyring.reviveDone.finally(() => Keyring.lock());


### PR DESCRIPTION
* when deleting accounts (will be supported for Qredo) make sure we clear permissions so we don't report wrong accounts to dapps

part of APPS-760