### PR TITLE
[pruner] initial version of checkpoints pruner

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -447,6 +447,9 @@ pub struct AuthorityStorePruningConfig {
     /// That ensures that all sst files eventually go through the compaction process
     #[serde(skip_serializing_if = "Option::is_none")]
     pub periodic_compaction_threshold_days: Option<usize>,
+    /// number of epochs to keep the latest version of transactions and effects for
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub num_epochs_to_retain_for_checkpoints: Option<u64>,
 }
 
 impl Default for AuthorityStorePruningConfig {
@@ -463,6 +466,7 @@ impl Default for AuthorityStorePruningConfig {
             max_transactions_in_batch: 1000,
             use_range_deletion: true,
             periodic_compaction_threshold_days: None,
+            num_epochs_to_retain_for_checkpoints: None,
         }
     }
 }
@@ -481,6 +485,7 @@ impl AuthorityStorePruningConfig {
             max_transactions_in_batch: 1000,
             use_range_deletion: true,
             periodic_compaction_threshold_days: None,
+            num_epochs_to_retain_for_checkpoints: None,
         }
     }
     pub fn fullnode_config() -> Self {
@@ -496,6 +501,7 @@ impl AuthorityStorePruningConfig {
             max_transactions_in_batch: 1000,
             use_range_deletion: true,
             periodic_compaction_threshold_days: None,
+            num_epochs_to_retain_for_checkpoints: None,
         }
     }
 }

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -546,21 +546,19 @@ impl Iterator for LiveSetIter<'_> {
 
 // These functions are used to initialize the DB tables
 fn owned_object_transaction_locks_table_default_config() -> DBOptions {
-    default_db_options()
-        .optimize_for_write_throughput()
-        .optimize_for_read(read_size_from_env(ENV_VAR_LOCKS_BLOCK_CACHE_SIZE).unwrap_or(1024))
-}
-
-fn objects_table_default_config() -> DBOptions {
     DBOptions {
         options: default_db_options()
             .optimize_for_write_throughput()
-            .optimize_for_read(
-                read_size_from_env(ENV_VAR_OBJECTS_BLOCK_CACHE_SIZE).unwrap_or(5 * 1024),
-            )
+            .optimize_for_read(read_size_from_env(ENV_VAR_LOCKS_BLOCK_CACHE_SIZE).unwrap_or(1024))
             .options,
-        rw_options: ReadWriteOptions::default().set_ignore_range_deletions(true),
+        rw_options: ReadWriteOptions::default().set_ignore_range_deletions(false),
     }
+}
+
+fn objects_table_default_config() -> DBOptions {
+    default_db_options()
+        .optimize_for_write_throughput()
+        .optimize_for_read(read_size_from_env(ENV_VAR_OBJECTS_BLOCK_CACHE_SIZE).unwrap_or(5 * 1024))
 }
 
 fn transactions_table_default_config() -> DBOptions {

--- a/crates/sui-storage/src/indexes.rs
+++ b/crates/sui-storage/src/indexes.rs
@@ -35,7 +35,7 @@ use sui_types::temporary_store::TxCoins;
 use tokio::task::spawn_blocking;
 use tracing::{debug, trace};
 use typed_store::rocks::{
-    default_db_options, read_size_from_env, DBBatch, DBMap, DBOptions, MetricConf, ReadWriteOptions,
+    default_db_options, read_size_from_env, DBBatch, DBMap, DBOptions, MetricConf,
 };
 use typed_store::traits::Map;
 use typed_store::traits::{TableSummary, TypedStoreDebug};
@@ -243,15 +243,11 @@ fn index_table_default_config() -> DBOptions {
     default_db_options()
 }
 fn coin_index_table_default_config() -> DBOptions {
-    DBOptions {
-        options: default_db_options()
-            .optimize_for_write_throughput()
-            .optimize_for_read(
-                read_size_from_env(ENV_VAR_COIN_INDEX_BLOCK_CACHE_SIZE_MB).unwrap_or(5 * 1024),
-            )
-            .options,
-        rw_options: ReadWriteOptions::default().set_ignore_range_deletions(true),
-    }
+    default_db_options()
+        .optimize_for_write_throughput()
+        .optimize_for_read(
+            read_size_from_env(ENV_VAR_COIN_INDEX_BLOCK_CACHE_SIZE_MB).unwrap_or(5 * 1024),
+        )
 }
 
 impl IndexStore {

--- a/crates/sui-types/src/digests.rs
+++ b/crates/sui-types/src/digests.rs
@@ -46,6 +46,18 @@ impl Digest {
     pub const fn into_inner(self) -> [u8; 32] {
         self.0
     }
+
+    pub fn next_lexicographical(&self) -> Option<Self> {
+        let mut next_digest = *self;
+        let pos = next_digest.0.iter().rposition(|&byte| byte != 255)?;
+        next_digest.0[pos] += 1;
+        next_digest
+            .0
+            .iter_mut()
+            .skip(pos + 1)
+            .for_each(|byte| *byte = 0);
+        Some(next_digest)
+    }
 }
 
 impl AsRef<[u8]> for Digest {
@@ -207,6 +219,10 @@ impl CheckpointDigest {
     pub fn base58_encode(&self) -> String {
         Base58::encode(self.0)
     }
+
+    pub fn next_lexicographical(&self) -> Option<Self> {
+        self.0.next_lexicographical().map(Self)
+    }
 }
 
 impl AsRef<[u8]> for CheckpointDigest {
@@ -293,6 +309,10 @@ impl CheckpointContentsDigest {
 
     pub fn base58_encode(&self) -> String {
         Base58::encode(self.0)
+    }
+
+    pub fn next_lexicographical(&self) -> Option<Self> {
+        self.0.next_lexicographical().map(Self)
     }
 }
 
@@ -427,6 +447,10 @@ impl TransactionDigest {
     pub fn base58_encode(&self) -> String {
         Base58::encode(self.0)
     }
+
+    pub fn next_lexicographical(&self) -> Option<Self> {
+        self.0.next_lexicographical().map(Self)
+    }
 }
 
 impl AsRef<[u8]> for TransactionDigest {
@@ -527,6 +551,10 @@ impl TransactionEffectsDigest {
     pub fn base58_encode(&self) -> String {
         Base58::encode(self.0)
     }
+
+    pub fn next_lexicographical(&self) -> Option<Self> {
+        self.0.next_lexicographical().map(Self)
+    }
 }
 
 impl AsRef<[u8]> for TransactionEffectsDigest {
@@ -592,6 +620,10 @@ impl TransactionEventsDigest {
 
     pub fn random() -> Self {
         Self(Digest::random())
+    }
+
+    pub fn next_lexicographical(&self) -> Option<Self> {
+        self.0.next_lexicographical().map(Self)
     }
 }
 

--- a/crates/sui-types/src/unit_tests/base_types_tests.rs
+++ b/crates/sui-types/src/unit_tests/base_types_tests.rs
@@ -15,6 +15,7 @@ use crate::crypto::{
     get_key_pair, get_key_pair_from_bytes, AccountKeyPair, AuthorityKeyPair, AuthoritySignature,
     Signature, SuiAuthoritySignature, SuiSignature,
 };
+use crate::digests::Digest;
 use crate::id::{ID, UID};
 use crate::{gas_coin::GasCoin, object::Object, SUI_FRAMEWORK_ADDRESS};
 use shared_crypto::intent::{Intent, IntentMessage, IntentScope};
@@ -435,4 +436,32 @@ fn move_object_type_consistency() {
     assert!(ty.is_dynamic_field());
     assert_consistent(&UID::type_());
     assert_consistent(&ID::type_());
+}
+
+#[test]
+fn next_lexicographical_digest() {
+    let mut output = [0; 32];
+    output[31] = 1;
+    assert_eq!(
+        TransactionDigest::ZERO.next_lexicographical(),
+        Some(TransactionDigest::from(output))
+    );
+
+    let max = [255; 32];
+    let mut input = max;
+    input[31] = 254;
+    assert_eq!(Digest::from(max).next_lexicographical(), None);
+    assert_eq!(
+        Digest::from(input).next_lexicographical(),
+        Some(Digest::from(max))
+    );
+
+    input = max;
+    input[0] = 0;
+    output = [0; 32];
+    output[0] = 1;
+    assert_eq!(
+        Digest::from(input).next_lexicographical(),
+        Some(Digest::from(output))
+    );
 }

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -2119,7 +2119,7 @@ impl ReadWriteOptions {
 impl Default for ReadWriteOptions {
     fn default() -> Self {
         Self {
-            ignore_range_deletions: false,
+            ignore_range_deletions: true,
             sync_to_disk: std::env::var("SUI_DB_SYNC_TO_DISK").map_or(false, |v| v != "0"),
         }
     }

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -517,7 +517,7 @@ async fn test_delete_range() {
         MetricConf::default(),
         None,
         None,
-        &ReadWriteOptions::default(),
+        &ReadWriteOptions::default().set_ignore_range_deletions(false),
     )
     .expect("Failed to open storage");
 


### PR DESCRIPTION
Initial version of the checkpoint pruner:
Similar to the existing objects pruner (i.e., tails checkpoints from the past epochs and removes relevant data).
Notes:
* current approach employs rocksdb's `delete_range` API. Point-delete tombstones have a negative performance impact on reads. It may still suffer from the same issue where deleted data occupies space in SST files, so alternative solutions like FIFO compaction style should be considered in the future
* each pruning batch affects both the perpetual DB and the checkpoint DB. We can't have an atomic batch between those two, so ordering is important. The perpetual DB batch must be committed first. Its changes are idempotent. Because of this, the pruning watermark is stored in the checkpoint DB
* the checkpoint pruner is blocked by the objects pruner watermark. It's necessary because once the checkpoint is gone, there's no way to delete the corresponding objects
* objects and checkpoints pruning are two separate routines. That's because a node can have different pruning policies for them, and objects pruning is not idempotent in general. In the future, a new Universal pruning mode can be added that aligns the two if pruning settings are similar. That should help with resource consumption on the node so that the same data won't be read twice during two different time windows