### PR TITLE
Remove semver metadata

### DIFF
--- a/crates/sui-snapshot/Cargo.toml
+++ b/crates/sui-snapshot/Cargo.toml
@@ -22,7 +22,7 @@ futures = "0.3.23"
 backoff = "0.4.0"
 object_store = "=0.5.4"
 prometheus = "0.13.3"
-zstd = "0.12.3+zstd.1.5.2"
+zstd = "0.12.3"
 typed-store.workspace = true
 typed-store-derive.workspace = true
 sui-types = { path = "../sui-types" }


### PR DESCRIPTION
## Description 

Avoid the build warning `version requirement `0.12.3+zstd.1.5.2` for dependency `zstd` includes semver metadata which will be ignored, removing the metadata is recommended to avoid confusion`

## Test Plan 

CI.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
