### PR TITLE
Add storage format enum to file metadata in archive manifest

### DIFF
--- a/crates/sui-archival/src/lib.rs
+++ b/crates/sui-archival/src/lib.rs
@@ -51,6 +51,10 @@ use sui_storage::{compute_sha3_checksum, Blob, Encoding, FileCompression, SHA3_B
 ///┌──────────────────────────────┐
 ///│       magic <4 byte>         │
 ///├──────────────────────────────┤
+///│  storage format <1 byte>     │
+// ├──────────────────────────────┤
+///│    file compression <1 byte> │
+// ├──────────────────────────────┤
 ///│ ┌──────────────────────────┐ │
 ///│ │   CheckpointContent 1    │ │
 ///│ ├──────────────────────────┤ │
@@ -68,6 +72,10 @@ use sui_storage::{compute_sha3_checksum, Blob, Encoding, FileCompression, SHA3_B
 ///┌──────────────────────────────┐
 ///│       magic <4 byte>         │
 ///├──────────────────────────────┤
+///│  storage format <1 byte>     │
+// ├──────────────────────────────┤
+// │  file compression <1 byte>   │
+// ├──────────────────────────────┤
 ///│ ┌──────────────────────────┐ │
 ///│ │   CheckpointSummary 1    │ │
 ///│ ├──────────────────────────┤ │
@@ -102,6 +110,14 @@ const MANIFEST_FILENAME: &str = "MANIFEST";
     Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, TryFromPrimitive, IntoPrimitive,
 )]
 #[repr(u8)]
