### PR TITLE
[wallet-ext] Add send warnings

### DIFF
--- a/apps/wallet/src/ui/app/components/alert/index.tsx
+++ b/apps/wallet/src/ui/app/components/alert/index.tsx
@@ -41,7 +41,7 @@ export default function Alert({ children, mode = 'warning' }: AlertProps) {
     return (
         <div className={alertStyles({ mode })}>
             {modeToIcon[mode]}
-            <div className="break-all flex-1">{children}</div>
+            <div className="break-words flex-1">{children}</div>
         </div>
     );
 }


### PR DESCRIPTION
## Description 

This adds warnings when an address has no transactions or is an object. It's non-blocking.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
