### PR TITLE
[Narwhal] measure batch broadcast quorum latency

### DIFF
--- a/narwhal/primary/src/certificate_fetcher.rs
+++ b/narwhal/primary/src/certificate_fetcher.rs
@@ -259,8 +259,7 @@ impl CertificateFetcher {
 
         self.targets.retain(|origin, target_round| {
             let last_written_round = written_rounds.get(origin).map_or(gc_round, |rounds| {
-                // TODO: switch to last() after it stabilizes for BTreeSet.
-                rounds.iter().rev().next().unwrap_or(&gc_round).to_owned()
+                rounds.last().unwrap_or(&gc_round).to_owned()
             });
             // Drop sync target when cert store already has an equal or higher round for the origin.
             // This applies GC to targets as well.
@@ -362,7 +361,6 @@ async fn fetch_certificates_helper(
     let fetch_timeout = PARALLEL_FETCH_REQUEST_INTERVAL_SECS * peers.len().try_into().unwrap()
         + PARALLEL_FETCH_REQUEST_ADDITIONAL_TIMEOUT;
     let fetch_callback = async move {
-        // TODO: shuffle by stake weight instead.
         debug!("Starting to fetch certificates");
         let mut fut = FuturesUnordered::new();
         // Loop until one peer returns with certificates, or no peer does.

--- a/narwhal/primary/src/certifier.rs
+++ b/narwhal/primary/src/certifier.rs
@@ -158,14 +158,12 @@ impl Certifier {
                 parents
             };
 
-            // TODO: Remove timeout from this RPC once anemo issue #10 is resolved.
-            match client
-                .request_vote(RequestVoteRequest {
-                    header: header.clone(),
-                    parents,
-                })
-                .await
-            {
+            let request = anemo::Request::new(RequestVoteRequest {
+                header: header.clone(),
+                parents,
+            })
+            .with_timeout(Duration::from_secs(30));
+            match client.request_vote(request).await {
                 Ok(response) => {
                     let response = response.into_body();
                     if response.vote.is_some() {

--- a/narwhal/worker/src/metrics.rs
+++ b/narwhal/worker/src/metrics.rs
@@ -63,6 +63,8 @@ pub struct WorkerMetrics {
     pub created_batch_latency: HistogramVec,
     /// The number of parallel worker batches currently processed by the worker
     pub parallel_worker_batches: IntGauge,
+    /// Latency of broadcasting batches to a quorum in seconds.
+    pub batch_broadcast_quorum_latency: Histogram,
     /// Counter of remote/local batch fetch statuses.
     pub worker_batch_fetch: IntCounterVec,
     /// Time it takes to download a payload from local worker peer
@@ -109,6 +111,14 @@ impl WorkerMetrics {
             parallel_worker_batches: register_int_gauge_with_registry!(
                 "parallel_worker_batches",
                 "The number of parallel worker batches currently processed by the worker",
+                registry
+            )
+            .unwrap(),
+            batch_broadcast_quorum_latency: register_histogram_with_registry!(
+                "batch_broadcast_quorum_latency",
+                "The latency of broadcasting batches to a quorum in seconds",
+                // buckets in seconds
+                LATENCY_SEC_BUCKETS.to_vec(),
                 registry
             )
             .unwrap(),

--- a/narwhal/worker/src/quorum_waiter.rs
+++ b/narwhal/worker/src/quorum_waiter.rs
@@ -3,12 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::batch_maker::MAX_PARALLEL_BATCH;
+use crate::metrics::WorkerMetrics;
 use config::{Authority, Committee, Stake, WorkerCache, WorkerId};
 use fastcrypto::hash::Hash;
 use futures::stream::{futures_unordered::FuturesUnordered, StreamExt as _};
 use mysten_metrics::metered_channel::Receiver;
 use mysten_metrics::{monitored_future, spawn_logged_monitored_task};
 use network::{CancelOnDropHandler, ReliableNetwork};
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::{task::JoinHandle, time::timeout};
 use tracing::{trace, warn};
@@ -34,6 +36,8 @@ pub struct QuorumWaiter {
     rx_quorum_waiter: Receiver<(Batch, tokio::sync::oneshot::Sender<()>)>,
     /// A network sender to broadcast the batches to the other workers.
     network: anemo::Network,
+    /// Record metrics for quorum waiter.
+    metrics: Arc<WorkerMetrics>,
 }
 
 impl QuorumWaiter {
@@ -47,6 +51,7 @@ impl QuorumWaiter {
         rx_shutdown: ConditionalBroadcastReceiver,
         rx_quorum_waiter: Receiver<(Batch, tokio::sync::oneshot::Sender<()>)>,
         network: anemo::Network,
+        metrics: Arc<WorkerMetrics>,
     ) -> JoinHandle<()> {
         spawn_logged_monitored_task!(
             async move {
@@ -58,6 +63,7 @@ impl QuorumWaiter {
                     rx_shutdown,
                     rx_quorum_waiter,
                     network,
+                    metrics,
                 }
                 .run()
                 .await;
@@ -98,6 +104,7 @@ impl QuorumWaiter {
                     let (primary_names, worker_names): (Vec<_>, _) = workers.into_iter().unzip();
                     let message  = WorkerBatchMessage{batch: batch.clone()};
                     let handlers = self.network.broadcast(worker_names, &message);
+                    let timer = self.metrics.batch_broadcast_quorum_latency.start_timer();
 
                     // Collect all the handlers to receive acknowledgements.
                     let mut wait_for_quorum: FuturesUnordered<_> = primary_names
@@ -116,6 +123,8 @@ impl QuorumWaiter {
                     let mut total_stake = self.authority.stake();
 
                     pipeline.push(async move {
+                        // Keep the timer until a quorum is reached.
+                        let _timer = timer;
                         // A future that sends to 2/3 stake then returns. Also prints a warning
                         // if we terminate before we have managed to get to the full 2/3 stake.
                         let mut opt_channel = Some(channel);

--- a/narwhal/worker/src/tests/quorum_waiter_tests.rs
+++ b/narwhal/worker/src/tests/quorum_waiter_tests.rs
@@ -1,8 +1,11 @@
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+
 use super::*;
+use crate::metrics::WorkerMetrics;
 use crate::NUM_SHUTDOWN_RECEIVERS;
+use prometheus::Registry;
 use test_utils::{
     batch, latest_protocol_version, test_network, CommitteeFixture, WorkerToWorkerMockServer,
 };
@@ -18,6 +21,7 @@ async fn wait_for_quorum() {
     let myself = fixture.authorities().next().unwrap().worker(0);
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
+    let node_metrics = Arc::new(WorkerMetrics::new(&Registry::new()));
 
     // setup network
     let network = test_network(myself.keypair(), &myself.info().worker_address);
@@ -30,6 +34,7 @@ async fn wait_for_quorum() {
         tx_shutdown.subscribe(),
         rx_quorum_waiter,
         network.clone(),
+        node_metrics,
     );
 
     // Make a batch.
@@ -75,6 +80,7 @@ async fn pipeline_for_quorum() {
     let myself = fixture.authorities().next().unwrap().worker(0);
 
     let mut tx_shutdown = PreSubscribedBroadcastSender::new(NUM_SHUTDOWN_RECEIVERS);
+    let node_metrics = Arc::new(WorkerMetrics::new(&Registry::new()));
 
     // setup network
     let network = test_network(myself.keypair(), &myself.info().worker_address);
@@ -87,6 +93,7 @@ async fn pipeline_for_quorum() {
         tx_shutdown.subscribe(),
         rx_quorum_waiter,
         network.clone(),
+        node_metrics,
     );
 
     // Make a batch.

--- a/narwhal/worker/src/worker.rs
+++ b/narwhal/worker/src/worker.rs
@@ -493,7 +493,7 @@ impl Worker {
             shutdown_receivers.pop().unwrap(),
             rx_batch_maker,
             tx_quorum_waiter,
-            node_metrics,
+            node_metrics.clone(),
             client,
             self.store.clone(),
             self.protocol_config.clone(),
@@ -509,6 +509,7 @@ impl Worker {
             shutdown_receivers.pop().unwrap(),
             rx_quorum_waiter,
             network,
+            node_metrics,
         );
 
         info!(


### PR DESCRIPTION
## Description 

This is going to be compared against `header_to_certificate_latency` to understand the quorum latencies of each validator.

## Test Plan 

CI. Private testnet.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
