### PR TITLE
Upgrade jsonrpsee to v0.18.2 (forked)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,21 +744,21 @@ dependencies = [
 
 [[package]]
 name = "aws-config"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc00553f5f3c06ffd4510a9d576f92143618706c45ea6ff81e84ad9be9588abd"
+checksum = "bcdcf0d683fe9c23d32cf5b53c9918ea0a500375a9fb20109802552658e576c9"
 dependencies = [
- "aws-credential-types 0.55.2",
- "aws-http 0.55.2",
- "aws-sdk-sso 0.27.0",
- "aws-sdk-sts 0.27.0",
+ "aws-credential-types 0.55.3",
+ "aws-http 0.55.3",
+ "aws-sdk-sso 0.28.0",
+ "aws-sdk-sts 0.28.0",
  "aws-smithy-async 0.55.3",
  "aws-smithy-client 0.55.3",
  "aws-smithy-http 0.55.3",
  "aws-smithy-http-tower 0.55.3",
  "aws-smithy-json 0.55.3",
  "aws-smithy-types 0.55.3",
- "aws-types 0.55.2",
+ "aws-types 0.55.3",
  "bytes",
  "fastrand",
  "hex",
@@ -787,9 +787,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cb57ac6088805821f78d282c0ba8aec809f11cbee10dda19a97b03ab040ccc2"
+checksum = "1fcdb2f7acbc076ff5ad05e7864bdb191ca70a6fd07668dc3a1a8bcd051de5ae"
 dependencies = [
  "aws-smithy-async 0.55.3",
  "aws-smithy-types 0.55.3",
@@ -815,13 +815,13 @@ dependencies = [
 
 [[package]]
 name = "aws-endpoint"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5f6f84a4f46f95a9bb71d9300b73cd67eb868bc43ae84f66ad34752299f4ac"
+checksum = "8cce1c41a6cfaa726adee9ebb9a56fcd2bbfd8be49fd8a04c5e20fd968330b04"
 dependencies = [
  "aws-smithy-http 0.55.3",
  "aws-smithy-types 0.55.3",
- "aws-types 0.55.2",
+ "aws-types 0.55.3",
  "http",
  "regex",
  "tracing",
@@ -848,14 +848,14 @@ dependencies = [
 
 [[package]]
 name = "aws-http"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a754683c322f7dc5167484266489fdebdcd04d26e53c162cad1f3f949f2c5671"
+checksum = "aadbc44e7a8f3e71c8b374e03ecd972869eb91dd2bc89ed018954a52ba84bc44"
 dependencies = [
- "aws-credential-types 0.55.2",
+ "aws-credential-types 0.55.3",
  "aws-smithy-http 0.55.3",
  "aws-smithy-types 0.55.3",
- "aws-types 0.55.2",
+ "aws-types 0.55.3",
  "bytes",
  "http",
  "http-body",
@@ -891,21 +891,21 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "babfd626348836a31785775e3c08a4c345a5ab4c6e06dfd9167f2bee0e6295d6"
+checksum = "c8b812340d86d4a766b2ca73f740dfd47a97c2dff0c06c8517a16d88241957e4"
 dependencies = [
- "aws-credential-types 0.55.2",
- "aws-endpoint 0.55.2",
- "aws-http 0.55.2",
- "aws-sig-auth 0.55.2",
+ "aws-credential-types 0.55.3",
+ "aws-endpoint 0.55.3",
+ "aws-http 0.55.3",
+ "aws-sig-auth 0.55.3",
  "aws-smithy-async 0.55.3",
  "aws-smithy-client 0.55.3",
  "aws-smithy-http 0.55.3",
  "aws-smithy-http-tower 0.55.3",
  "aws-smithy-json 0.55.3",
  "aws-smithy-types 0.55.3",
- "aws-types 0.55.2",
+ "aws-types 0.55.3",
  "bytes",
  "http",
  "regex",
@@ -942,14 +942,14 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d0fbe3c2c342bc8dfea4bb43937405a8ec06f99140a0dcb9c7b59e54dfa93a1"
+checksum = "265fac131fbfc188e5c3d96652ea90ecc676a934e3174eaaee523c6cec040b3b"
 dependencies = [
- "aws-credential-types 0.55.2",
- "aws-endpoint 0.55.2",
- "aws-http 0.55.2",
- "aws-sig-auth 0.55.2",
+ "aws-credential-types 0.55.3",
+ "aws-endpoint 0.55.3",
+ "aws-http 0.55.3",
+ "aws-sig-auth 0.55.3",
  "aws-smithy-async 0.55.3",
  "aws-smithy-client 0.55.3",
  "aws-smithy-http 0.55.3",
@@ -958,7 +958,7 @@ dependencies = [
  "aws-smithy-query 0.55.3",
  "aws-smithy-types 0.55.3",
  "aws-smithy-xml 0.55.3",
- "aws-types 0.55.2",
+ "aws-types 0.55.3",
  "bytes",
  "http",
  "regex",
@@ -982,14 +982,14 @@ dependencies = [
 
 [[package]]
 name = "aws-sig-auth"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84dc92a63ede3c2cbe43529cb87ffa58763520c96c6a46ca1ced80417afba845"
+checksum = "3b94acb10af0c879ecd5c7bdf51cda6679a0a4f4643ce630905a77673bfa3c61"
 dependencies = [
- "aws-credential-types 0.55.2",
- "aws-sigv4 0.55.2",
+ "aws-credential-types 0.55.3",
+ "aws-sigv4 0.55.3",
  "aws-smithy-http 0.55.3",
- "aws-types 0.55.2",
+ "aws-types 0.55.3",
  "http",
  "tracing",
 ]
@@ -1015,9 +1015,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "392fefab9d6fcbd76d518eb3b1c040b84728ab50f58df0c3c53ada4bea9d327e"
+checksum = "9d2ce6f507be68e968a33485ced670111d1cbad161ddbbab1e313c03d37d8f4c"
 dependencies = [
  "aws-smithy-http 0.55.3",
  "form_urlencoded",
@@ -1275,11 +1275,11 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0869598bfe46ec44ffe17e063ed33336e59df90356ca8ff0e8da6f7c1d994b"
+checksum = "6dd209616cc8d7bfb82f87811a5c655dc97537f592689b18743bddf5dc5c4829"
 dependencies = [
- "aws-credential-types 0.55.2",
+ "aws-credential-types 0.55.3",
  "aws-smithy-async 0.55.3",
  "aws-smithy-client 0.55.3",
  "aws-smithy-http 0.55.3",
@@ -1433,9 +1433,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f1e31e207a6b8fb791a38ea3105e6cb541f55e4d029902d3039a4ad07cc4105"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "base64-simd"
@@ -4542,9 +4542,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
@@ -4635,7 +4635,7 @@ dependencies = [
 [[package]]
 name = "jsonrpsee"
 version = "0.18.2"
-source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=66ce27cc207d5f193e007a743c2497477bae6fec#66ce27cc207d5f193e007a743c2497477bae6fec"
+source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2#56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -4651,7 +4651,7 @@ dependencies = [
 [[package]]
 name = "jsonrpsee-client-transport"
 version = "0.18.2"
-source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=66ce27cc207d5f193e007a743c2497477bae6fec#66ce27cc207d5f193e007a743c2497477bae6fec"
+source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2#56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -4672,7 +4672,7 @@ dependencies = [
 [[package]]
 name = "jsonrpsee-core"
 version = "0.18.2"
-source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=66ce27cc207d5f193e007a743c2497477bae6fec#66ce27cc207d5f193e007a743c2497477bae6fec"
+source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2#56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -4699,7 +4699,7 @@ dependencies = [
 [[package]]
 name = "jsonrpsee-http-client"
 version = "0.18.2"
-source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=66ce27cc207d5f193e007a743c2497477bae6fec#66ce27cc207d5f193e007a743c2497477bae6fec"
+source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2#56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2"
 dependencies = [
  "async-trait",
  "hyper",
@@ -4717,7 +4717,7 @@ dependencies = [
 [[package]]
 name = "jsonrpsee-proc-macros"
 version = "0.18.2"
-source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=66ce27cc207d5f193e007a743c2497477bae6fec#66ce27cc207d5f193e007a743c2497477bae6fec"
+source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2#56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-crate",
@@ -4729,7 +4729,7 @@ dependencies = [
 [[package]]
 name = "jsonrpsee-server"
 version = "0.18.2"
-source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=66ce27cc207d5f193e007a743c2497477bae6fec#66ce27cc207d5f193e007a743c2497477bae6fec"
+source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2#56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2"
 dependencies = [
  "futures-util",
  "hyper",
@@ -4748,7 +4748,7 @@ dependencies = [
 [[package]]
 name = "jsonrpsee-types"
 version = "0.18.2"
-source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=66ce27cc207d5f193e007a743c2497477bae6fec#66ce27cc207d5f193e007a743c2497477bae6fec"
+source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2#56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2"
 dependencies = [
  "anyhow",
  "beef",
@@ -4761,7 +4761,7 @@ dependencies = [
 [[package]]
 name = "jsonrpsee-wasm-client"
 version = "0.18.2"
-source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=66ce27cc207d5f193e007a743c2497477bae6fec#66ce27cc207d5f193e007a743c2497477bae6fec"
+source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2#56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -4771,7 +4771,7 @@ dependencies = [
 [[package]]
 name = "jsonrpsee-ws-client"
 version = "0.18.2"
-source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=66ce27cc207d5f193e007a743c2497477bae6fec#66ce27cc207d5f193e007a743c2497477bae6fec"
+source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2#56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2"
 dependencies = [
  "http",
  "jsonrpsee-client-transport",
@@ -6824,7 +6824,7 @@ dependencies = [
  "aws-config 0.54.1",
  "aws-credential-types 0.54.1",
  "aws-types 0.54.1",
- "base64 0.21.1",
+ "base64 0.21.2",
  "bytes",
  "chrono",
  "futures",
@@ -7364,7 +7364,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b7fa9f396f51dffd61546fd8573ee20592287996568e6175ceb0f8699ad75d"
 dependencies = [
- "base64 0.21.1",
+ "base64 0.21.2",
  "byteorder",
  "bytes",
  "fallible-iterator",
@@ -8106,9 +8106,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a59b5d8e97dee33696bf13c5ba8ab85341c002922fba050069326b9c498974"
+checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
 dependencies = [
  "aho-corasick 1.0.1",
  "memchr",
@@ -8142,7 +8142,7 @@ version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
- "base64 0.21.1",
+ "base64 0.21.2",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -8507,7 +8507,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64 0.21.1",
+ "base64 0.21.2",
 ]
 
 [[package]]
@@ -9385,7 +9385,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "async-trait",
- "aws-config 0.55.2",
+ "aws-config 0.55.3",
  "bcs",
  "bip32",
  "camino",
@@ -11674,7 +11674,7 @@ checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
  "async-trait",
  "axum",
- "base64 0.21.1",
+ "base64 0.21.2",
  "bytes",
  "futures-core",
  "futures-util",
@@ -12141,9 +12141,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "unicode-normalization"
@@ -12757,14 +12757,14 @@ dependencies = [
  "auto_ops",
  "autocfg",
  "autotools",
- "aws-config 0.55.2",
- "aws-credential-types 0.55.2",
- "aws-endpoint 0.55.2",
- "aws-http 0.55.2",
- "aws-sdk-sso 0.27.0",
- "aws-sdk-sts 0.27.0",
- "aws-sig-auth 0.55.2",
- "aws-sigv4 0.55.2",
+ "aws-config 0.55.3",
+ "aws-credential-types 0.55.3",
+ "aws-endpoint 0.55.3",
+ "aws-http 0.55.3",
+ "aws-sdk-sso 0.28.0",
+ "aws-sdk-sts 0.28.0",
+ "aws-sig-auth 0.55.3",
+ "aws-sigv4 0.55.3",
  "aws-smithy-async 0.55.3",
  "aws-smithy-client 0.55.3",
  "aws-smithy-http 0.55.3",
@@ -12773,7 +12773,7 @@ dependencies = [
  "aws-smithy-query 0.55.3",
  "aws-smithy-types 0.55.3",
  "aws-smithy-xml 0.55.3",
- "aws-types 0.55.2",
+ "aws-types 0.55.3",
  "axum",
  "axum-core",
  "axum-extra",
@@ -12784,7 +12784,7 @@ dependencies = [
  "base16ct 0.1.1",
  "base16ct 0.2.0",
  "base64 0.13.1",
- "base64 0.21.1",
+ "base64 0.21.2",
  "base64-simd",
  "base64ct",
  "bcs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,9 +25,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aead"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c192eb8f11fc081b0fe4259ba5af04217d4e0faddd02417310a927911abd7c8"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "crypto-common",
  "generic-array",
@@ -46,9 +46,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e1366e0c69c9f927b1fa5ce2c7bf9eafc8f9268c0b9800729e8b267612447c"
+checksum = "209b47e8954a928e1d72e86eca7000ebb6655fe1436d33eefc2201cad027e237"
 dependencies = [
  "aead",
  "aes",
@@ -64,19 +64,19 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom 0.2.9",
  "once_cell",
  "version_check",
 ]
 
 [[package]]
 name = "ahash"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf6ccdb167abbf410dcb915cabd428929d7f6a04980b54a11f26a39f1c7f7107"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.8",
+ "getrandom 0.2.9",
  "once_cell",
  "version_check",
 ]
@@ -86,6 +86,15 @@ name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
 ]
@@ -142,12 +151,12 @@ dependencies = [
  "rcgen",
  "ring",
  "rustls 0.21.1",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
  "tap",
  "thiserror",
  "tokio",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.8",
  "tower",
  "tracing",
  "webpki",
@@ -160,9 +169,9 @@ version = "0.0.0"
 source = "git+https://github.com/mystenlabs/anemo.git?rev=baa7cfc3ae841f88c2ff773396c5a803c377d054#baa7cfc3ae841f88c2ff773396c5a803c377d054"
 dependencies = [
  "prettyplease",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -173,7 +182,7 @@ dependencies = [
  "anemo",
  "anemo-tower",
  "bytes",
- "clap 4.1.4",
+ "clap 4.3.0",
  "dashmap",
  "rand 0.8.5",
  "tokio",
@@ -215,10 +224,59 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.69"
+name = "anstream"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 dependencies = [
  "backtrace",
 ]
@@ -238,7 +296,7 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 dependencies = [
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -279,7 +337,7 @@ dependencies = [
  "ark-std",
  "blake2",
  "derivative",
- "digest 0.10.6",
+ "digest 0.10.7",
  "rayon",
  "sha2 0.10.6",
  "tracing",
@@ -287,9 +345,9 @@ dependencies = [
 
 [[package]]
 name = "ark-ec"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c60370a92f8e1a5f053cad73a862e1b99bc642333cd676fa11c0c39f80f4ac2"
+checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
 dependencies = [
  "ark-ff",
  "ark-poly",
@@ -305,16 +363,16 @@ dependencies = [
 
 [[package]]
 name = "ark-ff"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c2d42532524bee1da5a4f6f733eb4907301baa480829557adcff5dfaeee1d9a"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
 dependencies = [
  "ark-ff-asm",
  "ark-ff-macros",
  "ark-serialize",
  "ark-std",
  "derivative",
- "digest 0.10.6",
+ "digest 0.10.7",
  "itertools",
  "num-bigint",
  "num-traits 0.2.15",
@@ -326,25 +384,25 @@ dependencies = [
 
 [[package]]
 name = "ark-ff-asm"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6873aaba7959593d89babed381d33e2329453368f1bf3c67e07686a1c1056f"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
 dependencies = [
- "quote 1.0.26",
- "syn 1.0.107",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "ark-ff-macros"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c2e7d0f2d67cc7fc925355c74d36e7eda19073639be4a0a233d4611b8c959d"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
  "num-bigint",
  "num-traits 0.2.15",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -365,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "ark-poly"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f6ec811462cabe265cfe1b102fcfe3df79d7d2929c2425673648ee9abfd0272"
+checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -419,25 +477,25 @@ dependencies = [
 
 [[package]]
 name = "ark-serialize"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e735959bc173ea4baf13327b19c22d452b8e9e8e8f7b7fc34e6bf0e316c33e"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-serialize-derive",
  "ark-std",
- "digest 0.10.6",
+ "digest 0.10.7",
  "num-bigint",
 ]
 
 [[package]]
 name = "ark-serialize-derive"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd34f0920d995d2c932f38861c416f70de89a6de9875876b012557079603e6cc"
+checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -465,9 +523,9 @@ dependencies = [
 
 [[package]]
 name = "arrayref"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
 name = "arrayvec"
@@ -483,18 +541,18 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "asn1-rs"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf6690c370453db30743b373a60ba498fc0d6d83b11f4abfd87a84a075db5dd4"
+checksum = "7f6fd5ddaf0351dff5b8da21b2fb4ff8e08ddd02857f0bf69c47639106c0fff0"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
- "nom 7.1.2",
+ "nom 7.1.3",
  "num-traits 0.2.15",
  "rusticata-macros",
  "thiserror",
- "time 0.3.17",
+ "time 0.3.21",
 ]
 
 [[package]]
@@ -503,9 +561,9 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
  "synstructure",
 ]
 
@@ -515,20 +573,21 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.7"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa3d466004a8b4cb1bc34044240a2fd29d17607e2e3bd613eb44fd48e8100da3"
+checksum = "86d6b683edf8d1119fe420a94f8a7e389239666aa72e65495d91c00462510151"
 dependencies = [
+ "anstyle",
  "bstr",
  "doc-comment",
- "predicates",
+ "predicates 3.0.3",
  "predicates-core",
  "predicates-tree",
  "wait-timeout",
@@ -550,12 +609,11 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8101efe8695a6c17e02911402145357e718ac92d3ff88ae8419e84b1707b685"
+checksum = "fa24f727524730b077666307f2734b4a1a1c57acb79193127dcc8914d5242dd7"
 dependencies = [
  "event-listener",
- "futures-lite",
 ]
 
 [[package]]
@@ -564,30 +622,31 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 2.0.10",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "async-stream"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
 dependencies = [
  "async-stream-impl",
  "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -601,9 +660,9 @@ version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 2.0.10",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -647,9 +706,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "autotools"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8138adefca3e5d2e73bfba83bd6eeaf904b26a7ac1b4a19892cfe16cc7e1701"
+checksum = "aef8da1805e028a172334c3b680f93e71126f2327622faef2ec3d893c0a4ad77"
 dependencies = [
  "cc",
 ]
@@ -676,7 +735,7 @@ dependencies = [
  "http",
  "hyper",
  "ring",
- "time 0.3.17",
+ "time 0.3.21",
  "tokio",
  "tower",
  "tracing",
@@ -685,20 +744,20 @@ dependencies = [
 
 [[package]]
 name = "aws-config"
-version = "0.55.1"
+version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd62464d1c4ad70f8b6cd693e7f30229f36bebdcdf3fce8c11803e1bdc0bc052"
+checksum = "fc00553f5f3c06ffd4510a9d576f92143618706c45ea6ff81e84ad9be9588abd"
 dependencies = [
  "aws-credential-types 0.55.2",
  "aws-http 0.55.2",
- "aws-sdk-sso 0.26.0",
- "aws-sdk-sts 0.26.0",
- "aws-smithy-async 0.55.2",
- "aws-smithy-client 0.55.2",
- "aws-smithy-http 0.55.2",
- "aws-smithy-http-tower 0.55.2",
- "aws-smithy-json 0.55.2",
- "aws-smithy-types 0.55.2",
+ "aws-sdk-sso 0.27.0",
+ "aws-sdk-sts 0.27.0",
+ "aws-smithy-async 0.55.3",
+ "aws-smithy-client 0.55.3",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-http-tower 0.55.3",
+ "aws-smithy-json 0.55.3",
+ "aws-smithy-types 0.55.3",
  "aws-types 0.55.2",
  "bytes",
  "fastrand",
@@ -706,7 +765,7 @@ dependencies = [
  "http",
  "hyper",
  "ring",
- "time 0.3.17",
+ "time 0.3.21",
  "tokio",
  "tower",
  "tracing",
@@ -732,8 +791,8 @@ version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cb57ac6088805821f78d282c0ba8aec809f11cbee10dda19a97b03ab040ccc2"
 dependencies = [
- "aws-smithy-async 0.55.2",
- "aws-smithy-types 0.55.2",
+ "aws-smithy-async 0.55.3",
+ "aws-smithy-types 0.55.3",
  "fastrand",
  "tokio",
  "tracing",
@@ -760,8 +819,8 @@ version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c5f6f84a4f46f95a9bb71d9300b73cd67eb868bc43ae84f66ad34752299f4ac"
 dependencies = [
- "aws-smithy-http 0.55.2",
- "aws-smithy-types 0.55.2",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-types 0.55.3",
  "aws-types 0.55.2",
  "http",
  "regex",
@@ -794,8 +853,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a754683c322f7dc5167484266489fdebdcd04d26e53c162cad1f3f949f2c5671"
 dependencies = [
  "aws-credential-types 0.55.2",
- "aws-smithy-http 0.55.2",
- "aws-smithy-types 0.55.2",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-types 0.55.3",
  "aws-types 0.55.2",
  "bytes",
  "http",
@@ -832,20 +891,20 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143953d46f77a0b18480e7d8bb1a651080b9484e0bb94c27b8645eaeb3c3e231"
+checksum = "babfd626348836a31785775e3c08a4c345a5ab4c6e06dfd9167f2bee0e6295d6"
 dependencies = [
  "aws-credential-types 0.55.2",
  "aws-endpoint 0.55.2",
  "aws-http 0.55.2",
  "aws-sig-auth 0.55.2",
- "aws-smithy-async 0.55.2",
- "aws-smithy-client 0.55.2",
- "aws-smithy-http 0.55.2",
- "aws-smithy-http-tower 0.55.2",
- "aws-smithy-json 0.55.2",
- "aws-smithy-types 0.55.2",
+ "aws-smithy-async 0.55.3",
+ "aws-smithy-client 0.55.3",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-http-tower 0.55.3",
+ "aws-smithy-json 0.55.3",
+ "aws-smithy-types 0.55.3",
  "aws-types 0.55.2",
  "bytes",
  "http",
@@ -883,22 +942,22 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7255c0d8053b89e8b5cdabb52e1dbf596e9968b1f45dce7a56b2cd57038fcfc9"
+checksum = "2d0fbe3c2c342bc8dfea4bb43937405a8ec06f99140a0dcb9c7b59e54dfa93a1"
 dependencies = [
  "aws-credential-types 0.55.2",
  "aws-endpoint 0.55.2",
  "aws-http 0.55.2",
  "aws-sig-auth 0.55.2",
- "aws-smithy-async 0.55.2",
- "aws-smithy-client 0.55.2",
- "aws-smithy-http 0.55.2",
- "aws-smithy-http-tower 0.55.2",
- "aws-smithy-json 0.55.2",
- "aws-smithy-query 0.55.2",
- "aws-smithy-types 0.55.2",
- "aws-smithy-xml 0.55.2",
+ "aws-smithy-async 0.55.3",
+ "aws-smithy-client 0.55.3",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-http-tower 0.55.3",
+ "aws-smithy-json 0.55.3",
+ "aws-smithy-query 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "aws-smithy-xml 0.55.3",
  "aws-types 0.55.2",
  "bytes",
  "http",
@@ -914,7 +973,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "660a02a98ab1af83bd8d714afbab2d502ba9b18c49e7e4cddd6bf8837ff778cb"
 dependencies = [
  "aws-credential-types 0.54.1",
- "aws-sigv4 0.54.1",
+ "aws-sigv4 0.54.2",
  "aws-smithy-http 0.54.4",
  "aws-types 0.54.1",
  "http",
@@ -929,7 +988,7 @@ checksum = "84dc92a63ede3c2cbe43529cb87ffa58763520c96c6a46ca1ced80417afba845"
 dependencies = [
  "aws-credential-types 0.55.2",
  "aws-sigv4 0.55.2",
- "aws-smithy-http 0.55.2",
+ "aws-smithy-http 0.55.3",
  "aws-types 0.55.2",
  "http",
  "tracing",
@@ -937,9 +996,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "0.54.1"
+version = "0.54.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdaf11005b7444e6cd66f600d09861a3aeb6eb89a0f003c7c9820dbab2d15297"
+checksum = "86529e7b64d902efea8fff52c1b2529368d04f90305cf632729e3713f6b57dc0"
 dependencies = [
  "aws-smithy-http 0.54.4",
  "form_urlencoded",
@@ -950,7 +1009,7 @@ dependencies = [
  "percent-encoding",
  "regex",
  "sha2 0.10.6",
- "time 0.3.17",
+ "time 0.3.21",
  "tracing",
 ]
 
@@ -960,7 +1019,7 @@ version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "392fefab9d6fcbd76d518eb3b1c040b84728ab50f58df0c3c53ada4bea9d327e"
 dependencies = [
- "aws-smithy-http 0.55.2",
+ "aws-smithy-http 0.55.3",
  "form_urlencoded",
  "hex",
  "hmac 0.12.1",
@@ -969,7 +1028,7 @@ dependencies = [
  "percent-encoding",
  "regex",
  "sha2 0.10.6",
- "time 0.3.17",
+ "time 0.3.21",
  "tracing",
 ]
 
@@ -987,9 +1046,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae23b9fe7a07d0919000116c4c5c0578303fbce6fc8d32efca1f7759d4c20faf"
+checksum = "13bda3996044c202d75b91afeb11a9afae9db9a721c6a7a427410018e286b880"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -1012,7 +1071,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.23.2",
  "lazy_static 1.4.0",
  "pin-project-lite",
  "tokio",
@@ -1022,23 +1081,23 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-client"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5230d25d244a51339273b8870f0f77874cd4449fb4f8f629b21188ae10cfc0ba"
+checksum = "0a86aa6e21e86c4252ad6a0e3e74da9617295d8d6e374d552be7d3059c41cedd"
 dependencies = [
- "aws-smithy-async 0.55.2",
- "aws-smithy-http 0.55.2",
- "aws-smithy-http-tower 0.55.2",
- "aws-smithy-types 0.55.2",
+ "aws-smithy-async 0.55.3",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-http-tower 0.55.3",
+ "aws-smithy-types 0.55.3",
  "bytes",
  "fastrand",
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.23.2",
  "lazy_static 1.4.0",
  "pin-project-lite",
- "rustls 0.20.7",
+ "rustls 0.20.8",
  "tokio",
  "tower",
  "tracing",
@@ -1066,11 +1125,11 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b60e2133beb9fe6ffe0b70deca57aaeff0a35ad24a9c6fab2fd3b4f45b99fdb5"
+checksum = "2b3b693869133551f135e1f2c77cb0b8277d9e3e17feaf2213f735857c4f0d28"
 dependencies = [
- "aws-smithy-types 0.55.2",
+ "aws-smithy-types 0.55.3",
  "bytes",
  "bytes-utils",
  "futures-core",
@@ -1102,12 +1161,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-tower"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a4d94f556c86a0dd916a5d7c39747157ea8cb909ca469703e20fee33e448b67"
+checksum = "3ae4f6c5798a247fac98a867698197d9ac22643596dc3777f0c76b91917616b9"
 dependencies = [
- "aws-smithy-http 0.55.2",
- "aws-smithy-types 0.55.2",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-types 0.55.3",
  "bytes",
  "http",
  "http-body",
@@ -1127,11 +1186,11 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce3d6e6ebb00b2cce379f079ad5ec508f9bcc3a9510d9b9c1840ed1d6f8af39"
+checksum = "23f9f42fbfa96d095194a632fbac19f60077748eba536eb0b9fecc28659807f8"
 dependencies = [
- "aws-smithy-types 0.55.2",
+ "aws-smithy-types 0.55.3",
 ]
 
 [[package]]
@@ -1146,11 +1205,11 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d58edfca32ef9bfbc1ca394599e17ea329cb52d6a07359827be74235b64b3298"
+checksum = "98819eb0b04020a1c791903533b638534ae6c12e2aceda3e6e6fba015608d51d"
 dependencies = [
- "aws-smithy-types 0.55.2",
+ "aws-smithy-types 0.55.3",
  "urlencoding",
 ]
 
@@ -1164,20 +1223,20 @@ dependencies = [
  "itoa",
  "num-integer",
  "ryu",
- "time 0.3.17",
+ "time 0.3.21",
 ]
 
 [[package]]
 name = "aws-smithy-types"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58db46fc1f4f26be01ebdb821751b4e2482cd43aa2b64a0348fb89762defaffa"
+checksum = "16a3d0bf4f324f4ef9793b86a1701d9700fbcdbd12a846da45eed104c634c6e8"
 dependencies = [
  "base64-simd",
  "itoa",
  "num-integer",
  "ryu",
- "time 0.3.17",
+ "time 0.3.21",
 ]
 
 [[package]]
@@ -1191,9 +1250,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.55.2"
+version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb557fe4995bd9ec87fb244bbb254666a971dc902a783e9da8b7711610e9664c"
+checksum = "b1b9d12875731bd07e767be7baad95700c3137b56730ec9ddeedb52a5e5ca63b"
 dependencies = [
  "xmlparser",
 ]
@@ -1221,10 +1280,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0869598bfe46ec44ffe17e063ed33336e59df90356ca8ff0e8da6f7c1d994b"
 dependencies = [
  "aws-credential-types 0.55.2",
- "aws-smithy-async 0.55.2",
- "aws-smithy-client 0.55.2",
- "aws-smithy-http 0.55.2",
- "aws-smithy-types 0.55.2",
+ "aws-smithy-async 0.55.3",
+ "aws-smithy-client 0.55.3",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-types 0.55.3",
  "http",
  "rustc_version",
  "tracing",
@@ -1232,9 +1291,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.6"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e246206a63c9830e118d12c894f56a82033da1a2361f5544deeee3df85c99d9"
+checksum = "f8175979259124331c1d7bf6586ee7e0da434155e4b2d48ec2c8386281d8df39"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -1252,14 +1311,13 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tower",
- "tower-http 0.3.5",
  "tower-layer",
  "tower-service",
 ]
@@ -1302,9 +1360,9 @@ dependencies = [
 
 [[package]]
 name = "axum-server"
-version = "0.4.4"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8456dab8f11484979a86651da8e619b355ede5d61a160755155f6c344bd18c47"
+checksum = "bace45b270e36e3c27a190c65883de6dfc9f1d18c829907c127464815dc67b24"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -1313,10 +1371,10 @@ dependencies = [
  "http-body",
  "hyper",
  "pin-project-lite",
- "rustls 0.20.7",
+ "rustls 0.20.8",
  "rustls-pemfile",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tower-service",
 ]
 
@@ -1327,7 +1385,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
  "futures-core",
- "getrandom 0.2.8",
+ "getrandom 0.2.9",
  "instant",
  "pin-project-lite",
  "rand 0.8.5",
@@ -1344,7 +1402,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.6.2",
  "object",
  "rustc-demangle",
 ]
@@ -1375,9 +1433,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+checksum = "3f1e31e207a6b8fb791a38ea3105e6cb541f55e4d029902d3039a4ad07cc4105"
 
 [[package]]
 name = "base64-simd"
@@ -1391,17 +1449,17 @@ dependencies = [
 
 [[package]]
 name = "base64ct"
-version = "1.5.3"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bcs"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b06b4c1f053002b70e7084ac944c77d58d5d92b2110dbc5e852735e00ad3ccc"
+checksum = "4bd3ffe8b19a604421a5d461d4a70346223e535903fbc3067138bddbebddcf77"
 dependencies = [
- "serde 1.0.152",
+ "serde 1.0.163",
  "thiserror",
 ]
 
@@ -1411,7 +1469,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 dependencies = [
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -1429,16 +1487,16 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3deeecb812ca5300b7d3f66f730cc2ebd3511c3d36c691dd79c165d5b19a26e3"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "bimap"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0455254eb5c6964c4545d8bac815e1a1be4f3afe0ae695ea539c12d728d44b"
+checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bincode"
@@ -1446,7 +1504,7 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -1461,12 +1519,12 @@ dependencies = [
  "lazy_static 1.4.0",
  "lazycell",
  "peeking_take_while",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1550,7 +1608,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1564,7 +1622,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1579,9 +1637,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
@@ -1594,9 +1652,9 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "block-padding"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a90ec2df9600c28a01c56c4784c9207a96d2451833aeceb8cc97e4c9548bb78"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
 ]
@@ -1627,9 +1685,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "2.3.2"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80"
+checksum = "4b6561fd3f895a11e8f72af2cb7d22e08366bebc2b6b57f7744c4bda27034744"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1646,14 +1704,14 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.1.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45ea9b00a7b3f2988e9a65ad3917e62123c38dba709b666506207be96d1790b"
+checksum = "a246e68bb43f6cd9db24bea052a53e40405417c5fb372e3d1a8a7f770a564ef5"
 dependencies = [
  "memchr",
  "once_cell",
  "regex-automata",
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -1669,7 +1727,7 @@ dependencies = [
  "merlin",
  "rand 0.8.5",
  "rand_core 0.6.4",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_derive",
  "sha3 0.9.1",
  "subtle-ng",
@@ -1678,9 +1736,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.11.1"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "byte-slice-cast"
@@ -1701,9 +1759,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaa3a8d9a1ca92e282c96a32d6511b695d7d994d1d102ba85d279f9b2756947f"
+checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
 
 [[package]]
 name = "byteorder"
@@ -1717,7 +1775,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 dependencies = [
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -1767,10 +1825,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e10ca87c81aaa3a949dbbe2b5e6c2c45dbc94ba4897e45ea31ff9ec5087be3dc"
 dependencies = [
  "cached_proc_macro_types",
- "darling",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "darling 0.14.4",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1781,11 +1839,11 @@ checksum = "3a4f925191b4367301851c6d99b09890311d74b0d43f274c0b34c86d308a3663"
 
 [[package]]
 name = "camino"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77df041dc383319cc661b428b6961a005db4d6808d5e12536931b1ca9556055"
+checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
 dependencies = [
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -1794,19 +1852,19 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
 dependencies = [
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
 name = "cargo_metadata"
-version = "0.15.2"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982a0cf6a99c350d7246035613882e376d58cebe571785abc5da4f648d53ac0a"
+checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.16",
- "serde 1.0.152",
+ "semver",
+ "serde 1.0.163",
  "serde_json",
  "thiserror",
 ]
@@ -1834,9 +1892,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 dependencies = [
  "jobserver",
 ]
@@ -1847,14 +1905,14 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom 7.1.2",
+ "nom 7.1.3",
 ]
 
 [[package]]
 name = "cfg-expr"
-version = "0.13.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a327683d7499ecc47369531a679fe38acdd300e09bf8c852d08b1e10558622bd"
+checksum = "c8790cf1286da485c72cf5fc7aeba308438800036ec67d89425924c4807268c9"
 dependencies = [
  "smallvec",
  "target-lexicon",
@@ -1876,7 +1934,7 @@ dependencies = [
  "js-sys",
  "num-integer",
  "num-traits 0.2.15",
- "serde 1.0.152",
+ "serde 1.0.163",
  "time 0.1.45",
  "wasm-bindgen",
  "winapi",
@@ -1906,26 +1964,26 @@ dependencies = [
 
 [[package]]
 name = "ciborium"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
 name = "ciborium-io"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
 
 [[package]]
 name = "ciborium-ll"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
 dependencies = [
  "ciborium-io",
  "half",
@@ -1933,9 +1991,9 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
@@ -1943,9 +2001,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.4.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa2e27ae6ab525c3d369ded447057bca5438d86dc3a68f6faafb8269ba82ebf3"
+checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
 dependencies = [
  "glob",
  "libc",
@@ -1969,13 +2027,13 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.23"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive 3.2.18",
+ "clap_derive 3.2.25",
  "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
@@ -1986,43 +2044,51 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.4"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
+checksum = "93aae7a4192245f70fe75dd9157fc7b4a5bf53e88d30bd4396f7d8f9284d5acc"
 dependencies = [
- "bitflags",
- "clap_derive 4.1.0",
- "clap_lex 0.3.1",
- "is-terminal",
+ "clap_builder",
+ "clap_derive 4.3.0",
  "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f423e341edefb78c9caba2d9c7f7687d0e72e89df3ce3394554754393ac3990"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
+ "clap_lex 0.5.0",
  "strsim 0.10.0",
- "termcolor",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
 dependencies = [
- "heck 0.4.0",
+ "heck 0.4.1",
  "proc-macro-error",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.1.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
+checksum = "191d9573962933b4027f932c600cd252ce27a8ad5979418fe78e43c07996f27b"
 dependencies = [
- "heck 0.4.0",
- "proc-macro-error",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "heck 0.4.1",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -2036,12 +2102,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.3.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "clear_on_drop"
@@ -2070,7 +2133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3362992a0d9f1dd7c3d0e89e0ab2bb540b7a95fea8cd798090e758fda2899b5e"
 dependencies = [
  "codespan-reporting",
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -2079,7 +2142,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
- "serde 1.0.152",
+ "serde 1.0.163",
  "termcolor",
  "unicode-width",
 ]
@@ -2089,6 +2152,12 @@ name = "collectable"
 version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08abddbaad209601e53c7dd4308d8c04c06f17bb7df006434e586a22b83be45a"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colored"
@@ -2141,9 +2210,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b1b9d958c2b1368a663f05538fc1b5975adce1e19f435acceae987aceeeb369"
 dependencies = [
  "lazy_static 1.4.0",
- "nom 5.1.2",
+ "nom 5.1.3",
  "rust-ini",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde-hjson",
  "serde_json",
  "toml",
@@ -2152,34 +2221,34 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.4"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b6515d269224923b26b5febea2ed42b2d5f2ce37284a4dd670fedd6cb8347a"
+checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
 dependencies = [
  "encode_unicode 0.3.6",
  "lazy_static 1.4.0",
  "libc",
  "unicode-width",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "console-api"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57ff02e8ad8e06ab9731d5dc72dc23bef9200778eae1a89d555d8c42e5d4a86"
+checksum = "c2895653b4d9f1538a83970077cb01dfc77a4810524e51a110944688e916b18e"
 dependencies = [
  "prost",
  "prost-types",
- "tonic",
+ "tonic 0.9.2",
  "tracing-core",
 ]
 
 [[package]]
 name = "console-subscriber"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a3a81dfaf6b66bce5d159eddae701e3a002f194d378cbf7be5f053c281d9be"
+checksum = "57ab2224a0311582eb03adba4caaf18644f7b1f10a760803a803b9b605187fc7"
 dependencies = [
  "console-api",
  "crossbeam-channel",
@@ -2188,15 +2257,15 @@ dependencies = [
  "hdrhistogram",
  "humantime",
  "prost-types",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
  "thread_local",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.9.2",
  "tracing",
  "tracing-core",
- "tracing-subscriber 0.3.16",
+ "tracing-subscriber 0.3.17",
 ]
 
 [[package]]
@@ -2207,15 +2276,15 @@ checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
 name = "const-str"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5bc011a04793b8ce7bca0efd59e3697c2061760df6efbb8c895e8a81548db67"
+checksum = "2b62c6d3ea43cbe0bc5a081f276fd477e4291d168aacc9f9d98073325333c0d4"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3ad85c1f65dc7b37604eb0e89748faf0b9653065f2a8ef69f96a687ec1e9279"
+checksum = "13418e745008f7349ec7e449155f419a61b92b58a99cc3616942b926825ec76b"
 
 [[package]]
 name = "convert_case"
@@ -2244,9 +2313,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "core2"
@@ -2259,18 +2328,18 @@ dependencies = [
 
 [[package]]
 name = "cpp_demangle"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b446fd40bcc17eddd6a4a78f24315eb90afdb3334999ddfd4909985c47722442"
+checksum = "2c76f98bdfc7f66172e6c7065f981ebb576ffc903fe4c0561d9f0c2509226dc6"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
 dependencies = [
  "libc",
 ]
@@ -2294,7 +2363,7 @@ dependencies = [
  "atty",
  "cast",
  "ciborium",
- "clap 3.2.23",
+ "clap 3.2.25",
  "criterion-plot",
  "futures",
  "itertools",
@@ -2304,7 +2373,7 @@ dependencies = [
  "plotters",
  "rayon",
  "regex",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_derive",
  "serde_json",
  "tinytemplate",
@@ -2324,9 +2393,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -2334,9 +2403,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -2345,22 +2414,22 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.13"
+version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset 0.7.1",
+ "memoffset 0.8.0",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
  "cfg-if",
 ]
@@ -2406,7 +2475,7 @@ dependencies = [
  "bitflags",
  "crossterm_winapi 0.9.0",
  "libc",
- "mio 0.8.5",
+ "mio 0.8.6",
  "parking_lot 0.12.1",
  "signal-hook",
  "signal-hook-mio",
@@ -2451,9 +2520,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2538c4e68e52548bacb3e83ac549f903d44f011ac9d5abb5e132e67d0808f7"
+checksum = "cf4c2f4e1afd912bc40bfd6fed5d9dc1f288e0ba01bfcc835cc5bc3eb13efe15"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
@@ -2491,7 +2560,7 @@ dependencies = [
  "csv-core",
  "itoa",
  "ryu",
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -2509,8 +2578,8 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
- "quote 1.0.26",
- "syn 1.0.107",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2545,88 +2614,79 @@ dependencies = [
  "byteorder",
  "digest 0.9.0",
  "rand_core 0.6.4",
- "serde 1.0.152",
+ "serde 1.0.163",
  "subtle-ng",
  "zeroize",
 ]
 
 [[package]]
-name = "cxx"
-version = "1.0.86"
+name = "darling"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d1075c37807dcf850c379432f0df05ba52cc30f279c5cfc43cc221ce7f8579"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.86"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5044281f61b27bc598f2f6647d480aed48d2bf52d6eb0b627d84c0361b17aa70"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "scratch",
- "syn 1.0.107",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.86"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b50bc93ba22c27b0d31128d2d130a0a6b3d267ae27ef7e4fae2167dfe8781c"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.86"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e61fda7e62115119469c7b3591fd913ecca96fb766cfd3f2e2502ab7bc87a5"
-dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
 ]
 
 [[package]]
 name = "darling"
-version = "0.14.2"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
+checksum = "0558d22a7b463ed0241e993f76f09f30b126687447751a8638587b864e4b3944"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.1",
+ "darling_macro 0.20.1",
 ]
 
 [[package]]
 name = "darling_core"
-version = "0.14.2"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "strsim 0.10.0",
- "syn 1.0.107",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8bfa2e259f8ee1ce5e97824a3c55ec4404a0d772ca7fa96bf19f0752a046eb"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "strsim 0.10.0",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.14.2"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
- "darling_core",
- "quote 1.0.26",
- "syn 1.0.107",
+ "darling_core 0.14.4",
+ "quote 1.0.27",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
+dependencies = [
+ "darling_core 0.20.1",
+ "quote 1.0.27",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -2639,20 +2699,20 @@ dependencies = [
  "hashbrown 0.12.3",
  "lock_api",
  "once_cell",
- "parking_lot_core 0.9.5",
+ "parking_lot_core 0.9.7",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
+checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86927b7cd2fe88fa698b87404b287ab98d1a0063a34071d92e575b72d3029aca"
+checksum = "c904b33cc60130e1aeea4956ab803d08a3f4a0ca82d64ed757afac3891f2bb99"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -2660,12 +2720,12 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5bbed42daaa95e780b60a50546aa345b8413a1e46f9a40a12907d3598f038db"
+checksum = "8fdf3fce3ce863539ec1d7fd1b6dcc3c645663376b43ed376bbf887733e4f772"
 dependencies = [
  "data-encoding",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2726,9 +2786,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e58dffcdcc8ee7b22f0c1f71a69243d7c2d9ad87b5a14361f2424a1565c219"
+checksum = "56acb310e15652100da43d130af8d97b509e95af61aab1c5a7939ef24337ee17"
 dependencies = [
  "const-oid",
  "pem-rfc7468 0.7.0",
@@ -2737,13 +2797,13 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
-version = "8.1.0"
+version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d4bc9b0db0a0df9ae64634ac5bdefb7afcb534e182275ca0beadbe486701c1"
+checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
 dependencies = [
  "asn1-rs",
  "displaydoc",
- "nom 7.1.2",
+ "nom 7.1.3",
  "num-bigint",
  "num-traits 0.2.15",
  "rusticata-macros",
@@ -2755,9 +2815,9 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2766,9 +2826,9 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e79116f119dd1dba1abf1f3405f03b9b0e79a27a3883864bfebded8a3dc768cd"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2777,9 +2837,9 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cdeb9ec472d588e539a818b2dee436825730da08ad0017c4b1a17676bdc8b7"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2797,10 +2857,10 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
 dependencies = [
- "darling",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "darling 0.14.4",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2810,7 +2870,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
 dependencies = [
  "derive_builder_core",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2820,10 +2880,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case 0.4.0",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "rustc_version",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2837,9 +2897,9 @@ dependencies = [
  "guppy",
  "guppy-workspace-hack",
  "once_cell",
- "petgraph 0.6.2",
+ "petgraph 0.6.3",
  "rayon",
- "serde 1.0.152",
+ "serde 1.0.163",
  "toml",
 ]
 
@@ -2851,9 +2911,9 @@ checksum = "850878694b7933ca4c9569d30a34b55031b9b139ee1fc7b94a527c4ef960d690"
 
 [[package]]
 name = "diesel"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4391a22b19c916e50bec4d6140f29bdda3e3bb187223fe6e3ea0b6e4d1021c04"
+checksum = "72eb77396836a4505da85bae0712fa324b74acfe1876d7c2f7e694ef3d0ee373"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -2867,9 +2927,9 @@ dependencies = [
 
 [[package]]
 name = "diesel-async"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67d310b8050b1068b32fd03c55bd73f8d9ef5a789e2443c5b4e92f4587c63ed3"
+checksum = "5897424d8409385a0cc83d64a44527d15bedb5e3797b65f99daf46374eb6df8e"
 dependencies = [
  "async-trait",
  "deadpool",
@@ -2886,10 +2946,10 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b10c03b954333d05bfd5be1d8a74eae2c9ca77b86e0f1c3a1ea29c49da1d6c2"
 dependencies = [
- "heck 0.4.0",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "heck 0.4.1",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2899,9 +2959,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad74fdcf086be3d4fdd142f67937678fe60ed431c3b2f08599e7687269410c4"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2962,11 +3022,11 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.3",
+ "block-buffer 0.10.4",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -2978,7 +3038,7 @@ version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.3.7",
 ]
 
 [[package]]
@@ -2987,7 +3047,16 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
 ]
 
 [[package]]
@@ -3012,6 +3081,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "dirs-sys-next"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3024,20 +3105,20 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
+checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "dissimilar"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5f0c7e4bd266b8ab2550e6238d2e74977c23c15536ac7be45e9c95e2e3fbbb"
+checksum = "210ec60ae7d710bed8683e333e9d2855a8a56a3e9892b38bad3bb0d4d29b0d5e"
 
 [[package]]
 name = "doc-comment"
@@ -3064,18 +3145,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f94be4825ff6a563f1bfbdb786ae10c687333c7524fade954e2271170e7f7e6d"
 dependencies = [
  "chrono",
- "nom 7.1.2",
+ "nom 7.1.3",
  "rust_decimal",
- "serde 1.0.152",
+ "serde 1.0.163",
  "thiserror",
- "time 0.3.17",
+ "time 0.3.21",
 ]
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b0705efd4599c15a38151f4721f7bc388306f61084d3bfd50bd07fbca5cb60"
+checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 
 [[package]]
 name = "ecdsa"
@@ -3091,15 +3172,16 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.16.6"
+version = "0.16.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a48e5d537b8a30c0b023116d981b16334be1485af7ca68db3a2b7024cbc957fd"
+checksum = "0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428"
 dependencies = [
- "der 0.7.5",
- "digest 0.10.6",
- "elliptic-curve 0.13.4",
+ "der 0.7.6",
+ "digest 0.10.7",
+ "elliptic-curve 0.13.5",
  "rfc6979 0.4.0",
- "signature 2.0.0",
+ "signature 2.1.0",
+ "spki 0.7.2",
 ]
 
 [[package]]
@@ -3109,7 +3191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
  "pkcs8 0.9.0",
- "serde 1.0.152",
+ "serde 1.0.163",
  "signature 1.6.4",
  "zeroize",
 ]
@@ -3123,7 +3205,7 @@ dependencies = [
  "curve25519-dalek-ng",
  "hex",
  "rand_core 0.6.4",
- "serde 1.0.152",
+ "serde 1.0.163",
  "sha2 0.9.9",
  "thiserror",
  "zeroize",
@@ -3138,7 +3220,7 @@ dependencies = [
  "curve25519-dalek-fiat",
  "ed25519",
  "rand 0.8.5",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_bytes",
  "sha2 0.9.9",
  "zeroize",
@@ -3146,9 +3228,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "elliptic-curve"
@@ -3159,7 +3241,7 @@ dependencies = [
  "base16ct 0.1.1",
  "crypto-bigint 0.4.9",
  "der 0.6.1",
- "digest 0.10.6",
+ "digest 0.10.7",
  "ff 0.12.1",
  "generic-array",
  "group 0.12.1",
@@ -3171,20 +3253,20 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c71eaa367f2e5d556414a8eea812bc62985c879748d6403edabd9cb03f16e7"
+checksum = "968405c8fdc9b3bf4df0a6638858cc0b52462836ab6b1c87377785dd09cf1c0b"
 dependencies = [
  "base16ct 0.2.0",
- "crypto-bigint 0.5.1",
- "digest 0.10.6",
+ "crypto-bigint 0.5.2",
+ "digest 0.10.7",
  "ff 0.13.0",
  "generic-array",
  "group 0.13.0",
  "pem-rfc7468 0.7.0",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sec1 0.7.1",
+ "sec1 0.7.2",
  "subtle",
  "zeroize",
 ]
@@ -3203,9 +3285,9 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.31"
+version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if",
 ]
@@ -3218,14 +3300,14 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "enum_dispatch"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1693044dcf452888dd3a6a6a0dab67f0652094e3920dfe029a54d2f37d9b7394"
+checksum = "11f36e95862220b211a6e2aa5eca09b4fa391b13cd52ceb8035a24bf65a79de2"
 dependencies = [
  "once_cell",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3249,17 +3331,6 @@ checksum = "5f11890ce181d47a64e5d1eb4b6caba0e7bae911a356723740d058a5d0340b7d"
 dependencies = [
  "autocfg",
  "scopeguard",
-]
-
-[[package]]
-name = "errno"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -3307,9 +3378,9 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "expect-test"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d4661aca38d826eb7c72fe128e4238220616de4c0cc00db7bfc38e2e1364dd3"
+checksum = "30d9eafeadd538e68fb28016364c9732d78e420b9ff8853fa5e4058861e9f8d3"
 dependencies = [
  "dissimilar",
  "once_cell",
@@ -3365,10 +3436,10 @@ dependencies = [
  "ctr",
  "curve25519-dalek-ng",
  "derive_more",
- "digest 0.10.6",
- "ecdsa 0.16.6",
+ "digest 0.10.7",
+ "ecdsa 0.16.7",
  "ed25519-consensus",
- "elliptic-curve 0.13.4",
+ "elliptic-curve 0.13.5",
  "eyre",
  "fastcrypto-derive",
  "generic-array",
@@ -3383,12 +3454,12 @@ dependencies = [
  "rsa",
  "schemars",
  "secp256k1",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_bytes",
  "serde_with",
  "sha2 0.10.6",
- "sha3 0.10.6",
- "signature 2.0.0",
+ "sha3 0.10.8",
+ "signature 2.1.0",
  "static_assertions",
  "thiserror",
  "tokio",
@@ -3402,9 +3473,9 @@ version = "0.1.2"
 source = "git+https://github.com/MystenLabs/fastcrypto?rev=c27e87fb539c88b6fe1eac7dd82561254bb1e07a#c27e87fb539c88b6fe1eac7dd82561254bb1e07a"
 dependencies = [
  "convert_case 0.6.0",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3428,22 +3499,22 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
 
 [[package]]
 name = "fd-lock"
-version = "3.0.8"
+version = "3.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb21c69b9fea5e15dbc1049e4b77145dd0ba1c84019c488102de0dc4ea4b0a27"
+checksum = "39ae6b3d9530211fb3b12a95374b8b0823be812f53d09e18c5675c0146b09642"
 dependencies = [
  "cfg-if",
- "rustix 0.36.6",
- "windows-sys 0.42.0",
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3477,9 +3548,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.1.17"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a214f5bb88731d436478f3ae1f8a277b62124089ba9fb67f4f93fb100ef73c90"
+checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
 
 [[package]]
 name = "findshlibs"
@@ -3519,12 +3590,12 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.7.1",
 ]
 
 [[package]]
@@ -3571,9 +3642,9 @@ checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3586,9 +3657,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3596,15 +3667,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -3613,47 +3684,32 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
-
-[[package]]
-name = "futures-lite"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-timer"
@@ -3667,9 +3723,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3685,11 +3741,11 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
- "serde 1.0.152",
+ "serde 1.0.163",
  "typenum",
  "version_check",
  "zeroize",
@@ -3708,9 +3764,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -3729,9 +3785,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
 name = "git-version"
@@ -3750,9 +3806,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe69f1cbdb6e28af2bac214e943b99ce8a0a06b447d15d3e61161b0423139f3f"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3767,7 +3823,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
 dependencies = [
- "aho-corasick",
+ "aho-corasick 0.7.20",
  "bstr",
  "fnv",
  "log",
@@ -3787,9 +3843,9 @@ dependencies = [
 
 [[package]]
 name = "gloo-net"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9050ff8617e950288d7bf7f300707639fdeda5ca0d0ecf380cff448cfd52f4a6"
+checksum = "9902a044653b26b99f7e3693a42f171312d9be8b26b5697bd1e43ad1f8a35e10"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3797,7 +3853,7 @@ dependencies = [
  "gloo-utils",
  "js-sys",
  "pin-project",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
  "thiserror",
  "wasm-bindgen",
@@ -3807,9 +3863,9 @@ dependencies = [
 
 [[package]]
 name = "gloo-timers"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c4a8d6391675c6b2ee1a6c8d06e8e2d03605c44cec1270675985a4c2a5500b"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3824,7 +3880,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8e8fc851e9c7b9852508bc6e3f690f452f474417e8545ec9857b7f7377036b5"
 dependencies = [
  "js-sys",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
  "wasm-bindgen",
  "web-sys",
@@ -3888,10 +3944,10 @@ dependencies = [
  "nested",
  "once_cell",
  "pathdiff",
- "petgraph 0.6.2",
+ "petgraph 0.6.3",
  "rayon",
- "semver 1.0.16",
- "serde 1.0.152",
+ "semver",
+ "serde 1.0.163",
  "serde_json",
  "smallvec",
  "static_assertions",
@@ -3909,8 +3965,8 @@ dependencies = [
  "cfg-if",
  "diffus",
  "guppy-workspace-hack",
- "semver 1.0.16",
- "serde 1.0.152",
+ "semver",
+ "serde 1.0.163",
  "toml",
 ]
 
@@ -3922,9 +3978,9 @@ checksum = "92620684d99f750bae383ecb3be3748142d6095760afd5cbcf2261e9a279d780"
 
 [[package]]
 name = "h2"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
+checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
 dependencies = [
  "bytes",
  "fnv",
@@ -3935,15 +3991,15 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.8",
  "tracing",
 ]
 
 [[package]]
 name = "hakari"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2c76369039f6ac178748e96def487662aebbeb26d43070d01a0eadd53964994"
+checksum = "2af0223111b69beda15417ad6a960bffb093c916f0eaa559036c7036efa2d199"
 dependencies = [
  "atomicwrites",
  "bimap",
@@ -3959,11 +4015,11 @@ dependencies = [
  "owo-colors",
  "pathdiff",
  "rayon",
- "serde 1.0.152",
+ "serde 1.0.163",
  "tabular",
  "target-spec",
  "toml",
- "toml_edit 0.15.0",
+ "toml_edit 0.17.1",
  "twox-hash",
 ]
 
@@ -3988,7 +4044,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.2",
+ "ahash 0.8.3",
 ]
 
 [[package]]
@@ -4001,7 +4057,7 @@ dependencies = [
  "byteorder",
  "crossbeam-channel",
  "flate2",
- "nom 7.1.2",
+ "nom 7.1.3",
  "num-traits 0.2.15",
 ]
 
@@ -4041,9 +4097,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -4106,7 +4162,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4117,11 +4173,11 @@ checksum = "77e806677ce663d0a199541030c816847b36e8dc095f70dae4a4f4ad63da5383"
 
 [[package]]
 name = "home"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747309b4b440c06d57b0b25f2aee03ee9b5e5397d288c60e21fc709bb98a7408"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4209,11 +4265,25 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls 0.20.7",
+ "rustls 0.20.8",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls",
- "webpki-roots",
+ "tokio-rustls 0.23.4",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
+dependencies = [
+ "http",
+ "hyper",
+ "log",
+ "rustls 0.21.1",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls 0.24.0",
 ]
 
 [[package]]
@@ -4230,26 +4300,25 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.53"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "winapi",
+ "windows",
 ]
 
 [[package]]
 name = "iana-time-zone-haiku"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
- "cxx",
- "cxx-build",
+ "cc",
 ]
 
 [[package]]
@@ -4276,9 +4345,9 @@ checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
 
 [[package]]
 name = "ignore"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a05705bc64e0b66a806c3740bd6578ea66051b157ec42dc219c785cbf185aef3"
+checksum = "dbe7873dab538a9a44ad79ede1faf5f30d49f9a5c883ddbab48bce81b64b7492"
 dependencies = [
  "globset",
  "lazy_static 1.4.0",
@@ -4320,7 +4389,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
 dependencies = [
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -4329,9 +4398,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4350,8 +4419,8 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b139284b5cf57ecfa712bcc66950bb635b31aff41c188e8a4cfc758eca374a3f"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
 ]
 
 [[package]]
@@ -4368,30 +4437,30 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
 name = "indicatif"
-version = "0.17.2"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4295cbb7573c16d310e99e713cf9e75101eb190ab31fccd35f2d2691b4352b19"
+checksum = "cef509aa9bc73864d6756f0d34d35504af3cf0844373afe9b8669a5b8005a729"
 dependencies = [
  "console",
  "number_prefix",
- "portable-atomic",
+ "portable-atomic 0.3.20",
  "unicode-width",
 ]
 
 [[package]]
 name = "inferno"
-version = "0.11.13"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7207d75fcf6c1868f1390fc1c610431fe66328e9ee6813330a041ef6879eca1"
+checksum = "2fb7c1b80a1dfa604bb4a649a5c5aeef3d913f7c520cb42b40e534e8a61bcdfc"
 dependencies = [
- "ahash 0.8.2",
- "atty",
+ "ahash 0.8.3",
  "indexmap",
+ "is-terminal",
  "itoa",
  "log",
  "num-format",
@@ -4407,15 +4476,15 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
- "block-padding 0.3.2",
+ "block-padding 0.3.3",
  "generic-array",
 ]
 
 [[package]]
 name = "inquire"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd079157ad94a32f7511b2e13037f3ae417ad80a6a9b0de29154d48b86f5d6c8"
+checksum = "c33e7c1ddeb15c9abcbfef6029d8e29f69b52b6d6c891031b88ed91b5065803b"
 dependencies = [
  "bitflags",
  "crossterm 0.25.0",
@@ -4429,16 +4498,16 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.26.0"
+version = "1.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f0f08b46e4379744de2ab67aa8f7de3ffd1da3e275adc41fcc82053ede46ff"
+checksum = "9a28d25139df397cbca21408bb742cf6837e04cdbebf1b07b760caf971d6a972"
 dependencies = [
  "console",
  "lazy_static 1.4.0",
  "linked-hash-map",
  "pest",
  "pest_derive",
- "serde 1.0.152",
+ "serde 1.0.163",
  "similar",
  "yaml-rust",
 ]
@@ -4473,19 +4542,20 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.3"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
+ "hermit-abi 0.3.1",
  "libc",
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
+checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
 
 [[package]]
 name = "iri-string"
@@ -4493,7 +4563,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f0f7638c1e223529f1bfdc48c8b133b9e0b434094d1d28473161ee48b235f78"
 dependencies = [
- "nom 7.1.2",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -4504,7 +4574,7 @@ checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
- "rustix 0.37.7",
+ "rustix",
  "windows-sys 0.48.0",
 ]
 
@@ -4519,9 +4589,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jemalloc-ctl"
@@ -4536,37 +4606,36 @@ dependencies = [
 
 [[package]]
 name = "jemalloc-sys"
-version = "0.5.2+5.3.0-patched"
+version = "0.5.3+5.3.0-patched"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134163979b6eed9564c98637b710b40979939ba351f59952708234ea11b5f3f8"
+checksum = "f9bd5d616ea7ed58b571b2e209a65759664d7fb021a0819d7a790afc67e47ca1"
 dependencies = [
  "cc",
- "fs_extra",
  "libc",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "jsonrpsee"
-version = "0.16.2"
-source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=b1b300784795f6a64d0fcdf8f03081a9bc38bde8#b1b300784795f6a64d0fcdf8f03081a9bc38bde8"
+version = "0.18.2"
+source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=66ce27cc207d5f193e007a743c2497477bae6fec#66ce27cc207d5f193e007a743c2497477bae6fec"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -4581,39 +4650,34 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.16.2"
-source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=b1b300784795f6a64d0fcdf8f03081a9bc38bde8#b1b300784795f6a64d0fcdf8f03081a9bc38bde8"
+version = "0.18.2"
+source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=66ce27cc207d5f193e007a743c2497477bae6fec#66ce27cc207d5f193e007a743c2497477bae6fec"
 dependencies = [
- "anyhow",
  "futures-channel",
- "futures-timer",
  "futures-util",
  "gloo-net",
  "http",
  "jsonrpsee-core",
- "jsonrpsee-types",
  "pin-project",
  "rustls-native-certs",
  "soketto",
  "thiserror",
  "tokio",
- "tokio-rustls",
- "tokio-util 0.7.4",
+ "tokio-rustls 0.24.0",
+ "tokio-util 0.7.8",
  "tracing",
- "webpki-roots",
+ "webpki-roots 0.23.0",
 ]
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.16.2"
-source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=b1b300784795f6a64d0fcdf8f03081a9bc38bde8#b1b300784795f6a64d0fcdf8f03081a9bc38bde8"
+version = "0.18.2"
+source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=66ce27cc207d5f193e007a743c2497477bae6fec#66ce27cc207d5f193e007a743c2497477bae6fec"
 dependencies = [
  "anyhow",
- "arrayvec 0.7.2",
  "async-lock",
  "async-trait",
  "beef",
- "futures-channel",
  "futures-timer",
  "futures-util",
  "globset",
@@ -4622,74 +4686,73 @@ dependencies = [
  "parking_lot 0.12.1",
  "rand 0.8.5",
  "rustc-hash",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
  "soketto",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tracing",
  "wasm-bindgen-futures",
 ]
 
 [[package]]
 name = "jsonrpsee-http-client"
-version = "0.16.2"
-source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=b1b300784795f6a64d0fcdf8f03081a9bc38bde8#b1b300784795f6a64d0fcdf8f03081a9bc38bde8"
+version = "0.18.2"
+source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=66ce27cc207d5f193e007a743c2497477bae6fec#66ce27cc207d5f193e007a743c2497477bae6fec"
 dependencies = [
  "async-trait",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.24.0",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "rustc-hash",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
  "thiserror",
  "tokio",
+ "tower",
  "tracing",
 ]
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.16.2"
-source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=b1b300784795f6a64d0fcdf8f03081a9bc38bde8#b1b300784795f6a64d0fcdf8f03081a9bc38bde8"
+version = "0.18.2"
+source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=66ce27cc207d5f193e007a743c2497477bae6fec#66ce27cc207d5f193e007a743c2497477bae6fec"
 dependencies = [
- "heck 0.4.0",
+ "heck 0.4.1",
  "proc-macro-crate",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.16.2"
-source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=b1b300784795f6a64d0fcdf8f03081a9bc38bde8#b1b300784795f6a64d0fcdf8f03081a9bc38bde8"
+version = "0.18.2"
+source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=66ce27cc207d5f193e007a743c2497477bae6fec#66ce27cc207d5f193e007a743c2497477bae6fec"
 dependencies = [
- "futures-channel",
  "futures-util",
- "http",
  "hyper",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
  "soketto",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.8",
  "tower",
  "tracing",
 ]
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.16.2"
-source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=b1b300784795f6a64d0fcdf8f03081a9bc38bde8#b1b300784795f6a64d0fcdf8f03081a9bc38bde8"
+version = "0.18.2"
+source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=66ce27cc207d5f193e007a743c2497477bae6fec#66ce27cc207d5f193e007a743c2497477bae6fec"
 dependencies = [
  "anyhow",
  "beef",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
  "thiserror",
  "tracing",
@@ -4697,8 +4760,8 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-wasm-client"
-version = "0.16.2"
-source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=b1b300784795f6a64d0fcdf8f03081a9bc38bde8#b1b300784795f6a64d0fcdf8f03081a9bc38bde8"
+version = "0.18.2"
+source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=66ce27cc207d5f193e007a743c2497477bae6fec#66ce27cc207d5f193e007a743c2497477bae6fec"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -4707,8 +4770,8 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.16.2"
-source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=b1b300784795f6a64d0fcdf8f03081a9bc38bde8#b1b300784795f6a64d0fcdf8f03081a9bc38bde8"
+version = "0.18.2"
+source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=66ce27cc207d5f193e007a743c2497477bae6fec#66ce27cc207d5f193e007a743c2497477bae6fec"
 dependencies = [
  "http",
  "jsonrpsee-client-transport",
@@ -4726,14 +4789,14 @@ dependencies = [
  "ecdsa 0.14.8",
  "elliptic-curve 0.12.3",
  "sha2 0.10.6",
- "sha3 0.10.6",
+ "sha3 0.10.8",
 ]
 
 [[package]]
 name = "keccak"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
 dependencies = [
  "cpufeatures",
 ]
@@ -4780,9 +4843,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libloading"
@@ -4796,9 +4859,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "librocksdb-sys"
@@ -4822,29 +4885,20 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79529479c298f5af41375b0c1a77ef670d450b4c9cd7949d2b43af08121b20ec"
 dependencies = [
- "clap 3.2.23",
+ "clap 3.2.25",
  "termcolor",
  "threadpool",
 ]
 
 [[package]]
 name = "libz-sys"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
+checksum = "56ee889ecc9568871456d42f603d6a0ce59ff328d291063a45cbdf0036baf6db"
 dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "link-cplusplus"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -4855,15 +4909,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lock_api"
@@ -4882,7 +4930,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -4957,7 +5005,7 @@ version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4968,9 +5016,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memmap2"
-version = "0.5.8"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b182332558b18d807c4ce1ca8ca983b34c3ee32765e47b3f0f69b90355cc1dc"
+checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
 dependencies = [
  "libc",
 ]
@@ -4986,9 +5034,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]
@@ -5011,7 +5059,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c493c09323068c01e54c685f7da41a9ccf9219735c3766fbfd6099806ea08fbc"
 dependencies = [
- "serde 1.0.152",
+ "serde 1.0.163",
  "toml",
 ]
 
@@ -5022,15 +5070,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a8ff27a350511de30cdabb77147501c36ef02e0451d957abea2f30caffb2b58"
 dependencies = [
  "migrations_internals",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
 ]
 
 [[package]]
 name = "mime"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mime_guess"
@@ -5058,6 +5106,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5072,14 +5129,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -5102,7 +5159,7 @@ dependencies = [
  "fragile",
  "lazy_static 1.4.0",
  "mockall_derive",
- "predicates",
+ "predicates 2.1.5",
  "predicates-tree",
 ]
 
@@ -5113,9 +5170,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
 dependencies = [
  "cfg-if",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5137,7 +5194,7 @@ dependencies = [
  "move-command-line-common",
  "move-core-types",
  "move-model",
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -5148,7 +5205,7 @@ dependencies = [
  "move-core-types",
  "once_cell",
  "ref-cast",
- "serde 1.0.152",
+ "serde 1.0.163",
  "variant_count",
 ]
 
@@ -5167,7 +5224,7 @@ dependencies = [
  "move-core-types",
  "move-ir-types",
  "move-symbol-pool",
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -5199,7 +5256,7 @@ name = "move-bytecode-viewer"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.23",
+ "clap 3.2.25",
  "crossterm 0.21.0",
  "move-binary-format",
  "move-bytecode-source-map",
@@ -5216,7 +5273,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs",
- "clap 3.2.23",
+ "clap 3.2.25",
  "codespan-reporting",
  "colored",
  "difference",
@@ -5247,7 +5304,7 @@ dependencies = [
  "read-write-set",
  "read-write-set-dynamic",
  "reqwest",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
  "serde_yaml",
  "tempfile",
@@ -5266,7 +5323,7 @@ dependencies = [
  "move-core-types",
  "num-bigint",
  "once_cell",
- "serde 1.0.152",
+ "serde 1.0.163",
  "sha2 0.9.9",
  "walkdir",
 ]
@@ -5277,7 +5334,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "bcs",
- "clap 3.2.23",
+ "clap 3.2.25",
  "codespan-reporting",
  "difference",
  "hex",
@@ -5315,7 +5372,7 @@ dependencies = [
  "proptest-derive",
  "rand 0.8.5",
  "ref-cast",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_bytes",
  "uint",
 ]
@@ -5326,7 +5383,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs",
- "clap 3.2.23",
+ "clap 3.2.25",
  "codespan",
  "colored",
  "move-binary-format",
@@ -5336,7 +5393,7 @@ dependencies = [
  "move-ir-types",
  "once_cell",
  "petgraph 0.5.1",
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -5344,7 +5401,7 @@ name = "move-disassembler"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.23",
+ "clap 3.2.25",
  "colored",
  "move-binary-format",
  "move-bytecode-source-map",
@@ -5370,7 +5427,7 @@ dependencies = [
  "num",
  "once_cell",
  "regex",
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -5383,7 +5440,7 @@ dependencies = [
  "move-command-line-common",
  "move-core-types",
  "move-model",
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -5392,7 +5449,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs",
- "clap 3.2.23",
+ "clap 3.2.25",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-bytecode-verifier",
@@ -5444,7 +5501,7 @@ dependencies = [
  "move-core-types",
  "move-symbol-pool",
  "once_cell",
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -5469,7 +5526,7 @@ dependencies = [
  "num",
  "once_cell",
  "regex",
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -5478,7 +5535,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs",
- "clap 3.2.23",
+ "clap 3.2.25",
  "colored",
  "dirs-next",
  "itertools",
@@ -5498,7 +5555,7 @@ dependencies = [
  "ptree",
  "regex",
  "reqwest",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_yaml",
  "sha2 0.9.9",
  "tempfile",
@@ -5514,7 +5571,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "atty",
- "clap 3.2.23",
+ "clap 3.2.25",
  "codespan",
  "codespan-reporting",
  "futures",
@@ -5536,7 +5593,7 @@ dependencies = [
  "once_cell",
  "pretty",
  "rand 0.8.5",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
  "simplelog",
  "tokio",
@@ -5564,7 +5621,7 @@ dependencies = [
  "pretty",
  "rand 0.8.5",
  "regex",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
  "tera",
  "tokio",
@@ -5577,7 +5634,7 @@ dependencies = [
  "anyhow",
  "move-binary-format",
  "move-core-types",
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -5591,7 +5648,7 @@ dependencies = [
  "move-bytecode-utils",
  "move-core-types",
  "once_cell",
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -5617,7 +5674,7 @@ dependencies = [
  "once_cell",
  "paste",
  "petgraph 0.5.1",
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -5626,7 +5683,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
- "clap 3.2.23",
+ "clap 3.2.25",
  "codespan-reporting",
  "itertools",
  "move-binary-format",
@@ -5634,7 +5691,7 @@ dependencies = [
  "move-model",
  "move-stackless-bytecode",
  "num",
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -5663,7 +5720,7 @@ name = "move-symbol-pool"
 version = "0.1.0"
 dependencies = [
  "once_cell",
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -5687,7 +5744,7 @@ name = "move-transactional-test-runner"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.23",
+ "clap 3.2.25",
  "colored",
  "move-binary-format",
  "move-bytecode-source-map",
@@ -5720,7 +5777,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "better_any",
- "clap 3.2.23",
+ "clap 3.2.25",
  "codespan-reporting",
  "colored",
  "itertools",
@@ -5778,7 +5835,7 @@ dependencies = [
  "move-core-types",
  "move-vm-types",
  "once_cell",
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -5789,7 +5846,7 @@ dependencies = [
  "move-binary-format",
  "move-core-types",
  "once_cell",
- "serde 1.0.152",
+ "serde 1.0.163",
  "smallvec",
 ]
 
@@ -5814,13 +5871,13 @@ dependencies = [
  "pin-project-lite",
  "rand 0.8.5",
  "real_tokio",
- "serde 1.0.152",
+ "serde 1.0.163",
  "socket2 0.4.9",
  "tap",
  "tokio-util 0.7.7",
  "toml",
  "tracing",
- "tracing-subscriber 0.3.16",
+ "tracing-subscriber 0.3.17",
 ]
 
 [[package]]
@@ -5828,25 +5885,26 @@ name = "msim-macros"
 version = "0.1.0"
 source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=5fdd0c5547fa656143eab43fa570893b88d3620f#5fdd0c5547fa656143eab43fa570893b88d3620f"
 dependencies = [
- "darling",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "darling 0.14.4",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "multiaddr"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b53e0cc5907a5c216ba6584bf74be8ab47d6d6289f72793b2dddbf15dc3bf8c"
+checksum = "2b36f567c7099511fa8612bbbb52dda2419ce0bdbacf31714e3a5ffdb766d3bd"
 dependencies = [
  "arrayref",
  "byteorder",
  "data-encoding",
+ "log",
  "multibase",
  "multihash",
  "percent-encoding",
- "serde 1.0.152",
+ "serde 1.0.163",
  "static_assertions",
  "unsigned-varint",
  "url",
@@ -5882,9 +5940,9 @@ checksum = "1d6d4752e6230d8ef7adf7bd5d8c4b1f6561c1014c5ba9a37445ccefe18aa1db"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
  "synstructure",
 ]
 
@@ -5934,11 +5992,11 @@ dependencies = [
  "futures",
  "http",
  "multiaddr",
- "serde 1.0.152",
+ "serde 1.0.163",
  "snap",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.8.3",
  "tonic-health",
  "tower",
  "tower-http 0.3.5",
@@ -5968,8 +6026,8 @@ dependencies = [
 name = "mysten-util-mem-derive"
 version = "0.1.0"
 dependencies = [
- "proc-macro2 1.0.54",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "syn 1.0.109",
  "synstructure",
  "workspace-hack",
 ]
@@ -6006,7 +6064,7 @@ dependencies = [
  "narwhal-crypto",
  "narwhal-test-utils",
  "rand 0.8.5",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
  "tempfile",
  "thiserror",
@@ -6057,7 +6115,7 @@ dependencies = [
  "hex-literal",
  "proptest",
  "proptest-derive",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde-reflection",
  "serde_json",
  "shared-crypto",
@@ -6091,7 +6149,7 @@ dependencies = [
  "prost",
  "protobuf-src",
  "tokio",
- "tonic",
+ "tonic 0.8.3",
  "tonic-build",
  "workspace-hack",
 ]
@@ -6123,12 +6181,12 @@ dependencies = [
  "narwhal-types",
  "prometheus",
  "rand 0.8.5",
- "serde 1.0.152",
+ "serde 1.0.163",
  "telemetry-subscribers",
  "tempfile",
  "thiserror",
  "tokio",
- "tonic",
+ "tonic 0.8.3",
  "tracing",
  "typed-store",
  "workspace-hack",
@@ -6205,7 +6263,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "tracing-subscriber 0.3.16",
+ "tracing-subscriber 0.3.17",
  "url",
  "workspace-hack",
 ]
@@ -6256,7 +6314,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "tonic",
+ "tonic 0.8.3",
  "tower",
  "tracing",
  "typed-store",
@@ -6313,7 +6371,7 @@ dependencies = [
  "telemetry-subscribers",
  "tempfile",
  "tokio",
- "tonic",
+ "tonic 0.8.3",
  "tracing",
  "typed-store",
  "workspace-hack",
@@ -6354,12 +6412,12 @@ dependencies = [
  "rand 0.8.5",
  "roaring",
  "rustversion",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_test",
  "serde_with",
  "thiserror",
  "tokio",
- "tonic",
+ "tonic 0.8.3",
  "tonic-build",
  "tracing",
  "typed-store",
@@ -6401,7 +6459,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "tonic",
+ "tonic 0.8.3",
  "tower",
  "tracing",
  "typed-store",
@@ -6435,7 +6493,7 @@ dependencies = [
  "hakari",
  "hex",
  "once_cell",
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -6450,7 +6508,7 @@ dependencies = [
  "guppy",
  "nexlint",
  "regex",
- "serde 1.0.152",
+ "serde 1.0.163",
  "toml",
 ]
 
@@ -6478,13 +6536,14 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.24.3"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
+ "static_assertions",
 ]
 
 [[package]]
@@ -6495,9 +6554,9 @@ checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
 
 [[package]]
 name = "nom"
-version = "5.1.2"
+version = "5.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+checksum = "08959a387a676302eebf4ddbcbc611da04285579f76f88ee0506c63b1a61dd4b"
 dependencies = [
  "lexical-core",
  "memchr",
@@ -6506,12 +6565,21 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.2"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom8"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -6537,9 +6605,9 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc51db7b362b205941f71232e56c625156eb9a929f8cf74a428fd5bc094a4afc"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
 dependencies = [
  "winapi",
 ]
@@ -6560,9 +6628,9 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be7d33be719c6f4d09e64e27c1ef4e73485dc4cc1f4d22201f89860a7fe22e22"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6572,9 +6640,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "066b468120587a402f0b47d8f80035c921f6a46f8209efd0632a89a16f5188a4"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6631,9 +6699,9 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
+checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
 dependencies = [
  "num-traits 0.2.15",
 ]
@@ -6726,9 +6794,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 2.0.10",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -6739,9 +6807,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.30.1"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d864c91689fdc196779b98dba0aceac6118594c2df6ee5d943eb6a8df4d107a"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
 dependencies = [
  "memchr",
 ]
@@ -6756,7 +6824,7 @@ dependencies = [
  "aws-config 0.54.1",
  "aws-credential-types 0.54.1",
  "aws-types 0.54.1",
- "base64 0.21.0",
+ "base64 0.21.1",
  "bytes",
  "chrono",
  "futures",
@@ -6768,7 +6836,7 @@ dependencies = [
  "reqwest",
  "ring",
  "rustls-pemfile",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
  "snafu",
  "tokio",
@@ -6788,9 +6856,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "oorandom"
@@ -6811,6 +6879,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "ordered-float"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6821,9 +6895,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.4.1"
+version = "6.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
 name = "ouroboros"
@@ -6837,12 +6911,12 @@ dependencies = [
 
 [[package]]
 name = "ouroboros"
-version = "0.15.5"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbb50b356159620db6ac971c6d5c9ab788c9cc38a6f49619fca2a27acb062ca"
+checksum = "e1358bd1558bd2a083fed428ffeda486fbfb323e698cdda7794259d592ca72db"
 dependencies = [
  "aliasable",
- "ouroboros_macro 0.15.5",
+ "ouroboros_macro 0.15.6",
 ]
 
 [[package]]
@@ -6853,22 +6927,22 @@ checksum = "03f2cb802b5bdfdf52f1ffa0b54ce105e4d346e91990dd571f86c91321ad49e2"
 dependencies = [
  "Inflector",
  "proc-macro-error",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "ouroboros_macro"
-version = "0.15.5"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0d9d1a6191c4f391f87219d1ea42b23f09ee84d64763cd05ee6ea88d9f384d"
+checksum = "5f7d21ccd03305a674437ee1248f3ab5d4b1db095cf1caf49f1713ddf61956b7"
 dependencies = [
  "Inflector",
  "proc-macro-error",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6904,8 +6978,8 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
- "ecdsa 0.16.6",
- "elliptic-curve 0.13.4",
+ "ecdsa 0.16.7",
+ "elliptic-curve 0.13.5",
  "primeorder",
  "sha2 0.10.6",
 ]
@@ -6921,7 +6995,7 @@ dependencies = [
  "byte-slice-cast",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -6931,16 +7005,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
-
-[[package]]
-name = "parking"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
@@ -6960,7 +7028,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.5",
+ "parking_lot_core 0.9.7",
 ]
 
 [[package]]
@@ -6972,22 +7040,22 @@ dependencies = [
  "cfg-if",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "winapi",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.5"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -7001,9 +7069,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "pathdiff"
@@ -7020,7 +7088,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -7031,9 +7099,9 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pem"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c64931a1a212348ec4f3b4362585eca7159d0d09cbdf4a7f74f02173596fd4"
+checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
 dependencies = [
  "base64 0.13.1",
 ]
@@ -7064,9 +7132,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6e86fb9e7026527a0d46bc308b841d73170ef8f443e1807f6ef88526a816d4"
+checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -7074,9 +7142,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96504449aa860c8dcde14f9fba5c58dc6658688ca1fe363589d6327b8662c603"
+checksum = "6b79d4c71c865a25a4322296122e3924d30bc8ee0834c8bfc8b95f7f054afbfb"
 dependencies = [
  "pest",
  "pest_generator",
@@ -7084,26 +7152,26 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "798e0220d1111ae63d66cb66a5dcb3fc2d986d520b98e49e1852bfdb11d7c5e7"
+checksum = "6c435bf1076437b851ebc8edc3a18442796b30f1728ffea6262d59bbe28b077e"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.5.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "984298b75898e30a843e278a9f2452c31e349a073a0ce6fd950a12a74464e065"
+checksum = "745a452f8eb71e39ffd8ee32b3c5f51d03845f99786fa9b68db6ff509c505411"
 dependencies = [
  "once_cell",
  "pest",
- "sha1",
+ "sha2 0.10.6",
 ]
 
 [[package]]
@@ -7118,9 +7186,9 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
+checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset 0.4.2",
  "indexmap",
@@ -7167,22 +7235,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -7225,15 +7293,15 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.5",
- "spki 0.7.1",
+ "der 0.7.6",
+ "spki 0.7.2",
 ]
 
 [[package]]
 name = "pkg-config"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "plotters"
@@ -7277,9 +7345,18 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
+checksum = "e30165d31df606f5726b090ec7592c308a0eaf61721ff64c9a3018e344a8753e"
+dependencies = [
+ "portable-atomic 1.3.2",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc59d1bcc64fc5d021d67521f818db868368028108d37f0e98d74e33f68297b5"
 
 [[package]]
 name = "postgres-protocol"
@@ -7287,7 +7364,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b7fa9f396f51dffd61546fd8573ee20592287996568e6175ceb0f8699ad75d"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.1",
  "byteorder",
  "bytes",
  "fallible-iterator",
@@ -7312,9 +7389,9 @@ dependencies = [
 
 [[package]]
 name = "pprof"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e20150f965e0e4c925982b9356da71c84bcd56cb66ef4e894825837cbcf6613e"
+checksum = "196ded5d4be535690899a4631cc9f18cdc41b7ebf24a79400f46f48e49a11059"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -7323,7 +7400,7 @@ dependencies = [
  "inferno",
  "libc",
  "log",
- "nix 0.24.3",
+ "nix 0.26.2",
  "once_cell",
  "parking_lot 0.12.1",
  "smallvec",
@@ -7340,9 +7417,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "pq-sys"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b845d6d8ec554f972a2c5298aad68953fd64e7441e846075450b44656a016d1"
+checksum = "31c0052426df997c0cbd30789eb44ca097e3541717a7b8fa36b1c464ee7edebd"
 dependencies = [
  "vcpkg",
 ]
@@ -7362,16 +7439,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "predicates-core"
-version = "1.0.5"
+name = "predicates"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f883590242d3c6fc5bf50299011695fa6590c2c70eac95ee1bdb9a733ad1a2"
+checksum = "09963355b9f467184c04017ced4a2ba2d75cbcb4e7462690d388233253d4b1a9"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "itertools",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54ff541861505aabf6ea722d2131ee980b8276e10a1297b94e896dd8b621850d"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -7401,12 +7490,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.1.23"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97e3215779627f01ee256d2fad52f3d95e8e1c11e9fc6fd08f7cd455d5d5c78"
+checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
 dependencies = [
- "proc-macro2 1.0.54",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7425,11 +7514,11 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7613fdcc0831c10060fa69833ea8fa2caa94b6456f51e25356a885b530a2e3d0"
+checksum = "cf8d3875361e28f7753baefef104386e7aa47642c93023356d97fdef4003bfb5"
 dependencies = [
- "elliptic-curve 0.13.4",
+ "elliptic-curve 0.13.5",
 ]
 
 [[package]]
@@ -7461,9 +7550,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -7473,8 +7562,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "version_check",
 ]
 
@@ -7495,9 +7584,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.54"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
+checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
 dependencies = [
  "unicode-ident",
 ]
@@ -7529,20 +7618,19 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
+checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
 dependencies = [
  "bit-set",
  "bitflags",
  "byteorder",
  "lazy_static 1.4.0",
  "num-traits 0.2.15",
- "quick-error 2.0.1",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift",
- "regex-syntax",
+ "regex-syntax 0.6.29",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -7561,9 +7649,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48e50df39172a3e7eb17e14642445da64996989bc212b583015435d39a58537"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -7571,44 +7659,44 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c828f93f5ca4826f97fedcbd3f9a536c16b12cff3dbbb4a007f932bbad95b12"
+checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
- "heck 0.4.0",
+ "heck 0.4.1",
  "itertools",
  "lazy_static 1.4.0",
  "log",
  "multimap",
- "petgraph 0.6.2",
+ "petgraph 0.6.3",
  "prettyplease",
  "prost",
  "prost-types",
  "regex",
- "syn 1.0.107",
+ "syn 1.0.109",
  "tempfile",
  "which",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea9b0f8cbe5e15a8a042d030bd96668db28ecb567ec37d691971ff5731d2b1b"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379119666929a1afd7a043aa6cf96fa67a6dce9af60c88095a4686dbce4c9c88"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
  "prost",
 ]
@@ -7641,8 +7729,8 @@ dependencies = [
  "atty",
  "config",
  "directories",
- "petgraph 0.6.2",
- "serde 1.0.152",
+ "petgraph 0.6.3",
+ "serde 1.0.163",
  "serde-value",
  "tint",
 ]
@@ -7670,12 +7758,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
-name = "quick-error"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
-
-[[package]]
 name = "quick-xml"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7691,7 +7773,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc053f057dd768a56f62cd7e434c42c831d296968997e9ac1f76ea7c2d14c41"
 dependencies = [
  "memchr",
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -7737,7 +7819,7 @@ checksum = "6df19e284d93757a9fb91d63672f7741b129246a669db09d1c0063071debc0c0"
 dependencies = [
  "bytes",
  "libc",
- "socket2 0.5.2",
+ "socket2 0.5.3",
  "tracing",
  "windows-sys 0.48.0",
 ]
@@ -7753,11 +7835,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
- "proc-macro2 1.0.54",
+ "proc-macro2 1.0.58",
 ]
 
 [[package]]
@@ -7846,7 +7928,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom 0.2.9",
 ]
 
 [[package]]
@@ -7878,18 +7960,18 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "10.6.0"
+version = "10.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6823ea29436221176fe662da99998ad3b4db2c7f31e7b6f5fe43adccd6320bb"
+checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
 dependencies = [
  "either",
  "rayon-core",
@@ -7897,9 +7979,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -7915,7 +7997,7 @@ checksum = "6413f3de1edee53342e6138e75b56d32e7bc6e332b3bd62d497b1929d4cfbcdd"
 dependencies = [
  "pem",
  "ring",
- "time 0.3.17",
+ "time 0.3.21",
  "yasna",
 ]
 
@@ -7946,13 +8028,13 @@ dependencies = [
 
 [[package]]
 name = "readonly"
-version = "0.2.3"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78725e4e53781014168628ef49b2dc2fc6ae8d01a08769a5064685d34ee116c"
+checksum = "eb656d27c22b5c47154452686cae5e096f12e124daacb36a0bfcb32dbebb39e3"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -7963,7 +8045,7 @@ dependencies = [
  "autocfg",
  "bytes",
  "libc",
- "mio 0.8.5",
+ "mio 0.8.6",
  "num_cpus",
  "parking_lot 0.12.1",
  "pin-project-lite",
@@ -7983,45 +8065,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.8",
- "redox_syscall",
+ "getrandom 0.2.9",
+ "redox_syscall 0.2.16",
  "thiserror",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c78fb8c9293bcd48ef6fce7b4ca950ceaf21210de6e105a883ee280c0f7b9ed"
+checksum = "f43faa91b1c8b36841ee70e97188a869d37ae21759da6846d4be66de5bf7b12c"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f9c0c92af03644e4806106281fe2e068ac5bc0ae74a707266d06ea27bccee5f"
+checksum = "8d2275aab483050ab2a7364c1a46604865ee7d6906684e08db0f090acf74f9e7"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "regex"
-version = "1.7.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "d1a59b5d8e97dee33696bf13c5ba8ab85341c002922fba050069326b9c498974"
 dependencies = [
- "aho-corasick",
+ "aho-corasick 1.0.1",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.2",
 ]
 
 [[package]]
@@ -8030,22 +8121,28 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "regex-syntax",
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "reqwest"
-version = "0.11.13"
+version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
+checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -8054,7 +8151,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.24.0",
  "ipnet",
  "js-sys",
  "log",
@@ -8062,20 +8159,21 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.20.7",
+ "rustls 0.21.1",
  "rustls-pemfile",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-rustls",
- "tokio-util 0.7.4",
+ "tokio-rustls 0.24.0",
+ "tokio-util 0.7.8",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.22.6",
  "winreg",
 ]
 
@@ -8108,9 +8206,9 @@ dependencies = [
 
 [[package]]
 name = "rgb"
-version = "0.8.34"
+version = "0.8.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3603b7d71ca82644f79b5a06d1220e9a58ede60bd32255f698cb1af8838b8db3"
+checksum = "20ec2d3e3fc7a92ced357df9cebd5a10b6fb2aa1ee797bf7e9ce2f17dffc8f59"
 dependencies = [
  "bytemuck",
 ]
@@ -8136,7 +8234,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -8168,7 +8266,7 @@ checksum = "300a51053b1cb55c80b7a9fde4120726ddf25ca241a1cbb926626f62fb136bff"
 dependencies = [
  "base64 0.13.1",
  "bitflags",
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -8178,7 +8276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55a77d189da1fee555ad95b7e50e7457d91c0e089ec68ca69ad2989413bbdab4"
 dependencies = [
  "byteorder",
- "digest 0.10.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-iter",
@@ -8187,7 +8285,7 @@ dependencies = [
  "pkcs8 0.9.0",
  "rand_core 0.6.4",
  "sha2 0.10.6",
- "signature 2.0.0",
+ "signature 2.1.0",
  "subtle",
  "zeroize",
 ]
@@ -8211,10 +8309,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7229b505ae0706e64f37ffc54a9c163e11022a6636d58fe1f3f52018257ff9f7"
 dependencies = [
  "cfg-if",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "rustc_version",
- "syn 1.0.107",
+ "syn 1.0.109",
  "unicode-ident",
 ]
 
@@ -8231,13 +8329,13 @@ dependencies = [
  "futures",
  "http",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.23.2",
  "lazy_static 1.4.0",
  "log",
  "rusoto_credential",
  "rusoto_signature",
  "rustc_version",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
  "tokio",
  "xml-rs",
@@ -8254,7 +8352,7 @@ dependencies = [
  "dirs-next",
  "futures",
  "hyper",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
  "shlex",
  "tokio",
@@ -8271,7 +8369,7 @@ dependencies = [
  "bytes",
  "futures",
  "rusoto_core",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
 ]
 
@@ -8296,7 +8394,7 @@ dependencies = [
  "pin-project-lite",
  "rusoto_credential",
  "rustc_version",
- "serde 1.0.152",
+ "serde 1.0.163",
  "sha2 0.9.9",
  "tokio",
 ]
@@ -8309,9 +8407,9 @@ checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
 
 [[package]]
 name = "rust_decimal"
-version = "1.27.0"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c321ee4e17d2b7abe12b5d20c1231db708dd36185c8a21e9de5fed6da4dbe9"
+checksum = "26bd36b60561ee1fb5ec2817f198b6fd09fa571c897a5e86d1487cfc2b096dfc"
 dependencies = [
  "arrayvec 0.7.2",
  "num-traits 0.2.15",
@@ -8319,9 +8417,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.21"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc-hash"
@@ -8341,7 +8439,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.16",
+ "semver",
 ]
 
 [[package]]
@@ -8350,42 +8448,28 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "nom 7.1.2",
+ "nom 7.1.3",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.36.6"
+version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
  "bitflags",
- "errno 0.2.8",
+ "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys 0.1.4",
- "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "rustix"
-version = "0.37.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aae838e49b3d63e9274e1c01833cc8139d3fec468c3b84688c628f44b1ae11d"
-dependencies = [
- "bitflags",
- "errno 0.3.1",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.3.1",
- "windows-sys 0.45.0",
+ "linux-raw-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.20.7"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
 dependencies = [
  "log",
  "ring",
@@ -8423,7 +8507,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.1",
 ]
 
 [[package]]
@@ -8438,9 +8522,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
 name = "rusty-fork"
@@ -8449,7 +8533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
 dependencies = [
  "fnv",
- "quick-error 1.2.3",
+ "quick-error",
  "tempfile",
  "wait-timeout",
 ]
@@ -8484,16 +8568,16 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "107c3d5d7f370ac09efa62a78375f94d94b8a33c61d8c278b96683fb4dbf2d8d"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "same-file"
@@ -8515,9 +8599,9 @@ dependencies = [
 
 [[package]]
 name = "scheduled-thread-pool"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977a7519bff143a44f842fd07e80ad1329295bd71686457f18e496736f4bf9bf"
+checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
 dependencies = [
  "parking_lot 0.12.1",
 ]
@@ -8531,7 +8615,7 @@ dependencies = [
  "dyn-clone",
  "either",
  "schemars_derive",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
 ]
 
@@ -8541,10 +8625,10 @@ version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "109da1e6b197438deb6db99952990c7f959572794b80ff93707d55a232545e7c"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "serde_derive_internals",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -8562,12 +8646,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "scratch"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
 
 [[package]]
 name = "sct"
@@ -8594,12 +8672,12 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48518a2b5775ba8ca5b46596aae011caa431e6ce7e4a67ead66d92f08884220e"
+checksum = "f0aec48e813d6b90b15f0b8948af3c63483992dee44c03e9930b3eebdabe046e"
 dependencies = [
  "base16ct 0.2.0",
- "der 0.7.5",
+ "der 0.7.6",
  "generic-array",
  "pkcs8 0.10.2",
  "subtle",
@@ -8628,9 +8706,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.7.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
+checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -8641,9 +8719,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.6.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -8651,29 +8729,11 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.11.0"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
-version = "1.0.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
-dependencies = [
- "serde 1.0.152",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -8690,9 +8750,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 dependencies = [
  "serde_derive",
 ]
@@ -8715,7 +8775,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b5b14ebbcc4e4f2b3642fa99c388649da58d1dc3308c7d109f39f565d1710f0"
 dependencies = [
- "serde 1.0.152",
+ "serde 1.0.163",
  "thiserror",
 ]
 
@@ -8726,7 +8786,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f05a5f801ac62a51a49d378fdb3884480041b99aced450b28990673e8ff99895"
 dependencies = [
  "once_cell",
- "serde 1.0.152",
+ "serde 1.0.163",
  "thiserror",
 ]
 
@@ -8737,7 +8797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
  "ordered-float",
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -8746,18 +8806,18 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
 dependencies = [
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -8766,50 +8826,50 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "indexmap",
  "itoa",
  "ryu",
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b04f22b563c91331a10074bda3dd5492e3cc39d56bd557e91c0af42b6c7341"
+checksum = "f7f05c1d5476066defcdfacce1f52fc3cae3af1d3089727100c02ae92e5abbe0"
 dependencies = [
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
 name = "serde_repr"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a5ec9fa74a20ebbe5d9ac23dac1fc96ba0ecfe9f50f2843b52e537b10fbcb4e"
+checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "serde_test"
-version = "1.0.152"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3611210d2d67e3513204742004d6ac6f589e521861dabb0f649b070eea8bed9e"
+checksum = "100168a8017b89fd4bcbeb8d857d95a8cfcbde829a7147c09cc82d3ab8d8cb41"
 dependencies = [
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -8821,35 +8881,35 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
 name = "serde_with"
-version = "2.1.0"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25bf4a5a814902cd1014dbccfa4d4560fb8432c779471e96e035602519f82eef"
+checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
 dependencies = [
  "base64 0.13.1",
  "chrono",
  "hex",
  "indexmap",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
  "serde_with_macros",
- "time 0.3.17",
+ "time 0.3.21",
 ]
 
 [[package]]
 name = "serde_with_macros"
-version = "2.1.0"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3452b4c0f6c1e357f73fdb87cd1efabaa12acf328c7a528e252893baeb3f4aa"
+checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
 dependencies = [
- "darling",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "darling 0.20.1",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -8860,7 +8920,7 @@ checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
 dependencies = [
  "indexmap",
  "ryu",
- "serde 1.0.152",
+ "serde 1.0.163",
  "yaml-rust",
 ]
 
@@ -8885,7 +8945,7 @@ checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -8896,7 +8956,7 @@ checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -8920,7 +8980,7 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -8937,11 +8997,11 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.6"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
  "keccak",
 ]
 
@@ -8961,7 +9021,7 @@ dependencies = [
  "bcs",
  "eyre",
  "fastcrypto",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_repr",
  "workspace-hack",
 ]
@@ -8978,7 +9038,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
 dependencies = [
- "dirs",
+ "dirs 5.0.1",
 ]
 
 [[package]]
@@ -8989,9 +9049,9 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
+checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -9005,15 +9065,15 @@ checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
 dependencies = [
  "libc",
  "mio 0.7.14",
- "mio 0.8.5",
+ "mio 0.8.6",
  "signal-hook",
 ]
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
@@ -9024,17 +9084,17 @@ version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "signature"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
+checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -9073,9 +9133,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]
@@ -9120,10 +9180,10 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "475b3bbe5245c26f2d8a6f62d67c1f30eb9fffeccee721c45d162c3ebbdf81b2"
 dependencies = [
- "heck 0.4.0",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "heck 0.4.1",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -9144,9 +9204,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d283f86695ae989d1e18440a943880967156325ba025f05049946bff47bcc2b"
+checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
@@ -9186,12 +9246,12 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a5be806ab6f127c3da44b7378837ebf01dadca8510a0e572460216b228bd0e"
+checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
 dependencies = [
  "base64ct",
- "der 0.7.5",
+ "der 0.7.6",
 ]
 
 [[package]]
@@ -9268,9 +9328,9 @@ checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck 0.3.3",
  "proc-macro-error",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -9288,11 +9348,11 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck 0.4.0",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
+ "heck 0.4.1",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "rustversion",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -9325,11 +9385,11 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "async-trait",
- "aws-config 0.55.1",
+ "aws-config 0.55.2",
  "bcs",
  "bip32",
  "camino",
- "clap 3.2.23",
+ "clap 3.2.25",
  "colored",
  "const-str",
  "csv",
@@ -9356,7 +9416,7 @@ dependencies = [
  "rusoto_kms",
  "rustyline",
  "rustyline-derive",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
  "serde_with",
  "serde_yaml",
@@ -9414,7 +9474,7 @@ dependencies = [
  "move-vm-types",
  "mysten-metrics",
  "once_cell",
- "serde 1.0.152",
+ "serde 1.0.163",
  "sui-macros",
  "sui-move-natives-latest",
  "sui-protocol-config",
@@ -9440,7 +9500,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bcs",
- "clap 3.2.23",
+ "clap 3.2.25",
  "comfy-table",
  "duration-str",
  "fastcrypto",
@@ -9457,7 +9517,7 @@ dependencies = [
  "regex",
  "roaring",
  "rocksdb",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
  "strum",
  "strum_macros",
@@ -9480,7 +9540,7 @@ dependencies = [
  "telemetry-subscribers",
  "test-utils",
  "tokio",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.8",
  "tracing",
  "typed-store",
  "workspace-hack",
@@ -9493,14 +9553,14 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bcs",
- "clap 3.2.23",
+ "clap 3.2.25",
  "fastcrypto",
  "futures",
  "jsonrpsee",
  "move-core-types",
  "prometheus",
  "reqwest",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
  "shared-crypto",
  "sui",
@@ -9534,7 +9594,7 @@ dependencies = [
  "anyhow",
  "bcs",
  "csv",
- "dirs",
+ "dirs 4.0.0",
  "fastcrypto",
  "insta",
  "move-binary-format",
@@ -9543,7 +9603,7 @@ dependencies = [
  "once_cell",
  "prometheus",
  "rand 0.8.5",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_with",
  "serde_yaml",
  "shared-crypto",
@@ -9567,7 +9627,7 @@ dependencies = [
  "bcs",
  "bytes",
  "chrono",
- "clap 3.2.23",
+ "clap 3.2.25",
  "criterion",
  "dashmap",
  "either",
@@ -9608,7 +9668,7 @@ dependencies = [
  "rand 0.8.5",
  "rocksdb",
  "scopeguard",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde-reflection",
  "serde_json",
  "serde_with",
@@ -9655,7 +9715,7 @@ dependencies = [
  "insta",
  "move-cli",
  "move-disassembler",
- "serde 1.0.152",
+ "serde 1.0.163",
  "strum",
  "strum_macros",
  "sui-config",
@@ -9679,7 +9739,7 @@ dependencies = [
  "move-vm-test-utils",
  "move-vm-types",
  "once_cell",
- "serde 1.0.152",
+ "serde 1.0.163",
  "workspace-hack",
 ]
 
@@ -9699,7 +9759,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "axum",
- "clap 3.2.23",
+ "clap 3.2.25",
  "eyre",
  "futures",
  "http",
@@ -9707,7 +9767,7 @@ dependencies = [
  "prometheus",
  "rocksdb",
  "scopeguard",
- "serde 1.0.152",
+ "serde 1.0.163",
  "shared-crypto",
  "sui",
  "sui-config",
@@ -9741,7 +9801,7 @@ dependencies = [
  "move-core-types",
  "move-package",
  "once_cell",
- "serde 1.0.152",
+ "serde 1.0.163",
  "sui-move-build",
  "sui-types",
  "tracing",
@@ -9755,7 +9815,7 @@ dependencies = [
  "anyhow",
  "bcs",
  "git-version",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
  "sui-framework",
  "sui-protocol-config",
@@ -9785,7 +9845,7 @@ dependencies = [
  "bcs",
  "camino",
  "csv",
- "dirs",
+ "dirs 4.0.0",
  "fastcrypto",
  "insta",
  "move-binary-format",
@@ -9795,7 +9855,7 @@ dependencies = [
  "once_cell",
  "prometheus",
  "rand 0.8.5",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_with",
  "serde_yaml",
  "shared-crypto",
@@ -9824,7 +9884,7 @@ dependencies = [
  "bcs",
  "cached",
  "chrono",
- "clap 3.2.23",
+ "clap 3.2.25",
  "criterion",
  "diesel",
  "diesel-async",
@@ -9839,8 +9899,8 @@ dependencies = [
  "ntest",
  "prometheus",
  "regex",
- "rustls 0.20.7",
- "serde 1.0.152",
+ "rustls 0.20.8",
+ "serde 1.0.163",
  "serde_json",
  "sui-config",
  "sui-core",
@@ -9877,7 +9937,7 @@ dependencies = [
  "move-core-types",
  "once_cell",
  "schemars",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
  "sui-framework",
  "sui-move-build",
@@ -9914,7 +9974,7 @@ dependencies = [
  "prometheus",
  "rand 0.8.5",
  "reqwest",
- "serde 1.0.152",
+ "serde 1.0.163",
  "shared-crypto",
  "signature 1.6.4",
  "sui-config",
@@ -9958,7 +10018,7 @@ dependencies = [
  "move-bytecode-utils",
  "move-core-types",
  "schemars",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
  "serde_with",
  "sui-enum-compat-util",
@@ -9978,7 +10038,7 @@ dependencies = [
  "bip32",
  "fastcrypto",
  "rand 0.8.5",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
  "shared-crypto",
  "signature 1.6.4",
@@ -10006,7 +10066,7 @@ version = "1.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
- "clap 3.2.23",
+ "clap 3.2.25",
  "colored",
  "const-str",
  "fastcrypto",
@@ -10104,7 +10164,7 @@ dependencies = [
  "mysten-network",
  "prometheus",
  "rand 0.8.5",
- "serde 1.0.152",
+ "serde 1.0.163",
  "shared-crypto",
  "sui-config",
  "sui-swarm-config",
@@ -10112,7 +10172,7 @@ dependencies = [
  "tap",
  "telemetry-subscribers",
  "tokio",
- "tonic",
+ "tonic 0.8.3",
  "tonic-build",
  "tower",
  "tracing",
@@ -10128,7 +10188,7 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "axum",
- "clap 3.2.23",
+ "clap 3.2.25",
  "const-str",
  "fastcrypto",
  "futures",
@@ -10140,7 +10200,7 @@ dependencies = [
  "narwhal-types",
  "prometheus",
  "reqwest",
- "serde 1.0.152",
+ "serde 1.0.163",
  "snap",
  "sui-config",
  "sui-core",
@@ -10168,13 +10228,13 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bcs",
- "clap 3.2.23",
+ "clap 3.2.25",
  "fastcrypto",
  "move-core-types",
  "pretty_assertions",
  "rand 0.8.5",
  "schemars",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
  "sui",
  "sui-core",
@@ -10194,9 +10254,9 @@ version = "0.1.0"
 dependencies = [
  "derive-syn-parse",
  "itertools",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
  "unescape",
  "workspace-hack",
 ]
@@ -10206,10 +10266,10 @@ name = "sui-proc-macros"
 version = "0.7.0"
 dependencies = [
  "msim-macros",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "sui-enum-compat-util",
- "syn 2.0.10",
+ "syn 2.0.16",
  "workspace-hack",
 ]
 
@@ -10219,7 +10279,7 @@ version = "0.1.0"
 dependencies = [
  "insta",
  "schemars",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_with",
  "sui-protocol-config-macros",
  "tracing",
@@ -10230,9 +10290,9 @@ dependencies = [
 name = "sui-protocol-config-macros"
 version = "0.1.0"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
  "workspace-hack",
 ]
 
@@ -10244,7 +10304,7 @@ dependencies = [
  "axum",
  "axum-server",
  "bytes",
- "clap 3.2.23",
+ "clap 3.2.25",
  "const-str",
  "fastcrypto",
  "git-version",
@@ -10261,9 +10321,9 @@ dependencies = [
  "protobuf",
  "rand 0.8.5",
  "reqwest",
- "rustls 0.20.7",
+ "rustls 0.20.8",
  "rustls-pemfile",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
  "serde_with",
  "serde_yaml",
@@ -10286,7 +10346,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "bcs",
- "clap 4.1.4",
+ "clap 4.3.0",
  "colored",
  "futures",
  "jsonrpsee",
@@ -10298,7 +10358,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "prometheus",
  "rand 0.8.5",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
  "serde_with",
  "serde_yaml",
@@ -10334,7 +10394,7 @@ dependencies = [
  "axum-extra",
  "bcs",
  "chrono",
- "clap 3.2.23",
+ "clap 3.2.25",
  "eyre",
  "fastcrypto",
  "futures",
@@ -10346,7 +10406,7 @@ dependencies = [
  "rand 0.8.5",
  "reqwest",
  "rocksdb",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
  "shared-crypto",
  "signature 1.6.4",
@@ -10378,9 +10438,9 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
- "clap 3.2.23",
+ "clap 3.2.25",
  "dashmap",
- "dirs",
+ "dirs 4.0.0",
  "eyre",
  "futures",
  "http",
@@ -10390,7 +10450,7 @@ dependencies = [
  "rand 0.8.5",
  "rocksdb",
  "scopeguard",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
  "shared-crypto",
  "shellexpand",
@@ -10410,7 +10470,7 @@ dependencies = [
  "test-utils",
  "thiserror",
  "tokio",
- "tonic",
+ "tonic 0.8.3",
  "tower",
  "tower-http 0.3.5",
  "tracing",
@@ -10428,15 +10488,15 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "bcs",
- "clap 3.2.23",
+ "clap 3.2.25",
  "colored",
- "dirs",
+ "dirs 4.0.0",
  "fastcrypto",
  "futures",
  "futures-core",
  "jsonrpsee",
  "move-core-types",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
  "serde_with",
  "shared-crypto",
@@ -10495,7 +10555,7 @@ dependencies = [
  "num_enum",
  "object_store",
  "prometheus",
- "serde 1.0.152",
+ "serde 1.0.163",
  "sui-core",
  "sui-protocol-config",
  "sui-storage",
@@ -10561,7 +10621,7 @@ dependencies = [
  "pretty_assertions",
  "prometheus",
  "rocksdb",
- "serde 1.0.152",
+ "serde 1.0.163",
  "sui-json-rpc-types",
  "sui-protocol-config",
  "sui-simulator",
@@ -10582,7 +10642,7 @@ version = "1.3.0"
 dependencies = [
  "async-trait",
  "bcs",
- "clap 3.2.23",
+ "clap 3.2.25",
  "futures",
  "indexmap",
  "move-binary-format",
@@ -10641,7 +10701,7 @@ dependencies = [
  "bcs",
  "camino",
  "csv",
- "dirs",
+ "dirs 4.0.0",
  "fastcrypto",
  "insta",
  "move-binary-format",
@@ -10651,7 +10711,7 @@ dependencies = [
  "once_cell",
  "prometheus",
  "rand 0.8.5",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_with",
  "serde_yaml",
  "shared-crypto",
@@ -10676,7 +10736,7 @@ version = "0.1.0"
 dependencies = [
  "fastcrypto",
  "reqwest",
- "serde 1.0.152",
+ "serde 1.0.163",
  "sui-core",
  "tokio",
  "tracing",
@@ -10701,7 +10761,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "axum",
- "clap 3.2.23",
+ "clap 3.2.25",
  "http",
  "sui-cluster-test",
  "sui-faucet",
@@ -10725,9 +10785,9 @@ dependencies = [
  "rand 0.8.5",
  "rcgen",
  "reqwest",
- "rustls 0.20.7",
+ "rustls 0.20.8",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tower-layer",
  "webpki",
  "workspace-hack",
@@ -10742,7 +10802,7 @@ dependencies = [
  "anemo-cli",
  "anyhow",
  "bcs",
- "clap 4.1.4",
+ "clap 4.3.0",
  "colored",
  "comfy-table",
  "eyre",
@@ -10758,7 +10818,7 @@ dependencies = [
  "prometheus",
  "rocksdb",
  "ron",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
  "similar",
  "strum",
@@ -10807,7 +10867,7 @@ dependencies = [
  "anyhow",
  "bcs",
  "bimap",
- "clap 3.2.23",
+ "clap 3.2.25",
  "fastcrypto",
  "move-binary-format",
  "move-bytecode-utils",
@@ -10866,7 +10926,7 @@ dependencies = [
  "rand 0.8.5",
  "roaring",
  "schemars",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde-name",
  "serde_json",
  "serde_with",
@@ -10882,7 +10942,7 @@ dependencies = [
  "sui-protocol-config",
  "tap",
  "thiserror",
- "tonic",
+ "tonic 0.8.3",
  "tracing",
  "typed-store",
  "workspace-hack",
@@ -10962,31 +11022,31 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.10"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40"
+checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "unicode-ident",
 ]
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "synstructure"
@@ -10994,22 +11054,22 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 1.0.109",
  "unicode-xid 0.2.4",
 ]
 
 [[package]]
 name = "sysinfo"
-version = "0.27.7"
+version = "0.27.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "975fe381e0ecba475d4acff52466906d95b153a40324956552e027b2a9eaa89e"
+checksum = "a902e9050fca0a5d6877550b769abd2bd1ce8c04634b941dbe2809735e1a1e33"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
  "libc",
- "ntapi 0.4.0",
+ "ntapi 0.4.1",
  "once_cell",
  "rayon",
  "winapi",
@@ -11033,19 +11093,19 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.5"
+version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
+checksum = "fd1ba337640d60c3e96bc6f0638a939b9c9a7f2c316a1598c279828b3d1dc8c5"
 
 [[package]]
 name = "target-spec"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb0303f2cecb4171c439135b28c33fe9da7b9fd7816fe674761834da70c9778"
+checksum = "0bf4306559bd50cb358e7af5692694d6f6fad95cf2c0bea2571dd419f5298e12"
 dependencies = [
  "cfg-expr",
  "guppy-workspace-hack",
- "serde 1.0.152",
+ "serde 1.0.163",
  "target-lexicon",
 ]
 
@@ -11060,21 +11120,21 @@ dependencies = [
  "prometheus",
  "tracing",
  "tracing-appender",
- "tracing-subscriber 0.3.16",
+ "tracing-subscriber 0.3.17",
  "workspace-hack",
 ]
 
 [[package]]
 name = "tempfile"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
- "rustix 0.36.6",
- "windows-sys 0.42.0",
+ "redox_syscall 0.3.5",
+ "rustix",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -11093,7 +11153,7 @@ dependencies = [
  "pest_derive",
  "rand 0.8.5",
  "regex",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
  "slug",
  "unic-segment",
@@ -11121,17 +11181,17 @@ dependencies = [
 
 [[package]]
 name = "termtree"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95059e91184749cb66be6dc994f67f182b6d897cb3df74a5bf66b5e709295fd8"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-fuzz"
-version = "3.0.5"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd4a3a7f00909d5a1d1f83b86b65d91e4c94f80b0c2d0ae37e2ef44da7b7a0a0"
+checksum = "857e884d611b1f26e63f00559975d348491e66b1271a8144a9806c9bd4a791cf"
 dependencies = [
- "serde 1.0.152",
+ "serde 1.0.163",
  "test-fuzz-internal",
  "test-fuzz-macro",
  "test-fuzz-runtime",
@@ -11139,45 +11199,45 @@ dependencies = [
 
 [[package]]
 name = "test-fuzz-internal"
-version = "3.0.5"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9186daca5c58cb307d09731e0ba06b13fd6c036c90672b9bfc31cecf76cf689"
+checksum = "48db3bbc562408b2111f3a0c96ec416ffa3ab66f8a6ab42579b608b9f74744e1"
 dependencies = [
  "cargo_metadata",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "serde 1.0.152",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "serde 1.0.163",
  "strum_macros",
 ]
 
 [[package]]
 name = "test-fuzz-macro"
-version = "3.0.5"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d187b450bfb5b7939f82f9747dc1ebb15a7a9c4a93cd304a41aece7149608b"
+checksum = "e17cd05c077c7b9c5d0045c539f9c5e911187bf65cd1b407d28239efc7b54880"
 dependencies = [
- "darling",
+ "darling 0.20.1",
  "if_chain",
+ "itertools",
  "lazy_static 1.4.0",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "subprocess",
- "syn 1.0.107",
+ "syn 2.0.16",
  "test-fuzz-internal",
  "toolchain_find",
- "unzip-n",
 ]
 
 [[package]]
 name = "test-fuzz-runtime"
-version = "3.0.5"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a0d69068569b9b7311095823fe0e49eedfd05ad4277eb64fc334cf1a5bc5116"
+checksum = "53d68728ca22d1a96a71645fd2327e37821b8979a7e75e44ad24a72e8051513d"
 dependencies = [
  "bincode",
  "hex",
  "num-traits 0.2.15",
- "serde 1.0.152",
+ "serde 1.0.163",
  "sha-1 0.10.1",
  "test-fuzz-internal",
 ]
@@ -11239,30 +11299,31 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.4"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
+ "cfg-if",
  "once_cell",
 ]
 
@@ -11288,27 +11349,27 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
 dependencies = [
  "itoa",
- "serde 1.0.152",
+ "serde 1.0.163",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.6"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
 dependencies = [
  "time-core",
 ]
@@ -11347,7 +11408,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
 ]
 
@@ -11362,9 +11423,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -11375,7 +11436,7 @@ dependencies = [
  "autocfg",
  "bytes",
  "libc",
- "mio 0.8.5",
+ "mio 0.8.6",
  "num_cpus",
  "parking_lot 0.12.1",
  "pin-project-lite",
@@ -11402,9 +11463,9 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 2.0.10",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -11412,16 +11473,16 @@ name = "tokio-macros"
 version = "2.1.0"
 source = "git+https://github.com/mystenmark/tokio-madsim-fork.git?rev=e4693500118d5e79ce098ee6dfc2c48f3ef19e45#e4693500118d5e79ce098ee6dfc2c48f3ef19e45"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 2.0.10",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29a12c1b3e0704ae7dfc25562629798b29c72e6b1d0a681b6f29ab4ae5e7f7bf"
+checksum = "6e89f6234aa8fd43779746012fcf53603cdb91fdd8399aa0de868c2d56b6dde1"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -11436,9 +11497,9 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "socket2 0.4.9",
+ "socket2 0.5.3",
  "tokio",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.8",
 ]
 
 [[package]]
@@ -11449,10 +11510,10 @@ checksum = "606f2b73660439474394432239c82249c0d45eb5f23d91f401be1e33590444a7"
 dependencies = [
  "futures",
  "ring",
- "rustls 0.20.7",
+ "rustls 0.20.8",
  "tokio",
  "tokio-postgres",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
 ]
 
 [[package]]
@@ -11472,9 +11533,19 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls 0.20.7",
+ "rustls 0.20.8",
  "tokio",
  "webpki",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
+dependencies = [
+ "rustls 0.21.1",
+ "tokio",
 ]
 
 [[package]]
@@ -11486,22 +11557,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.4",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-io",
- "futures-sink",
- "pin-project-lite",
- "tokio",
- "tracing",
+ "tokio-util 0.7.8",
 ]
 
 [[package]]
@@ -11522,13 +11578,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.5.10"
+name = "tokio-util"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
+checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "indexmap",
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -11546,18 +11617,18 @@ dependencies = [
  "combine",
  "indexmap",
  "itertools",
- "serde 1.0.152",
+ "serde 1.0.163",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.15.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1541ba70885967e662f69d31ab3aeca7b1aaecfcd58679590b893e9239c3646"
+checksum = "a34cc558345efd7e88b9eda9626df2138b80bb46a7606f695e751c892bc7dac6"
 dependencies = [
- "combine",
  "indexmap",
  "itertools",
+ "nom8",
  "toml_datetime",
 ]
 
@@ -11585,14 +11656,42 @@ dependencies = [
  "prost-derive",
  "rustls-pemfile",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tokio-stream",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.8",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
  "tracing-futures",
+]
+
+[[package]]
+name = "tonic"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64 0.21.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -11602,10 +11701,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
 dependencies = [
  "prettyplease",
- "proc-macro2 1.0.54",
+ "proc-macro2 1.0.58",
  "prost-build",
- "quote 1.0.26",
- "syn 1.0.107",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -11619,19 +11718,19 @@ dependencies = [
  "prost",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.8.3",
 ]
 
 [[package]]
 name = "toolchain_find"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e85654a10e7a07a47c6f19d93818f3f343e22927f2fa280c84f7c8042743413"
+checksum = "fa8c746c4e8d786ff304a6a73d7b406420d9a7c7d8292e090979dc85213113ed"
 dependencies = [
  "home",
- "lazy_static 1.4.0",
+ "once_cell",
  "regex",
- "semver 0.11.0",
+ "semver",
  "walkdir",
 ]
 
@@ -11650,7 +11749,7 @@ dependencies = [
  "rand 0.8.5",
  "slab",
  "tokio",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.8",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -11678,7 +11777,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.8",
  "tower",
  "tower-layer",
  "tower-service",
@@ -11737,26 +11836,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
 dependencies = [
  "crossbeam-channel",
- "time 0.3.17",
- "tracing-subscriber 0.3.16",
+ "time 0.3.21",
+ "tracing-subscriber 0.3.17",
 ]
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -11789,7 +11888,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
 dependencies = [
- "serde 1.0.152",
+ "serde 1.0.163",
  "tracing-core",
 ]
 
@@ -11804,20 +11903,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
  "regex",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
- "time 0.3.17",
+ "time 0.3.21",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -11895,16 +11994,16 @@ dependencies = [
  "msim",
  "num_cpus",
  "once_cell",
- "ouroboros 0.15.5",
- "proc-macro2 1.0.54",
+ "ouroboros 0.15.6",
+ "proc-macro2 1.0.58",
  "prometheus",
- "quote 1.0.26",
+ "quote 1.0.27",
  "rand 0.8.5",
  "rocksdb",
  "rstest",
- "serde 1.0.152",
+ "serde 1.0.163",
  "sui-macros",
- "syn 1.0.107",
+ "syn 1.0.109",
  "tap",
  "tempfile",
  "thiserror",
@@ -11920,10 +12019,10 @@ name = "typed-store-derive"
 version = "0.3.0"
 dependencies = [
  "eyre",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "rocksdb",
- "syn 1.0.107",
+ "syn 1.0.109",
  "tempfile",
  "tokio",
  "typed-store",
@@ -11962,9 +12061,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "uncased"
-version = "0.9.7"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b01702b0fd0b3fadcf98e098780badda8742d4f4a7676615cad90e8ac73622"
+checksum = "9b9bc53168a4be7402ab86c3aad243a84dd7381d09be0eddc81280c1da95ca68"
 dependencies = [
  "version_check",
 ]
@@ -12036,15 +12135,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.8"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-normalization"
@@ -12057,9 +12156,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"
@@ -12081,9 +12180,9 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "universal-hash"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3160b73c9a19f7e2939a2fdad446c57c1bbbbf4d919d3213ff1267a580d8b5"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
  "crypto-common",
  "subtle",
@@ -12100,17 +12199,6 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "unzip-n"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e7e85a0596447f0f2ac090e16bc4c516c6fe91771fb0c0ccf7fa3dae896b9c"
-dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
-]
 
 [[package]]
 name = "url"
@@ -12137,11 +12225,11 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.2.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
+checksum = "345444e32442451b267fc254ae85a209c64be56d2890e601a0c37ff0c3c5ecd2"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom 0.2.9",
  "rand 0.8.5",
 ]
 
@@ -12157,8 +12245,8 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae2faf80ac463422992abf4de234731279c058aaf33171ca70277c98406b124"
 dependencies = [
- "quote 1.0.26",
- "syn 1.0.107",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -12186,7 +12274,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee97e1d97bd593fb513912a07691b742361b3dd64ad56f2c694ea2dbfe0665d3"
 dependencies = [
  "itertools",
- "nom 7.1.2",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -12212,8 +12300,8 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
 ]
 
 [[package]]
@@ -12226,19 +12314,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "waker-fn"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
-
-[[package]]
 name = "walkdir"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
 dependencies = [
  "same-file",
- "winapi",
  "winapi-util",
 ]
 
@@ -12272,9 +12353,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -12282,24 +12363,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.33"
+version = "0.4.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+checksum = "2d1985d03709c53167ce907ff394f5316aa22cb4e12761295c5dc57dacb6297e"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -12309,38 +12390,51 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
 dependencies = [
- "quote 1.0.26",
+ "quote 1.0.27",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
+
+[[package]]
+name = "wasm-streams"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bbae3363c08332cadccd13b67db371814cd214c2524020932f0804b8cf7c078"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.60"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -12366,10 +12460,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "4.3.0"
+name = "webpki-roots"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
+checksum = "aa54963694b65584e170cf5dc46aeb4dcaa5584e652ff5f3952e56d66aff0125"
+dependencies = [
+ "rustls-webpki",
+]
+
+[[package]]
+name = "which"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
 dependencies = [
  "either",
  "libc",
@@ -12378,9 +12481,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45dbc71f0cdca27dc261a9bd37ddec174e4a0af2b900b890f378460f745426e3"
+checksum = "2c70234412ca409cc04e864e89523cb0fc37f5e1344ebed5a3ebf4192b6b9f68"
 dependencies = [
  "wasm-bindgen",
  "web-sys",
@@ -12422,6 +12525,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.0",
+]
 
 [[package]]
 name = "windows-sys"
@@ -12590,8 +12702,9 @@ dependencies = [
  "aes",
  "aes-gcm",
  "ahash 0.7.6",
- "ahash 0.8.2",
- "aho-corasick",
+ "ahash 0.8.3",
+ "aho-corasick 0.7.20",
+ "aho-corasick 1.0.1",
  "aliasable",
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -12601,6 +12714,11 @@ dependencies = [
  "anemo-tower",
  "anes",
  "ansi_term",
+ "anstream",
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
  "anyhow",
  "arbitrary",
  "arc-swap",
@@ -12639,22 +12757,22 @@ dependencies = [
  "auto_ops",
  "autocfg",
  "autotools",
- "aws-config 0.55.1",
+ "aws-config 0.55.2",
  "aws-credential-types 0.55.2",
  "aws-endpoint 0.55.2",
  "aws-http 0.55.2",
- "aws-sdk-sso 0.26.0",
- "aws-sdk-sts 0.26.0",
+ "aws-sdk-sso 0.27.0",
+ "aws-sdk-sts 0.27.0",
  "aws-sig-auth 0.55.2",
  "aws-sigv4 0.55.2",
- "aws-smithy-async 0.55.2",
- "aws-smithy-client 0.55.2",
- "aws-smithy-http 0.55.2",
- "aws-smithy-http-tower 0.55.2",
- "aws-smithy-json 0.55.2",
- "aws-smithy-query 0.55.2",
- "aws-smithy-types 0.55.2",
- "aws-smithy-xml 0.55.2",
+ "aws-smithy-async 0.55.3",
+ "aws-smithy-client 0.55.3",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-http-tower 0.55.3",
+ "aws-smithy-json 0.55.3",
+ "aws-smithy-query 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "aws-smithy-xml 0.55.3",
  "aws-types 0.55.2",
  "axum",
  "axum-core",
@@ -12666,7 +12784,7 @@ dependencies = [
  "base16ct 0.1.1",
  "base16ct 0.2.0",
  "base64 0.13.1",
- "base64 0.21.0",
+ "base64 0.21.1",
  "base64-simd",
  "base64ct",
  "bcs",
@@ -12686,10 +12804,10 @@ dependencies = [
  "bitvec",
  "blake2",
  "blake3",
- "block-buffer 0.10.3",
+ "block-buffer 0.10.4",
  "block-buffer 0.9.0",
  "block-padding 0.2.1",
- "block-padding 0.3.2",
+ "block-padding 0.3.3",
  "blst",
  "brotli",
  "brotli-decompressor",
@@ -12726,17 +12844,19 @@ dependencies = [
  "cipher",
  "clang-sys",
  "clap 2.34.0",
- "clap 3.2.23",
- "clap 4.1.4",
- "clap_derive 3.2.18",
- "clap_derive 4.1.0",
+ "clap 3.2.25",
+ "clap 4.3.0",
+ "clap_builder",
+ "clap_derive 3.2.25",
+ "clap_derive 4.3.0",
  "clap_lex 0.2.4",
- "clap_lex 0.3.1",
+ "clap_lex 0.5.0",
  "clear_on_drop",
  "clipboard-win",
  "codespan",
  "codespan-reporting",
  "collectable",
+ "colorchoice",
  "colored",
  "colored-diff",
  "combine",
@@ -12769,7 +12889,7 @@ dependencies = [
  "crossterm_winapi 0.9.0",
  "crunchy",
  "crypto-bigint 0.4.9",
- "crypto-bigint 0.5.1",
+ "crypto-bigint 0.5.2",
  "crypto-common",
  "crypto-mac",
  "csv",
@@ -12778,9 +12898,12 @@ dependencies = [
  "ctr",
  "curve25519-dalek-fiat",
  "curve25519-dalek-ng",
- "darling",
- "darling_core",
- "darling_macro",
+ "darling 0.14.4",
+ "darling 0.20.1",
+ "darling_core 0.14.4",
+ "darling_core 0.20.1",
+ "darling_macro 0.14.4",
+ "darling_macro 0.20.1",
  "dashmap",
  "data-encoding",
  "data-encoding-macro",
@@ -12791,7 +12914,7 @@ dependencies = [
  "debug-ignore",
  "debugid",
  "der 0.6.1",
- "der 0.7.5",
+ "der 0.7.6",
  "der-parser",
  "derivative",
  "derive-syn-parse",
@@ -12812,12 +12935,14 @@ dependencies = [
  "difflib",
  "diffus",
  "diffy",
- "digest 0.10.6",
+ "digest 0.10.7",
  "digest 0.9.0",
  "directories",
- "dirs",
+ "dirs 4.0.0",
+ "dirs 5.0.1",
  "dirs-next",
- "dirs-sys",
+ "dirs-sys 0.3.7",
+ "dirs-sys 0.4.1",
  "dirs-sys-next",
  "displaydoc",
  "dissimilar",
@@ -12826,20 +12951,19 @@ dependencies = [
  "duration-str",
  "dyn-clone",
  "ecdsa 0.14.8",
- "ecdsa 0.16.6",
+ "ecdsa 0.16.7",
  "ed25519",
  "ed25519-consensus",
  "ed25519-dalek-fiat",
  "either",
  "elliptic-curve 0.12.3",
- "elliptic-curve 0.13.4",
+ "elliptic-curve 0.13.5",
  "encode_unicode 0.3.6",
  "encode_unicode 1.0.0",
  "encoding_rs",
  "endian-type",
  "enum_dispatch",
- "errno 0.2.8",
- "errno 0.3.1",
+ "errno",
  "error-code",
  "ethnum",
  "event-listener",
@@ -12872,7 +12996,6 @@ dependencies = [
  "futures-core",
  "futures-executor",
  "futures-io",
- "futures-lite",
  "futures-macro",
  "futures-sink",
  "futures-task",
@@ -12880,7 +13003,7 @@ dependencies = [
  "futures-util",
  "generic-array",
  "getrandom 0.1.16",
- "getrandom 0.2.8",
+ "getrandom 0.2.9",
  "ghash",
  "gimli",
  "git-version",
@@ -12906,7 +13029,7 @@ dependencies = [
  "headers",
  "headers-core",
  "heck 0.3.3",
- "heck 0.4.0",
+ "heck 0.4.1",
  "hex",
  "hex-literal",
  "hkdf",
@@ -12922,7 +13045,8 @@ dependencies = [
  "humansize",
  "humantime",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.23.2",
+ "hyper-rustls 0.24.0",
  "hyper-timeout",
  "iana-time-zone",
  "ident_case",
@@ -12978,8 +13102,7 @@ dependencies = [
  "libtest-mimic",
  "libz-sys",
  "linked-hash-map",
- "linux-raw-sys 0.1.4",
- "linux-raw-sys 0.3.1",
+ "linux-raw-sys",
  "lock_api",
  "log",
  "lru",
@@ -12994,16 +13117,17 @@ dependencies = [
  "memchr",
  "memmap2",
  "memoffset 0.6.5",
- "memoffset 0.7.1",
+ "memoffset 0.8.0",
  "merlin",
  "migrations_internals",
  "migrations_macros",
  "mime",
  "mime_guess",
  "minimal-lexical",
- "miniz_oxide",
+ "miniz_oxide 0.6.2",
+ "miniz_oxide 0.7.1",
  "mio 0.7.14",
- "mio 0.8.5",
+ "mio 0.8.6",
  "mockall",
  "mockall_derive",
  "more-asserts",
@@ -13055,13 +13179,14 @@ dependencies = [
  "nexlint-lints",
  "nibble_vec",
  "nix 0.23.2",
- "nix 0.24.3",
+ "nix 0.26.2",
  "no-std-compat",
- "nom 5.1.2",
- "nom 7.1.2",
+ "nom 5.1.3",
+ "nom 7.1.3",
+ "nom8",
  "nonzero_ext",
  "normalize-line-endings",
- "ntapi 0.4.0",
+ "ntapi 0.4.1",
  "ntest",
  "ntest_test_cases",
  "ntest_timeout",
@@ -13086,11 +13211,12 @@ dependencies = [
  "oorandom",
  "opaque-debug",
  "openssl-probe",
+ "option-ext",
  "ordered-float",
  "os_str_bytes",
- "ouroboros 0.15.5",
+ "ouroboros 0.15.6",
  "ouroboros 0.9.5",
- "ouroboros_macro 0.15.5",
+ "ouroboros_macro 0.15.6",
  "ouroboros_macro 0.9.5",
  "output_vt100",
  "outref",
@@ -13099,11 +13225,10 @@ dependencies = [
  "p256",
  "parity-scale-codec",
  "parity-scale-codec-derive",
- "parking",
  "parking_lot 0.11.2",
  "parking_lot 0.12.1",
  "parking_lot_core 0.8.6",
- "parking_lot_core 0.9.5",
+ "parking_lot_core 0.9.7",
  "parse-zoneinfo",
  "paste",
  "pathdiff",
@@ -13118,7 +13243,7 @@ dependencies = [
  "pest_generator",
  "pest_meta",
  "petgraph 0.5.1",
- "petgraph 0.6.2",
+ "petgraph 0.6.3",
  "phf",
  "phf_codegen",
  "phf_generator",
@@ -13135,13 +13260,15 @@ dependencies = [
  "plotters-backend",
  "plotters-svg",
  "polyval",
- "portable-atomic",
+ "portable-atomic 0.3.20",
+ "portable-atomic 1.3.2",
  "postgres-protocol",
  "postgres-types",
  "pprof",
  "ppv-lite86",
  "pq-sys",
- "predicates",
+ "predicates 2.1.5",
+ "predicates 3.0.3",
  "predicates-core",
  "predicates-tree",
  "pretty",
@@ -13155,7 +13282,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro-hack",
  "proc-macro2 0.4.30",
- "proc-macro2 1.0.54",
+ "proc-macro2 1.0.58",
  "prometheus",
  "proptest",
  "proptest-derive",
@@ -13167,14 +13294,13 @@ dependencies = [
  "protobuf-src",
  "ptree",
  "quanta",
- "quick-error 1.2.3",
- "quick-error 2.0.1",
+ "quick-error",
  "quick-xml 0.26.0",
  "quinn",
  "quinn-proto",
  "quinn-udp",
  "quote 0.6.13",
- "quote 1.0.26",
+ "quote 1.0.27",
  "r2d2",
  "radium",
  "radix_trie",
@@ -13197,7 +13323,8 @@ dependencies = [
  "ref-cast-impl",
  "regex",
  "regex-automata",
- "regex-syntax",
+ "regex-syntax 0.6.29",
+ "regex-syntax 0.7.2",
  "reqwest",
  "retain_mut",
  "rfc6979 0.3.1",
@@ -13222,9 +13349,8 @@ dependencies = [
  "rustc-hex",
  "rustc_version",
  "rusticata-macros",
- "rustix 0.36.6",
- "rustix 0.37.7",
- "rustls 0.20.7",
+ "rustix",
+ "rustls 0.20.8",
  "rustls 0.21.1",
  "rustls-native-certs",
  "rustls-pemfile",
@@ -13243,17 +13369,15 @@ dependencies = [
  "scopeguard",
  "sct",
  "sec1 0.3.0",
- "sec1 0.7.1",
+ "sec1 0.7.2",
  "secp256k1",
  "secp256k1-sys",
  "security-framework",
  "security-framework-sys",
- "semver 0.11.0",
- "semver 1.0.16",
- "semver-parser",
+ "semver",
  "send_wrapper",
  "serde 0.8.23",
- "serde 1.0.152",
+ "serde 1.0.163",
  "serde-hjson",
  "serde-name",
  "serde-reflection",
@@ -13274,7 +13398,7 @@ dependencies = [
  "sha1",
  "sha2 0.10.6",
  "sha2 0.9.9",
- "sha3 0.10.6",
+ "sha3 0.10.8",
  "sha3 0.9.1",
  "sharded-slab",
  "shell-words",
@@ -13284,7 +13408,7 @@ dependencies = [
  "signal-hook-mio",
  "signal-hook-registry",
  "signature 1.6.4",
- "signature 2.0.0",
+ "signature 2.1.0",
  "similar",
  "simplelog",
  "siphasher",
@@ -13295,11 +13419,11 @@ dependencies = [
  "smallvec",
  "snap",
  "socket2 0.4.9",
- "socket2 0.5.2",
+ "socket2 0.5.3",
  "soketto",
  "spin",
  "spki 0.6.0",
- "spki 0.7.1",
+ "spki 0.7.2",
  "stable_deref_trait",
  "static_assertions",
  "str-buf",
@@ -13318,8 +13442,8 @@ dependencies = [
  "symbolic-common",
  "symbolic-demangle",
  "syn 0.15.44",
- "syn 1.0.107",
- "syn 2.0.10",
+ "syn 1.0.109",
+ "syn 2.0.16",
  "sync_wrapper",
  "synstructure",
  "sysinfo",
@@ -13343,7 +13467,7 @@ dependencies = [
  "thread_local",
  "threadpool",
  "time 0.1.45",
- "time 0.3.17",
+ "time 0.3.21",
  "time-core",
  "time-macros",
  "tint",
@@ -13357,14 +13481,16 @@ dependencies = [
  "tokio-postgres",
  "tokio-postgres-rustls",
  "tokio-retry",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
+ "tokio-rustls 0.24.0",
  "tokio-stream",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.8",
  "toml",
  "toml_datetime",
  "toml_edit 0.14.4",
- "toml_edit 0.15.0",
- "tonic",
+ "toml_edit 0.17.1",
+ "tonic 0.8.3",
+ "tonic 0.9.2",
  "tonic-build",
  "tonic-health",
  "toolchain_find",
@@ -13380,7 +13506,7 @@ dependencies = [
  "tracing-futures",
  "tracing-serde",
  "tracing-subscriber 0.2.25",
- "tracing-subscriber 0.3.16",
+ "tracing-subscriber 0.3.17",
  "try-lock",
  "tui",
  "twox-hash",
@@ -13408,7 +13534,6 @@ dependencies = [
  "universal-hash",
  "unsigned-varint",
  "untrusted",
- "unzip-n",
  "url",
  "urlencoding",
  "utf8parse",
@@ -13422,7 +13547,6 @@ dependencies = [
  "vte",
  "vte_generate_state_changes",
  "wait-timeout",
- "waker-fn",
  "walkdir",
  "want",
  "wasm-bindgen",
@@ -13433,14 +13557,17 @@ dependencies = [
  "wasm-bindgen-shared",
  "web-sys",
  "webpki",
- "webpki-roots",
+ "webpki-roots 0.22.6",
+ "webpki-roots 0.23.0",
  "which",
  "whoami",
  "widestring",
  "winapi",
  "winapi-util",
  "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
  "windows-sys 0.48.0",
+ "windows-targets 0.42.2",
  "windows-targets 0.48.0",
  "windows_x86_64_msvc 0.42.2",
  "windows_x86_64_msvc 0.48.0",
@@ -13470,7 +13597,7 @@ name = "x"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.23",
+ "clap 3.2.25",
  "nexlint",
  "nexlint-lints",
 ]
@@ -13486,18 +13613,18 @@ dependencies = [
  "data-encoding",
  "der-parser",
  "lazy_static 1.4.0",
- "nom 7.1.2",
+ "nom 7.1.3",
  "oid-registry",
  "rusticata-macros",
  "thiserror",
- "time 0.3.17",
+ "time 0.3.21",
 ]
 
 [[package]]
 name = "xml-rs"
-version = "0.8.7"
+version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "699d0104bcdd7e7af6d093d6c6e2d0c479b8a129ee0d1023b31d2e0c71bfdda2"
+checksum = "2d8f380ae16a37b30e6a2cf67040608071384b1450c189e61bea3ff57cde922d"
 
 [[package]]
 name = "xmlparser"
@@ -13522,32 +13649,31 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "yasna"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aed2e7a52e3744ab4d0c05c20aa065258e84c49fd4226f5191b2ed29712710b4"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
- "time 0.3.17",
+ "time 0.3.21",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.3.3"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
- "proc-macro2 1.0.54",
- "quote 1.0.26",
- "syn 1.0.107",
- "synstructure",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
 ]
 
 [[package]]

--- a/crates/sui-cluster-test/Cargo.toml
+++ b/crates/sui-cluster-test/Cargo.toml
@@ -12,7 +12,7 @@ futures = "0.3.24"
 serde_json = "1.0.88"
 tempfile = "3.3.0"
 tokio = { workspace = true, features = ["full"] }
-jsonrpsee = { git="https://github.com/wlmyng/jsonrpsee.git", rev= "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", features = ["http-client"] }
+jsonrpsee = { git="https://github.com/wlmyng/jsonrpsee.git", rev= "66ce27cc207d5f193e007a743c2497477bae6fec", features = ["http-client"] }
 tracing = "0.1.36"
 clap = { version = "3.1.14", features = ["derive"] }
 reqwest = { version = "0.11.13", default_features= false, features = ["blocking", "json", "rustls-tls"] }

--- a/crates/sui-cluster-test/Cargo.toml
+++ b/crates/sui-cluster-test/Cargo.toml
@@ -12,7 +12,7 @@ futures = "0.3.24"
 serde_json = "1.0.88"
 tempfile = "3.3.0"
 tokio = { workspace = true, features = ["full"] }
-jsonrpsee = { git="https://github.com/wlmyng/jsonrpsee.git", rev= "66ce27cc207d5f193e007a743c2497477bae6fec", features = ["http-client"] }
+jsonrpsee = { git="https://github.com/wlmyng/jsonrpsee.git", rev= "56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2", features = ["http-client"] }
 tracing = "0.1.36"
 clap = { version = "3.1.14", features = ["derive"] }
 reqwest = { version = "0.11.13", default_features= false, features = ["blocking", "json", "rustls-tls"] }

--- a/crates/sui-indexer/Cargo.toml
+++ b/crates/sui-indexer/Cargo.toml
@@ -22,7 +22,7 @@ tokio-postgres = "0.7.7"
 diesel-async = { version = "0.2.1", features = ["postgres", "deadpool"] }
 diesel-derive-enum = { version = "2.0.1", features = ["postgres"] }
 futures = "0.3.23"
-jsonrpsee = { git="https://github.com/wlmyng/jsonrpsee.git", rev= "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", features = ["full"] }
+jsonrpsee = { git="https://github.com/wlmyng/jsonrpsee.git", rev= "66ce27cc207d5f193e007a743c2497477bae6fec", features = ["full"] }
 prometheus = "0.13.3"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.83"

--- a/crates/sui-indexer/Cargo.toml
+++ b/crates/sui-indexer/Cargo.toml
@@ -22,7 +22,7 @@ tokio-postgres = "0.7.7"
 diesel-async = { version = "0.2.1", features = ["postgres", "deadpool"] }
 diesel-derive-enum = { version = "2.0.1", features = ["postgres"] }
 futures = "0.3.23"
-jsonrpsee = { git="https://github.com/wlmyng/jsonrpsee.git", rev= "66ce27cc207d5f193e007a743c2497477bae6fec", features = ["full"] }
+jsonrpsee = { git="https://github.com/wlmyng/jsonrpsee.git", rev= "56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2", features = ["full"] }
 prometheus = "0.13.3"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.83"

--- a/crates/sui-json-rpc-types/src/sui_coin.rs
+++ b/crates/sui-json-rpc-types/src/sui_coin.rs
@@ -35,7 +35,7 @@ pub struct Balance {
 }
 
 #[serde_as]
-#[derive(Serialize, Deserialize, Debug, JsonSchema, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Coin {
     pub coin_type: String,

--- a/crates/sui-json-rpc-types/src/sui_extended.rs
+++ b/crates/sui-json-rpc-types/src/sui_extended.rs
@@ -18,7 +18,7 @@ use crate::Page;
 pub type EpochPage = Page<EpochInfo, BigInt<u64>>;
 
 #[serde_as]
-#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct EpochInfo {
     /// epoch number
@@ -43,7 +43,7 @@ pub struct EpochInfo {
 }
 
 #[serde_as]
-#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct EndOfEpochInfo {
     #[schemars(with = "BigInt<u64>")]
@@ -119,7 +119,7 @@ pub struct NetworkMetrics {
 }
 
 #[serde_as]
-#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MoveCallMetrics {
     #[schemars(with = "Vec<(MoveFunctionName, BigInt<usize>)>")]
@@ -134,7 +134,7 @@ pub struct MoveCallMetrics {
 }
 
 #[serde_as]
-#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MoveFunctionName {
     pub package: ObjectID,
@@ -147,7 +147,7 @@ pub struct MoveFunctionName {
 }
 
 #[serde_as]
-#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AddressMetrics {
     pub checkpoint: u64,

--- a/crates/sui-json-rpc-types/src/sui_move.rs
+++ b/crates/sui-json-rpc-types/src/sui_move.rs
@@ -30,7 +30,7 @@ pub type SuiMoveTypeParameterIndex = u16;
 #[path = "unit_tests/sui_move_tests.rs"]
 mod sui_move_tests;
 
-#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 pub enum SuiMoveAbility {
     Copy,
     Drop,
@@ -38,33 +38,33 @@ pub enum SuiMoveAbility {
     Key,
 }
 
-#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 pub struct SuiMoveAbilitySet {
     pub abilities: Vec<SuiMoveAbility>,
 }
 
-#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 pub enum SuiMoveVisibility {
     Private,
     Public,
     Friend,
 }
 
-#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SuiMoveStructTypeParameter {
     pub constraints: SuiMoveAbilitySet,
     pub is_phantom: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 pub struct SuiMoveNormalizedField {
     pub name: String,
     #[serde(rename = "type")]
     pub type_: SuiMoveNormalizedType,
 }
 
-#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SuiMoveNormalizedStruct {
     pub abilities: SuiMoveAbilitySet,
@@ -72,7 +72,7 @@ pub struct SuiMoveNormalizedStruct {
     pub fields: Vec<SuiMoveNormalizedField>,
 }
 
-#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 pub enum SuiMoveNormalizedType {
     Bool,
     U8,
@@ -96,7 +96,7 @@ pub enum SuiMoveNormalizedType {
     MutableReference(Box<SuiMoveNormalizedType>),
 }
 
-#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SuiMoveNormalizedFunction {
     pub visibility: SuiMoveVisibility,
@@ -106,13 +106,13 @@ pub struct SuiMoveNormalizedFunction {
     pub return_: Vec<SuiMoveNormalizedType>,
 }
 
-#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 pub struct SuiMoveModuleId {
     address: String,
     name: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SuiMoveNormalizedModule {
     pub file_format_version: u32,
@@ -283,14 +283,14 @@ impl From<AbilitySet> for SuiMoveAbilitySet {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 pub enum ObjectValueKind {
     ByImmutableReference,
     ByMutableReference,
     ByValue,
 }
 
-#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 pub enum MoveFunctionArgType {
     Pure,
     Object(ObjectValueKind),

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -1445,7 +1445,7 @@ pub struct MoveCallParams {
 }
 
 #[serde_as]
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Serialize, Deserialize, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TransactionBlockBytes {
     /// BCS serialized transaction data bytes without its type tag, as base-64 encoded string.

--- a/crates/sui-json-rpc/Cargo.toml
+++ b/crates/sui-json-rpc/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 
 [dependencies]
 fastcrypto.workspace = true
-jsonrpsee = { git="https://github.com/wlmyng/jsonrpsee.git", rev= "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", features = ["full"] }
-jsonrpsee-proc-macros = {git="https://github.com/wlmyng/jsonrpsee.git", rev= "b1b300784795f6a64d0fcdf8f03081a9bc38bde8"}
+jsonrpsee = { git="https://github.com/wlmyng/jsonrpsee.git", rev= "66ce27cc207d5f193e007a743c2497477bae6fec", features = ["full"] }
+jsonrpsee-proc-macros = {git="https://github.com/wlmyng/jsonrpsee.git", rev= "66ce27cc207d5f193e007a743c2497477bae6fec"}
 hyper = "0.14"
 itertools = "0.10.4"
 linked-hash-map = "0.5.6"

--- a/crates/sui-json-rpc/Cargo.toml
+++ b/crates/sui-json-rpc/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 
 [dependencies]
 fastcrypto.workspace = true
-jsonrpsee = { git="https://github.com/wlmyng/jsonrpsee.git", rev= "66ce27cc207d5f193e007a743c2497477bae6fec", features = ["full"] }
-jsonrpsee-proc-macros = {git="https://github.com/wlmyng/jsonrpsee.git", rev= "66ce27cc207d5f193e007a743c2497477bae6fec"}
+jsonrpsee = { git="https://github.com/wlmyng/jsonrpsee.git", rev= "56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2", features = ["full"] }
+jsonrpsee-proc-macros = {git="https://github.com/wlmyng/jsonrpsee.git", rev= "56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2"}
 hyper = "0.14"
 itertools = "0.10.4"
 linked-hash-map = "0.5.6"

--- a/crates/sui-json-rpc/src/api/indexer.rs
+++ b/crates/sui-json-rpc/src/api/indexer.rs
@@ -66,16 +66,16 @@ pub trait IndexerApi {
     ) -> RpcResult<EventPage>;
 
     /// Subscribe to a stream of Sui event
-    #[subscription(name = "subscribeEvent", item = SuiEvent)]
-    fn subscribe_event(
-        &self,
-        /// the filter criteria of the event stream, see the [Sui docs](https://docs.sui.io/build/pubsub#event-filters) for detailed examples.
-        filter: EventFilter,
-    );
+    // #[subscription(name = "subscribeEvent", item = SuiEvent)]
+    // fn subscribe_event(
+    //     &self,
+    //     /// the filter criteria of the event stream, see the [Sui docs](https://docs.sui.io/build/pubsub#event-filters) for detailed examples.
+    //     filter: EventFilter,
+    // );
 
-    /// Subscribe to a stream of Sui transaction effects
-    #[subscription(name = "subscribeTransaction", item = SuiTransactionBlockEffects)]
-    fn subscribe_transaction(&self, filter: TransactionFilter);
+    // /// Subscribe to a stream of Sui transaction effects
+    // #[subscription(name = "subscribeTransaction", item = SuiTransactionBlockEffects)]
+    // fn subscribe_transaction(&self, filter: TransactionFilter);
 
     /// Return the list of dynamic field objects owned by an object.
     #[method(name = "getDynamicFields")]

--- a/crates/sui-json-rpc/src/error.rs
+++ b/crates/sui-json-rpc/src/error.rs
@@ -61,8 +61,14 @@ impl From<Error> for ErrorObjectOwned {
 impl Error {
     pub fn to_rpc_error(self) -> ErrorObjectOwned {
         match self {
-            Error::UserInputError(_) | Error::SuiRpcInputError(_) => {
+            Error::UserInputError(_) => {
                 ErrorObject::owned(ErrorCode::InvalidParams.code(), self.to_string(), None::<()>)
+            },
+            Error::SuiRpcInputError(err) => match err {
+                SuiRpcInputError::ContainsDuplicates => {
+                    ErrorObject::owned(-54321, err.to_string(), None::<()>)
+                }
+                _ => ErrorObject::owned(ErrorCode::InvalidParams.code(), err.to_string(), None::<()>)
             },
             Error::SuiError(err) => match err {
                 SuiError::TransactionNotFound { .. } | SuiError::TransactionsNotFound { .. } | SuiError::UserInputError { .. } => {

--- a/crates/sui-json-rpc/src/error.rs
+++ b/crates/sui-json-rpc/src/error.rs
@@ -61,17 +61,14 @@ impl From<Error> for ErrorObjectOwned {
 impl Error {
     pub fn to_rpc_error(self) -> ErrorObjectOwned {
         match self {
-            Error::UserInputError(err) => {
-                ErrorObject::owned(ErrorCode::InvalidParams.code(), err.into(), None)
-            }
-            Error::SuiRpcInputError(err) => {
-                ErrorObject::owned(ErrorCode::InvalidParams.code(), err.into(), None)
-            }
+            Error::UserInputError(_) | Error::SuiRpcInputError(_) => {
+                ErrorObject::owned(ErrorCode::InvalidParams.code(), self.to_string(), None::<()>)
+            },
             Error::SuiError(err) => match err {
-                SuiError::TransactionNotFound { .. } | SuiError::TransactionsNotFound { .. } => {
-                    ErrorObject::owned(ErrorCode::InvalidParams.code(), err.into(), None)
+                SuiError::TransactionNotFound { .. } | SuiError::TransactionsNotFound { .. } | SuiError::UserInputError { .. } => {
+                    ErrorObject::owned(ErrorCode::InvalidParams.code(), err.to_string(), None::<()>)
                 }
-                _ => ErrorObject::owned(CALL_EXECUTION_FAILED_CODE, err.into(), None)
+                _ => ErrorObject::owned(CALL_EXECUTION_FAILED_CODE, err.to_string(), None::<()>)
             },
             Error::QuorumDriverError(err) => match err {
                 QuorumDriverError::NonRecoverableTransactionError { errors } => {
@@ -81,9 +78,9 @@ impl Error {
                         Some(errors),
                     )
                 }
-                _ => ErrorObject::owned(CALL_EXECUTION_FAILED_CODE, err.into(), None)
+                _ => ErrorObject::owned(CALL_EXECUTION_FAILED_CODE, err.to_string(), None::<()>)
             },
-            _ => ErrorObject::owned(CALL_EXECUTION_FAILED_CODE, self.into(), None)
+            _ => ErrorObject::owned(CALL_EXECUTION_FAILED_CODE, self.to_string(), None::<()>)
         }
     }
 }

--- a/crates/sui-json-rpc/src/lib.rs
+++ b/crates/sui-json-rpc/src/lib.rs
@@ -121,9 +121,8 @@ impl JsonRpcServerBuilder {
             ]);
 
         let routing = self.rpc_doc.method_routing.clone();
-
-        self.module
-            .register_method("rpc.discover", move |_, _| Ok(self.rpc_doc.clone()))?;
+        // self.module // TODO: fix
+            // .register_method("rpc.discover", move |_, _| self.rpc_doc.clone())?;
         let methods_names = self.module.method_names().collect::<Vec<_>>();
 
         let max_connection = env::var("RPC_MAX_CONNECTION")
@@ -157,7 +156,7 @@ impl JsonRpcServerBuilder {
             .layer(routing_layer);
 
         let mut builder = ServerBuilder::default()
-            .batch_requests_supported(false)
+            .set_batch_request_config(jsonrpsee::server::BatchRequestConfig::Disabled)
             .max_response_body_size(MAX_REQUEST_SIZE)
             .max_connections(max_connection)
             .set_host_filtering(AllowHosts::Any)

--- a/crates/sui-json-rpc/src/logger.rs
+++ b/crates/sui-json-rpc/src/logger.rs
@@ -5,26 +5,14 @@
 macro_rules! with_tracing {
     ($future:expr) => {{
         use tracing::{info, error, Instrument, Span};
-        use jsonrpsee::core::{RpcResult, Error as RpcError};
-        use jsonrpsee::types::error::{CallError, INVALID_PARAMS_CODE, CALL_EXECUTION_FAILED_CODE};
+        use jsonrpsee::core::RpcResult;
 
         async move {
             let result: RpcResult<_> = $future.await;
 
             match &result {
                 Ok(_) => info!("success"),
-                Err(e) => {
-                    match e {
-                        RpcError::Call(call_error) => {
-                            let error_code = match call_error {
-                                CallError::InvalidParams(_) => INVALID_PARAMS_CODE,
-                                _ => CALL_EXECUTION_FAILED_CODE
-                            };
-                            error!(error = ?e, error_code = error_code);
-                        }
-                        _ => error!(error = ?e),
-                    }
-                }
+                Err(e) => error!(error = ?e, error_code = e.code())
             }
             result
         }

--- a/crates/sui-json-rpc/src/metrics.rs
+++ b/crates/sui-json-rpc/src/metrics.rs
@@ -221,6 +221,10 @@ impl Logger for MetricsLogger {
             .observe(req_latency_secs);
 
         if let Some(code) = error_code {
+            println!(
+                "RPC call failed: method={}, code={}, latency={:.3}s",
+                method_name, code, req_latency_secs
+            );
             if code == -32000 {
                 self.metrics
                     .server_errors_by_route
@@ -236,6 +240,11 @@ impl Logger for MetricsLogger {
                 .errors_by_route
                 .with_label_values(&[method_name])
                 .inc();
+        }
+        else {
+            println!("did not find code for: method={},latency={:.3}s",
+            method_name, req_latency_secs
+        );
         }
     }
 

--- a/crates/sui-json-rpc/src/metrics.rs
+++ b/crates/sui-json-rpc/src/metrics.rs
@@ -204,7 +204,7 @@ impl Logger for MetricsLogger {
     fn on_result(
         &self,
         method_name: &str,
-        _success: bool,
+        success: bool,
         error_code: Option<i32>,
         started_at: Self::Instant,
         _transport: TransportProtocol,
@@ -242,13 +242,14 @@ impl Logger for MetricsLogger {
                 .inc();
         }
         else {
-            println!("did not find code for: method={},latency={:.3}s",
-            method_name, req_latency_secs
+            println!("did not find code for: method={},latency={:.3}s, success={}",
+            method_name, req_latency_secs, success
         );
         }
     }
 
     fn on_response(&self, result: &str, _started_at: Self::Instant, t: TransportProtocol) {
+        println!("result: {}", result);
         self.metrics
             .rpc_response_size
             .with_label_values(&[&t.to_string()])

--- a/crates/sui-json-rpc/src/transaction_builder_api.rs
+++ b/crates/sui-json-rpc/src/transaction_builder_api.rs
@@ -24,6 +24,7 @@ use sui_types::sui_serde::BigInt;
 
 use crate::api::TransactionBuilderServer;
 use crate::SuiRpcModule;
+use crate::error::Error;
 
 pub struct TransactionBuilderApi(TransactionBuilder);
 
@@ -88,8 +89,8 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         let data = self
             .0
             .transfer_object(signer, object_id, gas, *gas_budget, recipient)
-            .await?;
-        Ok(TransactionBlockBytes::from_data(data)?)
+            .await.map_err(Error::from)?;
+        Ok(TransactionBlockBytes::from_data(data).map_err(Error::from)?)
     }
 
     async fn transfer_sui(
@@ -109,8 +110,8 @@ impl TransactionBuilderServer for TransactionBuilderApi {
                 recipient,
                 amount.map(|a| *a),
             )
-            .await?;
-        Ok(TransactionBlockBytes::from_data(data)?)
+            .await.map_err(Error::from)?;
+        Ok(TransactionBlockBytes::from_data(data).map_err(Error::from)?)
     }
 
     async fn pay(
@@ -132,8 +133,8 @@ impl TransactionBuilderServer for TransactionBuilderApi {
                 gas,
                 *gas_budget,
             )
-            .await?;
-        Ok(TransactionBlockBytes::from_data(data)?)
+            .await.map_err(Error::from)?;
+        Ok(TransactionBlockBytes::from_data(data).map_err(Error::from)?)
     }
 
     async fn pay_sui(
@@ -153,8 +154,8 @@ impl TransactionBuilderServer for TransactionBuilderApi {
                 amounts.into_iter().map(|a| *a).collect(),
                 *gas_budget,
             )
-            .await?;
-        Ok(TransactionBlockBytes::from_data(data)?)
+            .await.map_err(Error::from)?;
+        Ok(TransactionBlockBytes::from_data(data).map_err(Error::from)?)
     }
 
     async fn pay_all_sui(
@@ -167,8 +168,8 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         let data = self
             .0
             .pay_all_sui(signer, input_coins, recipient, *gas_budget)
-            .await?;
-        Ok(TransactionBlockBytes::from_data(data)?)
+            .await.map_err(Error::from)?;
+        Ok(TransactionBlockBytes::from_data(data).map_err(Error::from)?)
     }
 
     async fn publish(
@@ -182,12 +183,12 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         let compiled_modules = compiled_modules
             .into_iter()
             .map(|data| data.to_vec().map_err(|e| anyhow::anyhow!(e)))
-            .collect::<Result<Vec<_>, _>>()?;
+            .collect::<Result<Vec<_>, _>>().map_err(Error::from)?;
         let data = self
             .0
             .publish(sender, compiled_modules, dependencies, gas, *gas_budget)
-            .await?;
-        Ok(TransactionBlockBytes::from_data(data)?)
+            .await.map_err(Error::from)?;
+        Ok(TransactionBlockBytes::from_data(data).map_err(Error::from)?)
     }
 
     async fn split_coin(
@@ -202,8 +203,8 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         let data = self
             .0
             .split_coin(signer, coin_object_id, split_amounts, gas, *gas_budget)
-            .await?;
-        Ok(TransactionBlockBytes::from_data(data)?)
+            .await.map_err(Error::from)?;
+        Ok(TransactionBlockBytes::from_data(data).map_err(Error::from)?)
     }
 
     async fn split_coin_equal(
@@ -217,8 +218,8 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         let data = self
             .0
             .split_coin_equal(signer, coin_object_id, *split_count, gas, *gas_budget)
-            .await?;
-        Ok(TransactionBlockBytes::from_data(data)?)
+            .await.map_err(Error::from)?;
+        Ok(TransactionBlockBytes::from_data(data).map_err(Error::from)?)
     }
 
     async fn merge_coin(
@@ -232,8 +233,8 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         let data = self
             .0
             .merge_coins(signer, primary_coin, coin_to_merge, gas, *gas_budget)
-            .await?;
-        Ok(TransactionBlockBytes::from_data(data)?)
+            .await.map_err(Error::from)?;
+        Ok(TransactionBlockBytes::from_data(data).map_err(Error::from)?)
     }
 
     async fn move_call(
@@ -260,8 +261,8 @@ impl TransactionBuilderServer for TransactionBuilderApi {
                     gas,
                     *gas_budget,
                 )
-                .await?,
-        )?)
+                .await.map_err(Error::from)?,
+        ).map_err(Error::from)?)
     }
 
     async fn batch_transaction(
@@ -275,8 +276,8 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         Ok(TransactionBlockBytes::from_data(
             self.0
                 .batch_transaction(signer, params, gas, *gas_budget)
-                .await?,
-        )?)
+                .await.map_err(Error::from)?,
+        ).map_err(Error::from)?)
     }
 
     async fn request_add_stake(
@@ -292,8 +293,8 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         Ok(TransactionBlockBytes::from_data(
             self.0
                 .request_add_stake(signer, coins, amount, validator, gas, *gas_budget)
-                .await?,
-        )?)
+                .await.map_err(Error::from)?,
+        ).map_err(Error::from)?)
     }
 
     async fn request_withdraw_stake(
@@ -306,8 +307,8 @@ impl TransactionBuilderServer for TransactionBuilderApi {
         Ok(TransactionBlockBytes::from_data(
             self.0
                 .request_withdraw_stake(signer, staked_sui, gas, *gas_budget)
-                .await?,
-        )?)
+                .await.map_err(Error::from)?,
+        ).map_err(Error::from)?)
     }
 }
 

--- a/crates/sui-move/Cargo.toml
+++ b/crates/sui-move/Cargo.toml
@@ -46,7 +46,7 @@ jemalloc-ctl = "^0.5"
 [dev-dependencies]
 assert_cmd = "2.0.6"
 futures = "0.3.23"
-jsonrpsee = { git="https://github.com/wlmyng/jsonrpsee.git", rev= "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", features = ["jsonrpsee-core"] }
+jsonrpsee = { git="https://github.com/wlmyng/jsonrpsee.git", rev= "66ce27cc207d5f193e007a743c2497477bae6fec", features = ["jsonrpsee-core"] }
 rand = "0.8.5"
 tempfile = "3.3.0"
 

--- a/crates/sui-move/Cargo.toml
+++ b/crates/sui-move/Cargo.toml
@@ -46,7 +46,7 @@ jemalloc-ctl = "^0.5"
 [dev-dependencies]
 assert_cmd = "2.0.6"
 futures = "0.3.23"
-jsonrpsee = { git="https://github.com/wlmyng/jsonrpsee.git", rev= "66ce27cc207d5f193e007a743c2497477bae6fec", features = ["jsonrpsee-core"] }
+jsonrpsee = { git="https://github.com/wlmyng/jsonrpsee.git", rev= "56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2", features = ["jsonrpsee-core"] }
 rand = "0.8.5"
 tempfile = "3.3.0"
 

--- a/crates/sui-replay/Cargo.toml
+++ b/crates/sui-replay/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = { version = "1.0.64", features = ["backtrace"] }
 bcs = "0.1.4"
 prometheus = "0.13.3"
 async-trait = "0.1.61"
-jsonrpsee = { git="https://github.com/wlmyng/jsonrpsee.git", rev= "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", features = ["http-client"] }
+jsonrpsee = { git="https://github.com/wlmyng/jsonrpsee.git", rev= "66ce27cc207d5f193e007a743c2497477bae6fec", features = ["http-client"] }
 async-recursion = "1.0.4"
 clap = { version = "4.1.4", features = ["derive"] }
 colored = "2.0.0"

--- a/crates/sui-replay/Cargo.toml
+++ b/crates/sui-replay/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = { version = "1.0.64", features = ["backtrace"] }
 bcs = "0.1.4"
 prometheus = "0.13.3"
 async-trait = "0.1.61"
-jsonrpsee = { git="https://github.com/wlmyng/jsonrpsee.git", rev= "66ce27cc207d5f193e007a743c2497477bae6fec", features = ["http-client"] }
+jsonrpsee = { git="https://github.com/wlmyng/jsonrpsee.git", rev= "56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2", features = ["http-client"] }
 async-recursion = "1.0.4"
 clap = { version = "4.1.4", features = ["derive"] }
 colored = "2.0.0"

--- a/crates/sui-sdk/Cargo.toml
+++ b/crates/sui-sdk/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1.0.64"
 async-trait = "0.1.61"
 clap = { version = "3.2.17", features = ["derive"] }
 colored = "2.0.0"
-jsonrpsee = { git="https://github.com/wlmyng/jsonrpsee.git", rev= "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", features = ["http-client"] }
+jsonrpsee = { git="https://github.com/wlmyng/jsonrpsee.git", rev= "66ce27cc207d5f193e007a743c2497477bae6fec", features = ["http-client"] }
 serde = { version = "1.0.144", features = ["derive"] }
 serde_with = { version = "2.1.0", features = ["hex"] }
 serde_json = "1.0.88"

--- a/crates/sui-sdk/Cargo.toml
+++ b/crates/sui-sdk/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1.0.64"
 async-trait = "0.1.61"
 clap = { version = "3.2.17", features = ["derive"] }
 colored = "2.0.0"
-jsonrpsee = { git="https://github.com/wlmyng/jsonrpsee.git", rev= "66ce27cc207d5f193e007a743c2497477bae6fec", features = ["http-client"] }
+jsonrpsee = { git="https://github.com/wlmyng/jsonrpsee.git", rev= "56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2", features = ["http-client"] }
 serde = { version = "1.0.144", features = ["derive"] }
 serde_with = { version = "2.1.0", features = ["hex"] }
 serde_json = "1.0.88"

--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -85,7 +85,7 @@ impl SuiClientBuilder {
         let ws = if let Some(url) = self.ws_url {
             Some(
                 WsClientBuilder::default()
-                    .max_request_body_size(2 << 30)
+                    .max_request_size(2 << 30)
                     .max_concurrent_requests(self.max_concurrent_requests)
                     .set_headers(headers.clone())
                     .request_timeout(self.request_timeout)
@@ -97,7 +97,7 @@ impl SuiClientBuilder {
         };
 
         let http = HttpClientBuilder::default()
-            .max_request_body_size(2 << 30)
+            .max_request_size(2 << 30)
             .max_concurrent_requests(self.max_concurrent_requests)
             .set_headers(headers.clone())
             .request_timeout(self.request_timeout)

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -81,7 +81,7 @@ prometheus = "0.13.3"
 fs_extra = "1.3.0"
 indexmap = "1.9.2"
 insta = { version = "1.21.1", features = ["json"] }
-jsonrpsee = { git="https://github.com/wlmyng/jsonrpsee.git", rev= "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", features = ["jsonrpsee-core"] }
+jsonrpsee = { git="https://github.com/wlmyng/jsonrpsee.git", rev= "66ce27cc207d5f193e007a743c2497477bae6fec", features = ["jsonrpsee-core"] }
 test-utils = { path = "../test-utils" }
 rand = "0.8.5"
 expect-test = "1.4.0"

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -81,7 +81,7 @@ prometheus = "0.13.3"
 fs_extra = "1.3.0"
 indexmap = "1.9.2"
 insta = { version = "1.21.1", features = ["json"] }
-jsonrpsee = { git="https://github.com/wlmyng/jsonrpsee.git", rev= "66ce27cc207d5f193e007a743c2497477bae6fec", features = ["jsonrpsee-core"] }
+jsonrpsee = { git="https://github.com/wlmyng/jsonrpsee.git", rev= "56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2", features = ["jsonrpsee-core"] }
 test-utils = { path = "../test-utils" }
 rand = "0.8.5"
 expect-test = "1.4.0"

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -12,7 +12,7 @@ futures = "0.3.23"
 tempfile = "3.3.0"
 tracing = "0.1.36"
 bcs = "0.1.4"
-jsonrpsee = { git="https://github.com/wlmyng/jsonrpsee.git", rev= "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", features = ["http-client"] }
+jsonrpsee = { git="https://github.com/wlmyng/jsonrpsee.git", rev= "66ce27cc207d5f193e007a743c2497477bae6fec", features = ["http-client"] }
 prometheus = "0.13.3"
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 serde_json = "1.0.88"

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -12,7 +12,7 @@ futures = "0.3.23"
 tempfile = "3.3.0"
 tracing = "0.1.36"
 bcs = "0.1.4"
-jsonrpsee = { git="https://github.com/wlmyng/jsonrpsee.git", rev= "66ce27cc207d5f193e007a743c2497477bae6fec", features = ["http-client"] }
+jsonrpsee = { git="https://github.com/wlmyng/jsonrpsee.git", rev= "56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2", features = ["http-client"] }
 prometheus = "0.13.3"
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 serde_json = "1.0.88"

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -22,7 +22,8 @@ aes = { version = "0.8", default-features = false }
 aes-gcm = { version = "0.10" }
 ahash-c38e5c1d305a1b54 = { package = "ahash", version = "0.8", default-features = false }
 ahash-ca01ad9e24f5d932 = { package = "ahash", version = "0.7" }
-aho-corasick = { version = "0.7" }
+aho-corasick-ca01ad9e24f5d932 = { package = "aho-corasick", version = "0.7" }
+aho-corasick-dff4ba8e3ae991db = { package = "aho-corasick", version = "1" }
 aliasable = { version = "0.1" }
 alloc-no-stdlib = { version = "2", default-features = false }
 alloc-stdlib = { version = "0.2", default-features = false }
@@ -31,6 +32,10 @@ anemo-cli = { git = "https://github.com/mystenlabs/anemo.git", rev = "baa7cfc3ae
 anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "baa7cfc3ae841f88c2ff773396c5a803c377d054", default-features = false }
 anes = { version = "0.1" }
 ansi_term = { version = "0.12", default-features = false }
+anstream = { version = "0.3" }
+anstyle = { version = "1" }
+anstyle-parse = { version = "0.2" }
+anstyle-query = { version = "1", default-features = false }
 anyhow = { version = "1", features = ["backtrace"] }
 arbitrary = { version = "1", default-features = false, features = ["derive_arbitrary"] }
 arc-swap = { version = "1", default-features = false, features = ["serde"] }
@@ -48,7 +53,7 @@ ark-serialize = { version = "0.4", features = ["derive", "std"] }
 ark-snark = { version = "0.4", default-features = false }
 ark-std = { version = "0.4", default-features = false, features = ["parallel"] }
 arrayref = { version = "0.3", default-features = false }
-arrayvec-ca01ad9e24f5d932 = { package = "arrayvec", version = "0.7" }
+arrayvec-ca01ad9e24f5d932 = { package = "arrayvec", version = "0.7", default-features = false }
 arrayvec-d8f496e17d97b5cb = { package = "arrayvec", version = "0.5", features = ["array-sizes-33-128"] }
 asn1-rs = { version = "0.5", features = ["datetime"] }
 assert_cmd = { version = "2", default-features = false }
@@ -63,8 +68,8 @@ aws-config = { version = "0.55" }
 aws-credential-types = { version = "0.55", default-features = false }
 aws-endpoint = { version = "0.55", default-features = false }
 aws-http = { version = "0.55", default-features = false }
-aws-sdk-sso = { version = "0.26", default-features = false }
-aws-sdk-sts = { version = "0.26", default-features = false }
+aws-sdk-sso = { version = "0.27", default-features = false }
+aws-sdk-sts = { version = "0.27", default-features = false }
 aws-sig-auth = { version = "0.55", default-features = false }
 aws-sigv4 = { version = "0.55" }
 aws-smithy-async = { version = "0.55", default-features = false, features = ["rt-tokio"] }
@@ -129,7 +134,7 @@ cargo_metadata = { version = "0.15" }
 cassowary = { version = "0.3", default-features = false }
 cast = { version = "0.3", default-features = false }
 cbc = { version = "0.1", features = ["std"] }
-cfg-expr = { version = "0.13", features = ["targets"] }
+cfg-expr = { version = "0.15", features = ["targets"] }
 cfg-if = { version = "1", default-features = false }
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = { version = "0.6" }
@@ -140,19 +145,21 @@ cipher = { version = "0.4", default-features = false, features = ["block-padding
 clap-164d15cefe24d7eb = { package = "clap", version = "4", features = ["derive"] }
 clap-7b89eefb6aaa9bf3 = { package = "clap", version = "3", features = ["derive"] }
 clap-f595c2ba2a3f28df = { package = "clap", version = "2" }
-clap_lex-468e82937335b1c9 = { package = "clap_lex", version = "0.3", default-features = false }
+clap_builder = { version = "4", default-features = false, features = ["color", "help", "std", "suggestions", "usage"] }
 clap_lex-6f8ce4dd05d13bba = { package = "clap_lex", version = "0.2", default-features = false }
+clap_lex-d8f496e17d97b5cb = { package = "clap_lex", version = "0.5", default-features = false }
 clear_on_drop = { version = "0.2", default-features = false }
 codespan = { version = "0.11", default-features = false, features = ["serialization"] }
 codespan-reporting = { version = "0.11", default-features = false, features = ["serialization"] }
 collectable = { version = "0.0.2", default-features = false }
+colorchoice = { version = "1", default-features = false }
 colored = { version = "2", default-features = false }
 colored-diff = { version = "0.2", default-features = false }
 combine = { version = "4" }
 comfy-table = { version = "6" }
 config = { version = "0.11" }
 console = { version = "0.15", default-features = false, features = ["ansi-parsing", "unicode-width"] }
-console-api = { version = "0.4", default-features = false, features = ["transport"] }
+console-api = { version = "0.5", default-features = false, features = ["transport"] }
 console-subscriber = { version = "0.1" }
 const-oid = { version = "0.9", default-features = false }
 const-str = { version = "0.5" }
@@ -202,9 +209,11 @@ diffy = { version = "0.3", default-features = false }
 digest-274715c4dabd11b0 = { package = "digest", version = "0.9", default-features = false, features = ["std"] }
 digest-93f6ce9d446188ac = { package = "digest", version = "0.10", features = ["mac", "oid", "std"] }
 directories = { version = "4", default-features = false }
-dirs = { version = "4", default-features = false }
+dirs-164d15cefe24d7eb = { package = "dirs", version = "4", default-features = false }
+dirs-cdf1610d3e1514e9 = { package = "dirs", version = "5", default-features = false }
 dirs-next = { version = "2", default-features = false }
-dirs-sys = { version = "0.3", default-features = false }
+dirs-sys-468e82937335b1c9 = { package = "dirs-sys", version = "0.3", default-features = false }
+dirs-sys-9fbad63c4bcf4a8f = { package = "dirs-sys", version = "0.4", default-features = false }
 dirs-sys-next = { version = "0.1", default-features = false }
 dissimilar = { version = "1", default-features = false }
 doc-comment = { version = "0.3", default-features = false }
@@ -250,7 +259,6 @@ futures-channel = { version = "0.3", features = ["sink", "unstable"] }
 futures-core = { version = "0.3", features = ["unstable"] }
 futures-executor = { version = "0.3", default-features = false, features = ["std"] }
 futures-io = { version = "0.3", features = ["unstable"] }
-futures-lite = { version = "1" }
 futures-sink = { version = "0.3" }
 futures-task = { version = "0.3", default-features = false, features = ["std", "unstable"] }
 futures-timer = { version = "3", default-features = false, features = ["wasm-bindgen"] }
@@ -295,7 +303,8 @@ httpdate = { version = "1", default-features = false }
 humansize = { version = "1", default-features = false }
 humantime = { version = "2", default-features = false }
 hyper = { version = "0.14", features = ["full"] }
-hyper-rustls = { version = "0.23", features = ["http2", "webpki-tokio"] }
+hyper-rustls-2b5c6dc72f624058 = { package = "hyper-rustls", version = "0.23", features = ["http2"] }
+hyper-rustls-adf3d7031871b0af = { package = "hyper-rustls", version = "0.24", default-features = false, features = ["http1", "logging", "native-tokio", "tls12"] }
 hyper-timeout = { version = "0.4", default-features = false }
 idna = { version = "0.3", default-features = false }
 ignore = { version = "0.4", default-features = false }
@@ -318,14 +327,14 @@ is-terminal = { version = "0.4", default-features = false }
 itertools = { version = "0.10" }
 itoa = { version = "1", default-features = false }
 js-sys = { version = "0.3", default-features = false }
-jsonrpsee = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", default-features = false, features = ["full"] }
-jsonrpsee-client-transport = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", default-features = false, features = ["tls", "web", "ws"] }
-jsonrpsee-core = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", features = ["async-client", "async-wasm-client", "http-helpers", "server", "soketto"] }
-jsonrpsee-http-client = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8" }
-jsonrpsee-server = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", default-features = false }
-jsonrpsee-types = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", default-features = false }
-jsonrpsee-wasm-client = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", default-features = false }
-jsonrpsee-ws-client = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8" }
+jsonrpsee = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "66ce27cc207d5f193e007a743c2497477bae6fec", default-features = false, features = ["full"] }
+jsonrpsee-client-transport = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "66ce27cc207d5f193e007a743c2497477bae6fec", default-features = false, features = ["native-tls", "web", "webpki-tls", "ws"] }
+jsonrpsee-core = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "66ce27cc207d5f193e007a743c2497477bae6fec", features = ["async-client", "async-wasm-client", "http-helpers", "server", "soketto"] }
+jsonrpsee-http-client = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "66ce27cc207d5f193e007a743c2497477bae6fec" }
+jsonrpsee-server = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "66ce27cc207d5f193e007a743c2497477bae6fec", default-features = false }
+jsonrpsee-types = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "66ce27cc207d5f193e007a743c2497477bae6fec", default-features = false }
+jsonrpsee-wasm-client = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "66ce27cc207d5f193e007a743c2497477bae6fec", default-features = false }
+jsonrpsee-ws-client = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "66ce27cc207d5f193e007a743c2497477bae6fec" }
 k256 = { version = "0.11", default-features = false, features = ["ecdsa", "keccak256"] }
 keccak = { version = "0.1", default-features = false }
 lazy_static-6f8ce4dd05d13bba = { package = "lazy_static", version = "0.2", default-features = false }
@@ -349,13 +358,14 @@ matchit-d8f496e17d97b5cb = { package = "matchit", version = "0.5" }
 md-5-274715c4dabd11b0 = { package = "md-5", version = "0.9" }
 md-5-93f6ce9d446188ac = { package = "md-5", version = "0.10" }
 memchr = { version = "2", features = ["use_std"] }
-memoffset-ca01ad9e24f5d932 = { package = "memoffset", version = "0.7" }
+memoffset-c38e5c1d305a1b54 = { package = "memoffset", version = "0.8" }
 merlin = { version = "3" }
 migrations_internals = { version = "2", default-features = false }
 mime = { version = "0.3", default-features = false }
 mime_guess = { version = "2", default-features = false }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
-miniz_oxide = { version = "0.6", default-features = false, features = ["with-alloc"] }
+miniz_oxide-3b31131e45eafb45 = { package = "miniz_oxide", version = "0.6", default-features = false }
+miniz_oxide-ca01ad9e24f5d932 = { package = "miniz_oxide", version = "0.7", default-features = false, features = ["with-alloc"] }
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext"] }
 mockall = { version = "0.11", default-features = false }
 more-asserts = { version = "0.3", default-features = false }
@@ -407,6 +417,7 @@ nibble_vec = { version = "0.1", default-features = false }
 no-std-compat = { version = "0.4", default-features = false, features = ["alloc", "std"] }
 nom-15128469a54ed75a = { package = "nom", version = "7" }
 nom-cdf1610d3e1514e9 = { package = "nom", version = "5" }
+nom8 = { version = "0.2" }
 nonzero_ext = { version = "0.3" }
 normalize-line-endings = { version = "0.3", default-features = false }
 ntest = { version = "0.9", default-features = false }
@@ -428,6 +439,7 @@ oid-registry = { version = "0.6", features = ["crypto", "x509"] }
 once_cell = { version = "1" }
 oorandom = { version = "11", default-features = false }
 opaque-debug = { version = "0.3", default-features = false }
+option-ext = { version = "0.2", default-features = false }
 ordered-float = { version = "2" }
 os_str_bytes = { version = "6", default-features = false, features = ["raw_os_str"] }
 ouroboros-274715c4dabd11b0 = { package = "ouroboros", version = "0.9", default-features = false }
@@ -437,7 +449,6 @@ overload = { version = "0.1", default-features = false }
 owo-colors = { version = "3", default-features = false }
 p256 = { version = "0.13" }
 parity-scale-codec = { version = "2", default-features = false, features = ["max-encoded-len", "std"] }
-parking = { version = "2", default-features = false }
 parking_lot-5ef9efb8ec2df382 = { package = "parking_lot", version = "0.12" }
 parking_lot-a6292c17cd707f01 = { package = "parking_lot", version = "0.11" }
 parking_lot_core-274715c4dabd11b0 = { package = "parking_lot_core", version = "0.9", default-features = false }
@@ -463,13 +474,15 @@ plotters = { version = "0.3", default-features = false, features = ["area_series
 plotters-backend = { version = "0.3", default-features = false }
 plotters-svg = { version = "0.3", default-features = false }
 polyval = { version = "0.6", default-features = false }
-portable-atomic = { version = "0.3" }
+portable-atomic-468e82937335b1c9 = { package = "portable-atomic", version = "0.3" }
+portable-atomic-dff4ba8e3ae991db = { package = "portable-atomic", version = "1", default-features = false, features = ["fallback"] }
 postgres-protocol = { version = "0.6", default-features = false }
 postgres-types = { version = "0.2", default-features = false }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 pq-sys = { version = "0.4", default-features = false }
-predicates = { version = "2" }
+predicates-7b89eefb6aaa9bf3 = { package = "predicates", version = "3", default-features = false, features = ["diff"] }
 predicates-core = { version = "1", default-features = false }
+predicates-f595c2ba2a3f28df = { package = "predicates", version = "2" }
 predicates-tree = { version = "1", default-features = false }
 pretty = { version = "0.10", default-features = false }
 pretty_assertions = { version = "1" }
@@ -484,8 +497,7 @@ prost-types = { version = "0.11" }
 protobuf = { version = "2", default-features = false, features = ["with-bytes"] }
 ptree = { version = "0.4" }
 quanta = { version = "0.9" }
-quick-error-dff4ba8e3ae991db = { package = "quick-error", version = "1", default-features = false }
-quick-error-f595c2ba2a3f28df = { package = "quick-error", version = "2", default-features = false }
+quick-error = { version = "1", default-features = false }
 quinn = { version = "0.10", default-features = false, features = ["futures-io", "runtime-tokio", "tls-rustls"] }
 quinn-proto = { version = "0.10" }
 quinn-udp = { version = "0.4", default-features = false }
@@ -508,7 +520,8 @@ read-write-set-dynamic = { path = "../../external-crates/move/tools/read-write-s
 ref-cast = { version = "1", default-features = false }
 regex = { version = "1" }
 regex-automata = { version = "0.1" }
-regex-syntax = { version = "0.6" }
+regex-syntax-3b31131e45eafb45 = { package = "regex-syntax", version = "0.6" }
+regex-syntax-ca01ad9e24f5d932 = { package = "regex-syntax", version = "0.7" }
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 retain_mut = { version = "0.1", default-features = false }
 rfc6979-468e82937335b1c9 = { package = "rfc6979", version = "0.3", default-features = false }
@@ -548,7 +561,7 @@ sec1-468e82937335b1c9 = { package = "sec1", version = "0.3", features = ["subtle
 sec1-ca01ad9e24f5d932 = { package = "sec1", version = "0.7", features = ["pem", "std", "subtle"] }
 secp256k1 = { version = "0.27", features = ["bitcoin_hashes", "global-context", "rand-std", "recovery"] }
 secp256k1-sys = { version = "0.8", default-features = false, features = ["recovery", "std"] }
-semver-dff4ba8e3ae991db = { package = "semver", version = "1", features = ["serde"] }
+semver = { version = "1", features = ["serde"] }
 send_wrapper = { version = "0.4", default-features = false }
 serde-c38e5c1d305a1b54 = { package = "serde", version = "0.8" }
 serde-dff4ba8e3ae991db = { package = "serde", version = "1", features = ["alloc", "derive", "rc"] }
@@ -586,7 +599,7 @@ slug = { version = "0.1", default-features = false }
 smallvec = { version = "1", default-features = false }
 snap = { version = "1", default-features = false }
 socket2-9fbad63c4bcf4a8f = { package = "socket2", version = "0.4", default-features = false, features = ["all"] }
-socket2-d8f496e17d97b5cb = { package = "socket2", version = "0.5", default-features = false }
+socket2-d8f496e17d97b5cb = { package = "socket2", version = "0.5", default-features = false, features = ["all"] }
 soketto = { version = "0.7", features = ["http"] }
 spin = { version = "0.5", default-features = false }
 spki-3b31131e45eafb45 = { package = "spki", version = "0.6", default-features = false, features = ["pem", "std"] }
@@ -634,14 +647,16 @@ tokio-io-timeout = { version = "1", default-features = false }
 tokio-postgres = { version = "0.7" }
 tokio-postgres-rustls = { version = "0.9", default-features = false }
 tokio-retry = { version = "0.3", default-features = false }
-tokio-rustls = { version = "0.23" }
+tokio-rustls-2b5c6dc72f624058 = { package = "tokio-rustls", version = "0.23" }
+tokio-rustls-adf3d7031871b0af = { package = "tokio-rustls", version = "0.24" }
 tokio-stream = { version = "0.1", features = ["net", "sync"] }
 tokio-util = { version = "0.7", features = ["codec", "compat", "io"] }
 toml = { version = "0.5", features = ["preserve_order"] }
 toml_datetime = { version = "0.5", default-features = false }
-toml_edit-3575ec1268b04181 = { package = "toml_edit", version = "0.15" }
 toml_edit-582f2526e08bb6a0 = { package = "toml_edit", version = "0.14", features = ["easy"] }
-tonic = { version = "0.8", features = ["tls"] }
+toml_edit-9067fe90e8c1f593 = { package = "toml_edit", version = "0.17" }
+tonic-274715c4dabd11b0 = { package = "tonic", version = "0.9" }
+tonic-c38e5c1d305a1b54 = { package = "tonic", version = "0.8", features = ["tls"] }
 tonic-health = { version = "0.8" }
 tower = { version = "0.4", features = ["full"] }
 tower-http-468e82937335b1c9 = { package = "tower-http", version = "0.3", features = ["full"] }
@@ -689,14 +704,13 @@ versions = { version = "4", default-features = false }
 vsimd = { version = "0.8", default-features = false, features = ["detect"] }
 vte = { version = "0.10" }
 wait-timeout = { version = "0.2", default-features = false }
-waker-fn = { version = "1", default-features = false }
 walkdir = { version = "2", default-features = false }
 want = { version = "0.3", default-features = false }
 wasm-bindgen = { version = "0.2" }
 wasm-bindgen-futures = { version = "0.4", default-features = false }
 web-sys = { version = "0.3", default-features = false, features = ["AddEventListenerOptions", "BinaryType", "Blob", "CloseEvent", "CloseEventInit", "Document", "ErrorEvent", "FileReader", "History", "HtmlHeadElement", "Location", "MessageEvent", "ProgressEvent", "WebSocket", "Window"] }
 webpki = { version = "0.22", default-features = false, features = ["std"] }
-webpki-roots = { version = "0.22", default-features = false }
+webpki-roots-2b5c6dc72f624058 = { package = "webpki-roots", version = "0.23", default-features = false }
 whoami = { version = "1" }
 wyz = { version = "0.2", default-features = false, features = ["alloc"] }
 x509-parser = { version = "0.14" }
@@ -719,7 +733,8 @@ aes = { version = "0.8", default-features = false }
 aes-gcm = { version = "0.10" }
 ahash-c38e5c1d305a1b54 = { package = "ahash", version = "0.8", default-features = false }
 ahash-ca01ad9e24f5d932 = { package = "ahash", version = "0.7" }
-aho-corasick = { version = "0.7" }
+aho-corasick-ca01ad9e24f5d932 = { package = "aho-corasick", version = "0.7" }
+aho-corasick-dff4ba8e3ae991db = { package = "aho-corasick", version = "1" }
 aliasable = { version = "0.1" }
 alloc-no-stdlib = { version = "2", default-features = false }
 alloc-stdlib = { version = "0.2", default-features = false }
@@ -729,6 +744,10 @@ anemo-cli = { git = "https://github.com/mystenlabs/anemo.git", rev = "baa7cfc3ae
 anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "baa7cfc3ae841f88c2ff773396c5a803c377d054", default-features = false }
 anes = { version = "0.1" }
 ansi_term = { version = "0.12", default-features = false }
+anstream = { version = "0.3" }
+anstyle = { version = "1" }
+anstyle-parse = { version = "0.2" }
+anstyle-query = { version = "1", default-features = false }
 anyhow = { version = "1", features = ["backtrace"] }
 arbitrary = { version = "1", default-features = false, features = ["derive_arbitrary"] }
 arc-swap = { version = "1", default-features = false, features = ["serde"] }
@@ -749,7 +768,7 @@ ark-serialize-derive = { version = "0.4", default-features = false }
 ark-snark = { version = "0.4", default-features = false }
 ark-std = { version = "0.4", default-features = false, features = ["parallel"] }
 arrayref = { version = "0.3", default-features = false }
-arrayvec-ca01ad9e24f5d932 = { package = "arrayvec", version = "0.7" }
+arrayvec-ca01ad9e24f5d932 = { package = "arrayvec", version = "0.7", default-features = false }
 arrayvec-d8f496e17d97b5cb = { package = "arrayvec", version = "0.5", features = ["array-sizes-33-128"] }
 asn1-rs = { version = "0.5", features = ["datetime"] }
 asn1-rs-derive = { version = "0.4", default-features = false }
@@ -770,8 +789,8 @@ aws-config = { version = "0.55" }
 aws-credential-types = { version = "0.55", default-features = false }
 aws-endpoint = { version = "0.55", default-features = false }
 aws-http = { version = "0.55", default-features = false }
-aws-sdk-sso = { version = "0.26", default-features = false }
-aws-sdk-sts = { version = "0.26", default-features = false }
+aws-sdk-sso = { version = "0.27", default-features = false }
+aws-sdk-sts = { version = "0.27", default-features = false }
 aws-sig-auth = { version = "0.55", default-features = false }
 aws-sigv4 = { version = "0.55" }
 aws-smithy-async = { version = "0.55", default-features = false, features = ["rt-tokio"] }
@@ -842,7 +861,7 @@ cast = { version = "0.3", default-features = false }
 cbc = { version = "0.1", features = ["std"] }
 cc = { version = "1", default-features = false, features = ["parallel"] }
 cexpr = { version = "0.6", default-features = false }
-cfg-expr = { version = "0.13", features = ["targets"] }
+cfg-expr = { version = "0.15", features = ["targets"] }
 cfg-if = { version = "1", default-features = false }
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = { version = "0.6" }
@@ -855,21 +874,23 @@ clang-sys = { version = "1", default-features = false, features = ["clang_6_0", 
 clap-164d15cefe24d7eb = { package = "clap", version = "4", features = ["derive"] }
 clap-7b89eefb6aaa9bf3 = { package = "clap", version = "3", features = ["derive"] }
 clap-f595c2ba2a3f28df = { package = "clap", version = "2" }
+clap_builder = { version = "4", default-features = false, features = ["color", "help", "std", "suggestions", "usage"] }
 clap_derive-164d15cefe24d7eb = { package = "clap_derive", version = "4" }
 clap_derive-7b89eefb6aaa9bf3 = { package = "clap_derive", version = "3" }
-clap_lex-468e82937335b1c9 = { package = "clap_lex", version = "0.3", default-features = false }
 clap_lex-6f8ce4dd05d13bba = { package = "clap_lex", version = "0.2", default-features = false }
+clap_lex-d8f496e17d97b5cb = { package = "clap_lex", version = "0.5", default-features = false }
 clear_on_drop = { version = "0.2", default-features = false }
 codespan = { version = "0.11", default-features = false, features = ["serialization"] }
 codespan-reporting = { version = "0.11", default-features = false, features = ["serialization"] }
 collectable = { version = "0.0.2", default-features = false }
+colorchoice = { version = "1", default-features = false }
 colored = { version = "2", default-features = false }
 colored-diff = { version = "0.2", default-features = false }
 combine = { version = "4" }
 comfy-table = { version = "6" }
 config = { version = "0.11" }
 console = { version = "0.15", default-features = false, features = ["ansi-parsing", "unicode-width"] }
-console-api = { version = "0.4", default-features = false, features = ["transport"] }
+console-api = { version = "0.5", default-features = false, features = ["transport"] }
 console-subscriber = { version = "0.1" }
 const-oid = { version = "0.9", default-features = false }
 const-str = { version = "0.5" }
@@ -897,9 +918,12 @@ csv-core = { version = "0.1" }
 ctr = { version = "0.9", default-features = false }
 curve25519-dalek-fiat = { version = "0.1", default-features = false, features = ["fiat_u64_backend", "std"] }
 curve25519-dalek-ng = { version = "4", features = ["serde"] }
-darling = { version = "0.14" }
-darling_core = { version = "0.14", default-features = false, features = ["suggestions"] }
-darling_macro = { version = "0.14", default-features = false }
+darling-56bd22fc3884b12 = { package = "darling", version = "0.20" }
+darling-582f2526e08bb6a0 = { package = "darling", version = "0.14" }
+darling_core-56bd22fc3884b12 = { package = "darling_core", version = "0.20", default-features = false, features = ["suggestions"] }
+darling_core-582f2526e08bb6a0 = { package = "darling_core", version = "0.14", default-features = false, features = ["suggestions"] }
+darling_macro-56bd22fc3884b12 = { package = "darling_macro", version = "0.20", default-features = false }
+darling_macro-582f2526e08bb6a0 = { package = "darling_macro", version = "0.14", default-features = false }
 dashmap = { version = "5", default-features = false }
 data-encoding = { version = "2" }
 data-encoding-macro = { version = "0.1", default-features = false }
@@ -933,9 +957,11 @@ diffy = { version = "0.3", default-features = false }
 digest-274715c4dabd11b0 = { package = "digest", version = "0.9", default-features = false, features = ["std"] }
 digest-93f6ce9d446188ac = { package = "digest", version = "0.10", features = ["mac", "oid", "std"] }
 directories = { version = "4", default-features = false }
-dirs = { version = "4", default-features = false }
+dirs-164d15cefe24d7eb = { package = "dirs", version = "4", default-features = false }
+dirs-cdf1610d3e1514e9 = { package = "dirs", version = "5", default-features = false }
 dirs-next = { version = "2", default-features = false }
-dirs-sys = { version = "0.3", default-features = false }
+dirs-sys-468e82937335b1c9 = { package = "dirs-sys", version = "0.3", default-features = false }
+dirs-sys-9fbad63c4bcf4a8f = { package = "dirs-sys", version = "0.4", default-features = false }
 dirs-sys-next = { version = "0.1", default-features = false }
 displaydoc = { version = "0.2" }
 dissimilar = { version = "1", default-features = false }
@@ -984,7 +1010,6 @@ futures-channel = { version = "0.3", features = ["sink", "unstable"] }
 futures-core = { version = "0.3", features = ["unstable"] }
 futures-executor = { version = "0.3", default-features = false, features = ["std"] }
 futures-io = { version = "0.3", features = ["unstable"] }
-futures-lite = { version = "1" }
 futures-macro = { version = "0.3", default-features = false }
 futures-sink = { version = "0.3" }
 futures-task = { version = "0.3", default-features = false, features = ["std", "unstable"] }
@@ -1034,7 +1059,8 @@ httpdate = { version = "1", default-features = false }
 humansize = { version = "1", default-features = false }
 humantime = { version = "2", default-features = false }
 hyper = { version = "0.14", features = ["full"] }
-hyper-rustls = { version = "0.23", features = ["http2", "webpki-tokio"] }
+hyper-rustls-2b5c6dc72f624058 = { package = "hyper-rustls", version = "0.23", features = ["http2"] }
+hyper-rustls-adf3d7031871b0af = { package = "hyper-rustls", version = "0.24", default-features = false, features = ["http1", "logging", "native-tokio", "tls12"] }
 hyper-timeout = { version = "0.4", default-features = false }
 ident_case = { version = "1", default-features = false }
 idna = { version = "0.3", default-features = false }
@@ -1062,15 +1088,15 @@ itertools = { version = "0.10" }
 itoa = { version = "1", default-features = false }
 jobserver = { version = "0.1", default-features = false }
 js-sys = { version = "0.3", default-features = false }
-jsonrpsee = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", default-features = false, features = ["full"] }
-jsonrpsee-client-transport = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", default-features = false, features = ["tls", "web", "ws"] }
-jsonrpsee-core = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", features = ["async-client", "async-wasm-client", "http-helpers", "server", "soketto"] }
-jsonrpsee-http-client = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8" }
-jsonrpsee-proc-macros = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", default-features = false }
-jsonrpsee-server = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", default-features = false }
-jsonrpsee-types = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", default-features = false }
-jsonrpsee-wasm-client = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8", default-features = false }
-jsonrpsee-ws-client = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8" }
+jsonrpsee = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "66ce27cc207d5f193e007a743c2497477bae6fec", default-features = false, features = ["full"] }
+jsonrpsee-client-transport = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "66ce27cc207d5f193e007a743c2497477bae6fec", default-features = false, features = ["native-tls", "web", "webpki-tls", "ws"] }
+jsonrpsee-core = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "66ce27cc207d5f193e007a743c2497477bae6fec", features = ["async-client", "async-wasm-client", "http-helpers", "server", "soketto"] }
+jsonrpsee-http-client = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "66ce27cc207d5f193e007a743c2497477bae6fec" }
+jsonrpsee-proc-macros = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "66ce27cc207d5f193e007a743c2497477bae6fec", default-features = false }
+jsonrpsee-server = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "66ce27cc207d5f193e007a743c2497477bae6fec", default-features = false }
+jsonrpsee-types = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "66ce27cc207d5f193e007a743c2497477bae6fec", default-features = false }
+jsonrpsee-wasm-client = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "66ce27cc207d5f193e007a743c2497477bae6fec", default-features = false }
+jsonrpsee-ws-client = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "66ce27cc207d5f193e007a743c2497477bae6fec" }
 k256 = { version = "0.11", default-features = false, features = ["ecdsa", "keccak256"] }
 keccak = { version = "0.1", default-features = false }
 lazy_static-6f8ce4dd05d13bba = { package = "lazy_static", version = "0.2", default-features = false }
@@ -1096,14 +1122,15 @@ matchit-d8f496e17d97b5cb = { package = "matchit", version = "0.5" }
 md-5-274715c4dabd11b0 = { package = "md-5", version = "0.9" }
 md-5-93f6ce9d446188ac = { package = "md-5", version = "0.10" }
 memchr = { version = "2", features = ["use_std"] }
-memoffset-ca01ad9e24f5d932 = { package = "memoffset", version = "0.7" }
+memoffset-c38e5c1d305a1b54 = { package = "memoffset", version = "0.8" }
 merlin = { version = "3" }
 migrations_internals = { version = "2", default-features = false }
 migrations_macros = { version = "2" }
 mime = { version = "0.3", default-features = false }
 mime_guess = { version = "2", default-features = false }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
-miniz_oxide = { version = "0.6", default-features = false, features = ["with-alloc"] }
+miniz_oxide-3b31131e45eafb45 = { package = "miniz_oxide", version = "0.6", default-features = false }
+miniz_oxide-ca01ad9e24f5d932 = { package = "miniz_oxide", version = "0.7", default-features = false, features = ["with-alloc"] }
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext"] }
 mockall = { version = "0.11", default-features = false }
 mockall_derive = { version = "0.11", default-features = false }
@@ -1158,6 +1185,7 @@ nibble_vec = { version = "0.1", default-features = false }
 no-std-compat = { version = "0.4", default-features = false, features = ["alloc", "std"] }
 nom-15128469a54ed75a = { package = "nom", version = "7" }
 nom-cdf1610d3e1514e9 = { package = "nom", version = "5" }
+nom8 = { version = "0.2" }
 nonzero_ext = { version = "0.3" }
 normalize-line-endings = { version = "0.3", default-features = false }
 ntest = { version = "0.9", default-features = false }
@@ -1182,6 +1210,7 @@ oid-registry = { version = "0.6", features = ["crypto", "x509"] }
 once_cell = { version = "1" }
 oorandom = { version = "11", default-features = false }
 opaque-debug = { version = "0.3", default-features = false }
+option-ext = { version = "0.2", default-features = false }
 ordered-float = { version = "2" }
 os_str_bytes = { version = "6", default-features = false, features = ["raw_os_str"] }
 ouroboros-274715c4dabd11b0 = { package = "ouroboros", version = "0.9", default-features = false }
@@ -1194,7 +1223,6 @@ owo-colors = { version = "3", default-features = false }
 p256 = { version = "0.13" }
 parity-scale-codec = { version = "2", default-features = false, features = ["max-encoded-len", "std"] }
 parity-scale-codec-derive = { version = "2", default-features = false, features = ["max-encoded-len"] }
-parking = { version = "2", default-features = false }
 parking_lot-5ef9efb8ec2df382 = { package = "parking_lot", version = "0.12" }
 parking_lot-a6292c17cd707f01 = { package = "parking_lot", version = "0.11" }
 parking_lot_core-274715c4dabd11b0 = { package = "parking_lot_core", version = "0.9", default-features = false }
@@ -1230,13 +1258,15 @@ plotters = { version = "0.3", default-features = false, features = ["area_series
 plotters-backend = { version = "0.3", default-features = false }
 plotters-svg = { version = "0.3", default-features = false }
 polyval = { version = "0.6", default-features = false }
-portable-atomic = { version = "0.3" }
+portable-atomic-468e82937335b1c9 = { package = "portable-atomic", version = "0.3" }
+portable-atomic-dff4ba8e3ae991db = { package = "portable-atomic", version = "1", default-features = false, features = ["fallback"] }
 postgres-protocol = { version = "0.6", default-features = false }
 postgres-types = { version = "0.2", default-features = false }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 pq-sys = { version = "0.4", default-features = false }
-predicates = { version = "2" }
+predicates-7b89eefb6aaa9bf3 = { package = "predicates", version = "3", default-features = false, features = ["diff"] }
 predicates-core = { version = "1", default-features = false }
+predicates-f595c2ba2a3f28df = { package = "predicates", version = "2" }
 predicates-tree = { version = "1", default-features = false }
 pretty = { version = "0.10", default-features = false }
 pretty_assertions = { version = "1" }
@@ -1260,8 +1290,7 @@ prost-types = { version = "0.11" }
 protobuf = { version = "2", default-features = false, features = ["with-bytes"] }
 ptree = { version = "0.4" }
 quanta = { version = "0.9" }
-quick-error-dff4ba8e3ae991db = { package = "quick-error", version = "1", default-features = false }
-quick-error-f595c2ba2a3f28df = { package = "quick-error", version = "2", default-features = false }
+quick-error = { version = "1", default-features = false }
 quinn = { version = "0.10", default-features = false, features = ["futures-io", "runtime-tokio", "tls-rustls"] }
 quinn-proto = { version = "0.10" }
 quinn-udp = { version = "0.4", default-features = false }
@@ -1287,7 +1316,8 @@ ref-cast = { version = "1", default-features = false }
 ref-cast-impl = { version = "1", default-features = false }
 regex = { version = "1" }
 regex-automata = { version = "0.1" }
-regex-syntax = { version = "0.6" }
+regex-syntax-3b31131e45eafb45 = { package = "regex-syntax", version = "0.6" }
+regex-syntax-ca01ad9e24f5d932 = { package = "regex-syntax", version = "0.7" }
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 retain_mut = { version = "0.1", default-features = false }
 rfc6979-468e82937335b1c9 = { package = "rfc6979", version = "0.3", default-features = false }
@@ -1332,9 +1362,7 @@ sec1-468e82937335b1c9 = { package = "sec1", version = "0.3", features = ["subtle
 sec1-ca01ad9e24f5d932 = { package = "sec1", version = "0.7", features = ["pem", "std", "subtle"] }
 secp256k1 = { version = "0.27", features = ["bitcoin_hashes", "global-context", "rand-std", "recovery"] }
 secp256k1-sys = { version = "0.8", default-features = false, features = ["recovery", "std"] }
-semver-a6292c17cd707f01 = { package = "semver", version = "0.11" }
-semver-dff4ba8e3ae991db = { package = "semver", version = "1", features = ["serde"] }
-semver-parser = { version = "0.10", default-features = false }
+semver = { version = "1", features = ["serde"] }
 send_wrapper = { version = "0.4", default-features = false }
 serde-c38e5c1d305a1b54 = { package = "serde", version = "0.8" }
 serde-dff4ba8e3ae991db = { package = "serde", version = "1", features = ["alloc", "derive", "rc"] }
@@ -1376,7 +1404,7 @@ slug = { version = "0.1", default-features = false }
 smallvec = { version = "1", default-features = false }
 snap = { version = "1", default-features = false }
 socket2-9fbad63c4bcf4a8f = { package = "socket2", version = "0.4", default-features = false, features = ["all"] }
-socket2-d8f496e17d97b5cb = { package = "socket2", version = "0.5", default-features = false }
+socket2-d8f496e17d97b5cb = { package = "socket2", version = "0.5", default-features = false, features = ["all"] }
 soketto = { version = "0.7", features = ["http"] }
 spin = { version = "0.5", default-features = false }
 spki-3b31131e45eafb45 = { package = "spki", version = "0.6", default-features = false, features = ["pem", "std"] }
@@ -1396,7 +1424,7 @@ subtle = { version = "2", default-features = false, features = ["i128", "std"] }
 subtle-ng = { version = "2", default-features = false, features = ["std"] }
 syn-3575ec1268b04181 = { package = "syn", version = "0.15", features = ["extra-traits", "full", "visit"] }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
-syn-f595c2ba2a3f28df = { package = "syn", version = "2", features = ["extra-traits", "fold", "full", "visit-mut"] }
+syn-f595c2ba2a3f28df = { package = "syn", version = "2", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 sync_wrapper = { version = "0.1", default-features = false }
 synstructure = { version = "0.12" }
 sysinfo = { version = "0.27" }
@@ -1434,17 +1462,19 @@ tokio-macros = { version = "2", default-features = false }
 tokio-postgres = { version = "0.7" }
 tokio-postgres-rustls = { version = "0.9", default-features = false }
 tokio-retry = { version = "0.3", default-features = false }
-tokio-rustls = { version = "0.23" }
+tokio-rustls-2b5c6dc72f624058 = { package = "tokio-rustls", version = "0.23" }
+tokio-rustls-adf3d7031871b0af = { package = "tokio-rustls", version = "0.24" }
 tokio-stream = { version = "0.1", features = ["net", "sync"] }
 tokio-util = { version = "0.7", features = ["codec", "compat", "io"] }
 toml = { version = "0.5", features = ["preserve_order"] }
 toml_datetime = { version = "0.5", default-features = false }
-toml_edit-3575ec1268b04181 = { package = "toml_edit", version = "0.15" }
 toml_edit-582f2526e08bb6a0 = { package = "toml_edit", version = "0.14", features = ["easy"] }
-tonic = { version = "0.8", features = ["tls"] }
+toml_edit-9067fe90e8c1f593 = { package = "toml_edit", version = "0.17" }
+tonic-274715c4dabd11b0 = { package = "tonic", version = "0.9" }
 tonic-build = { version = "0.8" }
+tonic-c38e5c1d305a1b54 = { package = "tonic", version = "0.8", features = ["tls"] }
 tonic-health = { version = "0.8" }
-toolchain_find = { version = "0.2", default-features = false }
+toolchain_find = { version = "0.3", default-features = false }
 tower = { version = "0.4", features = ["full"] }
 tower-http-468e82937335b1c9 = { package = "tower-http", version = "0.3", features = ["full"] }
 tower-http-9fbad63c4bcf4a8f = { package = "tower-http", version = "0.4", features = ["trace"] }
@@ -1485,7 +1515,6 @@ unicode-xid-c65f7effa3be6d31 = { package = "unicode-xid", version = "0.1" }
 universal-hash = { version = "0.5", default-features = false }
 unsigned-varint = { version = "0.7", default-features = false, features = ["std"] }
 untrusted = { version = "0.7", default-features = false }
-unzip-n = { version = "0.1", default-features = false }
 url = { version = "2" }
 urlencoding = { version = "2", default-features = false }
 utf8parse = { version = "0.2" }
@@ -1498,7 +1527,6 @@ vsimd = { version = "0.8", default-features = false, features = ["detect"] }
 vte = { version = "0.10" }
 vte_generate_state_changes = { version = "0.1", default-features = false }
 wait-timeout = { version = "0.2", default-features = false }
-waker-fn = { version = "1", default-features = false }
 walkdir = { version = "2", default-features = false }
 want = { version = "0.3", default-features = false }
 wasm-bindgen = { version = "0.2" }
@@ -1509,7 +1537,7 @@ wasm-bindgen-macro-support = { version = "0.2", default-features = false, featur
 wasm-bindgen-shared = { version = "0.2", default-features = false }
 web-sys = { version = "0.3", default-features = false, features = ["AddEventListenerOptions", "BinaryType", "Blob", "CloseEvent", "CloseEventInit", "Document", "ErrorEvent", "FileReader", "History", "HtmlHeadElement", "Location", "MessageEvent", "ProgressEvent", "WebSocket", "Window"] }
 webpki = { version = "0.22", default-features = false, features = ["std"] }
-webpki-roots = { version = "0.22", default-features = false }
+webpki-roots-2b5c6dc72f624058 = { package = "webpki-roots", version = "0.23", default-features = false }
 which = { version = "4", default-features = false }
 whoami = { version = "1" }
 wyz = { version = "0.2", default-features = false, features = ["alloc"] }
@@ -1533,8 +1561,7 @@ cpp_demangle = { version = "0.4" }
 cpufeatures = { version = "0.2", default-features = false }
 debugid = { version = "0.8", default-features = false }
 encoding_rs = { version = "0.8" }
-errno-468e82937335b1c9 = { package = "errno", version = "0.3", default-features = false }
-errno-6f8ce4dd05d13bba = { package = "errno", version = "0.2", default-features = false }
+errno = { version = "0.3", default-features = false }
 findshlibs = { version = "0.10", default-features = false }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
 inferno = { version = "0.11", default-features = false, features = ["nameattr"] }
@@ -1547,15 +1574,14 @@ memmap2 = { version = "0.5", default-features = false }
 memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
 mio-ca01ad9e24f5d932 = { package = "mio", version = "0.7", features = ["os-util", "uds"] }
 nix-2b5c6dc72f624058 = { package = "nix", version = "0.23", default-features = false }
-nix-adf3d7031871b0af = { package = "nix", version = "0.24", default-features = false, features = ["fs", "signal"] }
+nix-2f80eeee3b1b6c7e = { package = "nix", version = "0.26", default-features = false, features = ["fs", "signal"] }
 num-format = { version = "0.4", default-features = false }
 once_cell = { version = "1", default-features = false, features = ["unstable"] }
 pprof = { version = "0.11", features = ["criterion", "flamegraph", "frame-pointer"] }
 quick-xml = { version = "0.26", default-features = false }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
 rgb = { version = "0.8" }
-rustix-4e55305914c60c55 = { package = "rustix", version = "0.36", features = ["fs"] }
-rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["termios"] }
+rustix = { version = "0.37", features = ["fs", "termios"] }
 security-framework = { version = "2" }
 security-framework-sys = { version = "2", default-features = false, features = ["OSX_10_9"] }
 signal-hook = { version = "0.3" }
@@ -1565,6 +1591,7 @@ str_stack = { version = "0.1", default-features = false }
 symbolic-common = { version = "10", default-features = false }
 symbolic-demangle = { version = "10", default-features = false, features = ["cpp", "rust"] }
 web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
+webpki-roots-3c51e837cfc5589a = { package = "webpki-roots", version = "0.22", default-features = false }
 
 [target.aarch64-apple-darwin.build-dependencies]
 ahash-c38e5c1d305a1b54 = { package = "ahash", version = "0.8" }
@@ -1575,8 +1602,7 @@ cpp_demangle = { version = "0.4" }
 cpufeatures = { version = "0.2", default-features = false }
 debugid = { version = "0.8", default-features = false }
 encoding_rs = { version = "0.8" }
-errno-468e82937335b1c9 = { package = "errno", version = "0.3", default-features = false }
-errno-6f8ce4dd05d13bba = { package = "errno", version = "0.2", default-features = false }
+errno = { version = "0.3", default-features = false }
 findshlibs = { version = "0.10", default-features = false }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
 inferno = { version = "0.11", default-features = false, features = ["nameattr"] }
@@ -1589,7 +1615,7 @@ memmap2 = { version = "0.5", default-features = false }
 memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
 mio-ca01ad9e24f5d932 = { package = "mio", version = "0.7", features = ["os-util", "uds"] }
 nix-2b5c6dc72f624058 = { package = "nix", version = "0.23", default-features = false }
-nix-adf3d7031871b0af = { package = "nix", version = "0.24", default-features = false, features = ["fs", "signal"] }
+nix-2f80eeee3b1b6c7e = { package = "nix", version = "0.26", default-features = false, features = ["fs", "signal"] }
 num-format = { version = "0.4", default-features = false }
 once_cell = { version = "1", default-features = false, features = ["unstable"] }
 pprof = { version = "0.11", features = ["criterion", "flamegraph", "frame-pointer"] }
@@ -1597,8 +1623,7 @@ protobuf-src = { version = "1", default-features = false }
 quick-xml = { version = "0.26", default-features = false }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
 rgb = { version = "0.8" }
-rustix-4e55305914c60c55 = { package = "rustix", version = "0.36", features = ["fs"] }
-rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["termios"] }
+rustix = { version = "0.37", features = ["fs", "termios"] }
 security-framework = { version = "2" }
 security-framework-sys = { version = "2", default-features = false, features = ["OSX_10_9"] }
 signal-hook = { version = "0.3" }
@@ -1608,6 +1633,7 @@ str_stack = { version = "0.1", default-features = false }
 symbolic-common = { version = "10", default-features = false }
 symbolic-demangle = { version = "10", default-features = false, features = ["cpp", "rust"] }
 web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
+webpki-roots-3c51e837cfc5589a = { package = "webpki-roots", version = "0.22", default-features = false }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 ahash-c38e5c1d305a1b54 = { package = "ahash", version = "0.8" }
@@ -1622,13 +1648,12 @@ ipnet = { version = "2" }
 jemalloc-ctl = { version = "0.5" }
 jemalloc-sys = { version = "0.5" }
 libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
-linux-raw-sys-468e82937335b1c9 = { package = "linux-raw-sys", version = "0.3", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
-linux-raw-sys-c65f7effa3be6d31 = { package = "linux-raw-sys", version = "0.1", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
+linux-raw-sys = { version = "0.3", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
 memmap2 = { version = "0.5", default-features = false }
 memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
 mio-ca01ad9e24f5d932 = { package = "mio", version = "0.7", features = ["os-util", "uds"] }
 nix-2b5c6dc72f624058 = { package = "nix", version = "0.23", default-features = false }
-nix-adf3d7031871b0af = { package = "nix", version = "0.24", default-features = false, features = ["fs", "signal"] }
+nix-2f80eeee3b1b6c7e = { package = "nix", version = "0.26", default-features = false, features = ["fs", "signal"] }
 num-format = { version = "0.4", default-features = false }
 once_cell = { version = "1", default-features = false, features = ["unstable"] }
 openssl-probe = { version = "0.1", default-features = false }
@@ -1637,8 +1662,7 @@ quick-xml = { version = "0.26", default-features = false }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
 raw-cpuid = { version = "10", default-features = false }
 rgb = { version = "0.8" }
-rustix-4e55305914c60c55 = { package = "rustix", version = "0.36", features = ["fs"] }
-rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["termios"] }
+rustix = { version = "0.37", features = ["fs", "termios"] }
 signal-hook = { version = "0.3" }
 signal-hook-mio = { version = "0.2", default-features = false, features = ["support-v0_7", "support-v0_8"] }
 signal-hook-registry = { version = "1", default-features = false }
@@ -1646,6 +1670,7 @@ str_stack = { version = "0.1", default-features = false }
 symbolic-common = { version = "10", default-features = false }
 symbolic-demangle = { version = "10", default-features = false, features = ["cpp", "rust"] }
 web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
+webpki-roots-3c51e837cfc5589a = { package = "webpki-roots", version = "0.22", default-features = false }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
 ahash-c38e5c1d305a1b54 = { package = "ahash", version = "0.8" }
@@ -1661,13 +1686,12 @@ ipnet = { version = "2" }
 jemalloc-ctl = { version = "0.5" }
 jemalloc-sys = { version = "0.5" }
 libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
-linux-raw-sys-468e82937335b1c9 = { package = "linux-raw-sys", version = "0.3", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
-linux-raw-sys-c65f7effa3be6d31 = { package = "linux-raw-sys", version = "0.1", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
+linux-raw-sys = { version = "0.3", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
 memmap2 = { version = "0.5", default-features = false }
 memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
 mio-ca01ad9e24f5d932 = { package = "mio", version = "0.7", features = ["os-util", "uds"] }
 nix-2b5c6dc72f624058 = { package = "nix", version = "0.23", default-features = false }
-nix-adf3d7031871b0af = { package = "nix", version = "0.24", default-features = false, features = ["fs", "signal"] }
+nix-2f80eeee3b1b6c7e = { package = "nix", version = "0.26", default-features = false, features = ["fs", "signal"] }
 num-format = { version = "0.4", default-features = false }
 once_cell = { version = "1", default-features = false, features = ["unstable"] }
 openssl-probe = { version = "0.1", default-features = false }
@@ -1677,8 +1701,7 @@ quick-xml = { version = "0.26", default-features = false }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
 raw-cpuid = { version = "10", default-features = false }
 rgb = { version = "0.8" }
-rustix-4e55305914c60c55 = { package = "rustix", version = "0.36", features = ["fs"] }
-rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["termios"] }
+rustix = { version = "0.37", features = ["fs", "termios"] }
 signal-hook = { version = "0.3" }
 signal-hook-mio = { version = "0.2", default-features = false, features = ["support-v0_7", "support-v0_8"] }
 signal-hook-registry = { version = "1", default-features = false }
@@ -1686,8 +1709,10 @@ str_stack = { version = "0.1", default-features = false }
 symbolic-common = { version = "10", default-features = false }
 symbolic-demangle = { version = "10", default-features = false, features = ["cpp", "rust"] }
 web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
+webpki-roots-3c51e837cfc5589a = { package = "webpki-roots", version = "0.22", default-features = false }
 
 [target.x86_64-pc-windows-msvc.dependencies]
+anstyle-wincon = { version = "1", default-features = false }
 clipboard-win = { version = "4", default-features = false }
 cpufeatures = { version = "0.2", default-features = false }
 crossterm_winapi-274715c4dabd11b0 = { package = "crossterm_winapi", version = "0.9", default-features = false }
@@ -1704,17 +1729,21 @@ raw-cpuid = { version = "10", default-features = false }
 schannel = { version = "0.1", default-features = false }
 str-buf = { version = "1", default-features = false }
 web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
+webpki-roots-3c51e837cfc5589a = { package = "webpki-roots", version = "0.22", default-features = false }
 widestring = { version = "0.5" }
 winapi = { version = "0.3", default-features = false, features = ["basetsd", "cfg", "combaseapi", "consoleapi", "errhandlingapi", "evntrace", "fileapi", "handleapi", "heapapi", "ifdef", "impl-debug", "impl-default", "in6addr", "inaddr", "ioapiset", "iphlpapi", "knownfolders", "libloaderapi", "lmaccess", "lmapibuf", "lmcons", "memoryapi", "minwinbase", "minwindef", "namedpipeapi", "netioapi", "ntdef", "ntlsa", "ntsecapi", "ntstatus", "objbase", "objidl", "oleauto", "pdh", "powerbase", "processenv", "processthreadsapi", "profileapi", "psapi", "rpcdce", "securitybaseapi", "shellapi", "shlobj", "std", "stringapiset", "synchapi", "sysinfoapi", "timezoneapi", "wbemcli", "winbase", "wincon", "windef", "winerror", "winioctl", "winnt", "winreg", "winsock2", "winuser", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
 winapi-util = { version = "0.1", default-features = false }
-windows-sys-b32c9ddb6d93a9d2 = { package = "windows-sys", version = "0.42", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse"] }
-windows-sys-c8eced492e86ede7 = { package = "windows-sys", version = "0.48", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming"] }
-windows-targets = { version = "0.48", default-features = false }
+windows-sys-53888c27b7ba5cf4 = { package = "windows-sys", version = "0.45", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse"] }
+windows-sys-b32c9ddb6d93a9d2 = { package = "windows-sys", version = "0.42", features = ["Win32_Foundation", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_System_Memory"] }
+windows-sys-c8eced492e86ede7 = { package = "windows-sys", version = "0.48", features = ["Win32_Foundation", "Win32_Globalization", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Shell"] }
+windows-targets-b32c9ddb6d93a9d2 = { package = "windows-targets", version = "0.42", default-features = false }
+windows-targets-c8eced492e86ede7 = { package = "windows-targets", version = "0.48", default-features = false }
 windows_x86_64_msvc-b32c9ddb6d93a9d2 = { package = "windows_x86_64_msvc", version = "0.42", default-features = false }
 windows_x86_64_msvc-c8eced492e86ede7 = { package = "windows_x86_64_msvc", version = "0.48", default-features = false }
 winreg = { version = "0.10", default-features = false }
 
 [target.x86_64-pc-windows-msvc.build-dependencies]
+anstyle-wincon = { version = "1", default-features = false }
 clipboard-win = { version = "4", default-features = false }
 cpufeatures = { version = "0.2", default-features = false }
 crossterm_winapi-274715c4dabd11b0 = { package = "crossterm_winapi", version = "0.9", default-features = false }
@@ -1733,12 +1762,15 @@ schannel = { version = "0.1", default-features = false }
 str-buf = { version = "1", default-features = false }
 vcpkg = { version = "0.2", default-features = false }
 web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
+webpki-roots-3c51e837cfc5589a = { package = "webpki-roots", version = "0.22", default-features = false }
 widestring = { version = "0.5" }
 winapi = { version = "0.3", default-features = false, features = ["basetsd", "cfg", "combaseapi", "consoleapi", "errhandlingapi", "evntrace", "fileapi", "handleapi", "heapapi", "ifdef", "impl-debug", "impl-default", "in6addr", "inaddr", "ioapiset", "iphlpapi", "knownfolders", "libloaderapi", "lmaccess", "lmapibuf", "lmcons", "memoryapi", "minwinbase", "minwindef", "namedpipeapi", "netioapi", "ntdef", "ntlsa", "ntsecapi", "ntstatus", "objbase", "objidl", "oleauto", "pdh", "powerbase", "processenv", "processthreadsapi", "profileapi", "psapi", "rpcdce", "securitybaseapi", "shellapi", "shlobj", "std", "stringapiset", "synchapi", "sysinfoapi", "timezoneapi", "wbemcli", "winbase", "wincon", "windef", "winerror", "winioctl", "winnt", "winreg", "winsock2", "winuser", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
 winapi-util = { version = "0.1", default-features = false }
-windows-sys-b32c9ddb6d93a9d2 = { package = "windows-sys", version = "0.42", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse"] }
-windows-sys-c8eced492e86ede7 = { package = "windows-sys", version = "0.48", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming"] }
-windows-targets = { version = "0.48", default-features = false }
+windows-sys-53888c27b7ba5cf4 = { package = "windows-sys", version = "0.45", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse"] }
+windows-sys-b32c9ddb6d93a9d2 = { package = "windows-sys", version = "0.42", features = ["Win32_Foundation", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_System_Memory"] }
+windows-sys-c8eced492e86ede7 = { package = "windows-sys", version = "0.48", features = ["Win32_Foundation", "Win32_Globalization", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Shell"] }
+windows-targets-b32c9ddb6d93a9d2 = { package = "windows-targets", version = "0.42", default-features = false }
+windows-targets-c8eced492e86ede7 = { package = "windows-targets", version = "0.48", default-features = false }
 windows_x86_64_msvc-b32c9ddb6d93a9d2 = { package = "windows_x86_64_msvc", version = "0.42", default-features = false }
 windows_x86_64_msvc-c8eced492e86ede7 = { package = "windows_x86_64_msvc", version = "0.48", default-features = false }
 winreg = { version = "0.10", default-features = false }

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -68,8 +68,8 @@ aws-config = { version = "0.55" }
 aws-credential-types = { version = "0.55", default-features = false }
 aws-endpoint = { version = "0.55", default-features = false }
 aws-http = { version = "0.55", default-features = false }
-aws-sdk-sso = { version = "0.27", default-features = false }
-aws-sdk-sts = { version = "0.27", default-features = false }
+aws-sdk-sso = { version = "0.28", default-features = false }
+aws-sdk-sts = { version = "0.28", default-features = false }
 aws-sig-auth = { version = "0.55", default-features = false }
 aws-sigv4 = { version = "0.55" }
 aws-smithy-async = { version = "0.55", default-features = false, features = ["rt-tokio"] }
@@ -327,14 +327,14 @@ is-terminal = { version = "0.4", default-features = false }
 itertools = { version = "0.10" }
 itoa = { version = "1", default-features = false }
 js-sys = { version = "0.3", default-features = false }
-jsonrpsee = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "66ce27cc207d5f193e007a743c2497477bae6fec", default-features = false, features = ["full"] }
-jsonrpsee-client-transport = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "66ce27cc207d5f193e007a743c2497477bae6fec", default-features = false, features = ["native-tls", "web", "webpki-tls", "ws"] }
-jsonrpsee-core = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "66ce27cc207d5f193e007a743c2497477bae6fec", features = ["async-client", "async-wasm-client", "http-helpers", "server", "soketto"] }
-jsonrpsee-http-client = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "66ce27cc207d5f193e007a743c2497477bae6fec" }
-jsonrpsee-server = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "66ce27cc207d5f193e007a743c2497477bae6fec", default-features = false }
-jsonrpsee-types = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "66ce27cc207d5f193e007a743c2497477bae6fec", default-features = false }
-jsonrpsee-wasm-client = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "66ce27cc207d5f193e007a743c2497477bae6fec", default-features = false }
-jsonrpsee-ws-client = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "66ce27cc207d5f193e007a743c2497477bae6fec" }
+jsonrpsee = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2", default-features = false, features = ["full"] }
+jsonrpsee-client-transport = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2", default-features = false, features = ["native-tls", "web", "webpki-tls", "ws"] }
+jsonrpsee-core = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2", features = ["async-client", "async-wasm-client", "http-helpers", "server", "soketto"] }
+jsonrpsee-http-client = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2" }
+jsonrpsee-server = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2", default-features = false }
+jsonrpsee-types = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2", default-features = false }
+jsonrpsee-wasm-client = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2", default-features = false }
+jsonrpsee-ws-client = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2" }
 k256 = { version = "0.11", default-features = false, features = ["ecdsa", "keccak256"] }
 keccak = { version = "0.1", default-features = false }
 lazy_static-6f8ce4dd05d13bba = { package = "lazy_static", version = "0.2", default-features = false }
@@ -789,8 +789,8 @@ aws-config = { version = "0.55" }
 aws-credential-types = { version = "0.55", default-features = false }
 aws-endpoint = { version = "0.55", default-features = false }
 aws-http = { version = "0.55", default-features = false }
-aws-sdk-sso = { version = "0.27", default-features = false }
-aws-sdk-sts = { version = "0.27", default-features = false }
+aws-sdk-sso = { version = "0.28", default-features = false }
+aws-sdk-sts = { version = "0.28", default-features = false }
 aws-sig-auth = { version = "0.55", default-features = false }
 aws-sigv4 = { version = "0.55" }
 aws-smithy-async = { version = "0.55", default-features = false, features = ["rt-tokio"] }
@@ -1088,15 +1088,15 @@ itertools = { version = "0.10" }
 itoa = { version = "1", default-features = false }
 jobserver = { version = "0.1", default-features = false }
 js-sys = { version = "0.3", default-features = false }
-jsonrpsee = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "66ce27cc207d5f193e007a743c2497477bae6fec", default-features = false, features = ["full"] }
-jsonrpsee-client-transport = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "66ce27cc207d5f193e007a743c2497477bae6fec", default-features = false, features = ["native-tls", "web", "webpki-tls", "ws"] }
-jsonrpsee-core = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "66ce27cc207d5f193e007a743c2497477bae6fec", features = ["async-client", "async-wasm-client", "http-helpers", "server", "soketto"] }
-jsonrpsee-http-client = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "66ce27cc207d5f193e007a743c2497477bae6fec" }
-jsonrpsee-proc-macros = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "66ce27cc207d5f193e007a743c2497477bae6fec", default-features = false }
-jsonrpsee-server = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "66ce27cc207d5f193e007a743c2497477bae6fec", default-features = false }
-jsonrpsee-types = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "66ce27cc207d5f193e007a743c2497477bae6fec", default-features = false }
-jsonrpsee-wasm-client = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "66ce27cc207d5f193e007a743c2497477bae6fec", default-features = false }
-jsonrpsee-ws-client = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "66ce27cc207d5f193e007a743c2497477bae6fec" }
+jsonrpsee = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2", default-features = false, features = ["full"] }
+jsonrpsee-client-transport = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2", default-features = false, features = ["native-tls", "web", "webpki-tls", "ws"] }
+jsonrpsee-core = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2", features = ["async-client", "async-wasm-client", "http-helpers", "server", "soketto"] }
+jsonrpsee-http-client = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2" }
+jsonrpsee-proc-macros = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2", default-features = false }
+jsonrpsee-server = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2", default-features = false }
+jsonrpsee-types = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2", default-features = false }
+jsonrpsee-wasm-client = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2", default-features = false }
+jsonrpsee-ws-client = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "56e8b4e6d618cc8cc5c4b1f6ce14a2628a57ddc2" }
 k256 = { version = "0.11", default-features = false, features = ["ecdsa", "keccak256"] }
 keccak = { version = "0.1", default-features = false }
 lazy_static-6f8ce4dd05d13bba = { package = "lazy_static", version = "0.2", default-features = false }


### PR DESCRIPTION
## Description 
Upgrade jsonrpsee from 0.16.2 to 0.18.2.
Breaking changes are that we now need to use ErrorObjectOwned, subscription api, 

Still point to a forked repo as `error_code` returned on `on_result` of logger is not yet supported by `jsonrpsee`.
Now much easier to do error handling in rpc:

		Err(ErrorObjectOwned::owned(1, "c", None::<()>))

After v0.16.2, `tls` is no longer a feature, `workspace-hack` sets both features `native-tls` and `webpki-tls`. Ok. I listen to workspace-hack.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
