### PR TITLE
[explorer] Support new validator map API

### DIFF
--- a/apps/explorer/src/components/validator-map/ValidatorLocation.tsx
+++ b/apps/explorer/src/components/validator-map/ValidatorLocation.tsx
@@ -3,10 +3,10 @@
 
 import { useCallback } from 'react';
 
-import { type ValidatorMapData } from './types';
+import { type ValidatorMapValidator } from './types';
 
 interface Props {
-    validator: ValidatorMapData;
+    validator: ValidatorMapValidator;
     projection: (loc: [number, number]) => [number, number] | null;
     onMouseOver(event: React.MouseEvent, countryCode?: string): void;
     onMouseOut(): void;

--- a/apps/explorer/src/components/validator-map/WorldMap.tsx
+++ b/apps/explorer/src/components/validator-map/WorldMap.tsx
@@ -8,7 +8,7 @@ import * as topojson from 'topojson-client';
 import { MapFeature } from './MapFeature';
 import { ValidatorLocation } from './ValidatorLocation';
 import world from './topology.json';
-import { type Feature, type ValidatorMapData } from './types';
+import { type Feature, type ValidatorMapValidator } from './types';
 
 // @ts-expect-error: The types of `world` here aren't aligned but they are correct
 const land = topojson.feature(world, world.objects.countries) as unknown as {
@@ -25,7 +25,7 @@ const filteredLand = land.features.filter(
 interface Props {
     width: number;
     height: number;
-    validators?: ValidatorMapData[];
+    validators?: ValidatorMapValidator[];
     onMouseOver(event: React.MouseEvent, countryCode?: string): void;
     onMouseOut(): void;
 }

--- a/apps/explorer/src/components/validator-map/index.tsx
+++ b/apps/explorer/src/components/validator-map/index.tsx
@@ -8,7 +8,11 @@ import { TooltipWithBounds, useTooltip } from '@visx/tooltip';
 import React, { type ReactNode, useCallback, useMemo } from 'react';
 
 import { WorldMap } from './WorldMap';
-import { type NodeLocation, type ValidatorMapData } from './types';
+import {
+    type ValidatorMapResponse,
+    type NodeLocation,
+    type ValidatorMapValidator,
+} from './types';
 
 import { useNetwork } from '~/context';
 import { useAppsBackend } from '~/hooks/useAppsBackend';
@@ -19,7 +23,7 @@ import { Text } from '~/ui/Text';
 
 const HOST = 'https://imgmod.sui.io';
 
-type ValidatorsMap = Record<string, ValidatorMapData>;
+type ValidatorsMap = Record<string, ValidatorMapValidator>;
 
 const numberFormatter = new Intl.NumberFormat('en');
 
@@ -46,7 +50,7 @@ export default function ValidatorMap({ minHeight }: Props) {
     const { data: systemState, isError: systemStateError } =
         useGetSystemState();
 
-    const appsBe = useAppsBackend();
+    const { request } = useAppsBackend();
 
     const { data: nodeData, isSuccess } = useQuery({
         queryKey: ['node-map'],
@@ -88,13 +92,12 @@ export default function ValidatorMap({ minHeight }: Props) {
         isError,
     } = useQuery({
         queryKey: ['validator-map'],
-        queryFn: (): Promise<ValidatorMapData[]> =>
-            appsBe('validator-map', {
+        queryFn: () =>
+            request<ValidatorMapResponse>('validator-map', {
                 network: network.toLowerCase(),
             }),
-        select: (validators: ValidatorMapData[]) =>
-            // Some validators will come back as null from the location API
-            validators.filter((validator: ValidatorMapData) => validator),
+        // NOTE: This selects out just the validators for now, since we don't currently use the node count:
+        select: ({ validators }) => validators,
     });
 
     const { countryCount, validatorMap } = useMemo<{

--- a/apps/explorer/src/components/validator-map/types.ts
+++ b/apps/explorer/src/components/validator-map/types.ts
@@ -48,9 +48,14 @@ interface ValidatorIpInfo {
     isEU: boolean;
 }
 
-export interface ValidatorMapData {
+export interface ValidatorMapValidator {
     ipInfo?: ValidatorIpInfo;
     suiAddress: string;
     name: string;
     votingPower: string;
+}
+
+export interface ValidatorMapResponse {
+    validators: ValidatorMapValidator[];
+    nodeCount?: number | null;
 }

--- a/apps/explorer/src/hooks/useAppsBackend.ts
+++ b/apps/explorer/src/hooks/useAppsBackend.ts
@@ -9,7 +9,7 @@ import { Network } from '~/utils/api/DefaultRpcClient';
 export function useAppsBackend() {
     const [network] = useNetwork();
 
-    return useCallback(
+    const request = useCallback(
         async <T>(
             path: string,
             queryString: Record<string, any>,
@@ -31,4 +31,6 @@ export function useAppsBackend() {
         },
         [network]
     );
+
+    return { request };
 }

--- a/apps/explorer/src/hooks/useSuiCoinData.ts
+++ b/apps/explorer/src/hooks/useSuiCoinData.ts
@@ -16,10 +16,10 @@ type CoinData = {
 };
 
 export function useSuiCoinData() {
-    const makeAppsBackendRequest = useAppsBackend();
+    const { request } = useAppsBackend();
     return useQuery({
         queryKey: ['sui-coin-data'],
-        queryFn: () => makeAppsBackendRequest<CoinData>('coins/sui', {}),
+        queryFn: () => request<CoinData>('coins/sui', {}),
         cacheTime: 24 * 60 * 60 * 1000,
         staleTime: Infinity,
     });


### PR DESCRIPTION
## Description

Updates the validator map logic to support the new API structure. Not consuming the new data yet, just changing this to read from the correct path.

## Test Plan

Ran locally.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
