### PR TITLE
Update connect-sui-network.md

### DIFF
--- a/doc/src/build/connect-sui-network.md
+++ b/doc/src/build/connect-sui-network.md
@@ -78,11 +78,11 @@ Select key scheme to generate keypair (0 for ed25519, 1 for secp256k1, 2 for sec
 
 Press **0**, **1**, or **2** to select a key scheme and the press **Enter**.
 
-Sui returns a message similar to the following (depending on the key scheme you selected) that includes the address and 24-word recovery phrase for the address:
+Sui returns a message similar to the following (depending on the key scheme you selected) that includes the address and 12-word recovery phrase for the address:
 
 ```
 Generated new keypair for address with scheme "ed25519" [0xb9c83a8b40d3263c9ba40d551514fbac1f8c12e98a4005a0dac072d3549c2442]
-Secret Recovery Phrase : [cap wheat many line human lazy few solid bored proud speed grocery raise erode there idea inform culture cousin shed sniff author spare carpet]
+Secret Recovery Phrase : [cap wheat many line human lazy few solid bored proud speed grocery]
 ```
 
 ### Connect to a custom RPC endpoint


### PR DESCRIPTION
## Description 
Change the default number of recovery phrase in the docs.

The default number of recovery phrase when entering `sui client` for the first time is 12.
Ans also the description of `sui client new-address` says that the default of word length is word12.

![image](https://github.com/MystenLabs/sui/assets/48719289/2b47868a-276c-4ce7-8986-dd0dee230f07)
![image](https://github.com/MystenLabs/sui/assets/48719289/577f46ad-e87f-42dd-b47a-5e5bd05724bf)

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
