### PR TITLE
wallet-ext: fix always showing loading spinner in nfts page

### DIFF
--- a/apps/core/src/hooks/useGetOriginByteKioskContents.ts
+++ b/apps/core/src/hooks/useGetOriginByteKioskContents.ts
@@ -66,6 +66,6 @@ export function useGetOriginByteKioskContents(
 
             return kioskContent;
         },
-        enabled: !!obKioskIds.length && !disable && !!address,
+        enabled: !disable && !!address,
     });
 }


### PR DESCRIPTION
* wallet was always showing the loading spinner when the address doesn't own any origin byte kiosk objects

before


https://github.com/MystenLabs/sui/assets/10210143/7302a2b8-9e8f-4666-b51f-8035f2bfc8f2


after


https://github.com/MystenLabs/sui/assets/10210143/ea98f980-d093-43a1-be7e-90606f00d9e1


context [here](https://mysten-labs.slack.com/archives/C0393DWJD7X/p1684523802991629)