### PR TITLE
Fix wormhole doc references

### DIFF
--- a/doc/src/learn/sui-bridging.md
+++ b/doc/src/learn/sui-bridging.md
@@ -35,11 +35,11 @@ The following table lists the address associated with each token type. You can c
 | Token   | Address                                                            |
 | ------- | ------------------------------------------------------------------ |
 | CELO    | 0xa198f3be41cda8c07b3bf3fee02263526e535d682499806979a111e88a5a8d0f |
-| tBTC    | 0x079b5d71523f15724f71dd40b238063d5ee756672435ccb27328c0a8664c0d16 |
+| tBTC    | 0x027792d9fed7f9844eb4839566001bb6f6cb4804f66aa2da6fe1ee242d896881 |
 | USDC    | 0x5d4b302506645c37ff133b98c4b50a5ae14841659738d6d733d59d0d217a93bf |
 | USDCarb | 0xe32d3ebafa42e6011b87ef1087bbc6053b499bf6f095807b9013aff5a6ecd7bb |
 | USDCbnb | 0x909cba62ce96d54de25bec9502de5ca7b4f28901747bbf96b76c2e63ec5f1cba |
-| USDCpol | 0xdb9ed08481f9dd565fd36b834eb3c2cda1ee5f388048154807cffcb0267ed3b2 |
+| USDCpol | 0xcf72ec52c0f8ddead746252481fb44ff6e8485a39b803825bde6b00d77cdb0bb |
 | USDCsol | 0xb231fcda8bbddb31f2ef02e6161444aec64a514e2c89279584ac9806ce9cf037 |
 | USDT    | 0xc060006111016b8a020ad5b33834984a437aaa7d3c74c18e09a95d48aceab08c |
 | WAVAX   | 0x1e8b532cca6569cab9f9b9ebc73f8c13885012ade714729aa3b450e0339ac766 |


### PR DESCRIPTION
## Description 

Wormhole docs references object IDs for two of the packages, instead of the package IDs. Updates to reference the correct package IDs.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
