### PR TITLE
[sdk] Adds a return if IDs are empty in the multiGetObjects

### DIFF
--- a/.changeset/brave-beers-pull.md
+++ b/.changeset/brave-beers-pull.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Adds an early return if ids are empty in multiGetObjects

--- a/.changeset/tame-grapes-sell.md
+++ b/.changeset/tame-grapes-sell.md
@@ -1,0 +1,5 @@
+---
+"@mysten/kiosk": patch
+---
+
+Removes getObjects utility function, replaces with multiGetObjects

--- a/sdk/kiosk/src/query/kiosk.ts
+++ b/sdk/kiosk/src/query/kiosk.ts
@@ -9,7 +9,7 @@ import {
   SuiObjectResponse,
   getObjectFields,
 } from '@mysten/sui.js';
-import { extractKioskData, getKioskObject, getObjects } from '../utils';
+import { extractKioskData, getKioskObject } from '../utils';
 import { Kiosk } from '../bcs';
 
 /**
@@ -64,7 +64,6 @@ export type FetchKioskOptions = {
   includeItems?: boolean;
   itemOptions?: SuiObjectDataOptions;
   withListingPrices?: boolean;
-  listingOptions?: SuiObjectDataOptions;
 };
 
 /**
@@ -97,12 +96,18 @@ export async function fetchKiosk(
       ? getKioskObject(provider, kioskId)
       : Promise.resolve(undefined),
     includeItems
-      ? getObjects(provider, kioskData.itemIds, itemOptions)
+      ? provider.multiGetObjects({
+          ids: kioskData.itemIds,
+          options: itemOptions,
+        })
       : Promise.resolve([]),
     withListingPrices
-      ? getObjects(provider, kioskData.listingIds, {
-          showBcs: true,
-          showContent: true,
+      ? provider.multiGetObjects({
+          ids: kioskData.listingIds,
+          options: {
+            showBcs: true,
+            showContent: true,
+          },
         })
       : Promise.resolve([]),
   ]);

--- a/sdk/kiosk/src/utils.ts
+++ b/sdk/kiosk/src/utils.ts
@@ -4,7 +4,6 @@
 import {
   JsonRpcProvider,
   SharedObjectRef,
-  SuiObjectDataOptions,
   SuiObjectRef,
   TransactionArgument,
   TransactionBlock,
@@ -96,19 +95,6 @@ export function extractKioskData(data: DynamicFieldInfo[]): KioskData {
     },
     { listings: [], items: [], itemIds: [], listingIds: [] },
   );
-}
-
-// simple multiGetObjects wrapper to simplify cases on functions.
-export function getObjects(
-  provider: JsonRpcProvider,
-  ids: string[],
-  options: SuiObjectDataOptions,
-) {
-  if (ids.length === 0) {
-    return Promise.resolve([]);
-  }
-
-  return provider.multiGetObjects({ ids, options });
 }
 
 // e.g. 0x2::kiosk::Item -> kiosk::Item

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -405,6 +405,10 @@ export class JsonRpcProvider {
     ids: ObjectId[];
     options?: SuiObjectDataOptions;
   }): Promise<SuiObjectResponse[]> {
+    if (input.ids.length === 0) {
+      return []
+    }
+
     input.ids.forEach((id) => {
       if (!id || !isValidSuiObjectId(normalizeSuiObjectId(id))) {
         throw new Error(`Invalid Sui Object id ${id}`);

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -406,7 +406,7 @@ export class JsonRpcProvider {
     options?: SuiObjectDataOptions;
   }): Promise<SuiObjectResponse[]> {
     if (input.ids.length === 0) {
-      return []
+      return [];
     }
 
     input.ids.forEach((id) => {


### PR DESCRIPTION
## Description 

sui.js: adds a return if IDs are empty in the multiGetObjects
kiosk: removes getObjects / uses multiGetObjects

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

- sui.js: adds a return if IDs are empty in the multiGetObjects
- kiosk: removes getObjects / uses multiGetObjects
