### PR TITLE
[Kiosk SDK] Support `kiosk_lock_rule` and environments

### DIFF
--- a/.changeset/nervous-eels-hammer.md
+++ b/.changeset/nervous-eels-hammer.md
@@ -1,0 +1,5 @@
+---
+"@mysten/kiosk": minor
+---
+
+Support kiosk_lock_rule and environment support for rules package. Breaks `purchaseAndResolvePolicies` as it changes signature and return format.

--- a/sdk/kiosk/CHANGELOG.md
+++ b/sdk/kiosk/CHANGELOG.md
@@ -6,9 +6,9 @@
 
 - c322a230da: Fix fetchKiosk consistency/naming, include locked state in items
 
-## 1.0.0
+## 0.1.0
 
-### Major Changes
+### Minor Changes
 
 - 4ea96d909a: Kiosk SDK for managing, querying and interacting with Kiosk and TransferPolicy objects
 

--- a/sdk/kiosk/README.md
+++ b/sdk/kiosk/README.md
@@ -172,11 +172,15 @@ import { TransactionBlock } from '@mysten/sui.js';
 const withdraw = async () => {
   const kiosk = 'SomeKioskId';
   const kioskCap = 'KioskCapObjectId';
+  const address = '0xSomeAddressThatReceivesTheFunds';
   const amount = '100000';
 
   const tx = new TransactionBlock();
 
   withdrawFromKiosk(tx, kiosk, kioskCap, amount);
+
+  // transfer the Coin to self or any other address.
+  tx.transferObjects([coin], tx.pure(address, 'address'));
 
   // ... continue to sign and execute the transaction
   // ...

--- a/sdk/kiosk/README.md
+++ b/sdk/kiosk/README.md
@@ -53,10 +53,10 @@ const getKiosk = async () => {
 </details>
 
 <details>
-<summary>Purchasing an item (currently supports royalty rule deployed on testnet or no rules)</summary>
+<summary>Purchasing an item (currently supports royalty rule, kiosk_lock_rule, no rules, (combination works too))</summary>
 
 ```typescript
-import { fetchKiosk } from '@mysten/kiosk';
+import { queryTransferPolicy, purchaseAndResolvePolicies, place, testnetEnvironment } from '@mysten/kiosk';
 import { Connection, JsonRpcProvider } from '@mysten/sui.js';
 
 const provider = new JsonRpcProvider(
@@ -88,16 +88,17 @@ const purchaseItem = async (item, kioskId) => {
   // initialize tx block.
   const tx = new TransactionBlock();
 
-  // Select the environment. Right now only `testnet` or `custom` is supported.
-  //  For custom, you need to supply the `address` of the rules' package.
-  const environment = { env: 'testnet', address?: '' }
-
   // Both are required if you there is a `kiosk_lock_rule`.
   // Optional otherwise. Function will throw an error if there's a kiosk_lock_rule and these are missing.
   const extraParams = {
     ownedKiosk,
     ownedKioskCap
   }
+  // Define the environment.
+  // To use a custom package address for rules, you could call:
+  // const environment = customEnvironment('<PackageAddress>');
+  const environment = testnetEnvironment;
+
   // Extra params. Optional, but required if the user tries to resolve a `kiosk_lock_rule`.
   // Purchases the item. Supports `kiosk_lock_rule`, `royalty_rule` (accepts combination too).
   const result = purchaseAndResolvePolicies(tx, item.type, item.listing.price, kioskId, item.objectId, policy[0], environment, extraParams);

--- a/sdk/kiosk/README.md
+++ b/sdk/kiosk/README.md
@@ -91,15 +91,22 @@ const purchaseItem = async (item, kioskId) => {
   // Select the environment. Right now only `testnet` or `custom` is supported.
   //  For custom, you need to supply the `address` of the rules' package.
   const environment = { env: 'testnet', address?: '' }
+
+  // Both are required if you there is a `kiosk_lock_rule`.
+  // Optional otherwise. Function will throw an error if there's a kiosk_lock_rule and these are missing.
+  const extraParams = {
+    ownedKiosk,
+    ownedKioskCap
+  }
+  // Extra params. Optional, but required if the user tries to resolve a `kiosk_lock_rule`.
   // Purchases the item. Supports `kiosk_lock_rule`, `royalty_rule` (accepts combination too).
-  // ownedKiosk & ownedKioskCap are optional, they are necessary only if the transfer policy includes a `kiosk_lock_rule`.
-  const result = purchaseAndResolvePolicies(tx, item.type, item.listing, kioskId, item.objectId, policy[0], environment, ownedKiosk, ownedKioskCap);
+  const result = purchaseAndResolvePolicies(tx, item.type, item.listing, kioskId, item.objectId, policy[0], environment, extraParams);
 
   // result = {item: <the_purchased_item>, canTransfer: true/false // depending on whether there was a kiosk lock rule }
-  // if the item didn't have a kiosk_lock_rule, we need to do something with it. 
+  // if the item didn't have a kiosk_lock_rule, we need to do something with it.
   // for e..g place it in our own kiosk. (demonstrated below)
   if(result.canTransfer) place(tx, item.type, ownedKiosk, ownedKioskCap , result.item);
-  
+
   // ...finally, sign PTB & execute it.
 
 };

--- a/sdk/kiosk/README.md
+++ b/sdk/kiosk/README.md
@@ -100,7 +100,7 @@ const purchaseItem = async (item, kioskId) => {
   }
   // Extra params. Optional, but required if the user tries to resolve a `kiosk_lock_rule`.
   // Purchases the item. Supports `kiosk_lock_rule`, `royalty_rule` (accepts combination too).
-  const result = purchaseAndResolvePolicies(tx, item.type, item.listing, kioskId, item.objectId, policy[0], environment, extraParams);
+  const result = purchaseAndResolvePolicies(tx, item.type, item.listing.price, kioskId, item.objectId, policy[0], environment, extraParams);
 
   // result = {item: <the_purchased_item>, canTransfer: true/false // depending on whether there was a kiosk lock rule }
   // if the item didn't have a kiosk_lock_rule, we need to do something with it.

--- a/sdk/kiosk/src/bcs.ts
+++ b/sdk/kiosk/src/bcs.ts
@@ -1,21 +1,16 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ObjectOwner, bcs } from '@mysten/sui.js';
-
-/**
- * The Kiosk object fields (for BCS queries).
- */
-export type Kiosk = {
-  id: string;
-  profits: string;
-  owner: string;
-  itemCount: number;
-  allowExtensions: boolean;
-};
+import { bcs } from '@mysten/sui.js';
+import {
+  KIOSK_PURCHASE_CAP,
+  KIOSK_TYPE,
+  TRANSFER_POLICY_CREATED_EVENT,
+  TRANSFER_POLICY_TYPE,
+} from './types';
 
 // Register the `Kiosk` struct for faster queries.
-bcs.registerStructType('0x2::kiosk::Kiosk', {
+bcs.registerStructType(KIOSK_TYPE, {
   id: 'address',
   profits: 'u64',
   owner: 'address',
@@ -23,44 +18,20 @@ bcs.registerStructType('0x2::kiosk::Kiosk', {
   allowExtensions: 'bool',
 });
 
-/**
- * PurchaseCap object fields (for BCS queries).
- */
-export type PurchaseCap = {
-  id: string;
-  kioskId: string;
-  itemId: string;
-  minPrice: string;
-};
-
 // Register the `PurchaseCap` for faster queries.
-bcs.registerStructType('0x2::kiosk::PurchaseCap', {
+bcs.registerStructType(KIOSK_PURCHASE_CAP, {
   id: 'address',
   kioskId: 'address',
   itemId: 'address',
   minPrice: 'u64',
 });
 
-/** Event emitted when a TransferPolicy is created. */
-export type TransferPolicyCreated = {
-  id: string;
-};
-
 // Register the `TransferPolicyCreated` event data.
-bcs.registerStructType('0x2::transfer_policy::TransferPolicyCreated', {
+bcs.registerStructType(TRANSFER_POLICY_CREATED_EVENT, {
   id: 'address',
 });
 
-/** The `TransferPolicy` object */
-export type TransferPolicy = {
-  id: string;
-  type: string;
-  balance: string;
-  rules: string[];
-  owner: ObjectOwner;
-};
-
-bcs.registerStructType('0x2::transfer_policy::TransferPolicy', {
+bcs.registerStructType(TRANSFER_POLICY_TYPE, {
   id: 'address',
   balance: 'u64',
   rules: ['vector', 'string'],

--- a/sdk/kiosk/src/constants.ts
+++ b/sdk/kiosk/src/constants.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/** The Transer Policy Rules package address on testnet */
+export const TESTNET_RULES_PACKAGE_ADDRESS =
+  'bd8fc1947cf119350184107a3087e2dc27efefa0dd82e25a1f699069fe81a585';
+
+/** The transfer policy rules package address on mainnet */
+export const MAINNET_RULES_PACKAGE_ADDRESS =
+  '0x434b5bd8f6a7b05fede0ff46c6e511d71ea326ed38056e3bcd681d2d7c2a7879';

--- a/sdk/kiosk/src/index.ts
+++ b/sdk/kiosk/src/index.ts
@@ -8,3 +8,4 @@ export * from './bcs';
 export * from './utils';
 export * from './query/transfer-policy';
 export * from './types';
+export * from './constants';

--- a/sdk/kiosk/src/index.ts
+++ b/sdk/kiosk/src/index.ts
@@ -7,3 +7,4 @@ export * from './query/kiosk';
 export * from './bcs';
 export * from './utils';
 export * from './query/transfer-policy';
+export * from './types';

--- a/sdk/kiosk/src/query/kiosk.ts
+++ b/sdk/kiosk/src/query/kiosk.ts
@@ -14,7 +14,7 @@ import {
   extractKioskData,
   getKioskObject,
 } from '../utils';
-import { Kiosk } from '../bcs';
+import { Kiosk } from '../types';
 
 /**
  * A dynamic field `Listing { ID, isExclusive }` attached to the Kiosk.

--- a/sdk/kiosk/src/query/transfer-policy.ts
+++ b/sdk/kiosk/src/query/transfer-policy.ts
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { JsonRpcProvider } from '@mysten/sui.js';
-import { TransferPolicy, bcs } from '../bcs';
-
-/** Name of the event emitted when a TransferPolicy for T is created. */
-export const TRANSFER_POLICY_CREATED_EVENT = `0x2::transfer_policy::TransferPolicyCreated`;
+import { bcs } from '../bcs';
+import {
+  TRANSFER_POLICY_CREATED_EVENT,
+  TRANSFER_POLICY_TYPE,
+  TransferPolicy,
+} from '../types';
 
 /**
  * Searches the `TransferPolicy`-s for the given type. The seach is performed via
@@ -44,15 +46,11 @@ export async function queryTransferPolicy(
         );
       }
 
-      let parsed = bcs.de(
-        '0x2::transfer_policy::TransferPolicy',
-        policy.bcs.bcsBytes,
-        'base64',
-      );
+      let parsed = bcs.de(TRANSFER_POLICY_TYPE, policy.bcs.bcsBytes, 'base64');
 
       return {
         id: policy?.objectId,
-        type: `0x2::transfer_policy::TransferPolicy<${type}>`,
+        type: `${TRANSFER_POLICY_TYPE}<${type}>`,
         owner: policy?.owner!,
         rules: parsed.rules,
         balance: parsed.balance,

--- a/sdk/kiosk/src/tx/kiosk.ts
+++ b/sdk/kiosk/src/tx/kiosk.ts
@@ -232,7 +232,12 @@ export function withdrawFromKiosk(
 ): TransactionArgument {
   let amountArg =
     amount !== null
-      ? tx.pure(amount, 'Option<u64>')
+      ? tx.pure(
+          {
+            Some: amount,
+          },
+          'Option<u64>',
+        )
       : tx.pure({ None: true }, 'Option<u64>');
 
   let [coin] = tx.moveCall({

--- a/sdk/kiosk/src/tx/kiosk.ts
+++ b/sdk/kiosk/src/tx/kiosk.ts
@@ -19,6 +19,7 @@ import {
   KIOSK_TYPE,
   ObjectArgument,
   PurchaseAndResolvePoliciesResponse,
+  PurchaseOptionalParams,
   RulesEnvironmentParam,
   TransferPolicy,
 } from '../types';
@@ -346,8 +347,7 @@ export function purchaseAndResolvePolicies(
   item: ObjectArgument,
   policy: TransferPolicy,
   environment: RulesEnvironmentParam,
-  ownedKiosk?: string,
-  ownedKioskCap?: string,
+  extraParams?: PurchaseOptionalParams,
 ): PurchaseAndResolvePoliciesResponse {
   // if we don't pass the listing or the listing doens't have a price, return.
   if (!listing || listing?.price === undefined)
@@ -386,7 +386,7 @@ export function purchaseAndResolvePolicies(
         );
         break;
       case 'kiosk_lock_rule::Rule':
-        if (!ownedKiosk || !ownedKioskCap)
+        if (!extraParams?.ownedKiosk || !extraParams?.ownedKioskCap)
           throw new Error(
             `This item type ${itemType} has a 'kiosk_lock_rule', but function call is missing user's kiosk and kioskCap params`,
           );
@@ -395,8 +395,8 @@ export function purchaseAndResolvePolicies(
           tx,
           itemType,
           purchasedItem,
-          ownedKiosk,
-          ownedKioskCap,
+          extraParams.ownedKiosk,
+          extraParams.ownedKioskCap,
           policy.id,
           transferRequest,
           environment,

--- a/sdk/kiosk/src/tx/kiosk.ts
+++ b/sdk/kiosk/src/tx/kiosk.ts
@@ -14,11 +14,13 @@ import {
   resolveRoyaltyRule,
 } from './transfer-policy';
 import {
+  KIOSK_LOCK_RULE,
   KIOSK_MODULE,
   KIOSK_TYPE,
   ObjectArgument,
   PurchaseAndResolvePoliciesResponse,
   PurchaseOptionalParams,
+  ROYALTY_RULE,
   RulesEnvironmentParam,
   TransferPolicy,
 } from '../types';
@@ -377,7 +379,7 @@ export function purchaseAndResolvePolicies(
     const ruleWithoutAddr = getTypeWithoutPackageAddress(rule);
 
     switch (ruleWithoutAddr) {
-      case 'royalty_rule::Rule':
+      case ROYALTY_RULE:
         resolveRoyaltyRule(
           tx,
           itemType,
@@ -387,7 +389,7 @@ export function purchaseAndResolvePolicies(
           environment,
         );
         break;
-      case 'kiosk_lock_rule::Rule':
+      case KIOSK_LOCK_RULE:
         if (!extraParams?.ownedKiosk || !extraParams?.ownedKioskCap)
           throw new Error(
             `This item type ${itemType} has a 'kiosk_lock_rule', but function call is missing user's kiosk and kioskCap params`,

--- a/sdk/kiosk/src/tx/kiosk.ts
+++ b/sdk/kiosk/src/tx/kiosk.ts
@@ -7,19 +7,21 @@ import {
   TransactionBlock,
 } from '@mysten/sui.js';
 
-import { ObjectArgument, getTypeWithoutPackageAddress, objArg } from '../utils';
+import { getTypeWithoutPackageAddress, objArg } from '../utils';
 import { KioskListing } from '../query/kiosk';
-import { TransferPolicy } from '../bcs';
-import { confirmRequest, resolveRoyaltyRule } from './transfer-policy';
-
-/** The Kiosk module. */
-export const KIOSK_MODULE = '0x2::kiosk';
-
-/** The Kiosk type. */
-export const KIOSK_TYPE = `${KIOSK_MODULE}::Kiosk`;
-
-/** The Kiosk Owner Cap Type */
-export const KIOSK_OWNER_CAP = `${KIOSK_MODULE}::KioskOwnerCap`;
+import {
+  confirmRequest,
+  resolveKioskLockRule,
+  resolveRoyaltyRule,
+} from './transfer-policy';
+import {
+  KIOSK_MODULE,
+  KIOSK_TYPE,
+  ObjectArgument,
+  PurchaseAndResolvePoliciesResponse,
+  RulesEnvironmentParam,
+  TransferPolicy,
+} from '../types';
 
 /**
  * Create a new shared Kiosk and returns the [kiosk, kioskOwnerCap] tuple.
@@ -200,20 +202,16 @@ export function purchase(
   tx: TransactionBlock,
   itemType: string,
   kiosk: ObjectArgument,
-  itemId: SuiAddress,
+  item: ObjectArgument,
   payment: ObjectArgument,
 ): [TransactionArgument, TransactionArgument] {
-  let [item, transferRequest] = tx.moveCall({
+  let [purchasedItem, transferRequest] = tx.moveCall({
     target: `${KIOSK_MODULE}::purchase`,
     typeArguments: [itemType],
-    arguments: [
-      objArg(tx, kiosk),
-      tx.pure(itemId, 'address'),
-      objArg(tx, payment),
-    ],
+    arguments: [objArg(tx, kiosk), objArg(tx, item), objArg(tx, payment)],
   });
 
-  return [item, transferRequest];
+  return [purchasedItem, transferRequest];
 }
 
 /**
@@ -335,28 +333,35 @@ export function returnValue(
  * Completes the full purchase flow that includes:
  * 1. Purchasing the item.
  * 2. Resolving all the transfer policies (if any).
- * 3. Returns the PurchasedItem OR places the item in the user's kiosk (if there's a kiosk lock policy).
+ * 3. Returns the item and whether the user can transfer it or not.
+ *
+ * If the item can be transferred, there's an extra transaction required by the user
+ * to transfer it to an address or place it in their kiosk.
  */
 export function purchaseAndResolvePolicies(
   tx: TransactionBlock,
   itemType: string,
   listing: KioskListing,
-  kioskId: string,
-  itemId: string,
+  kioskId: ObjectArgument,
+  item: ObjectArgument,
   policy: TransferPolicy,
-): TransactionArgument | null {
+  environment: RulesEnvironmentParam,
+  ownedKiosk?: string,
+  ownedKioskCap?: string,
+): PurchaseAndResolvePoliciesResponse {
   // if we don't pass the listing or the listing doens't have a price, return.
-  if (!listing || listing?.price === undefined) return null;
+  if (!listing || listing?.price === undefined)
+    throw new Error(`Listing not supplied.`);
 
   // Split the coin for the amount of the listing.
-  const coin = tx.splitCoins(tx.gas, [tx.pure(listing.price)]);
+  const coin = tx.splitCoins(tx.gas, [tx.pure(listing.price, 'u64')]);
 
   // initialize the purchase `kiosk::purchase`
   const [purchasedItem, transferRequest] = purchase(
     tx,
     itemType,
     kioskId,
-    itemId,
+    item,
     coin,
   );
 
@@ -364,6 +369,8 @@ export function purchaseAndResolvePolicies(
   // For now, we only support royalty rule.
   // Will need some tweaking to make it function properly with the other
   // ruleset.
+  let hasKioskLockRule = false;
+
   for (let rule of policy.rules) {
     const ruleWithoutAddr = getTypeWithoutPackageAddress(rule);
 
@@ -375,6 +382,24 @@ export function purchaseAndResolvePolicies(
           listing.price,
           policy.id,
           transferRequest,
+          environment,
+        );
+        break;
+      case 'kiosk_lock_rule::Rule':
+        if (!ownedKiosk || !ownedKioskCap)
+          throw new Error(
+            `This item type ${itemType} has a 'kiosk_lock_rule', but function call is missing user's kiosk and kioskCap params`,
+          );
+        hasKioskLockRule = true;
+        resolveKioskLockRule(
+          tx,
+          itemType,
+          purchasedItem,
+          ownedKiosk,
+          ownedKioskCap,
+          policy.id,
+          transferRequest,
+          environment,
         );
         break;
       default:
@@ -385,5 +410,8 @@ export function purchaseAndResolvePolicies(
   // confirm the Transfer Policy request.
   confirmRequest(tx, itemType, policy.id, transferRequest);
 
-  return purchasedItem;
+  return {
+    item: purchasedItem,
+    canTransfer: !hasKioskLockRule,
+  };
 }

--- a/sdk/kiosk/src/tx/transfer-policy.ts
+++ b/sdk/kiosk/src/tx/transfer-policy.ts
@@ -2,15 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { TransactionArgument, TransactionBlock } from '@mysten/sui.js';
-import { ObjectArgument, objArg } from '../utils';
-
-/** The Transfer Policy module. */
-export const TRANSFER_POLICY_MODULE = '0x2::transfer_policy';
-
-/** The Transer Policy Rules package address */
-// TODO: Figure out how we serve this for both testnet & mainnet (different package)
-export const TRANSFER_POLICY_RULES_PACKAGE_ADDRESS =
-  'bd8fc1947cf119350184107a3087e2dc27efefa0dd82e25a1f699069fe81a585';
+import { getRulePackageAddress, objArg } from '../utils';
+import { lock } from './kiosk';
+import {
+  ObjectArgument,
+  RulesEnvironmentParam,
+  TESTNET_TRANSFER_POLICY_RULES_PACKAGE_ADDRESS,
+  TRANSFER_POLICY_MODULE,
+} from '../types';
 
 /**
  * Call the `transfer_policy::new` function to create a new transfer policy.
@@ -104,13 +103,14 @@ export function resolveRoyaltyRule(
   tx: TransactionBlock,
   itemType: string,
   price: string,
-  policyId: string,
+  policyId: ObjectArgument,
   transferRequest: TransactionArgument,
+  environment: RulesEnvironmentParam,
 ) {
   const policyObj = objArg(tx, policyId);
   // calculates the amount
   const [amount] = tx.moveCall({
-    target: `${TRANSFER_POLICY_RULES_PACKAGE_ADDRESS}::royalty_rule::fee_amount`,
+    target: `${TESTNET_TRANSFER_POLICY_RULES_PACKAGE_ADDRESS}::royalty_rule::fee_amount`,
     typeArguments: [itemType],
     arguments: [policyObj, objArg(tx, price)],
   });
@@ -120,8 +120,34 @@ export function resolveRoyaltyRule(
 
   // pays the policy
   tx.moveCall({
-    target: `${TRANSFER_POLICY_RULES_PACKAGE_ADDRESS}::royalty_rule::pay`,
+    target: `${getRulePackageAddress(environment)}::royalty_rule::pay`,
     typeArguments: [itemType],
     arguments: [policyObj, transferRequest, feeCoin],
+  });
+}
+
+/**
+ * Locks the item in the supplied kiosk and
+ * proves to the `kiosk_lock` rule that the item was indeed locked,
+ * by calling the `kiosk_lock_rule::prove` function to resolve it.
+ */
+export function resolveKioskLockRule(
+  tx: TransactionBlock,
+  itemType: string,
+  item: TransactionArgument,
+  kiosk: ObjectArgument,
+  kioskCap: ObjectArgument,
+  policyId: ObjectArgument,
+  transferRequest: TransactionArgument,
+  environment: RulesEnvironmentParam,
+) {
+  // lock item in the kiosk.
+  lock(tx, itemType, kiosk, kioskCap, policyId, item);
+
+  // proves that the item is locked in the kiosk to the TP.
+  tx.moveCall({
+    target: `${getRulePackageAddress(environment)}::kiosk_lock_rule::prove`,
+    typeArguments: [itemType],
+    arguments: [transferRequest, objArg(tx, kiosk)],
   });
 }

--- a/sdk/kiosk/src/tx/transfer-policy.ts
+++ b/sdk/kiosk/src/tx/transfer-policy.ts
@@ -7,7 +7,6 @@ import { lock } from './kiosk';
 import {
   ObjectArgument,
   RulesEnvironmentParam,
-  TESTNET_TRANSFER_POLICY_RULES_PACKAGE_ADDRESS,
   TRANSFER_POLICY_MODULE,
 } from '../types';
 

--- a/sdk/kiosk/src/tx/transfer-policy.ts
+++ b/sdk/kiosk/src/tx/transfer-policy.ts
@@ -110,7 +110,7 @@ export function resolveRoyaltyRule(
   const policyObj = objArg(tx, policyId);
   // calculates the amount
   const [amount] = tx.moveCall({
-    target: `${TESTNET_TRANSFER_POLICY_RULES_PACKAGE_ADDRESS}::royalty_rule::fee_amount`,
+    target: `${getRulePackageAddress(environment)}::royalty_rule::fee_amount`,
     typeArguments: [itemType],
     arguments: [policyObj, objArg(tx, price)],
   });

--- a/sdk/kiosk/src/tx/transfer-policy.ts
+++ b/sdk/kiosk/src/tx/transfer-policy.ts
@@ -46,7 +46,7 @@ export function withdrawFromPolicy(
 ): TransactionArgument {
   let amountArg =
     amount !== null
-      ? tx.pure(amount, 'Option<u64>')
+      ? tx.pure({ Some: amount }, 'Option<u64>')
       : tx.pure({ None: true }, 'Option<u64>');
 
   let [profits] = tx.moveCall({

--- a/sdk/kiosk/src/types/env.ts
+++ b/sdk/kiosk/src/types/env.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { SuiAddress } from '@mysten/sui.js';
+
+/* A list of environments. */
+export type Environment = 'mainnet' | 'testnet' | 'devnet' | 'custom';
+
+/** A Parameter to support enivronments for rules.  */
+export type RulesEnvironmentParam = { env: Environment; address?: SuiAddress };

--- a/sdk/kiosk/src/types/env.ts
+++ b/sdk/kiosk/src/types/env.ts
@@ -8,3 +8,15 @@ export type Environment = 'mainnet' | 'testnet' | 'devnet' | 'custom';
 
 /** A Parameter to support enivronments for rules.  */
 export type RulesEnvironmentParam = { env: Environment; address?: SuiAddress };
+
+/** A default Testnet Environment object  */
+export const testnetEnvironment: RulesEnvironmentParam = { env: 'testnet' };
+
+/** A default Mainnet Environment object  */
+export const mainnetEnvironment: RulesEnvironmentParam = { env: 'mainnet' };
+
+/** A helper to easily export a custom environment */
+export const customEnvironment = (address: string): RulesEnvironmentParam => ({
+  env: 'custom',
+  address,
+});

--- a/sdk/kiosk/src/types/index.ts
+++ b/sdk/kiosk/src/types/index.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  SharedObjectRef,
+  SuiObjectRef,
+  TransactionArgument,
+} from '@mysten/sui.js';
+
+export * from './kiosk';
+export * from './transfer-policy';
+export * from './env';
+
+/**
+ * A valid argument for any of the Kiosk functions.
+ */
+export type ObjectArgument =
+  | string
+  | TransactionArgument
+  | SharedObjectRef
+  | SuiObjectRef;

--- a/sdk/kiosk/src/types/kiosk.ts
+++ b/sdk/kiosk/src/types/kiosk.ts
@@ -1,0 +1,55 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { TransactionArgument } from '@mysten/sui.js';
+
+/** The Kiosk module. */
+export const KIOSK_MODULE = '0x2::kiosk';
+
+/** The Kiosk type. */
+export const KIOSK_TYPE = `${KIOSK_MODULE}::Kiosk`;
+
+/** The Kiosk Owner Cap Type */
+export const KIOSK_OWNER_CAP = `${KIOSK_MODULE}::KioskOwnerCap`;
+
+/** The Kiosk Item Type */
+export const KIOSK_ITEM = `${KIOSK_MODULE}::Item`;
+
+/** The Kiosk Listing Type */
+export const KIOSK_LISTING = `${KIOSK_MODULE}::Listing`;
+
+/** The Kiosk Lock Type */
+export const KIOSK_LOCK = `${KIOSK_MODULE}::Lock`;
+
+/** The Kiosk PurchaseCap type */
+export const KIOSK_PURCHASE_CAP = `${KIOSK_MODULE}::PurchaseCap`;
+
+/**
+ * The Kiosk object fields (for BCS queries).
+ */
+export type Kiosk = {
+  id: string;
+  profits: string;
+  owner: string;
+  itemCount: number;
+  allowExtensions: boolean;
+};
+
+/**
+ * PurchaseCap object fields (for BCS queries).
+ */
+export type PurchaseCap = {
+  id: string;
+  kioskId: string;
+  itemId: string;
+  minPrice: string;
+};
+
+/**
+ * The response type of a successful purchase flow.
+ * Returns the item, and a `canTransfer` param.
+ */
+export type PurchaseAndResolvePoliciesResponse = {
+  item: TransactionArgument;
+  canTransfer: boolean;
+};

--- a/sdk/kiosk/src/types/kiosk.ts
+++ b/sdk/kiosk/src/types/kiosk.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { TransactionArgument } from '@mysten/sui.js';
+import { ObjectArgument } from '.';
 
 /** The Kiosk module. */
 export const KIOSK_MODULE = '0x2::kiosk';
@@ -52,4 +53,14 @@ export type PurchaseCap = {
 export type PurchaseAndResolvePoliciesResponse = {
   item: TransactionArgument;
   canTransfer: boolean;
+};
+
+/**
+ * Optional parameters for `purchaseAndResolvePolicies` flow.
+ * This gives us the chance to extend the function in further releases
+ * without introducing more breaking changes.
+ */
+export type PurchaseOptionalParams = {
+  ownedKiosk?: ObjectArgument;
+  ownedKioskCap?: ObjectArgument;
 };

--- a/sdk/kiosk/src/types/transfer-policy.ts
+++ b/sdk/kiosk/src/types/transfer-policy.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ObjectOwner } from '@mysten/sui.js';
+
+/** The Transfer Policy module. */
+export const TRANSFER_POLICY_MODULE = '0x2::transfer_policy';
+
+/** Name of the event emitted when a TransferPolicy for T is created. */
+export const TRANSFER_POLICY_CREATED_EVENT = `${TRANSFER_POLICY_MODULE}::TransferPolicyCreated`;
+
+/** The Transfer Policy Type */
+export const TRANSFER_POLICY_TYPE = `${TRANSFER_POLICY_MODULE}::TransferPolicy`;
+
+/** The Transer Policy Rules package address */
+export const TESTNET_TRANSFER_POLICY_RULES_PACKAGE_ADDRESS =
+  'bd8fc1947cf119350184107a3087e2dc27efefa0dd82e25a1f699069fe81a585';
+
+/** The `TransferPolicy` object */
+export type TransferPolicy = {
+  id: string;
+  type: string;
+  balance: string;
+  rules: string[];
+  owner: ObjectOwner;
+};
+
+/** Event emitted when a TransferPolicy is created. */
+export type TransferPolicyCreated = {
+  id: string;
+};

--- a/sdk/kiosk/src/types/transfer-policy.ts
+++ b/sdk/kiosk/src/types/transfer-policy.ts
@@ -12,14 +12,6 @@ export const TRANSFER_POLICY_CREATED_EVENT = `${TRANSFER_POLICY_MODULE}::Transfe
 /** The Transfer Policy Type */
 export const TRANSFER_POLICY_TYPE = `${TRANSFER_POLICY_MODULE}::TransferPolicy`;
 
-/** The Transer Policy Rules package address on testnet */
-export const TESTNET_RULES_PACKAGE_ADDRESS =
-  'bd8fc1947cf119350184107a3087e2dc27efefa0dd82e25a1f699069fe81a585';
-
-/** The transfer policy rules package address on mainnet */
-export const MAINNET_RULES_PACKAGE_ADDRESS =
-  '0x434b5bd8f6a7b05fede0ff46c6e511d71ea326ed38056e3bcd681d2d7c2a7879';
-
 /** The `TransferPolicy` object */
 export type TransferPolicy = {
   id: string;

--- a/sdk/kiosk/src/types/transfer-policy.ts
+++ b/sdk/kiosk/src/types/transfer-policy.ts
@@ -12,6 +12,12 @@ export const TRANSFER_POLICY_CREATED_EVENT = `${TRANSFER_POLICY_MODULE}::Transfe
 /** The Transfer Policy Type */
 export const TRANSFER_POLICY_TYPE = `${TRANSFER_POLICY_MODULE}::TransferPolicy`;
 
+/** The Kiosk Lock Rule */
+export const KIOSK_LOCK_RULE = 'kiosk_lock_rule::Rule';
+
+/** The Royalty rule */
+export const ROYALTY_RULE = 'royalty_rule::Rule';
+
 /** The `TransferPolicy` object */
 export type TransferPolicy = {
   id: string;

--- a/sdk/kiosk/src/types/transfer-policy.ts
+++ b/sdk/kiosk/src/types/transfer-policy.ts
@@ -12,9 +12,13 @@ export const TRANSFER_POLICY_CREATED_EVENT = `${TRANSFER_POLICY_MODULE}::Transfe
 /** The Transfer Policy Type */
 export const TRANSFER_POLICY_TYPE = `${TRANSFER_POLICY_MODULE}::TransferPolicy`;
 
-/** The Transer Policy Rules package address */
-export const TESTNET_TRANSFER_POLICY_RULES_PACKAGE_ADDRESS =
+/** The Transer Policy Rules package address on testnet */
+export const TESTNET_RULES_PACKAGE_ADDRESS =
   'bd8fc1947cf119350184107a3087e2dc27efefa0dd82e25a1f699069fe81a585';
+
+/** The transfer policy rules package address on mainnet */
+export const MAINNET_RULES_PACKAGE_ADDRESS =
+  '0x434b5bd8f6a7b05fede0ff46c6e511d71ea326ed38056e3bcd681d2d7c2a7879';
 
 /** The `TransferPolicy` object */
 export type TransferPolicy = {

--- a/sdk/kiosk/src/utils.ts
+++ b/sdk/kiosk/src/utils.ts
@@ -14,13 +14,11 @@ import {
 import { KioskData, KioskListing } from './query/kiosk';
 import { DynamicFieldInfo } from '@mysten/sui.js/dist/types/dynamic_fields';
 import { bcs } from './bcs';
+import { KIOSK_TYPE, Kiosk, RulesEnvironmentParam } from './types';
 import {
-  KIOSK_TYPE,
-  Kiosk,
   MAINNET_RULES_PACKAGE_ADDRESS,
-  RulesEnvironmentParam,
   TESTNET_RULES_PACKAGE_ADDRESS,
-} from './types';
+} from './constants';
 
 /* A simple map to the rule package addresses */
 // TODO: Supply the mainnet and devnet addresses.

--- a/sdk/kiosk/src/utils.ts
+++ b/sdk/kiosk/src/utils.ts
@@ -13,16 +13,22 @@ import {
 } from '@mysten/sui.js';
 import { KioskData, KioskListing } from './query/kiosk';
 import { DynamicFieldInfo } from '@mysten/sui.js/dist/types/dynamic_fields';
-import { bcs, Kiosk } from './bcs';
+import { bcs } from './bcs';
+import {
+  KIOSK_TYPE,
+  Kiosk,
+  RulesEnvironmentParam,
+  TESTNET_TRANSFER_POLICY_RULES_PACKAGE_ADDRESS,
+} from './types';
 
-/**
- * A valid argument for any of the Kiosk functions.
- */
-export type ObjectArgument =
-  | string
-  | TransactionArgument
-  | SharedObjectRef
-  | SuiObjectRef;
+/* A simple map to the rule package addresses */
+// TODO: Supply the mainnet and devnet addresses.
+export const rulesPackageAddresses = {
+  mainnet: '',
+  testnet: TESTNET_TRANSFER_POLICY_RULES_PACKAGE_ADDRESS,
+  devnet: '',
+  custom: null,
+};
 
 /**
  * Convert any valid input into a TransactionArgument.
@@ -68,7 +74,7 @@ export async function getKioskObject(
     throw new Error(`Invalid kiosk query: ${id}, expected object, got package`);
   }
 
-  return bcs.de('0x2::kiosk::Kiosk', queryRes.data.bcs!.bcsBytes, 'base64');
+  return bcs.de(KIOSK_TYPE, queryRes.data.bcs!.bcsBytes, 'base64');
 }
 
 // helper to extract kiosk data from dynamic fields.
@@ -109,18 +115,18 @@ export function extractKioskData(
 }
 
 // e.g. 0x2::kiosk::Item -> kiosk::Item
-export const getTypeWithoutPackageAddress = (type: string) => {
+export function getTypeWithoutPackageAddress(type: string) {
   return type.split('::').slice(-2).join('::');
-};
+}
 
 /**
  * A helper that attaches the listing prices to kiosk listings.
  */
-export const attachListingsAndPrices = (
+export function attachListingsAndPrices(
   kioskData: KioskData,
   listings: KioskListing[],
   listingObjects: SuiObjectResponse[],
-) => {
+) {
   // map item listings as {item_id: KioskListing}
   // for easier mapping on the nex
   const itemListings = listings.reduce<Record<ObjectId, KioskListing>>(
@@ -143,15 +149,15 @@ export const attachListingsAndPrices = (
   kioskData.items.map((item) => {
     item.listing = itemListings[item.objectId] || undefined;
   });
-};
+}
 
 /**
  * A Helper to attach locked state to items in Kiosk Data.
  */
-export const attachLockedItems = (
+export function attachLockedItems(
   kioskData: KioskData,
   lockedItemIds: ObjectId[],
-) => {
+) {
   // map lock status in an array of type { item_id: true }
   const lockedStatuses = lockedItemIds.reduce<Record<ObjectId, boolean>>(
     (acc: Record<ObjectId, boolean>, item: string) => {
@@ -165,4 +171,19 @@ export const attachLockedItems = (
   kioskData.items.map((item) => {
     item.isLocked = lockedStatuses[item.objectId] || false;
   });
-};
+}
+
+/**
+ * A helper to get a rule's environment address.
+ */
+export function getRulePackageAddress(
+  environment: RulesEnvironmentParam,
+): string {
+  // if we have custom environment, we return it.
+  if (environment.env === 'custom') {
+    if (!environment.address)
+      throw new Error('Please supply the custom package address for rules.');
+    return environment.address;
+  }
+  return rulesPackageAddresses[environment.env];
+}

--- a/sdk/kiosk/src/utils.ts
+++ b/sdk/kiosk/src/utils.ts
@@ -17,15 +17,16 @@ import { bcs } from './bcs';
 import {
   KIOSK_TYPE,
   Kiosk,
+  MAINNET_RULES_PACKAGE_ADDRESS,
   RulesEnvironmentParam,
-  TESTNET_TRANSFER_POLICY_RULES_PACKAGE_ADDRESS,
+  TESTNET_RULES_PACKAGE_ADDRESS,
 } from './types';
 
 /* A simple map to the rule package addresses */
 // TODO: Supply the mainnet and devnet addresses.
 export const rulesPackageAddresses = {
-  mainnet: '',
-  testnet: TESTNET_TRANSFER_POLICY_RULES_PACKAGE_ADDRESS,
+  mainnet: MAINNET_RULES_PACKAGE_ADDRESS,
+  testnet: TESTNET_RULES_PACKAGE_ADDRESS,
   devnet: '',
   custom: null,
 };


### PR DESCRIPTION
## Description 

In this PR: 

- (breaking) Change signature of `purchaseAndResolvePolicies` to a) support environments (e.g. mainnet, testnet) and b) accept `extraParams` (_to support kiosk_lock_rule_).
- Support for `kiosk_lock_rule`, enabling the SDK to fully support `strong royalties enforcement`.
- (breaking) Change return of `purchaseAndResolvePolicies` to include the item + `canTransfer` flag (whether it can be transferred or not, based on the ruleset).
- Isolate the Types of the Kiosk SDK and export them all properly (from `./types` directory).
- Reuse types in bcs definitions.
- Convert functions to plain format (instead of arrow fns) for consistency.
- Fixes `withdrawFromKiosk` and `withdrawFromPolicy` call amount params.

## Test Plan 

How did you test the new or updated feature?

Right now the changes are tested on the Demo Kiosk dapp that is being developed in parallel. We'll need to start creating a testing suite for the SDK, as we start finalizing our requirements.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [x] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes