### PR TITLE
Increase UDP socket buffer sizes for Anemo networks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,7 +123,7 @@ dependencies = [
 [[package]]
 name = "anemo"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=cf95fa2268b6b273ee1b3e9180c8adf525ed80b7#cf95fa2268b6b273ee1b3e9180c8adf525ed80b7"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=88dd6f93a81871657f177384eeeff1268b58083b#88dd6f93a81871657f177384eeeff1268b58083b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -176,7 +176,7 @@ dependencies = [
 [[package]]
 name = "anemo-build"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=cf95fa2268b6b273ee1b3e9180c8adf525ed80b7#cf95fa2268b6b273ee1b3e9180c8adf525ed80b7"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=88dd6f93a81871657f177384eeeff1268b58083b#88dd6f93a81871657f177384eeeff1268b58083b"
 dependencies = [
  "prettyplease 0.1.23",
  "proc-macro2 1.0.58",
@@ -187,7 +187,7 @@ dependencies = [
 [[package]]
 name = "anemo-cli"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=cf95fa2268b6b273ee1b3e9180c8adf525ed80b7#cf95fa2268b6b273ee1b3e9180c8adf525ed80b7"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=88dd6f93a81871657f177384eeeff1268b58083b#88dd6f93a81871657f177384eeeff1268b58083b"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -203,7 +203,7 @@ dependencies = [
 [[package]]
 name = "anemo-tower"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=cf95fa2268b6b273ee1b3e9180c8adf525ed80b7#cf95fa2268b6b273ee1b3e9180c8adf525ed80b7"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=88dd6f93a81871657f177384eeeff1268b58083b#88dd6f93a81871657f177384eeeff1268b58083b"
 dependencies = [
  "anemo",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5526,7 +5526,7 @@ dependencies = [
 [[package]]
 name = "msim"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=5fdd0c5547fa656143eab43fa570893b88d3620f#5fdd0c5547fa656143eab43fa570893b88d3620f"
+source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=f2c31421e273eca7e97c563c7e07b81b5afa2d3a#f2c31421e273eca7e97c563c7e07b81b5afa2d3a"
 dependencies = [
  "ahash 0.7.6",
  "async-task",
@@ -5556,7 +5556,7 @@ dependencies = [
 [[package]]
 name = "msim-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=5fdd0c5547fa656143eab43fa570893b88d3620f#5fdd0c5547fa656143eab43fa570893b88d3620f"
+source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=f2c31421e273eca7e97c563c7e07b81b5afa2d3a#f2c31421e273eca7e97c563c7e07b81b5afa2d3a"
 dependencies = [
  "darling",
  "proc-macro2 1.0.58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,10 +215,10 @@ fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "c27e87fb
 fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "c27e87fb539c88b6fe1eac7dd82561254bb1e07a", package = "fastcrypto-zkp" }
 
 # anemo dependencies
-anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "cf95fa2268b6b273ee1b3e9180c8adf525ed80b7" }
-anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "cf95fa2268b6b273ee1b3e9180c8adf525ed80b7" }
-anemo-cli = { git = "https://github.com/mystenlabs/anemo.git", rev = "cf95fa2268b6b273ee1b3e9180c8adf525ed80b7"}
-anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "cf95fa2268b6b273ee1b3e9180c8adf525ed80b7"}
+anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "88dd6f93a81871657f177384eeeff1268b58083b" }
+anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "88dd6f93a81871657f177384eeeff1268b58083b" }
+anemo-cli = { git = "https://github.com/mystenlabs/anemo.git", rev = "88dd6f93a81871657f177384eeeff1268b58083b"}
+anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "88dd6f93a81871657f177384eeeff1268b58083b"}
 
 # Use the same workspace-hack across crates.
 workspace-hack = { path = "crates/workspace-hack" }

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -627,6 +627,18 @@ impl SuiNode {
             // staking events in the epoch change txn.
             anemo_config.max_frame_size = Some(2 << 30);
 
+            // Set a higher default value for socket send/receive buffers if not already
+            // configured.
+            let mut quic_config = anemo_config.quic.unwrap_or_default();
+            if quic_config.socket_send_buffer_size.is_none() {
+                quic_config.socket_send_buffer_size = Some(20 << 20);
+            }
+            if quic_config.socket_receive_buffer_size.is_none() {
+                quic_config.socket_receive_buffer_size = Some(20 << 20);
+            }
+            quic_config.allow_failed_socket_buffer_size_setting = true;
+            anemo_config.quic = Some(quic_config);
+
             let server_name = format!("sui-{}", chain_identifier);
             let alt_server_name = "sui";
             let network = Network::bind(config.p2p_config.listen_address)

--- a/crates/sui-proc-macros/Cargo.toml
+++ b/crates/sui-proc-macros/Cargo.toml
@@ -17,4 +17,4 @@ proc-macro2 = "1"
 sui-enum-compat-util = { path = "../sui-enum-compat-util" }
 
 [target.'cfg(msim)'.dependencies]
-msim-macros = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "5fdd0c5547fa656143eab43fa570893b88d3620f", package = "msim-macros" }
+msim-macros = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "f2c31421e273eca7e97c563c7e07b81b5afa2d3a", package = "msim-macros" }

