### PR TITLE
refactor coin_api for unit tests around error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3085,9 +3085,9 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "expect-test"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d4661aca38d826eb7c72fe128e4238220616de4c0cc00db7bfc38e2e1364dd3"
+checksum = "30d9eafeadd538e68fb28016364c9732d78e420b9ff8853fa5e4058861e9f8d3"
 dependencies = [
  "dissimilar",
  "once_cell",
@@ -9905,6 +9905,7 @@ dependencies = [
  "async-trait",
  "bcs",
  "cached",
+ "expect-test",
  "eyre",
  "fastcrypto",
  "futures",

--- a/crates/sui-json-rpc-types/src/sui_coin.rs
+++ b/crates/sui-json-rpc-types/src/sui_coin.rs
@@ -56,7 +56,7 @@ impl Coin {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct SuiCoinMetadata {
     /// Number of decimal places the coin uses.

--- a/crates/sui-json-rpc-types/src/sui_coin.rs
+++ b/crates/sui-json-rpc-types/src/sui_coin.rs
@@ -35,7 +35,7 @@ pub struct Balance {
 }
 
 #[serde_as]
-#[derive(Serialize, Deserialize, Debug, JsonSchema, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Coin {
     pub coin_type: String,

--- a/crates/sui-json-rpc/Cargo.toml
+++ b/crates/sui-json-rpc/Cargo.toml
@@ -62,3 +62,4 @@ sui-macros.workspace = true
 sui-simulator.workspace = true
 reqwest.workspace = true
 mockall.workspace = true
+expect-test.workspace = true

--- a/crates/sui-json-rpc/Cargo.toml
+++ b/crates/sui-json-rpc/Cargo.toml
@@ -51,7 +51,6 @@ shared-crypto.workspace = true
 typed-store.workspace = true
 cached.workspace = true
 
-
 [dev-dependencies]
 sui-config.workspace = true
 sui-keys.workspace = true

--- a/crates/sui-json-rpc/Cargo.toml
+++ b/crates/sui-json-rpc/Cargo.toml
@@ -51,6 +51,7 @@ shared-crypto.workspace = true
 typed-store.workspace = true
 cached.workspace = true
 
+
 [dev-dependencies]
 sui-config.workspace = true
 sui-keys.workspace = true

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -885,7 +885,7 @@ mod tests {
             let error_result = response.unwrap_err();
             let error_object: ErrorObjectOwned = error_result.into();
             assert!(error_object.code() == -32000);
-            assert!(error_object.message() == "Type error while binding function arguments: \"Unable to deserialize TreasuryCap object: RemainingInput\".");
+            assert!(error_object.message() == "Failure deserializing object in the requested format: \"Unable to deserialize TreasuryCap object: remaining input\"");
         }
     }
 }

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -615,6 +615,7 @@ mod tests {
 
         #[tokio::test]
         async fn test_get_coins_iterator_typed_store_error() {
+            // Validate that we handle and return an error message when we encounter an unexpected error
             let owner = get_test_owner();
             let coin_type = get_test_coin_type(get_test_package_id());
             let mut mock_state = MockState::new();
@@ -750,6 +751,7 @@ mod tests {
 
         #[tokio::test]
         async fn test_get_balance_execution_error() {
+            // Validate that we handle and return an error message when we encounter an unexpected error
             let owner = get_test_owner();
             let coin_type = get_test_coin_type(get_test_package_id());
             let mut mock_state = MockState::new();

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -9,6 +10,9 @@ use cached::SizedCache;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::RpcModule;
 use move_core_types::language_storage::{StructTag, TypeTag};
+use sui_storage::indexes::TotalBalance;
+use sui_types::digests::TransactionDigest;
+use sui_types::transaction::VerifiedTransaction;
 use tracing::{debug, info, instrument};
 
 use mysten_metrics::spawn_monitored_task;
@@ -19,118 +23,29 @@ use sui_open_rpc::Module;
 use sui_types::balance::Supply;
 use sui_types::base_types::{ObjectID, SuiAddress};
 use sui_types::coin::{CoinMetadata, TreasuryCap};
-use sui_types::effects::TransactionEffectsAPI;
-use sui_types::error::SuiError;
+use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
+use sui_types::error::{SuiError, SuiResult};
 use sui_types::gas_coin::GAS;
-use sui_types::object::Object;
+use sui_types::object::{Object, ObjectRead};
 use sui_types::parse_sui_struct_tag;
 
 use crate::api::{cap_page_limit, CoinReadApiServer, JsonRpcMetrics};
-use crate::error::{Error, SuiRpcInputError};
+use crate::error::{Error, SuiApiResult, SuiRpcInputError};
 use crate::{with_tracing, SuiRpcModule};
 
+#[cfg(test)]
+use mockall::automock;
+
 pub struct CoinReadApi {
-    state: Arc<AuthorityState>,
-    pub metrics: Arc<JsonRpcMetrics>,
+    internal: Arc<dyn CoinReadInternalTrait + Send + Sync>,
 }
 
 impl CoinReadApi {
     pub fn new(state: Arc<AuthorityState>, metrics: Arc<JsonRpcMetrics>) -> Self {
-        Self { state, metrics }
-    }
-
-    async fn get_coins_iterator(
-        &self,
-        owner: SuiAddress,
-        cursor: (String, ObjectID),
-        limit: Option<usize>,
-        one_coin_type_only: bool,
-    ) -> Result<CoinPage, Error> {
-        let limit = cap_page_limit(limit);
-        self.metrics.get_coins_limit.report(limit as u64);
-        let state = self.state.clone();
-
-        let mut data = spawn_monitored_task!(async move {
-            Ok::<_, SuiError>(
-                state
-                    .get_owned_coins_iterator_with_cursor(
-                        owner,
-                        cursor,
-                        limit + 1,
-                        one_coin_type_only,
-                    )?
-                    .map(|(coin_type, coin_object_id, coin)| SuiCoin {
-                        coin_type,
-                        coin_object_id,
-                        version: coin.version,
-                        digest: coin.digest,
-                        balance: coin.balance,
-                        previous_transaction: coin.previous_transaction,
-                    })
-                    .collect::<Vec<_>>(),
-            )
-        })
-        .await??;
-
-        let has_next_page = data.len() > limit;
-        data.truncate(limit);
-
-        self.metrics.get_coins_result_size.report(data.len() as u64);
-        self.metrics
-            .get_coins_result_size_total
-            .inc_by(data.len() as u64);
-        let next_cursor = data.last().map(|coin| coin.coin_object_id);
-        Ok(CoinPage {
-            data,
-            next_cursor,
-            has_next_page,
-        })
-    }
-
-    async fn find_package_object(
-        &self,
-        package_id: &ObjectID,
-        object_struct_tag: StructTag,
-    ) -> Result<Object, Error> {
-        let object_id =
-            find_package_object_id(self.state.clone(), *package_id, object_struct_tag).await?;
-        Ok(self.state.get_object_read(&object_id)?.into_object()?)
-    }
-}
-
-#[cached(
-    type = "SizedCache<String, ObjectID>",
-    create = "{ SizedCache::with_size(10000) }",
-    convert = r#"{ format!("{}{}", package_id, object_struct_tag) }"#,
-    result = true
-)]
-async fn find_package_object_id(
-    state: Arc<AuthorityState>,
-    package_id: ObjectID,
-    object_struct_tag: StructTag,
-) -> Result<ObjectID, Error> {
-    spawn_monitored_task!(async move {
-        let publish_txn_digest = state.find_publish_txn_digest(package_id)?;
-
-        let (_, effect) = state
-            .get_executed_transaction_and_effects(publish_txn_digest)
-            .await?;
-
-        for ((id, _, _), _) in effect.created() {
-            if let Ok(object_read) = state.get_object_read(id) {
-                if let Ok(object) = object_read.into_object() {
-                    if matches!(object.type_(), Some(type_) if type_.is(&object_struct_tag)) {
-                        return Ok(*id);
-                    }
-                }
-            }
+        Self {
+            internal: Arc::new(CoinReadInternalService::new(state, metrics)),
         }
-        Err(Error::UnexpectedError(format!(
-            "Cannot find object [{}] from [{}] package event.",
-            object_struct_tag, package_id,
-        )))
-    })
-    .await?
+    }
 }
 
 impl SuiRpcModule for CoinReadApi {
@@ -156,7 +71,12 @@ impl CoinReadApiServer for CoinReadApi {
     ) -> RpcResult<CoinPage> {
         with_tracing!(async move {
             let coin_type_tag = TypeTag::Struct(Box::new(match coin_type {
-                Some(c) => parse_sui_struct_tag(&c)?,
+                Some(c) => parse_sui_struct_tag(&c).map_err(|_| {
+                    Error::SuiRpcInputError(
+                        // todo: clean up parse_sui_struct_tag to return actionable errors
+                        SuiRpcInputError::CannotParseSuiStructTag(c),
+                    )
+                })?,
                 None => GAS::type_(),
             }));
 
@@ -167,6 +87,7 @@ impl CoinReadApiServer for CoinReadApi {
             };
 
             let coins = self
+                .internal
                 .get_coins_iterator(
                     owner, cursor, limit, true, // only care about one type of coin
                 )
@@ -188,7 +109,8 @@ impl CoinReadApiServer for CoinReadApi {
             let cursor = match cursor {
                 Some(object_id) => {
                     let obj = self
-                        .state
+                        .internal
+                        .get_state()
                         .get_object(&object_id)
                         .await
                         .map_err(Error::from)?;
@@ -215,6 +137,7 @@ impl CoinReadApiServer for CoinReadApi {
             }?;
 
             let coins = self
+                .internal
                 .get_coins_iterator(
                     owner, cursor, limit, false, // return all types of coins
                 )
@@ -232,14 +155,14 @@ impl CoinReadApiServer for CoinReadApi {
     ) -> RpcResult<Balance> {
         with_tracing!(async move {
             let coin_type = TypeTag::Struct(Box::new(match coin_type {
-                Some(c) => parse_sui_struct_tag(&c)?,
+                Some(c) => parse_sui_struct_tag(&c).map_err(|_| {
+                    Error::SuiRpcInputError(SuiRpcInputError::CannotParseSuiStructTag(c))
+                })?,
                 None => GAS::type_(),
             }));
             let balance = self
-                .state
-                .indexes
-                .as_ref()
-                .ok_or(Error::SuiError(SuiError::IndexStoreNotAvailable))?
+                .internal
+                .get_state()
                 .get_balance(owner, coin_type.clone())
                 .await
                 .map_err(|e: SuiError| {
@@ -260,10 +183,8 @@ impl CoinReadApiServer for CoinReadApi {
     async fn get_all_balances(&self, owner: SuiAddress) -> RpcResult<Vec<Balance>> {
         with_tracing!(async move {
             let all_balance = self
-                .state
-                .indexes
-                .as_ref()
-                .ok_or(Error::SuiError(SuiError::IndexStoreNotAvailable))?
+                .internal
+                .get_state()
                 .get_all_balance(owner)
                 .await
                 .map_err(|e: SuiError| {
@@ -288,41 +209,683 @@ impl CoinReadApiServer for CoinReadApi {
     #[instrument(skip(self))]
     async fn get_coin_metadata(&self, coin_type: String) -> RpcResult<Option<SuiCoinMetadata>> {
         with_tracing!(async move {
-            let coin_struct = parse_sui_struct_tag(&coin_type)?;
-
-            let metadata_object = self
-                .find_package_object(
-                    &coin_struct.address.into(),
-                    CoinMetadata::type_(coin_struct),
-                )
-                .await
-                .ok();
-
-            Ok(metadata_object.and_then(|v: Object| v.try_into().ok()))
+            let coin_struct = parse_sui_struct_tag(&coin_type).map_err(|_| {
+                Error::SuiRpcInputError(SuiRpcInputError::CannotParseSuiStructTag(coin_type))
+            })?;
+            Ok(self.internal.get_coin_metadata(coin_struct).await?)
         })
     }
 
     #[instrument(skip(self))]
     async fn get_total_supply(&self, coin_type: String) -> RpcResult<Supply> {
         with_tracing!(async move {
-            let coin_struct = parse_sui_struct_tag(&coin_type)?;
+            let coin_struct = parse_sui_struct_tag(&coin_type).map_err(|_| {
+                Error::SuiRpcInputError(SuiRpcInputError::CannotParseSuiStructTag(coin_type))
+            })?;
 
             Ok(if GAS::is_gas(&coin_struct) {
                 Supply { value: 0 }
             } else {
-                let treasury_cap_object = self
-                    .find_package_object(
-                        &coin_struct.address.into(),
-                        TreasuryCap::type_(coin_struct),
-                    )
-                    .await?;
-
-                let treasury_cap = TreasuryCap::from_bcs_bytes(
-                    treasury_cap_object.data.try_as_move().unwrap().contents(),
-                )
-                .map_err(Error::from)?;
+                let treasury_cap = self.internal.get_treasury_cap(coin_struct).await?;
                 treasury_cap.total_supply
             })
         })
+    }
+}
+
+#[cfg_attr(test, automock)]
+#[async_trait]
+pub trait StateServiceWrapper {
+    fn get_object_read(&self, object_id: &ObjectID) -> SuiResult<ObjectRead>;
+    async fn get_object(&self, object_id: &ObjectID) -> SuiResult<Option<Object>>;
+    fn find_publish_txn_digest(&self, package_id: ObjectID) -> SuiResult<TransactionDigest>;
+    async fn find_package_object(
+        &self,
+        package_id: &ObjectID,
+        object_struct_tag: StructTag,
+    ) -> SuiApiResult<Object>;
+    fn get_owned_coins(
+        &self,
+        owner: SuiAddress,
+        // If `Some`, the query will start from the next item after the specified cursor
+        cursor: (String, ObjectID),
+        limit: usize,
+        one_coin_type_only: bool,
+    ) -> SuiResult<Vec<SuiCoin>>;
+    async fn get_executed_transaction_and_effects(
+        &self,
+        digest: TransactionDigest,
+    ) -> SuiResult<(VerifiedTransaction, TransactionEffects)>;
+    async fn get_balance(&self, owner: SuiAddress, coin_type: TypeTag) -> SuiResult<TotalBalance>;
+    async fn get_all_balance(
+        &self,
+        owner: SuiAddress,
+    ) -> SuiResult<Arc<HashMap<TypeTag, TotalBalance>>>;
+}
+
+pub struct AuthorityStateWrapper {
+    state: Arc<AuthorityState>,
+}
+
+impl AuthorityStateWrapper {
+    pub fn new(state: Arc<AuthorityState>) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl StateServiceWrapper for AuthorityStateWrapper {
+    fn get_object_read(&self, object_id: &ObjectID) -> SuiResult<ObjectRead> {
+        self.state.get_object_read(object_id)
+    }
+
+    async fn get_object(&self, object_id: &ObjectID) -> SuiResult<Option<Object>> {
+        self.state.get_object(object_id).await
+    }
+
+    fn find_publish_txn_digest(&self, package_id: ObjectID) -> SuiResult<TransactionDigest> {
+        self.state.find_publish_txn_digest(package_id)
+    }
+
+    async fn find_package_object(
+        &self,
+        package_id: &ObjectID,
+        object_struct_tag: StructTag,
+    ) -> SuiApiResult<Object> {
+        let object_id =
+            find_package_object_id(self.state.clone(), *package_id, object_struct_tag).await?;
+        Ok(self.get_object_read(&object_id)?.into_object()?)
+    }
+
+    fn get_owned_coins(
+        &self,
+        owner: SuiAddress,
+        cursor: (String, ObjectID),
+        limit: usize,
+        one_coin_type_only: bool,
+    ) -> SuiResult<Vec<SuiCoin>> {
+        Ok(self
+            .state
+            .get_owned_coins_iterator_with_cursor(owner, cursor, limit, one_coin_type_only)?
+            .map(|(coin_type, coin_object_id, coin)| SuiCoin {
+                coin_type,
+                coin_object_id,
+                version: coin.version,
+                digest: coin.digest,
+                balance: coin.balance,
+                previous_transaction: coin.previous_transaction,
+            })
+            .collect::<Vec<_>>())
+    }
+
+    async fn get_executed_transaction_and_effects(
+        &self,
+        digest: TransactionDigest,
+    ) -> SuiResult<(VerifiedTransaction, TransactionEffects)> {
+        self.state
+            .get_executed_transaction_and_effects(digest)
+            .await
+    }
+
+    async fn get_balance(&self, owner: SuiAddress, coin_type: TypeTag) -> SuiResult<TotalBalance> {
+        self.state
+            .indexes
+            .as_ref()
+            .ok_or(SuiError::IndexStoreNotAvailable)?
+            .get_balance(owner, coin_type)
+            .await
+    }
+
+    async fn get_all_balance(
+        &self,
+        owner: SuiAddress,
+    ) -> SuiResult<Arc<HashMap<TypeTag, TotalBalance>>> {
+        self.state
+            .indexes
+            .as_ref()
+            .ok_or(SuiError::IndexStoreNotAvailable)?
+            .get_all_balance(owner)
+            .await
+    }
+}
+
+#[cached(
+    type = "SizedCache<String, ObjectID>",
+    create = "{ SizedCache::with_size(10000) }",
+    convert = r#"{ format!("{}{}", package_id, object_struct_tag) }"#,
+    result = true
+)]
+async fn find_package_object_id(
+    state: Arc<AuthorityState>,
+    package_id: ObjectID,
+    object_struct_tag: StructTag,
+) -> SuiApiResult<ObjectID> {
+    spawn_monitored_task!(async move {
+        let publish_txn_digest = state.find_publish_txn_digest(package_id)?;
+
+        let (_, effect) = state
+            .get_executed_transaction_and_effects(publish_txn_digest)
+            .await?;
+
+        for ((id, _, _), _) in effect.created() {
+            if let Ok(object_read) = state.get_object_read(id) {
+                if let Ok(object) = object_read.into_object() {
+                    if matches!(object.type_(), Some(type_) if type_.is(&object_struct_tag)) {
+                        return Ok(*id);
+                    }
+                }
+            }
+        }
+        Err(SuiRpcInputError::GenericNotFound(format!(
+            "Cannot find object [{}] from [{}] package event.",
+            object_struct_tag, package_id,
+        ))
+        .into())
+    })
+    .await?
+}
+
+#[cfg_attr(test, automock)]
+#[async_trait]
+pub trait CoinReadInternalTrait {
+    fn get_state(&self) -> Arc<dyn StateServiceWrapper + Send + Sync>;
+    async fn get_coins_iterator(
+        &self,
+        owner: SuiAddress,
+        cursor: (String, ObjectID),
+        limit: Option<usize>,
+        one_coin_type_only: bool,
+    ) -> SuiApiResult<CoinPage>;
+    async fn get_coin_metadata(
+        &self,
+        coin_struct: StructTag,
+    ) -> SuiApiResult<Option<SuiCoinMetadata>>;
+    async fn get_treasury_cap(&self, coin_struct: StructTag) -> SuiApiResult<TreasuryCap>;
+}
+
+pub struct CoinReadInternalService {
+    state: Arc<dyn StateServiceWrapper + Send + Sync>,
+    pub metrics: Arc<JsonRpcMetrics>,
+}
+
+impl CoinReadInternalService {
+    pub fn new(state: Arc<AuthorityState>, metrics: Arc<JsonRpcMetrics>) -> Self {
+        Self {
+            state: Arc::new(AuthorityStateWrapper::new(state)),
+            metrics,
+        }
+    }
+}
+
+#[async_trait]
+impl CoinReadInternalTrait for CoinReadInternalService {
+    fn get_state(&self) -> Arc<dyn StateServiceWrapper + Send + Sync> {
+        self.state.clone()
+    }
+
+    async fn get_coins_iterator(
+        &self,
+        owner: SuiAddress,
+        cursor: (String, ObjectID),
+        limit: Option<usize>,
+        one_coin_type_only: bool,
+    ) -> SuiApiResult<CoinPage> {
+        let limit = cap_page_limit(limit);
+        self.metrics.get_coins_limit.report(limit as u64);
+
+        // This is needed for spawn_monitored_task
+        let state = self.get_state();
+        let mut data = spawn_monitored_task!(async move {
+            state.get_owned_coins(owner, cursor, limit + 1, one_coin_type_only)
+        })
+        .await??;
+
+        let has_next_page = data.len() > limit;
+        data.truncate(limit);
+
+        self.metrics.get_coins_result_size.report(data.len() as u64);
+        self.metrics
+            .get_coins_result_size_total
+            .inc_by(data.len() as u64);
+        let next_cursor = data.last().map(|coin| coin.coin_object_id);
+        Ok(CoinPage {
+            data,
+            next_cursor,
+            has_next_page,
+        })
+    }
+
+    async fn get_coin_metadata(
+        &self,
+        coin_struct: StructTag,
+    ) -> SuiApiResult<Option<SuiCoinMetadata>> {
+        let metadata_object = self
+            .state
+            .find_package_object(
+                &coin_struct.address.into(),
+                CoinMetadata::type_(coin_struct),
+            )
+            .await
+            .ok();
+        Ok(metadata_object.and_then(|v: Object| v.try_into().ok()))
+    }
+
+    async fn get_treasury_cap(&self, coin_struct: StructTag) -> SuiApiResult<TreasuryCap> {
+        let treasury_cap_object = self
+            .state
+            .find_package_object(&coin_struct.address.into(), TreasuryCap::type_(coin_struct))
+            .await?;
+
+        Ok(TreasuryCap::from_bcs_bytes(
+            treasury_cap_object.data.try_as_move().unwrap().contents(),
+        )?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use jsonrpsee::types::ErrorObjectOwned;
+    use move_core_types::language_storage::StructTag;
+    use sui_types::balance::Supply;
+    use sui_types::base_types::{ObjectID, SuiAddress};
+    use sui_types::coin::TreasuryCap;
+    use sui_types::id::UID;
+    use sui_types::object::Object;
+    use sui_types::parse_sui_struct_tag;
+
+    fn get_test_owner() -> SuiAddress {
+        SuiAddress::random_for_testing_only()
+    }
+
+    fn get_test_package_id() -> ObjectID {
+        ObjectID::random()
+    }
+
+    fn get_test_coin_type(package_id: ObjectID) -> String {
+        format!("{}::test_coin::TEST_COIN", package_id)
+    }
+
+    fn get_test_treasury_cap_peripherals(
+        package_id: ObjectID,
+    ) -> (String, StructTag, StructTag, TreasuryCap, Object) {
+        let coin_name = get_test_coin_type(package_id);
+        let input_coin_struct = parse_sui_struct_tag(&coin_name).expect("should not fail");
+        let treasury_cap_struct = TreasuryCap::type_(input_coin_struct.clone());
+        let treasury_cap = TreasuryCap {
+            id: UID::new(ObjectID::random()),
+            total_supply: Supply { value: 420 },
+        };
+        let treasury_cap_object =
+            Object::treasury_cap_for_testing(input_coin_struct.clone(), treasury_cap.clone());
+        (
+            coin_name,
+            input_coin_struct,
+            treasury_cap_struct,
+            treasury_cap,
+            treasury_cap_object,
+        )
+    }
+
+    mod get_coins_tests {
+        use super::super::*;
+        use super::*;
+        use jsonrpsee::types::ErrorObjectOwned;
+        use typed_store::TypedStoreError;
+
+        #[tokio::test]
+        async fn test_invalid_coin_type() {
+            let owner = get_test_owner();
+            let coin_type = "0x2::invalid::struct::tag";
+            let mock_internal = MockCoinReadInternalTrait::new();
+            let coin_read_api = CoinReadApi {
+                internal: Arc::new(mock_internal),
+            };
+
+            let response = coin_read_api
+                .get_coins(owner, Some(coin_type.to_string()), None, None)
+                .await;
+
+            assert!(response.is_err());
+            let error_result = response.unwrap_err();
+            let error_object: ErrorObjectOwned = error_result.into();
+            assert_eq!(error_object.code(), -32602);
+            assert_eq!(
+                error_object.message(),
+                "Invalid struct type: 0x2::invalid::struct::tag"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_get_coins_iterator_index_store_not_available() {
+            let owner = get_test_owner();
+            let coin_type = get_test_coin_type(get_test_package_id());
+            let mut mock_state = MockStateServiceWrapper::new();
+            mock_state
+                .expect_get_owned_coins()
+                .returning(move |_, _, _, _| Err(SuiError::IndexStoreNotAvailable));
+            let internal = CoinReadInternalService {
+                state: Arc::new(mock_state),
+                metrics: Arc::new(JsonRpcMetrics::new_for_tests()),
+            };
+            let coin_read_api = CoinReadApi {
+                internal: Arc::new(internal),
+            };
+
+            let response = coin_read_api
+                .get_coins(owner, Some(coin_type.to_string()), None, None)
+                .await;
+
+            assert!(response.is_err());
+            let error_result = response.unwrap_err();
+            let error_object: ErrorObjectOwned = error_result.into();
+
+            assert_eq!(error_object.code(), -32000);
+            assert_eq!(
+                error_object.message(),
+                "Index store not available on this Fullnode."
+            );
+        }
+
+        #[tokio::test]
+        async fn test_get_coins_iterator_typed_store_error() {
+            let owner = get_test_owner();
+            let coin_type = get_test_coin_type(get_test_package_id());
+            let mut mock_state = MockStateServiceWrapper::new();
+            mock_state
+                .expect_get_owned_coins()
+                .returning(move |_, _, _, _| {
+                    Err(TypedStoreError::RocksDBError("mock rocksdb error".to_string()).into())
+                });
+            let internal = CoinReadInternalService {
+                state: Arc::new(mock_state),
+                metrics: Arc::new(JsonRpcMetrics::new_for_tests()),
+            };
+            let coin_read_api = CoinReadApi {
+                internal: Arc::new(internal),
+            };
+
+            let response = coin_read_api
+                .get_coins(owner, Some(coin_type.to_string()), None, None)
+                .await;
+
+            assert!(response.is_err());
+            let error_result = response.unwrap_err();
+            let error_object: ErrorObjectOwned = error_result.into();
+
+            assert_eq!(error_object.code(), -32000);
+            assert_eq!(error_object.message(), "Storage error");
+        }
+    }
+
+    mod get_all_coins_tests {
+        use super::super::*;
+        use super::*;
+
+        #[tokio::test]
+        async fn test_object_is_not_coin() {
+            let owner = get_test_owner();
+            let object_id = get_test_package_id();
+            let (_, _, _, _, treasury_cap_object) = get_test_treasury_cap_peripherals(object_id);
+            let mut mock_state = MockStateServiceWrapper::new();
+            mock_state.expect_get_object().returning(move |obj_id| {
+                if obj_id == &object_id {
+                    Ok(Some(treasury_cap_object.clone()))
+                } else {
+                    panic!("should not be called with any other object id")
+                }
+            });
+            let internal = CoinReadInternalService {
+                state: Arc::new(mock_state),
+                metrics: Arc::new(JsonRpcMetrics::new_for_tests()),
+            };
+            let coin_read_api = CoinReadApi {
+                internal: Arc::new(internal),
+            };
+
+            let response = coin_read_api
+                .get_all_coins(owner, Some(object_id), None)
+                .await;
+
+            assert!(response.is_err());
+            let error_result = response.unwrap_err();
+            let error_object: ErrorObjectOwned = error_result.into();
+            assert_eq!(error_object.code(), -32602);
+            assert_eq!(
+                error_object.message(),
+                format!("Invalid Cursor {:?}, Object is not a coin", object_id)
+            );
+        }
+
+        #[tokio::test]
+        async fn test_object_not_found() {
+            let owner = get_test_owner();
+            let object_id = ObjectID::random();
+            let mut mock_state = MockStateServiceWrapper::new();
+            mock_state.expect_get_object().returning(move |_| Ok(None));
+
+            let internal = CoinReadInternalService {
+                state: Arc::new(mock_state),
+                metrics: Arc::new(JsonRpcMetrics::new_for_tests()),
+            };
+
+            let coin_read_api = CoinReadApi {
+                internal: Arc::new(internal),
+            };
+
+            let response = coin_read_api
+                .get_all_coins(owner, Some(object_id), None)
+                .await;
+
+            assert!(response.is_err());
+            let error_result = response.unwrap_err();
+            let error_object: ErrorObjectOwned = error_result.into();
+            assert_eq!(error_object.code(), -32602);
+            assert_eq!(
+                error_object.message(),
+                format!("Invalid Cursor {:?}, Object not found", object_id)
+            );
+        }
+    }
+
+    mod get_balance_tests {
+        use super::super::*;
+        use super::*;
+        use jsonrpsee::types::ErrorObjectOwned;
+
+        #[tokio::test]
+        async fn test_get_balance_index_store_not_available() {
+            let owner = get_test_owner();
+            let coin_type = get_test_coin_type(get_test_package_id());
+            let mut mock_state = MockStateServiceWrapper::new();
+            mock_state
+                .expect_get_balance()
+                .returning(move |_, _| Err(SuiError::IndexStoreNotAvailable));
+            let internal = CoinReadInternalService {
+                state: Arc::new(mock_state),
+                metrics: Arc::new(JsonRpcMetrics::new_for_tests()),
+            };
+            let coin_read_api = CoinReadApi {
+                internal: Arc::new(internal),
+            };
+
+            let response = coin_read_api
+                .get_balance(owner, Some(coin_type.to_string()))
+                .await;
+
+            assert!(response.is_err());
+            let error_result = response.unwrap_err();
+            let error_object: ErrorObjectOwned = error_result.into();
+            assert_eq!(error_object.code(), -32000);
+            assert_eq!(
+                error_object.message(),
+                "Index store not available on this Fullnode."
+            );
+        }
+
+        #[tokio::test]
+        async fn test_get_balance_execution_error() {
+            let owner = get_test_owner();
+            let coin_type = get_test_coin_type(get_test_package_id());
+            let mut mock_state = MockStateServiceWrapper::new();
+            mock_state
+                .expect_get_balance()
+                .returning(move |_, _| Err(SuiError::ExecutionError("mock db error".to_string())));
+            let internal = CoinReadInternalService {
+                state: Arc::new(mock_state),
+                metrics: Arc::new(JsonRpcMetrics::new_for_tests()),
+            };
+            let coin_read_api = CoinReadApi {
+                internal: Arc::new(internal),
+            };
+
+            let response = coin_read_api
+                .get_balance(owner, Some(coin_type.to_string()))
+                .await;
+
+            assert!(response.is_err());
+            let error_result = response.unwrap_err();
+            let error_object: ErrorObjectOwned = error_result.into();
+
+            assert_eq!(error_object.code(), -32000);
+            assert_eq!(error_object.message(), "Error executing mock db error");
+        }
+    }
+
+    mod get_coin_metadata_tests {
+        use super::super::*;
+        use super::*;
+        use mockall::predicate;
+        use sui_types::id::UID;
+
+        #[tokio::test]
+        async fn test_find_package_object_not_sui_coin_metadata() {
+            let package_id = get_test_package_id();
+            let coin_name = get_test_coin_type(package_id);
+            let input_coin_struct = parse_sui_struct_tag(&coin_name).expect("should not fail");
+            let coin_metadata_struct = CoinMetadata::type_(input_coin_struct.clone());
+            let treasury_cap = TreasuryCap {
+                id: UID::new(ObjectID::random()),
+                total_supply: Supply { value: 420 },
+            };
+            let treasury_cap_object =
+                Object::treasury_cap_for_testing(input_coin_struct.clone(), treasury_cap);
+            let mut mock_state = MockStateServiceWrapper::new();
+            // return TreasuryCap instead of CoinMetadata to set up test
+            mock_state
+                .expect_find_package_object()
+                .with(predicate::always(), predicate::eq(coin_metadata_struct))
+                .returning(move |object_id, _| {
+                    if object_id == &package_id {
+                        Ok(treasury_cap_object.clone())
+                    } else {
+                        panic!("should not be called with any other object id")
+                    }
+                });
+            let internal = CoinReadInternalService {
+                state: Arc::new(mock_state),
+                metrics: Arc::new(JsonRpcMetrics::new_for_tests()),
+            };
+            let coin_read_api = CoinReadApi {
+                internal: Arc::new(internal),
+            };
+
+            let response = coin_read_api.get_coin_metadata(coin_name.clone()).await;
+            assert!(response.is_ok());
+            let result = response.unwrap();
+            assert!(result.is_none());
+        }
+    }
+
+    mod get_total_supply_tests {
+        use super::super::*;
+        use super::*;
+        use mockall::predicate;
+        use sui_types::id::UID;
+
+        #[tokio::test]
+        async fn test_success_response_for_gas_coin() {
+            let coin_type = "0x2::sui::SUI";
+            let mock_internal = MockCoinReadInternalTrait::new();
+            let coin_read_api = CoinReadApi {
+                internal: Arc::new(mock_internal),
+            };
+
+            let response = coin_read_api.get_total_supply(coin_type.to_string()).await;
+
+            let supply = response.unwrap();
+            assert_eq!(supply.value, 0);
+        }
+
+        #[tokio::test]
+        async fn test_success_response_for_other_coin() {
+            let package_id = get_test_package_id();
+            let (coin_name, _, treasury_cap_struct, _, treasury_cap_object) =
+                get_test_treasury_cap_peripherals(package_id);
+            let mut mock_state = MockStateServiceWrapper::new();
+            mock_state
+                .expect_find_package_object()
+                .with(predicate::always(), predicate::eq(treasury_cap_struct))
+                .returning(move |object_id, _| {
+                    if object_id == &package_id {
+                        Ok(treasury_cap_object.clone())
+                    } else {
+                        panic!("should not be called with any other object id")
+                    }
+                });
+            let internal = CoinReadInternalService {
+                state: Arc::new(mock_state),
+                metrics: Arc::new(JsonRpcMetrics::new_for_tests()),
+            };
+            let coin_read_api = CoinReadApi {
+                internal: Arc::new(internal),
+            };
+
+            let response = coin_read_api.get_total_supply(coin_name.clone()).await;
+
+            assert!(response.is_ok());
+            let result = response.unwrap();
+            assert_eq!(result.value, 420);
+        }
+
+        #[tokio::test]
+        async fn test_find_package_object_not_treasury_cap() {
+            let package_id = get_test_package_id();
+            let (coin_name, input_coin_struct, treasury_cap_struct, _, _) =
+                get_test_treasury_cap_peripherals(package_id);
+            let coin_metadata = CoinMetadata {
+                id: UID::new(ObjectID::random()),
+                decimals: 2,
+                name: "test_coin".to_string(),
+                symbol: "TEST".to_string(),
+                description: "test coin".to_string(),
+                icon_url: None,
+            };
+            let coin_metadata_object =
+                Object::coin_metadata_for_testing(input_coin_struct.clone(), coin_metadata);
+            let mut mock_state = MockStateServiceWrapper::new();
+            mock_state
+                .expect_find_package_object()
+                .with(predicate::always(), predicate::eq(treasury_cap_struct))
+                .returning(move |object_id, _| {
+                    if object_id == &package_id {
+                        Ok(coin_metadata_object.clone())
+                    } else {
+                        panic!("should not be called with any other object id")
+                    }
+                });
+            let internal = CoinReadInternalService {
+                state: Arc::new(mock_state),
+                metrics: Arc::new(JsonRpcMetrics::new_for_tests()),
+            };
+            let coin_read_api = CoinReadApi {
+                internal: Arc::new(internal),
+            };
+
+            let response = coin_read_api.get_total_supply(coin_name.clone()).await;
+            let error_result = response.unwrap_err();
+            let error_object: ErrorObjectOwned = error_result.into();
+            assert!(error_object.code() == -32000);
+            assert!(error_object.message() == "Type error while binding function arguments: \"Unable to deserialize TreasuryCap object: RemainingInput\".");
+        }
     }
 }

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -120,14 +120,14 @@ impl CoinReadApiServer for CoinReadApi {
                             let coin_type = obj.coin_type_maybe();
                             if coin_type.is_none() {
                                 Err(Error::SuiRpcInputError(SuiRpcInputError::GenericInvalid(
-                                    format!("Invalid Cursor {:?}, Object is not a coin", object_id),
+                                    "cursor is not a coin".to_string(),
                                 )))
                             } else {
                                 Ok((coin_type.unwrap().to_string(), object_id))
                             }
                         }
                         None => Err(Error::SuiRpcInputError(SuiRpcInputError::GenericInvalid(
-                            format!("Invalid Cursor {:?}, Object not found", object_id),
+                            "cursor not found".to_string(),
                         ))),
                     }
                 }
@@ -490,6 +490,7 @@ impl CoinReadInternal for CoinReadInternalImpl {
 
 #[cfg(test)]
 mod tests {
+    use expect_test::expect;
     use jsonrpsee::types::ErrorObjectOwned;
     use move_core_types::language_storage::StructTag;
     use sui_types::balance::Supply;
@@ -554,11 +555,10 @@ mod tests {
             assert!(response.is_err());
             let error_result = response.unwrap_err();
             let error_object: ErrorObjectOwned = error_result.into();
-            assert_eq!(error_object.code(), -32602);
-            assert_eq!(
-                error_object.message(),
-                "Invalid struct type: 0x2::invalid::struct::tag. Got error: Expected end of token stream. Got: ::"
-            );
+            let expected = expect!["-32602"];
+            expected.assert_eq(&error_object.code().to_string());
+            let expected = expect!["Invalid struct type: 0x2::invalid::struct::tag. Got error: Expected end of token stream. Got: ::"];
+            expected.assert_eq(error_object.message());
         }
 
         #[tokio::test]
@@ -577,11 +577,11 @@ mod tests {
             assert!(response.is_err());
             let error_result = response.unwrap_err();
             let error_object: ErrorObjectOwned = error_result.into();
-            assert_eq!(error_object.code(), -32602);
-            assert_eq!(
-                error_object.message(),
-                "Invalid struct type: 0x2::sui:🤵. Got error: unrecognized token: :🤵"
-            );
+            let expected = expect!["-32602"];
+            expected.assert_eq(&error_object.code().to_string());
+            let expected =
+                expect!["Invalid struct type: 0x2::sui:🤵. Got error: unrecognized token: :🤵"];
+            expected.assert_eq(error_object.message());
         }
 
         #[tokio::test]
@@ -607,12 +607,10 @@ mod tests {
             assert!(response.is_err());
             let error_result = response.unwrap_err();
             let error_object: ErrorObjectOwned = error_result.into();
-
-            assert_eq!(error_object.code(), -32000);
-            assert_eq!(
-                error_object.message(),
-                "Index store not available on this Fullnode."
-            );
+            let expected = expect!["-32000"];
+            expected.assert_eq(&error_object.code().to_string());
+            let expected = expect!["Index store not available on this Fullnode."];
+            expected.assert_eq(error_object.message());
         }
 
         #[tokio::test]
@@ -640,9 +638,10 @@ mod tests {
             assert!(response.is_err());
             let error_result = response.unwrap_err();
             let error_object: ErrorObjectOwned = error_result.into();
-
-            assert_eq!(error_object.code(), -32000);
-            assert_eq!(error_object.message(), "Storage error");
+            let expected = expect!["-32000"];
+            expected.assert_eq(&error_object.code().to_string());
+            let expected = expect!["Storage error"];
+            expected.assert_eq(error_object.message());
         }
     }
 
@@ -679,10 +678,10 @@ mod tests {
             let error_result = response.unwrap_err();
             let error_object: ErrorObjectOwned = error_result.into();
             assert_eq!(error_object.code(), -32602);
-            assert_eq!(
-                error_object.message(),
-                format!("Invalid Cursor {:?}, Object is not a coin", object_id)
-            );
+            let expected = expect!["-32602"];
+            expected.assert_eq(&error_object.code().to_string());
+            let expected = expect!["cursor is not a coin"];
+            expected.assert_eq(error_object.message());
         }
 
         #[tokio::test]
@@ -708,11 +707,10 @@ mod tests {
             assert!(response.is_err());
             let error_result = response.unwrap_err();
             let error_object: ErrorObjectOwned = error_result.into();
-            assert_eq!(error_object.code(), -32602);
-            assert_eq!(
-                error_object.message(),
-                format!("Invalid Cursor {:?}, Object not found", object_id)
-            );
+            let expected = expect!["-32602"];
+            expected.assert_eq(&error_object.code().to_string());
+            let expected = expect!["cursor not found"];
+            expected.assert_eq(error_object.message());
         }
     }
 
@@ -744,11 +742,10 @@ mod tests {
             assert!(response.is_err());
             let error_result = response.unwrap_err();
             let error_object: ErrorObjectOwned = error_result.into();
-            assert_eq!(error_object.code(), -32000);
-            assert_eq!(
-                error_object.message(),
-                "Index store not available on this Fullnode."
-            );
+            let expected = expect!["-32000"];
+            expected.assert_eq(&error_object.code().to_string());
+            let expected = expect!["Index store not available on this Fullnode."];
+            expected.assert_eq(error_object.message());
         }
 
         #[tokio::test]
@@ -775,8 +772,10 @@ mod tests {
             let error_result = response.unwrap_err();
             let error_object: ErrorObjectOwned = error_result.into();
 
-            assert_eq!(error_object.code(), -32000);
-            assert_eq!(error_object.message(), "Error executing mock db error");
+            let expected = expect!["-32000"];
+            expected.assert_eq(&error_object.code().to_string());
+            let expected = expect!["Error executing mock db error"];
+            expected.assert_eq(error_object.message());
         }
     }
 
@@ -842,7 +841,8 @@ mod tests {
             let response = coin_read_api.get_total_supply(coin_type.to_string()).await;
 
             let supply = response.unwrap();
-            assert_eq!(supply.value, 0);
+            let expected = expect!["0"];
+            expected.assert_eq(&supply.value.to_string());
         }
 
         #[tokio::test]
@@ -873,7 +873,8 @@ mod tests {
 
             assert!(response.is_ok());
             let result = response.unwrap();
-            assert_eq!(result.value, 420);
+            let expected = expect!["420"];
+            expected.assert_eq(&result.value.to_string());
         }
 
         #[tokio::test]
@@ -913,8 +914,10 @@ mod tests {
             let response = coin_read_api.get_total_supply(coin_name.clone()).await;
             let error_result = response.unwrap_err();
             let error_object: ErrorObjectOwned = error_result.into();
-            assert!(error_object.code() == -32000);
-            assert!(error_object.message() == "Failure deserializing object in the requested format: \"Unable to deserialize TreasuryCap object: remaining input\"");
+            let expected = expect!["-32000"];
+            expected.assert_eq(&error_object.code().to_string());
+            let expected = expect!["Failure deserializing object in the requested format: \"Unable to deserialize TreasuryCap object: remaining input\""];
+            expected.assert_eq(error_object.message());
         }
     }
 }

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -556,6 +556,29 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn test_unrecognized_token() {
+            let owner = get_test_owner();
+            let coin_type = "0x2::sui:🤵";
+            let mock_internal = MockCoinReadInternalTrait::new();
+            let coin_read_api = CoinReadApi {
+                internal: Arc::new(mock_internal),
+            };
+
+            let response = coin_read_api
+                .get_coins(owner, Some(coin_type.to_string()), None, None)
+                .await;
+
+            assert!(response.is_err());
+            let error_result = response.unwrap_err();
+            let error_object: ErrorObjectOwned = error_result.into();
+            assert_eq!(error_object.code(), -32602);
+            assert_eq!(
+                error_object.message(),
+                "Invalid struct type: 0x2::sui:🤵. Got error: unrecognized token: :🤵"
+            );
+        }
+
+        #[tokio::test]
         async fn test_get_coins_iterator_index_store_not_available() {
             let owner = get_test_owner();
             let coin_type = get_test_coin_type(get_test_package_id());

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -71,10 +71,10 @@ impl CoinReadApiServer for CoinReadApi {
     ) -> RpcResult<CoinPage> {
         with_tracing!(async move {
             let coin_type_tag = TypeTag::Struct(Box::new(match coin_type {
-                Some(c) => parse_sui_struct_tag(&c).map_err(|_| {
+                Some(c) => parse_sui_struct_tag(&c).map_err(|e| {
                     Error::SuiRpcInputError(
                         // todo: clean up parse_sui_struct_tag to return actionable errors
-                        SuiRpcInputError::CannotParseSuiStructTag(c),
+                        SuiRpcInputError::CannotParseSuiStructTag(format!("{e}")),
                     )
                 })?,
                 None => GAS::type_(),
@@ -551,7 +551,7 @@ mod tests {
             assert_eq!(error_object.code(), -32602);
             assert_eq!(
                 error_object.message(),
-                "Invalid struct type: 0x2::invalid::struct::tag"
+                "Invalid struct type: 0x2::invalid::struct::tag. Got error: Expected end of token stream. Got: ::"
             );
         }
 

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -37,7 +37,7 @@ use crate::{with_tracing, SuiRpcModule};
 use mockall::automock;
 
 pub struct CoinReadApi {
-    internal: Arc<dyn CoinReadInternalTrait + Send + Sync>,
+    internal: Arc<dyn CoinReadInternal + Send + Sync>,
 }
 
 impl CoinReadApi {
@@ -386,7 +386,7 @@ async fn find_package_object_id(
 
 #[cfg_attr(test, automock)]
 #[async_trait]
-pub trait CoinReadInternalTrait {
+pub trait CoinReadInternal {
     fn get_state(&self) -> Arc<dyn StateServiceWrapper + Send + Sync>;
     async fn get_coins_iterator(
         &self,
@@ -417,7 +417,7 @@ impl CoinReadInternalService {
 }
 
 #[async_trait]
-impl CoinReadInternalTrait for CoinReadInternalService {
+impl CoinReadInternal for CoinReadInternalService {
     fn get_state(&self) -> Arc<dyn StateServiceWrapper + Send + Sync> {
         self.state.clone()
     }
@@ -535,7 +535,7 @@ mod tests {
         async fn test_invalid_coin_type() {
             let owner = get_test_owner();
             let coin_type = "0x2::invalid::struct::tag";
-            let mock_internal = MockCoinReadInternalTrait::new();
+            let mock_internal = MockCoinReadInternal::new();
             let coin_read_api = CoinReadApi {
                 internal: Arc::new(mock_internal),
             };
@@ -558,7 +558,7 @@ mod tests {
         async fn test_unrecognized_token() {
             let owner = get_test_owner();
             let coin_type = "0x2::sui:🤵";
-            let mock_internal = MockCoinReadInternalTrait::new();
+            let mock_internal = MockCoinReadInternal::new();
             let coin_read_api = CoinReadApi {
                 internal: Arc::new(mock_internal),
             };
@@ -827,7 +827,7 @@ mod tests {
         #[tokio::test]
         async fn test_success_response_for_gas_coin() {
             let coin_type = "0x2::sui::SUI";
-            let mock_internal = MockCoinReadInternalTrait::new();
+            let mock_internal = MockCoinReadInternal::new();
             let coin_read_api = CoinReadApi {
                 internal: Arc::new(mock_internal),
             };

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -995,8 +995,6 @@ mod tests {
             let expected = expect!["cursor not found"];
             expected.assert_eq(error_object.message());
         }
-
-        // Unexpected error scenarios
     }
 
     mod get_balance_tests {

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -247,7 +247,6 @@ pub trait StateServiceWrapper {
     fn get_owned_coins(
         &self,
         owner: SuiAddress,
-        // If `Some`, the query will start from the next item after the specified cursor
         cursor: (String, ObjectID),
         limit: usize,
         one_coin_type_only: bool,

--- a/crates/sui-json-rpc/src/error.rs
+++ b/crates/sui-json-rpc/src/error.rs
@@ -11,7 +11,7 @@ use sui_types::quorum_driver_types::QuorumDriverError;
 use thiserror::Error;
 use tokio::task::JoinError;
 
-pub type SuiApiResult<T = ()> = Result<T, Error>;
+pub type RpcInterimResult<T = ()> = Result<T, Error>;
 
 #[derive(Debug, Error)]
 pub enum Error {

--- a/crates/sui-json-rpc/src/error.rs
+++ b/crates/sui-json-rpc/src/error.rs
@@ -115,6 +115,6 @@ pub enum SuiRpcInputError {
     #[error("Unable to serialize: {0}")]
     CannotSerialize(#[from] bcs::Error),
 
-    #[error("Invalid struct type: {0}")]
+    #[error("{0}")]
     CannotParseSuiStructTag(String),
 }

--- a/crates/sui-json-rpc/src/error.rs
+++ b/crates/sui-json-rpc/src/error.rs
@@ -87,9 +87,6 @@ impl Error {
                 }
                 _ => RpcError::Call(CallError::Failed(err.into())),
             },
-            // such as with JoinError, perhaps this should just be a generic, "Internal server error"
-            // but only after we've mapped out everything
-            // so joinerror should explicitly be mapped for now
             _ => RpcError::Call(CallError::Failed(self.into())),
         }
     }

--- a/crates/sui-json-rpc/src/error.rs
+++ b/crates/sui-json-rpc/src/error.rs
@@ -11,6 +11,8 @@ use sui_types::quorum_driver_types::QuorumDriverError;
 use thiserror::Error;
 use tokio::task::JoinError;
 
+pub type SuiApiResult<T = ()> = Result<T, Error>;
+
 #[derive(Debug, Error)]
 pub enum Error {
     #[error(transparent)]
@@ -85,6 +87,9 @@ impl Error {
                 }
                 _ => RpcError::Call(CallError::Failed(err.into())),
             },
+            // such as with JoinError, perhaps this should just be a generic, "Internal server error"
+            // but only after we've mapped out everything
+            // so joinerror should explicitly be mapped for now
             _ => RpcError::Call(CallError::Failed(self.into())),
         }
     }
@@ -112,4 +117,7 @@ pub enum SuiRpcInputError {
 
     #[error("Unable to serialize: {0}")]
     CannotSerialize(#[from] bcs::Error),
+
+    #[error("Invalid struct type: {0}")]
+    CannotParseSuiStructTag(String),
 }

--- a/crates/sui-types/src/coin.rs
+++ b/crates/sui-types/src/coin.rs
@@ -151,8 +151,8 @@ pub struct TreasuryCap {
 impl TreasuryCap {
     /// Create a TreasuryCap from BCS bytes
     pub fn from_bcs_bytes(content: &[u8]) -> Result<Self, SuiError> {
-        bcs::from_bytes(content).map_err(|err| SuiError::TypeError {
-            error: format!("Unable to deserialize TreasuryCap object: {:?}", err),
+        bcs::from_bytes(content).map_err(|err| SuiError::ObjectDeserializationError {
+            error: format!("Unable to deserialize TreasuryCap object: {}", err),
         })
     }
 
@@ -207,8 +207,8 @@ impl CoinMetadata {
 
     /// Create a coin from BCS bytes
     pub fn from_bcs_bytes(content: &[u8]) -> Result<Self, SuiError> {
-        bcs::from_bytes(content).map_err(|err| SuiError::TypeError {
-            error: format!("Unable to deserialize CoinMetadata object: {:?}", err),
+        bcs::from_bytes(content).map_err(|err| SuiError::ObjectDeserializationError {
+            error: format!("Unable to deserialize CoinMetadata object: {}", err),
         })
     }
 

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -17,7 +17,7 @@ use serde_with::serde_as;
 use serde_with::Bytes;
 
 use crate::base_types::{MoveObjectType, ObjectIDParseError};
-use crate::coin::Coin;
+use crate::coin::{Coin, CoinMetadata, TreasuryCap};
 use crate::crypto::{default_hash, deterministic_random_account_key};
 use crate::error::{ExecutionError, ExecutionErrorKind, UserInputError, UserInputResult};
 use crate::error::{SuiError, SuiResult};
@@ -883,6 +883,36 @@ impl Object {
         });
         Self {
             owner: Owner::AddressOwner(owner),
+            data,
+            previous_transaction: TransactionDigest::genesis(),
+            storage_rebate: 0,
+        }
+    }
+
+    pub fn treasury_cap_for_testing(struct_tag: StructTag, treasury_cap: TreasuryCap) -> Self {
+        let data = Data::Move(MoveObject {
+            type_: TreasuryCap::type_(struct_tag).into(),
+            has_public_transfer: true,
+            version: OBJECT_START_VERSION,
+            contents: bcs::to_bytes(&treasury_cap).expect("Failed to serialize"),
+        });
+        Self {
+            owner: Owner::Immutable,
+            data,
+            previous_transaction: TransactionDigest::genesis(),
+            storage_rebate: 0,
+        }
+    }
+
+    pub fn coin_metadata_for_testing(struct_tag: StructTag, metadata: CoinMetadata) -> Self {
+        let data = Data::Move(MoveObject {
+            type_: CoinMetadata::type_(struct_tag).into(),
+            has_public_transfer: true,
+            version: OBJECT_START_VERSION,
+            contents: bcs::to_bytes(&metadata).expect("Failed to serialize"),
+        });
+        Self {
+            owner: Owner::Immutable,
             data,
             previous_transaction: TransactionDigest::genesis(),
             storage_rebate: 0,


### PR DESCRIPTION
## Description 

Map client-side errors to standard client error code: namely, invalid `coin_type` inputs to `coin_api` now yields a client `-32602` `CannotParseSuiStructTag` error instead of a `-32000` internal server error. Similarly, invalid cursors will also yield a -32602 if the provided cursor cannot be found or is not a coin.

Unit tests to cover user-facing errors and some internal errors.

As part of error handling improvements, I'd like to write unit tests that simulate different error scenarios to validate that appropriate errors are being generated and propagated correctly. This requires some refactoring.

To enable unit tests on our jsonrpc apis, I refactored the existing implementation such that there is a `StateServiceWrapper` wrapping `AuthorityState`, and a `CoinReadInternalTrait` that captures how the api interacts with the state and metrics. The boundaries are somewhat arbitrary, but the implementation for `StateServiceWrapper` tries to be as close to `state` as possible. Meanwhile, the implementation for `CoinReadInternalTrait` orchestrates methods that may need to make multiple, separate `state` calls, and serde from/to bcs.

This allows us to write unit tests mocking the state and the more nebulous `internal` implementation, as demonstrated in `get_total_supply_tests`, where the `test_success_response_for_gas_coin` test mocks out the internal implementation since it is never hit, and the `test_success_response_for_other_coin` mocks out the `state` so we can verify that bcs is correct between state and rpc. 

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [x] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Invalid `coin_type` inputs to `coin_api` now yield error code `-32602` instead of the default `-32000` error code, with error string beginning with `Invalid struct type`. Similarly, invalid cursors will also yield a -32602 if the provided cursor cannot be found (with language `cursor not found`) or is not a coin (with language `cursor is not a coin`). Error language has been modified slightly:
	1. "Invalid Cursor {:?}, Object is not a coin" -> "cursor is not a coin"
	2. "Invalid Cursor {:?}, Object not found" -> "cursor not found"
This is part of a larger effort to make jsonrpc errors more actionable, by splitting errors into three error codes: `-32602` for any client-facing error, `-32000` for noncritical server and catchall errors, and `-32603` for critical errors.