### PR TITLE
Implement copy() for SuiKeyPair

### DIFF
--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -145,6 +145,14 @@ impl SuiKeyPair {
             SuiKeyPair::Secp256r1(kp) => PublicKey::Secp256r1(kp.public().into()),
         }
     }
+
+    pub fn copy(&self) -> Self {
+        match self {
+            SuiKeyPair::Ed25519(kp) => SuiKeyPair::Ed25519(kp.copy()),
+            SuiKeyPair::Secp256k1(kp) => SuiKeyPair::Secp256k1(kp.copy()),
+            SuiKeyPair::Secp256r1(kp) => SuiKeyPair::Secp256r1(kp.copy()),
+        }
+    }
 }
 
 impl Signer<Signature> for SuiKeyPair {


### PR DESCRIPTION
## Description 

All variants have copy. It makes sense to also have copy for SuiKeyPair. This is useful in key management in test cluster.

## Test Plan 

cargo build

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
