### PR TITLE
[doc] update package address and gas budget

### DIFF
--- a/nre/sui_for_node_operators.md
+++ b/nre/sui_for_node_operators.md
@@ -243,13 +243,13 @@ To update metadata, a validator makes a MoveCall transaction that interacts with
 1. to update name to `new_validator_name`, use the Sui Client CLI to call `sui_system::update_validator_name`:
 
 ```
-sui client call --package 0x2 --module sui_system --function update_validator_name --args 0x5 \"new_validator_name\" --gas-budget 10000
+sui client call --package 0x3 --module sui_system --function update_validator_name --args 0x5 \"new_validator_name\" --gas-budget 5000000
 ```
 
 2. to update p2p address starting from next epoch to `/ip4/192.168.1.1`, use the Sui Client CLI to call `sui_system::update_validator_next_epoch_p2p_address`:
 
 ```
-sui client call --package 0x2 --module sui_system --function update_validator_next_epoch_p2p_address --args 0x5 "[4, 192, 168, 1, 1]" --gas-budget 10000
+sui client call --package 0x3 --module sui_system --function update_validator_next_epoch_p2p_address --args 0x5 "[4, 192, 168, 1, 1]" --gas-budget 5000000
 ```
 
 See the [full list of metadata update functions here](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/packages/sui-system/sources/sui_system.move#L267-L444).
@@ -263,7 +263,7 @@ Upon creating a `Validator`, an `UnverifiedValidatorOperationCap` is created as 
 To rotate the delegatee address or revoke the authorization, the current holder of `Cap` transfers it to another address. In the event of compromised or lost keys, the validator could create a new `Cap` object to invalidate the incumbent one. This is done by calling `sui_system::rotate_operation_cap`:
 
 ```
-sui client call --package 0x2 --module sui_system --function rotate_operation_cap --args 0x5 --gas-budget 10000
+sui client call --package 0x3 --module sui_system --function rotate_operation_cap --args 0x5 --gas-budget 5000000
 ```
 
 By default the new `Cap` object is transferred to the validator address, which then could be transferred to the new delegatee address. At this point, the old `Cap` becomes invalidated and no longer represents eligibility.
@@ -275,7 +275,7 @@ To get the current valid `Cap` object's ID of a validator, use the Sui Client CL
 To update the Gas Price Survey Quote of a validator, which is used to calculate the Reference Gas Price at the end of the epoch, the sender needs to hold a valid [`UnverifiedValidatorOperationCap`](#operation-cap). The sender could be the validator itself, or a trusted delegatee. To do so, call `sui_system::request_set_gas_price`:
 
 ```
-sui client call --package 0x2 --module sui_system --function request_set_gas_price --args 0x5 {cap_object_id} {new_gas_price} --gas-budget 10000
+sui client call --package 0x3 --module sui_system --function request_set_gas_price --args 0x5 {cap_object_id} {new_gas_price} --gas-budget 5000000
 ```
 
 ### Reporting/Un-reporting Validators
@@ -283,7 +283,7 @@ sui client call --package 0x2 --module sui_system --function request_set_gas_pri
 To report a validator or undo an existing reporting, the sender needs to hold a valid [`UnverifiedValidatorOperationCap`](#operation-cap). The sender could be the validator itself, or a trusted delegatee. To do so, call `sui_system::report_validator/undo_report_validator`:
 
 ```
-sui client call --package 0x2 --module sui_system --function report_validator/undo_report_validator --args 0x5 {cap_object_id} {reportee_address} --gas-budget 10000
+sui client call --package 0x3 --module sui_system --function report_validator/undo_report_validator --args 0x5 {cap_object_id} {reportee_address} --gas-budget 5000000
 ```
 
 Once a validator is reported by `2f + 1` other validators by voting power, their staking rewards will be slashed.
@@ -293,20 +293,20 @@ Once a validator is reported by `2f + 1` other validators by voting power, their
 In order for a Sui address to join the validator set, they need to first sign up as a validator candidate by calling `sui_system::request_add_validator_candidate` with their metadata and initial configs:
 
 ```
-sui client call --package 0x2 --module sui_system --function request_add_validator_candidate --args 0x5 {protocol_pubkey_bytes {network_pubkey_bytes} {worker_pubkey_bytes} {proof_of_possession} {name} {description} {image_url} {project_url} {net_address}
-{p2p_address} {primary_address} {worker_address} {gas_price} {commission_rate} --gas-budget 10000
+sui client call --package 0x3 --module sui_system --function request_add_validator_candidate --args 0x5 {protocol_pubkey_bytes} {network_pubkey_bytes} {worker_pubkey_bytes} {proof_of_possession} {name} {description} {image_url} {project_url} {net_address}
+{p2p_address} {primary_address} {worker_address} {gas_price} {commission_rate} --gas-budget 5000000
 ```
 
 After an address becomes a validator candidate, any address (including the candidate address itself) can start staking with the candidate's staking pool. Refer to our dedicated staking FAQ on how staking works. Once a candidate's staking pool has accumulated at least `sui_system::MIN_VALIDATOR_JOINING_STAKE` amount of stake, the candidate can call `sui_system::request_add_validator` to officially add themselves to next epoch's active validator set:
 ```
-sui client call --package 0x2 --module sui_system --function request_add_validator --args 0x5 --gas-budget 10000
+sui client call --package 0x3 --module sui_system --function request_add_validator --args 0x5 --gas-budget 5000000
 ```
 
 ### Leaving the Validator Set
 
 To leave the validator set starting next epoch, the sender needs to be an active validator in the current epoch and should call `sui_system::request_remove_validator`:
 ```
-sui client call --package 0x2 --module sui_system --function request_remove_validator --args 0x5 --gas-budget 10000
+sui client call --package 0x3 --module sui_system --function request_remove_validator --args 0x5 --gas-budget 5000000
 ```
 
 After the validator is removed at the next epoch change, the staking pool will become inactive and stakes can only be withdrawn from an inactive pool.


### PR DESCRIPTION
## Description 

The package address of `sui_system` should be 0x3. The gas budgets used in examples are also changed to more realistic values.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
