### PR TITLE
[explorer] - support for kiosk display 

### DIFF
--- a/apps/core/src/hooks/useGetOriginByteKioskContents.ts
+++ b/apps/core/src/hooks/useGetOriginByteKioskContents.ts
@@ -60,6 +60,7 @@ export function useGetOriginByteKioskContents(
                 ids: kioskObjectIds.flat(),
                 options: {
                     showDisplay: true,
+                    showType: true,
                 },
             });
 

--- a/apps/explorer/src/components/OwnedObjects/index.tsx
+++ b/apps/explorer/src/components/OwnedObjects/index.tsx
@@ -1,21 +1,37 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useGetOwnedObjects } from '@mysten/core';
+import {
+    useGetOriginByteKioskContents,
+    useGetOwnedObjects,
+} from '@mysten/core';
+import { useMemo, useState } from 'react';
 
 import OwnedObject from './OwnedObject';
 
-import { Heading } from '~/ui/Heading';
 import { LoadingSpinner } from '~/ui/LoadingSpinner';
 import { Pagination, useCursorPagination } from '~/ui/Pagination';
+import { RadioGroup, RadioOption } from '~/ui/Radio';
+
+const FILTER_OPTIONS = [
+    { label: 'NFTs', value: 'all' },
+    { label: 'Kiosks', value: 'kiosks' },
+];
 
 export function OwnedObjects({ id }: { id: string }) {
+    const [filter, setFilter] = useState('all');
     const ownedObjects = useGetOwnedObjects(id, {
         MatchNone: [{ StructType: '0x2::coin::Coin' }],
     });
+    const { data: kioskContents } = useGetOriginByteKioskContents(id);
 
     const { data, isError, isFetching, pagination } =
         useCursorPagination(ownedObjects);
+
+    const filteredData = useMemo(
+        () => (filter === 'all' ? data?.data : kioskContents),
+        [filter, data, kioskContents]
+    );
 
     if (isError) {
         return (
@@ -27,23 +43,40 @@ export function OwnedObjects({ id }: { id: string }) {
 
     return (
         <div className="flex flex-col gap-4 pt-5">
-            <Heading color="steel-darker" variant="heading4/semibold">
-                NFTs
-            </Heading>
-
+            <RadioGroup
+                className="flex"
+                ariaLabel="transaction filter"
+                value={filter}
+                onChange={setFilter}
+            >
+                {FILTER_OPTIONS.map((filter) => (
+                    <RadioOption
+                        key={filter.value}
+                        value={filter.value}
+                        label={filter.label}
+                        disabled={
+                            filter.value === 'kiosks' && !kioskContents?.length
+                        }
+                    />
+                ))}
+            </RadioGroup>
             {isFetching ? (
                 <LoadingSpinner />
             ) : (
-                <div className="flex max-h-80 flex-col overflow-auto">
-                    <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-                        {data?.data.map((obj) => (
-                            <OwnedObject obj={obj} key={obj?.data?.objectId} />
-                        ))}
+                <>
+                    <div className="flex max-h-80 flex-col overflow-auto">
+                        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                            {filteredData?.map((obj) => (
+                                <OwnedObject
+                                    obj={obj}
+                                    key={obj?.data?.objectId}
+                                />
+                            ))}
+                        </div>
                     </div>
-                </div>
+                    {filter !== 'kiosks' && <Pagination {...pagination} />}
+                </>
             )}
-
-            <Pagination {...pagination} />
         </div>
     );
 }

--- a/apps/explorer/src/ui/Modal/ImageModal.tsx
+++ b/apps/explorer/src/ui/Modal/ImageModal.tsx
@@ -26,7 +26,7 @@ export function ImageModal({
 }: ImageModalProps) {
     return (
         <Modal open={open} onClose={onClose}>
-            <div className="flex flex-col gap-5 overflow-auto">
+            <div className="flex flex-col gap-5">
                 <Image alt={alt} src={src} rounded="none" />
                 <Heading variant="heading2/semibold" color="sui-light" truncate>
                     {title}

--- a/apps/explorer/src/ui/Radio.tsx
+++ b/apps/explorer/src/ui/Radio.tsx
@@ -30,11 +30,11 @@ export type RadioOptionProps = ExtractProps<
 export function RadioOption({ label, children, ...props }: RadioOptionProps) {
     return (
         <HeadlessRadioGroup.Option
-            className="flex cursor-pointer flex-col rounded-md border border-transparent bg-white text-steel-dark hover:text-steel-darker ui-checked:border-steel ui-checked:text-hero-dark"
+            className="flex flex-col rounded-md border border-transparent bg-white text-steel-dark hover:text-steel-darker ui-checked:border-steel  ui-checked:text-hero-dark  ui-disabled:text-gray-60"
             {...props}
         >
             {label && (
-                <HeadlessRadioGroup.Label className="cursor-pointer px-2 py-1 text-captionSmall font-semibold">
+                <HeadlessRadioGroup.Label className="cursor-pointer px-2 py-1 text-captionSmall font-semibold ui-disabled:cursor-default">
                     {label}
                 </HeadlessRadioGroup.Label>
             )}


### PR DESCRIPTION
## Description 

Adds basic support for displaying kiosk items on the Owned Object page. To be improved in the future when we have better RPC support

This is an alternate to #11943 which tried to hack around the pagination logic

[Sample URL](https://explorer-git-mamos-explorer-kiosk-tabs-mysten-labs.vercel.app/address/358d9a1e0b99296a4560ef98f88565b8dcce7d33c7c3d46f75c5058c3a0e524f?network=mainnet)



## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
