### PR TITLE
authority: add jwk updater to authority server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9389,6 +9389,7 @@ dependencies = [
  "pretty_assertions",
  "prometheus",
  "rand 0.8.5",
+ "reqwest",
  "rocksdb",
  "scopeguard",
  "serde 1.0.152",

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -109,7 +109,7 @@ impl Genesis {
     pub fn checkpoint(&self) -> VerifiedCheckpoint {
         self.checkpoint
             .clone()
-            .verify(&self.committee().unwrap())
+            .verify(&self.committee().unwrap(), None)
             .unwrap()
     }
 

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -39,6 +39,7 @@ tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 tokio-retry = "0.3"
 tokio-stream = { version = "0.1.8", features = ["sync", "net"] }
 tracing = "0.1.36"
+reqwest = { version = "0.11.13", default_features= false, features = ["blocking", "json", "rustls-tls"] }
 
 fastcrypto.workspace = true
 move-binary-format.workspace = true

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -4,6 +4,7 @@
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use std::sync::RwLock;
 use std::time::Duration;
 use std::{collections::HashMap, fs, pin::Pin, sync::Arc};
 
@@ -23,6 +24,7 @@ use prometheus::{
     register_int_gauge_vec_with_registry, register_int_gauge_with_registry, Histogram, IntCounter,
     IntCounterVec, IntGauge, IntGaugeVec, Registry,
 };
+use reqwest::Client;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use sui_config::node::StateDebugDumpConfig;
@@ -126,7 +128,7 @@ use crate::module_cache_metrics::ResolverMetrics;
 use crate::stake_aggregator::StakeAggregator;
 use crate::state_accumulator::StateAccumulator;
 use crate::{transaction_input_checker, transaction_manager::TransactionManager};
-
+use once_cell::sync::Lazy;
 #[cfg(test)]
 #[cfg(feature = "test-utils")]
 #[path = "unit_tests/authority_tests.rs"]
@@ -164,6 +166,31 @@ pub(crate) mod authority_notify_read;
 pub(crate) mod authority_store;
 
 pub static CHAIN_IDENTIFIER: OnceCell<ChainIdentifier> = OnceCell::new();
+
+/// A default Google JWK raw response bytes from https://www.googleapis.com/oauth2/v2/certs
+/// retrieved on 05/30/2023.
+pub static DEFAULT_GOOGLE_JWK_BYTES: Lazy<Vec<u8>> = Lazy::new(|| {
+    r#"{
+        "keys": [
+          {
+            "n": "0NDRXWtH6_HnmuSuTAisgYVZ3Z67PQjHbRFz4XNYuD95BKx0wQr0GWOi_UCGLfI0col3i6J3_AF-b1YrTFTMEr_bL8CYDdK2CYLcGUzc5bLRDAySsqnKdlhWkneqfFdr3J66mHu11KUaIIRWiLsCkR9QFF-8o2PtZzv3F-3Uh7L4q7i_Evs1s7SJlO0OAnI4ew4rP2HbRaO0Q2zK0DL_d1eoAC72apQuEzz-2aXfQ-QYSTlVK74McBhP1MRtgD6zGF2lwg4uhgb55fDDQQh0VHWQSxwbvAL0Oox69zzpkFgpjJAJUqaxegzETU1jf3iKs1vyFIB0C4N-Jr__zwLQZw==",
+            "alg": "RS256",
+            "kty": "RSA",
+            "kid": "2d9a5ef5b12623c91671a7093cb323333cd07d09",
+            "e": "AQAB",
+            "use": "sig"
+          },
+          {
+            "kid": "6083dd5981673f661fde9dae646b6f0380a0145c",
+            "alg": "RS256",
+            "e": "AQAB",
+            "use": "sig",
+            "kty": "RSA",
+            "n": "1qrQCTst3RF04aMC9Ye_kGbsE0sftL4FOtB_WrzBDOFdrfVwLfflQuPX5kJ-0iYv9r2mjD5YIDy8b-iJKwevb69ISeoOrmL3tj6MStJesbbRRLVyFIm_6L7alHhZVyqHQtMKX7IaNndrfebnLReGntuNk76XCFxBBnRaIzAWnzr3WN4UPBt84A0KF74pei17dlqHZJ2HB2CsYbE9Ort8m7Vf6hwxYzFtCvMCnZil0fCtk2OQ73l6egcvYO65DkAJibFsC9xAgZaF-9GYRlSjMPd0SMQ8yU9i3W7beT00Xw6C0FYA9JAYaGaOvbT87l_6ZkAksOMuvIPD_jNVfTCPLQ=="
+          }
+        ]
+      }"#.as_bytes().to_vec()
+});
 
 pub type ReconfigConsensusMessage = (
     AuthorityKeyPair,
@@ -548,6 +575,9 @@ pub struct AuthorityState {
 
     /// Config for state dumping on forks
     debug_dump_config: StateDebugDumpConfig,
+
+    /// A serialized bytes array value of the Google JWK HTTP response.
+    google_jwk_as_bytes: Arc<RwLock<Vec<u8>>>,
 }
 
 /// The authority state encapsulates all state, drives execution, and ensures safety.
@@ -567,6 +597,54 @@ impl AuthorityState {
 
     pub fn committee_store(&self) -> &Arc<CommitteeStore> {
         &self.committee_store
+    }
+
+    pub fn get_google_jwk_as_bytes(&self) -> Vec<u8> {
+        match self.google_jwk_as_bytes.read() {
+            Ok(google_jwk_as_bytes) => google_jwk_as_bytes.clone(),
+            Err(_) => (*DEFAULT_GOOGLE_JWK_BYTES.clone()).to_vec(),
+        }
+    }
+
+    pub fn start_jwk_updater(self: Arc<Self>) {
+        debug!("Starting JWK updater thread for authority");
+        tokio::task::spawn(async move {
+            loop {
+                // Update the JWK value in the authority server
+                let res = self.update_google_jwk().await;
+                if let Err(e) = res {
+                    debug!("Error when fetching JWK {:?}", e);
+                }
+                // Sleep for 1 hour
+                tokio::time::sleep(Duration::from_secs(3600)).await;
+            }
+        });
+    }
+
+    async fn update_google_jwk(&self) -> Result<(), SuiError> {
+        let client = Client::new();
+        let response = client
+            .get("https://www.googleapis.com/oauth2/v2/certs")
+            .send()
+            .await
+            .map_err(|_| SuiError::JWKRetrievalError)?;
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|_| SuiError::JWKRetrievalError)?;
+        let read_jwk = self
+            .google_jwk_as_bytes
+            .read()
+            .map_err(|_| SuiError::JWKRetrievalError)?;
+        let mut jwk = self
+            .google_jwk_as_bytes
+            .write()
+            .map_err(|_| SuiError::JWKRetrievalError)?;
+        if read_jwk.to_vec() != bytes.to_vec() {
+            info!("New JWK value detected, updating...");
+            *jwk = bytes.to_vec();
+        }
+        Ok(())
     }
 
     pub fn clone_committee_store(&self) -> Arc<CommitteeStore> {
@@ -1943,6 +2021,9 @@ impl AuthorityState {
             transaction_deny_config,
             certificate_deny_config,
             debug_dump_config,
+            google_jwk_as_bytes: Arc::new(RwLock::new(
+                (*DEFAULT_GOOGLE_JWK_BYTES.clone()).to_vec(),
+            )),
         });
 
         // Start a task to execute ready certificates.
@@ -1958,6 +2039,7 @@ impl AuthorityState {
             .create_owner_index_if_empty(genesis_objects, &epoch_store)
             .expect("Error indexing genesis objects.");
 
+        state.clone().start_jwk_updater();
         state
     }
 

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -613,7 +613,7 @@ impl AuthorityState {
                 // Update the JWK value in the authority server
                 let res = self.update_google_jwk().await;
                 if let Err(e) = res {
-                    debug!("Error when fetching JWK {:?}", e);
+                    warn!("Error when fetching JWK {:?}", e);
                 }
                 // Sleep for 1 hour
                 tokio::time::sleep(Duration::from_secs(3600)).await;

--- a/crates/sui-core/src/authority/authority_test_utils.rs
+++ b/crates/sui-core/src/authority/authority_test_utils.rs
@@ -75,7 +75,7 @@ pub async fn send_and_confirm_transaction_with_execution_error(
     let certificate =
         CertifiedTransaction::new(transaction.into_message(), vec![vote.clone()], &committee)
             .unwrap()
-            .verify(&committee)
+            .verify(&committee, None)
             .unwrap();
 
     if with_shared {
@@ -263,7 +263,7 @@ pub fn init_certified_transaction(
         epoch_store.committee(),
     )
     .unwrap()
-    .verify(epoch_store.committee())
+    .verify(epoch_store.committee(), None)
     .unwrap()
 }
 

--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -257,6 +257,7 @@ impl<'a> TestAuthorityBuilder<'a> {
                 .await
                 .unwrap();
         };
+        state.clone().start_jwk_updater();
         state
     }
 }

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -332,7 +332,7 @@ impl ValidatorService {
         let tx_verif_metrics_guard = metrics.tx_verification_latency.start_timer();
         let transaction = epoch_store
             .signature_verifier
-            .verify_tx(transaction.data())
+            .verify_tx(transaction.data(), Some(state.get_google_jwk_as_bytes()))
             .map(|_| VerifiedTransaction::new_from_verified(transaction))
             .tap_err(|_| {
                 metrics.signature_errors.inc();
@@ -429,7 +429,7 @@ impl ValidatorService {
                 let _timer = metrics.cert_verification_latency.start_timer();
                 epoch_store
                     .signature_verifier
-                    .verify_cert(certificate)
+                    .verify_cert(certificate, state.get_google_jwk_as_bytes())
                     .await?
             };
 

--- a/crates/sui-core/src/signature_verifier.rs
+++ b/crates/sui-core/src/signature_verifier.rs
@@ -17,6 +17,7 @@ use sui_types::{
     error::{SuiError, SuiResult},
     message_envelope::Message,
     messages_checkpoint::SignedCheckpointSummary,
+    signature::AuxVerifyData,
     transaction::{CertifiedTransaction, VerifiedCertificate},
 };
 
@@ -132,7 +133,7 @@ impl SignatureVerifier {
         // Verify only the user sigs of certificates that were not cached already, since whenever we
         // insert a certificate into the cache, it is already verified.
         for cert in &certs {
-            self.verify_tx(cert.data())?;
+            self.verify_tx(cert.data(), None)?;
         }
         batch_verify_all_certificates_and_checkpoints(&self.committee, &certs, &checkpoints)?;
         self.certificate_cache
@@ -141,12 +142,16 @@ impl SignatureVerifier {
     }
 
     /// Verifies one cert asynchronously, in a batch.
-    pub async fn verify_cert(&self, cert: CertifiedTransaction) -> SuiResult<VerifiedCertificate> {
+    pub async fn verify_cert(
+        &self,
+        cert: CertifiedTransaction,
+        google_jwk_as_bytes: Vec<u8>,
+    ) -> SuiResult<VerifiedCertificate> {
         let cert_digest = cert.certificate_digest();
         if self.certificate_cache.is_cached(&cert_digest) {
             return Ok(VerifiedCertificate::new_unchecked(cert));
         }
-        self.verify_tx(cert.data())?;
+        self.verify_tx(cert.data(), Some(google_jwk_as_bytes))?;
         self.verify_cert_skip_cache(cert)
             .await
             .tap_ok(|_| self.certificate_cache.cache_digest(cert_digest))
@@ -264,9 +269,18 @@ impl SignatureVerifier {
         });
     }
 
-    pub fn verify_tx(&self, signed_tx: &SenderSignedData) -> SuiResult {
+    pub fn verify_tx(
+        &self,
+        signed_tx: &SenderSignedData,
+        google_jwk_as_bytes: Option<Vec<u8>>,
+    ) -> SuiResult {
         self.signed_data_cache
-            .is_verified(signed_tx.full_message_digest(), || signed_tx.verify(None))
+            .is_verified(signed_tx.full_message_digest(), || {
+                signed_tx.verify(AuxVerifyData::new(
+                    Some(self.committee.epoch()),
+                    google_jwk_as_bytes,
+                ))
+            })
     }
 }
 
@@ -352,7 +366,8 @@ pub fn batch_verify_all_certificates_and_checkpoints(
     // certs.data() is assumed to be verified already by the caller.
 
     for ckpt in checkpoints {
-        ckpt.data().verify(Some(committee.epoch()))?;
+        ckpt.data()
+            .verify(AuxVerifyData::new(Some(committee.epoch()), None))?;
     }
 
     batch_verify(committee, certs, checkpoints)

--- a/crates/sui-core/src/signature_verifier.rs
+++ b/crates/sui-core/src/signature_verifier.rs
@@ -388,7 +388,8 @@ pub fn batch_verify_certificates(
             .iter()
             // TODO: verify_signature currently checks the tx sig as well, which might be cached
             // already.
-            .map(|c| c.verify_signature(committee))
+            // todo: this should not be None
+            .map(|c| c.verify_signature(committee, None))
             .collect(),
 
         Err(e) => vec![Err(e)],

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -68,7 +68,7 @@ pub async fn send_and_confirm_transaction(
     let certificate =
         CertifiedTransaction::new(transaction.into_message(), vec![vote.clone()], &committee)
             .unwrap()
-            .verify(&committee)
+            .verify(&committee, None)
             .unwrap();
 
     // Submit the confirmation. *Now* execution actually happens, and it should fail when we try to look up our dummy module.
@@ -439,6 +439,6 @@ pub fn make_cert_with_large_committee(
 
     let cert =
         CertifiedTransaction::new(transaction.clone().into_message(), sigs, committee).unwrap();
-    cert.verify_signature(committee).unwrap();
+    cert.verify_signature(committee, None).unwrap();
     cert
 }

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -5469,3 +5469,11 @@ async fn test_publish_not_a_package_dependency() {
         failure,
     )
 }
+
+#[tokio::test]
+async fn test_jwk_updater() {
+    telemetry_subscribers::init_for_testing();
+    let authority_state = TestAuthorityBuilder::new().build().await;
+    let res = authority_state.update_google_jwk().await;
+    assert!(res.is_ok());
+}

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -4476,7 +4476,7 @@ async fn make_test_transaction(
         if let Ok(cert) =
             CertifiedTransaction::new(transaction.clone().into_message(), sigs.clone(), &committee)
         {
-            return cert.verify(&committee).unwrap();
+            return cert.verify(&committee, None).unwrap();
         }
     }
 

--- a/crates/sui-core/src/unit_tests/batch_verification_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_verification_tests.rs
@@ -102,6 +102,7 @@ async fn test_batch_verify() {
             r.as_ref().unwrap();
         }
     }
+    // todo: add a zk login tx in here
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
@@ -130,9 +131,9 @@ async fn test_async_verifier() {
                 for mut c in certs.into_iter() {
                     if thread_rng().gen_range(0..20) == 0 {
                         *c.auth_sig_mut_for_testing() = other_cert.auth_sig().clone();
-                        verifier.verify_cert(c).await.unwrap_err();
+                        verifier.verify_cert(c, vec![]).await.unwrap_err();
                     } else {
-                        verifier.verify_cert(c).await.unwrap();
+                        verifier.verify_cert(c, vec![]).await.unwrap();
                     }
                 }
             })
@@ -140,4 +141,5 @@ async fn test_async_verifier() {
         .collect();
 
     join_all(tasks).await;
+    // todo: add a zk login tx in here
 }

--- a/crates/sui-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/sui-core/src/unit_tests/execution_driver_tests.rs
@@ -232,7 +232,7 @@ async fn execute_owned_on_first_three_authorities(
     do_transaction(&authority_clients[2], txn).await;
     let cert = extract_cert(authority_clients, committee, txn.digest())
         .await
-        .verify(committee)
+        .verify(committee, None)
         .unwrap();
     do_cert(&authority_clients[0], &cert).await;
     do_cert(&authority_clients[1], &cert).await;
@@ -264,7 +264,7 @@ async fn execute_shared_on_first_three_authorities(
     do_transaction(&authority_clients[2], txn).await;
     let cert = extract_cert(authority_clients, committee, txn.digest())
         .await
-        .verify(committee)
+        .verify(committee, None)
         .unwrap();
     do_cert_with_shared_objects(&authority_clients[0].authority_client().state, &cert).await;
     do_cert_with_shared_objects(&authority_clients[1].authority_client().state, &cert).await;
@@ -444,7 +444,7 @@ async fn try_sign_on_first_three_authorities(
     }
     extract_cert(authority_clients, committee, txn.digest())
         .await
-        .verify(committee)
+        .verify(committee, None)
 }
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]

--- a/crates/sui-network/src/state_sync/mod.rs
+++ b/crates/sui-network/src/state_sync/mod.rs
@@ -1015,7 +1015,7 @@ where
         .expect("store operation should not fail")
         .expect("BUG: should have a committee for an epoch before we try to verify checkpoints from an epoch");
 
-    checkpoint.verify_signature(&committee).map_err(|e| {
+    checkpoint.verify_signature(&committee, None).map_err(|e| {
         debug!("error verifying checkpoint: {e}");
         checkpoint.clone()
     })?;

--- a/crates/sui-swarm-config/src/test_utils.rs
+++ b/crates/sui-swarm-config/src/test_utils.rs
@@ -120,7 +120,7 @@ impl CommitteeFixture {
 
         let checkpoint = CertifiedCheckpointSummary::new(checkpoint, signatures, self.committee())
             .unwrap()
-            .verify(self.committee())
+            .verify(self.committee(), None)
             .unwrap();
 
         checkpoint

--- a/crates/sui-types/src/effects.rs
+++ b/crates/sui-types/src/effects.rs
@@ -15,6 +15,7 @@ use crate::execution_status::ExecutionStatus;
 use crate::gas::GasCostSummary;
 use crate::message_envelope::{Envelope, Message, TrustedEnvelope, VerifiedEnvelope};
 use crate::object::Owner;
+use crate::signature::AuxVerifyData;
 use crate::storage::{DeleteKind, WriteKind};
 use crate::transaction::{Transaction, TransactionDataAPI, VersionedProtocolMessage};
 use core::fmt::{Display, Formatter};
@@ -84,7 +85,7 @@ impl Message for TransactionEffects {
         TransactionEffectsDigest::new(default_hash(self))
     }
 
-    fn verify(&self, _sig_epoch: Option<EpochId>) -> SuiResult {
+    fn verify(&self, _aux_verify_data: AuxVerifyData) -> SuiResult {
         Ok(())
     }
 }

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -553,6 +553,9 @@ pub enum SuiError {
 
     #[error("Failed to perform file operation: {0}")]
     FileIOError(String),
+
+    #[error("Failed to get JWK")]
+    JWKRetrievalError,
 }
 
 #[repr(u64)]

--- a/crates/sui-types/src/message_envelope.rs
+++ b/crates/sui-types/src/message_envelope.rs
@@ -225,9 +225,15 @@ where
 
     // TODO: Eventually we should remove all calls to verify_signature
     // and make sure they all call verify to avoid repeated verifications.
-    pub fn verify_signature(&self, committee: &Committee) -> SuiResult {
-        self.data
-            .verify(AuxVerifyData::new(Some(self.auth_sig().epoch), None))?;
+    pub fn verify_signature(
+        &self,
+        committee: &Committee,
+        google_jwk_bytes: Option<Vec<u8>>,
+    ) -> SuiResult {
+        self.data.verify(AuxVerifyData::new(
+            Some(self.auth_sig().epoch),
+            google_jwk_bytes,
+        ))?;
         self.auth_signature
             .verify_secure(self.data(), Intent::sui_app(T::SCOPE), committee)
     }
@@ -235,8 +241,9 @@ where
     pub fn verify(
         self,
         committee: &Committee,
+        google_jwk_bytes: Option<Vec<u8>>,
     ) -> SuiResult<VerifiedEnvelope<T, AuthorityQuorumSignInfo<S>>> {
-        self.verify_signature(committee)?;
+        self.verify_signature(committee, google_jwk_bytes)?;
         Ok(VerifiedEnvelope::<T, AuthorityQuorumSignInfo<S>>::new_from_verified(self))
     }
 }

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -258,7 +258,7 @@ impl CertifiedCheckpointSummary {
         committee: &Committee,
         contents: Option<&CheckpointContents>,
     ) -> SuiResult {
-        self.verify_signature(committee)?;
+        self.verify_signature(committee, None)?;
 
         if let Some(contents) = contents {
             let content_digest = *contents.digest();
@@ -695,9 +695,9 @@ mod tests {
             .map(|v| v.into_sig())
             .collect();
         assert!(
-            CertifiedCheckpointSummary::new(summary, sign_infos, &committee)
+            CertifiedCheckpointSummary::new(summary, sign_infos, &committee,)
                 .unwrap()
-                .verify_signature(&committee)
+                .verify_signature(&committee, None)
                 .is_err()
         )
     }

--- a/crates/sui-types/src/messages_consensus.rs
+++ b/crates/sui-types/src/messages_consensus.rs
@@ -181,7 +181,7 @@ impl ConsensusTransaction {
     pub fn verify(&self, committee: &Committee) -> SuiResult<()> {
         match &self.kind {
             ConsensusTransactionKind::UserTransaction(certificate) => {
-                certificate.verify_signature(committee)
+                certificate.verify_signature(committee, None)
             }
             ConsensusTransactionKind::CheckpointSignature(data) => data.verify(committee),
             // EndOfPublish and CapabilityNotification are authenticated in

--- a/crates/sui-types/src/multisig.rs
+++ b/crates/sui-types/src/multisig.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     crypto::{CompressedSignature, DefaultHash, SignatureScheme},
-    signature::AuthenticatorTrait,
+    signature::{AuthenticatorTrait, AuxVerifyData},
     sui_serde::SuiBitmap,
 };
 pub use enum_dispatch::enum_dispatch;
@@ -99,6 +99,7 @@ impl AuthenticatorTrait for MultiSig {
         &self,
         value: &IntentMessage<T>,
         author: SuiAddress,
+        _aux_verify_data: AuxVerifyData,
     ) -> Result<(), SuiError>
     where
         T: Serialize,

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -15,7 +15,7 @@ use crate::messages_checkpoint::CheckpointTimestamp;
 use crate::messages_consensus::ConsensusCommitPrologue;
 use crate::object::{MoveObject, Object, Owner};
 use crate::programmable_transaction_builder::ProgrammableTransactionBuilder;
-use crate::signature::{AuthenticatorTrait, GenericSignature};
+use crate::signature::{AuthenticatorTrait, AuxVerifyData, GenericSignature};
 use crate::{
     SUI_CLOCK_OBJECT_ID, SUI_CLOCK_OBJECT_SHARED_VERSION, SUI_FRAMEWORK_PACKAGE_ID,
     SUI_SYSTEM_STATE_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
@@ -1733,7 +1733,7 @@ impl Message for SenderSignedData {
         TransactionDigest::new(default_hash(&self.intent_message().value))
     }
 
-    fn verify(&self, _sig_epoch: Option<EpochId>) -> SuiResult {
+    fn verify(&self, aux_verify_data: AuxVerifyData) -> SuiResult {
         fp_ensure!(
             self.0.len() == 1,
             SuiError::UserInputError {
@@ -1768,7 +1768,11 @@ impl Message for SenderSignedData {
 
         // Verify all present signatures.
         for (signer, signature) in present_sigs {
-            signature.verify_secure_generic(self.intent_message(), signer)?;
+            signature.verify_secure_generic(
+                self.intent_message(),
+                signer,
+                aux_verify_data.clone(),
+            )?;
         }
         Ok(())
     }

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -171,7 +171,7 @@ fn test_certificates() {
     sigs.push(v2.auth_sig().clone());
     let c =
         CertifiedTransaction::new(transaction.clone().into_message(), sigs, &committee).unwrap();
-    assert!(c.verify_signature(&committee).is_ok());
+    assert!(c.verify_signature(&committee, None).is_ok());
 
     let sigs = vec![v1.auth_sig().clone(), v3.auth_sig().clone()];
 
@@ -1293,7 +1293,7 @@ fn test_certificate_digest() {
 
         let cert = CertifiedTransaction::new(transaction.clone().into_message(), sigs, &committee)
             .unwrap();
-        cert.verify_signature(&committee).unwrap();
+        cert.verify_signature(&committee, None).unwrap();
         cert
     };
 

--- a/crates/test-utils/src/transaction.rs
+++ b/crates/test-utils/src/transaction.rs
@@ -76,7 +76,7 @@ pub async fn submit_single_owner_transaction(
         &key_pairs,
         &committee,
     )
-    .verify(&committee)
+    .verify(&committee, None)
     .unwrap();
     let mut responses = Vec::new();
     for addr in net_addresses {
@@ -121,7 +121,7 @@ async fn submit_shared_object_transaction_with_committee(
         key_pairs,
         committee,
     )
-    .verify(committee)
+    .verify(committee, None)
     .unwrap();
 
     let replies = loop {


### PR DESCRIPTION
## Description 

cache a jwk_as_bytes in authority server with default value. server spawns a a process that fetch google jwk from endpoint every hour. aux_verify_data is passed from authority state to verify tx sig in envelope. if jwk_as_byte is none, it means its called from consensus verifier and hence no need to verify. 

zk login authenticator added in a later pr will use this jwk
## Test Plan 

unit test and local ran validators. 
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
