### PR TITLE
[2/n] [sui-json-rpc] refactor transaction_execution_api for unit testing

### DIFF
--- a/crates/sui-json-rpc/src/error.rs
+++ b/crates/sui-json-rpc/src/error.rs
@@ -11,6 +11,8 @@ use sui_types::quorum_driver_types::QuorumDriverError;
 use thiserror::Error;
 use tokio::task::JoinError;
 
+pub type SuiRpcServerResult<T = ()> = Result<T, Error>;
+
 #[derive(Debug, Error)]
 pub enum Error {
     #[error(transparent)]

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -41,7 +41,7 @@ use sui_types::move_package::normalize_modules;
 use sui_types::object::{Data, Object, ObjectRead, PastObjectRead};
 use sui_types::sui_serde::BigInt;
 use sui_types::transaction::TransactionDataAPI;
-use sui_types::transaction::{TransactionData, VerifiedTransaction};
+use sui_types::transaction::VerifiedTransaction;
 
 use crate::api::JsonRpcMetrics;
 use crate::api::{validate_limit, ReadApiServer};


### PR DESCRIPTION
## Description 

Similar to the changes made in https://github.com/MystenLabs/sui/pull/12053, move implementation details on the api into a trait object. This refactoring should help with two things:
1. Makes unit testing easier as we can mock particular components such as the `AuthorityState` instead of trying to recreate error scenarios.
2. Down the line, saves us from having to add a `.map_err(Error::from)` everywhere to convert an error into `sui_json_rpc::Error` (which then handles the conversion into `RpcResult`.) 

Is `SuiRpcServerResult` a good name? Maybe `SuiRpcInterimResult`?

## Test Plan 

Existing tests + a new unit test (more for demo than anything)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
