### PR TITLE
Remove test-utils dep from sui-types and sui-move

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9948,7 +9948,6 @@ dependencies = [
  "sui-types",
  "telemetry-subscribers",
  "tempfile",
- "test-utils",
  "tokio",
  "tracing",
 ]
@@ -10740,7 +10739,6 @@ dependencies = [
  "sui-macros",
  "sui-protocol-config",
  "tap",
- "test-utils",
  "thiserror",
  "tonic",
  "tracing",

--- a/crates/sui-move/Cargo.toml
+++ b/crates/sui-move/Cargo.toml
@@ -55,7 +55,6 @@ sui-core = { path = "../sui-core" }
 sui-macros = { path = "../sui-macros" }
 sui-node = { path = "../sui-node" }
 sui-simulator = { path = "../sui-simulator" }
-test-utils = { path = "../test-utils" }
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["jemalloc-ctl"]

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -64,7 +64,6 @@ proptest-derive = { version = "0.3.0" }
 
 [dev-dependencies]
 bincode = "1.3.3"
-test-utils = { path = "../test-utils" }
 criterion = { version = "0.4.0", features = ["async", "async_tokio"] }
 proptest = "1.0.0"
 proptest-derive = "0.3.0"


### PR DESCRIPTION
We have refactored enough code such that we can get rid of the dependency to test-utils in sui-types.
Removing it here will significantly speed up our builds, because for arbitrary changes we don't have to always rebuild sui-types and sui-framework.
The last bit of the circular dependency is in sui-core, which isn't yet ready to be removed.