### PR TITLE
rpc: address metrics

### DIFF
--- a/crates/sui-indexer/src/apis/extended_api.rs
+++ b/crates/sui-indexer/src/apis/extended_api.rs
@@ -10,8 +10,8 @@ use sui_json_rpc::api::{
 };
 use sui_json_rpc::SuiRpcModule;
 use sui_json_rpc_types::{
-    CheckpointedObjectID, EpochInfo, EpochPage, MoveCallMetrics, NetworkMetrics, Page,
-    QueryObjectsPage, SuiObjectDataFilter, SuiObjectResponse, SuiObjectResponseQuery,
+    AddressMetrics, CheckpointedObjectID, EpochInfo, EpochPage, MoveCallMetrics, NetworkMetrics,
+    Page, QueryObjectsPage, SuiObjectDataFilter, SuiObjectResponse, SuiObjectResponseQuery,
 };
 use sui_open_rpc::Module;
 use sui_types::sui_serde::BigInt;
@@ -126,6 +126,19 @@ impl<S: IndexerStore + Sync + Send + 'static> ExtendedApiServer for ExtendedApi<
 
     async fn get_move_call_metrics(&self) -> RpcResult<MoveCallMetrics> {
         Ok(self.state.get_move_call_metrics().await?)
+    }
+
+    async fn get_latest_address_metrics(&self) -> RpcResult<AddressMetrics> {
+        let address_stats = self.state.get_latest_address_stats().await?;
+        Ok(AddressMetrics::from(address_stats))
+    }
+
+    async fn get_checkpoint_address_metrics(&self, checkpoint: u64) -> RpcResult<AddressMetrics> {
+        let address_stats = self
+            .state
+            .get_checkpoint_address_stats(checkpoint as i64)
+            .await?;
+        Ok(AddressMetrics::from(address_stats))
     }
 }
 

--- a/crates/sui-indexer/src/models/addresses.rs
+++ b/crates/sui-indexer/src/models/addresses.rs
@@ -5,6 +5,8 @@ use std::collections::HashMap;
 
 use diesel::prelude::*;
 
+use sui_json_rpc_types::AddressMetrics;
+
 use crate::schema::{active_addresses, address_stats, addresses};
 use crate::types::AddressData;
 
@@ -93,4 +95,17 @@ pub struct AddressStats {
     pub cumulative_addresses: i64,
     pub cumulative_active_addresses: i64,
     pub daily_active_addresses: i64,
+}
+
+impl From<AddressStats> for AddressMetrics {
+    fn from(stats: AddressStats) -> Self {
+        AddressMetrics {
+            checkpoint: stats.checkpoint as u64,
+            epoch: stats.epoch as u64,
+            timestamp_ms: stats.timestamp_ms as u64,
+            cumulative_addresses: stats.cumulative_addresses as u64,
+            cumulative_active_addresses: stats.cumulative_active_addresses as u64,
+            daily_active_addresses: stats.daily_active_addresses as u64,
+        }
+    }
 }

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -240,6 +240,11 @@ pub trait IndexerStore {
     async fn get_last_address_processed_checkpoint(&self) -> Result<i64, IndexerError>;
     async fn calculate_address_stats(&self, checkpoint: i64) -> Result<AddressStats, IndexerError>;
     async fn persist_address_stats(&self, addr_stats: &AddressStats) -> Result<(), IndexerError>;
+    async fn get_latest_address_stats(&self) -> Result<AddressStats, IndexerError>;
+    async fn get_checkpoint_address_stats(
+        &self,
+        checkpoint: i64,
+    ) -> Result<AddressStats, IndexerError>;
 }
 
 #[derive(Clone, Debug)]

--- a/crates/sui-json-rpc-types/src/sui_extended.rs
+++ b/crates/sui-json-rpc-types/src/sui_extended.rs
@@ -145,3 +145,15 @@ pub struct MoveFunctionName {
     #[serde_as(as = "DisplayFromStr")]
     pub function: Identifier,
 }
+
+#[serde_as]
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AddressMetrics {
+    pub checkpoint: u64,
+    pub epoch: u64,
+    pub timestamp_ms: u64,
+    pub cumulative_addresses: u64,
+    pub cumulative_active_addresses: u64,
+    pub daily_active_addresses: u64,
+}

--- a/crates/sui-json-rpc/src/api/extended.rs
+++ b/crates/sui-json-rpc/src/api/extended.rs
@@ -5,8 +5,8 @@ use jsonrpsee::core::RpcResult;
 use jsonrpsee_proc_macros::rpc;
 
 use sui_json_rpc_types::{
-    CheckpointedObjectID, EpochInfo, EpochPage, MoveCallMetrics, NetworkMetrics, QueryObjectsPage,
-    SuiObjectResponseQuery,
+    AddressMetrics, CheckpointedObjectID, EpochInfo, EpochPage, MoveCallMetrics, NetworkMetrics,
+    QueryObjectsPage, SuiObjectResponseQuery,
 };
 use sui_open_rpc_macros::open_rpc;
 use sui_types::sui_serde::BigInt;
@@ -49,4 +49,10 @@ pub trait ExtendedApi {
     /// Return Network metrics
     #[method(name = "getMoveCallMetrics")]
     async fn get_move_call_metrics(&self) -> RpcResult<MoveCallMetrics>;
+
+    /// Address related metrics
+    #[method(name = "getLatestAddressMetrics")]
+    async fn get_latest_address_metrics(&self) -> RpcResult<AddressMetrics>;
+    #[method(name = "getCheckpointAddressMetrics")]
+    async fn get_checkpoint_address_metrics(&self, checkpoint: u64) -> RpcResult<AddressMetrics>;
 }


### PR DESCRIPTION
## Description 

Add address metrics to extended RPC

## Test Plan 

local run indexer as rpc server and verify that the new endpoints can return expected response
```
cargo run --bin sui-indexer -- --db-url "postgres://postgres:postgres@localhost/gegao" --rpc-client-url   http://ord-exp-val-01.experiments.sui.io:9000 --rpc-server-worker --rpc-server-url 127.0.0.1 --rpc-server-port 3030

curl --location --request POST http://127.0.0.1:3030 \
--header 'Content-Type: application/json' \
--data-raw '{
"jsonrpc": "2.0",
"id": 1,
"method": "suix_getLatestAddressMetrics",
"params": []
}'
{"jsonrpc":"2.0","result":{"checkpoint":9199,"epoch":1,"timestampMs":1683821111335,"cumulativeAddresses":16086,"cumulativeActiveAddresses":104,"dailyActiveAddresses":104},"id":1}% 


curl --location --request POST http://127.0.0.1:3030 \
--header 'Content-Type: application/json' \
--data-raw '{
"jsonrpc": "2.0",
"id": 1,
"method": "suix_getCheckpointAddressMetrics",
"params": [4999]
}'
{"jsonrpc":"2.0","result":{"checkpoint":4999,"epoch":0,"timestampMs":1683816628422,"cumulativeAddresses":604,"cumulativeActiveAddresses":5,"dailyActiveAddresses":5},"id":1}%     

```


---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
