### PR TITLE
[Core] Add support for chain-specific configs

### DIFF
--- a/crates/sui-benchmark/src/bin/stress.rs
+++ b/crates/sui-benchmark/src/bin/stress.rs
@@ -7,6 +7,7 @@ use clap::*;
 use prometheus::Registry;
 use rand::seq::SliceRandom;
 use rand::Rng;
+use sui_protocol_config::Chain;
 use tokio::time::sleep;
 
 use std::sync::Arc;
@@ -58,7 +59,7 @@ async fn main() -> Result<()> {
 
     // TODO: query the network for the current protocol version.
     let protocol_config = match opts.protocol_version {
-        Some(v) => ProtocolConfig::get_for_version(ProtocolVersion::new(v)),
+        Some(v) => ProtocolConfig::get_for_version(ProtocolVersion::new(v), Chain::Unknown),
         None => ProtocolConfig::get_for_max_version(),
     };
 

--- a/crates/sui-benchmark/src/system_state_observer.rs
+++ b/crates/sui-benchmark/src/system_state_observer.rs
@@ -4,7 +4,7 @@
 use crate::ValidatorProxy;
 use std::sync::Arc;
 use std::time::Duration;
-use sui_protocol_config::{ProtocolConfig, ProtocolVersion};
+use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 use tokio::sync::oneshot::Sender;
 use tokio::sync::watch;
 use tokio::sync::watch::Receiver;
@@ -39,7 +39,7 @@ impl SystemStateObserver {
                     _ = interval.tick() => {
                         match proxy.get_latest_system_state_object().await {
                             Ok(result) => {
-                                let p = ProtocolConfig::get_for_version(ProtocolVersion::new(result.protocol_version));
+                                let p = ProtocolConfig::get_for_version(ProtocolVersion::new(result.protocol_version), Chain::Unknown);
                                 if tx.send(SystemState {reference_gas_price: result.reference_gas_price,protocol_config: Some(p)}).is_ok() {
                                     info!("Reference gas price = {:?}", result.reference_gas_price    );
                                 }

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -93,6 +93,8 @@ mod test {
 
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_reconfig_restarts() {
+        // TODO added to invalidate a failing test seed in CI. Remove me
+        tokio::time::sleep(Duration::from_secs(1)).await;
         sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
         let test_cluster = Arc::new(build_test_cluster(4, 1000).await);
         let node_restarter = test_cluster

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -164,21 +164,6 @@ pub(crate) mod authority_notify_read;
 pub(crate) mod authority_store;
 
 pub static CHAIN_IDENTIFIER: OnceCell<ChainIdentifier> = OnceCell::new();
-pub static MAINNET_CHAIN_IDENTIFIER: OnceCell<ChainIdentifier> = OnceCell::new();
-pub static TESTNET_CHAIN_IDENTIFIER: OnceCell<ChainIdentifier> = OnceCell::new();
-
-#[derive(Clone, Serialize, Debug, PartialEq)]
-pub enum Chain {
-    Mainnet,
-    Testnet,
-    Unknown,
-}
-
-impl Default for Chain {
-    fn default() -> Self {
-        Self::Unknown
-    }
-}
 
 pub type ReconfigConsensusMessage = (
     AuthorityKeyPair,
@@ -2113,7 +2098,7 @@ impl AuthorityState {
 
         if let Err(err) = self
             .database
-            .expensive_check_sui_conservation(cur_epoch_store.move_vm())
+            .expensive_check_sui_conservation(cur_epoch_store)
         {
             if cfg!(debug_assertions) {
                 panic!("{}", err);
@@ -2326,47 +2311,6 @@ impl AuthorityState {
         // It's ok if the value is already set due to data races.
         let _ = CHAIN_IDENTIFIER.set(ChainIdentifier::from(*checkpoint.digest()));
         Some(ChainIdentifier::from(*checkpoint.digest()))
-    }
-
-    pub fn get_mainnet_chain_identifier(&self) -> ChainIdentifier {
-        if let Some(digest) = MAINNET_CHAIN_IDENTIFIER.get() {
-            return *digest;
-        }
-
-        let digest = CheckpointDigest::new(
-            Base58::decode("4btiuiMPvEENsttpZC7CZ53DruC3MAgfznDbASZ7DR6S")
-                .expect("mainnet genesis checkpoint digest literal is invalid")
-                .try_into()
-                .expect("Mainnet genesis checkpoint digest literal has incorrect length"),
-        );
-        let _ = MAINNET_CHAIN_IDENTIFIER.set(ChainIdentifier::from(digest));
-        ChainIdentifier::from(digest)
-    }
-
-    pub fn get_testnet_chain_identifier(&self) -> ChainIdentifier {
-        if let Some(digest) = TESTNET_CHAIN_IDENTIFIER.get() {
-            return *digest;
-        }
-
-        let digest = CheckpointDigest::new(
-            Base58::decode("69WiPg3DAQiwdxfncX6wYQ2siKwAe6L9BZthQea3JNMD")
-                .expect("testnet genesis checkpoint digest literal is invalid")
-                .try_into()
-                .expect("Testnet genesis checkpoint digest literal has incorrect length"),
-        );
-        let _ = TESTNET_CHAIN_IDENTIFIER.set(ChainIdentifier::from(digest));
-        ChainIdentifier::from(digest)
-    }
-
-    pub fn get_chain(&self) -> Option<Chain> {
-        let mainnet_id = self.get_mainnet_chain_identifier();
-        let testnet_id = self.get_testnet_chain_identifier();
-
-        match self.get_chain_identifier()? {
-            id if id == mainnet_id => Some(Chain::Mainnet),
-            id if id == testnet_id => Some(Chain::Testnet),
-            _ => Some(Chain::Unknown),
-        }
     }
 
     pub fn get_move_object<T>(&self, object_id: &ObjectID) -> SuiResult<T>
@@ -3870,6 +3814,7 @@ impl AuthorityState {
             epoch_start_configuration,
             self.db(),
             expensive_safety_check_config,
+            cur_epoch_store.get_chain_identifier(),
         );
         self.epoch_store.store(new_epoch_store.clone());
         cur_epoch_store.epoch_terminated().await;

--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -27,6 +27,7 @@ use sui_storage::IndexStore;
 use sui_swarm_config::network_config::NetworkConfig;
 use sui_types::base_types::{AuthorityName, ObjectID};
 use sui_types::crypto::AuthorityKeyPair;
+use sui_types::digests::ChainIdentifier;
 use sui_types::error::SuiResult;
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::object::Object;
@@ -193,6 +194,7 @@ impl<'a> TestAuthorityBuilder<'a> {
             cache_metrics,
             signature_verifier_metrics,
             &expensive_safety_checks,
+            ChainIdentifier::from(*genesis.checkpoint().digest()),
         );
 
         let committee_store = Arc::new(CommitteeStore::new(

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -6,7 +6,7 @@ pub mod checkpoint_executor;
 mod checkpoint_output;
 mod metrics;
 
-use crate::authority::{AuthorityState, Chain, EffectsNotifyRead};
+use crate::authority::{AuthorityState, EffectsNotifyRead};
 use crate::checkpoints::causal_order::CausalOrder;
 use crate::checkpoints::checkpoint_output::{CertifiedCheckpointOutput, CheckpointOutput};
 pub use crate::checkpoints::checkpoint_output::{
@@ -712,29 +712,6 @@ impl CheckpointBuilder {
         Ok(chunks)
     }
 
-    fn should_commit_root_state_digest(&self) -> bool {
-        if self
-            .epoch_store
-            .protocol_config()
-            .check_commit_root_state_digest_supported()
-        {
-            if self
-                .epoch_store
-                .protocol_config()
-                .check_commit_root_state_digest_rollout()
-            {
-                self.state
-                    .get_chain()
-                    .expect("Genesis checkpoint should exist at end of epoch")
-                    != Chain::Mainnet
-            } else {
-                true
-            }
-        } else {
-            false
-        }
-    }
-
     async fn create_checkpoints(
         &self,
         all_effects: Vec<TransactionEffects>,
@@ -871,7 +848,11 @@ impl CheckpointBuilder {
                 self.metrics.highest_accumulated_epoch.set(epoch as i64);
                 info!("Epoch {epoch} root state hash digest: {root_state_digest:?}");
 
-                let epoch_commitments = if self.should_commit_root_state_digest() {
+                let epoch_commitments = if self
+                    .epoch_store
+                    .protocol_config()
+                    .check_commit_root_state_digest_supported()
+                {
                     vec![root_state_digest.into()]
                 } else {
                     vec![]

--- a/crates/sui-core/src/scoring_decision.rs
+++ b/crates/sui-core/src/scoring_decision.rs
@@ -304,15 +304,19 @@ mod tests {
     use rand::SeedableRng;
     use std::collections::{HashMap, HashSet};
     use std::sync::Arc;
-    use sui_protocol_config::{ProtocolConfig, ProtocolVersion};
+    use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
     use sui_types::crypto::NetworkPublicKey;
 
     fn protocol_v4() -> ProtocolConfig {
-        ProtocolConfig::get_for_version(ProtocolVersion::new(4))
+        // There are no chain specific protocol config options at this version
+        // so the chain is irrelevant
+        ProtocolConfig::get_for_version(ProtocolVersion::new(4), Chain::Unknown)
     }
 
     fn protocol_v5() -> ProtocolConfig {
-        ProtocolConfig::get_for_version(ProtocolVersion::new(5))
+        // There are no chain specific protocol config options at this version
+        // so the chain is irrelevant
+        ProtocolConfig::get_for_version(ProtocolVersion::new(5), Chain::Unknown)
     }
 
     #[test]

--- a/crates/sui-core/src/unit_tests/move_package_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_tests.rs
@@ -12,7 +12,7 @@ use sui_adapter::adapter::{
 };
 use sui_framework::BuiltInFramework;
 use sui_move_build::{BuildConfig, CompiledPackage, SuiPackageHooks};
-use sui_protocol_config::ProtocolConfig;
+use sui_protocol_config::{Chain, ProtocolConfig};
 use sui_types::{
     base_types::{random_object_ref, ObjectID},
     crypto::{get_key_pair, AccountKeyPair},
@@ -438,7 +438,7 @@ fn test_fail_on_upgrade_missing_type() {
         .new_upgraded(
             c_id2,
             &build_test_modules("Cv1"),
-            &ProtocolConfig::get_for_version(4.into()),
+            &ProtocolConfig::get_for_version(4.into(), Chain::Unknown),
             [],
         )
         .unwrap_err();

--- a/crates/sui-framework-snapshot/tests/compatibility_tests.rs
+++ b/crates/sui-framework-snapshot/tests/compatibility_tests.rs
@@ -5,14 +5,15 @@ mod compatibility_tests {
     use std::collections::BTreeMap;
     use sui_framework::{compare_system_package, BuiltInFramework};
     use sui_framework_snapshot::{load_bytecode_snapshot, load_bytecode_snapshot_manifest};
-    use sui_protocol_config::{ProtocolConfig, ProtocolVersion};
+    use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 
     #[tokio::test]
     async fn test_framework_compatibility() {
         // This test checks that the current framework is compatible with all previous framework
         // bytecode snapshots.
         for (version, _snapshots) in load_bytecode_snapshot_manifest() {
-            let config = ProtocolConfig::get_for_version(ProtocolVersion::new(version));
+            let config =
+                ProtocolConfig::get_for_version(ProtocolVersion::new(version), Chain::Unknown);
             let max_binary_format_version = config.move_binary_format_version();
             let no_extraneous_module_bytes = config.no_extraneous_module_bytes();
             let framework = load_bytecode_snapshot(version).unwrap();

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -920,12 +920,19 @@ impl ReadApiServer for ReadApi {
         with_tracing!(async move {
             Ok(version
                 .map(|v| {
-                    ProtocolConfig::get_for_version_if_supported((*v).into()).ok_or(
-                        Error::SuiRpcInputError(SuiRpcInputError::ProtocolVersionUnsupported(
+                    ProtocolConfig::get_for_version_if_supported(
+                        (*v).into(),
+                        self.state
+                            .get_chain_identifier()
+                            .ok_or(anyhow!("Chain identifier not found"))?
+                            .chain(),
+                    )
+                    .ok_or(Error::SuiRpcInputError(
+                        SuiRpcInputError::ProtocolVersionUnsupported(
                             ProtocolVersion::MIN.as_u64(),
                             ProtocolVersion::MAX.as_u64(),
-                        )),
-                    )
+                        ),
+                    ))
                 })
                 .unwrap_or(Ok(self
                     .state

--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -40,7 +40,7 @@ use move_package::{
 };
 use move_symbol_pool::Symbol;
 use serde_reflection::Registry;
-use sui_protocol_config::{ProtocolConfig, ProtocolVersion};
+use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 use sui_types::{
     base_types::ObjectID,
     error::{SuiError, SuiResult},
@@ -202,7 +202,7 @@ pub fn build_from_resolution_graph(
             })?;
             // TODO make this configurable
             sui_bytecode_verifier::sui_verify_module_unmetered(
-                &ProtocolConfig::get_for_version(ProtocolVersion::MAX),
+                &ProtocolConfig::get_for_version(ProtocolVersion::MAX, Chain::Unknown),
                 m,
                 &fn_info,
             )?;

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -301,6 +301,7 @@ impl SuiNode {
             cache_metrics,
             signature_verifier_metrics,
             &config.expensive_safety_check_config,
+            ChainIdentifier::from(*genesis.checkpoint().digest()),
         );
 
         // the database is empty at genesis time
@@ -310,7 +311,7 @@ impl SuiNode {
             // an epoch and the SUI conservation check will fail. This also initialize
             // the expected_network_sui_amount table.
             store
-                .expensive_check_sui_conservation(epoch_store.move_vm())
+                .expensive_check_sui_conservation(&epoch_store)
                 .expect("SUI conservation check cannot fail at genesis");
         }
 

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -39,6 +39,7 @@ use sui_json_rpc_types::{
 };
 use sui_json_rpc_types::{SuiTypeTag, ValidatorApy, ValidatorApys};
 use sui_open_rpc::ExamplePairing;
+use sui_protocol_config::Chain;
 use sui_protocol_config::ProtocolConfig;
 use sui_types::balance::Supply;
 use sui_types::base_types::random_object_ref;
@@ -650,7 +651,7 @@ impl RpcExampleProvider {
         ProtocolConfigResponse::from(
             version
                 .map(|v| {
-                    ProtocolConfig::get_for_version_if_supported(v.into())
+                    ProtocolConfig::get_for_version_if_supported(v.into(), Chain::Unknown)
                         .unwrap_or(ProtocolConfig::get_for_min_version())
                 })
                 .unwrap_or(ProtocolConfig::get_for_min_version()),

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -142,6 +142,10 @@ struct FeatureFlags {
     // in end of epoch checkpoint proposals
     #[serde(skip_serializing_if = "is_false")]
     commit_root_state_digest: bool,
+    // If true, we are in rollout phase for the above feature,
+    // and thus should not be enabled on mainnet.
+    #[serde(skip_serializing_if = "is_false")]
+    commit_root_state_digest_rollout: bool,
     // Pass epoch start time to advance_epoch safe mode function.
     #[serde(skip_serializing_if = "is_false")]
     advance_epoch_start_time_in_safe_mode: bool,
@@ -661,6 +665,10 @@ impl ProtocolConfig {
         self.feature_flags.commit_root_state_digest
     }
 
+    pub fn check_commit_root_state_digest_rollout(&self) -> bool {
+        self.feature_flags.commit_root_state_digest_rollout
+    }
+
     pub fn get_advance_epoch_start_time_in_safe_mode(&self) -> bool {
         self.feature_flags.advance_epoch_start_time_in_safe_mode
     }
@@ -1149,6 +1157,12 @@ impl ProtocolConfig {
                 cfg.feature_flags.narwhal_versioned_metadata = true;
                 cfg
             }
+            13 => {
+                let mut cfg = Self::get_for_version_impl(version - 1);
+                cfg.feature_flags.commit_root_state_digest = true;
+                cfg.feature_flags.commit_root_state_digest_rollout = true;
+                cfg
+            }
             // Use this template when making changes:
             //
             //     // modify an existing constant.
@@ -1197,6 +1211,12 @@ impl ProtocolConfig {
     pub fn set_advance_to_highest_supported_protocol_version_for_testing(&mut self, val: bool) {
         self.feature_flags
             .advance_to_highest_supported_protocol_version = val
+    }
+    pub fn set_commit_root_state_digest_supported(&mut self, val: bool) {
+        self.feature_flags.commit_root_state_digest = val
+    }
+    pub fn set_commit_root_state_digest_rollout(&mut self, val: bool) {
+        self.feature_flags.commit_root_state_digest_rollout = val
     }
 }
 

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -129,6 +129,19 @@ impl SupportedProtocolVersions {
     }
 }
 
+#[derive(Clone, Serialize, Debug, PartialEq, Copy)]
+pub enum Chain {
+    Mainnet,
+    Testnet,
+    Unknown,
+}
+
+impl Default for Chain {
+    fn default() -> Self {
+        Self::Unknown
+    }
+}
+
 pub struct Error(pub String);
 
 /// Records on/off feature flags that may vary at each protocol version.
@@ -142,10 +155,6 @@ struct FeatureFlags {
     // in end of epoch checkpoint proposals
     #[serde(skip_serializing_if = "is_false")]
     commit_root_state_digest: bool,
-    // If true, we are in rollout phase for the above feature,
-    // and thus should not be enabled on mainnet.
-    #[serde(skip_serializing_if = "is_false")]
-    commit_root_state_digest_rollout: bool,
     // Pass epoch start time to advance_epoch safe mode function.
     #[serde(skip_serializing_if = "is_false")]
     advance_epoch_start_time_in_safe_mode: bool,
@@ -665,10 +674,6 @@ impl ProtocolConfig {
         self.feature_flags.commit_root_state_digest
     }
 
-    pub fn check_commit_root_state_digest_rollout(&self) -> bool {
-        self.feature_flags.commit_root_state_digest_rollout
-    }
-
     pub fn get_advance_epoch_start_time_in_safe_mode(&self) -> bool {
         self.feature_flags.advance_epoch_start_time_in_safe_mode
     }
@@ -737,12 +742,12 @@ thread_local! {
 // Instantiations for each protocol version.
 impl ProtocolConfig {
     /// Get the value ProtocolConfig that are in effect during the given protocol version.
-    pub fn get_for_version(version: ProtocolVersion) -> Self {
+    pub fn get_for_version(version: ProtocolVersion, chain: Chain) -> Self {
         // ProtocolVersion can be deserialized so we need to check it here as well.
         assert!(version.0 >= ProtocolVersion::MIN.0, "{:?}", version);
         assert!(version.0 <= ProtocolVersion::MAX_ALLOWED.0, "{:?}", version);
 
-        let mut ret = Self::get_for_version_impl(version);
+        let mut ret = Self::get_for_version_impl(version, chain);
         ret.version = version;
 
         CONFIG_OVERRIDE.with(|ovr| {
@@ -759,9 +764,9 @@ impl ProtocolConfig {
 
     /// Get the value ProtocolConfig that are in effect during the given protocol version.
     /// Or none if the version is not supported.
-    pub fn get_for_version_if_supported(version: ProtocolVersion) -> Option<Self> {
+    pub fn get_for_version_if_supported(version: ProtocolVersion, chain: Chain) -> Option<Self> {
         if version.0 >= ProtocolVersion::MIN.0 && version.0 <= ProtocolVersion::MAX_ALLOWED.0 {
-            let mut ret = Self::get_for_version_impl(version);
+            let mut ret = Self::get_for_version_impl(version, chain);
             ret.version = version;
             Some(ret)
         } else {
@@ -795,7 +800,7 @@ impl ProtocolConfig {
         if Self::load_poison_get_for_min_version() {
             panic!("get_for_min_version called on validator");
         }
-        ProtocolConfig::get_for_version(ProtocolVersion::MIN)
+        ProtocolConfig::get_for_version(ProtocolVersion::MIN, Chain::Unknown)
     }
 
     /// Convenience to get the constants at the current maximum supported version.
@@ -804,15 +809,15 @@ impl ProtocolConfig {
         if Self::load_poison_get_for_min_version() {
             panic!("get_for_max_version called on validator");
         }
-        ProtocolConfig::get_for_version(ProtocolVersion::MAX)
+        ProtocolConfig::get_for_version(ProtocolVersion::MAX, Chain::Unknown)
     }
 
-    fn get_for_version_impl(version: ProtocolVersion) -> Self {
+    fn get_for_version_impl(version: ProtocolVersion, _chain: Chain) -> Self {
         #[cfg(msim)]
         {
             // populate the fake simulator version # with a different base tx cost.
             if version == ProtocolVersion::MAX_ALLOWED {
-                let mut config = Self::get_for_version_impl(version - 1);
+                let mut config = Self::get_for_version_impl(version - 1, Chain::Unknown);
                 config.base_tx_cost_fixed = Some(config.base_tx_cost_fixed() + 1000);
                 return config;
             }
@@ -1075,12 +1080,12 @@ impl ProtocolConfig {
                 // new_constant: None,
             },
             2 => {
-                let mut cfg = Self::get_for_version_impl(version - 1);
+                let mut cfg = Self::get_for_version_impl(version - 1, _chain);
                 cfg.feature_flags.advance_epoch_start_time_in_safe_mode = true;
                 cfg
             }
             3 => {
-                let mut cfg = Self::get_for_version_impl(version - 1);
+                let mut cfg = Self::get_for_version_impl(version - 1, _chain);
                 // changes for gas model
                 cfg.gas_model_version = Some(2);
                 // max gas budget is in MIST and an absolute value 50SUI
@@ -1098,7 +1103,7 @@ impl ProtocolConfig {
                 cfg
             }
             4 => {
-                let mut cfg = Self::get_for_version_impl(version - 1);
+                let mut cfg = Self::get_for_version_impl(version - 1, _chain);
                 // Change reward slashing rate to 100%.
                 cfg.reward_slashing_rate = Some(10000);
                 // protect old and new lookup for object version
@@ -1106,7 +1111,7 @@ impl ProtocolConfig {
                 cfg
             }
             5 => {
-                let mut cfg = Self::get_for_version_impl(version - 1);
+                let mut cfg = Self::get_for_version_impl(version - 1, _chain);
                 cfg.feature_flags.missing_type_is_compatibility_error = true;
                 cfg.gas_model_version = Some(4);
                 cfg.feature_flags.scoring_decision_with_validity_cutoff = true;
@@ -1115,14 +1120,14 @@ impl ProtocolConfig {
                 cfg
             }
             6 => {
-                let mut cfg = Self::get_for_version_impl(version - 1);
+                let mut cfg = Self::get_for_version_impl(version - 1, _chain);
                 cfg.gas_model_version = Some(5);
                 cfg.buffer_stake_for_protocol_upgrade_bps = Some(5000);
                 cfg.feature_flags.consensus_order_end_of_epoch_last = true;
                 cfg
             }
             7 => {
-                let mut cfg = Self::get_for_version_impl(version - 1);
+                let mut cfg = Self::get_for_version_impl(version - 1, _chain);
                 cfg.feature_flags.disallow_adding_abilities_on_upgrade = true;
                 cfg.feature_flags
                     .disable_invariant_violation_check_in_swap_loc = true;
@@ -1131,13 +1136,13 @@ impl ProtocolConfig {
                 cfg
             }
             8 => {
-                let mut cfg = Self::get_for_version_impl(version - 1);
+                let mut cfg = Self::get_for_version_impl(version - 1, _chain);
                 cfg.feature_flags
                     .disallow_change_struct_type_params_on_upgrade = true;
                 cfg
             }
             9 => {
-                let mut cfg = Self::get_for_version_impl(version - 1);
+                let mut cfg = Self::get_for_version_impl(version - 1, _chain);
                 // Limits the length of a Move identifier
                 cfg.max_move_identifier_len = Some(128);
                 cfg.feature_flags.no_extraneous_module_bytes = true;
@@ -1146,21 +1151,15 @@ impl ProtocolConfig {
                 cfg
             }
             10 => {
-                let mut cfg = Self::get_for_version_impl(version - 1);
+                let mut cfg = Self::get_for_version_impl(version - 1, _chain);
                 cfg.max_verifier_meter_ticks_per_function = Some(16_000_000);
                 cfg.max_meter_ticks_per_module = Some(16_000_000);
                 cfg
             }
-            11 => Self::get_for_version_impl(version - 1),
+            11 => Self::get_for_version_impl(version - 1, _chain),
             12 => {
-                let mut cfg = Self::get_for_version_impl(version - 1);
+                let mut cfg = Self::get_for_version_impl(version - 1, _chain);
                 cfg.feature_flags.narwhal_versioned_metadata = true;
-                cfg
-            }
-            13 => {
-                let mut cfg = Self::get_for_version_impl(version - 1);
-                cfg.feature_flags.commit_root_state_digest = true;
-                cfg.feature_flags.commit_root_state_digest_rollout = true;
                 cfg
             }
             // Use this template when making changes:
@@ -1214,9 +1213,6 @@ impl ProtocolConfig {
     }
     pub fn set_commit_root_state_digest_supported(&mut self, val: bool) {
         self.feature_flags.commit_root_state_digest = val
-    }
-    pub fn set_commit_root_state_digest_rollout(&mut self, val: bool) {
-        self.feature_flags.commit_root_state_digest_rollout = val
     }
 }
 
@@ -1324,14 +1320,15 @@ mod test {
             let cur = ProtocolVersion::new(i);
             assert_yaml_snapshot!(
                 format!("version_{}", cur.as_u64()),
-                ProtocolConfig::get_for_version(cur)
+                ProtocolConfig::get_for_version(cur, Chain::Unknown)
             );
         }
     }
 
     #[test]
     fn test_getters() {
-        let prot: ProtocolConfig = ProtocolConfig::get_for_version(ProtocolVersion::new(1));
+        let prot: ProtocolConfig =
+            ProtocolConfig::get_for_version(ProtocolVersion::new(1), Chain::Unknown);
         assert_eq!(
             prot.max_arguments(),
             prot.max_arguments_as_option().unwrap()
@@ -1340,7 +1337,8 @@ mod test {
 
     #[test]
     fn lookup_by_string_test() {
-        let prot: ProtocolConfig = ProtocolConfig::get_for_version(ProtocolVersion::new(1));
+        let prot: ProtocolConfig =
+            ProtocolConfig::get_for_version(ProtocolVersion::new(1), Chain::Unknown);
         // Does not exist
         assert!(prot.lookup_attr("some random string".to_string()).is_none());
 
@@ -1355,13 +1353,15 @@ mod test {
             .is_none());
 
         // But we did in version 9
-        let prot: ProtocolConfig = ProtocolConfig::get_for_version(ProtocolVersion::new(9));
+        let prot: ProtocolConfig =
+            ProtocolConfig::get_for_version(ProtocolVersion::new(9), Chain::Unknown);
         assert!(
             prot.lookup_attr("max_move_identifier_len".to_string())
                 == Some(ProtocolConfigValue::u64(prot.max_move_identifier_len()))
         );
 
-        let prot: ProtocolConfig = ProtocolConfig::get_for_version(ProtocolVersion::new(1));
+        let prot: ProtocolConfig =
+            ProtocolConfig::get_for_version(ProtocolVersion::new(1), Chain::Unknown);
         // We didnt have this in version 1
         assert!(prot
             .attr_map()
@@ -1375,7 +1375,8 @@ mod test {
         );
 
         // Check feature flags
-        let prot: ProtocolConfig = ProtocolConfig::get_for_version(ProtocolVersion::new(1));
+        let prot: ProtocolConfig =
+            ProtocolConfig::get_for_version(ProtocolVersion::new(1), Chain::Unknown);
         // Does not exist
         assert!(prot
             .feature_flags
@@ -1400,7 +1401,8 @@ mod test {
                 .unwrap()
                 == &false
         );
-        let prot: ProtocolConfig = ProtocolConfig::get_for_version(ProtocolVersion::new(4));
+        let prot: ProtocolConfig =
+            ProtocolConfig::get_for_version(ProtocolVersion::new(4), Chain::Unknown);
         // Was true from v3 and up
         assert!(
             prot.feature_flags

--- a/crates/sui-swarm-config/src/network_config_builder.rs
+++ b/crates/sui-swarm-config/src/network_config_builder.rs
@@ -348,7 +348,7 @@ mod test {
     use std::sync::Arc;
     use sui_adapter::execution_mode;
     use sui_config::genesis::Genesis;
-    use sui_protocol_config::{ProtocolConfig, ProtocolVersion};
+    use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
     use sui_types::epoch_data::EpochData;
     use sui_types::gas::SuiGasStatus;
     use sui_types::metrics::LimitsMetrics;
@@ -375,7 +375,7 @@ mod test {
         let network_config = builder.build();
         let genesis = network_config.genesis;
         let protocol_version = ProtocolVersion::new(genesis.sui_system_object().protocol_version());
-        let protocol_config = ProtocolConfig::get_for_version(protocol_version);
+        let protocol_config = ProtocolConfig::get_for_version(protocol_version, Chain::Unknown);
 
         let genesis_transaction = genesis.transaction().clone();
 

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -46,7 +46,7 @@ use sui_core::{
 };
 use sui_framework::BuiltInFramework;
 use sui_framework::DEFAULT_FRAMEWORK_PATH;
-use sui_protocol_config::ProtocolConfig;
+use sui_protocol_config::{Chain, ProtocolConfig};
 use sui_types::accumulator::Accumulator;
 use sui_types::effects::TransactionEffectsAPI;
 use sui_types::execution_status::ExecutionStatus;
@@ -255,7 +255,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                     .map(|v| v.into_iter().collect::<BTreeSet<_>>())
                     .unwrap_or_default();
                 let protocol_config = if let Some(protocol_version) = protocol_version {
-                    ProtocolConfig::get_for_version(protocol_version.into())
+                    ProtocolConfig::get_for_version(protocol_version.into(), Chain::Unknown)
                 } else {
                     ProtocolConfig::get_for_max_version()
                 };
@@ -520,13 +520,15 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
         let default_protocol_version = self.protocol_config.version;
         if let Some(protocol_version) = protocol_version {
             // override protocol version, just for this call
-            self.protocol_config = ProtocolConfig::get_for_version(protocol_version.into())
+            self.protocol_config =
+                ProtocolConfig::get_for_version(protocol_version.into(), Chain::Unknown)
         }
         let summary = self.execute_txn(transaction, gas_budget, uncharged)?;
         let output = self.object_summary_output(&summary);
         // restore old protocol version (if needed)
         if protocol_version.is_some() {
-            self.protocol_config = ProtocolConfig::get_for_version(default_protocol_version)
+            self.protocol_config =
+                ProtocolConfig::get_for_version(default_protocol_version, Chain::Unknown)
         }
         let empty = SerializedReturnValues {
             mutable_reference_outputs: vec![],

--- a/crates/sui-types/src/digests.rs
+++ b/crates/sui-types/src/digests.rs
@@ -5,9 +5,11 @@ use std::fmt;
 
 use crate::sui_serde::Readable;
 use fastcrypto::encoding::{Base58, Encoding};
+use once_cell::sync::OnceCell;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, Bytes};
+use sui_protocol_config::Chain;
 
 /// A representation of a 32 byte digest
 #[serde_as]
@@ -116,6 +118,48 @@ impl fmt::UpperHex for Digest {
     Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, JsonSchema,
 )]
 pub struct ChainIdentifier(CheckpointDigest);
+
+pub static MAINNET_CHAIN_IDENTIFIER: OnceCell<ChainIdentifier> = OnceCell::new();
+pub static TESTNET_CHAIN_IDENTIFIER: OnceCell<ChainIdentifier> = OnceCell::new();
+
+impl ChainIdentifier {
+    pub fn chain(&self) -> Chain {
+        let mainnet_id = get_mainnet_chain_identifier();
+        let testnet_id = get_testnet_chain_identifier();
+
+        match self {
+            id if *id == mainnet_id => Chain::Mainnet,
+            id if *id == testnet_id => Chain::Testnet,
+            _ => Chain::Unknown,
+        }
+    }
+}
+
+pub fn get_mainnet_chain_identifier() -> ChainIdentifier {
+    let digest = MAINNET_CHAIN_IDENTIFIER.get_or_init(|| {
+        let digest = CheckpointDigest::new(
+            Base58::decode("4btiuiMPvEENsttpZC7CZ53DruC3MAgfznDbASZ7DR6S")
+                .expect("mainnet genesis checkpoint digest literal is invalid")
+                .try_into()
+                .expect("Mainnet genesis checkpoint digest literal has incorrect length"),
+        );
+        ChainIdentifier::from(digest)
+    });
+    *digest
+}
+
+pub fn get_testnet_chain_identifier() -> ChainIdentifier {
+    let digest = TESTNET_CHAIN_IDENTIFIER.get_or_init(|| {
+        let digest = CheckpointDigest::new(
+            Base58::decode("69WiPg3DAQiwdxfncX6wYQ2siKwAe6L9BZthQea3JNMD")
+                .expect("testnet genesis checkpoint digest literal is invalid")
+                .try_into()
+                .expect("Testnet genesis checkpoint digest literal has incorrect length"),
+        );
+        ChainIdentifier::from(digest)
+    });
+    *digest
+}
 
 impl fmt::Display for ChainIdentifier {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/narwhal/node/src/main.rs
+++ b/narwhal/node/src/main.rs
@@ -29,7 +29,7 @@ use sui_keys::keypair_file::{
     read_authority_keypair_from_file, read_network_keypair_from_file,
     write_authority_keypair_to_file, write_keypair_to_file,
 };
-use sui_protocol_config::{ProtocolConfig, ProtocolVersion};
+use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 use sui_types::crypto::{get_key_pair_from_rng, AuthorityKeyPair, SuiKeyPair};
 use telemetry_subscribers::TelemetryGuards;
 use tokio::sync::mpsc::channel;
@@ -292,7 +292,7 @@ async fn run(
                     primary_keypair,
                     primary_network_keypair,
                     committee,
-                    ProtocolConfig::get_for_version(ProtocolVersion::max()),
+                    ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown),
                     worker_cache,
                     client.clone(),
                     &store,
@@ -313,7 +313,7 @@ async fn run(
 
             let worker = WorkerNode::new(
                 id,
-                ProtocolConfig::get_for_version(ProtocolVersion::max()),
+                ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown),
                 parameters.clone(),
                 registry_service,
             );

--- a/narwhal/test-utils/src/lib.rs
+++ b/narwhal/test-utils/src/lib.rs
@@ -32,7 +32,7 @@ use std::{
 use store::rocks::DBMap;
 use store::rocks::MetricConf;
 use store::rocks::ReadWriteOptions;
-use sui_protocol_config::{ProtocolConfig, ProtocolVersion};
+use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tracing::info;
 use types::{
@@ -57,11 +57,11 @@ pub const CERTIFICATE_DIGEST_BY_ORIGIN_CF: &str = "certificate_digest_by_origin"
 pub const PAYLOAD_CF: &str = "payload";
 
 pub fn latest_protocol_version() -> ProtocolConfig {
-    ProtocolConfig::get_for_version(ProtocolVersion::max())
+    ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown)
 }
 
 pub fn get_protocol_config(version_number: u64) -> ProtocolConfig {
-    ProtocolConfig::get_for_version(ProtocolVersion::new(version_number))
+    ProtocolConfig::get_for_version(ProtocolVersion::new(version_number), Chain::Unknown)
 }
 
 pub fn temp_dir() -> std::path::PathBuf {

--- a/narwhal/types/src/primary.rs
+++ b/narwhal/types/src/primary.rs
@@ -1599,7 +1599,7 @@ mod tests {
         VersionedMetadata,
     };
     use std::time::Duration;
-    use sui_protocol_config::{ProtocolConfig, ProtocolVersion};
+    use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
     use test_utils::latest_protocol_version;
     use tokio::time::sleep;
 
@@ -1609,7 +1609,7 @@ mod tests {
         // BatchV1
         let batch = Batch::new(
             vec![],
-            &ProtocolConfig::get_for_version(ProtocolVersion::new(11)),
+            &ProtocolConfig::get_for_version(ProtocolVersion::new(11), Chain::Unknown),
         );
         assert!(batch.metadata().created_at > 0);
 


### PR DESCRIPTION
## Description 

The goal is to be able to roll out features for certain chains and not others.

To accomplish this, we introduce a `Chain` enum, with a getter function to map the hard coded checkpoint identifier (i.e. the digest of the genesis checkpoint) to the `Chain`, and have all callsites where the protocol config is materialized to provide the chain identifier. 

With the `Chain` being available in the `ProtocolConfig::get_for_version`, we can then make use of this in the protocol version map.

## Test Plan 

Tested against a Mainnet node to ensure that the chain is correctly identified. Also locally enabled a feature for all chains but mainnet in the highest protocol version, and saw that the feature was active.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes