### PR TITLE
[crypto] get_keypair from private key bytes

### DIFF
--- a/crates/sui-types/src/unit_tests/crypto_tests.rs
+++ b/crates/sui-types/src/unit_tests/crypto_tests.rs
@@ -94,6 +94,15 @@ proptest! {
     }
 
     #[test]
+    fn test_get_key_pair_from_private_key_bytes(
+        bytes in collection::vec(any::<u8>(), 0..1024)
+    ){
+        let _key_pair = get_key_pair_from_bytes::<AuthorityKeyPair>(&bytes);
+        let _key_pair = get_key_pair_from_bytes::<NetworkKeyPair>(&bytes);
+        let _key_pair = get_key_pair_from_bytes::<AccountKeyPair>(&bytes);
+    }
+
+    #[test]
     fn test_from_signable_bytes(
         bytes in collection::vec(any::<u8>(), 0..1024)
     ){
@@ -120,6 +129,4 @@ proptest! {
         let _skp: Result<SuiKeyPair, _> = bcs::from_bytes(&bytes);
         let _pk: Result<PublicKey, _> = bcs::from_bytes(&bytes);
     }
-
-
 }


### PR DESCRIPTION
## Description 

fixes https://github.com/MystenLabs/sui/issues/11031

## Test Plan 

added extra proptest

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration
