### PR TITLE
indexer: merge tx and object in checkpoint handler

### DIFF
--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -64,9 +64,6 @@ pub struct CheckpointHandler<S> {
     config: IndexerConfig,
     checkpoint_sender: Arc<Mutex<Sender<TemporaryCheckpointStore>>>,
     checkpoint_receiver: Arc<Mutex<Receiver<TemporaryCheckpointStore>>>,
-    // TODO(gegaowp): temp. solution for slow object commits, will be removed after
-    object_checkpoint_sender: Arc<Mutex<Sender<TemporaryCheckpointStore>>>,
-    object_checkpoint_receiver: Arc<Mutex<Receiver<TemporaryCheckpointStore>>>,
     epoch_sender: Arc<Mutex<Sender<TemporaryEpochStore>>>,
     epoch_receiver: Arc<Mutex<Receiver<TemporaryEpochStore>>>,
 }
@@ -84,8 +81,6 @@ where
     ) -> Self {
         let (checkpoint_sender, checkpoint_receiver) = mpsc::channel(CHECKPOINT_QUEUE_LIMIT);
         let (epoch_sender, epoch_receiver) = mpsc::channel(EPOCH_QUEUE_LIMIT);
-        let (object_checkpoint_sender, object_checkpoint_receiver) =
-            mpsc::channel(CHECKPOINT_QUEUE_LIMIT);
         Self {
             state,
             http_client,
@@ -94,8 +89,6 @@ where
             config: config.clone(),
             checkpoint_sender: Arc::new(Mutex::new(checkpoint_sender)),
             checkpoint_receiver: Arc::new(Mutex::new(checkpoint_receiver)),
-            object_checkpoint_sender: Arc::new(Mutex::new(object_checkpoint_sender)),
-            object_checkpoint_receiver: Arc::new(Mutex::new(object_checkpoint_receiver)),
             epoch_sender: Arc::new(Mutex::new(epoch_sender)),
             epoch_receiver: Arc::new(Mutex::new(epoch_receiver)),
         }
@@ -120,26 +113,6 @@ where
             }
         });
 
-        let object_download_handler = self.clone();
-        spawn_monitored_task!(async move {
-            let mut object_download_index_res = object_download_handler
-                .start_download_and_index_object()
-                .await;
-            while let Err(e) = &object_download_index_res {
-                warn!(
-                    "Indexer object download & index failed with error: {:?}, retrying after {:?} secs...",
-                    e, DOWNLOAD_RETRY_INTERVAL_IN_SECS
-                );
-                tokio::time::sleep(std::time::Duration::from_secs(
-                    DOWNLOAD_RETRY_INTERVAL_IN_SECS,
-                ))
-                .await;
-                object_download_index_res = object_download_handler
-                    .start_download_and_index_object()
-                    .await;
-            }
-        });
-
         let checkpoint_commit_handler = self.clone();
         spawn_monitored_task!(async move {
             let mut checkpoint_commit_res =
@@ -154,26 +127,6 @@ where
                 ))
                 .await;
                 checkpoint_commit_res = checkpoint_commit_handler.start_checkpoint_commit().await;
-            }
-        });
-
-        let object_checkpoint_commit_handler = self.clone();
-        spawn_monitored_task!(async move {
-            let mut object_checkpoint_commit_res = object_checkpoint_commit_handler
-                .start_object_checkpoint_commit()
-                .await;
-            while let Err(e) = &object_checkpoint_commit_res {
-                warn!(
-                    "Indexer object checkpoint commit failed with error: {:?}, retrying after {:?} secs...",
-                    e, DOWNLOAD_RETRY_INTERVAL_IN_SECS
-                );
-                tokio::time::sleep(std::time::Duration::from_secs(
-                    DOWNLOAD_RETRY_INTERVAL_IN_SECS,
-                ))
-                .await;
-                object_checkpoint_commit_res = object_checkpoint_commit_handler
-                    .start_object_checkpoint_commit()
-                    .await;
             }
         });
 
