### PR TITLE
Remove days from countdown timeAgo 

### DIFF
--- a/apps/core/src/hooks/useTimeAgo.ts
+++ b/apps/core/src/hooks/useTimeAgo.ts
@@ -33,7 +33,6 @@ const TIME_LABEL = {
 const ONE_SECOND = 1000;
 const ONE_MINUTE = ONE_SECOND * 60;
 const ONE_HOUR = ONE_MINUTE * 60;
-const ONE_DAY = ONE_HOUR * 24;
 
 /**
  * Formats a timestamp using `timeAgo`, and automatically updates it when the value is small.
@@ -82,12 +81,7 @@ export const timeAgo = (
     let timeUnit: [string, number][];
     let timeCol = Math.abs(timeNow - epochMilliSecs);
 
-    if (timeCol >= ONE_DAY) {
-        timeUnit = [
-            [TIME_LABEL.day[dateKeyType], ONE_DAY],
-            [TIME_LABEL.hour[dateKeyType], ONE_HOUR],
-        ];
-    } else if (timeCol >= ONE_HOUR) {
+    if (timeCol >= ONE_HOUR) {
         timeUnit = [
             [TIME_LABEL.hour[dateKeyType], ONE_HOUR],
             [TIME_LABEL.min[dateKeyType], ONE_MINUTE],

--- a/apps/core/src/hooks/useTimeAgo.ts
+++ b/apps/core/src/hooks/useTimeAgo.ts
@@ -44,7 +44,7 @@ type TimeAgoOptions = {
     shortedTimeLabel: boolean;
     shouldEnd?: boolean;
     endLabel?: string;
-    maxTimeUnitInHours?: boolean;
+    maxTimeLabelInHours?: boolean;
 };
 
 export function useTimeAgo(options: TimeAgoOptions) {
@@ -53,7 +53,7 @@ export function useTimeAgo(options: TimeAgoOptions) {
         shortedTimeLabel,
         shouldEnd,
         endLabel,
-        maxTimeUnitInHours,
+        maxTimeLabelInHours,
     } = options;
     const [now, setNow] = useState(() => Date.now());
 
@@ -71,9 +71,9 @@ export function useTimeAgo(options: TimeAgoOptions) {
                 now,
                 shortedTimeLabel,
                 endLabel,
-                maxTimeUnitInHours
+                maxTimeLabelInHours
             ),
-        [timeFrom, now, shortedTimeLabel, endLabel, maxTimeUnitInHours]
+        [timeFrom, now, shortedTimeLabel, endLabel, maxTimeLabelInHours]
     );
 
     useEffect(() => {
@@ -91,7 +91,7 @@ export const timeAgo = (
     timeNow?: number | null,
     shortenTimeLabel?: boolean,
     endLabel = `< 1 sec`,
-    maxTimeUnitInHours = false
+    maxTimeLabelInHours = false
 ): string => {
     if (!epochMilliSecs) return '';
 
@@ -101,7 +101,7 @@ export const timeAgo = (
     let timeUnit: [string, number][];
     let timeCol = Math.abs(timeNow - epochMilliSecs);
 
-    if (timeCol >= ONE_DAY && !maxTimeUnitInHours) {
+    if (timeCol >= ONE_DAY && !maxTimeLabelInHours) {
         timeUnit = [
             [TIME_LABEL.day[dateKeyType], ONE_DAY],
             [TIME_LABEL.hour[dateKeyType], ONE_HOUR],

--- a/apps/core/src/hooks/useTimeAgo.ts
+++ b/apps/core/src/hooks/useTimeAgo.ts
@@ -33,16 +33,23 @@ const TIME_LABEL = {
 const ONE_SECOND = 1000;
 const ONE_MINUTE = ONE_SECOND * 60;
 const ONE_HOUR = ONE_MINUTE * 60;
+const ONE_DAY = ONE_HOUR * 24;
 
 /**
  * Formats a timestamp using `timeAgo`, and automatically updates it when the value is small.
  */
-export function useTimeAgo(
-    timeFrom?: number | null,
-    shortedTimeLabel?: boolean,
-    shouldEnd?: boolean,
-    endLabel?: string
-) {
+
+type TimeAgoOptions = {
+    timeFrom: number | null;
+    shortedTimeLabel: boolean;
+    shouldEnd?: boolean;
+    endLabel?: string;
+    maxLabelInHours?: boolean;
+};
+
+export function useTimeAgo(options: TimeAgoOptions) {
+    const { timeFrom, shortedTimeLabel, shouldEnd, endLabel, maxLabelInHours } =
+        options;
     const [now, setNow] = useState(() => Date.now());
 
     // end interval when the difference between now and timeFrom is less than or equal to 0
@@ -53,8 +60,9 @@ export function useTimeAgo(
         continueInterval;
 
     const formattedTime = useMemo(
-        () => timeAgo(timeFrom, now, shortedTimeLabel, endLabel),
-        [now, timeFrom, shortedTimeLabel, endLabel]
+        () =>
+            timeAgo(timeFrom, now, shortedTimeLabel, endLabel, maxLabelInHours),
+        [timeFrom, now, shortedTimeLabel, endLabel, maxLabelInHours]
     );
 
     useEffect(() => {
@@ -71,7 +79,8 @@ export const timeAgo = (
     epochMilliSecs: number | null | undefined,
     timeNow?: number | null,
     shortenTimeLabel?: boolean,
-    endLabel = `< 1 sec`
+    endLabel = `< 1 sec`,
+    maxLabelInHours = false
 ): string => {
     if (!epochMilliSecs) return '';
 
@@ -81,7 +90,12 @@ export const timeAgo = (
     let timeUnit: [string, number][];
     let timeCol = Math.abs(timeNow - epochMilliSecs);
 
-    if (timeCol >= ONE_HOUR) {
+    if (timeCol >= ONE_DAY && !maxLabelInHours) {
+        timeUnit = [
+            [TIME_LABEL.day[dateKeyType], ONE_DAY],
+            [TIME_LABEL.hour[dateKeyType], ONE_HOUR],
+        ];
+    } else if (timeCol >= ONE_HOUR) {
         timeUnit = [
             [TIME_LABEL.hour[dateKeyType], ONE_HOUR],
             [TIME_LABEL.min[dateKeyType], ONE_MINUTE],

--- a/apps/core/src/hooks/useTimeAgo.ts
+++ b/apps/core/src/hooks/useTimeAgo.ts
@@ -100,7 +100,7 @@ export const timeAgo = (
             [TIME_LABEL.day[dateKeyType], TimeUnit.ONE_DAY],
             [TIME_LABEL.hour[dateKeyType], TimeUnit.ONE_HOUR],
         ];
-    } else if (timeCol >= maxTimeUnit && maxTimeUnit >= TimeUnit.ONE_HOUR) {
+    } else if (timeCol >= TimeUnit.ONE_HOUR) {
         timeUnit = [
             [TIME_LABEL.hour[dateKeyType], TimeUnit.ONE_HOUR],
             [TIME_LABEL.min[dateKeyType], TimeUnit.ONE_MINUTE],

--- a/apps/core/src/hooks/useTimeAgo.ts
+++ b/apps/core/src/hooks/useTimeAgo.ts
@@ -44,12 +44,17 @@ type TimeAgoOptions = {
     shortedTimeLabel: boolean;
     shouldEnd?: boolean;
     endLabel?: string;
-    maxLabelInHours?: boolean;
+    maxTimeUnitInHours?: boolean;
 };
 
 export function useTimeAgo(options: TimeAgoOptions) {
-    const { timeFrom, shortedTimeLabel, shouldEnd, endLabel, maxLabelInHours } =
-        options;
+    const {
+        timeFrom,
+        shortedTimeLabel,
+        shouldEnd,
+        endLabel,
+        maxTimeUnitInHours,
+    } = options;
     const [now, setNow] = useState(() => Date.now());
 
     // end interval when the difference between now and timeFrom is less than or equal to 0
@@ -61,8 +66,14 @@ export function useTimeAgo(options: TimeAgoOptions) {
 
     const formattedTime = useMemo(
         () =>
-            timeAgo(timeFrom, now, shortedTimeLabel, endLabel, maxLabelInHours),
-        [timeFrom, now, shortedTimeLabel, endLabel, maxLabelInHours]
+            timeAgo(
+                timeFrom,
+                now,
+                shortedTimeLabel,
+                endLabel,
+                maxTimeUnitInHours
+            ),
+        [timeFrom, now, shortedTimeLabel, endLabel, maxTimeUnitInHours]
     );
 
     useEffect(() => {
@@ -80,7 +91,7 @@ export const timeAgo = (
     timeNow?: number | null,
     shortenTimeLabel?: boolean,
     endLabel = `< 1 sec`,
-    maxLabelInHours = false
+    maxTimeUnitInHours = false
 ): string => {
     if (!epochMilliSecs) return '';
 
@@ -90,7 +101,7 @@ export const timeAgo = (
     let timeUnit: [string, number][];
     let timeCol = Math.abs(timeNow - epochMilliSecs);
 
-    if (timeCol >= ONE_DAY && !maxLabelInHours) {
+    if (timeCol >= ONE_DAY && !maxTimeUnitInHours) {
         timeUnit = [
             [TIME_LABEL.day[dateKeyType], ONE_DAY],
             [TIME_LABEL.hour[dateKeyType], ONE_HOUR],

--- a/apps/explorer/src/components/tx-time/TxTimeType.tsx
+++ b/apps/explorer/src/components/tx-time/TxTimeType.tsx
@@ -8,7 +8,10 @@ type Prop = {
 };
 
 export function TxTimeType({ timestamp }: Prop) {
-    const timeAgo = useTimeAgo(timestamp, true);
+    const timeAgo = useTimeAgo({
+        timeFrom: timestamp || null,
+        shortedTimeLabel: true,
+    });
 
     return (
         <section>

--- a/apps/explorer/src/pages/epochs/utils.ts
+++ b/apps/explorer/src/pages/epochs/utils.ts
@@ -15,7 +15,11 @@ export function useEpochProgress(suffix: string = 'left') {
         start !== undefined && duration !== undefined
             ? start + duration
             : undefined;
-    const time = useTimeAgo(end, true, true);
+    const time = useTimeAgo({
+        timeFrom: end || null,
+        shortedTimeLabel: true,
+        shouldEnd: true,
+    });
 
     if (!start || !end) {
         return {};

--- a/apps/wallet/src/ui/app/shared/countdown-timer/index.tsx
+++ b/apps/wallet/src/ui/app/shared/countdown-timer/index.tsx
@@ -38,7 +38,13 @@ export function CountDownTimer({
     endLabel = 'now',
     ...styles
 }: CountDownTimerProps) {
-    const timeAgo = useTimeAgo(timestamp, false, true, endLabel);
+    const timeAgo = useTimeAgo({
+        timeFrom: timestamp || null,
+        shortedTimeLabel: false,
+        shouldEnd: true,
+        endLabel: endLabel,
+        maxLabelInHours: true,
+    });
 
     return (
         <div className={timeStyle(styles)}>

--- a/apps/wallet/src/ui/app/shared/countdown-timer/index.tsx
+++ b/apps/wallet/src/ui/app/shared/countdown-timer/index.tsx
@@ -43,7 +43,7 @@ export function CountDownTimer({
         shortedTimeLabel: false,
         shouldEnd: true,
         endLabel: endLabel,
-        maxLabelInHours: true,
+        maxTimeLabelInHours: true,
     });
 
     return (

--- a/apps/wallet/src/ui/app/shared/countdown-timer/index.tsx
+++ b/apps/wallet/src/ui/app/shared/countdown-timer/index.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useTimeAgo } from '@mysten/core';
+import { useTimeAgo, TimeUnit } from '@mysten/core';
 import { cva, type VariantProps } from 'class-variance-authority';
 
 const timeStyle = cva([], {
@@ -43,7 +43,7 @@ export function CountDownTimer({
         shortedTimeLabel: false,
         shouldEnd: true,
         endLabel: endLabel,
-        maxTimeLabelInHours: true,
+        maxTimeUnit: TimeUnit.ONE_HOUR,
     });
 
     return (


### PR DESCRIPTION
## Description 
Removing days from the countdown `timeAgo`  helper. The wallet `Staking Rewards Redeemable` was the only place this is visible, and this should be in hours, not days. 

<img width="405" alt="Screenshot 2023-05-22 at 12 19 39 PM" src="https://github.com/MystenLabs/sui/assets/126525197/9d07f282-5bde-49aa-a01e-1667dcb84e69">


Describe the changes or additions included in this PR.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
