### PR TITLE
Cancel submission waits after close of epoch

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -136,6 +136,10 @@ pub struct AuthorityPerEpochStore {
 
     /// This is used to notify all epoch specific tasks that epoch has ended.
     epoch_alive_notify: NotifyOnce,
+
+    /// Used to notify all epoch specific tasks that user certs are closed.
+    user_certs_closed_notify: NotifyOnce,
+
     /// This lock acts as a barrier for tasks that should not be executed in parallel with reconfiguration
     /// See comments in AuthorityPerEpochStore::epoch_terminated() on how this is used
     /// Crash recovery note: we write next epoch in the database first, and then use this lock to
@@ -425,6 +429,7 @@ impl AuthorityPerEpochStore {
             db_options,
             reconfig_state_mem: RwLock::new(reconfig_state),
             epoch_alive_notify,
+            user_certs_closed_notify: NotifyOnce::new(),
             epoch_alive: tokio::sync::RwLock::new(true),
             consensus_notify_read: NotifyRead::new(),
             signature_verifier,
@@ -1347,7 +1352,15 @@ impl AuthorityPerEpochStore {
         if epoch_close_time.is_none() {
             // Only update it the first time epoch is closed.
             *epoch_close_time = Some(Instant::now());
+
+            self.user_certs_closed_notify
+                .notify()
+                .expect("user_certs_closed_notify called twice on same epoch store");
         }
+    }
+
+    pub async fn user_certs_closed_notify(&self) {
+        self.user_certs_closed_notify.wait().await
     }
 
     /// Notify epoch is terminated, can only be called once on epoch store


### PR DESCRIPTION
A node that is trying to send end-of-publish, but is waiting for locally executed transactions to be committed, may end up waiting a long time if the elected submitter of that cert has failed to submit. Instead, at reconfig time, we should immediately submit everything we are waiting for.

This greatly reduced reconfig pauses while testing my problematic PR #10360, and it may provide some benefit even during normal operation. There were no obvious problems caused by the temporary increase in amplification even though we were above 4K tps, so the inflight submission limit appears to be doing the right thing.