### PR TITLE
wallet-ext:wallet-kit: fix port disconnection when dapp preloads

### DIFF
--- a/.changeset/giant-flowers-collect.md
+++ b/.changeset/giant-flowers-collect.md
@@ -1,0 +1,7 @@
+---
+"@mysten/wallet-kit-core": patch
+---
+
+- delay auto connect until document is visible - fix preloading dapp issues
+  - fixes showing the wallet connect popup (for cases wallet was disconnected without dapp to be notified) when preloading the page (usually while typing the url)
+  - prevents content script from creating a Port to service worker while the dapp is hidden, which causes the port to be in a disconnected state in SW but without notifying the CS, when page is preloaded.

--- a/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
+++ b/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
@@ -208,7 +208,6 @@ export class SuiWallet implements Wallet {
                 this.#events.emit('change', { accounts: this.accounts });
             }
         });
-        this.#connected();
     }
 
     #on: StandardEventsOnMethod = (event, listener) => {

--- a/sdk/wallet-adapter/wallet-kit-core/src/index.ts
+++ b/sdk/wallet-adapter/wallet-kit-core/src/index.ts
@@ -83,6 +83,22 @@ const SUI_WALLET_NAME = "Sui Wallet";
 
 const RECENT_WALLET_STORAGE = "wallet-kit:last-wallet";
 
+function waitToBeVisible() {
+  if (!document || document.visibilityState === "visible") {
+    return Promise.resolve();
+  }
+  let promiseResolve: (() => void) | null = null;
+  const promise = new Promise<void>((r) => (promiseResolve = r));
+  const callback = () => {
+    if (promiseResolve && document.visibilityState === "visible") {
+      promiseResolve();
+      document.removeEventListener("visibilitychange", callback);
+    }
+  };
+  document.addEventListener("visibilitychange", callback);
+  return promise;
+}
+
 function sortWallets(wallets: WalletAdapter[], preferredWallets: string[]) {
   return [
     // Preferred wallets, in order:
@@ -167,7 +183,7 @@ export function createWalletKitCore({
   const walletKit: WalletKitCore = {
     async autoconnect() {
       if (state.currentWallet) return;
-
+      await waitToBeVisible();
       try {
         const lastWalletName = await storageAdapter.get(storageKey);
         if (lastWalletName) {


### PR DESCRIPTION
* this seems like a chrome issue, when dapp preloads and then user visits the page the port disconnects but content script never gets notified
* we avoid creating a port until the document is visible and that seems to solve the issue
* auto connect gets delayed and wait for the document to be visible
* wallet interface delay loading accounts until a dapp connects

fixes: 


https://github.com/MystenLabs/sui/assets/10210143/4a354026-1682-4e7a-b2fb-5539af8e7247


https://github.com/MystenLabs/sui/assets/10210143/cde9852f-b26f-46ff-a2f6-3dc2169002f6



closes APPS-1036