@@ -193,132 +146,6 @@ where
         })
     }
 
-    // TODO(gegaowp): temp. solution for slow object commits, will be removed after.
-    async fn start_download_and_index_object(&self) -> Result<(), IndexerError> {
-        info!("Indexer object checkpoint download & index task started...");
-        // NOTE: important not to cast i64 to u64 here,
-        // because -1 will be returned when checkpoints table is empty.
-        let last_seq_from_db = self
-            .state
-            .get_latest_object_checkpoint_sequence_number()
-            .await?;
-        if last_seq_from_db > 0 {
-            info!("Resuming from checkpoint {last_seq_from_db}");
-        }
-        let mut next_cursor_sequence_number = last_seq_from_db + 1;
-        // NOTE: we will download checkpoints in parallel, but we will commit them sequentially.
-        // We will start with MAX_PARALLEL_DOWNLOADS, and adjust if no more checkpoints are available.
-        let mut current_parallel_downloads = MAX_PARALLEL_DOWNLOADS;
-        loop {
-            let download_futures = (next_cursor_sequence_number
-                ..next_cursor_sequence_number + current_parallel_downloads as i64)
-                .map(|seq_num| {
-                    self.download_checkpoint_data(seq_num as u64, /* skip objects */ false)
-                });
-            let download_results = join_all(download_futures).await;
-            let mut downloaded_checkpoints = vec![];
-            // NOTE: Push sequentially and if one of the downloads failed,
-            // we will discard all following checkpoints and retry, to avoid messing up the DB commit order.
-            for download_result in download_results {
-                if let Ok(checkpoint) = download_result {
-                    downloaded_checkpoints.push(checkpoint);
-                } else {
-                    if let Err(IndexerError::UnexpectedFullnodeResponseError(fn_e)) =
-                        download_result
-                    {
-                        warn!(
-                            "Unexpected response from fullnode for object checkpoints: {}",
-                            fn_e
-                        );
-                    } else if let Err(IndexerError::FullNodeReadingError(fn_e)) = download_result {
-                        warn!("Fullnode reading error for object checkpoints {}: {}. It can be transient or due to rate limiting.", next_cursor_sequence_number, fn_e);
-                    } else {
-                        warn!(
-                            "Error downloading object checkpoints: {:?}",
-                            download_result
-                        );
-                    }
-                    break;
-                }
-            }
-            next_cursor_sequence_number += downloaded_checkpoints.len() as i64;
-            // NOTE: with this line, we can make sure that:
-            // - when indexer is way behind and catching up, we download MAX_PARALLEL_DOWNLOADS checkpoints in parallel;
-            // - when indexer is up to date, we download at least one checkpoint at a time.
-            current_parallel_downloads =
-                std::cmp::min(downloaded_checkpoints.len() + 1, MAX_PARALLEL_DOWNLOADS);
-            if downloaded_checkpoints.is_empty() {
-                warn!(
-                    "No object checkpoints were downloaded for sequence number {}, retrying...",
-                    next_cursor_sequence_number
-                );
-                continue;
-            }
-
-            // Index checkpoint data
-            let indexed_checkpoint_epoch_vec = join_all(downloaded_checkpoints.iter().map(
-                |downloaded_checkpoint| async {
-                    self.index_checkpoint(downloaded_checkpoint, /* index_epoch */ true)
-                        .await
-                },
-            ))
-            .await
-            .into_iter()
-            .collect::<Result<Vec<_>, IndexerError>>()
-            .map_err(|e| {
-                error!(
-                    "Failed to index checkpoints {:?} with error: {}",
-                    downloaded_checkpoints,
-                    e.to_string()
-                );
-                e
-            })?;
-            let (indexed_checkpoints, indexed_epochs): (Vec<_>, Vec<_>) =
-                indexed_checkpoint_epoch_vec.into_iter().unzip();
-            for epoch in indexed_epochs.into_iter().flatten() {
-                // for the first epoch, we need to store the epoch data first,
-                // otherwise send it to channel to be committed later.
-                if epoch.last_epoch.is_none() {
-                    let epoch_db_guard = self.metrics.epoch_db_commit_latency.start_timer();
-                    info!("Persisting first epoch...");
-                    let mut persist_first_epoch_res = self.state.persist_epoch(&epoch).await;
-                    while persist_first_epoch_res.is_err() {
-                        warn!("Failed to persist first epoch, retrying...");
-                        persist_first_epoch_res = self.state.persist_epoch(&epoch).await;
-                    }
-                    epoch_db_guard.stop_and_record();
-                    self.metrics.total_epoch_committed.inc();
-                    info!("Persisted first epoch");
-                } else {
-                    let epoch_sender_guard = self.epoch_sender.lock().await;
-                    // NOTE: when the channel is full, epoch_sender_guard will wait until the channel has space.
-                    epoch_sender_guard.send(epoch).await.map_err(|e| {
-                        error!(
-                            "Failed to send indexed epoch to epoch commit handler with error {}",
-                            e.to_string()
-                        );
-                        IndexerError::MpscChannelError(e.to_string())
-                    })?;
-                    drop(epoch_sender_guard);
-                }
-            }
-
-            let object_sender_guard = self.object_checkpoint_sender.lock().await;
-            // NOTE: when the channel is full, checkpoint_sender_guard will wait until the channel has space.
-            // Also add new checkpoint sequentially to stick to checkpoint order.
-            for indexed_checkpoint in indexed_checkpoints {
-                object_sender_guard
-                .send(indexed_checkpoint)
-                .await
-                .map_err(|e| {
-                    error!("Failed to send indexed checkpoint to checkpoint commit handler with error: {}", e.to_string());
-                    IndexerError::MpscChannelError(e.to_string())
-                })?;
-            }
-            drop(object_sender_guard);
-        }
-    }
-
     async fn start_download_and_index(&self) -> Result<(), IndexerError> {
         info!("Indexer checkpoint download & index task started...");
         // NOTE: important not to cast i64 to u64 here,
@@ -334,9 +161,7 @@ where
         loop {
             let download_futures = (next_cursor_sequence_number
                 ..next_cursor_sequence_number + current_parallel_downloads as i64)
-                .map(|seq_num| {
-                    self.download_checkpoint_data(seq_num as u64, /* skip objects */ true)
-                });
+                .map(|seq_num| self.download_checkpoint_data(seq_num as u64));
             let download_results = join_all(download_futures).await;
             let mut downloaded_checkpoints = vec![];
             // NOTE: Push sequentially and if one of the downloads failed,
@@ -376,11 +201,10 @@ where
             }
 
             // Index checkpoint data
-            let index_guard = self.metrics.checkpoint_index_latency.start_timer();
+            let index_timer = self.metrics.checkpoint_index_latency.start_timer();
             let indexed_checkpoint_epoch_vec = join_all(downloaded_checkpoints.iter().map(
                 |downloaded_checkpoint| async {
-                    self.index_checkpoint(downloaded_checkpoint, /* index_epoch */ false)
-                        .await
+                    self.index_checkpoint_and_epoch(downloaded_checkpoint).await
                 },
             ))
             .await
@@ -394,13 +218,40 @@ where
                 );
                 e
             })?;
