### PR TITLE
only block sui verifier on timeouts

### DIFF
--- a/crates/sui-core/src/unit_tests/move_package_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_tests.rs
@@ -579,12 +579,10 @@ async fn test_metered_move_bytecode_verifier() {
     );
     let elapsed = timer_start.elapsed().as_micros() as f64 / (1000.0 * 1000.0);
 
-    assert!(
-        r.unwrap_err()
-            == SuiError::ModuleVerificationFailure {
-                error: "Verification timedout".to_string()
-            }
-    );
+    assert!(matches!(
+        r.unwrap_err(),
+        SuiError::ModuleVerificationFailure { .. }
+    ));
 
     // Some new modules might have passed
     assert!(

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -356,6 +356,8 @@ ExecutionFailureStatus:
           - max_size: U64
     29:
       CertificateDenied: UNIT
+    30:
+      SuiMoveVerificationTimedout: UNIT
 ExecutionStatus:
   ENUM:
     0:

--- a/crates/sui-types/src/execution_status.rs
+++ b/crates/sui-types/src/execution_status.rs
@@ -171,6 +171,12 @@ pub enum ExecutionFailureStatus {
 
     #[error("Certificate is on the deny list")]
     CertificateDenied,
+
+    #[error(
+        "Sui Move Bytecode Verification Timeout. \
+        Please run the Sui Move Verifier for more information."
+    )]
+    SuiMoveVerificationTimedout,
     // NOTE: if you want to add a new enum,
     // please add it at the end for Rust SDK backward compatibility.
 }

--- a/sui-execution/latest/sui-verifier/src/lib.rs
+++ b/sui-execution/latest/sui-verifier/src/lib.rs
@@ -11,7 +11,7 @@ pub mod one_time_witness_verifier;
 pub mod private_generics;
 pub mod struct_with_key_verifier;
 
-use move_core_types::{ident_str, identifier::IdentStr};
+use move_core_types::{ident_str, identifier::IdentStr, vm_status::StatusCode};
 use sui_types::error::{ExecutionError, ExecutionErrorKind};
 
 pub const INIT_FN_NAME: &IdentStr = ident_str!("init");
@@ -19,4 +19,20 @@ pub const TEST_SCENARIO_MODULE_NAME: &str = "test_scenario";
 
 fn verification_failure(error: String) -> ExecutionError {
     ExecutionError::new_with_source(ExecutionErrorKind::SuiMoveVerificationError, error)
+}
+
+fn to_verification_timeout_error(error: String) -> ExecutionError {
+    ExecutionError::new_with_source(ExecutionErrorKind::SuiMoveVerificationTimedout, error)
+}
+
+/// Runs the Move verifier and checks if the error counts as a Move verifier timeout
+/// NOTE: this function only check if the verifier error is a timeout
+/// All other errors are ignored
+pub fn check_for_verifier_timeout(major_status_code: &StatusCode) -> bool {
+    [
+        StatusCode::PROGRAM_TOO_COMPLEX,
+        // Do we want to make this a substatus of `PROGRAM_TOO_COMPLEX`?
+        StatusCode::TOO_MANY_BACK_EDGES,
+    ]
+    .contains(major_status_code)
 }

--- a/sui-execution/latest/sui-verifier/src/verifier.rs
+++ b/sui-execution/latest/sui-verifier/src/verifier.rs
@@ -29,6 +29,28 @@ pub fn sui_verify_module_metered(
     one_time_witness_verifier::verify_module(module, fn_info_map)
 }
 
+/// Runs the Sui verifier and checks if the error counts as a Sui verifier timeout
+/// NOTE: this function only check if the verifier error is a timeout
+/// All other errors are ignored
+pub fn sui_verify_module_metered_check_timeout_only(
+    config: &ProtocolConfig,
+    module: &CompiledModule,
+    fn_info_map: &FnInfoMap,
+    meter: &mut impl Meter,
+) -> Result<(), ExecutionError> {
+    // Checks if the error counts as a Sui verifier timeout
+    if let Err(error) = sui_verify_module_metered(config, module, fn_info_map, meter) {
+        if matches!(
+            error.kind(),
+            sui_types::execution_status::ExecutionFailureStatus::SuiMoveVerificationTimedout
+        ) {
+            return Err(error);
+        }
+    }
+    // Any other scenario, including a non-timeout error counts as Ok
+    Ok(())
+}
+
 pub fn sui_verify_module_unmetered(
     config: &ProtocolConfig,
     module: &CompiledModule,

--- a/sui-execution/latest/sui-verifier/src/verifier.rs
+++ b/sui-execution/latest/sui-verifier/src/verifier.rs
@@ -56,5 +56,15 @@ pub fn sui_verify_module_unmetered(
     module: &CompiledModule,
     fn_info_map: &FnInfoMap,
 ) -> Result<(), ExecutionError> {
-    sui_verify_module_metered(config, module, fn_info_map, &mut DummyMeter)
+    sui_verify_module_metered(config, module, fn_info_map, &mut DummyMeter).map_err(|err| {
+        // We must never see timeout error in execution
+        debug_assert!(
+            !matches!(
+                err.kind(),
+                sui_types::execution_status::ExecutionFailureStatus::SuiMoveVerificationTimedout
+            ),
+            "Unexpected timeout error in execution"
+        );
+        err
+    })
 }


### PR DESCRIPTION
## Description 

Previously the metered verifier did not disambiguate Sui verifier errors when blocking at signing.
This PR changes that such that we only block when meter timesout.

## Test Plan 

Normal 
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
