### PR TITLE
[Narwhal] remove broadcast and retries from worker synchronize() handler

### DIFF
--- a/narwhal/network/src/retry.rs
+++ b/narwhal/network/src/retry.rs
@@ -9,7 +9,6 @@ use std::{future::Future, time::Duration};
 pub struct RetryConfig {
     /// The initial retry interval.
     ///
-    /// This is the first delay before a retry, for establishing connections and sending messages.
     /// The subsequent delay will be decided by the `retry_delay_multiplier`.
     pub initial_retry_interval: Duration,
 

--- a/narwhal/primary/src/synchronizer.rs
+++ b/narwhal/primary/src/synchronizer.rs
@@ -383,7 +383,7 @@ impl Synchronizer {
                     }
                 }
             },
-            "SynchronizerCertificateRecovery"
+            "Synchronizer::RecoverCertificates"
         );
 
         // Start a task to update gc_round, gc in-memory data, and trigger certificate catchup
@@ -449,7 +449,7 @@ impl Synchronizer {
                     }
                 }
             },
-            "SynchronizerGarbageCollection"
+            "Synchronizer::GarbageCollection"
         );
 
         // Start a task to accept certificates. See comment above `process_certificate_with_lock()`
@@ -473,7 +473,7 @@ impl Synchronizer {
                     );
                 }
             },
-            "SynchronizerCertificateAcceptor"
+            "Synchronizer::AcceptCertificates"
         );
 
         // Start tasks to broadcast created certificates.
@@ -504,7 +504,7 @@ impl Synchronizer {
                     }
                 }
             },
-            "SynchronizerCertificateBroadcasters"
+            "Synchronizer::BroadcastCertificates"
         );
 
         // Start a task to async download batches if needed
@@ -541,7 +541,7 @@ impl Synchronizer {
                     }
                 }
             },
-            "SynchronizerBatchSynchronizer"
+            "Synchronizer::SyncrhonizeBatches"
         );
 
         Self { inner }
