### PR TITLE
Use better narwhal configs for tests

### DIFF
--- a/crates/sui-swarm-config/src/network_config_builder.rs
+++ b/crates/sui-swarm-config/src/network_config_builder.rs
@@ -50,6 +50,9 @@ pub struct ConfigBuilder<R = OsRng> {
     genesis_config: Option<GenesisConfig>,
     reference_gas_price: Option<u64>,
     additional_objects: Vec<Object>,
+    /// Building configs for deployment (local or in private testnet) rather than testing.
+    /// When this is true, we use more realistic parameters (especially for Narwhal).
+    for_local_deploy: bool,
 }
 
 impl ConfigBuilder {
@@ -62,6 +65,7 @@ impl ConfigBuilder {
             genesis_config: None,
             reference_gas_price: None,
             additional_objects: vec![],
+            for_local_deploy: false,
         }
     }
 
@@ -144,6 +148,11 @@ impl<R> ConfigBuilder<R> {
         self
     }
 
+    pub fn for_local_deploy(mut self) -> Self {
+        self.for_local_deploy = true;
+        self
+    }
+
     pub fn rng<N: rand::RngCore + rand::CryptoRng>(self, rng: N) -> ConfigBuilder<N> {
         ConfigBuilder {
             rng: Some(rng),
@@ -153,6 +162,7 @@ impl<R> ConfigBuilder<R> {
             genesis_config: self.genesis_config,
             reference_gas_price: self.reference_gas_price,
             additional_objects: self.additional_objects,
+            for_local_deploy: self.for_local_deploy,
         }
     }
 
@@ -280,6 +290,9 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                         }
                     };
                     builder = builder.with_supported_protocol_versions(supported_versions);
+                }
+                if self.for_local_deploy {
+                    builder = builder.for_local_deploy();
                 }
                 builder.build(validator, genesis.clone())
             })

--- a/crates/sui-swarm-config/tests/snapshot_tests.rs
+++ b/crates/sui-swarm-config/tests/snapshot_tests.rs
@@ -116,6 +116,7 @@ fn network_config_snapshot_matches() {
     let mut network_config = ConfigBuilder::new(temp_dir)
         .committee_size(NonZeroUsize::new(committee_size).unwrap())
         .rng(rng)
+        .for_local_deploy()
         .build();
     // TODO: Inject static temp path and port numbers, instead of clearing them.
     for mut validator_config in &mut network_config.validator_configs {

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -416,11 +416,13 @@ async fn genesis(
         builder
             .with_genesis_config(genesis_conf)
             .with_validators(validators)
+            .for_local_deploy()
             .build()
     } else {
         builder
             .committee_size(NonZeroUsize::new(DEFAULT_NUMBER_OF_AUTHORITIES).unwrap())
             .with_genesis_config(genesis_conf)
+            .for_local_deploy()
             .build()
     };
 


### PR DESCRIPTION
## Description 

When generating network config for testing, we should use different narwhal config that would be much faster to run.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
