### PR TITLE
[Test] Allow specifying custom examples dir

### DIFF
--- a/crates/sui-test-transaction-builder/src/lib.rs
+++ b/crates/sui-test-transaction-builder/src/lib.rs
@@ -147,8 +147,15 @@ impl TestTransactionBuilder {
     }
 
     pub fn publish_examples(self, subpath: &'static str) -> Self {
-        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        path.extend(["..", "..", "sui_programmability", "examples", subpath]);
+        let path = if let Ok(p) = std::env::var("MOVE_EXAMPLES_DIR") {
+            let mut path = PathBuf::from(p);
+            path.extend([subpath]);
+            path
+        } else {
+            let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            path.extend(["..", "..", "sui_programmability", "examples", subpath]);
+            path
+        };
         self.publish(path)
     }
 


### PR DESCRIPTION
## Description 

This allows putting move examples in any directory, unrelated to where they were at build time.

## Test Plan 

Specified `MOVE_EXAMPLES_DIR` on stress binaries in private testnet.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
