### PR TITLE
[Faucet] Adding batch request to sui faucet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13112,6 +13112,7 @@ dependencies = [
  "tracing-subscriber 0.2.25",
  "tracing-subscriber 0.3.16",
  "try-lock",
+ "ttl_cache",
  "tui",
  "twox-hash",
  "typed-arena",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9218,6 +9218,7 @@ dependencies = [
  "futures",
  "jsonrpsee",
  "move-core-types",
+ "mysten-metrics",
  "prometheus",
  "reqwest",
  "serde 1.0.152",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9511,6 +9511,7 @@ dependencies = [
  "tower",
  "tower-http 0.3.5",
  "tracing",
+ "ttl_cache",
  "typed-store",
  "typed-store-derive",
  "uuid",
@@ -11596,6 +11597,15 @@ name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+
+[[package]]
+name = "ttl_cache"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4189890526f0168710b6ee65ceaedf1460c48a14318ceec933cb26baa492096a"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "tui"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9490,6 +9490,7 @@ dependencies = [
  "futures",
  "http",
  "mysten-metrics",
+ "parking_lot 0.12.1",
  "prometheus",
  "rocksdb",
  "scopeguard",

--- a/crates/sui-cluster-test/Cargo.toml
+++ b/crates/sui-cluster-test/Cargo.toml
@@ -23,6 +23,7 @@ uuid = {version = "1.1.2", features = [ "v4", "fast-rng"]}
 prometheus = "0.13.3"
 fastcrypto = { workspace = true }
 shared-crypto = { path = "../shared-crypto" }
+mysten-metrics = { path = "../../crates/mysten-metrics" }
 
 sui-indexer = { path = "../sui-indexer" }
 sui-faucet = { path = "../sui-faucet" }

--- a/crates/sui-cluster-test/src/faucet.rs
+++ b/crates/sui-cluster-test/src/faucet.rs
@@ -3,7 +3,6 @@
 use super::cluster::{new_wallet_context_from_cluster, Cluster};
 use async_trait::async_trait;
 use fastcrypto::encoding::{Encoding, Hex};
-use mysten_metrics::spawn_monitored_task;
 use std::collections::HashMap;
 use std::env;
 use std::sync::Arc;
@@ -42,19 +41,7 @@ impl FaucetClientFactory {
                 .await
                 .unwrap();
 
-                let faucet = Arc::new(simple_faucet);
-                let faucet_batch = faucet.clone();
-
-                spawn_monitored_task!(async move {
-                    loop {
-                        faucet_batch
-                            .batch_transfer_gases()
-                            .await
-                            .expect("unexpected unable to batch transfer");
-                    }
-                });
-
-                Arc::new(LocalFaucetClient::new(faucet))
+                Arc::new(LocalFaucetClient::new(simple_faucet))
             }
         }
     }

--- a/crates/sui-faucet/Cargo.toml
+++ b/crates/sui-faucet/Cargo.toml
@@ -27,6 +27,7 @@ ttl_cache = "0.5.1"
 eyre = "0.6.8"
 rocksdb = "0.21.0"
 tempfile = "3.3.0"
+parking_lot = "0.12.1"
 
 sui = { path = "../sui" }
 sui-node = { path = "../sui-node" }

--- a/crates/sui-faucet/Cargo.toml
+++ b/crates/sui-faucet/Cargo.toml
@@ -23,7 +23,7 @@ uuid = {version = "1.1.2", features = [ "v4", "fast-rng"]}
 prometheus = "0.13.3"
 scopeguard = "1.1"
 tap = "1.0"
-
+ttl_cache = "0.5.1"
 eyre = "0.6.8"
 rocksdb = "0.21.0"
 tempfile = "3.3.0"

--- a/crates/sui-faucet/src/errors.rs
+++ b/crates/sui-faucet/src/errors.rs
@@ -31,6 +31,12 @@ pub enum FaucetError {
     #[error("Coin Transfer Failed `{0}`")]
     Transfer(String),
 
+    #[error("Too many coins in the batch queue. Please try again later.")]
+    BatchSendQueueFull,
+
+    #[error("Request consumer queue closed.")]
+    ChannelClosed,
+
     #[error("Internal error: {0}")]
     Internal(String),
 }

--- a/crates/sui-faucet/src/errors.rs
+++ b/crates/sui-faucet/src/errors.rs
@@ -37,6 +37,9 @@ pub enum FaucetError {
     #[error("Request consumer queue closed.")]
     ChannelClosed,
 
+    #[error("Coin amounts sent are incorrect:`{0}`")]
+    CoinAmountTransferredIncorrect(String),
+
     #[error("Internal error: {0}")]
     Internal(String),
 }

--- a/crates/sui-faucet/src/faucet/mod.rs
+++ b/crates/sui-faucet/src/faucet/mod.rs
@@ -30,6 +30,20 @@ pub struct CoinInfo {
     pub transfer_tx_digest: TransactionDigest,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct BatchSendStatus {
+    pub status: BatchSendStatusType,
+    pub transferred_gas_objects: Option<FaucetReceipt>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum BatchSendStatusType {
+    INPROGRESS,
+    SUCCEEDED,
+    DISCARDED,
+}
+
 #[async_trait]
 pub trait Faucet {
     /// Send `Coin<SUI>` of the specified amount to the recipient
@@ -47,6 +61,9 @@ pub trait Faucet {
         recipient: SuiAddress,
         amounts: &[u64],
     ) -> Result<BatchFaucetReceipt, FaucetError>;
+
+    /// Get the status of a batch_send request
+    async fn get_batch_send_status(&self, task_id: Uuid) -> Result<BatchSendStatus, FaucetError>;
 }
 
 pub const DEFAULT_AMOUNT: u64 = 1_000_000_000;

--- a/crates/sui-faucet/src/faucet/mod.rs
+++ b/crates/sui-faucet/src/faucet/mod.rs
@@ -36,7 +36,7 @@ pub struct BatchSendStatus {
     pub transferred_gas_objects: Option<FaucetReceipt>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum BatchSendStatusType {
     INPROGRESS,
@@ -108,6 +108,9 @@ pub struct FaucetConfig {
 
     #[clap(long, default_value_t = 500)]
     pub batch_request_size: u64,
+
+    #[clap(long, default_value_t = 300)]
+    pub ttl_expiration: u64,
 }
 
 impl Default for FaucetConfig {
@@ -124,6 +127,7 @@ impl Default for FaucetConfig {
             wal_retry_interval: 300,
             max_request_queue_length: 10000,
             batch_request_size: 500,
+            ttl_expiration: 300,
         }
     }
 }

--- a/crates/sui-faucet/src/faucet/mod.rs
+++ b/crates/sui-faucet/src/faucet/mod.rs
@@ -18,6 +18,11 @@ pub struct FaucetReceipt {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct BatchFaucetReceipt {
+    pub task: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct CoinInfo {
     pub amount: u64,
@@ -34,6 +39,14 @@ pub trait Faucet {
         recipient: SuiAddress,
         amounts: &[u64],
     ) -> Result<FaucetReceipt, FaucetError>;
+
+    /// Send `Coin<SUI>` of the specified amount to the recipient in a batch request
+    async fn batch_send(
+        &self,
+        id: Uuid,
+        recipient: SuiAddress,
+        amounts: &[u64],
+    ) -> Result<BatchFaucetReceipt, FaucetError>;
 }
 
 pub const DEFAULT_AMOUNT: u64 = 1_000_000_000;
@@ -72,6 +85,12 @@ pub struct FaucetConfig {
 
     #[clap(long, default_value_t = 300)]
     pub wal_retry_interval: u64,
+
+    #[clap(long, default_value_t = 10000)]
+    pub max_request_queue_length: u64,
+
+    #[clap(long, default_value_t = 500)]
+    pub batch_request_size: u64,
 }
 
 impl Default for FaucetConfig {
@@ -86,6 +105,8 @@ impl Default for FaucetConfig {
             wallet_client_timeout_secs: 60,
             write_ahead_log: Default::default(),
             wal_retry_interval: 300,
+            max_request_queue_length: 10000,
+            batch_request_size: 500,
         }
     }
 }

--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -1165,6 +1165,8 @@ mod tests {
                 .map(|res| res.unwrap())
                 .collect::<Vec<BatchSendStatus>>();
 
+            // All requests are submitted and picked up by the same batch, so one success in the test
+            // will guarantee all success.
             if status_results[0].status == BatchSendStatusType::SUCCEEDED {
                 break;
             }
@@ -1712,6 +1714,8 @@ mod tests {
                 .map(|res| res.unwrap())
                 .collect::<Vec<BatchSendStatus>>();
 
+            // All requests are submitted and picked up by the same batch, so one success in the test
+            // will guarantee all success.
             if status_results[0].status == BatchSendStatusType::SUCCEEDED {
                 break;
             }

--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -761,7 +761,7 @@ impl SimpleFaucet {
 
         let mut address_coins_map: HashMap<SuiAddress, Vec<OwnedObjectRef>> = HashMap::new();
         created.iter().for_each(|created_coin_owner_ref| {
-            let owner = created_coin_owner_ref.owner.clone();
+            let owner = created_coin_owner_ref.owner;
             let coin_obj_ref = created_coin_owner_ref.clone();
 
             // Insert the coins into the map based on the destination address
@@ -1034,8 +1034,10 @@ mod tests {
     async fn test_batch_transfer_interface() {
         let test_cluster = TestClusterBuilder::new().build().await.unwrap();
         let context = test_cluster.wallet;
-        let mut config = FaucetConfig::default();
-        config.ttl_expiration = 10;
+        let config = FaucetConfig {
+            ttl_expiration: 10,
+            ..Default::default()
+        };
         let prom_registry = Registry::new();
         let tmp = tempfile::tempdir().unwrap();
         let faucet = SimpleFaucet::new(
@@ -1111,13 +1113,16 @@ mod tests {
         )
         .await;
 
-        let all_errors = status_results.iter().all(|status_result| {
-            if let Err(_) = status_result {
-                true // If it's an error, return true
-            } else {
-                false // If it's not an error, return false
-            }
-        });
+        let all_errors =
+            status_results.iter().all(
+                |status_result| {
+                    if status_result.is_err() {
+                        true
+                    } else {
+                        false
+                    }
+                },
+            );
 
         assert!(all_errors);
     }

--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -688,10 +688,10 @@ impl SimpleFaucet {
             let number_of_coins = amounts.len();
             // Get or insert sui_address into request count
             let index = *request_count.entry(addy).or_insert(0);
-            // If the number of objects don't match the number of coins panic
-            let coins_created_for_address = address_coins_map.entry(addy).or_insert_with(|| {
-                panic!("No entries found for address: {}", addy);
-            });
+
+            // The address coin map should contain the coins transferred in the given request.
+            let coins_created_for_address = address_coins_map.entry(addy).or_insert_with(Vec::new);
+
             if number_of_coins as u64 + index > coins_created_for_address.len() as u64 {
                 panic!("Less coins created expected than number requested");
             }

--- a/crates/sui-faucet/src/faucet/write_ahead_log.rs
+++ b/crates/sui-faucet/src/faucet/write_ahead_log.rs
@@ -29,6 +29,7 @@ pub struct WriteAheadLog {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct Entry {
     pub uuid: uuid::Bytes,
+    // TODO (jian): remove recipient
     pub recipient: SuiAddress,
     pub tx: TransactionData,
     pub retry_count: u64,

--- a/crates/sui-faucet/src/main.rs
+++ b/crates/sui-faucet/src/main.rs
@@ -140,8 +140,7 @@ async fn batch_request_gas(
     info!(uuid = ?id, "Got new gas request.");
     let result = match payload {
         FaucetRequest::FixedAmountRequest(requests) => {
-            // We spawn a tokio task for this such that connection drop will not interrupt
-            // it and impact the recycling of coins
+            // TODO: get ride of this task spawning since recycled coins are now handled by the batching task.
             spawn_monitored_task!(async move {
                 state
                     .faucet

--- a/crates/sui-faucet/src/main.rs
+++ b/crates/sui-faucet/src/main.rs
@@ -143,7 +143,7 @@ async fn health() -> &'static str {
     "OK"
 }
 
-/// handler for batch_request_gas reqesuts
+/// handler for batch_request_gas requests
 async fn batch_request_gas(
     Extension(state): Extension<Arc<AppState>>,
     Json(payload): Json<FaucetRequest>,

--- a/crates/sui-faucet/src/main.rs
+++ b/crates/sui-faucet/src/main.rs
@@ -20,7 +20,8 @@ use std::{
 };
 use sui_config::{sui_config_dir, SUI_CLIENT_CONFIG};
 use sui_faucet::{
-    Faucet, FaucetConfig, FaucetRequest, FaucetResponse, RequestMetricsLayer, SimpleFaucet,
+    BatchFaucetResponse, Faucet, FaucetConfig, FaucetRequest, FaucetResponse, RequestMetricsLayer,
+    SimpleFaucet,
 };
 use sui_sdk::wallet_context::WalletContext;
 use tower::{limit::RateLimitLayer, ServiceBuilder};
@@ -33,7 +34,6 @@ const CONCURRENCY_LIMIT: usize = 30;
 struct AppState<F = SimpleFaucet> {
     faucet: F,
     config: FaucetConfig,
-    // TODO: add counter
 }
 
 const PROM_PORT_ADDR: &str = "0.0.0.0:9184";
@@ -69,7 +69,6 @@ async fn main() -> Result<(), anyhow::Error> {
     info!("Starting Prometheus HTTP endpoint at {}", prom_binding);
     let registry_service = sui_node::metrics::start_prometheus_server(prom_binding);
     let prometheus_registry = registry_service.default_registry();
-
     let app_state = Arc::new(AppState {
         faucet: SimpleFaucet::new(
             context,
@@ -82,6 +81,8 @@ async fn main() -> Result<(), anyhow::Error> {
         config,
     });
 
+    let batching_thread_app_state = Arc::clone(&app_state);
+
     // TODO: restrict access if needed
     let cors = CorsLayer::new()
         .allow_methods(vec![Method::GET, Method::POST])
@@ -91,6 +92,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let app = Router::new()
         .route("/", get(health))
         .route("/gas", post(request_gas))
+        .route("/v1/gas", post(batch_request_gas))
         .layer(
             ServiceBuilder::new()
                 .layer(HandleErrorLayer::new(handle_error))
@@ -116,6 +118,17 @@ async fn main() -> Result<(), anyhow::Error> {
         }
     });
 
+    spawn_monitored_task!(async move {
+        info!("Starting task to handle batch faucet requests.");
+        loop {
+            batching_thread_app_state
+                .faucet
+                .batch_transfer_gases()
+                .await
+                .unwrap();
+        }
+    });
+
     let addr = SocketAddr::new(IpAddr::V4(host_ip), port);
     info!("listening on {}", addr);
     axum::Server::bind(&addr)
@@ -129,6 +142,47 @@ async fn health() -> &'static str {
     "OK"
 }
 
+/// handler for batch_request_gas reqesuts
+async fn batch_request_gas(
+    Extension(state): Extension<Arc<AppState>>,
+    Json(payload): Json<FaucetRequest>,
+) -> impl IntoResponse {
+    // ID for traceability
+    let id = Uuid::new_v4();
+    info!(uuid = ?id, "Got new gas request.");
+    let result = match payload {
+        FaucetRequest::FixedAmountRequest(requests) => {
+            // We spawn a tokio task for this such that connection drop will not interrupt
+            // it and impact the recycling of coins
+            spawn_monitored_task!(async move {
+                state
+                    .faucet
+                    .batch_send(
+                        id,
+                        requests.recipient,
+                        &vec![state.config.amount; state.config.num_coins],
+                    )
+                    .await
+            })
+            .await
+            .unwrap()
+        }
+    };
+    match result {
+        Ok(v) => {
+            info!(uuid =?id, "Request is successfully served");
+            (StatusCode::ACCEPTED, Json(BatchFaucetResponse::from(v)))
+        }
+        Err(v) => {
+            warn!(uuid =?id, "Failed to request gas: {:?}", v);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(BatchFaucetResponse::from(v)),
+            )
+        }
+    }
+}
+
 /// handler for all the request_gas requests
 async fn request_gas(
     Extension(state): Extension<Arc<AppState>>,
@@ -140,7 +194,7 @@ async fn request_gas(
     let result = match payload {
         FaucetRequest::FixedAmountRequest(requests) => {
             // We spawn a tokio task for this such that connection drop will not interrupt
-            // it and impact the reclycing of coins
+            // it and impact the recycling of coins
             spawn_monitored_task!(async move {
                 state
                     .faucet

--- a/crates/sui-faucet/src/metrics.rs
+++ b/crates/sui-faucet/src/metrics.rs
@@ -27,6 +27,7 @@ pub struct FaucetMetrics {
     pub(crate) current_executions_in_flight: IntGauge,
     pub(crate) total_available_coins: IntGauge,
     pub(crate) total_discarded_coins: IntGauge,
+    pub(crate) total_coin_requests_succeeded: IntGauge,
 }
 
 const LATENCY_SEC_BUCKETS: &[f64] = &[
@@ -102,6 +103,12 @@ impl FaucetMetrics {
             total_discarded_coins: register_int_gauge_with_registry!(
                 "total_discarded_coins",
                 "Total number of discarded coins",
+                registry,
+            )
+            .unwrap(),
+            total_coin_requests_succeeded: register_int_gauge_with_registry!(
+                "total_coin_requests_succeeded",
+                "Total number of requests processed successfully in Faucet (both batch and non_batched)",
                 registry,
             )
             .unwrap(),

--- a/crates/sui-faucet/src/requests.rs
+++ b/crates/sui-faucet/src/requests.rs
@@ -7,6 +7,7 @@ use sui_types::base_types::SuiAddress;
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum FaucetRequest {
     FixedAmountRequest(FixedAmountRequest),
+    GetBatchSendStatusRequest(GetBatchSendStatusRequest),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -14,10 +15,21 @@ pub struct FixedAmountRequest {
     pub recipient: SuiAddress,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct GetBatchSendStatusRequest {
+    pub task_id: String,
+}
+
 impl FaucetRequest {
     pub fn new_fixed_amount_request(recipient: impl Into<SuiAddress>) -> Self {
         Self::FixedAmountRequest(FixedAmountRequest {
             recipient: recipient.into(),
+        })
+    }
+
+    pub fn new_get_batch_send_status_request(task_id: impl Into<String>) -> Self {
+        Self::GetBatchSendStatusRequest(GetBatchSendStatusRequest {
+            task_id: task_id.into(),
         })
     }
 }

--- a/crates/sui-faucet/src/responses.rs
+++ b/crates/sui-faucet/src/responses.rs
@@ -28,3 +28,29 @@ impl From<FaucetReceipt> for FaucetResponse {
         }
     }
 }
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct BatchFaucetResponse {
+    // This string is the Uuid for the req
+    pub task: Option<String>,
+    pub error: Option<String>,
+}
+
+impl From<FaucetError> for BatchFaucetResponse {
+    fn from(e: FaucetError) -> Self {
+        Self {
+            error: Some(e.to_string()),
+            task: None,
+        }
+    }
+}
+
+impl From<BatchFaucetReceipt> for BatchFaucetResponse {
+    fn from(v: BatchFaucetReceipt) -> Self {
+        Self {
+            task: Some(v.task),
+            error: None,
+        }
+    }
+}

--- a/crates/sui-faucet/src/responses.rs
+++ b/crates/sui-faucet/src/responses.rs
@@ -54,3 +54,29 @@ impl From<BatchFaucetReceipt> for BatchFaucetResponse {
         }
     }
 }
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct BatchStatusFaucetResponse {
+    // This string is the Uuid for the req
+    pub status: Option<BatchSendStatus>,
+    pub error: Option<String>,
+}
+
+impl From<FaucetError> for BatchStatusFaucetResponse {
+    fn from(e: FaucetError) -> Self {
+        Self {
+            error: Some(e.to_string()),
+            status: None,
+        }
+    }
+}
+
+impl From<BatchSendStatus> for BatchStatusFaucetResponse {
+    fn from(v: BatchSendStatus) -> Self {
+        Self {
+            status: Some(v),
+            error: None,
+        }
+    }
+}

--- a/crates/sui-test-validator/src/main.rs
+++ b/crates/sui-test-validator/src/main.rs
@@ -154,6 +154,8 @@ async fn faucet_request(
         FaucetRequest::FixedAmountRequest(FixedAmountRequest { recipient }) => {
             state.faucet.request_sui_coins(recipient).await
         }
+        // (jian) TODO: add this onto the validator and cluster test faucets
+        FaucetRequest::GetBatchSendStatusRequest(_) => todo!(),
     };
 
     if !result.transferred_gas_objects.is_empty() {

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -628,6 +628,7 @@ tracing-serde = { version = "0.1", default-features = false }
 tracing-subscriber-468e82937335b1c9 = { package = "tracing-subscriber", version = "0.3", default-features = false, features = ["ansi", "env-filter", "json", "smallvec", "time"] }
 tracing-subscriber-6f8ce4dd05d13bba = { package = "tracing-subscriber", version = "0.2", default-features = false }
 try-lock = { version = "0.2", default-features = false }
+ttl_cache = { version = "0.5" }
 tui = { version = "0.17" }
 twox-hash = { version = "1", default-features = false }
 typed-arena = { version = "2" }
@@ -1401,6 +1402,7 @@ tracing-serde = { version = "0.1", default-features = false }
 tracing-subscriber-468e82937335b1c9 = { package = "tracing-subscriber", version = "0.3", default-features = false, features = ["ansi", "env-filter", "json", "smallvec", "time"] }
 tracing-subscriber-6f8ce4dd05d13bba = { package = "tracing-subscriber", version = "0.2", default-features = false }
 try-lock = { version = "0.2", default-features = false }
+ttl_cache = { version = "0.5" }
 tui = { version = "0.17" }
 twox-hash = { version = "1", default-features = false }
 typed-arena = { version = "2" }


### PR DESCRIPTION
## Description 

This PR adds the `/v1/gas` api to the faucet which is the batch send request. The request gets put into a MCSP queue which another thread pulls routinely from to serve up to 500 paysui transactions at once. 

This also adds the `/v1/status` api to the faucet which checks on the status of the request based on a Uuid that is generated from the initial gas request. The status of any given Uuid is cached for 5 minutes after the request completes, and if it is deleted the user will get nothing back.

Adding batch request on faucet: 

<img width="1243" alt="image" src="https://github.com/MystenLabs/sui/assets/123408603/bfa62f4a-8d14-4cf6-b17a-91bbb9c54378">

In Progress:
![image](https://github.com/MystenLabs/sui/assets/123408603/f6546c54-774f-44dd-b07d-a2a30d4df777)

Success:
![image](https://github.com/MystenLabs/sui/assets/123408603/8ac43331-c4ae-49b1-97cd-12bd6bd7e39f)

Follow up items:
Change wallet to use new API


## Test Plan 

How did you test the new or updated feature?

Local Testing / CI / CD / Will redirect discord devnet faucuet, and then testnet faucet onto this endpoint

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