-            let (indexed_checkpoints, _indexed_epochs): (Vec<_>, Vec<_>) =
+            let (indexed_checkpoints, indexed_epochs): (Vec<_>, Vec<_>) =
                 indexed_checkpoint_epoch_vec.into_iter().unzip();
-            index_guard.stop_and_record();
+            index_timer.stop_and_record();
+
+            for epoch in indexed_epochs.into_iter().flatten() {
+                // commit first epoch immediately, send other epochs to channel to be committed later.
+                if epoch.last_epoch.is_none() {
+                    let epoch_db_guard = self.metrics.epoch_db_commit_latency.start_timer();
+                    info!("Persisting first epoch...");
+                    let mut persist_first_epoch_res = self.state.persist_epoch(&epoch).await;
+                    while persist_first_epoch_res.is_err() {
+                        warn!("Failed to persist first epoch, retrying...");
+                        persist_first_epoch_res = self.state.persist_epoch(&epoch).await;
+                    }
+                    epoch_db_guard.stop_and_record();
+                    self.metrics.total_epoch_committed.inc();
+                    info!("Persisted first epoch");
+                } else {
+                    let epoch_sender_guard = self.epoch_sender.lock().await;
+                    // NOTE: when the channel is full, epoch_sender_guard will wait until the channel has space.
+                    epoch_sender_guard.send(epoch).await.map_err(|e| {
+                        error!(
+                            "Failed to send indexed epoch to epoch commit handler with error {}",
+                            e.to_string()
+                        );
+                        IndexerError::MpscChannelError(e.to_string())
+                    })?;
+                    drop(epoch_sender_guard);
+                }
+            }
 
             let checkpoint_sender_guard = self.checkpoint_sender.lock().await;
             // NOTE: when the channel is full, checkpoint_sender_guard will wait until the channel has space.
