### PR TITLE
add explicit iter range specifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11854,6 +11854,7 @@ dependencies = [
  "tokio",
  "tracing",
  "typed-store-derive",
+ "uint",
  "workspace-hack",
 ]
 

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -146,12 +146,8 @@ impl AuthorityPerpetualTables {
         object_id: ObjectID,
         version: SequenceNumber,
     ) -> Option<Object> {
-        use typed_store::traits::IterRangeBound;
-        let lower_bound = IterRangeBound::Inclusive(ObjectKey::min_for_id(&object_id));
-        let upper_bound = IterRangeBound::Inclusive(ObjectKey::max_for_id(&object_id));
-
         let Ok(iter) = self.objects
-            .iter_with_bounds_extended(lower_bound, upper_bound)
+            .range_iter(ObjectKey::min_for_id(&object_id)..=ObjectKey::max_for_id(&object_id))
             .skip_prior_to(&ObjectKey(object_id, version))else {
             return None
         };

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -146,8 +146,12 @@ impl AuthorityPerpetualTables {
         object_id: ObjectID,
         version: SequenceNumber,
     ) -> Option<Object> {
+        use typed_store::traits::IterRangeBound;
+        let lower_bound = IterRangeBound::Inclusive(ObjectKey::min_for_id(&object_id));
+        let upper_bound = IterRangeBound::Inclusive(ObjectKey::max_for_id(&object_id));
+
         let Ok(iter) = self.objects
-            .iter()
+            .iter_with_bounds_extended(lower_bound, upper_bound)
             .skip_prior_to(&ObjectKey(object_id, version))else {
             return None
         };

--- a/crates/sui-types/src/storage.rs
+++ b/crates/sui-types/src/storage.rs
@@ -705,6 +705,10 @@ impl ObjectKey {
     pub fn max_for_id(id: &ObjectID) -> Self {
         Self(*id, VersionNumber::MAX)
     }
+
+    pub fn min_for_id(id: &ObjectID) -> Self {
+        Self(*id, VersionNumber::MIN)
+    }
 }
 
 impl From<ObjectRef> for ObjectKey {

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -41,6 +41,7 @@ rstest = "0.16.0"
 rand = "0.8.5"
 syn = { version = "1.0.104", features = ["derive"] }
 typed-store-derive = {path = "../typed-store-derive"}
+uint = "0.9.4"
 
 # Most packages should depend on sui-simulator instead of directly on msim, but for typed-store
 # that creates a circular dependency.

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -605,7 +605,7 @@ async fn test_iter_with_bounds(#[values(true, false)] is_transactional: bool) {
 
 #[rstest]
 #[tokio::test]
-async fn test_iter_with_bounds_extended(#[values(true, false)] is_transactional: bool) {
+async fn test_range_iter(#[values(true, false)] is_transactional: bool) {
     let db = open_map(temp_dir(), None, is_transactional);
     let min = u64::MAX - 100;
     let max = u64::MAX;
@@ -614,13 +614,7 @@ async fn test_iter_with_bounds_extended(#[values(true, false)] is_transactional:
             db.insert(&i, &i.to_string()).unwrap();
         }
     }
-    let db_iter = db
-        .iter_with_bounds_extended(
-            IterRangeBound::Inclusive(min),
-            IterRangeBound::Inclusive(max),
-        )
-        .skip_prior_to(&(min + 50))
-        .unwrap();
+    let db_iter = db.range_iter(min..=max).skip_prior_to(&(min + 50)).unwrap();
 
     assert_eq!(
         (min + 49..min + 50)
@@ -640,10 +634,7 @@ async fn test_iter_with_bounds_extended(#[values(true, false)] is_transactional:
     }
 
     // Skip prior to will return an iterator starting with an "unexpected" key if the sought one is not in the table
-    let db_iter = db
-        .iter_with_bounds_extended(IterRangeBound::Inclusive(1), IterRangeBound::Inclusive(99))
-        .skip_prior_to(&50)
-        .unwrap();
+    let db_iter = db.range_iter(1..=99).skip_prior_to(&50).unwrap();
 
     assert_eq!(
         (49..50)
@@ -653,10 +644,7 @@ async fn test_iter_with_bounds_extended(#[values(true, false)] is_transactional:
         db_iter.collect::<Vec<_>>()
     );
 
-    let db_iter = db
-        .iter_with_bounds_extended(IterRangeBound::Inclusive(1), IterRangeBound::Inclusive(99))
-        .skip_prior_to(&1)
-        .unwrap();
+    let db_iter = db.range_iter(1..=99).skip_prior_to(&1).unwrap();
 
     assert_eq!(
         (1..50)
@@ -666,10 +654,7 @@ async fn test_iter_with_bounds_extended(#[values(true, false)] is_transactional:
         db_iter.collect::<Vec<_>>()
     );
 
-    let db_iter = db
-        .iter_with_bounds_extended(IterRangeBound::Exclusive(1), IterRangeBound::Inclusive(99))
-        .skip_prior_to(&2)
-        .unwrap();
+    let db_iter = db.range_iter(2..=99).skip_prior_to(&2).unwrap();
 
     assert_eq!(
         (2..50)
@@ -679,10 +664,7 @@ async fn test_iter_with_bounds_extended(#[values(true, false)] is_transactional:
         db_iter.collect::<Vec<_>>()
     );
 
-    let db_iter = db
-        .iter_with_bounds_extended(IterRangeBound::Exclusive(1), IterRangeBound::Exclusive(99))
-        .skip_prior_to(&2)
-        .unwrap();
+    let db_iter = db.range_iter(2..99).skip_prior_to(&2).unwrap();
 
     assert_eq!(
         (2..50)
@@ -701,27 +683,18 @@ async fn test_iter_with_bounds_extended(#[values(true, false)] is_transactional:
     );
 
     // Skip to a key which is not within the bounds (bound is [1, 50))
-    let db_iter = db
-        .iter_with_bounds_extended(IterRangeBound::Inclusive(1), IterRangeBound::Inclusive(50))
-        .skip_to(&50)
-        .unwrap();
+    let db_iter = db.range_iter(1..=50).skip_to(&50).unwrap();
     assert_eq!(Vec::<(i32, String)>::new(), db_iter.collect::<Vec<_>>());
 
     // Skip to first key in the bound (bound is [1, 49))
-    let db_iter = db
-        .iter_with_bounds_extended(IterRangeBound::Inclusive(1), IterRangeBound::Exclusive(49))
-        .skip_to(&1)
-        .unwrap();
+    let db_iter = db.range_iter(1..49).skip_to(&1).unwrap();
     assert_eq!(
         (1..49).map(|i| (i, i.to_string())).collect::<Vec<_>>(),
         db_iter.collect::<Vec<_>>()
     );
 
     // Skip to a key which is not within the bounds (bound is [1, 50))
-    let db_iter = db
-        .iter_with_bounds_extended(IterRangeBound::Inclusive(1), IterRangeBound::Inclusive(50))
-        .skip_prior_to(&50)
-        .unwrap();
+    let db_iter = db.range_iter(1..=50).skip_prior_to(&50).unwrap();
     assert_eq!(vec![(49, "49".to_string())], db_iter.collect::<Vec<_>>());
 }
 

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -603,6 +603,128 @@ async fn test_iter_with_bounds(#[values(true, false)] is_transactional: bool) {
     assert_eq!(vec![(49, "49".to_string())], db_iter.collect::<Vec<_>>());
 }
 
+#[rstest]
+#[tokio::test]
+async fn test_iter_with_bounds_extended(#[values(true, false)] is_transactional: bool) {
+    let db = open_map(temp_dir(), None, is_transactional);
+    let min = u64::MAX - 100;
+    let max = u64::MAX;
+    for i in min..=max {
+        if i != min + 50 {
+            db.insert(&i, &i.to_string()).unwrap();
+        }
+    }
+    let db_iter = db
+        .iter_with_bounds_extended(
+            IterRangeBound::Inclusive(min),
+            IterRangeBound::Inclusive(max),
+        )
+        .skip_prior_to(&(min + 50))
+        .unwrap();
+
+    assert_eq!(
+        (min + 49..min + 50)
+            .chain(min + 51..=max)
+            .map(|i| (i, i.to_string()))
+            .collect::<Vec<_>>(),
+        db_iter.collect::<Vec<_>>()
+    );
+
+    let db = open_map(temp_dir(), None, is_transactional);
+
+    // Add [1, 50) and (50, 100) in the db
+    for i in 1..100 {
+        if i != 50 {
+            db.insert(&i, &i.to_string()).unwrap();
+        }
+    }
+
+    // Skip prior to will return an iterator starting with an "unexpected" key if the sought one is not in the table
+    let db_iter = db
+        .iter_with_bounds_extended(IterRangeBound::Inclusive(1), IterRangeBound::Inclusive(99))
+        .skip_prior_to(&50)
+        .unwrap();
+
+    assert_eq!(
+        (49..50)
+            .chain(51..100)
+            .map(|i| (i, i.to_string()))
+            .collect::<Vec<_>>(),
+        db_iter.collect::<Vec<_>>()
+    );
+
+    let db_iter = db
+        .iter_with_bounds_extended(IterRangeBound::Inclusive(1), IterRangeBound::Inclusive(99))
+        .skip_prior_to(&1)
+        .unwrap();
+
+    assert_eq!(
+        (1..50)
+            .chain(51..100)
+            .map(|i| (i, i.to_string()))
+            .collect::<Vec<_>>(),
+        db_iter.collect::<Vec<_>>()
+    );
+
+    let db_iter = db
+        .iter_with_bounds_extended(IterRangeBound::Exclusive(1), IterRangeBound::Inclusive(99))
+        .skip_prior_to(&2)
+        .unwrap();
+
+    assert_eq!(
+        (2..50)
+            .chain(51..100)
+            .map(|i| (i, i.to_string()))
+            .collect::<Vec<_>>(),
+        db_iter.collect::<Vec<_>>()
+    );
+
+    let db_iter = db
+        .iter_with_bounds_extended(IterRangeBound::Exclusive(1), IterRangeBound::Exclusive(99))
+        .skip_prior_to(&2)
+        .unwrap();
+
+    assert_eq!(
+        (2..50)
+            .chain(51..99)
+            .map(|i| (i, i.to_string()))
+            .collect::<Vec<_>>(),
+        db_iter.collect::<Vec<_>>()
+    );
+
+    // Same logic in the keys iterator
+    let db_iter = db.keys().skip_prior_to(&50).unwrap();
+
+    assert_eq!(
+        (49..50).chain(51..100).map(Ok).collect::<Vec<_>>(),
+        db_iter.collect::<Vec<_>>()
+    );
+
+    // Skip to a key which is not within the bounds (bound is [1, 50))
+    let db_iter = db
+        .iter_with_bounds_extended(IterRangeBound::Inclusive(1), IterRangeBound::Inclusive(50))
+        .skip_to(&50)
+        .unwrap();
+    assert_eq!(Vec::<(i32, String)>::new(), db_iter.collect::<Vec<_>>());
+
+    // Skip to first key in the bound (bound is [1, 49))
+    let db_iter = db
+        .iter_with_bounds_extended(IterRangeBound::Inclusive(1), IterRangeBound::Exclusive(49))
+        .skip_to(&1)
+        .unwrap();
+    assert_eq!(
+        (1..49).map(|i| (i, i.to_string())).collect::<Vec<_>>(),
+        db_iter.collect::<Vec<_>>()
+    );
+
+    // Skip to a key which is not within the bounds (bound is [1, 50))
+    let db_iter = db
+        .iter_with_bounds_extended(IterRangeBound::Inclusive(1), IterRangeBound::Inclusive(50))
+        .skip_prior_to(&50)
+        .unwrap();
+    assert_eq!(vec![(49, "49".to_string())], db_iter.collect::<Vec<_>>());
+}
+
 #[tokio::test]
 async fn test_is_empty() {
     let db = DBMap::<i32, String>::open(

--- a/crates/typed-store/src/test_db.rs
+++ b/crates/typed-store/src/test_db.rs
@@ -281,6 +281,14 @@ where
         unimplemented!("umplemented API");
     }
 
+    fn iter_with_bounds_extended(
+        &'a self,
+        _lower_bound: crate::traits::IterRangeBound<K>,
+        _upper_bound: crate::traits::IterRangeBound<K>,
+    ) -> Self::Iterator {
+        unimplemented!("umplemented API");
+    }
+
     fn safe_iter(&'a self) -> Self::SafeIterator {
         TestDBIterBuilder {
             rows: self.rows.read().unwrap(),

--- a/crates/typed-store/src/test_db.rs
+++ b/crates/typed-store/src/test_db.rs
@@ -6,6 +6,7 @@ use std::{
     borrow::Borrow,
     collections::{btree_map::Iter, BTreeMap, HashMap, VecDeque},
     marker::PhantomData,
+    ops::RangeBounds,
     sync::{Arc, RwLock},
 };
 
@@ -281,11 +282,7 @@ where
         unimplemented!("umplemented API");
     }
 
-    fn iter_with_bounds_extended(
-        &'a self,
-        _lower_bound: crate::traits::IterRangeBound<K>,
-        _upper_bound: crate::traits::IterRangeBound<K>,
-    ) -> Self::Iterator {
+    fn range_iter(&'a self, _range: impl RangeBounds<K>) -> Self::Iterator {
         unimplemented!("umplemented API");
     }
 

--- a/crates/typed-store/src/traits.rs
+++ b/crates/typed-store/src/traits.rs
@@ -3,6 +3,7 @@
 use crate::TypedStoreError;
 use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};
+use std::ops::RangeBounds;
 use std::{borrow::Borrow, collections::BTreeMap, error::Error};
 
 pub trait Map<'a, K, V>
@@ -63,11 +64,7 @@ where
 
     /// Similar to `iter_with_bounds` but allows specifying inclusivity/exclusivity of ranges explicitly.
     /// TODO: find better name
-    fn iter_with_bounds_extended(
-        &'a self,
-        lower_bound: IterRangeBound<K>,
-        upper_bound: IterRangeBound<K>,
-    ) -> Self::Iterator;
+    fn range_iter(&'a self, range: impl RangeBounds<K>) -> Self::Iterator;
 
     /// Same as `iter` but performs status check
     fn safe_iter(&'a self) -> Self::SafeIterator;
@@ -136,14 +133,6 @@ where
 
     /// Try to catch up with primary when running as secondary
     fn try_catch_up_with_primary(&self) -> Result<(), Self::Error>;
-}
-
-pub enum IterRangeBound<K>
-where
-    K: Serialize + DeserializeOwned + ?Sized,
-{
-    Inclusive(K),
-    Exclusive(K),
 }
 
 #[async_trait]

--- a/crates/typed-store/src/traits.rs
+++ b/crates/typed-store/src/traits.rs
@@ -61,6 +61,14 @@ where
     fn iter_with_bounds(&'a self, lower_bound: Option<K>, upper_bound: Option<K>)
         -> Self::Iterator;
 
+    /// Similar to `iter_with_bounds` but allows specifying inclusivity/exclusivity of ranges explicitly.
+    /// TODO: find better name
+    fn iter_with_bounds_extended(
+        &'a self,
+        lower_bound: IterRangeBound<K>,
+        upper_bound: IterRangeBound<K>,
+    ) -> Self::Iterator;
+
     /// Same as `iter` but performs status check
     fn safe_iter(&'a self) -> Self::SafeIterator;
 
@@ -128,6 +136,14 @@ where
 
     /// Try to catch up with primary when running as secondary
     fn try_catch_up_with_primary(&self) -> Result<(), Self::Error>;
+}
+
+pub enum IterRangeBound<K>
+where
+    K: Serialize + DeserializeOwned + ?Sized,
+{
+    Inclusive(K),
+    Exclusive(K),
 }
 
 #[async_trait]


### PR DESCRIPTION
## Description 

Specify iter range keys with `std::ops::RangeBounds`
Next PR cleans up parts of the code that could use more constrained bounds

## Test Plan 

Unit tests
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
