### PR TITLE
wallet-ext: update useGetOwnedObjects stale time

### DIFF
--- a/apps/core/src/hooks/useGetOwnedObjects.ts
+++ b/apps/core/src/hooks/useGetOwnedObjects.ts
@@ -28,7 +28,7 @@ export function useGetOwnedObjects(
                 cursor: pageParam,
             }),
         {
-            staleTime: 10 * 60 * 1000,
+            staleTime: 10 * 1000,
             enabled: !!address,
             getNextPageParam: (lastPage) =>
                 lastPage?.hasNextPage ? lastPage.nextCursor : null,


### PR DESCRIPTION
* reduce it to 10 seconds to avoid issue with not showing new objects in nfts page

fixes https://mysten-labs.slack.com/archives/C04SPGVSPM5/p1684185722179829