### PR TITLE
[apps] Update growthbook to use new API

### DIFF
--- a/apps/explorer/src/utils/growthbook.ts
+++ b/apps/explorer/src/utils/growthbook.ts
@@ -3,12 +3,10 @@
 
 import { GrowthBook } from '@growthbook/growthbook';
 
-const GROWTHBOOK_API_KEY = import.meta.env.PROD
-    ? 'sdk-fHnfPId19IG3Lhj'
-    : 'sdk-qEEo0utCXJO2Oid3';
-
 export const growthbook = new GrowthBook({
-    apiHost: 'https://cdn.growthbook.io',
-    clientKey: GROWTHBOOK_API_KEY,
-    enableDevMode: true,
+    // If you want to develop locally, you can set the API host to this:
+    // apiHost: 'http://localhost:3003',
+    apiHost: 'https://apps-backend.sui.io',
+    clientKey: import.meta.env.PROD ? 'production' : 'development',
+    enableDevMode: import.meta.env.DEV,
 });

--- a/apps/wallet/src/shared/experimentation/features.ts
+++ b/apps/wallet/src/shared/experimentation/features.ts
@@ -6,15 +6,13 @@ import Browser from 'webextension-polyfill';
 
 import { API_ENV } from '_src/shared/api-env';
 
-const GROWTHBOOK_API_KEY =
-    process.env.NODE_ENV === 'production'
-        ? 'sdk-lJ5zaQ6WI9uPth6C'
-        : 'sdk-iUMYcob41m3pnAK';
-
 export const growthbook = new GrowthBook({
-    apiHost: 'https://cdn.growthbook.io',
-    clientKey: GROWTHBOOK_API_KEY,
-    enableDevMode: true,
+    // If you want to develop locally, you can set the API host to this:
+    // apiHost: 'http://localhost:3003',
+    apiHost: 'https://apps-backend.sui.io',
+    clientKey:
+        process.env.NODE_ENV === 'development' ? 'development' : 'production',
+    enableDevMode: process.env.NODE_ENV === 'development',
 });
 
 /**

--- a/apps/wallet/src/ui/app/experimentation/feature-gating.ts
+++ b/apps/wallet/src/ui/app/experimentation/feature-gating.ts
@@ -3,4 +3,5 @@
 
 import { GrowthBook } from '@growthbook/growthbook';
 
+// This is a separate growthbook instance for the wallet UI, with flag values synced from the service worker.
 export const growthbook = new GrowthBook();


### PR DESCRIPTION
## Description 

New cached API.

## Test Plan 

Ran locally.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
