### PR TITLE
indexer: move address to async processor

### DIFF
--- a/crates/sui-indexer/benches/indexer_benchmark.rs
+++ b/crates/sui-indexer/benches/indexer_benchmark.rs
@@ -90,8 +90,6 @@ fn create_checkpoint(sequence_number: i64) -> TemporaryCheckpointStore {
             changed_objects: (1..1000).map(|_| create_object(sequence_number)).collect(),
             deleted_objects: vec![],
         }],
-        addresses: vec![],
-        active_addresses: vec![],
         packages: vec![],
         input_objects: vec![],
         move_calls: vec![],

--- a/crates/sui-indexer/src/processors/address_processor.rs
+++ b/crates/sui-indexer/src/processors/address_processor.rs
@@ -1,12 +1,20 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use tracing::info;
+use tracing::{info, warn};
+
+use sui_json_rpc_types::{
+    CheckpointId, SuiTransactionBlockEvents, SuiTransactionBlockResponseOptions,
+};
 
 use crate::errors::IndexerError;
+use crate::models::addresses::{dedup_from_addresses, dedup_from_and_to_addresses};
 use crate::store::IndexerStore;
+use crate::types::{AddressData, CheckpointTransactionBlockResponse};
 
-const ADDRESS_STATS_BATCH_SIZE: i64 = 100;
+const ADDRESS_STATS_BATCH_SIZE: usize = 100;
+const DB_COMMIT_RETRY_INTERVAL_IN_MILLIS: u64 = 100;
+const PG_TX_READ_CHUNK_SIZE: usize = 1000;
 
 pub struct AddressProcessor<S> {
     pub store: S,
@@ -24,19 +32,107 @@ where
         info!("Indexer address async processor started...");
         let mut last_processed_addr_checkpoint =
             self.store.get_last_address_processed_checkpoint().await?;
-        // process another batch of events, 100 checkpoints at a time,
-        // otherwise sleep for 3 seconds
+        // process another batch of events, 100 checkpoints at a time, otherwise sleep for 3 seconds
         loop {
             let latest_checkpoint = self.store.get_latest_checkpoint_sequence_number().await?;
-            if latest_checkpoint >= last_processed_addr_checkpoint + ADDRESS_STATS_BATCH_SIZE {
+            if latest_checkpoint >= last_processed_addr_checkpoint + ADDRESS_STATS_BATCH_SIZE as i64
+            {
+                let cursor = match last_processed_addr_checkpoint {
+                    -1 => None,
+                    _ => Some(CheckpointId::SequenceNumber(
+                        last_processed_addr_checkpoint as u64,
+                    )),
+                };
+                let checkpoints = self
+                    .store
+                    .get_checkpoints(cursor, ADDRESS_STATS_BATCH_SIZE)
+                    .await?;
+                let tx_vec: Vec<sui_types::digests::TransactionDigest> = checkpoints
+                    .into_iter()
+                    .flat_map(|c| c.transactions)
+                    .collect();
+
+                for tx_chunk in tx_vec.chunks(PG_TX_READ_CHUNK_SIZE) {
+                    let tx_digest_strs = tx_chunk
+                        .iter()
+                        .map(|tx| tx.to_string())
+                        .collect::<Vec<String>>();
+                    let txs = self
+                        .store
+                        .multi_get_transactions_by_digests(&tx_digest_strs)
+                        .await?;
+                    let tx_option = SuiTransactionBlockResponseOptions {
+                        show_input: true,
+                        show_raw_input: true,
+                        show_effects: true,
+                        ..Default::default()
+                    };
+                    let sui_tx_resp_handles = txs.into_iter().map(|tx| {
+                        self.store
+                            .compose_sui_transaction_block_response(tx, Some(&tx_option))
+                    });
+                    let sui_tx_resp_vec = futures::future::join_all(sui_tx_resp_handles)
+                        .await
+                        .into_iter()
+                        .collect::<Result<Vec<_>, _>>()?
+                        .into_iter()
+                        // NOTE: need to set events to empty to avoid type hardening error
+                        .map(|mut resp| {
+                            resp.events = Some(SuiTransactionBlockEvents { data: vec![] });
+                            resp
+                        })
+                        .collect::<Vec<_>>();
+
+                    // retrieve address and active address data from txs
+                    let checkpoint_tx_resp_vec = sui_tx_resp_vec
+                        .into_iter()
+                        .map(CheckpointTransactionBlockResponse::try_from)
+                        .collect::<Result<Vec<_>, _>>()?;
+                    let from_and_to_address_data: Vec<AddressData> = checkpoint_tx_resp_vec
+                        .iter()
+                        .flat_map(|tx| tx.get_from_and_to_addresses())
+                        .collect();
+                    let from_address_data: Vec<AddressData> = checkpoint_tx_resp_vec
+                        .iter()
+                        .map(|tx| tx.get_from_address())
+                        .collect();
+                    let addresses = dedup_from_and_to_addresses(from_and_to_address_data);
+                    let active_addresses: Vec<crate::models::addresses::ActiveAddress> =
+                        dedup_from_addresses(from_address_data);
+
+                    // retry here to avoid duplicate DB reads
+                    let mut address_commit_res = self
+                        .store
+                        .persist_addresses(&addresses, &active_addresses)
+                        .await;
+                    while let Err(e) = address_commit_res {
+                        warn!(
+                        "Indexer address commit failed with error: {:?}, retrying after {:?} milli-secs...",
+                        e, DB_COMMIT_RETRY_INTERVAL_IN_MILLIS
+                    );
+                        tokio::time::sleep(std::time::Duration::from_millis(
+                            DB_COMMIT_RETRY_INTERVAL_IN_MILLIS,
+                        ))
+                        .await;
+                        address_commit_res = self
+                            .store
+                            .persist_addresses(&addresses, &active_addresses)
+                            .await;
+                    }
+                }
+
                 let addr_stats = self
                     .store
                     .calculate_address_stats(
-                        last_processed_addr_checkpoint + ADDRESS_STATS_BATCH_SIZE,
+                        last_processed_addr_checkpoint + ADDRESS_STATS_BATCH_SIZE as i64,
                     )
                     .await?;
                 self.store.persist_address_stats(&addr_stats).await?;
-                last_processed_addr_checkpoint += ADDRESS_STATS_BATCH_SIZE;
+                info!(
+                    "Processed addresses and address stats for checkpoint: {}",
+                    last_processed_addr_checkpoint
+                );
+                last_processed_addr_checkpoint += ADDRESS_STATS_BATCH_SIZE as i64;
             } else {
                 tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
                 continue;

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -37,6 +37,11 @@ pub trait IndexerStore {
 
     async fn get_latest_checkpoint_sequence_number(&self) -> Result<i64, IndexerError>;
     async fn get_checkpoint(&self, id: CheckpointId) -> Result<RpcCheckpoint, IndexerError>;
+    async fn get_checkpoints(
+        &self,
+        cursor: Option<CheckpointId>,
+        limit: usize,
+    ) -> Result<Vec<RpcCheckpoint>, IndexerError>;
     async fn get_checkpoint_sequence_number(
         &self,
         digest: CheckpointDigest,
@@ -294,8 +299,6 @@ pub struct TemporaryCheckpointStore {
     pub transactions: Vec<Transaction>,
     pub events: Vec<Event>,
     pub object_changes: Vec<TransactionObjectChanges>,
-    pub addresses: Vec<Address>,
-    pub active_addresses: Vec<ActiveAddress>,
     pub packages: Vec<Package>,
     pub input_objects: Vec<InputObject>,
     pub move_calls: Vec<MoveCall>,

--- a/crates/sui-indexer/src/types.rs
+++ b/crates/sui-indexer/src/types.rs
@@ -271,11 +271,17 @@ impl CheckpointTransactionBlockResponse {
             .collect()
     }
 
-    pub fn get_from_and_to_addresses(&self, epoch: u64, checkpoint: u64) -> Vec<AddressData> {
-        let mut addresses = self
-            .get_recipients(epoch, checkpoint)
-            .into_iter()
-            .map(|r| r.recipient)
+    pub fn get_from_and_to_addresses(&self) -> Vec<AddressData> {
+        let created = self.effects.created().iter();
+        let mutated = self.effects.mutated().iter();
+        let unwrapped = self.effects.unwrapped().iter();
+        let mut addresses = created
+            .chain(mutated)
+            .chain(unwrapped)
+            .filter_map(|obj_ref| match obj_ref.owner {
+                Owner::AddressOwner(address) => Some(address.to_string()),
+                _ => None,
+            })
             .collect::<Vec<String>>();
         addresses.push(self.transaction.data.sender().to_string());
         addresses


### PR DESCRIPTION
## Description 

Move processing of `addresses` table and `active_addresses` table to async processor.

The motivations are:
- address stats were not accurate, b/c both `addresses` and `active_addresses` are updated each checkpoint before this change and will not wait for `address_stats`; this is especially bad when we backfill `address_stats` with populated address tables
- updating `addresses` and `active_addresses` each checkpoint oftentimes caused concurrent writes and sometimes even dead_lock on PG commit; the deadlock is not end of world b/c PG can somehow recover from it.

After this change:
- the addresses and active_addresses tables are updated each 100 checkpoints, and wait for address_stats to update before moving for next 100 checkpoints
- such that it solves both problems above, we can adjust the batch size if better latency is needed.

## Test Plan 

local run and compare `addresses`, `active_addresses` & `address_stats` with and without the change.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
