### PR TITLE
Make checks for RPG more consistent (#12073)

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1320,8 +1320,10 @@ impl AuthorityState {
 
         transaction_kind.check_version_supported(epoch_store.protocol_config())?;
 
+        let reference_gas_price = epoch_store.reference_gas_price();
+        let protocol_config = epoch_store.protocol_config();
         let gas_price = match gas_price {
-            None => epoch_store.reference_gas_price(),
+            None => reference_gas_price,
             Some(gas) => {
                 if gas == 0 {
                     epoch_store.reference_gas_price()
@@ -1330,7 +1332,20 @@ impl AuthorityState {
                 }
             }
         };
-        let protocol_config = epoch_store.protocol_config();
+        if gas_price < reference_gas_price {
+            return Err(UserInputError::GasPriceUnderRGP {
+                gas_price,
+                reference_gas_price,
+            }
+            .into());
+        }
+        if protocol_config.gas_model_version() >= 4 && gas_price >= protocol_config.max_gas_price()
+        {
+            return Err(UserInputError::GasPriceTooHigh {
+                max_gas_price: protocol_config.max_gas_price(),
+            }
+            .into());
+        }
         let max_tx_gas = protocol_config.max_tx_gas();
 
         let gas_object_id = ObjectID::random();

--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -127,7 +127,6 @@ impl<'a> TestAuthorityBuilder<'a> {
 
     pub async fn build(self) -> Arc<AuthorityState> {
         let local_network_config = sui_config::builder::ConfigBuilder::new_with_temp_dir()
-            // TODO: change the default to 1000 instead after fixing tests.
             .with_reference_gas_price(self.reference_gas_price.unwrap_or(1))
             .build();
         let genesis = &self.genesis.unwrap_or(&local_network_config.genesis);

--- a/crates/sui-core/src/unit_tests/pay_sui_tests.rs
+++ b/crates/sui-core/src/unit_tests/pay_sui_tests.rs
@@ -425,7 +425,6 @@ async fn execute_pay_all_sui(
 ) -> PaySuiTransactionBlockExecutionResult {
     let dir = tempfile::TempDir::new().unwrap();
     let network_config = sui_config::builder::ConfigBuilder::new(&dir)
-        // TODO: fix numbers in tests to not depend on rgp being 1
         .with_reference_gas_price(1)
         .with_objects(
             input_coin_objects

--- a/crates/transaction-fuzzer/src/account_universe/account.rs
+++ b/crates/transaction-fuzzer/src/account_universe/account.rs
@@ -15,7 +15,8 @@ use sui_types::{
 
 use crate::executor::Executor;
 
-pub const INITIAL_BALANCE: u64 = 10_000_000_000;
+pub const INITIAL_BALANCE: u64 = 100_000_000_000_000;
+pub const PUBLISH_BUDGET: u64 = 1_000_000_000;
 pub const NUM_GAS_OBJECTS: usize = 1;
 
 #[derive(Debug)]

--- a/crates/transaction-fuzzer/src/executor.rs
+++ b/crates/transaction-fuzzer/src/executor.rs
@@ -14,7 +14,7 @@ use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{error::SuiError, messages::VerifiedTransaction, object::Object};
 use tokio::runtime::Runtime;
 
-use crate::account_universe::{AccountCurrent, INITIAL_BALANCE};
+use crate::account_universe::{AccountCurrent, PUBLISH_BUDGET};
 
 use std::path::PathBuf;
 use sui_move_build::BuildConfig;
@@ -123,8 +123,8 @@ impl Executor {
             gas_object.compute_object_reference(),
             modules,
             vec![],
-            INITIAL_BALANCE,
-            1,
+            PUBLISH_BUDGET,
+            1000,
         );
         let txn = to_sender_signed_transaction(data, &account.initial_data.account.key);
         let effects = self

--- a/crates/transaction-fuzzer/src/type_arg_fuzzer.rs
+++ b/crates/transaction-fuzzer/src/type_arg_fuzzer.rs
@@ -15,8 +15,8 @@ use sui_types::{TypeTag, SUI_FRAMEWORK_OBJECT_ID};
 use crate::account_universe::AccountCurrent;
 use crate::executor::{assert_is_acceptable_result, Executor};
 
-const GAS: u64 = 1_000_000;
-const GAS_PRICE: u64 = 1;
+const GAS_PRICE: u64 = 700;
+const GAS: u64 = 1_000_000 * GAS_PRICE;
 
 pub fn gen_type_tag() -> impl Strategy<Value = TypeTag> {
     prop_oneof![


### PR DESCRIPTION
Make dev inspect honor RGP and gas price to be more consistent and also remove as much as possible `RGP = 1` in testing

Added a test for gas price and see what tests fail

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

- [x] user-visible impact
- [x] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
