### PR TITLE
Network monitor tweak

### DIFF
--- a/apps/core/src/hooks/useAppsBackend.ts
+++ b/apps/core/src/hooks/useAppsBackend.ts
@@ -3,12 +3,7 @@
 
 import { useCallback } from 'react';
 
-import { useNetwork } from '~/context';
-import { Network } from '~/utils/api/DefaultRpcClient';
-
 export function useAppsBackend() {
-    const [network] = useNetwork();
-
     const request = useCallback(
         async <T>(
             path: string,
@@ -17,7 +12,7 @@ export function useAppsBackend() {
         ): Promise<T> => {
             const query = new URLSearchParams(queryString);
             const res = await fetch(
-                network === Network.LOCAL
+                process.env.NODE_ENV === 'development'
                     ? `http://localhost:3003/${path}?${query}`
                     : `https://apps-backend.sui.io/${path}?${query}`,
                 options
@@ -29,7 +24,7 @@ export function useAppsBackend() {
 
             return res.json();
         },
-        [network]
+        []
     );
 
     return { request };

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -28,3 +28,4 @@ export * from './hooks/useOnScreen';
 export * from './hooks/useGetOwnedObjects';
 export * from './hooks/useCopyToClipboard';
 export * from './hooks/useGetOriginByteKioskContents';
+export * from './hooks/useAppsBackend';

--- a/apps/explorer/src/components/Layout/index.tsx
+++ b/apps/explorer/src/components/Layout/index.tsx
@@ -1,10 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useFeatureIsOn } from '@growthbook/growthbook-react';
-import { RpcClientContext } from '@mysten/core';
+import { RpcClientContext, useAppsBackend } from '@mysten/core';
 import { WalletKitProvider } from '@mysten/wallet-kit';
-import { QueryClientProvider } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { Fragment, useMemo } from 'react';
 import { Toaster } from 'react-hot-toast';
@@ -16,13 +15,23 @@ import Header from '../header/Header';
 
 import { NetworkContext, useNetwork } from '~/context';
 import { Banner } from '~/ui/Banner';
-import { DefaultRpcClient } from '~/utils/api/DefaultRpcClient';
-import { queryClient } from '~/utils/queryClient';
+import { DefaultRpcClient, Network } from '~/utils/api/DefaultRpcClient';
 
 export function Layout() {
     const [network, setNetwork] = useNetwork();
     const jsonRpcProvider = useMemo(() => DefaultRpcClient(network), [network]);
-    const networkOutage = useFeatureIsOn('explorer-network-outage');
+    const { request } = useAppsBackend();
+    const { data } = useQuery({
+        queryKey: ['apps-backend', 'monitor-network'],
+        queryFn: () =>
+            request<{ degraded: boolean }>('monitor-network', {
+                project: 'EXPLORER',
+            }),
+        // Keep cached for 2 minutes:
+        staleTime: 2 * 60 * 1000,
+        retry: false,
+        enabled: network === Network.MAINNET,
+    });
 
     usePageView();
 
@@ -34,14 +43,14 @@ export function Layout() {
                 /*autoConnect={false}*/
                 enableUnsafeBurner={import.meta.env.DEV}
             >
-                <QueryClientProvider client={queryClient}>
-                    <RpcClientContext.Provider value={jsonRpcProvider}>
-                        <NetworkContext.Provider value={[network, setNetwork]}>
-                            <div className="w-full">
-                                <Header />
-                                <main className="relative z-10 min-h-screen bg-offwhite">
-                                    <section className="mx-auto max-w-[1440px] px-5 py-10 lg:px-10 2xl:px-0">
-                                        {networkOutage && (
+                <RpcClientContext.Provider value={jsonRpcProvider}>
+                    <NetworkContext.Provider value={[network, setNetwork]}>
+                        <div className="w-full">
+                            <Header />
+                            <main className="relative z-10 min-h-screen bg-offwhite">
+                                <section className="mx-auto max-w-[1440px] px-5 py-10 lg:px-10 2xl:px-0">
+                                    {network === Network.MAINNET &&
+                                        data?.degraded && (
                                             <div className="pb-2.5">
                                                 <Banner
                                                     variant="warning"
@@ -56,39 +65,38 @@ export function Layout() {
                                                 </Banner>
                                             </div>
                                         )}
-                                        <Outlet />
-                                    </section>
-                                </main>
-                                <Footer />
-                            </div>
+                                    <Outlet />
+                                </section>
+                            </main>
+                            <Footer />
+                        </div>
 
-                            <Toaster
-                                position="bottom-center"
-                                gutter={8}
-                                containerStyle={{
-                                    top: 40,
-                                    left: 40,
-                                    bottom: 40,
-                                    right: 40,
-                                }}
-                                toastOptions={{
-                                    duration: 4000,
-                                    success: {
-                                        icon: null,
-                                        className:
-                                            '!bg-success-light !text-success-dark',
-                                    },
-                                    error: {
-                                        icon: null,
-                                        className:
-                                            '!bg-issue-light !text-issue-dark',
-                                    },
-                                }}
-                            />
-                            <ReactQueryDevtools />
-                        </NetworkContext.Provider>
-                    </RpcClientContext.Provider>
-                </QueryClientProvider>
+                        <Toaster
+                            position="bottom-center"
+                            gutter={8}
+                            containerStyle={{
+                                top: 40,
+                                left: 40,
+                                bottom: 40,
+                                right: 40,
+                            }}
+                            toastOptions={{
+                                duration: 4000,
+                                success: {
+                                    icon: null,
+                                    className:
+                                        '!bg-success-light !text-success-dark',
+                                },
+                                error: {
+                                    icon: null,
+                                    className:
+                                        '!bg-issue-light !text-issue-dark',
+                                },
+                            }}
+                        />
+                        <ReactQueryDevtools />
+                    </NetworkContext.Provider>
+                </RpcClientContext.Provider>
             </WalletKitProvider>
         </Fragment>
     );

--- a/apps/explorer/src/components/validator-map/index.tsx
+++ b/apps/explorer/src/components/validator-map/index.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useGetSystemState } from '@mysten/core';
+import { useGetSystemState, useAppsBackend } from '@mysten/core';
 import { useQuery } from '@tanstack/react-query';
 import { ParentSize } from '@visx/responsive';
 import { TooltipWithBounds, useTooltip } from '@visx/tooltip';
@@ -15,7 +15,6 @@ import {
 } from './types';
 
 import { useNetwork } from '~/context';
-import { useAppsBackend } from '~/hooks/useAppsBackend';
 import { Card } from '~/ui/Card';
 import { Heading } from '~/ui/Heading';
 import { Placeholder } from '~/ui/Placeholder';

--- a/apps/explorer/src/hooks/useSuiCoinData.ts
+++ b/apps/explorer/src/hooks/useSuiCoinData.ts
@@ -1,9 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { useAppsBackend } from '@mysten/core';
 import { useQuery } from '@tanstack/react-query';
-
-import { useAppsBackend } from './useAppsBackend';
 
 // TODO: We should consider using tRPC or something for apps-backend
 type CoinData = {

--- a/apps/explorer/src/index.tsx
+++ b/apps/explorer/src/index.tsx
@@ -4,12 +4,14 @@
 import '@fontsource/inter/variable.css';
 import '@fontsource/red-hat-mono/variable.css';
 import { GrowthBookProvider } from '@growthbook/growthbook-react';
+import { QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { RouterProvider } from 'react-router-dom';
 
 import { router } from './pages';
 import { growthbook } from './utils/growthbook';
+import { queryClient } from './utils/queryClient';
 import './utils/sentry';
 import { reportWebVitals } from './utils/vitals';
 
@@ -21,7 +23,9 @@ growthbook.loadFeatures();
 ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
         <GrowthBookProvider growthbook={growthbook}>
-            <RouterProvider router={router} />
+            <QueryClientProvider client={queryClient}>
+                <RouterProvider router={router} />
+            </QueryClientProvider>
         </GrowthBookProvider>
     </React.StrictMode>
 );

--- a/sdk/typescript/src/types/epochs.ts
+++ b/sdk/typescript/src/types/epochs.ts
@@ -1,6 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-import { array, boolean, Infer, nullable, object, string } from 'superstruct';
+import {
+  array,
+  boolean,
+  Infer,
+  nullable,
+  number,
+  object,
+  string,
+} from 'superstruct';
 import { SuiValidatorSummary } from './validator';
 
 export const EndOfEpochInfo = object({
@@ -28,6 +36,7 @@ export const EpochInfo = object({
   firstCheckpointId: string(),
   epochStartTimestamp: string(),
   endOfEpochInfo: nullable(EndOfEpochInfo),
+  referenceGasPrice: nullable(number()),
 });
 
 export type EpochInfo = Infer<typeof EpochInfo>;


### PR DESCRIPTION
## Description 

This shuffles our network monitoring from being a manual feature flag to be endpoint-driven.

One side-effect is that when running locally, the apps backend _always_ uses the local API. Curious if folks are okay with this.

## Test Plan 

Ran locally.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