--- a/crates/sui-simulator/Cargo.toml
+++ b/crates/sui-simulator/Cargo.toml
@@ -26,4 +26,4 @@ tower = "0.4.13"
 lru = "0.10"
 
 [target.'cfg(msim)'.dependencies]
-msim = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "5fdd0c5547fa656143eab43fa570893b88d3620f", package = "msim" }
+msim = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "f2c31421e273eca7e97c563c7e07b81b5afa2d3a", package = "msim" }

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -46,4 +46,4 @@ uint = "0.9.4"
 # Most packages should depend on sui-simulator instead of directly on msim, but for typed-store
 # that creates a circular dependency.
 [target.'cfg(msim)'.dependencies]
-msim = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "5fdd0c5547fa656143eab43fa570893b88d3620f", package = "msim" }
+msim = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "f2c31421e273eca7e97c563c7e07b81b5afa2d3a", package = "msim" }

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -26,9 +26,9 @@ aho-corasick = { version = "0.7" }
 aliasable = { version = "0.1" }
 alloc-no-stdlib = { version = "2", default-features = false }
 alloc-stdlib = { version = "0.2", default-features = false }
-anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "cf95fa2268b6b273ee1b3e9180c8adf525ed80b7", default-features = false }
-anemo-cli = { git = "https://github.com/mystenlabs/anemo.git", rev = "cf95fa2268b6b273ee1b3e9180c8adf525ed80b7", default-features = false }
-anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "cf95fa2268b6b273ee1b3e9180c8adf525ed80b7", default-features = false }
+anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "88dd6f93a81871657f177384eeeff1268b58083b", default-features = false }
+anemo-cli = { git = "https://github.com/mystenlabs/anemo.git", rev = "88dd6f93a81871657f177384eeeff1268b58083b", default-features = false }
+anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "88dd6f93a81871657f177384eeeff1268b58083b", default-features = false }
 anes = { version = "0.1" }
 ansi_term = { version = "0.12", default-features = false }
 anyhow = { version = "1", features = ["backtrace"] }
@@ -700,10 +700,10 @@ aho-corasick = { version = "0.7" }
 aliasable = { version = "0.1" }
 alloc-no-stdlib = { version = "2", default-features = false }
 alloc-stdlib = { version = "0.2", default-features = false }
-anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "cf95fa2268b6b273ee1b3e9180c8adf525ed80b7", default-features = false }
-anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "cf95fa2268b6b273ee1b3e9180c8adf525ed80b7", default-features = false }
-anemo-cli = { git = "https://github.com/mystenlabs/anemo.git", rev = "cf95fa2268b6b273ee1b3e9180c8adf525ed80b7", default-features = false }
-anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "cf95fa2268b6b273ee1b3e9180c8adf525ed80b7", default-features = false }
+anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "88dd6f93a81871657f177384eeeff1268b58083b", default-features = false }
+anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "88dd6f93a81871657f177384eeeff1268b58083b", default-features = false }
+anemo-cli = { git = "https://github.com/mystenlabs/anemo.git", rev = "88dd6f93a81871657f177384eeeff1268b58083b", default-features = false }
+anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "88dd6f93a81871657f177384eeeff1268b58083b", default-features = false }
 anes = { version = "0.1" }
 ansi_term = { version = "0.12", default-features = false }
 anyhow = { version = "1", features = ["backtrace"] }

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -335,6 +335,9 @@ impl Primary {
             quic_config.receive_window = Some(200 << 20);
             quic_config.send_window = Some(200 << 20);
             quic_config.crypto_buffer_size = Some(1 << 20);
+            quic_config.socket_receive_buffer_size = Some(20 << 20);
+            quic_config.socket_send_buffer_size = Some(20 << 20);
+            quic_config.allow_failed_socket_buffer_size_setting = true;
             quic_config.max_idle_timeout_ms = Some(30_000);
             // Enable keep alives every 5s
             quic_config.keep_alive_interval_ms = Some(5_000);

--- a/narwhal/worker/src/worker.rs
+++ b/narwhal/worker/src/worker.rs
@@ -220,6 +220,9 @@ impl Worker {
             quic_config.receive_window = Some(200 << 20);
             quic_config.send_window = Some(200 << 20);
             quic_config.crypto_buffer_size = Some(1 << 20);
+            quic_config.socket_receive_buffer_size = Some(20 << 20);
+            quic_config.socket_send_buffer_size = Some(20 << 20);
+            quic_config.allow_failed_socket_buffer_size_setting = true;
             quic_config.max_idle_timeout_ms = Some(30_000);
             // Enable keep alives every 5s
             quic_config.keep_alive_interval_ms = Some(5_000);

--- a/scripts/simtest/cargo-simtest
+++ b/scripts/simtest/cargo-simtest
@@ -54,9 +54,9 @@ if [ -n "$LOCAL_MSIM_PATH" ]; then
 else
   cargo_patch_args=(
     --config 'patch.crates-io.tokio.git = "https://github.com/MystenLabs/mysten-sim.git"'
-    --config 'patch.crates-io.tokio.rev = "5fdd0c5547fa656143eab43fa570893b88d3620f"'
+    --config 'patch.crates-io.tokio.rev = "f2c31421e273eca7e97c563c7e07b81b5afa2d3a"'
     --config 'patch.crates-io.futures-timer.git = "https://github.com/MystenLabs/mysten-sim.git"'
-    --config 'patch.crates-io.futures-timer.rev = "5fdd0c5547fa656143eab43fa570893b88d3620f"'
+    --config 'patch.crates-io.futures-timer.rev = "f2c31421e273eca7e97c563c7e07b81b5afa2d3a"'
   )
 fi
 


### PR DESCRIPTION
## Description 

Increases size of UDP socket buffers for sui, primary, and worker Anemo networks. This improves performance under high load.

## Test Plan 

Manual benchmarks & testing on private-testnet.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Increases size of UDP socket buffers for sui, primary, and worker Anemo networks. This improves performance under high load.

**NOTE:** the buffer sizes requested after this change are larger than the default maximum buffer allowed by many operating systems. If the sui node binary logs errors about failure to set UDP socket buffer size, you may need to increase the maximum allowed by your OS.

Some examples:
* Linux: `sudo sysctl -w net.core.rmem_max=104857600; sudo sysctl -w net.core.wmem_max=104857600`
* MacOS: `sudo sysctl -w kern.ipc.maxsockbuf=104857600`