### PR TITLE
[sui-json-rpc] fix getter for move object bcs

### DIFF
--- a/crates/sui-json-rpc-types/src/sui_object.rs
+++ b/crates/sui-json-rpc-types/src/sui_object.rs
@@ -93,14 +93,15 @@ impl PartialOrd for SuiObjectResponse {
 
 impl SuiObjectResponse {
     pub fn move_object_bcs(&self) -> Option<&Vec<u8>> {
-        if let Some(data) = &self.data {
-            match &data.bcs {
-                Some(SuiRawData::MoveObject(obj)) => Some(&obj.bcs_bytes),
-                _ => None,
-            };
+        match &self.data {
+            Some(SuiObjectData {
+                bcs: Some(SuiRawData::MoveObject(obj)),
+                ..
+            }) => Some(&obj.bcs_bytes),
+            _ => None,
         }
-        None
     }
+
     pub fn owner(&self) -> Option<Owner> {
         if let Some(data) = &self.data {
             return data.owner;


### PR DESCRIPTION
## Description 

Right now `move_object_bcs` ignores the bcs bytes and just always returns `None`. This PR fixes that.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
