### PR TITLE
Make checks for RPG more consistent

### DIFF
--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -135,8 +135,7 @@ impl<'a> TestAuthorityBuilder<'a> {
     pub async fn build(self) -> Arc<AuthorityState> {
         let local_network_config =
             sui_swarm_config::network_config_builder::ConfigBuilder::new_with_temp_dir()
-                // TODO: change the default to 1000 instead after fixing tests.
-                .with_reference_gas_price(self.reference_gas_price.unwrap_or(1))
+                .with_reference_gas_price(self.reference_gas_price.unwrap_or(500))
                 .build();
         let genesis = &self.genesis.unwrap_or(&local_network_config.genesis);
         let genesis_committee = genesis.committee().unwrap();

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -573,7 +573,7 @@ async fn test_dev_inspect_dynamic_field() {
     };
     let kind = TransactionKind::programmable(pt);
     let DevInspectResults { error, .. } = fullnode
-        .dev_inspect_transaction_block(sender, kind, Some(1))
+        .dev_inspect_transaction_block(sender, kind, None)
         .await
         .unwrap();
     // produces an error
@@ -877,7 +877,7 @@ async fn test_dev_inspect_gas_coin_argument() {
     };
     let kind = TransactionKind::programmable(pt);
     let results = fullnode
-        .dev_inspect_transaction_block(sender, kind, Some(1))
+        .dev_inspect_transaction_block(sender, kind, None)
         .await
         .unwrap()
         .results
@@ -905,6 +905,48 @@ async fn test_dev_inspect_gas_coin_argument() {
     } = &results[1];
     assert!(mutable_reference_outputs.is_empty());
     assert!(return_values.is_empty());
+}
+
+#[tokio::test]
+async fn test_dev_inspect_gas_price() {
+    let (_, fullnode, _object_basics) =
+        init_state_with_ids_and_object_basics_with_fullnode(vec![]).await;
+
+    let sender = SuiAddress::random_for_testing_only();
+    let recipient = SuiAddress::random_for_testing_only();
+    let amount = 500;
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder.pay_sui(vec![recipient], vec![amount]).unwrap();
+        builder.finish()
+    };
+    let kind = TransactionKind::programmable(pt);
+    let error = fullnode
+        .dev_inspect_transaction_block(sender, kind.clone(), Some(1))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(
+            UserInputError::try_from(error.clone()).unwrap(),
+            UserInputError::GasPriceUnderRGP { .. }
+        ),
+        "{}",
+        error
+    );
+    let epoch_store = fullnode.epoch_store_for_testing();
+    let protocol_config = epoch_store.protocol_config();
+    let error = fullnode
+        .dev_inspect_transaction_block(sender, kind, Some(protocol_config.max_gas_price() + 1))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(
+            UserInputError::try_from(error.clone()).unwrap(),
+            UserInputError::GasPriceTooHigh { .. }
+        ),
+        "{}",
+        error
+    );
 }
 
 fn check_coin_value(actual_value: &[u8], actual_type: &SuiTypeTag, expected_value: u64) {
@@ -939,7 +981,11 @@ async fn test_dev_inspect_uses_unbound_object() {
     let kind = TransactionKind::programmable(pt);
 
     let result = fullnode
-        .dev_inspect_transaction_block(sender, kind, Some(1))
+        .dev_inspect_transaction_block(
+            sender,
+            kind,
+            Some(fullnode.reference_gas_price_for_testing().unwrap()),
+        )
         .await;
     let Err(err) = result else { panic!() };
     assert!(err.to_string().contains("ObjectNotFound"));
@@ -1077,16 +1123,16 @@ async fn test_dry_run_dev_inspect_dynamic_field_too_new() {
         }))],
     };
     let kind = TransactionKind::programmable(pt.clone());
+    let rgp = fullnode.reference_gas_price_for_testing().unwrap();
     // dev inspect
     let DevInspectResults { effects, .. } = fullnode
-        .dev_inspect_transaction_block(sender, kind, Some(1))
+        .dev_inspect_transaction_block(sender, kind, Some(rgp))
         .await
         .unwrap();
     assert_eq!(effects.deleted().len(), 1);
     let deleted = &effects.deleted()[0];
     assert_eq!(field.0, deleted.object_id);
     assert_eq!(deleted.version, SequenceNumber::MAX);
