### PR TITLE
Test cluster/WalletContext always check execution result

### DIFF
--- a/crates/sui-e2e-tests/tests/checkpoint_tests.rs
+++ b/crates/sui-e2e-tests/tests/checkpoint_tests.rs
@@ -13,7 +13,7 @@ async fn basic_checkpoints_integration_test() {
         .make_transfer_sui_transaction(None, None)
         .await;
     let digest = *tx.digest();
-    test_cluster.execute_transaction(tx).await.unwrap();
+    test_cluster.execute_transaction(tx).await;
 
     for _ in 0..600 {
         let all_included = test_cluster

--- a/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
@@ -157,7 +157,7 @@ async fn reconfig_with_revert_end_to_end_test() {
             .transfer_sui(None, sender)
             .build(),
     );
-    let effects1 = test_cluster.execute_transaction(tx).await.unwrap();
+    let effects1 = test_cluster.execute_transaction(tx).await;
     assert_eq!(0, effects1.effects.unwrap().executed_epoch());
 
     // gas2 transaction is (most likely) reverted
@@ -430,10 +430,8 @@ async fn test_validator_resign_effects() {
         .make_transfer_sui_transaction(None, None)
         .await;
     let effects0 = test_cluster
-        .wallet
-        .execute_transaction_block(tx.clone())
+        .execute_transaction(tx.clone())
         .await
-        .unwrap()
         .effects
         .unwrap();
     assert_eq!(effects0.executed_epoch(), 0);
@@ -1134,11 +1132,7 @@ async fn safe_mode_reconfig_test() {
         .wallet
         .make_staking_transaction(validator_address)
         .await;
-    let response = test_cluster
-        .execute_transaction(txn)
-        .await
-        .expect("Staking txn failed");
-    assert!(response.status_ok().unwrap());
+    let response = test_cluster.execute_transaction(txn).await;
 
     // Now remove the override and check that in the next epoch we are no longer in safe mode.
     test_cluster.set_safe_mode_expected(false);

--- a/crates/sui-e2e-tests/tests/simulator_tests.rs
+++ b/crates/sui-e2e-tests/tests/simulator_tests.rs
@@ -125,10 +125,12 @@ async fn test_hash_collections() {
 #[sim_test(check_determinism)]
 async fn test_net_determinism() {
     let mut test_cluster = TestClusterBuilder::new().build().await.unwrap();
-    let context = &mut test_cluster.wallet;
 
-    let txn = context.make_transfer_sui_transaction(None, None).await;
-    let digest = context.execute_transaction_block(txn).await.unwrap().digest;
+    let txn = test_cluster
+        .wallet
+        .make_transfer_sui_transaction(None, None)
+        .await;
+    let digest = test_cluster.execute_transaction(txn).await.digest;
 
     sleep(Duration::from_millis(1000)).await;
 

--- a/crates/sui-source-validation/src/tests.rs
+++ b/crates/sui-source-validation/src/tests.rs
@@ -581,7 +581,7 @@ fn sanitize_id(mut message: String, m: &HashMap<SuiAddress, &str>) -> String {
 /// Compile and publish package at absolute path `package` to chain.
 async fn publish_package(context: &WalletContext, package: PathBuf) -> (ObjectRef, ObjectRef) {
     let txn = context.make_publish_transaction(package).await;
-    let response = context.execute_transaction_block(txn).await.unwrap();
+    let response = context.execute_transaction_must_succeed(txn).await;
     let package = get_new_package_obj_from_response(&response).unwrap();
     let cap = get_new_package_upgrade_cap_from_response(&response).unwrap();
     (package, cap)
@@ -618,7 +618,7 @@ async fn upgrade_package(
 /// dependencies.
 async fn publish_package_and_deps(context: &WalletContext, package: PathBuf) -> ObjectRef {
     let txn = context.make_publish_transaction_with_deps(package).await;
-    let response = context.execute_transaction_block(txn).await.unwrap();
+    let response = context.execute_transaction_must_succeed(txn).await;
     get_new_package_obj_from_response(&response).unwrap()
 }
 
@@ -712,10 +712,7 @@ pub async fn upgrade_package_with_wallet(
         context.sign_transaction(&data)
     };
 
-    let resp = context
-        .execute_transaction_block(transaction)
-        .await
-        .unwrap();
+    let resp = context.execute_transaction_must_succeed(transaction).await;
 
     (
         get_new_package_obj_from_response(&resp).unwrap(),

--- a/crates/sui-surfer/src/surfer_state.rs
+++ b/crates/sui-surfer/src/surfer_state.rs
@@ -165,7 +165,12 @@ impl SurferState {
         .unwrap();
         let tx = self.cluster.wallet.sign_transaction(&tx_data);
         let response = loop {
-            match self.cluster.execute_transaction(tx.clone()).await {
+            match self
+                .cluster
+                .wallet
+                .execute_transaction_may_fail(tx.clone())
+                .await
+            {
                 Ok(effects) => break effects,
                 Err(e) => {
                     error!("Error executing transaction: {:?}", e);
@@ -319,7 +324,12 @@ impl SurferState {
         );
         let tx = self.cluster.wallet.sign_transaction(&tx_data);
         let response = loop {
-            match self.cluster.execute_transaction(tx.clone()).await {
+            match self
+                .cluster
+                .wallet
+                .execute_transaction_may_fail(tx.clone())
+                .await
+            {
                 Ok(response) => {
                     break response;
                 }

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -84,7 +84,7 @@ macro_rules! serialize_or_execute {
                 SuiClientCommandResult::SerializedSignedTransaction(sender_signed_data)
             } else {
                 let transaction = Transaction::new(sender_signed_data).verify()?;
-                let response = $context.execute_transaction_block(transaction).await?;
+                let response = $context.execute_transaction_may_fail(transaction).await?;
                 let effects = response.effects.as_ref().ok_or_else(|| {
                     anyhow!("Effects from SuiTransactionBlockResult should not be empty")
                 })?;
@@ -201,7 +201,7 @@ pub enum SuiClientCommands {
         serialize_signed_transaction: bool,
     },
 
-    /// Run the bytecode verifer on the package
+    /// Run the bytecode verifier on the package
     #[clap(name = "verify-bytecode-meter")]
     VerifyBytecodeMeter {
         /// Path to directory containing a Move package
@@ -1190,7 +1190,7 @@ impl SuiClientCommands {
                     Transaction::from_generic_sig_data(data, Intent::sui_transaction(), sigs)
                         .verify()?;
 
-                let response = context.execute_transaction_block(verified).await?;
+                let response = context.execute_transaction_may_fail(verified).await?;
                 SuiClientCommandResult::ExecuteSignedTx(response)
             }
             SuiClientCommands::NewEnv { alias, rpc, ws } => {

--- a/crates/sui/src/unit_tests/validator_tests.rs
+++ b/crates/sui/src/unit_tests/validator_tests.rs
@@ -7,7 +7,6 @@ use crate::validator_commands::{
 use anyhow::Ok;
 use fastcrypto::encoding::{Base64, Encoding};
 use shared_crypto::intent::{Intent, IntentMessage};
-use sui_json_rpc_types::SuiTransactionBlockResponse;
 use sui_types::crypto::SuiKeyPair;
 use sui_types::transaction::TransactionData;
 use sui_types::{
@@ -61,8 +60,7 @@ async fn test_print_raw_rgp_txn() -> Result<(), anyhow::Error> {
         Intent::sui_transaction(),
         vec![signature],
     ));
-    let res: SuiTransactionBlockResponse = context.execute_transaction_block(signed_txn).await?;
-    assert!(res.status_ok().unwrap());
+    context.execute_transaction_must_succeed(signed_txn).await;
     let (_, summary) = get_validator_summary(&sui_client, validator_address)
         .await?
         .unwrap();

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -14,11 +14,10 @@ use rand::{distributions::*, rngs::OsRng, seq::SliceRandom};
 use sui_config::node::DBCheckpointConfig;
 use sui_config::{Config, SUI_CLIENT_CONFIG, SUI_NETWORK_CONFIG};
 use sui_config::{NodeConfig, PersistedConfig, SUI_KEYSTORE_FILENAME};
-use sui_json_rpc_types::{SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions};
+use sui_json_rpc_types::SuiTransactionBlockResponse;
 use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use sui_node::SuiNodeHandle;
 use sui_protocol_config::{ProtocolVersion, SupportedProtocolVersions};
-use sui_sdk::error::SuiRpcResult;
 use sui_sdk::sui_client_config::{SuiClientConfig, SuiEnv};
 use sui_sdk::wallet_context::WalletContext;
 use sui_sdk::{SuiClient, SuiClientBuilder};
@@ -329,19 +328,13 @@ impl TestCluster {
         }
     }
 
+    /// Execute a transaction on the network and wait for it to be executed on the rpc fullnode.
+    /// Also expects the effects status to be ExecutionStatus::Success.
     pub async fn execute_transaction(
         &self,
-        transaction: VerifiedTransaction,
-    ) -> SuiRpcResult<SuiTransactionBlockResponse> {
-        self.fullnode_handle
-            .sui_client
-            .quorum_driver_api()
-            .execute_transaction_block(
-                transaction,
-                SuiTransactionBlockResponseOptions::new().with_effects(),
-                None,
-            )
-            .await
+        tx: VerifiedTransaction,
+    ) -> SuiTransactionBlockResponse {
+        self.wallet.execute_transaction_must_succeed(tx).await
     }
 
     #[cfg(msim)]


### PR DESCRIPTION
## Description 

Always check transaction execution result in TestCluster and WalletContext.
For cases where we expect the transaction may fail (typically non-testing cases), we add another API explicitly for it.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
