### PR TITLE
[kiosk] Adds 'default' entry function to Kiosk

### DIFF
--- a/crates/sui-framework/docs/kiosk.md
+++ b/crates/sui-framework/docs/kiosk.md
@@ -43,7 +43,7 @@ be used to implement application-specific transfer rules.
 -  [Struct `ItemPurchased`](#0x2_kiosk_ItemPurchased)
 -  [Struct `ItemDelisted`](#0x2_kiosk_ItemDelisted)
 -  [Constants](#@Constants_0)
--  [Function `new_default`](#0x2_kiosk_new_default)
+-  [Function `default`](#0x2_kiosk_default)
 -  [Function `new`](#0x2_kiosk_new)
 -  [Function `close_and_withdraw`](#0x2_kiosk_close_and_withdraw)
 -  [Function `set_owner`](#0x2_kiosk_set_owner)
@@ -632,15 +632,15 @@ Delisting an item that is not listed.
 
 
 
-<a name="0x2_kiosk_new_default"></a>
+<a name="0x2_kiosk_default"></a>
 
-## Function `new_default`
+## Function `default`
 
 Creates a new Kiosk in a default configuration: sender receives the
 <code><a href="kiosk.md#0x2_kiosk_KioskOwnerCap">KioskOwnerCap</a></code> and becomes the Owner, the <code><a href="kiosk.md#0x2_kiosk_Kiosk">Kiosk</a></code> is shared.
 
 
-<pre><code>entry <b>fun</b> <a href="kiosk.md#0x2_kiosk_new_default">new_default</a>(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+<pre><code>entry <b>fun</b> <a href="kiosk.md#0x2_kiosk_default">default</a>(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -649,7 +649,7 @@ Creates a new Kiosk in a default configuration: sender receives the
 <summary>Implementation</summary>
 
 
-<pre><code>entry <b>fun</b> <a href="kiosk.md#0x2_kiosk_new_default">new_default</a>(ctx: &<b>mut</b> TxContext) {
+<pre><code>entry <b>fun</b> <a href="kiosk.md#0x2_kiosk_default">default</a>(ctx: &<b>mut</b> TxContext) {
     <b>let</b> (<a href="kiosk.md#0x2_kiosk">kiosk</a>, cap) = <a href="kiosk.md#0x2_kiosk_new">new</a>(ctx);
     sui::transfer::transfer(cap, sender(ctx));
     sui::transfer::share_object(<a href="kiosk.md#0x2_kiosk">kiosk</a>);

--- a/crates/sui-framework/docs/kiosk.md
+++ b/crates/sui-framework/docs/kiosk.md
@@ -43,6 +43,7 @@ be used to implement application-specific transfer rules.
 -  [Struct `ItemPurchased`](#0x2_kiosk_ItemPurchased)
 -  [Struct `ItemDelisted`](#0x2_kiosk_ItemDelisted)
 -  [Constants](#@Constants_0)
+-  [Function `new_default`](#0x2_kiosk_new_default)
 -  [Function `new`](#0x2_kiosk_new)
 -  [Function `close_and_withdraw`](#0x2_kiosk_close_and_withdraw)
 -  [Function `set_owner`](#0x2_kiosk_set_owner)
@@ -89,6 +90,7 @@ be used to implement application-specific transfer rules.
 <b>use</b> <a href="event.md#0x2_event">0x2::event</a>;
 <b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
 <b>use</b> <a href="sui.md#0x2_sui">0x2::sui</a>;
+<b>use</b> <a href="transfer.md#0x2_transfer">0x2::transfer</a>;
 <b>use</b> <a href="transfer_policy.md#0x2_transfer_policy">0x2::transfer_policy</a>;
 <b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
 </code></pre>
@@ -629,6 +631,34 @@ Delisting an item that is not listed.
 </code></pre>
 
 
+
+<a name="0x2_kiosk_new_default"></a>
+
+## Function `new_default`
+
+Creates a new Kiosk in a default configuration: sender receives the
+<code><a href="kiosk.md#0x2_kiosk_KioskOwnerCap">KioskOwnerCap</a></code> and becomes the Owner, the <code><a href="kiosk.md#0x2_kiosk_Kiosk">Kiosk</a></code> is shared.
+
+
+<pre><code>entry <b>fun</b> <a href="kiosk.md#0x2_kiosk_new_default">new_default</a>(ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code>entry <b>fun</b> <a href="kiosk.md#0x2_kiosk_new_default">new_default</a>(ctx: &<b>mut</b> TxContext) {
+    <b>let</b> (<a href="kiosk.md#0x2_kiosk">kiosk</a>, cap) = <a href="kiosk.md#0x2_kiosk_new">new</a>(ctx);
+    sui::transfer::transfer(cap, sender(ctx));
+    sui::transfer::share_object(<a href="kiosk.md#0x2_kiosk">kiosk</a>);
+}
+</code></pre>
+
+
+
+</details>
 
 <a name="0x2_kiosk_new"></a>
 

--- a/crates/sui-framework/docs/transfer_policy.md
+++ b/crates/sui-framework/docs/transfer_policy.md
@@ -33,6 +33,7 @@ of the type at once.
 -  [Constants](#@Constants_0)
 -  [Function `new_request`](#0x2_transfer_policy_new_request)
 -  [Function `new`](#0x2_transfer_policy_new)
+-  [Function `default`](#0x2_transfer_policy_default)
 -  [Function `withdraw`](#0x2_transfer_policy_withdraw)
 -  [Function `destroy_and_withdraw`](#0x2_transfer_policy_destroy_and_withdraw)
 -  [Function `confirm_request`](#0x2_transfer_policy_confirm_request)
@@ -59,6 +60,7 @@ of the type at once.
 <b>use</b> <a href="object.md#0x2_object">0x2::object</a>;
 <b>use</b> <a href="package.md#0x2_package">0x2::package</a>;
 <b>use</b> <a href="sui.md#0x2_sui">0x2::sui</a>;
+<b>use</b> <a href="transfer.md#0x2_transfer">0x2::transfer</a>;
 <b>use</b> <a href="tx_context.md#0x2_tx_context">0x2::tx_context</a>;
 <b>use</b> <a href="vec_set.md#0x2_vec_set">0x2::vec_set</a>;
 </code></pre>
@@ -386,6 +388,35 @@ kiosks.
         <a href="transfer_policy.md#0x2_transfer_policy_TransferPolicy">TransferPolicy</a> { id, rules: <a href="vec_set.md#0x2_vec_set_empty">vec_set::empty</a>(), <a href="balance.md#0x2_balance">balance</a>: <a href="balance.md#0x2_balance_zero">balance::zero</a>() },
         <a href="transfer_policy.md#0x2_transfer_policy_TransferPolicyCap">TransferPolicyCap</a> { id: <a href="object.md#0x2_object_new">object::new</a>(ctx), policy_id }
     )
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_transfer_policy_default"></a>
+
+## Function `default`
+
+Initialize the Tranfer Policy in the default scenario: Create and share
+the <code><a href="transfer_policy.md#0x2_transfer_policy_TransferPolicy">TransferPolicy</a></code>, transfer <code><a href="transfer_policy.md#0x2_transfer_policy_TransferPolicyCap">TransferPolicyCap</a></code> to the transaction
+sender.
+
+
+<pre><code>entry <b>fun</b> <a href="transfer_policy.md#0x2_transfer_policy_default">default</a>&lt;T&gt;(pub: &<a href="package.md#0x2_package_Publisher">package::Publisher</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code>entry <b>fun</b> <a href="transfer_policy.md#0x2_transfer_policy_default">default</a>&lt;T&gt;(pub: &Publisher, ctx: &<b>mut</b> TxContext) {
+    <b>let</b> (policy, cap) = <a href="transfer_policy.md#0x2_transfer_policy_new">new</a>&lt;T&gt;(pub, ctx);
+    sui::transfer::share_object(policy);
+    sui::transfer::transfer(cap, sender(ctx));
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/transfer_policy.md
+++ b/crates/sui-framework/docs/transfer_policy.md
@@ -360,10 +360,10 @@ the transaction will fail.
 
 ## Function `new`
 
-Register a type in the Kiosk system and receive an <code><a href="transfer_policy.md#0x2_transfer_policy_TransferPolicyCap">TransferPolicyCap</a></code>
-which is required to confirm kiosk deals for the <code>T</code>. If there's no
-<code><a href="transfer_policy.md#0x2_transfer_policy_TransferPolicyCap">TransferPolicyCap</a></code> available for use, the type can not be traded in
-kiosks.
+Register a type in the Kiosk system and receive a <code><a href="transfer_policy.md#0x2_transfer_policy_TransferPolicy">TransferPolicy</a></code> and
+a <code><a href="transfer_policy.md#0x2_transfer_policy_TransferPolicyCap">TransferPolicyCap</a></code> for the type. The <code><a href="transfer_policy.md#0x2_transfer_policy_TransferPolicy">TransferPolicy</a></code> is required to
+confirm kiosk deals for the <code>T</code>. If there's no <code><a href="transfer_policy.md#0x2_transfer_policy_TransferPolicy">TransferPolicy</a></code>
+available for use, the type can not be traded in kiosks.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="transfer_policy.md#0x2_transfer_policy_new">new</a>&lt;T&gt;(pub: &<a href="package.md#0x2_package_Publisher">package::Publisher</a>, ctx: &<b>mut</b> <a href="tx_context.md#0x2_tx_context_TxContext">tx_context::TxContext</a>): (<a href="transfer_policy.md#0x2_transfer_policy_TransferPolicy">transfer_policy::TransferPolicy</a>&lt;T&gt;, <a href="transfer_policy.md#0x2_transfer_policy_TransferPolicyCap">transfer_policy::TransferPolicyCap</a>&lt;T&gt;)

--- a/crates/sui-framework/packages/sui-framework/sources/kiosk/kiosk.move
+++ b/crates/sui-framework/packages/sui-framework/sources/kiosk/kiosk.move
@@ -175,7 +175,7 @@ module sui::kiosk {
 
     /// Creates a new Kiosk in a default configuration: sender receives the
     /// `KioskOwnerCap` and becomes the Owner, the `Kiosk` is shared.
-    entry fun new_default(ctx: &mut TxContext) {
+    entry fun default(ctx: &mut TxContext) {
         let (kiosk, cap) = new(ctx);
         sui::transfer::transfer(cap, sender(ctx));
         sui::transfer::share_object(kiosk);

--- a/crates/sui-framework/packages/sui-framework/sources/kiosk/kiosk.move
+++ b/crates/sui-framework/packages/sui-framework/sources/kiosk/kiosk.move
@@ -173,6 +173,14 @@ module sui::kiosk {
 
     // === Kiosk packing and unpacking ===
 
+    /// Creates a new Kiosk in a default configuration: sender receives the
+    /// `KioskOwnerCap` and becomes the Owner, the `Kiosk` is shared.
+    entry fun new_default(ctx: &mut TxContext) {
+        let (kiosk, cap) = new(ctx);
+        sui::transfer::transfer(cap, sender(ctx));
+        sui::transfer::share_object(kiosk);
+    }
+
     /// Creates a new `Kiosk` with a matching `KioskOwnerCap`.
     public fun new(ctx: &mut TxContext): (Kiosk, KioskOwnerCap) {
         let kiosk = Kiosk {

--- a/crates/sui-framework/packages/sui-framework/sources/kiosk/transfer_policy.move
+++ b/crates/sui-framework/packages/sui-framework/sources/kiosk/transfer_policy.move
@@ -109,10 +109,10 @@ module sui::transfer_policy {
         TransferRequest { item, paid, from, receipts: vec_set::empty() }
     }
 
-    /// Register a type in the Kiosk system and receive an `TransferPolicyCap`
-    /// which is required to confirm kiosk deals for the `T`. If there's no
-    /// `TransferPolicyCap` available for use, the type can not be traded in
-    /// kiosks.
+    /// Register a type in the Kiosk system and receive a `TransferPolicy` and
+    /// a `TransferPolicyCap` for the type. The `TransferPolicy` is required to
+    /// confirm kiosk deals for the `T`. If there's no `TransferPolicy`
+    /// available for use, the type can not be traded in kiosks.
     public fun new<T>(
         pub: &Publisher, ctx: &mut TxContext
     ): (TransferPolicy<T>, TransferPolicyCap<T>) {

--- a/crates/sui-framework/packages/sui-framework/sources/kiosk/transfer_policy.move
+++ b/crates/sui-framework/packages/sui-framework/sources/kiosk/transfer_policy.move
@@ -26,7 +26,7 @@ module sui::transfer_policy {
     use std::option::{Self, Option};
     use std::type_name::{Self, TypeName};
     use sui::package::{Self, Publisher};
-    use sui::tx_context::TxContext;
+    use sui::tx_context::{sender, TxContext};
     use sui::object::{Self, ID, UID};
     use sui::vec_set::{Self, VecSet};
     use sui::dynamic_field as df;
@@ -126,6 +126,15 @@ module sui::transfer_policy {
             TransferPolicy { id, rules: vec_set::empty(), balance: balance::zero() },
             TransferPolicyCap { id: object::new(ctx), policy_id }
         )
+    }
+
+    /// Initialize the Tranfer Policy in the default scenario: Create and share
+    /// the `TransferPolicy`, transfer `TransferPolicyCap` to the transaction
+    /// sender.
+    entry fun default<T>(pub: &Publisher, ctx: &mut TxContext) {
+        let (policy, cap) = new<T>(pub, ctx);
+        sui::transfer::share_object(policy);
+        sui::transfer::transfer(cap, sender(ctx));
     }
 
     /// Withdraw some amount of profits from the `TransferPolicy`. If amount

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0x4933fecede684dfe39a6b6b6584523cae4430dd46d8c97b26f17b94a94198e6e"
+            id: "0xc36e2376605181ab6bbece6ee9fbf6f1bf85ecdfe3609c55e47a3b5e9d5a33a6"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0xf82c5673d39cb283516fb1953d3efa7342d8ccb34ea6e133b5a51bc6b9c93481"
+      operation_cap_id: "0x4bc413d229794a6ebe6549f3eb87fd0f27200eac04e0c9e3849b24467078c815"
       gas_price: 1000
       staking_pool:
-        id: "0xa3c45e4d99aac4e0c7d9712828b8ec3e4a3ac900ee85e8cf7fe74fb96993a189"
+        id: "0x2297dd106a5d74596cd063dda94178f4483b793e5fc3bd2f6150efca09b847af"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0x48b0dad4a36bbf5f25fa37ae8690b5444c9094fc1f34b4566e0272088eb8b328"
+          id: "0x2e18636566e9d7c224f4e22994cb55ce1e2dcdf0cda0c360d0665db17a17f417"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0x26b4706978b869e3ce28e74dd3f8d0dc002d101bdef67d36627992e3ef558b24"
+            id: "0x352d02225dfe3b21d64b05c018650fb81effe9a7536b32168a6da197ec5bbecc"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0xbc8a3c4cf415a18a692b225794a85663bbe9ead51a38a4eb6d961b5a31c3e182"
+          id: "0xa8f87aca64eb46258140366e3470c871be5b4ba6ccffdda785d20b1d46026837"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x7de8fb724d1a39e83469de607af182b086cde9faac26c855db3d82c75295ee05"
+      id: "0xa3319e63380bf8926a5e34909586a1ad58ff37977ea459b423605096586721b0"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0x3c0720954f22f5aeb1c5da184e8d02f3fa1ea2ce61cd8da9da84ca0641fd2b5c"
+    id: "0x139525268cc1a801d70e550ceca781e2838d3035ff6907efdbe1218891e2eb3f"
     size: 1
   inactive_validators:
-    id: "0xabd4f0b76638984c15e958b9d668c1a068ab482dc08d92a4b2eab8f5a381ee92"
+    id: "0x2e28b2f96d5d04c1cc3203cb96d051d01cf5831a0dcdd55e7ad373d06fa63696"
     size: 0
   validator_candidates:
-    id: "0xa167df90b964b232904cb5ad413fb78dd2b9cebd931fa2e05b69c65bbc240f79"
+    id: "0x147f6e5d344ee0800f034f44569603ba1a874cdecc397c250b66b5b8b7bf3077"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0xb7314000f740c7175b2194377ee9acbf1e2227ec0ef7368a0fb883d491d3d013"
+      id: "0x434c8bebe247d809deeddde5fb62965b183f20e5694368b14df69740e6e5975c"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x65a5c30c1b0b432b30dc2ed3561e21170a2288cdd23a201a2e93c99fbc15645e"
+      id: "0x44862d10d2669474416cca1e29105b062779e85d02f15f522113cd05fe3b7892"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0x7b44b32972d6cbdc6c789b87e0b9b39ba1a551775691abc9b2248ac1def4d98f"
+      id: "0xf253dc18d00124107beae5e6a39e7fcfeebe889f1921ceb16d6bc8560da84954"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,6 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0xce338efa26c9ebc689ac5a8c17d9d9871fefe28d028c68c1608ff3f702827c1c"
+    id: "0xb5cba82ab9cbd229a6c9902695031c907af42a3d1ade4357665c92fb3d64738b"
   size: 0
 


### PR DESCRIPTION
## Description 

For an easy CLI setup (it does not support PTBs yet), adds an entry function which shares the Kiosk and transfers the KioskOwnerCap to the tx sender. This is the most common setup for the Kiosk.

## Test Plan 

---

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

- adds `sui::kiosk::default()` function for easy Kiosk setup