### PR TITLE
[wallet-ext] - enable transfer of ob kiosk items

### DIFF
--- a/apps/core/src/hooks/useGetOriginByteKioskContents.ts
+++ b/apps/core/src/hooks/useGetOriginByteKioskContents.ts
@@ -7,9 +7,9 @@ import { useRpcClient } from '../api/RpcClientContext';
 import { useGetOwnedObjects } from './useGetOwnedObjects';
 
 // OriginByte contract address for mainnet (we only support mainnet)
-const ORIGINBYTE_KIOSK_MODULE =
+export const ORIGINBYTE_KIOSK_MODULE =
     '0x95a441d389b07437d00dd07e0b6f05f513d7659b13fd7c5d3923c7d9d847199b::ob_kiosk';
-const ORIGINBYTE_KIOSK_OWNER_TOKEN = `${ORIGINBYTE_KIOSK_MODULE}::OwnerToken`;
+export const ORIGINBYTE_KIOSK_OWNER_TOKEN = `${ORIGINBYTE_KIOSK_MODULE}::OwnerToken`;
 
 export function useGetOriginByteKioskContents(
     address?: SuiAddress | null,

--- a/apps/wallet/src/ui/app/pages/home/nft-transfer/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nft-transfer/index.tsx
@@ -36,7 +36,10 @@ function NftTransferPage() {
                                     size="sm"
                                 />
                             </div>
-                            <TransferNFTForm objectId={nftId} />
+                            <TransferNFTForm
+                                objectId={nftId}
+                                objectType={ownedNFT.type}
+                            />
                         </>
                     ) : (
                         <Navigate to="/" replace />

--- a/apps/wallet/src/ui/app/pages/home/nft-transfer/useTransferKioskItem.ts
+++ b/apps/wallet/src/ui/app/pages/home/nft-transfer/useTransferKioskItem.ts
@@ -1,0 +1,111 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+    ORIGINBYTE_KIOSK_MODULE,
+    ORIGINBYTE_KIOSK_OWNER_TOKEN,
+    useGetOwnedObjects,
+    useRpcClient,
+} from '@mysten/core';
+import { type SuiAddress, TransactionBlock } from '@mysten/sui.js';
+import { useMutation } from '@tanstack/react-query';
+
+import { useActiveAddress, useSigner } from '_src/ui/app/hooks';
+
+export function useTransferKioskItem({
+    objectId,
+    objectType,
+}: {
+    objectId: string;
+    objectType?: string;
+}) {
+    const rpc = useRpcClient();
+    const signer = useSigner();
+    const address = useActiveAddress();
+
+    const { data: kioskOwnerTokens } = useGetOwnedObjects(address, {
+        StructType: ORIGINBYTE_KIOSK_OWNER_TOKEN,
+    });
+    const kioskIds = kioskOwnerTokens?.pages
+        .flatMap((page) => page.data)
+        .map(
+            (obj) =>
+                obj.data?.content &&
+                'fields' in obj.data.content &&
+                obj.data.content.fields.kiosk
+        );
+
+    return useMutation({
+        mutationFn: async (to: SuiAddress) => {
+            if (!to || !signer || !objectType) {
+                throw new Error('Missing data');
+            }
+
+            const tx = new TransactionBlock();
+
+            // fetch the kiosks for the active address
+            const ownedKiosks = await rpc.multiGetObjects({
+                ids: kioskIds!,
+                options: { showContent: true },
+            });
+
+            // find the kiosk id containing the object that we want to transfer
+            const kioskId = ownedKiosks.find(async (kiosk) => {
+                if (!kiosk.data?.objectId) return false;
+                const objects = await rpc.getDynamicFields({
+                    parentId: kiosk.data.objectId,
+                });
+                return objects.data.some((obj) => obj.objectId === objectId);
+            })?.data?.objectId;
+
+            if (!kioskId)
+                throw new Error('failed to find kiosk containing object');
+
+            // determine if the recipient address already owns a kiosk
+            const recipientKiosks = await rpc.getOwnedObjects({
+                owner: to,
+                options: { showContent: true },
+                filter: { StructType: ORIGINBYTE_KIOSK_OWNER_TOKEN },
+            });
+
+            const recipientKiosk = recipientKiosks.data[0]?.data;
+
+            if (
+                recipientKiosk &&
+                recipientKiosk.content &&
+                'fields' in recipientKiosk.content &&
+                recipientKiosk.content.fields.kiosk
+            ) {
+                const recipientKioskId = recipientKiosk.content.fields.kiosk;
+                tx.moveCall({
+                    target: `${ORIGINBYTE_KIOSK_MODULE}::p2p_transfer`,
+                    typeArguments: [objectType],
+                    arguments: [
+                        tx.object(kioskId),
+                        tx.object(recipientKioskId),
+                        tx.pure(objectId),
+                    ],
+                });
+            } else {
+                tx.moveCall({
+                    target: `${ORIGINBYTE_KIOSK_MODULE}::p2p_transfer_and_create_target_kiosk`,
+                    typeArguments: [objectType],
+                    arguments: [
+                        tx.object(kioskId),
+                        tx.pure(to),
+                        tx.pure(objectId),
+                    ],
+                });
+            }
+
+            return signer.signAndExecuteTransactionBlock({
+                transactionBlock: tx,
+                options: {
+                    showInput: true,
+                    showEffects: true,
+                    showEvents: true,
+                },
+            });
+        },
+    });
+}


### PR DESCRIPTION
## Description 

Enables transfer of items contained within an OriginByte kiosk. There's some duplicate effort in finding the Kiosk for a given object, but wanted to get this in so that transfers work. 

## Test Plan 

Tested transfers to addresses both with + without existing kiosks

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
