### PR TITLE
[wallet][explorer] Only monitor RPC for mainnet

### DIFF
--- a/apps/explorer/src/utils/api/DefaultRpcClient.ts
+++ b/apps/explorer/src/utils/api/DefaultRpcClient.ts
@@ -42,8 +42,8 @@ export const DefaultRpcClient = (network: Network | string) => {
 
     const provider = new JsonRpcProvider(connection, {
         rpcClient:
-            // If the network is a known network, and not localnet, attach the sentry RPC client for instrumentation:
-            network in Network && network !== Network.LOCAL
+            // Only instrument mainnet:
+            network in Network && network === Network.MAINNET
                 ? new SentryRpcClient(connection.fullnode)
                 : undefined,
     });

--- a/apps/wallet/src/ui/app/ApiProvider.ts
+++ b/apps/wallet/src/ui/app/ApiProvider.ts
@@ -69,11 +69,7 @@ function getDefaultAPI(env: API_ENV) {
 }
 
 export const DEFAULT_API_ENV = getDefaultApiEnv();
-const SENTRY_MONITORED_ENVS = [
-    API_ENV.mainnet,
-    API_ENV.devNet,
-    API_ENV.testNet,
-];
+const SENTRY_MONITORED_ENVS = [API_ENV.mainnet];
 
 type NetworkTypes = keyof typeof API_ENV;
 


### PR DESCRIPTION
## Description 

This changes the Sentry RPC instrumentation to only apply to mainnet. Other networks are too low volume to effectively monitor, and just end up adding noise for our instrumentation.

## Test Plan 

Ran locally.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
