### PR TITLE
[sui-framework] Add deepbook tests

### DIFF
--- a/crates/sui-framework-tests/src/lib.rs
+++ b/crates/sui-framework-tests/src/lib.rs
@@ -11,14 +11,32 @@ mod test {
 
     #[test]
     #[cfg_attr(msim, ignore)]
-    fn run_framework_move_unit_tests() {
-        for package in ["sui-framework", "sui-system"] {
-            check_move_unit_tests({
-                let mut buf = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-                buf.extend(["..", "sui-framework", "packages", package]);
-                buf
-            });
-        }
+    fn run_sui_framework_tests() {
+        check_move_unit_tests({
+            let mut buf = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            buf.extend(["..", "sui-framework", "packages", "sui-framework"]);
+            buf
+        });
+    }
+
+    #[test]
+    #[cfg_attr(msim, ignore)]
+    fn run_sui_system_tests() {
+        check_move_unit_tests({
+            let mut buf = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            buf.extend(["..", "sui-framework", "packages", "sui-system"]);
+            buf
+        });
+    }
+
+    #[test]
+    #[cfg_attr(msim, ignore)]
+    fn run_deepbook_tests() {
+        check_move_unit_tests({
+            let mut buf = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            buf.extend(["..", "sui-framework", "packages", "deepbook"]);
+            buf
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Description

Run deepbook test among other `sui-framework-tests`.  Also separate framework tests each into their own test so that it's possible to run the tests for just one package.

## Test Plan

```
sui/crates/sui-framework-tests$ cargo nextest run -- run_deepbook_tests
```