### PR TITLE
[sdk, sui.js] Patches the response so it matches the RPC definition

### DIFF
--- a/.changeset/early-seas-tap.md
+++ b/.changeset/early-seas-tap.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Fixes BCS definition so it matches the RPC one

--- a/sdk/typescript/src/types/objects.ts
+++ b/sdk/typescript/src/types/objects.ts
@@ -89,7 +89,7 @@ export const SuiRawMoveObject = object({
   /** Move type (e.g., "0x2::coin::Coin<0x2::sui::SUI>") */
   type: string(),
   hasPublicTransfer: boolean(),
-  version: SequenceNumber,
+  version: number(),
   bcsBytes: string(),
 });
 export type SuiRawMoveObject = Infer<typeof SuiRawMoveObject>;


### PR DESCRIPTION
## Description 

Matches the RPC definition when "withBcs" is used.

## Test Plan 

Manually verified this dependency against RPC.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

- sui.js now has correct response type definition for the RPC "withBcs" call