### PR TITLE
[easy] Flush write buffer when writing manifest before computing checksum

### DIFF
--- a/crates/sui-archival/src/lib.rs
+++ b/crates/sui-archival/src/lib.rs
@@ -16,12 +16,10 @@ use num_enum::TryFromPrimitive;
 use object_store::path::Path;
 use object_store::DynObjectStore;
 use serde::{Deserialize, Serialize};
-use std::fs::File;
-use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
+use std::io::{BufWriter, Cursor, Read, Seek, SeekFrom, Write};
 use std::ops::Range;
-use std::path::PathBuf;
 use std::sync::Arc;
-use sui_storage::object_store::util::{copy_file, path_to_filesystem, put};
+use sui_storage::object_store::util::{get, put};
 use sui_storage::{compute_sha3_checksum, Blob, Encoding, FileCompression, SHA3_BYTES};
 
 /// The following describes the format of checkpoint (*.chk) and summary (*.sum) files used for
@@ -271,22 +269,11 @@ pub fn create_file_metadata(
     Ok(file_metadata)
 }
 
-pub async fn read_manifest(
-    local_root_path: PathBuf,
-    local_store: Arc<DynObjectStore>,
-    remote_store: Arc<DynObjectStore>,
-) -> Result<Manifest> {
+pub async fn read_manifest(remote_store: Arc<DynObjectStore>) -> Result<Manifest> {
     let manifest_file_path = Path::from(MANIFEST_FILENAME);
-    copy_file(
-        manifest_file_path.clone(),
-        manifest_file_path.clone(),
-        remote_store,
-        local_store,
-    )
-    .await?;
-    let manifest_file = File::open(path_to_filesystem(local_root_path, &manifest_file_path)?)?;
-    let manifest_file_size = manifest_file.metadata()?.len() as usize;
-    let mut manifest_reader = BufReader::new(manifest_file);
+    let vec = get(&manifest_file_path, remote_store).await?.to_vec();
+    let manifest_file_size = vec.len();
+    let mut manifest_reader = Cursor::new(vec);
     manifest_reader.rewind()?;
     let magic = manifest_reader.read_u32::<BigEndian>()?;
     if magic != MANIFEST_FILE_MAGIC {
@@ -310,21 +297,18 @@ pub async fn read_manifest(
     }
     manifest_reader.rewind()?;
     manifest_reader.seek(SeekFrom::Start(MAGIC_BYTES as u64))?;
-    let blob = Blob::read(&mut manifest_reader)?;
-    blob.decode()
+    Blob::read(&mut manifest_reader)?.decode()
 }
 
-pub async fn write_manifest(
-    manifest: Manifest,
-    path: Path,
-    remote_store: Arc<DynObjectStore>,
-) -> Result<()> {
+pub async fn write_manifest(manifest: Manifest, remote_store: Arc<DynObjectStore>) -> Result<()> {
+    let path = Path::from(MANIFEST_FILENAME);
     let mut buf = BufWriter::new(vec![]);
     buf.write_u32::<BigEndian>(MANIFEST_FILE_MAGIC)?;
     let blob = Blob::encode(&manifest, Encoding::Bcs)?;
     blob.write(&mut buf)?;
+    buf.flush()?;
     let mut hasher = Sha3_256::default();
-    hasher.update(buf.buffer());
+    hasher.update(buf.get_ref());
     let computed_digest = hasher.finalize().digest;
     buf.write_all(&computed_digest)?;
     let bytes = Bytes::from(buf.into_inner()?);

--- a/crates/sui-archival/src/writer.rs
+++ b/crates/sui-archival/src/writer.rs
@@ -29,6 +29,7 @@ use sui_types::storage::{ReadStore, WriteStore};
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::time::Instant;
+use tracing::debug;
 
 pub struct ArchiveMetrics {
     pub latest_checkpoint_archived: IntGauge,
@@ -342,7 +343,6 @@ impl ArchiveWriterV1 {
         let (kill_sender, _) = tokio::sync::broadcast::channel::<()>(1);
         tokio::spawn(Self::start_tailing_checkpoints(
             self.remote_object_store.clone(),
-            self.local_object_store.clone(),
             self.local_staging_dir_root.clone(),
             store,
             self.file_compression,
@@ -365,7 +365,6 @@ impl ArchiveWriterV1 {
 
     async fn start_tailing_checkpoints<S>(
         remote_object_store: Arc<DynObjectStore>,
-        local_object_store: Arc<DynObjectStore>,
         local_staging_root_dir: PathBuf,
         store: S,
         file_compression: FileCompression,
@@ -389,13 +388,9 @@ impl ArchiveWriterV1 {
             // Start from genesis
             Manifest::new(0, 0)
         } else {
-            read_manifest(
-                local_staging_root_dir.clone(),
-                local_object_store.clone(),
-                remote_object_store.clone(),
-            )
-            .await
-            .expect("Failed to read manifest")
+            read_manifest(remote_object_store.clone())
+                .await
+                .expect("Failed to read manifest")
         };
         let mut checkpoint_sequence_number = manifest.next_checkpoint_seq_num();
         let mut writer = CheckpointWriter::new(
@@ -459,10 +454,8 @@ impl ArchiveWriterV1 {
                         .await
                         .expect("Syncing checkpoint content should not fail");
 
-                        let manifest_file_path = checkpoint_updates.manifest_file_path();
                         write_manifest(
                             checkpoint_updates.manifest,
-                            manifest_file_path,
                             remote_object_store.clone()
                         )
                         .await
@@ -512,6 +505,7 @@ impl ArchiveWriterV1 {
         from: Arc<DynObjectStore>,
         to: Arc<DynObjectStore>,
     ) -> Result<()> {
+        debug!("Syncing archive file to remote: {:?}", path);
         copy_file(path.clone(), path.clone(), from, to).await?;
         fs::remove_file(path_to_filesystem(dir, &path)?)?;
         Ok(())

--- a/crates/sui-storage/src/lib.rs
+++ b/crates/sui-storage/src/lib.rs
@@ -12,7 +12,7 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::fs::File;
-use std::io::{BufReader, BufWriter, Read, Write};
+use std::io::{BufReader, Read, Write};
 use std::path::PathBuf;
 use std::{fs, io};
 use sui_simulator::fastcrypto::hash::{HashFunction, Sha3_256};
@@ -102,7 +102,7 @@ impl Blob {
         let res = bcs::from_bytes(&data)?;
         Ok(res)
     }
-    pub fn read<R: Read>(rbuf: &mut BufReader<R>) -> Result<Blob> {
+    pub fn read<R: Read>(rbuf: &mut R) -> Result<Blob> {
         let len = rbuf.read_varint::<u64>()? as usize;
         if len == 0 {
             return Err(anyhow!("Invalid object length of 0 in file"));
@@ -116,7 +116,7 @@ impl Blob {
         };
         Ok(blob)
     }
-    pub fn write<W: Write>(&self, wbuf: &mut BufWriter<W>) -> Result<usize> {
+    pub fn write<W: Write>(&self, wbuf: &mut W) -> Result<usize> {
         let mut buf = [0u8; MAX_VARINT_LENGTH];
         let mut counter = 0;
         let n = (self.data.len() as u64).encode_var(&mut buf);


### PR DESCRIPTION
## Description 

Without manually flushing the buffer, we may not be guaranteed to read the right data. Also, fix the manifest read/write api and make it simpler
## Test Plan 

Added unit test