### PR TITLE
wallet-ext: show pending qredo transactions

### DIFF
--- a/apps/core/src/hooks/useOnScreen.ts
+++ b/apps/core/src/hooks/useOnScreen.ts
@@ -11,7 +11,7 @@ export const useOnScreen = (ref: MutableRefObject<Element | null>) => {
         observerRef.current = new IntersectionObserver(
             ([entry]) => setIsIntersecting(entry.isIntersecting),
             {
-                threshold: [1],
+                threshold: [0.01],
             }
         );
     }

--- a/apps/wallet/src/shared/qredo-api.ts
+++ b/apps/wallet/src/shared/qredo-api.ts
@@ -3,6 +3,8 @@
 
 import { type SuiAddress } from '@mysten/sui.js';
 
+import { toSearchQueryString } from './utils';
+
 export type QredoAPIErrorResponse = {
     code: string;
     msg: string;
@@ -82,7 +84,7 @@ export type TransactionInfoResponse = {
     txID: string;
     txHash: string;
     status: TransactionStatus;
-    messageWithIntent: string;
+    MessageWithIntent: string;
     sig: string;
     timestamps: Partial<Record<TransactionStatus, number>>;
     events: {
@@ -95,6 +97,25 @@ export type TransactionInfoResponse = {
     network: string;
     createdBy: string;
     accountID: string;
+};
+
+export type GetTransactionsParams = {
+    network?: NetworkType;
+    /** Filter by address or part of address */
+    address?: SuiAddress;
+    /** Qredo wallet id */
+    wallet?: string;
+};
+
+export type GetTransactionsItem = {
+    walletID: string;
+    txID: string;
+    txHash: string;
+    status: TransactionStatus;
+};
+
+export type GetTransactionsResponse = {
+    list: GetTransactionsItem[];
 };
 
 export type AccessTokenRenewalFunction = (
@@ -155,11 +176,10 @@ export class QredoAPI {
         if (filters?.address) {
             searchParams.append('address', filters.address);
         }
-        const searchQuery = searchParams.toString();
         return this.#request(
-            `${this.baseURL}connect/sui/wallets${
-                searchQuery ? `?${searchQuery}` : ''
-            }`
+            `${this.baseURL}connect/sui/wallets${toSearchQueryString(
+                searchParams
+            )}`
         );
     }
 
@@ -180,6 +200,16 @@ export class QredoAPI {
     ): Promise<TransactionInfoResponse> {
         return this.#request(
             `${this.baseURL}connect/sui/transactions/${transactionID}`
+        );
+    }
+
+    public getTransactions(
+        params: GetTransactionsParams
+    ): Promise<GetTransactionsResponse> {
+        return this.#request(
+            `${this.baseURL}connect/sui/transactions${toSearchQueryString(
+                new URLSearchParams(params)
+            )}`
         );
     }
 

--- a/apps/wallet/src/shared/utils/index.ts
+++ b/apps/wallet/src/shared/utils/index.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useGrowthBook } from '@growthbook/growthbook-react';
+import { fromB64, toB64 } from '@mysten/sui.js';
 import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import Browser from 'webextension-polyfill';
@@ -60,4 +61,35 @@ export function prepareLinkToCompare(link: string) {
         adjLink += '/';
     }
     return adjLink;
+}
+
+/**
+ * Includes ? when query string is set
+ */
+export function toSearchQueryString(searchParams: URLSearchParams) {
+    const searchQuery = searchParams.toString();
+    if (searchQuery) {
+        return `?${searchQuery}`;
+    }
+    return '';
+}
+
+export function toUtf8OrB64(message: string | Uint8Array) {
+    const messageBytes =
+        typeof message === 'string' ? fromB64(message) : message;
+    let messageToReturn: string =
+        typeof message === 'string' ? message : toB64(message);
+    let type: 'utf8' | 'base64' = 'base64';
+    try {
+        messageToReturn = new TextDecoder('utf8', { fatal: true }).decode(
+            messageBytes
+        );
+        type = 'utf8';
+    } catch (e) {
+        // do nothing
+    }
+    return {
+        message: messageToReturn,
+        type,
+    };
 }

--- a/apps/wallet/src/ui/app/QredoSigner.ts
+++ b/apps/wallet/src/ui/app/QredoSigner.ts
@@ -71,10 +71,11 @@ export class QredoSigner extends WalletSigner {
                 (currentTxInfo) =>
                     !currentTxInfo.sig &&
                     [
-                        'pending',
                         'created',
                         'authorized',
+                        'pending',
                         'approved',
+                        'queued',
                         'signed',
                     ].includes(currentTxInfo.status),
                 clientIdentifier

--- a/apps/wallet/src/ui/app/QredoSigner.ts
+++ b/apps/wallet/src/ui/app/QredoSigner.ts
@@ -28,7 +28,7 @@ const MAX_POLLING_TIMES = Math.ceil((60 * 1000 * 10) / POLLING_INTERVAL);
 function sleep() {
     return new Promise((r) => setTimeout(r, POLLING_INTERVAL));
 }
-const API_ENV_TO_QREDO_NETWORK: Partial<Record<API_ENV, NetworkType>> = {
+export const API_ENV_TO_QREDO_NETWORK: Partial<Record<API_ENV, NetworkType>> = {
     [API_ENV.mainnet]: 'mainnet',
     [API_ENV.testNet]: 'testnet',
     [API_ENV.devNet]: 'devnet',

--- a/apps/wallet/src/ui/app/components/transactions-card/NoActivityCard.tsx
+++ b/apps/wallet/src/ui/app/components/transactions-card/NoActivityCard.tsx
@@ -5,12 +5,16 @@ import { TransferObject16 } from '@mysten/icons';
 
 import { Text } from '_src/ui/app/shared/text';
 
-export function NoActivityCard() {
+export type NoActivityCardType = {
+    message: string;
+};
+
+export function NoActivityCard({ message }: NoActivityCardType) {
     return (
         <div className="flex flex-col gap-4 justify-center items-center text-center h-full px-10">
             <TransferObject16 className="text-gray-45 text-3xl" />
             <Text variant="pBody" weight="medium" color="steel">
-                When available, your Sui network transactions will show up here.
+                {message}
             </Text>
         </div>
     );

--- a/apps/wallet/src/ui/app/components/transactions-card/TxnIcon.tsx
+++ b/apps/wallet/src/ui/app/components/transactions-card/TxnIcon.tsx
@@ -8,10 +8,12 @@ import {
     Swap16,
     Unstaked,
     Sui,
+    Account24,
 } from '@mysten/icons';
 import cl from 'classnames';
 
-// TODO: use update icons lib
+import LoadingIndicator from '../loading/LoadingIndicator';
+
 const icons = {
     Send: (
         <ArrowRight16
@@ -32,17 +34,18 @@ const icons = {
     Rewards: <Sui className="text-gradient-blue-start text-body" />,
     Swapped: <Swap16 className="text-gradient-blue-start text-heading6" />,
     Failed: <Info16 className="text-issue-dark text-heading6" />,
+    Loading: <LoadingIndicator />,
+    PersonalMessage: (
+        <Account24
+            fill="currentColor"
+            className="text-gradient-blue-start text-body"
+        />
+    ),
 };
 
 interface TxnItemIconProps {
     txnFailed?: boolean;
-    variant:
-        | 'Rewards'
-        | 'Staked'
-        | 'Unstaked'
-        | 'Swapped'
-        | 'Send'
-        | 'Received';
+    variant: keyof typeof icons;
 }
 
 export function TxnIcon({ txnFailed, variant }: TxnItemIconProps) {

--- a/apps/wallet/src/ui/app/hooks/useGetQredoTransaction.tsx
+++ b/apps/wallet/src/ui/app/hooks/useGetQredoTransaction.tsx
@@ -1,0 +1,37 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useQuery } from '@tanstack/react-query';
+
+import { useQredoAPI } from './useQredoAPI';
+
+export function useGetQredoTransaction({
+    qredoID,
+    qredoTransactionID,
+    forceDisabled,
+}: {
+    qredoID?: string;
+    qredoTransactionID?: string;
+    forceDisabled?: boolean;
+}) {
+    const [qredoAPI] = useQredoAPI(qredoID);
+    return useQuery({
+        queryKey: [
+            'get',
+            'qredo',
+            'transacion',
+            qredoAPI,
+            qredoID,
+            qredoTransactionID,
+        ],
+        queryFn: () => qredoAPI!.getTransaction(qredoTransactionID!),
+        enabled: !!(
+            qredoAPI &&
+            qredoID &&
+            qredoTransactionID &&
+            !forceDisabled
+        ),
+        staleTime: 5000,
+        refetchInterval: 5000,
+    });
+}

--- a/apps/wallet/src/ui/app/hooks/useGetQredoTransactions.tsx
+++ b/apps/wallet/src/ui/app/hooks/useGetQredoTransactions.tsx
@@ -1,0 +1,56 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useQuery } from '@tanstack/react-query';
+
+import { API_ENV_TO_QREDO_NETWORK } from '../QredoSigner';
+import { useActiveAddress } from './useActiveAddress';
+import useAppSelector from './useAppSelector';
+import { useQredoAPI } from './useQredoAPI';
+import { type TransactionStatus } from '_src/shared/qredo-api';
+
+export function useGetQredoTransactions({
+    qredoID,
+    filterStatus,
+    forceDisabled,
+}: {
+    qredoID?: string;
+    filterStatus?: TransactionStatus[];
+    forceDisabled?: boolean;
+}) {
+    const [qredoAPI] = useQredoAPI(qredoID);
+    const apiEnv = useAppSelector(({ app: { apiEnv } }) => apiEnv);
+    const networkName = API_ENV_TO_QREDO_NETWORK[apiEnv] || null;
+    const activeAddress = useActiveAddress();
+    return useQuery({
+        queryKey: [
+            'get',
+            'qredo',
+            'transacions',
+            qredoAPI,
+            qredoID,
+            networkName,
+            activeAddress,
+            filterStatus,
+        ],
+        queryFn: async () =>
+            (
+                await qredoAPI!.getTransactions({
+                    network: networkName!,
+                    address: activeAddress!,
+                })
+            ).list.filter(
+                ({ status }) =>
+                    !filterStatus?.length || filterStatus.includes(status)
+            ),
+        enabled: !!(
+            qredoAPI &&
+            qredoID &&
+            networkName &&
+            activeAddress &&
+            !forceDisabled
+        ),
+        staleTime: 5000,
+        refetchInterval: 5000,
+    });
+}

--- a/apps/wallet/src/ui/app/hooks/useGetQredoTransactions.tsx
+++ b/apps/wallet/src/ui/app/hooks/useGetQredoTransactions.tsx
@@ -33,13 +33,13 @@ export function useGetQredoTransactions({
             activeAddress,
             filterStatus,
         ],
-        queryFn: async () =>
-            (
-                await qredoAPI!.getTransactions({
-                    network: networkName!,
-                    address: activeAddress!,
-                })
-            ).list.filter(
+        queryFn: () =>
+            qredoAPI!.getTransactions({
+                network: networkName!,
+                address: activeAddress!,
+            }),
+        select: ({ list }) =>
+            list.filter(
                 ({ status }) =>
                     !filterStatus?.length || filterStatus.includes(status)
             ),

--- a/apps/wallet/src/ui/app/index.tsx
+++ b/apps/wallet/src/ui/app/index.tsx
@@ -71,7 +71,7 @@ const App = () => {
                     element={<NftTransferPage />}
                 />
                 <Route
-                    path="transactions"
+                    path="transactions/:status?"
                     element={<TransactionBlocksPage />}
                 />
                 <Route path="send" element={<TransferCoinPage />} />

--- a/apps/wallet/src/ui/app/pages/approval-request/SignMessageRequest.tsx
+++ b/apps/wallet/src/ui/app/pages/approval-request/SignMessageRequest.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { fromB64 } from '@mysten/sui.js';
 import { useMemo } from 'react';
 
 import { UserApproveContainer } from '../../components/user-approve-container';
@@ -12,30 +11,17 @@ import { Heading } from '../../shared/heading';
 import { PageMainLayoutTitle } from '../../shared/page-main-layout/PageMainLayoutTitle';
 import { Text } from '../../shared/text';
 import { type SignMessageApprovalRequest } from '_payloads/transactions/ApprovalRequest';
+import { toUtf8OrB64 } from '_src/shared/utils';
 
 export type SignMessageRequestProps = {
     request: SignMessageApprovalRequest;
 };
 
 export function SignMessageRequest({ request }: SignMessageRequestProps) {
-    const { message, type } = useMemo(() => {
-        const messageBytes = fromB64(request.tx.message);
-        let message: string = request.tx.message;
-        let type: 'utf8' | 'base64' = 'base64';
-        try {
-            message = new TextDecoder('utf8', { fatal: true }).decode(
-                messageBytes
-            );
-            type = 'utf8';
-        } catch (e) {
-            // do nothing
-        }
-        return {
-            message,
-            type,
-        };
-    }, [request.tx.message]);
-
+    const { message, type } = useMemo(
+        () => toUtf8OrB64(request.tx.message),
+        [request.tx.message]
+    );
     const signer = useSigner(request.tx.accountAddress);
     const dispatch = useAppDispatch();
     const { clientIdentifier, notificationModal } = useQredoTransaction();

--- a/apps/wallet/src/ui/app/pages/home/transactions/CompletedTransactions.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transactions/CompletedTransactions.tsx
@@ -1,0 +1,37 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { getTransactionDigest } from '@mysten/sui.js';
+
+import Alert from '_components/alert';
+import { ErrorBoundary } from '_components/error-boundary';
+import Loading from '_components/loading';
+import { TransactionCard } from '_components/transactions-card';
+import { NoActivityCard } from '_components/transactions-card/NoActivityCard';
+import { useQueryTransactionsByAddress } from '_hooks';
+import { useActiveAddress } from '_src/ui/app/hooks/useActiveAddress';
+
+export function CompletedTransactions() {
+    const activeAddress = useActiveAddress();
+    const {
+        data: txns,
+        isLoading,
+        error,
+    } = useQueryTransactionsByAddress(activeAddress);
+    if (error) {
+        return <Alert mode="warning">{(error as Error)?.message}</Alert>;
+    }
+    return (
+        <Loading loading={isLoading}>
+            {txns?.length && activeAddress ? (
+                txns.map((txn) => (
+                    <ErrorBoundary key={getTransactionDigest(txn)}>
+                        <TransactionCard txn={txn} address={activeAddress} />
+                    </ErrorBoundary>
+                ))
+            ) : (
+                <NoActivityCard message="When available, your Sui network transactions will show up here." />
+            )}
+        </Loading>
+    );
+}

--- a/apps/wallet/src/ui/app/pages/home/transactions/QredoPendingTransactions.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transactions/QredoPendingTransactions.tsx
@@ -1,0 +1,59 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { QredoTransaction } from './QredoTransaction';
+import { ErrorBoundary } from '_components/error-boundary';
+import Loading from '_components/loading';
+import { NoActivityCard } from '_components/transactions-card/NoActivityCard';
+import { AccountType } from '_src/background/keyring/Account';
+import { type TransactionStatus } from '_src/shared/qredo-api';
+import Alert from '_src/ui/app/components/alert';
+import { useActiveAccount } from '_src/ui/app/hooks/useActiveAccount';
+import { useActiveAddress } from '_src/ui/app/hooks/useActiveAddress';
+import { useGetQredoTransactions } from '_src/ui/app/hooks/useGetQredoTransactions';
+
+const PENDING_QREDO_TRANSACTION_STATUSES: TransactionStatus[] = [
+    'approved',
+    'authorized',
+    'created',
+    'pending',
+    'pushed',
+    'scheduled',
+    'signed',
+];
+
+export function QredoPendingTransactions() {
+    const activeAddress = useActiveAddress();
+    const activeAccount = useActiveAccount();
+    const isQredoAccount = activeAccount?.type === AccountType.QREDO;
+    const qredoID = isQredoAccount
+        ? activeAccount.qredoConnectionID
+        : undefined;
+    const {
+        data: qredoTransactions,
+        isLoading,
+        error,
+    } = useGetQredoTransactions({
+        qredoID,
+        filterStatus: PENDING_QREDO_TRANSACTION_STATUSES,
+    });
+    if (error) {
+        return <Alert mode="warning">{(error as Error)?.message}</Alert>;
+    }
+    return (
+        <Loading loading={isLoading}>
+            {qredoTransactions?.length && activeAddress ? (
+                qredoTransactions.map((txn) => (
+                    <ErrorBoundary key={txn.txID}>
+                        <QredoTransaction
+                            qredoID={qredoID}
+                            qredoTransactionID={txn.txID}
+                        />
+                    </ErrorBoundary>
+                ))
+            ) : (
+                <NoActivityCard message="When available, pending Qredo transactions will show up here." />
+            )}
+        </Loading>
+    );
+}

--- a/apps/wallet/src/ui/app/pages/home/transactions/QredoTransaction.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transactions/QredoTransaction.tsx
@@ -1,0 +1,100 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useOnScreen } from '@mysten/core';
+import { IntentScope, fromB64 } from '@mysten/sui.js';
+import { useMemo, useRef } from 'react';
+
+import { toUtf8OrB64 } from '_src/shared/utils';
+import { TxnIcon } from '_src/ui/app/components/transactions-card/TxnIcon';
+import { useGetQredoTransaction } from '_src/ui/app/hooks/useGetQredoTransaction';
+import { Text } from '_src/ui/app/shared/text';
+export type QredoTransactionProps = {
+    qredoID?: string;
+    qredoTransactionID?: string;
+};
+
+export function QredoTransaction({
+    qredoID,
+    qredoTransactionID,
+}: QredoTransactionProps) {
+    const transactionElementRef = useRef<HTMLDivElement>(null);
+    const { isIntersecting } = useOnScreen(transactionElementRef);
+    const { data, isLoading, error } = useGetQredoTransaction({
+        qredoID,
+        qredoTransactionID,
+        forceDisabled: !isIntersecting,
+    });
+    const messageWithIntent = useMemo(() => {
+        if (data?.MessageWithIntent) {
+            return fromB64(data.MessageWithIntent);
+        }
+        return null;
+    }, [data?.MessageWithIntent]);
+    const scope = messageWithIntent?.[0];
+    const isSignMessage = scope === IntentScope.PersonalMessage;
+    const transactionBytes = useMemo(
+        () => messageWithIntent?.slice(3) || null,
+        [messageWithIntent]
+    );
+    const messageToSign =
+        useMemo(
+            () => transactionBytes && toUtf8OrB64(transactionBytes),
+            [transactionBytes]
+        )?.message?.slice(0, 300) || null;
+    return (
+        <div
+            ref={transactionElementRef}
+            className="py-4 flex items-start gap-3"
+        >
+            <div>
+                <TxnIcon
+                    txnFailed={!!error}
+                    variant={
+                        isLoading
+                            ? 'Loading'
+                            : isSignMessage
+                            ? 'PersonalMessage'
+                            : 'Send'
+                    }
+                />
+            </div>
+            <div className="flex flex-col gap-1">
+                {isLoading ? (
+                    <>
+                        <div className="bg-sui-lightest h-3 w-20 rounded" />
+                        <div className="bg-sui-lightest h-3 w-16 rounded" />
+                    </>
+                ) : data ? (
+                    <>
+                        <div className="flex flex-nowrap gap-1 item-center">
+                            <Text color="gray-90" weight="semibold">
+                                {isSignMessage
+                                    ? 'Sign personal message'
+                                    : 'Transaction'}
+                            </Text>
+                            <Text color="gray-90" variant="bodySmall">
+                                ({data.status})
+                            </Text>
+                        </div>
+                        <Text color="gray-80" mono variant="bodySmall">
+                            #{data.txID}
+                        </Text>
+                        {isSignMessage && messageToSign ? (
+                            <div className="break-all">
+                                <Text color="gray-80" weight="normal">
+                                    {messageToSign}
+                                </Text>
+                            </div>
+                        ) : null}
+                    </>
+                ) : (
+                    <Text color="gray-80">
+                        {(error as Error)?.message ||
+                            'Something went wrong while fetching transaction details'}
+                    </Text>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/apps/wallet/src/ui/app/pages/home/transactions/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transactions/index.tsx
@@ -1,57 +1,49 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { getTransactionDigest } from '@mysten/sui.js';
+import cl from 'classnames';
+import { Navigate, useParams } from 'react-router-dom';
 
-import { ErrorBoundary } from '_components/error-boundary';
-import Loading from '_components/loading';
-import { TransactionCard } from '_components/transactions-card';
-import { NoActivityCard } from '_components/transactions-card/NoActivityCard';
-import { useQueryTransactionsByAddress } from '_hooks';
-import Alert from '_src/ui/app/components/alert';
-import { useActiveAddress } from '_src/ui/app/hooks/useActiveAddress';
+import { CompletedTransactions } from './CompletedTransactions';
+import { QredoPendingTransactions } from './QredoPendingTransactions';
+import FiltersPortal from '_components/filters-tags';
+import { AccountType } from '_src/background/keyring/Account';
+import { useActiveAccount } from '_src/ui/app/hooks/useActiveAccount';
 import PageTitle from '_src/ui/app/shared/PageTitle';
 
 function TransactionBlocksPage() {
-    const activeAddress = useActiveAddress();
-    const {
-        data: txns,
-        isLoading,
-        error,
-        isError,
-    } = useQueryTransactionsByAddress(activeAddress);
-
-    if (isError) {
-        return (
-            <div className="p-2">
-                <Alert mode="warning">
-                    <div className="font-semibold">
-                        {(error as Error).message}
-                    </div>
-                </Alert>
-            </div>
-        );
+    const activeAccount = useActiveAccount();
+    const isQredoAccount = activeAccount?.type === AccountType.QREDO;
+    const { status } = useParams();
+    const isPendingTransactions = status === 'pending';
+    if (activeAccount && !isQredoAccount && isPendingTransactions) {
+        return <Navigate to="/transactions" replace />;
     }
-
     return (
         <div className="flex flex-col flex-nowrap h-full overflow-x-visible">
+            {isQredoAccount ? (
+                <FiltersPortal
+                    tags={[
+                        { name: 'Complete', link: 'transactions' },
+                        {
+                            name: 'Pending Transactions',
+                            link: 'transactions/pending',
+                        },
+                    ]}
+                />
+            ) : null}
             <PageTitle title="Your Activity" />
-
-            <div className="mt-5 flex-grow overflow-y-auto px-5 -mx-5 divide-y divide-solid divide-gray-45 divide-x-0">
-                <Loading loading={isLoading}>
-                    {txns?.length && activeAddress ? (
-                        txns.map((txn) => (
-                            <ErrorBoundary key={getTransactionDigest(txn)}>
-                                <TransactionCard
-                                    txn={txn}
-                                    address={activeAddress}
-                                />
-                            </ErrorBoundary>
-                        ))
-                    ) : (
-                        <NoActivityCard />
-                    )}
-                </Loading>
+            <div
+                className={cl(
+                    'mt-5 flex-grow overflow-y-auto px-5 -mx-5 divide-y divide-solid divide-gray-45 divide-x-0',
+                    { 'mb-4': isQredoAccount }
+                )}
+            >
+                {isPendingTransactions ? (
+                    <QredoPendingTransactions />
+                ) : (
+                    <CompletedTransactions />
+                )}
             </div>
         </div>
     );


### PR DESCRIPTION
* when a qredo account is selected in user's activity view show an extra filter to allow user to switch between completed and pending (qredo) transactions
* use qredo api to load all transactions and filter out all completed
* for each visible transaction load extra details
* based on the Intent scope show if qredo transaction is sign message request or actual transaction
* transactions and transaction details refetch every 5s

Loading
<img width="364" alt="Screenshot 2023-05-22 at 23 38 49" src="https://github.com/MystenLabs/sui/assets/10210143/88b07c9d-abc8-4d3b-bea3-286e1edc9622">

No transactions
<img width="364" alt="Screenshot 2023-05-22 at 23 51 12" src="https://github.com/MystenLabs/sui/assets/10210143/ea4df84e-70c3-4b4b-a453-84587195fce4">

Error loading transactions
<img width="364" alt="Screenshot 2023-05-22 at 23 52 06" src="https://github.com/MystenLabs/sui/assets/10210143/01b6a6c8-7ec4-484d-9506-439c08fa953e">

Transactions
<img width="364" alt="Screenshot 2023-05-22 at 23 55 58" src="https://github.com/MystenLabs/sui/assets/10210143/59613023-500b-42bb-b9cc-9c59ed47fa5c">

Transaction that failed to load details

https://github.com/MystenLabs/sui/assets/10210143/99ee7e8b-4453-478a-aaa1-6346737bb2c4



closes APPS-796
