### PR TITLE
[move-compiler] Added warning suppression

### DIFF
--- a/external-crates/move/move-compiler/src/cfgir/ast.rs
+++ b/external-crates/move/move-compiler/src/cfgir/ast.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    diagnostics::WarningFilters,
     expansion::ast::{Attributes, Friend, ModuleIdent, Visibility},
     hlir::ast::{
         BaseType, Command, Command_, FunctionSignature, Label, SingleType, StructDefinition, Var,
@@ -33,6 +34,7 @@ pub struct Program {
 
 #[derive(Debug, Clone)]
 pub struct Script {
+    pub warning_filter: WarningFilters,
     // package name metadata from compiler arguments, not used for any language rules
     pub package_name: Option<Symbol>,
     pub attributes: Attributes,
@@ -48,6 +50,7 @@ pub struct Script {
 
 #[derive(Debug, Clone)]
 pub struct ModuleDefinition {
+    pub warning_filter: WarningFilters,
     // package name metadata from compiler arguments, not used for any language rules
     pub package_name: Option<Symbol>,
     pub attributes: Attributes,
@@ -66,6 +69,7 @@ pub struct ModuleDefinition {
 
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Constant {
+    pub warning_filter: WarningFilters,
     // index in the original order as defined in the source file
     pub index: usize,
     pub attributes: Attributes,
@@ -92,6 +96,7 @@ pub type FunctionBody = Spanned<FunctionBody_>;
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct Function {
+    pub warning_filter: WarningFilters,
     // index in the original order as defined in the source file
     pub index: usize,
     pub attributes: Attributes,
@@ -208,6 +213,7 @@ impl AstDebug for Program {
 impl AstDebug for Script {
     fn ast_debug(&self, w: &mut AstWriter) {
         let Script {
+            warning_filter,
             package_name,
             attributes,
             loc: _loc,
@@ -215,6 +221,7 @@ impl AstDebug for Script {
             function_name,
             function,
         } = self;
+        warning_filter.ast_debug(w);
         if let Some(n) = package_name {
             w.writeln(&format!("{}", n))
         }
@@ -230,6 +237,7 @@ impl AstDebug for Script {
 impl AstDebug for ModuleDefinition {
     fn ast_debug(&self, w: &mut AstWriter) {
         let ModuleDefinition {
+            warning_filter,
             package_name,
             attributes,
             is_source_module,
@@ -239,6 +247,7 @@ impl AstDebug for ModuleDefinition {
             constants,
             functions,
         } = self;
+        warning_filter.ast_debug(w);
         if let Some(n) = package_name {
             w.writeln(&format!("{}", n))
         }
@@ -273,6 +282,7 @@ impl AstDebug for (ConstantName, &Constant) {
         let (
             name,
             Constant {
+                warning_filter,
                 index,
                 attributes,
                 loc: _loc,
@@ -280,6 +290,7 @@ impl AstDebug for (ConstantName, &Constant) {
                 value,
             },
         ) = self;
+        warning_filter.ast_debug(w);
         attributes.ast_debug(w);
         w.write(&format!("const#{index} {name}:"));
         signature.ast_debug(w);
@@ -320,6 +331,7 @@ impl AstDebug for (FunctionName, &Function) {
         let (
             name,
             Function {
+                warning_filter,
                 index,
                 attributes,
                 visibility,
@@ -329,6 +341,7 @@ impl AstDebug for (FunctionName, &Function) {
                 body,
             },
         ) = self;
+        warning_filter.ast_debug(w);
         attributes.ast_debug(w);
         visibility.ast_debug(w);
         if entry.is_some() {

--- a/external-crates/move/move-compiler/src/cfgir/translate.rs
+++ b/external-crates/move/move-compiler/src/cfgir/translate.rs
@@ -183,6 +183,7 @@ fn module(
     mdef: H::ModuleDefinition,
 ) -> (ModuleIdent, G::ModuleDefinition) {
     let H::ModuleDefinition {
+        warning_filter,
         package_name,
         attributes,
         is_source_module,
@@ -193,11 +194,14 @@ fn module(
         constants: hconstants,
     } = mdef;
 
+    context.env.add_warning_filter_scope(warning_filter.clone());
     let constants = hconstants.map(|name, c| constant(context, name, c));
     let functions = hfunctions.map(|name, f| function(context, name, f));
+    context.env.pop_warning_filter_scope();
     (
         module_ident,
         G::ModuleDefinition {
+            warning_filter,
             package_name,
             attributes,
             is_source_module,
@@ -222,6 +226,7 @@ fn scripts(
 
 fn script(context: &mut Context, hscript: H::Script) -> G::Script {
     let H::Script {
+        warning_filter,
         package_name,
         attributes,
         loc,
@@ -229,9 +234,12 @@ fn script(context: &mut Context, hscript: H::Script) -> G::Script {
         function_name,
         function: hfunction,
     } = hscript;
+    context.env.add_warning_filter_scope(warning_filter.clone());
     let constants = hconstants.map(|name, c| constant(context, name, c));
     let function = function(context, function_name, hfunction);
+    context.env.pop_warning_filter_scope();
     G::Script {
+        warning_filter,
         package_name,
         attributes,
         loc,
@@ -247,6 +255,7 @@ fn script(context: &mut Context, hscript: H::Script) -> G::Script {
 
 fn constant(context: &mut Context, _name: ConstantName, c: H::Constant) -> G::Constant {
     let H::Constant {
+        warning_filter,
         index,
         attributes,
         loc,
@@ -254,10 +263,13 @@ fn constant(context: &mut Context, _name: ConstantName, c: H::Constant) -> G::Co
         value: (locals, block),
     } = c;
 
+    context.env.add_warning_filter_scope(warning_filter.clone());
     let final_value = constant_(context, loc, signature.clone(), locals, block);
     let value = final_value.and_then(move_value_from_exp);
 
+    context.env.pop_warning_filter_scope();
     G::Constant {
+        warning_filter,
         index,
         attributes,
         loc,
@@ -386,6 +398,7 @@ pub(crate) fn move_value_from_value_(v_: Value_) -> MoveValue {
 
 fn function(context: &mut Context, _name: FunctionName, f: H::Function) -> G::Function {
     let H::Function {
+        warning_filter,
         index,
         attributes,
         visibility,
@@ -394,8 +407,11 @@ fn function(context: &mut Context, _name: FunctionName, f: H::Function) -> G::Fu
         acquires,
         body,
     } = f;
+    context.env.add_warning_filter_scope(warning_filter.clone());
     let body = function_body(context, &signature, &acquires, body);
+    context.env.pop_warning_filter_scope();
     G::Function {
+        warning_filter,
         index,
         attributes,
         visibility,

--- a/external-crates/move/move-compiler/src/diagnostics/codes.rs
+++ b/external-crates/move/move-compiler/src/diagnostics/codes.rs
@@ -45,11 +45,15 @@ pub trait DiagnosticCode: Copy {
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 /// Represents a single annotation for a diagnostic filter
 pub enum WarningFilter {
+    /// Filters all warnings
     All,
+    /// Filters all warnings of a specific category
     Category(Category),
+    /// Filters a single warning, as defined by codes below
     Code(Category, /* code */ u8),
 }
 
+/// The text used in the attribute for warning suppression
 pub const WARNING_FILTER_ATTR: &str = "allow";
 
 //**************************************************************************************************

--- a/external-crates/move/move-compiler/src/expansion/ast.rs
+++ b/external-crates/move/move-compiler/src/expansion/ast.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    diagnostics::WarningFilters,
     parser::ast::{
         self as P, Ability, Ability_, BinOp, ConstantName, Field, FunctionName, ModuleName,
         QuantKind, SpecApplyPattern, StructName, UnaryOp, Var, ENTRY_MODIFIER,
@@ -76,6 +77,7 @@ pub type Attributes = UniqueMap<AttributeName, Attribute>;
 
 #[derive(Debug, Clone)]
 pub struct Script {
+    pub warning_filter: WarningFilters,
     // package name metadata from compiler arguments, not used for any language rules
     pub package_name: Option<Symbol>,
     pub attributes: Attributes,
@@ -106,6 +108,7 @@ pub type ModuleIdent = Spanned<ModuleIdent_>;
 
 #[derive(Debug, Clone)]
 pub struct ModuleDefinition {
+    pub warning_filter: WarningFilters,
     // package name metadata from compiler arguments, not used for any language rules
     pub package_name: Option<Symbol>,
     pub attributes: Attributes,
@@ -154,6 +157,7 @@ pub struct StructTypeParameter {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct StructDefinition {
+    pub warning_filter: WarningFilters,
     // index in the original order as defined in the source file
     pub index: usize,
     pub attributes: Attributes,
@@ -199,6 +203,7 @@ pub struct SpecId(usize);
 
 #[derive(PartialEq, Clone, Debug)]
 pub struct Function {
+    pub warning_filter: WarningFilters,
     // index in the original order as defined in the source file
     pub index: usize,
     pub attributes: Attributes,
@@ -217,6 +222,7 @@ pub struct Function {
 
 #[derive(PartialEq, Clone, Debug)]
 pub struct Constant {
+    pub warning_filter: WarningFilters,
     // index in the original order as defined in the source file
     pub index: usize,
     pub attributes: Attributes,
@@ -918,7 +924,9 @@ impl AstDebug for Script {
             function_name,
             function,
             specs,
+            warning_filter,
         } = self;
+        warning_filter.ast_debug(w);
         if let Some(n) = package_name {
             w.writeln(&format!("{}", n))
         }
@@ -958,7 +966,9 @@ impl AstDebug for ModuleDefinition {
             functions,
             constants,
             specs,
+            warning_filter,
         } = self;
+        warning_filter.ast_debug(w);
         if let Some(n) = package_name {
             w.writeln(&format!("{}", n))
         }
@@ -1021,11 +1031,11 @@ impl AstDebug for (StructName, &StructDefinition) {
                 abilities,
                 type_parameters,
                 fields,
+                warning_filter,
             },
         ) = self;
-
+        warning_filter.ast_debug(w);
         attributes.ast_debug(w);
-
         if let StructFields::Native(_) = fields {
             w.write("native ");
         }
@@ -1246,8 +1256,10 @@ impl AstDebug for (FunctionName, &Function) {
                 acquires,
                 body,
                 specs: _specs,
+                warning_filter,
             },
         ) = self;
+        warning_filter.ast_debug(w);
         attributes.ast_debug(w);
         visibility.ast_debug(w);
         if entry.is_some() {
@@ -1299,6 +1311,7 @@ impl AstDebug for (ConstantName, &Constant) {
         let (
             name,
             Constant {
+                warning_filter,
                 index,
                 attributes,
                 loc: _loc,
@@ -1306,6 +1319,7 @@ impl AstDebug for (ConstantName, &Constant) {
                 value,
             },
         ) = self;
+        warning_filter.ast_debug(w);
         attributes.ast_debug(w);
         w.write(&format!("const#{index} {}:", name));
         signature.ast_debug(w);

--- a/external-crates/move/move-compiler/src/hlir/ast.rs
+++ b/external-crates/move/move-compiler/src/hlir/ast.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    diagnostics::WarningFilters,
     expansion::ast::{
         ability_modifiers_ast_debug, AbilitySet, Attributes, Friend, ModuleIdent, SpecId,
         Visibility,
@@ -33,6 +34,7 @@ pub struct Program {
 
 #[derive(Debug, Clone)]
 pub struct Script {
+    pub warning_filter: WarningFilters,
     // package name metadata from compiler arguments, not used for any language rules
     pub package_name: Option<Symbol>,
     pub attributes: Attributes,
@@ -48,6 +50,7 @@ pub struct Script {
 
 #[derive(Debug, Clone)]
 pub struct ModuleDefinition {
+    pub warning_filter: WarningFilters,
     // package name metadata from compiler arguments, not used for any language rules
     pub package_name: Option<Symbol>,
     pub attributes: Attributes,
@@ -66,6 +69,7 @@ pub struct ModuleDefinition {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct StructDefinition {
+    pub warning_filter: WarningFilters,
     // index in the original order as defined in the source file
     pub index: usize,
     pub attributes: Attributes,
@@ -86,6 +90,7 @@ pub enum StructFields {
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct Constant {
+    pub warning_filter: WarningFilters,
     // index in the original order as defined in the source file
     pub index: usize,
     pub attributes: Attributes,
@@ -117,6 +122,7 @@ pub type FunctionBody = Spanned<FunctionBody_>;
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct Function {
+    pub warning_filter: WarningFilters,
     // index in the original order as defined in the source file
     pub index: usize,
     pub attributes: Attributes,
@@ -696,6 +702,7 @@ impl AstDebug for Program {
 impl AstDebug for Script {
     fn ast_debug(&self, w: &mut AstWriter) {
         let Script {
+            warning_filter,
             package_name,
             attributes,
             loc: _loc,
@@ -703,6 +710,7 @@ impl AstDebug for Script {
             function_name,
             function,
         } = self;
+        warning_filter.ast_debug(w);
         if let Some(n) = package_name {
             w.writeln(&format!("{}", n))
         }
@@ -718,6 +726,7 @@ impl AstDebug for Script {
 impl AstDebug for ModuleDefinition {
     fn ast_debug(&self, w: &mut AstWriter) {
         let ModuleDefinition {
+            warning_filter,
             package_name,
             attributes,
             is_source_module,
@@ -727,6 +736,7 @@ impl AstDebug for ModuleDefinition {
             constants,
             functions,
         } = self;
+        warning_filter.ast_debug(w);
         if let Some(n) = package_name {
             w.writeln(&format!("{}", n))
         }
@@ -761,6 +771,7 @@ impl AstDebug for (StructName, &StructDefinition) {
         let (
             name,
             StructDefinition {
+                warning_filter,
                 index,
                 attributes,
                 abilities,
@@ -768,6 +779,7 @@ impl AstDebug for (StructName, &StructDefinition) {
                 fields,
             },
         ) = self;
+        warning_filter.ast_debug(w);
         attributes.ast_debug(w);
         if let StructFields::Native(_) = fields {
             w.write("native ");
@@ -793,6 +805,7 @@ impl AstDebug for (FunctionName, &Function) {
         let (
             name,
             Function {
+                warning_filter,
                 index,
                 attributes,
                 visibility,
@@ -802,6 +815,7 @@ impl AstDebug for (FunctionName, &Function) {
                 body,
             },
         ) = self;
+        warning_filter.ast_debug(w);
         attributes.ast_debug(w);
         visibility.ast_debug(w);
         if entry.is_some() {
@@ -877,6 +891,7 @@ impl AstDebug for (ConstantName, &Constant) {
         let (
             name,
             Constant {
+                warning_filter,
                 index,
                 attributes,
                 loc: _loc,
@@ -884,6 +899,7 @@ impl AstDebug for (ConstantName, &Constant) {
                 value,
             },
         ) = self;
+        warning_filter.ast_debug(w);
         attributes.ast_debug(w);
         w.write(&format!("const#{index} {name}:"));
         signature.ast_debug(w);

--- a/external-crates/move/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/move-compiler/src/hlir/translate.rs
@@ -209,6 +209,7 @@ fn module(
     mdef: T::ModuleDefinition,
 ) -> (ModuleIdent, H::ModuleDefinition) {
     let T::ModuleDefinition {
+        warning_filter,
         package_name,
         attributes,
         is_source_module,
@@ -218,14 +219,16 @@ fn module(
         functions: tfunctions,
         constants: tconstants,
     } = mdef;
-
+    context.env.add_warning_filter_scope(warning_filter.clone());
     let structs = tstructs.map(|name, s| struct_def(context, name, s));
 
     let constants = tconstants.map(|name, c| constant(context, name, c));
     let functions = tfunctions.map(|name, f| function(context, name, f));
+    context.env.pop_warning_filter_scope();
     (
         module_ident,
         H::ModuleDefinition {
+            warning_filter,
             package_name,
             attributes,
             is_source_module,
@@ -250,6 +253,7 @@ fn scripts(
 
 fn script(context: &mut Context, tscript: T::Script) -> H::Script {
     let T::Script {
+        warning_filter,
         package_name,
         attributes,
         loc,
@@ -257,9 +261,12 @@ fn script(context: &mut Context, tscript: T::Script) -> H::Script {
         function_name,
         function: tfunction,
     } = tscript;
+    context.env.add_warning_filter_scope(warning_filter.clone());
     let constants = tconstants.map(|name, c| constant(context, name, c));
     let function = function(context, function_name, tfunction);
+    context.env.pop_warning_filter_scope();
     H::Script {
+        warning_filter,
         package_name,
         attributes,
         loc,
@@ -277,6 +284,7 @@ fn function(context: &mut Context, _name: FunctionName, f: T::Function) -> H::Fu
     assert!(context.has_empty_locals());
     assert!(context.tmp_counter == 0);
     let T::Function {
+        warning_filter,
         index,
         attributes,
         visibility,
@@ -285,9 +293,12 @@ fn function(context: &mut Context, _name: FunctionName, f: T::Function) -> H::Fu
         acquires,
         body,
     } = f;
+    context.env.add_warning_filter_scope(warning_filter.clone());
     let signature = function_signature(context, signature);
     let body = function_body(context, &signature, body);
+    context.env.pop_warning_filter_scope();
     H::Function {
+        warning_filter,
         index,
         attributes,
         visibility,
@@ -373,12 +384,14 @@ fn function_body_defined(
 
 fn constant(context: &mut Context, _name: ConstantName, cdef: T::Constant) -> H::Constant {
     let T::Constant {
+        warning_filter,
         index,
         attributes,
         loc,
         signature: tsignature,
         value: tvalue,
     } = cdef;
+    context.env.add_warning_filter_scope(warning_filter.clone());
     let signature = base_type(context, tsignature);
     let eloc = tvalue.exp.loc;
     let tseq = {
@@ -392,7 +405,9 @@ fn constant(context: &mut Context, _name: ConstantName, cdef: T::Constant) -> H:
         return_type: H::Type_::base(signature.clone()),
     };
     let (locals, body) = function_body_defined(context, &function_signature, eloc, tseq);
+    context.env.pop_warning_filter_scope();
     H::Constant {
+        warning_filter,
         index,
         attributes,
         loc,
@@ -411,14 +426,18 @@ fn struct_def(
     sdef: N::StructDefinition,
 ) -> H::StructDefinition {
     let N::StructDefinition {
+        warning_filter,
         index,
         attributes,
         abilities,
         type_parameters,
         fields,
     } = sdef;
+    context.env.add_warning_filter_scope(warning_filter.clone());
     let fields = struct_fields(context, fields);
+    context.env.pop_warning_filter_scope();
     H::StructDefinition {
+        warning_filter,
         index,
         attributes,
         abilities,

--- a/external-crates/move/move-compiler/src/naming/ast.rs
+++ b/external-crates/move/move-compiler/src/naming/ast.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    diagnostics::WarningFilters,
     expansion::ast::{
         ability_constraints_ast_debug, ability_modifiers_ast_debug, AbilitySet, Attributes, Fields,
         Friend, ModuleIdent, SpecId, Value, Value_, Visibility,
@@ -34,6 +35,7 @@ pub struct Program {
 
 #[derive(Debug, Clone)]
 pub struct Script {
+    pub warning_filter: WarningFilters,
     // package name metadata from compiler arguments, not used for any language rules
     pub package_name: Option<Symbol>,
     pub attributes: Attributes,
@@ -49,6 +51,7 @@ pub struct Script {
 
 #[derive(Debug, Clone)]
 pub struct ModuleDefinition {
+    pub warning_filter: WarningFilters,
     // package name metadata from compiler arguments, not used for any language rules
     pub package_name: Option<Symbol>,
     pub attributes: Attributes,
@@ -68,6 +71,7 @@ pub struct ModuleDefinition {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct StructDefinition {
+    pub warning_filter: WarningFilters,
     // index in the original order as defined in the source file
     pub index: usize,
     pub attributes: Attributes,
@@ -108,6 +112,7 @@ pub type FunctionBody = Spanned<FunctionBody_>;
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct Function {
+    pub warning_filter: WarningFilters,
     // index in the original order as defined in the source file
     pub index: usize,
     pub attributes: Attributes,
@@ -124,6 +129,7 @@ pub struct Function {
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct Constant {
+    pub warning_filter: WarningFilters,
     // index in the original order as defined in the source file
     pub index: usize,
     pub attributes: Attributes,
@@ -671,6 +677,7 @@ impl AstDebug for Program {
 impl AstDebug for Script {
     fn ast_debug(&self, w: &mut AstWriter) {
         let Script {
+            warning_filter,
             package_name,
             attributes,
             loc: _loc,
@@ -678,6 +685,7 @@ impl AstDebug for Script {
             function_name,
             function,
         } = self;
+        warning_filter.ast_debug(w);
         if let Some(n) = package_name {
             w.writeln(&format!("{}", n))
         }
@@ -693,6 +701,7 @@ impl AstDebug for Script {
 impl AstDebug for ModuleDefinition {
     fn ast_debug(&self, w: &mut AstWriter) {
         let ModuleDefinition {
+            warning_filter,
             package_name,
             attributes,
             is_source_module,
@@ -702,6 +711,7 @@ impl AstDebug for ModuleDefinition {
             constants,
             functions,
         } = self;
+        warning_filter.ast_debug(w);
         if let Some(n) = package_name {
             w.writeln(&format!("{}", n))
         }
@@ -736,6 +746,7 @@ impl AstDebug for (StructName, &StructDefinition) {
         let (
             name,
             StructDefinition {
+                warning_filter,
                 index,
                 attributes,
                 abilities,
@@ -743,6 +754,7 @@ impl AstDebug for (StructName, &StructDefinition) {
                 fields,
             },
         ) = self;
+        warning_filter.ast_debug(w);
         attributes.ast_debug(w);
         if let StructFields::Native(_) = fields {
             w.write("native ");
@@ -768,6 +780,7 @@ impl AstDebug for (FunctionName, &Function) {
         let (
             name,
             Function {
+                warning_filter,
                 index,
                 attributes,
                 visibility,
@@ -777,6 +790,7 @@ impl AstDebug for (FunctionName, &Function) {
                 body,
             },
         ) = self;
+        warning_filter.ast_debug(w);
         attributes.ast_debug(w);
         visibility.ast_debug(w);
         if entry.is_some() {
@@ -858,6 +872,7 @@ impl AstDebug for (ConstantName, &Constant) {
         let (
             name,
             Constant {
+                warning_filter,
                 index,
                 attributes,
                 loc: _loc,
@@ -865,6 +880,7 @@ impl AstDebug for (ConstantName, &Constant) {
                 value,
             },
         ) = self;
+        warning_filter.ast_debug(w);
         attributes.ast_debug(w);
         w.write(&format!("const#{index} {name}:"));
         signature.ast_debug(w);

--- a/external-crates/move/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/move-compiler/src/shared/mod.rs
@@ -4,7 +4,10 @@
 
 use crate::{
     command_line as cli,
-    diagnostics::{codes::Severity, Diagnostic, Diagnostics},
+    diagnostics::{
+        codes::{Severity, WarningFilter, WARNING_FILTER_ATTR},
+        Diagnostic, Diagnostics, WarningFilters,
+    },
     naming::ast::ModuleDefinition,
 };
 use clap::*;
@@ -173,6 +176,8 @@ pub type AttributeDeriver = dyn Fn(&mut CompilationEnv, &mut ModuleDefinition);
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CompilationEnv {
     flags: Flags,
+    // filters warnings when added.
+    warning_filter: Vec<WarningFilters>,
     diags: Diagnostics,
     // TODO(tzakian): Remove the global counter and use this counter instead
     // pub counter: u64,
@@ -182,16 +187,40 @@ impl CompilationEnv {
     pub fn new(flags: Flags) -> Self {
         Self {
             flags,
+            warning_filter: vec![],
             diags: Diagnostics::new(),
         }
     }
 
-    pub fn add_diag(&mut self, diag: Diagnostic) {
-        self.diags.add(diag)
+    pub fn add_diag(&mut self, mut diag: Diagnostic) {
+        let is_filtered = self
+            .warning_filter
+            .last()
+            .map(|filter| filter.is_filtered(&diag))
+            .unwrap_or(false);
+        if !is_filtered {
+            // add help to suppress warning, if applicable
+            // TODO do we want a centralized place for tips like this?
+            if diag.info().severity() == Severity::Warning {
+                let possible_filter =
+                    WarningFilter::Code(diag.info().category(), diag.info().code());
+                if let Some(filter_name) = possible_filter.to_str() {
+                    let help = format!(
+                        "This warning can be suppressed with with '#[{}({})]' \
+                        applied to the 'module' or module member ('const', 'fun', or 'struct')",
+                        WARNING_FILTER_ATTR, filter_name
+                    );
+                    diag.add_note(help)
+                }
+            }
+            self.diags.add(diag)
+        }
     }
 
     pub fn add_diags(&mut self, diags: Diagnostics) {
-        self.diags.extend(diags)
+        for diag in diags.into_vec() {
+            self.add_diag(diag)
+        }
     }
 
     pub fn has_warnings_or_errors(&self) -> bool {
@@ -233,6 +262,25 @@ impl CompilationEnv {
             .map(|s| s == Severity::Warning)
             .unwrap_or(true));
         final_diags
+    }
+
+    /// Add a new filter for warnings
+    pub fn add_warning_filter_scope(&mut self, mut filter: WarningFilters) {
+        // This essentially "clones" the current filter into the next scope. This should be
+        // efficient enough since the diag_filter vec should be only about 2 or 3 elements deep
+        // and the size of the filter should only be relatively small (at most 10 or so elements)
+        debug_assert!(
+            self.warning_filter.len() <= 3,
+            "TODO If triggered this TODO you might want to make this more efficient"
+        );
+        if let Some(cur_filter) = self.warning_filter.last() {
+            filter.union(&cur_filter)
+        }
+        self.warning_filter.push(filter)
+    }
+
+    pub fn pop_warning_filter_scope(&mut self) {
+        self.warning_filter.pop().unwrap();
     }
 
     pub fn flags(&self) -> &Flags {
@@ -410,6 +458,8 @@ pub mod known_attributes {
     use once_cell::sync::Lazy;
     use std::{collections::BTreeSet, fmt};
 
+    use crate::diagnostics::codes::WARNING_FILTER_ATTR;
+
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
     pub enum AttributePosition {
         AddressBlock,
@@ -428,6 +478,7 @@ pub mod known_attributes {
         Testing(TestingAttribute),
         Verification(VerificationAttribute),
         Native(NativeAttribute),
+        Diagnostic(DiagnosticAttribute),
     }
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -450,6 +501,11 @@ pub mod known_attributes {
     pub enum NativeAttribute {
         // It is a fake native function that actually compiles to a bytecode instruction
         BytecodeInstruction,
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    pub enum DiagnosticAttribute {
+        Allow,
     }
 
     impl fmt::Display for AttributePosition {
@@ -482,6 +538,7 @@ pub mod known_attributes {
                 NativeAttribute::BYTECODE_INSTRUCTION => {
                     Self::Native(NativeAttribute::BytecodeInstruction)
                 }
+                DiagnosticAttribute::ALLOW => Self::Diagnostic(DiagnosticAttribute::Allow),
                 _ => return None,
             })
         }
@@ -491,6 +548,7 @@ pub mod known_attributes {
                 Self::Testing(a) => a.name(),
                 Self::Verification(a) => a.name(),
                 Self::Native(a) => a.name(),
+                Self::Diagnostic(a) => a.name(),
             }
         }
 
@@ -499,6 +557,7 @@ pub mod known_attributes {
                 Self::Testing(a) => a.expected_positions(),
                 Self::Verification(a) => a.expected_positions(),
                 Self::Native(a) => a.expected_positions(),
+                Self::Diagnostic(a) => a.expected_positions(),
             }
         }
     }
@@ -525,7 +584,7 @@ pub mod known_attributes {
 
         pub fn expected_positions(&self) -> &'static BTreeSet<AttributePosition> {
             static TEST_ONLY_POSITIONS: Lazy<BTreeSet<AttributePosition>> = Lazy::new(|| {
-                IntoIterator::into_iter([
+                BTreeSet::from([
                     AttributePosition::AddressBlock,
                     AttributePosition::Module,
                     AttributePosition::Use,
@@ -534,12 +593,11 @@ pub mod known_attributes {
                     AttributePosition::Struct,
                     AttributePosition::Function,
                 ])
-                .collect()
             });
             static TEST_POSITIONS: Lazy<BTreeSet<AttributePosition>> =
-                Lazy::new(|| IntoIterator::into_iter([AttributePosition::Function]).collect());
+                Lazy::new(|| BTreeSet::from([AttributePosition::Function]));
             static EXPECTED_FAILURE_POSITIONS: Lazy<BTreeSet<AttributePosition>> =
-                Lazy::new(|| IntoIterator::into_iter([AttributePosition::Function]).collect());
+                Lazy::new(|| BTreeSet::from([AttributePosition::Function]));
             match self {
                 TestingAttribute::TestOnly => &TEST_ONLY_POSITIONS,
                 TestingAttribute::Test => &TEST_POSITIONS,
@@ -569,7 +627,7 @@ pub mod known_attributes {
 
         pub fn expected_positions(&self) -> &'static BTreeSet<AttributePosition> {
             static VERIFY_ONLY_POSITIONS: Lazy<BTreeSet<AttributePosition>> = Lazy::new(|| {
-                IntoIterator::into_iter([
+                BTreeSet::from([
                     AttributePosition::AddressBlock,
                     AttributePosition::Module,
                     AttributePosition::Use,
@@ -578,7 +636,6 @@ pub mod known_attributes {
                     AttributePosition::Struct,
                     AttributePosition::Function,
                 ])
-                .collect()
             });
             match self {
                 Self::VerifyOnly => &VERIFY_ONLY_POSITIONS,
@@ -600,6 +657,31 @@ pub mod known_attributes {
                 Lazy::new(|| IntoIterator::into_iter([AttributePosition::Function]).collect());
             match self {
                 NativeAttribute::BytecodeInstruction => &BYTECODE_INSTRUCTION_POSITIONS,
+            }
+        }
+    }
+
+    impl DiagnosticAttribute {
+        pub const ALLOW: &'static str = WARNING_FILTER_ATTR;
+
+        pub const fn name(&self) -> &str {
+            match self {
+                DiagnosticAttribute::Allow => Self::ALLOW,
+            }
+        }
+
+        pub fn expected_positions(&self) -> &'static BTreeSet<AttributePosition> {
+            static ALLOW_WARNING_POSITIONS: Lazy<BTreeSet<AttributePosition>> = Lazy::new(|| {
+                BTreeSet::from([
+                    AttributePosition::Module,
+                    AttributePosition::Script,
+                    AttributePosition::Constant,
+                    AttributePosition::Struct,
+                    AttributePosition::Function,
+                ])
+            });
+            match self {
+                DiagnosticAttribute::Allow => &ALLOW_WARNING_POSITIONS,
             }
         }
     }

--- a/external-crates/move/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/move-compiler/src/shared/mod.rs
@@ -206,7 +206,7 @@ impl CompilationEnv {
                     WarningFilter::Code(diag.info().category(), diag.info().code());
                 if let Some(filter_name) = possible_filter.to_str() {
                     let help = format!(
-                        "This warning can be suppressed with with '#[{}({})]' \
+                        "This warning can be suppressed with '#[{}({})]' \
                         applied to the 'module' or module member ('const', 'fun', or 'struct')",
                         WARNING_FILTER_ATTR, filter_name
                     );

--- a/external-crates/move/move-compiler/src/to_bytecode/translate.rs
+++ b/external-crates/move/move-compiler/src/to_bytecode/translate.rs
@@ -142,6 +142,7 @@ pub fn program(
     }
     for (key, s) in gscripts {
         let G::Script {
+            warning_filter: _warning_filter,
             package_name,
             attributes: _attributes,
             loc: _loc,
@@ -182,6 +183,7 @@ fn module(
 ) -> Option<AnnotatedCompiledUnit> {
     let mut context = Context::new(compilation_env, Some(&ident));
     let G::ModuleDefinition {
+        warning_filter: _warning_filter,
         package_name: _package_name,
         attributes: _attributes,
         is_source_module: _is_source_module,
@@ -483,6 +485,7 @@ fn struct_def(
     sdef: H::StructDefinition,
 ) -> IR::StructDefinition {
     let H::StructDefinition {
+        warning_filter: _warning_filter,
         index: _index,
         attributes: _attributes,
         abilities: abs,
@@ -606,6 +609,7 @@ fn function(
     fdef: G::Function,
 ) -> ((IR::FunctionName, IR::Function), CollectedInfo) {
     let G::Function {
+        warning_filter: _warning_filter,
         index: _index,
         attributes,
         visibility: v,

--- a/external-crates/move/move-compiler/src/typing/ast.rs
+++ b/external-crates/move/move-compiler/src/typing/ast.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    diagnostics::WarningFilters,
     expansion::ast::{Attributes, Fields, Friend, ModuleIdent, SpecId, Value, Visibility},
     naming::ast::{FunctionSignature, StructDefinition, Type, TypeName_, Type_, Var},
     parser::ast::{BinOp, ConstantName, Field, FunctionName, StructName, UnaryOp, ENTRY_MODIFIER},
@@ -31,6 +32,7 @@ pub struct Program {
 
 #[derive(Debug, Clone)]
 pub struct Script {
+    pub warning_filter: WarningFilters,
     // package name metadata from compiler arguments, not used for any language rules
     pub package_name: Option<Symbol>,
     pub attributes: Attributes,
@@ -46,6 +48,7 @@ pub struct Script {
 
 #[derive(Debug, Clone)]
 pub struct ModuleDefinition {
+    pub warning_filter: WarningFilters,
     // package name metadata from compiler arguments, not used for any language rules
     pub package_name: Option<Symbol>,
     pub attributes: Attributes,
@@ -71,6 +74,7 @@ pub type FunctionBody = Spanned<FunctionBody_>;
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct Function {
+    pub warning_filter: WarningFilters,
     // index in the original order as defined in the source file
     pub index: usize,
     pub attributes: Attributes,
@@ -87,6 +91,7 @@ pub struct Function {
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct Constant {
+    pub warning_filter: WarningFilters,
     // index in the original order as defined in the source file
     pub index: usize,
     pub attributes: Attributes,
@@ -279,6 +284,7 @@ impl AstDebug for Program {
 impl AstDebug for Script {
     fn ast_debug(&self, w: &mut AstWriter) {
         let Script {
+            warning_filter,
             package_name,
             attributes,
             loc: _loc,
@@ -286,6 +292,7 @@ impl AstDebug for Script {
             function_name,
             function,
         } = self;
+        warning_filter.ast_debug(w);
         if let Some(n) = package_name {
             w.writeln(&format!("{}", n))
         }
@@ -301,6 +308,7 @@ impl AstDebug for Script {
 impl AstDebug for ModuleDefinition {
     fn ast_debug(&self, w: &mut AstWriter) {
         let ModuleDefinition {
+            warning_filter,
             package_name,
             attributes,
             is_source_module,
@@ -310,6 +318,7 @@ impl AstDebug for ModuleDefinition {
             constants,
             functions,
         } = self;
+        warning_filter.ast_debug(w);
         if let Some(n) = package_name {
             w.writeln(&format!("{}", n))
         }
@@ -344,6 +353,7 @@ impl AstDebug for (FunctionName, &Function) {
         let (
             name,
             Function {
+                warning_filter,
                 index,
                 attributes,
                 visibility,
@@ -353,6 +363,7 @@ impl AstDebug for (FunctionName, &Function) {
                 body,
             },
         ) = self;
+        warning_filter.ast_debug(w);
         attributes.ast_debug(w);
         visibility.ast_debug(w);
         if entry.is_some() {
@@ -380,6 +391,7 @@ impl AstDebug for (ConstantName, &Constant) {
         let (
             name,
             Constant {
+                warning_filter,
                 index,
                 attributes,
                 loc: _loc,
@@ -387,6 +399,7 @@ impl AstDebug for (ConstantName, &Constant) {
                 value,
             },
         ) = self;
+        warning_filter.ast_debug(w);
         attributes.ast_debug(w);
         w.write(&format!("const#{index} {name}:"));
         signature.ast_debug(w);

--- a/external-crates/move/move-compiler/src/unit_test/filter_test_members.rs
+++ b/external-crates/move/move-compiler/src/unit_test/filter_test_members.rs
@@ -241,7 +241,9 @@ fn test_attributes(attrs: &P::Attributes) -> Vec<(Loc, known_attributes::Testing
         .filter_map(
             |attr| match KnownAttribute::resolve(attr.value.attribute_name().value)? {
                 KnownAttribute::Testing(test_attr) => Some((attr.loc, test_attr)),
-                KnownAttribute::Verification(_) | KnownAttribute::Native(_) => None,
+                KnownAttribute::Verification(_)
+                | KnownAttribute::Native(_)
+                | KnownAttribute::Diagnostic(_) => None,
             },
         )
         .collect()

--- a/external-crates/move/move-compiler/src/verification/ast_filter.rs
+++ b/external-crates/move/move-compiler/src/verification/ast_filter.rs
@@ -67,7 +67,9 @@ fn verification_attributes(
         .filter_map(
             |attr| match KnownAttribute::resolve(attr.value.attribute_name().value)? {
                 KnownAttribute::Verification(verify_attr) => Some((attr.loc, verify_attr)),
-                KnownAttribute::Testing(_) | KnownAttribute::Native(_) => None,
+                KnownAttribute::Testing(_)
+                | KnownAttribute::Native(_)
+                | KnownAttribute::Diagnostic(_) => None,
             },
         )
         .collect()

--- a/external-crates/move/move-compiler/tests/move_check/control_flow/infinite_loop_with_dead_exits.exp
+++ b/external-crates/move/move-compiler/tests/move_check/control_flow/infinite_loop_with_dead_exits.exp
@@ -3,10 +3,14 @@ warning[W09005]: dead or unreachable code
    │
 13 │             if (return) break;
    │                 ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+   │
+   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/control_flow/infinite_loop_with_dead_exits.move:13:25
    │
 13 │             if (return) break;
    │                         ^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
+   │
+   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/control_flow/infinite_loop_with_dead_exits.exp
+++ b/external-crates/move/move-compiler/tests/move_check/control_flow/infinite_loop_with_dead_exits.exp
@@ -4,7 +4,7 @@ warning[W09005]: dead or unreachable code
 13 │             if (return) break;
    │                 ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
    │
-   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/control_flow/infinite_loop_with_dead_exits.move:13:25
@@ -12,5 +12,5 @@ warning[W09005]: dead or unreachable code
 13 │             if (return) break;
    │                         ^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
    │
-   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/expansion/duplicate_alias.exp
+++ b/external-crates/move/move-compiler/tests/move_check/expansion/duplicate_alias.exp
@@ -12,5 +12,5 @@ warning[W09001]: unused alias
 8 │     use 0x2::Y as Z;
   │                   ^ Unused 'use' of alias 'Z'. Consider removing it
   │
-  = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/expansion/duplicate_alias.exp
+++ b/external-crates/move/move-compiler/tests/move_check/expansion/duplicate_alias.exp
@@ -11,4 +11,6 @@ warning[W09001]: unused alias
   │
 8 │     use 0x2::Y as Z;
   │                   ^ Unused 'use' of alias 'Z'. Consider removing it
+  │
+  = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/expansion/duplicate_field_assign.exp
+++ b/external-crates/move/move-compiler/tests/move_check/expansion/duplicate_field_assign.exp
@@ -14,5 +14,5 @@ warning[W09003]: unused assignment
 5 │         S { f, f } = S { f: 0 };
   │             ^ Unused assignment for variable 'f'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_f')
   │
-  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/expansion/duplicate_field_assign.exp
+++ b/external-crates/move/move-compiler/tests/move_check/expansion/duplicate_field_assign.exp
@@ -13,4 +13,6 @@ warning[W09003]: unused assignment
   │
 5 │         S { f, f } = S { f: 0 };
   │             ^ Unused assignment for variable 'f'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_f')
+  │
+  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/expansion/invalid_local_name.exp
+++ b/external-crates/move/move-compiler/tests/move_check/expansion/invalid_local_name.exp
@@ -39,4 +39,6 @@ warning[W09002]: unused variable
    │
 23 │         let vector;
    │             ^^^^^^ Unused local variable 'vector'. Consider removing or prefixing with an underscore: '_vector'
+   │
+   = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/expansion/invalid_local_name.exp
+++ b/external-crates/move/move-compiler/tests/move_check/expansion/invalid_local_name.exp
@@ -40,5 +40,5 @@ warning[W09002]: unused variable
 23 │         let vector;
    │             ^^^^^^ Unused local variable 'vector'. Consider removing or prefixing with an underscore: '_vector'
    │
-   = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/expansion/module_alias_as_type.exp
+++ b/external-crates/move/move-compiler/tests/move_check/expansion/module_alias_as_type.exp
@@ -3,6 +3,8 @@ warning[W09001]: unused alias
   │
 6 │     use 0x2::X;
   │              ^ Unused 'use' of alias 'X'. Consider removing it
+  │
+  = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E03004]: unbound type
   ┌─ tests/move_check/expansion/module_alias_as_type.move:7:16

--- a/external-crates/move/move-compiler/tests/move_check/expansion/module_alias_as_type.exp
+++ b/external-crates/move/move-compiler/tests/move_check/expansion/module_alias_as_type.exp
@@ -4,7 +4,7 @@ warning[W09001]: unused alias
 6 │     use 0x2::X;
   │              ^ Unused 'use' of alias 'X'. Consider removing it
   │
-  = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E03004]: unbound type
   ┌─ tests/move_check/expansion/module_alias_as_type.move:7:16

--- a/external-crates/move/move-compiler/tests/move_check/expansion/restricted_module_alias_names.exp
+++ b/external-crates/move/move-compiler/tests/move_check/expansion/restricted_module_alias_names.exp
@@ -9,4 +9,6 @@ warning[W09001]: unused alias
   │
 5 │     use 0x42::M as vector;
   │                    ^^^^^^ Unused 'use' of alias 'vector'. Consider removing it
+  │
+  = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/expansion/restricted_module_alias_names.exp
+++ b/external-crates/move/move-compiler/tests/move_check/expansion/restricted_module_alias_names.exp
@@ -10,5 +10,5 @@ warning[W09001]: unused alias
 5 │     use 0x42::M as vector;
   │                    ^^^^^^ Unused 'use' of alias 'vector'. Consider removing it
   │
-  = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/expansion/unpack_all_field_cases.exp
+++ b/external-crates/move/move-compiler/tests/move_check/expansion/unpack_all_field_cases.exp
@@ -3,12 +3,16 @@ warning[W09003]: unused assignment
    │
 10 │         S { f, g } = copy s;
    │             ^ Unused assignment for variable 'f'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_f')
+   │
+   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09003]: unused assignment
    ┌─ tests/move_check/expansion/unpack_all_field_cases.move:10:16
    │
 10 │         S { f, g } = copy s;
    │                ^ Unused assignment for variable 'g'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_g')
+   │
+   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E01009]: invalid assignment
    ┌─ tests/move_check/expansion/unpack_all_field_cases.move:11:16

--- a/external-crates/move/move-compiler/tests/move_check/expansion/unpack_all_field_cases.exp
+++ b/external-crates/move/move-compiler/tests/move_check/expansion/unpack_all_field_cases.exp
@@ -4,7 +4,7 @@ warning[W09003]: unused assignment
 10 │         S { f, g } = copy s;
    │             ^ Unused assignment for variable 'f'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_f')
    │
-   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09003]: unused assignment
    ┌─ tests/move_check/expansion/unpack_all_field_cases.move:10:16
@@ -12,7 +12,7 @@ warning[W09003]: unused assignment
 10 │         S { f, g } = copy s;
    │                ^ Unused assignment for variable 'g'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_g')
    │
-   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E01009]: invalid assignment
    ┌─ tests/move_check/expansion/unpack_all_field_cases.move:11:16

--- a/external-crates/move/move-compiler/tests/move_check/expansion/use_function_same_name_as_function.exp
+++ b/external-crates/move/move-compiler/tests/move_check/expansion/use_function_same_name_as_function.exp
@@ -20,4 +20,6 @@ warning[W09001]: unused alias
    │
 17 │     use 0x2::X::u as bar;
    │                      ^^^ Unused 'use' of alias 'bar'. Consider removing it
+   │
+   = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/expansion/use_function_same_name_as_function.exp
+++ b/external-crates/move/move-compiler/tests/move_check/expansion/use_function_same_name_as_function.exp
@@ -21,5 +21,5 @@ warning[W09001]: unused alias
 17 │     use 0x2::X::u as bar;
    │                      ^^^ Unused 'use' of alias 'bar'. Consider removing it
    │
-   = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/expansion/use_function_same_name_as_struct.exp
+++ b/external-crates/move/move-compiler/tests/move_check/expansion/use_function_same_name_as_struct.exp
@@ -4,7 +4,7 @@ warning[W09001]: unused alias
 9 │     use 0x2::X::u;
   │                 ^ Unused 'use' of alias 'u'. Consider removing it
   │
-  = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02010]: invalid name
    ┌─ tests/move_check/expansion/use_function_same_name_as_struct.move:10:12
@@ -26,5 +26,5 @@ warning[W09001]: unused alias
 15 │     use 0x2::X::u as Bar;
    │                      ^^^ Unused 'use' of alias 'Bar'. Consider removing it
    │
-   = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/expansion/use_function_same_name_as_struct.exp
+++ b/external-crates/move/move-compiler/tests/move_check/expansion/use_function_same_name_as_struct.exp
@@ -3,6 +3,8 @@ warning[W09001]: unused alias
   │
 9 │     use 0x2::X::u;
   │                 ^ Unused 'use' of alias 'u'. Consider removing it
+  │
+  = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02010]: invalid name
    ┌─ tests/move_check/expansion/use_function_same_name_as_struct.move:10:12
@@ -23,4 +25,6 @@ warning[W09001]: unused alias
    │
 15 │     use 0x2::X::u as Bar;
    │                      ^^^ Unused 'use' of alias 'Bar'. Consider removing it
+   │
+   = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/expansion/use_function_tparam_shadows.exp
+++ b/external-crates/move/move-compiler/tests/move_check/expansion/use_function_tparam_shadows.exp
@@ -3,6 +3,8 @@ warning[W09001]: unused alias
   │
 7 │     use 0x2::X::foo;
   │                 ^^^ Unused 'use' of alias 'foo'. Consider removing it
+  │
+  = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E03005]: unbound unscoped name
    ┌─ tests/move_check/expansion/use_function_tparam_shadows.move:10:9

--- a/external-crates/move/move-compiler/tests/move_check/expansion/use_function_tparam_shadows.exp
+++ b/external-crates/move/move-compiler/tests/move_check/expansion/use_function_tparam_shadows.exp
@@ -4,7 +4,7 @@ warning[W09001]: unused alias
 7 │     use 0x2::X::foo;
   │                 ^^^ Unused 'use' of alias 'foo'. Consider removing it
   │
-  = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E03005]: unbound unscoped name
    ┌─ tests/move_check/expansion/use_function_tparam_shadows.move:10:9

--- a/external-crates/move/move-compiler/tests/move_check/expansion/use_inner_scope_duplicates.exp
+++ b/external-crates/move/move-compiler/tests/move_check/expansion/use_inner_scope_duplicates.exp
@@ -11,6 +11,8 @@ warning[W09001]: unused alias
    │
 13 │         use 0x2::M::{check as foo, num as foo};
    │                                           ^^^ Unused 'use' of alias 'foo'. Consider removing it
+   │
+   = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
    ┌─ tests/move_check/expansion/use_inner_scope_duplicates.move:15:23
@@ -25,4 +27,6 @@ warning[W09001]: unused alias
    │
 15 │         use 0x2::M as N;
    │                       ^ Unused 'use' of alias 'N'. Consider removing it
+   │
+   = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/expansion/use_inner_scope_duplicates.exp
+++ b/external-crates/move/move-compiler/tests/move_check/expansion/use_inner_scope_duplicates.exp
@@ -12,7 +12,7 @@ warning[W09001]: unused alias
 13 │         use 0x2::M::{check as foo, num as foo};
    │                                           ^^^ Unused 'use' of alias 'foo'. Consider removing it
    │
-   = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
    ┌─ tests/move_check/expansion/use_inner_scope_duplicates.move:15:23
@@ -28,5 +28,5 @@ warning[W09001]: unused alias
 15 │         use 0x2::M as N;
    │                       ^ Unused 'use' of alias 'N'. Consider removing it
    │
-   = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/expansion/use_inner_scope_unused.exp
+++ b/external-crates/move/move-compiler/tests/move_check/expansion/use_inner_scope_unused.exp
@@ -4,7 +4,7 @@ warning[W09001]: unused alias
 13 │         use 0x2::M as X;
    │                       ^ Unused 'use' of alias 'X'. Consider removing it
    │
-   = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09001]: unused alias
    ┌─ tests/move_check/expansion/use_inner_scope_unused.move:14:31
@@ -12,7 +12,7 @@ warning[W09001]: unused alias
 14 │         use 0x2::M::{check as f, S1 as S8};
    │                               ^ Unused 'use' of alias 'f'. Consider removing it
    │
-   = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09001]: unused alias
    ┌─ tests/move_check/expansion/use_inner_scope_unused.move:14:40
@@ -20,5 +20,5 @@ warning[W09001]: unused alias
 14 │         use 0x2::M::{check as f, S1 as S8};
    │                                        ^^ Unused 'use' of alias 'S8'. Consider removing it
    │
-   = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/expansion/use_inner_scope_unused.exp
+++ b/external-crates/move/move-compiler/tests/move_check/expansion/use_inner_scope_unused.exp
@@ -3,16 +3,22 @@ warning[W09001]: unused alias
    │
 13 │         use 0x2::M as X;
    │                       ^ Unused 'use' of alias 'X'. Consider removing it
+   │
+   = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09001]: unused alias
    ┌─ tests/move_check/expansion/use_inner_scope_unused.move:14:31
    │
 14 │         use 0x2::M::{check as f, S1 as S8};
    │                               ^ Unused 'use' of alias 'f'. Consider removing it
+   │
+   = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09001]: unused alias
    ┌─ tests/move_check/expansion/use_inner_scope_unused.move:14:40
    │
 14 │         use 0x2::M::{check as f, S1 as S8};
    │                                        ^^ Unused 'use' of alias 'S8'. Consider removing it
+   │
+   = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/expansion/use_nested_self_as_invalid.exp
+++ b/external-crates/move/move-compiler/tests/move_check/expansion/use_nested_self_as_invalid.exp
@@ -3,6 +3,8 @@ warning[W09001]: unused alias
   │
 8 │     use 0x2::X::{Self as B, foo, S};
   │                          ^ Unused 'use' of alias 'B'. Consider removing it
+  │
+  = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E03002]: unbound module
    ┌─ tests/move_check/expansion/use_nested_self_as_invalid.move:10:19

--- a/external-crates/move/move-compiler/tests/move_check/expansion/use_nested_self_as_invalid.exp
+++ b/external-crates/move/move-compiler/tests/move_check/expansion/use_nested_self_as_invalid.exp
@@ -4,7 +4,7 @@ warning[W09001]: unused alias
 8 │     use 0x2::X::{Self as B, foo, S};
   │                          ^ Unused 'use' of alias 'B'. Consider removing it
   │
-  = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E03002]: unbound module
    ┌─ tests/move_check/expansion/use_nested_self_as_invalid.move:10:19

--- a/external-crates/move/move-compiler/tests/move_check/expansion/use_struct_same_name_as_function.exp
+++ b/external-crates/move/move-compiler/tests/move_check/expansion/use_struct_same_name_as_function.exp
@@ -31,7 +31,7 @@ warning[W09001]: unused alias
 15 │     use 0x2::X::{R, R as R2};
    │                  ^ Unused 'use' of alias 'R'. Consider removing it
    │
-   = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
    ┌─ tests/move_check/expansion/use_struct_same_name_as_function.move:15:26
@@ -48,5 +48,5 @@ warning[W09001]: unused alias
 15 │     use 0x2::X::{R, R as R2};
    │                          ^^ Unused 'use' of alias 'R2'. Consider removing it
    │
-   = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/expansion/use_struct_same_name_as_function.exp
+++ b/external-crates/move/move-compiler/tests/move_check/expansion/use_struct_same_name_as_function.exp
@@ -30,6 +30,8 @@ warning[W09001]: unused alias
    │
 15 │     use 0x2::X::{R, R as R2};
    │                  ^ Unused 'use' of alias 'R'. Consider removing it
+   │
+   = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
    ┌─ tests/move_check/expansion/use_struct_same_name_as_function.move:15:26
@@ -45,4 +47,6 @@ warning[W09001]: unused alias
    │
 15 │     use 0x2::X::{R, R as R2};
    │                          ^^ Unused 'use' of alias 'R2'. Consider removing it
+   │
+   = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/expansion/use_struct_same_name_as_struct.exp
+++ b/external-crates/move/move-compiler/tests/move_check/expansion/use_struct_same_name_as_struct.exp
@@ -31,7 +31,7 @@ warning[W09001]: unused alias
 15 │     use 0x2::X::{R, R as R2};
    │                  ^ Unused 'use' of alias 'R'. Consider removing it
    │
-   = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
    ┌─ tests/move_check/expansion/use_struct_same_name_as_struct.move:15:26
@@ -48,5 +48,5 @@ warning[W09001]: unused alias
 15 │     use 0x2::X::{R, R as R2};
    │                          ^^ Unused 'use' of alias 'R2'. Consider removing it
    │
-   = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/expansion/use_struct_same_name_as_struct.exp
+++ b/external-crates/move/move-compiler/tests/move_check/expansion/use_struct_same_name_as_struct.exp
@@ -30,6 +30,8 @@ warning[W09001]: unused alias
    │
 15 │     use 0x2::X::{R, R as R2};
    │                  ^ Unused 'use' of alias 'R'. Consider removing it
+   │
+   = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
    ┌─ tests/move_check/expansion/use_struct_same_name_as_struct.move:15:26
@@ -45,4 +47,6 @@ warning[W09001]: unused alias
    │
 15 │     use 0x2::X::{R, R as R2};
    │                          ^^ Unused 'use' of alias 'R2'. Consider removing it
+   │
+   = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/liveness/loop_weirdness.exp
+++ b/external-crates/move/move-compiler/tests/move_check/liveness/loop_weirdness.exp
@@ -8,5 +8,5 @@ warning[W09004]: unnecessary trailing semicolon
   │                                      │    A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
   │                                      Any code after this expression will not be reached
   │
-  = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/liveness/loop_weirdness.exp
+++ b/external-crates/move/move-compiler/tests/move_check/liveness/loop_weirdness.exp
@@ -7,4 +7,6 @@ warning[W09004]: unnecessary trailing semicolon
   │                                      │    Invalid trailing ';'
   │                                      │    A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
   │                                      Any code after this expression will not be reached
+  │
+  = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/liveness/trailing_semi.exp
+++ b/external-crates/move/move-compiler/tests/move_check/liveness/trailing_semi.exp
@@ -8,7 +8,7 @@ warning[W09004]: unnecessary trailing semicolon
   │         │     A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
   │         Any code after this expression will not be reached
   │
-  = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
   ┌─ tests/move_check/liveness/trailing_semi.move:9:16
@@ -20,7 +20,7 @@ warning[W09004]: unnecessary trailing semicolon
   │         │      A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
   │         Any code after this expression will not be reached
   │
-  = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
    ┌─ tests/move_check/liveness/trailing_semi.move:15:19
@@ -32,7 +32,7 @@ warning[W09004]: unnecessary trailing semicolon
    │           │       A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
    │           Any code after this expression will not be reached
    │
-   = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
    ┌─ tests/move_check/liveness/trailing_semi.move:21:20
@@ -44,7 +44,7 @@ warning[W09004]: unnecessary trailing semicolon
    │           │        A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
    │           Any code after this expression will not be reached
    │
-   = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
    ┌─ tests/move_check/liveness/trailing_semi.move:29:19
@@ -56,7 +56,7 @@ warning[W09004]: unnecessary trailing semicolon
    │             │     A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
    │             Any code after this expression will not be reached
    │
-   = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
    ┌─ tests/move_check/liveness/trailing_semi.move:43:14
@@ -72,7 +72,7 @@ warning[W09004]: unnecessary trailing semicolon
    │ │              A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
    │ ╰─────────────' Any code after this expression will not be reached
    │  
-   = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
    ┌─ tests/move_check/liveness/trailing_semi.move:52:24
@@ -84,7 +84,7 @@ warning[W09004]: unnecessary trailing semicolon
    │                 │      A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
    │                 Any code after this expression will not be reached
    │
-   = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
    ┌─ tests/move_check/liveness/trailing_semi.move:54:23
@@ -96,7 +96,7 @@ warning[W09004]: unnecessary trailing semicolon
    │                 │     A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
    │                 Any code after this expression will not be reached
    │
-   = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
    ┌─ tests/move_check/liveness/trailing_semi.move:55:14
@@ -112,5 +112,5 @@ warning[W09004]: unnecessary trailing semicolon
    │ │              A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
    │ ╰─────────────' Any code after this expression will not be reached
    │  
-   = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/liveness/trailing_semi.exp
+++ b/external-crates/move/move-compiler/tests/move_check/liveness/trailing_semi.exp
@@ -7,6 +7,8 @@ warning[W09004]: unnecessary trailing semicolon
   │         │     Invalid trailing ';'
   │         │     A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
   │         Any code after this expression will not be reached
+  │
+  = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
   ┌─ tests/move_check/liveness/trailing_semi.move:9:16
@@ -17,6 +19,8 @@ warning[W09004]: unnecessary trailing semicolon
   │         │      Invalid trailing ';'
   │         │      A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
   │         Any code after this expression will not be reached
+  │
+  = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
    ┌─ tests/move_check/liveness/trailing_semi.move:15:19
@@ -27,6 +31,8 @@ warning[W09004]: unnecessary trailing semicolon
    │           │       Invalid trailing ';'
    │           │       A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
    │           Any code after this expression will not be reached
+   │
+   = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
    ┌─ tests/move_check/liveness/trailing_semi.move:21:20
@@ -37,6 +43,8 @@ warning[W09004]: unnecessary trailing semicolon
    │           │        Invalid trailing ';'
    │           │        A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
    │           Any code after this expression will not be reached
+   │
+   = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
    ┌─ tests/move_check/liveness/trailing_semi.move:29:19
@@ -47,6 +55,8 @@ warning[W09004]: unnecessary trailing semicolon
    │             │     Invalid trailing ';'
    │             │     A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
    │             Any code after this expression will not be reached
+   │
+   = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
    ┌─ tests/move_check/liveness/trailing_semi.move:43:14
@@ -61,6 +71,8 @@ warning[W09004]: unnecessary trailing semicolon
    │ │              Invalid trailing ';'
    │ │              A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
    │ ╰─────────────' Any code after this expression will not be reached
+   │  
+   = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
    ┌─ tests/move_check/liveness/trailing_semi.move:52:24
@@ -71,6 +83,8 @@ warning[W09004]: unnecessary trailing semicolon
    │                 │      Invalid trailing ';'
    │                 │      A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
    │                 Any code after this expression will not be reached
+   │
+   = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
    ┌─ tests/move_check/liveness/trailing_semi.move:54:23
@@ -81,6 +95,8 @@ warning[W09004]: unnecessary trailing semicolon
    │                 │     Invalid trailing ';'
    │                 │     A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
    │                 Any code after this expression will not be reached
+   │
+   = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
    ┌─ tests/move_check/liveness/trailing_semi.move:55:14
@@ -95,4 +111,6 @@ warning[W09004]: unnecessary trailing semicolon
    │ │              Invalid trailing ';'
    │ │              A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
    │ ╰─────────────' Any code after this expression will not be reached
+   │  
+   = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/liveness/trailing_semi_loops.exp
+++ b/external-crates/move/move-compiler/tests/move_check/liveness/trailing_semi_loops.exp
@@ -7,6 +7,8 @@ warning[W09004]: unnecessary trailing semicolon
   │         │      Invalid trailing ';'
   │         │      A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
   │         Any code after this expression will not be reached
+  │
+  = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
   ┌─ tests/move_check/liveness/trailing_semi_loops.move:9:26
@@ -17,6 +19,8 @@ warning[W09004]: unnecessary trailing semicolon
   │            │             Invalid trailing ';'
   │            │             A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
   │            Any code after this expression will not be reached
+  │
+  = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
    ┌─ tests/move_check/liveness/trailing_semi_loops.move:18:10
@@ -30,12 +34,16 @@ warning[W09004]: unnecessary trailing semicolon
    │ │          Invalid trailing ';'
    │ │          A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
    │ ╰─────────' Any code after this expression will not be reached
+   │  
+   = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/liveness/trailing_semi_loops.move:27:26
    │
 27 │             let _: u64 = if (true) break else break;
    │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+   │
+   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
    ┌─ tests/move_check/liveness/trailing_semi_loops.move:35:18
@@ -46,6 +54,8 @@ warning[W09004]: unnecessary trailing semicolon
    │             │    Invalid trailing ';'
    │             │    A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
    │             Any code after this expression will not be reached
+   │
+   = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
    ┌─ tests/move_check/liveness/trailing_semi_loops.move:44:22
@@ -56,6 +66,8 @@ warning[W09004]: unnecessary trailing semicolon
    │                 │    Invalid trailing ';'
    │                 │    A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
    │                 Any code after this expression will not be reached
+   │
+   = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
    ┌─ tests/move_check/liveness/trailing_semi_loops.move:55:42
@@ -66,6 +78,8 @@ warning[W09004]: unnecessary trailing semicolon
    │             │                            Invalid trailing ';'
    │             │                            A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
    │             Any code after this expression will not be reached
+   │
+   = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
    ┌─ tests/move_check/liveness/trailing_semi_loops.move:63:42
@@ -76,12 +90,16 @@ warning[W09004]: unnecessary trailing semicolon
    │             │                            Invalid trailing ';'
    │             │                            A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
    │             Any code after this expression will not be reached
+   │
+   = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09003]: unused assignment
    ┌─ tests/move_check/liveness/trailing_semi_loops.move:76:17
    │
 76 │                 x = 2;
    │                 ^ Unused assignment for variable 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
+   │
+   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
    ┌─ tests/move_check/liveness/trailing_semi_loops.move:78:14
@@ -98,6 +116,8 @@ warning[W09004]: unnecessary trailing semicolon
    │ │              Invalid trailing ';'
    │ │              A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
    │ ╰─────────────' Any code after this expression will not be reached
+   │  
+   = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
    ┌─ tests/move_check/liveness/trailing_semi_loops.move:88:22
@@ -108,6 +128,8 @@ warning[W09004]: unnecessary trailing semicolon
    │                 │    Invalid trailing ';'
    │                 │    A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
    │                 Any code after this expression will not be reached
+   │
+   = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
    ┌─ tests/move_check/liveness/trailing_semi_loops.move:90:25
@@ -118,6 +140,8 @@ warning[W09004]: unnecessary trailing semicolon
    │                 │       Invalid trailing ';'
    │                 │       A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
    │                 Any code after this expression will not be reached
+   │
+   = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
    ┌─ tests/move_check/liveness/trailing_semi_loops.move:91:14
@@ -132,6 +156,8 @@ warning[W09004]: unnecessary trailing semicolon
    │ │              Invalid trailing ';'
    │ │              A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
    │ ╰─────────────' Any code after this expression will not be reached
+   │  
+   = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
     ┌─ tests/move_check/liveness/trailing_semi_loops.move:100:23
@@ -142,6 +168,8 @@ warning[W09004]: unnecessary trailing semicolon
     │                 │     Invalid trailing ';'
     │                 │     A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
     │                 Any code after this expression will not be reached
+    │
+    = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
     ┌─ tests/move_check/liveness/trailing_semi_loops.move:102:24
@@ -152,6 +180,8 @@ warning[W09004]: unnecessary trailing semicolon
     │                 │      Invalid trailing ';'
     │                 │      A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
     │                 Any code after this expression will not be reached
+    │
+    = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
     ┌─ tests/move_check/liveness/trailing_semi_loops.move:103:14
@@ -166,4 +196,6 @@ warning[W09004]: unnecessary trailing semicolon
     │ │              Invalid trailing ';'
     │ │              A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
     │ ╰─────────────' Any code after this expression will not be reached
+    │  
+    = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/liveness/trailing_semi_loops.exp
+++ b/external-crates/move/move-compiler/tests/move_check/liveness/trailing_semi_loops.exp
@@ -8,7 +8,7 @@ warning[W09004]: unnecessary trailing semicolon
   │         │      A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
   │         Any code after this expression will not be reached
   │
-  = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
   ┌─ tests/move_check/liveness/trailing_semi_loops.move:9:26
@@ -20,7 +20,7 @@ warning[W09004]: unnecessary trailing semicolon
   │            │             A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
   │            Any code after this expression will not be reached
   │
-  = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
    ┌─ tests/move_check/liveness/trailing_semi_loops.move:18:10
@@ -35,7 +35,7 @@ warning[W09004]: unnecessary trailing semicolon
    │ │          A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
    │ ╰─────────' Any code after this expression will not be reached
    │  
-   = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/liveness/trailing_semi_loops.move:27:26
@@ -43,7 +43,7 @@ warning[W09005]: dead or unreachable code
 27 │             let _: u64 = if (true) break else break;
    │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
    │
-   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
    ┌─ tests/move_check/liveness/trailing_semi_loops.move:35:18
@@ -55,7 +55,7 @@ warning[W09004]: unnecessary trailing semicolon
    │             │    A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
    │             Any code after this expression will not be reached
    │
-   = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
    ┌─ tests/move_check/liveness/trailing_semi_loops.move:44:22
@@ -67,7 +67,7 @@ warning[W09004]: unnecessary trailing semicolon
    │                 │    A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
    │                 Any code after this expression will not be reached
    │
-   = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
    ┌─ tests/move_check/liveness/trailing_semi_loops.move:55:42
@@ -79,7 +79,7 @@ warning[W09004]: unnecessary trailing semicolon
    │             │                            A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
    │             Any code after this expression will not be reached
    │
-   = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
    ┌─ tests/move_check/liveness/trailing_semi_loops.move:63:42
@@ -91,7 +91,7 @@ warning[W09004]: unnecessary trailing semicolon
    │             │                            A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
    │             Any code after this expression will not be reached
    │
-   = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09003]: unused assignment
    ┌─ tests/move_check/liveness/trailing_semi_loops.move:76:17
@@ -99,7 +99,7 @@ warning[W09003]: unused assignment
 76 │                 x = 2;
    │                 ^ Unused assignment for variable 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
    │
-   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
    ┌─ tests/move_check/liveness/trailing_semi_loops.move:78:14
@@ -117,7 +117,7 @@ warning[W09004]: unnecessary trailing semicolon
    │ │              A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
    │ ╰─────────────' Any code after this expression will not be reached
    │  
-   = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
    ┌─ tests/move_check/liveness/trailing_semi_loops.move:88:22
@@ -129,7 +129,7 @@ warning[W09004]: unnecessary trailing semicolon
    │                 │    A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
    │                 Any code after this expression will not be reached
    │
-   = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
    ┌─ tests/move_check/liveness/trailing_semi_loops.move:90:25
@@ -141,7 +141,7 @@ warning[W09004]: unnecessary trailing semicolon
    │                 │       A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
    │                 Any code after this expression will not be reached
    │
-   = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
    ┌─ tests/move_check/liveness/trailing_semi_loops.move:91:14
@@ -157,7 +157,7 @@ warning[W09004]: unnecessary trailing semicolon
    │ │              A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
    │ ╰─────────────' Any code after this expression will not be reached
    │  
-   = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
     ┌─ tests/move_check/liveness/trailing_semi_loops.move:100:23
@@ -169,7 +169,7 @@ warning[W09004]: unnecessary trailing semicolon
     │                 │     A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
     │                 Any code after this expression will not be reached
     │
-    = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = This warning can be suppressed with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
     ┌─ tests/move_check/liveness/trailing_semi_loops.move:102:24
@@ -181,7 +181,7 @@ warning[W09004]: unnecessary trailing semicolon
     │                 │      A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
     │                 Any code after this expression will not be reached
     │
-    = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = This warning can be suppressed with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09004]: unnecessary trailing semicolon
     ┌─ tests/move_check/liveness/trailing_semi_loops.move:103:14
@@ -197,5 +197,5 @@ warning[W09004]: unnecessary trailing semicolon
     │ │              A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
     │ ╰─────────────' Any code after this expression will not be reached
     │  
-    = This warning can be suppressed with with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+    = This warning can be suppressed with '#[allow(unused_trailing_semi)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/liveness/unused_assignment.exp
+++ b/external-crates/move/move-compiler/tests/move_check/liveness/unused_assignment.exp
@@ -3,52 +3,70 @@ warning[W09003]: unused assignment
   │
 3 │         let x = 0;
   │             ^ Unused assignment for variable 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
+  │
+  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09003]: unused assignment
   ┌─ tests/move_check/liveness/unused_assignment.move:7:13
   │
 7 │         let x = 0;
   │             ^ Unused assignment for variable 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
+  │
+  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09003]: unused assignment
   ┌─ tests/move_check/liveness/unused_assignment.move:8:9
   │
 8 │         x = 0;
   │         ^ Unused assignment for variable 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
+  │
+  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09003]: unused assignment
    ┌─ tests/move_check/liveness/unused_assignment.move:13:17
    │
 13 │             let x = 0;
    │                 ^ Unused assignment for variable 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
+   │
+   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09003]: unused assignment
    ┌─ tests/move_check/liveness/unused_assignment.move:21:13
    │
 21 │             x = 0;
    │             ^ Unused assignment for variable 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
+   │
+   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09003]: unused assignment
    ┌─ tests/move_check/liveness/unused_assignment.move:26:13
    │
 26 │         let x = 0;
    │             ^ Unused assignment for variable 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
+   │
+   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09003]: unused assignment
    ┌─ tests/move_check/liveness/unused_assignment.move:28:13
    │
 28 │             x = 1;
    │             ^ Unused assignment for variable 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
+   │
+   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09003]: unused assignment
    ┌─ tests/move_check/liveness/unused_assignment.move:30:13
    │
 30 │             x = 2;
    │             ^ Unused assignment for variable 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
+   │
+   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09003]: unused assignment
    ┌─ tests/move_check/liveness/unused_assignment.move:41:13
    │
 41 │             x = 1;
    │             ^ Unused assignment for variable 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
+   │
+   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/liveness/unused_assignment.exp
+++ b/external-crates/move/move-compiler/tests/move_check/liveness/unused_assignment.exp
@@ -4,7 +4,7 @@ warning[W09003]: unused assignment
 3 │         let x = 0;
   │             ^ Unused assignment for variable 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
   │
-  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09003]: unused assignment
   ┌─ tests/move_check/liveness/unused_assignment.move:7:13
@@ -12,7 +12,7 @@ warning[W09003]: unused assignment
 7 │         let x = 0;
   │             ^ Unused assignment for variable 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
   │
-  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09003]: unused assignment
   ┌─ tests/move_check/liveness/unused_assignment.move:8:9
@@ -20,7 +20,7 @@ warning[W09003]: unused assignment
 8 │         x = 0;
   │         ^ Unused assignment for variable 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
   │
-  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09003]: unused assignment
    ┌─ tests/move_check/liveness/unused_assignment.move:13:17
@@ -28,7 +28,7 @@ warning[W09003]: unused assignment
 13 │             let x = 0;
    │                 ^ Unused assignment for variable 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
    │
-   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09003]: unused assignment
    ┌─ tests/move_check/liveness/unused_assignment.move:21:13
@@ -36,7 +36,7 @@ warning[W09003]: unused assignment
 21 │             x = 0;
    │             ^ Unused assignment for variable 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
    │
-   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09003]: unused assignment
    ┌─ tests/move_check/liveness/unused_assignment.move:26:13
@@ -44,7 +44,7 @@ warning[W09003]: unused assignment
 26 │         let x = 0;
    │             ^ Unused assignment for variable 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
    │
-   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09003]: unused assignment
    ┌─ tests/move_check/liveness/unused_assignment.move:28:13
@@ -52,7 +52,7 @@ warning[W09003]: unused assignment
 28 │             x = 1;
    │             ^ Unused assignment for variable 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
    │
-   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09003]: unused assignment
    ┌─ tests/move_check/liveness/unused_assignment.move:30:13
@@ -60,7 +60,7 @@ warning[W09003]: unused assignment
 30 │             x = 2;
    │             ^ Unused assignment for variable 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
    │
-   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09003]: unused assignment
    ┌─ tests/move_check/liveness/unused_assignment.move:41:13
@@ -68,5 +68,5 @@ warning[W09003]: unused assignment
 41 │             x = 1;
    │             ^ Unused assignment for variable 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
    │
-   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/locals/assign_partial_resource.exp
+++ b/external-crates/move/move-compiler/tests/move_check/locals/assign_partial_resource.exp
@@ -4,7 +4,7 @@ warning[W09003]: unused assignment
 6 │         if (cond) { r = R{}; };
   │                     ^ Unused assignment for variable 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
   │
-  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E06001]: unused value without 'drop'
   ┌─ tests/move_check/locals/assign_partial_resource.move:7:9
@@ -25,7 +25,7 @@ warning[W09003]: unused assignment
 13 │         if (cond) {} else { r = R{}; };
    │                             ^ Unused assignment for variable 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
    │
-   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E06001]: unused value without 'drop'
    ┌─ tests/move_check/locals/assign_partial_resource.move:14:9
@@ -46,7 +46,7 @@ warning[W09003]: unused assignment
 20 │         while (cond) { r = R{} };
    │                        ^ Unused assignment for variable 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
    │
-   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E06001]: unused value without 'drop'
    ┌─ tests/move_check/locals/assign_partial_resource.move:20:24
@@ -81,7 +81,7 @@ warning[W09003]: unused assignment
 27 │         loop { r = R{} }
    │                ^ Unused assignment for variable 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
    │
-   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E06001]: unused value without 'drop'
    ┌─ tests/move_check/locals/assign_partial_resource.move:27:16

--- a/external-crates/move/move-compiler/tests/move_check/locals/assign_partial_resource.exp
+++ b/external-crates/move/move-compiler/tests/move_check/locals/assign_partial_resource.exp
@@ -3,6 +3,8 @@ warning[W09003]: unused assignment
   │
 6 │         if (cond) { r = R{}; };
   │                     ^ Unused assignment for variable 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
+  │
+  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E06001]: unused value without 'drop'
   ┌─ tests/move_check/locals/assign_partial_resource.move:7:9
@@ -22,6 +24,8 @@ warning[W09003]: unused assignment
    │
 13 │         if (cond) {} else { r = R{}; };
    │                             ^ Unused assignment for variable 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
+   │
+   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E06001]: unused value without 'drop'
    ┌─ tests/move_check/locals/assign_partial_resource.move:14:9
@@ -41,6 +45,8 @@ warning[W09003]: unused assignment
    │
 20 │         while (cond) { r = R{} };
    │                        ^ Unused assignment for variable 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
+   │
+   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E06001]: unused value without 'drop'
    ┌─ tests/move_check/locals/assign_partial_resource.move:20:24
@@ -74,6 +80,8 @@ warning[W09003]: unused assignment
    │
 27 │         loop { r = R{} }
    │                ^ Unused assignment for variable 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
+   │
+   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E06001]: unused value without 'drop'
    ┌─ tests/move_check/locals/assign_partial_resource.move:27:16

--- a/external-crates/move/move-compiler/tests/move_check/locals/assign_resource.exp
+++ b/external-crates/move/move-compiler/tests/move_check/locals/assign_resource.exp
@@ -4,7 +4,7 @@ warning[W09003]: unused assignment
 5 │         let r = R{};
   │             ^ Unused assignment for variable 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
   │
-  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E06001]: unused value without 'drop'
   ┌─ tests/move_check/locals/assign_resource.move:6:9
@@ -64,7 +64,7 @@ warning[W09003]: unused assignment
 29 │         let r = R{};
    │             ^ Unused assignment for variable 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
    │
-   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E06001]: unused value without 'drop'
    ┌─ tests/move_check/locals/assign_resource.move:30:16

--- a/external-crates/move/move-compiler/tests/move_check/locals/assign_resource.exp
+++ b/external-crates/move/move-compiler/tests/move_check/locals/assign_resource.exp
@@ -3,6 +3,8 @@ warning[W09003]: unused assignment
   │
 5 │         let r = R{};
   │             ^ Unused assignment for variable 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
+  │
+  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E06001]: unused value without 'drop'
   ┌─ tests/move_check/locals/assign_resource.move:6:9
@@ -61,6 +63,8 @@ warning[W09003]: unused assignment
    │
 29 │         let r = R{};
    │             ^ Unused assignment for variable 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
+   │
+   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E06001]: unused value without 'drop'
    ┌─ tests/move_check/locals/assign_resource.move:30:16

--- a/external-crates/move/move-compiler/tests/move_check/locals/unused_copyable.exp
+++ b/external-crates/move/move-compiler/tests/move_check/locals/unused_copyable.exp
@@ -4,7 +4,7 @@ warning[W09002]: unused variable
 5 │     fun t0(i: u64, s: S) {
   │            ^ Unused parameter 'i'. Consider removing or prefixing with an underscore: '_i'
   │
-  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09002]: unused variable
   ┌─ tests/move_check/locals/unused_copyable.move:5:20
@@ -12,7 +12,7 @@ warning[W09002]: unused variable
 5 │     fun t0(i: u64, s: S) {
   │                    ^ Unused parameter 's'. Consider removing or prefixing with an underscore: '_s'
   │
-  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09003]: unused assignment
   ┌─ tests/move_check/locals/unused_copyable.move:9:13
@@ -20,5 +20,5 @@ warning[W09003]: unused assignment
 9 │         let s = S{};
   │             ^ Unused assignment for variable 's'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_s')
   │
-  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/locals/unused_copyable.exp
+++ b/external-crates/move/move-compiler/tests/move_check/locals/unused_copyable.exp
@@ -3,16 +3,22 @@ warning[W09002]: unused variable
   │
 5 │     fun t0(i: u64, s: S) {
   │            ^ Unused parameter 'i'. Consider removing or prefixing with an underscore: '_i'
+  │
+  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09002]: unused variable
   ┌─ tests/move_check/locals/unused_copyable.move:5:20
   │
 5 │     fun t0(i: u64, s: S) {
   │                    ^ Unused parameter 's'. Consider removing or prefixing with an underscore: '_s'
+  │
+  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09003]: unused assignment
   ┌─ tests/move_check/locals/unused_copyable.move:9:13
   │
 9 │         let s = S{};
   │             ^ Unused assignment for variable 's'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_s')
+  │
+  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/locals/unused_resource.exp
+++ b/external-crates/move/move-compiler/tests/move_check/locals/unused_resource.exp
@@ -4,7 +4,7 @@ warning[W09003]: unused assignment
 5 │         let r = R{};
   │             ^ Unused assignment for variable 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
   │
-  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E06001]: unused value without 'drop'
   ┌─ tests/move_check/locals/unused_resource.move:5:20
@@ -36,7 +36,7 @@ warning[W09003]: unused assignment
 15 │         if (cond) { r = R{}; };
    │                     ^ Unused assignment for variable 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
    │
-   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E06001]: unused value without 'drop'
    ┌─ tests/move_check/locals/unused_resource.move:15:31
@@ -56,7 +56,7 @@ warning[W09003]: unused assignment
 20 │         if (cond) {} else { r = R{}; };
    │                             ^ Unused assignment for variable 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
    │
-   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E06001]: unused value without 'drop'
    ┌─ tests/move_check/locals/unused_resource.move:20:39
@@ -76,7 +76,7 @@ warning[W09003]: unused assignment
 25 │         while (cond) { r = R{} };
    │                        ^ Unused assignment for variable 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
    │
-   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E06001]: unused value without 'drop'
    ┌─ tests/move_check/locals/unused_resource.move:25:24
@@ -108,7 +108,7 @@ warning[W09003]: unused assignment
 29 │         loop { let r = R{}; }
    │                    ^ Unused assignment for variable 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
    │
-   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E06001]: unused value without 'drop'
    ┌─ tests/move_check/locals/unused_resource.move:29:20

--- a/external-crates/move/move-compiler/tests/move_check/locals/unused_resource.exp
+++ b/external-crates/move/move-compiler/tests/move_check/locals/unused_resource.exp
@@ -3,6 +3,8 @@ warning[W09003]: unused assignment
   │
 5 │         let r = R{};
   │             ^ Unused assignment for variable 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
+  │
+  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E06001]: unused value without 'drop'
   ┌─ tests/move_check/locals/unused_resource.move:5:20
@@ -33,6 +35,8 @@ warning[W09003]: unused assignment
    │
 15 │         if (cond) { r = R{}; };
    │                     ^ Unused assignment for variable 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
+   │
+   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E06001]: unused value without 'drop'
    ┌─ tests/move_check/locals/unused_resource.move:15:31
@@ -51,6 +55,8 @@ warning[W09003]: unused assignment
    │
 20 │         if (cond) {} else { r = R{}; };
    │                             ^ Unused assignment for variable 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
+   │
+   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E06001]: unused value without 'drop'
    ┌─ tests/move_check/locals/unused_resource.move:20:39
@@ -69,6 +75,8 @@ warning[W09003]: unused assignment
    │
 25 │         while (cond) { r = R{} };
    │                        ^ Unused assignment for variable 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
+   │
+   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E06001]: unused value without 'drop'
    ┌─ tests/move_check/locals/unused_resource.move:25:24
@@ -99,6 +107,8 @@ warning[W09003]: unused assignment
    │
 29 │         loop { let r = R{}; }
    │                    ^ Unused assignment for variable 'r'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r')
+   │
+   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E06001]: unused value without 'drop'
    ┌─ tests/move_check/locals/unused_resource.move:29:20

--- a/external-crates/move/move-compiler/tests/move_check/locals/use_before_assign_while.exp
+++ b/external-crates/move/move-compiler/tests/move_check/locals/use_before_assign_while.exp
@@ -35,4 +35,6 @@ warning[W09003]: unused assignment
    │
 19 │         while (cond) { let y = &x; _ = move y; if (cond) { x = 0 }; break }
    │                                                            ^ Unused assignment for variable 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
+   │
+   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/locals/use_before_assign_while.exp
+++ b/external-crates/move/move-compiler/tests/move_check/locals/use_before_assign_while.exp
@@ -36,5 +36,5 @@ warning[W09003]: unused assignment
 19 │         while (cond) { let y = &x; _ = move y; if (cond) { x = 0 }; break }
    │                                                            ^ Unused assignment for variable 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
    │
-   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/naming/duplicate_type_parameter_struct.exp
+++ b/external-crates/move/move-compiler/tests/move_check/naming/duplicate_type_parameter_struct.exp
@@ -4,7 +4,7 @@ warning[W09006]: unused struct type parameter
 2 │     struct S<T, T> { f: T }
   │              ^ Unused type parameter 'T'. Consider declaring it as phantom
   │
-  = This warning can be suppressed with with '#[allow(type_parameter)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_type_parameter)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/naming/duplicate_type_parameter_struct.move:2:17
@@ -20,7 +20,7 @@ warning[W09006]: unused struct type parameter
 3 │     struct S2<T: drop, T: key, T> { f: T }
   │               ^ Unused type parameter 'T'. Consider declaring it as phantom
   │
-  = This warning can be suppressed with with '#[allow(type_parameter)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_type_parameter)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/naming/duplicate_type_parameter_struct.move:3:24
@@ -36,7 +36,7 @@ warning[W09006]: unused struct type parameter
 3 │     struct S2<T: drop, T: key, T> { f: T }
   │                        ^ Unused type parameter 'T'. Consider declaring it as phantom
   │
-  = This warning can be suppressed with with '#[allow(type_parameter)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_type_parameter)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/naming/duplicate_type_parameter_struct.move:3:32
@@ -52,7 +52,7 @@ warning[W09006]: unused struct type parameter
 4 │     struct R<T, T> { f: T }
   │              ^ Unused type parameter 'T'. Consider declaring it as phantom
   │
-  = This warning can be suppressed with with '#[allow(type_parameter)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_type_parameter)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/naming/duplicate_type_parameter_struct.move:4:17
@@ -68,7 +68,7 @@ warning[W09006]: unused struct type parameter
 5 │     struct R2<T: drop, T: key, T> { f: T }
   │               ^ Unused type parameter 'T'. Consider declaring it as phantom
   │
-  = This warning can be suppressed with with '#[allow(type_parameter)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_type_parameter)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/naming/duplicate_type_parameter_struct.move:5:24
@@ -84,7 +84,7 @@ warning[W09006]: unused struct type parameter
 5 │     struct R2<T: drop, T: key, T> { f: T }
   │                        ^ Unused type parameter 'T'. Consider declaring it as phantom
   │
-  = This warning can be suppressed with with '#[allow(type_parameter)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_type_parameter)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/naming/duplicate_type_parameter_struct.move:5:32

--- a/external-crates/move/move-compiler/tests/move_check/naming/duplicate_type_parameter_struct.exp
+++ b/external-crates/move/move-compiler/tests/move_check/naming/duplicate_type_parameter_struct.exp
@@ -3,6 +3,8 @@ warning[W09006]: unused struct type parameter
   │
 2 │     struct S<T, T> { f: T }
   │              ^ Unused type parameter 'T'. Consider declaring it as phantom
+  │
+  = This warning can be suppressed with with '#[allow(type_parameter)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/naming/duplicate_type_parameter_struct.move:2:17
@@ -17,6 +19,8 @@ warning[W09006]: unused struct type parameter
   │
 3 │     struct S2<T: drop, T: key, T> { f: T }
   │               ^ Unused type parameter 'T'. Consider declaring it as phantom
+  │
+  = This warning can be suppressed with with '#[allow(type_parameter)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/naming/duplicate_type_parameter_struct.move:3:24
@@ -31,6 +35,8 @@ warning[W09006]: unused struct type parameter
   │
 3 │     struct S2<T: drop, T: key, T> { f: T }
   │                        ^ Unused type parameter 'T'. Consider declaring it as phantom
+  │
+  = This warning can be suppressed with with '#[allow(type_parameter)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/naming/duplicate_type_parameter_struct.move:3:32
@@ -45,6 +51,8 @@ warning[W09006]: unused struct type parameter
   │
 4 │     struct R<T, T> { f: T }
   │              ^ Unused type parameter 'T'. Consider declaring it as phantom
+  │
+  = This warning can be suppressed with with '#[allow(type_parameter)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/naming/duplicate_type_parameter_struct.move:4:17
@@ -59,6 +67,8 @@ warning[W09006]: unused struct type parameter
   │
 5 │     struct R2<T: drop, T: key, T> { f: T }
   │               ^ Unused type parameter 'T'. Consider declaring it as phantom
+  │
+  = This warning can be suppressed with with '#[allow(type_parameter)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/naming/duplicate_type_parameter_struct.move:5:24
@@ -73,6 +83,8 @@ warning[W09006]: unused struct type parameter
   │
 5 │     struct R2<T: drop, T: key, T> { f: T }
   │                        ^ Unused type parameter 'T'. Consider declaring it as phantom
+  │
+  = This warning can be suppressed with with '#[allow(type_parameter)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/naming/duplicate_type_parameter_struct.move:5:32

--- a/external-crates/move/move-compiler/tests/move_check/naming/standalone_module_ident.exp
+++ b/external-crates/move/move-compiler/tests/move_check/naming/standalone_module_ident.exp
@@ -4,7 +4,7 @@ warning[W09001]: unused alias
 6 │     use 0x2::X;
   │              ^ Unused 'use' of alias 'X'. Consider removing it
   │
-  = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E03005]: unbound unscoped name
   ┌─ tests/move_check/naming/standalone_module_ident.move:8:17

--- a/external-crates/move/move-compiler/tests/move_check/naming/standalone_module_ident.exp
+++ b/external-crates/move/move-compiler/tests/move_check/naming/standalone_module_ident.exp
@@ -3,6 +3,8 @@ warning[W09001]: unused alias
   │
 6 │     use 0x2::X;
   │              ^ Unused 'use' of alias 'X'. Consider removing it
+  │
+  = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E03005]: unbound unscoped name
   ┌─ tests/move_check/naming/standalone_module_ident.move:8:17

--- a/external-crates/move/move-compiler/tests/move_check/parser/control_exp_as_term.exp
+++ b/external-crates/move/move-compiler/tests/move_check/parser/control_exp_as_term.exp
@@ -4,7 +4,7 @@ warning[W09005]: dead or unreachable code
 7 │         1 + loop {} + 2;
   │             ^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
   │
-  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
   ┌─ tests/move_check/parser/control_exp_as_term.move:8:13
@@ -12,7 +12,7 @@ warning[W09005]: dead or unreachable code
 8 │         1 + return + 0;
   │             ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
   │
-  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/control_exp_as_term.move:10:14
@@ -20,7 +20,7 @@ warning[W09005]: dead or unreachable code
 10 │         foo(&if (cond) 0 else 1);
    │              ^^^^^^^^^^^^^^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
    │
-   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/control_exp_as_term.move:11:14
@@ -28,7 +28,7 @@ warning[W09005]: dead or unreachable code
 11 │         foo(&loop {});
    │              ^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
    │
-   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/control_exp_as_term.move:12:14
@@ -36,7 +36,7 @@ warning[W09005]: dead or unreachable code
 12 │         foo(&return);
    │              ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
    │
-   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/control_exp_as_term.move:13:14
@@ -44,5 +44,5 @@ warning[W09005]: dead or unreachable code
 13 │         foo(&abort 0);
    │              ^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
    │
-   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/parser/control_exp_as_term.exp
+++ b/external-crates/move/move-compiler/tests/move_check/parser/control_exp_as_term.exp
@@ -3,34 +3,46 @@ warning[W09005]: dead or unreachable code
   │
 7 │         1 + loop {} + 2;
   │             ^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+  │
+  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
   ┌─ tests/move_check/parser/control_exp_as_term.move:8:13
   │
 8 │         1 + return + 0;
   │             ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+  │
+  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/control_exp_as_term.move:10:14
    │
 10 │         foo(&if (cond) 0 else 1);
    │              ^^^^^^^^^^^^^^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
+   │
+   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/control_exp_as_term.move:11:14
    │
 11 │         foo(&loop {});
    │              ^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+   │
+   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/control_exp_as_term.move:12:14
    │
 12 │         foo(&return);
    │              ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+   │
+   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/control_exp_as_term.move:13:14
    │
 13 │         foo(&abort 0);
    │              ^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+   │
+   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/parser/control_exp_associativity_unreachable_code.exp
+++ b/external-crates/move/move-compiler/tests/move_check/parser/control_exp_associativity_unreachable_code.exp
@@ -3,70 +3,94 @@ warning[W09002]: unused variable
   │
 9 │     fun t(cond: bool): u64 {
   │           ^^^^ Unused parameter 'cond'. Consider removing or prefixing with an underscore: '_cond'
+  │
+  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:11:13
    │
 11 │         1 + loop { foo() } + 2;
    │             ^^^^^^^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+   │
+   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:12:13
    │
 12 │         1 + loop foo();
    │             ^^^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+   │
+   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:12:18
    │
 12 │         1 + loop foo();
    │                  ^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
+   │
+   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:13:9
    │
 13 │         loop { foo() } + 1;
    │         ^^^^^^^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+   │
+   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:13:16
    │
 13 │         loop { foo() } + 1;
    │                ^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
+   │
+   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:17:9
    │
 17 │         return { 1 + 2 };
    │         ^^^^^^^^^^^^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
+   │
+   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:18:9
    │
 18 │         return { 1 } && false;
    │         ^^^^^^^^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
+   │
+   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:18:9
    │
 18 │         return { 1 } && false;
    │         ^^^^^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+   │
+   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:22:9
    │
 22 │         abort { 1 + 2 };
    │         ^^^^^^^^^^^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
+   │
+   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:23:9
    │
 23 │         abort { 1 } && false;
    │         ^^^^^^^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
+   │
+   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:23:9
    │
 23 │         abort { 1 } && false;
    │         ^^^^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+   │
+   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/parser/control_exp_associativity_unreachable_code.exp
+++ b/external-crates/move/move-compiler/tests/move_check/parser/control_exp_associativity_unreachable_code.exp
@@ -4,7 +4,7 @@ warning[W09002]: unused variable
 9 │     fun t(cond: bool): u64 {
   │           ^^^^ Unused parameter 'cond'. Consider removing or prefixing with an underscore: '_cond'
   │
-  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:11:13
@@ -12,7 +12,7 @@ warning[W09005]: dead or unreachable code
 11 │         1 + loop { foo() } + 2;
    │             ^^^^^^^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
    │
-   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:12:13
@@ -20,7 +20,7 @@ warning[W09005]: dead or unreachable code
 12 │         1 + loop foo();
    │             ^^^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
    │
-   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:12:18
@@ -28,7 +28,7 @@ warning[W09005]: dead or unreachable code
 12 │         1 + loop foo();
    │                  ^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
    │
-   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:13:9
@@ -36,7 +36,7 @@ warning[W09005]: dead or unreachable code
 13 │         loop { foo() } + 1;
    │         ^^^^^^^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
    │
-   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:13:16
@@ -44,7 +44,7 @@ warning[W09005]: dead or unreachable code
 13 │         loop { foo() } + 1;
    │                ^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
    │
-   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:17:9
@@ -52,7 +52,7 @@ warning[W09005]: dead or unreachable code
 17 │         return { 1 + 2 };
    │         ^^^^^^^^^^^^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
    │
-   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:18:9
@@ -60,7 +60,7 @@ warning[W09005]: dead or unreachable code
 18 │         return { 1 } && false;
    │         ^^^^^^^^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
    │
-   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:18:9
@@ -68,7 +68,7 @@ warning[W09005]: dead or unreachable code
 18 │         return { 1 } && false;
    │         ^^^^^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
    │
-   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:22:9
@@ -76,7 +76,7 @@ warning[W09005]: dead or unreachable code
 22 │         abort { 1 + 2 };
    │         ^^^^^^^^^^^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
    │
-   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:23:9
@@ -84,7 +84,7 @@ warning[W09005]: dead or unreachable code
 23 │         abort { 1 } && false;
    │         ^^^^^^^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
    │
-   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/control_exp_associativity_unreachable_code.move:23:9
@@ -92,5 +92,5 @@ warning[W09005]: dead or unreachable code
 23 │         abort { 1 } && false;
    │         ^^^^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
    │
-   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/parser/doc_comments_placement.exp
+++ b/external-crates/move/move-compiler/tests/move_check/parser/doc_comments_placement.exp
@@ -3,28 +3,38 @@ warning[W01004]: invalid documentation comment
   │
 6 │     /** There can be no doc comment on uses. */
   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Documentation comment cannot be matched to a language item
+  │
+  = This warning can be suppressed with with '#[allow(invalid_doc_comment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W01004]: invalid documentation comment
    ┌─ tests/move_check/parser/doc_comments_placement.move:16:9
    │
 16 │         /// There can be no doc comment after last field.
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Documentation comment cannot be matched to a language item
+   │
+   = This warning can be suppressed with with '#[allow(invalid_doc_comment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W01004]: invalid documentation comment
    ┌─ tests/move_check/parser/doc_comments_placement.move:23:9
    │
 23 │         /// There can be no doc comment after last block member.
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Documentation comment cannot be matched to a language item
+   │
+   = This warning can be suppressed with with '#[allow(invalid_doc_comment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W01004]: invalid documentation comment
    ┌─ tests/move_check/parser/doc_comments_placement.move:26:5
    │
 26 │     /// There can be no doc comment after last module item.
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Documentation comment cannot be matched to a language item
+   │
+   = This warning can be suppressed with with '#[allow(invalid_doc_comment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W01004]: invalid documentation comment
    ┌─ tests/move_check/parser/doc_comments_placement.move:29:1
    │
 29 │ /// There can be no doc comment at end of file.
    │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Documentation comment cannot be matched to a language item
+   │
+   = This warning can be suppressed with with '#[allow(invalid_doc_comment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/parser/doc_comments_placement.exp
+++ b/external-crates/move/move-compiler/tests/move_check/parser/doc_comments_placement.exp
@@ -3,38 +3,28 @@ warning[W01004]: invalid documentation comment
   │
 6 │     /** There can be no doc comment on uses. */
   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Documentation comment cannot be matched to a language item
-  │
-  = This warning can be suppressed with with '#[allow(invalid_doc_comment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W01004]: invalid documentation comment
    ┌─ tests/move_check/parser/doc_comments_placement.move:16:9
    │
 16 │         /// There can be no doc comment after last field.
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Documentation comment cannot be matched to a language item
-   │
-   = This warning can be suppressed with with '#[allow(invalid_doc_comment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W01004]: invalid documentation comment
    ┌─ tests/move_check/parser/doc_comments_placement.move:23:9
    │
 23 │         /// There can be no doc comment after last block member.
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Documentation comment cannot be matched to a language item
-   │
-   = This warning can be suppressed with with '#[allow(invalid_doc_comment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W01004]: invalid documentation comment
    ┌─ tests/move_check/parser/doc_comments_placement.move:26:5
    │
 26 │     /// There can be no doc comment after last module item.
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Documentation comment cannot be matched to a language item
-   │
-   = This warning can be suppressed with with '#[allow(invalid_doc_comment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W01004]: invalid documentation comment
    ┌─ tests/move_check/parser/doc_comments_placement.move:29:1
    │
 29 │ /// There can be no doc comment at end of file.
    │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Documentation comment cannot be matched to a language item
-   │
-   = This warning can be suppressed with with '#[allow(invalid_doc_comment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/parser/return_in_binop.exp
+++ b/external-crates/move/move-compiler/tests/move_check/parser/return_in_binop.exp
@@ -4,7 +4,7 @@ warning[W09005]: dead or unreachable code
 3 │         return >> 0;
   │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
   │
-  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
   ┌─ tests/move_check/parser/return_in_binop.move:4:9
@@ -12,7 +12,7 @@ warning[W09005]: dead or unreachable code
 4 │         return << 0;
   │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
   │
-  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
   ┌─ tests/move_check/parser/return_in_binop.move:5:9
@@ -20,7 +20,7 @@ warning[W09005]: dead or unreachable code
 5 │         return || false;
   │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
   │
-  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
   ┌─ tests/move_check/parser/return_in_binop.move:6:9
@@ -28,7 +28,7 @@ warning[W09005]: dead or unreachable code
 6 │         return && false;
   │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
   │
-  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
   ┌─ tests/move_check/parser/return_in_binop.move:7:9
@@ -36,7 +36,7 @@ warning[W09005]: dead or unreachable code
 7 │         return + 0;
   │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
   │
-  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
   ┌─ tests/move_check/parser/return_in_binop.move:8:9
@@ -44,7 +44,7 @@ warning[W09005]: dead or unreachable code
 8 │         return - 0;
   │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
   │
-  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
   ┌─ tests/move_check/parser/return_in_binop.move:9:9
@@ -52,7 +52,7 @@ warning[W09005]: dead or unreachable code
 9 │         return % 0;
   │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
   │
-  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/return_in_binop.move:10:9
@@ -60,7 +60,7 @@ warning[W09005]: dead or unreachable code
 10 │         return / 1;
    │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
    │
-   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/return_in_binop.move:11:9
@@ -68,7 +68,7 @@ warning[W09005]: dead or unreachable code
 11 │         return < 0;
    │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
    │
-   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/return_in_binop.move:12:9
@@ -76,7 +76,7 @@ warning[W09005]: dead or unreachable code
 12 │         return > 0;
    │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
    │
-   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/return_in_binop.move:13:9
@@ -84,7 +84,7 @@ warning[W09005]: dead or unreachable code
 13 │         return <= 0;
    │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
    │
-   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/return_in_binop.move:14:9
@@ -92,7 +92,7 @@ warning[W09005]: dead or unreachable code
 14 │         return == 0;
    │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
    │
-   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/return_in_binop.move:15:9
@@ -100,7 +100,7 @@ warning[W09005]: dead or unreachable code
 15 │         return >= 0;
    │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
    │
-   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/return_in_binop.move:16:9
@@ -108,7 +108,7 @@ warning[W09005]: dead or unreachable code
 16 │         return != 0;
    │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
    │
-   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/return_in_binop.move:17:9
@@ -116,7 +116,7 @@ warning[W09005]: dead or unreachable code
 17 │         return | 0;
    │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
    │
-   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/return_in_binop.move:18:9
@@ -124,5 +124,5 @@ warning[W09005]: dead or unreachable code
 18 │         return ^ 0;
    │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
    │
-   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/parser/return_in_binop.exp
+++ b/external-crates/move/move-compiler/tests/move_check/parser/return_in_binop.exp
@@ -3,94 +3,126 @@ warning[W09005]: dead or unreachable code
   │
 3 │         return >> 0;
   │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+  │
+  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
   ┌─ tests/move_check/parser/return_in_binop.move:4:9
   │
 4 │         return << 0;
   │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+  │
+  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
   ┌─ tests/move_check/parser/return_in_binop.move:5:9
   │
 5 │         return || false;
   │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+  │
+  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
   ┌─ tests/move_check/parser/return_in_binop.move:6:9
   │
 6 │         return && false;
   │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+  │
+  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
   ┌─ tests/move_check/parser/return_in_binop.move:7:9
   │
 7 │         return + 0;
   │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+  │
+  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
   ┌─ tests/move_check/parser/return_in_binop.move:8:9
   │
 8 │         return - 0;
   │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+  │
+  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
   ┌─ tests/move_check/parser/return_in_binop.move:9:9
   │
 9 │         return % 0;
   │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+  │
+  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/return_in_binop.move:10:9
    │
 10 │         return / 1;
    │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+   │
+   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/return_in_binop.move:11:9
    │
 11 │         return < 0;
    │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+   │
+   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/return_in_binop.move:12:9
    │
 12 │         return > 0;
    │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+   │
+   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/return_in_binop.move:13:9
    │
 13 │         return <= 0;
    │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+   │
+   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/return_in_binop.move:14:9
    │
 14 │         return == 0;
    │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+   │
+   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/return_in_binop.move:15:9
    │
 15 │         return >= 0;
    │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+   │
+   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/return_in_binop.move:16:9
    │
 16 │         return != 0;
    │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+   │
+   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/return_in_binop.move:17:9
    │
 17 │         return | 0;
    │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+   │
+   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/parser/return_in_binop.move:18:9
    │
 18 │         return ^ 0;
    │         ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+   │
+   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/parser/spec_parsing_fun_type_fail.exp
+++ b/external-crates/move/move-compiler/tests/move_check/parser/spec_parsing_fun_type_fail.exp
@@ -3,6 +3,8 @@ warning[W09002]: unused variable
   │
 2 │     fun fun_type_in_prog(p: |u64|u64) {
   │                          ^ Unused parameter 'p'. Consider removing or prefixing with an underscore: '_p'
+  │
+  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E01010]: syntax item restricted to spec contexts
   ┌─ tests/move_check/parser/spec_parsing_fun_type_fail.move:2:29

--- a/external-crates/move/move-compiler/tests/move_check/parser/spec_parsing_fun_type_fail.exp
+++ b/external-crates/move/move-compiler/tests/move_check/parser/spec_parsing_fun_type_fail.exp
@@ -4,7 +4,7 @@ warning[W09002]: unused variable
 2 │     fun fun_type_in_prog(p: |u64|u64) {
   │                          ^ Unused parameter 'p'. Consider removing or prefixing with an underscore: '_p'
   │
-  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E01010]: syntax item restricted to spec contexts
   ┌─ tests/move_check/parser/spec_parsing_fun_type_fail.move:2:29

--- a/external-crates/move/move-compiler/tests/move_check/parser/spec_parsing_index_fail.exp
+++ b/external-crates/move/move-compiler/tests/move_check/parser/spec_parsing_index_fail.exp
@@ -4,7 +4,7 @@ warning[W09002]: unused variable
 2 │     fun index_in_prog(x: u64) {
   │                       ^ Unused parameter 'x'. Consider removing or prefixing with an underscore: '_x'
   │
-  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E01010]: syntax item restricted to spec contexts
   ┌─ tests/move_check/parser/spec_parsing_index_fail.move:3:15

--- a/external-crates/move/move-compiler/tests/move_check/parser/spec_parsing_index_fail.exp
+++ b/external-crates/move/move-compiler/tests/move_check/parser/spec_parsing_index_fail.exp
@@ -3,6 +3,8 @@ warning[W09002]: unused variable
   │
 2 │     fun index_in_prog(x: u64) {
   │                       ^ Unused parameter 'x'. Consider removing or prefixing with an underscore: '_x'
+  │
+  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E01010]: syntax item restricted to spec contexts
   ┌─ tests/move_check/parser/spec_parsing_index_fail.move:3:15

--- a/external-crates/move/move-compiler/tests/move_check/parser/spec_parsing_lambda_fail.exp
+++ b/external-crates/move/move-compiler/tests/move_check/parser/spec_parsing_lambda_fail.exp
@@ -3,6 +3,8 @@ warning[W09002]: unused variable
   │
 2 │     fun lambda_in_prog(x: u64) {
   │                        ^ Unused parameter 'x'. Consider removing or prefixing with an underscore: '_x'
+  │
+  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E01010]: syntax item restricted to spec contexts
   ┌─ tests/move_check/parser/spec_parsing_lambda_fail.move:3:15

--- a/external-crates/move/move-compiler/tests/move_check/parser/spec_parsing_lambda_fail.exp
+++ b/external-crates/move/move-compiler/tests/move_check/parser/spec_parsing_lambda_fail.exp
@@ -4,7 +4,7 @@ warning[W09002]: unused variable
 2 │     fun lambda_in_prog(x: u64) {
   │                        ^ Unused parameter 'x'. Consider removing or prefixing with an underscore: '_x'
   │
-  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E01010]: syntax item restricted to spec contexts
   ┌─ tests/move_check/parser/spec_parsing_lambda_fail.move:3:15

--- a/external-crates/move/move-compiler/tests/move_check/translated_ir_tests/move/commands/break_unreachable.exp
+++ b/external-crates/move/move-compiler/tests/move_check/translated_ir_tests/move/commands/break_unreachable.exp
@@ -4,5 +4,5 @@ warning[W09005]: dead or unreachable code
 8 │         x = 5;
   │         ^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
   │
-  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/translated_ir_tests/move/commands/break_unreachable.exp
+++ b/external-crates/move/move-compiler/tests/move_check/translated_ir_tests/move/commands/break_unreachable.exp
@@ -3,4 +3,6 @@ warning[W09005]: dead or unreachable code
   │
 8 │         x = 5;
   │         ^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
+  │
+  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/translated_ir_tests/move/commands/dead_return.exp
+++ b/external-crates/move/move-compiler/tests/move_check/translated_ir_tests/move/commands/dead_return.exp
@@ -4,5 +4,5 @@ warning[W09005]: dead or unreachable code
 4 │         return 0
   │         ^^^^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
   │
-  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/translated_ir_tests/move/commands/dead_return.exp
+++ b/external-crates/move/move-compiler/tests/move_check/translated_ir_tests/move/commands/dead_return.exp
@@ -3,4 +3,6 @@ warning[W09005]: dead or unreachable code
   │
 4 │         return 0
   │         ^^^^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
+  │
+  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/translated_ir_tests/move/commands/dead_return_local.exp
+++ b/external-crates/move/move-compiler/tests/move_check/translated_ir_tests/move/commands/dead_return_local.exp
@@ -4,7 +4,7 @@ warning[W09005]: dead or unreachable code
 4 │     assert!(false, 42);
   │     ^^^^^^^^^^^^^^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
   │
-  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
   ┌─ tests/move_check/translated_ir_tests/move/commands/dead_return_local.move:5:5
@@ -12,5 +12,5 @@ warning[W09005]: dead or unreachable code
 5 │     return ()
   │     ^^^^^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
   │
-  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/translated_ir_tests/move/commands/dead_return_local.exp
+++ b/external-crates/move/move-compiler/tests/move_check/translated_ir_tests/move/commands/dead_return_local.exp
@@ -3,10 +3,14 @@ warning[W09005]: dead or unreachable code
   │
 4 │     assert!(false, 42);
   │     ^^^^^^^^^^^^^^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
+  │
+  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
   ┌─ tests/move_check/translated_ir_tests/move/commands/dead_return_local.move:5:5
   │
 5 │     return ()
   │     ^^^^^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
+  │
+  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/translated_ir_tests/move/commands/invalid_fallthrough2.exp
+++ b/external-crates/move/move-compiler/tests/move_check/translated_ir_tests/move/commands/invalid_fallthrough2.exp
@@ -4,5 +4,5 @@ warning[W09005]: dead or unreachable code
 5 │   x = 7
   │   ^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
   │
-  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/translated_ir_tests/move/commands/invalid_fallthrough2.exp
+++ b/external-crates/move/move-compiler/tests/move_check/translated_ir_tests/move/commands/invalid_fallthrough2.exp
@@ -3,4 +3,6 @@ warning[W09005]: dead or unreachable code
   │
 5 │   x = 7
   │   ^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
+  │
+  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/translated_ir_tests/move/commands/invalid_fallthrough3.exp
+++ b/external-crates/move/move-compiler/tests/move_check/translated_ir_tests/move/commands/invalid_fallthrough3.exp
@@ -4,5 +4,5 @@ warning[W09005]: dead or unreachable code
 5 │   x = 7;
   │   ^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
   │
-  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/translated_ir_tests/move/commands/invalid_fallthrough3.exp
+++ b/external-crates/move/move-compiler/tests/move_check/translated_ir_tests/move/commands/invalid_fallthrough3.exp
@@ -3,4 +3,6 @@ warning[W09005]: dead or unreachable code
   │
 5 │   x = 7;
   │   ^^^^^ Unreachable code. This statement (and any following statements) will not be executed.
+  │
+  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/translated_ir_tests/move/commands/mixed_lvalue.exp
+++ b/external-crates/move/move-compiler/tests/move_check/translated_ir_tests/move/commands/mixed_lvalue.exp
@@ -4,7 +4,7 @@ warning[W09003]: unused assignment
 11 │         let r_ref = &mut r;
    │             ^^^^^ Unused assignment for variable 'r_ref'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r_ref')
    │
-   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09003]: unused assignment
    ┌─ tests/move_check/translated_ir_tests/move/commands/mixed_lvalue.move:12:13
@@ -12,7 +12,7 @@ warning[W09003]: unused assignment
 12 │         let s = S { f: 0 };
    │             ^ Unused assignment for variable 's'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_s')
    │
-   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E01009]: invalid assignment
    ┌─ tests/move_check/translated_ir_tests/move/commands/mixed_lvalue.move:14:19

--- a/external-crates/move/move-compiler/tests/move_check/translated_ir_tests/move/commands/mixed_lvalue.exp
+++ b/external-crates/move/move-compiler/tests/move_check/translated_ir_tests/move/commands/mixed_lvalue.exp
@@ -3,12 +3,16 @@ warning[W09003]: unused assignment
    │
 11 │         let r_ref = &mut r;
    │             ^^^^^ Unused assignment for variable 'r_ref'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_r_ref')
+   │
+   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09003]: unused assignment
    ┌─ tests/move_check/translated_ir_tests/move/commands/mixed_lvalue.move:12:13
    │
 12 │         let s = S { f: 0 };
    │             ^ Unused assignment for variable 's'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_s')
+   │
+   = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E01009]: invalid assignment
    ┌─ tests/move_check/translated_ir_tests/move/commands/mixed_lvalue.move:14:19

--- a/external-crates/move/move-compiler/tests/move_check/translated_ir_tests/move/commands/move_before_assign.exp
+++ b/external-crates/move/move-compiler/tests/move_check/translated_ir_tests/move/commands/move_before_assign.exp
@@ -4,7 +4,7 @@ warning[W09003]: unused assignment
 4 │     let y = move x;
   │         ^ Unused assignment for variable 'y'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_y')
   │
-  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E06002]: use of unassigned variable
   ┌─ tests/move_check/translated_ir_tests/move/commands/move_before_assign.move:4:13

--- a/external-crates/move/move-compiler/tests/move_check/translated_ir_tests/move/commands/move_before_assign.exp
+++ b/external-crates/move/move-compiler/tests/move_check/translated_ir_tests/move/commands/move_before_assign.exp
@@ -3,6 +3,8 @@ warning[W09003]: unused assignment
   │
 4 │     let y = move x;
   │         ^ Unused assignment for variable 'y'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_y')
+  │
+  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E06002]: use of unassigned variable
   ┌─ tests/move_check/translated_ir_tests/move/commands/move_before_assign.move:4:13

--- a/external-crates/move/move-compiler/tests/move_check/translated_ir_tests/move/commands/use_before_assign.exp
+++ b/external-crates/move/move-compiler/tests/move_check/translated_ir_tests/move/commands/use_before_assign.exp
@@ -4,7 +4,7 @@ warning[W09003]: unused assignment
 4 │     let y = x;
   │         ^ Unused assignment for variable 'y'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_y')
   │
-  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E06002]: use of unassigned variable
   ┌─ tests/move_check/translated_ir_tests/move/commands/use_before_assign.move:4:13

--- a/external-crates/move/move-compiler/tests/move_check/translated_ir_tests/move/commands/use_before_assign.exp
+++ b/external-crates/move/move-compiler/tests/move_check/translated_ir_tests/move/commands/use_before_assign.exp
@@ -3,6 +3,8 @@ warning[W09003]: unused assignment
   │
 4 │     let y = x;
   │         ^ Unused assignment for variable 'y'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_y')
+  │
+  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E06002]: use of unassigned variable
   ┌─ tests/move_check/translated_ir_tests/move/commands/use_before_assign.move:4:13

--- a/external-crates/move/move-compiler/tests/move_check/typing/abort_any_type.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/abort_any_type.exp
@@ -4,7 +4,7 @@ warning[W09005]: dead or unreachable code
 5 │         0 + (abort 0);
   │             ^^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
   │
-  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
   ┌─ tests/move_check/typing/abort_any_type.move:9:13
@@ -12,5 +12,5 @@ warning[W09005]: dead or unreachable code
 9 │         foo(abort 0);
   │             ^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
   │
-  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/typing/abort_any_type.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/abort_any_type.exp
@@ -3,10 +3,14 @@ warning[W09005]: dead or unreachable code
   │
 5 │         0 + (abort 0);
   │             ^^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+  │
+  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
   ┌─ tests/move_check/typing/abort_any_type.move:9:13
   │
 9 │         foo(abort 0);
   │             ^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+  │
+  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/typing/assign_duplicate_assigning.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/assign_duplicate_assigning.exp
@@ -3,6 +3,8 @@ warning[W09003]: unused assignment
   │
 6 │         (x, x) = (0, 0);
   │          ^ Unused assignment for variable 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
+  │
+  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/typing/assign_duplicate_assigning.move:6:13
@@ -17,12 +19,16 @@ warning[W09003]: unused assignment
   │
 6 │         (x, x) = (0, 0);
   │             ^ Unused assignment for variable 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
+  │
+  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09003]: unused assignment
   ┌─ tests/move_check/typing/assign_duplicate_assigning.move:8:10
   │
 8 │         (f, R{f}, f) = (0, R { f: 0 }, 0);
   │          ^ Unused assignment for variable 'f'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_f')
+  │
+  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/typing/assign_duplicate_assigning.move:8:15
@@ -37,6 +43,8 @@ warning[W09003]: unused assignment
   │
 8 │         (f, R{f}, f) = (0, R { f: 0 }, 0);
   │               ^ Unused assignment for variable 'f'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_f')
+  │
+  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/typing/assign_duplicate_assigning.move:8:19
@@ -51,4 +59,6 @@ warning[W09003]: unused assignment
   │
 8 │         (f, R{f}, f) = (0, R { f: 0 }, 0);
   │                   ^ Unused assignment for variable 'f'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_f')
+  │
+  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/typing/assign_duplicate_assigning.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/assign_duplicate_assigning.exp
@@ -4,7 +4,7 @@ warning[W09003]: unused assignment
 6 │         (x, x) = (0, 0);
   │          ^ Unused assignment for variable 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
   │
-  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/typing/assign_duplicate_assigning.move:6:13
@@ -20,7 +20,7 @@ warning[W09003]: unused assignment
 6 │         (x, x) = (0, 0);
   │             ^ Unused assignment for variable 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
   │
-  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09003]: unused assignment
   ┌─ tests/move_check/typing/assign_duplicate_assigning.move:8:10
@@ -28,7 +28,7 @@ warning[W09003]: unused assignment
 8 │         (f, R{f}, f) = (0, R { f: 0 }, 0);
   │          ^ Unused assignment for variable 'f'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_f')
   │
-  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/typing/assign_duplicate_assigning.move:8:15
@@ -44,7 +44,7 @@ warning[W09003]: unused assignment
 8 │         (f, R{f}, f) = (0, R { f: 0 }, 0);
   │               ^ Unused assignment for variable 'f'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_f')
   │
-  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/typing/assign_duplicate_assigning.move:8:19
@@ -60,5 +60,5 @@ warning[W09003]: unused assignment
 8 │         (f, R{f}, f) = (0, R { f: 0 }, 0);
   │                   ^ Unused assignment for variable 'f'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_f')
   │
-  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/typing/assign_nested.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/assign_nested.exp
@@ -4,7 +4,7 @@ warning[W09002]: unused variable
 10 │         let x: u64;
    │             ^ Unused local variable 'x'. Consider removing or prefixing with an underscore: '_x'
    │
-   = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E01009]: invalid assignment
    ┌─ tests/move_check/typing/assign_nested.move:14:19

--- a/external-crates/move/move-compiler/tests/move_check/typing/assign_nested.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/assign_nested.exp
@@ -3,6 +3,8 @@ warning[W09002]: unused variable
    │
 10 │         let x: u64;
    │             ^ Unused local variable 'x'. Consider removing or prefixing with an underscore: '_x'
+   │
+   = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E01009]: invalid assignment
    ┌─ tests/move_check/typing/assign_nested.move:14:19

--- a/external-crates/move/move-compiler/tests/move_check/typing/bind_duplicate_binding.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/bind_duplicate_binding.exp
@@ -3,6 +3,8 @@ warning[W09003]: unused assignment
   │
 5 │         let (x, x) = (0, 0); x;
   │              ^ Unused assignment for variable 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
+  │
+  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/typing/bind_duplicate_binding.move:5:17
@@ -17,6 +19,8 @@ warning[W09003]: unused assignment
   │
 6 │         let (f, R{f}, f) = (0, R { f: 0 }, 0); f;
   │              ^ Unused assignment for variable 'f'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_f')
+  │
+  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/typing/bind_duplicate_binding.move:6:19
@@ -31,6 +35,8 @@ warning[W09003]: unused assignment
   │
 6 │         let (f, R{f}, f) = (0, R { f: 0 }, 0); f;
   │                   ^ Unused assignment for variable 'f'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_f')
+  │
+  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/typing/bind_duplicate_binding.move:6:23

--- a/external-crates/move/move-compiler/tests/move_check/typing/bind_duplicate_binding.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/bind_duplicate_binding.exp
@@ -4,7 +4,7 @@ warning[W09003]: unused assignment
 5 │         let (x, x) = (0, 0); x;
   │              ^ Unused assignment for variable 'x'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_x')
   │
-  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/typing/bind_duplicate_binding.move:5:17
@@ -20,7 +20,7 @@ warning[W09003]: unused assignment
 6 │         let (f, R{f}, f) = (0, R { f: 0 }, 0); f;
   │              ^ Unused assignment for variable 'f'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_f')
   │
-  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/typing/bind_duplicate_binding.move:6:19
@@ -36,7 +36,7 @@ warning[W09003]: unused assignment
 6 │         let (f, R{f}, f) = (0, R { f: 0 }, 0); f;
   │                   ^ Unused assignment for variable 'f'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_f')
   │
-  = This warning can be suppressed with with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/typing/bind_duplicate_binding.move:6:23

--- a/external-crates/move/move-compiler/tests/move_check/typing/borrow_divergent.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/borrow_divergent.exp
@@ -3,16 +3,22 @@ warning[W09005]: dead or unreachable code
   │
 4 │            &break;
   │             ^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+  │
+  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/typing/borrow_divergent.move:11:12
    │
 11 │         &{ return };
    │            ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+   │
+   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/typing/borrow_divergent.move:18:10
    │
 18 │         &(if (cond) return else return);
    │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+   │
+   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/typing/borrow_divergent.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/borrow_divergent.exp
@@ -4,7 +4,7 @@ warning[W09005]: dead or unreachable code
 4 │            &break;
   │             ^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
   │
-  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/typing/borrow_divergent.move:11:12
@@ -12,7 +12,7 @@ warning[W09005]: dead or unreachable code
 11 │         &{ return };
    │            ^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
    │
-   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/typing/borrow_divergent.move:18:10
@@ -20,5 +20,5 @@ warning[W09005]: dead or unreachable code
 18 │         &(if (cond) return else return);
    │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
    │
-   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/typing/break_any_type.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/break_any_type.exp
@@ -3,10 +3,14 @@ warning[W09005]: dead or unreachable code
   │
 6 │             0 + break;
   │                 ^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+  │
+  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/typing/break_any_type.move:12:17
    │
 12 │             foo(break)
    │                 ^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+   │
+   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/typing/break_any_type.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/break_any_type.exp
@@ -4,7 +4,7 @@ warning[W09005]: dead or unreachable code
 6 │             0 + break;
   │                 ^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
   │
-  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/typing/break_any_type.move:12:17
@@ -12,5 +12,5 @@ warning[W09005]: dead or unreachable code
 12 │             foo(break)
    │                 ^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
    │
-   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/typing/constraints_not_satisfied_lvalues_bind_type.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/constraints_not_satisfied_lvalues_bind_type.exp
@@ -17,4 +17,6 @@ warning[W09005]: dead or unreachable code
   │
 6 │         let _x: CupC<R> = abort 0;
   │                           ^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+  │
+  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/typing/constraints_not_satisfied_lvalues_bind_type.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/constraints_not_satisfied_lvalues_bind_type.exp
@@ -18,5 +18,5 @@ warning[W09005]: dead or unreachable code
 6 │         let _x: CupC<R> = abort 0;
   │                           ^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
   │
-  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/typing/constraints_not_satisfied_lvalues_pack_type_args.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/constraints_not_satisfied_lvalues_pack_type_args.exp
@@ -17,6 +17,8 @@ warning[W09005]: dead or unreachable code
   │
 8 │         let B<CupC<R>> {} = abort 0;
   │                             ^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+  │
+  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E05001]: ability constraint not satisfied
   ┌─ tests/move_check/typing/constraints_not_satisfied_lvalues_pack_type_args.move:9:11
@@ -37,4 +39,6 @@ warning[W09005]: dead or unreachable code
   │
 9 │         B<CupC<R>> {} = abort 0;
   │                         ^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+  │
+  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/typing/constraints_not_satisfied_lvalues_pack_type_args.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/constraints_not_satisfied_lvalues_pack_type_args.exp
@@ -18,7 +18,7 @@ warning[W09005]: dead or unreachable code
 8 │         let B<CupC<R>> {} = abort 0;
   │                             ^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
   │
-  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E05001]: ability constraint not satisfied
   ┌─ tests/move_check/typing/constraints_not_satisfied_lvalues_pack_type_args.move:9:11
@@ -40,5 +40,5 @@ warning[W09005]: dead or unreachable code
 9 │         B<CupC<R>> {} = abort 0;
   │                         ^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
   │
-  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/typing/constraints_not_satisfied_type_annotation.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/constraints_not_satisfied_type_annotation.exp
@@ -3,6 +3,8 @@ warning[W09005]: dead or unreachable code
   │
 7 │         ignore((abort 0: CupC<R>));
   │                 ^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+  │
+  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E05001]: ability constraint not satisfied
   ┌─ tests/move_check/typing/constraints_not_satisfied_type_annotation.move:7:26

--- a/external-crates/move/move-compiler/tests/move_check/typing/constraints_not_satisfied_type_annotation.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/constraints_not_satisfied_type_annotation.exp
@@ -4,7 +4,7 @@ warning[W09005]: dead or unreachable code
 7 │         ignore((abort 0: CupC<R>));
   │                 ^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
   │
-  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E05001]: ability constraint not satisfied
   ┌─ tests/move_check/typing/constraints_not_satisfied_type_annotation.move:7:26

--- a/external-crates/move/move-compiler/tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.exp
@@ -28,7 +28,7 @@ warning[W09005]: dead or unreachable code
 8 │         Box<CupD<R>>{ f: abort 0 };
   │                          ^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
   │
-  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E05001]: ability constraint not satisfied
   ┌─ tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.move:9:9

--- a/external-crates/move/move-compiler/tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.exp
@@ -27,6 +27,8 @@ warning[W09005]: dead or unreachable code
   │
 8 │         Box<CupD<R>>{ f: abort 0 };
   │                          ^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+  │
+  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E05001]: ability constraint not satisfied
   ┌─ tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.move:9:9

--- a/external-crates/move/move-compiler/tests/move_check/typing/continue_any_type.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/continue_any_type.exp
@@ -4,7 +4,7 @@ warning[W09005]: dead or unreachable code
 6 │             0 + continue;
   │                 ^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
   │
-  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/typing/continue_any_type.move:12:17
@@ -12,5 +12,5 @@ warning[W09005]: dead or unreachable code
 12 │             foo(continue)
    │                 ^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
    │
-   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/typing/continue_any_type.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/continue_any_type.exp
@@ -3,10 +3,14 @@ warning[W09005]: dead or unreachable code
   │
 6 │             0 + continue;
   │                 ^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+  │
+  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/typing/continue_any_type.move:12:17
    │
 12 │             foo(continue)
    │                 ^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+   │
+   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/typing/declare_duplicate_binding.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/declare_duplicate_binding.exp
@@ -3,6 +3,8 @@ warning[W09002]: unused variable
   │
 5 │         let (x, x);
   │              ^ Unused local variable 'x'. Consider removing or prefixing with an underscore: '_x'
+  │
+  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/typing/declare_duplicate_binding.move:5:17
@@ -17,6 +19,8 @@ warning[W09002]: unused variable
   │
 6 │         let (f, R{f}, f);
   │              ^ Unused local variable 'f'. Consider removing or prefixing with an underscore: '_f'
+  │
+  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/typing/declare_duplicate_binding.move:6:19
@@ -31,6 +35,8 @@ warning[W09002]: unused variable
   │
 6 │         let (f, R{f}, f);
   │                   ^ Unused local variable 'f'. Consider removing or prefixing with an underscore: '_f'
+  │
+  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/typing/declare_duplicate_binding.move:6:23

--- a/external-crates/move/move-compiler/tests/move_check/typing/declare_duplicate_binding.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/declare_duplicate_binding.exp
@@ -4,7 +4,7 @@ warning[W09002]: unused variable
 5 │         let (x, x);
   │              ^ Unused local variable 'x'. Consider removing or prefixing with an underscore: '_x'
   │
-  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/typing/declare_duplicate_binding.move:5:17
@@ -20,7 +20,7 @@ warning[W09002]: unused variable
 6 │         let (f, R{f}, f);
   │              ^ Unused local variable 'f'. Consider removing or prefixing with an underscore: '_f'
   │
-  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/typing/declare_duplicate_binding.move:6:19
@@ -36,7 +36,7 @@ warning[W09002]: unused variable
 6 │         let (f, R{f}, f);
   │                   ^ Unused local variable 'f'. Consider removing or prefixing with an underscore: '_f'
   │
-  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/typing/declare_duplicate_binding.move:6:23

--- a/external-crates/move/move-compiler/tests/move_check/typing/declare_with_type_annot.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/declare_with_type_annot.exp
@@ -4,7 +4,7 @@ warning[W09002]: unused variable
 6 │         let x: u64;
   │             ^ Unused local variable 'x'. Consider removing or prefixing with an underscore: '_x'
   │
-  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09002]: unused variable
   ┌─ tests/move_check/typing/declare_with_type_annot.move:7:14
@@ -12,7 +12,7 @@ warning[W09002]: unused variable
 7 │         let (x, b, R{f}): (u64, bool, R);
   │              ^ Unused local variable 'x'. Consider removing or prefixing with an underscore: '_x'
   │
-  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09002]: unused variable
   ┌─ tests/move_check/typing/declare_with_type_annot.move:7:17
@@ -20,7 +20,7 @@ warning[W09002]: unused variable
 7 │         let (x, b, R{f}): (u64, bool, R);
   │                 ^ Unused local variable 'b'. Consider removing or prefixing with an underscore: '_b'
   │
-  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09002]: unused variable
   ┌─ tests/move_check/typing/declare_with_type_annot.move:7:22
@@ -28,5 +28,5 @@ warning[W09002]: unused variable
 7 │         let (x, b, R{f}): (u64, bool, R);
   │                      ^ Unused local variable 'f'. Consider removing or prefixing with an underscore: '_f'
   │
-  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/typing/declare_with_type_annot.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/declare_with_type_annot.exp
@@ -3,22 +3,30 @@ warning[W09002]: unused variable
   │
 6 │         let x: u64;
   │             ^ Unused local variable 'x'. Consider removing or prefixing with an underscore: '_x'
+  │
+  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09002]: unused variable
   ┌─ tests/move_check/typing/declare_with_type_annot.move:7:14
   │
 7 │         let (x, b, R{f}): (u64, bool, R);
   │              ^ Unused local variable 'x'. Consider removing or prefixing with an underscore: '_x'
+  │
+  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09002]: unused variable
   ┌─ tests/move_check/typing/declare_with_type_annot.move:7:17
   │
 7 │         let (x, b, R{f}): (u64, bool, R);
   │                 ^ Unused local variable 'b'. Consider removing or prefixing with an underscore: '_b'
+  │
+  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09002]: unused variable
   ┌─ tests/move_check/typing/declare_with_type_annot.move:7:22
   │
 7 │         let (x, b, R{f}): (u64, bool, R);
   │                      ^ Unused local variable 'f'. Consider removing or prefixing with an underscore: '_f'
+  │
+  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/typing/duplicate_function_parameter_names.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/duplicate_function_parameter_names.exp
@@ -3,6 +3,8 @@ warning[W09002]: unused variable
   │
 2 │     fun foo(x: u64, x: u64) {}
   │             ^ Unused parameter 'x'. Consider removing or prefixing with an underscore: '_x'
+  │
+  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/typing/duplicate_function_parameter_names.move:2:21
@@ -17,4 +19,6 @@ warning[W09002]: unused variable
   │
 2 │     fun foo(x: u64, x: u64) {}
   │                     ^ Unused local variable 'x'. Consider removing or prefixing with an underscore: '_x'
+  │
+  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/typing/duplicate_function_parameter_names.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/duplicate_function_parameter_names.exp
@@ -4,7 +4,7 @@ warning[W09002]: unused variable
 2 │     fun foo(x: u64, x: u64) {}
   │             ^ Unused parameter 'x'. Consider removing or prefixing with an underscore: '_x'
   │
-  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/typing/duplicate_function_parameter_names.move:2:21
@@ -20,5 +20,5 @@ warning[W09002]: unused variable
 2 │     fun foo(x: u64, x: u64) {}
   │                     ^ Unused local variable 'x'. Consider removing or prefixing with an underscore: '_x'
   │
-  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/typing/loop_result_type.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/loop_result_type.exp
@@ -3,10 +3,14 @@ warning[W09005]: dead or unreachable code
    │
 19 │         foo(loop {})
    │             ^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+   │
+   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/typing/loop_result_type.move:25:23
    │
 25 │         let x: X::R = loop { 0; };
    │                       ^^^^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+   │
+   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/typing/loop_result_type.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/loop_result_type.exp
@@ -4,7 +4,7 @@ warning[W09005]: dead or unreachable code
 19 │         foo(loop {})
    │             ^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
    │
-   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
    ┌─ tests/move_check/typing/loop_result_type.move:25:23
@@ -12,5 +12,5 @@ warning[W09005]: dead or unreachable code
 25 │         let x: X::R = loop { 0; };
    │                       ^^^^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
    │
-   = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/typing/non_phantom_in_phantom_pos.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/non_phantom_in_phantom_pos.exp
@@ -3,10 +3,14 @@ warning[W02014]: invalid non-phantom type parameter usage
   │
 5 │     struct S2<T1, T2> {
   │               ^^ The parameter 'T1' is only used as an argument to phantom parameters. Consider adding a phantom declaration here
+  │
+  = This warning can be suppressed with with '#[allow(missing_phantom)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W02014]: invalid non-phantom type parameter usage
    ┌─ tests/move_check/typing/non_phantom_in_phantom_pos.move:15:15
    │
 15 │     struct S4<T1, T2> {
    │               ^^ The parameter 'T1' is only used as an argument to phantom parameters. Consider adding a phantom declaration here
+   │
+   = This warning can be suppressed with with '#[allow(missing_phantom)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/typing/non_phantom_in_phantom_pos.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/non_phantom_in_phantom_pos.exp
@@ -4,7 +4,7 @@ warning[W02014]: invalid non-phantom type parameter usage
 5 │     struct S2<T1, T2> {
   │               ^^ The parameter 'T1' is only used as an argument to phantom parameters. Consider adding a phantom declaration here
   │
-  = This warning can be suppressed with with '#[allow(missing_phantom)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(missing_phantom)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W02014]: invalid non-phantom type parameter usage
    ┌─ tests/move_check/typing/non_phantom_in_phantom_pos.move:15:15
@@ -12,5 +12,5 @@ warning[W02014]: invalid non-phantom type parameter usage
 15 │     struct S4<T1, T2> {
    │               ^^ The parameter 'T1' is only used as an argument to phantom parameters. Consider adding a phantom declaration here
    │
-   = This warning can be suppressed with with '#[allow(missing_phantom)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(missing_phantom)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/typing/return_any_type.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/return_any_type.exp
@@ -4,7 +4,7 @@ warning[W09005]: dead or unreachable code
 5 │         0 + (return ());
   │             ^^^^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
   │
-  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
   ┌─ tests/move_check/typing/return_any_type.move:9:13
@@ -12,5 +12,5 @@ warning[W09005]: dead or unreachable code
 9 │         foo(return ());
   │             ^^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
   │
-  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/typing/return_any_type.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/return_any_type.exp
@@ -3,10 +3,14 @@ warning[W09005]: dead or unreachable code
   │
 5 │         0 + (return ());
   │             ^^^^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+  │
+  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09005]: dead or unreachable code
   ┌─ tests/move_check/typing/return_any_type.move:9:13
   │
 9 │         foo(return ());
   │             ^^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed.
+  │
+  = This warning can be suppressed with with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/typing/unused_local.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/unused_local.exp
@@ -4,7 +4,7 @@ warning[W09002]: unused variable
 5 │         let x: u64;
   │             ^ Unused local variable 'x'. Consider removing or prefixing with an underscore: '_x'
   │
-  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09002]: unused variable
   ┌─ tests/move_check/typing/unused_local.move:9:14
@@ -12,7 +12,7 @@ warning[W09002]: unused variable
 9 │         let (x, y): (u64, u64);
   │              ^ Unused local variable 'x'. Consider removing or prefixing with an underscore: '_x'
   │
-  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09002]: unused variable
   ┌─ tests/move_check/typing/unused_local.move:9:17
@@ -20,7 +20,7 @@ warning[W09002]: unused variable
 9 │         let (x, y): (u64, u64);
   │                 ^ Unused local variable 'y'. Consider removing or prefixing with an underscore: '_y'
   │
-  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09002]: unused variable
    ┌─ tests/move_check/typing/unused_local.move:13:16
@@ -28,7 +28,7 @@ warning[W09002]: unused variable
 13 │         let S{ f, g }: S;
    │                ^ Unused local variable 'f'. Consider removing or prefixing with an underscore: '_f'
    │
-   = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09002]: unused variable
    ┌─ tests/move_check/typing/unused_local.move:13:19
@@ -36,7 +36,7 @@ warning[W09002]: unused variable
 13 │         let S{ f, g }: S;
    │                   ^ Unused local variable 'g'. Consider removing or prefixing with an underscore: '_g'
    │
-   = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09002]: unused variable
    ┌─ tests/move_check/typing/unused_local.move:25:22
@@ -44,7 +44,7 @@ warning[W09002]: unused variable
 25 │     fun unused_param(x: u64) {
    │                      ^ Unused parameter 'x'. Consider removing or prefixing with an underscore: '_x'
    │
-   = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09002]: unused variable
    ┌─ tests/move_check/typing/unused_local.move:28:20
@@ -52,7 +52,7 @@ warning[W09002]: unused variable
 28 │     fun two_unused(x: u64, y: bool) {
    │                    ^ Unused parameter 'x'. Consider removing or prefixing with an underscore: '_x'
    │
-   = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09002]: unused variable
    ┌─ tests/move_check/typing/unused_local.move:28:28
@@ -60,7 +60,7 @@ warning[W09002]: unused variable
 28 │     fun two_unused(x: u64, y: bool) {
    │                            ^ Unused parameter 'y'. Consider removing or prefixing with an underscore: '_y'
    │
-   = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09002]: unused variable
    ┌─ tests/move_check/typing/unused_local.move:31:35
@@ -68,7 +68,7 @@ warning[W09002]: unused variable
 31 │     fun unused_param1_used_param2(x: u64, y: bool): bool {
    │                                   ^ Unused parameter 'x'. Consider removing or prefixing with an underscore: '_x'
    │
-   = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09002]: unused variable
    ┌─ tests/move_check/typing/unused_local.move:35:43
@@ -76,5 +76,5 @@ warning[W09002]: unused variable
 35 │     fun unused_param2_used_param1(x: u64, y: bool): u64 {
    │                                           ^ Unused parameter 'y'. Consider removing or prefixing with an underscore: '_y'
    │
-   = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/typing/unused_local.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/unused_local.exp
@@ -3,58 +3,78 @@ warning[W09002]: unused variable
   │
 5 │         let x: u64;
   │             ^ Unused local variable 'x'. Consider removing or prefixing with an underscore: '_x'
+  │
+  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09002]: unused variable
   ┌─ tests/move_check/typing/unused_local.move:9:14
   │
 9 │         let (x, y): (u64, u64);
   │              ^ Unused local variable 'x'. Consider removing or prefixing with an underscore: '_x'
+  │
+  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09002]: unused variable
   ┌─ tests/move_check/typing/unused_local.move:9:17
   │
 9 │         let (x, y): (u64, u64);
   │                 ^ Unused local variable 'y'. Consider removing or prefixing with an underscore: '_y'
+  │
+  = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09002]: unused variable
    ┌─ tests/move_check/typing/unused_local.move:13:16
    │
 13 │         let S{ f, g }: S;
    │                ^ Unused local variable 'f'. Consider removing or prefixing with an underscore: '_f'
+   │
+   = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09002]: unused variable
    ┌─ tests/move_check/typing/unused_local.move:13:19
    │
 13 │         let S{ f, g }: S;
    │                   ^ Unused local variable 'g'. Consider removing or prefixing with an underscore: '_g'
+   │
+   = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09002]: unused variable
    ┌─ tests/move_check/typing/unused_local.move:25:22
    │
 25 │     fun unused_param(x: u64) {
    │                      ^ Unused parameter 'x'. Consider removing or prefixing with an underscore: '_x'
+   │
+   = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09002]: unused variable
    ┌─ tests/move_check/typing/unused_local.move:28:20
    │
 28 │     fun two_unused(x: u64, y: bool) {
    │                    ^ Unused parameter 'x'. Consider removing or prefixing with an underscore: '_x'
+   │
+   = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09002]: unused variable
    ┌─ tests/move_check/typing/unused_local.move:28:28
    │
 28 │     fun two_unused(x: u64, y: bool) {
    │                            ^ Unused parameter 'y'. Consider removing or prefixing with an underscore: '_y'
+   │
+   = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09002]: unused variable
    ┌─ tests/move_check/typing/unused_local.move:31:35
    │
 31 │     fun unused_param1_used_param2(x: u64, y: bool): bool {
    │                                   ^ Unused parameter 'x'. Consider removing or prefixing with an underscore: '_x'
+   │
+   = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09002]: unused variable
    ┌─ tests/move_check/typing/unused_local.move:35:43
    │
 35 │     fun unused_param2_used_param1(x: u64, y: bool): u64 {
    │                                           ^ Unused parameter 'y'. Consider removing or prefixing with an underscore: '_y'
+   │
+   = This warning can be suppressed with with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/typing/unused_non_phantom_param.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/unused_non_phantom_param.exp
@@ -3,4 +3,6 @@ warning[W09006]: unused struct type parameter
   │
 2 │     struct S<T1, T2> {
   │                  ^^ Unused type parameter 'T2'. Consider declaring it as phantom
+  │
+  = This warning can be suppressed with with '#[allow(type_parameter)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/typing/unused_non_phantom_param.exp
+++ b/external-crates/move/move-compiler/tests/move_check/typing/unused_non_phantom_param.exp
@@ -4,5 +4,5 @@ warning[W09006]: unused struct type parameter
 2 │     struct S<T1, T2> {
   │                  ^^ Unused type parameter 'T2'. Consider declaring it as phantom
   │
-  = This warning can be suppressed with with '#[allow(type_parameter)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_type_parameter)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/unit_test/extra_attributes.unit_test.exp
+++ b/external-crates/move/move-compiler/tests/move_check/unit_test/extra_attributes.unit_test.exp
@@ -3,28 +3,38 @@ warning[W09007]: unused attribute
   │
 8 │     #[expected_failure(vector_error, location=std::vector, hello=0)]
   │                                                            ^^^^^ Unused attribute for expected_failure
+  │
+  = This warning can be suppressed with with '#[allow(unused_attribute)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09007]: unused attribute
    ┌─ tests/move_check/unit_test/extra_attributes.move:12:54
    │
 12 │     #[expected_failure(arithmetic_error, location=n, wowza)]
    │                                                      ^^^^^ Unused attribute for expected_failure
+   │
+   = This warning can be suppressed with with '#[allow(unused_attribute)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09007]: unused attribute
    ┌─ tests/move_check/unit_test/extra_attributes.move:16:51
    │
 16 │     #[expected_failure(out_of_gas, location=Self, so_many_attrs)]
    │                                                   ^^^^^^^^^^^^^ Unused attribute for expected_failure
+   │
+   = This warning can be suppressed with with '#[allow(unused_attribute)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09007]: unused attribute
    ┌─ tests/move_check/unit_test/extra_attributes.move:20:43
    │
 20 │     #[expected_failure(major_status=4004, an_attr_here_is_unused, location=Self)]
    │                                           ^^^^^^^^^^^^^^^^^^^^^^ Unused attribute for expected_failure
+   │
+   = This warning can be suppressed with with '#[allow(unused_attribute)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09007]: unused attribute
    ┌─ tests/move_check/unit_test/extra_attributes.move:24:43
    │
 24 │     #[expected_failure(major_status=4016, minor_code=0, location=Self)]
    │                                           ^^^^^^^^^^ Unused attribute for expected_failure
+   │
+   = This warning can be suppressed with with '#[allow(unused_attribute)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/unit_test/extra_attributes.unit_test.exp
+++ b/external-crates/move/move-compiler/tests/move_check/unit_test/extra_attributes.unit_test.exp
@@ -4,7 +4,7 @@ warning[W09007]: unused attribute
 8 │     #[expected_failure(vector_error, location=std::vector, hello=0)]
   │                                                            ^^^^^ Unused attribute for expected_failure
   │
-  = This warning can be suppressed with with '#[allow(unused_attribute)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_attribute)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09007]: unused attribute
    ┌─ tests/move_check/unit_test/extra_attributes.move:12:54
@@ -12,7 +12,7 @@ warning[W09007]: unused attribute
 12 │     #[expected_failure(arithmetic_error, location=n, wowza)]
    │                                                      ^^^^^ Unused attribute for expected_failure
    │
-   = This warning can be suppressed with with '#[allow(unused_attribute)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_attribute)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09007]: unused attribute
    ┌─ tests/move_check/unit_test/extra_attributes.move:16:51
@@ -20,7 +20,7 @@ warning[W09007]: unused attribute
 16 │     #[expected_failure(out_of_gas, location=Self, so_many_attrs)]
    │                                                   ^^^^^^^^^^^^^ Unused attribute for expected_failure
    │
-   = This warning can be suppressed with with '#[allow(unused_attribute)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_attribute)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09007]: unused attribute
    ┌─ tests/move_check/unit_test/extra_attributes.move:20:43
@@ -28,7 +28,7 @@ warning[W09007]: unused attribute
 20 │     #[expected_failure(major_status=4004, an_attr_here_is_unused, location=Self)]
    │                                           ^^^^^^^^^^^^^^^^^^^^^^ Unused attribute for expected_failure
    │
-   = This warning can be suppressed with with '#[allow(unused_attribute)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_attribute)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W09007]: unused attribute
    ┌─ tests/move_check/unit_test/extra_attributes.move:24:43
@@ -36,5 +36,5 @@ warning[W09007]: unused attribute
 24 │     #[expected_failure(major_status=4016, minor_code=0, location=Self)]
    │                                           ^^^^^^^^^^ Unused attribute for expected_failure
    │
-   = This warning can be suppressed with with '#[allow(unused_attribute)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(unused_attribute)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/warning_suppression/all.move
+++ b/external-crates/move/move-compiler/tests/move_check/warning_suppression/all.move
@@ -1,0 +1,42 @@
+module 0x42::x {}
+
+#[allow(all)]
+module 0x42::m {
+    struct B<phantom T> {}
+    struct S<T1, T2> { f: B<T1> }
+
+    use 0x42::x;
+    fun var(a: u64) {
+        use 0x42::x;
+        let x;
+    }
+    fun dead() {
+        use 0x42::x;
+        loop {};
+        assert!(1 == 0, 0)
+    }
+    fun ab() {
+        abort 0;
+    }
+    fun assgn(x: u64) {
+        let y = 0;
+        x = 1;
+    }
+}
+
+module 0x42::n {
+    struct B<phantom T> {}
+    #[allow(all)]
+    struct S<T1, T2> { f: B<T1> }
+
+    #[allow(all)]
+    fun dead(a: u64) {
+        use 0x42::x;
+        let y;
+        let z = 0;
+        a = 0;
+        let x = abort 0;
+        x + 1;
+        abort 0;
+    }
+}

--- a/external-crates/move/move-compiler/tests/move_check/warning_suppression/allow_with_no_filter.exp
+++ b/external-crates/move/move-compiler/tests/move_check/warning_suppression/allow_with_no_filter.exp
@@ -1,0 +1,6 @@
+error[E10003]: invalid attribute value
+  ┌─ tests/move_check/warning_suppression/allow_with_no_filter.move:2:3
+  │
+2 │ #[allow]
+  │   ^^^^^ Expected list of warnings, e.g. 'allow(unused)'
+

--- a/external-crates/move/move-compiler/tests/move_check/warning_suppression/allow_with_no_filter.move
+++ b/external-crates/move/move-compiler/tests/move_check/warning_suppression/allow_with_no_filter.move
@@ -1,0 +1,3 @@
+// allow needs a warning
+#[allow]
+module 0x42::m {}

--- a/external-crates/move/move-compiler/tests/move_check/warning_suppression/bad_attr.exp
+++ b/external-crates/move/move-compiler/tests/move_check/warning_suppression/bad_attr.exp
@@ -1,0 +1,24 @@
+error[E10003]: invalid attribute value
+  ┌─ tests/move_check/warning_suppression/bad_attr.move:3:3
+  │
+3 │ #[allow(all(), unused = true, unused_(assignment, variable))]
+  │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unknown warning filter 'unused_'
+
+error[E10003]: invalid attribute value
+  ┌─ tests/move_check/warning_suppression/bad_attr.move:3:9
+  │
+3 │ #[allow(all(), unused = true, unused_(assignment, variable))]
+  │         ^^^ Expected a stand alone warning filter identifier, e.g. 'allow(all)'
+
+error[E10003]: invalid attribute value
+  ┌─ tests/move_check/warning_suppression/bad_attr.move:3:16
+  │
+3 │ #[allow(all(), unused = true, unused_(assignment, variable))]
+  │                ^^^^^^ Expected a stand alone warning filter identifier, e.g. 'allow(unused)'
+
+error[E10003]: invalid attribute value
+  ┌─ tests/move_check/warning_suppression/bad_attr.move:3:31
+  │
+3 │ #[allow(all(), unused = true, unused_(assignment, variable))]
+  │                               ^^^^^^^ Expected a stand alone warning filter identifier, e.g. 'allow(unused_)'
+

--- a/external-crates/move/move-compiler/tests/move_check/warning_suppression/bad_attr.move
+++ b/external-crates/move/move-compiler/tests/move_check/warning_suppression/bad_attr.move
@@ -1,0 +1,5 @@
+// tests an incorrect attribute for warning supression
+
+#[allow(all(), unused = true, unused_(assignment, variable))]
+module 0x42::m {
+}

--- a/external-crates/move/move-compiler/tests/move_check/warning_suppression/bad_location.exp
+++ b/external-crates/move/move-compiler/tests/move_check/warning_suppression/bad_location.exp
@@ -13,7 +13,7 @@ warning[W09001]: unused alias
 5 │     use 0x42::x;
   │               ^ Unused 'use' of alias 'x'. Consider removing it
   │
-  = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E02015]: invalid attribute
   ┌─ tests/move_check/warning_suppression/bad_location.move:7:7

--- a/external-crates/move/move-compiler/tests/move_check/warning_suppression/bad_location.exp
+++ b/external-crates/move/move-compiler/tests/move_check/warning_suppression/bad_location.exp
@@ -1,0 +1,26 @@
+error[E02015]: invalid attribute
+  ┌─ tests/move_check/warning_suppression/bad_location.move:4:7
+  │
+4 │     #[allow(unused)]
+  │       ^^^^^
+  │       │
+  │       Known attribute 'allow' is not expected with a use
+  │       Expected to be used with one of the following: module, script, constant, struct, function
+
+warning[W09001]: unused alias
+  ┌─ tests/move_check/warning_suppression/bad_location.move:5:15
+  │
+5 │     use 0x42::x;
+  │               ^ Unused 'use' of alias 'x'. Consider removing it
+  │
+  = This warning can be suppressed with with '#[allow(unused_use)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+error[E02015]: invalid attribute
+  ┌─ tests/move_check/warning_suppression/bad_location.move:7:7
+  │
+7 │     #[allow(all)]
+  │       ^^^^^
+  │       │
+  │       Known attribute 'allow' is not expected with a friend
+  │       Expected to be used with one of the following: module, script, constant, struct, function
+

--- a/external-crates/move/move-compiler/tests/move_check/warning_suppression/bad_location.move
+++ b/external-crates/move/move-compiler/tests/move_check/warning_suppression/bad_location.move
@@ -1,0 +1,13 @@
+// tests an unsupported location for the attribute for warning supression
+
+module 0x42::m {
+    #[allow(unused)]
+    use 0x42::x;
+
+    #[allow(all)]
+    friend 0x42::a;
+}
+
+module 0x42::x {}
+
+module 0x42::a {}

--- a/external-crates/move/move-compiler/tests/move_check/warning_suppression/dead_code.move
+++ b/external-crates/move/move-compiler/tests/move_check/warning_suppression/dead_code.move
@@ -1,0 +1,15 @@
+#[allow(dead_code)]
+module 0x42::m {
+    fun foo() {
+        loop {};
+        assert!(1 == 0, 0)
+    }
+}
+
+module 0x42::n {
+    #[allow(dead_code)]
+    fun foo() {
+        let x = abort 0;
+        x + 1;
+    }
+}

--- a/external-crates/move/move-compiler/tests/move_check/warning_suppression/missing_phantom.move
+++ b/external-crates/move/move-compiler/tests/move_check/warning_suppression/missing_phantom.move
@@ -1,0 +1,12 @@
+#[allow(missing_phantom)]
+module 0x42::m {
+    struct B<phantom T> {}
+    struct S<T> { f: B<T> }
+}
+
+module 0x42::n {
+    struct B<phantom T> {}
+
+    #[allow(missing_phantom)]
+    struct S<T> { f: B<T> }
+}

--- a/external-crates/move/move-compiler/tests/move_check/warning_suppression/unknown_warning.exp
+++ b/external-crates/move/move-compiler/tests/move_check/warning_suppression/unknown_warning.exp
@@ -1,0 +1,6 @@
+error[E10003]: invalid attribute value
+  ┌─ tests/move_check/warning_suppression/unknown_warning.move:3:3
+  │
+3 │ #[allow(who_am_i)]
+  │   ^^^^^^^^^^^^^^^ Unknown warning filter 'who_am_i'
+

--- a/external-crates/move/move-compiler/tests/move_check/warning_suppression/unknown_warning.move
+++ b/external-crates/move/move-compiler/tests/move_check/warning_suppression/unknown_warning.move
@@ -1,0 +1,5 @@
+// tests a unknown warning
+
+#[allow(who_am_i)]
+module 0x42::m {
+}

--- a/external-crates/move/move-compiler/tests/move_check/warning_suppression/unused.exp
+++ b/external-crates/move/move-compiler/tests/move_check/warning_suppression/unused.exp
@@ -1,0 +1,16 @@
+warning[W02014]: invalid non-phantom type parameter usage
+  ┌─ tests/move_check/warning_suppression/unused.move:8:14
+  │
+8 │     struct S<T1, T2> { f: B<T1> }
+  │              ^^ The parameter 'T1' is only used as an argument to phantom parameters. Consider adding a phantom declaration here
+  │
+  = This warning can be suppressed with with '#[allow(missing_phantom)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[W02014]: invalid non-phantom type parameter usage
+   ┌─ tests/move_check/warning_suppression/unused.move:32:14
+   │
+32 │     struct S<T1, T2> { f: B<T1> }
+   │              ^^ The parameter 'T1' is only used as an argument to phantom parameters. Consider adding a phantom declaration here
+   │
+   = This warning can be suppressed with with '#[allow(missing_phantom)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+

--- a/external-crates/move/move-compiler/tests/move_check/warning_suppression/unused.exp
+++ b/external-crates/move/move-compiler/tests/move_check/warning_suppression/unused.exp
@@ -4,7 +4,7 @@ warning[W02014]: invalid non-phantom type parameter usage
 8 │     struct S<T1, T2> { f: B<T1> }
   │              ^^ The parameter 'T1' is only used as an argument to phantom parameters. Consider adding a phantom declaration here
   │
-  = This warning can be suppressed with with '#[allow(missing_phantom)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  = This warning can be suppressed with '#[allow(missing_phantom)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[W02014]: invalid non-phantom type parameter usage
    ┌─ tests/move_check/warning_suppression/unused.move:32:14
@@ -12,5 +12,5 @@ warning[W02014]: invalid non-phantom type parameter usage
 32 │     struct S<T1, T2> { f: B<T1> }
    │              ^^ The parameter 'T1' is only used as an argument to phantom parameters. Consider adding a phantom declaration here
    │
-   = This warning can be suppressed with with '#[allow(missing_phantom)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   = This warning can be suppressed with '#[allow(missing_phantom)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/move-compiler/tests/move_check/warning_suppression/unused.move
+++ b/external-crates/move/move-compiler/tests/move_check/warning_suppression/unused.move
@@ -1,0 +1,44 @@
+// missing_phantom is currently the only unused
+
+module 0x42::x {}
+
+#[allow(unused)]
+module 0x42::m {
+    struct B<phantom T> {}
+    struct S<T1, T2> { f: B<T1> }
+
+    use 0x42::x;
+    fun var(a: u64) {
+        use 0x42::x;
+        let x;
+    }
+    fun dead() {
+        use 0x42::x;
+        loop {};
+        assert!(1 == 0, 0)
+    }
+    fun ab() {
+        abort 0;
+    }
+    fun assgn(x: u64) {
+        let y = 0;
+        x = 1;
+    }
+}
+
+module 0x42::n {
+    struct B<phantom T> {}
+    #[allow(unused)]
+    struct S<T1, T2> { f: B<T1> }
+
+    #[allow(unused)]
+    fun dead(a: u64) {
+        use 0x42::x;
+        let y;
+        let z = 0;
+        a = 0;
+        let x = abort 0;
+        x + 1;
+        abort 0;
+    }
+}

--- a/external-crates/move/move-compiler/tests/move_check/warning_suppression/unused_assignment.move
+++ b/external-crates/move/move-compiler/tests/move_check/warning_suppression/unused_assignment.move
@@ -1,0 +1,26 @@
+#[allow(unused_assignment)]
+module 0x42::m {
+    fun foo() {
+        let x = 0;
+    }
+
+    fun bar() {
+        let x = 1;
+        assert!(x == 1, 0);
+        x = 0;
+    }
+}
+
+module 0x42::n {
+    #[allow(unused_assignment)]
+    fun foo() {
+        let x = 0;
+    }
+
+    #[allow(unused_assignment)]
+    fun bar() {
+        let x = 1;
+        assert!(x == 1, 0);
+        x = 0;
+    }
+}

--- a/external-crates/move/move-compiler/tests/move_check/warning_suppression/unused_trailing_semi.move
+++ b/external-crates/move/move-compiler/tests/move_check/warning_suppression/unused_trailing_semi.move
@@ -1,0 +1,13 @@
+#[allow(unused_trailing_semi)]
+module 0x42::m {
+    fun foo() {
+        abort 0;
+    }
+}
+
+module 0x42::n {
+    #[allow(unused_trailing_semi)]
+    fun foo() {
+        abort 0;
+    }
+}

--- a/external-crates/move/move-compiler/tests/move_check/warning_suppression/unused_type_parameter.move
+++ b/external-crates/move/move-compiler/tests/move_check/warning_suppression/unused_type_parameter.move
@@ -1,0 +1,9 @@
+#[allow(unused_type_parameter)]
+module 0x42::m {
+    struct S<T> { }
+}
+
+module 0x42::n {
+    #[allow(unused_type_parameter)]
+    struct S<T> { }
+}

--- a/external-crates/move/move-compiler/tests/move_check/warning_suppression/unused_use.move
+++ b/external-crates/move/move-compiler/tests/move_check/warning_suppression/unused_use.move
@@ -1,0 +1,19 @@
+module 0x42::x {}
+
+#[allow(unused_use)]
+module 0x42::m {
+    use 0x42::x;
+}
+
+module 0x42::n {
+    #[allow(unused_use)]
+    const FOO: u64 = {
+        use 0x42::x;
+        0
+    };
+
+    #[allow(unused_use)]
+    fun foo() {
+        use 0x42::x;
+    }
+}

--- a/external-crates/move/move-compiler/tests/move_check/warning_suppression/unused_variable.move
+++ b/external-crates/move/move-compiler/tests/move_check/warning_suppression/unused_variable.move
@@ -1,0 +1,13 @@
+#[allow(unused_variable)]
+module 0x42::m {
+    fun foo(a: u64) {
+        let x;
+    }
+}
+
+module 0x42::n {
+    #[allow(unused_variable)]
+    fun foo(a: u64) {
+        let x;
+    }
+}

--- a/external-crates/move/move-model/src/lib.rs
+++ b/external-crates/move/move-model/src/lib.rs
@@ -510,6 +510,7 @@ fn run_spec_checker(env: &mut GlobalEnv, units: Vec<AnnotatedCompiledUnit>, mut 
                     function_info,
                 }) => {
                     let move_compiler::expansion::ast::Script {
+                        warning_filter: _warning_filter,
                         package_name,
                         attributes,
                         loc,
@@ -542,6 +543,7 @@ fn run_spec_checker(env: &mut GlobalEnv, units: Vec<AnnotatedCompiledUnit>, mut 
                     let mut functions = UniqueMap::new();
                     functions.add(function_name, function).unwrap();
                     let expanded_module = ModuleDefinition {
+                        warning_filter: _warning_filter,
                         package_name,
                         attributes,
                         loc,

--- a/external-crates/move/tools/move-cli/tests/build_tests/build_with_warnings/args.exp
+++ b/external-crates/move/tools/move-cli/tests/build_tests/build_with_warnings/args.exp
@@ -5,6 +5,8 @@ warning[W09002]: unused variable
   │
 2 │ public fun foo(x: u64): u64 {
   │                ^ Unused parameter 'x'. Consider removing or prefixing with an underscore: '_x'
+  │
+  = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 Command `disassemble --package Test --name m`:
 // Move bytecode v6
@@ -22,4 +24,6 @@ warning[W09002]: unused variable
   │
 2 │ public fun foo(x: u64): u64 {
   │                ^ Unused parameter 'x'. Consider removing or prefixing with an underscore: '_x'
+  │
+  = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 

--- a/external-crates/move/tools/move-cli/tests/build_tests/include_exclude_stdlib/args.exp
+++ b/external-crates/move/tools/move-cli/tests/build_tests/include_exclude_stdlib/args.exp
@@ -11,6 +11,8 @@ warning[W09002]: unused variable
   │
 5 │   public fun f(account: &signer): address {
   │                ^^^^^^^ Unused parameter 'account'. Consider removing or prefixing with an underscore: '_account'
+  │
+  = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 error[E03002]: unbound module
   ┌─ ./sources/UseSigner.move:6:5


### PR DESCRIPTION
## Description 

- Added warning suppression via an `#[allow(..)]` attribute
- Warnings now tell you how to suppress them 
- Special ones include `allow(unused)` and `allow(all)` to suppress unused item warnings or any warning respectively
  - Thoughts on surfacing these in the help message?

## Test Plan 

- Added tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
