### PR TITLE
[hardening] Add enum snapshot tests to `SuiMoveValue` and `SuiMoveStruct`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9647,6 +9647,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "sui-enum-compat-util"
+version = "0.1.0"
+dependencies = [
+ "serde_yaml",
+ "workspace-hack",
+]
+
+[[package]]
 name = "sui-faucet"
 version = "1.2.0"
 dependencies = [
@@ -9914,7 +9922,9 @@ dependencies = [
  "serde 1.0.152",
  "serde_json",
  "serde_with",
+ "sui-enum-compat-util",
  "sui-json",
+ "sui-macros",
  "sui-protocol-config",
  "sui-types",
  "tracing",
@@ -10155,6 +10165,7 @@ dependencies = [
  "msim-macros",
  "proc-macro2 1.0.54",
  "quote 1.0.26",
+ "sui-enum-compat-util",
  "syn 2.0.10",
  "workspace-hack",
 ]
@@ -10825,6 +10836,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "sui-cost-tables",
+ "sui-enum-compat-util",
  "sui-macros",
  "sui-protocol-config",
  "tap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ members = [
     "crates/sui-core",
     "crates/sui-cost",
     "crates/sui-cost-tables",
+    "crates/sui-enum-compat-util",
     "crates/sui-faucet",
     "crates/sui-framework",
     "crates/sui-framework-snapshot",

--- a/crates/sui-core/src/generate_format.rs
+++ b/crates/sui-core/src/generate_format.rs
@@ -193,7 +193,7 @@ fn main() {
         }
         Action::Test => {
             let reference = std::fs::read_to_string(FILE_PATH).unwrap();
-            let content = serde_yaml::to_string(&registry).unwrap() + "\n";
+            let content: String = serde_yaml::to_string(&registry).unwrap() + "\n";
             assert_str_eq!(&reference, &content);
         }
     }

--- a/crates/sui-enum-compat-util/Cargo.toml
+++ b/crates/sui-enum-compat-util/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sui-enum-compat-util"
+version = "0.1.0"
+authors = ["Mysten Labs <build@mystenlabs.com>"]
+license = "Apache-2.0"
+publish = false
+edition = "2021"
+
+[dependencies]
+serde_yaml = "0.8.26"
+workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/crates/sui-enum-compat-util/src/lib.rs
+++ b/crates/sui-enum-compat-util/src/lib.rs
@@ -1,0 +1,47 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::Write;
+use std::path::PathBuf;
+
+pub trait EnumOrderMap {
+    fn order_to_variant_map() -> std::collections::BTreeMap<u64, String>;
+}
+
+pub fn check_enum_compat_order<T: EnumOrderMap>(snapshot_file: PathBuf) {
+    let new_map = T::order_to_variant_map();
+
+    if let Err(err) = std::fs::read_to_string(snapshot_file.clone()) {
+        if err.kind() == std::io::ErrorKind::NotFound {
+            // Create the file if not exists
+            let mut file = std::fs::File::create(snapshot_file).unwrap();
+            let content: String = serde_yaml::to_string(&new_map).unwrap();
+
+            write!(file, "{}", content).unwrap();
+            return;
+        }
+        panic!("Error reading file: {:?}: err {:?}", snapshot_file, err);
+    }
+
+    let existing_map: std::collections::BTreeMap<u64, String> =
+        serde_yaml::from_str(&std::fs::read_to_string(snapshot_file.clone()).unwrap()).unwrap();
+
+    // Check that the new map includes the existing map in order
+    for (pos, val) in existing_map {
+        match new_map.get(&pos) {
+            None => {
+                panic!("Enum variant {} has been removed. Not allowed: enum must be backward compatible.", val);
+            }
+            Some(new_val) if new_val == &val => continue,
+            Some(new_val) => {
+                panic!("Enum variant {val} has been swapped with {new_val} at position {pos}. Not allowed: enum must be backward compatible.");
+            }
+        }
+    }
+
+    // Update the file
+    let mut file = std::fs::File::create(snapshot_file).unwrap();
+    let content: String = serde_yaml::to_string(&new_map).unwrap();
+
+    write!(file, "{}", content).unwrap();
+}

--- a/crates/sui-json-rpc-types/Cargo.toml
+++ b/crates/sui-json-rpc-types/Cargo.toml
@@ -18,6 +18,8 @@ itertools = "0.10.5"
 tracing = "0.1.36"
 bcs = "0.1.4"
 sui-protocol-config = { path = "../sui-protocol-config" }
+sui-macros = { path = "../sui-macros" }
+sui-enum-compat-util = { path = "../sui-enum-compat-util" }
 enum_dispatch = "^0.3"
 
 move-binary-format.workspace = true
@@ -27,3 +29,6 @@ move-bytecode-utils.workspace = true
 sui-types = { path = "../sui-types" }
 sui-json = { path = "../sui-json" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
+
+[dev-dependencies]
+sui-types = { path = "../sui-types", features = ["test-utils"] }

--- a/crates/sui-json-rpc-types/src/sui_move.rs
+++ b/crates/sui-json-rpc-types/src/sui_move.rs
@@ -18,12 +18,17 @@ use serde_with::serde_as;
 use std::collections::BTreeMap;
 use std::fmt;
 use std::fmt::{Display, Formatter, Write};
+use sui_macros::EnumVariantOrder;
 use tracing::warn;
 
 use sui_types::base_types::{ObjectID, SuiAddress};
 use sui_types::sui_serde::SuiStructTag;
 
 pub type SuiMoveTypeParameterIndex = u16;
+
+#[cfg(test)]
+#[path = "unit_tests/sui_move_tests.rs"]
+mod sui_move_tests;
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 pub enum SuiMoveAbility {
@@ -284,7 +289,7 @@ pub enum MoveFunctionArgType {
 }
 
 #[serde_as]
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Eq, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Eq, PartialEq, EnumVariantOrder)]
 #[serde(untagged, rename = "MoveValue")]
 pub enum SuiMoveValue {
     // u64 and u128 are converted to String to avoid overflow
@@ -385,7 +390,7 @@ fn to_bytearray(value: &[MoveValue]) -> Option<Vec<u8>> {
 }
 
 #[serde_as]
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Eq, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Eq, PartialEq, EnumVariantOrder)]
 #[serde(untagged, rename = "MoveStruct")]
 pub enum SuiMoveStruct {
     Runtime(Vec<SuiMoveValue>),

--- a/crates/sui-json-rpc-types/src/unit_tests/sui_move_tests.rs
+++ b/crates/sui-json-rpc-types/src/unit_tests/sui_move_tests.rs
@@ -1,0 +1,17 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use sui_enum_compat_util::*;
+
+use crate::{SuiMoveStruct, SuiMoveValue};
+
+#[test]
+fn enforce_order_test() {
+    let mut path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.extend(["tests", "staged", "sui_move_struct.yaml"]);
+    check_enum_compat_order::<SuiMoveStruct>(path);
+
+    let mut path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.extend(["tests", "staged", "sui_move_value.yaml"]);
+    check_enum_compat_order::<SuiMoveValue>(path);
+}

--- a/crates/sui-json-rpc-types/tests/staged/sui_move_struct.yaml
+++ b/crates/sui-json-rpc-types/tests/staged/sui_move_struct.yaml
@@ -1,0 +1,4 @@
+---
+0: Runtime
+1: WithTypes
+2: WithFields

--- a/crates/sui-json-rpc-types/tests/staged/sui_move_value.yaml
+++ b/crates/sui-json-rpc-types/tests/staged/sui_move_value.yaml
@@ -1,0 +1,9 @@
+---
+0: Number
+1: Bool
+2: Address
+3: Vector
+4: String
+5: UID
+6: Struct
+7: Option

--- a/crates/sui-proc-macros/Cargo.toml
+++ b/crates/sui-proc-macros/Cargo.toml
@@ -14,6 +14,7 @@ quote = "1"
 syn = { version = "2", features = ["full", "fold", "extra-traits"] }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 proc-macro2 = "1"
+sui-enum-compat-util = { path = "../sui-enum-compat-util" }
 
 [target.'cfg(msim)'.dependencies]
 msim-macros = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "48ed7409b8b8cc413fae4d9d9638a849282f81c7", package = "msim-macros" }

