### PR TITLE
[WIP][Core] Introduce chain dependent protocol config

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -163,6 +163,8 @@ pub(crate) mod authority_notify_read;
 pub(crate) mod authority_store;
 
 static CHAIN_IDENTIFIER: OnceCell<CheckpointDigest> = OnceCell::new();
+static MAINNET_CHAIN_IDENTIFIER: OnceCell<CheckpointDigest> = OnceCell::new();
+static TESTNET_CHAIN_IDENTIFIER: OnceCell<CheckpointDigest> = OnceCell::new();
 
 pub type ReconfigConsensusMessage = (
     AuthorityKeyPair,
@@ -2295,6 +2297,41 @@ impl AuthorityState {
         // It's ok if the value is already set due to data races.
         let _ = CHAIN_IDENTIFIER.set(*checkpoint.digest());
         Some(*checkpoint.digest())
+    }
+
+    pub fn get_mainnet_chain_identifier(&self) -> CheckpointDigest {
+        if let Some(digest) = MAINNET_CHAIN_IDENTIFIER.get() {
+            return *digest;
+        }
+
+        let digest = CheckpointDigest::new(Base58::decode(
+            "4btiuiMPvEENsttpZC7CZ53DruC3MAgfznDbASZ7DR6S",
+        ));
+        let _ = CHAIN_IDENTIFIER.set(digest);
+        digest.clone()
+    }
+
+    pub fn get_testnet_chain_identifier(&self) -> CheckpointDigest {
+        if let Some(digest) = TESTNET_CHAIN_IDENTIFIER.get() {
+            return *digest;
+        }
+
+        let digest = CheckpointDigest::new(Base58::decode(
+            "69WiPg3DAQiwdxfncX6wYQ2siKwAe6L9BZthQea3JNMD",
+        ));
+        let _ = CHAIN_IDENTIFIER.set(digest);
+        digest.clone()
+    }
+
+    pub fn get_chain(&self) -> Option<Chain> {
+        mainnet_id = get_mainnet_chain_identifier();
+        testnet_id = get_testnet_chain_identifier();
+
+        match self.get_chain_identifier()? {
+            mainnet_id => Chain::Mainnet,
+            testnet_id => Chain::Testnet,
+            _ => Chain::Unknown,
+        }
     }
 
     pub fn get_move_object<T>(&self, object_id: &ObjectID) -> SuiResult<T>

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -847,10 +847,16 @@ impl CheckpointBuilder {
                 self.metrics.highest_accumulated_epoch.set(epoch as i64);
                 info!("Epoch {epoch} root state hash digest: {root_state_digest:?}");
 
+                let chain = self
+                    .state
+                    .get_chain()
+                    .expect("Genesis checkpoint should exist if creating last checkpoint of epoch");
+
                 let epoch_commitments = if self
                     .epoch_store
                     .protocol_config()
-                    .check_commit_root_state_digest_supported()
+                    .get_commit_root_state_digest_supported_chains()
+                    .contains(chain)
                 {
                     vec![root_state_digest.into()]
                 } else {


### PR DESCRIPTION
## Description 

Also use root state digest commitments as first use case (for all networks but mainnet).

This introduces another field to `ProtocolConfig`,  `FeaturePerChainConfigs`, which maps a feature identifier to a `ChainAllowlist` (i.e. vector of chains for which the feature is to be allowlisted). This therefore serves as a generalization of `FeatureFlag`.

## Test Plan 

TODO
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
