### PR TITLE
[narwhal] expose hostname to consensus metrics

### DIFF
--- a/crates/sui-core/src/scoring_decision.rs
+++ b/crates/sui-core/src/scoring_decision.rs
@@ -713,7 +713,7 @@ mod tests {
         let mut committee_builder = CommitteeBuilder::new(0);
         let mut rng = StdRng::from_rng(&mut OsRng).unwrap();
 
-        for _ in 0..committee_size {
+        for i in 0..committee_size {
             let pair = KeyPair::generate(&mut rng);
             let public_key = pair.public().clone();
 
@@ -722,6 +722,7 @@ mod tests {
                 1,
                 Multiaddr::empty(),
                 NetworkPublicKey::insecure_default(),
+                i.to_string(),
             );
         }
 

--- a/crates/sui-types/src/sui_system_state/epoch_start_sui_system_state.rs
+++ b/crates/sui-types/src/sui_system_state/epoch_start_sui_system_state.rs
@@ -142,6 +142,7 @@ impl EpochStartSystemStateTrait for EpochStartSystemStateV1 {
                 validator.voting_power as narwhal_config::Stake,
                 validator.narwhal_primary_address.clone(),
                 validator.narwhal_network_pubkey.clone(),
+                validator.hostname.clone(),
             );
         }
 

--- a/narwhal/benchmark/benchmark/config.py
+++ b/narwhal/benchmark/benchmark/config.py
@@ -173,7 +173,8 @@ class Committee:
                 'protocol_key': name,
                 'protocol_key_bytes': name,
                 'primary_address': primary_addr,
-                'network_key': network_name
+                'network_key': network_name,
+                'hostname': host
             }
 
     def primary_addresses(self, faults=0):

--- a/narwhal/config/src/committee.rs
+++ b/narwhal/config/src/committee.rs
@@ -99,9 +99,9 @@ impl Authority {
         self.network_key.clone()
     }
 
-    pub fn hostname(&self) -> String {
+    pub fn hostname(&self) -> &str {
         assert!(self.initialised);
-        self.hostname.clone()
+        self.hostname.as_str()
     }
 }
 

