### PR TITLE
[benchmark] add option to use different gas price in shared counter txns

### DIFF
--- a/crates/sui-benchmark/src/options.rs
+++ b/crates/sui-benchmark/src/options.rs
@@ -10,7 +10,7 @@ use crate::drivers::Interval;
 #[derive(Parser)]
 #[clap(name = "Stress Testing Framework")]
 pub struct Opts {
-    /// Si&ze of the Sui committee.
+    /// Size of the Sui committee.
     #[clap(long, default_value = "4", global = true)]
     pub committee_size: u64,
     /// Num of accounts to use for transfer objects
@@ -161,6 +161,10 @@ pub enum RunSpec {
         // total_shared_counters = max(1, qps * (1.0 - hotness/100.0))
         #[clap(long, default_value = "50")]
         shared_counter_hotness_factor: u32,
+        // Maximum gas price increment over the RGP for shared counter transactions.
+        // The actual increment for each transaction is chosen at random a value between 0 and this value.
+        #[clap(long, default_value = "0")]
+        shared_counter_max_tip: u64,
         // batch size use for batch payment workload
         #[clap(long, default_value = "15")]
         batch_payment_size: u32,

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -499,6 +499,7 @@ mod test {
         let adversarial_weight = 0;
 
         let shared_counter_hotness_factor = 50;
+        let shared_counter_max_tip = 0;
 
         let workloads = WorkloadConfiguration::build_workloads(
             num_workers,
@@ -511,6 +512,7 @@ mod test {
             adversarial_cfg,
             batch_payment_size,
             shared_counter_hotness_factor,
+            shared_counter_max_tip,
             target_qps,
             in_flight_ratio,
             bank,


### PR DESCRIPTION
## Description 

This PR adds an option to `sui-benchmark` allowing us to pass in a max tip amount for shared counter workloads. Each shared counter transaction picks a random gas price increment between 0 and this max amount, and use RGP + the picked increment as the gas price. This will be useful for experimenting later. Following PRs will add metrics exposing the rank correlation between gas price and txn processing order. We may also introduce separate workloads with specific gas price behavior later.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
