### PR TITLE
Simplify `handle_checkpoint_from_consensus`

### DIFF
--- a/crates/sui-archival/src/tests.rs
+++ b/crates/sui-archival/src/tests.rs
@@ -49,7 +49,7 @@ async fn write_new_checkpoints_to_store(
         );
     }
     for checkpoint in ordered_checkpoints.iter() {
-        store.inner_mut().insert_checkpoint(checkpoint.clone());
+        store.inner_mut().insert_checkpoint(checkpoint);
     }
     Ok(ordered_checkpoints.last().cloned())
 }

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -471,7 +471,7 @@ fn sync_checkpoint(
     sender: &Sender<VerifiedCheckpoint>,
 ) {
     checkpoint_store
-        .insert_verified_checkpoint(checkpoint.clone())
+        .insert_verified_checkpoint(checkpoint)
         .unwrap();
     checkpoint_store
         .insert_checkpoint_contents(empty_contents().into_inner().into_checkpoint_contents())

--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -145,7 +145,7 @@ impl ReadStore for RocksDbStore {
 }
 
 impl WriteStore for RocksDbStore {
-    fn insert_checkpoint(&self, checkpoint: VerifiedCheckpoint) -> Result<(), Self::Error> {
+    fn insert_checkpoint(&self, checkpoint: &VerifiedCheckpoint) -> Result<(), Self::Error> {
         if let Some(EndOfEpochData {
             next_epoch_committee,
             ..
@@ -165,6 +165,14 @@ impl WriteStore for RocksDbStore {
     ) -> Result<(), Self::Error> {
         self.checkpoint_store
             .update_highest_synced_checkpoint(checkpoint)
+    }
+
+    fn update_highest_verified_checkpoint(
+        &self,
+        checkpoint: &VerifiedCheckpoint,
+    ) -> Result<(), Self::Error> {
+        self.checkpoint_store
+            .update_highest_verified_checkpoint(checkpoint)
     }
 
     fn insert_checkpoint_contents(

--- a/crates/sui-network/src/state_sync/tests.rs
+++ b/crates/sui-network/src/state_sync/tests.rs
@@ -129,7 +129,7 @@ async fn server_get_checkpoint() {
 
     // Populate the node's store with some checkpoints
     for checkpoint in ordered_checkpoints.clone() {
-        builder.store.inner_mut().insert_checkpoint(checkpoint)
+        builder.store.inner_mut().insert_checkpoint(&checkpoint)
     }
     let latest = ordered_checkpoints.last().unwrap().clone();
     builder
@@ -201,7 +201,7 @@ async fn isolated_sync_job() {
     {
         let mut store = event_loop_2.store.inner_mut();
         for checkpoint in ordered_checkpoints.clone() {
-            store.insert_checkpoint(checkpoint);
+            store.insert_checkpoint(&checkpoint);
         }
     }
 
@@ -307,6 +307,7 @@ async fn sync_with_checkpoints_being_inserted() {
     store_1
         .insert_checkpoint_contents(&checkpoint, empty_contents())
         .unwrap();
+    store_1.insert_certified_checkpoint(&checkpoint);
     handle_1.send_checkpoint(checkpoint).await;
 
     timeout(Duration::from_secs(1), async {
@@ -324,6 +325,7 @@ async fn sync_with_checkpoints_being_inserted() {
 
     // Inject all the checkpoints
     for checkpoint in checkpoint_iter {
+        store_1.insert_certified_checkpoint(&checkpoint);
         handle_1.send_checkpoint(checkpoint).await;
     }
 


### PR DESCRIPTION
## Description

Based on feedback, now this PR simplifies `handle_checkpoint_from_consensus`. Previously there is a branch to handle when the checkpoint is too new (newer than the highest_verified_checkpoint). I think this case wouldn't happen because consensus sends checkpoint in order. So we consolidate the two cases into one, which is, whenever consensus sends a checkpoint, we do the following things:
1. check the previous digest matches. This is to ensure state sync and consensus do not brain-split.
2. if the checkpoint is older, ignore and exit
3. update metrics and bump watermark
4. notify others

--------------------------
# Old

## Description 

When consensus sends checkpoint y, it means all prior checkpoints are verified and sent, so `highest_verified_checkpoint` can be safely updated without looking at the checkpoint store. However it's a bit tricky for `highest_synced_checkpoint`, because there are a few cfs (e.g. `full_checkpoint_contents`) that could only be updated in state sync checkpoint contents. If we bump this watermarks, those cfs may not be filled at all.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Do not update highest_synced_checkpoint when consensus sends a too new checkpoint