@@ -1004,10 +1004,7 @@ impl Synchronizer {
                 .expect("Author of valid header is not in the worker cache")
                 .name;
             let client = inner.client.clone();
-            let retry_config = RetryConfig {
-                retrying_max_elapsed_time: None, // Retry forever.
-                ..Default::default()
-            };
+            let retry_config = RetryConfig::default(); // 30s timeout
             let handle = retry_config.retry(move || {
                 let digests = digests.clone();
                 let message = WorkerSynchronizeMessage {

--- a/narwhal/worker/src/handlers.rs
+++ b/narwhal/worker/src/handlers.rs
@@ -1,27 +1,23 @@
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+
 use anemo::{types::response::StatusCode, Network};
 use anyhow::Result;
 use async_trait::async_trait;
 use config::{AuthorityIdentifier, Committee, WorkerCache, WorkerId};
 use fastcrypto::hash::Hash;
-use futures::{stream::FuturesUnordered, StreamExt};
 use itertools::Itertools;
 use network::{client::NetworkClient, WorkerToPrimaryClient};
-use rand::seq::SliceRandom;
 use std::{collections::HashSet, time::Duration};
 use store::{rocks::DBMap, Map};
-use tokio::time::sleep;
-use tracing::{debug, trace, warn};
+use tracing::{debug, trace};
 use types::{
     Batch, BatchDigest, FetchBatchesRequest, FetchBatchesResponse, PrimaryToWorker,
     RequestBatchRequest, RequestBatchResponse, RequestBatchesRequest, RequestBatchesResponse,
     WorkerBatchMessage, WorkerDeleteBatchesMessage, WorkerOthersBatchMessage,
     WorkerSynchronizeMessage, WorkerToWorker, WorkerToWorkerClient,
 };
-
-use mysten_metrics::monitored_future;
 
 use crate::{batch_fetcher::BatchFetcher, TransactionValidator};
 
@@ -174,146 +170,67 @@ impl<V: TransactionValidator> PrimaryToWorker for PrimaryReceiverHandler<V> {
                 }
             };
         }
-
-        // Keep attempting to retrieve missing batches until we get them all or the client
-        // abandons the RPC.
-        // TODO: synchronize() should only be used for header payloads, so remove the broadcast
-        // logic after first attempt.
-        // TODO: synchronize() should not be cancelled when the higher level RequestVote gets
-        // cancelled, if payload requests are already inflight. This avoids wasting work and
-        // potentially stuck when there are many batches to fetch.
-        let mut first_attempt = true;
-        loop {
-            if missing.is_empty() {
-                return Ok(anemo::Response::new(()));
-            }
-
-            // TODO: migrate to RequestBatches RPC, or use BatchFetcher.
-            let batch_requests: Vec<_> = missing
-                .iter()
-                .cloned()
-                .map(|batch| RequestBatchRequest { batch })
-                .collect();
-
-            let mut handles = FuturesUnordered::new();
-            let request_batch_fn =
-                |mut client: WorkerToWorkerClient<anemo::Peer>, batch_request, timeout| {
-                    // Wrapper function enables us to move `client` into the future.
-                    monitored_future!(async move {
-                        client
-                            .request_batch(anemo::Request::new(batch_request).with_timeout(timeout))
-                            .await
-                    })
-                };
-            if first_attempt {
-                // Send first sync request to a single node.
-                let worker_name = match self.worker_cache.worker(
-                    self.committee
-                        .authority(&message.target)
-                        .unwrap()
-                        .protocol_key(),
-                    &self.id,
-                ) {
-                    Ok(worker_info) => worker_info.name,
-                    Err(e) => {
-                        return Err(anemo::rpc::Status::internal(format!(
-                            "The primary asked us to sync with an unknown node: {e}"
-                        )));
-                    }
-                };
-                let peer_id = anemo::PeerId(worker_name.0.to_bytes());
-                if let Some(peer) = network.peer(peer_id) {
-                    debug!(
-                        "Sending BatchRequests to {worker_name}: {:?}",
-                        batch_requests
-                    );
-                    handles.extend(batch_requests.into_iter().map(|request| {
-                        request_batch_fn(
-                            WorkerToWorkerClient::new(peer.clone()),
-                            request,
-                            self.request_batch_timeout,
-                        )
-                    }));
-                } else {
-                    warn!("Unable to reach primary peer {worker_name} on the network");
-                }
-            } else {
-                // If first request timed out or was missing batches, try broadcasting to some others.
-                let names: Vec<_> = self
-                    .worker_cache
-                    .others_workers_by_id(
-                        self.committee
-                            .authority(&self.authority_id)
-                            .unwrap()
-                            .protocol_key(),
-                        &self.id,
-                    )
-                    .into_iter()
-                    .map(|(_, info)| info.name)
-                    .collect();
-                handles.extend(
-                    names
-                        .choose_multiple(&mut rand::thread_rng(), self.request_batch_retry_nodes)
-                        .filter_map(|name| network.peer(anemo::PeerId(name.0.to_bytes())))
-                        .flat_map(|peer| {
-                            batch_requests.iter().cloned().map(move |request| {
-                                let peer = peer.clone();
-                                request_batch_fn(
-                                    WorkerToWorkerClient::new(peer),
-                                    request,
-                                    self.request_batch_timeout,
-                                )
-                            })
-                        }),
-                );
-                debug!(
-                    "Sending BatchRequest retries to workers {names:?}: {:?}",
-                    batch_requests
-                );
-            }
-
-            // Fire off batch request(s) and process results. Stop as soon as we have all the
-            // missing batches.
-            while let Some(result) = handles.next().await {
-                match result {
-                    Ok(response) => {
-                        if let Some(batch) = response.into_body().batch {
-                            if !message.is_certified {
-                                // This batch is not part of a certificate, so we need to validate it.
-                                if let Err(err) = self.validator.validate_batch(&batch).await {
-                                    // The batch is invalid, we don't want to process it.
-                                    return Err(anemo::rpc::Status::new_with_message(
-                                        StatusCode::BadRequest,
-                                        format!("Invalid batch: {err}"),
-                                    ));
-                                }
-                            }
-                            let digest = batch.digest();
-                            if missing.remove(&digest) {
-                                self.store.insert(&digest, &batch).map_err(|e| {
-                                    anemo::rpc::Status::internal(format!(
-                                        "failed to write to batch store: {e:?}"
-                                    ))
-                                })?;
-                            }
-                        }
-                        if missing.is_empty() {
-                            return Ok(anemo::Response::new(()));
-                        }
-                    }
-                    Err(e) => {
-                        debug!(
-                            "RequestBatchRequest to worker {:?} failed: {e:?}",
-                            e.peer_id()
-                        )
-                    }
-                }
-            }
-
-            first_attempt = false;
-            // Add a delay before retrying.
-            sleep(Duration::from_secs(1)).await;
+        if missing.is_empty() {
+            return Ok(anemo::Response::new(()));
         }
+
+        let worker_name = match self.worker_cache.worker(
+            self.committee
+                .authority(&message.target)
+                .unwrap()
+                .protocol_key(),
+            &self.id,
+        ) {
+            Ok(worker_info) => worker_info.name,
+            Err(e) => {
+                return Err(anemo::rpc::Status::internal(format!(
+                    "The primary asked worker to sync with an unknown node: {e}"
+                )));
+            }
+        };
+        let Some(peer) = network.peer(anemo::PeerId(worker_name.0.to_bytes())) else {
+            return Err(anemo::rpc::Status::internal(format!(
+                "Not connected with worker peer {worker_name}"
+            )));
+        };
+        let mut client = WorkerToWorkerClient::new(peer.clone());
+
+        // Attempt to retrieve missing batches.
+        // Retried at a higher level in Synchronizer::sync_batches_internal().
+        let request = RequestBatchesRequest {
+            batch_digests: missing.iter().cloned().collect(),
+        };
+        debug!(
+            "Sending RequestBatchesRequest to {worker_name}: {:?}",
+            request
+        );
+        let response = client
+            .request_batches(anemo::Request::new(request).with_timeout(self.request_batch_timeout))
+            .await?
+            .into_inner();
+        for batch in response.batches {
+            if !message.is_certified {
+                // This batch is not part of a certificate, so we need to validate it.
+                if let Err(err) = self.validator.validate_batch(&batch).await {
+                    // The batch is invalid, we don't want to process it.
+                    return Err(anemo::rpc::Status::new_with_message(
+                        StatusCode::BadRequest,
+                        format!("Invalid batch: {err}"),
+                    ));
+                }
+            }
+            let digest = batch.digest();
+            if missing.remove(&digest) {
+                self.store.insert(&digest, &batch).map_err(|e| {
+                    anemo::rpc::Status::internal(format!("failed to write to batch store: {e:?}"))
+                })?;
+            }
+        }
+
+        if missing.is_empty() {
+            return Ok(anemo::Response::new(()));
+        }
+        Err(anemo::rpc::Status::internal("failed to fetch payloads"))
     }
 
     async fn fetch_batches(


### PR DESCRIPTION
## Description 

Currently worker `synchronize()` handler is responsible for
- Fetching header payloads, which does not need to broadcast
- Fetching certificate payloads asynchronously, which is non-critical
- BlockWaiter, which will be removed

So it seems to we can simplify `synchronize()` by removing internal broadcast and retries. Fetching payloads via `synchronize()` are still retried at a higher level at `Synchronize::sync_batches_internal()`.

Also, since `Synchronize::sync_batches_internal()` will get retried for voting, add a timeout to the retry logic.

We can see if this helps with the spikes of futures trying to fetch batches:

![image](https://github.com/MystenLabs/sui/assets/81660174/dc69fba9-8e6b-4fba-838f-470e5bc82377)

`request_batch()` handler and messages can be cleaned up after BlockWaiter is removed.

## Test Plan 

CI. Private testnet.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
