### PR TITLE
use miliescond to avoid underflow when setting up pruner

### DIFF
--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -286,11 +286,11 @@ impl AuthorityStorePruner {
             "Starting object pruning service with num_epochs_to_retain={}",
             config.num_epochs_to_retain
         );
-        let tick_duration = Duration::from_secs(config.pruning_run_delay_seconds.unwrap_or(
+        let tick_duration = Duration::from_millis(config.pruning_run_delay_seconds.unwrap_or(
             if config.num_epochs_to_retain > 0 {
-                min(epoch_duration_ms / (2 * 1000), 60 * 60)
+                min(epoch_duration_ms / 2, 60 * 60 * 1000)
             } else {
-                60
+                60 * 1000
             },
         ));
         let pruning_initial_delay =

--- a/crates/sui/tests/snapshots/snapshot_tests__basic_read_cmd_snapshot_tests.snap
+++ b/crates/sui/tests/snapshots/snapshot_tests__basic_read_cmd_snapshot_tests.snap
@@ -7,14 +7,14 @@ expression: "run_one(cmds, context).await?"
   [
     {
       "data": {
-        "objectId": "0x3ae68e9c211429b233566c8e41a51f20493bcea0ceb47fb4d9e9a0482545c7cf",
+        "objectId": "0x015eb1cc1ebb06dbbd14e84969295f6caf78202fff2601655906e28353a63e88",
         "version": "1",
-        "digest": "FhyYuWy2bzZdMFU8HKMnVsQHGcfb5zPayz7SAf8KcZBb",
+        "digest": "39gqeAkzCo6pQZD31or6JCFY77VkSk3fJ44vM4MvrDgA",
         "type": "0x2::coin::Coin<0x2::sui::SUI>",
         "owner": {
-          "AddressOwner": "0x164f0565069cfbc2a65d327b6866a606aacd64050f9916a475b3738239877285"
+          "AddressOwner": "0x1622042f6771478e8cc246b0522d00fa592b1b7609b2ddac6c87fede9e6cf38e"
         },
-        "previousTransaction": "7DLVe3T7XrBMXDLLoHoo4mwkXkfhvQXvADFVh6U678eF",
+        "previousTransaction": "43kzEhSq4hHAhvthfURRix3MdrD1YavYtWgDmaaeDhWx",
         "storageRebate": "0",
         "content": {
           "dataType": "moveObject",
@@ -23,7 +23,7 @@ expression: "run_one(cmds, context).await?"
           "fields": {
             "balance": "30000000000000000",
             "id": {
-              "id": "0x3ae68e9c211429b233566c8e41a51f20493bcea0ceb47fb4d9e9a0482545c7cf"
+              "id": "0x015eb1cc1ebb06dbbd14e84969295f6caf78202fff2601655906e28353a63e88"
             }
           }
         }
@@ -31,14 +31,14 @@ expression: "run_one(cmds, context).await?"
     },
     {
       "data": {
-        "objectId": "0x763de283f13dcad36e084f57516c4f608374b0ac7ca5ccf02ce80264722b0a54",
+        "objectId": "0x0885c1b066d5a790a2a6a5ce8a4412db4de678b83bfb4dbbea42daaba31f1c26",
         "version": "1",
-        "digest": "CXZgaEU5hBVrFwYmEYtu3VgfC3nZD87QnhTmr5vsReDt",
+        "digest": "3rXYStHhqmXoYLG2imRmcd3BQQd1RFx2jKJxW1a93k8E",
         "type": "0x2::coin::Coin<0x2::sui::SUI>",
         "owner": {
-          "AddressOwner": "0x164f0565069cfbc2a65d327b6866a606aacd64050f9916a475b3738239877285"
+          "AddressOwner": "0x1622042f6771478e8cc246b0522d00fa592b1b7609b2ddac6c87fede9e6cf38e"
         },
-        "previousTransaction": "7DLVe3T7XrBMXDLLoHoo4mwkXkfhvQXvADFVh6U678eF",
+        "previousTransaction": "43kzEhSq4hHAhvthfURRix3MdrD1YavYtWgDmaaeDhWx",
         "storageRebate": "0",
         "content": {
           "dataType": "moveObject",
@@ -47,7 +47,7 @@ expression: "run_one(cmds, context).await?"
           "fields": {
             "balance": "30000000000000000",
             "id": {
-              "id": "0x763de283f13dcad36e084f57516c4f608374b0ac7ca5ccf02ce80264722b0a54"
+              "id": "0x0885c1b066d5a790a2a6a5ce8a4412db4de678b83bfb4dbbea42daaba31f1c26"
             }
           }
         }
@@ -55,14 +55,14 @@ expression: "run_one(cmds, context).await?"
     },
     {
       "data": {
-        "objectId": "0x76539d7542b6738c03d2544f81cd66e8bff8e3b5ca8d34b6c1b83cad983120f3",
+        "objectId": "0x6dbabf324ab04fee80b4c6e053cb923d88d2fd8ecee5b12339196e441afa238a",
         "version": "1",
-        "digest": "iwobZubtKpgNgiKs1rNzU3RoTAxmbnN6heMeTvLu4hE",
+        "digest": "7EJFpi3zwoXb2jeSMXxDRD542JEjBkFBUefTaL1ooKk4",
         "type": "0x2::coin::Coin<0x2::sui::SUI>",
         "owner": {
-          "AddressOwner": "0x164f0565069cfbc2a65d327b6866a606aacd64050f9916a475b3738239877285"
+          "AddressOwner": "0x1622042f6771478e8cc246b0522d00fa592b1b7609b2ddac6c87fede9e6cf38e"
         },
-        "previousTransaction": "7DLVe3T7XrBMXDLLoHoo4mwkXkfhvQXvADFVh6U678eF",
+        "previousTransaction": "43kzEhSq4hHAhvthfURRix3MdrD1YavYtWgDmaaeDhWx",
         "storageRebate": "0",
         "content": {
           "dataType": "moveObject",
@@ -71,7 +71,7 @@ expression: "run_one(cmds, context).await?"
           "fields": {
             "balance": "30000000000000000",
             "id": {
-              "id": "0x76539d7542b6738c03d2544f81cd66e8bff8e3b5ca8d34b6c1b83cad983120f3"
+              "id": "0x6dbabf324ab04fee80b4c6e053cb923d88d2fd8ecee5b12339196e441afa238a"
             }
           }
         }
@@ -79,14 +79,14 @@ expression: "run_one(cmds, context).await?"
     },
     {
       "data": {
-        "objectId": "0xf77efbe96f3ba282ce07c87e1f6770f13bd16024ffd98a3b2c81b57e2bf258cd",
+        "objectId": "0x71807745b3c78070bae26cccc23e5ea3064ff512708a191b37c01f33cf780bc4",
         "version": "1",
-        "digest": "72wBSwCafD91kACfYjwWQ9yiMF5dyQtjLHB94JuC3Sk2",
+        "digest": "3DhKR4hnV5SCvoEZ1CYxtMsP9CDSMDwqZo57cYSJ7aMt",
         "type": "0x2::coin::Coin<0x2::sui::SUI>",
         "owner": {
-          "AddressOwner": "0x164f0565069cfbc2a65d327b6866a606aacd64050f9916a475b3738239877285"
+          "AddressOwner": "0x1622042f6771478e8cc246b0522d00fa592b1b7609b2ddac6c87fede9e6cf38e"
         },
-        "previousTransaction": "7DLVe3T7XrBMXDLLoHoo4mwkXkfhvQXvADFVh6U678eF",
+        "previousTransaction": "43kzEhSq4hHAhvthfURRix3MdrD1YavYtWgDmaaeDhWx",
         "storageRebate": "0",
         "content": {
           "dataType": "moveObject",
@@ -95,7 +95,7 @@ expression: "run_one(cmds, context).await?"
           "fields": {
             "balance": "30000000000000000",
             "id": {
-              "id": "0xf77efbe96f3ba282ce07c87e1f6770f13bd16024ffd98a3b2c81b57e2bf258cd"
+              "id": "0x71807745b3c78070bae26cccc23e5ea3064ff512708a191b37c01f33cf780bc4"
             }
           }
         }
@@ -103,14 +103,14 @@ expression: "run_one(cmds, context).await?"
     },
     {
       "data": {
-        "objectId": "0xfe796d9b3d2fe7be8e9b0ce03261f99877d3387bbc5543b8875f17048ca98023",
+        "objectId": "0xebab59ee919ea4bbe9e219218acb1db97ab98c8a01e69932a13182be684149cd",
         "version": "1",
-        "digest": "HTdzYSnJp9RGRA1ES5SSW4PPVzciULJAoWjBPdJVP6HY",
+        "digest": "865X7R26pXS2guTachsAfzRdmTAH1Y4CsSfjd3Ly6Uyq",
         "type": "0x2::coin::Coin<0x2::sui::SUI>",
         "owner": {
-          "AddressOwner": "0x164f0565069cfbc2a65d327b6866a606aacd64050f9916a475b3738239877285"
+          "AddressOwner": "0x1622042f6771478e8cc246b0522d00fa592b1b7609b2ddac6c87fede9e6cf38e"
         },
-        "previousTransaction": "7DLVe3T7XrBMXDLLoHoo4mwkXkfhvQXvADFVh6U678eF",
+        "previousTransaction": "43kzEhSq4hHAhvthfURRix3MdrD1YavYtWgDmaaeDhWx",
         "storageRebate": "0",
         "content": {
           "dataType": "moveObject",
@@ -119,7 +119,7 @@ expression: "run_one(cmds, context).await?"
           "fields": {
             "balance": "30000000000000000",
             "id": {
-              "id": "0xfe796d9b3d2fe7be8e9b0ce03261f99877d3387bbc5543b8875f17048ca98023"
+              "id": "0xebab59ee919ea4bbe9e219218acb1db97ab98c8a01e69932a13182be684149cd"
             }
           }
         }
@@ -134,7 +134,7 @@ expression: "run_one(cmds, context).await?"
       "data": {
         "objectId": "0x0000000000000000000000000000000000000000000000000000000000000005",
         "version": "1",
-        "digest": "BNTcDY46MjDTPKUM7pJEshha7ArRvSM2uTGKhFovTFtV",
+        "digest": "DWrRMM6HMzjc6qdS9otBK5536bmTWk78HgzVZYWYrJoQ",
         "type": "0x3::sui_system::SuiSystemState",
         "owner": {
           "Shared": {
@@ -143,7 +143,7 @@ expression: "run_one(cmds, context).await?"
             }
           }
         },
-        "previousTransaction": "7DLVe3T7XrBMXDLLoHoo4mwkXkfhvQXvADFVh6U678eF",
+        "previousTransaction": "43kzEhSq4hHAhvthfURRix3MdrD1YavYtWgDmaaeDhWx",
         "storageRebate": "0",
         "content": {
           "dataType": "moveObject",
@@ -165,7 +165,7 @@ expression: "run_one(cmds, context).await?"
       "data": {
         "objectId": "0x0000000000000000000000000000000000000000000000000000000000000005",
         "version": "1",
-        "digest": "BNTcDY46MjDTPKUM7pJEshha7ArRvSM2uTGKhFovTFtV",
+        "digest": "DWrRMM6HMzjc6qdS9otBK5536bmTWk78HgzVZYWYrJoQ",
         "type": "0x3::sui_system::SuiSystemState",
         "owner": {
           "Shared": {
@@ -174,7 +174,7 @@ expression: "run_one(cmds, context).await?"
             }
           }
         },
-        "previousTransaction": "7DLVe3T7XrBMXDLLoHoo4mwkXkfhvQXvADFVh6U678eF",
+        "previousTransaction": "43kzEhSq4hHAhvthfURRix3MdrD1YavYtWgDmaaeDhWx",
         "storageRebate": "0",
         "bcs": {
           "dataType": "moveObject",
@@ -198,7 +198,7 @@ expression: "run_one(cmds, context).await?"
     }
   ],
   "sui client tx-block Duwr9uSk9ZvNdEa8oDHunx345i6oyrp3e78MYHVAbYdv",
-  "RPC call failed: ErrorObject { code: ServerError(-32000), message: \"Could not find the referenced transaction [TransactionDigest(Duwr9uSk9ZvNdEa8oDHunx345i6oyrp3e78MYHVAbYdv)].\", data: None }",
+  "RPC call failed: ErrorObject { code: InvalidParams, message: \"Could not find the referenced transaction [TransactionDigest(Duwr9uSk9ZvNdEa8oDHunx345i6oyrp3e78MYHVAbYdv)].\", data: None }",
   "sui client tx-block EgMTHQygMi6SRsBqrPHAEKZCNrpShXurCp9rcb9qbSg8",
-  "RPC call failed: ErrorObject { code: ServerError(-32000), message: \"Could not find the referenced transaction [TransactionDigest(EgMTHQygMi6SRsBqrPHAEKZCNrpShXurCp9rcb9qbSg8)].\", data: None }"
+  "RPC call failed: ErrorObject { code: InvalidParams, message: \"Could not find the referenced transaction [TransactionDigest(EgMTHQygMi6SRsBqrPHAEKZCNrpShXurCp9rcb9qbSg8)].\", data: None }"
 ]


### PR DESCRIPTION
## Description 

when `epoch_duration_ms` < 2000, `tick_duration` may be `0` which makes `tokio::time::interval_at` panic. The fix is to use `Duration::from_millis(`

## Test Plan 

`cargo nextest run test_passive_reconfig` passes now which fails otherwise
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