-            // Also add new checkpoint sequentially to stick to checkpoint order.
+            // Checkpoints are sent sequentially to stick to the order of checkpoint sequence numbers.
             for indexed_checkpoint in indexed_checkpoints {
                 checkpoint_sender_guard
                 .send(indexed_checkpoint)
@@ -448,13 +299,13 @@ where
                     checkpoint,
                     transactions,
                     events,
-                    object_changes: _,
+                    object_changes,
                     addresses,
                     active_addresses,
-                    packages: _,
-                    input_objects: _,
-                    move_calls: _,
-                    recipients: _,
+                    packages,
+                    input_objects,
+                    move_calls,
+                    recipients,
                 } = indexed_checkpoint;
                 let checkpoint_seq = checkpoint.sequence_number;
 
@@ -497,6 +348,50 @@ where
                     }
                 });
 
+                let packages_handler = self.clone();
+                spawn_monitored_task!(async move {
+                    let mut package_commit_res =
+                        packages_handler.state.persist_packages(&packages).await;
+                    while let Err(e) = package_commit_res {
+                        warn!(
+                            "Indexer package commit failed with error: {:?}, retrying after {:?} milli-secs...",
+                            e, DB_COMMIT_RETRY_INTERVAL_IN_MILLIS
+                        );
+                        tokio::time::sleep(std::time::Duration::from_millis(
+                            DB_COMMIT_RETRY_INTERVAL_IN_MILLIS,
+                        ))
+                        .await;
+                        package_commit_res =
+                            packages_handler.state.persist_packages(&packages).await;
+                    }
+                });
+
+                let tx_index_table_handler = self.clone();
+                spawn_monitored_task!(async move {
+                    let mut transaction_index_tables_commit_res = tx_index_table_handler
+                        .state
+                        .persist_transaction_index_tables(&input_objects, &move_calls, &recipients)
+                        .await;
+                    while let Err(e) = transaction_index_tables_commit_res {
+                        warn!(
+                            "Indexer transaction index tables commit failed with error: {:?}, retrying after {:?} milli-secs...",
+                            e, DB_COMMIT_RETRY_INTERVAL_IN_MILLIS
+                        );
+                        tokio::time::sleep(std::time::Duration::from_millis(
+                            DB_COMMIT_RETRY_INTERVAL_IN_MILLIS,
+                        ))
+                        .await;
+                        transaction_index_tables_commit_res = tx_index_table_handler
+                            .state
+                            .persist_transaction_index_tables(
+                                &input_objects,
+                                &move_calls,
+                                &recipients,
+                            )
+                            .await;
+                    }
+                });
+
                 let checkpoint_tx_db_guard =
                     self.metrics.checkpoint_db_commit_latency.start_timer();
                 let mut checkpoint_tx_commit_res = self
@@ -534,85 +429,15 @@ where
                 self.metrics
                     .transaction_per_checkpoint
                     .observe(tx_count as f64);
