### PR TITLE
[move-stdlib/type_name] rename get_original to get_with_original_ids

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/upgrade/type_names.exp
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/type_names.exp
@@ -16,7 +16,7 @@ gas summary: computation_cost: 1000000, storage_cost: 6520800,  storage_rebate: 
 task 3 'upgrade'. lines 32-62:
 created: object(3,0)
 mutated: object(0,0), object(1,1)
-gas summary: computation_cost: 1000000, storage_cost: 9066800,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+gas summary: computation_cost: 1000000, storage_cost: 9135200,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
 
 task 4 'run'. lines 64-64:
 created: object(4,0)

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/type_names.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/type_names.move
@@ -47,7 +47,7 @@ module A2::m {
 
     entry fun canary<T>(use_original: bool, ctx: &mut TxContext) {
         let type = if (use_original) {
-            type_name::get_original<T>()
+            type_name::get_with_original_ids<T>()
         } else {
             type_name::get<T>()
         };

--- a/crates/sui-framework/docs/package.md
+++ b/crates/sui-framework/docs/package.md
@@ -341,7 +341,7 @@ but multiple per package (!).
 <pre><code><b>public</b> <b>fun</b> <a href="package.md#0x2_package_claim">claim</a>&lt;OTW: drop&gt;(otw: OTW, ctx: &<b>mut</b> TxContext): <a href="package.md#0x2_package_Publisher">Publisher</a> {
     <b>assert</b>!(<a href="types.md#0x2_types_is_one_time_witness">types::is_one_time_witness</a>(&otw), <a href="package.md#0x2_package_ENotOneTimeWitness">ENotOneTimeWitness</a>);
 
-    <b>let</b> type = <a href="_get_original">type_name::get_original</a>&lt;OTW&gt;();
+    <b>let</b> type = <a href="_get_with_original_ids">type_name::get_with_original_ids</a>&lt;OTW&gt;();
 
     <a href="package.md#0x2_package_Publisher">Publisher</a> {
         id: <a href="object.md#0x2_object_new">object::new</a>(ctx),
@@ -426,7 +426,7 @@ Check whether type belongs to the same package as the publisher object.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="package.md#0x2_package_from_package">from_package</a>&lt;T&gt;(self: &<a href="package.md#0x2_package_Publisher">Publisher</a>): bool {
-    <b>let</b> type = <a href="_get_original">type_name::get_original</a>&lt;T&gt;();
+    <b>let</b> type = <a href="_get_with_original_ids">type_name::get_with_original_ids</a>&lt;T&gt;();
 
     (<a href="_get_address">type_name::get_address</a>(&type) == self.<a href="package.md#0x2_package">package</a>)
 }
@@ -453,7 +453,7 @@ Check whether a type belongs to the same module as the publisher object.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="package.md#0x2_package_from_module">from_module</a>&lt;T&gt;(self: &<a href="package.md#0x2_package_Publisher">Publisher</a>): bool {
-    <b>let</b> type = <a href="_get_original">type_name::get_original</a>&lt;T&gt;();
+    <b>let</b> type = <a href="_get_with_original_ids">type_name::get_with_original_ids</a>&lt;T&gt;();
 
     (<a href="_get_address">type_name::get_address</a>(&type) == self.<a href="package.md#0x2_package">package</a>)
         && (<a href="_get_module">type_name::get_module</a>(&type) == self.module_name)

--- a/crates/sui-framework/packages/move-stdlib/sources/type_name.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/type_name.move
@@ -35,8 +35,8 @@ module std::type_name {
     /// this function are original IDs (the ID of the first version of
     /// the package, even if the type in question was introduced in a
     /// later upgrade).
-    public native fun get_original<T>(): TypeName;
-    spec get_original {
+    public native fun get_with_original_ids<T>(): TypeName;
+    spec get_with_original_ids {
         pragma opaque;
     }
 

--- a/crates/sui-framework/packages/sui-framework/sources/package.move
+++ b/crates/sui-framework/packages/sui-framework/sources/package.move
@@ -93,7 +93,7 @@ module sui::package {
     public fun claim<OTW: drop>(otw: OTW, ctx: &mut TxContext): Publisher {
         assert!(types::is_one_time_witness(&otw), ENotOneTimeWitness);
 
-        let type = type_name::get_original<OTW>();
+        let type = type_name::get_with_original_ids<OTW>();
 
         Publisher {
             id: object::new(ctx),
@@ -118,14 +118,14 @@ module sui::package {
 
     /// Check whether type belongs to the same package as the publisher object.
     public fun from_package<T>(self: &Publisher): bool {
-        let type = type_name::get_original<T>();
+        let type = type_name::get_with_original_ids<T>();
 
         (type_name::get_address(&type) == self.package)
     }
 
     /// Check whether a type belongs to the same module as the publisher object.
     public fun from_module<T>(self: &Publisher): bool {
-        let type = type_name::get_original<T>();
+        let type = type_name::get_with_original_ids<T>();
 
         (type_name::get_address(&type) == self.package)
             && (type_name::get_module(&type) == self.module_name)
@@ -271,7 +271,7 @@ module sui::package {
     #[test_only]
     /// Test-only function to claim a Publisher object bypassing OTW check.
     public fun test_claim<OTW: drop>(_: OTW, ctx: &mut TxContext): Publisher {
-        let type = type_name::get_original<OTW>();
+        let type = type_name::get_with_original_ids<OTW>();
 
         Publisher {
             id: object::new(ctx),

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -36,7 +36,7 @@ const MAX_PROTOCOL_VERSION: u64 = 11;
 // Version 10:increase bytecode verifier `max_verifier_meter_ticks_per_function` and
 //            `max_meter_ticks_per_module` limits each from 6_000_000 to 16_000_000. sui-system
 //            framework changes.
-// Version 11: Introduce `std::type_name::get_original` to the system frameworks.
+// Version 11: Introduce `std::type_name::get_with_original_ids` to the system frameworks.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0xabf28cc51eab70e8b10bf4aeaac8444baf81a77b192a36657aaa72bfa9ff0d07"
+            id: "0xb200fbad958a0ca7cf144574fb28b04c6cc5f95a7f75d6c4175a2fc4713459d5"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0x71254747fbce24ae8262c06d3041467f05c779ddbdc1bf0aa108101cbbe112eb"
+      operation_cap_id: "0x06b2a39853210c5969114910968752d19d27951eeb38f97945ddcefcadccb77d"
       gas_price: 1000
       staking_pool:
-        id: "0x881449974facb30e887ce27317c081a39813a202b27869df58549a61d45574e2"
+        id: "0x97421ab87a5ec5cee54e3b6e32a3e5bfa743ddbf89b3d785cd03b443f4be7e8a"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0x12b5f28dfc5a31896a2945a98a4cdd8937c10b881946e855af7499c41865882c"
+          id: "0x2709b2d76aeffdcba2c76d7010efd753ef729ac8d44f7e4602ee5c22049fb417"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0x3768151f2bc597c09385256c4549b956abc482c27c3110f3f7a77c57966437c6"
+            id: "0xd706a3ab8d8b48123eeab8c1607beeb13778082ee320a1543f14bdb634ea0146"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0x717edc94c60f3f78410e2e7b2e4587e141b231e69f8b708e3c8b1d1f1c11dab3"
+          id: "0xa734baf32401df798fb88f0bf75bcedcf4a971b98d3c0e80442eb73e746ce418"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x8fd549a887b9bb7ddf9a0eba4199decab3ad131a696a7e852cf9a52703a078b5"
+      id: "0x3ebe16e9b6ccee8fa7646d2bec501699d63360c421e63aa2c248a36a7ac1864a"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0xd461f51f7818dceedda767c92e06e3bf22a98d5443cc344a6fb73c10bae5bbda"
+    id: "0x54dbc10aa27bc93e77eed41212a5b4fa5c4e72373aa266b19850da565f732e5e"
     size: 1
   inactive_validators:
-    id: "0x0947ba235c57dc9d22e41333a1cdf38d577c561cb56e079c7c0d4f7c0b812bfe"
+    id: "0x44778d2ae41e052a053eeaa5d4b55b22865ac959e82a5dd7f406230155faea9a"
     size: 0
   validator_candidates:
-    id: "0xcc2c8f1b10a73c54dc0444e4dbb23f31b5faa8d209e66ba8d9508b4f1f494885"
+    id: "0x7b2a5e818462f1f838ce3e99f23f25f4d53bddaa5294b3e6a1eae8b873839b51"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0x88ad024711a99eeb1adbdc459b65812723ffb29905c95ce196610628e5002a57"
+      id: "0x57167f4fd7db28ef42ba061618e7315e2cfbf4e2d5f86ca26ecd37d9083b3186"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0xa265f9b638902928195d72316976265f4a351b3727bafcf22ed5d1ceb3207b61"
+      id: "0x9eab6f2037f499823124969851bc1da6fb5680a6213815080787734780e1675d"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0x7625dd3496905c01a9d350bff605e4b21fbc6dc0fb38c9f53809c57fd2b4474d"
+      id: "0x47d75d1ae46fdc4111f964f49dcc4c35b327e018709699a9214a20e9d6f0accd"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,6 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0xe5e51fc1d5dbc25599510b0eca95ffb69d56c678d6c4c94b18b7de24e068ff67"
+    id: "0xb102cb867c14a2051254be7abd31e7b5a9e6f0872e33ed4afc057ab9db838235"
   size: 0
 

--- a/external-crates/move/move-stdlib/docs/type_name.md
+++ b/external-crates/move/move-stdlib/docs/type_name.md
@@ -8,7 +8,7 @@ Functionality for converting Move types into values. Use with care!
 
 -  [Struct `TypeName`](#0x1_type_name_TypeName)
 -  [Function `get`](#0x1_type_name_get)
--  [Function `get_original`](#0x1_type_name_get_original)
+-  [Function `get_with_original_ids`](#0x1_type_name_get_with_original_ids)
 -  [Function `borrow_string`](#0x1_type_name_borrow_string)
 -  [Function `into_string`](#0x1_type_name_into_string)
 
@@ -57,9 +57,8 @@ Functionality for converting Move types into values. Use with care!
 
 Return a value representation of the type <code>T</code>.  Package IDs
 that appear in fully qualified type names in the output from
-this function are original IDs (the ID of the first version of
-the package, even if the type in question was introduced in a
-later upgrade).
+this function are defining IDs (the ID of the package in
+storage that first introduced the type).
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="type_name.md#0x1_type_name_get">get</a>&lt;T&gt;(): <a href="type_name.md#0x1_type_name_TypeName">type_name::TypeName</a>
@@ -78,9 +77,9 @@ later upgrade).
 
 </details>
 
-<a name="0x1_type_name_get_original"></a>
+<a name="0x1_type_name_get_with_original_ids"></a>
 
-## Function `get_original`
+## Function `get_with_original_ids`
 
 Return a value representation of the type <code>T</code>.  Package IDs
 that appear in fully qualified type names in the output from
@@ -89,7 +88,7 @@ the package, even if the type in question was introduced in a
 later upgrade).
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="type_name.md#0x1_type_name_get_original">get_original</a>&lt;T&gt;(): <a href="type_name.md#0x1_type_name_TypeName">type_name::TypeName</a>
+<pre><code><b>public</b> <b>fun</b> <a href="type_name.md#0x1_type_name_get_with_original_ids">get_with_original_ids</a>&lt;T&gt;(): <a href="type_name.md#0x1_type_name_TypeName">type_name::TypeName</a>
 </code></pre>
 
 
@@ -98,7 +97,7 @@ later upgrade).
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="type_name.md#0x1_type_name_get_original">get_original</a>&lt;T&gt;(): <a href="type_name.md#0x1_type_name_TypeName">TypeName</a>;
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="type_name.md#0x1_type_name_get_with_original_ids">get_with_original_ids</a>&lt;T&gt;(): <a href="type_name.md#0x1_type_name_TypeName">TypeName</a>;
 </code></pre>
 
 

--- a/external-crates/move/move-stdlib/sources/type_name.move
+++ b/external-crates/move/move-stdlib/sources/type_name.move
@@ -15,9 +15,8 @@ module std::type_name {
 
     /// Return a value representation of the type `T`.  Package IDs
     /// that appear in fully qualified type names in the output from
-    /// this function are original IDs (the ID of the first version of
-    /// the package, even if the type in question was introduced in a
-    /// later upgrade).
+    /// this function are defining IDs (the ID of the package in
+    /// storage that first introduced the type).
     public native fun get<T>(): TypeName;
 
     /// Return a value representation of the type `T`.  Package IDs
@@ -25,7 +24,7 @@ module std::type_name {
     /// this function are original IDs (the ID of the first version of
     /// the package, even if the type in question was introduced in a
     /// later upgrade).
-    public native fun get_original<T>(): TypeName;
+    public native fun get_with_original_ids<T>(): TypeName;
 
     /// Get the String representation of `self`
     public fun borrow_string(self: &TypeName): &String {

--- a/external-crates/move/move-stdlib/src/natives/type_name.rs
+++ b/external-crates/move/move-stdlib/src/natives/type_name.rs
@@ -80,7 +80,7 @@ pub fn make_all(gas_params: GasParameters) -> impl Iterator<Item = (String, Nati
             make_native_get(/* use_original_id */ false, gas_params.get.clone()),
         ),
         (
-            "get_original",
+            "get_with_original_ids",
             make_native_get(/* use_original_id */ true, gas_params.get),
         ),
     ];


### PR DESCRIPTION
## Description

Address follow-ups from #12026, related to a typo in a doc comment, and an improvement to the function name.

## Test Plan:

```
sui$ cargo simtest
sui$ env SUI_SKIP_SIMTESTS=1 cargo nextest run
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Renaming `std::type_name::get_original` (introduced to the framework as protocol version 11) to `std::type_name::get_with_original_ids`.