### PR TITLE
add option getters

### DIFF
--- a/crates/sui-protocol-config-macros/src/lib.rs
+++ b/crates/sui-protocol-config-macros/src/lib.rs
@@ -15,7 +15,11 @@ use syn::{parse_macro_input, Data, DeriveInput, Fields, Type};
 ///     pub fn new_constant(&self) -> u64 {
 ///         self.new_constant.expect(Self::CONSTANT_ERR_MSG)
 ///     }
-///
+///     /// Returns the value of the field if exists at the given version, otherise None
+///     /// Useful when one doesnt want to crash. Particularly for feature gating
+///     pub fn new_constant_as_option(&self) -> Option<u64> {
+///         self.new_constant
+///     }
 ///     // We auto derive an enum such that the variants are all the types of the fields
 ///     pub enum ProtocolConfigValue {
 ///        u32(u32),
@@ -76,10 +80,18 @@ pub fn getters_macro(input: TokenStream) -> TokenStream {
                             panic!("Expected angle bracketed arguments.");
                         };
 
+                        let as_option_name = format!("{field_name}_as_option");
+                        let as_option_name: proc_macro2::TokenStream =
+                        as_option_name.parse().unwrap();
+
                         let getter = quote! {
                             // Derive the getter
                             pub fn #field_name(&self) -> #inner_type {
                                 self.#field_name.expect(Self::CONSTANT_ERR_MSG)
+                            }
+
+                            pub fn #as_option_name(&self) -> #field_type {
+                                self.#field_name
                             }
                         };
 

--- a/crates/sui-protocol-config-macros/src/lib.rs
+++ b/crates/sui-protocol-config-macros/src/lib.rs
@@ -15,8 +15,7 @@ use syn::{parse_macro_input, Data, DeriveInput, Fields, Type};
 ///     pub fn new_constant(&self) -> u64 {
 ///         self.new_constant.expect(Self::CONSTANT_ERR_MSG)
 ///     }
-///     /// Returns the value of the field if exists at the given version, otherise None
-///     /// Useful when one doesnt want to crash. Particularly for feature gating
+///     /// Returns the value of the field if exists at the given version, otherise None.
 ///     pub fn new_constant_as_option(&self) -> Option<u64> {
 ///         self.new_constant
 ///     }

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -704,27 +704,6 @@ impl ProtocolConfig {
     }
 }
 
-// Special getters
-impl ProtocolConfig {
-    /// We don't want to use the default getter which unwraps and could panic.
-    /// Instead we want to be able to selectively fetch this value
-    pub fn max_size_written_objects_as_option(&self) -> Option<u64> {
-        self.max_size_written_objects
-    }
-
-    /// We don't want to use the default getter which unwraps and could panic.
-    /// Instead we want to be able to selectively fetch this value
-    pub fn max_size_written_objects_system_tx_as_option(&self) -> Option<u64> {
-        self.max_size_written_objects_system_tx
-    }
-
-    /// We don't want to use the default getter which unwraps and could panic.
-    /// Instead we want to be able to selectively fetch this value
-    pub fn max_move_identifier_len_as_option(&self) -> Option<u64> {
-        self.max_move_identifier_len
-    }
-}
-
 #[cfg(not(msim))]
 static POISON_VERSION_METHODS: AtomicBool = AtomicBool::new(false);
 
@@ -1310,6 +1289,15 @@ mod test {
                 ProtocolConfig::get_for_version(cur)
             );
         }
+    }
+
+    #[test]
+    fn test_getters() {
+        let prot: ProtocolConfig = ProtocolConfig::get_for_version(ProtocolVersion::new(1));
+        assert_eq!(
+            prot.max_arguments(),
+            prot.max_arguments_as_option().unwrap()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description 

Each field `X` will now have getter `X_as_option` which returns `Option<T>` instead of panicking when `T` is `None`.

## Test Plan 

Unit test
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