-            } else {
-                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-            }
-        }
-    }
 
-    async fn start_object_checkpoint_commit(&self) -> Result<(), IndexerError> {
-        info!("Indexer object checkpoint commit task started...");
-        loop {
-            let mut object_checkpoint_receiver_guard = self.object_checkpoint_receiver.lock().await;
-            let indexed_checkpoint = object_checkpoint_receiver_guard.recv().await;
-            drop(object_checkpoint_receiver_guard);
-
-            if let Some(indexed_checkpoint) = indexed_checkpoint {
-                let TemporaryCheckpointStore {
-                    checkpoint,
-                    transactions: _,
-                    events: _,
-                    object_changes: tx_object_changes,
-                    addresses: _,
-                    active_addresses: _,
-                    packages,
-                    input_objects,
-                    move_calls,
-                    recipients,
-                } = indexed_checkpoint;
-                let checkpoint_seq = checkpoint.sequence_number;
-
-                let packages_handler = self.clone();
-                spawn_monitored_task!(async move {
-                    let mut package_commit_res =
-                        packages_handler.state.persist_packages(&packages).await;
-                    while let Err(e) = package_commit_res {
-                        warn!(
-                            "Indexer package commit failed with error: {:?}, retrying after {:?} milli-secs...",
-                            e, DB_COMMIT_RETRY_INTERVAL_IN_MILLIS
-                        );
-                        tokio::time::sleep(std::time::Duration::from_millis(
-                            DB_COMMIT_RETRY_INTERVAL_IN_MILLIS,
-                        ))
-                        .await;
-                        package_commit_res =
-                            packages_handler.state.persist_packages(&packages).await;
-                    }
-                });
-
-                let transactions_handler = self.clone();
-                spawn_monitored_task!(async move {
-                    let mut transaction_index_tables_commit_res = transactions_handler
-                        .state
-                        .persist_transaction_index_tables(&input_objects, &move_calls, &recipients)
-                        .await;
-                    while let Err(e) = transaction_index_tables_commit_res {
-                        warn!(
-                            "Indexer transaction index tables commit failed with error: {:?}, retrying after {:?} milli-secs...",
-                            e, DB_COMMIT_RETRY_INTERVAL_IN_MILLIS
-                        );
-                        tokio::time::sleep(std::time::Duration::from_millis(
-                            DB_COMMIT_RETRY_INTERVAL_IN_MILLIS,
-                        ))
-                        .await;
-                        transaction_index_tables_commit_res = transactions_handler
-                            .state
-                            .persist_transaction_index_tables(
-                                &input_objects,
-                                &move_calls,
-                                &recipients,
-                            )
-                            .await;
-                    }
-                });
-
-                // NOTE: commit object changes in the current task to stick to the original order.
-                let object_db_guard = self.metrics.object_db_commit_latency.start_timer();
+                // NOTE: commit object changes in the current task to stick to the original order,
+                // spawned tasks are possible to be executed in a different order.
+                let object_commit_timer = self.metrics.object_db_commit_latency.start_timer();
                 let mut object_changes_commit_res = self
                     .state
                     .persist_object_changes(
                         &checkpoint,
-                        &tx_object_changes,
+                        &object_changes,
                         self.metrics.object_mutation_db_commit_latency.clone(),
                         self.metrics.object_deletion_db_commit_latency.clone(),
                     )
@@ -630,17 +455,17 @@ where
                         .state
                         .persist_object_changes(
                             &checkpoint,
-                            &tx_object_changes,
+                            &object_changes,
                             self.metrics.object_mutation_db_commit_latency.clone(),
                             self.metrics.object_deletion_db_commit_latency.clone(),
                         )
                         .await;
                 }
-                object_db_guard.stop_and_record();
+                object_commit_timer.stop_and_record();
                 self.metrics.total_object_checkpoint_committed.inc();
                 self.metrics
                     .total_object_change_committed
-                    .inc_by(tx_object_changes.len() as u64);
+                    .inc_by(object_changes.len() as u64);
                 self.metrics
                     .latest_indexer_object_checkpoint_sequence_number
                     .set(checkpoint_seq);
@@ -689,7 +514,6 @@ where
     async fn download_checkpoint_data(
         &self,
         seq: CheckpointSequenceNumber,
-        skip_object: bool,
     ) -> Result<CheckpointData, IndexerError> {
         let latest_fn_checkpoint_seq = self
             .http_client
@@ -753,14 +577,6 @@ where
         })?;
         fn_transaction_guard.stop_and_record();
 
-        if skip_object {
-            return Ok(CheckpointData {
-                checkpoint,
-                transactions,
-                changed_objects: vec![],
-            });
-        }
-
         let fn_object_guard = self.metrics.fullnode_object_download_latency.start_timer();
         let object_changes = transactions
             .iter()
@@ -777,10 +593,9 @@ where
         })
     }
 
