### PR TITLE
[Faucet] Faucet rewrite to take in batch requests instead of single requests BREAKING VERSION

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9498,6 +9498,7 @@ dependencies = [
  "futures",
  "jsonrpsee",
  "move-core-types",
+ "mysten-metrics",
  "prometheus",
  "reqwest",
  "serde 1.0.152",

--- a/apps/wallet/src/ui/app/shared/faucet/FaucetMessageInfo.tsx
+++ b/apps/wallet/src/ui/app/shared/faucet/FaucetMessageInfo.tsx
@@ -1,36 +1,31 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useFormatCoin } from '@mysten/core';
+// import { useFormatCoin } from '@mysten/core';
 
-import { GAS_TYPE_ARG } from '_redux/slices/sui-objects/Coin';
+// import { GAS_TYPE_ARG } from '_redux/slices/sui-objects/Coin';
 
 export type FaucetMessageInfoProps = {
     error?: string | null;
     loading?: boolean;
-    totalReceived?: number | null;
+    task?: string | null;
 };
 
 function FaucetMessageInfo({
     error = null,
     loading = false,
-    totalReceived = null,
+    task = null,
 }: FaucetMessageInfoProps) {
-    const [coinsReceivedFormatted, coinsReceivedSymbol] = useFormatCoin(
-        totalReceived,
-        GAS_TYPE_ARG
-    );
     if (loading) {
         return <>Request in progress</>;
     }
     if (error) {
         return <>{error}</>;
     }
-    return (
-        <>{`${
-            totalReceived ? `${coinsReceivedFormatted} ` : ''
-        }${coinsReceivedSymbol} received`}</>
-    );
+    if (!task) {
+        return <>Try faucet request again!</>;
+    }
+    return <>Faucet request in progress.</>;
 }
 
 export default FaucetMessageInfo;

