### PR TITLE
[ts-sdk] Use protocol config in transaction builder

### DIFF
--- a/.changeset/grumpy-owls-float.md
+++ b/.changeset/grumpy-owls-float.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+The `TransactionBlock` builder now uses the protocol config from the chain when constructing and validating transactions, instead of using hard-coded limits. If you wish to perform signing offline (without a provider), you can either define a `protocolConfig` option when building a transaction, or explicitly set `limits`, which will be used instead of the protocol config.

--- a/.changeset/hip-bananas-occur.md
+++ b/.changeset/hip-bananas-occur.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Added `getProtocolConfig()` method to the provider.

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -246,8 +246,6 @@ pub struct ProtocolConfig {
 
     // ==== Transaction input limits ====
     /// Maximum serialized size of a transaction (in bytes).
-    // NOTE: This value should be kept in sync with the corresponding value in
-    // sdk/typescript/src/builder/TransactionData.ts
     max_tx_size_bytes: Option<u64>,
 
     /// Maximum number of input objects to a transaction. Enforced by the transaction input checker

--- a/sdk/typescript/src/builder/Inputs.ts
+++ b/sdk/typescript/src/builder/Inputs.ts
@@ -37,17 +37,14 @@ export type ObjectCallArg = Infer<typeof ObjectCallArg>;
 export const BuilderCallArg = union([PureCallArg, ObjectCallArg]);
 export type BuilderCallArg = Infer<typeof BuilderCallArg>;
 
-const MAX_PURE_ARGUMENT_SIZE = 16 * 1024;
-
 export const Inputs = {
   Pure(data: unknown, type?: string): PureCallArg {
     return {
       Pure: Array.from(
         data instanceof Uint8Array
           ? data
-          : builder
-              .ser(type!, data, { maxSize: MAX_PURE_ARGUMENT_SIZE })
-              .toBytes(),
+          : // NOTE: We explicitly set this to be growable to infinity, because we have maxSize validation at the builder-level:
+            builder.ser(type!, data, { maxSize: Infinity }).toBytes(),
       ),
     };
   },

--- a/sdk/typescript/src/builder/TransactionBlock.ts
+++ b/sdk/typescript/src/builder/TransactionBlock.ts
@@ -14,6 +14,7 @@ import {
   SuiMoveNormalizedType,
   SuiObjectRef,
   SUI_TYPE_ARG,
+  ProtocolConfig,
 } from '../types';
 import {
   Transactions,
@@ -29,6 +30,7 @@ import {
   Inputs,
   isMutableSharedObjectInput,
   ObjectCallArg,
+  PureCallArg,
 } from './Inputs';
 import { getPureSerializationType, isTxContext } from './serializer';
 import {
@@ -85,25 +87,30 @@ function createTransactionResult(index: number): TransactionResult {
   }) as TransactionResult;
 }
 
-function expectProvider(
-  provider: JsonRpcProvider | undefined,
-): JsonRpcProvider {
-  if (!provider) {
+function expectProvider(options: BuildOptions): JsonRpcProvider {
+  if (!options.provider) {
     throw new Error(
       `No provider passed to Transaction#build, but transaction data was not sufficient to build offline.`,
     );
   }
 
-  return provider;
+  return options.provider;
 }
 
 const TRANSACTION_BRAND = Symbol.for('@mysten/transaction');
 
-// The maximum number of gas objects that can be selected for one transaction.
-const MAX_GAS_OBJECTS = 256;
+const LIMITS = {
+  // The maximum gas that is allowed.
+  maxTxGas: 'max_tx_gas',
+  // The maximum number of gas objects that can be selected for one transaction.
+  maxGasObjects: 'max_gas_payment_objects',
+  // The maximum size (in bytes) that the transaction can be:
+  maxTxSizeBytes: 'max_tx_size_bytes',
+  // The maximum size (in bytes) that pure arguments can be:
+  maxPureArgumentSize: 'max_pure_argument_size',
+} as const;
 
-// The maximum gas that is allowed.
-const MAX_GAS = 50_000_000_000;
+type Limits = Partial<Record<keyof typeof LIMITS, number>>;
 
 // An amount of gas (in gas units) that is added to transactions as an overhead to ensure transactions do not fail.
 const GAS_SAFE_OVERHEAD = 1000n;
@@ -119,6 +126,10 @@ const chunk = <T>(arr: T[], size: number): T[][] =>
 interface BuildOptions {
   provider?: JsonRpcProvider;
   onlyTransactionKind?: boolean;
+  /** Define a protocol config to build against, instead of having it fetched from the provider at build time. */
+  protocolConfig?: ProtocolConfig;
+  /** Define limits that are used when building the transaction. In general, we recommend using the protocol configuration instead of defining limits. */
+  limits?: Limits;
 }
 
 /**
@@ -206,11 +217,6 @@ export class TransactionBlock {
     this.#blockData.gasConfig.owner = owner;
   }
   setGasPayment(payments: SuiObjectRef[]) {
-    if (payments.length >= MAX_GAS_OBJECTS) {
-      throw new Error(
-        `Payment objects exceed maximum amount ${MAX_GAS_OBJECTS}`,
-      );
-    }
     this.#blockData.gasConfig.payment = payments.map((payment) =>
       mask(payment, SuiObjectRef),
     );
@@ -366,13 +372,51 @@ export class TransactionBlock {
     return JSON.stringify(this.#blockData.snapshot());
   }
 
+  #getConfig(
+    key: keyof typeof LIMITS,
+    { protocolConfig, limits }: BuildOptions,
+  ) {
+    // Use the limits definition if that exists:
+    if (limits && typeof limits[key] === 'number') {
+      return limits[key]!;
+    }
+
+    if (!protocolConfig) {
+      throw new Error(
+        'Missing protocol config, cannot build transaction without either a protocol config, or explicit limits',
+      );
+    }
+
+    // Fallback to protocol config:
+    const attribute = protocolConfig?.attributes[LIMITS[key]];
+    if (!attribute) {
+      throw new Error(`Missing expected protocol config: "${LIMITS[key]}"`);
+    }
+
+    const value =
+      'u64' in attribute
+        ? attribute.u64
+        : 'u32' in attribute
+        ? attribute.u32
+        : attribute.f64;
+
+    if (!value) {
+      throw new Error(
+        `Unexpected protocol config value found for: "${LIMITS[key]}"`,
+      );
+    }
+
+    // NOTE: Technically this is not a safe conversion, but we know all of the values in protocol config are safe
+    return Number(value);
+  }
+
   /** Build the transaction to BCS bytes. */
-  async build({
-    provider,
-    onlyTransactionKind,
-  }: BuildOptions = {}): Promise<Uint8Array> {
-    await this.#prepare({ provider, onlyTransactionKind });
-    return this.#blockData.build({ onlyTransactionKind });
+  async build(options: BuildOptions = {}): Promise<Uint8Array> {
+    await this.#prepare(options);
+    return this.#blockData.build({
+      maxSizeBytes: this.#getConfig('maxTxSizeBytes', options),
+      onlyTransactionKind: options.onlyTransactionKind,
+    });
   }
 
   /** Derive transaction digest */
@@ -385,16 +429,39 @@ export class TransactionBlock {
     return this.#blockData.getDigest();
   }
 
+  #validate(options: BuildOptions) {
+    const maxPureArgumentSize = this.#getConfig('maxPureArgumentSize', options);
+    // Validate all inputs are the correct size:
+    this.#blockData.inputs.forEach((input, index) => {
+      if (is(input.value, PureCallArg)) {
+        if (input.value.Pure.length > maxPureArgumentSize) {
+          throw new Error(
+            `Input at index ${index} is too large, max pure input size is ${maxPureArgumentSize} bytes, got ${input.value.Pure.length} bytes`,
+          );
+        }
+      }
+    });
+  }
+
   // The current default is just picking _all_ coins we can which may not be ideal.
