### PR TITLE
set alt server name for anemo

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -163,7 +163,7 @@ pub mod test_authority_builder;
 pub(crate) mod authority_notify_read;
 pub(crate) mod authority_store;
 
-static CHAIN_IDENTIFIER: OnceCell<ChainIdentifier> = OnceCell::new();
+pub static CHAIN_IDENTIFIER: OnceCell<ChainIdentifier> = OnceCell::new();
 
 pub type ReconfigConsensusMessage = (
     AuthorityKeyPair,


### PR DESCRIPTION
## Description 

update anemo to https://github.com/MystenLabs/anemo/commit/1bfa7842f66a85d35345b5ada358df90c3efd579 which includes the `alternate_server_name` change. Set primary server name as `sui-{chain-id}`. 

## Test Plan 

tested in labnet.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
update anemo to https://github.com/MystenLabs/anemo/commit/1bfa7842f66a85d35345b5ada358df90c3efd579 which includes the `alternate_server_name` change. Set primary server name as `sui-{chain-id}`.  Note that if node starts to run this version in testnet/mainnet before the update is officially rolled out, it's likely the node won't be able to state sync. 