### PR TITLE
authority: inject google jwk bytes global value

### DIFF
--- a/crates/sui-e2e-tests/tests/full_node_tests.rs
+++ b/crates/sui-e2e-tests/tests/full_node_tests.rs
@@ -840,6 +840,7 @@ async fn test_validator_node_has_no_transaction_orchestrator() {
     assert!(node
         .subscribe_to_transaction_orchestrator_effects()
         .is_err());
+    assert!(node.get_google_jwk_bytes().is_ok());
 }
 
 #[sim_test]

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -20,10 +20,12 @@ use arc_swap::ArcSwap;
 use futures::TryFutureExt;
 use mysten_common::sync::async_once_cell::AsyncOnceCell;
 use prometheus::Registry;
+use reqwest::Client;
 use sui_core::authority::CHAIN_IDENTIFIER;
 use sui_core::consensus_adapter::LazyNarwhalClient;
 use sui_json_rpc::api::JsonRpcMetrics;
 use sui_types::digests::ChainIdentifier;
+use sui_types::message_envelope::get_google_jwk_bytes;
 use sui_types::sui_system_state::SuiSystemState;
 use tap::tap::TapFallible;
 use tokio::runtime::Handle;
@@ -179,6 +181,46 @@ impl SuiNode {
         Ok(node_one_cell.get().await)
     }
 
