### PR TITLE
[sui cli] add validator command to print out raw gas price setting txn

### DIFF
--- a/crates/sui-swarm-config/src/network_config_builder.rs
+++ b/crates/sui-swarm-config/src/network_config_builder.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::genesis_config::AccountConfig;
+use crate::genesis_config::{AccountConfig, DEFAULT_GAS_AMOUNT};
 use crate::genesis_config::{GenesisConfig, ValidatorGenesisConfig};
 use crate::network_config::NetworkConfig;
 use fastcrypto::encoding::{Encoding, Hex};
@@ -314,11 +314,18 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
             for validator in &validators {
                 let account_key: PublicKey = validator.account_key_pair.public();
                 let address = SuiAddress::from(&account_key);
+                // Give each validator some gas so they can pay for their transactions.
+                let gas_coin = TokenAllocation {
+                    recipient_address: address,
+                    amount_mist: DEFAULT_GAS_AMOUNT,
+                    staked_with_validator: None,
+                };
                 let stake = TokenAllocation {
                     recipient_address: address,
                     amount_mist: validator.stake,
                     staked_with_validator: Some(address),
                 };
+                builder.add_allocation(gas_coin);
                 builder.add_allocation(stake);
             }
             builder.build()

--- a/crates/sui/src/unit_tests/validator_tests.rs
+++ b/crates/sui/src/unit_tests/validator_tests.rs
@@ -1,0 +1,73 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::validator_commands::{
+    get_validator_summary, SuiValidatorCommand, SuiValidatorCommandResponse,
+};
+use anyhow::Ok;
+use fastcrypto::encoding::{Base64, Encoding};
+use shared_crypto::intent::{Intent, IntentMessage};
+use sui_json_rpc_types::SuiTransactionBlockResponse;
+use sui_types::crypto::SuiKeyPair;
+use sui_types::transaction::TransactionData;
+use sui_types::{
+    base_types::SuiAddress,
+    crypto::Signature,
+    transaction::{Transaction, VerifiedTransaction},
+};
+use test_utils::network::TestClusterBuilder;
+
+#[tokio::test]
+async fn test_print_raw_rgp_txn() -> Result<(), anyhow::Error> {
+    let test_cluster = TestClusterBuilder::new().build().await?;
+    let keypair: &SuiKeyPair = test_cluster
+        .swarm
+        .config()
+        .validator_configs
+        .first()
+        .unwrap()
+        .account_key_pair
+        .keypair();
+    let validator_address: SuiAddress = SuiAddress::from(&keypair.public());
+    let mut context = test_cluster.wallet;
+    let sui_client = context.get_client().await?;
+    let (_, summary) = get_validator_summary(&sui_client, validator_address)
+        .await?
+        .unwrap();
+    let operation_cap_id = summary.operation_cap_id;
+
+    // Execute the command and get the serialized transaction data.
+    let response = SuiValidatorCommand::DisplayGasPriceUpdateRawTxn {
+        sender_address: validator_address,
+        new_gas_price: 42,
+        operation_cap_id,
+        gas_budget: None,
+    }
+    .execute(&mut context)
+    .await?;
+    let SuiValidatorCommandResponse::DisplayGasPriceUpdateRawTxn { data, serialized_data } = response else {
+        panic!("Expected DisplayGasPriceUpdateRawTxn");
+    };
+
+    // Construct the signed transaction and execute it.
+    let deserialized_data =
+        bcs::from_bytes::<TransactionData>(&Base64::decode(&serialized_data).unwrap())?;
+    let signature = Signature::new_secure(
+        &IntentMessage::new(Intent::sui_transaction(), deserialized_data),
+        keypair,
+    );
+    let signed_txn = VerifiedTransaction::new_unchecked(Transaction::from_data(
+        data,
+        Intent::sui_transaction(),
+        vec![signature],
+    ));
+    let res: SuiTransactionBlockResponse = context.execute_transaction_block(signed_txn).await?;
+    assert!(res.status_ok().unwrap());
+    let (_, summary) = get_validator_summary(&sui_client, validator_address)
+        .await?
+        .unwrap();
+
+    // Check that the gas price is updated correctly.
+    assert_eq!(summary.next_epoch_gas_price, 42);
+    Ok(())
+}


### PR DESCRIPTION
## Description 

This PR adds a validator command that prints out the base64 representation of a transaction that updates a validator's gas price quote to a new value. I considered making this part of the original `UpdateGasPrice` command but decided it's different enough to be its own command, primarily because the active address of the wallet context can be someone other than the transaction sender in the case of the new command.
 
## Test Plan 

Added a test.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
