### PR TITLE
Do not notify about ignored certificates

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -98,6 +98,15 @@ impl CertTxGuard {
     pub fn commit_tx(self) {}
 }
 
+pub enum ConsensusCertificateResult {
+    /// The consensus message was ignored (e.g. because it has already been processed).
+    Ignored,
+    /// An executable transaction (can be a user tx or a system tx)
+    SuiTransaction(VerifiedExecutableTransaction),
+    /// Everything else, e.g. AuthorityCapabilities, CheckpointSignatures, etc.
+    ConsensusMessage,
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
 pub struct ExecutionIndicesWithHash {
     pub index: ExecutionIndices,
@@ -1415,7 +1424,7 @@ impl AuthorityPerEpochStore {
         parent_sync_store: impl ParentSync,
     ) -> SuiResult<Vec<VerifiedExecutableTransaction>> {
         let mut batch = self.db_batch();
-        let (executable_txns, _lock) = self
+        let (executable_txns, notifications, _lock) = self
             .process_consensus_transactions(
                 &mut batch,
                 transactions,
@@ -1426,14 +1435,7 @@ impl AuthorityPerEpochStore {
             .await?;
         batch.write()?;
 
-        for tx in transactions
-            .iter()
-            .chain(end_of_publish_transactions.iter())
-        {
-            let key = tx.0.transaction.key();
-            self.consensus_notify_read.notify(&key, &());
-        }
-
+        self.process_notifications(&notifications, end_of_publish_transactions);
         Ok(executable_txns)
     }
 
@@ -1449,7 +1451,7 @@ impl AuthorityPerEpochStore {
             .into_iter()
             .partition(|txn| !txn.0.is_end_of_publish());
 
-        let (certs, _lock) = self
+        let (certs, notifications, _lock) = self
             .process_consensus_transactions(
                 &mut batch,
                 &transactions,
@@ -1460,15 +1462,22 @@ impl AuthorityPerEpochStore {
             .await?;
         batch.write()?;
 
-        for tx in transactions
+        self.process_notifications(&notifications, &end_of_publish_transactions);
+        Ok(certs)
+    }
+
+    fn process_notifications(
+        &self,
+        notifications: &[SequencedConsensusTransactionKey],
+        end_of_publish: &[VerifiedSequencedConsensusTransaction],
+    ) {
+        for key in notifications
             .iter()
-            .chain(end_of_publish_transactions.iter())
+            .cloned()
+            .chain(end_of_publish.iter().map(|tx| tx.0.transaction.key()))
         {
-            let key = tx.0.transaction.key();
             self.consensus_notify_read.notify(&key, &());
         }
-
-        Ok(certs)
     }
 
     /// Depending on the type of the VerifiedSequencedConsensusTransaction wrappers,
@@ -1484,9 +1493,11 @@ impl AuthorityPerEpochStore {
         parent_sync_store: impl ParentSync,
     ) -> SuiResult<(
         Vec<VerifiedExecutableTransaction>,
+        Vec<SequencedConsensusTransactionKey>, // keys to notify as complete
         Option<parking_lot::RwLockWriteGuard<ReconfigState>>,
     )> {
-        let mut verified_certificates = Vec::new();
+        let mut verified_certificates = Vec::with_capacity(transactions.len());
+        let mut notifications = Vec::with_capacity(transactions.len());
 
         // get the current next versions for each shared object in transactions
         let mut shared_input_next_versions = {
@@ -1515,7 +1526,9 @@ impl AuthorityPerEpochStore {
         };
 
         for tx in transactions {
-            if let Some(cert) = self
+            let key = tx.0.transaction.key();
+
+            match self
                 .process_consensus_transaction(
                     batch,
                     &mut shared_input_next_versions,
@@ -1524,7 +1537,12 @@ impl AuthorityPerEpochStore {
                 )
                 .await?
             {
-                verified_certificates.push(cert);
+                ConsensusCertificateResult::SuiTransaction(cert) => {
+                    notifications.push(key);
+                    verified_certificates.push(cert);
+                }
+                ConsensusCertificateResult::ConsensusMessage => notifications.push(key),
+                ConsensusCertificateResult::Ignored => (),
             }
         }
 
@@ -1535,7 +1553,7 @@ impl AuthorityPerEpochStore {
 
         let lock = self.process_end_of_publish_transactions(batch, end_of_publish_transactions)?;
 
-        Ok((verified_certificates, lock))
+        Ok((verified_certificates, notifications, lock))
     }
 
     fn process_end_of_publish_transactions(
@@ -1619,7 +1637,7 @@ impl AuthorityPerEpochStore {
         shared_input_next_versions: &mut HashMap<ObjectID, SequenceNumber>,
         transaction: &VerifiedSequencedConsensusTransaction,
         checkpoint_service: &Arc<C>,
-    ) -> SuiResult<Option<VerifiedExecutableTransaction>> {
+    ) -> SuiResult<ConsensusCertificateResult> {
         let _scope = monitored_scope("HandleConsensusTransaction");
         let VerifiedSequencedConsensusTransaction(SequencedConsensusTransaction {
             certificate: _consensus_output,
@@ -1641,7 +1659,7 @@ impl AuthorityPerEpochStore {
                         certificate.epoch(),
                         self.epoch()
                     );
-                    return Ok(None);
+                    return Ok(ConsensusCertificateResult::Ignored);
                 }
                 if self.has_sent_end_of_publish(certificate_author)? {
                     // This can not happen with valid authority
@@ -1649,7 +1667,7 @@ impl AuthorityPerEpochStore {
                     // However this certificate will be filtered out before this line by `consensus_message_processed` call in `verify_consensus_transaction`
                     // If we see some new certificate here it means authority is byzantine and sent certificate after EndOfPublish (or we have some bug in ConsensusAdapter)
                     warn!("[Byzantine authority] Authority {:?} sent a new, previously unseen certificate {:?} after it sent EndOfPublish message to consensus", certificate_author.concise(), certificate.digest());
-                    return Ok(None);
+                    return Ok(ConsensusCertificateResult::Ignored);
                 }
                 // Safe because signatures are verified when VerifiedSequencedConsensusTransaction
                 // is constructed.
@@ -1668,7 +1686,7 @@ impl AuthorityPerEpochStore {
                 {
                     debug!("Ignoring consensus certificate for transaction {:?} because of end of epoch",
                     certificate.digest());
-                    return Ok(None);
+                    return Ok(ConsensusCertificateResult::Ignored);
                 }
 
                 if certificate.contains_shared_object() {
@@ -1690,7 +1708,7 @@ impl AuthorityPerEpochStore {
                     .await?;
                 }
 
-                Ok(Some(certificate))
+                Ok(ConsensusCertificateResult::SuiTransaction(certificate))
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
                 kind: ConsensusTransactionKind::CheckpointSignature(info),
@@ -1698,7 +1716,7 @@ impl AuthorityPerEpochStore {
             }) => {
                 checkpoint_service.notify_checkpoint_signature(self, info)?;
                 self.record_consensus_transaction_processed(batch, transaction, consensus_index)?;
-                Ok(None)
+                Ok(ConsensusCertificateResult::ConsensusMessage)
             }
             SequencedConsensusTransactionKind::External(ConsensusTransaction {
                 kind: ConsensusTransactionKind::EndOfPublish(_),
@@ -1728,7 +1746,7 @@ impl AuthorityPerEpochStore {
                     );
                 }
                 self.record_consensus_transaction_processed(batch, transaction, consensus_index)?;
-                Ok(None)
+                Ok(ConsensusCertificateResult::ConsensusMessage)
             }
             SequencedConsensusTransactionKind::System(system_transaction) => {
                 if !self
@@ -1739,7 +1757,7 @@ impl AuthorityPerEpochStore {
                         "Ignoring system transaction {:?} because of end of epoch",
                         system_transaction.digest()
                     );
-                    return Ok(None);
+                    return Ok(ConsensusCertificateResult::Ignored);
                 }
 
                 // If needed we can support owned object system transactions as well...
@@ -1753,7 +1771,9 @@ impl AuthorityPerEpochStore {
                 )
                 .await?;
 
-                Ok(Some(system_transaction.clone()))
+                Ok(ConsensusCertificateResult::SuiTransaction(
+                    system_transaction.clone(),
+                ))
             }
         }
     }


### PR DESCRIPTION
Fixes a bug where txns that are ignored due to end of epoch are not reverted during reconfig