### PR TITLE
make sui CLI log gated by env flag

### DIFF
--- a/crates/sui/src/main.rs
+++ b/crates/sui/src/main.rs
@@ -3,6 +3,7 @@
 
 use clap::*;
 use colored::Colorize;
+use std::env;
 use sui::sui_commands::SuiCommand;
 use sui_types::exit_main;
 use tracing::debug;
@@ -10,6 +11,8 @@ use tracing::debug;
 #[cfg(test)]
 #[path = "unit_tests/cli_tests.rs"]
 mod cli_tests;
+
+const LOG_FILE_ENABLE: &str = "LOG_FILE_ENABLE";
 
 const GIT_REVISION: &str = {
     if let Some(revision) = option_env!("GIT_REVISION") {
@@ -27,6 +30,19 @@ const GIT_REVISION: &str = {
     }
 };
 const VERSION: &str = const_str::concat!(env!("CARGO_PKG_VERSION"), "-", GIT_REVISION);
+
+pub fn read_log_file_flag_env() -> Option<u8> {
+    env::var(LOG_FILE_ENABLE)
+        .ok()?
+        .parse::<u8>()
+        .map_err(|e| {
+            println!(
+                "Env var {} does not contain valid u8 integer: {}",
+                LOG_FILE_ENABLE, e
+            )
+        })
+        .ok()
+}
 
 #[derive(Parser)]
 #[clap(
@@ -50,10 +66,13 @@ async fn main() {
     let args = Args::parse();
     let _guard = match args.command {
         SuiCommand::Console { .. } | SuiCommand::Client { .. } => {
-            telemetry_subscribers::TelemetryConfig::new()
-                .with_log_file(&format!("{bin_name}.log"))
-                .with_env()
-                .init()
+            let mut t = telemetry_subscribers::TelemetryConfig::new().with_env();
+            if let Some(flag) = read_log_file_flag_env() {
+                if flag > 0 {
+                    t = t.with_log_file(&format!("{bin_name}.log"));
+                }
+            };
+            t.init()
         }
         _ => telemetry_subscribers::TelemetryConfig::new()
             .with_env()


### PR DESCRIPTION
## Description 

Enable or disable logging to file with env `LOG_FILE_ENABLE=1`
Default is 0 (off).

## Test Plan 

Manual

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
