### PR TITLE
crypto: Multisig support in typescript

### DIFF
--- a/.changeset/fresh-fishes-relax.md
+++ b/.changeset/fresh-fishes-relax.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Add multisig support

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
 ]
@@ -1025,9 +1025,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.18"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8175979259124331c1d7bf6586ee7e0da434155e4b2d48ec2c8386281d8df39"
+checksum = "4e246206a63c9830e118d12c894f56a82033da1a2361f5544deeee3df85c99d9"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -1052,6 +1052,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tower",
+ "tower-http 0.3.5",
  "tower-layer",
  "tower-service",
 ]
@@ -6780,7 +6781,7 @@ dependencies = [
  "cfg-if",
  "instant",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall",
  "smallvec",
  "winapi",
 ]
@@ -6793,7 +6794,7 @@ checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall",
  "smallvec",
  "windows-sys 0.42.0",
 ]
@@ -7795,22 +7796,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom 0.2.8",
- "redox_syscall 0.2.16",
+ "redox_syscall",
  "thiserror",
 ]
 
@@ -7840,7 +7832,7 @@ version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
- "aho-corasick 1.0.1",
+ "aho-corasick 1.0.2",
  "memchr",
  "regex-syntax 0.7.2",
 ]
@@ -11028,15 +11020,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.5.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall 0.3.5",
- "rustix 0.37.7",
- "windows-sys 0.45.0",
+ "redox_syscall",
+ "rustix 0.36.6",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -12589,7 +12581,7 @@ dependencies = [
  "ahash 0.7.6",
  "ahash 0.8.2",
  "aho-corasick 0.7.20",
- "aho-corasick 1.0.1",
+ "aho-corasick 1.0.2",
  "aliasable",
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -13426,9 +13418,7 @@ dependencies = [
  "winapi",
  "winapi-util",
  "windows-sys 0.42.0",
- "windows-sys 0.45.0",
  "windows-sys 0.48.0",
- "windows-targets 0.42.2",
  "windows-targets 0.48.0",
  "windows_x86_64_msvc 0.42.2",
  "windows_x86_64_msvc 0.48.0",

--- a/crates/sui-core/src/generate_format.rs
+++ b/crates/sui-core/src/generate_format.rs
@@ -80,8 +80,12 @@ fn get_registry() -> Result<Registry> {
     let kp3: SuiKeyPair =
         SuiKeyPair::Secp256r1(get_key_pair_from_rng(&mut StdRng::from_seed([0; 32])).1);
 
-    let multisig_pk =
-        MultiSigPublicKey::new(vec![kp1.public(), kp2.public()], vec![1, 1], 2).unwrap();
+    let multisig_pk = MultiSigPublicKey::new(
+        vec![kp1.public(), kp2.public(), kp3.public()],
+        vec![1, 1, 1],
+        2,
+    )
+    .unwrap();
 
     let msg = IntentMessage::new(
         Intent::sui_transaction(),
@@ -94,7 +98,8 @@ fn get_registry() -> Result<Registry> {
     let sig2 = Signature::new_secure(&msg, &kp2);
     let sig3 = Signature::new_secure(&msg, &kp3);
 
-    let multi_sig = MultiSig::combine(vec![sig1.clone(), sig2.clone()], multisig_pk).unwrap();
+    let multi_sig =
+        MultiSig::combine(vec![sig1.clone(), sig2.clone(), sig3.clone()], multisig_pk).unwrap();
     tracer.trace_value(&mut samples, &multi_sig)?;
 
     let generic_sig_multi = GenericSignature::MultiSig(multi_sig);

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -197,6 +197,12 @@ CompressedSignature:
           TUPLEARRAY:
             CONTENT: U8
             SIZE: 64
+    2:
+      Secp256r1:
+        NEWTYPE:
+          TUPLEARRAY:
+            CONTENT: U8
+            SIZE: 64
 ConsensusCommitPrologue:
   STRUCT:
     - epoch: U64
@@ -547,7 +553,7 @@ MultiSig:
     - sigs:
         SEQ:
           TYPENAME: CompressedSignature
-    - bitmap: BYTES
+    - bitmap: U16
     - multisig_pk:
         TYPENAME: MultiSigPublicKey
 MultiSigPublicKey:
@@ -555,7 +561,7 @@ MultiSigPublicKey:
     - pk_map:
         SEQ:
           TUPLE:
-            - STR
+            - TYPENAME: PublicKey
             - U8
     - threshold: U16
 ObjectArg:
@@ -660,6 +666,26 @@ ProgrammableTransaction:
           TYPENAME: Command
 ProtocolVersion:
   NEWTYPESTRUCT: U64
+PublicKey:
+  ENUM:
+    0:
+      Ed25519:
+        NEWTYPE:
+          TUPLEARRAY:
+            CONTENT: U8
+            SIZE: 32
+    1:
+      Secp256k1:
+        NEWTYPE:
+          TUPLEARRAY:
+            CONTENT: U8
+            SIZE: 33
+    2:
+      Secp256r1:
+        NEWTYPE:
+          TUPLEARRAY:
+            CONTENT: U8
+            SIZE: 33
 SenderSignedData:
   NEWTYPESTRUCT:
     SEQ:

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -6291,6 +6291,18 @@
           {
             "type": "object",
             "required": [
+              "MultiSigLegacy"
+            ],
+            "properties": {
+              "MultiSigLegacy": {
+                "$ref": "#/components/schemas/MultiSigLegacy"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
               "Signature"
             ],
             "properties": {
@@ -6576,11 +6588,9 @@
         "properties": {
           "bitmap": {
             "description": "A bitmap that indicates the position of which public key the signature should be authenticated with.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Base64"
-              }
-            ]
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0.0
           },
           "multisig_pk": {
             "description": "The public key encoded with each public key with its signature scheme used along with the corresponding weight.",
@@ -6599,8 +6609,77 @@
           }
         }
       },
+      "MultiSigLegacy": {
+        "description": "Deprecated, use [struct MultiSig] instead. The struct that contains signatures and public keys necessary for authenticating a MultiSigLegacy.",
+        "type": "object",
+        "required": [
+          "bitmap",
+          "multisig_pk",
+          "sigs"
+        ],
+        "properties": {
+          "bitmap": {
+            "description": "A bitmap that indicates the position of which public key the signature should be authenticated with.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Base64"
+              }
+            ]
+          },
+          "multisig_pk": {
+            "description": "The public key encoded with each public key with its signature scheme used along with the corresponding weight.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MultiSigPublicKeyLegacy"
+              }
+            ]
+          },
+          "sigs": {
+            "description": "The plain signature encoded with signature scheme.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CompressedSignature"
+            }
+          }
+        }
+      },
       "MultiSigPublicKey": {
         "description": "The struct that contains the public key used for authenticating a MultiSig.",
+        "type": "object",
+        "required": [
+          "pk_map",
+          "threshold"
+        ],
+        "properties": {
+          "pk_map": {
+            "description": "A list of public key and its corresponding weight.",
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/components/schemas/PublicKey"
+                },
+                {
+                  "type": "integer",
+                  "format": "uint8",
+                  "minimum": 0.0
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          },
+          "threshold": {
+            "description": "If the total weight of the public keys corresponding to verified signatures is larger than threshold, the MultiSig is verified.",
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0.0
+          }
+        }
+      },
+      "MultiSigPublicKeyLegacy": {
+        "description": "Deprecated, use [struct MultiSigPublicKey] instead. The struct that contains the public key used for authenticating a MultiSig.",
         "type": "object",
         "required": [
           "pk_map",

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -234,7 +234,7 @@ impl<'de> Deserialize<'de> for SuiKeyPair {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, JsonSchema, Serialize, Deserialize)]
 pub enum PublicKey {
     Ed25519(Ed25519PublicKeyAsBytes),
     Secp256k1(Secp256k1PublicKeyAsBytes),
@@ -284,28 +284,6 @@ impl EncodeDecodeBase64 for PublicKey {
             }
             _ => Err(eyre!("Invalid bytes")),
         }
-    }
-}
-
-impl Serialize for PublicKey {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let s = self.encode_base64();
-        serializer.serialize_str(&s)
-    }
-}
-
-impl<'de> Deserialize<'de> for PublicKey {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        use serde::de::Error;
-        let s = String::deserialize(deserializer)?;
-        <PublicKey as EncodeDecodeBase64>::decode_base64(&s)
-            .map_err(|e| Error::custom(e.to_string()))
     }
 }
 

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -55,6 +55,7 @@ pub mod messages_grpc;
 pub mod metrics;
 pub mod move_package;
 pub mod multisig;
+pub mod multisig_legacy;
 pub mod object;
 pub mod programmable_transaction_builder;
 pub mod quorum_driver_types;

--- a/crates/sui-types/src/multisig_legacy.rs
+++ b/crates/sui-types/src/multisig_legacy.rs
@@ -1,0 +1,308 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    crypto::{CompressedSignature, SignatureScheme},
+    multisig::{MultiSig, MultiSigPublicKey},
+    signature::{AuthenticatorTrait, AuxVerifyData},
+    sui_serde::SuiBitmap,
+};
+pub use enum_dispatch::enum_dispatch;
+use fastcrypto::{
+    encoding::Base64,
+    error::FastCryptoError,
+    traits::{EncodeDecodeBase64, ToFromBytes},
+};
+use once_cell::sync::OnceCell;
+use roaring::RoaringBitmap;
+use schemars::JsonSchema;
+use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer};
+use serde_with::serde_as;
+use shared_crypto::intent::IntentMessage;
+use std::hash::{Hash, Hasher};
+
+use crate::{
+    base_types::SuiAddress,
+    crypto::{PublicKey, Signature},
+    error::SuiError,
+};
+
+pub type WeightUnit = u8;
+pub type ThresholdUnit = u16;
+pub const MAX_SIGNER_IN_MULTISIG: usize = 10;
+
+/// Deprecated, use [struct MultiSig] instead.
+/// The struct that contains signatures and public keys necessary for authenticating a MultiSigLegacy.
+#[serde_as]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+pub struct MultiSigLegacy {
+    /// The plain signature encoded with signature scheme.
+    sigs: Vec<CompressedSignature>,
+    /// A bitmap that indicates the position of which public key the signature should be authenticated with.
+    #[schemars(with = "Base64")]
+    #[serde_as(as = "SuiBitmap")]
+    bitmap: RoaringBitmap,
+    /// The public key encoded with each public key with its signature scheme used along with the corresponding weight.
+    multisig_pk: MultiSigPublicKeyLegacy,
+    /// A bytes representation of [struct MultiSigLegacy]. This helps with implementing [trait AsRef<[u8]>].
+    #[serde(skip)]
+    bytes: OnceCell<Vec<u8>>,
+}
+
+/// This initialize the underlying bytes representation of MultiSig. It encodes
+/// [struct MultiSigLegacy] as the MultiSig flag (0x03) concat with the bcs bytes
+/// of [struct MultiSigLegacy] i.e. `flag || bcs_bytes(MultiSig)`.
+impl AsRef<[u8]> for MultiSigLegacy {
+    fn as_ref(&self) -> &[u8] {
+        self.bytes
+            .get_or_try_init::<_, eyre::Report>(|| {
+                let as_bytes = bcs::to_bytes(self).expect("BCS serialization should not fail");
+                let mut bytes = Vec::with_capacity(1 + as_bytes.len());
+                bytes.push(SignatureScheme::MultiSig.flag());
+                bytes.extend_from_slice(as_bytes.as_slice());
+                Ok(bytes)
+            })
+            .expect("OnceCell invariant violated")
+    }
+}
+
+/// Necessary trait for [struct SenderSignedData].
+impl PartialEq for MultiSigLegacy {
+    fn eq(&self, other: &Self) -> bool {
+        self.sigs == other.sigs
+            && self.bitmap == other.bitmap
+            && self.multisig_pk == other.multisig_pk
+    }
+}
+
+/// Necessary trait for [struct SenderSignedData].
+impl Eq for MultiSigLegacy {}
+
+/// Necessary trait for [struct SenderSignedData].
+impl Hash for MultiSigLegacy {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_ref().hash(state);
+    }
+}
+
+impl AuthenticatorTrait for MultiSigLegacy {
+    fn verify_secure_generic<T>(
+        &self,
+        value: &IntentMessage<T>,
+        author: SuiAddress,
+        _aux_verify_data: AuxVerifyData,
+    ) -> Result<(), SuiError>
+    where
+        T: Serialize,
+    {
+        let multisig: MultiSig = self.clone().try_into()?;
+        multisig.verify_secure_generic(value, author, _aux_verify_data)
+    }
+}
+
+impl TryFrom<MultiSigLegacy> for MultiSig {
+    type Error = SuiError;
+
+    fn try_from(multisig: MultiSigLegacy) -> Result<Self, Self::Error> {
+        Ok(MultiSig::new(
+            multisig.clone().sigs,
+            bitmap_to_u16(multisig.clone().bitmap)?,
+            multisig.multisig_pk.into(),
+        ))
+    }
+}
+
+impl From<MultiSigPublicKeyLegacy> for MultiSigPublicKey {
+    fn from(multisig: MultiSigPublicKeyLegacy) -> Self {
+        MultiSigPublicKey::construct(multisig.pk_map, multisig.threshold)
+    }
+}
+
+/// Convert a roaring bitmap to plain bitmap.
+pub fn bitmap_to_u16(roaring: RoaringBitmap) -> Result<u16, SuiError> {
+    let indices: Vec<u32> = roaring.into_iter().collect();
+    let mut val = 0;
+    for i in indices {
+        if i >= 10 {
+            return Err(SuiError::InvalidSignature {
+                error: "Invalid bitmap".to_string(),
+            });
+        }
+        val |= 1 << i as u8;
+    }
+    Ok(val)
+}
+
+impl MultiSigLegacy {
+    /// This combines a list of [enum Signature] `flag || signature || pk` to a MultiSig.
+    pub fn combine(
+        full_sigs: Vec<Signature>,
+        multisig_pk: MultiSigPublicKeyLegacy,
+    ) -> Result<Self, SuiError> {
+        multisig_pk
+            .validate()
+            .map_err(|_| SuiError::InvalidSignature {
+                error: "Invalid multisig public key".to_string(),
+            })?;
+
+        if full_sigs.len() > multisig_pk.pk_map.len() || full_sigs.is_empty() {
+            return Err(SuiError::InvalidSignature {
+                error: "Invalid number of signatures".to_string(),
+            });
+        }
+        let mut bitmap = RoaringBitmap::new();
+        let mut sigs = Vec::with_capacity(full_sigs.len());
+        for s in full_sigs {
+            let pk = s.to_public_key()?;
+            let inserted = bitmap.insert(multisig_pk.get_index(&pk).ok_or(
+                SuiError::IncorrectSigner {
+                    error: format!("pk does not exist: {:?}", pk),
+                },
+            )?);
+            if !inserted {
+                return Err(SuiError::InvalidSignature {
+                    error: "Duplicate sigature".to_string(),
+                });
+            }
+            sigs.push(s.to_compressed()?);
+        }
+        Ok(MultiSigLegacy {
+            sigs,
+            bitmap,
+            multisig_pk,
+            bytes: OnceCell::new(),
+        })
+    }
+
+    pub fn validate(&self) -> Result<(), FastCryptoError> {
+        if bitmap_to_u16(self.bitmap.clone()).is_err()
+            || self.sigs.len() > self.multisig_pk.pk_map.len()
+            || self.sigs.is_empty()
+        {
+            return Err(FastCryptoError::InvalidInput);
+        }
+        self.multisig_pk.validate()?;
+        Ok(())
+    }
+
+    pub fn get_pk(&self) -> &MultiSigPublicKeyLegacy {
+        &self.multisig_pk
+    }
+
+    pub fn get_sigs(&self) -> &[CompressedSignature] {
+        &self.sigs
+    }
+
+    pub fn get_bitmap(&self) -> &RoaringBitmap {
+        &self.bitmap
+    }
+}
+
+impl ToFromBytes for MultiSigLegacy {
+    fn from_bytes(bytes: &[u8]) -> Result<MultiSigLegacy, FastCryptoError> {
+        // The first byte matches the flag of MultiSig.
+        if bytes.first().ok_or(FastCryptoError::InvalidInput)? != &SignatureScheme::MultiSig.flag()
+        {
+            return Err(FastCryptoError::InvalidInput);
+        }
+        let multisig: MultiSigLegacy =
+            bcs::from_bytes(&bytes[1..]).map_err(|_| FastCryptoError::InvalidSignature)?;
+        multisig.validate()?;
+        Ok(multisig)
+    }
+}
+
+/// Deprecated, use [struct MultiSigPublicKey] instead.
+/// The struct that contains the public key used for authenticating a MultiSig.
+#[derive(Debug, Clone, PartialEq, Eq, JsonSchema, Serialize, Deserialize)]
+pub struct MultiSigPublicKeyLegacy {
+    /// A list of public key and its corresponding weight.
+    #[serde(serialize_with = "serialize_pk_map")]
+    #[serde(deserialize_with = "deserialize_pk_map")]
+    pk_map: Vec<(PublicKey, WeightUnit)>,
+    /// If the total weight of the public keys corresponding to verified signatures is larger than threshold, the MultiSig is verified.
+    threshold: ThresholdUnit,
+}
+
+/// Legacy serialization for MultiSigPublicKey where PublicKey is serialized as string in base64 encoding.
+fn serialize_pk_map<S>(pk_map: &[(PublicKey, WeightUnit)], serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let pk_weight_arr: Vec<(String, WeightUnit)> = pk_map
+        .iter()
+        .map(|(pk, w)| (pk.encode_base64(), *w))
+        .collect();
+
+    let mut seq = serializer.serialize_seq(Some(pk_weight_arr.len()))?;
+    for (pk_string, w) in pk_weight_arr {
+        seq.serialize_element(&(pk_string, w))?;
+    }
+    seq.end()
+}
+
+/// Legacy deserialization for MultiSigPublicKey where PublicKey is deserialized from base64 encoded string.
+fn deserialize_pk_map<'de, D>(deserializer: D) -> Result<Vec<(PublicKey, WeightUnit)>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::de::Error;
+    let pk_weight_arr: Vec<(String, WeightUnit)> = Vec::deserialize(deserializer)?;
+    pk_weight_arr
+        .into_iter()
+        .map(|(s, w)| {
+            let pk = <PublicKey as EncodeDecodeBase64>::decode_base64(&s)
+                .map_err(|e| Error::custom(e.to_string()))?;
+            Ok((pk, w))
+        })
+        .collect()
+}
+
+impl MultiSigPublicKeyLegacy {
+    pub fn new(
+        pks: Vec<PublicKey>,
+        weights: Vec<WeightUnit>,
+        threshold: ThresholdUnit,
+    ) -> Result<Self, SuiError> {
+        if pks.is_empty()
+            || weights.is_empty()
+            || threshold == 0
+            || pks.len() != weights.len()
+            || pks.len() > MAX_SIGNER_IN_MULTISIG
+            || weights.iter().any(|w| *w == 0)
+            || weights
+                .iter()
+                .map(|w| *w as ThresholdUnit)
+                .sum::<ThresholdUnit>()
+                < threshold
+        {
+            return Err(SuiError::InvalidSignature {
+                error: "Invalid multisig public key construction".to_string(),
+            });
+        }
+        Ok(MultiSigPublicKeyLegacy {
+            pk_map: pks.into_iter().zip(weights.into_iter()).collect(),
+            threshold,
+        })
+    }
+
+    pub fn get_index(&self, pk: &PublicKey) -> Option<u32> {
+        self.pk_map
+            .iter()
+            .position(|x| &x.0 == pk)
+            .map(|x| x as u32)
+    }
+
+    pub fn threshold(&self) -> &ThresholdUnit {
+        &self.threshold
+    }
+
+    pub fn pubkeys(&self) -> &[(PublicKey, WeightUnit)] {
+        &self.pk_map
+    }
+
+    pub fn validate(&self) -> Result<(), FastCryptoError> {
+        let multisig: MultiSigPublicKey = self.clone().into();
+        multisig.validate()
+    }
+}