+pub enum StorageFormat {
+    Blob = 0,
+}
+
+#[derive(
+    Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, TryFromPrimitive, IntoPrimitive,
+)]
+#[repr(u8)]
 pub enum FileType {
     CheckpointContent = 0,
     CheckpointSummary,
@@ -113,6 +129,7 @@ pub struct FileMetadata {
     pub epoch_num: u64,
     pub checkpoint_seq_range: Range<u64>,
     pub file_compression: FileCompression,
+    pub storage_format: StorageFormat,
     pub sha3_digest: [u8; 32],
 }
 
@@ -237,6 +254,7 @@ pub fn create_file_metadata(
     file_path: &std::path::Path,
     file_compression: FileCompression,
     file_type: FileType,
+    storage_format: StorageFormat,
     epoch_num: u64,
     checkpoint_seq_range: Range<u64>,
 ) -> Result<FileMetadata> {
@@ -247,6 +265,7 @@ pub fn create_file_metadata(
         epoch_num,
         checkpoint_seq_range,
         file_compression,
+        storage_format,
         sha3_digest,
     };
     Ok(file_metadata)

--- a/crates/sui-archival/src/tests.rs
+++ b/crates/sui-archival/src/tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::writer::ArchiveWriterV1;
-use crate::{read_manifest, FileCompression, EPOCH_DIR_PREFIX};
+use crate::{read_manifest, FileCompression, StorageFormat, EPOCH_DIR_PREFIX};
 use object_store::path::Path;
 use object_store::DynObjectStore;
 use prometheus::Registry;
@@ -72,6 +72,7 @@ async fn setup_checkpoint_writer(temp_dir: PathBuf) -> anyhow::Result<TestState>
         local_store_config.clone(),
         remote_store_config.clone(),
         FileCompression::Zstd,
+        StorageFormat::Blob,
         Duration::from_secs(10),
         20,
         &Registry::default(),

--- a/crates/sui-archival/src/writer.rs
+++ b/crates/sui-archival/src/writer.rs
@@ -4,12 +4,12 @@
 
 use crate::{
     create_file_metadata, read_manifest, write_manifest, CheckpointUpdates, FileCompression,
-    FileMetadata, FileType, Manifest, CHECKPOINT_FILE_MAGIC, CHECKPOINT_FILE_SUFFIX,
+    FileMetadata, FileType, Manifest, StorageFormat, CHECKPOINT_FILE_MAGIC, CHECKPOINT_FILE_SUFFIX,
     EPOCH_DIR_PREFIX, MAGIC_BYTES, SUMMARY_FILE_MAGIC, SUMMARY_FILE_SUFFIX,
 };
 use anyhow::Result;
 use anyhow::{anyhow, Context};
-use byteorder::{BigEndian, ByteOrder};
+use byteorder::{BigEndian, ByteOrder, WriteBytesExt};
 use object_store::DynObjectStore;
 use prometheus::{register_int_gauge_with_registry, IntGauge, Registry};
 use std::fs;
@@ -58,6 +58,7 @@ struct CheckpointWriter {
     sender: Sender<CheckpointUpdates>,
     checkpoint_buf_offset: usize,
     file_compression: FileCompression,
+    storage_format: StorageFormat,
     manifest: Manifest,
     last_commit_instant: Instant,
     commit_duration: Duration,
@@ -68,6 +69,7 @@ impl CheckpointWriter {
     fn new(
         root_dir_path: PathBuf,
         file_compression: FileCompression,
+        storage_format: StorageFormat,
         sender: Sender<CheckpointUpdates>,
         manifest: Manifest,
         commit_duration: Duration,
@@ -85,12 +87,16 @@ impl CheckpointWriter {
             checkpoint_sequence_num,
             CHECKPOINT_FILE_SUFFIX,
             CHECKPOINT_FILE_MAGIC,
+            storage_format,
+            file_compression,
         )?;
         let summary_file = Self::next_file(
             &epoch_dir,
             checkpoint_sequence_num,
             SUMMARY_FILE_SUFFIX,
             SUMMARY_FILE_MAGIC,
+            storage_format,
+            file_compression,
         )?;
         Ok(CheckpointWriter {
             root_dir_path,
@@ -101,13 +107,28 @@ impl CheckpointWriter {
             checkpoint_buf_offset: 0,
             sender,
             file_compression,
+            storage_format,
             manifest,
             last_commit_instant: Instant::now(),
             commit_duration,
             commit_file_size,
         })
     }
+
     pub async fn write(
+        &mut self,
+        checkpoint_contents: CheckpointContents,
+        checkpoint_summary: Checkpoint,
+    ) -> Result<()> {
+        match self.storage_format {
+            StorageFormat::Blob => {
+                self.write_as_blob(checkpoint_contents, checkpoint_summary)
+                    .await
+            }
+        }
+    }
+
+    pub async fn write_as_blob(
         &mut self,
         checkpoint_contents: CheckpointContents,
         checkpoint_summary: Checkpoint,
@@ -174,6 +195,7 @@ impl CheckpointWriter {
             &file_path,
             self.file_compression,
             FileType::CheckpointContent,
+            self.storage_format,
             self.epoch_num,
             self.checkpoint_range.clone(),
         )?;
@@ -192,6 +214,7 @@ impl CheckpointWriter {
             &file_path,
             self.file_compression,
             FileType::CheckpointSummary,
+            self.storage_format,
             self.epoch_num,
             self.checkpoint_range.clone(),
         )?;
@@ -217,6 +240,8 @@ impl CheckpointWriter {
         checkpoint_sequence_num: u64,
         suffix: &str,
         magic_bytes: u32,
+        storage_format: StorageFormat,
+        file_compression: FileCompression,
     ) -> Result<File> {
         let next_file_path = dir_path.join(format!("{checkpoint_sequence_num}.{suffix}"));
         let mut f = File::create(next_file_path.clone())?;
@@ -226,6 +251,8 @@ impl CheckpointWriter {
         drop(f);
         f = OpenOptions::new().append(true).open(next_file_path)?;
         f.seek(SeekFrom::Start(n as u64))?;
+        f.write_u8(storage_format.into())?;
+        f.write_u8(file_compression.into())?;
         Ok(f)
     }
     fn create_new_files(&mut self) -> Result<()> {
@@ -234,6 +261,8 @@ impl CheckpointWriter {
             self.checkpoint_range.start,
             CHECKPOINT_FILE_SUFFIX,
             CHECKPOINT_FILE_MAGIC,
+            self.storage_format,
+            self.file_compression,
         )?;
         self.checkpoint_buf_offset = MAGIC_BYTES;
         self.wbuf = BufWriter::new(f);
@@ -242,6 +271,8 @@ impl CheckpointWriter {
             self.checkpoint_range.start,
             SUMMARY_FILE_SUFFIX,
             SUMMARY_FILE_MAGIC,
+            self.storage_format,
+            self.file_compression,
         )?;
         self.summary_wbuf = BufWriter::new(f);
         Ok(())
@@ -271,6 +302,7 @@ impl CheckpointWriter {
 /// simultaneously uploading them to a remote object store
 pub struct ArchiveWriterV1 {
     file_compression: FileCompression,
+    storage_format: StorageFormat,
     local_staging_dir_root: PathBuf,
     local_object_store: Arc<DynObjectStore>,
     remote_object_store: Arc<DynObjectStore>,
@@ -284,12 +316,14 @@ impl ArchiveWriterV1 {
         local_store_config: ObjectStoreConfig,
         remote_store_config: ObjectStoreConfig,
         file_compression: FileCompression,
+        storage_format: StorageFormat,
         commit_duration: Duration,
         commit_file_size: usize,
         registry: &Registry,
     ) -> Result<Self> {
         Ok(ArchiveWriterV1 {
             file_compression,
+            storage_format,
             remote_object_store: remote_store_config.make()?,
             local_object_store: local_store_config.make()?,
             local_staging_dir_root: local_store_config.directory.context("Missing local dir")?,
@@ -312,6 +346,7 @@ impl ArchiveWriterV1 {
             self.local_staging_dir_root.clone(),
             store,
             self.file_compression,
+            self.storage_format,
             self.commit_duration,
             self.commit_file_size,
             sender,
@@ -334,6 +369,7 @@ impl ArchiveWriterV1 {
         local_staging_root_dir: PathBuf,
         store: S,
         file_compression: FileCompression,
+        storage_format: StorageFormat,
         commit_duration: Duration,
         commit_file_size: usize,
         sender: Sender<CheckpointUpdates>,
@@ -365,6 +401,7 @@ impl ArchiveWriterV1 {
         let mut writer = CheckpointWriter::new(
             local_staging_root_dir,
             file_compression,
+            storage_format,
             sender,
             manifest,
             commit_duration,

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -44,6 +44,7 @@ use mysten_network::server::ServerBuilder;
 use narwhal_network::metrics::MetricsMakeCallbackHandler;
 use narwhal_network::metrics::{NetworkConnectionMetrics, NetworkMetrics};
 use sui_archival::writer::ArchiveWriterV1;
+use sui_archival::StorageFormat;
 use sui_config::node::DBCheckpointConfig;
 use sui_config::node_config_metrics::NodeConfigMetrics;
 use sui_config::{ConsensusConfig, NodeConfig};
@@ -388,6 +389,7 @@ impl SuiNode {
                     local_store_config,
                     remote_store_config.clone(),
                     FileCompression::Zstd,
+                    StorageFormat::Blob,
                     Duration::from_secs(600),
                     1024 * 1024 * 1024,
                     &prometheus_registry,


### PR DESCRIPTION
## Description 

Right now we always assume the underlying storage format is blob. This allows us to migrate to with other storage formats in the future without needing to migrate older data to newer format. We would be able to just add a new enum value and start writing newer checkpoints with newer storage format.

## Test Plan 

Existing tests