### PR TITLE
set CHECKPOINT_PROGRESS_LOG_COUNT_INTERVAL to 10

### DIFF
--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -64,7 +64,7 @@ pub(crate) mod tests;
 type CheckpointExecutionBuffer = FuturesOrdered<JoinHandle<VerifiedCheckpoint>>;
 
 /// The interval to log checkpoint progress, in # of checkpoints processed.
-const CHECKPOINT_PROGRESS_LOG_COUNT_INTERVAL: u64 = 5000;
+const CHECKPOINT_PROGRESS_LOG_COUNT_INTERVAL: u64 = 10;
 
 pub struct CheckpointExecutor {
     mailbox: broadcast::Receiver<VerifiedCheckpoint>,


### PR DESCRIPTION
## Description 

5000 is too small -> 1 log every 1.38 hour. Change it to 10 so we log every ~10s.

## Test Plan 

CI
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