--- a/narwhal/config/src/committee.rs
+++ b/narwhal/config/src/committee.rs
@@ -30,6 +30,8 @@ pub struct Authority {
     primary_address: Multiaddr,
     /// Network key of the primary.
     network_key: NetworkPublicKey,
+    /// The validator's hostname
+    hostname: String,
     /// There are secondary indexes that should be initialised before we are ready to use the
     /// authority - this bool protect us for premature use.
     #[serde(skip)]
@@ -46,6 +48,7 @@ impl Authority {
         stake: Stake,
         primary_address: Multiaddr,
         network_key: NetworkPublicKey,
+        hostname: String,
     ) -> Self {
         let protocol_key_bytes = PublicKeyBytes::from(&protocol_key);
 
@@ -56,6 +59,7 @@ impl Authority {
             stake,
             primary_address,
             network_key,
+            hostname,
             initialised: false,
         }
     }
@@ -93,6 +97,11 @@ impl Authority {
     pub fn network_key(&self) -> NetworkPublicKey {
         assert!(self.initialised);
         self.network_key.clone()
+    }
+
+    pub fn hostname(&self) -> String {
+        assert!(self.initialised);
+        self.hostname.clone()
     }
 }
 
@@ -472,8 +481,15 @@ impl CommitteeBuilder {
         stake: Stake,
         primary_address: Multiaddr,
         network_key: NetworkPublicKey,
+        hostname: String,
     ) -> Self {
-        let authority = Authority::new(protocol_key.clone(), stake, primary_address, network_key);
+        let authority = Authority::new(
+            protocol_key.clone(),
+            stake,
+            primary_address,
+            network_key,
+            hostname,
+        );
         self.authorities.insert(protocol_key, authority);
         self
     }
@@ -499,7 +515,7 @@ mod tests {
         let num_of_authorities = 10;
 
         let authorities = (0..num_of_authorities)
-            .map(|_i| {
+            .map(|i| {
                 let keypair = KeyPair::generate(&mut rng);
                 let network_keypair = NetworkKeyPair::generate(&mut rng);
 
@@ -508,6 +524,7 @@ mod tests {
                     1,
                     Multiaddr::empty(),
                     network_keypair.public().clone(),
+                    i.to_string(),
                 );
 
                 (keypair.public().clone(), a)

--- a/narwhal/config/tests/snapshots/config_tests__committee.snap
+++ b/narwhal/config/tests/snapshots/config_tests__committee.snap
@@ -9,28 +9,32 @@ expression: committee
       "protocol_key_bytes": "ku8PylNwBUMzkshpDSeMnbV25O8rPkUFDPcqAyeEXztH02eOq6WemzFMEsi1p0LrBvKBvTLpwLwHhkCatYptihcO75iZRjtFkYwkAlv0GmQQyHZ+xO+UYweLQiYdFHtf",
       "stake": 1,
       "primary_address": "/ip4/127.0.0.1/udp/0",
-      "network_key": "Zm3+Rl2weh6VsEmVBAALZ9Pk1yOf+nHpT8LsI1l/0q8="
+      "network_key": "Zm3+Rl2weh6VsEmVBAALZ9Pk1yOf+nHpT8LsI1l/0q8=",
+      "hostname": "/ip4/127.0.0.1/udp/0"
     },
     "mfJe9h+AMrkUY2RgmCxcxvE07x3a52ZX8sv+wev8jQlzdAgN9vzw3Li8Sw2OCvXYDrv/K0xZn1T0LWMS38MUJ2B4wcw0fru+xRmL4lhRPzhrkw0CwnSagD4jMJVevRoQ": {
       "protocol_key": "mfJe9h+AMrkUY2RgmCxcxvE07x3a52ZX8sv+wev8jQlzdAgN9vzw3Li8Sw2OCvXYDrv/K0xZn1T0LWMS38MUJ2B4wcw0fru+xRmL4lhRPzhrkw0CwnSagD4jMJVevRoQ",
       "protocol_key_bytes": "mfJe9h+AMrkUY2RgmCxcxvE07x3a52ZX8sv+wev8jQlzdAgN9vzw3Li8Sw2OCvXYDrv/K0xZn1T0LWMS38MUJ2B4wcw0fru+xRmL4lhRPzhrkw0CwnSagD4jMJVevRoQ",
       "stake": 1,
       "primary_address": "/ip4/127.0.0.1/udp/0",
-      "network_key": "iRf3oG9ka0fwbVnVX9BQ3m9wisZbj4rDCF/q5oTjLU4="
+      "network_key": "iRf3oG9ka0fwbVnVX9BQ3m9wisZbj4rDCF/q5oTjLU4=",
+      "hostname": "/ip4/127.0.0.1/udp/0"
     },
     "ofT8sYBvqkB+c/sjDYTwar96xgZbTdi/ncbet8ja9ePYhtSje59zyarNpF/ZxM1dAncK6uyr9Xv1lS7bJs+nSj2k0bMvbStf5RORLeuPwYz/yJrDOQQf4MxOnW0u8Gzo": {
       "protocol_key": "ofT8sYBvqkB+c/sjDYTwar96xgZbTdi/ncbet8ja9ePYhtSje59zyarNpF/ZxM1dAncK6uyr9Xv1lS7bJs+nSj2k0bMvbStf5RORLeuPwYz/yJrDOQQf4MxOnW0u8Gzo",
       "protocol_key_bytes": "ofT8sYBvqkB+c/sjDYTwar96xgZbTdi/ncbet8ja9ePYhtSje59zyarNpF/ZxM1dAncK6uyr9Xv1lS7bJs+nSj2k0bMvbStf5RORLeuPwYz/yJrDOQQf4MxOnW0u8Gzo",
       "stake": 1,
       "primary_address": "/ip4/127.0.0.1/udp/0",
-      "network_key": "LC/82uPqS70tgF56yNcxk5O1TD37cuMArVZDxvROh6M="
+      "network_key": "LC/82uPqS70tgF56yNcxk5O1TD37cuMArVZDxvROh6M=",
+      "hostname": "/ip4/127.0.0.1/udp/0"
     },
     "q1ys+9ZU8B5aHgYbgyC5N0XQlGdq1B7xY9D8JOyT89upZpiuKRUDBsq3h/WbLtd4AvLNFNECBjlAG06r8heq7tEs6ol97VfaS2579e4b337eJAwd/y1bIt4F+LhEc3sV": {
       "protocol_key": "q1ys+9ZU8B5aHgYbgyC5N0XQlGdq1B7xY9D8JOyT89upZpiuKRUDBsq3h/WbLtd4AvLNFNECBjlAG06r8heq7tEs6ol97VfaS2579e4b337eJAwd/y1bIt4F+LhEc3sV",
       "protocol_key_bytes": "q1ys+9ZU8B5aHgYbgyC5N0XQlGdq1B7xY9D8JOyT89upZpiuKRUDBsq3h/WbLtd4AvLNFNECBjlAG06r8heq7tEs6ol97VfaS2579e4b337eJAwd/y1bIt4F+LhEc3sV",
       "stake": 1,
       "primary_address": "/ip4/127.0.0.1/udp/0",
-      "network_key": "dqJ63C6YZnD7A5GKXt7kPzZ/HzbCxobxbOy3xRXx+2U="
+      "network_key": "dqJ63C6YZnD7A5GKXt7kPzZ/HzbCxobxbOy3xRXx+2U=",
+      "hostname": "/ip4/127.0.0.1/udp/0"
     }
   },
   "epoch": 0

--- a/narwhal/consensus/src/bullshark.rs
+++ b/narwhal/consensus/src/bullshark.rs
@@ -204,7 +204,6 @@ impl Bullshark {
                 .unwrap_or_default();
 
             if !last_election_round.leader_found {
-
                 self.metrics
                     .leader_election
                     .with_label_values(&["not_found", &hostname])
@@ -339,9 +338,16 @@ impl Bullshark {
 
         self.last_successful_leader_election_timestamp = Instant::now();
 
+        let hostname = self
+            .last_leader_election
+            .leader
+            .as_ref()
+            .map(|authority| authority.hostname())
+            .unwrap_or_default();
+
         self.metrics
             .leader_election
-            .with_label_values(&["elected"])
+            .with_label_values(&["elected", &hostname])
             .inc();
 
         // The total leader_commits are expected to grow the same amount on validators,

--- a/narwhal/consensus/src/bullshark.rs
+++ b/narwhal/consensus/src/bullshark.rs
@@ -112,15 +112,15 @@ impl Bullshark {
         committee: &Committee,
         round: Round,
         dag: &'a Dag,
-    ) -> (Option<&'a Certificate>, Authority) {
+    ) -> (Authority, Option<&'a Certificate>) {
         // Note: this function is often called with even rounds only. While we do not aim at random selection
         // yet (see issue #10), repeated calls to this function should still pick from the whole roster of leaders.
         let leader = Self::leader_authority(committee, round);
 
         // Return its certificate and the certificate's digest.
         match dag.get(&round).and_then(|x| x.get(&leader.id())) {
-            None => (None, leader),
-            Some((_, certificate)) => (Some(certificate), leader),
+            None => (leader, None),
+            Some((_, certificate)) => (leader, Some(certificate)),
         }
     }
 
@@ -237,8 +237,8 @@ impl Bullshark {
 
         let (leader, leader_authority) =
             match Self::leader(&self.committee, leader_round, &state.dag) {
-                (Some(certificate), leader_authority) => (certificate, leader_authority),
-                (None, leader_authority) => {
+                (leader_authority, Some(certificate)) => (certificate, leader_authority),
+                (leader_authority, None) => {
                     self.last_leader_election = LastRound {
                         leader: Some(leader_authority),
                         leader_found: false,

--- a/narwhal/consensus/src/bullshark.rs
+++ b/narwhal/consensus/src/bullshark.rs
@@ -206,12 +206,12 @@ impl Bullshark {
             if !last_election_round.leader_found {
                 self.metrics
                     .leader_election
-                    .with_label_values(&["not_found", &hostname])
+                    .with_label_values(&["not_found", hostname])
                     .inc();
             } else if !last_election_round.leader_has_support {
                 self.metrics
                     .leader_election
-                    .with_label_values(&["not_enough_support", &hostname])
+                    .with_label_values(&["not_enough_support", hostname])
                     .inc();
             }
         }
@@ -347,7 +347,7 @@ impl Bullshark {
 
         self.metrics
             .leader_election
-            .with_label_values(&["elected", &hostname])
+            .with_label_values(&["elected", hostname])
             .inc();
 
         // The total leader_commits are expected to grow the same amount on validators,

--- a/narwhal/consensus/src/bullshark.rs
+++ b/narwhal/consensus/src/bullshark.rs
@@ -6,16 +6,13 @@ use crate::{
     consensus::{ConsensusState, Dag},
     utils, ConsensusError, Outcome,
 };
-use config::{AuthorityIdentifier, Committee, Stake};
+use config::{Authority, Committee, Stake};
 use fastcrypto::hash::Hash;
 use std::sync::Arc;
 use storage::ConsensusStore;
 use tokio::time::Instant;
 use tracing::{debug, error_span};
-use types::{
-    Certificate, CertificateAPI, CertificateDigest, CommittedSubDag, HeaderAPI, ReputationScores,
-    Round,
-};
+use types::{Certificate, CertificateAPI, CommittedSubDag, HeaderAPI, ReputationScores, Round};
 
 #[cfg(test)]
 #[path = "tests/bullshark_tests.rs"]
@@ -32,6 +29,9 @@ pub mod randomized_tests;
 /// and consequently a commit.
 #[derive(Default)]
 pub struct LastRound {
+    /// The elected leader of the round. That's irrespective of whether the corresponding certificate
+    /// is found or not.
+    leader: Option<Authority>,
     /// True when the leader has actually proposed a certificate
     /// and found in our DAG
     leader_found: bool,
@@ -77,10 +77,10 @@ impl Bullshark {
         }
     }
 
-    // Returns the PublicKey of the authority which is the leader for the provided `round`.
+    // Returns the the authority which is the leader for the provided `round`.
     // Pay attention that this method will return always the first authority as the leader
     // when used under a test environment.
-    pub fn leader_authority(committee: &Committee, round: Round) -> AuthorityIdentifier {
+    pub fn leader_authority(committee: &Committee, round: Round) -> Authority {
         assert_eq!(
             round % 2,
             0,
@@ -97,27 +97,31 @@ impl Bullshark {
                 let next_leader = (round/2 - 1) as usize % committee.size();
                 let authorities = committee.authorities().collect::<Vec<_>>();
 
-                authorities.get(next_leader).unwrap().id()
+                (*authorities.get(next_leader).unwrap()).clone()
             } else {
                 // Elect the leader in a stake-weighted choice seeded by the round
-                committee.leader(round).id()
+                committee.leader(round)
             }
         }
     }
 
-    /// Returns the certificate (and the certificate's digest) originated by the leader of the
-    /// specified round (if any).
+    /// Returns the certificate originated by the leader of the specified round (if any). The Authority
+    /// leader of the round is always returned and that's irrespective of whether the certificate exists
+    /// as that's deterministically determined.
     fn leader<'a>(
         committee: &Committee,
         round: Round,
         dag: &'a Dag,
-    ) -> Option<&'a (CertificateDigest, Certificate)> {
+    ) -> (Option<&'a Certificate>, Authority) {
         // Note: this function is often called with even rounds only. While we do not aim at random selection
         // yet (see issue #10), repeated calls to this function should still pick from the whole roster of leaders.
         let leader = Self::leader_authority(committee, round);
 
         // Return its certificate and the certificate's digest.
-        dag.get(&round).and_then(|x| x.get(&leader))
+        match dag.get(&round).and_then(|x| x.get(&leader.id())) {
+            None => (None, leader),
+            Some((_, certificate)) => (Some(certificate), leader),
+        }
     }
 
     /// Calculates the reputation score for the current commit by taking into account the reputation
@@ -193,16 +197,22 @@ impl Bullshark {
         // Report last leader election if was unsuccessful
         if round > self.max_inserted_certificate_round && round % 2 == 0 {
             let last_election_round = &self.last_leader_election;
+            let hostname = last_election_round
+                .leader
+                .as_ref()
+                .map(|authority| authority.hostname())
+                .unwrap_or_default();
 
             if !last_election_round.leader_found {
+
                 self.metrics
                     .leader_election
-                    .with_label_values(&["not_found"])
+                    .with_label_values(&["not_found", &hostname])
                     .inc();
             } else if !last_election_round.leader_has_support {
                 self.metrics
                     .leader_election
-                    .with_label_values(&["not_enough_support"])
+                    .with_label_values(&["not_enough_support", &hostname])
                     .inc();
             }
         }
@@ -225,18 +235,21 @@ impl Bullshark {
         if leader_round <= state.last_round.committed_round {
             return Ok((Outcome::LeaderBelowCommitRound, Vec::new()));
         }
-        let (leader_digest, leader) = match Self::leader(&self.committee, leader_round, &state.dag)
-        {
-            Some(x) => x,
-            None => {
-                self.last_leader_election = LastRound {
-                    leader_found: false,
-                    leader_has_support: false,
-                };
-                // leader has not been found - we don't have any certificate
-                return Ok((Outcome::LeaderNotFound, Vec::new()));
-            }
-        };
+
+        let (leader, leader_authority) =
+            match Self::leader(&self.committee, leader_round, &state.dag) {
+                (Some(certificate), leader_authority) => (certificate, leader_authority),
+                (None, leader_authority) => {
+                    self.last_leader_election = LastRound {
+                        leader: Some(leader_authority),
+                        leader_found: false,
+                        leader_has_support: false,
+                    };
+
+                    // leader has not been found - we don't have any certificate
+                    return Ok((Outcome::LeaderNotFound, Vec::new()));
+                }
+            };
 
         // Check if the leader has f+1 support from its children (ie. round r+1).
         let stake: Stake = state
@@ -244,11 +257,12 @@ impl Bullshark {
             .get(&round)
             .expect("We should have the whole history by now")
             .values()
-            .filter(|(_, x)| x.header().parents().contains(leader_digest))
+            .filter(|(_, x)| x.header().parents().contains(&leader.digest()))
             .map(|(_, x)| self.committee.stake_by_id(x.origin()))
             .sum();
 
         self.last_leader_election = LastRound {
+            leader: Some(leader_authority),
             leader_found: true,
             leader_has_support: false,
         };

--- a/narwhal/consensus/src/metrics.rs
+++ b/narwhal/consensus/src/metrics.rs
@@ -105,7 +105,7 @@ impl ConsensusMetrics {
             leader_election: register_int_counter_vec_with_registry!(
                 "leader_election",
                 "The outcome of a leader election round",
-                &["outcome"],
+                &["outcome", "authority"],
                 registry
             ).unwrap(),
             leader_commits: register_int_counter_vec_with_registry!(

--- a/narwhal/consensus/src/tests/bullshark_tests.rs
+++ b/narwhal/consensus/src/tests/bullshark_tests.rs
@@ -9,6 +9,7 @@ use crate::consensus::ConsensusRound;
 use crate::consensus_utils::NUM_SUB_DAGS_PER_SCHEDULE;
 use crate::consensus_utils::*;
 use crate::{metrics::ConsensusMetrics, Consensus, NUM_SHUTDOWN_RECEIVERS};
+use config::AuthorityIdentifier;
 #[allow(unused_imports)]
 use fastcrypto::traits::KeyPair;
 use prometheus::Registry;

--- a/narwhal/consensus/src/tests/consensus_tests.rs
+++ b/narwhal/consensus/src/tests/consensus_tests.rs
@@ -142,7 +142,7 @@ async fn test_consensus_recovery_with_bullshark() {
         let last_round = *last_committed.get(&id).unwrap();
 
         // For the leader of round 6 we expect to have last committed round of 6.
-        if id == Bullshark::leader_authority(&committee, 6) {
+        if id == Bullshark::leader_authority(&committee, 6).id() {
             assert_eq!(last_round, 6);
         } else {
             // For the others should be 5.

--- a/narwhal/consensus/src/utils.rs
+++ b/narwhal/consensus/src/utils.rs
@@ -15,7 +15,7 @@ pub fn order_leaders<'a, LeaderElector>(
     get_leader: LeaderElector,
 ) -> Vec<Certificate>
 where
-    LeaderElector: Fn(&Committee, Round, &'a Dag) -> (Option<&'a Certificate>, Authority),
+    LeaderElector: Fn(&Committee, Round, &'a Dag) -> (Authority, Option<&'a Certificate>),
 {
     let mut to_commit = vec![leader.clone()];
     let mut leader = leader;
@@ -26,8 +26,8 @@ where
     {
         // Get the certificate proposed by the previous leader.
         let prev_leader = match get_leader(committee, r, &state.dag) {
-            (Some(x), _) => x,
-            (None, _) => continue,
+            (_authority, Some(x)) => x,
+            (_authority, None) => continue,
         };
 
         // Check whether there is a path between the last two leaders.

--- a/narwhal/consensus/src/utils.rs
+++ b/narwhal/consensus/src/utils.rs
@@ -2,10 +2,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crate::consensus::{ConsensusState, Dag};
-use config::Committee;
+use config::{Authority, Committee};
 use std::collections::HashSet;
 use tracing::debug;
-use types::{Certificate, CertificateAPI, CertificateDigest, HeaderAPI, Round};
+use types::{Certificate, CertificateAPI, HeaderAPI, Round};
 
 /// Order the past leaders that we didn't already commit.
 pub fn order_leaders<'a, LeaderElector>(
@@ -15,7 +15,7 @@ pub fn order_leaders<'a, LeaderElector>(
     get_leader: LeaderElector,
 ) -> Vec<Certificate>
 where
-    LeaderElector: Fn(&Committee, Round, &'a Dag) -> Option<&'a (CertificateDigest, Certificate)>,
+    LeaderElector: Fn(&Committee, Round, &'a Dag) -> (Option<&'a Certificate>, Authority),
 {
     let mut to_commit = vec![leader.clone()];
     let mut leader = leader;
@@ -25,9 +25,9 @@ where
         .step_by(2)
     {
         // Get the certificate proposed by the previous leader.
-        let (_, prev_leader) = match get_leader(committee, r, &state.dag) {
-            Some(x) => x,
-            None => continue,
+        let prev_leader = match get_leader(committee, r, &state.dag) {
+            (Some(x), _) => x,
+            (None, _) => continue,
         };
 
         // Check whether there is a path between the last two leaders.

--- a/narwhal/node/src/generate_format.rs
+++ b/narwhal/node/src/generate_format.rs
@@ -55,6 +55,7 @@ fn get_registry() -> Result<Registry> {
             1,
             primary_address,
             network_key.public().clone(),
+            i.to_string(),
         );
     }
 

--- a/narwhal/primary/tests/integration_tests_proposer_api.rs
+++ b/narwhal/primary/tests/integration_tests_proposer_api.rs
@@ -100,6 +100,7 @@ async fn test_rounds_errors() {
                 authority.stake(),
                 authority.primary_address(),
                 authority.network_key(),
+                authority.id().to_string(),
             );
         }
     }

--- a/narwhal/test-utils/src/lib.rs
+++ b/narwhal/test-utils/src/lib.rs
@@ -881,7 +881,7 @@ impl<R: rand::RngCore + rand::CryptoRng> Builder<R> {
                 self.stake.pop_front().unwrap_or(1),
                 a.address.clone(),
                 a.network_public_key(),
-                a.id().to_string(),
+                a.public_key().to_string(),
             );
         }
         let committee = committee_builder.build();

--- a/narwhal/test-utils/src/lib.rs
+++ b/narwhal/test-utils/src/lib.rs
@@ -881,6 +881,7 @@ impl<R: rand::RngCore + rand::CryptoRng> Builder<R> {
                 self.stake.pop_front().unwrap_or(1),
                 a.address.clone(),
                 a.network_public_key(),
+                a.id().to_string(),
             );
         }
         let committee = committee_builder.build();

--- a/narwhal/test-utils/src/lib.rs
+++ b/narwhal/test-utils/src/lib.rs
@@ -881,7 +881,7 @@ impl<R: rand::RngCore + rand::CryptoRng> Builder<R> {
                 self.stake.pop_front().unwrap_or(1),
                 a.address.clone(),
                 a.network_public_key(),
-                a.public_key().to_string(),
+                a.address.to_string(),
             );
         }
         let committee = committee_builder.build();


### PR DESCRIPTION
## Description 

This PR is doing mainly two things:
* extending Narwhal committee with the hostname as given by SUI
* exposing the hostname to consensus metrics to identify successful and failed leader elections

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
