### PR TITLE
[rocksdb] allow setting sync to disk on WriteOptions

### DIFF
--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -559,9 +559,7 @@ fn objects_table_default_config() -> DBOptions {
                 read_size_from_env(ENV_VAR_OBJECTS_BLOCK_CACHE_SIZE).unwrap_or(5 * 1024),
             )
             .options,
-        rw_options: ReadWriteOptions {
-            ignore_range_deletions: true,
-        },
+        rw_options: ReadWriteOptions::default().set_ignore_range_deletions(true),
     }
 }
 

--- a/crates/sui-storage/src/indexes.rs
+++ b/crates/sui-storage/src/indexes.rs
@@ -250,9 +250,7 @@ fn coin_index_table_default_config() -> DBOptions {
                 read_size_from_env(ENV_VAR_COIN_INDEX_BLOCK_CACHE_SIZE_MB).unwrap_or(5 * 1024),
             )
             .options,
-        rw_options: ReadWriteOptions {
-            ignore_range_deletions: true,
-        },
+        rw_options: ReadWriteOptions::default().set_ignore_range_deletions(true),
     }
 }
 


### PR DESCRIPTION
## Description 

There have been reports of fullnode operators seeing data corruptions, where fullnodes are running in evictable pods. Add an option to ensure rocksdb writes are flushed to disk, so operators can experiment with its effectiveness.

Eventually we want to make sync to disk the default behavior, but right now this slows down maximum write throughput a bit too much.

## Test Plan 

CI. Private testnet.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
