### PR TITLE
[ts-sdk] Add struct tag helpers

### DIFF
--- a/.changeset/forty-rockets-cheer.md
+++ b/.changeset/forty-rockets-cheer.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Add `normalizeStructTag` and `parseStructTag` helper functions

--- a/sdk/typescript/src/types/__tests__/common.test.ts
+++ b/sdk/typescript/src/types/__tests__/common.test.ts
@@ -1,0 +1,56 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from 'vitest';
+import { parseStructTag, normalizeStructTag } from '../common';
+
+describe('parseStructTag', () => {
+  it('parses struct tags correctly', () => {
+    expect(parseStructTag('0x2::foo::bar')).toMatchInlineSnapshot(`
+      {
+        "address": "0x0000000000000000000000000000000000000000000000000000000000000002",
+        "module": "foo",
+        "name": "bar",
+        "typeParams": [],
+      }
+    `);
+
+    expect(
+      parseStructTag('0x2::foo::bar<0x3::baz::qux<0x4::nested::result>, bool>'),
+    ).toMatchInlineSnapshot(`
+      {
+        "address": "0x0000000000000000000000000000000000000000000000000000000000000002",
+        "module": "foo",
+        "name": "bar",
+        "typeParams": [
+          {
+            "address": "0x0000000000000000000000000000000000000000000000000000000000000003",
+            "module": "baz",
+            "name": "qux",
+            "typeParams": [
+              {
+                "address": "0x0000000000000000000000000000000000000000000000000000000000000004",
+                "module": "nested",
+                "name": "result",
+                "typeParams": [],
+              },
+            ],
+          },
+          "bool",
+        ],
+      }
+    `);
+  });
+});
+
+describe('normalizeStructTag', () => {
+  it('normalizes package addresses', () => {
+    expect(normalizeStructTag('0x2::kiosk::Item')).toEqual(
+      '0x0000000000000000000000000000000000000000000000000000000000000002::kiosk::Item',
+    );
+
+    expect(normalizeStructTag('0x2::foo::bar<0x3::another::package>')).toEqual(
+      '0x0000000000000000000000000000000000000000000000000000000000000002::foo::bar<0x0000000000000000000000000000000000000000000000000000000000000003::another::package>',
+    );
+  });
+});


### PR DESCRIPTION
## Description 

Requested to do easier equality checks around structs, and have more robust parsing of struct tags in general.

## Test Plan 

Added tests.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
