### PR TITLE
Fix test_onsite_reconfig_observer_basic

### DIFF
--- a/crates/sui-e2e-tests/tests/onsite_reconfig_observer_tests.rs
+++ b/crates/sui-e2e-tests/tests/onsite_reconfig_observer_tests.rs
@@ -38,7 +38,7 @@ async fn test_onsite_reconfig_observer_basic() {
         AuthAggMetrics::new(&registry),
     );
     let qd_clone = qd.clone_quorum_driver();
-    let _observer_handle = tokio::task::spawn(async move { observer.run(qd_clone).await });
+    let observer_handle = tokio::task::spawn(async move { observer.run(qd_clone).await });
 
     // Wait for all nodes to reach the next epoch.
     info!("Waiting for nodes to advance to epoch 1");
@@ -56,4 +56,7 @@ async fn test_onsite_reconfig_observer_basic() {
         fullnode.with(|node| node.clone_authority_aggregator().unwrap().committee.epoch),
         1
     );
+    // The observer thread is not managed by simtest, and hence we must abort it manually to make sure
+    // it stops running first. Otherwise it may lead to unexpected channel close issue.
+    observer_handle.abort();
 }


### PR DESCRIPTION
## Description 

As described in the comment

## Test Plan 

cargo simtest

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
