### PR TITLE
[sui-framework/package] `Publisher` checks recognise upgrades

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/upgrade/publisher.exp
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/publisher.exp
@@ -1,0 +1,22 @@
+processed 5 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 6-17:
+created: object(1,0), object(1,1), object(1,2)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 8557600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'upgrade'. lines 19-35:
+created: object(2,0)
+mutated: object(0,0), object(1,2)
+gas summary: computation_cost: 1000000, storage_cost: 7691200,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 3 'run'. lines 37-37:
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 2812000,  storage_rebate: 2783880, non_refundable_storage_fee: 28120
+
+task 4 'run'. lines 39-39:
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 2812000,  storage_rebate: 2783880, non_refundable_storage_fee: 28120

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/publisher.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/publisher.move
@@ -1,0 +1,39 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses A0=0x0 A1=0x0 --accounts A
+
+//# publish --upgradeable --sender A
+module A0::m {
+    use sui::package;
+    use sui::tx_context::TxContext;
+
+    struct A {}
+    struct M has drop {}
+
+    fun init(m: M, ctx: &mut TxContext) {
+        package::claim_and_keep(m, ctx);
+    }
+}
+
+//# upgrade --package A0 --upgrade-capability 1,2 --sender A
+module A1::m {
+    use sui::package::{Self, Publisher};
+    use sui::tx_context::TxContext;
+
+    struct A {}
+    struct B {}
+    struct M has drop {}
+
+    fun init(m: M, ctx: &mut TxContext) {
+        package::claim_and_keep(m, ctx);
+    }
+
+    entry fun test<T>(p: &Publisher) {
+        assert!(package::from_package<T>(p), 0)
+    }
+}
+
+//# run A1::m::test --type-args A0::m::A --args object(1,1) --sender A
+
+//# run A1::m::test --type-args A1::m::B --args object(1,1) --sender A

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/type_names.exp
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/type_names.exp
@@ -1,0 +1,59 @@
+processed 12 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 6-17:
+created: object(1,0), object(1,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6171200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'upgrade'. lines 19-30:
+created: object(2,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 6520800,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 3 'upgrade'. lines 32-62:
+created: object(3,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 9066800,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 4 'run'. lines 64-64:
+created: object(4,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2728400,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5 'run'. lines 66-66:
+created: object(5,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2728400,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6 'run'. lines 68-68:
+created: object(6,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2728400,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 7 'run'. lines 70-70:
+created: object(7,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2728400,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 8 'view-object'. lines 72-72:
+Owner: Account Address ( A )
+Version: 5
+Contents: A0::m::Canary {id: sui::object::UID {id: sui::object::ID {bytes: fake(4,0)}}, addr: vector[57u8, 98u8, 48u8, 52u8, 101u8, 52u8, 50u8, 57u8, 50u8, 54u8, 101u8, 55u8, 48u8, 54u8, 54u8, 56u8, 99u8, 101u8, 56u8, 50u8, 97u8, 52u8, 99u8, 50u8, 51u8, 56u8, 56u8, 98u8, 101u8, 52u8, 101u8, 50u8, 100u8, 52u8, 99u8, 53u8, 98u8, 54u8, 54u8, 49u8, 98u8, 101u8, 48u8, 50u8, 52u8, 98u8, 53u8, 56u8, 101u8, 49u8, 53u8, 49u8, 56u8, 101u8, 55u8, 49u8, 99u8, 55u8, 54u8, 56u8, 57u8, 50u8, 51u8, 54u8]}
+
+task 9 'view-object'. lines 74-74:
+Owner: Account Address ( A )
+Version: 6
+Contents: A0::m::Canary {id: sui::object::UID {id: sui::object::ID {bytes: fake(5,0)}}, addr: vector[57u8, 98u8, 48u8, 52u8, 101u8, 52u8, 50u8, 57u8, 50u8, 54u8, 101u8, 55u8, 48u8, 54u8, 54u8, 56u8, 99u8, 101u8, 56u8, 50u8, 97u8, 52u8, 99u8, 50u8, 51u8, 56u8, 56u8, 98u8, 101u8, 52u8, 101u8, 50u8, 100u8, 52u8, 99u8, 53u8, 98u8, 54u8, 54u8, 49u8, 98u8, 101u8, 48u8, 50u8, 52u8, 98u8, 53u8, 56u8, 101u8, 49u8, 53u8, 49u8, 56u8, 101u8, 55u8, 49u8, 99u8, 55u8, 54u8, 56u8, 57u8, 50u8, 51u8, 54u8]}
+
+task 10 'view-object'. lines 76-76:
+Owner: Account Address ( A )
+Version: 7
+Contents: A0::m::Canary {id: sui::object::UID {id: sui::object::ID {bytes: fake(6,0)}}, addr: vector[57u8, 98u8, 48u8, 52u8, 101u8, 52u8, 50u8, 57u8, 50u8, 54u8, 101u8, 55u8, 48u8, 54u8, 54u8, 56u8, 99u8, 101u8, 56u8, 50u8, 97u8, 52u8, 99u8, 50u8, 51u8, 56u8, 56u8, 98u8, 101u8, 52u8, 101u8, 50u8, 100u8, 52u8, 99u8, 53u8, 98u8, 54u8, 54u8, 49u8, 98u8, 101u8, 48u8, 50u8, 52u8, 98u8, 53u8, 56u8, 101u8, 49u8, 53u8, 49u8, 56u8, 101u8, 55u8, 49u8, 99u8, 55u8, 54u8, 56u8, 57u8, 50u8, 51u8, 54u8]}
+
+task 11 'view-object'. lines 78-78:
+Owner: Account Address ( A )
+Version: 8
+Contents: A0::m::Canary {id: sui::object::UID {id: sui::object::ID {bytes: fake(7,0)}}, addr: vector[98u8, 55u8, 50u8, 55u8, 55u8, 53u8, 48u8, 100u8, 98u8, 50u8, 54u8, 48u8, 49u8, 52u8, 101u8, 53u8, 54u8, 101u8, 99u8, 102u8, 57u8, 50u8, 99u8, 100u8, 51u8, 50u8, 101u8, 52u8, 100u8, 48u8, 54u8, 56u8, 50u8, 51u8, 56u8, 56u8, 50u8, 49u8, 54u8, 50u8, 51u8, 99u8, 48u8, 52u8, 54u8, 57u8, 56u8, 100u8, 57u8, 54u8, 50u8, 57u8, 48u8, 56u8, 100u8, 49u8, 50u8, 48u8, 97u8, 53u8, 49u8, 54u8, 100u8, 48u8]}

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/type_names.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/type_names.move
@@ -1,0 +1,78 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses A0=0x0 A1=0x0 A2=0x0 --accounts A
+
+//# publish --upgradeable --sender A
+module A0::m {
+    use sui::object::UID;
+
+    struct Canary has key {
+        id: UID,
+        addr: vector<u8>,
+    }
+
+    struct A {}
+
+}
+
+//# upgrade --package A0 --upgrade-capability 1,1 --sender A
+module A1::m {
+    use sui::object::UID;
+
+    struct Canary has key {
+        id: UID,
+        addr: vector<u8>,
+    }
+
+    struct A {}
+    struct B {}
+}
+
+//# upgrade --package A1 --upgrade-capability 1,1 --sender A
+module A2::m {
+    use std::ascii;
+    use std::type_name;
+    use sui::object::{Self, UID};
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+
+    struct Canary has key {
+        id: UID,
+        addr: vector<u8>,
+    }
+
+    struct A {}
+    struct B {}
+
+    entry fun canary<T>(use_original: bool, ctx: &mut TxContext) {
+        let type = if (use_original) {
+            type_name::get_original<T>()
+        } else {
+            type_name::get<T>()
+        };
+
+        let addr = ascii::into_bytes(type_name::get_address(&type));
+
+        transfer::transfer(
+            Canary { id: object::new(ctx), addr },
+            tx_context::sender(ctx),
+        )
+    }
+}
+
+//# run A2::m::canary --type-args A0::m::A --args true --sender A
+
+//# run A2::m::canary --type-args A1::m::B --args true --sender A
+
+//# run A2::m::canary --type-args A0::m::A --args false --sender A
+
+//# run A2::m::canary --type-args A1::m::B --args false --sender A
+
+//# view-object 4,0
+
+//# view-object 5,0
+
+//# view-object 6,0
+
+//# view-object 7,0

--- a/crates/sui-framework/docs/package.md
+++ b/crates/sui-framework/docs/package.md
@@ -341,7 +341,7 @@ but multiple per package (!).
 <pre><code><b>public</b> <b>fun</b> <a href="package.md#0x2_package_claim">claim</a>&lt;OTW: drop&gt;(otw: OTW, ctx: &<b>mut</b> TxContext): <a href="package.md#0x2_package_Publisher">Publisher</a> {
     <b>assert</b>!(<a href="types.md#0x2_types_is_one_time_witness">types::is_one_time_witness</a>(&otw), <a href="package.md#0x2_package_ENotOneTimeWitness">ENotOneTimeWitness</a>);
 
-    <b>let</b> type = <a href="_get">type_name::get</a>&lt;OTW&gt;();
+    <b>let</b> type = <a href="_get_original">type_name::get_original</a>&lt;OTW&gt;();
 
     <a href="package.md#0x2_package_Publisher">Publisher</a> {
         id: <a href="object.md#0x2_object_new">object::new</a>(ctx),
@@ -426,7 +426,7 @@ Check whether type belongs to the same package as the publisher object.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="package.md#0x2_package_from_package">from_package</a>&lt;T&gt;(self: &<a href="package.md#0x2_package_Publisher">Publisher</a>): bool {
-    <b>let</b> type = <a href="_get">type_name::get</a>&lt;T&gt;();
+    <b>let</b> type = <a href="_get_original">type_name::get_original</a>&lt;T&gt;();
 
     (<a href="_get_address">type_name::get_address</a>(&type) == self.<a href="package.md#0x2_package">package</a>)
 }
@@ -453,7 +453,7 @@ Check whether a type belongs to the same module as the publisher object.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="package.md#0x2_package_from_module">from_module</a>&lt;T&gt;(self: &<a href="package.md#0x2_package_Publisher">Publisher</a>): bool {
-    <b>let</b> type = <a href="_get">type_name::get</a>&lt;T&gt;();
+    <b>let</b> type = <a href="_get_original">type_name::get_original</a>&lt;T&gt;();
 
     (<a href="_get_address">type_name::get_address</a>(&type) == self.<a href="package.md#0x2_package">package</a>)
         && (<a href="_get_module">type_name::get_module</a>(&type) == self.module_name)

--- a/crates/sui-framework/packages/move-stdlib/sources/type_name.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/type_name.move
@@ -21,8 +21,21 @@ module std::type_name {
         name: String
     }
 
-    /// Return a value representation of the type `T`.
+    /// Return a value representation of the type `T`.  Package IDs
+    /// that appear in fully qualified type names in the output from
+    /// this function are defining IDs (the ID of the package in
+    /// storage that first introduced the type).
     public native fun get<T>(): TypeName;
+    spec get {
+        pragma opaque;
+    }
+
+    /// Return a value representation of the type `T`.  Package IDs
+    /// that appear in fully qualified type names in the output from
+    /// this function are original IDs (the ID of the first version of
+    /// the package, even if the type in question was introduced in a
+    /// later upgrade).
+    public native fun get_original<T>(): TypeName;
     spec get {
         pragma opaque;
     }

--- a/crates/sui-framework/packages/sui-framework/sources/package.move
+++ b/crates/sui-framework/packages/sui-framework/sources/package.move
@@ -93,7 +93,7 @@ module sui::package {
     public fun claim<OTW: drop>(otw: OTW, ctx: &mut TxContext): Publisher {
         assert!(types::is_one_time_witness(&otw), ENotOneTimeWitness);
 
-        let type = type_name::get<OTW>();
+        let type = type_name::get_original<OTW>();
 
         Publisher {
             id: object::new(ctx),
@@ -118,14 +118,14 @@ module sui::package {
 
     /// Check whether type belongs to the same package as the publisher object.
     public fun from_package<T>(self: &Publisher): bool {
-        let type = type_name::get<T>();
+        let type = type_name::get_original<T>();
 
         (type_name::get_address(&type) == self.package)
     }
 
     /// Check whether a type belongs to the same module as the publisher object.
     public fun from_module<T>(self: &Publisher): bool {
-        let type = type_name::get<T>();
+        let type = type_name::get_original<T>();
 
         (type_name::get_address(&type) == self.package)
             && (type_name::get_module(&type) == self.module_name)
@@ -271,7 +271,7 @@ module sui::package {
     #[test_only]
     /// Test-only function to claim a Publisher object bypassing OTW check.
     public fun test_claim<OTW: drop>(_: OTW, ctx: &mut TxContext): Publisher {
-        let type = type_name::get<OTW>();
+        let type = type_name::get_original<OTW>();
 
         Publisher {
             id: object::new(ctx),

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1320,7 +1320,7 @@
             "name": "Result",
             "value": {
               "minSupportedProtocolVersion": "1",
-              "maxSupportedProtocolVersion": "10",
+              "maxSupportedProtocolVersion": "11",
               "protocolVersion": "6",
               "featureFlags": {
                 "advance_epoch_start_time_in_safe_mode": true,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -10,7 +10,7 @@ use tracing::{info, warn};
 
 /// The minimum and maximum protocol versions supported by this build.
 const MIN_PROTOCOL_VERSION: u64 = 1;
-const MAX_PROTOCOL_VERSION: u64 = 10;
+const MAX_PROTOCOL_VERSION: u64 = 11;
 
 // Record history of protocol version allocations here:
 //
@@ -36,6 +36,7 @@ const MAX_PROTOCOL_VERSION: u64 = 10;
 // Version 10:increase bytecode verifier `max_verifier_meter_ticks_per_function` and
 //            `max_meter_ticks_per_module` limits each from 6_000_000 to 16_000_000. sui-system
 //            framework changes.
+// Version 11: Introduce `std::type_name::get_original` to the system frameworks.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -1150,6 +1151,7 @@ impl ProtocolConfig {
                 cfg.max_meter_ticks_per_module = Some(16_000_000);
                 cfg
             }
+            11 => Self::get_for_version_impl(version - 1),
             // Use this template when making changes:
             //
             //     // modify an existing constant.

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_11.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_11.snap
@@ -1,0 +1,179 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur)"
+---
+version: 11
+feature_flags:
+  package_upgrades: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 128
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 6
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 256
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 2000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+gas_model_version: 5
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 52
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 52
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 52
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 52
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 52
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 52
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 52
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 52
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 52
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 52
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 52
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 52
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 52
+groth16_prepare_verifying_key_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 52
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 52
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+scoring_decision_mad_divisor: 2.3
+scoring_decision_cutoff_value: 2.5
+

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -1,11 +1,11 @@
 ---
-source: crates/sui-config/tests/snapshot_tests.rs
+source: crates/sui-swarm-config/tests/snapshot_tests.rs
 expression: genesis_config
 ---
 validator_config_info: ~
 parameters:
   chain_start_timestamp_ms: 0
-  protocol_version: 10
+  protocol_version: 11
   allow_insertion_of_extra_objects: true
   epoch_duration_ms: 86400000
   stake_subsidy_start_epoch: 0

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -1,9 +1,9 @@
 ---
-source: crates/sui-config/tests/snapshot_tests.rs
+source: crates/sui-swarm-config/tests/snapshot_tests.rs
 expression: genesis.sui_system_object().into_genesis_version_for_tooling()
 ---
 epoch: 0
-protocol_version: 10
+protocol_version: 11
 system_state_version: 1
 validators:
   total_stake: 20000000000000000
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0x394f9cd9d7fee2a0b64b7b8898ea9444248e857225271f408d888d0fc7b526f7"
+            id: "0xabf28cc51eab70e8b10bf4aeaac8444baf81a77b192a36657aaa72bfa9ff0d07"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0x7e35983d7cffd4fa3b873645f1a79c4c565703b858acb0cb1584707caa184349"
+      operation_cap_id: "0x71254747fbce24ae8262c06d3041467f05c779ddbdc1bf0aa108101cbbe112eb"
       gas_price: 1000
       staking_pool:
-        id: "0x0bc101228f5442dc50248938e857501e712b61561f9d5cc2c101b04fa96a59fb"
+        id: "0x881449974facb30e887ce27317c081a39813a202b27869df58549a61d45574e2"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0xb18b679c7f78ea4470610d91bb3d5b17cfd135944e2a657beac366543a7b044c"
+          id: "0x12b5f28dfc5a31896a2945a98a4cdd8937c10b881946e855af7499c41865882c"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0x34cf488ffc6a4a7164e38d77479c054f19cec0c29fae442c13c5df1d6a6d0ade"
+            id: "0x3768151f2bc597c09385256c4549b956abc482c27c3110f3f7a77c57966437c6"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0x36ff0217619b793c9daa3606b8f9c7bfcfc7db68461799513880212e2c844cab"
+          id: "0x717edc94c60f3f78410e2e7b2e4587e141b231e69f8b708e3c8b1d1f1c11dab3"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x98780fa3d8b012b2c87e9f415dc247071288568dab5968edfb1492ddde178ac2"
+      id: "0x8fd549a887b9bb7ddf9a0eba4199decab3ad131a696a7e852cf9a52703a078b5"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0xf7ac16e826d8c1795035dfaa10c7bc28ad521527818439bb8c48c544dafaff14"
+    id: "0xd461f51f7818dceedda767c92e06e3bf22a98d5443cc344a6fb73c10bae5bbda"
     size: 1
   inactive_validators:
-    id: "0x30d5018ead847e7898ad96b388f6e476b99dacccad077d22ced9598121ab016d"
+    id: "0x0947ba235c57dc9d22e41333a1cdf38d577c561cb56e079c7c0d4f7c0b812bfe"
     size: 0
   validator_candidates:
-    id: "0x0b9f93b0fed1485723f381c902b3d60aa1e57e2e238c70f8e5a3cd297e5e5e28"
+    id: "0xcc2c8f1b10a73c54dc0444e4dbb23f31b5faa8d209e66ba8d9508b4f1f494885"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0xdb6f1f71e6c5b57b93ad954e91c69dd15ad4e361cee91113ee780ecdeabd9eb8"
+      id: "0x88ad024711a99eeb1adbdc459b65812723ffb29905c95ce196610628e5002a57"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x92753a57d00fc615b1af4ba3a6755f63f59c27cce8dd6cb5a223805d8dca6d65"
+      id: "0xa265f9b638902928195d72316976265f4a351b3727bafcf22ed5d1ceb3207b61"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0xf3017ec58450c6e5c79534fa01baaa7e39a81e9ebc9ad38868fc143b0dc32db3"
+      id: "0x7625dd3496905c01a9d350bff605e4b21fbc6dc0fb38c9f53809c57fd2b4474d"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,6 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0xfe08f018280495462582458bbdcab7c2aa2f91f678dea3d177a21c070ed0d89d"
+    id: "0xe5e51fc1d5dbc25599510b0eca95ffb69d56c678d6c4c94b18b7de24e068ff67"
   size: 0
 

--- a/external-crates/move/move-stdlib/docs/type_name.md
+++ b/external-crates/move/move-stdlib/docs/type_name.md
@@ -8,6 +8,7 @@ Functionality for converting Move types into values. Use with care!
 
 -  [Struct `TypeName`](#0x1_type_name_TypeName)
 -  [Function `get`](#0x1_type_name_get)
+-  [Function `get_original`](#0x1_type_name_get_original)
 -  [Function `borrow_string`](#0x1_type_name_borrow_string)
 -  [Function `into_string`](#0x1_type_name_into_string)
 
@@ -54,7 +55,11 @@ Functionality for converting Move types into values. Use with care!
 
 ## Function `get`
 
-Return a value representation of the type <code>T</code>.
+Return a value representation of the type <code>T</code>.  Package IDs
+that appear in fully qualified type names in the output from
+this function are original IDs (the ID of the first version of
+the package, even if the type in question was introduced in a
+later upgrade).
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="type_name.md#0x1_type_name_get">get</a>&lt;T&gt;(): <a href="type_name.md#0x1_type_name_TypeName">type_name::TypeName</a>
@@ -67,6 +72,33 @@ Return a value representation of the type <code>T</code>.
 
 
 <pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="type_name.md#0x1_type_name_get">get</a>&lt;T&gt;(): <a href="type_name.md#0x1_type_name_TypeName">TypeName</a>;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_type_name_get_original"></a>
+
+## Function `get_original`
+
+Return a value representation of the type <code>T</code>.  Package IDs
+that appear in fully qualified type names in the output from
+this function are original IDs (the ID of the first version of
+the package, even if the type in question was introduced in a
+later upgrade).
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="type_name.md#0x1_type_name_get_original">get_original</a>&lt;T&gt;(): <a href="type_name.md#0x1_type_name_TypeName">type_name::TypeName</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="type_name.md#0x1_type_name_get_original">get_original</a>&lt;T&gt;(): <a href="type_name.md#0x1_type_name_TypeName">TypeName</a>;
 </code></pre>
 
 

--- a/external-crates/move/move-stdlib/sources/type_name.move
+++ b/external-crates/move/move-stdlib/sources/type_name.move
@@ -13,8 +13,19 @@ module std::type_name {
         name: String
     }
 
-    /// Return a value representation of the type `T`.
+    /// Return a value representation of the type `T`.  Package IDs
+    /// that appear in fully qualified type names in the output from
+    /// this function are original IDs (the ID of the first version of
+    /// the package, even if the type in question was introduced in a
+    /// later upgrade).
     public native fun get<T>(): TypeName;
+
+    /// Return a value representation of the type `T`.  Package IDs
+    /// that appear in fully qualified type names in the output from
+    /// this function are original IDs (the ID of the first version of
+    /// the package, even if the type in question was introduced in a
+    /// later upgrade).
+    public native fun get_original<T>(): TypeName;
 
     /// Get the String representation of `self`
     public fun borrow_string(self: &TypeName): &String {

--- a/external-crates/move/move-vm/runtime/src/native_functions.rs
+++ b/external-crates/move/move-vm/runtime/src/native_functions.rs
@@ -153,6 +153,10 @@ impl<'a, 'b> NativeContext<'a, 'b> {
         self.resolver.loader().type_to_type_tag(ty)
     }
 
+    pub fn type_to_runtime_type_tag(&self, ty: &Type) -> PartialVMResult<TypeTag> {
+        self.resolver.loader().type_to_runtime_type_tag(ty)
+    }
+
     pub fn type_to_type_layout(&self, ty: &Type) -> PartialVMResult<Option<MoveTypeLayout>> {
         match self.resolver.type_to_type_layout(ty) {
             Ok(ty_layout) => Ok(Some(ty_layout)),


### PR DESCRIPTION
## Description

Change the behaviour of functions like:

```
sui::package::from_package<T>(self: &Publisher): bool
sui::package::from_module<T>(self: &Publisher): bool
```

to return `true` when `T` is from an upgraded version of the package associated with `Publisher`.  Previously it was impossible to check the package ownership of a type introduced in an upgraded package (the upgraded type's type name didn't match the original package's `Publisher` and it was impossible to create a `Publisher` for the upgraded package, because it requires an OTW which we can't create for upgraded packages).

This support was added by introducing a new stdlib function: `std::typename::get_original`, as of protocol version 11, which produces a runtime representation of the type that uses original (aka runtime) package IDs instead of defining package IDs (the default behaviour for `std::typename::get` and any other case where a runtime representation of the type is converted into an on-chain or storage representation of a type).

## Test Plan

New transactional test cases for `std::type_name::get_original` and `sui::package::from_package`:

```
$ cargo nextest run -- upgrade/type_names.move
$ cargo nextest run -- upgrade/publisher.move
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

As of protocol version 11:

- `sui::package::from_package<T>(self: &Publisher)` and `sui::package::from_module<T>(self: &Publisher)` return `true` when `T` is a type introduced at any upgraded version of the package associated with `self: &Publisher` (rather than just the types originally present when that package was published).
- `std::type_name::get_original` is introduced as a new stdlib function to return a representation of the type where package IDs have all been normalized to "original" IDs (the ID of the first version of a package) in contrast to the default behaviour of `std::type_name::get` which distinguishes types introduced at different versions of a package by assigning them the ID of the package that introduced them.