### PR TITLE
[wallet-ext] - display all owned objects in NFT view

### DIFF
--- a/apps/wallet/src/ui/app/hooks/useGetNFTs.ts
+++ b/apps/wallet/src/ui/app/hooks/useGetNFTs.ts
@@ -5,16 +5,9 @@ import {
     useGetOwnedObjects,
     useGetOriginByteKioskContents,
 } from '@mysten/core';
-import {
-    getObjectDisplay,
-    type SuiObjectData,
-    type SuiAddress,
-    type SuiObjectResponse,
-} from '@mysten/sui.js';
+import { type SuiObjectData, type SuiAddress } from '@mysten/sui.js';
 
 import useAppSelector from './useAppSelector';
-
-const hasDisplayData = (obj: SuiObjectResponse) => !!getObjectDisplay(obj).data;
 
 export function useGetNFTs(address?: SuiAddress | null) {
     const {
@@ -40,15 +33,12 @@ export function useGetNFTs(address?: SuiAddress | null) {
         useGetOriginByteKioskContents(address, !shouldFetchKioskContents);
 
     const filteredKioskContents =
-        obKioskContents
-            ?.filter(hasDisplayData)
-            .map(({ data }) => data as SuiObjectData) || [];
+        obKioskContents?.map(({ data }) => data as SuiObjectData) || [];
 
     const nfts = [
         ...filteredKioskContents,
         ...(data?.pages
             .flatMap((page) => page.data)
-            .filter(hasDisplayData)
             .map(({ data }) => data as SuiObjectData) || []),
     ];
 


### PR DESCRIPTION
## Description 

Removes filtering by display data in wallet NFT tab. Pending a decision on what the behavior should be. 

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
