### PR TITLE
[wallet-ext] - invalidate kiosk query after transfer

### DIFF
--- a/apps/wallet/src/ui/app/pages/home/nft-transfer/TransferNFTForm.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nft-transfer/TransferNFTForm.tsx
@@ -93,6 +93,7 @@ export function TransferNFTForm({
         },
         onSuccess: (response) => {
             queryClient.invalidateQueries(['object', objectId]);
+            queryClient.invalidateQueries(['originbyte-kiosk-contents']);
             queryClient.invalidateQueries(['get-owned-objects']);
             return navigate(
                 `/receipt?${new URLSearchParams({


### PR DESCRIPTION
## Description 

Didn't catch this in testing, if you hit the cache at the wrong time a Kiosk NFT will stick around the NFT page. This adds an invalidation after successful transfer. 

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