-    let rgp = fullnode.reference_gas_price_for_testing().unwrap();
     // dry run
     let data = TransactionData::new_programmable(
         sender,
@@ -1138,7 +1184,7 @@ async fn test_dry_run_dev_inspect_max_gas_version() {
     let kind = TransactionKind::programmable(pt.clone());
     // dev inspect
     let DevInspectResults { effects, .. } = fullnode
-        .dev_inspect_transaction_block(sender, kind, Some(1))
+        .dev_inspect_transaction_block(sender, kind, Some(rgp + 100))
         .await
         .unwrap();
     assert_eq!(effects.status(), &SuiExecutionStatus::Success);
@@ -5030,7 +5076,11 @@ async fn test_for_inc_201_dev_inspect() {
     ));
     let kind = TransactionKind::programmable(builder.finish());
     let DevInspectResults { events, .. } = fullnode
-        .dev_inspect_transaction_block(sender, kind, Some(1))
+        .dev_inspect_transaction_block(
+            sender,
+            kind,
+            Some(fullnode.reference_gas_price_for_testing().unwrap() + 1000),
+        )
         .await
         .unwrap();
 

--- a/crates/sui-core/src/unit_tests/pay_sui_tests.rs
+++ b/crates/sui-core/src/unit_tests/pay_sui_tests.rs
@@ -427,8 +427,7 @@ async fn execute_pay_all_sui(
 ) -> PaySuiTransactionBlockExecutionResult {
     let dir = tempfile::TempDir::new().unwrap();
     let network_config = sui_swarm_config::network_config_builder::ConfigBuilder::new(&dir)
-        // TODO: fix numbers in tests to not depend on rgp being 1
-        .with_reference_gas_price(1)
+        .with_reference_gas_price(700)
         .with_objects(
             input_coin_objects
                 .clone()

--- a/crates/transaction-fuzzer/src/account_universe/account.rs
+++ b/crates/transaction-fuzzer/src/account_universe/account.rs
@@ -15,7 +15,8 @@ use sui_types::{
 
 use crate::executor::Executor;
 
-pub const INITIAL_BALANCE: u64 = 10_000_000_000;
+pub const INITIAL_BALANCE: u64 = 100_000_000_000_000;
+pub const PUBLISH_BUDGET: u64 = 1_000_000_000;
 pub const NUM_GAS_OBJECTS: usize = 1;
 
 #[derive(Debug)]

--- a/crates/transaction-fuzzer/src/executor.rs
+++ b/crates/transaction-fuzzer/src/executor.rs
@@ -18,7 +18,7 @@ use sui_types::transaction::{TransactionData, VerifiedTransaction};
 use sui_types::utils::to_sender_signed_transaction;
 use tokio::runtime::Runtime;
 
-use crate::account_universe::{AccountCurrent, INITIAL_BALANCE};
+use crate::account_universe::{AccountCurrent, PUBLISH_BUDGET};
 
 pub type ExecutionResult = Result<ExecutionStatus, SuiError>;
 
@@ -124,8 +124,8 @@ impl Executor {
             gas_object.compute_object_reference(),
             modules,
             dep_ids,
-            INITIAL_BALANCE,
-            1,
+            PUBLISH_BUDGET,
+            1000,
         );
         let txn = to_sender_signed_transaction(data, &account.initial_data.account.key);
         let effects = self

--- a/crates/transaction-fuzzer/src/type_arg_fuzzer.rs
+++ b/crates/transaction-fuzzer/src/type_arg_fuzzer.rs
@@ -18,8 +18,8 @@ use sui_types::{TypeTag, SUI_FRAMEWORK_PACKAGE_ID};
 use crate::account_universe::AccountCurrent;
 use crate::executor::{assert_is_acceptable_result, Executor};
 
-const GAS: u64 = 1_000_000;
-const GAS_PRICE: u64 = 1;
+const GAS_PRICE: u64 = 700;
+const GAS: u64 = 1_000_000 * GAS_PRICE;
 
 pub fn gen_type_tag() -> impl Strategy<Value = TypeTag> {
     prop_oneof![


### PR DESCRIPTION
## Description 

Make dev inspect honor RGP and gas price to be more consistent and also remove as much as possible `RGP = 1` in testing

## Test Plan 

Added a test for gas price and see what tests fail

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [x] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
