### PR TITLE
rpc: DAU chart endpoint

### DIFF
--- a/crates/sui-indexer/src/apis/extended_api.rs
+++ b/crates/sui-indexer/src/apis/extended_api.rs
@@ -140,6 +140,20 @@ impl<S: IndexerStore + Sync + Send + 'static> ExtendedApiServer for ExtendedApi<
             .await?;
         Ok(AddressMetrics::from(address_stats))
     }
+
+    async fn get_all_epoch_address_metrics(
+        &self,
+        descending_order: Option<bool>,
+    ) -> RpcResult<Vec<AddressMetrics>> {
+        let epoch_address_stats = self
+            .state
+            .get_all_epoch_address_stats(descending_order)
+            .await?;
+        Ok(epoch_address_stats
+            .into_iter()
+            .map(AddressMetrics::from)
+            .collect())
+    }
 }
 
 impl<S> SuiRpcModule for ExtendedApi<S>

--- a/crates/sui-indexer/src/models/addresses.rs
+++ b/crates/sui-indexer/src/models/addresses.rs
@@ -4,6 +4,8 @@
 use std::collections::HashMap;
 
 use diesel::prelude::*;
+use diesel::sql_types::BigInt;
+use diesel::QueryableByName;
 
 use sui_json_rpc_types::AddressMetrics;
 
@@ -106,6 +108,35 @@ impl From<AddressStats> for AddressMetrics {
             cumulative_addresses: stats.cumulative_addresses as u64,
             cumulative_active_addresses: stats.cumulative_active_addresses as u64,
             daily_active_addresses: stats.daily_active_addresses as u64,
+        }
+    }
+}
+
+#[derive(QueryableByName, Debug, Clone, Default)]
+pub struct DBAddressStats {
+    #[diesel(sql_type = BigInt)]
+    pub checkpoint: i64,
+    #[diesel(sql_type = BigInt)]
+    pub epoch: i64,
+    #[diesel(sql_type = BigInt)]
+    pub timestamp_ms: i64,
+    #[diesel(sql_type = BigInt)]
+    pub cumulative_addresses: i64,
+    #[diesel(sql_type = BigInt)]
+    pub cumulative_active_addresses: i64,
+    #[diesel(sql_type = BigInt)]
+    pub daily_active_addresses: i64,
+}
+
+impl From<DBAddressStats> for AddressStats {
+    fn from(stats: DBAddressStats) -> Self {
+        AddressStats {
+            checkpoint: stats.checkpoint,
+            epoch: stats.epoch,
+            timestamp_ms: stats.timestamp_ms,
+            cumulative_addresses: stats.cumulative_addresses,
+            cumulative_active_addresses: stats.cumulative_active_addresses,
+            daily_active_addresses: stats.daily_active_addresses,
         }
     }
 }

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -258,6 +258,10 @@ pub trait IndexerStore {
         &self,
         checkpoint: i64,
     ) -> Result<AddressStats, IndexerError>;
+    async fn get_all_epoch_address_stats(
+        &self,
+        descending_order: Option<bool>,
+    ) -> Result<Vec<AddressStats>, IndexerError>;
 }
 
 #[derive(Clone, Debug)]

--- a/crates/sui-json-rpc/src/api/extended.rs
+++ b/crates/sui-json-rpc/src/api/extended.rs
@@ -55,4 +55,9 @@ pub trait ExtendedApi {
     async fn get_latest_address_metrics(&self) -> RpcResult<AddressMetrics>;
     #[method(name = "getCheckpointAddressMetrics")]
     async fn get_checkpoint_address_metrics(&self, checkpoint: u64) -> RpcResult<AddressMetrics>;
+    #[method(name = "getAllEpochAddressMetrics")]
+    async fn get_all_epoch_address_metrics(
+        &self,
+        descending_order: Option<bool>,
+    ) -> RpcResult<Vec<AddressMetrics>>;
 }


### PR DESCRIPTION
## Description 

Add endpoints for DAU over epochs.

## Test Plan 

```
curl --location --request POST http://127.0.0.1:3030 \
--header 'Content-Type: application/json' \
--data-raw '{
"jsonrpc": "2.0",
"id": 1,
"method": "suix_getAllEpochAddressMetrics",
"params": [true]
}'
{"jsonrpc":"2.0","result":[{"checkpoint":36799,"epoch":1,"timestampMs":1683849325183,"cumulativeAddresses":84280,"cumulativeActiveAddresses":1218,"dailyActiveAddresses":1218},{"checkpoint":5499,"epoch":0,"timestampMs":1683817158611,"cumulativeAddresses":690,"cumulativeActiveAddresses":5,"dailyActiveAddresses":5}],"id":1}%             
curl --location --request POST http://127.0.0.1:3030 \
--header 'Content-Type: application/json' \
--data-raw '{
"jsonrpc": "2.0",
"id": 1,
"method": "suix_getAllEpochAddressMetrics",
"params": []
}'
{"jsonrpc":"2.0","result":[{"checkpoint":5499,"epoch":0,"timestampMs":1683817158611,"cumulativeAddresses":690,"cumulativeActiveAddresses":5,"dailyActiveAddresses":5},{"checkpoint":36799,"epoch":1,"timestampMs":1683849325183,"cumulativeAddresses":84280,"cumulativeActiveAddresses":1218,"dailyActiveAddresses":1218}],"id":1}% 
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
