### PR TITLE
add fallback button request coins from faucet if only one coin

### DIFF
--- a/apps/wallet/src/shared/constants.ts
+++ b/apps/wallet/src/shared/constants.ts
@@ -16,3 +16,4 @@ export const DEFAULT_NFT_IMAGE =
 // Staking Rewards Redeemable
 export const NUM_OF_EPOCH_BEFORE_STAKING_REWARDS_REDEEMABLE = 2;
 export const NUM_OF_EPOCH_BEFORE_STAKING_REWARDS_STARTS = 1;
+export const MIN_NUMBER_SUI_TO_STAKE = '1';

--- a/apps/wallet/src/shared/constants.ts
+++ b/apps/wallet/src/shared/constants.ts
@@ -16,4 +16,4 @@ export const DEFAULT_NFT_IMAGE =
 // Staking Rewards Redeemable
 export const NUM_OF_EPOCH_BEFORE_STAKING_REWARDS_REDEEMABLE = 2;
 export const NUM_OF_EPOCH_BEFORE_STAKING_REWARDS_STARTS = 1;
-export const MIN_NUMBER_SUI_TO_STAKE = '1';
+export const MIN_NUMBER_SUI_TO_STAKE = 1;

--- a/apps/wallet/src/ui/app/shared/faucet/FaucetRequestButton.tsx
+++ b/apps/wallet/src/ui/app/shared/faucet/FaucetRequestButton.tsx
@@ -13,10 +13,12 @@ import { useAppSelector } from '_hooks';
 
 export type FaucetRequestButtonProps = {
     variant?: ButtonProps['variant'];
+    size?: ButtonProps['size'];
 };
 
 function FaucetRequestButton({
     variant = 'primary',
+    size = 'narrow',
 }: FaucetRequestButtonProps) {
     const network = useAppSelector(({ app }) => app.apiEnv);
     const networkName = API_ENV_TO_INFO[network].name.replace(/sui\s*/gi, '');
@@ -32,6 +34,7 @@ function FaucetRequestButton({
     return mutation.enabled ? (
         <Button
             variant={variant}
+            size={size}
             disabled={isRateLimited}
             onClick={() => {
                 toast.promise(mutation.mutateAsync(), {

--- a/apps/wallet/src/ui/app/staking/delegation-detail/DelegationDetailCard.tsx
+++ b/apps/wallet/src/ui/app/staking/delegation-detail/DelegationDetailCard.tsx
@@ -4,6 +4,7 @@
 import { useFeature } from '@growthbook/growthbook-react';
 import { useGetValidatorsApy, useGetSystemState } from '@mysten/core';
 import { ArrowLeft16, StakeAdd16, StakeRemove16 } from '@mysten/icons';
+import { SUI_TYPE_ARG } from '@mysten/sui.js';
 import { useMemo } from 'react';
 
 import { useActiveAddress } from '../../hooks/useActiveAddress';
@@ -19,7 +20,10 @@ import { Text } from '_app/shared/text';
 import { IconTooltip } from '_app/shared/tooltip';
 import Alert from '_components/alert';
 import LoadingIndicator from '_components/loading/LoadingIndicator';
+import { useAppSelector, useGetCoinBalance } from '_hooks';
+import { API_ENV } from '_src/shared/api-env';
 import { FEATURES } from '_src/shared/experimentation/features';
+import FaucetRequestButton from '_src/ui/app/shared/faucet/FaucetRequestButton';
 
 type DelegationDetailCardProps = {
     validatorAddress: string;
@@ -43,6 +47,12 @@ export function DelegationDetailCard({
         isLoading,
         isError,
     } = useGetDelegatedStake(accountAddress || '');
+
+    const apiEnv = useAppSelector(({ app }) => app.apiEnv);
+    const { data: suiCoinBalance } = useGetCoinBalance(
+        SUI_TYPE_ARG,
+        accountAddress
+    );
 
     const { data: rollingAverageApys } = useGetValidatorsApy();
 
@@ -237,13 +247,21 @@ export function DelegationDetailCard({
                         </div>
                     </div>
                 </Content>
-                <Button
-                    size="tall"
-                    variant="secondary"
-                    to="/stake"
-                    before={<ArrowLeft16 />}
-                    text="Back"
-                />
+
+                {/* show faucet request button on devnet or testnet whenever there is only one coin  */}
+                {apiEnv !== API_ENV.mainnet &&
+                suiCoinBalance &&
+                suiCoinBalance?.coinObjectCount <= 1 ? (
+                    <FaucetRequestButton size="tall" />
+                ) : (
+                    <Button
+                        size="tall"
+                        variant="secondary"
+                        to="/stake"
+                        before={<ArrowLeft16 />}
+                        text="Back"
+                    />
+                )}
             </BottomMenuLayout>
         </div>
     );

--- a/apps/wallet/src/ui/app/staking/delegation-detail/DelegationDetailCard.tsx
+++ b/apps/wallet/src/ui/app/staking/delegation-detail/DelegationDetailCard.tsx
@@ -281,7 +281,8 @@ export function DelegationDetailCard({
                                 weight="medium"
                                 color="steel-darker"
                             >
-                                You need a minimum of 1 SUI to continue staking.
+                                You need a minimum of {MIN_NUMBER_SUI_TO_STAKE}{' '}
+                                SUI to continue staking.
                             </Text>
                         </div>
                         <FaucetRequestButton size="tall" />

--- a/apps/wallet/src/ui/app/staking/delegation-detail/DelegationDetailCard.tsx
+++ b/apps/wallet/src/ui/app/staking/delegation-detail/DelegationDetailCard.tsx
@@ -9,6 +9,7 @@ import {
 } from '@mysten/core';
 import { ArrowLeft16, StakeAdd16, StakeRemove16 } from '@mysten/icons';
 import { SUI_TYPE_ARG } from '@mysten/sui.js';
+import BigNumber from 'bignumber.js';
 import { useMemo } from 'react';
 
 import { useActiveAddress } from '../../hooks/useActiveAddress';
@@ -24,7 +25,6 @@ import { Text } from '_app/shared/text';
 import { IconTooltip } from '_app/shared/tooltip';
 import Alert from '_components/alert';
 import LoadingIndicator from '_components/loading/LoadingIndicator';
-import { parseAmount } from '_helpers';
 import { useAppSelector, useGetCoinBalance } from '_hooks';
 import { API_ENV } from '_src/shared/api-env';
 import { MIN_NUMBER_SUI_TO_STAKE } from '_src/shared/constants';
@@ -68,11 +68,11 @@ export function DelegationDetailCard({
             apiEnv === API_ENV.mainnet
         )
             return false;
-
-        return (
-            parseAmount(suiCoinBalance.totalBalance, metadata.decimals) >
-            parseAmount(MIN_NUMBER_SUI_TO_STAKE, metadata.decimals)
+        const currentBalance = new BigNumber(suiCoinBalance.totalBalance);
+        const minStakeAmount = new BigNumber(MIN_NUMBER_SUI_TO_STAKE).shiftedBy(
+            metadata.decimals
         );
+        return currentBalance.lt(minStakeAmount.toString());
     }, [apiEnv, metadata?.decimals, suiCoinBalance?.totalBalance]);
 
     const { data: rollingAverageApys } = useGetValidatorsApy();
@@ -249,7 +249,10 @@ export function DelegationDetailCard({
                                     to={stakeByValidatorAddress}
                                     before={<StakeAdd16 />}
                                     text="Stake SUI"
-                                    disabled={!stakingEnabled}
+                                    disabled={
+                                        !stakingEnabled ||
+                                        showRequestMoreSuiToken
+                                    }
                                 />
                             ) : null}
 

--- a/apps/wallet/src/ui/app/staking/stake/StakingCard.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/StakingCard.tsx
@@ -41,6 +41,7 @@ import Loading from '_components/loading';
 import { parseAmount } from '_helpers';
 import { useSigner, useGetCoinBalance } from '_hooks';
 import { Coin } from '_redux/slices/sui-objects/Coin';
+import { MIN_NUMBER_SUI_TO_STAKE } from '_src/shared/constants';
 import { FEATURES } from '_src/shared/experimentation/features';
 import { trackEvent } from '_src/shared/plausible';
 
@@ -94,7 +95,7 @@ function StakingCard() {
     const { data: metadata } = useCoinMetadata(coinType);
     const coinDecimals = metadata?.decimals ?? 0;
     // set minimum stake amount to 1 SUI
-    const minimumStake = parseAmount('1', coinDecimals);
+    const minimumStake = parseAmount(MIN_NUMBER_SUI_TO_STAKE, coinDecimals);
 
     const validationSchema = useMemo(
         () =>

--- a/apps/wallet/src/ui/app/staking/stake/StakingCard.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/StakingCard.tsx
@@ -95,7 +95,10 @@ function StakingCard() {
     const { data: metadata } = useCoinMetadata(coinType);
     const coinDecimals = metadata?.decimals ?? 0;
     // set minimum stake amount to 1 SUI
-    const minimumStake = parseAmount(MIN_NUMBER_SUI_TO_STAKE, coinDecimals);
+    const minimumStake = parseAmount(
+        MIN_NUMBER_SUI_TO_STAKE.toString(),
+        coinDecimals
+    );
 
     const validationSchema = useMemo(
         () =>


### PR DESCRIPTION
Add request SUI coins from the faucet whenever SUI balance is less than or equal to 1 and if the network is not mainnet 

<img width="417" alt="Screenshot 2023-05-22 at 11 53 27 AM" src="https://github.com/MystenLabs/sui/assets/126525197/5692c06e-d176-4ef4-b78e-ae4b2e5ccdc8">


https://github.com/MystenLabs/sui/assets/126525197/35e6d53b-065d-45b7-b563-d51f22fc07e1


## Description 

Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
