### PR TITLE
add sticky network config for replay system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8950,9 +8950,9 @@ checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "shellexpand"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd1c7ddea665294d484c39fd0c0d2b7e35bbfe10035c5fe1854741a57f6880e1"
+checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
 dependencies = [
  "dirs",
 ]
@@ -10265,6 +10265,9 @@ dependencies = [
  "rand 0.8.5",
  "serde 1.0.152",
  "serde_json",
+ "serde_with",
+ "serde_yaml",
+ "shellexpand",
  "similar",
  "sui-adapter-latest",
  "sui-config",
@@ -10278,6 +10281,7 @@ dependencies = [
  "sui-sdk",
  "sui-storage",
  "sui-types",
+ "tempfile",
  "thiserror",
  "tokio",
  "tracing",

--- a/crates/sui-replay/Cargo.toml
+++ b/crates/sui-replay/Cargo.toml
@@ -24,6 +24,10 @@ tracing = "0.1.36"
 rand = "0.8.5"
 lru = "0.10"
 parking_lot = "0.12.1"
+serde_with = "2.1.0"
+serde_yaml = "0.8.26"
+shellexpand = "3.1.0"
+tempfile = "3.3.0"
 
 move-binary-format.workspace = true
 move-bytecode-utils.workspace = true

--- a/crates/sui-replay/src/config.rs
+++ b/crates/sui-replay/src/config.rs
@@ -1,0 +1,163 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{fs::File, io::BufReader, path::PathBuf, str::FromStr};
+
+use crate::types::ReplayEngineError;
+use jsonrpsee::client_transport::ws::Uri;
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+use tracing::log::warn;
+
+pub const DEFAULT_CONFIG_PATH: &str = "~/.sui-replay/network-config.yaml";
+
+#[serde_as]
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub struct ReplayableNetworkConfigSet {
+    #[serde(skip)]
+    path: Option<PathBuf>,
+    #[serde(default)]
+    pub base_network_configs: Vec<ReplayableNetworkBaseConfig>,
+}
+
+#[serde_as]
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub struct ReplayableNetworkBaseConfig {
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub epoch_zero_start_timestamp: u64,
+    #[serde(default)]
+    pub epoch_zero_rgp: u64,
+    #[serde(default = "default_full_node_address")]
+    pub public_full_node: String,
+}
+
+impl ReplayableNetworkConfigSet {
+    pub fn load_config(override_path: Option<String>) -> Result<Self, ReplayEngineError> {
+        let path = override_path.unwrap_or_else(|| {
+            warn!(
+                "No network config path specified, using default path: {}",
+                DEFAULT_CONFIG_PATH
+            );
+            DEFAULT_CONFIG_PATH.to_string()
+        });
+        let path = shellexpand::tilde(&path).to_string();
+        let path = PathBuf::from_str(&path).unwrap();
+        ReplayableNetworkConfigSet::from_file(path.clone()).map_err(|err| {
+            ReplayEngineError::UnableToOpenYamlFile {
+                path: path.as_os_str().to_string_lossy().to_string(),
+                err: err.to_string(),
+            }
+        })
+    }
+
+    pub fn save_config(&self, override_path: Option<String>) -> Result<PathBuf, ReplayEngineError> {
+        let path = override_path.unwrap_or_else(|| DEFAULT_CONFIG_PATH.to_string());
+        let path = shellexpand::tilde(&path).to_string();
+        let path = PathBuf::from_str(&path).unwrap();
+        self.to_file(path.clone())
+            .map_err(|err| ReplayEngineError::UnableToOpenYamlFile {
+                path: path.as_os_str().to_string_lossy().to_string(),
+                err: err.to_string(),
+            })?;
+        Ok(path)
+    }
+
+    pub fn from_file(path: PathBuf) -> Result<Self, ReplayEngineError> {
+        let file =
+            File::open(path.clone()).map_err(|err| ReplayEngineError::UnableToOpenYamlFile {
+                path: path.as_os_str().to_string_lossy().to_string(),
+                err: err.to_string(),
+            })?;
+        let reader = BufReader::new(file);
+        let mut config: ReplayableNetworkConfigSet =
+            serde_yaml::from_reader(reader).map_err(|err| {
+                ReplayEngineError::UnableToOpenYamlFile {
+                    path: path.as_os_str().to_string_lossy().to_string(),
+                    err: err.to_string(),
+                }
+            })?;
+        config.path = Some(path);
+        Ok(config)
+    }
+
+    pub fn to_file(&self, path: PathBuf) -> Result<(), ReplayEngineError> {
+        let prefix = path.parent().unwrap();
+        std::fs::create_dir_all(prefix).unwrap();
+        let file =
+            File::create(path.clone()).map_err(|err| ReplayEngineError::UnableToOpenYamlFile {
+                path: path.as_os_str().to_string_lossy().to_string(),
+                err: err.to_string(),
+            })?;
+        serde_yaml::to_writer(file, self).map_err(|err| {
+            ReplayEngineError::UnableToWriteYamlFile {
+                path: path.as_os_str().to_string_lossy().to_string(),
+                err: err.to_string(),
+            }
+        })?;
+        Ok(())
+    }
+}
+
+impl Default for ReplayableNetworkConfigSet {
+    fn default() -> Self {
+        let testnet = ReplayableNetworkBaseConfig {
+            name: "testnet".to_string(),
+            epoch_zero_start_timestamp: 0,
+            epoch_zero_rgp: 0,
+            public_full_node: url_from_str("https://fullnode.testnet.sui.io:443")
+                .expect("invalid socket address")
+                .to_string(),
+        };
+        let devnet = ReplayableNetworkBaseConfig {
+            name: "devnet".to_string(),
+            epoch_zero_start_timestamp: 0,
+            epoch_zero_rgp: 0,
+            public_full_node: url_from_str("https://fullnode.devnet.sui.io:443")
+                .expect("invalid socket address")
+                .to_string(),
+        };
+        let mainnet = ReplayableNetworkBaseConfig {
+            name: "mainnet".to_string(),
+            epoch_zero_start_timestamp: 0,
+            epoch_zero_rgp: 0,
+            public_full_node: url_from_str("https://fullnode.mainnet.sui.io:443")
+                .expect("invalid socket address")
+                .to_string(),
+        };
+
+        Self {
+            path: None,
+            base_network_configs: vec![testnet, devnet, mainnet],
+        }
+    }
+}
+
+pub fn default_full_node_address() -> String {
+    // Assume local node
+    "0.0.0.0:9000".to_string()
+}
+
+pub fn url_from_str(s: &str) -> Result<Uri, ReplayEngineError> {
+    Uri::from_str(s).map_err(|e| ReplayEngineError::InvalidUrl {
+        err: e.to_string(),
+        url: s.to_string(),
+    })
+}
+
+#[test]
+fn test_yaml() {
+    let set = ReplayableNetworkConfigSet::default();
+
+    let path = tempfile::tempdir().unwrap().path().to_path_buf();
+    let path_str = path.to_str().unwrap().to_owned();
+
+    set.save_config(Some(path_str.clone())).unwrap();
+
+    // Read from file
+    let data = ReplayableNetworkConfigSet::load_config(Some(path_str)).unwrap();
+    assert!(set == data);
+}

--- a/crates/sui-replay/src/config.rs
+++ b/crates/sui-replay/src/config.rs
@@ -150,14 +150,15 @@ pub fn url_from_str(s: &str) -> Result<Uri, ReplayEngineError> {
 
 #[test]
 fn test_yaml() {
-    let set = ReplayableNetworkConfigSet::default();
+    let mut set = ReplayableNetworkConfigSet::default();
 
     let path = tempfile::tempdir().unwrap().path().to_path_buf();
     let path_str = path.to_str().unwrap().to_owned();
 
-    set.save_config(Some(path_str.clone())).unwrap();
+    let final_path = set.save_config(Some(path_str.clone())).unwrap();
 
     // Read from file
     let data = ReplayableNetworkConfigSet::load_config(Some(path_str)).unwrap();
+    set.path = Some(final_path);
     assert!(set == data);
 }

--- a/crates/sui-replay/src/lib.rs
+++ b/crates/sui-replay/src/lib.rs
@@ -3,19 +3,23 @@
 
 use async_recursion::async_recursion;
 use clap::Parser;
+use config::ReplayableNetworkConfigSet;
 use fuzz::ReplayFuzzer;
 use fuzz::ReplayFuzzerConfig;
 use fuzz::ShuffleMutator;
 use rand::SeedableRng;
 use sui_types::message_envelope::Message;
+use tracing::warn;
 use transaction_provider::TransactionSource;
 
 use crate::replay::LocalExec;
 use crate::replay::ProtocolVersionSummary;
+use std::path::PathBuf;
 use std::str::FromStr;
 use sui_config::node::ExpensiveSafetyCheckConfig;
 use sui_types::digests::TransactionDigest;
 use tracing::{error, info};
+pub mod config;
 mod data_fetcher;
 mod db_rider;
 pub mod fuzz;
@@ -26,6 +30,11 @@ pub mod types;
 #[derive(Parser, Clone)]
 #[clap(rename_all = "kebab-case")]
 pub enum ReplayToolCommand {
+    /// Generate a new network config file
+    #[clap(name = "gen")]
+    GenerateDefaultConfig,
+
+    /// Replay transaction
     #[clap(name = "tx")]
     ReplayTransaction {
         #[clap(long, short)]
@@ -34,6 +43,7 @@ pub enum ReplayToolCommand {
         show_effects: bool,
     },
 
+    /// Replay a transaction from a node state dump
     #[clap(name = "rd")]
     ReplayDump {
         #[clap(long, short)]
@@ -42,6 +52,7 @@ pub enum ReplayToolCommand {
         show_effects: bool,
     },
 
+    /// Replay all transactions in a range of checkpoints
     #[clap(name = "ch")]
     ReplayCheckpoints {
         #[clap(long, short)]
@@ -54,6 +65,7 @@ pub enum ReplayToolCommand {
         max_tasks: u64,
     },
 
+    /// Replay all transactions in an epoch
     #[clap(name = "ep")]
     ReplayEpoch {
         #[clap(long, short)]
@@ -64,6 +76,7 @@ pub enum ReplayToolCommand {
         max_tasks: u64,
     },
 
+    /// Run the replay based fuzzer
     #[clap(name = "fz")]
     Fuzz {
         #[clap(long, short)]
@@ -80,17 +93,25 @@ pub enum ReplayToolCommand {
 
 #[async_recursion]
 pub async fn execute_replay_command(
-    rpc_url: String,
+    rpc_url: Option<String>,
     safety_checks: bool,
     use_authority: bool,
+    cfg_path: Option<PathBuf>,
     cmd: ReplayToolCommand,
-) -> anyhow::Result<(u64, u64)> {
+) -> anyhow::Result<Option<(u64, u64)>> {
     let safety = if safety_checks {
         ExpensiveSafetyCheckConfig::new_enable_all()
     } else {
         ExpensiveSafetyCheckConfig::default()
     };
     Ok(match cmd {
+        ReplayToolCommand::GenerateDefaultConfig => {
+            let set = ReplayableNetworkConfigSet::default();
+            let path = set.save_config(None).unwrap();
+            println!("Default config saved to: {}", path.to_str().unwrap());
+            warn!("Note: default config nodes might prune epochs/objects");
+            None
+        }
         ReplayToolCommand::Fuzz {
             start_checkpoint,
             num_mutations_per_base,
@@ -106,9 +127,11 @@ pub async fn execute_replay_command(
                 fail_over_on_err: false,
                 expensive_safety_check_config: Default::default(),
             };
-            let fuzzer = ReplayFuzzer::new(rpc_url, config).await.unwrap();
+            let fuzzer = ReplayFuzzer::new(rpc_url.expect("Url must be provided"), config)
+                .await
+                .unwrap();
             fuzzer.run(num_base_transactions).await.unwrap();
-            (1u64, 1u64)
+            None
         }
         ReplayToolCommand::ReplayDump { path, show_effects } => {
             let mut lx = LocalExec::new_for_state_dump(&path).await?;
@@ -130,7 +153,7 @@ pub async fn execute_replay_command(
             }
 
             info!("Execution finished successfully. Local and on-chain effects match.");
-            (1u64, 1u64)
+            Some((1u64, 1u64))
         }
         ReplayToolCommand::ReplayTransaction {
             tx_digest,
@@ -138,12 +161,14 @@ pub async fn execute_replay_command(
         } => {
             let tx_digest = TransactionDigest::from_str(&tx_digest)?;
             info!("Executing tx: {}", tx_digest);
-            let sandbox_state = LocalExec::new_from_fn_url(&rpc_url)
-                .await?
-                .init_for_execution()
-                .await?
-                .execute_transaction(&tx_digest, safety, use_authority)
-                .await?;
+            let sandbox_state = LocalExec::replay_with_network_config(
+                rpc_url,
+                cfg_path.map(|p| p.to_str().unwrap().to_string()),
+                tx_digest,
+                safety,
+                use_authority,
+            )
+            .await?;
 
             let effects = sandbox_state.local_exec_effects.clone();
             if show_effects {
@@ -153,11 +178,12 @@ pub async fn execute_replay_command(
             sandbox_state.check_effects()?;
 
             info!("Execution finished successfully. Local and on-chain effects match.");
-            (1u64, 1u64)
+            Some((1u64, 1u64))
         }
 
         ReplayToolCommand::Report => {
-            let mut lx = LocalExec::new_from_fn_url(&rpc_url).await?;
+            let mut lx =
+                LocalExec::new_from_fn_url(&rpc_url.expect("Url must be provided")).await?;
             let epoch_table = lx.protocol_ver_to_epoch_map().await?;
 
             // We need this for other activities in this session
@@ -196,7 +222,7 @@ pub async fn execute_replay_command(
                     println!("Package: {} Seq: {}", package_id, seq_num);
                 }
             }
-            (0u64, 0u64)
+            None
         }
 
         ReplayToolCommand::ReplayCheckpoints {
@@ -222,7 +248,7 @@ pub async fn execute_replay_command(
                 handles.push(tokio::spawn(async move {
                     info!("Spawning task {task_count} for checkpoints {checkpoints:?}");
                     let time = std::time::Instant::now();
-                    let (succeeded, total) = LocalExec::new_from_fn_url(&rpc_url)
+                    let (succeeded, total) = LocalExec::new_from_fn_url(&rpc_url.expect("Url must be provided"))
                         .await
                         .unwrap()
                         .init_for_execution()
@@ -264,14 +290,15 @@ pub async fn execute_replay_command(
                 total_time_ms,
                 (total_tx as f64) / (total_time_ms as f64 / 1000.0)
             );
-            (total_succeeded, total_tx)
+            Some((total_succeeded, total_tx))
         }
         ReplayToolCommand::ReplayEpoch {
             epoch,
             terminate_early,
             max_tasks,
         } => {
-            let lx = LocalExec::new_from_fn_url(&rpc_url).await?;
+            let lx =
+                LocalExec::new_from_fn_url(&rpc_url.clone().expect("Url must be provided")).await?;
 
             let (start, end) = lx.checkpoints_for_epoch(epoch).await?;
 
@@ -283,6 +310,7 @@ pub async fn execute_replay_command(
                 rpc_url,
                 safety_checks,
                 use_authority,
+                cfg_path,
                 ReplayToolCommand::ReplayCheckpoints {
                     start,
                     end,
@@ -292,13 +320,16 @@ pub async fn execute_replay_command(
             )
             .await;
             match status {
-                Ok((succeeded, total)) => {
+                Ok(Some((succeeded, total))) => {
                     info!(
                         "Epoch {} replay finished {} out of {} TXs",
                         epoch, succeeded, total
                     );
 
-                    return Ok((succeeded, total));
+                    return Ok(Some((succeeded, total)));
+                }
+                Ok(None) => {
+                    return Ok(None);
                 }
                 Err(e) => {
                     error!("Epoch {} replay failed: {:?}", epoch, e);

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::config::ReplayableNetworkConfigSet;
 use crate::data_fetcher::extract_epoch_and_version;
 use crate::data_fetcher::DataFetcher;
 use crate::data_fetcher::Fetchers;
@@ -56,6 +57,7 @@ use sui_types::transaction::{
     TransactionData, TransactionDataAPI, TransactionKind, VerifiedTransaction,
 };
 use sui_types::DEEPBOOK_PACKAGE_ID;
+use tracing::info;
 use tracing::{error, warn};
 
 // TODO: add persistent cache. But perf is good enough already.
@@ -288,6 +290,67 @@ impl LocalExec {
             None,
         )
         .await
+    }
+
+    pub async fn replay_with_network_config(
+        rpc_url: Option<String>,
+        path: Option<String>,
+        tx_digest: TransactionDigest,
+        expensive_safety_check_config: ExpensiveSafetyCheckConfig,
+        use_authority: bool,
+    ) -> Result<ExecutionSandboxState, ReplayEngineError> {
+        async fn inner_exec(
+            rpc_url: String,
+            tx_digest: TransactionDigest,
+            expensive_safety_check_config: ExpensiveSafetyCheckConfig,
+            use_authority: bool,
+        ) -> Result<ExecutionSandboxState, ReplayEngineError> {
+            LocalExec::new_from_fn_url(&rpc_url)
+                .await?
+                .init_for_execution()
+                .await?
+                .execute_transaction(&tx_digest, expensive_safety_check_config, use_authority)
+                .await
+        }
+
+        if let Some(url) = rpc_url.clone() {
+            info!("Using RPC URL: {}", url);
+            if let Ok(x) = inner_exec(
+                url,
+                tx_digest,
+                expensive_safety_check_config.clone(),
+                use_authority,
+            )
+            .await
+            {
+                return Ok(x);
+            }
+            warn!("Failed to execute transaction with provided RPC URL. Attempting to load configs from file");
+        }
+
+        let cfg = ReplayableNetworkConfigSet::load_config(path)?;
+        for cfg in &cfg.base_network_configs {
+            info!(
+                "Attempting to replay with network rpc: {}",
+                cfg.public_full_node.clone()
+            );
+            match inner_exec(
+                cfg.public_full_node.clone(),
+                tx_digest,
+                expensive_safety_check_config.clone(),
+                use_authority,
+            )
+            .await
+            {
+                Ok(exec_state) => return Ok(exec_state),
+                Err(e) => {
+                    warn!("Failed to execute transaction with network config: {}. Attempting next network config...", e);
+                    continue;
+                }
+            }
+        }
+        error!("No more configs to attempt. Try specifing Full Node RPC URL directly or provide a config file with a valid URL");
+        Err(ReplayEngineError::UnableToExecuteWithNetworkConfigs { cfgs: cfg })
     }
 
     /// This captures the state of the network at a given point in time and populates

--- a/crates/sui-replay/src/types.rs
+++ b/crates/sui-replay/src/types.rs
@@ -19,6 +19,8 @@ use thiserror::Error;
 use tokio::time::Duration;
 use tracing::error;
 
+use crate::config::ReplayableNetworkConfigSet;
+
 // TODO: make these configurable
 pub(crate) const RPC_TIMEOUT_ERR_SLEEP_RETRY_PERIOD: Duration = Duration::from_millis(10_000);
 pub(crate) const RPC_TIMEOUT_ERR_NUM_RETRIES: u32 = 2;
@@ -156,6 +158,21 @@ pub enum ReplayEngineError {
 
     #[error("Unsupported epoch in replay engine: {epoch}")]
     EpochNotSupported { epoch: u64 },
+
+    #[error("Unable to open yaml cfg file at {}: {}", path, err)]
+    UnableToOpenYamlFile { path: String, err: String },
+
+    #[error("Unable to write yaml file at {}: {}", path, err)]
+    UnableToWriteYamlFile { path: String, err: String },
+
+    #[error("Unable to convert string {} to URL {}", url, err)]
+    InvalidUrl { url: String, err: String },
+
+    #[error(
+        "Unable to execute transaction with existing network configs {:#?}",
+        cfgs
+    )]
+    UnableToExecuteWithNetworkConfigs { cfgs: ReplayableNetworkConfigSet },
 }
 
 impl From<SuiObjectResponseError> for ReplayEngineError {

--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -168,11 +168,13 @@ pub enum ToolCommand {
     #[clap(name = "replay")]
     Replay {
         #[clap(long = "rpc")]
-        rpc_url: String,
+        rpc_url: Option<String>,
         #[clap(long = "safety-checks")]
         safety_checks: bool,
         #[clap(long = "authority")]
         use_authority: bool,
+        #[clap(long = "cfg-path", short)]
+        cfg_path: Option<PathBuf>,
         #[clap(subcommand)]
         cmd: ReplayToolCommand,
     },
@@ -354,8 +356,10 @@ impl ToolCommand {
                 safety_checks,
                 cmd,
                 use_authority,
+                cfg_path,
             } => {
-                execute_replay_command(rpc_url, safety_checks, use_authority, cmd).await?;
+                execute_replay_command(rpc_url, safety_checks, use_authority, cfg_path, cmd)
+                    .await?;
             }
             ToolCommand::SignTransaction {
                 genesis,


### PR DESCRIPTION
## Description 

Allows for loading and writing default configs for replay to `~/.sui-replay/network-config.yaml`
This way we can omit specifying the RPC endpoint on each operation.
Also adds a command for generating a default file

Example
```
./target/debug/sui-tool replay  tx -t jgE26bo5ZWhGJbEq8brC8TrmFu8W4d2UDvyhdATvFwq
2023-05-18T22:45:26.858972Z  INFO sui_replay: Executing tx: jgE26bo5ZWhGJbEq8brC8TrmFu8W4d2UDvyhdATvFwq
2023-05-18T22:45:26.859350Z  INFO sui_replay::replay: Attempting to replay with network rpc:  https://fullnode.testnet.sui.io:443/
2023-05-18T22:45:28.992366Z  INFO sui_replay: Execution finished successfully. Local and on-chain effects match.
```

File generated
```
base-network-configs:
  - name: testnet
    epoch-zero-start-timestamp: 0
    epoch-zero-rgp: 0
    public-full-node: "https://fullnode.testnet.sui.io:443/"
  - name: devnet
    epoch-zero-start-timestamp: 0
    epoch-zero-rgp: 0
    public-full-node: "https://fullnode.devnet.sui.io:443/"
  - name: mainnet
    epoch-zero-start-timestamp: 0
    epoch-zero-rgp: 0
    public-full-node: "https://fullnode.mainnet.sui.io:443/"
```

## Test Plan 

Manual, unit test.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
