### PR TITLE
[sui-execution] Introduce Executor interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9307,7 +9307,6 @@ dependencies = [
  "move-core-types",
  "move-package",
  "move-symbol-pool",
- "move-vm-runtime",
  "mysten-common",
  "mysten-metrics",
  "mysten-network",
@@ -9338,12 +9337,12 @@ dependencies = [
  "signature 1.6.4",
  "sui-adapter-latest",
  "sui-config",
+ "sui-execution",
  "sui-framework",
  "sui-genesis-builder",
  "sui-json-rpc-types",
  "sui-macros",
  "sui-move-build",
- "sui-move-natives-latest",
  "sui-network",
  "sui-protocol-config",
  "sui-simulator",
@@ -9463,6 +9462,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sui-execution"
+version = "0.1.0"
+dependencies = [
+ "move-bytecode-utils",
+ "move-core-types",
+ "move-vm-runtime",
+ "sui-adapter-latest",
+ "sui-move-natives-latest",
+ "sui-protocol-config",
+ "sui-types",
+ "sui-verifier-latest",
+]
+
+[[package]]
 name = "sui-faucet"
 version = "1.3.0"
 dependencies = [
@@ -9561,7 +9574,6 @@ dependencies = [
  "insta",
  "move-binary-format",
  "move-core-types",
- "move-vm-runtime",
  "narwhal-config",
  "once_cell",
  "prometheus",
@@ -9570,11 +9582,10 @@ dependencies = [
  "serde_with",
  "serde_yaml",
  "shared-crypto",
- "sui-adapter-latest",
  "sui-config",
+ "sui-execution",
  "sui-framework",
  "sui-keys",
- "sui-move-natives-latest",
  "sui-protocol-config",
  "sui-simulator",
  "sui-storage",
@@ -10072,14 +10083,13 @@ dependencies = [
  "serde_yaml",
  "shellexpand",
  "similar",
- "sui-adapter-latest",
  "sui-config",
  "sui-core",
+ "sui-execution",
  "sui-framework",
  "sui-json-rpc",
  "sui-json-rpc-types",
  "sui-macros",
- "sui-move-natives-latest",
  "sui-protocol-config",
  "sui-sdk",
  "sui-storage",
@@ -10418,7 +10428,6 @@ dependencies = [
  "insta",
  "move-binary-format",
  "move-core-types",
- "move-vm-runtime",
  "narwhal-config",
  "once_cell",
  "prometheus",
@@ -10427,12 +10436,11 @@ dependencies = [
  "serde_with",
  "serde_yaml",
  "shared-crypto",
- "sui-adapter-latest",
  "sui-config",
+ "sui-execution",
  "sui-framework",
  "sui-genesis-builder",
  "sui-keys",
- "sui-move-natives-latest",
  "sui-protocol-config",
  "sui-simulator",
  "sui-storage",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9473,6 +9473,7 @@ dependencies = [
  "sui-protocol-config",
  "sui-types",
  "sui-verifier-latest",
+ "workspace-hack",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,7 @@ members = [
     "narwhal/test-utils",
     "narwhal/types",
     "narwhal/worker",
+    "sui-execution",
     "sui-execution/latest/sui-adapter",
     "sui-execution/latest/sui-move-natives",
     "sui-execution/latest/sui-verifier",
@@ -192,14 +193,11 @@ axum = { version = "0.6.6", default-features = false, features = ["headers", "to
 # Move dependencies
 move-binary-format = { path = "external-crates/move/move-binary-format" }
 move-bytecode-utils = { path = "external-crates/move/tools/move-bytecode-utils" }
-move-bytecode-verifier = { path = "external-crates/move/move-bytecode-verifier" }
 move-cli = { path = "external-crates/move/tools/move-cli" }
 move-compiler = { path = "external-crates/move/move-compiler" }
 move-core-types = { path = "external-crates/move/move-core/types", features = ["address32"] }
 move-disassembler = { path = "external-crates/move/tools/move-disassembler" }
 move-package = { path = "external-crates/move/tools/move-package" }
-move-stdlib = { path = "external-crates/move/move-stdlib" }
-move-vm-runtime =  { path = "external-crates/move/move-vm/runtime" }
 move-unit-test = { path = "external-crates/move/tools/move-unit-test" }
 move-vm-config = { path = "external-crates/move/move-vm/config" }
 move-vm-test-utils = { path = "external-crates/move/move-vm/test-utils" }

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -43,12 +43,10 @@ tracing = "0.1.36"
 fastcrypto.workspace = true
 fastcrypto-zkp.workspace = true
 move-binary-format.workspace = true
-move-bytecode-verifier.workspace = true
 move-bytecode-utils.workspace = true
 move-core-types.workspace = true
 move-package.workspace = true
 move-symbol-pool.workspace = true
-move-vm-runtime.workspace = true
 mysten-common.workspace = true
 mysten-network.workspace = true
 telemetry-subscribers.workspace = true
@@ -56,8 +54,9 @@ typed-store-derive.workspace = true
 typed-store.workspace = true
 
 # TODO use sui-execution versioned crate
+move-bytecode-verifier = { path = "../../external-crates/move/move-bytecode-verifier" }
 sui-adapter = { path = "../../sui-execution/latest/sui-adapter", package = "sui-adapter-latest" }
-sui-move-natives = { path = "../../sui-execution/latest/sui-move-natives", package = "sui-move-natives-latest" }
+sui-verifier = { path = "../../sui-execution/latest/sui-verifier", package = "sui-verifier-latest" }
 
 mysten-metrics = { path = "../mysten-metrics" }
 narwhal-config = { path = "../../narwhal/config" }
@@ -69,6 +68,7 @@ narwhal-types = { path = "../../narwhal/types" }
 narwhal-worker = { path = "../../narwhal/worker" }
 shared-crypto = { path = "../shared-crypto" }
 sui-config = { path = "../sui-config" }
+sui-execution = { path = "../../sui-execution" }
 sui-framework = { path = "../sui-framework" }
 sui-swarm-config = { path = "../sui-swarm-config" }
 sui-genesis-builder = { path = "../sui-genesis-builder" }
@@ -81,7 +81,6 @@ sui-simulator = { path = "../sui-simulator" }
 sui-storage = { path = "../sui-storage" }
 sui-test-transaction-builder = { path = "../sui-test-transaction-builder" }
 sui-types = { path = "../sui-types" }
-sui-verifier = { path = "../../sui-execution/latest/sui-verifier", package = "sui-verifier-latest" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]
@@ -95,9 +94,6 @@ serde-reflection = "0.3.6"
 serde_yaml = "0.8.26"
 
 move-symbol-pool.workspace = true
-
-# TODO use sui-execution versioned crate
-sui-verifier = { path = "../../sui-execution/latest/sui-verifier", package = "sui-verifier-latest" }
 
 narwhal-test-utils = { path = "../../narwhal/test-utils" }
 sui-types = { path = "../sui-types", features = ["test-utils"] }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -15,6 +15,7 @@ use fastcrypto::encoding::Encoding;
 use itertools::Itertools;
 use move_binary_format::CompiledModule;
 use move_core_types::language_storage::ModuleId;
+use move_core_types::value::MoveStructLayout;
 use mysten_metrics::{TX_TYPE_SHARED_OBJ_TX, TX_TYPE_SINGLE_WRITER_TX};
 use parking_lot::Mutex;
 use prometheus::{
@@ -41,9 +42,6 @@ use narwhal_config::{
 };
 use once_cell::sync::OnceCell;
 use shared_crypto::intent::{Intent, IntentScope};
-use sui_adapter::adapter;
-use sui_adapter::execution_engine;
-use sui_adapter::type_layout_resolver::TypeLayoutResolver;
 use sui_config::certificate_deny_config::CertificateDenyConfig;
 use sui_config::genesis::Genesis;
 use sui_config::node::{
@@ -75,7 +73,6 @@ use sui_types::effects::{
 use sui_types::error::{ExecutionError, UserInputError};
 use sui_types::event::{Event, EventID};
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
-use sui_types::execution_mode;
 use sui_types::gas::{GasCostSummary, SuiGasStatus};
 use sui_types::message_envelope::Message;
 use sui_types::messages_checkpoint::{
@@ -98,7 +95,6 @@ pub use sui_types::temporary_store::TemporaryStore;
 use sui_types::temporary_store::{
     InnerTemporaryStore, ObjectMap, TemporaryModuleResolver, TxCoins, WrittenObjects,
 };
-use sui_types::type_resolver::LayoutResolver;
 use sui_types::{
     base_types::*,
     committee::Committee,
@@ -1153,17 +1149,7 @@ impl AuthorityState {
         let transaction_data = &certificate.data().intent_message().value;
         let (kind, signer, gas) = transaction_data.execution_parts();
         let (inner_temp_store, effects, execution_error_opt) =
-            execution_engine::execute_transaction_to_effects::<execution_mode::Normal, _>(
-                shared_object_refs,
-                temporary_store,
-                kind,
-                signer,
-                &gas,
-                *certificate.digest(),
-                transaction_dependencies,
-                epoch_store.move_vm(),
-                gas_status,
-                &epoch_store.epoch_start_config().epoch_data(),
+            epoch_store.executor().execute_transaction_to_effects(
                 epoch_store.protocol_config(),
                 self.metrics.limits_metrics.clone(),
                 // TODO: would be nice to pass the whole NodeConfig here, but it creates a
@@ -1171,6 +1157,19 @@ impl AuthorityState {
                 self.expensive_safety_check_config
                     .enable_deep_per_tx_sui_conservation_check(),
                 self.certificate_deny_config.certificate_deny_set(),
+                &epoch_store.epoch_start_config().epoch_data().epoch_id(),
+                epoch_store
+                    .epoch_start_config()
+                    .epoch_data()
+                    .epoch_start_timestamp(),
+                temporary_store,
+                shared_object_refs,
+                gas_status,
+                &gas,
+                kind,
+                signer,
+                *certificate.digest(),
+                transaction_dependencies,
             );
 
         Ok((inner_temp_store, effects, execution_error_opt.err()))
@@ -1254,32 +1253,37 @@ impl AuthorityState {
             epoch_store.protocol_config(),
         );
         let (kind, signer, _) = transaction.execution_parts();
+
+        let silent = true;
         // don't bother with paranoid checks in dry run
         let enable_move_vm_paranoid_checks = false;
-        let move_vm = Arc::new(
-            adapter::new_move_vm(
-                epoch_store.native_functions().clone(),
-                epoch_store.protocol_config(),
-                enable_move_vm_paranoid_checks,
-            )
-            .expect("We defined natives to not fail here"),
-        );
-        let (inner_temp_store, effects, _execution_error) =
-            execution_engine::execute_transaction_to_effects::<execution_mode::Normal, _>(
-                shared_object_refs,
-                temporary_store,
-                kind,
-                signer,
-                &gas_object_refs,
-                transaction_digest,
-                transaction_dependencies,
-                &move_vm,
-                gas_status,
-                &epoch_store.epoch_start_config().epoch_data(),
+        let executor = sui_execution::executor(
+            epoch_store.protocol_config(),
+            enable_move_vm_paranoid_checks,
+            silent,
+        )
+        .expect("Creating an executor should not fail here");
+
+        let expensive_checks = false;
+        let (inner_temp_store, effects, _execution_error) = executor
+            .execute_transaction_to_effects(
                 epoch_store.protocol_config(),
                 self.metrics.limits_metrics.clone(),
-                false, // enable_expensive_checks
+                expensive_checks,
                 self.certificate_deny_config.certificate_deny_set(),
+                &epoch_store.epoch_start_config().epoch_data().epoch_id(),
+                epoch_store
+                    .epoch_start_config()
+                    .epoch_data()
+                    .epoch_start_timestamp(),
+                temporary_store,
+                shared_object_refs,
+                gas_status,
+                &gas_object_refs,
+                kind,
+                signer,
+                transaction_digest,
+                transaction_dependencies,
             );
         let tx_digest = *effects.transaction_digest();
 
@@ -1395,32 +1399,34 @@ impl AuthorityState {
             protocol_config,
         );
         let gas_status = SuiGasStatus::new_with_budget(max_tx_gas, gas_price, protocol_config);
-        let move_vm = Arc::new(
-            adapter::new_move_vm(
-                epoch_store.native_functions().clone(),
-                epoch_store.protocol_config(),
-                self.expensive_safety_check_config
-                    .enable_move_vm_paranoid_checks(),
-            )
-            .expect("We defined natives to not fail here"),
+        let silent = true;
+        let executor = sui_execution::executor(
+            epoch_store.protocol_config(),
+            self.expensive_safety_check_config
+                .enable_move_vm_paranoid_checks(),
+            silent,
+        )
+        .expect("Creating an executor should not fail here");
+        let expensive_checks = false;
+        let (inner_temp_store, effects, execution_result) = executor.dev_inspect_transaction(
+            protocol_config,
+            self.metrics.limits_metrics.clone(),
+            expensive_checks,
+            self.certificate_deny_config.certificate_deny_set(),
+            &epoch_store.epoch_start_config().epoch_data().epoch_id(),
+            epoch_store
+                .epoch_start_config()
+                .epoch_data()
+                .epoch_start_timestamp(),
+            temporary_store,
+            shared_object_refs,
+            gas_status,
+            &[gas_object_ref],
+            transaction_kind,
+            sender,
+            transaction_digest,
+            transaction_dependencies,
         );
-        let (inner_temp_store, effects, execution_result) =
-            execution_engine::execute_transaction_to_effects::<execution_mode::DevInspect, _>(
-                shared_object_refs,
-                temporary_store,
-                transaction_kind,
-                sender,
-                &[gas_object_ref],
-                transaction_digest,
-                transaction_dependencies,
-                &move_vm,
-                gas_status,
-                &epoch_store.epoch_start_config().epoch_data(),
-                protocol_config,
-                self.metrics.limits_metrics.clone(),
-                false, // enable_expensive_checks
-                self.certificate_deny_config.certificate_deny_set(),
-            );
 
         let module_cache =
             TemporaryModuleResolver::new(&inner_temp_store, epoch_store.module_cache().clone());
@@ -1784,10 +1790,12 @@ impl AuthorityState {
         let layout = if let (Some(format), Some(move_obj)) =
             (request.object_format_options, object.data.try_as_move())
         {
-            let epoch_store = self.load_epoch_store_one_call_per_task();
-            let move_vm = epoch_store.move_vm();
-            let mut layout_resolver = TypeLayoutResolver::new(move_vm, self.database.as_ref());
-            Some(layout_resolver.get_layout(move_obj, format)?)
+            Some(
+                self.load_epoch_store_one_call_per_task()
+                    .executor()
+                    .type_layout_resolver(Box::new(self.database.as_ref()))
+                    .get_layout(move_obj, format)?,
+            )
         } else {
             None
         };
@@ -2255,45 +2263,26 @@ impl AuthorityState {
     }
 
     pub fn get_object_read(&self, object_id: &ObjectID) -> SuiResult<ObjectRead> {
-        match self.database.get_object_or_tombstone(*object_id)? {
-            None => Ok(ObjectRead::NotExists(*object_id)),
-            Some(obj_ref) => {
-                if obj_ref.2.is_alive() {
-                    match self.database.get_object_by_key(object_id, obj_ref.1)? {
-                        None => {
-                            error!("Object with in parent_entry is missing from object store, datastore is inconsistent");
-                            Err(UserInputError::ObjectNotFound {
-                                object_id: *object_id,
-                                version: Some(obj_ref.1),
-                            }
-                            .into())
-                        }
-                        Some(object) => {
-                            let layout = {
-                                match object.data.try_as_move() {
-                                    None => None,
-                                    Some(move_obj) => {
-                                        let epoch_store = self.load_epoch_store_one_call_per_task();
-                                        let move_vm = epoch_store.move_vm();
-                                        let mut layout_resolver = TypeLayoutResolver::new(
-                                            move_vm,
-                                            self.database.as_ref(),
-                                        );
-                                        Some(
-                                            layout_resolver.get_layout(
-                                                move_obj,
-                                                ObjectFormatOptions::default(),
-                                            )?,
-                                        )
-                                    }
-                                }
-                            };
-                            Ok(ObjectRead::Exists(obj_ref, object, layout))
-                        }
-                    }
-                } else {
-                    Ok(ObjectRead::Deleted(obj_ref))
+        let Some(obj_ref) = self.database.get_object_or_tombstone(*object_id)? else {
+            return Ok(ObjectRead::NotExists(*object_id))
+        };
+
+        if !obj_ref.2.is_alive() {
+            return Ok(ObjectRead::Deleted(obj_ref));
+        }
+
+        match self.read_object_at_version(object_id, obj_ref.1)? {
+            Some((object, layout)) => Ok(ObjectRead::Exists(obj_ref, object, layout)),
+            None => {
+                error!(
+                    "Object with in parent_entry is missing from object store, datastore is \
+                     inconsistent",
+                );
+                Err(UserInputError::ObjectNotFound {
+                    object_id: *object_id,
+                    version: Some(obj_ref.1),
                 }
+                .into())
             }
         }
     }
@@ -2357,85 +2346,72 @@ impl AuthorityState {
         object_id: &ObjectID,
         version: SequenceNumber,
     ) -> SuiResult<PastObjectRead> {
-        // Firstly we see if the object ever exists by getting its latest data
-        match self.database.get_object_or_tombstone(*object_id)? {
-            None => Ok(PastObjectRead::ObjectNotExists(*object_id)),
-            Some(obj_ref) => {
-                if version > obj_ref.1 {
-                    return Ok(PastObjectRead::VersionTooHigh {
-                        object_id: *object_id,
-                        asked_version: version,
-                        latest_version: obj_ref.1,
-                    });
+        // Firstly we see if the object ever existed by getting its latest data
+        let Some(obj_ref) = self.database.get_object_or_tombstone(*object_id)? else {
+            return Ok(PastObjectRead::ObjectNotExists(*object_id));
+        };
+
+        if version > obj_ref.1 {
+            return Ok(PastObjectRead::VersionTooHigh {
+                object_id: *object_id,
+                asked_version: version,
+                latest_version: obj_ref.1,
+            });
+        }
+
+        if version < obj_ref.1 {
+            // Read past objects
+            return Ok(match self.read_object_at_version(object_id, version)? {
+                Some((object, layout)) => {
+                    let obj_ref = object.compute_object_reference();
+                    PastObjectRead::VersionFound(obj_ref, object, layout)
                 }
-                if version < obj_ref.1 {
-                    // Read past objects
-                    return Ok(match self.database.get_object_by_key(object_id, version)? {
-                        None => PastObjectRead::VersionNotFound(*object_id, version),
-                        Some(object) => {
-                            let layout = {
-                                match object.data.try_as_move() {
-                                    None => None,
-                                    Some(move_obj) => {
-                                        let epoch_store = self.load_epoch_store_one_call_per_task();
-                                        let move_vm = epoch_store.move_vm();
-                                        let mut layout_resolver = TypeLayoutResolver::new(
-                                            move_vm,
-                                            self.database.as_ref(),
-                                        );
-                                        Some(
-                                            layout_resolver.get_layout(
-                                                move_obj,
-                                                ObjectFormatOptions::default(),
-                                            )?,
-                                        )
-                                    }
-                                }
-                            };
-                            let obj_ref = object.compute_object_reference();
-                            PastObjectRead::VersionFound(obj_ref, object, layout)
-                        }
-                    });
+
+                None => PastObjectRead::VersionNotFound(*object_id, version),
+            });
+        }
+
+        if !obj_ref.2.is_alive() {
+            return Ok(PastObjectRead::ObjectDeleted(obj_ref));
+        }
+
+        match self.read_object_at_version(object_id, obj_ref.1)? {
+            Some((object, layout)) => Ok(PastObjectRead::VersionFound(obj_ref, object, layout)),
+            None => {
+                error!(
+                    "Object with in parent_entry is missing from object store, datastore is \
+                     inconsistent",
+                );
+                Err(UserInputError::ObjectNotFound {
+                    object_id: *object_id,
+                    version: Some(obj_ref.1),
                 }
-                // version is equal to the latest seq number this node knows
-                if obj_ref.2.is_alive() {
-                    match self.database.get_object_by_key(object_id, obj_ref.1)? {
-                        None => {
-                            error!("Object with in parent_entry is missing from object store, datastore is inconsistent");
-                            Err(UserInputError::ObjectNotFound {
-                                object_id: *object_id,
-                                version: Some(obj_ref.1),
-                            }
-                            .into())
-                        }
-                        Some(object) => {
-                            let layout = {
-                                match object.data.try_as_move() {
-                                    None => None,
-                                    Some(move_obj) => {
-                                        let epoch_store = self.load_epoch_store_one_call_per_task();
-                                        let move_vm = epoch_store.move_vm();
-                                        let mut layout_resolver = TypeLayoutResolver::new(
-                                            move_vm,
-                                            self.database.as_ref(),
-                                        );
-                                        Some(
-                                            layout_resolver.get_layout(
-                                                move_obj,
-                                                ObjectFormatOptions::default(),
-                                            )?,
-                                        )
-                                    }
-                                }
-                            };
-                            Ok(PastObjectRead::VersionFound(obj_ref, object, layout))
-                        }
-                    }
-                } else {
-                    Ok(PastObjectRead::ObjectDeleted(obj_ref))
-                }
+                .into())
             }
         }
+    }
+
+    fn read_object_at_version(
+        &self,
+        object_id: &ObjectID,
+        version: SequenceNumber,
+    ) -> SuiResult<Option<(Object, Option<MoveStructLayout>)>> {
+        let Some(object) = self.database.get_object_by_key(object_id, version)? else {
+            return Ok(None);
+        };
+
+        let layout = object
+            .data
+            .try_as_move()
+            .map(|object| {
+                self.load_epoch_store_one_call_per_task()
+                    .executor()
+                    .type_layout_resolver(Box::new(self.database.as_ref()))
+                    .get_layout(object, ObjectFormatOptions::default())
+            })
+            .transpose()?;
+
+        Ok(Some((object, layout)))
     }
 
     fn get_owner_at_version(

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -14,23 +14,22 @@ use move_bytecode_utils::module_cache::GetModule;
 use move_core_types::resolver::ModuleResolver;
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
-use sui_types::messages_checkpoint::ECMHLiveObjectSetDigest;
-use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
-use tokio::time::Instant;
-use tracing::{debug, info, trace};
-
 use sui_protocol_config::ProtocolConfig;
 use sui_storage::mutex_table::{MutexGuard, MutexTable, RwLockGuard, RwLockTable};
 use sui_types::accumulator::Accumulator;
 use sui_types::digests::TransactionEventsDigest;
 use sui_types::error::UserInputError;
 use sui_types::message_envelope::Message;
+use sui_types::messages_checkpoint::ECMHLiveObjectSetDigest;
 use sui_types::object::Owner;
 use sui_types::storage::{
     get_module_by_id, BackingPackageStore, ChildObjectResolver, DeleteKind, ObjectKey, ObjectStore,
 };
 use sui_types::sui_system_state::get_sui_system_state;
 use sui_types::{base_types::SequenceNumber, fp_bail, fp_ensure, storage::ParentSync};
+use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+use tokio::time::Instant;
+use tracing::{debug, info, trace};
 use typed_store::rocks::{DBBatch, DBMap, TypedStoreError};
 use typed_store::traits::Map;
 
@@ -43,7 +42,6 @@ use crate::authority::epoch_start_configuration::{EpochFlag, EpochStartConfigura
 use super::authority_store_tables::LiveObject;
 use super::{authority_store_tables::AuthorityPerpetualTables, *};
 use mysten_common::sync::notify_read::NotifyRead;
-use sui_adapter::type_layout_resolver::TypeLayoutResolver;
 use sui_storage::package_object_cache::PackageObjectCache;
 use sui_types::effects::{TransactionEffects, TransactionEvents};
 use sui_types::gas_coin::TOTAL_SUPPLY_MIST;
@@ -1582,7 +1580,7 @@ impl AuthorityStore {
             return Ok(());
         }
 
-        let move_vm = old_epoch_store.move_vm();
+        let executor = old_epoch_store.executor();
         let chain_identifier = old_epoch_store.get_chain_identifier();
 
         let protocol_version = ProtocolVersion::new(
@@ -1615,7 +1613,7 @@ impl AuthorityStore {
                             let package_cache_clone = package_cache.clone();
                             pending_tasks.push(s.spawn(move || {
                                 let mut layout_resolver =
-                                    TypeLayoutResolver::new(move_vm, &package_cache_clone);
+                                    executor.type_layout_resolver(Box::new(&package_cache_clone));
                                 let mut total_storage_rebate = 0;
                                 let mut total_sui = 0;
                                 for object in task_objects {
@@ -1623,7 +1621,7 @@ impl AuthorityStore {
                                     // get_total_sui includes storage rebate, however all storage rebate is
                                     // also stored in the storage fund, so we need to subtract it here.
                                     total_sui +=
-                                        object.get_total_sui(&mut layout_resolver).unwrap()
+                                        object.get_total_sui(layout_resolver.as_mut()).unwrap()
                                             - object.storage_rebate;
                                 }
                                 if count % 50_000_000 == 0 {
@@ -1641,11 +1639,11 @@ impl AuthorityStore {
                 (init.0 + result.0, init.1 + result.1)
             })
         });
-        let mut layout_resolver = TypeLayoutResolver::new(move_vm, self.as_ref());
+        let mut layout_resolver = executor.type_layout_resolver(Box::new(self.as_ref()));
         for object in pending_objects {
             total_storage_rebate += object.storage_rebate;
             total_sui +=
-                object.get_total_sui(&mut layout_resolver).unwrap() - object.storage_rebate;
+                object.get_total_sui(layout_resolver.as_mut()).unwrap() - object.storage_rebate;
         }
         info!(
             "Scanned {} live objects, took {:?}",

--- a/crates/sui-genesis-builder/Cargo.toml
+++ b/crates/sui-genesis-builder/Cargo.toml
@@ -16,7 +16,6 @@ dirs = "4.0.0"
 fastcrypto.workspace = true
 move-binary-format.workspace = true
 move-core-types.workspace = true
-move-vm-runtime.workspace = true
 once_cell = "1.16"
 rand = "0.8.5"
 serde = { version = "1.0.144", features = ["derive", "rc"] }
@@ -26,13 +25,10 @@ tempfile = "3.3.0"
 tracing = "0.1.36"
 prometheus = "0.13.3"
 
-# TODO use sui-execution versioned crate
-sui-adapter = { path = "../../sui-execution/latest/sui-adapter", package = "sui-adapter-latest" }
-sui-move-natives = { path = "../../sui-execution/latest/sui-move-natives", package = "sui-move-natives-latest" }
-
 narwhal-config = { path = "../../narwhal/config" }
 shared-crypto = { path = "../shared-crypto" }
 sui-config = { path = "../sui-config" }
+sui-execution = { path = "../../sui-execution" }
 sui-framework = { path = "../sui-framework" }
 sui-keys = { path = "../sui-keys" }
 sui-protocol-config = { path = "../sui-protocol-config" }

--- a/crates/sui-genesis-builder/src/lib.rs
+++ b/crates/sui-genesis-builder/src/lib.rs
@@ -7,17 +7,16 @@ use fastcrypto::hash::HashFunction;
 use fastcrypto::traits::KeyPair;
 use move_binary_format::CompiledModule;
 use move_core_types::ident_str;
-use move_vm_runtime::move_vm::MoveVM;
 use shared_crypto::intent::{Intent, IntentMessage, IntentScope};
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::fs;
 use std::path::Path;
 use std::sync::Arc;
-use sui_adapter::{adapter, programmable_transactions};
 use sui_config::genesis::{
     Genesis, GenesisCeremonyParameters, GenesisChainParameters, TokenDistributionSchedule,
     UnsignedGenesis,
 };
+use sui_execution::{self, Executor};
 use sui_framework::BuiltInFramework;
 use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 use sui_types::base_types::{
@@ -30,7 +29,6 @@ use sui_types::crypto::{
 };
 use sui_types::effects::{TransactionEffects, TransactionEvents};
 use sui_types::epoch_data::EpochData;
-use sui_types::execution_mode;
 use sui_types::gas::SuiGasStatus;
 use sui_types::gas_coin::GasCoin;
 use sui_types::governance::StakedSui;
@@ -809,46 +807,40 @@ fn create_genesis_transaction(
 
     // execute txn to effects
     let (effects, events, objects) = {
-        let mut store = sui_types::in_memory_storage::InMemoryStorage::new(Vec::new());
         let temporary_store = TemporaryStore::new(
-            &mut store,
+            InMemoryStorage::new(Vec::new()),
             InputObjects::new(vec![]),
             *genesis_transaction.digest(),
             protocol_config,
         );
 
-        let native_functions = sui_move_natives::all_natives(/* silent */ true);
-        let enable_move_vm_paranoid_checks = false;
-        let move_vm = std::sync::Arc::new(
-            adapter::new_move_vm(
-                native_functions,
-                protocol_config,
-                enable_move_vm_paranoid_checks,
-            )
-            .expect("We defined natives to not fail here"),
-        );
+        let silent = true;
+        let paranoid_checks = false;
+        let executor = sui_execution::executor(protocol_config, paranoid_checks, silent)
+            .expect("Creating an executor should not fail here");
 
+        let expensive_checks = false;
+        let certificate_deny_set = HashSet::new();
+        let shared_object_refs = vec![];
         let transaction_data = &genesis_transaction.data().intent_message().value;
         let (kind, signer, gas) = transaction_data.execution_parts();
-        let (inner_temp_store, effects, _execution_error) =
-            sui_adapter::execution_engine::execute_transaction_to_effects::<
-                execution_mode::Normal,
-                _,
-            >(
-                vec![],
-                temporary_store,
-                kind,
-                signer,
-                &gas,
-                *genesis_transaction.digest(),
-                Default::default(),
-                &move_vm,
-                SuiGasStatus::new_unmetered(protocol_config),
-                epoch_data,
+        let transaction_dependencies = BTreeSet::new();
+        let (inner_temp_store, effects, _execution_error) = executor
+            .execute_transaction_to_effects(
                 protocol_config,
                 metrics,
-                false, // enable_expensive_checks
-                &HashSet::new(),
+                expensive_checks,
+                &certificate_deny_set,
+                &epoch_data.epoch_id(),
+                epoch_data.epoch_start_timestamp(),
+                temporary_store,
+                shared_object_refs,
+                SuiGasStatus::new_unmetered(protocol_config),
+                &gas,
+                kind,
+                signer,
+                *genesis_transaction.digest(),
+                transaction_dependencies,
             );
         assert!(inner_temp_store.objects.is_empty());
         assert!(inner_temp_store.mutable_inputs.is_empty());
@@ -885,20 +877,16 @@ fn create_genesis_objects(
         Chain::Unknown,
     );
 
-    let native_functions = sui_move_natives::all_natives(/* silent */ true);
+    let silent = true;
     // paranoid checks are a last line of defense for malicious code, no need to run them in genesis
-    let enable_move_vm_paranoid_checks = false;
-    let move_vm = adapter::new_move_vm(
-        native_functions.clone(),
-        &protocol_config,
-        enable_move_vm_paranoid_checks,
-    )
-    .expect("We defined natives to not fail here");
+    let paranoid_checks = false;
+    let executor = sui_execution::executor(&protocol_config, paranoid_checks, silent)
+        .expect("Creating an executor should not fail here");
 
     for system_package in BuiltInFramework::iter_system_packages() {
         process_package(
             &mut store,
-            &move_vm,
+            executor.as_ref(),
             genesis_ctx,
             &system_package.modules(),
             system_package.dependencies().to_vec(),
@@ -908,13 +896,16 @@ fn create_genesis_objects(
         .unwrap();
     }
 
-    for object in input_objects {
-        store.insert_object(object.to_owned());
+    {
+        let store = Arc::get_mut(&mut store).expect("only one reference to store");
+        for object in input_objects {
+            store.insert_object(object.to_owned());
+        }
     }
 
     generate_genesis_system_object(
         &mut store,
-        &move_vm,
+        executor.as_ref(),
         validators,
         genesis_ctx,
         parameters,
@@ -923,12 +914,13 @@ fn create_genesis_objects(
     )
     .unwrap();
 
+    let store = Arc::try_unwrap(store).expect("only one reference to store");
     store.into_inner().into_values().collect()
 }
 
 fn process_package(
-    store: &mut InMemoryStorage,
-    vm: &MoveVM,
+    store: &mut Arc<InMemoryStorage>,
+    executor: &dyn Executor,
     ctx: &mut TxContext,
     modules: &[CompiledModule],
     dependencies: Vec<ObjectID>,
@@ -968,7 +960,7 @@ fn process_package(
         .collect();
 
     let mut temporary_store = TemporaryStore::new(
-        &*store,
+        store.clone(),
         InputObjects::new(loaded_dependencies),
         ctx.digest(),
         protocol_config,
@@ -988,14 +980,12 @@ fn process_package(
         builder.command(Command::Publish(module_bytes, dependencies));
         builder.finish()
     };
-    programmable_transactions::execution::execute::<_, execution_mode::Genesis>(
+    executor.update_genesis_state(
         protocol_config,
         metrics,
-        vm,
         &mut temporary_store,
         ctx,
         &mut gas_status,
-        None,
         pt,
     )?;
 
@@ -1003,14 +993,15 @@ fn process_package(
         written, deleted, ..
     } = temporary_store.into_inner();
 
+    let store = Arc::get_mut(store).expect("only one reference to store");
     store.finish(written, deleted);
 
     Ok(())
 }
 
 pub fn generate_genesis_system_object(
-    store: &mut InMemoryStorage,
-    move_vm: &MoveVM,
+    store: &mut Arc<InMemoryStorage>,
+    executor: &dyn Executor,
     genesis_validators: &[GenesisValidatorMetadata],
     genesis_ctx: &mut TxContext,
     genesis_chain_parameters: &GenesisChainParameters,
@@ -1026,7 +1017,7 @@ pub fn generate_genesis_system_object(
         sui_protocol_config::Chain::Unknown,
     );
     let mut temporary_store = TemporaryStore::new(
-        &*store,
+        store.clone(),
         InputObjects::new(vec![]),
         genesis_digest,
         &protocol_config,
@@ -1083,14 +1074,13 @@ pub fn generate_genesis_system_object(
         );
         builder.finish()
     };
-    programmable_transactions::execution::execute::<_, execution_mode::Genesis>(
+
+    executor.update_genesis_state(
         &protocol_config,
         metrics,
-        move_vm,
         &mut temporary_store,
         genesis_ctx,
         &mut SuiGasStatus::new_unmetered(&protocol_config),
-        None,
         pt,
     )?;
 
@@ -1098,6 +1088,7 @@ pub fn generate_genesis_system_object(
         written, deleted, ..
     } = temporary_store.into_inner();
 
+    let store = Arc::get_mut(store).expect("only one reference to store");
     store.finish(written, deleted);
 
     Ok(())

--- a/crates/sui-move-build/Cargo.toml
+++ b/crates/sui-move-build/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = { version = "1.0.64", features = ["backtrace"] }
 fastcrypto = { workspace = true }
 tempfile = "3.3.0"
 
+move-bytecode-verifier = { path = "../../external-crates/move/move-bytecode-verifier" }
 sui-adapter = { path = "../../sui-execution/latest/sui-adapter", package = "sui-adapter-latest" }
 sui-verifier = { path = "../../sui-execution/latest/sui-verifier", package = "sui-verifier-latest" }
 
@@ -21,7 +22,6 @@ sui-protocol-config = { path = "../sui-protocol-config" }
 
 move-binary-format.workspace = true
 move-bytecode-utils.workspace = true
-move-bytecode-verifier.workspace = true
 move-compiler.workspace = true
 move-core-types.workspace = true
 move-package.workspace = true

--- a/crates/sui-move/Cargo.toml
+++ b/crates/sui-move/Cargo.toml
@@ -27,11 +27,11 @@ move-package.workspace = true
 move-prover-boogie-backend.workspace = true
 move-prover.workspace = true
 move-unit-test.workspace = true
-move-vm-runtime.workspace = true
 move-vm-test-utils.workspace = true
 telemetry-subscribers.workspace = true
 tokio = { workspace = true, features = ["full"] }
 
+move-vm-runtime = { path = "../../external-crates/move/move-vm/runtime" }
 sui-move-natives = { path = "../../sui-execution/latest/sui-move-natives", package = "sui-move-natives-latest" }
 
 sui-core = { path = "../sui-core", optional = true }

--- a/crates/sui-replay/Cargo.toml
+++ b/crates/sui-replay/Cargo.toml
@@ -36,12 +36,9 @@ move-package.workspace = true
 tokio.workspace = true
 typed-store.workspace = true
 
-# TODO use sui-execution versioned crate
-sui-adapter = { path = "../../sui-execution/latest/sui-adapter", package = "sui-adapter-latest" }
-sui-move-natives = { path = "../../sui-execution/latest/sui-move-natives", package = "sui-move-natives-latest" }
-
 sui-config = { path = "../sui-config" }
 sui-core = { path = "../sui-core" }
+sui-execution = { path = "../../sui-execution" }
 sui-framework = { path = "../sui-framework" }
 sui-json-rpc = { path = "../sui-json-rpc" }
 sui-json-rpc-types = { path = "../sui-json-rpc-types" }

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -20,8 +20,6 @@ use std::collections::{BTreeMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex;
-use sui_adapter::adapter;
-use sui_adapter::execution_engine::execute_transaction_to_effects_impl;
 use sui_config::node::ExpensiveSafetyCheckConfig;
 use sui_core::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use sui_core::authority::epoch_start_configuration::EpochStartConfiguration;
@@ -32,6 +30,7 @@ use sui_core::authority::TemporaryStore;
 use sui_core::epoch::epoch_metrics::EpochMetrics;
 use sui_core::module_cache_metrics::ResolverMetrics;
 use sui_core::signature_verifier::SignatureVerifierMetrics;
+use sui_execution::Executor;
 use sui_framework::BuiltInFramework;
 use sui_json_rpc_types::SuiTransactionBlockEffects;
 use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
@@ -46,7 +45,6 @@ use sui_types::digests::TransactionDigest;
 use sui_types::error::ExecutionError;
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
-use sui_types::execution_mode;
 use sui_types::gas::SuiGasStatus;
 use sui_types::metrics::LimitsMetrics;
 use sui_types::object::{Data, Object, Owner};
@@ -70,11 +68,11 @@ pub struct ExecutionSandboxState {
     pub transaction_info: OnChainTransactionInfo,
     /// All the obejcts that are required for the execution of the transaction
     pub required_objects: Vec<Object>,
-    /// Temporary store from executing this locally in `execute_transaction_to_effects_impl`
+    /// Temporary store from executing this locally in `execute_transaction_to_effects`
     pub local_exec_temporary_store: Option<InnerTemporaryStore>,
-    /// Effects from executing this locally in `execute_transaction_to_effects_impl`
+    /// Effects from executing this locally in `execute_transaction_to_effects`
     pub local_exec_effects: SuiTransactionBlockEffects,
-    /// Status from executing this locally in `execute_transaction_to_effects_impl`
+    /// Status from executing this locally in `execute_transaction_to_effects`
     pub local_exec_status: Result<(), ExecutionError>,
 }
 
@@ -429,8 +427,10 @@ impl LocalExec {
         tx_digest: &TransactionDigest,
         input_objects: InputObjects,
         protocol_config: &ProtocolConfig,
-    ) -> TemporaryStore<&mut LocalExec> {
-        TemporaryStore::new(self, input_objects, *tx_digest, protocol_config)
+    ) -> TemporaryStore {
+        // Wrap `&mut self` in an `Arc` because of `TemporaryStore`'s interface, not because it will
+        // be shared across multiple threads
+        TemporaryStore::new(Arc::new(self), input_objects, *tx_digest, protocol_config)
     }
 
     pub async fn multi_download_and_store(
@@ -672,26 +672,27 @@ impl LocalExec {
         let temporary_store =
             self.to_temporary_store(tx_digest, InputObjects::new(input_objects), protocol_config);
 
-        // We could probably cache the VM per protocol config
-        let move_vm = get_vm(protocol_config, expensive_safety_check_config)?;
+        // We could probably cache the executor per protocol config
+        let executor = get_executor(protocol_config, expensive_safety_check_config);
 
         // All prep done
-        let res = execute_transaction_to_effects_impl::<execution_mode::Normal, _>(
-            tx_info.shared_object_refs.clone(),
-            temporary_store,
-            override_transaction_kind.unwrap_or(tx_info.kind.clone()),
-            tx_info.sender,
-            &tx_info.gas.clone(),
-            *tx_digest,
-            tx_info.dependencies.clone().into_iter().collect(),
-            &move_vm,
-            gas_status,
-            &tx_info.executed_epoch,
-            epoch_start_timestamp,
+        let expensive_checks = true;
+        let certificate_deny_set = HashSet::new();
+        let res = executor.execute_transaction_to_effects(
             protocol_config,
             metrics,
-            true,
-            &HashSet::new(),
+            expensive_checks,
+            &certificate_deny_set,
+            &tx_info.executed_epoch,
+            epoch_start_timestamp,
+            temporary_store,
+            tx_info.shared_object_refs.clone(),
+            gas_status,
+            &tx_info.gas,
+            override_transaction_kind.unwrap_or(tx_info.kind.clone()),
+            tx_info.sender,
+            *tx_digest,
+            tx_info.dependencies.clone().into_iter().collect(),
         );
 
         let all_required_objects = self.storage.all_objects();
@@ -873,7 +874,7 @@ impl LocalExec {
     }
 
     /// Must be called after `init_for_execution`
-    /// This executes from `sui_adapter::execution_engine::execute_transaction_to_effects_impl`
+    /// This executes from `sui_adapter::execution_engine::execute_transaction_to_effects`
     pub async fn execution_engine_execute(
         &mut self,
         tx_digest: &TransactionDigest,
@@ -1647,7 +1648,7 @@ impl ParentSync for LocalExec {
 }
 
 impl ResourceResolver for LocalExec {
-    type Error = ReplayEngineError;
+    type Error = SuiError;
 
     /// In this case we might need to download a Move object on the fly which was not present in the
     /// modified at versions list because packages are immutable
@@ -1655,12 +1656,12 @@ impl ResourceResolver for LocalExec {
         &self,
         address: &AccountAddress,
         typ: &StructTag,
-    ) -> Result<Option<Vec<u8>>, Self::Error> {
+    ) -> SuiResult<Option<Vec<u8>>> {
         fn inner(
             self_: &LocalExec,
             address: &AccountAddress,
             typ: &StructTag,
-        ) -> Result<Option<Vec<u8>>, ReplayEngineError> {
+        ) -> SuiResult<Option<Vec<u8>>> {
             // If package not present fetch it from the network or some remote location
             let Some(object) = self_.get_or_download_object(
                 &ObjectID::from(*address),false /* we expect a Move obj*/)? else {
@@ -1697,15 +1698,12 @@ impl ResourceResolver for LocalExec {
 }
 
 impl ModuleResolver for LocalExec {
-    type Error = ReplayEngineError;
+    type Error = SuiError;
 
     /// This fetches a module which must already be present in the store
     /// We do not download
-    fn get_module(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
-        fn inner(
-            self_: &LocalExec,
-            module_id: &ModuleId,
-        ) -> Result<Option<Vec<u8>>, ReplayEngineError> {
+    fn get_module(&self, module_id: &ModuleId) -> SuiResult<Option<Vec<u8>>> {
+        fn inner(self_: &LocalExec, module_id: &ModuleId) -> SuiResult<Option<Vec<u8>>> {
             Ok(self_
                 .get_package(&ObjectID::from(*module_id.address()))
                 .map_err(ReplayEngineError::from)?
@@ -1730,9 +1728,9 @@ impl ModuleResolver for LocalExec {
 }
 
 impl ModuleResolver for &mut LocalExec {
-    type Error = ReplayEngineError;
+    type Error = SuiError;
 
-    fn get_module(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
+    fn get_module(&self, module_id: &ModuleId) -> SuiResult<Option<Vec<u8>>> {
         // Recording event here will be double-counting since its already recorded in the get_module fn
         (**self).get_module(module_id)
     }
@@ -1741,7 +1739,7 @@ impl ModuleResolver for &mut LocalExec {
 impl ObjectStore for LocalExec {
     /// The object must be present in store by normal process we used to backfill store in init
     /// We dont download if not present
-    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
+    fn get_object(&self, object_id: &ObjectID) -> SuiResult<Option<Object>> {
         let res = Ok(self.storage.live_objects_store.get(object_id).cloned());
         self.exec_store_events
             .lock()
@@ -1759,7 +1757,7 @@ impl ObjectStore for LocalExec {
         &self,
         object_id: &ObjectID,
         version: VersionNumber,
-    ) -> Result<Option<Object>, SuiError> {
+    ) -> SuiResult<Option<Object>> {
         let res = Ok(self
             .storage
             .live_objects_store
@@ -1786,7 +1784,7 @@ impl ObjectStore for LocalExec {
 }
 
 impl ObjectStore for &mut LocalExec {
-    fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
+    fn get_object(&self, object_id: &ObjectID) -> SuiResult<Option<Object>> {
         // Recording event here will be double-counting since its already recorded in the get_module fn
         (**self).get_object(object_id)
     }
@@ -1795,18 +1793,18 @@ impl ObjectStore for &mut LocalExec {
         &self,
         object_id: &ObjectID,
         version: VersionNumber,
-    ) -> Result<Option<Object>, SuiError> {
+    ) -> SuiResult<Option<Object>> {
         // Recording event here will be double-counting since its already recorded in the get_module fn
         (**self).get_object_by_key(object_id, version)
     }
 }
 
 impl GetModule for LocalExec {
-    type Error = ReplayEngineError;
+    type Error = SuiError;
     type Item = CompiledModule;
 
-    fn get_module_by_id(&self, id: &ModuleId) -> anyhow::Result<Option<Self::Item>, Self::Error> {
-        let res = get_module_by_id(self, id).map_err(|e| e.into());
+    fn get_module_by_id(&self, id: &ModuleId) -> SuiResult<Option<Self::Item>> {
+        let res = get_module_by_id(self, id);
 
         self.exec_store_events
             .lock()
@@ -1821,20 +1819,17 @@ impl GetModule for LocalExec {
 
 // <--------------------- Util functions ----------------------->
 
-pub fn get_vm(
+pub fn get_executor(
     protocol_config: &ProtocolConfig,
     expensive_safety_check_config: ExpensiveSafetyCheckConfig,
-) -> Result<Arc<adapter::MoveVM>, ReplayEngineError> {
-    let native_functions = sui_move_natives::all_natives(/* disable silent */ false);
-    let move_vm = Arc::new(
-        adapter::new_move_vm(
-            native_functions.clone(),
-            protocol_config,
-            expensive_safety_check_config.enable_move_vm_paranoid_checks(),
-        )
-        .expect("We defined natives to not fail here"),
-    );
-    Ok(move_vm)
+) -> Arc<dyn Executor + Send + Sync> {
+    let silent = true;
+    sui_execution::executor(
+        protocol_config,
+        expensive_safety_check_config.enable_move_vm_paranoid_checks(),
+        silent,
+    )
+    .expect("Creating an executor should not fail here")
 }
 
 async fn prep_network(

--- a/crates/sui-replay/src/types.rs
+++ b/crates/sui-replay/src/types.rs
@@ -252,11 +252,11 @@ pub enum ExecutionStoreEvent {
     ResourceResolverGetResource {
         address: AccountAddress,
         typ: StructTag,
-        result: Result<Option<Vec<u8>>, ReplayEngineError>,
+        result: SuiResult<Option<Vec<u8>>>,
     },
     ModuleResolverGetModule {
         module_id: ModuleId,
-        result: Result<Option<Vec<u8>>, ReplayEngineError>,
+        result: SuiResult<Option<Vec<u8>>>,
     },
     ObjectStoreGetObject {
         object_id: ObjectID,
@@ -269,6 +269,6 @@ pub enum ExecutionStoreEvent {
     },
     GetModuleGetModuleByModuleId {
         id: ModuleId,
-        result: Result<Option<CompiledModule>, ReplayEngineError>,
+        result: SuiResult<Option<CompiledModule>>,
     },
 }

--- a/crates/sui-swarm-config/Cargo.toml
+++ b/crates/sui-swarm-config/Cargo.toml
@@ -16,7 +16,6 @@ dirs = "4.0.0"
 fastcrypto.workspace = true
 move-binary-format.workspace = true
 move-core-types.workspace = true
-move-vm-runtime.workspace = true
 once_cell = "1.16"
 rand = "0.8.5"
 serde = { version = "1.0.144", features = ["derive", "rc"] }
@@ -44,6 +43,4 @@ sui-simulator = { path = "../sui-simulator" }
 insta = { version = "1.21.1", features = ["redactions", "yaml"] }
 tempfile = "3.3.0"
 
-# TODO use sui-execution versioned crate
-sui-adapter = { path = "../../sui-execution/latest/sui-adapter", package = "sui-adapter-latest" }
-sui-move-natives = { path = "../../sui-execution/latest/sui-move-natives", package = "sui-move-natives-latest" }
+sui-execution = { path = "../../sui-execution" }

--- a/crates/sui-swarm-config/src/network_config_builder.rs
+++ b/crates/sui-swarm-config/src/network_config_builder.rs
@@ -344,13 +344,13 @@ mod tests {
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashSet;
+    use std::collections::{BTreeSet, HashSet};
     use std::sync::Arc;
     use sui_config::genesis::Genesis;
     use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
     use sui_types::epoch_data::EpochData;
-    use sui_types::execution_mode;
     use sui_types::gas::SuiGasStatus;
+    use sui_types::in_memory_storage::InMemoryStorage;
     use sui_types::metrics::LimitsMetrics;
     use sui_types::sui_system_state::SuiSystemStateTrait;
     use sui_types::temporary_store::TemporaryStore;
@@ -379,50 +379,45 @@ mod test {
 
         let genesis_transaction = genesis.transaction().clone();
 
-        let mut store = sui_types::in_memory_storage::InMemoryStorage::new(Vec::new());
         let temporary_store = TemporaryStore::new(
-            &mut store,
+            InMemoryStorage::new(Vec::new()),
             InputObjects::new(vec![]),
             *genesis_transaction.digest(),
             &protocol_config,
         );
 
-        let enable_move_vm_paranoid_checks = false;
-        let native_functions = sui_move_natives::all_natives(/* silent */ true);
-        let move_vm = std::sync::Arc::new(
-            sui_adapter::adapter::new_move_vm(
-                native_functions,
-                &protocol_config,
-                enable_move_vm_paranoid_checks,
-            )
-            .expect("We defined natives to not fail here"),
-        );
+        let silent = true;
+        let paranoid_checks = false;
+        let executor = sui_execution::executor(&protocol_config, paranoid_checks, silent)
+            .expect("Creating an executor should not fail here");
 
         // Use a throwaway metrics registry for genesis transaction execution.
         let registry = prometheus::Registry::new();
         let metrics = Arc::new(LimitsMetrics::new(&registry));
-
+        let expensive_checks = false;
+        let certificate_deny_set = HashSet::new();
+        let epoch = EpochData::new_test();
+        let shared_object_refs = vec![];
         let transaction_data = &genesis_transaction.data().intent_message().value;
         let (kind, signer, gas) = transaction_data.execution_parts();
-        let (_inner_temp_store, effects, _execution_error) =
-            sui_adapter::execution_engine::execute_transaction_to_effects::<
-                execution_mode::Normal,
-                _,
-            >(
-                vec![],
-                temporary_store,
-                kind,
-                signer,
-                &gas,
-                *genesis_transaction.digest(),
-                Default::default(),
-                &move_vm,
-                SuiGasStatus::new_unmetered(&protocol_config),
-                &EpochData::new_test(),
+        let transaction_dependencies = BTreeSet::new();
+
+        let (_inner_temp_store, effects, _execution_error) = executor
+            .execute_transaction_to_effects(
                 &protocol_config,
                 metrics,
-                false, // enable_expensive_checks
-                &HashSet::new(),
+                expensive_checks,
+                &certificate_deny_set,
+                &epoch.epoch_id(),
+                epoch.epoch_start_timestamp(),
+                temporary_store,
+                shared_object_refs,
+                SuiGasStatus::new_unmetered(&protocol_config),
+                &gas,
+                kind,
+                signer,
+                *genesis_transaction.digest(),
+                transaction_dependencies,
             );
 
         assert_eq!(&effects, genesis.effects());

--- a/crates/sui-transactional-test-runner/Cargo.toml
+++ b/crates/sui-transactional-test-runner/Cargo.toml
@@ -23,11 +23,11 @@ move-bytecode-utils.workspace = true
 move-command-line-common.workspace = true
 move-compiler.workspace = true
 move-core-types.workspace = true
-move-stdlib.workspace = true
 move-symbol-pool.workspace = true
 move-transactional-test-runner.workspace = true
-move-vm-runtime.workspace = true
 
+move-stdlib = { path = "../../external-crates/move/move-stdlib" }
+move-vm-runtime = { path = "../../external-crates/move/move-vm/runtime" }
 sui-adapter = { path = "../../sui-execution/latest/sui-adapter", package = "sui-adapter-latest" }
 sui-move-natives = { path = "../../sui-execution/latest/sui-move-natives", package = "sui-move-natives-latest" }
 

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -326,7 +326,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                 )
                 .unwrap(),
             ),
-            storage: Arc::new(InMemoryStorage::new(objects)),
+            storage: InMemoryStorage::new(objects),
             compiled_state: CompiledState::new(
                 named_address_mapping,
                 pre_compiled_deps,
@@ -1138,7 +1138,8 @@ impl<'a> SuiTestAdapter<'a> {
             .value
             .clone();
         let (kind, signer, gas) = transaction_data.execution_parts();
-
+        // TODO: Support different epochs in transactional tests.
+        let epoch_data = EpochData::new_test();
         let (
             inner,
             effects,
@@ -1157,7 +1158,7 @@ impl<'a> SuiTestAdapter<'a> {
             },
             */
             execution_error,
-        ) = execution_engine::execute_transaction_to_effects::<execution_mode::Normal, _>(
+        ) = execution_engine::execute_transaction_to_effects::<execution_mode::Normal>(
             shared_object_refs,
             temporary_store,
             kind,
@@ -1167,8 +1168,8 @@ impl<'a> SuiTestAdapter<'a> {
             transaction_dependencies,
             &self.vm,
             gas_status,
-            // TODO: Support different epochs in transactional tests.
-            &EpochData::new_test(),
+            &epoch_data.epoch_id(),
+            epoch_data.epoch_start_timestamp(),
             &self.protocol_config,
             self.metrics.clone(),
             false, // enable_expensive_checks

--- a/crates/sui-types/src/coin.rs
+++ b/crates/sui-types/src/coin.rs
@@ -166,8 +166,8 @@ impl TreasuryCap {
     }
 }
 
-pub fn transfer_coin<S>(
-    temporary_store: &mut TemporaryStore<S>,
+pub fn transfer_coin(
+    temporary_store: &mut TemporaryStore<'_>,
     coin: &Coin,
     recipient: SuiAddress,
     coin_type: MoveObjectType,

--- a/crates/sui-types/src/dynamic_field.rs
+++ b/crates/sui-types/src/dynamic_field.rs
@@ -271,13 +271,12 @@ where
 /// from the `object_store`. The key type `K` must implement `MoveTypeTagTrait` which has an associated
 /// function that returns the Move type tag.
 /// Note that this function returns the Field object itself, not the value in the field.
-pub fn get_dynamic_field_object_from_store<S, K>(
-    object_store: &S,
+pub fn get_dynamic_field_object_from_store<K>(
+    object_store: &dyn ObjectStore,
     parent_id: ObjectID,
     key: &K,
 ) -> Result<Object, SuiError>
 where
-    S: ObjectStore,
     K: MoveTypeTagTrait + Serialize + DeserializeOwned + fmt::Debug,
 {
     let id = derive_dynamic_field_id(parent_id, &K::get_type_tag(), &bcs::to_bytes(key).unwrap())
@@ -293,13 +292,12 @@ where
 
 /// Similar to `get_dynamic_field_object_from_store`, but returns the value in the field instead of
 /// the Field object itself.
-pub fn get_dynamic_field_from_store<S, K, V>(
-    object_store: &S,
+pub fn get_dynamic_field_from_store<K, V>(
+    object_store: &dyn ObjectStore,
     parent_id: ObjectID,
     key: &K,
 ) -> Result<V, SuiError>
 where
-    S: ObjectStore,
     K: MoveTypeTagTrait + Serialize + DeserializeOwned + fmt::Debug,
     V: Serialize + DeserializeOwned,
 {

--- a/crates/sui-types/src/in_memory_storage.rs
+++ b/crates/sui-types/src/in_memory_storage.rs
@@ -15,6 +15,7 @@ use move_binary_format::CompiledModule;
 use move_bytecode_utils::module_cache::GetModule;
 use move_core_types::{language_storage::ModuleId, resolver::ModuleResolver};
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 // TODO: We should use AuthorityTemporaryStore instead.
 // Keeping this functionally identical to AuthorityTemporaryStore is a pain.
@@ -139,16 +140,16 @@ impl GetModule for InMemoryStorage {
 }
 
 impl InMemoryStorage {
-    pub fn new(objects: Vec<Object>) -> Self {
+    pub fn new(objects: Vec<Object>) -> Arc<Self> {
         let mut persistent = BTreeMap::new();
         for o in objects {
             persistent.insert(o.id(), o);
         }
-        Self {
+        Arc::new(Self {
             persistent,
             last_entry_for_deleted: BTreeMap::new(),
             wrapped: BTreeMap::new(),
-        }
+        })
     }
 
     pub fn get_object(&self, id: &ObjectID) -> Option<&Object> {

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -354,10 +354,7 @@ impl MoveObject {
     }
 
     /// Get the total amount of SUI embedded in `self`. Intended for testing purposes
-    pub fn get_total_sui(
-        &self,
-        layout_resolver: &mut impl LayoutResolver,
-    ) -> Result<u64, SuiError> {
+    pub fn get_total_sui(&self, layout_resolver: &mut dyn LayoutResolver) -> Result<u64, SuiError> {
         if self.type_.is_gas_coin() {
             // Fast path without deserialization.
             return Ok(self.get_coin_value_unsafe());
@@ -832,10 +829,7 @@ impl Object {
 // Testing-related APIs.
 impl Object {
     /// Get the total amount of SUI embedded in `self`, including both Move objects and the storage rebate
-    pub fn get_total_sui(
-        &self,
-        layout_resolver: &mut impl LayoutResolver,
-    ) -> Result<u64, SuiError> {
+    pub fn get_total_sui(&self, layout_resolver: &mut dyn LayoutResolver) -> Result<u64, SuiError> {
         Ok(self.storage_rebate
             + match &self.data {
                 Data::Move(m) => m.get_total_sui(layout_resolver)?,

--- a/crates/sui-types/src/storage.rs
+++ b/crates/sui-types/src/storage.rs
@@ -93,50 +93,6 @@ pub trait BackingPackageStore {
         self.get_package_object(package_id)
             .map(|opt_obj| opt_obj.and_then(|obj| obj.data.try_into_package()))
     }
-    /// Returns Ok(<object for each package id in `package_ids`>) if all package IDs in
-    /// `package_id` were found. If any package in `package_ids` was not found it returns a list
-    /// of any package ids that are unable to be found>).
-    fn get_package_objects<'a>(
-        &self,
-        package_ids: impl IntoIterator<Item = &'a ObjectID>,
-    ) -> SuiResult<PackageFetchResults<Object>> {
-        let package_objects: Vec<Result<Object, ObjectID>> = package_ids
-            .into_iter()
-            .map(|id| match self.get_package_object(id) {
-                Ok(None) => Ok(Err(*id)),
-                Ok(Some(o)) => Ok(Ok(o)),
-                Err(x) => Err(x),
-            })
-            .collect::<SuiResult<_>>()?;
-
-        let (fetched, failed_to_fetch): (Vec<_>, Vec<_>) =
-            package_objects.into_iter().partition_result();
-        if !failed_to_fetch.is_empty() {
-            Ok(Err(failed_to_fetch))
-        } else {
-            Ok(Ok(fetched))
-        }
-    }
-    fn get_packages<'a>(
-        &self,
-        package_ids: impl IntoIterator<Item = &'a ObjectID>,
-    ) -> SuiResult<PackageFetchResults<MovePackage>> {
-        let objects = self.get_package_objects(package_ids)?;
-        Ok(objects.and_then(|objects| {
-            let (packages, failed): (Vec<_>, Vec<_>) = objects
-                .into_iter()
-                .map(|obj| {
-                    let obj_id = obj.id();
-                    obj.data.try_into_package().ok_or(obj_id)
-                })
-                .partition_result();
-            if !failed.is_empty() {
-                Err(failed)
-            } else {
-                Ok(packages)
-            }
-        }))
-    }
 }
 
 impl<S: BackingPackageStore> BackingPackageStore for std::sync::Arc<S> {
@@ -145,16 +101,62 @@ impl<S: BackingPackageStore> BackingPackageStore for std::sync::Arc<S> {
     }
 }
 
-impl<S: BackingPackageStore> BackingPackageStore for &S {
+impl<S: ?Sized + BackingPackageStore> BackingPackageStore for &S {
     fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<Object>> {
         BackingPackageStore::get_package_object(*self, package_id)
     }
 }
 
-impl<S: BackingPackageStore> BackingPackageStore for &mut S {
+impl<S: ?Sized + BackingPackageStore> BackingPackageStore for &mut S {
     fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<Object>> {
         BackingPackageStore::get_package_object(*self, package_id)
     }
+}
+
+/// Returns Ok(<object for each package id in `package_ids`>) if all package IDs in
+/// `package_id` were found. If any package in `package_ids` was not found it returns a list
+/// of any package ids that are unable to be found>).
+pub fn get_package_objects<'a>(
+    store: &impl BackingPackageStore,
+    package_ids: impl IntoIterator<Item = &'a ObjectID>,
+) -> SuiResult<PackageFetchResults<Object>> {
+    let package_objects: Vec<Result<Object, ObjectID>> = package_ids
+        .into_iter()
+        .map(|id| match store.get_package_object(id) {
+            Ok(None) => Ok(Err(*id)),
+            Ok(Some(o)) => Ok(Ok(o)),
+            Err(x) => Err(x),
+        })
+        .collect::<SuiResult<_>>()?;
+
+    let (fetched, failed_to_fetch): (Vec<_>, Vec<_>) =
+        package_objects.into_iter().partition_result();
+    if !failed_to_fetch.is_empty() {
+        Ok(Err(failed_to_fetch))
+    } else {
+        Ok(Ok(fetched))
+    }
+}
+
+pub fn get_packages<'a>(
+    store: &impl BackingPackageStore,
+    package_ids: impl IntoIterator<Item = &'a ObjectID>,
+) -> SuiResult<PackageFetchResults<MovePackage>> {
+    let objects = get_package_objects(store, package_ids)?;
+    Ok(objects.and_then(|objects| {
+        let (packages, failed): (Vec<_>, Vec<_>) = objects
+            .into_iter()
+            .map(|obj| {
+                let obj_id = obj.id();
+                obj.data.try_into_package().ok_or(obj_id)
+            })
+            .partition_result();
+        if !failed.is_empty() {
+            Err(failed)
+        } else {
+            Ok(packages)
+        }
+    }))
 }
 
 pub fn get_module<S: BackingPackageStore>(

--- a/crates/sui-types/src/sui_system_state/mod.rs
+++ b/crates/sui-types/src/sui_system_state/mod.rs
@@ -73,15 +73,12 @@ impl SuiSystemStateWrapper {
         }
     }
 
-    pub fn advance_epoch_safe_mode<S>(
+    pub fn advance_epoch_safe_mode(
         &self,
         params: &AdvanceEpochParams,
-        object_store: &S,
+        object_store: &dyn ObjectStore,
         protocol_config: &ProtocolConfig,
-    ) -> Object
-    where
-        S: ObjectStore,
-    {
+    ) -> Object {
         let id = self.id.id.bytes;
         let mut field_object = get_dynamic_field_object_from_store(object_store, id, &self.version)
             .expect("Dynamic field object of wrapper should always be present in the object store");
@@ -220,10 +217,9 @@ impl SuiSystemState {
     }
 }
 
-pub fn get_sui_system_state_wrapper<S>(object_store: &S) -> Result<SuiSystemStateWrapper, SuiError>
-where
-    S: ObjectStore,
-{
+pub fn get_sui_system_state_wrapper(
+    object_store: &dyn ObjectStore,
+) -> Result<SuiSystemStateWrapper, SuiError> {
     let wrapper = object_store
         .get_object(&SUI_SYSTEM_STATE_OBJECT_ID)?
         // Don't panic here on None because object_store is a generic store.
@@ -240,10 +236,7 @@ where
     Ok(result)
 }
 
-pub fn get_sui_system_state<S>(object_store: &S) -> Result<SuiSystemState, SuiError>
-where
-    S: ObjectStore,
-{
+pub fn get_sui_system_state(object_store: &dyn ObjectStore) -> Result<SuiSystemState, SuiError> {
     let wrapper = get_sui_system_state_wrapper(object_store)?;
     let id = wrapper.id.id.bytes;
     match wrapper.version {

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -30,9 +30,11 @@ rusoto_kms = { version = "0.48.0", default_features=false, features=["rustls"] }
 prometheus = "0.13.3"
 git-version = "0.3.5"
 const-str = "0.5.3"
-
-sui-adapter = { path = "../../sui-execution/latest/sui-adapter", package = "sui-adapter-latest" }
 num-bigint = "0.4.3"
+
+move-bytecode-verifier = { path = "../../external-crates/move/move-bytecode-verifier" }
+sui-adapter = { path = "../../sui-execution/latest/sui-adapter", package = "sui-adapter-latest" }
+sui-verifier = { path = "../../sui-execution/latest/sui-verifier", package = "sui-verifier-latest" }
 
 sui-config = { path = "../sui-config" }
 sui-swarm-config = { path = "../sui-swarm-config" }
@@ -47,7 +49,6 @@ sui-source-validation = { path = "../sui-source-validation" }
 sui-move = { path = "../sui-move", features = ["all"] }
 sui-move-build = { path = "../sui-move-build" }
 sui-protocol-config = { path = "../sui-protocol-config" }
-sui-verifier = { path = "../../sui-execution/latest/sui-verifier", package = "sui-verifier-latest" }
 shared-crypto = { path = "../shared-crypto" }
 
 fastcrypto.workspace = true
@@ -65,7 +66,6 @@ telemetry-subscribers.workspace = true
 
 move-core-types.workspace = true
 move-package.workspace = true
-move-bytecode-verifier.workspace = true
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 csv = "1.2.1"
 

--- a/crates/transaction-fuzzer/src/account_universe.rs
+++ b/crates/transaction-fuzzer/src/account_universe.rs
@@ -8,7 +8,6 @@ use crate::executor::{ExecutionResult, Executor};
 use once_cell::sync::Lazy;
 use proptest::{prelude::*, strategy::Union};
 use std::{fmt, sync::Arc};
-use sui_adapter::type_layout_resolver::TypeLayoutResolver;
 use sui_types::{storage::ObjectStore, transaction::VerifiedTransaction};
 
 mod account;
@@ -130,13 +129,14 @@ pub fn assert_accounts_match(
     let state = executor.state.clone();
     let store = state.db();
     let epoch_store = state.load_epoch_store_one_call_per_task();
-    let move_vm = epoch_store.move_vm();
-    let mut layout_resolver = TypeLayoutResolver::new(move_vm, store.as_ref());
+    let mut layout_resolver = epoch_store
+        .executor()
+        .type_layout_resolver(Box::new(store.as_ref()));
     for (idx, account) in universe.accounts().iter().enumerate() {
         for (balance_idx, acc_object) in account.current_coins.iter().enumerate() {
             let object = store.get_object(&acc_object.id()).unwrap().unwrap();
             let total_sui_value =
-                object.get_total_sui(&mut layout_resolver).unwrap() - object.storage_rebate;
+                object.get_total_sui(layout_resolver.as_mut()).unwrap() - object.storage_rebate;
             let account_balance_i = account.current_balances[balance_idx];
             prop_assert_eq!(
                 account_balance_i,

--- a/sui-execution/Cargo.toml
+++ b/sui-execution/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "sui-execution"
+version = "0.1.0"
+authors = ["Mysten Labs <eng@mystenlabs.com>"]
+description = "Multiplexer to choose between multiple versions of sui and move execution crates."
+license = "Apache-2.0"
+publish = false
+edition = "2021"
+
+[dependencies]
+sui-protocol-config = { path = "../crates/sui-protocol-config" }
+sui-types = { path = "../crates/sui-types" }
+
+move-bytecode-utils.workspace = true
+move-core-types.workspace = true
+
+sui-adapter-latest = { path = "latest/sui-adapter" }
+sui-move-natives-latest = { path = "latest/sui-move-natives" }
+sui-verifier-latest = { path = "latest/sui-verifier" }
+
+move-vm-runtime-latest = { path = "../external-crates/move/move-vm/runtime", package = "move-vm-runtime" }

--- a/sui-execution/Cargo.toml
+++ b/sui-execution/Cargo.toml
@@ -19,3 +19,5 @@ sui-move-natives-latest = { path = "latest/sui-move-natives" }
 sui-verifier-latest = { path = "latest/sui-verifier" }
 
 move-vm-runtime-latest = { path = "../external-crates/move/move-vm/runtime", package = "move-vm-runtime" }
+
+workspace-hack = { version = "0.1", path = "../crates/workspace-hack" }

--- a/sui-execution/latest/sui-adapter/Cargo.toml
+++ b/sui-execution/latest/sui-adapter/Cargo.toml
@@ -17,12 +17,12 @@ serde = { version = "1.0.140", features = ["derive"] }
 
 move-binary-format.workspace = true
 move-bytecode-utils.workspace = true
-move-bytecode-verifier.workspace = true
 move-core-types.workspace = true
 move-vm-config.workspace = true
-move-vm-runtime.workspace = true
 move-vm-types.workspace = true
 
+move-bytecode-verifier = { path = "../../../external-crates/move/move-bytecode-verifier" }
+move-vm-runtime = { path = "../../../external-crates/move/move-vm/runtime" }
 sui-move-natives = { path = "../sui-move-natives", package = "sui-move-natives-latest" }
 sui-verifier = { path = "../sui-verifier", package = "sui-verifier-latest" }
 

--- a/sui-execution/latest/sui-adapter/src/adapter.rs
+++ b/sui-execution/latest/sui-adapter/src/adapter.rs
@@ -12,9 +12,9 @@ use move_vm_config::{
     runtime::{VMConfig, VMRuntimeLimitsConfig},
     verifier::VerifierConfig,
 };
-pub use move_vm_runtime::move_vm::MoveVM;
 use move_vm_runtime::{
-    native_extensions::NativeContextExtensions, native_functions::NativeFunctionTable,
+    move_vm::MoveVM, native_extensions::NativeContextExtensions,
+    native_functions::NativeFunctionTable,
 };
 use sui_types::metrics::BytecodeVerifierMetrics;
 use sui_verifier::check_for_verifier_timeout;
@@ -106,7 +106,7 @@ pub fn new_move_vm(
 }
 
 pub fn new_native_extensions<'r>(
-    child_resolver: &'r impl ChildObjectResolver,
+    child_resolver: &'r dyn ChildObjectResolver,
     input_objects: BTreeMap<ObjectID, Owner>,
     is_metered: bool,
     protocol_config: &ProtocolConfig,
@@ -114,7 +114,7 @@ pub fn new_native_extensions<'r>(
 ) -> NativeContextExtensions<'r> {
     let mut extensions = NativeContextExtensions::default();
     extensions.add(ObjectRuntime::new(
-        Box::new(child_resolver),
+        child_resolver,
         input_objects,
         is_metered,
         protocol_config,

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -25,14 +25,14 @@ use sui_types::{
     coin::Coin,
     error::{ExecutionError, ExecutionErrorKind},
     execution::{
-        ExecutionResults, InputObjectMetadata, InputValue, ObjectValue, RawValueType, ResultValue,
-        SuiResolver, UsageKind,
+        ExecutionResults, ExecutionState, InputObjectMetadata, InputValue, ObjectValue,
+        RawValueType, ResultValue, UsageKind,
     },
     gas::{SuiGasStatus, SuiGasStatusAPI},
     metrics::LimitsMetrics,
     move_package::MovePackage,
     object::{Data, MoveObject, Object, Owner},
-    storage::{ObjectChange, StorageView, WriteKind},
+    storage::{BackingPackageStore, ChildObjectResolver, ObjectChange, WriteKind},
     transaction::{Argument, CallArg, ObjectArg},
     type_resolver::TypeTagResolver,
 };
@@ -50,7 +50,7 @@ use super::linkage_view::{LinkageInfo, LinkageView, SavedLinkage};
 sui_macros::checked_arithmetic! {
 
 /// Maintains all runtime state specific to programmable transactions
-pub struct ExecutionContext<'vm, 'state, 'a, S: StorageView> {
+pub struct ExecutionContext<'vm, 'state, 'a> {
     /// The protocol config
     pub protocol_config: &'a ProtocolConfig,
     /// Metrics for reporting exceeded limits
@@ -58,14 +58,14 @@ pub struct ExecutionContext<'vm, 'state, 'a, S: StorageView> {
     /// The MoveVM
     pub vm: &'vm MoveVM,
     /// The global state, used for resolving packages
-    pub state_view: &'state S,
+    pub state_view: &'state dyn ExecutionState,
     /// A shared transaction context, contains transaction digest information and manages the
     /// creation of new object IDs
     pub tx_context: &'a mut TxContext,
     /// The gas status used for metering
     pub gas_status: &'a mut SuiGasStatus,
     /// The session used for interacting with Move types and calls
-    pub session: Session<'state, 'vm, LinkageView<&'state S>>,
+    pub session: Session<'state, 'vm, LinkageView<'state>>,
     /// Additional transfers not from the Move runtime
     additional_transfers: Vec<(/* new owner */ SuiAddress, ObjectValue)>,
     /// Newly published packages
@@ -98,15 +98,12 @@ struct AdditionalWrite {
     bytes: Vec<u8>,
 }
 
-impl<'vm, 'state, 'a, S: StorageView> ExecutionContext<'vm, 'state, 'a, S>
-where
-    &'state S: SuiResolver,
-{
+impl<'vm, 'state, 'a> ExecutionContext<'vm, 'state, 'a> {
     pub fn new(
         protocol_config: &'a ProtocolConfig,
         metrics: Arc<LimitsMetrics>,
         vm: &'vm MoveVM,
-        state_view: &'state S,
+        state_view: &'state dyn ExecutionState,
         tx_context: &'a mut TxContext,
         gas_status: &'a mut SuiGasStatus,
         gas_coin_opt: Option<ObjectID>,
@@ -120,9 +117,11 @@ where
 
         // we need a new session just for loading types, which is sad
         // TODO remove this
+        let linkage = LinkageView::new(Box::new(state_view.as_sui_resolver()), init_linkage);
         let mut tmp_session = new_session(
             vm,
-            LinkageView::new(state_view, init_linkage),
+            linkage,
+            state_view.as_child_resolver(),
             BTreeMap::new(),
             !gas_status.is_unmetered(),
             protocol_config,
@@ -187,6 +186,7 @@ where
         let session = new_session(
             vm,
             linkage,
+            state_view.as_child_resolver(),
             object_owner_map,
             !gas_status.is_unmetered(),
             protocol_config,
@@ -665,6 +665,7 @@ where
         let tmp_session = new_session(
             vm,
             linkage,
+            state_view.as_child_resolver(),
             BTreeMap::new(),
             !gas_status.is_unmetered(),
             protocol_config,
@@ -864,44 +865,46 @@ where
     }
 }
 
-impl<'vm, 'state, 'a, S: StorageView> TypeTagResolver for ExecutionContext<'vm, 'state, 'a, S>
-where
-    &'state S: SuiResolver,
-{
+impl<'vm, 'state, 'a> TypeTagResolver for ExecutionContext<'vm, 'state, 'a> {
     fn get_type_tag(&self, type_: &Type) -> Result<TypeTag, ExecutionError> {
-        self.session.get_type_tag(type_).map_err(|e| self.convert_vm_error(e))
+        self.session
+            .get_type_tag(type_)
+            .map_err(|e| self.convert_vm_error(e))
     }
 }
 
-pub(crate) fn new_session<'state, 'vm, S: StorageView>(
+pub(crate) fn new_session<'state, 'vm>(
     vm: &'vm MoveVM,
-    linkage: LinkageView<&'state S>,
+    linkage: LinkageView<'state>,
+    child_resolver: &'state dyn ChildObjectResolver,
     input_objects: BTreeMap<ObjectID, Owner>,
     is_metered: bool,
     protocol_config: &ProtocolConfig,
     metrics: Arc<LimitsMetrics>,
-) -> Session<'state, 'vm, LinkageView<&'state S>>
-where
-    &'state S: SuiResolver,
-{
-    let store = *linkage.storage();
+) -> Session<'state, 'vm, LinkageView<'state>> {
     vm.new_session_with_extensions(
         linkage,
-        new_native_extensions(store, input_objects, is_metered, protocol_config, metrics),
+        new_native_extensions(
+            child_resolver,
+            input_objects,
+            is_metered,
+            protocol_config,
+            metrics,
+        ),
     )
 }
 
 // Create a new Session suitable for resolving type and type operations rather than execution
-pub(crate) fn new_session_for_linkage<'state, S: SuiResolver>(
-    vm: &MoveVM,
-    linkage: LinkageView<S>,
-) -> Session<'state, '_, LinkageView<S>> {
+pub(crate) fn new_session_for_linkage<'vm, 'state>(
+    vm: &'vm MoveVM,
+    linkage: LinkageView<'state>,
+) -> Session<'state, 'vm, LinkageView<'state>> {
     vm.new_session(linkage)
 }
 
 /// Set the link context for the session from the linkage information in the `package`.
-pub fn set_linkage<S: SuiResolver>(
-    session: &mut Session<LinkageView<S>>,
+pub fn set_linkage(
+    session: &mut Session<LinkageView>,
     linkage: &MovePackage,
 ) -> Result<AccountAddress, ExecutionError> {
     session.get_resolver_mut().set_linkage(linkage)
@@ -909,18 +912,16 @@ pub fn set_linkage<S: SuiResolver>(
 
 /// Turn off linkage information, so that the next use of the session will need to set linkage
 /// information to succeed.
-pub fn reset_linkage<S: SuiResolver>(session: &mut Session<LinkageView<S>>) {
+pub fn reset_linkage(session: &mut Session<LinkageView>) {
     session.get_resolver_mut().reset_linkage();
 }
 
-pub fn steal_linkage<S: SuiResolver>(
-    session: &mut Session<LinkageView<S>>,
-) -> Option<SavedLinkage> {
+pub fn steal_linkage(session: &mut Session<LinkageView>) -> Option<SavedLinkage> {
     session.get_resolver_mut().steal_linkage()
 }
 
-pub fn restore_linkage<S: SuiResolver>(
-    session: &mut Session<LinkageView<S>>,
+pub fn restore_linkage(
+    session: &mut Session<LinkageView>,
     saved: Option<SavedLinkage>,
 ) -> Result<(), ExecutionError> {
     session.get_resolver_mut().restore_linkage(saved)
@@ -928,15 +929,14 @@ pub fn restore_linkage<S: SuiResolver>(
 
 /// Fetch the package at `package_id` with a view to using it as a link context.  Produces an error
 /// if the object at that ID does not exist, or is not a package.
-fn package_for_linkage<S: SuiResolver>(
-    session: &Session<LinkageView<S>>,
+fn package_for_linkage(
+    session: &Session<LinkageView>,
     package_id: ObjectID,
 ) -> VMResult<MovePackage> {
     use move_binary_format::errors::PartialVMError;
     use move_core_types::vm_status::StatusCode;
 
-    let storage = session.get_resolver().storage();
-    match storage.get_package(&package_id) {
+    match session.get_resolver().get_package(&package_id) {
         Ok(Some(package)) => Ok(package),
         Ok(None) => Err(PartialVMError::new(StatusCode::LINKER_ERROR)
             .with_message(format!("Cannot find link context {package_id} in store"))
@@ -951,10 +951,7 @@ fn package_for_linkage<S: SuiResolver>(
 
 /// Load `type_tag` to get a `Type` in the provided `session`.  `session`'s linkage context may be
 /// reset after this operation, because during the operation, it may change when loading a struct.
-pub fn load_type<S: SuiResolver>(
-    session: &mut Session<LinkageView<S>>,
-    type_tag: &TypeTag,
-) -> VMResult<Type> {
+pub fn load_type(session: &mut Session<LinkageView>, type_tag: &TypeTag) -> VMResult<Type> {
     use move_binary_format::errors::PartialVMError;
     use move_core_types::vm_status::StatusCode;
 
@@ -1027,17 +1024,14 @@ pub fn load_type<S: SuiResolver>(
     })
 }
 
-pub(crate) fn make_object_value<'vm, 'state, S: StorageView>(
+pub(crate) fn make_object_value<'vm, 'state>(
     vm: &'vm MoveVM,
-    session: &mut Session<'state, 'vm, LinkageView<&'state S>>,
+    session: &mut Session<'state, 'vm, LinkageView<'state>>,
     type_: MoveObjectType,
     has_public_transfer: bool,
     used_in_non_entry_move_call: bool,
     contents: &[u8],
-) -> Result<ObjectValue, ExecutionError>
-where
-    &'state S: SuiResolver,
-{
+) -> Result<ObjectValue, ExecutionError> {
     let contents = if type_.is_coin() {
         let Ok(coin) = Coin::from_bcs_bytes(contents) else {
             invariant_violation!("Could not deserialize a coin")
@@ -1058,14 +1052,11 @@ where
     })
 }
 
-pub(crate) fn value_from_object<'vm, 'state, S: StorageView>(
+pub(crate) fn value_from_object<'vm, 'state>(
     vm: &'vm MoveVM,
-    session: &mut Session<'state, 'vm, LinkageView<&'state S>>,
+    session: &mut Session<'state, 'vm, LinkageView<'state>>,
     object: &Object,
-) -> Result<ObjectValue, ExecutionError>
-where
-    &'state S: SuiResolver,
-{
+) -> Result<ObjectValue, ExecutionError> {
     let Object { data: Data::Move(object), .. } = object else {
         invariant_violation!("Expected a Move object");
     };
@@ -1082,17 +1073,14 @@ where
 }
 
 /// Load an input object from the state_view
-fn load_object<'vm, 'state, S: StorageView>(
+fn load_object<'vm, 'state>(
     vm: &'vm MoveVM,
-    state_view: &'state S,
-    session: &mut Session<'state, 'vm, LinkageView<&'state S>>,
+    state_view: &'state dyn ExecutionState,
+    session: &mut Session<'state, 'vm, LinkageView<'state>>,
     object_owner_map: &mut BTreeMap<ObjectID, Owner>,
     override_as_immutable: bool,
     id: ObjectID,
-) -> Result<InputValue, ExecutionError>
-where
-    &'state S: SuiResolver,
-{
+) -> Result<InputValue, ExecutionError> {
     let Some(obj) = state_view.read_object(&id) else {
         // protected by transaction input checker
         invariant_violation!("Object {} does not exist yet", id);
@@ -1125,16 +1113,13 @@ where
 }
 
 /// Load an a CallArg, either an object or a raw set of BCS bytes
-fn load_call_arg<'vm, 'state, S: StorageView>(
+fn load_call_arg<'vm, 'state>(
     vm: &'vm MoveVM,
-    state_view: &'state S,
-    session: &mut Session<'state, 'vm, LinkageView<&'state S>>,
+    state_view: &'state dyn ExecutionState,
+    session: &mut Session<'state, 'vm, LinkageView<'state>>,
     object_owner_map: &mut BTreeMap<ObjectID, Owner>,
     call_arg: CallArg,
-) -> Result<InputValue, ExecutionError>
-where
-    &'state S: SuiResolver,
-{
+) -> Result<InputValue, ExecutionError> {
     Ok(match call_arg {
         CallArg::Pure(bytes) => InputValue::new_raw(RawValueType::Any, bytes),
         CallArg::Object(obj_arg) => {
@@ -1144,16 +1129,13 @@ where
 }
 
 /// Load an ObjectArg from state view, marking if it can be treated as mutable or not
-fn load_object_arg<'vm, 'state, S: StorageView>(
+fn load_object_arg<'vm, 'state>(
     vm: &'vm MoveVM,
-    state_view: &'state S,
-    session: &mut Session<'state, 'vm, LinkageView<&'state S>>,
+    state_view: &'state dyn ExecutionState,
+    session: &mut Session<'state, 'vm, LinkageView<'state>>,
     object_owner_map: &mut BTreeMap<ObjectID, Owner>,
     obj_arg: ObjectArg,
-) -> Result<InputValue, ExecutionError>
-where
-    &'state S: SuiResolver,
-{
+) -> Result<InputValue, ExecutionError> {
     match obj_arg {
         ObjectArg::ImmOrOwnedObject((id, _, _)) => load_object(
             vm,
@@ -1235,9 +1217,9 @@ fn refund_max_gas_budget(
 ///
 /// This function assumes proper generation of has_public_transfer, either from the abilities of
 /// the StructTag, or from the runtime correctly propagating from the inputs
-unsafe fn create_written_object<'state, S: StorageView>(
-    vm: &MoveVM,
-    session: &Session<'state, '_, LinkageView<&'state S>>,
+unsafe fn create_written_object<'vm, 'state>(
+    vm: &'vm MoveVM,
+    session: &Session<'state, 'vm, LinkageView<'state>>,
     protocol_config: &ProtocolConfig,
     input_object_metadata: &BTreeMap<ObjectID, InputObjectMetadata>,
     loaded_child_objects: &BTreeMap<ObjectID, SequenceNumber>,
@@ -1246,10 +1228,7 @@ unsafe fn create_written_object<'state, S: StorageView>(
     has_public_transfer: bool,
     contents: Vec<u8>,
     write_kind: WriteKind,
-) -> Result<MoveObject, ExecutionError>
-where
-    &'state S: SuiResolver,
-{
+) -> Result<MoveObject, ExecutionError> {
     debug_assert_eq!(
         id,
         MoveObject::id_opt(&contents).expect("object contents should start with an id")

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
@@ -36,7 +36,7 @@ use sui_types::{
     error::{command_argument_error, ExecutionError, ExecutionErrorKind},
     event::Event,
     execution::{
-        CommandKind, ExecutionResults, ObjectContents, ObjectValue, RawValueType, SuiResolver,
+        CommandKind, ExecutionResults, ExecutionState, ObjectContents, ObjectValue, RawValueType,
         Value,
     },
     gas::{SuiGasStatus, SuiGasStatusAPI},
@@ -46,14 +46,13 @@ use sui_types::{
         normalize_deserialized_modules, MovePackage, TypeOrigin, UpgradeCap, UpgradePolicy,
         UpgradeReceipt, UpgradeTicket,
     },
-    storage::StorageView,
+    storage::get_packages,
     transaction::{Argument, Command, ProgrammableMoveCall, ProgrammableTransaction},
     Identifier, SUI_FRAMEWORK_ADDRESS,
 };
 use sui_types::{
     execution_mode::ExecutionMode,
     execution_status::{CommandArgumentError, PackageUpgradeError},
-    storage::BackingPackageStore,
 };
 use sui_verifier::{
     private_generics::{EVENT_MODULE, PRIVATE_TRANSFER_FUNCTIONS, TRANSFER_MODULE},
@@ -65,19 +64,16 @@ use crate::adapter::substitute_package_id;
 
 sui_macros::checked_arithmetic! {
 
-pub fn execute<S: StorageView, Mode: ExecutionMode>(
+pub fn execute<Mode: ExecutionMode>(
     protocol_config: &ProtocolConfig,
     metrics: Arc<LimitsMetrics>,
     vm: &MoveVM,
-    state_view: &mut S,
+    state_view: &mut dyn ExecutionState,
     tx_context: &mut TxContext,
     gas_status: &mut SuiGasStatus,
     gas_coin: Option<ObjectID>,
     pt: ProgrammableTransaction,
-) -> Result<Mode::ExecutionResults, ExecutionError>
-where
-    for<'state> &'state S: SuiResolver,
-{
+) -> Result<Mode::ExecutionResults, ExecutionError> {
     let ProgrammableTransaction { inputs, commands } = pt;
     let mut context = ExecutionContext::new(
         protocol_config,
@@ -92,7 +88,7 @@ where
     // execute commands
     let mut mode_results = Mode::empty_results();
     for (idx, command) in commands.into_iter().enumerate() {
-        if let Err(err) = execute_command::<_, Mode>(&mut context, &mut mode_results, command) {
+        if let Err(err) = execute_command::<Mode>(&mut context, &mut mode_results, command) {
             let object_runtime: &ObjectRuntime = context.session.get_native_extensions().get();
             // We still need to record the loaded child objects for replay
             let loaded_child_objects = object_runtime.loaded_child_objects();
@@ -130,13 +126,11 @@ where
 }
 
 /// Execute a single command
-fn execute_command<'vm, 'state, 'a, S: StorageView, Mode: ExecutionMode>(
-    context: &mut ExecutionContext<'vm, 'state, 'a, S>,
+fn execute_command<Mode: ExecutionMode>(
+    context: &mut ExecutionContext<'_, '_, '_>,
     mode_results: &mut Mode::ExecutionResults,
     command: Command,
 ) -> Result<(), ExecutionError>
-where
-    &'state S: SuiResolver,
 {
     let mut argument_updates = Mode::empty_arguments();
     let results = match command {
@@ -188,7 +182,7 @@ where
             };
             for (idx, arg) in arg_iter {
                 let value: Value = context.by_value_arg(CommandKind::MakeMoveVec, idx, arg)?;
-                check_param_type::<_, Mode>(context, idx, &value, &elem_ty)?;
+                check_param_type::<Mode>(context, idx, &value, &elem_ty)?;
                 used_in_non_entry_move_call =
                     used_in_non_entry_move_call || value.was_used_in_non_entry_move_call();
                 value.write_bcs_bytes(&mut res);
@@ -308,7 +302,7 @@ where
 
             let original_address = context.set_link_context(package)?;
             let runtime_id = ModuleId::new(original_address, module);
-            let return_values = execute_move_call::<_, Mode>(
+            let return_values = execute_move_call::<Mode>(
                 context,
                 &mut argument_updates,
                 &runtime_id,
@@ -322,10 +316,10 @@ where
             return_values?
         }
         Command::Publish(modules, dep_ids) => {
-            execute_move_publish::<_, Mode>(context, &mut argument_updates, modules, dep_ids)?
+            execute_move_publish::<Mode>(context, &mut argument_updates, modules, dep_ids)?
         }
         Command::Upgrade(modules, dep_ids, current_package_id, upgrade_ticket) => {
-            execute_move_upgrade::<_, Mode>(
+            execute_move_upgrade::<Mode>(
                 context,
                 modules,
                 dep_ids,
@@ -341,8 +335,8 @@ where
 }
 
 /// Execute a single Move call
-fn execute_move_call<'vm, 'state, 'a, S: StorageView, Mode: ExecutionMode>(
-    context: &mut ExecutionContext<'vm, 'state, 'a, S>,
+fn execute_move_call<Mode: ExecutionMode>(
+    context: &mut ExecutionContext<'_, '_, '_>,
     argument_updates: &mut Mode::ArgumentUpdates,
     module_id: &ModuleId,
     function: &IdentStr,
@@ -350,8 +344,6 @@ fn execute_move_call<'vm, 'state, 'a, S: StorageView, Mode: ExecutionMode>(
     arguments: Vec<Argument>,
     is_init: bool,
 ) -> Result<Vec<Value>, ExecutionError>
-where
-    &'state S: SuiResolver,
 {
     // check that the function is either an entry function or a valid public function
     let LoadedFunctionInfo {
@@ -360,7 +352,7 @@ where
         return_value_kinds,
         index,
         last_instr,
-    } = check_visibility_and_signature::<_, Mode>(
+    } = check_visibility_and_signature::<Mode>(
         context,
         module_id,
         function,
@@ -369,7 +361,7 @@ where
     )?;
     // build the arguments, storing meta data about by-mut-ref args
     let (tx_context_kind, by_mut_ref, serialized_arguments) =
-        build_move_args::<_, Mode>(context, module_id, function, kind, &signature, &arguments)?;
+        build_move_args::<Mode>(context, module_id, function, kind, &signature, &arguments)?;
     // invoke the VM
     let SerializedReturnValues {
         mutable_reference_outputs,
@@ -395,7 +387,7 @@ where
     // write back mutable inputs. We also update if they were used in non entry Move calls
     // though we do not care for immutable usages of objects or other values
     let used_in_non_entry_move_call = kind == FunctionKind::NonEntry;
-    let res = write_back_results::<_, Mode>(
+    let res = write_back_results::<Mode>(
         context,
         argument_updates,
         &arguments,
@@ -412,8 +404,8 @@ where
     res
 }
 
-fn write_back_results<'vm, 'state, 'a, S: StorageView, Mode: ExecutionMode>(
-    context: &mut ExecutionContext<'vm, 'state, 'a, S>,
+fn write_back_results<Mode: ExecutionMode>(
+    context: &mut ExecutionContext<'_, '_, '_>,
     argument_updates: &mut Mode::ArgumentUpdates,
     arguments: &[Argument],
     non_entry_move_call: bool,
@@ -422,8 +414,6 @@ fn write_back_results<'vm, 'state, 'a, S: StorageView, Mode: ExecutionMode>(
     return_values: impl IntoIterator<Item = Vec<u8>>,
     return_value_kinds: impl IntoIterator<Item = ValueKind>,
 ) -> Result<Vec<Value>, ExecutionError>
-where
-    &'state S: SuiResolver,
 {
     for ((i, bytes), (j, kind)) in mut_ref_values.into_iter().zip(mut_ref_kinds) {
         assert_invariant!(i == j, "lost mutable input");
@@ -444,14 +434,12 @@ where
         .collect()
 }
 
-fn make_value<'vm, 'state, 'a, S: StorageView>(
-    context: &mut ExecutionContext<'vm, 'state, 'a, S>,
+fn make_value(
+    context: &mut ExecutionContext<'_, '_, '_>,
     value_info: ValueKind,
     bytes: Vec<u8>,
     used_in_non_entry_move_call: bool,
 ) -> Result<Value, ExecutionError>
-where
-    &'state S: SuiResolver
 {
     Ok(match value_info {
         ValueKind::Object {
@@ -478,14 +466,12 @@ where
 
 /// Publish Move modules and call the init functions.  Returns an `UpgradeCap` for the newly
 /// published package on success.
-fn execute_move_publish<'vm, 'state, 'a, S: StorageView, Mode: ExecutionMode>(
-    context: &mut ExecutionContext<'vm, 'state, 'a, S>,
+fn execute_move_publish<Mode: ExecutionMode>(
+    context: &mut ExecutionContext<'_, '_, '_>,
     argument_updates: &mut Mode::ArgumentUpdates,
     module_bytes: Vec<Vec<u8>>,
     dep_ids: Vec<ObjectID>,
 ) -> Result<Vec<Value>, ExecutionError>
-where
-    &'state S: SuiResolver,
 {
     assert_invariant!(
         !module_bytes.is_empty(),
@@ -495,7 +481,7 @@ where
         .gas_status
         .charge_publish_package(module_bytes.iter().map(|v| v.len()).sum())?;
 
-    let mut modules = deserialize_modules::<_, Mode>(context, &module_bytes)?;
+    let mut modules = deserialize_modules::<Mode>(context, &module_bytes)?;
 
     // It should be fine that this does not go through ExecutionContext::fresh_id since the Move
     // runtime does not to know about new packages created, since Move objects and Move packages
@@ -524,7 +510,7 @@ where
 
         context.set_linkage(package)?;
         let res = publish_and_verify_modules(context, runtime_id, &modules)
-            .and_then(|_| init_modules::<_, Mode>(context, argument_updates, &modules));
+            .and_then(|_| init_modules::<Mode>(context, argument_updates, &modules));
         context.reset_linkage();
         res?;
 
@@ -535,7 +521,7 @@ where
         publish_and_verify_modules(context, runtime_id, &modules)?;
         let dependencies = fetch_packages(context, &dep_ids)?;
         let package = context.new_package(&modules, &dependencies)?;
-        init_modules::<_, Mode>(context, argument_updates, &modules)?;
+        init_modules::<Mode>(context, argument_updates, &modules)?;
         package
     };
 
@@ -558,15 +544,13 @@ where
 }
 
 /// Upgrade a Move package.  Returns an `UpgradeReceipt` for the upgraded package on success.
-fn execute_move_upgrade<'vm, 'state, 'a, S: StorageView, Mode: ExecutionMode>(
-    context: &mut ExecutionContext<'vm, 'state, 'a, S>,
+fn execute_move_upgrade<Mode: ExecutionMode>(
+    context: &mut ExecutionContext<'_, '_, '_>,
     module_bytes: Vec<Vec<u8>>,
     dep_ids: Vec<ObjectID>,
     current_package_id: ObjectID,
     upgrade_ticket_arg: Argument,
 ) -> Result<Vec<Value>, ExecutionError>
-where
-    &'state S: SuiResolver,
 {
     // Check that package upgrades are supported.
     context
@@ -590,7 +574,7 @@ where
         let mut ticket_bytes = Vec::new();
         let ticket_val: Value =
             context.by_value_arg(CommandKind::Upgrade, 0, upgrade_ticket_arg)?;
-        check_param_type::<_, Mode>(context, 0, &ticket_val, &upgrade_ticket_type)?;
+        check_param_type::<Mode>(context, 0, &ticket_val, &upgrade_ticket_type)?;
         ticket_val.write_bcs_bytes(&mut ticket_bytes);
         bcs::from_bytes(&ticket_bytes).map_err(|_| {
             ExecutionError::from_kind(ExecutionErrorKind::CommandArgumentError {
@@ -632,7 +616,7 @@ where
     // Check that this package ID points to a package and get the package we're upgrading.
     let current_package = fetch_package(context, &upgrade_ticket.package.bytes)?;
 
-    let mut modules = deserialize_modules::<_, Mode>(context, &module_bytes)?;
+    let mut modules = deserialize_modules::<Mode>(context, &module_bytes)?;
     let runtime_id = current_package.original_package_id();
     substitute_package_id(&mut modules, runtime_id)?;
 
@@ -697,8 +681,8 @@ where
     )])
 }
 
-fn check_compatibility<'a, S: StorageView>(
-    context: &ExecutionContext<S>,
+fn check_compatibility<'a>(
+    context: &ExecutionContext,
     existing_package: &MovePackage,
     upgrading_modules: impl IntoIterator<Item = &'a CompiledModule>,
     policy: u8,
@@ -712,7 +696,12 @@ fn check_compatibility<'a, S: StorageView>(
         ));
     };
 
-    let Ok(current_normalized) = existing_package.normalize(context.protocol_config.move_binary_format_version(), context.protocol_config.no_extraneous_module_bytes()) else {
+    let Ok(current_normalized) = existing_package
+        .normalize(
+            context.protocol_config.move_binary_format_version(),
+            context.protocol_config.no_extraneous_module_bytes(),
+        )
+    else {
         invariant_violation!("Tried to normalize modules in existing package but failed")
     };
 
@@ -743,12 +732,10 @@ fn check_compatibility<'a, S: StorageView>(
     Ok(())
 }
 
-fn fetch_package<'vm, 'state, 'a, S: StorageView>(
-    context: &ExecutionContext<'vm, 'state, 'a, S>,
+fn fetch_package(
+    context: &ExecutionContext<'_, '_, '_>,
     package_id: &ObjectID,
 ) -> Result<MovePackage, ExecutionError>
-where
-    &'state S: SuiResolver,
 {
     let mut fetched_packages = fetch_packages(context, vec![package_id])?;
     assert_invariant!(
@@ -763,15 +750,13 @@ where
     }
 }
 
-fn fetch_packages<'ctx, 'vm, 'state, 'a, S: StorageView>(
-    context: &'ctx ExecutionContext<'vm, 'state, 'a, S>,
+fn fetch_packages<'ctx, 'vm, 'state, 'a>(
+    context: &'ctx ExecutionContext<'vm, 'state, 'a>,
     package_ids: impl IntoIterator<Item = &'ctx ObjectID>,
 ) -> Result<Vec<MovePackage>, ExecutionError>
-where
-    &'state S: SuiResolver,
 {
     let package_ids: BTreeSet<_> = package_ids.into_iter().collect();
-    match context.state_view.get_packages(package_ids) {
+    match get_packages(&context.state_view, package_ids) {
         Err(e) => Err(ExecutionError::new_with_source(
             ExecutionErrorKind::PublishUpgradeMissingDependency,
             e,
@@ -798,16 +783,14 @@ where
  * Move execution
  **************************************************************************************************/
 
-fn vm_move_call<'vm, 'state, 'a, S: StorageView>(
-    context: &mut ExecutionContext<'vm, 'state, 'a, S>,
+fn vm_move_call(
+    context: &mut ExecutionContext<'_, '_, '_>,
     module_id: &ModuleId,
     function: &IdentStr,
     type_arguments: Vec<Type>,
     tx_context_kind: TxContextKind,
     mut serialized_arguments: Vec<Vec<u8>>,
 ) -> Result<SerializedReturnValues, ExecutionError>
-where
-    &'state S: SuiResolver,
 {
     match tx_context_kind {
         TxContextKind::None => (),
@@ -848,12 +831,10 @@ where
     Ok(result)
 }
 
-fn deserialize_modules<'vm, 'state, 'a, S: StorageView, Mode: ExecutionMode>(
-    context: &mut ExecutionContext<'vm, 'state, 'a, S>,
+fn deserialize_modules<Mode: ExecutionMode>(
+    context: &mut ExecutionContext<'_, '_, '_>,
     module_bytes: &[Vec<u8>],
 ) -> Result<Vec<CompiledModule>, ExecutionError>
-where
-    &'state S: SuiResolver,
 {
     let modules = module_bytes
         .iter()
@@ -876,13 +857,11 @@ where
     Ok(modules)
 }
 
-fn publish_and_verify_modules<'vm, 'state, 'a, S: StorageView>(
-    context: &mut ExecutionContext<'vm, 'state, 'a, S>,
+fn publish_and_verify_modules(
+    context: &mut ExecutionContext<'_, '_, '_>,
     package_id: ObjectID,
     modules: &[CompiledModule],
 ) -> Result<(), ExecutionError>
-where
-    &'state S: SuiResolver,
 {
     // TODO(https://github.com/MystenLabs/sui/issues/69): avoid this redundant serialization by exposing VM API that allows us to run the linker directly on `Vec<CompiledModule>`
     let new_module_bytes: Vec<_> = modules
@@ -918,13 +897,11 @@ where
     Ok(())
 }
 
-fn init_modules<'vm, 'state, 'a, S: StorageView, Mode: ExecutionMode>(
-    context: &mut ExecutionContext<'vm, 'state, 'a, S>,
+fn init_modules<Mode: ExecutionMode>(
+    context: &mut ExecutionContext<'_, '_, '_>,
     argument_updates: &mut Mode::ArgumentUpdates,
     modules: &[CompiledModule],
 ) -> Result<(), ExecutionError>
-where
-    &'state S: SuiResolver,
 {
     let modules_to_init = modules.iter().filter_map(|module| {
         for fdef in &module.function_defs {
@@ -938,7 +915,7 @@ where
     });
 
     for module_id in modules_to_init {
-        let return_values = execute_move_call::<_, Mode>(
+        let return_values = execute_move_call::<Mode>(
             context,
             argument_updates,
             &module_id,
@@ -996,15 +973,13 @@ struct LoadedFunctionInfo {
 /// - an entry function
 /// - a public function that does not return references
 /// - module init (only internal usage)
-fn check_visibility_and_signature<'vm, 'state, 'a, S: StorageView, Mode: ExecutionMode>(
-    context: &mut ExecutionContext<'vm, 'state, 'a, S>,
+fn check_visibility_and_signature<Mode: ExecutionMode>(
+    context: &mut ExecutionContext<'_, '_, '_>,
     module_id: &ModuleId,
     function: &IdentStr,
     type_arguments: &[Type],
     from_init: bool,
 ) -> Result<LoadedFunctionInfo, ExecutionError>
-where
-    &'state S: SuiResolver,
 {
     if from_init {
         // the session is weird and does not load the module on publishing. This is a temporary
@@ -1085,7 +1060,7 @@ where
             vec![]
         }
         FunctionKind::PrivateEntry | FunctionKind::PublicEntry | FunctionKind::NonEntry => {
-            check_non_entry_signature::<_, Mode>(context, module_id, function, &signature)?
+            check_non_entry_signature::<Mode>(context, module_id, function, &signature)?
         }
     };
     check_private_generics(context, module_id, function, type_arguments)?;
@@ -1125,14 +1100,12 @@ fn subst_signature(
 
 /// Checks that the non-entry function does not return references. And marks the return values
 /// as object or non-object return values
-fn check_non_entry_signature<'vm, 'state, 'a, S: StorageView, Mode: ExecutionMode>(
-    context: &mut ExecutionContext<'vm, 'state, 'a, S>,
+fn check_non_entry_signature<Mode: ExecutionMode>(
+    context: &mut ExecutionContext<'_, '_, '_>,
     _module_id: &ModuleId,
     _function: &IdentStr,
     signature: &LoadedFunctionInstantiation,
 ) -> Result<Vec<ValueKind>, ExecutionError>
-where
-    &'state S: SuiResolver,
 {
     signature
         .return_
@@ -1190,8 +1163,8 @@ where
         .collect()
 }
 
-fn check_private_generics<S: StorageView>(
-    _context: &mut ExecutionContext<S>,
+fn check_private_generics(
+    _context: &mut ExecutionContext,
     module_id: &ModuleId,
     function: &IdentStr,
     _type_arguments: &[Type],
@@ -1231,16 +1204,14 @@ type ArgInfo = (
 
 /// Serializes the arguments into BCS values for Move. Performs the necessary type checking for
 /// each value
-fn build_move_args<'vm, 'state, 'a, S: StorageView, Mode: ExecutionMode>(
-    context: &mut ExecutionContext<'vm, 'state, 'a, S>,
+fn build_move_args<Mode: ExecutionMode>(
+    context: &mut ExecutionContext<'_, '_, '_>,
     module_id: &ModuleId,
     function: &IdentStr,
     function_kind: FunctionKind,
     signature: &LoadedFunctionInstantiation,
     args: &[Argument],
 ) -> Result<ArgInfo, ExecutionError>
-where
-    &'state S: SuiResolver,
 {
     // check the arity
     let parameters = &signature.parameters;
@@ -1332,7 +1303,7 @@ where
                 idx,
             ));
         }
-        check_param_type::<_, Mode>(context, idx, &value, non_ref_param_ty)?;
+        check_param_type::<Mode>(context, idx, &value, non_ref_param_ty)?;
         let bytes = {
             let mut v = vec![];
             value.write_bcs_bytes(&mut v);
@@ -1344,14 +1315,12 @@ where
 }
 
 /// checks that the value is compatible with the specified type
-fn check_param_type<'vm, 'state, 'a, S: StorageView, Mode: ExecutionMode>(
-    context: &mut ExecutionContext<'vm, 'state, 'a, S>,
+fn check_param_type<Mode: ExecutionMode>(
+    context: &mut ExecutionContext<'_, '_, '_>,
     idx: usize,
     value: &Value,
     param_ty: &Type,
 ) -> Result<(), ExecutionError>
-where
-    &'state S: SuiResolver,
 {
     let ty = match value {
         // For dev-spect, allow any BCS bytes. This does mean internal invariants for types can
@@ -1410,12 +1379,10 @@ fn get_struct_ident(s: &StructType) -> (&AccountAddress, &IdentStr, &IdentStr) {
 // Returns Some(kind) if the type is a reference to the TxnContext. kind being Mutable with
 // a MutableReference, and Immutable otherwise.
 // Returns None for all other types
-pub fn is_tx_context<'vm, 'state, 'a, S: StorageView>(
-    context: &mut ExecutionContext<'vm, 'state, 'a, S>,
+pub fn is_tx_context(
+    context: &mut ExecutionContext<'_, '_, '_>,
     t: &Type,
 ) -> Result<TxContextKind, ExecutionError>
-where
-    &'state S: SuiResolver,
 {
     let (is_mut, inner) = match t {
         Type::MutableReference(inner) => (true, inner),
@@ -1442,12 +1409,10 @@ where
 }
 
 /// Returns Some(layout) iff it is a primitive, an ID, a String, or an option/vector of a valid type
-fn primitive_serialization_layout<'vm, 'state, 'a, S: StorageView>(
-    context: &mut ExecutionContext<'vm, 'state, 'a, S>,
+fn primitive_serialization_layout(
+    context: &mut ExecutionContext<'_, '_, '_>,
     param_ty: &Type,
 ) -> Result<Option<PrimitiveArgumentLayout>, ExecutionError>
-where
-    &'state S: SuiResolver,
 {
     Ok(match param_ty {
         Type::Signer => return Ok(None),

--- a/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
+++ b/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
@@ -13,6 +13,7 @@ use move_core_types::value::{MoveStructLayout, MoveTypeLayout};
 use move_vm_runtime::{move_vm::MoveVM, session::Session};
 use sui_types::base_types::ObjectID;
 use sui_types::error::SuiResult;
+use sui_types::execution::TypeLayoutStore;
 use sui_types::object::Object;
 use sui_types::storage::BackingPackageStore;
 use sui_types::{
@@ -24,33 +25,25 @@ use sui_types::{
 /// Retrieve a `MoveStructLayout` from a `Type`.
 /// Invocation into the `Session` to leverage the `LinkageView` implementation
 /// common to the runtime.
-pub struct TypeLayoutResolver<
-    'state,
-    'vm,
-    S: BackingPackageStore + ModuleResolver<Error = SuiError>,
-> {
-    session: Session<'state, 'vm, LinkageView<NullSuiResolver<S>>>,
+pub struct TypeLayoutResolver<'state, 'vm> {
+    session: Session<'state, 'vm, LinkageView<'state>>,
 }
 
 /// Implements SuiResolver traits by providing null implementations for module and resource
-/// resolution and delegating backing package resolution to the wrapped type.
-struct NullSuiResolver<S: BackingPackageStore + ModuleResolver<Error = SuiError>>(S);
+/// resolution and delegating backing package resolution to the trait object.
+struct NullSuiResolver<'state>(Box<dyn TypeLayoutStore + 'state>);
 
-impl<'state, 'vm, S: BackingPackageStore + ModuleResolver<Error = SuiError>>
-    TypeLayoutResolver<'state, 'vm, S>
-{
-    pub fn new(vm: &'vm MoveVM, state_view: S) -> Self {
+impl<'state, 'vm> TypeLayoutResolver<'state, 'vm> {
+    pub fn new(vm: &'vm MoveVM, state_view: Box<dyn TypeLayoutStore + 'state>) -> Self {
         let session = new_session_for_linkage(
             vm,
-            LinkageView::new(NullSuiResolver(state_view), LinkageInfo::Unset),
+            LinkageView::new(Box::new(NullSuiResolver(state_view)), LinkageInfo::Unset),
         );
         Self { session }
     }
 }
 
-impl<'state, 'vm, S: BackingPackageStore + ModuleResolver<Error = SuiError>> LayoutResolver
-    for TypeLayoutResolver<'state, 'vm, S>
-{
+impl<'state, 'vm> LayoutResolver for TypeLayoutResolver<'state, 'vm> {
     fn get_layout(
         &mut self,
         object: &MoveObject,
@@ -77,17 +70,13 @@ impl<'state, 'vm, S: BackingPackageStore + ModuleResolver<Error = SuiError>> Lay
     }
 }
 
-impl<S: BackingPackageStore + ModuleResolver<Error = SuiError>> BackingPackageStore
-    for NullSuiResolver<S>
-{
+impl<'state> BackingPackageStore for NullSuiResolver<'state> {
     fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<Object>> {
         self.0.get_package_object(package_id)
     }
 }
 
-impl<S: BackingPackageStore + ModuleResolver<Error = SuiError>> ModuleResolver
-    for NullSuiResolver<S>
-{
+impl<'state> ModuleResolver for NullSuiResolver<'state> {
     type Error = SuiError;
 
     fn get_module(&self, id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
@@ -95,9 +84,7 @@ impl<S: BackingPackageStore + ModuleResolver<Error = SuiError>> ModuleResolver
     }
 }
 
-impl<S: BackingPackageStore + ModuleResolver<Error = SuiError>> ResourceResolver
-    for NullSuiResolver<S>
-{
+impl<'state> ResourceResolver for NullSuiResolver<'state> {
     type Error = SuiError;
 
     fn get_resource(

--- a/sui-execution/latest/sui-move-natives/Cargo.toml
+++ b/sui-execution/latest/sui-move-natives/Cargo.toml
@@ -17,9 +17,10 @@ fastcrypto-zkp.workspace = true
 fastcrypto.workspace = true
 move-binary-format.workspace = true
 move-core-types.workspace = true
-move-stdlib.workspace = true
-move-vm-runtime.workspace = true
 move-vm-types.workspace = true
+
+move-stdlib = { path = "../../../external-crates/move/move-stdlib" }
+move-vm-runtime = { path = "../../../external-crates/move/move-vm/runtime" }
 
 sui-protocol-config = { path = "../../../crates/sui-protocol-config" }
 sui-types = { path = "../../../crates/sui-types" }

--- a/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
@@ -151,7 +151,7 @@ impl TestInventories {
 
 impl<'a> ObjectRuntime<'a> {
     pub fn new(
-        object_resolver: Box<dyn ChildObjectResolver + 'a>,
+        object_resolver: &'a dyn ChildObjectResolver,
         input_objects: BTreeMap<ObjectID, Owner>,
         is_metered: bool,
         protocol_config: &ProtocolConfig,

--- a/sui-execution/latest/sui-move-natives/src/object_runtime/object_store.rs
+++ b/sui-execution/latest/sui-move-natives/src/object_runtime/object_store.rs
@@ -38,7 +38,7 @@ pub(crate) struct ChildObjectEffect {
 
 struct Inner<'a> {
     // used for loading child objects
-    resolver: Box<dyn ChildObjectResolver + 'a>,
+    resolver: &'a dyn ChildObjectResolver,
     // cached objects from the resolver. An object might be in this map but not in the store
     // if it's existence was queried, but the value was not used.
     cached_objects: BTreeMap<ObjectID, Option<MoveObject>>,
@@ -193,7 +193,7 @@ impl<'a> Inner<'a> {
 
 impl<'a> ObjectStore<'a> {
     pub(super) fn new(
-        resolver: Box<dyn ChildObjectResolver + 'a>,
+        resolver: &'a dyn ChildObjectResolver,
         is_metered: bool,
         constants: LocalProtocolConfig,
         metrics: Arc<LimitsMetrics>,

--- a/sui-execution/latest/sui-verifier/Cargo.toml
+++ b/sui-execution/latest/sui-verifier/Cargo.toml
@@ -10,9 +10,10 @@ publish = false
 [dependencies]
 move-binary-format.workspace = true
 move-bytecode-utils.workspace = true
-move-bytecode-verifier.workspace = true
 move-core-types.workspace = true
 move-vm-config.workspace = true
+
+move-bytecode-verifier = { path = "../../../external-crates/move/move-bytecode-verifier" }
 
 sui-types = { path = "../../../crates/sui-types" }
 workspace-hack = { version = "0.1", path = "../../../crates/workspace-hack" }

--- a/sui-execution/src/executor.rs
+++ b/sui-execution/src/executor.rs
@@ -1,0 +1,96 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::{BTreeSet, HashSet},
+    sync::Arc,
+};
+
+use sui_protocol_config::ProtocolConfig;
+use sui_types::{
+    base_types::{ObjectRef, SuiAddress, TxContext},
+    committee::EpochId,
+    digests::TransactionDigest,
+    effects::TransactionEffects,
+    error::ExecutionError,
+    execution::{ExecutionState, TypeLayoutStore},
+    execution_mode::ExecutionResult,
+    gas::SuiGasStatus,
+    metrics::LimitsMetrics,
+    temporary_store::{InnerTemporaryStore, TemporaryStore},
+    transaction::{ProgrammableTransaction, TransactionKind},
+    type_resolver::LayoutResolver,
+};
+
+/// Abstracts over access to the VM across versions of the execution layer.
+pub trait Executor {
+    fn execute_transaction_to_effects(
+        &self,
+        // Configuration
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+        enable_expensive_checks: bool,
+        certificate_deny_set: &HashSet<TransactionDigest>,
+        // Epoch
+        epoch_id: &EpochId,
+        epoch_timestamp_ms: u64,
+        // Transaction Inputs
+        temporary_store: TemporaryStore,
+        shared_object_refs: Vec<ObjectRef>,
+        gas_status: SuiGasStatus,
+        gas: &[ObjectRef],
+        // Transaction
+        transaction_kind: TransactionKind,
+        transaction_signer: SuiAddress,
+        transaction_digest: TransactionDigest,
+        transaction_dependencies: BTreeSet<TransactionDigest>,
+    ) -> (
+        InnerTemporaryStore,
+        TransactionEffects,
+        Result<(), ExecutionError>,
+    );
+
+    fn dev_inspect_transaction(
+        &self,
+        // Configuration
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+        enable_expensive_checks: bool,
+        certificate_deny_set: &HashSet<TransactionDigest>,
+        // Epoch
+        epoch_id: &EpochId,
+        epoch_timestamp_ms: u64,
+        // Transaction Inputs
+        temporary_store: TemporaryStore,
+        shared_object_refs: Vec<ObjectRef>,
+        gas_status: SuiGasStatus,
+        gas: &[ObjectRef],
+        // Transaction
+        transaction_kind: TransactionKind,
+        transaction_signer: SuiAddress,
+        transaction_digest: TransactionDigest,
+        transaction_dependencies: BTreeSet<TransactionDigest>,
+    ) -> (
+        InnerTemporaryStore,
+        TransactionEffects,
+        Result<Vec<ExecutionResult>, ExecutionError>,
+    );
+
+    fn update_genesis_state(
+        &self,
+        // Configuration
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+        // Genesis State
+        state_view: &mut dyn ExecutionState,
+        tx_context: &mut TxContext,
+        gas_status: &mut SuiGasStatus,
+        // Transaction
+        pt: ProgrammableTransaction,
+    ) -> Result<(), ExecutionError>;
+
+    fn type_layout_resolver<'r, 'vm: 'r, 'store: 'r>(
+        &'vm self,
+        store: Box<dyn TypeLayoutStore + 'store>,
+    ) -> Box<dyn LayoutResolver + 'r>;
+}

--- a/sui-execution/src/latest.rs
+++ b/sui-execution/src/latest.rs
@@ -1,0 +1,158 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::{BTreeSet, HashSet},
+    sync::Arc,
+};
+
+use sui_protocol_config::ProtocolConfig;
+use sui_types::{
+    base_types::{ObjectRef, SuiAddress, TxContext},
+    committee::EpochId,
+    digests::TransactionDigest,
+    effects::TransactionEffects,
+    error::{ExecutionError, SuiError},
+    execution::{ExecutionState, TypeLayoutStore},
+    execution_mode::{self, ExecutionResult},
+    gas::SuiGasStatus,
+    metrics::LimitsMetrics,
+    temporary_store::{InnerTemporaryStore, TemporaryStore},
+    transaction::{ProgrammableTransaction, TransactionKind},
+    type_resolver::LayoutResolver,
+};
+
+use move_vm_runtime_latest::move_vm::MoveVM;
+use sui_adapter_latest::adapter::new_move_vm;
+use sui_adapter_latest::execution_engine::execute_transaction_to_effects;
+use sui_adapter_latest::programmable_transactions;
+use sui_adapter_latest::type_layout_resolver::TypeLayoutResolver;
+use sui_move_natives_latest::all_natives;
+
+use crate::executor::Executor;
+
+pub(crate) struct VM(Arc<MoveVM>);
+
+impl VM {
+    pub(crate) fn new(
+        protocol_config: &ProtocolConfig,
+        paranoid_type_checks: bool,
+        silent: bool,
+    ) -> Result<Self, SuiError> {
+        Ok(VM(Arc::new(new_move_vm(
+            all_natives(silent),
+            protocol_config,
+            paranoid_type_checks,
+        )?)))
+    }
+}
+
+impl Executor for VM {
+    fn execute_transaction_to_effects(
+        &self,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+        enable_expensive_checks: bool,
+        certificate_deny_set: &HashSet<TransactionDigest>,
+        epoch_id: &EpochId,
+        epoch_timestamp_ms: u64,
+        temporary_store: TemporaryStore,
+        shared_object_refs: Vec<ObjectRef>,
+        gas_status: SuiGasStatus,
+        gas: &[ObjectRef],
+        transaction_kind: TransactionKind,
+        transaction_signer: SuiAddress,
+        transaction_digest: TransactionDigest,
+        transaction_dependencies: BTreeSet<TransactionDigest>,
+    ) -> (
+        InnerTemporaryStore,
+        TransactionEffects,
+        Result<(), ExecutionError>,
+    ) {
+        execute_transaction_to_effects::<execution_mode::Normal>(
+            shared_object_refs,
+            temporary_store,
+            transaction_kind,
+            transaction_signer,
+            gas,
+            transaction_digest,
+            transaction_dependencies,
+            &self.0,
+            gas_status,
+            epoch_id,
+            epoch_timestamp_ms,
+            protocol_config,
+            metrics,
+            enable_expensive_checks,
+            certificate_deny_set,
+        )
+    }
+
+    fn dev_inspect_transaction(
+        &self,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+        enable_expensive_checks: bool,
+        certificate_deny_set: &HashSet<TransactionDigest>,
+        epoch_id: &EpochId,
+        epoch_timestamp_ms: u64,
+        temporary_store: TemporaryStore,
+        shared_object_refs: Vec<ObjectRef>,
+        gas_status: SuiGasStatus,
+        gas: &[ObjectRef],
+        transaction_kind: TransactionKind,
+        transaction_signer: SuiAddress,
+        transaction_digest: TransactionDigest,
+        transaction_dependencies: BTreeSet<TransactionDigest>,
+    ) -> (
+        InnerTemporaryStore,
+        TransactionEffects,
+        Result<Vec<ExecutionResult>, ExecutionError>,
+    ) {
+        execute_transaction_to_effects::<execution_mode::DevInspect>(
+            shared_object_refs,
+            temporary_store,
+            transaction_kind,
+            transaction_signer,
+            gas,
+            transaction_digest,
+            transaction_dependencies,
+            &self.0,
+            gas_status,
+            epoch_id,
+            epoch_timestamp_ms,
+            protocol_config,
+            metrics,
+            enable_expensive_checks,
+            certificate_deny_set,
+        )
+    }
+
+    fn update_genesis_state(
+        &self,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+        state_view: &mut dyn ExecutionState,
+        tx_context: &mut TxContext,
+        gas_status: &mut SuiGasStatus,
+        pt: ProgrammableTransaction,
+    ) -> Result<(), ExecutionError> {
+        programmable_transactions::execution::execute::<execution_mode::Genesis>(
+            protocol_config,
+            metrics,
+            &self.0,
+            state_view,
+            tx_context,
+            gas_status,
+            None,
+            pt,
+        )
+    }
+
+    fn type_layout_resolver<'r, 'vm: 'r, 'store: 'r>(
+        &'vm self,
+        store: Box<dyn TypeLayoutStore + 'store>,
+    ) -> Box<dyn LayoutResolver + 'r> {
+        Box::new(TypeLayoutResolver::new(&self.0, store))
+    }
+}

--- a/sui-execution/src/lib.rs
+++ b/sui-execution/src/lib.rs
@@ -1,0 +1,23 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+pub use executor::Executor;
+use sui_protocol_config::ProtocolConfig;
+use sui_types::error::SuiError;
+
+pub mod executor;
+pub mod latest;
+
+pub fn executor(
+    protocol_config: &ProtocolConfig,
+    paranoid_type_checks: bool,
+    silent: bool,
+) -> Result<Arc<dyn Executor + Send + Sync>, SuiError> {
+    Ok(Arc::new(latest::VM::new(
+        protocol_config,
+        paranoid_type_checks,
+        silent,
+    )?))
+}


### PR DESCRIPTION
## Description

This will be the uniform interface through which requests are made to the MoveVM within nodes.  It allows us to easily bundle multiple versions of the VM, adapter, natives and verifier into node software, and switch between them according to protocol config.

### Dynamic Interfaces

This change requires making previously static generics into trait objects, or shifting where the dynamism/ownership lies.

- Access to execution will be via the new `Executor` trait object.
- `TemporaryStore`'s access to the backing store (now via the `BackingStore` grouping trait).
- `ObjectRuntime` previously took a `Box<dyn ChildObjectResolver>`, now it's just a `&dyn ChildObjectResolver`.
- Execution engine's access to the store (now via the `ExecutionState` grouping trait).
- Type layout resolver's access to modules/packages etc (now via the `TypeLayoutStore` grouping trait).
- `LinkageView`'s access to the sui resolver traits is now via a trait object.

Some of these traits group multiple other traits, so extra functions have been added to do explicit conversion (e.g. from the vtable for an `A + B` trait object to the vtable for an `A` or a `B` trait object).

### Other Changes

- `InMemoryStorage::new` returns `Arc`
- Don't save native functions in `ExecutionComponents` -- create fresh, each time (hides native function related types in execution layer)
- Re-order function parameters for execution functions (only in newly introduced execution layer, will push this change down into execution implementations in a follow-up PR) to group together similar parameters.
-  genesis-related crates fully ported over to execution crate.
- `sui-replay` fully ported over to execution crate.
- De-nested implementation of `get_object_read` and `get_past_object_read` on `AuthorityState`.
- `sui-move/src/unit_test` creates a lazy `TEST_STORE` instead of relying on the `ObjectRuntime` to keep the store alive.
- `sui-replay`'s `LocalExec` implementation of all the various backing store traits return `SuiError` instead of `LocalExecError` (now that we use dynamic dispatch, the error type needs to be standardised).
- `get_package_objects` and `get_packages` helper functions on `BackingPackageStore` were previously default implemented trait functions, but they have turned into free functions.  This is because they are lifetime generic, and this interfered with the ability to use this trait (or any trait derived from it) as the basis of a trait object.
- Removed `temporary_store::empty_for_testing` and `::with_input_objects_for_testing` as unused, rather than port them (which would have been complicated and messy).
- Replaced `execute_transaction_to_effects` with `execute_transaction_to_effects_impl`, to avoid doubling up the number of functions in the new `Executor` interface.

## Test Plan

```
sui$ cargo simtest
sui$ env SUI_SKIP_SIMTESTS=1 cargo nextest run
```

Also manually test replay tool on a recent transaction digest:

```
sui/crates/sui-tool$ cargo run replay --rpc https://fullnode.testnet.sui.io:443 tx -t <digest>
```