### PR TITLE
fix epoch missing the latest checkoutpoint

### DIFF
--- a/apps/core/src/hooks/useTimeAgo.ts
+++ b/apps/core/src/hooks/useTimeAgo.ts
@@ -68,7 +68,6 @@ export function useTimeAgo(options: TimeAgoOptions) {
 
     useEffect(() => {
         if (!timeFrom || !intervalEnabled) return;
-        console.log('interval enabled');
         const timeout = setInterval(
             () => setNow(Date.now()),
             TimeUnit.ONE_SECOND

--- a/apps/explorer/src/components/checkpoints/CheckpointsTable.tsx
+++ b/apps/explorer/src/components/checkpoints/CheckpointsTable.tsx
@@ -39,12 +39,8 @@ export function CheckpointsTable({
         queryKey: ['checkpoints', 'count'],
         queryFn: () => rpc.getLatestCheckpointSequenceNumber(),
     });
-    // cursor should be the sequence number of the last checkpoint + 1  if we want to query with desc. order
-    const initialCursorPlusOne = Number(initialCursor) + 1;
-    const checkpoints = useGetCheckpoints(
-        initialCursorPlusOne.toString(),
-        limit
-    );
+
+    const checkpoints = useGetCheckpoints(initialCursor, limit);
 
     const { data, isFetching, pagination, isLoading, isError } =
         useCursorPagination(checkpoints);

--- a/apps/explorer/src/components/checkpoints/CheckpointsTable.tsx
+++ b/apps/explorer/src/components/checkpoints/CheckpointsTable.tsx
@@ -39,8 +39,12 @@ export function CheckpointsTable({
         queryKey: ['checkpoints', 'count'],
         queryFn: () => rpc.getLatestCheckpointSequenceNumber(),
     });
-
-    const checkpoints = useGetCheckpoints(initialCursor, limit);
+    // cursor should be the sequence number of the last checkpoint + 1  if we want to query with desc. order
+    const initialCursorPlusOne = Number(initialCursor) + 1;
+    const checkpoints = useGetCheckpoints(
+        initialCursorPlusOne.toString(),
+        limit
+    );
 
     const { data, isFetching, pagination, isLoading, isError } =
         useCursorPagination(checkpoints);

--- a/apps/explorer/src/hooks/useGetCheckpoints.ts
+++ b/apps/explorer/src/hooks/useGetCheckpoints.ts
@@ -14,7 +14,7 @@ export function useGetCheckpoints(
     const rpc = useRpcClient();
 
     return useInfiniteQuery(
-        ['get-checkpoints', limit],
+        ['get-checkpoints', limit, cursor],
         async ({ pageParam }) =>
             await rpc.getCheckpoints({
                 descendingOrder: true,

--- a/apps/explorer/src/pages/epochs/EpochDetail.tsx
+++ b/apps/explorer/src/pages/epochs/EpochDetail.tsx
@@ -81,6 +81,11 @@ export default function EpochDetail() {
         epochData.endOfEpochInfo
     );
 
+    // cursor should be the sequence number of the last checkpoint + 1  if we want to query with desc. order
+    const initialCursorPlusOne = epochData.endOfEpochInfo?.lastCheckpointId
+        ? (Number(epochData.endOfEpochInfo?.lastCheckpointId) + 1).toString()
+        : undefined;
+
     return (
         <div className="flex flex-col space-y-16">
             <div className="grid grid-flow-row gap-4 sm:gap-2 md:flex md:gap-6">
@@ -139,9 +144,7 @@ export default function EpochDetail() {
                 <TabPanels className="mt-4">
                     <TabPanel>
                         <CheckpointsTable
-                            initialCursor={
-                                epochData.endOfEpochInfo?.lastCheckpointId
-                            }
+                            initialCursor={initialCursorPlusOne}
                             maxCursor={epochData.firstCheckpointId}
                             initialLimit={20}
                         />


### PR DESCRIPTION
## Description 

Describe the changes or additions included in this PR.
Fix Epoch checkout is missing the latest 


## Test Plan 
Before checkoutpoint ends at 
<img width="1152" alt="Screenshot 2023-05-24 at 5 04 44 PM" src="https://github.com/MystenLabs/sui/assets/126525197/f6a45c92-65e6-4bec-ab6e-a3277a660b62">
https://suiexplorer.com/epoch/41

After 
<img width="1203" alt="Screenshot 2023-05-24 at 5 06 07 PM" src="https://github.com/MystenLabs/sui/assets/126525197/e4dcf75d-ab7c-414b-ac30-b2ca421b8bd6">
https://explorer-git-gj-explorer-epoch-checkpoint-bug-mysten-labs.vercel.app/epoch/41
