### PR TITLE
[apps] allow no query parameters to be passed when making apps-backend requests

### DIFF
--- a/apps/core/src/hooks/useAppsBackend.ts
+++ b/apps/core/src/hooks/useAppsBackend.ts
@@ -3,18 +3,20 @@
 
 import { useCallback } from 'react';
 
+const backendUrl =
+    process.env.NODE_ENV === 'development'
+        ? 'http://localhost:3003'
+        : 'https://apps-backend.sui.io';
+
 export function useAppsBackend() {
     const request = useCallback(
         async <T>(
             path: string,
-            queryString: Record<string, any>,
+            queryParams?: Record<string, any>,
             options?: RequestInit
         ): Promise<T> => {
-            const query = new URLSearchParams(queryString);
             const res = await fetch(
-                process.env.NODE_ENV === 'development'
-                    ? `http://localhost:3003/${path}?${query}`
-                    : `https://apps-backend.sui.io/${path}?${query}`,
+                formatRequestURL(`${backendUrl}/${path}`, queryParams),
                 options
             );
 
@@ -28,4 +30,12 @@ export function useAppsBackend() {
     );
 
     return { request };
+}
+
+function formatRequestURL(url: string, queryParams?: Record<string, any>) {
+    if (queryParams && Object.keys(queryParams).length > 0) {
+        const searchParams = new URLSearchParams(queryParams);
+        return `${url}?${searchParams}`;
+    }
+    return url;
 }


### PR DESCRIPTION
## Description 

This is just a small improvement to the `request` interface in `useAppsBackend`. If you have an endpoint with no query parameters, you have to do `request(path, {})` which leads to the URL having an extra `?` at the end of it. This only affects one endpoint right now, but I'm adding another endpoint that doesn't have query parameters so I figured I'd go ahead and make this change 😄 

## Test Plan 
- Existing endpoints work on Sui Explorer and Sui Wallet
- Tested with prod URL and localhost URL
- /coins/sui URL is formatted properly (`http://localhost:3003/coins/sui` vs `http://localhost:3003/coins/sui?`)
- Other apps-backend endpoints are formatted properly (e.g. `http://localhost:3003/validator-map?network=mainnet&version=2`)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
N/A
