### PR TITLE
[refactor] exit early on certificate processing when already processed

### DIFF
--- a/narwhal/primary/src/synchronizer.rs
+++ b/narwhal/primary/src/synchronizer.rs
@@ -701,6 +701,14 @@ impl Synchronizer {
         early_suspend: bool,
     ) -> DagResult<()> {
         let _scope = monitored_scope("Synchronizer::process_certificate_with_lock");
+        let digest = certificate.digest();
+
+        // We re-check here in case we already have in pipeline the same certificate for processing
+        // more that once.
+        if inner.certificate_store.contains(&digest)? {
+            debug!("Skip processing certificate {:?}", certificate);
+            return Ok(());
+        }
 
         debug!("Processing certificate {:?}", certificate);
 
@@ -710,8 +718,6 @@ impl Synchronizer {
         // and certificates are sent to consensus in causal order.
         // It is possible to reduce the critical section below, but it seems unnecessary for now.
         let mut state = inner.state.lock().await;
-
-        let digest = certificate.digest();
 
         // Ensure parents are checked if !early_suspend.
         // See comments above `try_accept_fetched_certificate()` for details.


### PR DESCRIPTION
## Description 

Looking over on some mainnet logs (before the recent improvements on the proposer certificate requests) it seems that nodes were re-processing same certificate after this has been enqueued for processing in the `rx_certificate_acceptor` channel. Ex:

```
2023-05-09T20:52:32.430427Z DEBUG narwhal_consensus::bullshark: Processing KCS+7qgt4aRBk05R: C27294(24, KCS+7qgt4aRBk05R, E27)
2023-05-09T20:52:32.432573Z DEBUG request{route=/narwhal.PrimaryToPrimary/RequestVote remote_peer_id=e1b69e22 direction=inbound}: narwhal_primary::synchronizer: Processing certificate KCS+7qgt4aRBk05R: C27294(24, KCS+7qgt4aRBk05R, E27) round:27294
2023-05-09T20:52:32.449009Z DEBUG request{route=/narwhal.PrimaryToPrimary/RequestVote remote_peer_id=f6dee950 direction=inbound}: narwhal_primary::synchronizer: Processing certificate KCS+7qgt4aRBk05R: C27294(24, KCS+7qgt4aRBk05R, E27) round:27294
2023-05-09T20:52:32.453237Z DEBUG request{route=/narwhal.PrimaryToPrimary/RequestVote remote_peer_id=476f689c direction=inbound}: narwhal_primary::synchronizer: Processing certificate KCS+7qgt4aRBk05R: C27294(24, KCS+7qgt4aRBk05R, E27) round:27294
2023-05-09T20:52:37.339802Z DEBUG process_certificate_with_lock: narwhal_primary::synchronizer: Processing certificate KCS+7qgt4aRBk05R: C27294(24, KCS+7qgt4aRBk05R, E27)
2023-05-09T20:52:37.552668Z DEBUG process_certificate_with_lock:accept_certificate_internal: narwhal_primary::synchronizer: Processing certificate KCS+7qgt4aRBk05R: C27294(24, KCS+7qgt4aRBk05R, E27)
2023-05-09T20:52:37.552839Z DEBUG narwhal_consensus::bullshark: Processing KCS+7qgt4aRBk05R: C27294(24, KCS+7qgt4aRBk05R, E27)
2023-05-09T20:52:53.634274Z DEBUG process_certificate_with_lock: narwhal_primary::synchronizer: Processing certificate KCS+7qgt4aRBk05R: C27294(24, KCS+7qgt4aRBk05R, E27)
2023-05-09T20:52:53.825338Z DEBUG process_certificate_with_lock:accept_certificate_internal: narwhal_primary::synchronizer: Processing certificate KCS+7qgt4aRBk05R: C27294(24, KCS+7qgt4aRBk05R, E27)
2023-05-09T20:52:53.825588Z DEBUG narwhal_consensus::bullshark: Processing KCS+7qgt4aRBk05R: C27294(24, KCS+7qgt4aRBk05R, E27)
2023-05-09T20:52:55.546217Z DEBUG process_certificate_with_lock: narwhal_primary::synchronizer: Processing certificate KCS+7qgt4aRBk05R: C27294(24, KCS+7qgt4aRBk05R, E27)
2023-05-09T20:52:55.855896Z DEBUG process_certificate_with_lock:accept_certificate_internal: narwhal_primary::synchronizer: Processing certificate KCS+7qgt4aRBk05R: C27294(24, KCS+7qgt4aRBk05R, E27)
2023-05-09T20:52:55.856105Z DEBUG narwhal_consensus::bullshark: Processing KCS+7qgt4aRBk05R: C27294(24, KCS+7qgt4aRBk05R, E27)
2023-05-09T20:52:56.119861Z DEBUG process_certificate_with_lock: narwhal_primary::synchronizer: Processing certificate KCS+7qgt4aRBk05R: C27294(24, KCS+7qgt4aRBk05R, E27)
2023-05-09T20:52:56.361722Z DEBUG process_certificate_with_lock:accept_certificate_internal: narwhal_primary::synchronizer: Processing certificate KCS+7qgt4aRBk05R: C27294(24, KCS+7qgt4aRBk05R, E27)
2023-05-09T20:52:56.361919Z DEBUG narwhal_consensus::bullshark: Processing KCS+7qgt4aRBk05R: C27294(24, KCS+7qgt4aRBk05R, E27)
2023-05-09T20:53:08.279937Z DEBUG narwhal_consensus::utils: Sequencing KCS+7qgt4aRBk05R: C27294(24, KCS+7qgt4aRBk05R, E27)
2023-05-09T20:53:08.281682Z DEBUG narwhal_consensus::consensus: Certificate KCS+7qgt4aRBk05RWqzoY8AVcIth6tl6m1Z59Q+eccY= took 36.2 seconds to be committed at round 27294
2023-05-09T20:53:08.302452Z DEBUG narwhal_executor::subscriber: Adding fetched batch MD1H+em9MjxzBoWi from certificate KCS+7qgt4aRBk05R to consensus output
```

now, [since those changes](https://github.com/MystenLabs/sui/pull/11835) I don't expect to see this happening frequently, but still it worth making this check before processing without cost - as we'll most probably hit certificate store's memory cache.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
