### PR TITLE
do not insert_checkpoint when get_checkpoint_by_sequence_number returns data

### DIFF
--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -107,6 +107,10 @@ impl ReadStore for RocksDbStore {
         }
 
         // Otherwise gather it from the individual components.
+        // Note we can't insert the constructed contents into `full_checkpoint_content`,
+        // because it needs to be inserted along with `checkpoint_sequence_by_contents_digest`
+        // and `checkpoint_content`. However at this point it's likely we don't know the
+        // corresponding sequence number yet.
         self.checkpoint_store
             .get_checkpoint_contents(digest)?
             .map(|contents| FullCheckpointContents::from_checkpoint_contents(&self, contents))


### PR DESCRIPTION
## Description 

There are two noticeable changes for `fn handle_checkpoint_from_consensus` in this PR:
1. if the checkpoint sent by consensus is ahead of `highest_verified_checkpoint`, we will try to fill the gap. One thing we do here is `store.insert_checkpoint` if `store.get_checkpoint_by_sequence_number` returns `Some`. This is not needed because it's only possible for `store.get_checkpoint_by_sequence_number` to return `Some` when we already have `store.insert_checkpoint` happened before. Particularly, these two functions update/check cf `certified_checkpoints`.
2.  when `if` in line 462-463 fails, and the checkpoint sequence number match, it means we have a fork, `assert_eq` is not needed.

## Test Plan 

unit tests.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Do not insert_checkpoint when get_checkpoint_by_sequence_number returns data
