### PR TITLE
[1/n] [sui-json-rpc] unit testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5101,9 +5101,9 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e4a1c770583dac7ab5e2f6c139153b783a53a1bbee9729613f193e59828326"
+checksum = "4c84490118f2ee2d74570d114f3d0493cbf02790df303d2707606c3e14e07c96"
 dependencies = [
  "cfg-if",
  "downcast",
@@ -5116,9 +5116,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "832663583d5fa284ca8810bf7015e46c9fff9622d3cf34bd1eea5003fec06dd0"
+checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
 dependencies = [
  "cfg-if",
  "proc-macro2 1.0.54",
@@ -9857,6 +9857,7 @@ dependencies = [
  "jsonrpsee",
  "jsonrpsee-proc-macros",
  "linked-hash-map",
+ "mockall",
  "move-binary-format",
  "move-bytecode-utils",
  "move-core-types",

--- a/crates/sui-json-rpc-types/src/sui_move.rs
+++ b/crates/sui-json-rpc-types/src/sui_move.rs
@@ -118,6 +118,14 @@ pub struct SuiMoveNormalizedModule {
     pub exposed_functions: BTreeMap<String, SuiMoveNormalizedFunction>,
 }
 
+impl PartialEq for SuiMoveNormalizedModule {
+    fn eq(&self, other: &Self) -> bool {
+        self.file_format_version == other.file_format_version
+            && self.address == other.address
+            && self.name == other.name
+    }
+}
+
 impl From<NormalizedModule> for SuiMoveNormalizedModule {
     fn from(module: NormalizedModule) -> Self {
         Self {

--- a/crates/sui-json-rpc/Cargo.toml
+++ b/crates/sui-json-rpc/Cargo.toml
@@ -61,3 +61,4 @@ rand = "0.8.5"
 sui-macros = { path = "../sui-macros" }
 sui-simulator = { path = "../sui-simulator" }
 reqwest = { version = "0.11.13", default_features = false, features = ["rustls-tls"] }
+mockall = "0.11.4"

--- a/crates/sui-json-rpc/src/move_utils.rs
+++ b/crates/sui-json-rpc/src/move_utils.rs
@@ -8,8 +8,12 @@ use crate::{with_tracing, SuiRpcModule};
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::RpcModule;
-use move_binary_format::file_format_common::VERSION_MAX;
-use move_binary_format::normalized::Type;
+#[cfg(test)]
+use mockall::automock;
+use move_binary_format::{
+    file_format_common::VERSION_MAX,
+    normalized::{Module as NormalizedModule, Type},
+};
 use move_core_types::identifier::Identifier;
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -24,13 +28,73 @@ use sui_types::move_package::normalize_modules;
 use sui_types::object::{Data, ObjectRead};
 use tracing::instrument;
 
-pub struct MoveUtils {
+#[cfg_attr(test, automock)]
+#[async_trait]
+pub trait MoveUtilsInternalTrait {
+    fn get_state(&self) -> &AuthorityState;
+
+    async fn get_move_module(
+        &self,
+        package: ObjectID,
+        module_name: String,
+    ) -> Result<NormalizedModule, Error>;
+
+    async fn get_move_modules_by_package(
+        &self,
+        package: ObjectID,
+    ) -> Result<BTreeMap<String, NormalizedModule>, Error>;
+
+    fn get_object_read(&self, package: ObjectID) -> Result<ObjectRead, Error>;
+}
+
+pub struct MoveUtilsInternal {
     state: Arc<AuthorityState>,
+}
+
+impl MoveUtilsInternal {
+    pub fn new(state: Arc<AuthorityState>) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl MoveUtilsInternalTrait for MoveUtilsInternal {
+    fn get_state(&self) -> &AuthorityState {
+        &self.state
+    }
+
+    async fn get_move_module(
+        &self,
+        package: ObjectID,
+        module_name: String,
+    ) -> Result<NormalizedModule, Error> {
+        get_move_module(self.get_state(), package, module_name).await
+    }
+
+    async fn get_move_modules_by_package(
+        &self,
+        package: ObjectID,
+    ) -> Result<BTreeMap<String, NormalizedModule>, Error> {
+        get_move_modules_by_package(self.get_state(), package).await
+    }
+
+    fn get_object_read(&self, package: ObjectID) -> Result<ObjectRead, Error> {
+        self.get_state()
+            .get_object_read(&package)
+            .map_err(Error::from)
+    }
+}
+
+pub struct MoveUtils {
+    internal: Arc<dyn MoveUtilsInternalTrait + Send + Sync>,
 }
 
 impl MoveUtils {
     pub fn new(state: Arc<AuthorityState>) -> Self {
-        Self { state }
+        Self {
+            internal: Arc::new(MoveUtilsInternal::new(state))
+                as Arc<dyn MoveUtilsInternalTrait + Send + Sync>,
+        }
     }
 }
 
@@ -52,7 +116,7 @@ impl MoveUtilsServer for MoveUtils {
         package: ObjectID,
     ) -> RpcResult<BTreeMap<String, SuiMoveNormalizedModule>> {
         with_tracing!(async move {
-            let modules = get_move_modules_by_package(&self.state, package).await?;
+            let modules = self.internal.get_move_modules_by_package(package).await?;
             Ok(modules
                 .into_iter()
                 .map(|(name, module)| (name, module.into()))
@@ -67,7 +131,7 @@ impl MoveUtilsServer for MoveUtils {
         module_name: String,
     ) -> RpcResult<SuiMoveNormalizedModule> {
         with_tracing!(async move {
-            let module = get_move_module(&self.state, package, module_name).await?;
+            let module = self.internal.get_move_module(package, module_name).await?;
             Ok(module.into())
         })
     }
@@ -80,7 +144,7 @@ impl MoveUtilsServer for MoveUtils {
         struct_name: String,
     ) -> RpcResult<SuiMoveNormalizedStruct> {
         with_tracing!(async move {
-            let module = get_move_module(&self.state, package, module_name).await?;
+            let module = self.internal.get_move_module(package, module_name).await?;
             let structs = module.structs;
             let identifier = Identifier::new(struct_name.as_str()).map_err(|e| {
                 Error::SuiRpcInputError(SuiRpcInputError::GenericInvalid(format!("{e}")))
@@ -102,7 +166,7 @@ impl MoveUtilsServer for MoveUtils {
         function_name: String,
     ) -> RpcResult<SuiMoveNormalizedFunction> {
         with_tracing!(async move {
-            let module = get_move_module(&self.state, package, module_name).await?;
+            let module = self.internal.get_move_module(package, module_name).await?;
             let functions = module.functions;
             let identifier = Identifier::new(function_name.as_str()).map_err(|e| {
                 Error::SuiRpcInputError(SuiRpcInputError::GenericInvalid(format!("{e}")))
@@ -124,7 +188,7 @@ impl MoveUtilsServer for MoveUtils {
         function: String,
     ) -> RpcResult<Vec<MoveFunctionArgType>> {
         with_tracing!(async move {
-            let object_read = self.state.get_object_read(&package).map_err(Error::from)?;
+            let object_read = self.internal.get_object_read(package)?;
 
             let normalized = match object_read {
                 ObjectRead::Exists(_obj_ref, object, _layout) => match object.data {
@@ -178,5 +242,69 @@ impl MoveUtilsServer for MoveUtils {
                 ))),
             }?)
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    mod get_normalized_move_module_tests {
+        use super::super::*;
+        use jsonrpsee::types::ErrorObjectOwned;
+        use move_binary_format::file_format::basic_test_module;
+
+        fn setup() -> (ObjectID, String) {
+            (ObjectID::random(), String::from("test_module"))
+        }
+
+        #[tokio::test]
+        async fn test_success_response() {
+            let (package, module_name) = setup();
+            let mut mock_internal = MockMoveUtilsInternalTrait::new();
+
+            let m = basic_test_module();
+            let normalized_module = NormalizedModule::new(&m);
+            let expected_module: SuiMoveNormalizedModule = normalized_module.clone().into();
+
+            mock_internal
+                .expect_get_move_module()
+                .return_once(move |_package, _module_name| Ok(normalized_module));
+
+            let move_utils = MoveUtils {
+                internal: Arc::new(mock_internal),
+            };
+
+            let response = move_utils
+                .get_normalized_move_module(package, module_name)
+                .await;
+
+            assert!(response.is_ok());
+            let result = response.unwrap();
+            assert_eq!(result, expected_module);
+        }
+
+        #[tokio::test]
+        async fn test_no_module_found() {
+            let (package, module_name) = setup();
+            let mut mock_internal = MockMoveUtilsInternalTrait::new();
+            let error_string = format!("No module found with module name {module_name}");
+            let expected_error =
+                Error::SuiRpcInputError(SuiRpcInputError::GenericNotFound(error_string.clone()));
+            mock_internal
+                .expect_get_move_module()
+                .return_once(move |_package, _module_name| Err(expected_error));
+            let move_utils = MoveUtils {
+                internal: Arc::new(mock_internal),
+            };
+
+            let response = move_utils
+                .get_normalized_move_module(package, module_name)
+                .await;
+            let error_result = response.unwrap_err();
+            let error_object: ErrorObjectOwned = error_result.into();
+
+            assert_eq!(error_object.code(), -32602);
+            assert_eq!(error_object.message(), &error_string);
+        }
     }
 }


### PR DESCRIPTION
## Description 

Given the recent changes to error handling and error response codes on rpc, adding some unit tests so we can expect behavior without having to reproduce potentially difficult error states through integration/ e2e tests.

1. `MoveUtils` previously took `AuthorityState`, now has field `MoveUtilsInternalTrait` trait object. Moved most implementation of MoveUtils input the trait object so we can mock various states and expect the correct success or error response.
2. Two unit tests for `get_normalized_move_module` for success and error responses.

## Test Plan 
Existing tests + new unit tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
