### PR TITLE
Push types to type stack when calling a native

### DIFF
--- a/crates/sui-core/src/authority/authority_test_utils.rs
+++ b/crates/sui-core/src/authority/authority_test_utils.rs
@@ -186,6 +186,24 @@ pub async fn init_state_with_object_id(
     init_state_with_ids(std::iter::once((address, object))).await
 }
 
+pub async fn init_state_with_ids_and_expensive_checks<
+    I: IntoIterator<Item = (SuiAddress, ObjectID)>,
+>(
+    objects: I,
+    config: ExpensiveSafetyCheckConfig,
+) -> Arc<AuthorityState> {
+    let state = TestAuthorityBuilder::new()
+        .with_expensive_safety_checks(config)
+        .build()
+        .await;
+    for (address, object_id) in objects {
+        let obj = Object::with_id_owner_for_testing(object_id, address);
+        // TODO: Make this part of genesis initialization instead of explicit insert.
+        state.insert_genesis_object(obj).await;
+    }
+    state
+}
+
 pub fn init_transfer_transaction(
     sender: SuiAddress,
     secret: &AccountKeyPair,

--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -45,6 +45,7 @@ pub struct TestAuthorityBuilder<'a> {
     node_keypair: Option<&'a AuthorityKeyPair>,
     genesis: Option<&'a Genesis>,
     starting_objects: Option<&'a [Object]>,
+    expensive_safety_checks: Option<ExpensiveSafetyCheckConfig>,
 }
 
 impl<'a> TestAuthorityBuilder<'a> {
@@ -116,6 +117,11 @@ impl<'a> TestAuthorityBuilder<'a> {
         )
     }
 
+    pub fn with_expensive_safety_checks(mut self, config: ExpensiveSafetyCheckConfig) -> Self {
+        assert!(self.expensive_safety_checks.replace(config).is_none());
+        self
+    }
+
     pub async fn side_load_objects(
         authority_state: Arc<AuthorityState>,
         objects: &'a [Object],
@@ -172,6 +178,10 @@ impl<'a> TestAuthorityBuilder<'a> {
             genesis.sui_system_object().into_epoch_start_state(),
             *genesis.checkpoint().digest(),
         );
+        let expensive_safety_checks = match self.expensive_safety_checks {
+            None => ExpensiveSafetyCheckConfig::default(),
+            Some(config) => config,
+        };
         let epoch_store = AuthorityPerEpochStore::new(
             name,
             Arc::new(genesis_committee.clone()),
@@ -182,7 +192,7 @@ impl<'a> TestAuthorityBuilder<'a> {
             authority_store.clone(),
             cache_metrics,
             signature_verifier_metrics,
-            &ExpensiveSafetyCheckConfig::default(),
+            &expensive_safety_checks,
         );
 
         let committee_store = Arc::new(CommitteeStore::new(

--- a/external-crates/move/move-vm/runtime/src/interpreter.rs
+++ b/external-crates/move/move-vm/runtime/src/interpreter.rs
@@ -117,6 +117,23 @@ impl Interpreter {
             }
             let link_context = data_store.link_context();
             let resolver = function.get_resolver(link_context, loader);
+
+            if interpreter.paranoid_type_checks {
+                for ty in function.parameter_types() {
+                    let type_ = if ty_args.is_empty() {
+                        ty.clone()
+                    } else {
+                        resolver
+                            .subst(ty, &ty_args)
+                            .map_err(|e| e.finish(Location::Undefined))?
+                    };
+                    interpreter
+                        .operand_stack
+                        .push_ty(type_)
+                        .map_err(|e| e.finish(Location::Undefined))?;
+                }
+            }
+
             let return_values = interpreter
                 .call_native_return_values(
                     &resolver,


### PR DESCRIPTION
## Description 

Make paranoid mode for native calls work correctly.
We may or may not enable paranoid mode but the change seems safe

## Test Plan 
Added test

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
