### PR TITLE
use camelCase for `unwrappedThenDeleted`

### DIFF
--- a/.changeset/rotten-shrimps-enjoy.md
+++ b/.changeset/rotten-shrimps-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Previously, effects had an unwrapped_then_deleted field on ts-sdk. This is an issue since jsonrpc returns the field as unwrappedThenDeleted. Update the transaction type definition to use camelcase.

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -243,7 +243,7 @@ export const TransactionEffects = object({
   /** Object Refs of objects now deleted (the old refs) */
   deleted: optional(array(SuiObjectRef)),
   /** Object Refs of objects now deleted (the old refs) */
-  unwrapped_then_deleted: optional(array(SuiObjectRef)),
+  unwrappedThenDeleted: optional(array(SuiObjectRef)),
   /** Object refs of objects now wrapped in other objects */
   wrapped: optional(array(SuiObjectRef)),
   /**


### PR DESCRIPTION
## Description 

Previously, `effects` had an `unwrapped_then_deleted` field on ts-sdk. This is an issue since jsonrpc returns the field as `unwrappedThenDeleted`.

## Test Plan 

Locally built ts-sdk and explorer. Verified that visiting this page: http://localhost:3000/txblock/3T2AYzJTvW5Hg4JhZaTgeFaTPSetyEBYZ44bVzScfibS?network=mainnet did not result in any errors printed to console.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
