### PR TITLE
insert committee when handling checkpoint from consensus

### DIFF
--- a/crates/sui-network/src/state_sync/mod.rs
+++ b/crates/sui-network/src/state_sync/mod.rs
@@ -57,10 +57,11 @@ use std::{
 };
 use sui_config::p2p::StateSyncConfig;
 use sui_types::{
+    committee::Committee,
     digests::CheckpointDigest,
     messages_checkpoint::{
-        CertifiedCheckpointSummary as Checkpoint, CheckpointSequenceNumber, FullCheckpointContents,
-        VerifiedCheckpoint, VerifiedCheckpointContents,
+        CertifiedCheckpointSummary as Checkpoint, CheckpointSequenceNumber, EndOfEpochData,
+        FullCheckpointContents, VerifiedCheckpoint, VerifiedCheckpointContents,
     },
     storage::ReadStore,
     storage::WriteStore,
@@ -494,6 +495,22 @@ where
                         });
                 })
                 .collect::<Vec<_>>();
+        }
+
+        // If this is the last checkpoint of a epoch, we need to make sure
+        // new committee is in store before we verify newer checkpoints in next epoch.
+        // This could happen before this validator's reconfiguration finishes, because
+        // state sync does not reconfig.
+        if let Some(EndOfEpochData {
+            next_epoch_committee,
+            ..
+        }) = checkpoint.end_of_epoch_data.as_ref()
+        {
+            let next_committee = next_epoch_committee.iter().cloned().collect();
+            let committee = Committee::new(checkpoint.epoch().saturating_add(1), next_committee);
+            self.store
+                .insert_committee(committee)
+                .expect("store operation should not fail");
         }
 
         self.metrics
@@ -965,9 +982,9 @@ where
 
     if Some(*current.digest()) != checkpoint.previous_digest {
         debug!(
-            current_sequence_number = current.sequence_number(),
+            current_checkpoint_seq = current.sequence_number(),
             current_digest =% current.digest(),
-            checkpoint_sequence_number = checkpoint.sequence_number(),
+            checkpoint_seq = checkpoint.sequence_number(),
             checkpoint_digest =% checkpoint.digest(),
             checkpoint_previous_digest =? checkpoint.previous_digest,
             "checkpoint not on same chain"
@@ -979,8 +996,10 @@ where
     if checkpoint.epoch() != current_epoch && checkpoint.epoch() != current_epoch.saturating_add(1)
     {
         debug!(
-            current_epoch = current_epoch,
+            checkpoint_seq = checkpoint.sequence_number(),
             checkpoint_epoch = checkpoint.epoch(),
+            current_checkpoint_seq = current.sequence_number(),
+            current_epoch = current_epoch,
             "cannot verify checkpoint with too high of an epoch",
         );
         return Err(checkpoint);
@@ -990,6 +1009,10 @@ where
         && current.next_epoch_committee().is_none()
     {
         debug!(
+            checkpoint_seq = checkpoint.sequence_number(),
+            checkpoint_epoch = checkpoint.epoch(),
+            current_checkpoint_seq = current.sequence_number(),
+            current_epoch = current_epoch,
             "next checkpoint claims to be from the next epoch but the latest verified \
             checkpoint does not indicate that it is the last checkpoint of an epoch"
         );
@@ -999,7 +1022,13 @@ where
     let committee = store
         .get_committee(checkpoint.epoch())
         .expect("store operation should not fail")
-        .expect("BUG: should have a committee for an epoch before we try to verify checkpoints from an epoch");
+        .unwrap_or_else(|| {
+            panic!(
+                "BUG: should have committee for epoch {} before we try to verify checkpoint {}",
+                checkpoint.epoch(),
+                checkpoint.sequence_number()
+            )
+        });
 
     checkpoint.verify_signature(&committee).map_err(|e| {
         debug!("error verifying checkpoint: {e}");

--- a/crates/sui-network/src/state_sync/mod.rs
+++ b/crates/sui-network/src/state_sync/mod.rs
@@ -501,6 +501,8 @@ where
         // new committee is in store before we verify newer checkpoints in next epoch.
         // This could happen before this validator's reconfiguration finishes, because
         // state sync does not reconfig.
+        // TODO: make CheckpointAggregator use WriteStore so we don't need to do this
+        // committee insertion in two places (only in `insert_checkpoint`).
         if let Some(EndOfEpochData {
             next_epoch_committee,
             ..


### PR DESCRIPTION
## Description 

In https://github.com/MystenLabs/sui/pull/12212, we refactored `handle_checkpoint_from_consensus`. The PR missed one thing: when a last checkpoint of an epoch is certified in consensus and sent to state sync, we do not update the committee store. This is problematic because state sync does not reconfig. It means if a validator is slow in reconfiguration (where committee store would also be updated) and gets checkpoints in the next epoch from peers, it will panic in that it couldn't find the committee. This PR fixes it. 


## Test Plan 

```
for f in `seq 1 20`; do MSIM_TEST_NUM=5 MSIM_TEST_SEED=98$f RUST_LOG=off simt test_simulated_load_reconfig_restarts --no-capture > log-$f 2>&1 &; done
```

```
grep FAIL log-*
```
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Insert committee when handling checkpoint from consensus.