### PR TITLE
sui ns: add default configs

### DIFF
--- a/crates/sui-json-rpc/src/indexer_api.rs
+++ b/crates/sui-json-rpc/src/indexer_api.rs
@@ -47,6 +47,12 @@ const NAME_SERVICE_VALUE: &str = "value";
 const NAME_SERVICE_TARGET_ADDRESS: &str = "target_address";
 const NAME_SERVICE_DOMAIN_MODULE: &IdentStr = ident_str!("domain");
 const NAME_SERVICE_DOMAIN_STRUCT: &IdentStr = ident_str!("Domain");
+const NAME_SERVICE_DEFAULT_PACKAGE_ADDRESS: &str =
+    "0xd22b24490e0bae52676651b4f56660a5ff8022a2576e0089f79b3c88d44e08f0";
+const NAME_SERVICE_DEFAULT_REGISTRY: &str =
+    "0xe64cd9db9f829c6cc405d9790bd71567ae07259855f4fba6f02c84f52298c106";
+const NAME_SERVICE_DEFAULT_REVERSE_REGISTRY: &str =
+    "0x2fd099e17a292d2bc541df474f9fafa595653848cbabb2d7a4656ec786a1969f";
 
 pub fn spawn_subscription<S, T>(mut sink: SubscriptionSink, rx: S)
 where
