### PR TITLE
[fuzz] replay fuzz from tx digest start

### DIFF
--- a/crates/sui-replay/src/lib.rs
+++ b/crates/sui-replay/src/lib.rs
@@ -9,7 +9,7 @@ use fuzz::ReplayFuzzerConfig;
 use fuzz_mutations::base_fuzzers;
 use sui_types::message_envelope::Message;
 use tracing::warn;
-use transaction_provider::TransactionSource;
+use transaction_provider::{FuzzStartPoint, TransactionSource};
 
 use crate::replay::LocalExec;
 use crate::replay::ProtocolVersionSummary;
@@ -80,7 +80,7 @@ pub enum ReplayToolCommand {
     #[clap(name = "fz")]
     Fuzz {
         #[clap(long, short)]
-        start_checkpoint: Option<u64>,
+        start: Option<FuzzStartPoint>,
         #[clap(long, short)]
         num_mutations_per_base: u64,
         #[clap(long, short = 'b', default_value = "18446744073709551614")]
@@ -113,14 +113,14 @@ pub async fn execute_replay_command(
             None
         }
         ReplayToolCommand::Fuzz {
-            start_checkpoint,
+            start,
             num_mutations_per_base,
             num_base_transactions,
         } => {
             let config = ReplayFuzzerConfig {
                 num_mutations_per_base,
                 mutator: Box::new(base_fuzzers(num_mutations_per_base)),
-                tx_source: TransactionSource::TailLatest { start_checkpoint },
+                tx_source: TransactionSource::TailLatest { start },
                 fail_over_on_err: false,
                 expensive_safety_check_config: Default::default(),
             };

--- a/crates/sui-replay/src/transaction_provider.rs
+++ b/crates/sui-replay/src/transaction_provider.rs
@@ -5,10 +5,13 @@ use crate::{
     data_fetcher::{DataFetcher, RemoteFetcher},
     types::{ReplayEngineError, MAX_CONCURRENT_REQUESTS, RPC_TIMEOUT_ERR_SLEEP_RETRY_PERIOD},
 };
-use std::fmt::Debug;
 use std::{collections::VecDeque, fmt::Formatter};
+use std::{fmt::Debug, str::FromStr};
 use sui_sdk::SuiClientBuilder;
 use sui_types::digests::TransactionDigest;
+use tracing::info;
+
+const VALID_CHECKPOINT_START: u64 = 1;
 
 #[derive(Clone, Debug)]
 pub enum TransactionSource {
@@ -17,7 +20,7 @@ pub enum TransactionSource {
     /// Fetch a transaction from the network with a specific checkpoint ID
     FromCheckpoint(u64),
     /// Use the latest transaction from the network
-    TailLatest { start_checkpoint: Option<u64> },
+    TailLatest { start: Option<FuzzStartPoint> },
     /// Use a random transaction from an inclusive range of checkpoint IDs
     FromInclusiveCheckpointRange {
         checkpoint_start: u64,
@@ -31,6 +34,29 @@ pub struct TransactionProvider {
     pub source: TransactionSource,
     pub last_checkpoint: Option<u64>,
     pub transactions_left: VecDeque<TransactionDigest>,
+}
+
+#[derive(Eq, PartialEq, Clone, Copy, PartialOrd, Ord, Hash, Debug)]
+pub enum FuzzStartPoint {
+    Checkpoint(u64),
+    TxDigest(TransactionDigest),
+}
+
+impl FromStr for FuzzStartPoint {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.parse::<u64>() {
+            Ok(n) => Ok(FuzzStartPoint::Checkpoint(n)),
+            Err(u64_err) => match TransactionDigest::from_str(s) {
+                Ok(d) => Ok(FuzzStartPoint::TxDigest(d)),
+                Err(tx_err) => {
+                    info!("{} is not a valid checkpoint (err: {:?}) or transaction digest (err: {:?})", s, u64_err, tx_err);
+                    Err(tx_err)
+                }
+            },
+        }
+    }
 }
 
 impl Debug for TransactionProvider {
@@ -74,13 +100,34 @@ impl TransactionProvider {
                     .await?;
                 Some(tx)
             }
-            TransactionSource::TailLatest { start_checkpoint } => {
+            TransactionSource::TailLatest { start } => {
                 if let Some(tx) = self.transactions_left.pop_front() {
                     Some(tx)
                 } else {
-                    let next_checkpoint =
-                    // Advance to next checkpoint
-                    self.last_checkpoint.map(|c| c + 1).unwrap_or(start_checkpoint.unwrap_or(1));
+                    let next_checkpoint = match start {
+                        Some(x) => match x {
+                            // Checkpoint specified
+                            FuzzStartPoint::Checkpoint(checkpoint_id) => Some(*checkpoint_id),
+                            // Digest specified. Find the checkpoint for the digest
+                            FuzzStartPoint::TxDigest(tx_digest) => {
+                                let ch = self
+                                    .fetcher
+                                    .get_transaction(tx_digest)
+                                    .await?
+                                    .checkpoint
+                                    .expect("Transaction must have a checkpoint");
+                                // For the next round
+                                self.source = TransactionSource::TailLatest {
+                                    start: Some(FuzzStartPoint::Checkpoint(ch + 1)),
+                                };
+                                Some(ch)
+                            }
+                        },
+                        // Advance to next checkpoint if available
+                        None => self.last_checkpoint.map(|c| c + 1),
+                    }
+                    .unwrap_or(VALID_CHECKPOINT_START);
+
                     self.transactions_left = self
                         .fetcher
                         .get_checkpoint_txs(next_checkpoint)


### PR DESCRIPTION
## Description 

Allows specifying start of fuzz as either checkpoint or tx digest

## Test Plan 

Manual

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
