### PR TITLE
wallet-ext: add support for displaying qredo accounts

### DIFF
--- a/apps/wallet/src/background/keyring/Account.ts
+++ b/apps/wallet/src/background/keyring/Account.ts
@@ -15,17 +15,20 @@ import {
     type LedgerAccount,
     type SerializedLedgerAccount,
 } from './LedgerAccount';
+import { type QredoAccount, type SerializedQredoAccount } from './QredoAccount';
 
 export enum AccountType {
     IMPORTED = 'IMPORTED',
     DERIVED = 'DERIVED',
     LEDGER = 'LEDGER',
+    QREDO = 'QREDO',
 }
 
 export type SerializedAccount =
     | SerializedImportedAccount
     | SerializedDerivedAccount
-    | SerializedLedgerAccount;
+    | SerializedLedgerAccount
+    | SerializedQredoAccount;
 
 export interface Account {
     readonly type: AccountType;
@@ -51,4 +54,7 @@ export function isDerivedAccount(account: Account): account is DerivedAccount {
 
 export function isLedgerAccount(account: Account): account is LedgerAccount {
     return account.type === AccountType.LEDGER;
+}
+export function isQredoAccount(account: Account): account is QredoAccount {
+    return account.type === AccountType.QREDO;
 }

--- a/apps/wallet/src/background/keyring/DerivedAccount.ts
+++ b/apps/wallet/src/background/keyring/DerivedAccount.ts
@@ -25,7 +25,7 @@ export class DerivedAccount implements Account {
         derivationPath: string;
         keypair: Keypair;
     }) {
-        this.type = AccountType.IMPORTED;
+        this.type = AccountType.DERIVED;
         this.derivationPath = derivationPath;
         this.accountKeypair = new AccountKeypair(keypair);
         this.address = this.accountKeypair.publicKey.toSuiAddress();

--- a/apps/wallet/src/background/keyring/QredoAccount.ts
+++ b/apps/wallet/src/background/keyring/QredoAccount.ts
@@ -1,0 +1,47 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { normalizeSuiAddress, type SuiAddress } from '@mysten/sui.js';
+
+import { type Account, AccountType } from './Account';
+import { type Wallet } from '_src/shared/qredo-api';
+
+export type SerializedQredoAccount = {
+    type: AccountType.QREDO;
+    address: SuiAddress;
+    qredoConnectionID: string;
+    qredoWalletID: string;
+    labels?: Wallet['labels'];
+    derivationPath: null;
+};
+
+export class QredoAccount implements Account {
+    readonly type = AccountType.QREDO;
+    readonly address: SuiAddress;
+    readonly qredoConnectionID: string;
+    readonly qredoWalletID: string;
+    readonly labels: Wallet['labels'];
+
+    constructor({
+        address,
+        qredoConnectionID,
+        qredoWalletID,
+        labels = [],
+    }: Omit<SerializedQredoAccount, 'type' | 'derivationPath'>) {
+        this.address = normalizeSuiAddress(address);
+        this.qredoConnectionID = qredoConnectionID;
+        this.qredoWalletID = qredoWalletID;
+        this.labels = labels;
+    }
+
+    toJSON(): SerializedQredoAccount {
+        return {
+            type: this.type,
+            address: this.address,
+            qredoConnectionID: this.qredoConnectionID,
+            qredoWalletID: this.qredoWalletID,
+            labels: this.labels,
+            derivationPath: null,
+        };
+    }
+}

--- a/apps/wallet/src/ui/app/components/AccountBadge.tsx
+++ b/apps/wallet/src/ui/app/components/AccountBadge.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { BadgeLabel } from './BadgeLabel';
 import { AccountType } from '_src/background/keyring/Account';
-import { Text } from '_src/ui/app/shared/text';
 
 type AccountBadgeProps = {
     accountType: AccountType;
@@ -20,15 +20,12 @@ export function AccountBadge({ accountType }: AccountBadgeProps) {
         case AccountType.DERIVED:
             badgeText = null;
             break;
+        case AccountType.QREDO:
+            badgeText = 'Qredo';
+            break;
         default:
             throw new Error(`Encountered unknown account type ${accountType}`);
     }
 
-    return badgeText ? (
-        <div className="bg-gray-40 rounded-2xl border border-solid border-gray-45 py-1 px-1.5">
-            <Text variant="captionSmallExtra" color="steel-dark">
-                {badgeText}
-            </Text>
-        </div>
-    ) : null;
+    return badgeText ? <BadgeLabel label={badgeText} /> : null;
 }

--- a/apps/wallet/src/ui/app/components/BadgeLabel.tsx
+++ b/apps/wallet/src/ui/app/components/BadgeLabel.tsx
@@ -1,0 +1,20 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { type ReactNode } from 'react';
+
+import { Text } from '_src/ui/app/shared/text';
+
+type BadgeLabelProps = {
+    label: ReactNode;
+};
+
+export function BadgeLabel({ label }: BadgeLabelProps) {
+    return (
+        <div className="bg-gray-40 rounded-2xl border border-solid border-gray-45 py-1 px-1.5">
+            <Text variant="captionSmallExtra" color="steel-dark">
+                {label}
+            </Text>
+        </div>
+    );
+}

--- a/apps/wallet/src/ui/app/components/menu/content/AccountActions.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/AccountActions.tsx
@@ -1,6 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { type ReactNode } from 'react';
+
+import { BadgeLabel } from '../../BadgeLabel';
 import { useNextMenuUrl } from '../hooks';
 import { VerifyLedgerConnectionStatus } from './VerifyLedgerConnectionStatus';
 import {
@@ -16,34 +19,45 @@ export type AccountActionsProps = {
 export function AccountActions({ account }: AccountActionsProps) {
     const exportAccountUrl = useNextMenuUrl(true, `/export/${account.address}`);
 
-    let actionContent: JSX.Element | null = null;
+    let actionContent: ReactNode | null = null;
     switch (account.type) {
         case AccountType.LEDGER:
             actionContent = (
-                <VerifyLedgerConnectionStatus
-                    accountAddress={account.address}
-                    derivationPath={account.derivationPath}
-                />
+                <div>
+                    <VerifyLedgerConnectionStatus
+                        accountAddress={account.address}
+                        derivationPath={account.derivationPath}
+                    />
+                </div>
             );
             break;
         case AccountType.IMPORTED:
         case AccountType.DERIVED:
             actionContent = (
-                <Link
-                    text="Export Private Key"
-                    to={exportAccountUrl}
-                    color="heroDark"
-                    weight="medium"
-                />
+                <div>
+                    <Link
+                        text="Export Private Key"
+                        to={exportAccountUrl}
+                        color="heroDark"
+                        weight="medium"
+                    />
+                </div>
             );
+            break;
+        case AccountType.QREDO:
+            actionContent = account.labels?.length
+                ? account.labels!.map(({ name, value }) => (
+                      <BadgeLabel label={value} key={name} />
+                  ))
+                : null;
             break;
         default:
             throw new Error(`Encountered unknown account type`);
     }
 
     return (
-        <div className="flex flex-row flex-nowrap items-center flex-1">
-            <div>{actionContent}</div>
+        <div className="flex flex-row items-center flex-1 gap-1">
+            {actionContent}
         </div>
     );
 }

--- a/apps/wallet/src/ui/app/components/menu/content/AccountActions.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/AccountActions.tsx
@@ -46,7 +46,7 @@ export function AccountActions({ account }: AccountActionsProps) {
             break;
         case AccountType.QREDO:
             actionContent = account.labels?.length
-                ? account.labels!.map(({ name, value }) => (
+                ? account.labels.map(({ name, value }) => (
                       <BadgeLabel label={value} key={name} />
                   ))
                 : null;

--- a/apps/wallet/src/ui/app/redux/slices/account/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/account/index.ts
@@ -65,6 +65,7 @@ const sortOrderByAccountType = [
     AccountType.DERIVED,
     AccountType.IMPORTED,
     AccountType.LEDGER,
+    AccountType.QREDO,
 ];
 
 const accountsAdapter = createEntityAdapter<SerializedAccount>({


### PR DESCRIPTION
* implements only the display part, the actual work on Keyring side will follow
* to test now just add a mock qredo account in keyring

<img width="363" alt="Screenshot 2023-05-15 at 19 43 09" src="https://github.com/MystenLabs/sui/assets/10210143/e0b42303-a00d-41dd-b508-87d759885da6">
<img width="363" alt="Screenshot 2023-05-15 at 19 44 35" src="https://github.com/MystenLabs/sui/assets/10210143/a249c069-92fe-4ff1-96be-9b515da8e5d6">


part of APPS-760