+    fn start_jwk_updater() {
+        info!("Starting JWK updater thread for authority");
+        tokio::task::spawn(async move {
+            loop {
+                // Update the JWK value in the authority server
+                let res = Self::update_google_jwk().await;
+                if let Err(e) = res {
+                    warn!("Error when fetching JWK {:?}", e);
+                }
+                // Sleep for 1 hour
+                tokio::time::sleep(Duration::from_secs(3600)).await;
+            }
+        });
+    }
+
+    async fn update_google_jwk() -> Result<(), SuiError> {
+        if cfg!(msim) {
+            return Ok(());
+        }
+
+        let client = Client::new();
+        let response = client
+            .get("https://www.googleapis.com/oauth2/v2/certs")
+            .send()
+            .await
+            .map_err(|_| SuiError::JWKRetrievalError)?;
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|_| SuiError::JWKRetrievalError)?;
+        let jwk = get_google_jwk_bytes();
+        if let Ok(mut jwk) = jwk.write() {
+            if jwk.to_vec() != bytes.to_vec() {
+                *jwk = bytes.to_vec();
+                info!("New JWK value updated");
+            }
+        }
+        Ok(())
+    }
+
     pub async fn start_async(
         config: &NodeConfig,
         registry_service: RegistryService,
@@ -186,7 +228,7 @@ impl SuiNode {
         custom_rpc_runtime: Option<Handle>,
     ) -> Result<()> {
         NodeConfigMetrics::new(&registry_service.default_registry()).record_metrics(config);
-
+        Self::start_jwk_updater();
         let mut config = config.clone();
         if config.supported_protocol_versions.is_none() {
             info!(
@@ -971,6 +1013,13 @@ impl SuiNode {
         &self,
     ) -> Option<Arc<TransactiondOrchestrator<NetworkAuthorityClient>>> {
         self.transaction_orchestrator.clone()
+    }
+
+    pub fn get_google_jwk_bytes(&self) -> Result<Vec<u8>, SuiError> {
+        Ok(get_google_jwk_bytes()
+            .read()
+            .map_err(|_| SuiError::JWKRetrievalError)?
+            .to_vec())
     }
 
     pub fn subscribe_to_transaction_orchestrator_effects(

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -63,6 +63,7 @@ use std::fmt;
 use std::str::FromStr;
 
 #[cfg(test)]
+#[cfg(feature = "test-utils")]
 #[path = "unit_tests/base_types_tests.rs"]
 mod base_types_tests;
 

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -55,6 +55,7 @@ use tracing::warn;
 mod crypto_tests;
 
 #[cfg(test)]
+#[cfg(feature = "test-utils")]
 #[path = "unit_tests/intent_tests.rs"]
 mod intent_tests;
 

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -553,6 +553,9 @@ pub enum SuiError {
 
     #[error("Failed to perform file operation: {0}")]
     FileIOError(String),
+
+    #[error("Failed to get JWK")]
+    JWKRetrievalError,
 }
 
 #[repr(u64)]

--- a/crates/sui-types/src/message_envelope.rs
+++ b/crates/sui-types/src/message_envelope.rs
@@ -17,8 +17,39 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use shared_crypto::intent::{Intent, IntentScope};
 use std::fmt::{Debug, Display, Formatter};
 use std::ops::{Deref, DerefMut};
+use std::sync::Arc;
+use std::sync::RwLock;
 use sui_protocol_config::ProtocolConfig;
 
+pub static GOOGLE_JWK_BYTES: OnceCell<Arc<RwLock<Vec<u8>>>> = OnceCell::new();
+
+pub fn get_google_jwk_bytes() -> Arc<RwLock<Vec<u8>>> {
+    GOOGLE_JWK_BYTES
+        .get_or_init(|| {
+            Arc::new(RwLock::new(
+                r#"{
+                    "keys": [
+                      {
+                        "n": "0NDRXWtH6_HnmuSuTAisgYVZ3Z67PQjHbRFz4XNYuD95BKx0wQr0GWOi_UCGLfI0col3i6J3_AF-b1YrTFTMEr_bL8CYDdK2CYLcGUzc5bLRDAySsqnKdlhWkneqfFdr3J66mHu11KUaIIRWiLsCkR9QFF-8o2PtZzv3F-3Uh7L4q7i_Evs1s7SJlO0OAnI4ew4rP2HbRaO0Q2zK0DL_d1eoAC72apQuEzz-2aXfQ-QYSTlVK74McBhP1MRtgD6zGF2lwg4uhgb55fDDQQh0VHWQSxwbvAL0Oox69zzpkFgpjJAJUqaxegzETU1jf3iKs1vyFIB0C4N-Jr__zwLQZw==",
+                        "alg": "RS256",
+                        "kty": "RSA",
+                        "kid": "2d9a5ef5b12623c91671a7093cb323333cd07d09",
+                        "e": "AQAB",
+                        "use": "sig"
+                      },
+                      {
+                        "kid": "6083dd5981673f661fde9dae646b6f0380a0145c",
+                        "alg": "RS256",
+                        "e": "AQAB",
+                        "use": "sig",
+                        "kty": "RSA",
+                        "n": "1qrQCTst3RF04aMC9Ye_kGbsE0sftL4FOtB_WrzBDOFdrfVwLfflQuPX5kJ-0iYv9r2mjD5YIDy8b-iJKwevb69ISeoOrmL3tj6MStJesbbRRLVyFIm_6L7alHhZVyqHQtMKX7IaNndrfebnLReGntuNk76XCFxBBnRaIzAWnzr3WN4UPBt84A0KF74pei17dlqHZJ2HB2CsYbE9Ort8m7Vf6hwxYzFtCvMCnZil0fCtk2OQ73l6egcvYO65DkAJibFsC9xAgZaF-9GYRlSjMPd0SMQ8yU9i3W7beT00Xw6C0FYA9JAYaGaOvbT87l_6ZkAksOMuvIPD_jNVfTCPLQ=="
+                      }
+                    ]
+                  }"#.as_bytes().to_vec()
+            ))
+        }).clone()
+}
 pub trait Message {
     type DigestType: Clone + Debug;
     const SCOPE: IntentScope;

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -564,6 +564,7 @@ impl VerifiedCheckpointContents {
 }
 
 #[cfg(test)]
+#[cfg(feature = "test-utils")]
 mod tests {
     use fastcrypto::traits::KeyPair;
     use rand::prelude::StdRng;

--- a/crates/sui-types/src/multisig.rs
+++ b/crates/sui-types/src/multisig.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     crypto::{CompressedSignature, DefaultHash, SignatureScheme},
-    signature::AuthenticatorTrait,
+    signature::{AuthenticatorTrait, AuxVerifyData},
     sui_serde::SuiBitmap,
 };
 pub use enum_dispatch::enum_dispatch;
@@ -99,6 +99,7 @@ impl AuthenticatorTrait for MultiSig {
         &self,
         value: &IntentMessage<T>,
         author: SuiAddress,
+        _aux_verify_data: AuxVerifyData,
     ) -> Result<(), SuiError>
     where
         T: Serialize,

--- a/crates/sui-types/src/signature.rs
+++ b/crates/sui-types/src/signature.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::committee::EpochId;
 use crate::crypto::{SignatureScheme, SuiSignature};
 use crate::{base_types::SuiAddress, crypto::Signature, error::SuiError, multisig::MultiSig};
 pub use enum_dispatch::enum_dispatch;
@@ -12,7 +13,20 @@ use schemars::JsonSchema;
 use serde::Serialize;
 use shared_crypto::intent::IntentMessage;
 use std::hash::Hash;
+#[derive(Default, Debug, Clone)]
+pub struct AuxVerifyData {
+    pub epoch: Option<EpochId>,
+    pub google_jwk_as_bytes: Option<Vec<u8>>,
+}
 
+impl AuxVerifyData {
+    pub fn new(epoch: Option<EpochId>, google_jwk_as_bytes: Option<Vec<u8>>) -> Self {
+        Self {
+            epoch,
+            google_jwk_as_bytes,
+        }
+    }
+}
 /// A lightweight trait that all members of [enum GenericSignature] implement.
 #[enum_dispatch]
 pub trait AuthenticatorTrait {
@@ -20,6 +34,7 @@ pub trait AuthenticatorTrait {
         &self,
         value: &IntentMessage<T>,
         author: SuiAddress,
+        aux_verify_data: AuxVerifyData,
     ) -> Result<(), SuiError>
     where
         T: Serialize;
@@ -110,6 +125,7 @@ impl AuthenticatorTrait for Signature {
         &self,
         value: &IntentMessage<T>,
         author: SuiAddress,
+        _aux_verify_data: AuxVerifyData,
     ) -> Result<(), SuiError>
     where
         T: Serialize,

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -10,12 +10,14 @@ use crate::crypto::{
     ToFromBytes,
 };
 use crate::digests::{CertificateDigest, SenderSignedDataDigest};
-use crate::message_envelope::{Envelope, Message, TrustedEnvelope, VerifiedEnvelope};
+use crate::message_envelope::{
+    get_google_jwk_bytes, Envelope, Message, TrustedEnvelope, VerifiedEnvelope,
+};
 use crate::messages_checkpoint::CheckpointTimestamp;
 use crate::messages_consensus::ConsensusCommitPrologue;
 use crate::object::{MoveObject, Object, Owner};
 use crate::programmable_transaction_builder::ProgrammableTransactionBuilder;
-use crate::signature::{AuthenticatorTrait, GenericSignature};
+use crate::signature::{AuthenticatorTrait, AuxVerifyData, GenericSignature};
 use crate::{
     SUI_CLOCK_OBJECT_ID, SUI_CLOCK_OBJECT_SHARED_VERSION, SUI_FRAMEWORK_PACKAGE_ID,
     SUI_SYSTEM_STATE_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
@@ -57,6 +59,7 @@ pub const DEFAULT_VALIDATOR_GAS_PRICE: u64 = 1000;
 const BLOCKED_MOVE_FUNCTIONS: [(ObjectID, &str, &str); 0] = [];
 
 #[cfg(test)]
+#[cfg(feature = "test-utils")]
 #[path = "unit_tests/messages_tests.rs"]
 mod messages_tests;
 
@@ -1733,7 +1736,7 @@ impl Message for SenderSignedData {
         TransactionDigest::new(default_hash(&self.intent_message().value))
     }
 
-    fn verify(&self, _sig_epoch: Option<EpochId>) -> SuiResult {
+    fn verify(&self, sig_epoch: Option<EpochId>) -> SuiResult {
         fp_ensure!(
             self.0.len() == 1,
             SuiError::UserInputError {
@@ -1768,7 +1771,14 @@ impl Message for SenderSignedData {
 
         // Verify all present signatures.
         for (signer, signature) in present_sigs {
-            signature.verify_secure_generic(self.intent_message(), signer)?;
+            signature.verify_secure_generic(
+                self.intent_message(),
+                signer,
+                AuxVerifyData::new(
+                    sig_epoch,
+                    Some(get_google_jwk_bytes().read().unwrap().clone()),
+                ),
+            )?;
         }
         Ok(())
     }


### PR DESCRIPTION
## Description 

store google jwk as a global value for envelope to access during sig verify. spawn a task in sui node to update it every 1 hour. 

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