--- a/crates/sui-proc-macros/src/lib.rs
+++ b/crates/sui-proc-macros/src/lib.rs
@@ -540,14 +540,14 @@ pub fn enum_variant_order_derive(input: TokenStream) -> TokenStream {
             .map(|(index, variant)| {
                 let variant_name = variant.ident.to_string();
                 quote! {
-                    map.insert( #index, (#variant_name).to_string());
+                    map.insert( #index as u64, (#variant_name).to_string());
                 }
             })
             .collect::<Vec<_>>();
 
         let deriv = quote! {
-            impl #name {
-                pub fn order_to_variant_map() -> std::collections::BTreeMap<usize, String > {
+            impl sui_enum_compat_util::EnumOrderMap for #name {
+                fn order_to_variant_map() -> std::collections::BTreeMap<u64, String > {
                     let mut map = std::collections::BTreeMap::new();
                     #(#variant_entries)*
                     map

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -53,6 +53,7 @@ shared-crypto = { path = "../shared-crypto" }
 mysten-network = { path = "../mysten-network" }
 mysten-metrics = { path = "../mysten-metrics" }
 sui-macros = { path = "../sui-macros" }
+sui-enum-compat-util = { path = "../sui-enum-compat-util" }
 
 fastcrypto = { workspace = true, features = ["copy_key"] }
 

--- a/crates/sui-types/src/unit_tests/execution_status_tests.rs
+++ b/crates/sui-types/src/unit_tests/execution_status_tests.rs
@@ -2,24 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::execution_status::ExecutionFailureStatus;
+use sui_enum_compat_util::*;
 #[test]
 fn enforce_order_test() {
-    let new_map = ExecutionFailureStatus::order_to_variant_map();
     let mut path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.extend(["tests", "staged", "exec_failure_status.yaml"]);
-    let existing_map: std::collections::BTreeMap<usize, String> =
-        serde_yaml::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
-
-    // Check that the new map includes the existing map in order
-    for (pos, val) in existing_map {
-        match new_map.get(&pos) {
-            None => {
-                panic!("Enum variant {} has been removed. Not allowed: enum must be backward compatible.", val);
-            }
-            Some(new_val) if new_val == &val => continue,
-            Some(new_val) => {
-                panic!("Enum variant {val} has been swapped with {new_val} at position {pos}. Not allowed: enum must be backward compatible.");
-            }
-        }
-    }
+    check_enum_compat_order::<ExecutionFailureStatus>(path);
 }


### PR DESCRIPTION
## Description 

Similarly to this [PR](https://github.com/MystenLabs/sui/pull/12036)
For some enums we require that variants are appended to the end of an enum to ensure backward compat for SDK etc.
We currently use comments like [this](https://github.com/MystenLabs/sui/blob/25678de7f57438f7b9a6af8f908e3051d1505205/crates/sui-types/src/execution_status.rs#L180-L181)
```
    // NOTE: if you want to add a new enum,
    // please add it at the end for Rust SDK backward compatibility.
```
 to inform folks to append but we dont actually enforce it.

This PR adds enforcement test on `ExecutionFailureStatus` and will add for other types as I discover them.
Example test failure from swapping variants
```
panicked at 'Enum variant SuiMoveVerificationTimedout has been swapped with SuiMoveVerificationTimedoutNew at position 30. Not allowed: enum must be backward compatible.', crates/sui-types/src/execution_status.rs:380:17
```

++
Separates the test util for enum order checking into its own crate so it can be shared
Adds tests to enforce enum ord is preserved for backward compat.



## Test Plan 

Manual.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
