### PR TITLE
Fix typo in README example

### DIFF
--- a/sdk/bcs/README.md
+++ b/sdk/bcs/README.md
@@ -29,7 +29,7 @@ bcs.registerStructType("Coin", {
 });
 
 // deserialization: BCS bytes into Coin
-let bytes = bcs
+let bcsBytes = bcs
   .ser("Coin", {
     id: "0000000000000000000000000000000000000000000000000000000000000001",
     value: 1000000n,


### PR DESCRIPTION
BCS deserialization example in README used a value named "bcsBytes" where the name of value for the serialized object is "bytes".

## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