--- a/apps/wallet/src/ui/app/shared/faucet/FaucetRequestButton.tsx
+++ b/apps/wallet/src/ui/app/shared/faucet/FaucetRequestButton.tsx
@@ -39,9 +39,7 @@ function FaucetRequestButton({
             onClick={() => {
                 toast.promise(mutation.mutateAsync(), {
                     loading: <FaucetMessageInfo loading />,
-                    success: (totalReceived) => (
-                        <FaucetMessageInfo totalReceived={totalReceived} />
-                    ),
+                    success: (task) => <FaucetMessageInfo task={task} />,
                     error: (error) => (
                         <FaucetMessageInfo error={error.message} />
                     ),

--- a/apps/wallet/src/ui/app/shared/faucet/useFaucetMutation.ts
+++ b/apps/wallet/src/ui/app/shared/faucet/useFaucetMutation.ts
@@ -22,15 +22,12 @@ export function useFaucetMutation(options?: UseFaucetMutationOptions) {
             if (!address) {
                 throw new Error('Failed, wallet address not found.');
             }
-            const { error, transferredGasObjects } =
-                await api.requestSuiFromFaucet(address);
+            const { error, task } = await api.requestSuiFromFaucet(address);
             if (error) {
                 throw new Error(error);
             }
-            return transferredGasObjects.reduce(
-                (total, { amount }) => total + amount,
-                0
-            );
+            // Returns the task Uuid assigned to this faucet
+            return task;
         },
         ...options,
     });

--- a/crates/sui-cluster-test/Cargo.toml
+++ b/crates/sui-cluster-test/Cargo.toml
@@ -23,6 +23,7 @@ uuid = {version = "1.1.2", features = [ "v4", "fast-rng"]}
 prometheus = "0.13.3"
 fastcrypto = { workspace = true }
 shared-crypto = { path = "../shared-crypto" }
+mysten-metrics = { path = "../../crates/mysten-metrics" }
 
 sui-indexer = { path = "../sui-indexer" }
 sui-faucet = { path = "../sui-faucet" }

--- a/crates/sui-cluster-test/src/faucet.rs
+++ b/crates/sui-cluster-test/src/faucet.rs
@@ -3,12 +3,14 @@
 use super::cluster::{new_wallet_context_from_cluster, Cluster};
 use async_trait::async_trait;
 use fastcrypto::encoding::{Encoding, Hex};
+use mysten_metrics::spawn_monitored_task;
 use std::collections::HashMap;
 use std::env;
 use std::sync::Arc;
 use sui_faucet::{Faucet, FaucetConfig, FaucetResponse, SimpleFaucet};
 use sui_types::base_types::SuiAddress;
 use sui_types::crypto::KeypairTraits;
+use tokio::time::Duration;
 use tracing::{debug, info, info_span, Instrument};
 use uuid::Uuid;
 
@@ -41,7 +43,22 @@ impl FaucetClientFactory {
                 .await
                 .unwrap();
 
-                Arc::new(LocalFaucetClient::new(simple_faucet))
+                let faucet = Arc::new(simple_faucet);
+                let faucet_batch = Arc::clone(&faucet);
+
+                // Spawn async thread here to batch_process_faucet reuuests every 1 second window
+                spawn_monitored_task!(async move {
+                    loop {
+                        // Every 2 seconds we commit faucet requests
+                        tokio::time::sleep(Duration::from_secs(1)).await;
+                        faucet_batch
+                            .batch_transfer_gases()
+                            .await
+                            .expect("unexpected unable to batch transfer");
+                    }
+                });
+
+                Arc::new(LocalFaucetClient::new(faucet))
             }
         }
     }
@@ -102,18 +119,20 @@ impl FaucetClient for RemoteFaucetClient {
 
 /// A local faucet that holds some coins since genesis
 pub struct LocalFaucetClient {
-    simple_faucet: SimpleFaucet,
+    simple_faucet: Arc<SimpleFaucet>,
 }
 
 impl LocalFaucetClient {
-    fn new(simple_faucet: SimpleFaucet) -> Self {
+    fn new(simple_faucet: Arc<SimpleFaucet>) -> Self {
         info!("Use local faucet");
         Self { simple_faucet }
     }
 }
+
 #[async_trait]
 impl FaucetClient for LocalFaucetClient {
     async fn request_sui_coins(&self, request_address: SuiAddress) -> FaucetResponse {
+        // TODO rewrite these tests.
         let receipt = self
             .simple_faucet
             .send(Uuid::new_v4(), request_address, &[200_000_000_000; 5])

--- a/crates/sui-cluster-test/src/lib.rs
+++ b/crates/sui-cluster-test/src/lib.rs
@@ -62,7 +62,7 @@ impl TestContext {
 
         // Sleep from for faucet to batch transfer
         thread::sleep(Duration::from_secs(10));
-
+        let mut counter = 0;
         loop {
             let gas_coins: Vec<GasCoin> = self
                 .client
@@ -79,6 +79,11 @@ impl TestContext {
                 return gas_coins; // Break the loop and return the gas coins
             }
 
+            if counter > 5 {
+                panic!("Too many tries to get gas coins.");
+            }
+
+            counter += 1;
             // Sleep before retrying
             thread::sleep(Duration::from_secs(5));
         }

--- a/crates/sui-cluster-test/src/lib.rs
+++ b/crates/sui-cluster-test/src/lib.rs
@@ -85,7 +85,7 @@ impl TestContext {
 
             counter += 1;
             // Sleep before retrying
-            thread::sleep(Duration::from_secs(5));
+            thread::sleep(Duration::from_secs(5 * (counter + 1)));
         }
     }
 

--- a/crates/sui-cluster-test/src/test_case/coin_index_test.rs
+++ b/crates/sui-cluster-test/src/test_case/coin_index_test.rs
@@ -36,7 +36,7 @@ impl TestCaseImpl for CoinIndexTest {
         let rgp = ctx.get_reference_gas_price().await;
 
         // 0. Get some coins first
-        ctx.get_sui_from_faucet(None).await;
+        ctx.request_sui_from_faucet(None).await;
 
         // Record initial balances
         let Balance {

--- a/crates/sui-cluster-test/src/test_case/coin_merge_split_test.rs
+++ b/crates/sui-cluster-test/src/test_case/coin_merge_split_test.rs
@@ -23,13 +23,15 @@ impl TestCaseImpl for CoinMergeSplitTest {
     }
 
     async fn run(&self, ctx: &mut TestContext) -> Result<(), anyhow::Error> {
-        let mut sui_objs = ctx.get_sui_from_faucet(Some(1)).await;
+        // Call 2x to get 2 gas objects
+        ctx.request_sui_from_faucet(Some(1)).await;
+        ctx.request_sui_from_faucet(Some(1)).await;
+        let mut sui_objs = ctx.get_unique_gas_object(vec![]).await;
         let gas_obj = sui_objs.swap_remove(0);
 
         let signer = ctx.get_wallet_address();
-        let mut sui_objs_2 = ctx.get_sui_from_faucet(Some(1)).await;
 
-        let primary_coin = sui_objs_2.swap_remove(0);
+        let primary_coin = sui_objs.swap_remove(0);
         let primary_coin_id = *primary_coin.id();
         let original_value = primary_coin.value();
 
@@ -157,6 +159,6 @@ impl CoinMergeSplitTest {
             .await
             .unwrap();
 
-        ctx.sign_and_execute(data, "coin merge").await
+        ctx.sign_and_execute(data, "split coin").await
     }
 }

--- a/crates/sui-cluster-test/src/test_case/fullnode_execute_transaction_test.rs
+++ b/crates/sui-cluster-test/src/test_case/fullnode_execute_transaction_test.rs
@@ -41,7 +41,7 @@ impl TestCaseImpl for FullNodeExecuteTransactionTest {
 
     async fn run(&self, ctx: &mut TestContext) -> Result<(), anyhow::Error> {
         let txn_count = 4;
-        ctx.get_sui_from_faucet(Some(1)).await;
+        ctx.request_sui_from_faucet(Some(1)).await;
 
         let mut txns = ctx.make_transactions(txn_count).await;
         assert!(

--- a/crates/sui-cluster-test/src/test_case/native_transfer_test.rs
+++ b/crates/sui-cluster-test/src/test_case/native_transfer_test.rs
@@ -31,8 +31,10 @@ impl TestCaseImpl for NativeTransferTest {
 
     async fn run(&self, ctx: &mut TestContext) -> Result<(), anyhow::Error> {
         info!("Testing gas coin transfer");
-        let mut sui_objs = ctx.get_sui_from_faucet(Some(1)).await;
-        let gas_obj = ctx.get_sui_from_faucet(Some(1)).await.swap_remove(0);
+        ctx.request_sui_from_faucet(Some(1)).await;
+        ctx.request_sui_from_faucet(Some(1)).await;
+        let mut sui_objs = ctx.get_unique_gas_object(vec![]).await;
+        let gas_obj = sui_objs.swap_remove(0);
 
         let signer = ctx.get_wallet_address();
         let (recipient_addr, _): (_, AccountKeyPair) = get_key_pair();
@@ -48,11 +50,11 @@ impl TestCaseImpl for NativeTransferTest {
         let data = ctx
             .build_transaction_remotely("unsafe_transferObject", params)
             .await?;
-        let mut response = ctx.sign_and_execute(data, "coin transfer").await;
+        let mut response = ctx.sign_and_execute(data, "object transfer").await;
 
         Self::examine_response(ctx, &mut response, signer, recipient_addr, obj_to_transfer).await;
 
-        let mut sui_objs_2 = ctx.get_sui_from_faucet(Some(1)).await;
+        let mut sui_objs_2 = ctx.get_unique_gas_object(vec![]).await;
         // Test transfer sui
         let obj_to_transfer_2 = *sui_objs_2.swap_remove(0).id();
         let params = rpc_params![

--- a/crates/sui-cluster-test/src/test_case/shared_object_test.rs
+++ b/crates/sui-cluster-test/src/test_case/shared_object_test.rs
@@ -23,7 +23,7 @@ impl TestCaseImpl for SharedCounterTest {
     async fn run(&self, ctx: &mut TestContext) -> Result<(), anyhow::Error> {
         info!("Testing shared object transactions.");
 
-        let sui_objs = ctx.get_sui_from_faucet(Some(1)).await;
+        let sui_objs = ctx.request_sui_from_faucet(Some(1)).await;
         assert!(!sui_objs.is_empty());
 
         let wallet_context: &WalletContext = ctx.get_wallet();

--- a/crates/sui-faucet/src/faucet/mod.rs
+++ b/crates/sui-faucet/src/faucet/mod.rs
@@ -14,7 +14,12 @@ use std::{net::Ipv4Addr, path::PathBuf};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct FaucetReceipt {
-    pub sent: Vec<CoinInfo>,
+    pub task: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct FaucetCompletedReceipt {
+    pub sent: Option<Vec<CoinInfo>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -27,7 +32,7 @@ pub struct CoinInfo {
 
 #[async_trait]
 pub trait Faucet {
-    /// Send `Coin<SUI>` of the specified amount to the recipient
+    /// Send `Coin<SUI>` of the specified amount to the recipient.
     async fn send(
         &self,
         id: Uuid,

--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -610,12 +610,12 @@ impl Faucet for SimpleFaucet {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use sui::client_commands::{SuiClientCommandResult, SuiClientCommands};
     use sui_json_rpc_types::SuiExecutionStatus;
+    use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
     use sui_sdk::wallet_context::WalletContext;
     use test_utils::network::TestClusterBuilder;
-
-    use super::*;
 
     #[tokio::test]
     async fn simple_faucet_basic_interface_should_work() {

--- a/crates/sui-faucet/src/responses.rs
+++ b/crates/sui-faucet/src/responses.rs
@@ -7,7 +7,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct FaucetResponse {
-    pub transferred_gas_objects: Vec<CoinInfo>,
+    // This string is the Uuid for the req
+    pub task: Option<String>,
     pub error: Option<String>,
 }
 
@@ -15,7 +16,7 @@ impl From<FaucetError> for FaucetResponse {
     fn from(e: FaucetError) -> Self {
         Self {
             error: Some(e.to_string()),
-            transferred_gas_objects: vec![],
+            task: None,
         }
     }
 }
@@ -23,7 +24,7 @@ impl From<FaucetError> for FaucetResponse {
 impl From<FaucetReceipt> for FaucetResponse {
     fn from(v: FaucetReceipt) -> Self {
         Self {
-            transferred_gas_objects: v.sent,
+            task: Some(v.task),
             error: None,
         }
     }

--- a/crates/sui-test-validator/src/main.rs
+++ b/crates/sui-test-validator/src/main.rs
@@ -156,7 +156,12 @@ async fn faucet_request(
         }
     };
 
-    if !result.transferred_gas_objects.is_empty() {
+    if !result
+        .task
+        .clone()
+        .expect("unexpected- queue is full")
+        .is_empty()
+    {
         (StatusCode::CREATED, Json(result))
     } else {
         (StatusCode::INTERNAL_SERVER_ERROR, Json(result))

--- a/crates/sui-types/src/gas_coin.rs
+++ b/crates/sui-types/src/gas_coin.rs
@@ -63,7 +63,7 @@ impl GAS {
 }
 
 /// Rust version of the Move sui::coin::Coin<Sui::sui::SUI> type
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GasCoin(pub Coin);
 
 impl GasCoin {

--- a/sdk/typescript/src/types/faucet.ts
+++ b/sdk/typescript/src/types/faucet.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { array, nullable, number, object, Infer, string } from 'superstruct';
+import { nullable, number, object, Infer, string } from 'superstruct';
 import { TransactionDigest, ObjectId } from './common';
 
 export const FaucetCoinInfo = object({
@@ -13,7 +13,7 @@ export const FaucetCoinInfo = object({
 export type FaucetCoinInfo = Infer<typeof FaucetCoinInfo>;
 
 export const FaucetResponse = object({
-  transferredGasObjects: array(FaucetCoinInfo),
+  task: nullable(string()),
   error: nullable(string()),
 });
 


### PR DESCRIPTION
## Description 

This is a major rewrite of the FaucetResponse and Faucet behavior. In this PR we keep the same request format for faucet, but we change the response to:

```
pub struct FaucetResponse {
    // This string is the Uuid for the req
    pub task: Option<String>,
    pub error: Option<String>,
}
```
where the person instead receives a tracking ID for their task. We will instead return HTTP 202 to show that their request has been accepted, and error if it has not been.

The incoming requests are stored in a queue which is read from and cleared every 2 seconds (this time is configurable). 

The overall logic of faucet has changed to instead of processing 1 request at a time, we decide to process up to 500 requests every 2 seconds, and we use programmable txns to batch send coins out.

## Test Plan 

How did you test the new or updated feature?

Local test, but we probably need to roll out in staging / devnet. This change will a fast follow in the discord bot to accomodate the behavior change here. 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] user-visible impact
- [x] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
