### PR TITLE
[execution][dynamic fields] Support versioned child object reads

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/mvcc/child_of_child.exp
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/child_of_child.exp
@@ -1,0 +1,62 @@
+processed 14 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 8-69:
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 9234000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'programmable'. lines 71-73:
+created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 9750800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'view-object'. lines 75-75:
+Owner: Account Address ( A )
+Version: 2
+Contents: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,2)}}, value: 0u64}
+
+task 4 'programmable'. lines 77-78:
+mutated: object(0,0), object(2,2), object(2,3), object(2,4)
+gas summary: computation_cost: 1000000, storage_cost: 4841200,  storage_rebate: 4792788, non_refundable_storage_fee: 48412
+
+task 5 'view-object'. lines 80-80:
+Owner: Account Address ( A )
+Version: 3
+Contents: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,2)}}, value: 1u64}
+
+task 6 'programmable'. lines 82-83:
+mutated: object(0,0), object(2,2)
+deleted: object(2,0), object(2,3)
+gas summary: computation_cost: 1000000, storage_cost: 2272400,  storage_rebate: 5951484, non_refundable_storage_fee: 60116
+
+task 7 'view-object'. lines 85-88:
+Owner: Account Address ( A )
+Version: 4
+Contents: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,2)}}, value: 1u64}
+
+task 8 'programmable'. lines 90-91:
+mutated: object(_), object(2,2)
+gas summary: computation_cost: 500000, storage_cost: 2272400,  storage_rebate: 1271556, non_refundable_storage_fee: 12844
+
+task 9 'programmable'. lines 93-94:
+mutated: object(_), object(2,2)
+gas summary: computation_cost: 500000, storage_cost: 2272400,  storage_rebate: 1271556, non_refundable_storage_fee: 12844
+
+task 10 'programmable'. lines 96-100:
+mutated: object(_), object(2,2)
+gas summary: computation_cost: 500000, storage_cost: 2272400,  storage_rebate: 1271556, non_refundable_storage_fee: 12844
+
+task 11 'programmable'. lines 102-103:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 3, instruction: 10, function_name: Some("check") }, 0) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 3, instruction: 10, function_name: Some("check") }, 0) in command 0
+
+task 12 'programmable'. lines 105-106:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 11, instruction: 0, function_name: Some("borrow_child_object") }, 1) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 11, instruction: 0, function_name: Some("borrow_child_object") }, 1) in command 0
+
+task 13 'programmable'. lines 108-109:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 3, instruction: 10, function_name: Some("check") }, 0) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 3, instruction: 10, function_name: Some("check") }, 0) in command 0

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/child_of_child.move
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/child_of_child.move
@@ -1,0 +1,109 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests accessing the versions of a child of a child
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+
+module test::m {
+    use std::option::{Self, Option};
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::dynamic_object_field as ofield;
+
+    struct Obj has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    const KEY: u64 = 0;
+
+    //////////////////////////////////////////////////////////////
+    // new
+
+    public fun new(ctx: &mut TxContext): Obj {
+        let grand = Obj { id: object::new(ctx), value: 0 };
+        let parent = Obj { id: object::new(ctx), value: 0 };
+        let child = Obj { id: object::new(ctx), value: 0 };
+        ofield::add(&mut parent.id, KEY, child);
+        ofield::add(&mut grand.id, KEY, parent);
+        grand
+    }
+
+    //////////////////////////////////////////////////////////////
+    // set
+
+    public fun set(grand: &mut Obj, v1: u64, v2: u64, v3: u64) {
+        grand.value = v1;
+        let parent: &mut Obj = ofield::borrow_mut(&mut grand.id, KEY);
+        parent.value = v2;
+        let child: &mut Obj = ofield::borrow_mut(&mut parent.id, KEY);
+        child.value = v3;
+    }
+
+    //////////////////////////////////////////////////////////////
+    // remove
+
+    public fun remove(grand: &mut Obj) {
+        let parent: &mut Obj = ofield::borrow_mut(&mut grand.id, KEY);
+        let Obj { id, value: _ } = ofield::remove(&mut parent.id, KEY);
+        object::delete(id);
+    }
+
+    //////////////////////////////////////////////////////////////
+    // check
+
+    public fun check(grand: &Obj, v1: u64, v2: u64, v3: Option<u64>) {
+        assert!(grand.value == v1, 0);
+        let parent: &Obj = ofield::borrow(&grand.id, KEY);
+        assert!(parent.value == v2, 0);
+        if (option::is_some(&v3)) {
+            let child: &Obj = ofield::borrow(&parent.id, KEY);
+            assert!(&child.value == option::borrow(&v3), 0);
+        } else {
+            assert!(!ofield::exists_<u64>(&parent.id, KEY), 0);
+        }
+    }
+}
+
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> TransferObjects([Result(0)], Input(0))
+
+//# view-object 2,2
+
+//# programmable --sender A --inputs object(2,2) 1 2 3
+//> test::m::set(Input(0), Input(1), Input(2), Input(3))
+
+//# view-object 2,2
+
+//# programmable --sender A --inputs object(2,2)
+//> test::m::remove(Input(0))
+
+//# view-object 2,2
+
+
+// dev-inspect with 'check' and correct values
+
+//# programmable --sender A --inputs object(2,2)@2 0 0 vector[0] --dev-inspect
+//> test::m::check(Input(0), Input(1), Input(2), Input(3))
+
+//# programmable --sender A --inputs object(2,2)@3 1 2 vector[3] --dev-inspect
+//> test::m::check(Input(0), Input(1), Input(2), Input(3))
+
+//# programmable --sender A --inputs object(2,2)@4 1 2 vector[] --dev-inspect
+//> test::m::check(Input(0), Input(1), Input(2), Input(3))
+
+
+// dev-inspect with 'check' and _incorrect_ values
+
+//# programmable --sender A --inputs object(2,2)@3 0 0 vector[0] --dev-inspect
+//> test::m::check(Input(0), Input(1), Input(2), Input(3))
+
+//# programmable --sender A --inputs object(2,2)@4 1 2 vector[3] --dev-inspect
+//> test::m::check(Input(0), Input(1), Input(2), Input(3))
+
+//# programmable --sender A --inputs object(2,2)@2 1 2 vector[] --dev-inspect
+//> test::m::check(Input(0), Input(1), Input(2), Input(3))

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/find_all_uids.exp
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/find_all_uids.exp
@@ -1,0 +1,62 @@
+processed 14 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 8-121:
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 12220800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'programmable'. lines 123-125:
+created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,8)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 15640800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'view-object'. lines 127-127:
+Owner: Account Address ( A )
+Version: 2
+Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,8)}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}, wrapped: test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, many: vector[test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}]}
+
+task 4 'programmable'. lines 129-130:
+mutated: object(0,0), object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,8)
+gas summary: computation_cost: 1000000, storage_cost: 15640800,  storage_rebate: 15484392, non_refundable_storage_fee: 156408
+
+task 5 'view-object'. lines 132-132:
+Owner: Account Address ( A )
+Version: 3
+Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,8)}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}, wrapped: test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, many: vector[test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}]}
+
+task 6 'programmable'. lines 134-135:
+mutated: object(0,0), object(2,8)
+deleted: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7)
+gas summary: computation_cost: 1000000, storage_cost: 3906400,  storage_rebate: 15484392, non_refundable_storage_fee: 156408
+
+task 7 'view-object'. lines 137-140:
+Owner: Account Address ( A )
+Version: 4
+Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,8)}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}, wrapped: test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, many: vector[test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}]}
+
+task 8 'programmable'. lines 142-143:
+mutated: object(_), object(2,8)
+gas summary: computation_cost: 500000, storage_cost: 3906400,  storage_rebate: 2889216, non_refundable_storage_fee: 29184
+
+task 9 'programmable'. lines 145-146:
+mutated: object(_), object(2,8)
+gas summary: computation_cost: 500000, storage_cost: 3906400,  storage_rebate: 2889216, non_refundable_storage_fee: 29184
+
+task 10 'programmable'. lines 148-152:
+mutated: object(_), object(2,8)
+gas summary: computation_cost: 500000, storage_cost: 3906400,  storage_rebate: 2889216, non_refundable_storage_fee: 29184
+
+task 11 'programmable'. lines 154-155:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 10, instruction: 12, function_name: Some("check_") }, 0) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 10, instruction: 12, function_name: Some("check_") }, 0) in command 0
+
+task 12 'programmable'. lines 157-158:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 11, instruction: 0, function_name: Some("borrow_child_object") }, 1) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 11, instruction: 0, function_name: Some("borrow_child_object") }, 1) in command 0
+
+task 13 'programmable'. lines 160-161:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 10, instruction: 21, function_name: Some("check_") }, 0) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 10, instruction: 21, function_name: Some("check_") }, 0) in command 0

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/find_all_uids.move
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/find_all_uids.move
@@ -1,0 +1,161 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests finding UIDs for dynamic field access
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+
+module test::m {
+    use std::option::{Self, Option};
+    use std::vector;
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::dynamic_field as field;
+
+    struct S has key, store {
+        id: UID,
+        other: UID,
+        wrapped: Wrapped,
+        many: vector<Wrapped>,
+    }
+
+    struct Wrapped has key, store {
+        id: UID,
+        other: UID,
+    }
+
+    const KEY: u64 = 0;
+
+    //////////////////////////////////////////////////////////////
+    // new
+
+    public fun new(ctx: &mut TxContext): S {
+        let s = S {
+            id: object::new(ctx),
+            other: object::new(ctx),
+            wrapped: wrapped(ctx),
+            many: vector[wrapped(ctx), wrapped(ctx)],
+        };
+        field::add(&mut s.id, KEY, 0);
+        field::add(&mut s.other, KEY, 0);
+        s
+    }
+
+    fun wrapped(ctx: &mut TxContext): Wrapped {
+        let w = Wrapped {
+            id: object::new(ctx),
+            other: object::new(ctx),
+        };
+        field::add(&mut w.id, KEY, 0);
+        field::add(&mut w.other, KEY, 0);
+        w
+    }
+
+    //////////////////////////////////////////////////////////////
+    // set
+
+    public fun set(s: &mut S, value: u64) {
+        set_(&mut s.id, value);
+        set_(&mut s.other, value);
+        set_wrapped(&mut s.wrapped, value);
+        set_wrapped(vector::borrow_mut(&mut s.many, 0), value);
+        set_wrapped(vector::borrow_mut(&mut s.many, 1), value);
+    }
+
+    fun set_wrapped(w: &mut Wrapped, value: u64) {
+        set_(&mut w.id, value);
+        set_(&mut w.other, value);
+
+    }
+
+    fun set_(id: &mut UID, value: u64) {
+        *field::borrow_mut(id, KEY) = value;
+    }
+
+    //////////////////////////////////////////////////////////////
+    // remove
+
+    public fun remove(s: &mut S) {
+        remove_(&mut s.id);
+        remove_(&mut s.other);
+        remove_wrapped(&mut s.wrapped);
+        remove_wrapped(vector::borrow_mut(&mut s.many, 0));
+        remove_wrapped(vector::borrow_mut(&mut s.many, 1));
+    }
+
+    fun remove_wrapped(w: &mut Wrapped) {
+        remove_(&mut w.id);
+        remove_(&mut w.other);
+    }
+
+    fun remove_(id: &mut UID) {
+        field::remove<u64, u64>(id, KEY);
+    }
+
+    //////////////////////////////////////////////////////////////
+    // check
+
+    public fun check(s: &S, expected: Option<u64>) {
+        check_(&s.id, expected);
+        check_(&s.other, expected);
+        check_wrapped(&s.wrapped, expected);
+        check_wrapped(vector::borrow(&s.many, 0), expected);
+        check_wrapped(vector::borrow(&s.many, 1), expected);
+    }
+
+    fun check_wrapped(w: &Wrapped, expected: Option<u64>) {
+        check_(&w.id, expected);
+        check_(&w.other, expected);
+    }
+
+    fun check_(id: &UID, expected: Option<u64>) {
+        if (option::is_some(&expected)) {
+            let f = field::borrow(id, KEY);
+            assert!(f == option::borrow(&expected), 0);
+        } else {
+            assert!(!field::exists_with_type<u64, u64>(id, KEY), 0);
+        }
+    }
+}
+
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> TransferObjects([Result(0)], Input(0))
+
+//# view-object 2,8
+
+//# programmable --sender A --inputs object(2,8) 112
+//> test::m::set(Input(0), Input(1))
+
+//# view-object 2,8
+
+//# programmable --sender A --inputs object(2,8) 112
+//> test::m::remove(Input(0))
+
+//# view-object 2,8
+
+
+// dev-inspect with 'check' and correct values
+
+//# programmable --sender A --inputs object(2,8)@2 vector[0] --dev-inspect
+//> test::m::check(Input(0), Input(1))
+
+//# programmable --sender A --inputs object(2,8)@3 vector[112] --dev-inspect
+//> test::m::check(Input(0), Input(1))
+
+//# programmable --sender A --inputs object(2,8)@4 vector[] --dev-inspect
+//> test::m::check(Input(0), Input(1))
+
+
+// dev-inspect with 'check' and _incorrect_ values
+
+//# programmable --sender A --inputs object(2,8)@3 vector[0] --dev-inspect
+//> test::m::check(Input(0), Input(1))
+
+//# programmable --sender A --inputs object(2,8)@4 vector[112] --dev-inspect
+//> test::m::check(Input(0), Input(1))
+
+//# programmable --sender A --inputs object(2,8)@2 vector[] --dev-inspect
+//> test::m::check(Input(0), Input(1))

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/find_all_uids_dof.exp
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/find_all_uids_dof.exp
@@ -1,0 +1,62 @@
+processed 14 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 8-134:
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 13368400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'programmable'. lines 136-138:
+created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,8), object(2,9), object(2,10), object(2,11), object(2,12), object(2,13), object(2,14), object(2,15), object(2,16)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 33941600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'view-object'. lines 140-140:
+Owner: Account Address ( A )
+Version: 2
+Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,8)}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}, wrapped: test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, many: vector[test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}]}
+
+task 4 'programmable'. lines 142-143:
+mutated: object(0,0), object(2,8), object(2,9), object(2,10), object(2,11), object(2,12), object(2,13), object(2,14), object(2,15), object(2,16)
+gas summary: computation_cost: 1000000, storage_cost: 14303200,  storage_rebate: 14160168, non_refundable_storage_fee: 143032
+
+task 5 'view-object'. lines 145-145:
+Owner: Account Address ( A )
+Version: 3
+Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,8)}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}, wrapped: test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, many: vector[test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}]}
+
+task 6 'programmable'. lines 147-148:
+mutated: object(0,0), object(2,8)
+deleted: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,9), object(2,10), object(2,11), object(2,12), object(2,13), object(2,14), object(2,15), object(2,16)
+gas summary: computation_cost: 1000000, storage_cost: 3906400,  storage_rebate: 33602184, non_refundable_storage_fee: 339416
+
+task 7 'view-object'. lines 150-153:
+Owner: Account Address ( A )
+Version: 4
+Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,8)}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}, wrapped: test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, many: vector[test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}]}
+
+task 8 'programmable'. lines 155-156:
+mutated: object(_), object(2,8)
+gas summary: computation_cost: 500000, storage_cost: 3906400,  storage_rebate: 2889216, non_refundable_storage_fee: 29184
+
+task 9 'programmable'. lines 158-159:
+mutated: object(_), object(2,8)
+gas summary: computation_cost: 500000, storage_cost: 3906400,  storage_rebate: 2889216, non_refundable_storage_fee: 29184
+
+task 10 'programmable'. lines 161-165:
+mutated: object(_), object(2,8)
+gas summary: computation_cost: 500000, storage_cost: 3906400,  storage_rebate: 2889216, non_refundable_storage_fee: 29184
+
+task 11 'programmable'. lines 167-168:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 11, instruction: 18, function_name: Some("check_") }, 0) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 11, instruction: 18, function_name: Some("check_") }, 0) in command 0
+
+task 12 'programmable'. lines 170-171:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 11, instruction: 0, function_name: Some("borrow_child_object") }, 1) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 11, instruction: 0, function_name: Some("borrow_child_object") }, 1) in command 0
+
+task 13 'programmable'. lines 173-174:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 11, instruction: 27, function_name: Some("check_") }, 0) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 11, instruction: 27, function_name: Some("check_") }, 0) in command 0

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/find_all_uids_dof.move
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/find_all_uids_dof.move
@@ -1,0 +1,174 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests finding UIDs for dynamic object field access
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+
+module test::m {
+    use std::option::{Self, Option};
+    use std::vector;
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::dynamic_object_field as ofield;
+
+    struct S has key, store {
+        id: UID,
+        other: UID,
+        wrapped: Wrapped,
+        many: vector<Wrapped>,
+    }
+
+    struct Wrapped has key, store {
+        id: UID,
+        other: UID,
+    }
+
+    struct Value has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    const KEY: u64 = 0;
+
+    //////////////////////////////////////////////////////////////
+    // new
+
+    public fun new(ctx: &mut TxContext): S {
+        let s = S {
+            id: object::new(ctx),
+            other: object::new(ctx),
+            wrapped: wrapped(ctx),
+            many: vector[wrapped(ctx), wrapped(ctx)],
+        };
+        ofield::add(&mut s.id, KEY, value(0, ctx));
+        ofield::add(&mut s.other, KEY, value(0, ctx));
+        s
+    }
+
+    fun wrapped(ctx: &mut TxContext): Wrapped {
+        let w = Wrapped {
+            id: object::new(ctx),
+            other: object::new(ctx),
+        };
+        ofield::add(&mut w.id, KEY, value(0, ctx));
+        ofield::add(&mut w.other, KEY, value(0, ctx));
+        w
+    }
+
+    fun value(value: u64, ctx: &mut TxContext): Value {
+        Value {
+            id: object::new(ctx),
+            value
+        }
+    }
+
+    //////////////////////////////////////////////////////////////
+    // set
+
+    public fun set(s: &mut S, value: u64) {
+        set_(&mut s.id, value);
+        set_(&mut s.other, value);
+        set_wrapped(&mut s.wrapped, value);
+        set_wrapped(vector::borrow_mut(&mut s.many, 0), value);
+        set_wrapped(vector::borrow_mut(&mut s.many, 1), value);
+    }
+
+    fun set_wrapped(w: &mut Wrapped, value: u64) {
+        set_(&mut w.id, value);
+        set_(&mut w.other, value);
+
+    }
+
+    fun set_(id: &mut UID, value: u64) {
+        ofield::borrow_mut<u64, Value>(id, KEY).value = value;
+    }
+
+    //////////////////////////////////////////////////////////////
+    // remove
+
+    public fun remove(s: &mut S) {
+        remove_(&mut s.id);
+        remove_(&mut s.other);
+        remove_wrapped(&mut s.wrapped);
+        remove_wrapped(vector::borrow_mut(&mut s.many, 0));
+        remove_wrapped(vector::borrow_mut(&mut s.many, 1));
+    }
+
+    fun remove_wrapped(w: &mut Wrapped) {
+        remove_(&mut w.id);
+        remove_(&mut w.other);
+    }
+
+    fun remove_(id: &mut UID) {
+        let Value { id, value: _ } = ofield::remove(id, KEY);
+        object::delete(id);
+    }
+
+    //////////////////////////////////////////////////////////////
+    // check
+
+    public fun check(s: &S, expected: Option<u64>) {
+        check_(&s.id, expected);
+        check_(&s.other, expected);
+        check_wrapped(&s.wrapped, expected);
+        check_wrapped(vector::borrow(&s.many, 0), expected);
+        check_wrapped(vector::borrow(&s.many, 1), expected);
+    }
+
+    fun check_wrapped(w: &Wrapped, expected: Option<u64>) {
+        check_(&w.id, expected);
+        check_(&w.other, expected);
+    }
+
+    fun check_(id: &UID, expected: Option<u64>) {
+        if (option::is_some(&expected)) {
+            let Value { id: _, value } = ofield::borrow(id, KEY);
+            assert!(value == option::borrow(&expected), 0);
+        } else {
+            assert!(!ofield::exists_with_type<u64, Value>(id, KEY), 0);
+        }
+    }
+}
+
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> TransferObjects([Result(0)], Input(0))
+
+//# view-object 2,8
+
+//# programmable --sender A --inputs object(2,8) 112
+//> test::m::set(Input(0), Input(1))
+
+//# view-object 2,8
+
+//# programmable --sender A --inputs object(2,8) 112
+//> test::m::remove(Input(0))
+
+//# view-object 2,8
+
+
+// dev-inspect with 'check' and correct values
+
+//# programmable --sender A --inputs object(2,8)@2 vector[0] --dev-inspect
+//> test::m::check(Input(0), Input(1))
+
+//# programmable --sender A --inputs object(2,8)@3 vector[112] --dev-inspect
+//> test::m::check(Input(0), Input(1))
+
+//# programmable --sender A --inputs object(2,8)@4 vector[] --dev-inspect
+//> test::m::check(Input(0), Input(1))
+
+
+// dev-inspect with 'check' and _incorrect_ values
+
+//# programmable --sender A --inputs object(2,8)@3 vector[0] --dev-inspect
+//> test::m::check(Input(0), Input(1))
+
+//# programmable --sender A --inputs object(2,8)@4 vector[112] --dev-inspect
+//> test::m::check(Input(0), Input(1))
+
+//# programmable --sender A --inputs object(2,8)@2 vector[] --dev-inspect
+//> test::m::check(Input(0), Input(1))

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/find_all_uids_on_child.exp
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/find_all_uids_on_child.exp
@@ -1,0 +1,62 @@
+processed 14 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 8-144:
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 13877600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'programmable'. lines 146-148:
+created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,8), object(2,9)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 17609200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'view-object'. lines 150-150:
+Owner: Account Address ( A )
+Version: 2
+Contents: test::m::Parent {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,9)}}}
+
+task 4 'programmable'. lines 152-153:
+mutated: object(0,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,8), object(2,9)
+gas summary: computation_cost: 1000000, storage_cost: 13968800,  storage_rebate: 13829112, non_refundable_storage_fee: 139688
+
+task 5 'view-object'. lines 155-155:
+Owner: Account Address ( A )
+Version: 3
+Contents: test::m::Parent {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,9)}}}
+
+task 6 'programmable'. lines 157-158:
+mutated: object(0,0), object(2,9)
+deleted: object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,8)
+gas summary: computation_cost: 1000000, storage_cost: 2234400,  storage_rebate: 13829112, non_refundable_storage_fee: 139688
+
+task 7 'view-object'. lines 160-163:
+Owner: Account Address ( A )
+Version: 4
+Contents: test::m::Parent {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,9)}}}
+
+task 8 'programmable'. lines 165-166:
+mutated: object(_), object(2,9)
+gas summary: computation_cost: 500000, storage_cost: 2234400,  storage_rebate: 1233936, non_refundable_storage_fee: 12464
+
+task 9 'programmable'. lines 168-169:
+mutated: object(_), object(2,9)
+gas summary: computation_cost: 500000, storage_cost: 2234400,  storage_rebate: 1233936, non_refundable_storage_fee: 12464
+
+task 10 'programmable'. lines 171-175:
+mutated: object(_), object(2,9)
+gas summary: computation_cost: 500000, storage_cost: 2234400,  storage_rebate: 1233936, non_refundable_storage_fee: 12464
+
+task 11 'programmable'. lines 177-178:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 14, instruction: 12, function_name: Some("check_") }, 0) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 14, instruction: 12, function_name: Some("check_") }, 0) in command 0
+
+task 12 'programmable'. lines 180-181:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 11, instruction: 0, function_name: Some("borrow_child_object") }, 1) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 11, instruction: 0, function_name: Some("borrow_child_object") }, 1) in command 0
+
+task 13 'programmable'. lines 183-184:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 14, instruction: 21, function_name: Some("check_") }, 0) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 14, instruction: 21, function_name: Some("check_") }, 0) in command 0

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/find_all_uids_on_child.move
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/find_all_uids_on_child.move
@@ -1,0 +1,184 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests finding UIDs for dynamic field access on a child object (non-input)
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+
+module test::m {
+    use std::option::{Self, Option};
+    use std::vector;
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::dynamic_field as field;
+
+    struct Parent has key, store {
+        id: UID,
+    }
+
+    struct S has key, store {
+        id: UID,
+        other: UID,
+        wrapped: Wrapped,
+        many: vector<Wrapped>,
+    }
+
+    struct Wrapped has key, store {
+        id: UID,
+        other: UID,
+    }
+
+    const KEY: u64 = 0;
+
+    //////////////////////////////////////////////////////////////
+    // new
+
+    public fun new(ctx: &mut TxContext): Parent {
+        let parent = Parent { id: object::new(ctx) };
+        field::add(&mut parent.id, KEY, s(ctx));
+        parent
+    }
+
+    fun s(ctx: &mut TxContext): S {
+        let s = S {
+            id: object::new(ctx),
+            other: object::new(ctx),
+            wrapped: wrapped(ctx),
+            many: vector[wrapped(ctx), wrapped(ctx)],
+        };
+        field::add(&mut s.id, KEY, 0);
+        field::add(&mut s.other, KEY, 0);
+        s
+    }
+
+    fun wrapped(ctx: &mut TxContext): Wrapped {
+        let w = Wrapped {
+            id: object::new(ctx),
+            other: object::new(ctx),
+        };
+        field::add(&mut w.id, KEY, 0);
+        field::add(&mut w.other, KEY, 0);
+        w
+    }
+
+    //////////////////////////////////////////////////////////////
+    // set
+
+    public fun set(parent: &mut Parent, value: u64) {
+        set_s(field::borrow_mut(&mut parent.id, KEY), value);
+    }
+
+
+    fun set_s(s: &mut S, value: u64) {
+        set_(&mut s.id, value);
+        set_(&mut s.other, value);
+        set_wrapped(&mut s.wrapped, value);
+        set_wrapped(vector::borrow_mut(&mut s.many, 0), value);
+        set_wrapped(vector::borrow_mut(&mut s.many, 1), value);
+    }
+
+    fun set_wrapped(w: &mut Wrapped, value: u64) {
+        set_(&mut w.id, value);
+        set_(&mut w.other, value);
+
+    }
+
+    fun set_(id: &mut UID, value: u64) {
+        *field::borrow_mut(id, KEY) = value;
+    }
+
+    //////////////////////////////////////////////////////////////
+    // remove
+
+    public fun remove(parent: &mut Parent) {
+        remove_s(field::borrow_mut(&mut parent.id, KEY));
+    }
+
+    fun remove_s(s: &mut S) {
+        remove_(&mut s.id);
+        remove_(&mut s.other);
+        remove_wrapped(&mut s.wrapped);
+        remove_wrapped(vector::borrow_mut(&mut s.many, 0));
+        remove_wrapped(vector::borrow_mut(&mut s.many, 1));
+    }
+
+    fun remove_wrapped(w: &mut Wrapped) {
+        remove_(&mut w.id);
+        remove_(&mut w.other);
+    }
+
+    fun remove_(id: &mut UID) {
+        field::remove<u64, u64>(id, KEY);
+    }
+
+    //////////////////////////////////////////////////////////////
+    // check
+
+    public fun check(parent: &Parent, expected: Option<u64>) {
+        check_s(field::borrow(&parent.id, KEY), expected);
+    }
+
+    fun check_s(s: &S, expected: Option<u64>) {
+        check_(&s.id, expected);
+        check_(&s.other, expected);
+        check_wrapped(&s.wrapped, expected);
+        check_wrapped(vector::borrow(&s.many, 0), expected);
+        check_wrapped(vector::borrow(&s.many, 1), expected);
+    }
+
+    fun check_wrapped(w: &Wrapped, expected: Option<u64>) {
+        check_(&w.id, expected);
+        check_(&w.other, expected);
+    }
+
+    fun check_(id: &UID, expected: Option<u64>) {
+        if (option::is_some(&expected)) {
+            let f = field::borrow(id, KEY);
+            assert!(f == option::borrow(&expected), 0);
+        } else {
+            assert!(!field::exists_with_type<u64, u64>(id, KEY), 0);
+        }
+    }
+}
+
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> TransferObjects([Result(0)], Input(0))
+
+//# view-object 2,9
+
+//# programmable --sender A --inputs object(2,9) 112
+//> test::m::set(Input(0), Input(1))
+
+//# view-object 2,9
+
+//# programmable --sender A --inputs object(2,9) 112
+//> test::m::remove(Input(0))
+
+//# view-object 2,9
+
+
+// dev-inspect with 'check' and correct values
+
+//# programmable --sender A --inputs object(2,9)@2 vector[0] --dev-inspect
+//> test::m::check(Input(0), Input(1))
+
+//# programmable --sender A --inputs object(2,9)@3 vector[112] --dev-inspect
+//> test::m::check(Input(0), Input(1))
+
+//# programmable --sender A --inputs object(2,9)@4 vector[] --dev-inspect
+//> test::m::check(Input(0), Input(1))
+
+
+// dev-inspect with 'check' and _incorrect_ values
+
+//# programmable --sender A --inputs object(2,9)@3 vector[0] --dev-inspect
+//> test::m::check(Input(0), Input(1))
+
+//# programmable --sender A --inputs object(2,9)@4 vector[112] --dev-inspect
+//> test::m::check(Input(0), Input(1))
+
+//# programmable --sender A --inputs object(2,9)@2 vector[] --dev-inspect
+//> test::m::check(Input(0), Input(1))

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/middle_version_less_than_child.exp
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/middle_version_less_than_child.exp
@@ -1,0 +1,52 @@
+processed 11 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 8-53:
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 7493600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'programmable'. lines 55-59:
+created: object(2,0), object(2,1), object(2,2)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6285200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'view-object'. lines 61-61:
+Owner: Object ID: ( _ )
+Version: 2
+Contents: sui::dynamic_field::Field<u64, test::m::Obj> {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, name: 0u64, value: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: _}}, value: 0u64}}
+
+task 4 'view-object'. lines 63-63:
+Owner: Object ID: ( fake(2,2) )
+Version: 2
+Contents: sui::dynamic_field::Field<u64, test::m::Obj> {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,1)}}, name: 0u64, value: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: _}}, value: 0u64}}
+
+task 5 'view-object'. lines 65-65:
+Owner: Account Address ( A )
+Version: 2
+Contents: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,2)}}, value: 0u64}
+
+task 6 'programmable'. lines 67-70:
+mutated: object(0,0), object(2,0), object(2,2)
+gas summary: computation_cost: 1000000, storage_cost: 4278800,  storage_rebate: 4236012, non_refundable_storage_fee: 42788
+
+task 7 'view-object'. lines 72-72:
+Owner: Object ID: ( _ )
+Version: 3
+Contents: sui::dynamic_field::Field<u64, test::m::Obj> {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, name: 0u64, value: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: _}}, value: 112u64}}
+
+task 8 'view-object'. lines 74-74:
+Owner: Object ID: ( fake(2,2) )
+Version: 2
+Contents: sui::dynamic_field::Field<u64, test::m::Obj> {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,1)}}, name: 0u64, value: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: _}}, value: 0u64}}
+
+task 9 'view-object'. lines 76-79:
+Owner: Account Address ( A )
+Version: 3
+Contents: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,2)}}, value: 0u64}
+
+task 10 'programmable'. lines 81-82:
+mutated: object(0,0), object(2,2)
+gas summary: computation_cost: 1000000, storage_cost: 2272400,  storage_rebate: 2249676, non_refundable_storage_fee: 22724

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/middle_version_less_than_child.move
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/middle_version_less_than_child.move
@@ -1,0 +1,82 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests accessing the versions of a child of a child
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+
+module test::m {
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::dynamic_field as field;
+
+    struct Obj has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    const KEY: u64 = 0;
+
+    //////////////////////////////////////////////////////////////
+    // new
+
+    public fun new(ctx: &mut TxContext): Obj {
+        let grand = Obj { id: object::new(ctx), value: 0 };
+        let parent = Obj { id: object::new(ctx), value: 0 };
+        let child = Obj { id: object::new(ctx), value: 0 };
+        field::add(&mut parent.id, KEY, child);
+        field::add(&mut grand.id, KEY, parent);
+        grand
+    }
+
+    //////////////////////////////////////////////////////////////
+    // set
+
+    public fun set(grand: &mut Obj, v: u64) {
+        let parent: &mut Obj = field::borrow_mut(&mut grand.id, KEY);
+        let child: &mut Obj = field::borrow_mut(&mut parent.id, KEY);
+        child.value = v;
+    }
+
+    //////////////////////////////////////////////////////////////
+    // check
+
+    public fun check(grand: &Obj, expected: u64) {
+        assert!(grand.value == 0, 0);
+        let parent: &Obj = field::borrow(&grand.id, KEY);
+        assert!(parent.value == 0, 0);
+        let child: &Obj = field::borrow(&parent.id, KEY);
+        assert!(child.value == expected, 0);
+    }
+}
+
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> TransferObjects([Result(0)], Input(0))
+
+// All 3 objects have version 2
+
+//# view-object 2,0
+
+//# view-object 2,1
+
+//# view-object 2,2
+
+//# programmable --sender A --inputs object(2,2) 112
+//> test::m::set(Input(0), Input(1))
+
+// The middle object has version 2, while the root and modified leaf have version 3
+
+//# view-object 2,0
+
+//# view-object 2,1
+
+//# view-object 2,2
+
+// correctly load the leaf even though it has a version greater than its immediate
+// parent
+
+//# programmable --sender A --inputs object(2,2) 112
+//> test::m::check(Input(0), Input(1))

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/not_root_version.exp
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/not_root_version.exp
@@ -1,0 +1,66 @@
+processed 14 tasks
+
+init:
+P1: object(0,0), P2: object(0,1)
+
+task 1 'publish'. lines 8-55:
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 7432800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'programmable'. lines 57-59:
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2196400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'programmable'. lines 61-62:
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2196400,  storage_rebate: 2174436, non_refundable_storage_fee: 21964
+
+task 4 'programmable'. lines 64-65:
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2196400,  storage_rebate: 2174436, non_refundable_storage_fee: 21964
+
+task 5 'view-object'. lines 67-70:
+Owner: Account Address ( P1 )
+Version: 4
+Contents: test::m::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}}
+
+task 6 'programmable'. lines 72-74:
+created: object(6,0), object(6,1)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 3663200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 7 'view-object'. lines 76-76:
+Owner: Object ID: ( fake(6,1) )
+Version: 2
+Contents: sui::dynamic_field::Field<u64, u64> {id: sui::object::UID {id: sui::object::ID {bytes: fake(6,0)}}, name: 0u64, value: 0u64}
+
+task 8 'programmable'. lines 78-79:
+mutated: object(0,1), object(6,0), object(6,1)
+gas summary: computation_cost: 1000000, storage_cost: 3663200,  storage_rebate: 3626568, non_refundable_storage_fee: 36632
+
+task 9 'view-object'. lines 81-85:
+Owner: Object ID: ( fake(6,1) )
+Version: 3
+Contents: sui::dynamic_field::Field<u64, u64> {id: sui::object::UID {id: sui::object::ID {bytes: fake(6,0)}}, name: 0u64, value: 1u64}
+
+task 10 'programmable'. lines 87-92:
+created: object(10,0)
+mutated: object(_), object(2,0)
+wrapped: object(6,1)
+gas summary: computation_cost: 500000, storage_cost: 4126800,  storage_rebate: 2392632, non_refundable_storage_fee: 24168
+
+task 11 'programmable'. lines 94-98:
+created: object(10,0)
+mutated: object(_), object(2,0)
+wrapped: object(6,1)
+gas summary: computation_cost: 500000, storage_cost: 4126800,  storage_rebate: 2392632, non_refundable_storage_fee: 24168
+
+task 12 'programmable'. lines 100-104:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 4, instruction: 13, function_name: Some("check") }, 0) in command 1
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 4, instruction: 13, function_name: Some("check") }, 0) in command 1
+
+task 13 'programmable'. lines 106-108:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 4, instruction: 13, function_name: Some("check") }, 0) in command 1
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 4, instruction: 13, function_name: Some("check") }, 0) in command 1

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/not_root_version.move
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/not_root_version.move
@@ -1,0 +1,108 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests accessing version of the input parent, not the runtime parent
+
+//# init --addresses test=0x0 --accounts P1 P2
+
+//# publish
+
+module test::m {
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::dynamic_field as field;
+
+    struct A has key, store {
+        id: UID,
+    }
+
+    struct B has key, store {
+        id: UID,
+    }
+
+    const KEY: u64 = 0;
+
+    public fun a(ctx: &mut TxContext): A {
+        A { id: object::new(ctx) }
+    }
+
+    public fun b(ctx: &mut TxContext): B {
+        let b = B { id: object::new(ctx) };
+        field::add(&mut b.id, KEY, 0);
+        b
+
+    }
+
+    public fun bump(b: &mut B) {
+        let f = field::borrow_mut(&mut b.id, KEY);
+        *f = *f + 1;
+    }
+
+    public fun append(a: &mut A, b: B) {
+        field::add(&mut a.id, KEY, b);
+    }
+
+    public fun check(a: &A, expected: u64) {
+        let b: &B = field::borrow(&a.id, KEY);
+        let v = *field::borrow(&b.id, KEY);
+        assert!(v == expected, 0);
+    }
+
+    public fun nop() {
+    }
+}
+
+// Create object A and bump the version to 4
+
+//# programmable --sender P1 --inputs @P1
+//> 0: test::m::a();
+//> TransferObjects([Result(0)], Input(0))
+
+//# programmable --sender P1 --inputs object(2,0)
+//> test::m::nop();
+
+//# programmable --sender P1 --inputs object(2,0)
+//> test::m::nop();
+
+//# view-object 2,0
+
+
+// Create object B witha version 2 and 3 for it's dynamic field
+
+//# programmable --sender P2 --inputs @P2
+//> 0: test::m::b();
+//> TransferObjects([Result(0)], Input(0))
+
+//# view-object 6,0
+
+//# programmable --sender P2 --inputs object(6,1)
+//> 0: test::m::bump(Input(0));
+
+//# view-object 6,0
+
+
+// Append object B to object A, but using version 2 of object B. And ensure that
+// when we later read the dynamic field of object B, we get the version 2 value.
+
+//# programmable --sender P2 --inputs object(2,0)@4 object(6,1)@2 0 --dev-inspect
+//> 0: test::m::append(Input(0), Input(1));
+//> 1: test::m::check(Input(0), Input(2));
+
+// checking that with version 3 we get the other value, then flip them to ensure
+// they abort
+
+//# programmable --sender P2 --inputs object(2,0)@4 object(6,1)@3 1 --dev-inspect
+//> 0: test::m::append(Input(0), Input(1));
+//> 1: test::m::check(Input(0), Input(2));
+
+// @2 with value 1 aborts
+
+//# programmable --sender P2 --inputs object(2,0)@4 object(6,1)@2 1 --dev-inspect
+//> 0: test::m::append(Input(0), Input(1));
+//> 1: test::m::check(Input(0), Input(2));
+
+// @3 with value 0 aborts
+
+//# programmable --sender P2 --inputs object(2,0)@4 object(6,1)@3 0 --dev-inspect
+//> 0: test::m::append(Input(0), Input(1));
+//> 1: test::m::check(Input(0), Input(2));

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/not_root_version_flipped_case.exp
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/not_root_version_flipped_case.exp
@@ -1,0 +1,58 @@
+processed 12 tasks
+
+init:
+P1: object(0,0), P2: object(0,1)
+
+task 1 'publish'. lines 8-55:
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 7432800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'programmable'. lines 57-59:
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2196400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'view-object'. lines 62-65:
+Owner: Account Address ( P1 )
+Version: 2
+Contents: test::m::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}}
+
+task 4 'programmable'. lines 67-69:
+created: object(4,0), object(4,1)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 3663200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 5 'view-object'. lines 71-71:
+Owner: Object ID: ( fake(4,1) )
+Version: 2
+Contents: sui::dynamic_field::Field<u64, u64> {id: sui::object::UID {id: sui::object::ID {bytes: fake(4,0)}}, name: 0u64, value: 0u64}
+
+task 6 'programmable'. lines 73-74:
+mutated: object(0,1), object(4,0), object(4,1)
+gas summary: computation_cost: 1000000, storage_cost: 3663200,  storage_rebate: 3626568, non_refundable_storage_fee: 36632
+
+task 7 'view-object'. lines 76-79:
+Owner: Object ID: ( fake(4,1) )
+Version: 3
+Contents: sui::dynamic_field::Field<u64, u64> {id: sui::object::UID {id: sui::object::ID {bytes: fake(4,0)}}, name: 0u64, value: 1u64}
+
+task 8 'programmable'. lines 81-86:
+created: object(8,0)
+mutated: object(_), object(2,0)
+wrapped: object(4,1)
+gas summary: computation_cost: 500000, storage_cost: 4126800,  storage_rebate: 2392632, non_refundable_storage_fee: 24168
+
+task 9 'programmable'. lines 88-92:
+created: object(8,0)
+mutated: object(_), object(2,0)
+wrapped: object(4,1)
+gas summary: computation_cost: 500000, storage_cost: 4126800,  storage_rebate: 2392632, non_refundable_storage_fee: 24168
+
+task 10 'programmable'. lines 94-98:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 4, instruction: 13, function_name: Some("check") }, 0) in command 1
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 4, instruction: 13, function_name: Some("check") }, 0) in command 1
+
+task 11 'programmable'. lines 100-102:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 4, instruction: 13, function_name: Some("check") }, 0) in command 1
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 4, instruction: 13, function_name: Some("check") }, 0) in command 1

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/not_root_version_flipped_case.move
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/not_root_version_flipped_case.move
@@ -1,0 +1,102 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests accessing version of the input parent, not the runtime parent
+
+//# init --addresses test=0x0 --accounts P1 P2
+
+//# publish
+
+module test::m {
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::dynamic_field as field;
+
+    struct A has key, store {
+        id: UID,
+    }
+
+    struct B has key, store {
+        id: UID,
+    }
+
+    const KEY: u64 = 0;
+
+    public fun a(ctx: &mut TxContext): A {
+        A { id: object::new(ctx) }
+    }
+
+    public fun b(ctx: &mut TxContext): B {
+        let b = B { id: object::new(ctx) };
+        field::add(&mut b.id, KEY, 0);
+        b
+
+    }
+
+    public fun bump(b: &mut B) {
+        let f = field::borrow_mut(&mut b.id, KEY);
+        *f = *f + 1;
+    }
+
+    public fun append(a: &mut A, b: B) {
+        field::add(&mut a.id, KEY, b);
+    }
+
+    public fun check(a: &A, expected: u64) {
+        let b: &B = field::borrow(&a.id, KEY);
+        let v = *field::borrow(&b.id, KEY);
+        assert!(v == expected, 0);
+    }
+
+    public fun nop() {
+    }
+}
+
+// Create object A at version 2
+
+//# programmable --sender P1 --inputs @P1
+//> 0: test::m::a();
+//> TransferObjects([Result(0)], Input(0))
+
+
+//# view-object 2,0
+
+
+// Create object B with a version 2 and 3 for it's dynamic field
+
+//# programmable --sender P2 --inputs @P2
+//> 0: test::m::b();
+//> TransferObjects([Result(0)], Input(0))
+
+//# view-object 4,0
+
+//# programmable --sender P2 --inputs object(4,1)
+//> 0: test::m::bump(Input(0));
+
+//# view-object 4,0
+
+// Append object B to object A. And ensure that when we later read the dynamic
+// field of object B, we get the most recent version.
+
+//# programmable --sender P2 --inputs object(2,0)@2 object(4,1)@3 1 --dev-inspect
+//> 0: test::m::append(Input(0), Input(1));
+//> 1: test::m::check(Input(0), Input(2));
+
+// checking that with version 3 we get the other value, then flip them to ensure
+// they abort
+
+//# programmable --sender P2 --inputs object(2,0)@2 object(4,1)@2 0 --dev-inspect
+//> 0: test::m::append(Input(0), Input(1));
+//> 1: test::m::check(Input(0), Input(2));
+
+// @2 with value 1 aborts
+
+//# programmable --sender P2 --inputs object(2,0)@2 object(4,1)@2 1 --dev-inspect
+//> 0: test::m::append(Input(0), Input(1));
+//> 1: test::m::check(Input(0), Input(2));
+
+// @3 with value 0 aborts
+
+//# programmable --sender P2 --inputs object(2,0)@2 object(4,1)@3 0 --dev-inspect
+//> 0: test::m::append(Input(0), Input(1));
+//> 1: test::m::check(Input(0), Input(2));

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/v0/child_of_child.exp
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/v0/child_of_child.exp
@@ -1,0 +1,62 @@
+processed 14 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 8-69:
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 9234000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'programmable'. lines 71-73:
+created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 9750800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'view-object'. lines 75-75:
+Owner: Account Address ( A )
+Version: 2
+Contents: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,2)}}, value: 0u64}
+
+task 4 'programmable'. lines 77-78:
+mutated: object(0,0), object(2,2), object(2,3), object(2,4)
+gas summary: computation_cost: 1000000, storage_cost: 4841200,  storage_rebate: 4792788, non_refundable_storage_fee: 48412
+
+task 5 'view-object'. lines 80-80:
+Owner: Account Address ( A )
+Version: 3
+Contents: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,2)}}, value: 1u64}
+
+task 6 'programmable'. lines 82-83:
+mutated: object(0,0), object(2,2)
+deleted: object(2,0), object(2,3)
+gas summary: computation_cost: 1000000, storage_cost: 2272400,  storage_rebate: 5951484, non_refundable_storage_fee: 60116
+
+task 7 'view-object'. lines 85-88:
+Owner: Account Address ( A )
+Version: 4
+Contents: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,2)}}, value: 1u64}
+
+task 8 'programmable'. lines 90-91:
+mutated: object(_), object(2,2)
+gas summary: computation_cost: 500000, storage_cost: 2272400,  storage_rebate: 1271556, non_refundable_storage_fee: 12844
+
+task 9 'programmable'. lines 93-94:
+mutated: object(_), object(2,2)
+gas summary: computation_cost: 500000, storage_cost: 2272400,  storage_rebate: 1271556, non_refundable_storage_fee: 12844
+
+task 10 'programmable'. lines 96-100:
+mutated: object(_), object(2,2)
+gas summary: computation_cost: 500000, storage_cost: 2272400,  storage_rebate: 1271556, non_refundable_storage_fee: 12844
+
+task 11 'programmable'. lines 102-103:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 3, instruction: 10, function_name: Some("check") }, 0) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 3, instruction: 10, function_name: Some("check") }, 0) in command 0
+
+task 12 'programmable'. lines 105-106:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 11, instruction: 0, function_name: Some("borrow_child_object") }, 1) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 11, instruction: 0, function_name: Some("borrow_child_object") }, 1) in command 0
+
+task 13 'programmable'. lines 108-109:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 3, instruction: 10, function_name: Some("check") }, 0) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 3, instruction: 10, function_name: Some("check") }, 0) in command 0

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/v0/child_of_child.move
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/v0/child_of_child.move
@@ -1,0 +1,109 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests accessing the versions of a child of a child
+
+//# init --addresses test=0x0 --accounts A --protocol-version 16
+
+//# publish
+
+module test::m {
+    use std::option::{Self, Option};
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::dynamic_object_field as ofield;
+
+    struct Obj has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    const KEY: u64 = 0;
+
+    //////////////////////////////////////////////////////////////
+    // new
+
+    public fun new(ctx: &mut TxContext): Obj {
+        let grand = Obj { id: object::new(ctx), value: 0 };
+        let parent = Obj { id: object::new(ctx), value: 0 };
+        let child = Obj { id: object::new(ctx), value: 0 };
+        ofield::add(&mut parent.id, KEY, child);
+        ofield::add(&mut grand.id, KEY, parent);
+        grand
+    }
+
+    //////////////////////////////////////////////////////////////
+    // set
+
+    public fun set(grand: &mut Obj, v1: u64, v2: u64, v3: u64) {
+        grand.value = v1;
+        let parent: &mut Obj = ofield::borrow_mut(&mut grand.id, KEY);
+        parent.value = v2;
+        let child: &mut Obj = ofield::borrow_mut(&mut parent.id, KEY);
+        child.value = v3;
+    }
+
+    //////////////////////////////////////////////////////////////
+    // remove
+
+    public fun remove(grand: &mut Obj) {
+        let parent: &mut Obj = ofield::borrow_mut(&mut grand.id, KEY);
+        let Obj { id, value: _ } = ofield::remove(&mut parent.id, KEY);
+        object::delete(id);
+    }
+
+    //////////////////////////////////////////////////////////////
+    // check
+
+    public fun check(grand: &Obj, v1: u64, v2: u64, v3: Option<u64>) {
+        assert!(grand.value == v1, 0);
+        let parent: &Obj = ofield::borrow(&grand.id, KEY);
+        assert!(parent.value == v2, 0);
+        if (option::is_some(&v3)) {
+            let child: &Obj = ofield::borrow(&parent.id, KEY);
+            assert!(&child.value == option::borrow(&v3), 0);
+        } else {
+            assert!(!ofield::exists_<u64>(&parent.id, KEY), 0);
+        }
+    }
+}
+
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> TransferObjects([Result(0)], Input(0))
+
+//# view-object 2,2
+
+//# programmable --sender A --inputs object(2,2) 1 2 3
+//> test::m::set(Input(0), Input(1), Input(2), Input(3))
+
+//# view-object 2,2
+
+//# programmable --sender A --inputs object(2,2)
+//> test::m::remove(Input(0))
+
+//# view-object 2,2
+
+
+// dev-inspect with 'check' and correct values
+
+//# programmable --sender A --inputs object(2,2)@2 0 0 vector[0] --dev-inspect
+//> test::m::check(Input(0), Input(1), Input(2), Input(3))
+
+//# programmable --sender A --inputs object(2,2)@3 1 2 vector[3] --dev-inspect
+//> test::m::check(Input(0), Input(1), Input(2), Input(3))
+
+//# programmable --sender A --inputs object(2,2)@4 1 2 vector[] --dev-inspect
+//> test::m::check(Input(0), Input(1), Input(2), Input(3))
+
+
+// dev-inspect with 'check' and _incorrect_ values
+
+//# programmable --sender A --inputs object(2,2)@3 0 0 vector[0] --dev-inspect
+//> test::m::check(Input(0), Input(1), Input(2), Input(3))
+
+//# programmable --sender A --inputs object(2,2)@4 1 2 vector[3] --dev-inspect
+//> test::m::check(Input(0), Input(1), Input(2), Input(3))
+
+//# programmable --sender A --inputs object(2,2)@2 1 2 vector[] --dev-inspect
+//> test::m::check(Input(0), Input(1), Input(2), Input(3))

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/v0/find_all_uids.exp
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/v0/find_all_uids.exp
@@ -1,0 +1,62 @@
+processed 14 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 8-121:
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 12220800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'programmable'. lines 123-125:
+created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,8)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 15640800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'view-object'. lines 127-127:
+Owner: Account Address ( A )
+Version: 2
+Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,8)}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}, wrapped: test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, many: vector[test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}]}
+
+task 4 'programmable'. lines 129-130:
+mutated: object(0,0), object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,8)
+gas summary: computation_cost: 1000000, storage_cost: 15640800,  storage_rebate: 15484392, non_refundable_storage_fee: 156408
+
+task 5 'view-object'. lines 132-132:
+Owner: Account Address ( A )
+Version: 3
+Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,8)}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}, wrapped: test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, many: vector[test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}]}
+
+task 6 'programmable'. lines 134-135:
+mutated: object(0,0), object(2,8)
+deleted: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7)
+gas summary: computation_cost: 1000000, storage_cost: 3906400,  storage_rebate: 15484392, non_refundable_storage_fee: 156408
+
+task 7 'view-object'. lines 137-140:
+Owner: Account Address ( A )
+Version: 4
+Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,8)}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}, wrapped: test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, many: vector[test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}]}
+
+task 8 'programmable'. lines 142-143:
+mutated: object(_), object(2,8)
+gas summary: computation_cost: 500000, storage_cost: 3906400,  storage_rebate: 2889216, non_refundable_storage_fee: 29184
+
+task 9 'programmable'. lines 145-146:
+mutated: object(_), object(2,8)
+gas summary: computation_cost: 500000, storage_cost: 3906400,  storage_rebate: 2889216, non_refundable_storage_fee: 29184
+
+task 10 'programmable'. lines 148-152:
+mutated: object(_), object(2,8)
+gas summary: computation_cost: 500000, storage_cost: 3906400,  storage_rebate: 2889216, non_refundable_storage_fee: 29184
+
+task 11 'programmable'. lines 154-155:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 10, instruction: 12, function_name: Some("check_") }, 0) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 10, instruction: 12, function_name: Some("check_") }, 0) in command 0
+
+task 12 'programmable'. lines 157-158:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 11, instruction: 0, function_name: Some("borrow_child_object") }, 1) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 11, instruction: 0, function_name: Some("borrow_child_object") }, 1) in command 0
+
+task 13 'programmable'. lines 160-161:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 10, instruction: 21, function_name: Some("check_") }, 0) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 10, instruction: 21, function_name: Some("check_") }, 0) in command 0

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/v0/find_all_uids.move
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/v0/find_all_uids.move
@@ -1,0 +1,161 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests finding UIDs for dynamic field access
+
+//# init --addresses test=0x0 --accounts A --protocol-version 16
+
+//# publish
+
+module test::m {
+    use std::option::{Self, Option};
+    use std::vector;
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::dynamic_field as field;
+
+    struct S has key, store {
+        id: UID,
+        other: UID,
+        wrapped: Wrapped,
+        many: vector<Wrapped>,
+    }
+
+    struct Wrapped has key, store {
+        id: UID,
+        other: UID,
+    }
+
+    const KEY: u64 = 0;
+
+    //////////////////////////////////////////////////////////////
+    // new
+
+    public fun new(ctx: &mut TxContext): S {
+        let s = S {
+            id: object::new(ctx),
+            other: object::new(ctx),
+            wrapped: wrapped(ctx),
+            many: vector[wrapped(ctx), wrapped(ctx)],
+        };
+        field::add(&mut s.id, KEY, 0);
+        field::add(&mut s.other, KEY, 0);
+        s
+    }
+
+    fun wrapped(ctx: &mut TxContext): Wrapped {
+        let w = Wrapped {
+            id: object::new(ctx),
+            other: object::new(ctx),
+        };
+        field::add(&mut w.id, KEY, 0);
+        field::add(&mut w.other, KEY, 0);
+        w
+    }
+
+    //////////////////////////////////////////////////////////////
+    // set
+
+    public fun set(s: &mut S, value: u64) {
+        set_(&mut s.id, value);
+        set_(&mut s.other, value);
+        set_wrapped(&mut s.wrapped, value);
+        set_wrapped(vector::borrow_mut(&mut s.many, 0), value);
+        set_wrapped(vector::borrow_mut(&mut s.many, 1), value);
+    }
+
+    fun set_wrapped(w: &mut Wrapped, value: u64) {
+        set_(&mut w.id, value);
+        set_(&mut w.other, value);
+
+    }
+
+    fun set_(id: &mut UID, value: u64) {
+        *field::borrow_mut(id, KEY) = value;
+    }
+
+    //////////////////////////////////////////////////////////////
+    // remove
+
+    public fun remove(s: &mut S) {
+        remove_(&mut s.id);
+        remove_(&mut s.other);
+        remove_wrapped(&mut s.wrapped);
+        remove_wrapped(vector::borrow_mut(&mut s.many, 0));
+        remove_wrapped(vector::borrow_mut(&mut s.many, 1));
+    }
+
+    fun remove_wrapped(w: &mut Wrapped) {
+        remove_(&mut w.id);
+        remove_(&mut w.other);
+    }
+
+    fun remove_(id: &mut UID) {
+        field::remove<u64, u64>(id, KEY);
+    }
+
+    //////////////////////////////////////////////////////////////
+    // check
+
+    public fun check(s: &S, expected: Option<u64>) {
+        check_(&s.id, expected);
+        check_(&s.other, expected);
+        check_wrapped(&s.wrapped, expected);
+        check_wrapped(vector::borrow(&s.many, 0), expected);
+        check_wrapped(vector::borrow(&s.many, 1), expected);
+    }
+
+    fun check_wrapped(w: &Wrapped, expected: Option<u64>) {
+        check_(&w.id, expected);
+        check_(&w.other, expected);
+    }
+
+    fun check_(id: &UID, expected: Option<u64>) {
+        if (option::is_some(&expected)) {
+            let f = field::borrow(id, KEY);
+            assert!(f == option::borrow(&expected), 0);
+        } else {
+            assert!(!field::exists_with_type<u64, u64>(id, KEY), 0);
+        }
+    }
+}
+
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> TransferObjects([Result(0)], Input(0))
+
+//# view-object 2,8
+
+//# programmable --sender A --inputs object(2,8) 112
+//> test::m::set(Input(0), Input(1))
+
+//# view-object 2,8
+
+//# programmable --sender A --inputs object(2,8) 112
+//> test::m::remove(Input(0))
+
+//# view-object 2,8
+
+
+// dev-inspect with 'check' and correct values
+
+//# programmable --sender A --inputs object(2,8)@2 vector[0] --dev-inspect
+//> test::m::check(Input(0), Input(1))
+
+//# programmable --sender A --inputs object(2,8)@3 vector[112] --dev-inspect
+//> test::m::check(Input(0), Input(1))
+
+//# programmable --sender A --inputs object(2,8)@4 vector[] --dev-inspect
+//> test::m::check(Input(0), Input(1))
+
+
+// dev-inspect with 'check' and _incorrect_ values
+
+//# programmable --sender A --inputs object(2,8)@3 vector[0] --dev-inspect
+//> test::m::check(Input(0), Input(1))
+
+//# programmable --sender A --inputs object(2,8)@4 vector[112] --dev-inspect
+//> test::m::check(Input(0), Input(1))
+
+//# programmable --sender A --inputs object(2,8)@2 vector[] --dev-inspect
+//> test::m::check(Input(0), Input(1))

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/v0/find_all_uids_dof.exp
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/v0/find_all_uids_dof.exp
@@ -1,0 +1,62 @@
+processed 14 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 8-134:
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 13368400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'programmable'. lines 136-138:
+created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,8), object(2,9), object(2,10), object(2,11), object(2,12), object(2,13), object(2,14), object(2,15), object(2,16)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 33941600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'view-object'. lines 140-140:
+Owner: Account Address ( A )
+Version: 2
+Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,8)}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}, wrapped: test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, many: vector[test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}]}
+
+task 4 'programmable'. lines 142-143:
+mutated: object(0,0), object(2,8), object(2,9), object(2,10), object(2,11), object(2,12), object(2,13), object(2,14), object(2,15), object(2,16)
+gas summary: computation_cost: 1000000, storage_cost: 14303200,  storage_rebate: 14160168, non_refundable_storage_fee: 143032
+
+task 5 'view-object'. lines 145-145:
+Owner: Account Address ( A )
+Version: 3
+Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,8)}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}, wrapped: test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, many: vector[test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}]}
+
+task 6 'programmable'. lines 147-148:
+mutated: object(0,0), object(2,8)
+deleted: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,9), object(2,10), object(2,11), object(2,12), object(2,13), object(2,14), object(2,15), object(2,16)
+gas summary: computation_cost: 1000000, storage_cost: 3906400,  storage_rebate: 33602184, non_refundable_storage_fee: 339416
+
+task 7 'view-object'. lines 150-153:
+Owner: Account Address ( A )
+Version: 4
+Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,8)}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}, wrapped: test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, many: vector[test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}, test::m::Wrapped {id: sui::object::UID {id: sui::object::ID {bytes: _}}, other: sui::object::UID {id: sui::object::ID {bytes: _}}}]}
+
+task 8 'programmable'. lines 155-156:
+mutated: object(_), object(2,8)
+gas summary: computation_cost: 500000, storage_cost: 3906400,  storage_rebate: 2889216, non_refundable_storage_fee: 29184
+
+task 9 'programmable'. lines 158-159:
+mutated: object(_), object(2,8)
+gas summary: computation_cost: 500000, storage_cost: 3906400,  storage_rebate: 2889216, non_refundable_storage_fee: 29184
+
+task 10 'programmable'. lines 161-165:
+mutated: object(_), object(2,8)
+gas summary: computation_cost: 500000, storage_cost: 3906400,  storage_rebate: 2889216, non_refundable_storage_fee: 29184
+
+task 11 'programmable'. lines 167-168:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 11, instruction: 18, function_name: Some("check_") }, 0) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 11, instruction: 18, function_name: Some("check_") }, 0) in command 0
+
+task 12 'programmable'. lines 170-171:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 11, instruction: 0, function_name: Some("borrow_child_object") }, 1) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 11, instruction: 0, function_name: Some("borrow_child_object") }, 1) in command 0
+
+task 13 'programmable'. lines 173-174:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 11, instruction: 27, function_name: Some("check_") }, 0) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 11, instruction: 27, function_name: Some("check_") }, 0) in command 0

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/v0/find_all_uids_dof.move
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/v0/find_all_uids_dof.move
@@ -1,0 +1,174 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests finding UIDs for dynamic object field access
+
+//# init --addresses test=0x0 --accounts A --protocol-version 16
+
+//# publish
+
+module test::m {
+    use std::option::{Self, Option};
+    use std::vector;
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::dynamic_object_field as ofield;
+
+    struct S has key, store {
+        id: UID,
+        other: UID,
+        wrapped: Wrapped,
+        many: vector<Wrapped>,
+    }
+
+    struct Wrapped has key, store {
+        id: UID,
+        other: UID,
+    }
+
+    struct Value has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    const KEY: u64 = 0;
+
+    //////////////////////////////////////////////////////////////
+    // new
+
+    public fun new(ctx: &mut TxContext): S {
+        let s = S {
+            id: object::new(ctx),
+            other: object::new(ctx),
+            wrapped: wrapped(ctx),
+            many: vector[wrapped(ctx), wrapped(ctx)],
+        };
+        ofield::add(&mut s.id, KEY, value(0, ctx));
+        ofield::add(&mut s.other, KEY, value(0, ctx));
+        s
+    }
+
+    fun wrapped(ctx: &mut TxContext): Wrapped {
+        let w = Wrapped {
+            id: object::new(ctx),
+            other: object::new(ctx),
+        };
+        ofield::add(&mut w.id, KEY, value(0, ctx));
+        ofield::add(&mut w.other, KEY, value(0, ctx));
+        w
+    }
+
+    fun value(value: u64, ctx: &mut TxContext): Value {
+        Value {
+            id: object::new(ctx),
+            value
+        }
+    }
+
+    //////////////////////////////////////////////////////////////
+    // set
+
+    public fun set(s: &mut S, value: u64) {
+        set_(&mut s.id, value);
+        set_(&mut s.other, value);
+        set_wrapped(&mut s.wrapped, value);
+        set_wrapped(vector::borrow_mut(&mut s.many, 0), value);
+        set_wrapped(vector::borrow_mut(&mut s.many, 1), value);
+    }
+
+    fun set_wrapped(w: &mut Wrapped, value: u64) {
+        set_(&mut w.id, value);
+        set_(&mut w.other, value);
+
+    }
+
+    fun set_(id: &mut UID, value: u64) {
+        ofield::borrow_mut<u64, Value>(id, KEY).value = value;
+    }
+
+    //////////////////////////////////////////////////////////////
+    // remove
+
+    public fun remove(s: &mut S) {
+        remove_(&mut s.id);
+        remove_(&mut s.other);
+        remove_wrapped(&mut s.wrapped);
+        remove_wrapped(vector::borrow_mut(&mut s.many, 0));
+        remove_wrapped(vector::borrow_mut(&mut s.many, 1));
+    }
+
+    fun remove_wrapped(w: &mut Wrapped) {
+        remove_(&mut w.id);
+        remove_(&mut w.other);
+    }
+
+    fun remove_(id: &mut UID) {
+        let Value { id, value: _ } = ofield::remove(id, KEY);
+        object::delete(id);
+    }
+
+    //////////////////////////////////////////////////////////////
+    // check
+
+    public fun check(s: &S, expected: Option<u64>) {
+        check_(&s.id, expected);
+        check_(&s.other, expected);
+        check_wrapped(&s.wrapped, expected);
+        check_wrapped(vector::borrow(&s.many, 0), expected);
+        check_wrapped(vector::borrow(&s.many, 1), expected);
+    }
+
+    fun check_wrapped(w: &Wrapped, expected: Option<u64>) {
+        check_(&w.id, expected);
+        check_(&w.other, expected);
+    }
+
+    fun check_(id: &UID, expected: Option<u64>) {
+        if (option::is_some(&expected)) {
+            let Value { id: _, value } = ofield::borrow(id, KEY);
+            assert!(value == option::borrow(&expected), 0);
+        } else {
+            assert!(!ofield::exists_with_type<u64, Value>(id, KEY), 0);
+        }
+    }
+}
+
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> TransferObjects([Result(0)], Input(0))
+
+//# view-object 2,8
+
+//# programmable --sender A --inputs object(2,8) 112
+//> test::m::set(Input(0), Input(1))
+
+//# view-object 2,8
+
+//# programmable --sender A --inputs object(2,8) 112
+//> test::m::remove(Input(0))
+
+//# view-object 2,8
+
+
+// dev-inspect with 'check' and correct values
+
+//# programmable --sender A --inputs object(2,8)@2 vector[0] --dev-inspect
+//> test::m::check(Input(0), Input(1))
+
+//# programmable --sender A --inputs object(2,8)@3 vector[112] --dev-inspect
+//> test::m::check(Input(0), Input(1))
+
+//# programmable --sender A --inputs object(2,8)@4 vector[] --dev-inspect
+//> test::m::check(Input(0), Input(1))
+
+
+// dev-inspect with 'check' and _incorrect_ values
+
+//# programmable --sender A --inputs object(2,8)@3 vector[0] --dev-inspect
+//> test::m::check(Input(0), Input(1))
+
+//# programmable --sender A --inputs object(2,8)@4 vector[112] --dev-inspect
+//> test::m::check(Input(0), Input(1))
+
+//# programmable --sender A --inputs object(2,8)@2 vector[] --dev-inspect
+//> test::m::check(Input(0), Input(1))

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/v0/find_all_uids_on_child.exp
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/v0/find_all_uids_on_child.exp
@@ -1,0 +1,62 @@
+processed 14 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 8-144:
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 13877600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'programmable'. lines 146-148:
+created: object(2,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,8), object(2,9)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 17609200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'view-object'. lines 150-150:
+Owner: Account Address ( A )
+Version: 2
+Contents: test::m::Parent {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,9)}}}
+
+task 4 'programmable'. lines 152-153:
+mutated: object(0,0), object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,8), object(2,9)
+gas summary: computation_cost: 1000000, storage_cost: 13968800,  storage_rebate: 13829112, non_refundable_storage_fee: 139688
+
+task 5 'view-object'. lines 155-155:
+Owner: Account Address ( A )
+Version: 3
+Contents: test::m::Parent {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,9)}}}
+
+task 6 'programmable'. lines 157-158:
+mutated: object(0,0), object(2,9)
+deleted: object(2,1), object(2,2), object(2,3), object(2,4), object(2,5), object(2,6), object(2,7), object(2,8)
+gas summary: computation_cost: 1000000, storage_cost: 2234400,  storage_rebate: 13829112, non_refundable_storage_fee: 139688
+
+task 7 'view-object'. lines 160-163:
+Owner: Account Address ( A )
+Version: 4
+Contents: test::m::Parent {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,9)}}}
+
+task 8 'programmable'. lines 165-166:
+mutated: object(_), object(2,9)
+gas summary: computation_cost: 500000, storage_cost: 2234400,  storage_rebate: 1233936, non_refundable_storage_fee: 12464
+
+task 9 'programmable'. lines 168-169:
+mutated: object(_), object(2,9)
+gas summary: computation_cost: 500000, storage_cost: 2234400,  storage_rebate: 1233936, non_refundable_storage_fee: 12464
+
+task 10 'programmable'. lines 171-175:
+mutated: object(_), object(2,9)
+gas summary: computation_cost: 500000, storage_cost: 2234400,  storage_rebate: 1233936, non_refundable_storage_fee: 12464
+
+task 11 'programmable'. lines 177-178:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 14, instruction: 12, function_name: Some("check_") }, 0) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 14, instruction: 12, function_name: Some("check_") }, 0) in command 0
+
+task 12 'programmable'. lines 180-181:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 11, instruction: 0, function_name: Some("borrow_child_object") }, 1) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("dynamic_field") }, function: 11, instruction: 0, function_name: Some("borrow_child_object") }, 1) in command 0
+
+task 13 'programmable'. lines 183-184:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 14, instruction: 21, function_name: Some("check_") }, 0) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 14, instruction: 21, function_name: Some("check_") }, 0) in command 0

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/v0/find_all_uids_on_child.move
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/v0/find_all_uids_on_child.move
@@ -1,0 +1,184 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests finding UIDs for dynamic field access on a child object (non-input)
+
+//# init --addresses test=0x0 --accounts A --protocol-version 16
+
+//# publish
+
+module test::m {
+    use std::option::{Self, Option};
+    use std::vector;
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::dynamic_field as field;
+
+    struct Parent has key, store {
+        id: UID,
+    }
+
+    struct S has key, store {
+        id: UID,
+        other: UID,
+        wrapped: Wrapped,
+        many: vector<Wrapped>,
+    }
+
+    struct Wrapped has key, store {
+        id: UID,
+        other: UID,
+    }
+
+    const KEY: u64 = 0;
+
+    //////////////////////////////////////////////////////////////
+    // new
+
+    public fun new(ctx: &mut TxContext): Parent {
+        let parent = Parent { id: object::new(ctx) };
+        field::add(&mut parent.id, KEY, s(ctx));
+        parent
+    }
+
+    fun s(ctx: &mut TxContext): S {
+        let s = S {
+            id: object::new(ctx),
+            other: object::new(ctx),
+            wrapped: wrapped(ctx),
+            many: vector[wrapped(ctx), wrapped(ctx)],
+        };
+        field::add(&mut s.id, KEY, 0);
+        field::add(&mut s.other, KEY, 0);
+        s
+    }
+
+    fun wrapped(ctx: &mut TxContext): Wrapped {
+        let w = Wrapped {
+            id: object::new(ctx),
+            other: object::new(ctx),
+        };
+        field::add(&mut w.id, KEY, 0);
+        field::add(&mut w.other, KEY, 0);
+        w
+    }
+
+    //////////////////////////////////////////////////////////////
+    // set
+
+    public fun set(parent: &mut Parent, value: u64) {
+        set_s(field::borrow_mut(&mut parent.id, KEY), value);
+    }
+
+
+    fun set_s(s: &mut S, value: u64) {
+        set_(&mut s.id, value);
+        set_(&mut s.other, value);
+        set_wrapped(&mut s.wrapped, value);
+        set_wrapped(vector::borrow_mut(&mut s.many, 0), value);
+        set_wrapped(vector::borrow_mut(&mut s.many, 1), value);
+    }
+
+    fun set_wrapped(w: &mut Wrapped, value: u64) {
+        set_(&mut w.id, value);
+        set_(&mut w.other, value);
+
+    }
+
+    fun set_(id: &mut UID, value: u64) {
+        *field::borrow_mut(id, KEY) = value;
+    }
+
+    //////////////////////////////////////////////////////////////
+    // remove
+
+    public fun remove(parent: &mut Parent) {
+        remove_s(field::borrow_mut(&mut parent.id, KEY));
+    }
+
+    fun remove_s(s: &mut S) {
+        remove_(&mut s.id);
+        remove_(&mut s.other);
+        remove_wrapped(&mut s.wrapped);
+        remove_wrapped(vector::borrow_mut(&mut s.many, 0));
+        remove_wrapped(vector::borrow_mut(&mut s.many, 1));
+    }
+
+    fun remove_wrapped(w: &mut Wrapped) {
+        remove_(&mut w.id);
+        remove_(&mut w.other);
+    }
+
+    fun remove_(id: &mut UID) {
+        field::remove<u64, u64>(id, KEY);
+    }
+
+    //////////////////////////////////////////////////////////////
+    // check
+
+    public fun check(parent: &Parent, expected: Option<u64>) {
+        check_s(field::borrow(&parent.id, KEY), expected);
+    }
+
+    fun check_s(s: &S, expected: Option<u64>) {
+        check_(&s.id, expected);
+        check_(&s.other, expected);
+        check_wrapped(&s.wrapped, expected);
+        check_wrapped(vector::borrow(&s.many, 0), expected);
+        check_wrapped(vector::borrow(&s.many, 1), expected);
+    }
+
+    fun check_wrapped(w: &Wrapped, expected: Option<u64>) {
+        check_(&w.id, expected);
+        check_(&w.other, expected);
+    }
+
+    fun check_(id: &UID, expected: Option<u64>) {
+        if (option::is_some(&expected)) {
+            let f = field::borrow(id, KEY);
+            assert!(f == option::borrow(&expected), 0);
+        } else {
+            assert!(!field::exists_with_type<u64, u64>(id, KEY), 0);
+        }
+    }
+}
+
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> TransferObjects([Result(0)], Input(0))
+
+//# view-object 2,9
+
+//# programmable --sender A --inputs object(2,9) 112
+//> test::m::set(Input(0), Input(1))
+
+//# view-object 2,9
+
+//# programmable --sender A --inputs object(2,9) 112
+//> test::m::remove(Input(0))
+
+//# view-object 2,9
+
+
+// dev-inspect with 'check' and correct values
+
+//# programmable --sender A --inputs object(2,9)@2 vector[0] --dev-inspect
+//> test::m::check(Input(0), Input(1))
+
+//# programmable --sender A --inputs object(2,9)@3 vector[112] --dev-inspect
+//> test::m::check(Input(0), Input(1))
+
+//# programmable --sender A --inputs object(2,9)@4 vector[] --dev-inspect
+//> test::m::check(Input(0), Input(1))
+
+
+// dev-inspect with 'check' and _incorrect_ values
+
+//# programmable --sender A --inputs object(2,9)@3 vector[0] --dev-inspect
+//> test::m::check(Input(0), Input(1))
+
+//# programmable --sender A --inputs object(2,9)@4 vector[112] --dev-inspect
+//> test::m::check(Input(0), Input(1))
+
+//# programmable --sender A --inputs object(2,9)@2 vector[] --dev-inspect
+//> test::m::check(Input(0), Input(1))

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/v0/middle_version_less_than_child.exp
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/v0/middle_version_less_than_child.exp
@@ -1,0 +1,52 @@
+processed 11 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 8-53:
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 7493600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'programmable'. lines 55-59:
+created: object(2,0), object(2,1), object(2,2)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6285200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'view-object'. lines 61-61:
+Owner: Object ID: ( _ )
+Version: 2
+Contents: sui::dynamic_field::Field<u64, test::m::Obj> {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, name: 0u64, value: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: _}}, value: 0u64}}
+
+task 4 'view-object'. lines 63-63:
+Owner: Object ID: ( fake(2,2) )
+Version: 2
+Contents: sui::dynamic_field::Field<u64, test::m::Obj> {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,1)}}, name: 0u64, value: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: _}}, value: 0u64}}
+
+task 5 'view-object'. lines 65-65:
+Owner: Account Address ( A )
+Version: 2
+Contents: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,2)}}, value: 0u64}
+
+task 6 'programmable'. lines 67-70:
+mutated: object(0,0), object(2,0), object(2,2)
+gas summary: computation_cost: 1000000, storage_cost: 4278800,  storage_rebate: 4236012, non_refundable_storage_fee: 42788
+
+task 7 'view-object'. lines 72-72:
+Owner: Object ID: ( _ )
+Version: 3
+Contents: sui::dynamic_field::Field<u64, test::m::Obj> {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}, name: 0u64, value: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: _}}, value: 112u64}}
+
+task 8 'view-object'. lines 74-74:
+Owner: Object ID: ( fake(2,2) )
+Version: 2
+Contents: sui::dynamic_field::Field<u64, test::m::Obj> {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,1)}}, name: 0u64, value: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: _}}, value: 0u64}}
+
+task 9 'view-object'. lines 76-79:
+Owner: Account Address ( A )
+Version: 3
+Contents: test::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,2)}}, value: 0u64}
+
+task 10 'programmable'. lines 81-82:
+mutated: object(0,0), object(2,2)
+gas summary: computation_cost: 1000000, storage_cost: 2272400,  storage_rebate: 2249676, non_refundable_storage_fee: 22724

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/v0/middle_version_less_than_child.move
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/v0/middle_version_less_than_child.move
@@ -1,0 +1,82 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests accessing the versions of a child of a child
+
+//# init --addresses test=0x0 --accounts A --protocol-version 16
+
+//# publish
+
+module test::m {
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::dynamic_field as field;
+
+    struct Obj has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    const KEY: u64 = 0;
+
+    //////////////////////////////////////////////////////////////
+    // new
+
+    public fun new(ctx: &mut TxContext): Obj {
+        let grand = Obj { id: object::new(ctx), value: 0 };
+        let parent = Obj { id: object::new(ctx), value: 0 };
+        let child = Obj { id: object::new(ctx), value: 0 };
+        field::add(&mut parent.id, KEY, child);
+        field::add(&mut grand.id, KEY, parent);
+        grand
+    }
+
+    //////////////////////////////////////////////////////////////
+    // set
+
+    public fun set(grand: &mut Obj, v: u64) {
+        let parent: &mut Obj = field::borrow_mut(&mut grand.id, KEY);
+        let child: &mut Obj = field::borrow_mut(&mut parent.id, KEY);
+        child.value = v;
+    }
+
+    //////////////////////////////////////////////////////////////
+    // check
+
+    public fun check(grand: &Obj, expected: u64) {
+        assert!(grand.value == 0, 0);
+        let parent: &Obj = field::borrow(&grand.id, KEY);
+        assert!(parent.value == 0, 0);
+        let child: &Obj = field::borrow(&parent.id, KEY);
+        assert!(child.value == expected, 0);
+    }
+}
+
+//# programmable --sender A --inputs @A
+//> 0: test::m::new();
+//> TransferObjects([Result(0)], Input(0))
+
+// All 3 objects have version 2
+
+//# view-object 2,0
+
+//# view-object 2,1
+
+//# view-object 2,2
+
+//# programmable --sender A --inputs object(2,2) 112
+//> test::m::set(Input(0), Input(1))
+
+// The middle object has version 2, while the root and modified leaf have version 3
+
+//# view-object 2,0
+
+//# view-object 2,1
+
+//# view-object 2,2
+
+// correctly load the leaf even though it has a version greater than its immediate
+// parent
+
+//# programmable --sender A --inputs object(2,2) 112
+//> test::m::check(Input(0), Input(1))

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/v0/not_root_version.exp
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/v0/not_root_version.exp
@@ -1,0 +1,66 @@
+processed 14 tasks
+
+init:
+P1: object(0,0), P2: object(0,1)
+
+task 1 'publish'. lines 8-55:
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 7432800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'programmable'. lines 57-59:
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2196400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'programmable'. lines 61-62:
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2196400,  storage_rebate: 2174436, non_refundable_storage_fee: 21964
+
+task 4 'programmable'. lines 64-65:
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2196400,  storage_rebate: 2174436, non_refundable_storage_fee: 21964
+
+task 5 'view-object'. lines 67-70:
+Owner: Account Address ( P1 )
+Version: 4
+Contents: test::m::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}}
+
+task 6 'programmable'. lines 72-74:
+created: object(6,0), object(6,1)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 3663200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 7 'view-object'. lines 76-76:
+Owner: Object ID: ( fake(6,1) )
+Version: 2
+Contents: sui::dynamic_field::Field<u64, u64> {id: sui::object::UID {id: sui::object::ID {bytes: fake(6,0)}}, name: 0u64, value: 0u64}
+
+task 8 'programmable'. lines 78-79:
+mutated: object(0,1), object(6,0), object(6,1)
+gas summary: computation_cost: 1000000, storage_cost: 3663200,  storage_rebate: 3626568, non_refundable_storage_fee: 36632
+
+task 9 'view-object'. lines 81-85:
+Owner: Object ID: ( fake(6,1) )
+Version: 3
+Contents: sui::dynamic_field::Field<u64, u64> {id: sui::object::UID {id: sui::object::ID {bytes: fake(6,0)}}, name: 0u64, value: 1u64}
+
+task 10 'programmable'. lines 87-92:
+created: object(10,0)
+mutated: object(_), object(2,0)
+wrapped: object(6,1)
+gas summary: computation_cost: 500000, storage_cost: 4126800,  storage_rebate: 2392632, non_refundable_storage_fee: 24168
+
+task 11 'programmable'. lines 94-98:
+created: object(10,0)
+mutated: object(_), object(2,0)
+wrapped: object(6,1)
+gas summary: computation_cost: 500000, storage_cost: 4126800,  storage_rebate: 2392632, non_refundable_storage_fee: 24168
+
+task 12 'programmable'. lines 100-104:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 4, instruction: 13, function_name: Some("check") }, 0) in command 1
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 4, instruction: 13, function_name: Some("check") }, 0) in command 1
+
+task 13 'programmable'. lines 106-108:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 4, instruction: 13, function_name: Some("check") }, 0) in command 1
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 4, instruction: 13, function_name: Some("check") }, 0) in command 1

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/v0/not_root_version.move
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/v0/not_root_version.move
@@ -1,0 +1,108 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests accessing version of the input parent, not the runtime parent
+
+//# init --addresses test=0x0 --accounts P1 P2 --protocol-version 16
+
+//# publish
+
+module test::m {
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::dynamic_field as field;
+
+    struct A has key, store {
+        id: UID,
+    }
+
+    struct B has key, store {
+        id: UID,
+    }
+
+    const KEY: u64 = 0;
+
+    public fun a(ctx: &mut TxContext): A {
+        A { id: object::new(ctx) }
+    }
+
+    public fun b(ctx: &mut TxContext): B {
+        let b = B { id: object::new(ctx) };
+        field::add(&mut b.id, KEY, 0);
+        b
+
+    }
+
+    public fun bump(b: &mut B) {
+        let f = field::borrow_mut(&mut b.id, KEY);
+        *f = *f + 1;
+    }
+
+    public fun append(a: &mut A, b: B) {
+        field::add(&mut a.id, KEY, b);
+    }
+
+    public fun check(a: &A, expected: u64) {
+        let b: &B = field::borrow(&a.id, KEY);
+        let v = *field::borrow(&b.id, KEY);
+        assert!(v == expected, 0);
+    }
+
+    public fun nop() {
+    }
+}
+
+// Create object A and bump the version to 4
+
+//# programmable --sender P1 --inputs @P1
+//> 0: test::m::a();
+//> TransferObjects([Result(0)], Input(0))
+
+//# programmable --sender P1 --inputs object(2,0)
+//> test::m::nop();
+
+//# programmable --sender P1 --inputs object(2,0)
+//> test::m::nop();
+
+//# view-object 2,0
+
+
+// Create object B witha version 2 and 3 for it's dynamic field
+
+//# programmable --sender P2 --inputs @P2
+//> 0: test::m::b();
+//> TransferObjects([Result(0)], Input(0))
+
+//# view-object 6,0
+
+//# programmable --sender P2 --inputs object(6,1)
+//> 0: test::m::bump(Input(0));
+
+//# view-object 6,0
+
+
+// Append object B to object A, but using version 2 of object B. And ensure that
+// when we later read the dynamic field of object B, we get the version 2 value.
+
+//# programmable --sender P2 --inputs object(2,0)@4 object(6,1)@2 0 --dev-inspect
+//> 0: test::m::append(Input(0), Input(1));
+//> 1: test::m::check(Input(0), Input(2));
+
+// checking that with version 3 we get the other value, then flip them to ensure
+// they abort
+
+//# programmable --sender P2 --inputs object(2,0)@4 object(6,1)@3 1 --dev-inspect
+//> 0: test::m::append(Input(0), Input(1));
+//> 1: test::m::check(Input(0), Input(2));
+
+// @2 with value 1 aborts
+
+//# programmable --sender P2 --inputs object(2,0)@4 object(6,1)@2 1 --dev-inspect
+//> 0: test::m::append(Input(0), Input(1));
+//> 1: test::m::check(Input(0), Input(2));
+
+// @3 with value 0 aborts
+
+//# programmable --sender P2 --inputs object(2,0)@4 object(6,1)@3 0 --dev-inspect
+//> 0: test::m::append(Input(0), Input(1));
+//> 1: test::m::check(Input(0), Input(2));

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/v0/not_root_version_flipped_case.exp
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/v0/not_root_version_flipped_case.exp
@@ -1,0 +1,58 @@
+processed 12 tasks
+
+init:
+P1: object(0,0), P2: object(0,1)
+
+task 1 'publish'. lines 8-55:
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 7432800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'programmable'. lines 57-59:
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2196400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3 'view-object'. lines 62-65:
+Owner: Account Address ( P1 )
+Version: 2
+Contents: test::m::A {id: sui::object::UID {id: sui::object::ID {bytes: fake(2,0)}}}
+
+task 4 'programmable'. lines 67-69:
+created: object(4,0), object(4,1)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 3663200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 5 'view-object'. lines 71-71:
+Owner: Object ID: ( fake(4,1) )
+Version: 2
+Contents: sui::dynamic_field::Field<u64, u64> {id: sui::object::UID {id: sui::object::ID {bytes: fake(4,0)}}, name: 0u64, value: 0u64}
+
+task 6 'programmable'. lines 73-74:
+mutated: object(0,1), object(4,0), object(4,1)
+gas summary: computation_cost: 1000000, storage_cost: 3663200,  storage_rebate: 3626568, non_refundable_storage_fee: 36632
+
+task 7 'view-object'. lines 76-79:
+Owner: Object ID: ( fake(4,1) )
+Version: 3
+Contents: sui::dynamic_field::Field<u64, u64> {id: sui::object::UID {id: sui::object::ID {bytes: fake(4,0)}}, name: 0u64, value: 1u64}
+
+task 8 'programmable'. lines 81-86:
+created: object(8,0)
+mutated: object(_), object(2,0)
+wrapped: object(4,1)
+gas summary: computation_cost: 500000, storage_cost: 4126800,  storage_rebate: 2392632, non_refundable_storage_fee: 24168
+
+task 9 'programmable'. lines 88-92:
+created: object(8,0)
+mutated: object(_), object(2,0)
+wrapped: object(4,1)
+gas summary: computation_cost: 500000, storage_cost: 4126800,  storage_rebate: 2392632, non_refundable_storage_fee: 24168
+
+task 10 'programmable'. lines 94-98:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 4, instruction: 13, function_name: Some("check") }, 0) in command 1
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 4, instruction: 13, function_name: Some("check") }, 0) in command 1
+
+task 11 'programmable'. lines 100-102:
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 4, instruction: 13, function_name: Some("check") }, 0) in command 1
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 4, instruction: 13, function_name: Some("check") }, 0) in command 1