@@ -324,90 +330,96 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
     #[instrument(skip(self))]
     async fn resolve_name_service_address(&self, name: String) -> RpcResult<Option<SuiAddress>> {
         with_tracing!(async move {
-            if let (Some(pkg_addr), Some(registry_id)) = (self.ns_package_addr, self.ns_registry_id)
-            {
-                let package_addr = AccountAddress::new(pkg_addr.to_inner());
-                let name_type_tag = TypeTag::Struct(Box::new(StructTag {
-                    address: package_addr,
-                    module: NAME_SERVICE_DOMAIN_MODULE.to_owned(),
-                    name: NAME_SERVICE_DOMAIN_STRUCT.to_owned(),
-                    type_params: vec![],
-                }));
-                let domain = Domain::from_str(&name).map_err(|e| {
+            let pkg_addr = match self.ns_package_addr {
+                Some(addr) => addr,
+                None => SuiAddress::from_str(NAME_SERVICE_DEFAULT_PACKAGE_ADDRESS)?,
+            };
+            let registry_id = match self.ns_registry_id {
+                Some(id) => id,
+                None => ObjectID::from_str(NAME_SERVICE_DEFAULT_REGISTRY).map_err(|e| {
                     Error::UnexpectedError(format!(
-                        "Failed to parse NameService Domain with error: {:?}",
+                        "Parsing name service default registry ID failed with error: {:?}",
                         e
                     ))
-                })?;
-                let domain_bcs_value = bcs::to_bytes(&domain).map_err(|e| {
+                })?,
+            };
+            let package_addr = AccountAddress::new(pkg_addr.to_inner());
+            let name_type_tag = TypeTag::Struct(Box::new(StructTag {
+                address: package_addr,
+                module: NAME_SERVICE_DOMAIN_MODULE.to_owned(),
+                name: NAME_SERVICE_DOMAIN_STRUCT.to_owned(),
+                type_params: vec![],
+            }));
+            let domain = Domain::from_str(&name).map_err(|e| {
+                Error::UnexpectedError(format!(
+                    "Failed to parse NameService Domain with error: {:?}",
+                    e
+                ))
+            })?;
+            let domain_bcs_value = bcs::to_bytes(&domain).map_err(|e| {
+                Error::SuiRpcInputError(SuiRpcInputError::GenericInvalid(format!(
+                    "Unable to serialize name: {:?} with error: {:?}",
+                    domain, e
+                )))
+            })?;
+            let record_object_id_option = self
+                .state
+                .get_dynamic_field_object_id(registry_id, name_type_tag, &domain_bcs_value)
+                .map_err(|e| {
                     Error::SuiRpcInputError(SuiRpcInputError::GenericInvalid(format!(
-                        "Unable to serialize name: {:?} with error: {:?}",
-                        domain, e
+                        "Unable to lookup name in name service registry with error: {:?}",
+                        e
                     )))
                 })?;
-                let record_object_id_option = self
-                    .state
-                    .get_dynamic_field_object_id(registry_id, name_type_tag, &domain_bcs_value)
-                    .map_err(|e| {
-                        Error::SuiRpcInputError(SuiRpcInputError::GenericInvalid(format!(
-                            "Unable to lookup name in name service registry with error: {:?}",
+            if let Some(record_object_id) = record_object_id_option {
+                let record_object_read =
+                    self.state.get_object_read(&record_object_id).map_err(|e| {
+                        Error::UnexpectedError(format!(
+                            "Failed to get object read of name with error {:?}",
                             e
-                        )))
+                        ))
                     })?;
-                if let Some(record_object_id) = record_object_id_option {
-                    let record_object_read =
-                        self.state.get_object_read(&record_object_id).map_err(|e| {
-                            Error::UnexpectedError(format!(
-                                "Failed to get object read of name with error {:?}",
-                                e
-                            ))
-                        })?;
-                    let record_parsed_move_object =
-                        SuiParsedMoveObject::try_from_object_read(record_object_read)?;
-                    // NOTE: "value" is the field name to get the address info
-                    let address_info_move_value = record_parsed_move_object
-                        .read_dynamic_field_value(NAME_SERVICE_VALUE)
-                        .ok_or_else(|| {
-                            Error::UnexpectedError(
-                                "Cannot find value field in record Move struct".to_string(),
-                            )
-                        })?;
-                    let address_info_move_struct = match address_info_move_value {
-                        SuiMoveValue::Struct(a) => Ok(a),
-                        _ => Err(Error::UnexpectedError(
-                            "value field is not found.".to_string(),
-                        )),
-                    }?;
-                    // NOTE: "target_address" is the field name to get the address
-                    let address_str_move_value = address_info_move_struct
-                        .read_dynamic_field_value(NAME_SERVICE_TARGET_ADDRESS)
-                        .ok_or_else(|| {
-                            Error::UnexpectedError(format!(
+                let record_parsed_move_object =
+                    SuiParsedMoveObject::try_from_object_read(record_object_read)?;
+                // NOTE: "value" is the field name to get the address info
+                let address_info_move_value = record_parsed_move_object
+                    .read_dynamic_field_value(NAME_SERVICE_VALUE)
+                    .ok_or_else(|| {
+                        Error::UnexpectedError(
+                            "Cannot find value field in record Move struct".to_string(),
+                        )
+                    })?;
+                let address_info_move_struct = match address_info_move_value {
+                    SuiMoveValue::Struct(a) => Ok(a),
+                    _ => Err(Error::UnexpectedError(
+                        "value field is not found.".to_string(),
+                    )),
+                }?;
+                // NOTE: "target_address" is the field name to get the address
+                let address_str_move_value = address_info_move_struct
+                    .read_dynamic_field_value(NAME_SERVICE_TARGET_ADDRESS)
+                    .ok_or_else(|| {
+                        Error::UnexpectedError(format!(
                             "Cannot find target_address field in address info Move struct: {:?}",
                             address_info_move_struct
                         ))
-                        })?;
-                    let addr = match &address_str_move_value {
-                        SuiMoveValue::Option(boxed_addr) => match **boxed_addr {
-                            Some(SuiMoveValue::Address(ref addr)) => Ok(*addr),
-                            _ => Err(Error::UnexpectedError(format!(
-                                "No SuiAddress found in option: {:?}",
-                                address_str_move_value
-                            ))),
-                        },
+                    })?;
+                let addr = match &address_str_move_value {
+                    SuiMoveValue::Option(boxed_addr) => match **boxed_addr {
+                        Some(SuiMoveValue::Address(ref addr)) => Ok(*addr),
                         _ => Err(Error::UnexpectedError(format!(
-                            "No SuiAddress found in: {:?}",
+                            "No SuiAddress found in option: {:?}",
                             address_str_move_value
                         ))),
-                    }?;
-                    return Ok(Some(addr));
-                }
-                Ok(None)
-            } else {
-                Err(Error::UnexpectedError(
-                    "Name service package address or registry ID is not set.".to_string(),
-                ))?
+                    },
+                    _ => Err(Error::UnexpectedError(format!(
+                        "No SuiAddress found in: {:?}",
+                        address_str_move_value
+                    ))),
+                }?;
+                return Ok(Some(addr));
             }
+            Ok(None)
         })
     }
 
@@ -419,95 +431,91 @@ impl<R: ReadApiServer> IndexerApiServer for IndexerApi<R> {
         _limit: Option<usize>,
     ) -> RpcResult<Page<String, ObjectID>> {
         with_tracing!(async move {
-            if let Some(reverse_registry_id) = self.ns_reverse_registry_id {
-                let name_type_tag = TypeTag::Address;
-                let addr_bcs_value = bcs::to_bytes(&address).map_err(|e| {
-                    Error::SuiRpcInputError(SuiRpcInputError::GenericInvalid(format!(
-                        "Unable to serialize address: {:?} with error: {:?}",
-                        address, e
-                    )))
-                })?;
+            let reverse_registry_id = match self.ns_reverse_registry_id {
+                Some(id) => id,
+                None => ObjectID::from_str(NAME_SERVICE_DEFAULT_REVERSE_REGISTRY).map_err(|e| {
+                    Error::UnexpectedError(format!(
+                        "Parsing name service default reverse registry ID failed with error: {:?}",
+                        e
+                    ))
+                })?,
+            };
 
-                let addr_object_id = self
-                    .state
-                    .get_dynamic_field_object_id(
-                        reverse_registry_id,
-                        name_type_tag,
-                        &addr_bcs_value,
+            let name_type_tag = TypeTag::Address;
+            let addr_bcs_value = bcs::to_bytes(&address).map_err(|e| {
+                Error::SuiRpcInputError(SuiRpcInputError::GenericInvalid(format!(
+                    "Unable to serialize address: {:?} with error: {:?}",
+                    address, e
+                )))
+            })?;
+
+            let addr_object_id = self
+                .state
+                .get_dynamic_field_object_id(reverse_registry_id, name_type_tag, &addr_bcs_value)
+                .map_err(|e| {
+                    Error::UnexpectedError(format!(
+                        "Read name service reverse dynamic field table failed with error: {:?}",
+                        e
+                    ))
+                })?
+                .ok_or_else(|| {
+                    Error::UnexpectedError(format!("Record not found for address: {:?}", address))
+                })?;
+            let addr_object_read = self.state.get_object_read(&addr_object_id).map_err(|e| {
+                warn!(
+                    "Failed to get object read of address {:?} with error: {:?}",
+                    addr_object_id, e
+                );
+                Error::UnexpectedError(format!(
+                    "Failed to get object read of address with err: {:?}",
+                    e
+                ))
+            })?;
+            let addr_parsed_move_object =
+                SuiParsedMoveObject::try_from_object_read(addr_object_read)?;
+            let address_info_move_value = addr_parsed_move_object
+                .read_dynamic_field_value(NAME_SERVICE_VALUE)
+                .ok_or_else(|| {
+                    Error::UnexpectedError(
+                        "Cannot find value field in record Move struct".to_string(),
                     )
-                    .map_err(|e| {
-                        Error::UnexpectedError(format!(
-                            "Read name service reverse dynamic field table failed with error: {:?}",
-                            e
-                        ))
-                    })?
-                    .ok_or_else(|| {
-                        Error::UnexpectedError(format!(
-                            "Record not found for address: {:?}",
-                            address
-                        ))
-                    })?;
-                let addr_object_read =
-                    self.state.get_object_read(&addr_object_id).map_err(|e| {
-                        warn!(
-                            "Failed to get object read of address {:?} with error: {:?}",
-                            addr_object_id, e
-                        );
-                        Error::UnexpectedError(format!(
-                            "Failed to get object read of address with err: {:?}",
-                            e
-                        ))
-                    })?;
-                let addr_parsed_move_object =
-                    SuiParsedMoveObject::try_from_object_read(addr_object_read)?;
-                let address_info_move_value = addr_parsed_move_object
-                    .read_dynamic_field_value(NAME_SERVICE_VALUE)
-                    .ok_or_else(|| {
-                        Error::UnexpectedError(
-                            "Cannot find value field in record Move struct".to_string(),
-                        )
-                    })?;
-                let domain_info_move_struct = match address_info_move_value {
-                    SuiMoveValue::Struct(a) => Ok(a),
-                    _ => Err(Error::UnexpectedError(
-                        "value field is not found.".to_string(),
-                    )),
-                }?;
-                let labels_move_value = domain_info_move_struct
-                    .read_dynamic_field_value("labels")
-                    .ok_or_else(|| {
-                        Error::UnexpectedError(format!(
-                            "Cannot find labels field in address info Move struct: {:?}",
-                            domain_info_move_struct
-                        ))
-                    })?;
-                let primary_domain = match labels_move_value {
-                    SuiMoveValue::Vector(labels) => {
-                        let label_strs: Vec<String> = labels
-                            .iter()
-                            .rev()
-                            .filter_map(|label| match label {
-                                SuiMoveValue::String(label_str) => Some(label_str.clone()),
-                                _ => None,
-                            })
-                            .collect();
-                        Ok(label_strs.join("."))
-                    }
-                    _ => Err(Error::UnexpectedError(format!(
-                        "No string field for primary name is found in {:?}",
-                        labels_move_value
-                    ))),
-                }?;
-                Ok(Page {
-                    data: vec![primary_domain],
-                    next_cursor: Some(addr_object_id),
-                    has_next_page: false,
-                })
-            } else {
-                Err(Error::UnexpectedError(
-                    "Name service reverse registry ID is not set".to_string(),
-                ))?
-            }
+                })?;
+            let domain_info_move_struct = match address_info_move_value {
+                SuiMoveValue::Struct(a) => Ok(a),
+                _ => Err(Error::UnexpectedError(
+                    "value field is not found.".to_string(),
+                )),
+            }?;
+            let labels_move_value = domain_info_move_struct
+                .read_dynamic_field_value("labels")
+                .ok_or_else(|| {
+                    Error::UnexpectedError(format!(
+                        "Cannot find labels field in address info Move struct: {:?}",
+                        domain_info_move_struct
+                    ))
+                })?;
+            let primary_domain = match labels_move_value {
+                SuiMoveValue::Vector(labels) => {
+                    let label_strs: Vec<String> = labels
+                        .iter()
+                        .rev()
+                        .filter_map(|label| match label {
+                            SuiMoveValue::String(label_str) => Some(label_str.clone()),
+                            _ => None,
+                        })
+                        .collect();
+                    Ok(label_strs.join("."))
+                }
+                _ => Err(Error::UnexpectedError(format!(
+                    "No string field for primary name is found in {:?}",
+                    labels_move_value
+                ))),
+            }?;
+            Ok(Page {
+                data: vec![primary_domain],
+                next_cursor: Some(addr_object_id),
+                has_next_page: false,
+            })
         })
     }
 }


### PR DESCRIPTION
## Description 

before this PR, FN config is required to make sui NS work, this PR added default mainnet sui ns config so that
- without extra setup, sui ns on mainnet should just work
- if RPC provider wants to override with custom ones, they still can
- on other *nets, overriding is still required.

## Test Plan 

Test on testnet with & without overriding.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