--- a/crates/sui-types/src/signature.rs
+++ b/crates/sui-types/src/signature.rs
@@ -3,6 +3,7 @@
 
 use crate::committee::EpochId;
 use crate::crypto::{SignatureScheme, SuiSignature};
+use crate::multisig_legacy::MultiSigLegacy;
 use crate::zk_login_authenticator::ZkLoginAuthenticator;
 use crate::{base_types::SuiAddress, crypto::Signature, error::SuiError, multisig::MultiSig};
 pub use enum_dispatch::enum_dispatch;
@@ -49,6 +50,7 @@ pub trait AuthenticatorTrait {
 #[derive(Debug, Clone, PartialEq, Eq, JsonSchema, Hash)]
 pub enum GenericSignature {
     MultiSig,
+    MultiSigLegacy,
     Signature,
     ZkLoginAuthenticator,
 }
@@ -60,8 +62,10 @@ impl GenericSignature {
 }
 
 /// GenericSignature encodes a single signature [enum Signature] as is `flag || signature || pubkey`.
-/// It encodes [struct MultiSig] as the MultiSig flag (0x03) concat with the bcs serializedbytes
-/// of [struct MultiSig] i.e. `flag || bcs_bytes(MultiSig)`.
+/// It encodes [struct MultiSigLegacy] as the MultiSig flag (0x03) concat with the bcs serializedbytes
+/// of [struct MultiSigLegacy] i.e. `flag || bcs_bytes(MultiSigLegacy)`.
+/// [struct Multisig] is encodede as the MultiSig flag (0x03) concat with the bcs serializedbytes
+/// of [struct Multisig] i.e. `flag || bcs_bytes(Multisig)`.
 impl ToFromBytes for GenericSignature {
     fn from_bytes(bytes: &[u8]) -> Result<Self, FastCryptoError> {
         match SignatureScheme::from_flag_byte(
@@ -73,10 +77,13 @@ impl ToFromBytes for GenericSignature {
                 | SignatureScheme::Secp256r1 => Ok(GenericSignature::Signature(
                     Signature::from_bytes(bytes).map_err(|_| FastCryptoError::InvalidSignature)?,
                 )),
-                SignatureScheme::MultiSig => {
-                    let multisig = MultiSig::from_bytes(bytes)?;
-                    Ok(GenericSignature::MultiSig(multisig))
-                }
+                SignatureScheme::MultiSig => match MultiSig::from_bytes(bytes) {
+                    Ok(multisig) => Ok(GenericSignature::MultiSig(multisig)),
+                    Err(_) => {
+                        let multisig = MultiSigLegacy::from_bytes(bytes)?;
+                        Ok(GenericSignature::MultiSigLegacy(multisig))
+                    }
+                },
                 SignatureScheme::ZkLoginAuthenticator => {
                     let zk_login = ZkLoginAuthenticator::from_bytes(bytes)?;
                     Ok(GenericSignature::ZkLoginAuthenticator(zk_login))
@@ -93,6 +100,7 @@ impl AsRef<[u8]> for GenericSignature {
     fn as_ref(&self) -> &[u8] {
         match self {
             GenericSignature::MultiSig(s) => s.as_ref(),
+            GenericSignature::MultiSigLegacy(s) => s.as_ref(),
             GenericSignature::Signature(s) => s.as_ref(),
             GenericSignature::ZkLoginAuthenticator(s) => s.as_ref(),
         }

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -1724,12 +1724,12 @@ impl VersionedProtocolMessage for SenderSignedData {
         // SuiError::WrongMessageVersion
         for sig in &self.inner().tx_signatures {
             match sig {
-                GenericSignature::Signature(_)
-                | GenericSignature::MultiSig(_)
+                GenericSignature::MultiSig(_)
+                | GenericSignature::Signature(_)
+                | GenericSignature::MultiSigLegacy(_)
                 | GenericSignature::ZkLoginAuthenticator(_) => (),
             }
         }
-
         Ok(())
     }
 }

--- a/crates/sui-types/src/unit_tests/crypto_tests.rs
+++ b/crates/sui-types/src/unit_tests/crypto_tests.rs
@@ -8,11 +8,14 @@ use proptest::prelude::*;
 #[test]
 fn serde_pubkey() {
     let skp = SuiKeyPair::Ed25519(get_key_pair().1);
-    let mut bytes = Vec::new();
-    bytes.extend_from_slice(&[skp.public().flag()]);
-    bytes.extend_from_slice(skp.public().as_ref());
     let ser = serde_json::to_string(&skp.public()).unwrap();
-    assert_eq!(ser, format!("\"{}\"", Base64::encode(&bytes)));
+    assert_eq!(
+        ser,
+        format!(
+            "{{\"Ed25519\":\"{}\"}}",
+            Base64::encode(skp.public().as_ref())
+        )
+    );
 }
 
 #[test]

--- a/crates/sui-types/src/unit_tests/multisig_tests.rs
+++ b/crates/sui-types/src/unit_tests/multisig_tests.rs
@@ -3,11 +3,6 @@
 
 use std::str::FromStr;
 
-use fastcrypto::traits::ToFromBytes;
-use once_cell::sync::OnceCell;
-use rand::{rngs::StdRng, SeedableRng};
-use roaring::RoaringBitmap;
-
 use super::{MultiSigPublicKey, ThresholdUnit, WeightUnit};
 use crate::{
     base_types::SuiAddress,
@@ -15,9 +10,19 @@ use crate::{
         get_key_pair, get_key_pair_from_rng, Ed25519SuiSignature, Signature, SuiKeyPair,
         SuiSignatureInner,
     },
-    multisig::{MultiSig, MAX_SIGNER_IN_MULTISIG},
+    multisig::{as_indices, MultiSig, MAX_SIGNER_IN_MULTISIG},
+    multisig_legacy::{bitmap_to_u16, MultiSigLegacy, MultiSigPublicKeyLegacy},
     signature::{AuthenticatorTrait, AuxVerifyData, GenericSignature},
 };
+use fastcrypto::{
+    ed25519::{Ed25519KeyPair, Ed25519PrivateKey},
+    encoding::{Base64, Encoding},
+    secp256k1::{Secp256k1KeyPair, Secp256k1PrivateKey},
+    traits::ToFromBytes,
+};
+use once_cell::sync::OnceCell;
+use rand::{rngs::StdRng, SeedableRng};
+use roaring::RoaringBitmap;
 use shared_crypto::intent::{Intent, IntentMessage, PersonalMessage};
 
 pub fn keys() -> Vec<SuiKeyPair> {
@@ -98,7 +103,17 @@ fn multisig_scenarios() {
         3,
     )
     .unwrap();
+    let multisig_pk_legacy_2 = MultiSigPublicKeyLegacy::new(
+        vec![pk1.clone(), pk2.clone(), pk3.clone()],
+        vec![1, 2, 3],
+        3,
+    )
+    .unwrap();
+
+    // Address parsing remain the same.
     let addr_2 = SuiAddress::from(&multisig_pk_2);
+    let addr_legacy_2 = SuiAddress::from(&multisig_pk_legacy_2);
+    assert_eq!(addr_2, addr_legacy_2);
 
     // sig1 and sig2 (3 of 6) verifies ok.
     let multi_sig_6 =
@@ -110,10 +125,17 @@ fn multisig_scenarios() {
     // providing the same sig twice fails.
     assert!(MultiSig::combine(vec![sig1.clone(), sig1.clone()], multisig_pk_2.clone()).is_err());
 
-    // Change position for sig2 and sig1 fails.
+    // Change position for sig2 and sig1 is not ok with plain bitmap.
     let multi_sig_7 =
         MultiSig::combine(vec![sig2.clone(), sig1.clone()], multisig_pk_2.clone()).unwrap();
     assert!(multi_sig_7
+        .verify_secure_generic(&msg, addr_2, AuxVerifyData::default())
+        .is_err());
+
+    // Change position for sig2 and sig1 is not ok with legacy using roaring bitmap.
+    let multi_sig_legacy_7 =
+        MultiSigLegacy::combine(vec![sig2.clone(), sig1.clone()], multisig_pk_legacy_2).unwrap();
+    assert!(multi_sig_legacy_7
         .verify_secure_generic(&msg, addr_2, AuxVerifyData::default())
         .is_err());
 
@@ -145,11 +167,9 @@ fn multisig_scenarios() {
         .is_err());
 
     // Wrong bitmap verifies fail.
-    let mut bitmap = RoaringBitmap::new();
-    bitmap.insert(1);
     let multi_sig_10 = MultiSig {
         sigs: vec![sig1.to_compressed().unwrap()], // sig1 has index 0
-        bitmap,
+        bitmap: 1,
         multisig_pk: MultiSigPublicKey::new(vec![pk1, pk2, pk3], vec![1, 2, 3], 3).unwrap(),
         bytes: OnceCell::new(),
     };
@@ -218,7 +238,7 @@ fn test_serde_roundtrip() {
     };
     let multisig = MultiSig {
         sigs: vec![], // No sigs
-        bitmap: RoaringBitmap::new(),
+        bitmap: 0,
         multisig_pk,
         bytes: OnceCell::new(),
     };
@@ -235,7 +255,7 @@ fn test_serde_roundtrip() {
 
     let multisig_1 = MultiSig {
         sigs: vec![],
-        bitmap: RoaringBitmap::new(),
+        bitmap: 0,
         multisig_pk: multisig_pk_1,
         bytes: OnceCell::new(),
     };
@@ -395,4 +415,123 @@ fn test_max_sig() {
     assert!(multisig
         .verify_secure_generic(&msg, address, AuxVerifyData::default())
         .is_ok());
+}
+
+#[test]
+fn multisig_serde_test() {
+    let k1 = SuiKeyPair::Ed25519(Ed25519KeyPair::from(
+        Ed25519PrivateKey::from_bytes(&[
+            59, 148, 11, 85, 134, 130, 61, 253, 2, 174, 59, 70, 27, 180, 51, 107, 94, 203, 174,
+            253, 102, 39, 170, 146, 46, 252, 4, 143, 236, 12, 136, 28,
+        ])
+        .unwrap(),
+    ));
+    let pk1 = k1.public();
+    assert_eq!(
+        pk1.as_ref(),
+        [
+            90, 226, 32, 180, 178, 246, 94, 151, 124, 18, 237, 230, 21, 121, 255, 81, 112, 182,
+            194, 44, 0, 97, 104, 195, 123, 94, 124, 97, 175, 1, 128, 131
+        ]
+    );
+
+    let k2 = SuiKeyPair::Secp256k1(Secp256k1KeyPair::from(
+        Secp256k1PrivateKey::from_bytes(&[
+            59, 148, 11, 85, 134, 130, 61, 253, 2, 174, 59, 70, 27, 180, 51, 107, 94, 203, 174,
+            253, 102, 39, 170, 146, 46, 252, 4, 143, 236, 12, 136, 28,
+        ])
+        .unwrap(),
+    ));
+    let pk2 = k2.public();
+    assert_eq!(
+        pk2.as_ref(),
+        [
+            2, 29, 21, 35, 7, 198, 183, 43, 14, 208, 65, 139, 14, 112, 205, 128, 231, 245, 41, 91,
+            141, 134, 245, 114, 45, 63, 82, 19, 251, 210, 57, 79, 54
+        ]
+    );
+
+    let k3 = SuiKeyPair::Ed25519(Ed25519KeyPair::from(
+        Ed25519PrivateKey::from_bytes(&[0; 32]).unwrap(),
+    ));
+    let pk3 = k3.public();
+    assert_eq!(
+        pk3.as_ref(),
+        [
+            59, 106, 39, 188, 206, 182, 164, 45, 98, 163, 168, 208, 42, 111, 13, 115, 101, 50, 21,
+            119, 29, 226, 67, 166, 58, 192, 72, 161, 139, 89, 218, 41
+        ]
+    );
+
+    let multisig_pk = MultiSigPublicKey::new(vec![pk1, pk2, pk3], vec![1, 2, 3], 3).unwrap();
+    let addr = SuiAddress::from(&multisig_pk);
+
+    let msg = IntentMessage::new(
+        Intent::sui_transaction(),
+        PersonalMessage {
+            message: "Hello".as_bytes().to_vec(),
+        },
+    );
+    let sig1 = Signature::new_secure(&msg, &k1);
+    let sig2 = Signature::new_secure(&msg, &k2);
+
+    let multi_sig = MultiSig::combine(vec![sig1, sig2], multisig_pk).unwrap();
+    assert_eq!(Base64::encode(multi_sig.as_bytes()), "AwIAvlJnUP0iJFZL+QTxkKC9FHZGwCa5I4TITHS/QDQ12q1sYW6SMt2Yp3PSNzsAay0Fp2MPVohqyyA02UtdQ2RNAQGH0eLk4ifl9h1I8Uc+4QlRYfJC21dUbP8aFaaRqiM/f32TKKg/4PSsGf9lFTGwKsHJYIMkDoqKwI8Xqr+3apQzAwADAFriILSy9l6XfBLt5hV5/1FwtsIsAGFow3tefGGvAYCDAQECHRUjB8a3Kw7QQYsOcM2A5/UpW42G9XItP1IT+9I5TzYCADtqJ7zOtqQtYqOo0CpvDXNlMhV3HeJDpjrASKGLWdopAwMA");
+
+    assert!(multi_sig
+        .verify_secure_generic(&msg, addr, AuxVerifyData::default())
+        .is_ok());
+
+    assert_eq!(
+        addr,
+        SuiAddress::from_str("0x37b048598ca569756146f4e8ea41666c657406db154a31f11bb5c1cbaf0b98d7")
+            .unwrap()
+    );
+}
+
+#[test]
+fn multisig_legacy_serde_test() {
+    let keys = keys();
+    let pk1 = keys[0].public();
+    let pk2 = keys[1].public();
+    let pk3 = keys[2].public();
+    let msg = IntentMessage::new(
+        Intent::sui_transaction(),
+        PersonalMessage {
+            message: "Hello".as_bytes().to_vec(),
+        },
+    );
+    let sig0 = Signature::new_secure(&msg, &keys[0]);
+    let sig2 = Signature::new_secure(&msg, &keys[2]);
+
+    let multisig_pk_legacy =
+        MultiSigPublicKeyLegacy::new(vec![pk1, pk2, pk3], vec![1, 2, 3], 3).unwrap();
+    let addr: SuiAddress = (&multisig_pk_legacy).into();
+
+    let multi_sig_legacy = MultiSigLegacy::combine(vec![sig0, sig2], multisig_pk_legacy).unwrap();
+
+    let binding = GenericSignature::MultiSigLegacy(multi_sig_legacy);
+    let serialized_multisig = binding.as_ref();
+    let deserialized_multisig = GenericSignature::from_bytes(serialized_multisig).unwrap();
+    assert!(deserialized_multisig
+        .verify_secure_generic(&msg, addr, AuxVerifyData::default())
+        .is_ok());
+}
+
+#[test]
+fn test_to_from_indices() {
+    assert!(as_indices(0b11111111110).is_err());
+    assert_eq!(as_indices(0b0000010110).unwrap(), vec![1, 2, 4]);
+    assert_eq!(
+        as_indices(0b1111111111).unwrap(),
+        vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    );
+
+    let mut bitmap = RoaringBitmap::new();
+    bitmap.insert(1);
+    bitmap.insert(2);
+    bitmap.insert(4);
+    assert_eq!(bitmap_to_u16(bitmap.clone()).unwrap(), 0b0000010110);
+    bitmap.insert(11);
+    assert!(bitmap_to_u16(bitmap).is_err());
 }

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -1526,7 +1526,7 @@ quick-xml = { version = "0.26", default-features = false }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
 rgb = { version = "0.8" }
 rustix-4e55305914c60c55 = { package = "rustix", version = "0.36", features = ["fs"] }
-rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["fs", "termios"] }
+rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["termios"] }
 security-framework = { version = "2" }
 security-framework-sys = { version = "2", default-features = false, features = ["OSX_10_9"] }
 signal-hook = { version = "0.3" }
@@ -1571,7 +1571,7 @@ quick-xml = { version = "0.26", default-features = false }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
 rgb = { version = "0.8" }
 rustix-4e55305914c60c55 = { package = "rustix", version = "0.36", features = ["fs"] }
-rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["fs", "termios"] }
+rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["termios"] }
 security-framework = { version = "2" }
 security-framework-sys = { version = "2", default-features = false, features = ["OSX_10_9"] }
 signal-hook = { version = "0.3" }
@@ -1613,7 +1613,7 @@ rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", defau
 raw-cpuid = { version = "10", default-features = false }
 rgb = { version = "0.8" }
 rustix-4e55305914c60c55 = { package = "rustix", version = "0.36", features = ["fs"] }
-rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["fs", "termios"] }
+rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["termios"] }
 signal-hook = { version = "0.3" }
 signal-hook-mio = { version = "0.2", default-features = false, features = ["support-v0_7", "support-v0_8"] }
 signal-hook-registry = { version = "1", default-features = false }
@@ -1655,7 +1655,7 @@ rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", defau
 raw-cpuid = { version = "10", default-features = false }
 rgb = { version = "0.8" }
 rustix-4e55305914c60c55 = { package = "rustix", version = "0.36", features = ["fs"] }
-rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["fs", "termios"] }
+rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["termios"] }
 signal-hook = { version = "0.3" }
 signal-hook-mio = { version = "0.2", default-features = false, features = ["support-v0_7", "support-v0_8"] }
 signal-hook-registry = { version = "1", default-features = false }
@@ -1688,11 +1688,9 @@ web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 widestring = { version = "0.5" }
 winapi = { version = "0.3", default-features = false, features = ["basetsd", "cfg", "combaseapi", "consoleapi", "errhandlingapi", "evntrace", "fileapi", "handleapi", "heapapi", "ifdef", "impl-debug", "impl-default", "in6addr", "inaddr", "ioapiset", "iphlpapi", "knownfolders", "libloaderapi", "lmaccess", "lmapibuf", "lmcons", "memoryapi", "minwinbase", "minwindef", "namedpipeapi", "netioapi", "ntdef", "ntlsa", "ntsecapi", "ntstatus", "objbase", "objidl", "oleauto", "pdh", "powerbase", "processenv", "processthreadsapi", "profileapi", "psapi", "rpcdce", "securitybaseapi", "shellapi", "shlobj", "std", "stringapiset", "synchapi", "sysinfoapi", "timezoneapi", "wbemcli", "winbase", "wincon", "windef", "winerror", "winioctl", "winnt", "winreg", "winsock2", "winuser", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
 winapi-util = { version = "0.1", default-features = false }
-windows-sys-53888c27b7ba5cf4 = { package = "windows-sys", version = "0.45", features = ["Win32_Foundation", "Win32_Storage_FileSystem"] }
 windows-sys-b32c9ddb6d93a9d2 = { package = "windows-sys", version = "0.42", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse"] }
 windows-sys-c8eced492e86ede7 = { package = "windows-sys", version = "0.48", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming"] }
-windows-targets-b32c9ddb6d93a9d2 = { package = "windows-targets", version = "0.42", default-features = false }
-windows-targets-c8eced492e86ede7 = { package = "windows-targets", version = "0.48", default-features = false }
+windows-targets = { version = "0.48", default-features = false }
 windows_x86_64_msvc-b32c9ddb6d93a9d2 = { package = "windows_x86_64_msvc", version = "0.42", default-features = false }
 windows_x86_64_msvc-c8eced492e86ede7 = { package = "windows_x86_64_msvc", version = "0.48", default-features = false }
 winreg = { version = "0.10", default-features = false }
@@ -1722,11 +1720,9 @@ web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 widestring = { version = "0.5" }
 winapi = { version = "0.3", default-features = false, features = ["basetsd", "cfg", "combaseapi", "consoleapi", "errhandlingapi", "evntrace", "fileapi", "handleapi", "heapapi", "ifdef", "impl-debug", "impl-default", "in6addr", "inaddr", "ioapiset", "iphlpapi", "knownfolders", "libloaderapi", "lmaccess", "lmapibuf", "lmcons", "memoryapi", "minwinbase", "minwindef", "namedpipeapi", "netioapi", "ntdef", "ntlsa", "ntsecapi", "ntstatus", "objbase", "objidl", "oleauto", "pdh", "powerbase", "processenv", "processthreadsapi", "profileapi", "psapi", "rpcdce", "securitybaseapi", "shellapi", "shlobj", "std", "stringapiset", "synchapi", "sysinfoapi", "timezoneapi", "wbemcli", "winbase", "wincon", "windef", "winerror", "winioctl", "winnt", "winreg", "winsock2", "winuser", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
 winapi-util = { version = "0.1", default-features = false }
-windows-sys-53888c27b7ba5cf4 = { package = "windows-sys", version = "0.45", features = ["Win32_Foundation", "Win32_Storage_FileSystem"] }
 windows-sys-b32c9ddb6d93a9d2 = { package = "windows-sys", version = "0.42", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse"] }
 windows-sys-c8eced492e86ede7 = { package = "windows-sys", version = "0.48", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming"] }
-windows-targets-b32c9ddb6d93a9d2 = { package = "windows-targets", version = "0.42", default-features = false }
-windows-targets-c8eced492e86ede7 = { package = "windows-targets", version = "0.48", default-features = false }
+windows-targets = { version = "0.48", default-features = false }
 windows_x86_64_msvc-b32c9ddb6d93a9d2 = { package = "windows_x86_64_msvc", version = "0.42", default-features = false }
 windows_x86_64_msvc-c8eced492e86ede7 = { package = "windows_x86_64_msvc", version = "0.48", default-features = false }
 winreg = { version = "0.10", default-features = false }

--- a/doc/src/learn/cryptography/sui-multisig.md
+++ b/doc/src/learn/cryptography/sui-multisig.md
@@ -55,7 +55,7 @@ $ADDR_3     | $PK_3               | ed25519
 
 ## Step 2: Create a MultiSig address
 
-To create a MultiSig address, input a list of public keys to use for the MultiSig address and list their corresponding weights.
+To create a MultiSig address, input a list of public keys to use for the MultiSig address and a list their corresponding weights and the threshold.
 
 ```shell
 $SUI_BINARY keytool multi-sig-address --pks $PK_1 $PK_2 $PK_3 --weights 1 2 3 --threshold 3
@@ -89,10 +89,10 @@ The response resembles the following:
 
 ## Step 3: Serialize ANY transaction
 
-This section demonstrates how to use an object that belongs to a MultiSig address and serialize a transfer to be signed. Note that the tx_bytes can be *ANY* serialized transaction data where the sender is the MultiSig address, simply use the `--serialize-output` flag for supported commands in `sui client -h` (e.g. `publish`, `upgrade`, `call`, `transfer`, `transfer-sui`, `pay`, `pay-all-sui`, `pay-sui`, `split`, `merge-coin`) to output the Base64 encoded transaction bytes. 
+This section demonstrates how to use an object that belongs to a MultiSig address and serialize a transfer to be signed. Note that the tx_bytes can be *ANY* serialized transaction data where the sender is the MultiSig address, simply use the `--serialize-unsigned-transaction` flag for supported commands in `sui client -h` (e.g. `publish`, `upgrade`, `call`, `transfer`, `transfer-sui`, `pay`, `pay-all-sui`, `pay-sui`, `split`, `merge-coin`) to output the Base64 encoded transaction bytes. 
 
 ```shell
-$SUI_BINARY client transfer --to $MULTISIG_ADDR --object-id $OBJECT_ID --gas-budget 1000 --serialize-output
+$SUI_BINARY client transfer --to $MULTISIG_ADDR --object-id $OBJECT_ID --gas-budget 100000 --serialize-unsigned-transaction
 
 Raw tx_bytes to execute: $TX_BYTES
 ```
@@ -123,6 +123,8 @@ MultiSig address: $MULTISIG_ADDRESS # Informational
 MultiSig parsed: $HUMAN_READABLE_STRUCT # Informational
 MultiSig serialized: $SERIALIZED_MULTISIG
 ```
+
+Note that only the signatures of the participating signers whose sum of weights `>=k` are needed. All public keys and their weights and the threshold that defined the MultiSig address are required to be provided. 
 
 ## Step 6: Execute a transaction with MultiSig
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -313,13 +313,13 @@ const provider = new JsonRpcProvider();
 const txn = await provider.getTransactionBlock({
   digest: '9XFneskU8tW7UxQf7tE5qFRfcN4FadtC2Z3HAZkgeETd=',
   // only fetch the effects field
-    options: {
-        showEffects: true,
-        showInput: false,
-        showEvents: false,
-        showObjectChanges: false,
-        showBalanceChanges: false
-    }
+  options: {
+    showEffects: true,
+    showInput: false,
+    showEvents: false,
+    showObjectChanges: false,
+    showBalanceChanges: false,
+  },
 });
 
 // You can also fetch multiple transactions in one batch request
@@ -333,38 +333,51 @@ const txns = await provider.multiGetTransactionBlocks({
 });
 ```
 
-
 ### Get Checkpoints
 
 Get latest 100 Checkpoints in descending order and print Transaction Digests for each one of them.
+
 ```typescript
+provider
+  .getCheckpoints({ descendingOrder: true })
+  .then(function (checkpointPage: CheckpointPage) {
+    console.log(checkpointPage);
 
-provider.getCheckpoints({descendingOrder: true})
-    .then(function (checkpointPage: CheckpointPage) {
-        console.log(checkpointPage);
-
-        checkpointPage.data.forEach(checkpoint => {
-            console.log("---------------------------------------------------------------")
-            console.log(" -----------   Transactions for Checkpoint:  ", checkpoint.sequenceNumber, " -------- ")
-            console.log("---------------------------------------------------------------")
-            checkpoint.transactions.forEach(tx => {
-                console.log(tx);
-            })
-            console.log("***************************************************************")
-        })
+    checkpointPage.data.forEach((checkpoint) => {
+      console.log(
+        '---------------------------------------------------------------',
+      );
+      console.log(
+        ' -----------   Transactions for Checkpoint:  ',
+        checkpoint.sequenceNumber,
+        ' -------- ',
+      );
+      console.log(
+        '---------------------------------------------------------------',
+      );
+      checkpoint.transactions.forEach((tx) => {
+        console.log(tx);
+      });
+      console.log(
+        '***************************************************************',
+      );
     });
+  });
 ```
 
-
 Get Checkpoint 1994010 and print details.
-```typescript
-provider.getCheckpoint({id: "1994010"})
-    .then(function (checkpoint: Checkpoint) {
-        console.log("Checkpoint Sequence Num ", checkpoint.sequenceNumber);
-        console.log("Checkpoint timestampMs ", checkpoint.timestampMs);
-        console.log("Checkpoint # of Transactions ", checkpoint.transactions.length);
 
-    });
+```typescript
+provider
+  .getCheckpoint({ id: '1994010' })
+  .then(function (checkpoint: Checkpoint) {
+    console.log('Checkpoint Sequence Num ', checkpoint.sequenceNumber);
+    console.log('Checkpoint timestampMs ', checkpoint.timestampMs);
+    console.log(
+      'Checkpoint # of Transactions ',
+      checkpoint.transactions.length,
+    );
+  });
 ```
 
 ### Get Coins

--- a/sdk/typescript/src/cryptography/ed25519-publickey.ts
+++ b/sdk/typescript/src/cryptography/ed25519-publickey.ts
@@ -77,4 +77,11 @@ export class Ed25519PublicKey {
       bytesToHex(blake2b(tmp, { dkLen: 32 })).slice(0, SUI_ADDRESS_LENGTH * 2),
     );
   }
+
+  /**
+   * Return the Sui address associated with this Ed25519 public key
+   */
+  flag(): number {
+    return SIGNATURE_SCHEME_TO_FLAG['ED25519'];
+  }
 }

--- a/sdk/typescript/src/cryptography/multisig.ts
+++ b/sdk/typescript/src/cryptography/multisig.ts
@@ -1,0 +1,222 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { toB64 } from '@mysten/bcs';
+import {
+  SIGNATURE_SCHEME_TO_FLAG,
+  SerializedSignature,
+  SignaturePubkeyPair,
+  SignatureScheme,
+  fromSerializedSignature,
+} from './signature';
+import { PublicKey } from './publickey';
+import { blake2b } from '@noble/hashes/blake2b';
+import { bytesToHex } from '@noble/hashes/utils';
+
+import { normalizeSuiAddress } from '../types';
+import {
+  Ed25519PublicKey,
+  Secp256k1PublicKey,
+  Secp256r1PublicKey,
+  builder,
+  fromB64,
+} from '..';
+
+export type PubkeyWeightPair = {
+  pubKey: PublicKey;
+  weight: number;
+};
+
+export type CompressedSignature =
+  | { ED25519: number[] }
+  | { Secp256k1: number[] }
+  | { Secp256r1: number[] };
+
+export type PublicKeyEnum =
+  | { ED25519: number[] }
+  | { Secp256k1: number[] }
+  | { Secp256r1: number[] };
+
+export type PubkeyEnumWeightPair = {
+  pubKey: PublicKeyEnum;
+  weight: number;
+};
+
+export type MultiSigPublicKey = {
+  pk_map: PubkeyEnumWeightPair[];
+  threshold: number;
+};
+
+export type MultiSig = {
+  sigs: CompressedSignature[];
+  bitmap: number;
+  multisig_pk: MultiSigPublicKey;
+};
+
+export const MAX_SIGNER_IN_MULTISIG = 10;
+
+/// Derives a multisig address from a list of pk and weights and threshold.
+// It is the 32-byte Blake2b hash of the serializd bytes of `flag_MultiSig || threshold || flag_1 || pk_1 || weight_1
+/// || ... || flag_n || pk_n || weight_n`
+export function toMultiSigAddress(
+  pks: PubkeyWeightPair[],
+  threshold: number,
+): string {
+  if (pks.length > MAX_SIGNER_IN_MULTISIG) {
+    throw new Error(
+      `Max number of signers in a multisig is ${MAX_SIGNER_IN_MULTISIG}`,
+    );
+  }
+  // max length = 1 flag byte + (max pk size + max weight size (u8)) * max signer size + 2 threshold bytes (u16)
+  let maxLength = 1 + (64 + 1) * MAX_SIGNER_IN_MULTISIG + 2;
+  let tmp = new Uint8Array(maxLength);
+  tmp.set([SIGNATURE_SCHEME_TO_FLAG['MultiSig']]);
+
+  let arr = to_uint8array(threshold);
+  tmp.set(arr, 1);
+  let i = 3;
+  for (const pk of pks) {
+    tmp.set([pk.pubKey.flag()], i);
+    tmp.set(pk.pubKey.toBytes(), i + 1);
+    tmp.set([pk.weight], i + 1 + pk.pubKey.toBytes().length);
+    i += pk.pubKey.toBytes().length + 2;
+  }
+  return normalizeSuiAddress(
+    bytesToHex(blake2b(tmp.slice(0, i), { dkLen: 32 })),
+  );
+}
+
+/// Combine a list of serialized sigs, a list of pk weight pairs
+/// and threshold into a single multisig. `sigs` are required to
+/// be in the same order as `pks`. e.g. for [pk1, pk2, pk3, pk4, pk5],
+/// [sig1, sig2, sig5] is valid, but [sig2, sig1, sig5] is invalid.
+export function combinePartialSigs(
+  sigs: SerializedSignature[],
+  pks: PubkeyWeightPair[],
+  threshold: number,
+): SerializedSignature {
+  let multisig_pk: MultiSigPublicKey = {
+    pk_map: pks.map((x) => toPkWeightPair(x)),
+    threshold: threshold,
+  };
+
+  let bitmap = 0;
+  let compressed_sigs: CompressedSignature[] = new Array(sigs.length);
+  for (let i = 0; i < sigs.length; i++) {
+    let parsed = fromSerializedSignature(sigs[i]);
+    let bytes = Array.from(parsed.signature.map((x) => Number(x)));
+    if (parsed.signatureScheme === 'ED25519') {
+      compressed_sigs[i] = { ED25519: bytes };
+    } else if (parsed.signatureScheme === 'Secp256k1') {
+      compressed_sigs[i] = { Secp256k1: bytes };
+    } else if (parsed.signatureScheme === 'Secp256r1') {
+      compressed_sigs[i] = { Secp256r1: bytes };
+    }
+    for (let j = 0; j < pks.length; j++) {
+      if (parsed.pubKey.equals(pks[j].pubKey)) {
+        bitmap |= 1 << j;
+        break;
+      }
+    }
+  }
+  let multisig: MultiSig = {
+    sigs: compressed_sigs,
+    bitmap,
+    multisig_pk,
+  };
+
+  const bytes = builder.ser('MultiSig', multisig).toBytes();
+  let tmp = new Uint8Array(bytes.length + 1);
+  tmp.set([SIGNATURE_SCHEME_TO_FLAG['MultiSig']]);
+  tmp.set(bytes, 1);
+  return toB64(tmp);
+}
+
+export function decodeMultiSig(signature: string): SignaturePubkeyPair[] {
+  const parsed = fromB64(signature);
+  if (parsed.length < 1 || parsed[0] !== SIGNATURE_SCHEME_TO_FLAG['MultiSig']) {
+    throw new Error('Invalid MultiSig flag');
+  }
+  const multisig: MultiSig = builder.de('MultiSig', parsed.slice(1));
+  let res: SignaturePubkeyPair[] = new Array(multisig.sigs.length);
+  for (let i = 0; i < multisig.sigs.length; i++) {
+    let s: CompressedSignature = multisig.sigs[i];
+    let pk_index = as_indices(multisig.bitmap).at(i);
+    let pk_bytes = Object.values(
+      multisig.multisig_pk.pk_map[pk_index as number].pubKey,
+    )[0];
+    const scheme = Object.keys(s)[0] as SignatureScheme;
+
+    if (scheme === 'MultiSig') {
+      throw new Error('MultiSig is not supported inside MultiSig');
+    }
+
+    const SIGNATURE_SCHEME_TO_PUBLIC_KEY = {
+      ED25519: Ed25519PublicKey,
+      Secp256k1: Secp256k1PublicKey,
+      Secp256r1: Secp256r1PublicKey,
+    };
+
+    const PublicKey = SIGNATURE_SCHEME_TO_PUBLIC_KEY[scheme];
+
+    res[i] = {
+      signatureScheme: scheme,
+      signature: Uint8Array.from(Object.values(s)[0]),
+      pubKey: new PublicKey(pk_bytes),
+    };
+  }
+  return res;
+}
+
+function toPkWeightPair(pair: PubkeyWeightPair): PubkeyEnumWeightPair {
+  let pk_bytes = Array.from(pair.pubKey.toBytes().map((x) => Number(x)));
+  switch (pair.pubKey.flag()) {
+    case SIGNATURE_SCHEME_TO_FLAG['Secp256k1']:
+      return {
+        pubKey: {
+          Secp256k1: pk_bytes,
+        },
+        weight: pair.weight,
+      };
+    case SIGNATURE_SCHEME_TO_FLAG['Secp256r1']:
+      return {
+        pubKey: {
+          Secp256r1: pk_bytes,
+        },
+        weight: pair.weight,
+      };
+    case SIGNATURE_SCHEME_TO_FLAG['ED25519']:
+      return {
+        pubKey: {
+          ED25519: pk_bytes,
+        },
+        weight: pair.weight,
+      };
+    default:
+      throw new Error('Unsupported signature scheme');
+  }
+}
+
+/// Convert u16 to Uint8Array of length 2 in little endian.
+function to_uint8array(threshold: number): Uint8Array {
+  if (threshold < 0 || threshold > 65535) {
+    throw new Error('Invalid threshold');
+  }
+  let arr = new Uint8Array(2);
+  arr[0] = threshold & 0xff;
+  arr[1] = threshold >> 8;
+  return arr;
+}
+
+function as_indices(bitmap: number): Uint8Array {
+  if (bitmap < 0 || bitmap > 1024) {
+    throw new Error('Invalid bitmap');
+  }
+  let res: number[] = [];
+  for (let i = 0; i < 10; i++) {
+    if ((bitmap & (1 << i)) !== 0) {
+      res.push(i);
+    }
+  }
+  return Uint8Array.from(res);
+}

--- a/sdk/typescript/src/cryptography/publickey.ts
+++ b/sdk/typescript/src/cryptography/publickey.ts
@@ -53,6 +53,11 @@ export interface PublicKey {
    * Return the Sui address associated with this public key
    */
   toSuiAddress(): string;
+
+  /**
+   * Return signature scheme flag of the public key
+   */
+  flag(): number;
 }
 
 export function publicKeyFromSerialized(

--- a/sdk/typescript/src/cryptography/secp256k1-publickey.ts
+++ b/sdk/typescript/src/cryptography/secp256k1-publickey.ts
@@ -77,4 +77,11 @@ export class Secp256k1PublicKey implements PublicKey {
       bytesToHex(blake2b(tmp, { dkLen: 32 })).slice(0, SUI_ADDRESS_LENGTH * 2),
     );
   }
+
+  /**
+   * Return the Sui address associated with this Secp256k1 public key
+   */
+  flag(): number {
+    return SIGNATURE_SCHEME_TO_FLAG['Secp256k1'];
+  }
 }

--- a/sdk/typescript/src/cryptography/secp256r1-publickey.ts
+++ b/sdk/typescript/src/cryptography/secp256r1-publickey.ts
@@ -77,4 +77,11 @@ export class Secp256r1PublicKey implements PublicKey {
       bytesToHex(blake2b(tmp, { dkLen: 32 })).slice(0, SUI_ADDRESS_LENGTH * 2),
     );
   }
+
+  /**
+   * Return the Sui address associated with this Secp256r1 public key
+   */
+  flag(): number {
+    return SIGNATURE_SCHEME_TO_FLAG['Secp256r1'];
+  }
 }

--- a/sdk/typescript/src/cryptography/signature.ts
+++ b/sdk/typescript/src/cryptography/signature.ts
@@ -10,7 +10,11 @@ import { Secp256r1PublicKey } from './secp256r1-publickey';
 /**
  * A keypair used for signing transactions.
  */
-export type SignatureScheme = 'ED25519' | 'Secp256k1' | 'Secp256r1';
+export type SignatureScheme =
+  | 'ED25519'
+  | 'Secp256k1'
+  | 'Secp256r1'
+  | 'MultiSig';
 
 /**
  * Pair of signature and corresponding public key
@@ -33,13 +37,16 @@ export const SIGNATURE_SCHEME_TO_FLAG = {
   ED25519: 0x00,
   Secp256k1: 0x01,
   Secp256r1: 0x02,
+  MultiSig: 0x03,
 };
 
 export const SIGNATURE_FLAG_TO_SCHEME = {
   0x00: 'ED25519',
   0x01: 'Secp256k1',
   0x02: 'Secp256r1',
+  0x03: 'MultiSig',
 } as const;
+export type SignatureFlag = keyof typeof SIGNATURE_FLAG_TO_SCHEME;
 
 export function toSerializedSignature({
   signature,
@@ -61,6 +68,11 @@ export function fromSerializedSignature(
   const bytes = fromB64(serializedSignature);
   const signatureScheme =
     SIGNATURE_FLAG_TO_SCHEME[bytes[0] as keyof typeof SIGNATURE_FLAG_TO_SCHEME];
+
+  if (signatureScheme === 'MultiSig') {
+    // TODO(joyqvq): add multisig parsing support
+    throw new Error('MultiSig is not supported');
+  }
 
   const SIGNATURE_SCHEME_TO_PUBLIC_KEY = {
     ED25519: Ed25519PublicKey,

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -7,6 +7,7 @@ export * from './cryptography/keypair';
 export * from './cryptography/ed25519-publickey';
 export * from './cryptography/secp256k1-publickey';
 export * from './cryptography/secp256r1-publickey';
+export * from './cryptography/multisig';
 export * from './cryptography/publickey';
 export * from './cryptography/mnemonics';
 export * from './cryptography/signature';

--- a/sdk/typescript/test/unit/cryptography/multisig.test.ts
+++ b/sdk/typescript/test/unit/cryptography/multisig.test.ts
@@ -1,0 +1,81 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from 'vitest';
+import {
+  combinePartialSigs,
+  decodeMultiSig,
+  toMultiSigAddress,
+} from '../../../src/cryptography/multisig';
+import {
+  Ed25519Keypair,
+  Secp256k1Keypair,
+  toSerializedSignature,
+} from '../../../src';
+import { blake2b } from '@noble/hashes/blake2b';
+
+describe('multisig address and combine sigs', () => {
+  // Address and combined multisig matches rust impl: fn multisig_serde_test()
+  it('combines signature to multisig', () => {
+    const VALID_SECP256K1_SECRET_KEY = [
+      59, 148, 11, 85, 134, 130, 61, 253, 2, 174, 59, 70, 27, 180, 51, 107, 94,
+      203, 174, 253, 102, 39, 170, 146, 46, 252, 4, 143, 236, 12, 136, 28,
+    ];
+    const secret_key = new Uint8Array(VALID_SECP256K1_SECRET_KEY);
+    let k1 = Ed25519Keypair.fromSecretKey(secret_key);
+    let pk1 = k1.getPublicKey();
+
+    let k2 = Secp256k1Keypair.fromSecretKey(secret_key);
+    let pk2 = k2.getPublicKey();
+
+    let k3 = Ed25519Keypair.fromSecretKey(new Uint8Array(32).fill(0));
+    let pk3 = k3.getPublicKey();
+
+    const data = new Uint8Array([0, 0, 0, 5, 72, 101, 108, 108, 111]);
+    const digest = blake2b(data, { dkLen: 32 });
+
+    const sig1 = {
+      signature: k1.signData(digest),
+      signatureScheme: k1.getKeyScheme(),
+      pubKey: pk1,
+    };
+
+    const ser_sig1 = toSerializedSignature(sig1);
+
+    const sig2 = {
+      signature: k2.signData(digest),
+      signatureScheme: k2.getKeyScheme(),
+      pubKey: pk2,
+    };
+
+    const ser_sig2 = toSerializedSignature(sig2);
+    expect(
+      toMultiSigAddress(
+        [
+          { pubKey: pk1, weight: 1 },
+          { pubKey: pk2, weight: 2 },
+          { pubKey: pk3, weight: 3 },
+        ],
+        3,
+      ),
+    ).toEqual(
+      '0x37b048598ca569756146f4e8ea41666c657406db154a31f11bb5c1cbaf0b98d7',
+    );
+
+    let multisig = combinePartialSigs(
+      [ser_sig1, ser_sig2],
+      [
+        { pubKey: pk1, weight: 1 },
+        { pubKey: pk2, weight: 2 },
+        { pubKey: pk3, weight: 3 },
+      ],
+      3,
+    );
+    expect(multisig).toEqual(
+      'AwIAvlJnUP0iJFZL+QTxkKC9FHZGwCa5I4TITHS/QDQ12q1sYW6SMt2Yp3PSNzsAay0Fp2MPVohqyyA02UtdQ2RNAQGH0eLk4ifl9h1I8Uc+4QlRYfJC21dUbP8aFaaRqiM/f32TKKg/4PSsGf9lFTGwKsHJYIMkDoqKwI8Xqr+3apQzAwADAFriILSy9l6XfBLt5hV5/1FwtsIsAGFow3tefGGvAYCDAQECHRUjB8a3Kw7QQYsOcM2A5/UpW42G9XItP1IT+9I5TzYCADtqJ7zOtqQtYqOo0CpvDXNlMhV3HeJDpjrASKGLWdopAwMA',
+    );
+
+    let decoded = decodeMultiSig(multisig);
+    expect(decoded).toEqual([sig1, sig2]);
+  });
+});


### PR DESCRIPTION
## Description 

This PR 1) updates serialization for multisig signature format and still maintain MultisigLegacy 2) add typescript support for the latest multisig. 

Due to the incompatibility of roaring bitmap in typescript (no broswer support), we decide to upgrade the bitmap in multisig format to use plain bitmap instead of roaring bitmap in sui protocol. This results in more compact serialization of a multisig: the bitmap field is reduced from 37 bytes to at most 10 bytes (max number of signers = 10). 

In addition, we upgrade the public key serialization to use plain bytes instead of string. This also reduce each pubkey serialization in multisig. 

The typescript sdk and rust keytool introduced in this PR follows the new protocol. MultisigLegacy is still supported in the sui protocol to provide backward compatibility. i.e. multisig returned from old rust keytool or legacy client impl in other languages using the legacy format can still be executed, but upgrade client to use latest serialization is strongly recommended with better compression and first class support. 

The multisig address remains unchanged. 

After https://github.com/MystenLabs/sui/pull/12250 lands rebase and include r1.
Thanks @damirka for bcs help!

## Test Plan 

unit test ser/de for multisig legacy + latest. consistency test in typescript vs rust. 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