--- a/crates/sui-adapter-transactional-tests/tests/mvcc/v0/not_root_version_flipped_case.move
+++ b/crates/sui-adapter-transactional-tests/tests/mvcc/v0/not_root_version_flipped_case.move
@@ -1,0 +1,102 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests accessing version of the input parent, not the runtime parent
+
+//# init --addresses test=0x0 --accounts P1 P2 --protocol-version 16
+
+//# publish
+
+module test::m {
+    use sui::object::{Self, UID};
+    use sui::tx_context::TxContext;
+    use sui::dynamic_field as field;
+
+    struct A has key, store {
+        id: UID,
+    }
+
+    struct B has key, store {
+        id: UID,
+    }
+
+    const KEY: u64 = 0;
+
+    public fun a(ctx: &mut TxContext): A {
+        A { id: object::new(ctx) }
+    }
+
+    public fun b(ctx: &mut TxContext): B {
+        let b = B { id: object::new(ctx) };
+        field::add(&mut b.id, KEY, 0);
+        b
+
+    }
+
+    public fun bump(b: &mut B) {
+        let f = field::borrow_mut(&mut b.id, KEY);
+        *f = *f + 1;
+    }
+
+    public fun append(a: &mut A, b: B) {
+        field::add(&mut a.id, KEY, b);
+    }
+
+    public fun check(a: &A, expected: u64) {
+        let b: &B = field::borrow(&a.id, KEY);
+        let v = *field::borrow(&b.id, KEY);
+        assert!(v == expected, 0);
+    }
+
+    public fun nop() {
+    }
+}
+
+// Create object A at version 2
+
+//# programmable --sender P1 --inputs @P1
+//> 0: test::m::a();
+//> TransferObjects([Result(0)], Input(0))
+
+
+//# view-object 2,0
+
+
+// Create object B with a version 2 and 3 for it's dynamic field
+
+//# programmable --sender P2 --inputs @P2
+//> 0: test::m::b();
+//> TransferObjects([Result(0)], Input(0))
+
+//# view-object 4,0
+
+//# programmable --sender P2 --inputs object(4,1)
+//> 0: test::m::bump(Input(0));
+
+//# view-object 4,0
+
+// Append object B to object A. And ensure that when we later read the dynamic
+// field of object B, we get the most recent version.
+
+//# programmable --sender P2 --inputs object(2,0)@2 object(4,1)@3 1 --dev-inspect
+//> 0: test::m::append(Input(0), Input(1));
+//> 1: test::m::check(Input(0), Input(2));
+
+// checking that with version 3 we get the other value, then flip them to ensure
+// they abort
+
+//# programmable --sender P2 --inputs object(2,0)@2 object(4,1)@2 0 --dev-inspect
+//> 0: test::m::append(Input(0), Input(1));
+//> 1: test::m::check(Input(0), Input(2));
+
+// @2 with value 1 aborts
+
+//# programmable --sender P2 --inputs object(2,0)@2 object(4,1)@2 1 --dev-inspect
+//> 0: test::m::append(Input(0), Input(1));
+//> 1: test::m::check(Input(0), Input(2));
+
+// @3 with value 0 aborts
+
+//# programmable --sender P2 --inputs object(2,0)@2 object(4,1)@3 0 --dev-inspect
+//> 0: test::m::append(Input(0), Input(1));
+//> 1: test::m::check(Input(0), Input(2));

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1856,11 +1856,18 @@ impl ObjectStore for AuthorityStore {
 }
 
 impl ChildObjectResolver for AuthorityStore {
-    fn read_child_object(&self, parent: &ObjectID, child: &ObjectID) -> SuiResult<Option<Object>> {
-        let child_object = match self.get_object(child)? {
-            None => return Ok(None),
-            Some(o) => o,
+    fn read_child_object(
+        &self,
+        parent: &ObjectID,
+        child: &ObjectID,
+        child_version_upper_bound: SequenceNumber,
+    ) -> SuiResult<Option<Object>> {
+        let Some(child_object) =
+            self.find_object_lt_or_eq_version(*child, child_version_upper_bound)
+        else {
+            return Ok(None)
         };
+
         let parent = *parent;
         if child_object.owner != Owner::ObjectOwner(parent.into()) {
             return Err(SuiError::InvalidChildObjectAccess {

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -1029,7 +1029,8 @@ async fn test_dry_run_on_validator() {
     assert!(response.is_err());
 }
 
-// Tests using a dynamic field that a is newer than the parent in dev inspect/dry run
+// Tests using a dynamic field that a is newer than the parent in dev inspect/dry run results
+// in not being able to access the dynamic field object
 #[tokio::test]
 async fn test_dry_run_dev_inspect_dynamic_field_too_new() {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
@@ -1105,13 +1106,12 @@ async fn test_dry_run_dev_inspect_dynamic_field_too_new() {
     .unwrap();
     assert_eq!(effects.status(), &ExecutionStatus::Success);
     assert_eq!(effects.created().len(), 1);
-    let field = effects.created()[0].0;
 
     // make sure the parent was updated
     let new_parent = fullnode.get_object(&parent.0).await.unwrap().unwrap();
     assert!(parent.1 < new_parent.version());
 
-    // delete the child, but using the old version of the parent
+    // no child to delete since we are using the old version of the parent
     let pt = ProgrammableTransaction {
         inputs: vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(parent))],
         commands: vec![Command::MoveCall(Box::new(ProgrammableMoveCall {
@@ -1129,11 +1129,9 @@ async fn test_dry_run_dev_inspect_dynamic_field_too_new() {
         .dev_inspect_transaction_block(sender, kind, Some(rgp))
         .await
         .unwrap();
-    assert_eq!(effects.deleted().len(), 1);
-    let deleted = &effects.deleted()[0];
-    assert_eq!(field.0, deleted.object_id);
-    assert_eq!(deleted.version, SequenceNumber::MAX);
+    assert_eq!(effects.deleted().len(), 0);
     // dry run
+    let rgp = fullnode.reference_gas_price_for_testing().unwrap();
     let data = TransactionData::new_programmable(
         sender,
         vec![gas_object_ref],
@@ -1145,10 +1143,7 @@ async fn test_dry_run_dev_inspect_dynamic_field_too_new() {
     let digest = *transaction.digest();
     let DryRunTransactionBlockResponse { effects, .. } =
         fullnode.dry_exec_transaction(data, digest).await.unwrap().0;
-    assert_eq!(effects.deleted().len(), 1);
-    let deleted = &effects.deleted()[0];
-    assert_eq!(field.0, deleted.object_id);
-    assert_eq!(deleted.version, SequenceNumber::MAX);
+    assert_eq!(effects.deleted().len(), 0);
 }
 
 // tests using a gas coin with version MAX - 1

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -1029,7 +1029,7 @@ async fn test_dry_run_on_validator() {
     assert!(response.is_err());
 }
 
-// Tests using a dynamic field that a is newer than the parent in dev inspect/dry run results
+// Tests using a dynamic field that is newer than the parent in dev inspect/dry run results
 // in not being able to access the dynamic field object
 #[tokio::test]
 async fn test_dry_run_dev_inspect_dynamic_field_too_new() {

--- a/crates/sui-types/src/in_memory_storage.rs
+++ b/crates/sui-types/src/in_memory_storage.rs
@@ -33,7 +33,12 @@ impl BackingPackageStore for InMemoryStorage {
 }
 
 impl ChildObjectResolver for InMemoryStorage {
-    fn read_child_object(&self, parent: &ObjectID, child: &ObjectID) -> SuiResult<Option<Object>> {
+    fn read_child_object(
+        &self,
+        parent: &ObjectID,
+        child: &ObjectID,
+        child_version_upper_bound: SequenceNumber,
+    ) -> SuiResult<Option<Object>> {
         let child_object = match self.persistent.get(child).cloned() {
             None => return Ok(None),
             Some(obj) => obj,
@@ -44,6 +49,12 @@ impl ChildObjectResolver for InMemoryStorage {
                 object: *child,
                 given_parent: parent,
                 actual_owner: child_object.owner,
+            });
+        }
+        if child_object.version() > child_version_upper_bound {
+            return Err(SuiError::UnsupportedFeatureError {
+                error: "TODO InMemoryStorage::read_child_object does not yet support bounded reads"
+                    .to_owned(),
             });
         }
         Ok(Some(child_object))

--- a/crates/sui-types/src/storage.rs
+++ b/crates/sui-types/src/storage.rs
@@ -101,7 +101,12 @@ impl<T: Storage + ParentSync + ChildObjectResolver> StorageView for T {}
 /// An abstraction of the (possibly distributed) store for objects. This
 /// API only allows for the retrieval of objects, not any state changes
 pub trait ChildObjectResolver {
-    fn read_child_object(&self, parent: &ObjectID, child: &ObjectID) -> SuiResult<Option<Object>>;
+    fn read_child_object(
+        &self,
+        parent: &ObjectID,
+        child: &ObjectID,
+        child_version_upper_bound: SequenceNumber,
+    ) -> SuiResult<Option<Object>>;
 }
 
 /// An abstraction of the (possibly distributed) store for objects, and (soon) events and transactions
@@ -240,20 +245,40 @@ impl<S: ParentSync> ParentSync for &mut S {
 }
 
 impl<S: ChildObjectResolver> ChildObjectResolver for std::sync::Arc<S> {
-    fn read_child_object(&self, parent: &ObjectID, child: &ObjectID) -> SuiResult<Option<Object>> {
-        ChildObjectResolver::read_child_object(self.as_ref(), parent, child)
+    fn read_child_object(
+        &self,
+        parent: &ObjectID,
+        child: &ObjectID,
+        child_version_upper_bound: SequenceNumber,
+    ) -> SuiResult<Option<Object>> {
+        ChildObjectResolver::read_child_object(
+            self.as_ref(),
+            parent,
+            child,
+            child_version_upper_bound,
+        )
     }
 }
 
 impl<S: ChildObjectResolver> ChildObjectResolver for &S {
-    fn read_child_object(&self, parent: &ObjectID, child: &ObjectID) -> SuiResult<Option<Object>> {
-        ChildObjectResolver::read_child_object(*self, parent, child)
+    fn read_child_object(
+        &self,
+        parent: &ObjectID,
+        child: &ObjectID,
+        child_version_upper_bound: SequenceNumber,
+    ) -> SuiResult<Option<Object>> {
+        ChildObjectResolver::read_child_object(*self, parent, child, child_version_upper_bound)
     }
 }
 
 impl<S: ChildObjectResolver> ChildObjectResolver for &mut S {
-    fn read_child_object(&self, parent: &ObjectID, child: &ObjectID) -> SuiResult<Option<Object>> {
-        ChildObjectResolver::read_child_object(*self, parent, child)
+    fn read_child_object(
+        &self,
+        parent: &ObjectID,
+        child: &ObjectID,
+        child_version_upper_bound: SequenceNumber,
+    ) -> SuiResult<Option<Object>> {
+        ChildObjectResolver::read_child_object(*self, parent, child, child_version_upper_bound)
     }
 }
 

--- a/crates/sui-types/src/temporary_store.rs
+++ b/crates/sui-types/src/temporary_store.rs
@@ -1543,14 +1543,20 @@ impl<'backing> TemporaryStore<'backing> {
 }
 
 impl<'backing> ChildObjectResolver for TemporaryStore<'backing> {
-    fn read_child_object(&self, parent: &ObjectID, child: &ObjectID) -> SuiResult<Option<Object>> {
+    fn read_child_object(
+        &self,
+        parent: &ObjectID,
+        child: &ObjectID,
+        child_version_upper_bound: SequenceNumber,
+    ) -> SuiResult<Option<Object>> {
         // there should be no read after delete
         debug_assert!(self.deleted.get(child).is_none());
         let obj_opt = self.written.get(child).map(|(obj, _kind)| obj);
         if obj_opt.is_some() {
             Ok(obj_opt.cloned())
         } else {
-            self.store.read_child_object(parent, child)
+            self.store
+                .read_child_object(parent, child, child_version_upper_bound)
         }
     }
 }

--- a/sui-execution/latest/sui-adapter/src/adapter.rs
+++ b/sui-execution/latest/sui-adapter/src/adapter.rs
@@ -16,6 +16,7 @@ use move_vm_runtime::{
     move_vm::MoveVM, native_extensions::NativeContextExtensions,
     native_functions::NativeFunctionTable,
 };
+use sui_move_natives::object_runtime;
 use sui_types::metrics::BytecodeVerifierMetrics;
 use sui_verifier::check_for_verifier_timeout;
 use tracing::instrument;
@@ -27,7 +28,6 @@ use sui_types::{
     error::ExecutionError,
     error::{ExecutionErrorKind, SuiError},
     metrics::LimitsMetrics,
-    object::Owner,
     storage::ChildObjectResolver,
 };
 use sui_verifier::verifier::sui_verify_module_metered_check_timeout_only;
@@ -110,7 +110,7 @@ pub fn new_move_vm(
 
 pub fn new_native_extensions<'r>(
     child_resolver: &'r dyn ChildObjectResolver,
-    input_objects: BTreeMap<ObjectID, Owner>,
+    input_objects: BTreeMap<ObjectID, object_runtime::InputObject>,
     is_metered: bool,
     protocol_config: &ProtocolConfig,
     metrics: Arc<LimitsMetrics>,

--- a/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
@@ -5,8 +5,11 @@ use better_any::{Tid, TidAble};
 use linked_hash_map::LinkedHashMap;
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
-    account_address::AccountAddress, effects::Op, language_storage::StructTag,
-    value::MoveTypeLayout, vm_status::StatusCode,
+    account_address::AccountAddress,
+    effects::Op,
+    language_storage::StructTag,
+    value::{MoveStruct, MoveTypeLayout, MoveValue},
+    vm_status::StatusCode,
 };
 use move_vm_types::{
     loaded_data::runtime_types::Type,
@@ -20,6 +23,7 @@ use sui_protocol_config::{check_limit_by_meter, LimitThresholdCrossed, ProtocolC
 use sui_types::{
     base_types::{MoveObjectType, ObjectID, SequenceNumber, SuiAddress},
     error::{ExecutionError, ExecutionErrorKind, VMMemoryLimitExceededSubStatusCode},
+    id::UID,
     metrics::LimitsMetrics,
     object::{MoveObject, Owner},
     storage::{ChildObjectResolver, DeleteKind, WriteKind},
@@ -143,6 +147,12 @@ pub enum TransferResult {
     OwnerChanged,
 }
 
+pub struct InputObject {
+    pub contained_uids: BTreeSet<ObjectID>,
+    pub version: SequenceNumber,
+    pub owner: Owner,
+}
+
 impl TestInventories {
     fn new() -> Self {
         Self::default()
@@ -152,21 +162,40 @@ impl TestInventories {
 impl<'a> ObjectRuntime<'a> {
     pub fn new(
         object_resolver: &'a dyn ChildObjectResolver,
-        input_objects: BTreeMap<ObjectID, Owner>,
+        input_objects: BTreeMap<ObjectID, InputObject>,
         is_metered: bool,
         protocol_config: &ProtocolConfig,
         metrics: Arc<LimitsMetrics>,
     ) -> Self {
+        let mut input_object_owners = BTreeMap::new();
+        let mut effective_owner_map = BTreeMap::new();
+        let mut root_version = BTreeMap::new();
+        for (id, input_object) in input_objects {
+            let InputObject {
+                contained_uids,
+                version,
+                owner,
+            } = input_object;
+            input_object_owners.insert(id, owner);
+            effective_owner_map.insert(id, id);
+            root_version.insert(id, version);
+            for contained_uid in contained_uids {
+                effective_owner_map.insert(contained_uid, id);
+                root_version.insert(contained_uid, version);
+            }
+        }
         Self {
             object_store: ObjectStore::new(
                 object_resolver,
+                effective_owner_map,
+                root_version,
                 is_metered,
                 LocalProtocolConfig::new(protocol_config),
                 metrics.clone(),
             ),
             test_inventories: TestInventories::new(),
             state: ObjectRuntimeState {
-                input_objects,
+                input_objects: input_object_owners,
                 new_ids: Set::new(),
                 deleted_ids: Set::new(),
                 transfers: LinkedHashMap::new(),
@@ -318,7 +347,8 @@ impl<'a> ObjectRuntime<'a> {
         parent: ObjectID,
         child: ObjectID,
         child_ty: &Type,
-        child_layout: MoveTypeLayout,
+        child_layout: &MoveTypeLayout,
+        child_fully_annotated_layout: &MoveTypeLayout,
         child_move_type: MoveObjectType,
     ) -> PartialVMResult<ObjectResult<&mut GlobalValue>> {
         let res = self.object_store.get_or_fetch_object(
@@ -326,6 +356,7 @@ impl<'a> ObjectRuntime<'a> {
             child,
             child_ty,
             child_layout,
+            child_fully_annotated_layout,
             child_move_type,
         )?;
         Ok(match res {
@@ -569,6 +600,53 @@ fn update_owner_map(
                 }
                 object_owner_map.insert(id, new_owner);
             }
+        }
+    }
+    Ok(())
+}
+
+// TODO use a custom DeserializerSeed and improve this performance
+pub fn get_all_uids(
+    fully_annotated_layout: &MoveTypeLayout,
+    bcs_bytes: &[u8],
+) -> Result<BTreeSet<ObjectID>, /* invariant violation */ String> {
+    let mut ids = BTreeSet::new();
+    let v = MoveValue::simple_deserialize(bcs_bytes, fully_annotated_layout)
+        .map_err(|e| format!("Failed to deserialize. {e:?}"))?;
+    get_all_uids_in_value(&mut ids, &v)?;
+    Ok(ids)
+}
+
+fn get_all_uids_in_value(
+    acc: &mut BTreeSet<ObjectID>,
+    v: &MoveValue,
+) -> Result<(), /* invariant violation */ String> {
+    let mut stack = vec![v];
+    while let Some(cur) = stack.pop() {
+        let s = match cur {
+            MoveValue::Struct(s) => s,
+            MoveValue::Vector(vec) => {
+                stack.extend(vec);
+                continue;
+            }
+            _ => continue,
+        };
+        match s {
+            MoveStruct::WithTypes { type_, fields } => {
+                if type_ == &UID::type_() {
+                    let inner = match &fields[0].1 {
+                        MoveValue::Struct(MoveStruct::WithTypes { fields, .. }) => fields,
+                        v => return Err(format!("Unexpected UID layout. {v:?}")),
+                    };
+                    match &inner[0].1 {
+                        MoveValue::Address(id) => acc.insert((*id).into()),
+                        v => return Err(format!("Unexpected ID layout. {v:?}")),
+                    };
+                } else {
+                    stack.extend(fields.iter().map(|(_, v)| v));
+                }
+            }
+            v => return Err(format!("Unexpected struct layout. {v:?}")),
         }
     }
     Ok(())

--- a/sui-execution/latest/sui-move-natives/src/object_runtime/object_store.rs
+++ b/sui-execution/latest/sui-move-natives/src/object_runtime/object_store.rs
@@ -20,6 +20,8 @@ use sui_types::{
     object::{Data, MoveObject, Owner},
     storage::ChildObjectResolver,
 };
+
+use super::get_all_uids;
 pub(super) struct ChildObject {
     pub(super) owner: ObjectID,
     pub(super) ty: Type,
@@ -39,6 +41,14 @@ pub(crate) struct ChildObjectEffect {
 struct Inner<'a> {
     // used for loading child objects
     resolver: &'a dyn ChildObjectResolver,
+    // Map to from UID to the object that contained it at the beginning of the transaction.
+    // If it is a wrapped object, it points to the object that contained it.
+    // Otherwise, it points to itself.
+    effective_owner_map: BTreeMap<ObjectID, ObjectID>,
+    // The version of the root object in ownership at the beginning of the transaction.
+    // If it was a child object, it resolves to the root parent's sequence number.
+    // Otherwise, it is just the sequence number at the beginning of the transaction.
+    root_version: BTreeMap<ObjectID, SequenceNumber>,
     // cached objects from the resolver. An object might be in this map but not in the store
     // if it's existence was queried, but the value was not used.
     cached_objects: BTreeMap<ObjectID, Option<MoveObject>>,
@@ -79,14 +89,26 @@ impl<'a> Inner<'a> {
         child: ObjectID,
     ) -> PartialVMResult<Option<&MoveObject>> {
         let cached_objects_count = self.cached_objects.len() as u64;
+        let parents_root_version = self.root_version.get(&parent).copied();
+        let had_parent_root_version = parents_root_version.is_some();
+        // if not found, it must be new so it won't have any child objects, thus
+        // we can return SequenceNumber(0) as no child object will be found
+        let parents_root_version = parents_root_version.unwrap_or(SequenceNumber::new());
         if let btree_map::Entry::Vacant(e) = self.cached_objects.entry(child) {
             let child_opt = self
                 .resolver
-                .read_child_object(&parent, &child)
+                .read_child_object(&parent, &child, parents_root_version)
                 .map_err(|msg| {
                     PartialVMError::new(StatusCode::STORAGE_ERROR).with_message(format!("{msg}"))
                 })?;
             let obj_opt = if let Some(object) = child_opt {
+                // if there was no root version, guard against reading a child object. A newly
+                // created parent should not have a child in storage
+                if !had_parent_root_version {
+                    return Err(PartialVMError::new(StatusCode::STORAGE_ERROR).with_message(
+                        format!("A new parent {parent} should not have a child object {child}."),
+                    ));
+                }
                 // guard against bugs in `read_child_object`: if it returns a child object such that
                 // C.parent != parent, we raise an invariant violation
                 match &object.owner {
@@ -149,7 +171,8 @@ impl<'a> Inner<'a> {
         parent: ObjectID,
         child: ObjectID,
         child_ty: &Type,
-        child_ty_layout: MoveTypeLayout,
+        child_ty_layout: &MoveTypeLayout,
+        child_ty_fully_annotated_layout: &MoveTypeLayout,
         child_move_type: MoveObjectType,
     ) -> PartialVMResult<ObjectResult<(Type, MoveObjectType, GlobalValue)>> {
         let obj = match self.get_or_fetch_object_from_store(parent, child)? {
@@ -166,7 +189,9 @@ impl<'a> Inner<'a> {
         if obj.type_() != &child_move_type {
             return Ok(ObjectResult::MismatchedType);
         }
-        let v = match Value::simple_deserialize(obj.contents(), &child_ty_layout) {
+        // generate a GlobalValue
+        let obj_contents = obj.contents();
+        let v = match Value::simple_deserialize(obj_contents, child_ty_layout) {
             Some(v) => v,
             None => return Err(
                 PartialVMError::new(StatusCode::FAILED_TO_DESERIALIZE_RESOURCE).with_message(
@@ -183,6 +208,22 @@ impl<'a> Inner<'a> {
                     ))
                 }
             };
+        // Find all UIDs inside of the value and update the object parent maps
+        let contained_uids =
+            get_all_uids(child_ty_fully_annotated_layout, obj_contents).map_err(|e| {
+                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                    .with_message(format!("Failed to find UIDs. ERROR: {e}"))
+            })?;
+        let parents_root_version = self.root_version.get(&parent).copied();
+        if let Some(v) = parents_root_version {
+            self.root_version.insert(child, v);
+        }
+        for id in contained_uids {
+            self.effective_owner_map.insert(id, child);
+            if let Some(v) = parents_root_version {
+                self.root_version.insert(id, v);
+            }
+        }
         Ok(ObjectResult::Loaded((
             child_ty.clone(),
             child_move_type,
@@ -194,6 +235,8 @@ impl<'a> Inner<'a> {
 impl<'a> ObjectStore<'a> {
     pub(super) fn new(
         resolver: &'a dyn ChildObjectResolver,
+        effective_owner_map: BTreeMap<ObjectID, ObjectID>,
+        root_version: BTreeMap<ObjectID, SequenceNumber>,
         is_metered: bool,
         constants: LocalProtocolConfig,
         metrics: Arc<LimitsMetrics>,
@@ -201,6 +244,8 @@ impl<'a> ObjectStore<'a> {
         Self {
             inner: Inner {
                 resolver,
+                effective_owner_map,
+                root_version,
                 cached_objects: BTreeMap::new(),
                 is_metered,
                 constants: constants.clone(),
@@ -248,7 +293,8 @@ impl<'a> ObjectStore<'a> {
         parent: ObjectID,
         child: ObjectID,
         child_ty: &Type,
-        child_layout: MoveTypeLayout,
+        child_layout: &MoveTypeLayout,
+        child_fully_annotated_layout: &MoveTypeLayout,
         child_move_type: MoveObjectType,
     ) -> PartialVMResult<ObjectResult<&mut ChildObject>> {
         let store_entries_count = self.store.len() as u64;
@@ -259,6 +305,7 @@ impl<'a> ObjectStore<'a> {
                     child,
                     child_ty,
                     child_layout,
+                    child_fully_annotated_layout,
                     child_move_type,
                 )? {
                     ObjectResult::MismatchedType => return Ok(ObjectResult::MismatchedType),

--- a/sui-execution/latest/sui-move-natives/src/object_runtime/object_store.rs
+++ b/sui-execution/latest/sui-move-natives/src/object_runtime/object_store.rs
@@ -41,7 +41,7 @@ pub(crate) struct ChildObjectEffect {
 struct Inner<'a> {
     // used for loading child objects
     resolver: &'a dyn ChildObjectResolver,
-    // Map to from UID to the object that contained it at the beginning of the transaction.
+    // Map from UID to the object that contained it at the beginning of the transaction.
     // If it is a wrapped object, it points to the object that contained it.
     // Otherwise, it points to itself.
     effective_owner_map: BTreeMap<ObjectID, ObjectID>,

--- a/sui-execution/v0/sui-adapter/src/adapter.rs
+++ b/sui-execution/v0/sui-adapter/src/adapter.rs
@@ -16,6 +16,7 @@ use move_vm_runtime::{
     move_vm::MoveVM, native_extensions::NativeContextExtensions,
     native_functions::NativeFunctionTable,
 };
+use sui_move_natives::object_runtime;
 use sui_types::metrics::BytecodeVerifierMetrics;
 use sui_verifier::check_for_verifier_timeout;
 use tracing::instrument;
@@ -27,7 +28,6 @@ use sui_types::{
     error::ExecutionError,
     error::{ExecutionErrorKind, SuiError},
     metrics::LimitsMetrics,
-    object::Owner,
     storage::ChildObjectResolver,
 };
 use sui_verifier::verifier::sui_verify_module_metered_check_timeout_only;
@@ -110,7 +110,7 @@ pub fn new_move_vm(
 
 pub fn new_native_extensions<'r>(
     child_resolver: &'r dyn ChildObjectResolver,
-    input_objects: BTreeMap<ObjectID, Owner>,
+    input_objects: BTreeMap<ObjectID, object_runtime::InputObject>,
     is_metered: bool,
     protocol_config: &ProtocolConfig,
     metrics: Arc<LimitsMetrics>,

--- a/sui-execution/v0/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v0/sui-adapter/src/programmable_transactions/context.rs
@@ -6,6 +6,8 @@ use std::{
     sync::Arc,
 };
 
+use crate::adapter::{missing_unwrapped_msg, new_native_extensions};
+use crate::error::convert_vm_error;
 use move_binary_format::{
     errors::{Location, VMError, VMResult},
     file_format::{CodeOffset, FunctionDefinitionIndex, TypeParameterIndex},
@@ -17,7 +19,9 @@ use move_core_types::{
 };
 use move_vm_runtime::{move_vm::MoveVM, session::Session};
 use move_vm_types::loaded_data::runtime_types::Type;
-use sui_move_natives::object_runtime::{max_event_error, ObjectRuntime, RuntimeResults};
+use sui_move_natives::object_runtime::{
+    self, get_all_uids, max_event_error, ObjectRuntime, RuntimeResults,
+};
 use sui_protocol_config::ProtocolConfig;
 use sui_types::{
     balance::Balance,
@@ -45,8 +49,6 @@ use sui_types::{
     execution_mode::ExecutionMode,
     execution_status::CommandArgumentError,
 };
-
-use crate::adapter::{missing_unwrapped_msg, new_native_extensions};
 
 use super::linkage_view::{LinkageInfo, LinkageView, SavedLinkage};
 
@@ -130,7 +132,7 @@ impl<'vm, 'state, 'a> ExecutionContext<'vm, 'state, 'a> {
             protocol_config,
             metrics.clone(),
         );
-        let mut object_owner_map = BTreeMap::new();
+        let mut input_object_map = BTreeMap::new();
         let inputs = inputs
             .into_iter()
             .map(|call_arg| {
@@ -138,7 +140,7 @@ impl<'vm, 'state, 'a> ExecutionContext<'vm, 'state, 'a> {
                     vm,
                     state_view,
                     &mut tmp_session,
-                    &mut object_owner_map,
+                    &mut input_object_map,
                     call_arg,
                 )
             })
@@ -148,7 +150,7 @@ impl<'vm, 'state, 'a> ExecutionContext<'vm, 'state, 'a> {
                 vm,
                 state_view,
                 &mut tmp_session,
-                &mut object_owner_map,
+                &mut input_object_map,
                 /* imm override */ false,
                 gas_coin,
             )?;
@@ -190,7 +192,7 @@ impl<'vm, 'state, 'a> ExecutionContext<'vm, 'state, 'a> {
             vm,
             linkage,
             state_view.as_child_resolver(),
-            object_owner_map,
+            input_object_map,
             !gas_status.is_unmetered(),
             protocol_config,
             metrics.clone(),
@@ -526,7 +528,6 @@ impl<'vm, 'state, 'a> ExecutionContext<'vm, 'state, 'a> {
 
     /// Determine the object changes and collect all user events
     pub fn finish<Mode: ExecutionMode>(self) -> Result<ExecutionResults, ExecutionError> {
-        use crate::error::convert_vm_error;
         let Self {
             protocol_config,
             metrics,
@@ -907,7 +908,7 @@ pub(crate) fn new_session<'state, 'vm>(
     vm: &'vm MoveVM,
     linkage: LinkageView<'state>,
     child_resolver: &'state dyn ChildObjectResolver,
-    input_objects: BTreeMap<ObjectID, Owner>,
+    input_objects: BTreeMap<ObjectID, object_runtime::InputObject>,
     is_metered: bool,
     protocol_config: &ProtocolConfig,
     metrics: Arc<LimitsMetrics>,
@@ -1107,7 +1108,7 @@ fn load_object<'vm, 'state>(
     vm: &'vm MoveVM,
     state_view: &'state dyn ExecutionState,
     session: &mut Session<'state, 'vm, LinkageView<'state>>,
-    object_owner_map: &mut BTreeMap<ObjectID, Owner>,
+    input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
     override_as_immutable: bool,
     id: ObjectID,
 ) -> Result<InputValue, ExecutionError> {
@@ -1129,16 +1130,36 @@ fn load_object<'vm, 'state>(
             invariant_violation!("ObjectOwner objects cannot be input")
         }
     };
+    let owner = obj.owner;
+    let version = obj.version();
     let object_metadata = InputObjectMetadata {
         id,
         is_mutable_input,
-        owner: obj.owner,
-        version: obj.version(),
+        owner,
+        version,
     };
-    let prev = object_owner_map.insert(id, obj.owner);
+    let obj_value = value_from_object(vm, session, obj)?;
+    let contained_uids = {
+        let fully_annotated_layout = session
+            .type_to_fully_annotated_layout(&obj_value.type_)
+            .map_err(|e| convert_vm_error(e, vm, session.get_resolver()))?;
+        let mut bytes = vec![];
+        obj_value.write_bcs_bytes(&mut bytes);
+        match get_all_uids(&fully_annotated_layout, &bytes) {
+            Err(e) => invariant_violation!(
+                "Unable to retrieve UIDs for object. Got error: {e}"
+            ),
+            Ok(uids) => uids,
+        }
+    };
+    let runtime_input = object_runtime::InputObject {
+        contained_uids,
+        owner,
+        version,
+    };
+    let prev = input_object_map.insert(id, runtime_input);
     // protected by transaction input checker
     assert_invariant!(prev.is_none(), "Duplicate input object {}", id);
-    let obj_value = value_from_object(vm, session, obj)?;
     Ok(InputValue::new_object(object_metadata, obj_value))
 }
 
@@ -1147,13 +1168,13 @@ fn load_call_arg<'vm, 'state>(
     vm: &'vm MoveVM,
     state_view: &'state dyn ExecutionState,
     session: &mut Session<'state, 'vm, LinkageView<'state>>,
-    object_owner_map: &mut BTreeMap<ObjectID, Owner>,
+    input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
     call_arg: CallArg,
 ) -> Result<InputValue, ExecutionError> {
     Ok(match call_arg {
         CallArg::Pure(bytes) => InputValue::new_raw(RawValueType::Any, bytes),
         CallArg::Object(obj_arg) => {
-            load_object_arg(vm, state_view, session, object_owner_map, obj_arg)?
+            load_object_arg(vm, state_view, session, input_object_map, obj_arg)?
         }
     })
 }
@@ -1163,7 +1184,7 @@ fn load_object_arg<'vm, 'state>(
     vm: &'vm MoveVM,
     state_view: &'state dyn ExecutionState,
     session: &mut Session<'state, 'vm, LinkageView<'state>>,
-    object_owner_map: &mut BTreeMap<ObjectID, Owner>,
+    input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
     obj_arg: ObjectArg,
 ) -> Result<InputValue, ExecutionError> {
     match obj_arg {
@@ -1171,7 +1192,7 @@ fn load_object_arg<'vm, 'state>(
             vm,
             state_view,
             session,
-            object_owner_map,
+            input_object_map,
             /* imm override */ false,
             id,
         ),
@@ -1179,7 +1200,7 @@ fn load_object_arg<'vm, 'state>(
             vm,
             state_view,
             session,
-            object_owner_map,
+            input_object_map,
             /* imm override */ !mutable,
             id,
         ),

--- a/sui-execution/v0/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/v0/sui-move-natives/src/object_runtime/mod.rs
@@ -5,8 +5,11 @@ use better_any::{Tid, TidAble};
 use linked_hash_map::LinkedHashMap;
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
-    account_address::AccountAddress, effects::Op, language_storage::StructTag,
-    value::MoveTypeLayout, vm_status::StatusCode,
+    account_address::AccountAddress,
+    effects::Op,
+    language_storage::StructTag,
+    value::{MoveStruct, MoveTypeLayout, MoveValue},
+    vm_status::StatusCode,
 };
 use move_vm_types::{
     loaded_data::runtime_types::Type,
@@ -20,6 +23,7 @@ use sui_protocol_config::{check_limit_by_meter, LimitThresholdCrossed, ProtocolC
 use sui_types::{
     base_types::{MoveObjectType, ObjectID, SequenceNumber, SuiAddress},
     error::{ExecutionError, ExecutionErrorKind, VMMemoryLimitExceededSubStatusCode},
+    id::UID,
     metrics::LimitsMetrics,
     object::{MoveObject, Owner},
     storage::{ChildObjectResolver, DeleteKind, WriteKind},
@@ -143,6 +147,12 @@ pub enum TransferResult {
     OwnerChanged,
 }
 
+pub struct InputObject {
+    pub contained_uids: BTreeSet<ObjectID>,
+    pub version: SequenceNumber,
+    pub owner: Owner,
+}
+
 impl TestInventories {
     fn new() -> Self {
         Self::default()
@@ -152,21 +162,40 @@ impl TestInventories {
 impl<'a> ObjectRuntime<'a> {
     pub fn new(
         object_resolver: &'a dyn ChildObjectResolver,
-        input_objects: BTreeMap<ObjectID, Owner>,
+        input_objects: BTreeMap<ObjectID, InputObject>,
         is_metered: bool,
         protocol_config: &ProtocolConfig,
         metrics: Arc<LimitsMetrics>,
     ) -> Self {
+        let mut input_object_owners = BTreeMap::new();
+        let mut effective_owner_map = BTreeMap::new();
+        let mut root_version = BTreeMap::new();
+        for (id, input_object) in input_objects {
+            let InputObject {
+                contained_uids,
+                version,
+                owner,
+            } = input_object;
+            input_object_owners.insert(id, owner);
+            effective_owner_map.insert(id, id);
+            root_version.insert(id, version);
+            for contained_uid in contained_uids {
+                effective_owner_map.insert(contained_uid, id);
+                root_version.insert(contained_uid, version);
+            }
+        }
         Self {
             object_store: ObjectStore::new(
                 object_resolver,
+                effective_owner_map,
+                root_version,
                 is_metered,
                 LocalProtocolConfig::new(protocol_config),
                 metrics.clone(),
             ),
             test_inventories: TestInventories::new(),
             state: ObjectRuntimeState {
-                input_objects,
+                input_objects: input_object_owners,
                 new_ids: Set::new(),
                 deleted_ids: Set::new(),
                 transfers: LinkedHashMap::new(),
@@ -318,7 +347,8 @@ impl<'a> ObjectRuntime<'a> {
         parent: ObjectID,
         child: ObjectID,
         child_ty: &Type,
-        child_layout: MoveTypeLayout,
+        child_layout: &MoveTypeLayout,
+        child_fully_annotated_layout: &MoveTypeLayout,
         child_move_type: MoveObjectType,
     ) -> PartialVMResult<ObjectResult<&mut GlobalValue>> {
         let res = self.object_store.get_or_fetch_object(
@@ -326,6 +356,7 @@ impl<'a> ObjectRuntime<'a> {
             child,
             child_ty,
             child_layout,
+            child_fully_annotated_layout,
             child_move_type,
         )?;
         Ok(match res {
@@ -569,6 +600,53 @@ fn update_owner_map(
                 }
                 object_owner_map.insert(id, new_owner);
             }
+        }
+    }
+    Ok(())
+}
+
+// TODO use a custom DeserializerSeed and improve this performance
+pub fn get_all_uids(
+    fully_annotated_layout: &MoveTypeLayout,
+    bcs_bytes: &[u8],
+) -> Result<BTreeSet<ObjectID>, /* invariant violation */ String> {
+    let mut ids = BTreeSet::new();
+    let v = MoveValue::simple_deserialize(bcs_bytes, fully_annotated_layout)
+        .map_err(|e| format!("Failed to deserialize. {e:?}"))?;
+    get_all_uids_in_value(&mut ids, &v)?;
+    Ok(ids)
+}
+
+fn get_all_uids_in_value(
+    acc: &mut BTreeSet<ObjectID>,
+    v: &MoveValue,
+) -> Result<(), /* invariant violation */ String> {
+    let mut stack = vec![v];
+    while let Some(cur) = stack.pop() {
+        let s = match cur {
+            MoveValue::Struct(s) => s,
+            MoveValue::Vector(vec) => {
+                stack.extend(vec);
+                continue;
+            }
+            _ => continue,
+        };
+        match s {
+            MoveStruct::WithTypes { type_, fields } => {
+                if type_ == &UID::type_() {
+                    let inner = match &fields[0].1 {
+                        MoveValue::Struct(MoveStruct::WithTypes { fields, .. }) => fields,
+                        v => return Err(format!("Unexpected UID layout. {v:?}")),
+                    };
+                    match &inner[0].1 {
+                        MoveValue::Address(id) => acc.insert((*id).into()),
+                        v => return Err(format!("Unexpected ID layout. {v:?}")),
+                    };
+                } else {
+                    stack.extend(fields.iter().map(|(_, v)| v));
+                }
+            }
+            v => return Err(format!("Unexpected struct layout. {v:?}")),
         }
     }
     Ok(())

--- a/sui-execution/v0/sui-move-natives/src/object_runtime/object_store.rs
+++ b/sui-execution/v0/sui-move-natives/src/object_runtime/object_store.rs
@@ -20,6 +20,8 @@ use sui_types::{
     object::{Data, MoveObject, Owner},
     storage::ChildObjectResolver,
 };
+
+use super::get_all_uids;
 pub(super) struct ChildObject {
     pub(super) owner: ObjectID,
     pub(super) ty: Type,
@@ -39,6 +41,14 @@ pub(crate) struct ChildObjectEffect {
 struct Inner<'a> {
     // used for loading child objects
     resolver: &'a dyn ChildObjectResolver,
+    // Map to from UID to the object that contained it at the beginning of the transaction.
+    // If it is a wrapped object, it points to the object that contained it.
+    // Otherwise, it points to itself.
+    effective_owner_map: BTreeMap<ObjectID, ObjectID>,
+    // The version of the root object in ownership at the beginning of the transaction.
+    // If it was a child object, it resolves to the root parent's sequence number.
+    // Otherwise, it is just the sequence number at the beginning of the transaction.
+    root_version: BTreeMap<ObjectID, SequenceNumber>,
     // cached objects from the resolver. An object might be in this map but not in the store
     // if it's existence was queried, but the value was not used.
     cached_objects: BTreeMap<ObjectID, Option<MoveObject>>,
@@ -79,14 +89,26 @@ impl<'a> Inner<'a> {
         child: ObjectID,
     ) -> PartialVMResult<Option<&MoveObject>> {
         let cached_objects_count = self.cached_objects.len() as u64;
+        let parents_root_version = self.root_version.get(&parent).copied();
+        let had_parent_root_version = parents_root_version.is_some();
+        // if not found, it must be new so it won't have any child objects, thus
+        // we can return SequenceNumber(0) as no child object will be found
+        let parents_root_version = parents_root_version.unwrap_or(SequenceNumber::new());
         if let btree_map::Entry::Vacant(e) = self.cached_objects.entry(child) {
             let child_opt = self
                 .resolver
-                .read_child_object(&parent, &child)
+                .read_child_object(&parent, &child, parents_root_version)
                 .map_err(|msg| {
                     PartialVMError::new(StatusCode::STORAGE_ERROR).with_message(format!("{msg}"))
                 })?;
             let obj_opt = if let Some(object) = child_opt {
+                // if there was no root version, guard against reading a child object. A newly
+                // created parent should not have a child in storage
+                if !had_parent_root_version {
+                    return Err(PartialVMError::new(StatusCode::STORAGE_ERROR).with_message(
+                        format!("A new parent {parent} should not have a child object {child}."),
+                    ));
+                }
                 // guard against bugs in `read_child_object`: if it returns a child object such that
                 // C.parent != parent, we raise an invariant violation
                 match &object.owner {
@@ -149,7 +171,8 @@ impl<'a> Inner<'a> {
         parent: ObjectID,
         child: ObjectID,
         child_ty: &Type,
-        child_ty_layout: MoveTypeLayout,
+        child_ty_layout: &MoveTypeLayout,
+        child_ty_fully_annotated_layout: &MoveTypeLayout,
         child_move_type: MoveObjectType,
     ) -> PartialVMResult<ObjectResult<(Type, MoveObjectType, GlobalValue)>> {
         let obj = match self.get_or_fetch_object_from_store(parent, child)? {
@@ -166,7 +189,9 @@ impl<'a> Inner<'a> {
         if obj.type_() != &child_move_type {
             return Ok(ObjectResult::MismatchedType);
         }
-        let v = match Value::simple_deserialize(obj.contents(), &child_ty_layout) {
+        // generate a GlobalValue
+        let obj_contents = obj.contents();
+        let v = match Value::simple_deserialize(obj_contents, child_ty_layout) {
             Some(v) => v,
             None => return Err(
                 PartialVMError::new(StatusCode::FAILED_TO_DESERIALIZE_RESOURCE).with_message(
@@ -183,6 +208,22 @@ impl<'a> Inner<'a> {
                     ))
                 }
             };
+        // Find all UIDs inside of the value and update the object parent maps
+        let contained_uids =
+            get_all_uids(child_ty_fully_annotated_layout, obj_contents).map_err(|e| {
+                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                    .with_message(format!("Failed to find UIDs. ERROR: {e}"))
+            })?;
+        let parents_root_version = self.root_version.get(&parent).copied();
+        if let Some(v) = parents_root_version {
+            self.root_version.insert(child, v);
+        }
+        for id in contained_uids {
+            self.effective_owner_map.insert(id, child);
+            if let Some(v) = parents_root_version {
+                self.root_version.insert(id, v);
+            }
+        }
         Ok(ObjectResult::Loaded((
             child_ty.clone(),
             child_move_type,
@@ -194,6 +235,8 @@ impl<'a> Inner<'a> {
 impl<'a> ObjectStore<'a> {
     pub(super) fn new(
         resolver: &'a dyn ChildObjectResolver,
+        effective_owner_map: BTreeMap<ObjectID, ObjectID>,
+        root_version: BTreeMap<ObjectID, SequenceNumber>,
         is_metered: bool,
         constants: LocalProtocolConfig,
         metrics: Arc<LimitsMetrics>,
@@ -201,6 +244,8 @@ impl<'a> ObjectStore<'a> {
         Self {
             inner: Inner {
                 resolver,
+                effective_owner_map,
+                root_version,
                 cached_objects: BTreeMap::new(),
                 is_metered,
                 constants: constants.clone(),
@@ -248,7 +293,8 @@ impl<'a> ObjectStore<'a> {
         parent: ObjectID,
         child: ObjectID,
         child_ty: &Type,
-        child_layout: MoveTypeLayout,
+        child_layout: &MoveTypeLayout,
+        child_fully_annotated_layout: &MoveTypeLayout,
         child_move_type: MoveObjectType,
     ) -> PartialVMResult<ObjectResult<&mut ChildObject>> {
         let store_entries_count = self.store.len() as u64;
@@ -259,6 +305,7 @@ impl<'a> ObjectStore<'a> {
                     child,
                     child_ty,
                     child_layout,
+                    child_fully_annotated_layout,
                     child_move_type,
                 )? {
                     ObjectResult::MismatchedType => return Ok(ObjectResult::MismatchedType),

--- a/sui-execution/v0/sui-move-natives/src/object_runtime/object_store.rs
+++ b/sui-execution/v0/sui-move-natives/src/object_runtime/object_store.rs
@@ -41,7 +41,7 @@ pub(crate) struct ChildObjectEffect {
 struct Inner<'a> {
     // used for loading child objects
     resolver: &'a dyn ChildObjectResolver,
-    // Map to from UID to the object that contained it at the beginning of the transaction.
+    // Map from UID to the object that contained it at the beginning of the transaction.
     // If it is a wrapped object, it points to the object that contained it.
     // Otherwise, it points to itself.
     effective_owner_map: BTreeMap<ObjectID, ObjectID>,


### PR DESCRIPTION
## Description 

- We now track wrapped UIDs when loading an object in execution
- This information is used to build a map from UID to the root object's version at the beginning of the transaction
- We then bound a child object version when doing dynamic field lookups

## Test Plan 

- We only have 1 existing test that tries reading a dynamic field with an "old" parent version, but that test is for dev inspect.
- Added tests that leverage dev-inspect to load old versions of objects 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

This release fixes dev-inspect's handling of old versions of dynamic fields. Prior to this change, the runtime always fetched the most recent version of dynamic fields. For example if the most recent version of an object was version `10`, and you used dev-inspect to query a dynamic field on version `7` of the object, you would still see the dynamic field for version `10`. After this change, you will correctly view the dynamic field as it was on version `7`. 
