### PR TITLE
update self.checkpoint_sequence_by_contents_digest atomically along with other cfs

### DIFF
--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -400,11 +400,12 @@ impl CheckpointStore {
         checkpoint: &VerifiedCheckpoint,
         full_contents: VerifiedCheckpointContents,
     ) -> Result<(), TypedStoreError> {
-        self.checkpoint_sequence_by_contents_digest
-            .insert(&checkpoint.content_digest, checkpoint.sequence_number())?;
-        let full_contents = full_contents.into_inner();
-
         let mut batch = self.full_checkpoint_content.batch();
+        batch.insert_batch(
+            &self.checkpoint_sequence_by_contents_digest,
+            [(&checkpoint.content_digest, checkpoint.sequence_number())],
+        )?;
+        let full_contents = full_contents.into_inner();
         batch.insert_batch(
             &self.full_checkpoint_content,
             [(checkpoint.sequence_number(), &full_contents)],


### PR DESCRIPTION

## Description 

It's not causing any problems today but in case in the future we mistakenly assume these inserts happen atomically.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
update self.checkpoint_sequence_by_contents_digest atomically along with other cfs