-  async #prepareGasPayment({ provider, onlyTransactionKind }: BuildOptions) {
+  async #prepareGasPayment(options: BuildOptions) {
+    if (this.#blockData.gasConfig.payment) {
+      const maxGasObjects = this.#getConfig('maxGasObjects', options);
+      if (this.#blockData.gasConfig.payment.length > maxGasObjects) {
+        throw new Error(
+          `Payment objects exceed maximum amount: ${maxGasObjects}`,
+        );
+      }
+    }
+
     // Early return if the payment is already set:
-    if (onlyTransactionKind || this.#blockData.gasConfig.payment) {
+    if (options.onlyTransactionKind || this.#blockData.gasConfig.payment) {
       return;
     }
 
     const gasOwner = this.#blockData.gasConfig.owner ?? this.#blockData.sender;
 
-    const coins = await expectProvider(provider).getCoins({
+    const coins = await expectProvider(options).getCoins({
       owner: gasOwner!,
       coinType: SUI_TYPE_ARG,
     });
@@ -416,7 +483,7 @@ export class TransactionBlock {
 
         return !matchingInput;
       })
-      .slice(0, MAX_GAS_OBJECTS - 1)
+      .slice(0, this.#getConfig('maxGasObjects', options) - 1)
       .map((coin) => ({
         objectId: coin.coinObjectId,
         digest: coin.digest,
@@ -430,15 +497,15 @@ export class TransactionBlock {
     this.setGasPayment(paymentCoins);
   }
 
-  async #prepareGasPrice({ provider, onlyTransactionKind }: BuildOptions) {
-    if (onlyTransactionKind || this.#blockData.gasConfig.price) {
+  async #prepareGasPrice(options: BuildOptions) {
+    if (options.onlyTransactionKind || this.#blockData.gasConfig.price) {
       return;
     }
 
-    this.setGasPrice(await expectProvider(provider).getReferenceGasPrice());
+    this.setGasPrice(await expectProvider(options).getReferenceGasPrice());
   }
 
-  async #prepareTransactions(provider?: JsonRpcProvider) {
+  async #prepareTransactions(options: BuildOptions) {
     const { inputs, transactions } = this.#blockData;
 
     const moveModulesToResolve: MoveCallTransaction[] = [];
@@ -527,7 +594,7 @@ export class TransactionBlock {
             moveCall.target.split('::');
 
           const normalized = await expectProvider(
-            provider,
+            options,
           ).getNormalizedMoveFunction({
             package: normalizeSuiObjectId(packageId),
             module: moduleName,
@@ -605,7 +672,7 @@ export class TransactionBlock {
       const objects = (
         await Promise.all(
           objectChunks.map((chunk) =>
-            expectProvider(provider).multiGetObjects({
+            expectProvider(options).multiGetObjects({
               ids: chunk,
               options: { showOwner: true },
             }),
@@ -659,27 +726,34 @@ export class TransactionBlock {
    * Prepare the transaction by valdiating the transaction data and resolving all inputs
    * so that it can be built into bytes.
    */
-  async #prepare({ provider, onlyTransactionKind }: BuildOptions) {
-    if (!onlyTransactionKind && !this.#blockData.sender) {
+  async #prepare(options: BuildOptions) {
+    if (!options.onlyTransactionKind && !this.#blockData.sender) {
       throw new Error('Missing transaction sender');
     }
 
+    if (!options.protocolConfig && !options.limits) {
+      options.protocolConfig = await expectProvider(
+        options,
+      ).getProtocolConfig();
+    }
+
     await Promise.all([
-      this.#prepareGasPrice({ provider, onlyTransactionKind }),
-      this.#prepareTransactions(provider),
+      this.#prepareGasPrice(options),
+      this.#prepareTransactions(options),
     ]);
 
-    if (!onlyTransactionKind) {
-      await this.#prepareGasPayment({ provider, onlyTransactionKind });
+    if (!options.onlyTransactionKind) {
+      await this.#prepareGasPayment(options);
 
       if (!this.#blockData.gasConfig.budget) {
         const dryRunResult = await expectProvider(
-          provider,
+          options,
         ).dryRunTransactionBlock({
           transactionBlock: this.#blockData.build({
+            maxSizeBytes: this.#getConfig('maxTxSizeBytes', options),
             overrides: {
               gasConfig: {
-                budget: String(MAX_GAS),
+                budget: String(this.#getConfig('maxTxGas', options)),
                 payment: [],
               },
             },
@@ -711,5 +785,8 @@ export class TransactionBlock {
         );
       }
     }
+
+    // Perform final validation on the transaction:
+    this.#validate(options);
   }
 }

--- a/sdk/typescript/src/builder/TransactionBlockData.ts
+++ b/sdk/typescript/src/builder/TransactionBlockData.ts
@@ -70,10 +70,6 @@ function prepareSuiAddress(address: string) {
   return normalizeSuiAddress(address).replace('0x', '');
 }
 
-// NOTE: This value should be kept in sync with the corresponding value in
-// crates/sui-protocol-config/src/lib.rs
-const TRANSACTION_DATA_MAX_SIZE = 128 * 1024;
-
 export class TransactionBlockDataBuilder {
   static fromKindBytes(bytes: Uint8Array) {
     const kind = builder.de('TransactionKind', bytes);
@@ -172,9 +168,11 @@ export class TransactionBlockDataBuilder {
   }
 
   build({
+    maxSizeBytes = Infinity,
     overrides,
     onlyTransactionKind,
   }: {
+    maxSizeBytes?: number;
     overrides?: Pick<
       Partial<TransactionBlockDataBuilder>,
       'sender' | 'gasConfig' | 'expiration'
@@ -196,7 +194,7 @@ export class TransactionBlockDataBuilder {
 
     if (onlyTransactionKind) {
       return builder
-        .ser('TransactionKind', kind, { maxSize: TRANSACTION_DATA_MAX_SIZE })
+        .ser('TransactionKind', kind, { maxSize: maxSizeBytes })
         .toBytes();
     }
 
@@ -241,7 +239,7 @@ export class TransactionBlockDataBuilder {
       .ser(
         'TransactionData',
         { V1: transactionData },
-        { maxSize: TRANSACTION_DATA_MAX_SIZE },
+        { maxSize: maxSizeBytes },
       )
       .toBytes();
   }

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -49,6 +49,7 @@ import {
   TransactionEffects,
   Unsubscribe,
   ResolvedNameServiceNames,
+  ProtocolConfig,
 } from '../types';
 import { DynamicFieldName, DynamicFieldPage } from '../types/dynamic_fields';
 import {
@@ -862,6 +863,16 @@ export class JsonRpcProvider {
       'suix_resolveNameServiceNames',
       [input.address],
       ResolvedNameServiceNames,
+    );
+  }
+
+  async getProtocolConfig(input?: {
+    version?: string;
+  }): Promise<ProtocolConfig> {
+    return await this.client.requestWithType(
+      'sui_getProtocolConfig',
+      [input?.version],
+      ProtocolConfig,
     );
   }
 

--- a/sdk/typescript/src/types/common.ts
+++ b/sdk/typescript/src/types/common.ts
@@ -2,11 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+  boolean,
   define,
   Infer,
   literal,
+  nullable,
   number,
   object,
+  record,
   string,
   union,
 } from 'superstruct';
@@ -54,6 +57,22 @@ export type SuiJsonValue =
   | CallArg
   | Array<SuiJsonValue>;
 export const SuiJsonValue = define<SuiJsonValue>('SuiJsonValue', () => true);
+
+const ProtocolConfigValue = union([
+  object({ u32: string() }),
+  object({ u64: string() }),
+  object({ f64: string() }),
+]);
+type ProtocolConfigValue = Infer<typeof ProtocolConfigValue>;
+
+export const ProtocolConfig = object({
+  attributes: record(string(), nullable(ProtocolConfigValue)),
+  featureFlags: record(string(), boolean()),
+  maxSupportedProtocolVersion: string(),
+  minSupportedProtocolVersion: string(),
+  protocolVersion: string(),
+});
+export type ProtocolConfig = Infer<typeof ProtocolConfig>;
 
 // source of truth is
 // https://github.com/MystenLabs/sui/blob/acb2b97ae21f47600e05b0d28127d88d0725561d/crates/sui-types/src/base_types.rs#L171

--- a/sdk/typescript/test/e2e/protocol-config.test.ts
+++ b/sdk/typescript/test/e2e/protocol-config.test.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect, it } from 'vitest';
+import { setup } from './utils/setup';
+
+it('can fetch protocol config', async () => {
+  const toolbox = await setup();
+  const config = await toolbox.provider.getProtocolConfig();
+  expect(config).toBeTypeOf('object');
+});


### PR DESCRIPTION
## Description 

- Adds `getProtocolConfig()`
- Reworks the hard-coded limits to instead use the protocol config. As a performance optimization, a `protocolConfig` option can be used instead of having it fetch whenever it builds the transaction. Additionally, you can hard-code `limits` if you wish, to entirely avoid working with protocol config (not recommended, but can be used to override protocol config if you wanted to for whatever reason).
  - I had to rework the limit for pure inputs so that it happens as validation instead of during serialization to bytes. This means that pure inputs are completely unlimited (can grow to infinity).
  - Some things that previously errored during setting properties will now error during transaction construction to bytes (for example, setting payment coins).

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
