### PR TITLE
add checkpoint low watermark for state sync

### DIFF
--- a/crates/sui-archival/src/tests.rs
+++ b/crates/sui-archival/src/tests.rs
@@ -40,7 +40,7 @@ async fn write_new_checkpoints_to_store(
 ) -> anyhow::Result<Option<VerifiedCheckpoint>> {
     let (ordered_checkpoints, _contents, _sequence_number_to_digest, _checkpoints) = test_state
         .committee
-        .make_random_checkpoints(num_checkpoints, prev_checkpoint.clone());
+        .make_empty_checkpoints(num_checkpoints, prev_checkpoint.clone());
     if prev_checkpoint.is_none() {
         store.inner_mut().insert_genesis_state(
             ordered_checkpoints.first().cloned().unwrap(),

--- a/crates/sui-archival/src/tests.rs
+++ b/crates/sui-archival/src/tests.rs
@@ -38,9 +38,9 @@ async fn write_new_checkpoints_to_store(
     num_checkpoints: usize,
     prev_checkpoint: Option<VerifiedCheckpoint>,
 ) -> anyhow::Result<Option<VerifiedCheckpoint>> {
-    let (ordered_checkpoints, _sequence_number_to_digest, _checkpoints) = test_state
+    let (ordered_checkpoints, _contents, _sequence_number_to_digest, _checkpoints) = test_state
         .committee
-        .make_checkpoints(num_checkpoints, prev_checkpoint.clone());
+        .make_random_checkpoints(num_checkpoints, prev_checkpoint.clone());
     if prev_checkpoint.is_none() {
         store.inner_mut().insert_genesis_state(
             ordered_checkpoints.first().cloned().unwrap(),

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -425,8 +425,8 @@ fn sync_new_checkpoints(
     previous_checkpoint: Option<VerifiedCheckpoint>,
     committee: &CommitteeFixture,
 ) -> Vec<VerifiedCheckpoint> {
-    let (ordered_checkpoints, _sequence_number_to_digest, _checkpoints) =
-        committee.make_checkpoints(number_of_checkpoints, previous_checkpoint);
+    let (ordered_checkpoints, _, _sequence_number_to_digest, _checkpoints) =
+        committee.make_checkpoints(number_of_checkpoints, previous_checkpoint, false);
 
     for checkpoint in ordered_checkpoints.iter() {
         sync_checkpoint(checkpoint, checkpoint_store, sender);

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/tests.rs
@@ -426,7 +426,7 @@ fn sync_new_checkpoints(
     committee: &CommitteeFixture,
 ) -> Vec<VerifiedCheckpoint> {
     let (ordered_checkpoints, _, _sequence_number_to_digest, _checkpoints) =
-        committee.make_checkpoints(number_of_checkpoints, previous_checkpoint, false);
+        committee.make_empty_checkpoints(number_of_checkpoints, previous_checkpoint);
 
     for checkpoint in ordered_checkpoints.iter() {
         sync_checkpoint(checkpoint, checkpoint_store, sender);

--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -81,6 +81,12 @@ impl ReadStore for RocksDbStore {
             })
     }
 
+    fn get_lowest_available_checkpoint(&self) -> Result<CheckpointSequenceNumber, Self::Error> {
+        // TODO: use checkpoint_store.get_highest_pruned_checkpoint_seq_number once
+        // https://github.com/MystenLabs/sui/pull/12067 lands
+        Ok(0)
+    }
+
     fn get_full_checkpoint_contents_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,

--- a/crates/sui-network/build.rs
+++ b/crates/sui-network/build.rs
@@ -155,6 +155,15 @@ fn build_anemo_services(out_dir: &Path) {
                 .codec_path(codec_path)
                 .build(),
         )
+        .method(
+            anemo_build::manual::Method::builder()
+                .name("get_peer_latest_checkpoint_info")
+                .route_name("GetPeerLatestCheckpointInfo")
+                .request_type("()")
+                .response_type("crate::state_sync::GetPeerLatestCheckpointInfoResponse")
+                .codec_path(codec_path)
+                .build(),
+        )
         .build();
 
     anemo_build::manual::Builder::new()

--- a/crates/sui-network/build.rs
+++ b/crates/sui-network/build.rs
@@ -157,10 +157,10 @@ fn build_anemo_services(out_dir: &Path) {
         )
         .method(
             anemo_build::manual::Method::builder()
-                .name("get_peer_latest_checkpoint_info")
-                .route_name("GetPeerLatestCheckpointInfo")
+                .name("get_checkpoint_availability")
+                .route_name("GetCheckpointAvailability")
                 .request_type("()")
-                .response_type("crate::state_sync::GetPeerLatestCheckpointInfoResponse")
+                .response_type("crate::state_sync::GetCheckpointAvailabilityResponse")
                 .codec_path(codec_path)
                 .build(),
         )

--- a/crates/sui-network/src/state_sync/builder.rs
+++ b/crates/sui-network/src/state_sync/builder.rs
@@ -6,6 +6,7 @@ use anemo_tower::{inflight_limit, rate_limit};
 use std::{
     collections::HashMap,
     sync::{Arc, RwLock},
+    time::Duration,
 };
 use sui_config::p2p::StateSyncConfig;
 use sui_types::{messages_checkpoint::VerifiedCheckpoint, storage::ReadStore};
@@ -134,6 +135,7 @@ where
             peers: HashMap::new(),
             unprocessed_checkpoints: HashMap::new(),
             sequence_number_to_digest: HashMap::new(),
+            no_peer_to_sync_content_wait_internal: Duration::from_secs(10),
         }
         .pipe(RwLock::new)
         .pipe(Arc::new);

--- a/crates/sui-network/src/state_sync/builder.rs
+++ b/crates/sui-network/src/state_sync/builder.rs
@@ -135,7 +135,7 @@ where
             peers: HashMap::new(),
             unprocessed_checkpoints: HashMap::new(),
             sequence_number_to_digest: HashMap::new(),
-            no_peer_to_sync_content_wait_internal: Duration::from_secs(10),
+            wait_interval_when_no_peer_to_sync_content: Duration::from_secs(10),
         }
         .pipe(RwLock::new)
         .pipe(Arc::new);

--- a/crates/sui-network/src/state_sync/mod.rs
+++ b/crates/sui-network/src/state_sync/mod.rs
@@ -88,6 +88,7 @@ pub use generated::{
     state_sync_server::{StateSync, StateSyncServer},
 };
 pub use server::GetCheckpointSummaryRequest;
+pub use server::GetPeerLatestCheckpointInfoResponse;
 
 use self::{metrics::Metrics, server::CheckpointContentsDownloadLimitLayer};
 
@@ -128,6 +129,8 @@ struct PeerHeights {
     peers: HashMap<PeerId, PeerStateSyncInfo>,
     unprocessed_checkpoints: HashMap<CheckpointDigest, Checkpoint>,
     sequence_number_to_digest: HashMap<CheckpointSequenceNumber, CheckpointDigest>,
+
+    no_peer_to_sync_content_wait_internal: Duration,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -138,6 +141,9 @@ struct PeerStateSyncInfo {
     on_same_chain_as_us: bool,
     /// Highest checkpoint sequence number we know of for this Peer.
     height: CheckpointSequenceNumber,
+    /// lowest available checkpoint watermark for this Peer.
+    /// This defaults to 0 for now.
+    lowest: CheckpointSequenceNumber,
 }
 
 impl PeerHeights {
@@ -164,13 +170,21 @@ impl PeerHeights {
     //
     // This will return false if the given peer doesn't have an entry or is not on the same chain
     // as us
-    pub fn update_peer_info(&mut self, peer_id: PeerId, checkpoint: Checkpoint) -> bool {
+    pub fn update_peer_info(
+        &mut self,
+        peer_id: PeerId,
+        checkpoint: Checkpoint,
+        low_watermark: Option<CheckpointSequenceNumber>,
+    ) -> bool {
         let info = match self.peers.get_mut(&peer_id) {
             Some(info) if info.on_same_chain_as_us => info,
             _ => return false,
         };
 
         info.height = std::cmp::max(*checkpoint.sequence_number(), info.height);
+        if let Some(low_watermark) = low_watermark {
+            info.lowest = low_watermark;
+        }
         self.insert_checkpoint(checkpoint);
 
         true
@@ -209,6 +223,7 @@ impl PeerHeights {
             .retain(|&s, _digest| s > sequence_number);
     }
 
+    // TODO: also record who gives this checkpoint info for peer quality measurement?
     pub fn insert_checkpoint(&mut self, checkpoint: Checkpoint) {
         let digest = *checkpoint.digest();
         let sequence_number = *checkpoint.sequence_number();
@@ -236,6 +251,15 @@ impl PeerHeights {
     pub fn get_checkpoint_by_digest(&self, digest: &CheckpointDigest) -> Option<&Checkpoint> {
         self.unprocessed_checkpoints.get(digest)
     }
+
+    #[cfg(test)]
+    pub fn set_no_peer_to_sync_content_wait_internal(&mut self, duration: Duration) {
+        self.no_peer_to_sync_content_wait_internal = duration;
+    }
+
+    pub fn no_peer_to_sync_content_wait_internal(&self) -> Duration {
+        self.no_peer_to_sync_content_wait_internal
+    }
 }
 
 // PeerBalancer is an Iterator that selects peers based on RTT with some added randomness.
@@ -243,10 +267,21 @@ impl PeerHeights {
 struct PeerBalancer {
     peers: VecDeque<(anemo::Peer, PeerStateSyncInfo)>,
     requested_checkpoint: Option<CheckpointSequenceNumber>,
+    request_type: PeerCheckpointRequestType,
+}
+
+#[derive(Clone)]
+enum PeerCheckpointRequestType {
+    Summary,
+    Content,
 }
 
 impl PeerBalancer {
-    pub fn new(network: &anemo::Network, peer_heights: Arc<RwLock<PeerHeights>>) -> Self {
+    pub fn new(
+        network: &anemo::Network,
+        peer_heights: Arc<RwLock<PeerHeights>>,
+        request_type: PeerCheckpointRequestType,
+    ) -> Self {
         let mut peers: Vec<_> = peer_heights
             .read()
             .unwrap()
@@ -260,6 +295,7 @@ impl PeerBalancer {
         Self {
             peers: peers.into(),
             requested_checkpoint: None,
+            request_type,
         }
     }
 
@@ -278,9 +314,19 @@ impl Iterator for PeerBalancer {
             let idx =
                 rand::thread_rng().gen_range(0..std::cmp::min(SELECTION_WINDOW, self.peers.len()));
             let (peer, info) = self.peers.remove(idx).unwrap();
-
-            if info.height >= self.requested_checkpoint.unwrap_or(0) {
-                return Some(StateSyncClient::new(peer));
+            let requested_checkpoint = self.requested_checkpoint.unwrap_or(0);
+            // Summary will never be pruned
+            match &self.request_type {
+                PeerCheckpointRequestType::Summary if info.height >= requested_checkpoint => {
+                    return Some(StateSyncClient::new(peer));
+                }
+                PeerCheckpointRequestType::Content
+                    if info.height >= requested_checkpoint
+                        && info.lowest <= requested_checkpoint =>
+                {
+                    return Some(StateSyncClient::new(peer));
+                }
+                _ => {}
             }
         }
         None
@@ -736,12 +782,14 @@ async fn get_latest_from_peer(
                         genesis_checkpoint_digest: digest,
                         on_same_chain_as_us: our_genesis_checkpoint_digest == digest,
                         height: *checkpoint.sequence_number(),
+                        lowest: CheckpointSequenceNumber::default(),
                     }
                 }
                 Ok(None) => PeerStateSyncInfo {
                     genesis_checkpoint_digest: CheckpointDigest::default(),
                     on_same_chain_as_us: false,
                     height: CheckpointSequenceNumber::default(),
+                    lowest: CheckpointSequenceNumber::default(),
                 },
                 Err(status) => {
                     trace!("get_latest_checkpoint_summary request failed: {status:?}");
@@ -760,27 +808,56 @@ async fn get_latest_from_peer(
     if !info.on_same_chain_as_us {
         return;
     }
+    let Some((highest_checkpoint, low_watermark)) = query_peer_for_latest_info(&mut client, timeout).await else {
+        return;
+    };
+    peer_heights
+        .write()
+        .unwrap()
+        .update_peer_info(peer_id, highest_checkpoint, low_watermark);
+}
 
-    let checkpoint = {
-        let request = Request::new(GetCheckpointSummaryRequest::Latest).with_timeout(timeout);
-        let response = client
-            .get_checkpoint_summary(request)
-            .await
-            .map(Response::into_inner);
-        match response {
-            Ok(Some(checkpoint)) => checkpoint,
-            Ok(None) => return,
-            Err(status) => {
-                trace!("get_latest_checkpoint_summary request failed: {status:?}");
-                return;
+/// Queries a peer for their highest_synced_checkpoint and low checkpoint watermark
+async fn query_peer_for_latest_info(
+    client: &mut StateSyncClient<anemo::Peer>,
+    timeout: Duration,
+) -> Option<(Checkpoint, Option<CheckpointSequenceNumber>)> {
+    let request = Request::new(()).with_timeout(timeout);
+    let response = client
+        .get_peer_latest_checkpoint_info(request)
+        .await
+        .map(Response::into_inner);
+    match response {
+        Ok(GetPeerLatestCheckpointInfoResponse {
+            highest_synced_checkpoint,
+            lowest_available_checkpoint,
+        }) => {
+            return Some((highest_synced_checkpoint, Some(lowest_available_checkpoint)));
+        }
+        Err(status) => {
+            // If peer hasn't upgraded they would return 404 NotFound error
+            if status.status() != anemo::types::response::StatusCode::NotFound {
+                trace!("get_peer_latest_checkpoint_info request failed: {status:?}");
+                return None;
             }
         }
     };
 
-    peer_heights
-        .write()
-        .unwrap()
-        .update_peer_info(peer_id, checkpoint);
+    // Then we try the old query
+    // TODO: remove this once the new feature stabilizes
+    let request = Request::new(GetCheckpointSummaryRequest::Latest).with_timeout(timeout);
+    let response = client
+        .get_checkpoint_summary(request)
+        .await
+        .map(Response::into_inner);
+    match response {
+        Ok(Some(checkpoint)) => Some((checkpoint, None)),
+        Ok(None) => None,
+        Err(status) => {
+            trace!("get_checkpoint_summary (latest) request failed: {status:?}");
+            None
+        }
+    }
 }
 
 async fn query_peers_for_their_latest_checkpoint(
@@ -801,23 +878,14 @@ async fn query_peers_for_their_latest_checkpoint(
             let mut client = StateSyncClient::new(peer);
 
             async move {
-                let request =
-                    Request::new(GetCheckpointSummaryRequest::Latest).with_timeout(timeout);
-                let response = client
-                    .get_checkpoint_summary(request)
-                    .await
-                    .map(Response::into_inner);
+                let response = query_peer_for_latest_info(&mut client, timeout).await;
                 match response {
-                    Ok(Some(checkpoint)) => peer_heights
+                    Some((highest_checkpoint, low_watermark)) => peer_heights
                         .write()
                         .unwrap()
-                        .update_peer_info(peer_id, checkpoint.clone())
-                        .then_some(checkpoint),
-                    Ok(None) => None,
-                    Err(status) => {
-                        trace!("get_latest_checkpoint_summary request failed: {status:?}");
-                        None
-                    }
+                        .update_peer_info(peer_id, highest_checkpoint.clone(), low_watermark)
+                        .then_some(highest_checkpoint),
+                    None => None,
                 }
             }
         })
@@ -870,7 +938,11 @@ where
         ));
     }
 
-    let peer_balancer = PeerBalancer::new(&network, peer_heights.clone());
+    let peer_balancer = PeerBalancer::new(
+        &network,
+        peer_heights.clone(),
+        PeerCheckpointRequestType::Summary,
+    );
     // range of the next sequence_numbers to fetch
     let mut request_stream = (current.sequence_number().saturating_add(1)
         ..=*checkpoint.sequence_number())
@@ -901,6 +973,11 @@ where
                     {
                         // peer didn't give us a checkpoint with the height that we requested
                         if *checkpoint.sequence_number() != next {
+                            tracing::error!(
+                                "peer returned checkpoint with wrong sequence number: expected {}, got {}",
+                                next,
+                                checkpoint.sequence_number()
+                            );
                             continue;
                         }
 
@@ -912,7 +989,6 @@ where
                         return (Some(checkpoint), next, Some(peer.inner().peer_id()));
                     }
                 }
-
                 (None, next, None)
             }
         })
@@ -924,8 +1000,9 @@ where
 
         // Verify the checkpoint
         let checkpoint = {
-            let checkpoint = maybe_checkpoint
-                .ok_or_else(|| anyhow::anyhow!("no peers were able to help sync"))?;
+            let checkpoint = maybe_checkpoint.ok_or_else(|| {
+                anyhow::anyhow!("no peers were able to help sync checkpoint {}", next)
+            })?;
             match verify_checkpoint(&current, &store, checkpoint) {
                 Ok(verified_checkpoint) => verified_checkpoint,
                 Err(checkpoint) => {
@@ -1101,7 +1178,7 @@ async fn sync_checkpoint_contents<S>(
                     }
                     Err(checkpoint) => {
                         let _: &VerifiedCheckpoint = &checkpoint;  // type hint
-                        debug!("unable to sync contents of checkpoint {}", checkpoint.sequence_number());
+                        info!("unable to sync contents of checkpoint {}", checkpoint.sequence_number());
                         // Retry contents sync on failure.
                         checkpoint_contents_tasks.push_front(sync_one_checkpoint_contents(
                             network.clone(),
@@ -1168,11 +1245,17 @@ where
     S: WriteStore + Clone,
     <S as ReadStore>::Error: std::error::Error,
 {
-    let peers = PeerBalancer::new(&network, peer_heights.clone())
-        .with_checkpoint(*checkpoint.sequence_number());
+    let peers = PeerBalancer::new(
+        &network,
+        peer_heights.clone(),
+        PeerCheckpointRequestType::Content,
+    )
+    .with_checkpoint(*checkpoint.sequence_number());
     let Some(contents) = get_full_checkpoint_contents(peers, &store, &checkpoint, timeout).await else {
         // Delay completion in case of error so we don't hammer the network with retries.
-        tokio::time::sleep(Duration::from_secs(10)).await;
+        // TODO: we might want to connect to better peers here.
+        let duration = peer_heights.read().unwrap().no_peer_to_sync_content_wait_internal();
+        tokio::time::sleep(duration).await;
         return Err(checkpoint);
     };
 

--- a/crates/sui-network/src/state_sync/server.rs
+++ b/crates/sui-network/src/state_sync/server.rs
@@ -27,7 +27,7 @@ pub enum GetCheckpointSummaryRequest {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct GetPeerLatestCheckpointInfoResponse {
+pub struct GetCheckpointAvailabilityResponse {
     pub(crate) highest_synced_checkpoint: Checkpoint,
     pub(crate) lowest_available_checkpoint: CheckpointSequenceNumber,
 }
@@ -101,23 +101,23 @@ where
         Ok(Response::new(checkpoint))
     }
 
-    async fn get_peer_latest_checkpoint_info(
+    async fn get_checkpoint_availability(
         &self,
         _request: Request<()>,
-    ) -> Result<Response<GetPeerLatestCheckpointInfoResponse>, Status> {
-        let highest_synced = self
+    ) -> Result<Response<GetCheckpointAvailabilityResponse>, Status> {
+        let highest_synced_checkpoint = self
             .store
             .get_highest_synced_checkpoint()
             .map_err(|e| Status::internal(e.to_string()))
             .map(VerifiedCheckpoint::into_inner)?;
-        let lowest_available = self
+        let lowest_available_checkpoint = self
             .store
             .get_lowest_available_checkpoint()
             .map_err(|e| Status::internal(e.to_string()))?;
 
-        Ok(Response::new(GetPeerLatestCheckpointInfoResponse {
-            highest_synced_checkpoint: highest_synced,
-            lowest_available_checkpoint: lowest_available,
+        Ok(Response::new(GetCheckpointAvailabilityResponse {
+            highest_synced_checkpoint,
+            lowest_available_checkpoint,
         }))
     }
 

--- a/crates/sui-network/src/state_sync/tests.rs
+++ b/crates/sui-network/src/state_sync/tests.rs
@@ -453,6 +453,7 @@ async fn sync_with_checkpoints_watermark() {
     store_1
         .insert_checkpoint_contents(&checkpoint_1, contents_1.clone())
         .unwrap();
+    store_1.insert_certified_checkpoint(&checkpoint_1);
     handle_1.send_checkpoint(checkpoint_1.clone()).await;
 
     timeout(Duration::from_secs(3), async {
@@ -515,6 +516,7 @@ async fn sync_with_checkpoints_watermark() {
         store_1
             .insert_checkpoint_contents(&checkpoint, contents)
             .unwrap();
+        store_1.insert_certified_checkpoint(&checkpoint);
         handle_1.send_checkpoint(checkpoint).await;
     }
 

--- a/crates/sui-network/src/state_sync/tests.rs
+++ b/crates/sui-network/src/state_sync/tests.rs
@@ -20,8 +20,8 @@ use tokio::time::timeout;
 #[tokio::test]
 async fn server_push_checkpoint() {
     let committee = CommitteeFixture::generate(rand::rngs::OsRng, 0, 4);
-    let (ordered_checkpoints, _sequence_number_to_digest, _checkpoints) =
-        committee.make_checkpoints(2, None);
+    let (ordered_checkpoints, _, _sequence_number_to_digest, _checkpoints) =
+        committee.make_checkpoints(2, None, false);
     let store = SharedInMemoryStore::default();
     store.inner_mut().insert_genesis_state(
         ordered_checkpoints.first().cloned().unwrap(),
@@ -46,6 +46,7 @@ async fn server_push_checkpoint() {
             genesis_checkpoint_digest: *ordered_checkpoints[0].digest(),
             on_same_chain_as_us: true,
             height: 0,
+            lowest: 0,
         },
     );
 
@@ -59,6 +60,7 @@ async fn server_push_checkpoint() {
             genesis_checkpoint_digest: *ordered_checkpoints[0].digest(),
             on_same_chain_as_us: true,
             height: 1,
+            lowest: 0,
         })
     );
     assert_eq!(
@@ -89,8 +91,8 @@ async fn server_push_checkpoint() {
 #[tokio::test]
 async fn server_get_checkpoint() {
     let committee = CommitteeFixture::generate(rand::rngs::OsRng, 0, 4);
-    let (ordered_checkpoints, _sequence_number_to_digest, _checkpoints) =
-        committee.make_checkpoints(3, None);
+    let (ordered_checkpoints, _, _sequence_number_to_digest, _checkpoints) =
+        committee.make_checkpoints(3, None, false);
 
     let (builder, server) = Builder::new()
         .store(SharedInMemoryStore::default())
@@ -173,8 +175,8 @@ async fn server_get_checkpoint() {
 async fn isolated_sync_job() {
     let committee = CommitteeFixture::generate(rand::rngs::OsRng, 0, 4);
     // build mock data
-    let (ordered_checkpoints, sequence_number_to_digest, checkpoints) =
-        committee.make_checkpoints(100, None);
+    let (ordered_checkpoints, _, sequence_number_to_digest, checkpoints) =
+        committee.make_checkpoints(100, None, false);
 
     // Build and connect two nodes
     let (builder, server) = Builder::new().store(SharedInMemoryStore::default()).build();
@@ -212,6 +214,7 @@ async fn isolated_sync_job() {
             genesis_checkpoint_digest: *ordered_checkpoints[0].digest(),
             on_same_chain_as_us: true,
             height: *ordered_checkpoints.last().unwrap().sequence_number(),
+            lowest: 0,
         },
     );
     event_loop_1
@@ -258,8 +261,8 @@ async fn sync_with_checkpoints_being_inserted() {
     telemetry_subscribers::init_for_testing();
     let committee = CommitteeFixture::generate(rand::rngs::OsRng, 0, 4);
     // build mock data
-    let (ordered_checkpoints, sequence_number_to_digest, checkpoints) =
-        committee.make_checkpoints(4, None);
+    let (ordered_checkpoints, _contents, sequence_number_to_digest, checkpoints) =
+        committee.make_checkpoints(4, None, false);
 
     // Build and connect two nodes
     let (builder, server) = Builder::new().store(SharedInMemoryStore::default()).build();
@@ -292,6 +295,7 @@ async fn sync_with_checkpoints_being_inserted() {
             genesis_checkpoint_digest: *ordered_checkpoints[0].digest(),
             on_same_chain_as_us: true,
             height: 0,
+            lowest: 0,
         },
     );
     // Start both event loops
@@ -379,5 +383,348 @@ async fn sync_with_checkpoints_being_inserted() {
     assert_eq!(
         store_2.checkpoint_sequence_number_to_digest(),
         &sequence_number_to_digest
+    );
+}
+
+#[tokio::test]
+async fn sync_with_checkpoints_watermark() {
+    telemetry_subscribers::init_for_testing();
+    let committee = CommitteeFixture::generate(rand::rngs::OsRng, 0, 4);
+    // build mock data
+    let (ordered_checkpoints, contents, _sequence_number_to_digest, _checkpoints) =
+        committee.make_checkpoints(4, None, true);
+    let last_checkpoint_seq = *ordered_checkpoints
+        .last()
+        .cloned()
+        .unwrap()
+        .sequence_number();
+    // Build and connect two nodes
+    let (builder, server) = Builder::new().store(SharedInMemoryStore::default()).build();
+    let network_1 = build_network(|router| router.add_rpc_service(server));
+    let (event_loop_1, handle_1) = builder.build(network_1.clone());
+    let (builder, server) = Builder::new().store(SharedInMemoryStore::default()).build();
+    let network_2 = build_network(|router| router.add_rpc_service(server));
+    let (event_loop_2, handle_2) = builder.build(network_2.clone());
+
+    // Init the root committee in both nodes
+    let genesis_checkpoint_content = contents.first().cloned().unwrap();
+    event_loop_1.store.inner_mut().insert_genesis_state(
+        ordered_checkpoints.first().cloned().unwrap(),
+        genesis_checkpoint_content.clone(),
+        committee.committee().to_owned(),
+    );
+    event_loop_2.store.inner_mut().insert_genesis_state(
+        ordered_checkpoints.first().cloned().unwrap(),
+        genesis_checkpoint_content.clone(),
+        committee.committee().to_owned(),
+    );
+
+    // get handles to each node's stores
+    let store_1 = event_loop_1.store.clone();
+    let store_2 = event_loop_2.store.clone();
+    let peer_id_1 = network_1.peer_id();
+
+    let peer_heights_1 = event_loop_1.peer_heights.clone();
+    let peer_heights_2 = event_loop_2.peer_heights.clone();
+    peer_heights_1
+        .write()
+        .unwrap()
+        .set_no_peer_to_sync_content_wait_internal(Duration::from_secs(1));
+    peer_heights_2
+        .write()
+        .unwrap()
+        .set_no_peer_to_sync_content_wait_internal(Duration::from_secs(1));
+
+    // Start both event loops
+    tokio::spawn(event_loop_1.start());
+    tokio::spawn(event_loop_2.start());
+
+    let mut subscriber_1 = handle_1.subscribe_to_synced_checkpoints();
+    let mut subscriber_2 = handle_2.subscribe_to_synced_checkpoints();
+
+    network_1.connect(network_2.local_addr()).await.unwrap();
+
+    // Inject one checkpoint and verify that it was shared with the other node
+    let mut checkpoint_iter = ordered_checkpoints.clone().into_iter().skip(1);
+    let mut contents_iter = contents.clone().into_iter().skip(1);
+    let checkpoint_1 = checkpoint_iter.next().unwrap();
+    let contents_1 = contents_iter.next().unwrap();
+    let checkpoint_seq = checkpoint_1.sequence_number();
+    store_1
+        .insert_checkpoint_contents(&checkpoint_1, contents_1.clone())
+        .unwrap();
+    handle_1.send_checkpoint(checkpoint_1.clone()).await;
+
+    timeout(Duration::from_secs(3), async {
+        assert_eq!(
+            subscriber_1.recv().await.unwrap().data(),
+            ordered_checkpoints[1].data(),
+        );
+        assert_eq!(
+            subscriber_2.recv().await.unwrap().data(),
+            ordered_checkpoints[1].data()
+        );
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(
+        store_1
+            .get_highest_synced_checkpoint()
+            .unwrap()
+            .sequence_number(),
+        checkpoint_seq
+    );
+    assert_eq!(
+        store_2
+            .get_highest_synced_checkpoint()
+            .unwrap()
+            .sequence_number(),
+        checkpoint_seq
+    );
+    assert_eq!(
+        store_1
+            .get_highest_verified_checkpoint()
+            .unwrap()
+            .sequence_number(),
+        &1
+    );
+    assert_eq!(
+        store_2
+            .get_highest_verified_checkpoint()
+            .unwrap()
+            .sequence_number(),
+        &1
+    );
+
+    // So far so good.
+    // Now we increase Peer 1's low watermark to a high number.
+    let a_very_high_checkpoint_seq = 1000;
+    store_1
+        .inner_mut()
+        .set_lowest_available_checkpoint(a_very_high_checkpoint_seq);
+
+    assert!(peer_heights_2.write().unwrap().update_peer_info(
+        peer_id_1,
+        checkpoint_1.clone().into(),
+        Some(a_very_high_checkpoint_seq),
+    ));
+
+    // Inject all the checkpoints to Peer 1
+    for (checkpoint, contents) in checkpoint_iter.zip(contents_iter) {
+        store_1
+            .insert_checkpoint_contents(&checkpoint, contents)
+            .unwrap();
+        handle_1.send_checkpoint(checkpoint).await;
+    }
+
+    // Peer 1 has all the checkpoint contents, but not Peer 2
+    timeout(Duration::from_secs(1), async {
+        for (checkpoint, contents) in ordered_checkpoints[2..]
+            .iter()
+            .zip(contents.clone().into_iter().skip(2))
+        {
+            assert_eq!(subscriber_1.recv().await.unwrap().data(), checkpoint.data());
+            let content_digest = contents.into_checkpoint_contents_digest();
+            store_1
+                .get_full_checkpoint_contents(&content_digest)
+                .unwrap()
+                .unwrap();
+            assert_eq!(
+                store_2
+                    .get_full_checkpoint_contents(&content_digest)
+                    .unwrap(),
+                None
+            );
+        }
+    })
+    .await
+    .unwrap();
+    subscriber_2.try_recv().unwrap_err();
+
+    assert_eq!(
+        store_1
+            .get_highest_synced_checkpoint()
+            .unwrap()
+            .sequence_number(),
+        ordered_checkpoints.last().unwrap().sequence_number()
+    );
+    assert_eq!(
+        store_2
+            .get_highest_synced_checkpoint()
+            .unwrap()
+            .sequence_number(),
+        ordered_checkpoints[1].sequence_number()
+    );
+
+    assert_eq!(
+        store_1
+            .get_highest_verified_checkpoint()
+            .unwrap()
+            .sequence_number(),
+        &last_checkpoint_seq
+    );
+
+    // Add Peer 3
+    let (builder, server) = Builder::new().store(SharedInMemoryStore::default()).build();
+    let network_3 = build_network(|router| router.add_rpc_service(server));
+    let (event_loop_3, handle_3) = builder.build(network_3.clone());
+
+    let mut subscriber_3 = handle_3.subscribe_to_synced_checkpoints();
+    network_3.connect(network_1.local_addr()).await.unwrap();
+    network_3.connect(network_2.local_addr()).await.unwrap();
+    let store_3 = event_loop_3.store.clone();
+    let peer_heights_3 = event_loop_3.peer_heights.clone();
+    peer_heights_3
+        .write()
+        .unwrap()
+        .set_no_peer_to_sync_content_wait_internal(Duration::from_secs(1));
+    event_loop_3.store.inner_mut().insert_genesis_state(
+        ordered_checkpoints.first().cloned().unwrap(),
+        genesis_checkpoint_content.clone(),
+        committee.committee().to_owned(),
+    );
+    tokio::spawn(event_loop_3.start());
+
+    // Peer 3 is able to sync checkpoint 1 with teh help from Peer 2
+    timeout(Duration::from_secs(1), async {
+        assert_eq!(
+            subscriber_3.recv().await.unwrap().data(),
+            ordered_checkpoints[1].data()
+        );
+        let content_digest = contents[1].clone().into_checkpoint_contents_digest();
+        store_3
+            .get_full_checkpoint_contents(&content_digest)
+            .unwrap()
+            .unwrap();
+    })
+    .await
+    .unwrap();
+    subscriber_3.try_recv().unwrap_err();
+    subscriber_2.try_recv().unwrap_err();
+
+    assert_eq!(
+        store_2
+            .get_highest_synced_checkpoint()
+            .unwrap()
+            .sequence_number(),
+        ordered_checkpoints[1].sequence_number(),
+    );
+    assert_eq!(
+        store_3
+            .get_highest_synced_checkpoint()
+            .unwrap()
+            .sequence_number(),
+        ordered_checkpoints[1].sequence_number(),
+    );
+
+    // Now set Peer 1's low watermark back to 0
+    store_1.inner_mut().set_lowest_available_checkpoint(0);
+
+    // Peer 2 and Peer 3 will know about this change by `get_peer_latest_checkpoint_info`
+    // Soon we expect them to have all checkpoints's content.
+    timeout(Duration::from_secs(6), async {
+        for (checkpoint, contents) in ordered_checkpoints[2..]
+            .iter()
+            .zip(contents.clone().into_iter().skip(2))
+        {
+            assert_eq!(subscriber_2.recv().await.unwrap().data(), checkpoint.data());
+            assert_eq!(subscriber_3.recv().await.unwrap().data(), checkpoint.data());
+            let content_digest = contents.into_checkpoint_contents_digest();
+            store_2
+                .get_full_checkpoint_contents(&content_digest)
+                .unwrap()
+                .unwrap();
+            store_3
+                .get_full_checkpoint_contents(&content_digest)
+                .unwrap()
+                .unwrap();
+        }
+    })
+    .await
+    .unwrap();
+    assert_eq!(
+        store_2
+            .get_highest_synced_checkpoint()
+            .unwrap()
+            .sequence_number(),
+        &last_checkpoint_seq
+    );
+    assert_eq!(
+        store_3
+            .get_highest_synced_checkpoint()
+            .unwrap()
+            .sequence_number(),
+        &last_checkpoint_seq
+    );
+    assert_eq!(
+        store_2
+            .get_highest_verified_checkpoint()
+            .unwrap()
+            .sequence_number(),
+        &last_checkpoint_seq
+    );
+    assert_eq!(
+        store_3
+            .get_highest_verified_checkpoint()
+            .unwrap()
+            .sequence_number(),
+        &last_checkpoint_seq
+    );
+
+    // Now set Peer 1 and 2's low watermark to a very high number
+    store_1
+        .inner_mut()
+        .set_lowest_available_checkpoint(a_very_high_checkpoint_seq);
+
+    store_2
+        .inner_mut()
+        .set_lowest_available_checkpoint(a_very_high_checkpoint_seq);
+
+    // Start Peer 4
+    let (builder, server) = Builder::new().store(SharedInMemoryStore::default()).build();
+    let network_4 = build_network(|router| router.add_rpc_service(server));
+    let (event_loop_4, handle_4) = builder.build(network_4.clone());
+
+    let mut subscriber_4 = handle_4.subscribe_to_synced_checkpoints();
+    let store_4 = event_loop_4.store.clone();
+    let peer_heights_4 = event_loop_4.peer_heights.clone();
+    peer_heights_4
+        .write()
+        .unwrap()
+        .set_no_peer_to_sync_content_wait_internal(Duration::from_secs(1));
+    event_loop_4.store.inner_mut().insert_genesis_state(
+        ordered_checkpoints.first().cloned().unwrap(),
+        genesis_checkpoint_content,
+        committee.committee().to_owned(),
+    );
+    tokio::spawn(event_loop_4.start());
+    // Need to connect 4 to 1, 2, 3 manually, as it does not have discovery enabled
+    network_4.connect(network_1.local_addr()).await.unwrap();
+    network_4.connect(network_2.local_addr()).await.unwrap();
+    network_4.connect(network_3.local_addr()).await.unwrap();
+
+    // Peer 4 syncs everything with Peer 3
+    timeout(Duration::from_secs(3), async {
+        for (checkpoint, contents) in ordered_checkpoints[1..]
+            .iter()
+            .zip(contents.clone().into_iter().skip(1))
+        {
+            assert_eq!(subscriber_4.recv().await.unwrap().data(), checkpoint.data());
+            let content_digest = contents.into_checkpoint_contents_digest();
+            store_4
+                .get_full_checkpoint_contents(&content_digest)
+                .unwrap()
+                .unwrap();
+        }
+    })
+    .await
+    .unwrap();
+    assert_eq!(
+        store_4
+            .get_highest_synced_checkpoint()
+            .unwrap()
+            .sequence_number(),
+        &last_checkpoint_seq
     );
 }

--- a/crates/sui-swarm-config/src/test_utils.rs
+++ b/crates/sui-swarm-config/src/test_utils.rs
@@ -79,7 +79,7 @@ impl CommitteeFixture {
         &self.committee
     }
 
-    fn create_root_checkpoint(&self) -> VerifiedCheckpoint {
+    fn create_root_checkpoint(&self) -> (VerifiedCheckpoint, VerifiedCheckpointContents) {
         assert_eq!(self.epoch, 0, "root checkpoint must be epoch 0");
         let checkpoint = CheckpointSummary {
             epoch: 0,
@@ -97,7 +97,10 @@ impl CommitteeFixture {
             checkpoint_commitments: Default::default(),
         };
 
-        self.create_certified_checkpoint(checkpoint)
+        (
+            self.create_certified_checkpoint(checkpoint),
+            empty_contents(),
+        )
     }
 
     fn create_certified_checkpoint(&self, checkpoint: CheckpointSummary) -> VerifiedCheckpoint {
@@ -126,43 +129,57 @@ impl CommitteeFixture {
         checkpoint
     }
 
+    #[allow(clippy::type_complexity)]
     pub fn make_checkpoints(
         &self,
         number_of_checkpoints: usize,
         previous_checkpoint: Option<VerifiedCheckpoint>,
+        random_content: bool,
     ) -> (
         Vec<VerifiedCheckpoint>,
+        Vec<VerifiedCheckpointContents>,
         HashMap<CheckpointSequenceNumber, CheckpointDigest>,
         HashMap<CheckpointDigest, VerifiedCheckpoint>,
     ) {
         // Only skip the first one if it was supplied
         let skip = previous_checkpoint.is_some() as usize;
-        let first = previous_checkpoint.unwrap_or_else(|| self.create_root_checkpoint());
+        let first = previous_checkpoint
+            .map(|c| (c, empty_contents()))
+            .unwrap_or_else(|| self.create_root_checkpoint());
 
-        let ordered_checkpoints = std::iter::successors(Some(first), |prev| {
-            let summary = CheckpointSummary {
-                epoch: self.epoch,
-                sequence_number: prev.sequence_number + 1,
-                network_total_transactions: 0,
-                content_digest: *empty_contents()
+        let (ordered_checkpoints, contents): (Vec<_>, Vec<_>) =
+            std::iter::successors(Some(first), |prev| {
+                let contents = if random_content {
+                    random_contents()
+                } else {
+                    empty_contents()
+                };
+                let contents_digest = *contents
+                    .clone()
                     .into_inner()
                     .into_checkpoint_contents()
-                    .digest(),
-                previous_digest: Some(*prev.digest()),
-                epoch_rolling_gas_cost_summary: Default::default(),
-                end_of_epoch_data: None,
-                timestamp_ms: 0,
-                version_specific_data: Vec::new(),
-                checkpoint_commitments: Default::default(),
-            };
+                    .digest();
+                let summary = CheckpointSummary {
+                    epoch: self.epoch,
+                    sequence_number: prev.0.sequence_number + 1,
+                    network_total_transactions: prev.0.network_total_transactions
+                        + contents.num_of_transactions() as u64,
+                    content_digest: contents_digest,
+                    previous_digest: Some(*prev.0.digest()),
+                    epoch_rolling_gas_cost_summary: Default::default(),
+                    end_of_epoch_data: None,
+                    timestamp_ms: 0,
+                    version_specific_data: Vec::new(),
+                    checkpoint_commitments: Default::default(),
+                };
 
-            let checkpoint = self.create_certified_checkpoint(summary);
+                let checkpoint = self.create_certified_checkpoint(summary);
 
-            Some(checkpoint)
-        })
-        .skip(skip)
-        .take(number_of_checkpoints)
-        .collect::<Vec<_>>();
+                Some((checkpoint, contents))
+            })
+            .skip(skip)
+            .take(number_of_checkpoints)
+            .unzip();
 
         let (sequence_number_to_digest, checkpoints) = ordered_checkpoints
             .iter()
@@ -173,7 +190,12 @@ impl CommitteeFixture {
             })
             .unzip();
 
-        (ordered_checkpoints, sequence_number_to_digest, checkpoints)
+        (
+            ordered_checkpoints,
+            contents,
+            sequence_number_to_digest,
+            checkpoints,
+        )
     }
 
     pub fn make_end_of_epoch_checkpoint(
@@ -211,4 +233,8 @@ pub fn empty_contents() -> VerifiedCheckpointContents {
     VerifiedCheckpointContents::new_unchecked(
         FullCheckpointContents::new_with_causally_ordered_transactions(std::iter::empty()),
     )
+}
+
+pub fn random_contents() -> VerifiedCheckpointContents {
+    VerifiedCheckpointContents::new_unchecked(FullCheckpointContents::random_for_testing())
 }

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -576,6 +576,10 @@ pub(crate) fn make_anemo_config() -> anemo_cli::Config {
                         get_checkpoint_contents,
                         sui_types::messages_checkpoint::CheckpointContentsDigest
                     ),
+                )
+                .add_method(
+                    "GetPeerLatestCheckpointInfo",
+                    anemo_cli::ron_method!(StateSyncClient, get_peer_latest_checkpoint_info, ()),
                 ),
         )
 }

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -578,8 +578,8 @@ pub(crate) fn make_anemo_config() -> anemo_cli::Config {
                     ),
                 )
                 .add_method(
-                    "GetPeerLatestCheckpointInfo",
-                    anemo_cli::ron_method!(StateSyncClient, get_peer_latest_checkpoint_info, ()),
+                    "GetCheckpointAvailability",
+                    anemo_cli::ron_method!(StateSyncClient, get_checkpoint_availability, ()),
                 ),
         )
 }


### PR DESCRIPTION
## Description 

This PR adds the checkpoint low watermark for state sync. This lets a node to know who to query checkpoint contents according to the watermarks, once checkpoint pruning is enabled.

* It adds a new state sync method `get_peer_latest_checkpoint_info`. This call will eventually replace `GetCheckpointSummaryRequest::Latest` request and is called between every tick in `get_latest_from_peer`. The response include the highest synced checkpoint summary and the lowest available checkpoint content watermark.
  * To deal with the upgrade, we first query `get_peer_latest_checkpoint_info`, if it's 404 then we query `get_checkpoint_summary` and set the low watermark to 0 (if the node hasn't upgraded, they will have all the checkpoint content up to genesis).
* this low watermark is then updated in `PeerHeights`. When a node queries peer for checkpoint content, it will only contact peers who has low-watermark lower than the requested checkpoint.
* currently all nodes has low-watermark set to 0, once https://github.com/MystenLabs/sui/pull/12067 lands, we will use the watermark set there.

## Test Plan 

Tests in `state_sync/tests/rs`

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Adds the checkpoint low watermark for state sync. This lets a node to know who to query checkpoint contents according to the watermarks, once checkpoint pruning is enabled.
