### PR TITLE
[move-execution] Move config out of runtime and verifier crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5190,6 +5190,7 @@ dependencies = [
  "move-binary-format",
  "move-borrow-graph",
  "move-core-types",
+ "move-vm-config",
  "petgraph 0.5.1",
 ]
 
@@ -5703,6 +5704,7 @@ dependencies = [
  "move-stackless-bytecode-interpreter",
  "move-stdlib",
  "move-symbol-pool",
+ "move-vm-config",
  "move-vm-runtime",
  "move-vm-test-utils",
  "move-vm-types",
@@ -5743,6 +5745,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "move-vm-config"
+version = "0.1.0"
+dependencies = [
+ "move-binary-format",
+]
+
+[[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
 dependencies = [
@@ -5751,6 +5760,7 @@ dependencies = [
  "move-binary-format",
  "move-bytecode-verifier",
  "move-core-types",
+ "move-vm-config",
  "move-vm-types",
  "once_cell",
  "parking_lot 0.11.2",
@@ -9399,6 +9409,7 @@ dependencies = [
  "move-bytecode-verifier",
  "move-core-types",
  "move-package",
+ "move-vm-config",
  "move-vm-runtime",
  "move-vm-types",
  "mysten-metrics",
@@ -10900,6 +10911,7 @@ dependencies = [
  "move-bytecode-utils",
  "move-bytecode-verifier",
  "move-core-types",
+ "move-vm-config",
  "sui-protocol-config",
  "sui-types",
  "workspace-hack",
@@ -13027,6 +13039,7 @@ dependencies = [
  "move-table-extension",
  "move-transactional-test-runner",
  "move-unit-test",
+ "move-vm-config",
  "move-vm-runtime",
  "move-vm-test-utils",
  "move-vm-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ exclude = [
     "external-crates/move/move-prover/test-utils",
     "external-crates/move/move-stdlib",
     "external-crates/move/move-symbol-pool",
+    "external-crates/move/move-vm/config",
     "external-crates/move/move-vm/integration-tests",
     "external-crates/move/move-vm/paranoid-tests",
     "external-crates/move/move-vm/runtime",
@@ -197,6 +198,7 @@ move-package = { path = "external-crates/move/tools/move-package" }
 move-stdlib = { path = "external-crates/move/move-stdlib" }
 move-vm-runtime =  { path = "external-crates/move/move-vm/runtime" }
 move-unit-test = { path = "external-crates/move/tools/move-unit-test" }
+move-vm-config = { path = "external-crates/move/move-vm/config" }
 move-vm-test-utils = { path = "external-crates/move/move-vm/test-utils" }
 move-vm-types = { path = "external-crates/move/move-vm/types" }
 move-command-line-common = { path = "external-crates/move/move-command-line-common" }

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -391,6 +391,7 @@ move-symbol-pool = { path = "../../external-crates/move/move-symbol-pool" }
 move-table-extension = { path = "../../external-crates/move/extensions/move-table-extension", default-features = false }
 move-transactional-test-runner = { path = "../../external-crates/move/testing-infra/transactional-test-runner", default-features = false }
 move-unit-test = { path = "../../external-crates/move/tools/move-unit-test", default-features = false }
+move-vm-config = { path = "../../external-crates/move/move-vm/config", default-features = false }
 move-vm-runtime = { path = "../../external-crates/move/move-vm/runtime", features = ["debugging", "testing"] }
 move-vm-test-utils = { path = "../../external-crates/move/move-vm/test-utils", features = ["tiered-gas"] }
 move-vm-types = { path = "../../external-crates/move/move-vm/types" }
@@ -1139,6 +1140,7 @@ move-symbol-pool = { path = "../../external-crates/move/move-symbol-pool" }
 move-table-extension = { path = "../../external-crates/move/extensions/move-table-extension", default-features = false }
 move-transactional-test-runner = { path = "../../external-crates/move/testing-infra/transactional-test-runner", default-features = false }
 move-unit-test = { path = "../../external-crates/move/tools/move-unit-test", default-features = false }
+move-vm-config = { path = "../../external-crates/move/move-vm/config", default-features = false }
 move-vm-runtime = { path = "../../external-crates/move/move-vm/runtime", features = ["debugging", "testing"] }
 move-vm-test-utils = { path = "../../external-crates/move/move-vm/test-utils", features = ["tiered-gas"] }
 move-vm-types = { path = "../../external-crates/move/move-vm/types" }

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -596,6 +596,7 @@ dependencies = [
  "move-binary-format",
  "move-bytecode-verifier",
  "move-core-types",
+ "move-vm-config",
  "petgraph 0.5.1",
  "proptest",
 ]
@@ -3604,6 +3605,7 @@ dependencies = [
  "move-core-types",
  "move-stdlib",
  "move-table-extension",
+ "move-vm-config",
  "move-vm-runtime",
  "move-vm-test-utils",
  "move-vm-types",

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -2887,6 +2887,7 @@ dependencies = [
  "move-binary-format",
  "move-borrow-graph",
  "move-core-types",
+ "move-vm-config",
  "petgraph 0.5.1",
 ]
 
@@ -3537,6 +3538,7 @@ dependencies = [
  "move-stackless-bytecode-interpreter",
  "move-stdlib",
  "move-symbol-pool",
+ "move-vm-config",
  "move-vm-runtime",
  "move-vm-test-utils",
  "move-vm-types",
@@ -3583,6 +3585,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "move-vm-config"
+version = "0.1.0"
+dependencies = [
+ "move-binary-format",
+]
+
+[[package]]
 name = "move-vm-integration-tests"
 version = "0.1.0"
 dependencies = [
@@ -3623,6 +3632,7 @@ dependencies = [
  "move-compiler",
  "move-core-types",
  "move-ir-compiler",
+ "move-vm-config",
  "move-vm-types",
  "once_cell",
  "parking_lot 0.11.2",

--- a/external-crates/move/Cargo.toml
+++ b/external-crates/move/Cargo.toml
@@ -48,6 +48,7 @@ members = [
     "move-prover/tools/spec-flatten",
     "move-stdlib",
     "move-symbol-pool",
+    "move-vm/config",
     "move-vm/integration-tests",
     "move-vm/paranoid-tests",
     "move-vm/runtime",

--- a/external-crates/move/move-bytecode-verifier/Cargo.toml
+++ b/external-crates/move/move-bytecode-verifier/Cargo.toml
@@ -17,6 +17,7 @@ fail = "0.4.0"
 move-borrow-graph = { path = "../move-borrow-graph" }
 move-binary-format = { path = "../move-binary-format" }
 move-core-types = { path = "../move-core/types" }
+move-vm-config = { path = "../move-vm/config" }
 
 [dev-dependencies]
 hex-literal = "0.3.4"

--- a/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/Cargo.toml
+++ b/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/Cargo.toml
@@ -14,10 +14,12 @@ petgraph = "0.5.1"
 proptest = "1.0.0"
 fail = { version = "0.4.0", features = ['failpoints']}
 hex = "0.4.3"
-move-bytecode-verifier = { path = "../" }
+
 invalid-mutations = { path = "../invalid-mutations" }
-move-core-types = { path = "../../move-core/types" }
 move-binary-format = { path = "../../move-binary-format", features = ["fuzzing"] }
+move-bytecode-verifier = { path = "../" }
+move-core-types = { path = "../../move-core/types" }
+move-vm-config = { path = "../../move-vm/config" }
 
 [features]
 fuzzing = ["move-binary-format/fuzzing"]

--- a/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/catch_unwind.rs
+++ b/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/catch_unwind.rs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 use fail::FailScenario;
 use move_binary_format::file_format::empty_module;
-use move_bytecode_verifier::VerifierConfig;
 use move_core_types::{
     state::{self, VMState},
     vm_status::StatusCode,
 };
+use move_vm_config::verifier::VerifierConfig;
 use std::panic::{self, PanicInfo};
 
 #[ignore]

--- a/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/code_unit_tests.rs
+++ b/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/code_unit_tests.rs
@@ -5,8 +5,9 @@
 use crate::support::dummy_procedure_module;
 use move_binary_format::file_format::Bytecode;
 use move_bytecode_verifier::meter::DummyMeter;
-use move_bytecode_verifier::{CodeUnitVerifier, VerifierConfig};
+use move_bytecode_verifier::CodeUnitVerifier;
 use move_core_types::vm_status::StatusCode;
+use move_vm_config::verifier::VerifierConfig;
 
 #[test]
 fn invalid_fallthrough_br_true() {

--- a/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/control_flow_tests.rs
+++ b/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/control_flow_tests.rs
@@ -8,8 +8,9 @@ use move_binary_format::{
     errors::PartialVMResult,
     file_format::{Bytecode, CompiledModule, FunctionDefinitionIndex, TableIndex},
 };
-use move_bytecode_verifier::{control_flow, meter::DummyMeter, VerifierConfig};
+use move_bytecode_verifier::{control_flow, meter::DummyMeter};
 use move_core_types::vm_status::StatusCode;
+use move_vm_config::verifier::VerifierConfig;
 
 fn verify_module(verifier_config: &VerifierConfig, module: &CompiledModule) -> PartialVMResult<()> {
     for (idx, function_definition) in module

--- a/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/limit_tests.rs
+++ b/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/limit_tests.rs
@@ -4,13 +4,12 @@
 use crate::unit_tests::production_config;
 use move_binary_format::file_format::*;
 use move_bytecode_verifier::{
-    limits::LimitsVerifier, meter::DummyMeter, verifier::DEFAULT_MAX_IDENTIFIER_LENGTH,
-    verify_module_with_config_for_test,
+    limits::LimitsVerifier, meter::DummyMeter, verify_module_with_config_for_test,
 };
 use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, vm_status::StatusCode,
 };
-use move_vm_config::verifier::VerifierConfig;
+use move_vm_config::verifier::{VerifierConfig, DEFAULT_MAX_IDENTIFIER_LENGTH};
 
 #[test]
 fn test_function_handle_type_instantiation() {

--- a/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/limit_tests.rs
+++ b/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/limit_tests.rs
@@ -5,11 +5,12 @@ use crate::unit_tests::production_config;
 use move_binary_format::file_format::*;
 use move_bytecode_verifier::{
     limits::LimitsVerifier, meter::DummyMeter, verifier::DEFAULT_MAX_IDENTIFIER_LENGTH,
-    verify_module_with_config_for_test, VerifierConfig,
+    verify_module_with_config_for_test,
 };
 use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, vm_status::StatusCode,
 };
+use move_vm_config::verifier::VerifierConfig;
 
 #[test]
 fn test_function_handle_type_instantiation() {

--- a/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/mod.rs
+++ b/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/mod.rs
@@ -4,8 +4,8 @@
 
 use move_bytecode_verifier::{
     verifier::DEFAULT_MAX_CONSTANT_VECTOR_LEN, verifier::DEFAULT_MAX_IDENTIFIER_LENGTH,
-    VerifierConfig,
 };
+use move_vm_config::verifier::VerifierConfig;
 
 pub mod ability_field_requirements_tests;
 pub mod binary_samples;

--- a/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/mod.rs
+++ b/external-crates/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/mod.rs
@@ -2,10 +2,9 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_bytecode_verifier::{
-    verifier::DEFAULT_MAX_CONSTANT_VECTOR_LEN, verifier::DEFAULT_MAX_IDENTIFIER_LENGTH,
+use move_vm_config::verifier::{
+    VerifierConfig, DEFAULT_MAX_CONSTANT_VECTOR_LEN, DEFAULT_MAX_IDENTIFIER_LENGTH,
 };
-use move_vm_config::verifier::VerifierConfig;
 
 pub mod ability_field_requirements_tests;
 pub mod binary_samples;

--- a/external-crates/move/move-bytecode-verifier/src/code_unit_verifier.rs
+++ b/external-crates/move/move-bytecode-verifier/src/code_unit_verifier.rs
@@ -12,7 +12,6 @@ use crate::{
     reference_safety,
     stack_usage_verifier::StackUsageVerifier,
     type_safety,
-    verifier::VerifierConfig,
 };
 use move_binary_format::{
     access::ModuleAccess,
@@ -26,6 +25,7 @@ use move_binary_format::{
     IndexKind,
 };
 use move_core_types::vm_status::StatusCode;
+use move_vm_config::verifier::VerifierConfig;
 use std::collections::HashMap;
 
 pub struct CodeUnitVerifier<'a> {

--- a/external-crates/move/move-bytecode-verifier/src/control_flow.rs
+++ b/external-crates/move/move-bytecode-verifier/src/control_flow.rs
@@ -16,7 +16,6 @@ use crate::{
     control_flow_v5,
     loop_summary::{LoopPartition, LoopSummary},
     meter::Meter,
-    verifier::VerifierConfig,
 };
 use move_binary_format::{
     access::{ModuleAccess, ScriptAccess},
@@ -28,6 +27,7 @@ use move_binary_format::{
     CompiledModule,
 };
 use move_core_types::vm_status::StatusCode;
+use move_vm_config::verifier::VerifierConfig;
 use std::collections::BTreeSet;
 
 /// Perform control flow verification on the compiled function, returning its `FunctionView` if

--- a/external-crates/move/move-bytecode-verifier/src/control_flow_v5.rs
+++ b/external-crates/move/move-bytecode-verifier/src/control_flow_v5.rs
@@ -7,13 +7,13 @@
 //! - All forward jumps do not enter into the middle of a loop
 //! - All "breaks" (forward, loop-exiting jumps) go to the "end" of the loop
 //! - All "continues" (back jumps in a loop) are only to the current loop
-use crate::verifier::VerifierConfig;
 use move_binary_format::{
     errors::{PartialVMError, PartialVMResult},
     file_format::{Bytecode, CodeOffset, CodeUnit, FunctionDefinitionIndex},
     safe_unwrap,
 };
 use move_core_types::vm_status::StatusCode;
+use move_vm_config::verifier::VerifierConfig;
 use std::{collections::HashSet, convert::TryInto};
 
 pub fn verify(

--- a/external-crates/move/move-bytecode-verifier/src/lib.rs
+++ b/external-crates/move/move-bytecode-verifier/src/lib.rs
@@ -37,7 +37,7 @@ pub use struct_defs::RecursiveStructDefChecker;
 pub use verifier::{
     verify_module_unmetered, verify_module_with_config_for_test, verify_module_with_config_metered,
     verify_module_with_config_unmetered, verify_script_unmetered,
-    verify_script_with_config_metered, verify_script_with_config_unmetered, VerifierConfig,
+    verify_script_with_config_metered, verify_script_with_config_unmetered,
 };
 
 mod acquires_list_verifier;

--- a/external-crates/move/move-bytecode-verifier/src/limits.rs
+++ b/external-crates/move/move-bytecode-verifier/src/limits.rs
@@ -1,7 +1,6 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::VerifierConfig;
 use move_binary_format::{
     binary_views::BinaryIndexedView,
     errors::{verification_error, Location, PartialVMError, PartialVMResult, VMResult},
@@ -11,6 +10,7 @@ use move_binary_format::{
     IndexKind,
 };
 use move_core_types::{value::MoveValue, vm_status::StatusCode};
+use move_vm_config::verifier::VerifierConfig;
 
 pub struct LimitsVerifier<'a> {
     resolver: BinaryIndexedView<'a>,

--- a/external-crates/move/move-bytecode-verifier/src/meter.rs
+++ b/external-crates/move/move-bytecode-verifier/src/meter.rs
@@ -1,9 +1,9 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::VerifierConfig;
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::vm_status::StatusCode;
+use move_vm_config::verifier::VerifierConfig;
 use std::ops::Mul;
 
 /// Scope of meterinng

--- a/external-crates/move/move-bytecode-verifier/src/regression_tests/reference_analysis.rs
+++ b/external-crates/move/move-bytecode-verifier/src/regression_tests/reference_analysis.rs
@@ -18,9 +18,8 @@ use move_binary_format::{
 use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, vm_status::StatusCode,
 };
+use move_vm_config::verifier::VerifierConfig;
 use std::str::FromStr;
-
-use crate::VerifierConfig;
 
 #[test]
 fn unbalanced_stack_crash() {

--- a/external-crates/move/move-bytecode-verifier/src/stack_usage_verifier.rs
+++ b/external-crates/move/move-bytecode-verifier/src/stack_usage_verifier.rs
@@ -9,7 +9,7 @@
 //! the stack height by the number of values returned by the function as indicated in its
 //! signature. Additionally, the stack height must not dip below that at the beginning of the
 //! block for any basic block.
-use crate::{meter::Meter, VerifierConfig};
+use crate::meter::Meter;
 use move_binary_format::{
     binary_views::{BinaryIndexedView, FunctionView},
     control_flow_graph::{BlockId, ControlFlowGraph},
@@ -17,6 +17,7 @@ use move_binary_format::{
     file_format::{Bytecode, CodeUnit, FunctionDefinitionIndex, Signature, StructFieldInformation},
 };
 use move_core_types::vm_status::StatusCode;
+use move_vm_config::verifier::VerifierConfig;
 
 pub(crate) struct StackUsageVerifier<'a> {
     resolver: &'a BinaryIndexedView<'a>,

--- a/external-crates/move/move-bytecode-verifier/src/verifier.rs
+++ b/external-crates/move/move-bytecode-verifier/src/verifier.rs
@@ -17,32 +17,8 @@ use move_binary_format::{
     errors::{Location, VMResult},
     file_format::{CompiledModule, CompiledScript},
 };
+use move_vm_config::verifier::VerifierConfig;
 use std::time::Instant;
-
-pub const DEFAULT_MAX_CONSTANT_VECTOR_LEN: u64 = 1024 * 1024;
-pub const DEFAULT_MAX_IDENTIFIER_LENGTH: u64 = 128;
-
-#[derive(Debug, Clone)]
-pub struct VerifierConfig {
-    pub max_loop_depth: Option<usize>,
-    pub max_function_parameters: Option<usize>,
-    pub max_generic_instantiation_length: Option<usize>,
-    pub max_basic_blocks: Option<usize>,
-    pub max_value_stack_size: usize,
-    pub max_type_nodes: Option<usize>,
-    pub max_push_size: Option<usize>,
-    pub max_dependency_depth: Option<usize>,
-    pub max_struct_definitions: Option<usize>,
-    pub max_fields_in_struct: Option<usize>,
-    pub max_function_definitions: Option<usize>,
-    pub max_constant_vector_len: Option<u64>,
-    pub max_back_edges_per_function: Option<usize>,
-    pub max_back_edges_per_module: Option<usize>,
-    pub max_basic_blocks_in_script: Option<usize>,
-    pub max_per_fun_meter_units: Option<u128>,
-    pub max_per_mod_meter_units: Option<u128>,
-    pub max_idenfitier_len: Option<u64>,
-}
 
 /// Helper for a "canonical" verification of a module.
 ///
@@ -155,54 +131,4 @@ pub fn verify_script_with_config_unmetered(
     script: &CompiledScript,
 ) -> VMResult<()> {
     verify_script_with_config_metered(config, script, &mut DummyMeter)
-}
-
-impl Default for VerifierConfig {
-    fn default() -> Self {
-        Self {
-            max_loop_depth: None,
-            max_function_parameters: None,
-            max_generic_instantiation_length: None,
-            max_basic_blocks: None,
-            max_type_nodes: None,
-            // Max size set to 1024 to match the size limit in the interpreter.
-            max_value_stack_size: 1024,
-            // Max number of pushes in one function
-            max_push_size: None,
-            // Max depth in dependency tree for both direct and friend dependencies
-            max_dependency_depth: None,
-            // Max count of structs in a module
-            max_struct_definitions: None,
-            // Max count of fields in a struct
-            max_fields_in_struct: None,
-            // Max count of functions in a module
-            max_function_definitions: None,
-            // Max size set to 10000 to restrict number of pushes in one function
-            // max_push_size: Some(10000),
-            // max_dependency_depth: Some(100),
-            // max_struct_definitions: Some(200),
-            // max_fields_in_struct: Some(30),
-            // max_function_definitions: Some(1000),
-            max_back_edges_per_function: None,
-            max_back_edges_per_module: None,
-            max_basic_blocks_in_script: None,
-            /// General metering for the verifier. This defaults to a bound which should align
-            /// with production, so all existing test cases apply it.
-            max_per_fun_meter_units: Some(1000 * 8000),
-            max_per_mod_meter_units: Some(1000 * 8000),
-            max_constant_vector_len: Some(DEFAULT_MAX_CONSTANT_VECTOR_LEN),
-            max_idenfitier_len: Some(DEFAULT_MAX_IDENTIFIER_LENGTH),
-        }
-    }
-}
-
-impl VerifierConfig {
-    /// Returns truly unbounded config, even relaxing metering.
-    pub fn unbounded() -> Self {
-        Self {
-            max_per_fun_meter_units: None,
-            max_per_mod_meter_units: None,
-            ..VerifierConfig::default()
-        }
-    }
 }

--- a/external-crates/move/move-vm/config/Cargo.toml
+++ b/external-crates/move/move-vm/config/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "move-vm-config"
+version = "0.1.0"
+authors = ["Diem Association <opensource@diem.com>"]
+repository = "https://github.com/move-language/move"
+license = "Apache-2.0"
+publish = false
+edition = "2021"
+
+[dependencies]
+move-binary-format = { path = "../../move-binary-format" }

--- a/external-crates/move/move-vm/config/src/lib.rs
+++ b/external-crates/move/move-vm/config/src/lib.rs
@@ -1,0 +1,5 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod runtime;
+pub mod verifier;

--- a/external-crates/move/move-vm/config/src/runtime.rs
+++ b/external-crates/move/move-vm/config/src/runtime.rs
@@ -1,8 +1,8 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::verifier::{VerifierConfig, DEFAULT_MAX_CONSTANT_VECTOR_LEN};
 use move_binary_format::file_format_common::VERSION_MAX;
-use move_bytecode_verifier::{verifier::DEFAULT_MAX_CONSTANT_VECTOR_LEN, VerifierConfig};
 
 /// Dynamic config options for the Move VM.
 pub struct VMConfig {
@@ -37,6 +37,7 @@ pub struct VMRuntimeLimitsConfig {
     /// Maximum number of items that can be pushed into a vec
     pub vector_len_max: u64,
 }
+
 impl Default for VMRuntimeLimitsConfig {
     fn default() -> Self {
         Self {

--- a/external-crates/move/move-vm/config/src/verifier.rs
+++ b/external-crates/move/move-vm/config/src/verifier.rs
@@ -1,0 +1,77 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pub const DEFAULT_MAX_CONSTANT_VECTOR_LEN: u64 = 1024 * 1024;
+pub const DEFAULT_MAX_IDENTIFIER_LENGTH: u64 = 128;
+
+#[derive(Debug, Clone)]
+pub struct VerifierConfig {
+    pub max_loop_depth: Option<usize>,
+    pub max_function_parameters: Option<usize>,
+    pub max_generic_instantiation_length: Option<usize>,
+    pub max_basic_blocks: Option<usize>,
+    pub max_value_stack_size: usize,
+    pub max_type_nodes: Option<usize>,
+    pub max_push_size: Option<usize>,
+    pub max_dependency_depth: Option<usize>,
+    pub max_struct_definitions: Option<usize>,
+    pub max_fields_in_struct: Option<usize>,
+    pub max_function_definitions: Option<usize>,
+    pub max_constant_vector_len: Option<u64>,
+    pub max_back_edges_per_function: Option<usize>,
+    pub max_back_edges_per_module: Option<usize>,
+    pub max_basic_blocks_in_script: Option<usize>,
+    pub max_per_fun_meter_units: Option<u128>,
+    pub max_per_mod_meter_units: Option<u128>,
+    pub max_idenfitier_len: Option<u64>,
+}
+
+impl Default for VerifierConfig {
+    fn default() -> Self {
+        Self {
+            max_loop_depth: None,
+            max_function_parameters: None,
+            max_generic_instantiation_length: None,
+            max_basic_blocks: None,
+            max_type_nodes: None,
+            // Max size set to 1024 to match the size limit in the interpreter.
+            max_value_stack_size: 1024,
+            // Max number of pushes in one function
+            max_push_size: None,
+            // Max depth in dependency tree for both direct and friend dependencies
+            max_dependency_depth: None,
+            // Max count of structs in a module
+            max_struct_definitions: None,
+            // Max count of fields in a struct
+            max_fields_in_struct: None,
+            // Max count of functions in a module
+            max_function_definitions: None,
+            // Max size set to 10000 to restrict number of pushes in one function
+            // max_push_size: Some(10000),
+            // max_dependency_depth: Some(100),
+            // max_struct_definitions: Some(200),
+            // max_fields_in_struct: Some(30),
+            // max_function_definitions: Some(1000),
+            max_back_edges_per_function: None,
+            max_back_edges_per_module: None,
+            max_basic_blocks_in_script: None,
+            /// General metering for the verifier. This defaults to a bound which should align
+            /// with production, so all existing test cases apply it.
+            max_per_fun_meter_units: Some(1000 * 8000),
+            max_per_mod_meter_units: Some(1000 * 8000),
+            max_constant_vector_len: Some(DEFAULT_MAX_CONSTANT_VECTOR_LEN),
+            max_idenfitier_len: Some(DEFAULT_MAX_IDENTIFIER_LENGTH),
+        }
+    }
+}
+
+impl VerifierConfig {
+    /// Returns truly unbounded config, even relaxing metering.
+    pub fn unbounded() -> Self {
+        Self {
+            max_per_fun_meter_units: None,
+            max_per_mod_meter_units: None,
+            ..VerifierConfig::default()
+        }
+    }
+}

--- a/external-crates/move/move-vm/integration-tests/Cargo.toml
+++ b/external-crates/move/move-vm/integration-tests/Cargo.toml
@@ -21,6 +21,7 @@ move-core-types = {path = "../../move-core/types" }
 move-binary-format = { path = "../../move-binary-format" }
 move-bytecode-verifier = { path = "../../move-bytecode-verifier" }
 move-compiler = { path = "../../move-compiler" }
+move-vm-config = { path = "../config" }
 move-vm-runtime = { path = "../runtime" }
 move-vm-types = { path = "../types" }
 move-vm-test-utils = { path = "../test-utils" }

--- a/external-crates/move/move-vm/integration-tests/src/tests/binary_format_version.rs
+++ b/external-crates/move/move-vm/integration-tests/src/tests/binary_format_version.rs
@@ -6,7 +6,8 @@ use move_binary_format::{
     file_format_common::VERSION_MAX,
 };
 use move_core_types::{account_address::AccountAddress, vm_status::StatusCode};
-use move_vm_runtime::{config::VMConfig, move_vm::MoveVM};
+use move_vm_config::runtime::VMConfig;
+use move_vm_runtime::move_vm::MoveVM;
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::gas::UnmeteredGasMeter;
 

--- a/external-crates/move/move-vm/integration-tests/src/tests/loader_tests.rs
+++ b/external-crates/move/move-vm/integration-tests/src/tests/loader_tests.rs
@@ -12,7 +12,6 @@ use move_binary_format::{
     },
     CompiledModule,
 };
-use move_bytecode_verifier::VerifierConfig;
 use move_compiler::Compiler;
 use move_core_types::{
     account_address::AccountAddress,
@@ -23,7 +22,8 @@ use move_core_types::{
     resolver::{LinkageResolver, ModuleResolver, ResourceResolver},
     value::MoveValue,
 };
-use move_vm_runtime::{config::VMConfig, move_vm::MoveVM, session::SerializedReturnValues};
+use move_vm_config::{runtime::VMConfig, verifier::VerifierConfig};
+use move_vm_runtime::{move_vm::MoveVM, session::SerializedReturnValues};
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::{gas::UnmeteredGasMeter, loaded_data::runtime_types::Type};
 

--- a/external-crates/move/move-vm/integration-tests/src/tests/nested_loop_tests.rs
+++ b/external-crates/move/move-vm/integration-tests/src/tests/nested_loop_tests.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::compiler::{as_module, as_script, compile_units};
-use move_bytecode_verifier::VerifierConfig;
 use move_core_types::account_address::AccountAddress;
-use move_vm_runtime::{config::VMConfig, move_vm::MoveVM};
+use move_vm_config::{runtime::VMConfig, verifier::VerifierConfig};
+use move_vm_runtime::move_vm::MoveVM;
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::gas::UnmeteredGasMeter;
 

--- a/external-crates/move/move-vm/runtime/Cargo.toml
+++ b/external-crates/move/move-vm/runtime/Cargo.toml
@@ -22,6 +22,7 @@ smallvec = "1.6.1"
 
 move-bytecode-verifier = { path = "../../move-bytecode-verifier" }
 move-core-types = { path = "../../move-core/types" }
+move-vm-config = { path = "../config" }
 move-vm-types = { path = "../types" }
 move-binary-format = { path = "../../move-binary-format" }
 

--- a/external-crates/move/move-vm/runtime/src/interpreter.rs
+++ b/external-crates/move/move-vm/runtime/src/interpreter.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    config::VMRuntimeLimitsConfig,
     loader::{Function, Loader, Resolver},
     native_functions::NativeContext,
     trace,
@@ -19,6 +18,7 @@ use move_core_types::{
     language_storage::TypeTag,
     vm_status::{StatusCode, StatusType},
 };
+use move_vm_config::runtime::VMRuntimeLimitsConfig;
 use move_vm_types::{
     data_store::DataStore,
     gas::{GasMeter, SimpleInstruction},

--- a/external-crates/move/move-vm/runtime/src/lib.rs
+++ b/external-crates/move/move-vm/runtime/src/lib.rs
@@ -21,7 +21,6 @@ mod runtime;
 pub mod session;
 #[macro_use]
 mod tracing;
-pub mod config;
 
 // Only include debugging functionality in debug builds
 #[cfg(any(debug_assertions, feature = "debugging"))]

--- a/external-crates/move/move-vm/runtime/src/loader.rs
+++ b/external-crates/move/move-vm/runtime/src/loader.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    config::VMConfig,
     logging::expect_no_verification_errors,
     native_functions::{NativeFunction, NativeFunctions, UnboxedNativeFunction},
     session::LoadedFunctionInstantiation,
@@ -30,6 +29,7 @@ use move_core_types::{
     value::{MoveFieldLayout, MoveStructLayout, MoveTypeLayout},
     vm_status::StatusCode,
 };
+use move_vm_config::runtime::VMConfig;
 use move_vm_types::{
     data_store::DataStore,
     loaded_data::runtime_types::{CachedStructIndex, StructType, Type},

--- a/external-crates/move/move-vm/runtime/src/move_vm.rs
+++ b/external-crates/move/move-vm/runtime/src/move_vm.rs
@@ -5,7 +5,7 @@
 use std::sync::Arc;
 
 use crate::{
-    config::VMConfig, data_cache::TransactionDataCache, native_extensions::NativeContextExtensions,
+    data_cache::TransactionDataCache, native_extensions::NativeContextExtensions,
     native_functions::NativeFunction, runtime::VMRuntime, session::Session,
 };
 use move_binary_format::{
@@ -16,6 +16,7 @@ use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, language_storage::ModuleId,
     metadata::Metadata, resolver::MoveResolver,
 };
+use move_vm_config::runtime::VMConfig;
 
 pub struct MoveVM {
     runtime: VMRuntime,

--- a/external-crates/move/move-vm/runtime/src/native_functions.rs
+++ b/external-crates/move/move-vm/runtime/src/native_functions.rs
@@ -3,8 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    config::VMRuntimeLimitsConfig, interpreter::Interpreter, loader::Resolver,
-    native_extensions::NativeContextExtensions,
+    interpreter::Interpreter, loader::Resolver, native_extensions::NativeContextExtensions,
 };
 use move_binary_format::errors::{ExecutionState, PartialVMError, PartialVMResult};
 use move_core_types::{
@@ -15,6 +14,7 @@ use move_core_types::{
     value::MoveTypeLayout,
     vm_status::{StatusCode, StatusType},
 };
+use move_vm_config::runtime::VMRuntimeLimitsConfig;
 use move_vm_types::{
     data_store::DataStore, loaded_data::runtime_types::Type, natives::function::NativeResult,
     values::Value,

--- a/external-crates/move/move-vm/runtime/src/runtime.rs
+++ b/external-crates/move/move-vm/runtime/src/runtime.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    config::VMConfig,
     data_cache::TransactionDataCache,
     interpreter::Interpreter,
     loader::{Function, Loader},
@@ -26,6 +25,7 @@ use move_core_types::{
     value::MoveTypeLayout,
     vm_status::StatusCode,
 };
+use move_vm_config::runtime::VMConfig;
 use move_vm_types::{
     data_store::DataStore,
     gas::GasMeter,

--- a/external-crates/move/testing-infra/transactional-test-runner/Cargo.toml
+++ b/external-crates/move/testing-infra/transactional-test-runner/Cargo.toml
@@ -33,6 +33,7 @@ move-ir-types = { path = "../../move-ir/types" }
 move-compiler = { path = "../../move-compiler" }
 move-stdlib = { path = "../../move-stdlib", features = ["testing"] }
 move-symbol-pool = { path = "../../move-symbol-pool" }
+move-vm-config = { path = "../../move-vm/config" }
 move-vm-test-utils = { path = "../../move-vm/test-utils" }
 move-vm-types = { path = "../../move-vm/types" }
 move-vm-runtime = { path = "../../move-vm/runtime" }

--- a/external-crates/move/testing-infra/transactional-test-runner/src/vm_test_harness.rs
+++ b/external-crates/move/testing-infra/transactional-test-runner/src/vm_test_harness.rs
@@ -31,8 +31,8 @@ use move_core_types::{
 use move_resource_viewer::MoveValueAnnotator;
 use move_stdlib::move_stdlib_named_addresses;
 use move_symbol_pool::Symbol;
+use move_vm_config::runtime::VMConfig;
 use move_vm_runtime::{
-    config::VMConfig,
     move_vm::MoveVM,
     session::{SerializedReturnValues, Session},
 };

--- a/sui-execution/latest/sui-adapter/Cargo.toml
+++ b/sui-execution/latest/sui-adapter/Cargo.toml
@@ -19,6 +19,7 @@ move-binary-format.workspace = true
 move-bytecode-utils.workspace = true
 move-bytecode-verifier.workspace = true
 move-core-types.workspace = true
+move-vm-config.workspace = true
 move-vm-runtime.workspace = true
 move-vm-types.workspace = true
 

--- a/sui-execution/latest/sui-adapter/src/adapter.rs
+++ b/sui-execution/latest/sui-adapter/src/adapter.rs
@@ -6,13 +6,15 @@ use std::{collections::BTreeMap, sync::Arc};
 use anyhow::Result;
 use move_binary_format::{access::ModuleAccess, file_format::CompiledModule};
 use move_bytecode_verifier::meter::Meter;
-use move_bytecode_verifier::{verify_module_with_config_metered, VerifierConfig};
+use move_bytecode_verifier::verify_module_with_config_metered;
 use move_core_types::account_address::AccountAddress;
+use move_vm_config::{
+    runtime::{VMConfig, VMRuntimeLimitsConfig},
+    verifier::VerifierConfig,
+};
 pub use move_vm_runtime::move_vm::MoveVM;
 use move_vm_runtime::{
-    config::{VMConfig, VMRuntimeLimitsConfig},
-    native_extensions::NativeContextExtensions,
-    native_functions::NativeFunctionTable,
+    native_extensions::NativeContextExtensions, native_functions::NativeFunctionTable,
 };
 use sui_types::metrics::BytecodeVerifierMetrics;
 use sui_verifier::check_for_verifier_timeout;

--- a/sui-execution/latest/sui-verifier/Cargo.toml
+++ b/sui-execution/latest/sui-verifier/Cargo.toml
@@ -12,6 +12,7 @@ move-binary-format.workspace = true
 move-bytecode-utils.workspace = true
 move-bytecode-verifier.workspace = true
 move-core-types.workspace = true
+move-vm-config.workspace = true
 
 sui-types = { path = "../../../crates/sui-types" }
 workspace-hack = { version = "0.1", path = "../../../crates/workspace-hack" }

--- a/sui-execution/latest/sui-verifier/src/meter.rs
+++ b/sui-execution/latest/sui-verifier/src/meter.rs
@@ -2,11 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
-use move_bytecode_verifier::{
-    meter::{Meter, Scope},
-    VerifierConfig,
-};
+use move_bytecode_verifier::meter::{Meter, Scope};
 use move_core_types::vm_status::StatusCode;
+use move_vm_config::verifier::VerifierConfig;
 
 struct SuiVerifierMeterBounds {
     name: String,


### PR DESCRIPTION
## Description

Move `VMConfig`, `VMRuntimeLimitsConfig`, and `VerifierConfig` into their own crate, separate from `move-vm/runtime` and `move-bytecode-verifier` because these types are part of the interface shared by all versions of `move-execution`, so cannot be duplicated across multiple versions.

## Test Plan

```
external-crates$ sh ./tests.sh
sui$ cargo simtest
sui$ env SUI_SKIP_SIMTESTS=1 cargo nextest run
```