### PR TITLE
Remove unnecessary workspace versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9590,7 +9590,7 @@ dependencies = [
 
 [[package]]
 name = "sui-core"
-version = "1.3.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -10195,7 +10195,7 @@ dependencies = [
 
 [[package]]
 name = "sui-open-rpc"
-version = "0.0.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "bcs",
@@ -10716,7 +10716,7 @@ dependencies = [
 
 [[package]]
 name = "sui-test-transaction-builder"
-version = "1.3.0"
+version = "0.1.0"
 dependencies = [
  "bcs",
  "move-core-types",
@@ -10864,7 +10864,7 @@ dependencies = [
 
 [[package]]
 name = "sui-types"
-version = "1.3.0"
+version = "0.1.0"
 dependencies = [
  "anemo",
  "anyhow",

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sui-core"
-version.workspace = true
+version = "0.1.0"
 authors = ["Mysten Labs <build@mystenlabs.com>"]
 license = "Apache-2.0"
 publish = false

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -54,5 +54,3 @@ pub mod signature_verifier;
 
 pub mod runtime;
 mod transaction_signing_filter;
-
-pub const SUI_CORE_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/sui-open-rpc/Cargo.toml
+++ b/crates/sui-open-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sui-open-rpc"
-version = "0.0.0"
+version.workspace = true
 authors = ["Mysten Labs <build@mystenlabs.com>"]
 license = "Apache-2.0"
 publish = false

--- a/crates/sui-open-rpc/src/generate_json_rpc_spec.rs
+++ b/crates/sui-open-rpc/src/generate_json_rpc_spec.rs
@@ -7,7 +7,6 @@ use clap::Parser;
 use pretty_assertions::assert_str_eq;
 use std::fs::File;
 use std::io::Write;
-use sui_core::SUI_CORE_VERSION;
 //temporarily remove api ref content for indexer methods
 //use sui_json_rpc::api::ExtendedApiOpenRpc;
 use sui_json_rpc::api::IndexerApiOpenRpc;
@@ -41,11 +40,14 @@ struct Options {
 
 const FILE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/spec/openrpc.json",);
 
+// TODO: This currently always use workspace version, which is not ideal.
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 #[tokio::main]
 async fn main() {
     let options = Options::parse();
 
-    let mut open_rpc = sui_rpc_doc(SUI_CORE_VERSION);
+    let mut open_rpc = sui_rpc_doc(VERSION);
     open_rpc.add_module(ReadApi::rpc_doc_module());
     open_rpc.add_module(CoinReadApi::rpc_doc_module());
     open_rpc.add_module(IndexerApiOpenRpc::module_doc());

--- a/crates/sui-test-transaction-builder/Cargo.toml
+++ b/crates/sui-test-transaction-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sui-test-transaction-builder"
-version.workspace = true
+version = "0.1.0"
 authors = ["Mysten Labs <build@mystenlabs.com>"]
 license = "Apache-2.0"
 publish = false

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sui-types"
-version.workspace = true
+version = "0.1.0"
 authors = ["Mysten Labs <build@mystenlabs.com>"]
 license = "Apache-2.0"
 publish = false


### PR DESCRIPTION
## Description 

A few crates don't/shouldn't inherit workspace version. Give them individual versions.
Also the open-json-rpc is generating version using sui-core's version, which is always the workspace version. This is wrong to me. This PR is a short-term fix to just use workspace version directly in open-json-rpc, but we should make it a real version.

## Test Plan 

cargo build

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
