### PR TITLE
[ts-sdk] RPC validation error fix

### DIFF
--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -101,7 +101,7 @@ export const SuiTransaction = union([
 export const SuiCallArg = union([
   object({
     type: literal('pure'),
-    valueType: optional(string()),
+    valueType: nullable(string()),
     value: SuiJsonValue,
   }),
   object({
@@ -168,7 +168,7 @@ export const SuiTransactionBlockData = object({
   messageVersion: literal('v1'),
   transaction: SuiTransactionBlockKind,
   sender: SuiAddress,
-  gasData: SuiGasData, // this shit is diff bw wallet and explorer
+  gasData: SuiGasData,
 });
 export type SuiTransactionBlockData = Infer<typeof SuiTransactionBlockData>;
 

--- a/sdk/typescript/test/e2e/read-transactions.test.ts
+++ b/sdk/typescript/test/e2e/read-transactions.test.ts
@@ -99,7 +99,13 @@ describe('Transaction Reading API', () => {
   });
 
   it('Query Transactions with opts', async () => {
-    const options = { showEvents: true, showEffects: true };
+    const options = {
+      showInput: true,
+      showEffects: true,
+      showEvents: true,
+      showObjectChanges: true,
+      showBalanceChanges: true,
+    };
     const resp = await toolbox.provider.queryTransactionBlocks({
       options,
       limit: 1,


### PR DESCRIPTION
## Description

This resolves an issue where we hit RPC validation warnings for some users. Fixes #12061.

## Test Plan

Ran locally.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