-    async fn index_checkpoint(
+    async fn index_checkpoint_and_epoch(
         &self,
         data: &CheckpointData,
-        index_epoch: bool,
     ) -> Result<(TemporaryCheckpointStore, Option<TemporaryEpochStore>), IndexerError> {
         let CheckpointData {
             checkpoint,
@@ -880,115 +695,109 @@ where
 
         // NOTE: Index epoch when object checkpoint index has reached the same checkpoint,
         // because epoch info is based on the latest system state object by the current checkpoint.
-        let mut epoch_index = None;
-        if index_epoch {
-            epoch_index = if checkpoint.epoch == 0 && checkpoint.sequence_number == 0 {
-                // very first epoch
-                let system_state = get_sui_system_state(data)?;
-                let system_state: SuiSystemStateSummary =
-                    system_state.into_sui_system_state_summary();
-                let validators = system_state
-                    .active_validators
-                    .iter()
-                    .map(|v| (system_state.epoch, v.clone()).into())
-                    .collect();
+        let epoch_index = if checkpoint.epoch == 0 && checkpoint.sequence_number == 0 {
+            // very first epoch
+            let system_state = get_sui_system_state(data)?;
+            let system_state: SuiSystemStateSummary = system_state.into_sui_system_state_summary();
+            let validators = system_state
+                .active_validators
+                .iter()
+                .map(|v| (system_state.epoch, v.clone()).into())
+                .collect();
 
-                Some(TemporaryEpochStore {
-                    last_epoch: None,
-                    new_epoch: DBEpochInfo {
-                        epoch: 0,
-                        first_checkpoint_id: 0,
-                        epoch_start_timestamp: system_state.epoch_start_timestamp_ms as i64,
-                        ..Default::default()
-                    },
-                    system_state: system_state.into(),
-                    validators,
+            Some(TemporaryEpochStore {
+                last_epoch: None,
+                new_epoch: DBEpochInfo {
+                    epoch: 0,
+                    first_checkpoint_id: 0,
+                    epoch_start_timestamp: system_state.epoch_start_timestamp_ms as i64,
+                    ..Default::default()
+                },
+                system_state: system_state.into(),
+                validators,
+            })
+        } else if let Some(end_of_epoch_data) = &checkpoint.end_of_epoch_data {
+            let system_state = get_sui_system_state(data)?;
+            let system_state: SuiSystemStateSummary = system_state.into_sui_system_state_summary();
+            let epoch_event = transactions.iter().find_map(|tx| {
+                tx.events.data.iter().find(|ev| {
+                    ev.type_.address == SUI_SYSTEM_ADDRESS
+                        && ev.type_.module.as_ident_str() == ident_str!("sui_system_state_inner")
+                        && ev.type_.name.as_ident_str() == ident_str!("SystemEpochInfoEvent")
                 })
-            } else if let Some(end_of_epoch_data) = &checkpoint.end_of_epoch_data {
-                let system_state = get_sui_system_state(data)?;
-                let system_state: SuiSystemStateSummary =
-                    system_state.into_sui_system_state_summary();
-                let epoch_event = transactions.iter().find_map(|tx| {
-                    tx.events.data.iter().find(|ev| {
-                        ev.type_.address == SUI_SYSTEM_ADDRESS
-                            && ev.type_.module.as_ident_str()
-                                == ident_str!("sui_system_state_inner")
-                            && ev.type_.name.as_ident_str() == ident_str!("SystemEpochInfoEvent")
-                    })
-                });
+            });
 
-                let event = epoch_event
-                    .map(|e| bcs::from_bytes::<SystemEpochInfoEvent>(&e.bcs))
-                    .transpose()?;
+            let event = epoch_event
+                .map(|e| bcs::from_bytes::<SystemEpochInfoEvent>(&e.bcs))
+                .transpose()?;
 
-                let validators = system_state
-                    .active_validators
-                    .iter()
-                    .map(|v| (system_state.epoch, v.clone()).into())
-                    .collect();
+            let validators = system_state
+                .active_validators
+                .iter()
+                .map(|v| (system_state.epoch, v.clone()).into())
+                .collect();
 
-                let epoch_commitments = end_of_epoch_data
-                    .epoch_commitments
-                    .iter()
-                    .map(|c| match c {
-                        CheckpointCommitment::ECMHLiveObjectSetDigest(d) => {
-                            Some(d.digest.into_inner().to_vec())
-                        }
-                    })
-                    .collect();
-
-                let (next_epoch_committee, next_epoch_committee_stake) =
-                    end_of_epoch_data.next_epoch_committee.iter().fold(
-                        (vec![], vec![]),
-                        |(mut names, mut stakes), (name, stake)| {
-                            names.push(Some(name.as_bytes().to_vec()));
-                            stakes.push(Some(*stake as i64));
-                            (names, stakes)
-                        },
-                    );
-
-                let event = event.as_ref();
-
-                Some(TemporaryEpochStore {
-                    last_epoch: Some(DBEpochInfo {
-                        epoch: system_state.epoch as i64 - 1,
-                        first_checkpoint_id: 0,
-                        last_checkpoint_id: Some(checkpoint.sequence_number as i64),
-                        epoch_start_timestamp: 0,
-                        epoch_end_timestamp: Some(checkpoint.timestamp_ms as i64),
-                        epoch_total_transactions: 0,
-                        next_epoch_version: Some(
-                            end_of_epoch_data.next_epoch_protocol_version.as_u64() as i64,
-                        ),
-                        next_epoch_committee,
-                        next_epoch_committee_stake,
-                        stake_subsidy_amount: event.map(|e| e.stake_subsidy_amount),
-                        reference_gas_price: event.map(|e| e.reference_gas_price),
-                        storage_fund_balance: event.map(|e| e.storage_fund_balance),
-                        total_gas_fees: event.map(|e| e.total_gas_fees),
-                        total_stake_rewards_distributed: event
-                            .map(|e| e.total_stake_rewards_distributed),
-                        total_stake: event.map(|e| e.total_stake),
-                        storage_fund_reinvestment: event.map(|e| e.storage_fund_reinvestment),
-                        storage_charge: event.map(|e| e.storage_charge),
-                        protocol_version: event.map(|e| e.protocol_version),
-                        storage_rebate: event.map(|e| e.storage_rebate),
-                        leftover_storage_fund_inflow: event.map(|e| e.leftover_storage_fund_inflow),
-                        epoch_commitments,
-                    }),
-                    new_epoch: DBEpochInfo {
-                        epoch: system_state.epoch as i64,
-                        first_checkpoint_id: checkpoint.sequence_number as i64 + 1,
-                        epoch_start_timestamp: system_state.epoch_start_timestamp_ms as i64,
-                        ..Default::default()
-                    },
-                    system_state: system_state.into(),
-                    validators,
+            let epoch_commitments = end_of_epoch_data
+                .epoch_commitments
+                .iter()
+                .map(|c| match c {
+                    CheckpointCommitment::ECMHLiveObjectSetDigest(d) => {
+                        Some(d.digest.into_inner().to_vec())
+                    }
                 })
-            } else {
-                None
-            };
-        }
+                .collect();
+
+            let (next_epoch_committee, next_epoch_committee_stake) =
+                end_of_epoch_data.next_epoch_committee.iter().fold(
+                    (vec![], vec![]),
+                    |(mut names, mut stakes), (name, stake)| {
+                        names.push(Some(name.as_bytes().to_vec()));
+                        stakes.push(Some(*stake as i64));
+                        (names, stakes)
+                    },
+                );
+
+            let event = event.as_ref();
+
+            Some(TemporaryEpochStore {
+                last_epoch: Some(DBEpochInfo {
+                    epoch: system_state.epoch as i64 - 1,
+                    first_checkpoint_id: 0,
+                    last_checkpoint_id: Some(checkpoint.sequence_number as i64),
+                    epoch_start_timestamp: 0,
+                    epoch_end_timestamp: Some(checkpoint.timestamp_ms as i64),
+                    epoch_total_transactions: 0,
+                    next_epoch_version: Some(
+                        end_of_epoch_data.next_epoch_protocol_version.as_u64() as i64,
+                    ),
+                    next_epoch_committee,
+                    next_epoch_committee_stake,
+                    stake_subsidy_amount: event.map(|e| e.stake_subsidy_amount),
+                    reference_gas_price: event.map(|e| e.reference_gas_price),
+                    storage_fund_balance: event.map(|e| e.storage_fund_balance),
+                    total_gas_fees: event.map(|e| e.total_gas_fees),
+                    total_stake_rewards_distributed: event
+                        .map(|e| e.total_stake_rewards_distributed),
+                    total_stake: event.map(|e| e.total_stake),
+                    storage_fund_reinvestment: event.map(|e| e.storage_fund_reinvestment),
+                    storage_charge: event.map(|e| e.storage_charge),
+                    protocol_version: event.map(|e| e.protocol_version),
+                    storage_rebate: event.map(|e| e.storage_rebate),
+                    leftover_storage_fund_inflow: event.map(|e| e.leftover_storage_fund_inflow),
+                    epoch_commitments,
+                }),
+                new_epoch: DBEpochInfo {
+                    epoch: system_state.epoch as i64,
+                    first_checkpoint_id: checkpoint.sequence_number as i64 + 1,
+                    epoch_start_timestamp: system_state.epoch_start_timestamp_ms as i64,
+                    ..Default::default()
+                },
+                system_state: system_state.into(),
+                validators,
+            })
+        } else {
+            None
+        };
         let total_transactions = db_transactions.iter().map(|t| t.transaction_count).sum();
         let total_successful_transaction_blocks = db_transactions
             .iter()

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -36,7 +36,6 @@ pub trait IndexerStore {
     type ModuleCache;
 
     async fn get_latest_checkpoint_sequence_number(&self) -> Result<i64, IndexerError>;
-    async fn get_latest_object_checkpoint_sequence_number(&self) -> Result<i64, IndexerError>;
     async fn get_checkpoint(&self, id: CheckpointId) -> Result<RpcCheckpoint, IndexerError>;
     async fn get_checkpoint_sequence_number(
         &self,


### PR DESCRIPTION
## Description 

It was split before mainnet for better backfill speed on testnet, it's no longer urgent b/c TPS is not super high today, but this split is very error-prune and caused issues and affected reliability in the past, thus 

To improve peak TPS handling capability, it's planned to rewrite object commit via replacing upsert with append-only.

## Test Plan 

running locally agains both testnet and mainnet to make sure 
- all obj handler related tables are all populated as expected including `objects`, `epochs`, `packages`, `input_objects`, `move_calls` and `recipients`.
- compared commit speeds over first 10k checkpoints and the obj is still the bottle-neck and it's not any faster
  - testnet with change: 650s <> testnet without changes: 1) tx: 510s 2) obj: 670s
  - mainnet with change: 150s <> mainnet without changes: 1) tx: 110s 2) obj: 145s
  
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
