### PR TITLE
Remove accounts from TestCluster

### DIFF
--- a/crates/sui-e2e-tests/tests/protocol_version_tests.rs
+++ b/crates/sui-e2e-tests/tests/protocol_version_tests.rs
@@ -459,7 +459,7 @@ mod sim_only_tests {
 
     async fn dev_inspect_call(cluster: &TestCluster, call: ProgrammableMoveCall) -> u64 {
         let client = cluster.rpc_client();
-        let sender = cluster.accounts.first().cloned().unwrap();
+        let sender = cluster.get_address_0();
 
         let pt = {
             let mut builder = ProgrammableTransactionBuilder::new();

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -10,7 +10,6 @@ use std::path::Path;
 #[cfg(not(msim))]
 use std::str::FromStr;
 use std::time::Duration;
-use sui_config::SUI_KEYSTORE_FILENAME;
 use sui_json::{call_args, type_args};
 use sui_json_rpc_types::ObjectChange;
 use sui_json_rpc_types::ObjectsPage;
@@ -19,7 +18,6 @@ use sui_json_rpc_types::{
     SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery, SuiTransactionBlockEffectsAPI,
     SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions, TransactionBlockBytes,
 };
-use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use sui_macros::sim_test;
 use sui_move_build::BuildConfig;
 use sui_swarm_config::genesis_config::{DEFAULT_GAS_AMOUNT, DEFAULT_NUMBER_OF_OBJECT_PER_ACCOUNT};
@@ -30,7 +28,6 @@ use sui_types::coin::{TreasuryCap, COIN_MODULE_NAME};
 use sui_types::digests::ObjectDigest;
 use sui_types::gas_coin::GAS;
 use sui_types::quorum_driver_types::ExecuteTransactionRequestType;
-use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{parse_sui_struct_tag, SUI_FRAMEWORK_ADDRESS};
 use test_utils::network::TestClusterBuilder;
 use tokio::time::sleep;
@@ -40,11 +37,11 @@ async fn test_get_objects() -> Result<(), anyhow::Error> {
     let cluster = TestClusterBuilder::new().build().await?;
 
     let http_client = cluster.rpc_client();
-    let address = cluster.accounts.first().unwrap();
+    let address = cluster.get_address_0();
 
     let objects = http_client
         .get_owned_objects(
-            *address,
+            address,
             Some(SuiObjectResponseQuery::new_with_options(
                 SuiObjectDataOptions::new(),
             )),
@@ -92,11 +89,11 @@ async fn test_get_package_with_display_should_not_fail() -> Result<(), anyhow::E
 async fn test_public_transfer_object() -> Result<(), anyhow::Error> {
     let cluster = TestClusterBuilder::new().build().await?;
     let http_client = cluster.rpc_client();
-    let address = cluster.accounts.first().unwrap();
+    let address = cluster.get_address_0();
 
     let objects = http_client
         .get_owned_objects(
-            *address,
+            address,
             Some(SuiObjectResponseQuery::new_with_options(
                 SuiObjectDataOptions::new()
                     .with_type()
@@ -113,12 +110,12 @@ async fn test_public_transfer_object() -> Result<(), anyhow::Error> {
     let gas = objects.clone().last().unwrap().object().unwrap().object_id;
 
     let transaction_bytes: TransactionBlockBytes = http_client
-        .transfer_object(*address, obj, Some(gas), 10_000.into(), *address)
+        .transfer_object(address, obj, Some(gas), 10_000.into(), address)
         .await?;
 
-    let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);
-    let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
-    let tx = to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
+    let tx = cluster
+        .wallet
+        .sign_transaction(&transaction_bytes.to_data()?);
     let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
     let tx_bytes1 = tx_bytes.clone();
     let dryrun_response = http_client.dry_run_transaction_block(tx_bytes).await?;
@@ -174,11 +171,11 @@ fn assert_same_object_changes_ignoring_version_and_digest(
 async fn test_publish() -> Result<(), anyhow::Error> {
     let cluster = TestClusterBuilder::new().build().await?;
     let http_client = cluster.rpc_client();
-    let address = cluster.accounts.first().unwrap();
+    let address = cluster.get_address_0();
 
     let objects = http_client
         .get_owned_objects(
-            *address,
+            address,
             Some(SuiObjectResponseQuery::new_with_options(
                 SuiObjectDataOptions::new()
                     .with_type()
@@ -199,7 +196,7 @@ async fn test_publish() -> Result<(), anyhow::Error> {
 
     let transaction_bytes: TransactionBlockBytes = http_client
         .publish(
-            *address,
+            address,
             compiled_modules_bytes,
             dependencies,
             Some(gas.object_id),
@@ -207,9 +204,9 @@ async fn test_publish() -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);
-    let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
-    let tx = to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
+    let tx = cluster
+        .wallet
+        .sign_transaction(&transaction_bytes.to_data()?);
     let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     let tx_response = http_client
@@ -228,11 +225,11 @@ async fn test_publish() -> Result<(), anyhow::Error> {
 async fn test_move_call() -> Result<(), anyhow::Error> {
     let cluster = TestClusterBuilder::new().build().await?;
     let http_client = cluster.rpc_client();
-    let address = cluster.accounts.first().unwrap();
+    let address = cluster.get_address_0();
 
     let objects = http_client
         .get_owned_objects(
-            *address,
+            address,
             Some(SuiObjectResponseQuery::new_with_options(
                 SuiObjectDataOptions::new()
                     .with_type()
@@ -255,7 +252,7 @@ async fn test_move_call() -> Result<(), anyhow::Error> {
 
     let transaction_bytes: TransactionBlockBytes = http_client
         .move_call(
-            *address,
+            address,
             package_id,
             module,
             function,
@@ -267,9 +264,9 @@ async fn test_move_call() -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);
-    let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
-    let tx = to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
+    let tx = cluster
+        .wallet
+        .sign_transaction(&transaction_bytes.to_data()?);
 
     let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
@@ -289,10 +286,10 @@ async fn test_move_call() -> Result<(), anyhow::Error> {
 async fn test_get_object_info() -> Result<(), anyhow::Error> {
     let cluster = TestClusterBuilder::new().build().await?;
     let http_client = cluster.rpc_client();
-    let address = cluster.accounts.first().unwrap();
+    let address = cluster.get_address_0();
     let objects = http_client
         .get_owned_objects(
-            *address,
+            address,
             Some(SuiObjectResponseQuery::new_with_options(
                 SuiObjectDataOptions::new()
                     .with_type()
@@ -314,7 +311,7 @@ async fn test_get_object_info() -> Result<(), anyhow::Error> {
             )
             .await?;
         assert!(
-            matches!(result, SuiObjectResponse { data: Some(object), .. } if oref.object_id == object.object_id && &object.owner.unwrap().get_owner_address()? == address)
+            matches!(result, SuiObjectResponse { data: Some(object), .. } if oref.object_id == object.object_id && object.owner.unwrap().get_owner_address()? == address)
         );
     }
     Ok(())
@@ -324,10 +321,10 @@ async fn test_get_object_info() -> Result<(), anyhow::Error> {
 async fn test_get_object_data_with_content() -> Result<(), anyhow::Error> {
     let cluster = TestClusterBuilder::new().build().await?;
     let http_client = cluster.rpc_client();
-    let address = cluster.accounts.first().unwrap();
+    let address = cluster.get_address_0();
     let objects = http_client
         .get_owned_objects(
-            *address,
+            address,
             Some(SuiObjectResponseQuery::new_with_options(
                 SuiObjectDataOptions::new().with_content().with_owner(),
             )),
@@ -346,7 +343,7 @@ async fn test_get_object_data_with_content() -> Result<(), anyhow::Error> {
             )
             .await?;
         assert!(
-            matches!(result, SuiObjectResponse { data: Some(object), .. } if oref.object_id == object.object_id && &object.owner.unwrap().get_owner_address()? == address)
+            matches!(result, SuiObjectResponse { data: Some(object), .. } if oref.object_id == object.object_id && object.owner.unwrap().get_owner_address()? == address)
         );
     }
     Ok(())
@@ -356,33 +353,33 @@ async fn test_get_object_data_with_content() -> Result<(), anyhow::Error> {
 async fn test_get_coins() -> Result<(), anyhow::Error> {
     let cluster = TestClusterBuilder::new().build().await?;
     let http_client = cluster.rpc_client();
-    let address = cluster.accounts.first().unwrap();
+    let address = cluster.get_address_0();
 
-    let result: CoinPage = http_client.get_coins(*address, None, None, None).await?;
+    let result: CoinPage = http_client.get_coins(address, None, None, None).await?;
     assert_eq!(5, result.data.len());
     assert!(!result.has_next_page);
 
     let result: CoinPage = http_client
-        .get_coins(*address, Some("0x2::sui::TestCoin".into()), None, None)
+        .get_coins(address, Some("0x2::sui::TestCoin".into()), None, None)
         .await?;
     assert_eq!(0, result.data.len());
 
     let result: CoinPage = http_client
-        .get_coins(*address, Some("0x2::sui::SUI".into()), None, None)
+        .get_coins(address, Some("0x2::sui::SUI".into()), None, None)
         .await?;
     assert_eq!(5, result.data.len());
     assert!(!result.has_next_page);
 
     // Test paging
     let result: CoinPage = http_client
-        .get_coins(*address, Some("0x2::sui::SUI".into()), None, Some(3))
+        .get_coins(address, Some("0x2::sui::SUI".into()), None, Some(3))
         .await?;
     assert_eq!(3, result.data.len());
     assert!(result.has_next_page);
 
     let result: CoinPage = http_client
         .get_coins(
-            *address,
+            address,
             Some("0x2::sui::SUI".into()),
             result.next_cursor,
             Some(3),
@@ -393,7 +390,7 @@ async fn test_get_coins() -> Result<(), anyhow::Error> {
 
     let result: CoinPage = http_client
         .get_coins(
-            *address,
+            address,
             Some("0x2::sui::SUI".into()),
             result.next_cursor,
             None,
@@ -429,11 +426,11 @@ async fn test_get_metadata() -> Result<(), anyhow::Error> {
     let cluster = TestClusterBuilder::new().build().await?;
 
     let http_client = cluster.rpc_client();
-    let address = cluster.accounts.first().unwrap();
+    let address = cluster.get_address_0();
 
     let objects = http_client
         .get_owned_objects(
-            *address,
+            address,
             Some(SuiObjectResponseQuery::new_with_options(
                 SuiObjectDataOptions::new()
                     .with_type()
@@ -457,7 +454,7 @@ async fn test_get_metadata() -> Result<(), anyhow::Error> {
 
     let transaction_bytes: TransactionBlockBytes = http_client
         .publish(
-            *address,
+            address,
             compiled_modules_bytes,
             dependencies,
             Some(gas.object_id),
@@ -465,9 +462,9 @@ async fn test_get_metadata() -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);
-    let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
-    let tx = to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
+    let tx = cluster
+        .wallet
+        .sign_transaction(&transaction_bytes.to_data()?);
     let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     let tx_response = http_client
@@ -513,11 +510,11 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
     let cluster = TestClusterBuilder::new().build().await?;
 
     let http_client = cluster.rpc_client();
-    let address = cluster.accounts.first().unwrap();
+    let address = cluster.get_address_0();
 
     let objects = http_client
         .get_owned_objects(
-            *address,
+            address,
             Some(SuiObjectResponseQuery::new_with_options(
                 SuiObjectDataOptions::new()
                     .with_type()
@@ -540,7 +537,7 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
 
     let transaction_bytes: TransactionBlockBytes = http_client
         .publish(
-            *address,
+            address,
             compiled_modules_bytes,
             dependencies,
             Some(gas.object_id),
@@ -548,9 +545,9 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);
-    let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
-    let tx = to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
+    let tx = cluster
+        .wallet
+        .sign_transaction(&transaction_bytes.to_data()?);
     let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     let tx_response: SuiTransactionBlockResponse = http_client
@@ -608,7 +605,7 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
 
     let transaction_bytes: TransactionBlockBytes = http_client
         .move_call(
-            *address,
+            address,
             SUI_FRAMEWORK_ADDRESS.into(),
             COIN_MODULE_NAME.to_string(),
             "mint_and_transfer".into(),
@@ -620,9 +617,9 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let tx = transaction_bytes.to_data()?;
-
-    let tx = to_sender_signed_transaction(tx, keystore.get_key(address)?);
+    let tx = cluster
+        .wallet
+        .sign_transaction(&transaction_bytes.to_data()?);
     let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
     let tx_response = http_client
@@ -649,11 +646,11 @@ async fn test_staking() -> Result<(), anyhow::Error> {
     let cluster = TestClusterBuilder::new().build().await?;
 
     let http_client = cluster.rpc_client();
-    let address = cluster.accounts.first().unwrap();
+    let address = cluster.get_address_0();
 
     let objects: ObjectsPage = http_client
         .get_owned_objects(
-            *address,
+            address,
             Some(SuiObjectResponseQuery::new_with_options(
                 SuiObjectDataOptions::new()
                     .with_type()
@@ -667,7 +664,7 @@ async fn test_staking() -> Result<(), anyhow::Error> {
     assert_eq!(5, objects.data.len());
 
     // Check StakedSui object before test
-    let staked_sui: Vec<DelegatedStake> = http_client.get_stakes(*address).await?;
+    let staked_sui: Vec<DelegatedStake> = http_client.get_stakes(address).await?;
     assert!(staked_sui.is_empty());
 
     let validator = http_client
@@ -680,7 +677,7 @@ async fn test_staking() -> Result<(), anyhow::Error> {
     // Delegate some SUI
     let transaction_bytes: TransactionBlockBytes = http_client
         .request_add_stake(
-            *address,
+            address,
             vec![coin],
             Some(1000000000.into()),
             validator,
@@ -688,9 +685,9 @@ async fn test_staking() -> Result<(), anyhow::Error> {
             100_000_000.into(),
         )
         .await?;
-    let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);
-    let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
-    let tx = to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
+    let tx = cluster
+        .wallet
+        .sign_transaction(&transaction_bytes.to_data()?);
 
     let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
@@ -704,7 +701,7 @@ async fn test_staking() -> Result<(), anyhow::Error> {
         .await?;
 
     // Check DelegatedStake object
-    let staked_sui: Vec<DelegatedStake> = http_client.get_stakes(*address).await?;
+    let staked_sui: Vec<DelegatedStake> = http_client.get_stakes(address).await?;
     assert_eq!(1, staked_sui.len());
     assert_eq!(1000000000, staked_sui[0].stakes[0].principal);
     assert!(matches!(
@@ -730,13 +727,13 @@ async fn test_unstaking() -> Result<(), anyhow::Error> {
         .await?;
 
     let http_client = cluster.rpc_client();
-    let address = cluster.accounts.first().unwrap();
+    let address = cluster.get_address_0();
 
-    let coins: CoinPage = http_client.get_coins(*address, None, None, None).await?;
+    let coins: CoinPage = http_client.get_coins(address, None, None, None).await?;
     assert_eq!(5, coins.data.len());
 
     // Check StakedSui object before test
-    let staked_sui: Vec<DelegatedStake> = http_client.get_stakes(*address).await?;
+    let staked_sui: Vec<DelegatedStake> = http_client.get_stakes(address).await?;
     assert!(staked_sui.is_empty());
 
     let validator = http_client
@@ -749,7 +746,7 @@ async fn test_unstaking() -> Result<(), anyhow::Error> {
     for i in 0..3 {
         let transaction_bytes: TransactionBlockBytes = http_client
             .request_add_stake(
-                *address,
+                address,
                 vec![coins.data[i].coin_object_id],
                 Some(1000000000.into()),
                 validator,
@@ -757,10 +754,9 @@ async fn test_unstaking() -> Result<(), anyhow::Error> {
                 100_000_000.into(),
             )
             .await?;
-        let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);
-        let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
-        let tx =
-            to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
+        let tx = cluster
+            .wallet
+            .sign_transaction(&transaction_bytes.to_data()?);
 
         let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
@@ -774,7 +770,7 @@ async fn test_unstaking() -> Result<(), anyhow::Error> {
             .await?;
     }
     // Check DelegatedStake object
-    let staked_sui: Vec<DelegatedStake> = http_client.get_stakes(*address).await?;
+    let staked_sui: Vec<DelegatedStake> = http_client.get_stakes(address).await?;
     assert_eq!(1, staked_sui.len());
     assert_eq!(1000000000, staked_sui[0].stakes[0].principal);
 
@@ -809,15 +805,15 @@ async fn test_unstaking() -> Result<(), anyhow::Error> {
 
     let transaction_bytes: TransactionBlockBytes = http_client
         .request_withdraw_stake(
-            *address,
+            address,
             staked_sui_copy[0].stakes[2].staked_sui_id,
             None,
             1_000_000.into(),
         )
         .await?;
-    let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);
-    let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
-    let tx = to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
+    let tx = cluster
+        .wallet
+        .sign_transaction(&transaction_bytes.to_data()?);
 
     let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
@@ -864,15 +860,15 @@ async fn test_staking_multiple_coins() -> Result<(), anyhow::Error> {
     let cluster = TestClusterBuilder::new().build().await?;
 
     let http_client = cluster.rpc_client();
-    let address = cluster.accounts.first().unwrap();
+    let address = cluster.get_address_0();
 
-    let coins: CoinPage = http_client.get_coins(*address, None, None, None).await?;
+    let coins: CoinPage = http_client.get_coins(address, None, None, None).await?;
     assert_eq!(5, coins.data.len());
 
     let genesis_coin_amount = coins.data[0].balance;
 
     // Check StakedSui object before test
-    let staked_sui: Vec<DelegatedStake> = http_client.get_stakes(*address).await?;
+    let staked_sui: Vec<DelegatedStake> = http_client.get_stakes(address).await?;
     assert!(staked_sui.is_empty());
 
     let validator = http_client
@@ -883,7 +879,7 @@ async fn test_staking_multiple_coins() -> Result<(), anyhow::Error> {
     // Delegate some SUI
     let transaction_bytes: TransactionBlockBytes = http_client
         .request_add_stake(
-            *address,
+            address,
             vec![
                 coins.data[0].coin_object_id,
                 coins.data[1].coin_object_id,
@@ -895,9 +891,9 @@ async fn test_staking_multiple_coins() -> Result<(), anyhow::Error> {
             100_000_000.into(),
         )
         .await?;
-    let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);
-    let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
-    let tx = to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
+    let tx = cluster
+        .wallet
+        .sign_transaction(&transaction_bytes.to_data()?);
 
     let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
 
@@ -931,7 +927,7 @@ async fn test_staking_multiple_coins() -> Result<(), anyhow::Error> {
     );
 
     // Check DelegatedStake object
-    let staked_sui: Vec<DelegatedStake> = http_client.get_stakes(*address).await?;
+    let staked_sui: Vec<DelegatedStake> = http_client.get_stakes(address).await?;
     assert_eq!(1, staked_sui.len());
     assert_eq!(1000000000, staked_sui[0].stakes[0].principal);
     assert!(matches!(
@@ -940,7 +936,7 @@ async fn test_staking_multiple_coins() -> Result<(), anyhow::Error> {
     ));
 
     // Coins should be merged into one and returned to the sender.
-    let coins: CoinPage = http_client.get_coins(*address, None, None, None).await?;
+    let coins: CoinPage = http_client.get_coins(address, None, None, None).await?;
     assert_eq!(3, coins.data.len());
 
     // Find the new coin

--- a/crates/sui-json-rpc/tests/balance_changes_tests.rs
+++ b/crates/sui-json-rpc/tests/balance_changes_tests.rs
@@ -10,10 +10,10 @@ use test_utils::network::TestClusterBuilder;
 
 #[tokio::test]
 async fn test_dry_run_publish_with_mocked_coin() -> Result<(), anyhow::Error> {
-    let mut cluster = TestClusterBuilder::new().build().await.unwrap();
-    let context = &mut cluster.wallet;
+    let cluster = TestClusterBuilder::new().build().await.unwrap();
+    let context = &cluster.wallet;
 
-    let address = &cluster.accounts[0];
+    let address = cluster.get_address_0();
     let client: SuiClient = context.get_client().await.unwrap();
 
     // Publish test coin package
@@ -32,7 +32,7 @@ async fn test_dry_run_publish_with_mocked_coin() -> Result<(), anyhow::Error> {
 
     let publish = TransactionKind::programmable(builder.finish());
     let transaction_bytes =
-        TransactionData::new_with_gas_coins(publish, *address, vec![], 100000000, 1000);
+        TransactionData::new_with_gas_coins(publish, address, vec![], 100000000, 1000);
 
     let result = client
         .read_api()

--- a/crates/sui-json-rpc/tests/subscription_tests.rs
+++ b/crates/sui-json-rpc/tests/subscription_tests.rs
@@ -17,7 +17,7 @@ use test_utils::network::TestClusterBuilder;
 async fn test_subscribe_transaction() -> Result<(), anyhow::Error> {
     let cluster = TestClusterBuilder::new().build().await.unwrap();
 
-    let address = &cluster.accounts[0];
+    let address = &cluster.get_address_0();
     let wallet = cluster.wallet;
 
     let ws_client = cluster.fullnode_handle.ws_client;

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -44,8 +44,9 @@ async fn test_transfer_sui() {
     let rgp = network.get_reference_gas_price().await;
 
     // Test Transfer Sui
-    let sender = get_random_address(&network.accounts, vec![]);
-    let recipient = get_random_address(&network.accounts, vec![sender]);
+    let addresses = network.get_addresses();
+    let sender = get_random_address(&addresses, vec![]);
+    let recipient = get_random_address(&addresses, vec![sender]);
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
         builder.transfer_sui(recipient, Some(50000));
@@ -73,8 +74,9 @@ async fn test_transfer_sui_whole_coin() {
     let rgp = network.get_reference_gas_price().await;
 
     // Test transfer sui whole coin
-    let sender = get_random_address(&network.accounts, vec![]);
-    let recipient = get_random_address(&network.accounts, vec![sender]);
+    let addresses = network.get_addresses();
+    let sender = get_random_address(&addresses, vec![]);
+    let recipient = get_random_address(&addresses, vec![sender]);
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
         builder.transfer_sui(recipient, None);
@@ -102,8 +104,9 @@ async fn test_transfer_object() {
     let rgp = network.get_reference_gas_price().await;
 
     // Test transfer object
-    let sender = get_random_address(&network.accounts, vec![]);
-    let recipient = get_random_address(&network.accounts, vec![sender]);
+    let addresses = network.get_addresses();
+    let sender = get_random_address(&addresses, vec![]);
+    let recipient = get_random_address(&addresses, vec![sender]);
     let object_ref = get_random_sui(&client, sender, vec![]).await;
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
@@ -132,7 +135,8 @@ async fn test_publish_and_move_call() {
     let rgp = network.get_reference_gas_price().await;
 
     // Test publish
-    let sender = get_random_address(&network.accounts, vec![]);
+    let addresses = network.get_addresses();
+    let sender = get_random_address(&addresses, vec![]);
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.extend([
         "..",
@@ -180,7 +184,7 @@ async fn test_publish_and_move_call() {
     // TODO: Improve tx response to make it easier to find objects.
     let treasury = find_module_object(&object_changes, "::TreasuryCap");
     let treasury = treasury.clone().reference.to_object_ref();
-    let recipient = *network.accounts.choose(&mut OsRng::default()).unwrap();
+    let recipient = *addresses.choose(&mut OsRng::default()).unwrap();
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
         builder
@@ -221,7 +225,7 @@ async fn test_split_coin() {
     let rgp = network.get_reference_gas_price().await;
 
     // Test spilt coin
-    let sender = get_random_address(&network.accounts, vec![]);
+    let sender = get_random_address(&network.get_addresses(), vec![]);
     let coin = get_random_sui(&client, sender, vec![]).await;
     let tx = client
         .transaction_builder()
@@ -254,7 +258,7 @@ async fn test_merge_coin() {
     let rgp = network.get_reference_gas_price().await;
 
     // Test merge coin
-    let sender = get_random_address(&network.accounts, vec![]);
+    let sender = get_random_address(&network.get_addresses(), vec![]);
     let coin = get_random_sui(&client, sender, vec![]).await;
     let coin2 = get_random_sui(&client, sender, vec![coin.0]).await;
     let tx = client
@@ -288,8 +292,9 @@ async fn test_pay() {
     let rgp = network.get_reference_gas_price().await;
 
     // Test Pay
-    let sender = get_random_address(&network.accounts, vec![]);
-    let recipient = get_random_address(&network.accounts, vec![sender]);
+    let addresses = network.get_addresses();
+    let sender = get_random_address(&addresses, vec![]);
+    let recipient = get_random_address(&addresses, vec![sender]);
     let coin = get_random_sui(&client, sender, vec![]).await;
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
@@ -320,9 +325,10 @@ async fn test_pay_multiple_coin_multiple_recipient() {
     let rgp = network.get_reference_gas_price().await;
 
     // Test Pay multiple coin multiple recipient
-    let sender = get_random_address(&network.accounts, vec![]);
-    let recipient1 = get_random_address(&network.accounts, vec![sender]);
-    let recipient2 = get_random_address(&network.accounts, vec![sender, recipient1]);
+    let addresses = network.get_addresses();
+    let sender = get_random_address(&addresses, vec![]);
+    let recipient1 = get_random_address(&addresses, vec![sender]);
+    let recipient2 = get_random_address(&addresses, vec![sender, recipient1]);
     let coin1 = get_random_sui(&client, sender, vec![]).await;
     let coin2 = get_random_sui(&client, sender, vec![coin1.0]).await;
     let pt = {
@@ -358,8 +364,9 @@ async fn test_pay_sui_multiple_coin_same_recipient() {
     let rgp = network.get_reference_gas_price().await;
 
     // Test Pay multiple coin same recipient
-    let sender = get_random_address(&network.accounts, vec![]);
-    let recipient1 = get_random_address(&network.accounts, vec![sender]);
+    let addresses = network.get_addresses();
+    let sender = get_random_address(&addresses, vec![]);
+    let recipient1 = get_random_address(&addresses, vec![sender]);
     let coin1 = get_random_sui(&client, sender, vec![]).await;
     let coin2 = get_random_sui(&client, sender, vec![coin1.0]).await;
     let pt = {
@@ -394,9 +401,10 @@ async fn test_pay_sui() {
     let rgp = network.get_reference_gas_price().await;
 
     // Test Pay Sui
-    let sender = get_random_address(&network.accounts, vec![]);
-    let recipient1 = get_random_address(&network.accounts, vec![sender]);
-    let recipient2 = get_random_address(&network.accounts, vec![sender, recipient1]);
+    let addresses = network.get_addresses();
+    let sender = get_random_address(&addresses, vec![]);
+    let recipient1 = get_random_address(&addresses, vec![sender]);
+    let recipient2 = get_random_address(&addresses, vec![sender, recipient1]);
     let coin1 = get_random_sui(&client, sender, vec![]).await;
     let coin2 = get_random_sui(&client, sender, vec![coin1.0]).await;
     let pt = {
@@ -428,9 +436,10 @@ async fn test_failed_pay_sui() {
     let rgp = network.get_reference_gas_price().await;
 
     // Test failed Pay Sui
-    let sender = get_random_address(&network.accounts, vec![]);
-    let recipient1 = get_random_address(&network.accounts, vec![sender]);
-    let recipient2 = get_random_address(&network.accounts, vec![sender, recipient1]);
+    let addresses = network.get_addresses();
+    let sender = get_random_address(&addresses, vec![]);
+    let recipient1 = get_random_address(&addresses, vec![sender]);
+    let recipient2 = get_random_address(&addresses, vec![sender, recipient1]);
     let coin1 = get_random_sui(&client, sender, vec![]).await;
     let coin2 = get_random_sui(&client, sender, vec![coin1.0]).await;
     let pt = {
@@ -462,7 +471,7 @@ async fn test_stake_sui() {
     let rgp = network.get_reference_gas_price().await;
 
     // Test Delegate Sui
-    let sender = get_random_address(&network.accounts, vec![]);
+    let sender = get_random_address(&network.get_addresses(), vec![]);
     let coin1 = get_random_sui(&client, sender, vec![]).await;
     let coin2 = get_random_sui(&client, sender, vec![coin1.0]).await;
     let validator = client
@@ -510,7 +519,7 @@ async fn test_stake_sui_with_none_amount() {
     let rgp = network.get_reference_gas_price().await;
 
     // Test Staking Sui
-    let sender = get_random_address(&network.accounts, vec![]);
+    let sender = get_random_address(&network.get_addresses(), vec![]);
     let coin1 = get_random_sui(&client, sender, vec![]).await;
     let coin2 = get_random_sui(&client, sender, vec![coin1.0]).await;
     let validator = client
@@ -558,8 +567,9 @@ async fn test_pay_all_sui() {
     let rgp = network.get_reference_gas_price().await;
 
     // Test Pay All Sui
-    let sender = get_random_address(&network.accounts, vec![]);
-    let recipient = get_random_address(&network.accounts, vec![sender]);
+    let addresses = network.get_addresses();
+    let sender = get_random_address(&addresses, vec![]);
+    let recipient = get_random_address(&addresses, vec![sender]);
     let coin1 = get_random_sui(&client, sender, vec![]).await;
     let coin2 = get_random_sui(&client, sender, vec![coin1.0]).await;
     let pt = {
@@ -586,7 +596,7 @@ async fn test_delegation_parsing() -> Result<(), anyhow::Error> {
     let network = TestClusterBuilder::new().build().await.unwrap();
     let rgp = network.get_reference_gas_price().await;
     let client = network.wallet.get_client().await.unwrap();
-    let sender = get_random_address(&network.accounts, vec![]);
+    let sender = get_random_address(&network.get_addresses(), vec![]);
     let gas = get_random_sui(&client, sender, vec![]).await;
     let validator = client
         .governance_api()

--- a/crates/sui-rosetta/tests/end_to_end_tests.rs
+++ b/crates/sui-rosetta/tests/end_to_end_tests.rs
@@ -26,7 +26,7 @@ mod rosetta_client;
 #[tokio::test]
 async fn test_get_staked_sui() {
     let test_cluster = TestClusterBuilder::new().build().await.unwrap();
-    let address = test_cluster.accounts[0];
+    let address = test_cluster.get_address_0();
     let client = test_cluster.wallet.get_client().await.unwrap();
     let keystore = &test_cluster.wallet.config.keystore;
 
@@ -127,7 +127,7 @@ async fn test_get_staked_sui() {
 #[tokio::test]
 async fn test_stake() {
     let test_cluster = TestClusterBuilder::new().build().await.unwrap();
-    let sender = test_cluster.accounts[0];
+    let sender = test_cluster.get_address_0();
     let client = test_cluster.wallet.get_client().await.unwrap();
     let keystore = &test_cluster.wallet.config.keystore;
 
@@ -188,7 +188,7 @@ async fn test_stake() {
 #[tokio::test]
 async fn test_stake_all() {
     let test_cluster = TestClusterBuilder::new().build().await.unwrap();
-    let sender = test_cluster.accounts[0];
+    let sender = test_cluster.get_address_0();
     let client = test_cluster.wallet.get_client().await.unwrap();
     let keystore = &test_cluster.wallet.config.keystore;
 
@@ -252,7 +252,7 @@ async fn test_withdraw_stake() {
         .build()
         .await
         .unwrap();
-    let sender = test_cluster.accounts[0];
+    let sender = test_cluster.get_address_0();
     let client = test_cluster.wallet.get_client().await.unwrap();
     let keystore = &test_cluster.wallet.config.keystore;
 
@@ -375,8 +375,8 @@ async fn test_withdraw_stake() {
 #[tokio::test]
 async fn test_pay_sui() {
     let test_cluster = TestClusterBuilder::new().build().await.unwrap();
-    let sender = test_cluster.accounts[0];
-    let recipient = test_cluster.accounts[1];
+    let sender = test_cluster.get_address_0();
+    let recipient = test_cluster.get_address_1();
     let client = test_cluster.wallet.get_client().await.unwrap();
     let keystore = &test_cluster.wallet.config.keystore;
 
@@ -434,8 +434,8 @@ async fn test_pay_sui_multiple_times() {
         .build()
         .await
         .unwrap();
-    let sender = test_cluster.accounts[0];
-    let recipient = test_cluster.accounts[1];
+    let sender = test_cluster.get_address_0();
+    let recipient = test_cluster.get_address_1();
     let client = test_cluster.wallet.get_client().await.unwrap();
     let keystore = &test_cluster.wallet.config.keystore;
 

--- a/crates/sui-surfer/src/default_surf_strategy.rs
+++ b/crates/sui-surfer/src/default_surf_strategy.rs
@@ -67,7 +67,7 @@ impl DefaultSurfStrategy {
                 Type::U64 => CallArg::Pure(bcs::to_bytes(&state.rng.gen::<u64>()).unwrap()),
                 Type::U128 => CallArg::Pure(bcs::to_bytes(&state.rng.gen::<u128>()).unwrap()),
                 Type::Address => CallArg::Pure(
-                    bcs::to_bytes(&state.cluster.accounts.choose(&mut state.rng)).unwrap(),
+                    bcs::to_bytes(&state.cluster.get_addresses().choose(&mut state.rng)).unwrap(),
                 ),
                 ty @ Type::Struct { .. } => {
                     match Self::choose_object_call_arg(

--- a/crates/sui-surfer/src/surfer_task.rs
+++ b/crates/sui-surfer/src/surfer_task.rs
@@ -34,7 +34,7 @@ impl SurferTask {
         let shared_objects: SharedObjects = Arc::new(RwLock::new(HashMap::new()));
 
         let mut accounts: HashMap<SuiAddress, (Option<ObjectRef>, OwnedObjects)> = cluster
-            .accounts
+            .get_addresses()
             .iter()
             .map(|address| (*address, (None, HashMap::new())))
             .collect();

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -78,7 +78,6 @@ impl FullNodeHandle {
 
 pub struct TestCluster {
     pub swarm: Swarm,
-    pub accounts: Vec<SuiAddress>,
     pub wallet: WalletContext,
     pub fullnode_handle: FullNodeHandle,
 }
@@ -100,37 +99,23 @@ impl TestCluster {
         &mut self.wallet
     }
 
+    pub fn get_addresses(&self) -> Vec<SuiAddress> {
+        self.wallet.get_addresses()
+    }
+
     // Helper function to get the 0th address in WalletContext
     pub fn get_address_0(&self) -> SuiAddress {
-        self.wallet
-            .config
-            .keystore
-            .addresses()
-            .get(0)
-            .cloned()
-            .unwrap()
+        self.get_addresses()[0]
     }
 
     // Helper function to get the 1st address in WalletContext
     pub fn get_address_1(&self) -> SuiAddress {
-        self.wallet
-            .config
-            .keystore
-            .addresses()
-            .get(1)
-            .cloned()
-            .unwrap()
+        self.get_addresses()[1]
     }
 
     // Helper function to get the 2nd address in WalletContext
     pub fn get_address_2(&self) -> SuiAddress {
-        self.wallet
-            .config
-            .keystore
-            .addresses()
-            .get(2)
-            .cloned()
-            .unwrap()
+        self.get_addresses()[2]
     }
 
     pub fn fullnode_config_builder(&self) -> FullnodeConfigBuilder {
@@ -570,8 +555,6 @@ impl TestClusterBuilder {
         });
         wallet_conf.active_env = Some("localnet".to_string());
 
-        let accounts = wallet_conf.keystore.addresses();
-
         wallet_conf
             .persisted(&working_dir.join(SUI_CLIENT_CONFIG))
             .save()?;
@@ -581,7 +564,6 @@ impl TestClusterBuilder {
 
         Ok(TestCluster {
             swarm,
-            accounts,
             wallet,
             fullnode_handle,
         })


### PR DESCRIPTION
## Description 

TestCluster.accounts can be obtained from the wallet context within, and hence it's redundant.
Since it's a testing method we don't particularly care much about efficiency considering that the typical number of accounts in a cluster is small. If we really want to cache it, we should cache inside wallet context instead of the cluster.
Removing it from TestCluster.
This will set up the code better for consolidating TestCluster and Swarm.

## Test Plan 

cargo test

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
