### PR TITLE
Add sui-metric-checker crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7845,9 +7845,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
  "aho-corasick 1.0.1",
  "memchr",
@@ -9927,6 +9927,7 @@ dependencies = [
  "clap 4.3.1",
  "humantime",
  "prometheus-http-query",
+ "regex",
  "reqwest",
  "serde 1.0.152",
  "serde_yaml 0.9.21",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,7 +178,7 @@ dependencies = [
  "anemo-build",
  "anemo-tower",
  "anyhow",
- "clap 4.1.4",
+ "clap 4.3.1",
  "mysten-network",
  "rand 0.8.5",
  "sui-types",
@@ -201,7 +207,7 @@ dependencies = [
  "anemo",
  "anemo-tower",
  "bytes",
- "clap 4.1.4",
+ "clap 4.3.1",
  "dashmap",
  "rand 0.8.5",
  "tokio",
@@ -243,10 +249,59 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.69"
+name = "anstream"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 dependencies = [
  "backtrace",
 ]
@@ -867,7 +922,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.23.2",
  "lazy_static 1.4.0",
  "pin-project-lite",
  "tokio",
@@ -1053,7 +1108,7 @@ dependencies = [
  "rustls 0.20.7",
  "rustls-pemfile",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tower-service",
 ]
 
@@ -1112,9 +1167,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.0"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "base64-simd"
@@ -1606,13 +1661,13 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.24"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-integer",
  "num-traits 0.2.15",
  "serde 1.0.152",
  "time 0.1.45",
@@ -1724,17 +1779,26 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.4"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
+checksum = "b4ed2379f8603fa2b7509891660e802b88c70a79a6427a70abb5968054de2c28"
 dependencies = [
- "bitflags",
- "clap_derive 4.1.0",
- "clap_lex 0.3.1",
- "is-terminal",
+ "clap_builder",
+ "clap_derive 4.3.1",
  "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72394f3339a76daf211e57d4bcb374410f3965dcc606dd0e03738c7888766980"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
+ "clap_lex 0.5.0",
  "strsim 0.10.0",
- "termcolor",
 ]
 
 [[package]]
@@ -1752,15 +1816,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.1.0"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
+checksum = "59e9ef9a08ee1c0e1f2e162121665ac45ac3783b0f897db7244ae75ad9a8f65b"
 dependencies = [
  "heck 0.4.0",
- "proc-macro-error",
  "proc-macro2 1.0.58",
  "quote 1.0.26",
- "syn 1.0.107",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -1774,12 +1837,18 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
+checksum = "033f6b7a4acb1f358c742aaca805c939ee73b4c6209ae4318ec7aca81c42e646"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "clear_on_drop"
@@ -1827,6 +1896,12 @@ name = "collectable"
 version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08abddbaad209601e53c7dd4308d8c04c06f17bb7df006434e586a22b83be45a"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colored"
@@ -2924,7 +2999,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 name = "enum-compat-util"
 version = "0.1.0"
 dependencies = [
- "serde_yaml",
+ "serde_yaml 0.8.26",
 ]
 
 [[package]]
@@ -3925,8 +4000,21 @@ dependencies = [
  "rustls 0.20.7",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "webpki-roots",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
+dependencies = [
+ "http",
+ "hyper",
+ "rustls 0.21.1",
+ "tokio",
+ "tokio-rustls 0.24.0",
 ]
 
 [[package]]
@@ -4310,7 +4398,7 @@ dependencies = [
  "soketto",
  "thiserror",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tokio-util 0.7.4",
  "tracing",
  "webpki-roots",
@@ -4351,7 +4439,7 @@ source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=b1b300784795f6a64d0fcd
 dependencies = [
  "async-trait",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.23.2",
  "jsonrpsee-core",
  "jsonrpsee-types",
  "rustc-hash",
@@ -4955,7 +5043,7 @@ dependencies = [
  "reqwest",
  "serde 1.0.152",
  "serde_json",
- "serde_yaml",
+ "serde_yaml 0.8.26",
  "tempfile",
  "toml_edit 0.14.4",
  "walkdir",
@@ -5207,7 +5295,7 @@ dependencies = [
  "regex",
  "reqwest",
  "serde 1.0.152",
- "serde_yaml",
+ "serde_yaml 0.8.26",
  "sha2 0.9.9",
  "tempfile",
  "toml",
@@ -5918,7 +6006,7 @@ dependencies = [
  "rand 0.8.5",
  "reqwest",
  "serde-reflection",
- "serde_yaml",
+ "serde_yaml 0.8.26",
  "structopt",
  "sui-keys",
  "sui-protocol-config",
@@ -6485,7 +6573,7 @@ dependencies = [
  "aws-config",
  "aws-credential-types",
  "aws-types",
- "base64 0.21.0",
+ "base64 0.21.2",
  "bytes",
  "chrono",
  "futures",
@@ -7248,6 +7336,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus-http-query"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7970fd6e91b5cb87e9a093657572a896d133879ced7752d2c7635beae29eaba0"
+dependencies = [
+ "reqwest",
+ "serde 1.0.152",
+ "serde_json",
+ "time 0.3.17",
+ "url",
+]
+
+[[package]]
 name = "proptest"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7776,11 +7877,11 @@ checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "reqwest"
-version = "0.11.13"
+version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
+checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.2",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -7789,7 +7890,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.24.0",
  "ipnet",
  "js-sys",
  "log",
@@ -7797,18 +7898,19 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.20.7",
+ "rustls 0.21.1",
  "rustls-pemfile",
  "serde 1.0.152",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.0",
  "tokio-util 0.7.4",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
  "winreg",
@@ -7966,7 +8068,7 @@ dependencies = [
  "futures",
  "http",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.23.2",
  "lazy_static 1.4.0",
  "log",
  "rusoto_credential",
@@ -8158,7 +8260,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.2",
 ]
 
 [[package]]
@@ -8587,6 +8689,19 @@ dependencies = [
  "ryu",
  "serde 1.0.152",
  "yaml-rust",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9d684e3ec7de3bf5466b32bd75303ac16f0736426e5a4e0d6e489559ce1249c"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde 1.0.152",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -9069,7 +9184,7 @@ dependencies = [
  "serde 1.0.152",
  "serde_json",
  "serde_with",
- "serde_yaml",
+ "serde_yaml 0.8.26",
  "shared-crypto",
  "shell-words",
  "signature 1.6.4",
@@ -9288,7 +9403,7 @@ dependencies = [
  "rand 0.8.5",
  "serde 1.0.152",
  "serde_with",
- "serde_yaml",
+ "serde_yaml 0.8.26",
  "shared-crypto",
  "sui-keys",
  "sui-protocol-config",
@@ -9355,7 +9470,7 @@ dependencies = [
  "serde-reflection",
  "serde_json",
  "serde_with",
- "serde_yaml",
+ "serde_yaml 0.8.26",
  "shared-crypto",
  "signature 1.6.4",
  "sui-adapter-latest",
@@ -9480,7 +9595,7 @@ dependencies = [
 name = "sui-enum-compat-util"
 version = "0.1.0"
 dependencies = [
- "serde_yaml",
+ "serde_yaml 0.8.26",
  "workspace-hack",
 ]
 
@@ -9604,7 +9719,7 @@ dependencies = [
  "rand 0.8.5",
  "serde 1.0.152",
  "serde_with",
- "serde_yaml",
+ "serde_yaml 0.8.26",
  "shared-crypto",
  "sui-config",
  "sui-execution",
@@ -9803,6 +9918,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "sui-metric-checker"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "base64 0.21.2",
+ "chrono",
+ "clap 4.3.1",
+ "humantime",
+ "prometheus-http-query",
+ "reqwest",
+ "serde 1.0.152",
+ "serde_yaml 0.9.21",
+ "strum_macros",
+ "telemetry-subscribers",
+ "tokio",
+ "tracing",
+ "workspace-hack",
+]
+
+[[package]]
 name = "sui-move"
 version = "1.4.0"
 dependencies = [
@@ -9831,7 +9966,7 @@ dependencies = [
  "prometheus",
  "rand 0.8.5",
  "serde_json",
- "serde_yaml",
+ "serde_yaml 0.8.26",
  "sui-core",
  "sui-cost-tables",
  "sui-macros",
@@ -10069,7 +10204,7 @@ dependencies = [
  "serde 1.0.152",
  "serde_json",
  "serde_with",
- "serde_yaml",
+ "serde_yaml 0.8.26",
  "snap",
  "sui-tls",
  "sui-types",
@@ -10089,7 +10224,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "bcs",
- "clap 4.1.4",
+ "clap 4.3.1",
  "colored",
  "futures",
  "jsonrpsee",
@@ -10104,7 +10239,7 @@ dependencies = [
  "serde 1.0.152",
  "serde_json",
  "serde_with",
- "serde_yaml",
+ "serde_yaml 0.8.26",
  "shellexpand",
  "similar",
  "sui-config",
@@ -10458,7 +10593,7 @@ dependencies = [
  "rand 0.8.5",
  "serde 1.0.152",
  "serde_with",
- "serde_yaml",
+ "serde_yaml 0.8.26",
  "shared-crypto",
  "sui-config",
  "sui-execution",
@@ -10532,7 +10667,7 @@ dependencies = [
  "reqwest",
  "rustls 0.20.7",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tower-layer",
  "webpki",
  "workspace-hack",
@@ -10547,7 +10682,7 @@ dependencies = [
  "anemo-cli",
  "anyhow",
  "bcs",
- "clap 4.1.4",
+ "clap 4.3.1",
  "colored",
  "comfy-table",
  "eyre",
@@ -10677,7 +10812,7 @@ dependencies = [
  "serde-name",
  "serde_json",
  "serde_with",
- "serde_yaml",
+ "serde_yaml 0.8.26",
  "shared-crypto",
  "signature 1.6.4",
  "static_assertions",
@@ -11246,6 +11381,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
+dependencies = [
+ "rustls 0.21.1",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11353,7 +11498,7 @@ dependencies = [
  "prost-derive",
  "rustls-pemfile",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tokio-stream",
  "tokio-util 0.7.4",
  "tower",
@@ -11858,6 +12003,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
+
+[[package]]
 name = "unsigned-varint"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11889,6 +12040,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde 1.0.152",
 ]
 
 [[package]]
@@ -12103,6 +12255,19 @@ name = "wasm-bindgen-shared"
 version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+
+[[package]]
+name = "wasm-streams"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bbae3363c08332cadccd13b67db371814cd214c2524020932f0804b8cf7c078"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "web-sys"
@@ -12418,7 +12583,7 @@ dependencies = [
  "base16ct 0.1.1",
  "base16ct 0.2.0",
  "base64 0.13.1",
- "base64 0.21.0",
+ "base64 0.21.2",
  "base64ct",
  "bcs",
  "beef",
@@ -12477,11 +12642,11 @@ dependencies = [
  "clang-sys",
  "clap 2.34.0",
  "clap 3.2.23",
- "clap 4.1.4",
+ "clap 4.3.1",
  "clap_derive 3.2.18",
- "clap_derive 4.1.0",
+ "clap_derive 4.3.1",
  "clap_lex 0.2.4",
- "clap_lex 0.3.1",
+ "clap_lex 0.3.3",
  "clear_on_drop",
  "clipboard-win",
  "codespan",
@@ -12669,7 +12834,7 @@ dependencies = [
  "humansize",
  "humantime",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.23.2",
  "hyper-timeout",
  "iana-time-zone",
  "ident_case",
@@ -13014,7 +13179,7 @@ dependencies = [
  "serde_urlencoded",
  "serde_with",
  "serde_with_macros",
- "serde_yaml",
+ "serde_yaml 0.8.26",
  "sha-1 0.10.1",
  "sha-1 0.9.8",
  "sha1",
@@ -13100,7 +13265,7 @@ dependencies = [
  "tokio-io-timeout",
  "tokio-macros 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-retry",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tokio-stream",
  "tokio-util 0.7.4",
  "toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9913,6 +9913,7 @@ name = "sui-metric-checker"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "backoff",
  "base64 0.21.2",
  "chrono",
  "clap 4.3.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,15 +1837,6 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "033f6b7a4acb1f358c742aaca805c939ee73b4c6209ae4318ec7aca81c42e646"
-dependencies = [
- "os_str_bytes",
-]
-
-[[package]]
-name = "clap_lex"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
@@ -6605,9 +6596,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "oorandom"
@@ -9926,6 +9917,7 @@ dependencies = [
  "chrono",
  "clap 4.3.1",
  "humantime",
+ "once_cell",
  "prometheus-http-query",
  "regex",
  "reqwest",
@@ -12536,6 +12528,11 @@ dependencies = [
  "anemo-tower",
  "anes",
  "ansi_term",
+ "anstream",
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
  "anyhow",
  "arbitrary",
  "arc-swap",
@@ -12644,15 +12641,17 @@ dependencies = [
  "clap 2.34.0",
  "clap 3.2.23",
  "clap 4.3.1",
+ "clap_builder",
  "clap_derive 3.2.18",
  "clap_derive 4.3.1",
  "clap_lex 0.2.4",
- "clap_lex 0.3.3",
+ "clap_lex 0.5.0",
  "clear_on_drop",
  "clipboard-win",
  "codespan",
  "codespan-reporting",
  "collectable",
+ "colorchoice",
  "colored",
  "colored-diff",
  "combine",
@@ -12836,6 +12835,7 @@ dependencies = [
  "humantime",
  "hyper",
  "hyper-rustls 0.23.2",
+ "hyper-rustls 0.24.0",
  "hyper-timeout",
  "iana-time-zone",
  "ident_case",
@@ -13069,6 +13069,7 @@ dependencies = [
  "proc-macro2 0.4.30",
  "proc-macro2 1.0.58",
  "prometheus",
+ "prometheus-http-query",
  "proptest",
  "proptest-derive",
  "prost",
@@ -13181,6 +13182,7 @@ dependencies = [
  "serde_with",
  "serde_with_macros",
  "serde_yaml 0.8.26",
+ "serde_yaml 0.9.21",
  "sha-1 0.10.1",
  "sha-1 0.9.8",
  "sha1",
@@ -13267,6 +13269,7 @@ dependencies = [
  "tokio-macros 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-retry",
  "tokio-rustls 0.23.4",
+ "tokio-rustls 0.24.0",
  "tokio-stream",
  "tokio-util 0.7.4",
  "toml",
@@ -13315,6 +13318,7 @@ dependencies = [
  "unicode-xid 0.1.0",
  "unicode-xid 0.2.4",
  "universal-hash",
+ "unsafe-libyaml",
  "unsigned-varint",
  "untrusted",
  "unzip-n",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9919,7 +9919,6 @@ dependencies = [
  "humantime",
  "once_cell",
  "prometheus-http-query",
- "regex",
  "reqwest",
  "serde 1.0.152",
  "serde_yaml 0.9.21",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ members = [
     "crates/sui-json-rpc-types",
     "crates/sui-keys",
     "crates/sui-macros",
+    "crates/sui-metric-checker",
     "crates/sui-move",
     "crates/sui-move-build",
     "crates/sui-network",

--- a/crates/sui-metric-checker/Cargo.toml
+++ b/crates/sui-metric-checker/Cargo.toml
@@ -13,6 +13,7 @@ chrono = "0.4.26"
 clap = { version = "4.3.0", features = ["derive"] }
 humantime = "2.1.0"
 prometheus-http-query = { version = "0.6.6", default_features = false, features = ["rustls-tls"] }
+regex = "1.8.4"
 reqwest = { version = "0.11.18", default_features = false, features = ["rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9.21"

--- a/crates/sui-metric-checker/Cargo.toml
+++ b/crates/sui-metric-checker/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.71"
+backoff = "0.4.0"
 base64 = "0.21.2"
 chrono = "0.4.26"
 clap = { version = "4.3.0", features = ["derive"] }

--- a/crates/sui-metric-checker/Cargo.toml
+++ b/crates/sui-metric-checker/Cargo.toml
@@ -12,6 +12,7 @@ base64 = "0.21.2"
 chrono = "0.4.26"
 clap = { version = "4.3.0", features = ["derive"] }
 humantime = "2.1.0"
+once_cell = "1.18.0"
 prometheus-http-query = { version = "0.6.6", default_features = false, features = ["rustls-tls"] }
 regex = "1.8.4"
 reqwest = { version = "0.11.18", default_features = false, features = ["rustls-tls"] }

--- a/crates/sui-metric-checker/Cargo.toml
+++ b/crates/sui-metric-checker/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "sui-metric-checker"
+version = "0.0.0"
+authors = ["Mysten Labs <build@mystenlabs.com>"]
+license = "Apache-2.0"
+publish = false
+edition = "2021"
+
+[dependencies]
+anyhow = "1.0.71"
+base64 = "0.21.2"
+chrono = "0.4.26"
+clap = { version = "4.3.0", features = ["derive"] }
+humantime = "2.1.0"
+prometheus-http-query = { version = "0.6.6", default_features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.11.18", default_features = false, features = ["rustls-tls"] }
+serde = { version = "1", features = ["derive"] }
+serde_yaml = "0.9.21"
+strum_macros = "0.24.3"
+telemetry-subscribers.workspace = true
+tokio = { workspace = true, features = ["full"] }
+tracing = "0.1.37"
+
+workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/crates/sui-metric-checker/Cargo.toml
+++ b/crates/sui-metric-checker/Cargo.toml
@@ -14,7 +14,6 @@ clap = { version = "4.3.0", features = ["derive"] }
 humantime = "2.1.0"
 once_cell = "1.18.0"
 prometheus-http-query = { version = "0.6.6", default_features = false, features = ["rustls-tls"] }
-regex = "1.8.4"
 reqwest = { version = "0.11.18", default_features = false, features = ["rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9.21"

--- a/crates/sui-metric-checker/README.md
+++ b/crates/sui-metric-checker/README.md
@@ -1,4 +1,4 @@
-The `sui-metric-checker` crate is used for querying prometheus metrics and validating the results. It will primarly be used to check for performance regressions in nightly deployments. Requires `api_key`, `api_user` & prometheus `url` which can be found in `sui-ops` repo or by asking the PE team.
+The `sui-metric-checker` crate is used for querying prometheus metrics and validating the results. It will primarily be used to check for performance regressions in nightly deployments. Requires `api_key`, `api_user` & prometheus `url` which can be found in `sui-ops` repo or by asking the PE team.
 
 ## Guide
 

--- a/crates/sui-metric-checker/README.md
+++ b/crates/sui-metric-checker/README.md
@@ -1,0 +1,57 @@
+The `sui-metric-checker` crate is used for querying prometheus metrics and validating the results. It will primarly be used to check for performance regressions in nightly deployments. Requires `api_key`, `api_user` & prometheus `url` which can be found in `sui-ops` repo or by asking the PE team.
+
+## Guide
+
+Example usage:
+
+```
+RUST_LOG=debug cargo run --package sui-metric-checker --bin sui-metric-checker  -- --api-key xxxxxxxx --api-user xxxx_metrics --config checks.yaml --url https://xxxx.sui.io/prometheus
+```
+
+Example `.yaml` contents:
+
+```
+  # Check current epoch
+  - query: 'max(current_epoch{network="private-testnet"})'
+    type: "Instant"
+  # Narwhal batch execution latency - p50
+  - query: 'histogram_quantile(0.50, sum by(le) (rate(batch_execution_latency_bucket{network="private-testnet"}[15m])))'
+    type: "Range"
+    validate_result:
+      threshold: 3.0
+      failure_condition: Greater
+    start: "now-11h"
+    end: "now-3h"
+    step: 60.0
+  # TPS
+  - query: 'avg(rate(total_transaction_effects{network="private-testnet"}[5m]))'
+    type: "Range"
+    validate_result:
+      threshold: 5500.0
+      failure_condition: Less
+    start: "now-11h"
+    end: "now-3h"
+    step: 60.0
+  # CPS
+  - query: 'avg (rate(batch_size_sum{network="private-testnet"}[5m]))'
+    type: "Range"
+    validate_result:
+      threshold: 5500.0
+      failure_condition: Less
+    start: "now-11h"
+    end: "now-3h"
+    step: 60.0
+```
+
+Example error output:
+
+```
+Error: Following queries failed to meet threshold conditions: [
+    "After 3 retry attempts - Did not get expected response from server for histogram_quantile(0.5, sum by(le) (rate(latency_s_bucket{network=\"private-testnet\"}[15m])))",
+    "After 3 retry attempts - Did not get expected response from server for histogram_quantile(0.95, sum by(le) (rate(latency_s_bucket{network=\"private-testnet\"}[15m])))",
+    "After 3 retry attempts - Did not get expected response from server for sum(rate(num_success{network=\"private-testnet\"}[5m]))",
+    "Query \"histogram_quantile(0.50, sum by(le) (rate(batch_execution_latency_bucket{network=\"private-testnet\"}[15m])))\" returned value of 3.112150385622982 which is Greater 3",
+    "Query \"avg(rate(total_transaction_effects{network=\"private-testnet\"}[5m]))\" returned value of 1.081275647819765 which is Less 5500",
+    "Query \"avg (rate(batch_size_sum{network=\"private-testnet\"}[5m]))\" returned value of 0.24698238962944846 which is Less 5500",
+]
+```

--- a/crates/sui-metric-checker/README.md
+++ b/crates/sui-metric-checker/README.md
@@ -2,48 +2,17 @@ The `sui-metric-checker` crate is used for querying prometheus metrics and valid
 
 ## Guide
 
-Example usage:
+### Example Usage
 
 ```
 RUST_LOG=debug cargo run --package sui-metric-checker --bin sui-metric-checker  -- --api-key xxxxxxxx --api-user xxxx_metrics --config checks.yaml --url https://xxxx.sui.io/prometheus
 ```
 
-Example `.yaml` contents:
+### Example Config
 
-```
-  # Check current epoch
-  - query: 'max(current_epoch{network="private-testnet"})'
-    type: "Instant"
-  # Narwhal batch execution latency - p50
-  - query: 'histogram_quantile(0.50, sum by(le) (rate(batch_execution_latency_bucket{network="private-testnet"}[15m])))'
-    type: "Range"
-    validate_result:
-      threshold: 3.0
-      failure_condition: Greater
-    start: "now-11h"
-    end: "now-3h"
-    step: 60.0
-  # TPS
-  - query: 'avg(rate(total_transaction_effects{network="private-testnet"}[5m]))'
-    type: "Range"
-    validate_result:
-      threshold: 5500.0
-      failure_condition: Less
-    start: "now-11h"
-    end: "now-3h"
-    step: 60.0
-  # CPS
-  - query: 'avg (rate(batch_size_sum{network="private-testnet"}[5m]))'
-    type: "Range"
-    validate_result:
-      threshold: 5500.0
-      failure_condition: Less
-    start: "now-11h"
-    end: "now-3h"
-    step: 60.0
-```
+[example/config.yaml](example/config.yaml#L1-L32)
 
-Example error output:
+### Example Error Output
 
 ```
 Error: Following queries failed to meet threshold conditions: [

--- a/crates/sui-metric-checker/example/config.yaml
+++ b/crates/sui-metric-checker/example/config.yaml
@@ -1,0 +1,32 @@
+queries:
+  # ***** Validator ******
+  # Check current epoch
+  - query: 'max(current_epoch{network="private-testnet"})'
+    type: Instant
+  # Narwhal batch execution latency - p50
+  - query: 'histogram_quantile(0.50, sum by(le) (rate(batch_execution_latency_bucket{network="private-testnet"}[15m])))'
+    type: !Range
+      start: "now-8h"
+      end: "now"
+      step: 60.0
+    validate_result:
+      threshold: 3.0
+      failure_condition: Greater
+  # TPS
+  - query: 'avg(rate(total_transaction_effects{network="private-testnet"}[5m]))'
+    type: !Range
+      start: "now-8h"
+      end: "now"
+      step: 60.0
+    validate_result:
+      threshold: 5000.0
+      failure_condition: Less
+  # CPS
+  - query: 'avg (rate(batch_size_sum{network="private-testnet"}[5m]))'
+    type: !Range
+      start: "now-8h"
+      end: "now"
+      step: 60.0
+    validate_result:
+      threshold: 5000.0
+      failure_condition: Less

--- a/crates/sui-metric-checker/src/lib.rs
+++ b/crates/sui-metric-checker/src/lib.rs
@@ -3,34 +3,43 @@
 use anyhow::anyhow;
 use chrono::{DateTime, Duration, NaiveDateTime, Utc};
 use humantime::parse_duration;
+use regex::Regex;
 use serde::Deserialize;
 use strum_macros::Display;
 
 pub mod query;
 
-#[derive(Debug, Display, Deserialize)]
+#[derive(Debug, Display, Deserialize, PartialEq)]
 pub enum QueryType {
     Instant,
     Range,
 }
 
-#[derive(Debug, Display, Deserialize)]
-pub enum ErrorCondition {
+#[derive(Debug, Display, Deserialize, PartialEq)]
+pub enum Condition {
     Greater,
     Equal,
     Less,
 }
 
-#[derive(Debug, Deserialize)]
+// Used to specify validation rules for query result e.g.
+//
+// validate_result:
+//   threshold: 10
+//   failure_condition: Greater
+//
+// Program will report error if queried value is greater than 10, otherwise
+// no error will be reported.
+#[derive(Debug, Deserialize, PartialEq)]
 pub struct QueryResultValidation {
     // Threshold to report error on
     pub threshold: f64,
     // Program will report error if threshold violates condition specifed by this
     // field.
-    pub condition: ErrorCondition,
+    pub failure_condition: Condition,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, PartialEq)]
 pub struct Query {
     // PromQL query to exeute
     pub query: String,
@@ -38,10 +47,12 @@ pub struct Query {
     #[serde(rename = "type")]
     pub query_type: QueryType,
     pub validate_result: Option<QueryResultValidation>,
-    // Both start & end accepts formats
-    //  - %Y-%m-%d %H:%M:%S (UTC)
-    //  - now
-    //  - relative time offset before now, i.e. 1h 30m 10s
+    // Both start & end accepts specific time formats
+    //  - "%Y-%m-%d %H:%M:%S" (UTC)
+    // Or relative time + offset, i.e.
+    //  - "now"
+    //  - "now-1h"
+    //  - "now-30m 10s"
     pub start: Option<String>,
     pub end: Option<String>,
     // Query resolution step width as float number of seconds
@@ -53,44 +64,133 @@ pub struct Config {
     pub queries: Vec<Query>,
 }
 
-pub fn unix_seconds_to_timestamp(unix_seconds: i64) -> String {
-    let datetime = NaiveDateTime::from_timestamp_opt(unix_seconds, 0);
-    let timestamp = DateTime::<Utc>::from_utc(datetime.unwrap(), Utc);
-    timestamp.to_string()
-}
+// Convert timestamp string to unix seconds.
+// Accepts the following time formats
+//  - "%Y-%m-%d %H:%M:%S" (UTC)
+// Or relative time + offset, i.e.
+//  - "now"
+//  - "now-1h"
+//  - "now-30m 10s"
+pub fn timestamp_string_to_unix_seconds(timestamp: &str) -> Result<i64, anyhow::Error> {
+    let now_regex = Regex::new(r"^now(-.*)?$").unwrap();
+    let relative_time_regex = Regex::new(r"^now-([\dsmh ]+)$").unwrap();
 
-pub fn timestamp_to_unix_seconds(timestamp: &str) -> Result<i64, anyhow::Error> {
-    match timestamp {
-        "now" => Ok(Utc::now().timestamp()),
-        _ => {
-            let parsed_timestamp = NaiveDateTime::parse_from_str(timestamp, "%Y-%m-%d %H:%M:%S");
-            if let Ok(datetime) = parsed_timestamp {
-                let utc_datetime = DateTime::<Utc>::from_utc(datetime, Utc);
-                Ok(utc_datetime.timestamp())
-            } else {
-                // Parse timestamp from relative time offset, i.e. "1h 30m 10s"
-                let duration = parse_duration(timestamp)?;
+    if now_regex.is_match(timestamp) {
+        if let Some(capture) = relative_time_regex.captures(timestamp) {
+            if let Some(relative_timestamp) = capture.get(1) {
+                let duration = parse_duration(relative_timestamp.as_str())?;
                 let now = Utc::now();
-                let new_datetime = now.checked_sub_signed(Duration::from_std(duration).unwrap());
+                let new_datetime = now.checked_sub_signed(Duration::from_std(duration)?);
 
                 if let Some(datetime) = new_datetime {
-                    Ok(datetime.timestamp())
+                    return Ok(datetime.timestamp());
                 } else {
-                    Err(anyhow!("Unable calculate time offset"))
+                    return Err(anyhow!("Unable to calculate time offset"));
                 }
             }
         }
+
+        return Ok(Utc::now().timestamp());
+    }
+
+    if let Ok(datetime) = NaiveDateTime::parse_from_str(timestamp, "%Y-%m-%d %H:%M:%S") {
+        let utc_datetime = DateTime::<Utc>::from_utc(datetime, Utc);
+        Ok(utc_datetime.timestamp())
+    } else {
+        Err(anyhow!("Invalid timestamp format"))
     }
 }
 
 pub fn fails_threshold_condition(
     queried_value: f64,
     threshold: f64,
-    error_condition: &ErrorCondition,
+    failure_condition: &Condition,
 ) -> Result<bool, anyhow::Error> {
-    match error_condition {
-        ErrorCondition::Greater => Ok(queried_value > threshold),
-        ErrorCondition::Equal => Ok(queried_value == threshold),
-        ErrorCondition::Less => Ok(queried_value < threshold),
+    match failure_condition {
+        Condition::Greater => Ok(queried_value > threshold),
+        Condition::Equal => Ok(queried_value == threshold),
+        Condition::Less => Ok(queried_value < threshold),
+    }
+}
+
+fn unix_seconds_to_timestamp_string(unix_seconds: i64) -> String {
+    let datetime = NaiveDateTime::from_timestamp_opt(unix_seconds, 0);
+    let timestamp = DateTime::<Utc>::from_utc(datetime.unwrap(), Utc);
+    timestamp.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_timestamp_string_to_unix_seconds() {
+        let timestamp = "2021-08-10 00:00:00";
+        let unix_seconds = timestamp_string_to_unix_seconds(timestamp).unwrap();
+        assert_eq!(unix_seconds, 1628553600);
+
+        let timestamp = "now";
+        let unix_seconds = timestamp_string_to_unix_seconds(timestamp).unwrap();
+        assert_eq!(unix_seconds, Utc::now().timestamp());
+
+        let timestamp = "now-1h";
+        let unix_seconds = timestamp_string_to_unix_seconds(timestamp).unwrap();
+        assert_eq!(unix_seconds, Utc::now().timestamp() - 3600);
+
+        let timestamp = "now-30m 10s";
+        let unix_seconds = timestamp_string_to_unix_seconds(timestamp).unwrap();
+        assert_eq!(unix_seconds, Utc::now().timestamp() - 1810);
+    }
+
+    #[test]
+    fn test_unix_seconds_to_timestamp_string() {
+        let unix_seconds = 1628534400;
+        let timestamp = unix_seconds_to_timestamp_string(unix_seconds);
+        assert_eq!(timestamp, "2021-08-09 18:40:00 UTC");
+    }
+
+    #[test]
+    fn test_parse_config() {
+        let config = r#"
+            queries:
+              - query: 'max(current_epoch{network="testnet"})'
+                type: "Instant"
+
+              - query: 'histogram_quantile(0.50, sum by(le) (rate(round_latency{network="testnet"}[15m])))'
+                type: "Range"
+                validate_result:
+                  threshold: 3.0
+                  failure_condition: Greater
+                start: "now-1h"
+                end: "now"
+                step: 60.0
+        "#;
+
+        let config: Config = serde_yaml::from_str(config).unwrap();
+
+        let expected_range_query = Query {
+            query: "histogram_quantile(0.50, sum by(le) (rate(round_latency{network=\"testnet\"}[15m])))".to_string(),
+            query_type: QueryType::Range,
+            validate_result: Some(QueryResultValidation {
+                threshold: 3.0,
+                failure_condition: Condition::Greater,
+            }),
+            start: Some("now-1h".to_string()),
+            end: Some("now".to_string()),
+            step: Some(60.0),
+        };
+
+        let expected_instant_query = Query {
+            query: "max(current_epoch{network=\"testnet\"})".to_string(),
+            query_type: QueryType::Instant,
+            validate_result: None,
+            start: None,
+            end: None,
+            step: None,
+        };
+
+        let expected_queries = vec![expected_instant_query, expected_range_query];
+
+        assert_eq!(config.queries, expected_queries);
     }
 }

--- a/crates/sui-metric-checker/src/lib.rs
+++ b/crates/sui-metric-checker/src/lib.rs
@@ -1,0 +1,96 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use anyhow::anyhow;
+use chrono::{DateTime, Duration, NaiveDateTime, Utc};
+use humantime::parse_duration;
+use serde::Deserialize;
+use strum_macros::Display;
+
+pub mod query;
+
+#[derive(Debug, Display, Deserialize)]
+pub enum QueryType {
+    Instant,
+    Range,
+}
+
+#[derive(Debug, Display, Deserialize)]
+pub enum ErrorCondition {
+    Greater,
+    Equal,
+    Less,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct QueryResultValidation {
+    // Threshold to report error on
+    pub threshold: f64,
+    // Program will report error if threshold violates condition specifed by this
+    // field.
+    pub condition: ErrorCondition,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Query {
+    // PromQL query to exeute
+    pub query: String,
+    // Type of query to execute
+    #[serde(rename = "type")]
+    pub query_type: QueryType,
+    pub validate_result: Option<QueryResultValidation>,
+    // Both start & end accepts formats
+    //  - %Y-%m-%d %H:%M:%S (UTC)
+    //  - now
+    //  - relative time offset before now, i.e. 1h 30m 10s
+    pub start: Option<String>,
+    pub end: Option<String>,
+    // Query resolution step width as float number of seconds
+    pub step: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Config {
+    pub queries: Vec<Query>,
+}
+
+pub fn unix_seconds_to_timestamp(unix_seconds: i64) -> String {
+    let datetime = NaiveDateTime::from_timestamp_opt(unix_seconds, 0);
+    let timestamp = DateTime::<Utc>::from_utc(datetime.unwrap(), Utc);
+    timestamp.to_string()
+}
+
+pub fn timestamp_to_unix_seconds(timestamp: &str) -> Result<i64, anyhow::Error> {
+    match timestamp {
+        "now" => Ok(Utc::now().timestamp()),
+        _ => {
+            let parsed_timestamp = NaiveDateTime::parse_from_str(timestamp, "%Y-%m-%d %H:%M:%S");
+            if let Ok(datetime) = parsed_timestamp {
+                let utc_datetime = DateTime::<Utc>::from_utc(datetime, Utc);
+                Ok(utc_datetime.timestamp())
+            } else {
+                // Parse timestamp from relative time offset, i.e. "1h 30m 10s"
+                let duration = parse_duration(timestamp)?;
+                let now = Utc::now();
+                let new_datetime = now.checked_sub_signed(Duration::from_std(duration).unwrap());
+
+                if let Some(datetime) = new_datetime {
+                    Ok(datetime.timestamp())
+                } else {
+                    Err(anyhow!("Unable calculate time offset"))
+                }
+            }
+        }
+    }
+}
+
+pub fn fails_threshold_condition(
+    queried_value: f64,
+    threshold: f64,
+    error_condition: &ErrorCondition,
+) -> Result<bool, anyhow::Error> {
+    match error_condition {
+        ErrorCondition::Greater => Ok(queried_value > threshold),
+        ErrorCondition::Equal => Ok(queried_value == threshold),
+        ErrorCondition::Less => Ok(queried_value < threshold),
+    }
+}

--- a/crates/sui-metric-checker/src/main.rs
+++ b/crates/sui-metric-checker/src/main.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use anyhow::anyhow;
+use backoff::{future::retry, ExponentialBackoff};
 use chrono::{DateTime, Utc};
 use clap::*;
 use once_cell::sync::Lazy;
@@ -8,7 +9,7 @@ use prometheus_http_query::Client;
 use std::fs::File;
 use std::io::Read;
 use std::time::Duration;
-use sui_metric_checker::query::{instant_query_with_retries, range_query_with_retries};
+use sui_metric_checker::query::{instant_query, range_query};
 use sui_metric_checker::{
     fails_threshold_condition, timestamp_string_to_unix_seconds, Config, NowProvider, QueryType,
 };
@@ -61,22 +62,35 @@ async fn main() -> Result<(), anyhow::Error> {
         Client::from(c, &opts.url).unwrap()
     };
 
+    let backoff = ExponentialBackoff {
+        max_elapsed_time: Some(Duration::from_secs(5)),
+        ..ExponentialBackoff::default()
+    };
+
     let mut failed_queries = Vec::new();
     for query in config.queries {
         let queried_result = match query.query_type {
             QueryType::Instant => {
-                instant_query_with_retries(&auth_header, client.clone(), &query.query, 3).await
+                retry(backoff.clone(), || async {
+                    instant_query(&auth_header, client.clone(), &query.query)
+                        .await
+                        .map_err(backoff::Error::transient)
+                })
+                .await
             }
             QueryType::Range { start, end, step } => {
-                range_query_with_retries(
-                    &auth_header,
-                    client.clone(),
-                    &query.query,
-                    timestamp_string_to_unix_seconds::<UtcNowOnceProvider>(&start)?,
-                    timestamp_string_to_unix_seconds::<UtcNowOnceProvider>(&end)?,
-                    step,
-                    3,
-                )
+                retry(backoff.clone(), || async {
+                    range_query(
+                        &auth_header,
+                        client.clone(),
+                        &query.query,
+                        timestamp_string_to_unix_seconds::<UtcNowOnceProvider>(&start)?,
+                        timestamp_string_to_unix_seconds::<UtcNowOnceProvider>(&end)?,
+                        step,
+                    )
+                    .await
+                    .map_err(backoff::Error::transient)
+                })
                 .await
             }
         };

--- a/crates/sui-metric-checker/src/main.rs
+++ b/crates/sui-metric-checker/src/main.rs
@@ -1,13 +1,17 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use anyhow::anyhow;
+use chrono::{DateTime, Utc};
 use clap::*;
+use once_cell::sync::Lazy;
 use prometheus_http_query::Client;
 use std::fs::File;
 use std::io::Read;
-use sui_metric_checker::query::{instant_query, range_query};
+use std::sync::Mutex;
+use std::time::Duration;
+use sui_metric_checker::query::{instant_query_with_retries, range_query_with_retries};
 use sui_metric_checker::{
-    fails_threshold_condition, timestamp_string_to_unix_seconds, Config, QueryType,
+    fails_threshold_condition, timestamp_string_to_unix_seconds, Config, NowProvider, QueryType,
 };
 
 #[derive(Parser)]
@@ -19,9 +23,28 @@ pub struct Opts {
     // Path to the config file
     #[clap(long, required = true)]
     config: String,
-    // URL of the Prometheus server, defaults to gateway for dev environments
-    #[clap(long, default_value = "https://gateway.mimir.sui.io/prometheus")]
+    // URL of the Prometheus server
+    #[clap(long, required = true)]
     url: String,
+}
+
+// This allows us to use the same value for now() for all queries checked during
+// the duration of tool.
+struct UtcNowOnceProvider {}
+
+impl NowProvider for UtcNowOnceProvider {
+    fn now() -> DateTime<Utc> {
+        static NOW: Lazy<Mutex<Option<DateTime<Utc>>>> = Lazy::new(|| Mutex::new(None));
+
+        let mut now = NOW.lock().unwrap();
+        if let Some(value) = *now {
+            value
+        } else {
+            let value = Utc::now();
+            *now = Some(value);
+            value
+        }
+    }
 }
 
 #[tokio::main]
@@ -39,45 +62,62 @@ async fn main() -> Result<(), anyhow::Error> {
     let config: Config = serde_yaml::from_str(&contents)?;
 
     let client = {
-        let c = reqwest::Client::builder().no_proxy().build().unwrap();
+        let c = reqwest::Client::builder()
+            .no_proxy()
+            .timeout(Duration::from_secs(10))
+            .build()
+            .unwrap();
         Client::from(c, &opts.url).unwrap()
     };
 
     let mut failed_queries = Vec::new();
     for query in config.queries {
-        let queried_value = match query.query_type {
-            QueryType::Instant => instant_query(&auth_header, client.clone(), &query.query).await?,
+        let queried_result = match query.query_type {
+            QueryType::Instant => {
+                instant_query_with_retries(&auth_header, client.clone(), &query.query, 3).await
+            }
             QueryType::Range => {
-                range_query(
+                range_query_with_retries(
                     &auth_header,
                     client.clone(),
                     &query.query,
-                    timestamp_string_to_unix_seconds(
+                    timestamp_string_to_unix_seconds::<UtcNowOnceProvider>(
                         &query
                             .start
                             .expect("Start timestamp is required for range query"),
                     )?,
-                    timestamp_string_to_unix_seconds(
+                    timestamp_string_to_unix_seconds::<UtcNowOnceProvider>(
                         &query
                             .end
                             .expect("End timestamp is required for range query"),
                     )?,
                     query.step.expect("Step is required for range query"),
+                    3,
                 )
-                .await?
+                .await
             }
         };
 
         if let Some(validate_result) = query.validate_result {
-            if fails_threshold_condition(
-                queried_value,
-                validate_result.threshold,
-                &validate_result.failure_condition,
-            )? {
-                failed_queries.push(format!(
-                    "Query {} returned value of {queried_value} which is {} {}",
-                    query.query, validate_result.failure_condition, validate_result.threshold
-                ));
+            match queried_result {
+                Ok(queried_value) => {
+                    if fails_threshold_condition(
+                        queried_value,
+                        validate_result.threshold,
+                        &validate_result.failure_condition,
+                    ) {
+                        failed_queries.push(format!(
+                            "Query \"{}\" returned value of {queried_value} which is {} {}",
+                            query.query,
+                            validate_result.failure_condition,
+                            validate_result.threshold
+                        ));
+                    }
+                }
+                Err(error) => {
+                    failed_queries.push(error.to_string());
+                    continue;
+                }
             }
         }
     }

--- a/crates/sui-metric-checker/src/main.rs
+++ b/crates/sui-metric-checker/src/main.rs
@@ -1,0 +1,90 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use anyhow::anyhow;
+use clap::*;
+use prometheus_http_query::Client;
+use std::fs::File;
+use std::io::Read;
+use sui_metric_checker::query::{instant_query, range_query};
+use sui_metric_checker::{fails_threshold_condition, timestamp_to_unix_seconds, Config, QueryType};
+
+#[derive(Parser)]
+#[clap(name = "Prometheus Query")]
+pub struct Opts {
+    #[clap(long, required = true)]
+    api_user: String,
+    #[clap(long, required = true)]
+    api_key: String,
+    #[clap(long, required = true)]
+    config: String,
+    // URL of the Prometheus server, defaults to gateway for dev environments
+    #[clap(long, default_value = "https://gateway.mimir.sui.io/prometheus")]
+    url: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    let opts: Opts = Opts::parse();
+    let _guard = telemetry_subscribers::TelemetryConfig::new()
+        .with_env()
+        .init();
+
+    let auth_header = format!("{}:{}", opts.api_user, opts.api_key);
+
+    let mut file = File::open(opts.config)?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)?;
+    let config: Config = serde_yaml::from_str(&contents)?;
+
+    let client = {
+        let c = reqwest::Client::builder().no_proxy().build().unwrap();
+        Client::from(c, &opts.url).unwrap()
+    };
+
+    let mut failed_queries = Vec::new();
+    for query in config.queries {
+        let queried_value = match query.query_type {
+            QueryType::Instant => instant_query(&auth_header, client.clone(), &query.query).await?,
+            QueryType::Range => {
+                range_query(
+                    &auth_header,
+                    client.clone(),
+                    &query.query,
+                    timestamp_to_unix_seconds(
+                        &query
+                            .start
+                            .expect("Start timestamp is required for range query"),
+                    )?,
+                    timestamp_to_unix_seconds(
+                        &query
+                            .end
+                            .expect("End timestamp is required for range query"),
+                    )?,
+                    query.step.expect("Step is required for range query"),
+                )
+                .await?
+            }
+        };
+
+        if let Some(validate_result) = query.validate_result {
+            if fails_threshold_condition(
+                queried_value,
+                validate_result.threshold,
+                &validate_result.condition,
+            )? {
+                failed_queries.push(format!(
+                    "Query {} returned value of {queried_value} which is {} {}",
+                    query.query, validate_result.condition, validate_result.threshold
+                ));
+            }
+        }
+    }
+
+    if !failed_queries.is_empty() {
+        return Err(anyhow!(
+            "Following queries failed to meet threshold conditions: {failed_queries:#?}"
+        ));
+    }
+
+    Ok(())
+}

--- a/crates/sui-metric-checker/src/query.rs
+++ b/crates/sui-metric-checker/src/query.rs
@@ -1,0 +1,88 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use crate::unix_seconds_to_timestamp;
+use anyhow::anyhow;
+use base64::{engine::general_purpose, Engine};
+use prometheus_http_query::Client;
+use reqwest::header::{HeaderValue, AUTHORIZATION};
+use tracing::debug;
+
+pub async fn instant_query(
+    auth_header: &str,
+    client: Client,
+    query: &str,
+) -> Result<f64, anyhow::Error> {
+    debug!("Executing {query}");
+    let response = client
+        .query(query)
+        .header(
+            AUTHORIZATION,
+            HeaderValue::from_str(&format!(
+                "Basic {}",
+                general_purpose::STANDARD.encode(auth_header)
+            ))?,
+        )
+        .get()
+        .await?;
+
+    let result = response
+        .data()
+        .as_vector()
+        .unwrap_or_else(|| panic!("Expected result of type vector for {query}"));
+
+    if !result.is_empty() {
+        let first = result.first().unwrap();
+        debug!("Got value {}", first.sample().value());
+        Ok(first.sample().value())
+    } else {
+        Err(anyhow!(
+            "Did not get expected response from server for {query}"
+        ))
+    }
+}
+
+// This will return the average value of the queried metric over the given time range.
+pub async fn range_query(
+    auth_header: &str,
+    client: Client,
+    query: &str,
+    start: i64,
+    end: i64,
+    step: f64,
+) -> Result<f64, anyhow::Error> {
+    debug!("Executing {query}");
+    let response = client
+        .query_range(query, start, end, step)
+        .header(
+            AUTHORIZATION,
+            HeaderValue::from_str(&format!(
+                "Basic {}",
+                general_purpose::STANDARD.encode(auth_header)
+            ))?,
+        )
+        .get()
+        .await?;
+
+    let result = response
+        .data()
+        .as_matrix()
+        .unwrap_or_else(|| panic!("Expected result of type matrix for {query}"));
+
+    if !result.is_empty() {
+        let samples = result.first().unwrap().samples();
+        let sum: f64 = samples.iter().map(|sample| sample.value()).sum();
+        let count = samples.len();
+
+        let avg = if count > 0 { sum / count as f64 } else { 0.0 };
+        debug!(
+            "Got average value {avg} over time range {} - {}",
+            unix_seconds_to_timestamp(start),
+            unix_seconds_to_timestamp(end)
+        );
+        Ok(avg)
+    } else {
+        Err(anyhow!(
+            "Did not get expected response from server for {query}"
+        ))
+    }
+}

--- a/crates/sui-metric-checker/src/query.rs
+++ b/crates/sui-metric-checker/src/query.rs
@@ -5,7 +5,71 @@ use anyhow::anyhow;
 use base64::{engine::general_purpose, Engine};
 use prometheus_http_query::Client;
 use reqwest::header::{HeaderValue, AUTHORIZATION};
+use std::time::Duration;
+use tokio::time::sleep;
 use tracing::debug;
+
+const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
+const MAX_BACKOFF: Duration = Duration::from_secs(5);
+
+pub async fn instant_query_with_retries(
+    auth_header: &str,
+    client: Client,
+    query: &str,
+    max_retries: u32,
+) -> Result<f64, anyhow::Error> {
+    let mut retries = 0;
+    let mut backoff = INITIAL_BACKOFF;
+
+    loop {
+        match instant_query(auth_header, client.clone(), query).await {
+            Ok(value) => return Ok(value),
+            Err(error) => {
+                if retries >= max_retries {
+                    return Err(anyhow!("After {max_retries} retry attempts - {error}"));
+                }
+                retries += 1;
+                debug!("Query \"{query}\" failed, retry attempt {retries}");
+                sleep(backoff).await;
+                backoff *= 2;
+                if backoff > MAX_BACKOFF {
+                    backoff = MAX_BACKOFF;
+                }
+            }
+        }
+    }
+}
+
+pub async fn range_query_with_retries(
+    auth_header: &str,
+    client: Client,
+    query: &str,
+    start: i64,
+    end: i64,
+    step: f64,
+    max_retries: u32,
+) -> Result<f64, anyhow::Error> {
+    let mut retries = 0;
+    let mut backoff = INITIAL_BACKOFF;
+
+    loop {
+        match range_query(auth_header, client.clone(), query, start, end, step).await {
+            Ok(value) => return Ok(value),
+            Err(error) => {
+                if retries >= max_retries {
+                    return Err(anyhow!("After {max_retries} retry attempts - {error}"));
+                }
+                retries += 1;
+                debug!("Query \"{query}\" failed, retry attempt {retries}");
+                sleep(backoff).await;
+                backoff *= 2;
+                if backoff > MAX_BACKOFF {
+                    backoff = MAX_BACKOFF;
+                }
+            }
+        }
+    }
+}
 
 pub async fn instant_query(
     auth_header: &str,

--- a/crates/sui-metric-checker/src/query.rs
+++ b/crates/sui-metric-checker/src/query.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::unix_seconds_to_timestamp;
+use crate::unix_seconds_to_timestamp_string;
 use anyhow::anyhow;
 use base64::{engine::general_purpose, Engine};
 use prometheus_http_query::Client;
@@ -76,8 +76,8 @@ pub async fn range_query(
         let avg = if count > 0 { sum / count as f64 } else { 0.0 };
         debug!(
             "Got average value {avg} over time range {} - {}",
-            unix_seconds_to_timestamp(start),
-            unix_seconds_to_timestamp(end)
+            unix_seconds_to_timestamp_string(start),
+            unix_seconds_to_timestamp_string(end)
         );
         Ok(avg)
     } else {

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -32,6 +32,10 @@ anemo-cli = { git = "https://github.com/mystenlabs/anemo.git", rev = "0f0ae8d8f2
 anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "0f0ae8d8f222820a20b586088ea7a2941478a159", default-features = false }
 anes = { version = "0.1" }
 ansi_term = { version = "0.12", default-features = false }
+anstream = { version = "0.3" }
+anstyle = { version = "1" }
+anstyle-parse = { version = "0.2" }
+anstyle-query = { version = "1", default-features = false }
 anyhow = { version = "1", features = ["backtrace"] }
 arbitrary = { version = "1", default-features = false, features = ["derive_arbitrary"] }
 arc-swap = { version = "1", default-features = false, features = ["serde"] }
@@ -122,12 +126,14 @@ cipher = { version = "0.4", default-features = false, features = ["block-padding
 clap-164d15cefe24d7eb = { package = "clap", version = "4", features = ["derive"] }
 clap-7b89eefb6aaa9bf3 = { package = "clap", version = "3", features = ["derive"] }
 clap-f595c2ba2a3f28df = { package = "clap", version = "2" }
-clap_lex-468e82937335b1c9 = { package = "clap_lex", version = "0.3", default-features = false }
+clap_builder = { version = "4", default-features = false, features = ["color", "help", "std", "suggestions", "usage"] }
 clap_lex-6f8ce4dd05d13bba = { package = "clap_lex", version = "0.2", default-features = false }
+clap_lex-d8f496e17d97b5cb = { package = "clap_lex", version = "0.5", default-features = false }
 clear_on_drop = { version = "0.2", default-features = false }
 codespan = { version = "0.11", default-features = false, features = ["serialization"] }
 codespan-reporting = { version = "0.11", default-features = false, features = ["serialization"] }
 collectable = { version = "0.0.2", default-features = false }
+colorchoice = { version = "1", default-features = false }
 colored = { version = "2", default-features = false }
 colored-diff = { version = "0.2", default-features = false }
 combine = { version = "4" }
@@ -274,7 +280,7 @@ httpdate = { version = "1", default-features = false }
 humansize = { version = "1", default-features = false }
 humantime = { version = "2", default-features = false }
 hyper = { version = "0.14", features = ["full"] }
-hyper-rustls = { version = "0.23", features = ["http2", "webpki-tokio"] }
+hyper-rustls-2b5c6dc72f624058 = { package = "hyper-rustls", version = "0.23", features = ["http2", "webpki-tokio"] }
 hyper-timeout = { version = "0.4", default-features = false }
 idna = { version = "0.3", default-features = false }
 ignore = { version = "0.4", default-features = false }
@@ -454,6 +460,7 @@ primeorder = { version = "0.13", default-features = false }
 primitive-types = { version = "0.10", features = ["impl-serde"] }
 proc-macro2-dff4ba8e3ae991db = { package = "proc-macro2", version = "1", features = ["span-locations"] }
 prometheus = { version = "0.13" }
+prometheus-http-query = { version = "0.6", default-features = false, features = ["rustls-tls"] }
 proptest = { version = "1" }
 prost = { version = "0.11" }
 prost-types = { version = "0.11" }
@@ -538,7 +545,8 @@ serde_path_to_error = { version = "0.1", default-features = false }
 serde_test = { version = "1", default-features = false }
 serde_urlencoded = { version = "0.7", default-features = false }
 serde_with = { version = "2", features = ["hex"] }
-serde_yaml = { version = "0.8", default-features = false }
+serde_yaml-274715c4dabd11b0 = { package = "serde_yaml", version = "0.9", default-features = false }
+serde_yaml-c38e5c1d305a1b54 = { package = "serde_yaml", version = "0.8", default-features = false }
 sha-1-274715c4dabd11b0 = { package = "sha-1", version = "0.9", default-features = false }
 sha-1-93f6ce9d446188ac = { package = "sha-1", version = "0.10" }
 sha1 = { version = "0.10" }
@@ -607,7 +615,7 @@ tinyvec_macros = { version = "0.1", default-features = false }
 tokio = { version = "1", features = ["full", "test-util", "tracing"] }
 tokio-io-timeout = { version = "1", default-features = false }
 tokio-retry = { version = "0.3", default-features = false }
-tokio-rustls = { version = "0.23" }
+tokio-rustls-2b5c6dc72f624058 = { package = "tokio-rustls", version = "0.23" }
 tokio-stream = { version = "0.1", features = ["net", "sync"] }
 tokio-util = { version = "0.7", features = ["codec", "compat", "io"] }
 toml = { version = "0.5", features = ["preserve_order"] }
@@ -651,9 +659,10 @@ unicode-normalization = { version = "0.1" }
 unicode-segmentation = { version = "1", default-features = false }
 unicode-width = { version = "0.1" }
 universal-hash = { version = "0.5", default-features = false }
+unsafe-libyaml = { version = "0.2", default-features = false }
 unsigned-varint = { version = "0.7", default-features = false, features = ["std"] }
 untrusted = { version = "0.7", default-features = false }
-url = { version = "2" }
+url = { version = "2", features = ["serde"] }
 utf8parse = { version = "0.2" }
 uuid = { version = "1", features = ["fast-rng", "v4"] }
 vec_map = { version = "0.8", default-features = false }
@@ -700,6 +709,10 @@ anemo-cli = { git = "https://github.com/mystenlabs/anemo.git", rev = "0f0ae8d8f2
 anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "0f0ae8d8f222820a20b586088ea7a2941478a159", default-features = false }
 anes = { version = "0.1" }
 ansi_term = { version = "0.12", default-features = false }
+anstream = { version = "0.3" }
+anstyle = { version = "1" }
+anstyle-parse = { version = "0.2" }
+anstyle-query = { version = "1", default-features = false }
 anyhow = { version = "1", features = ["backtrace"] }
 arbitrary = { version = "1", default-features = false, features = ["derive_arbitrary"] }
 arc-swap = { version = "1", default-features = false, features = ["serde"] }
@@ -807,14 +820,16 @@ clang-sys = { version = "1", default-features = false, features = ["clang_6_0", 
 clap-164d15cefe24d7eb = { package = "clap", version = "4", features = ["derive"] }
 clap-7b89eefb6aaa9bf3 = { package = "clap", version = "3", features = ["derive"] }
 clap-f595c2ba2a3f28df = { package = "clap", version = "2" }
+clap_builder = { version = "4", default-features = false, features = ["color", "help", "std", "suggestions", "usage"] }
 clap_derive-164d15cefe24d7eb = { package = "clap_derive", version = "4" }
 clap_derive-7b89eefb6aaa9bf3 = { package = "clap_derive", version = "3" }
-clap_lex-468e82937335b1c9 = { package = "clap_lex", version = "0.3", default-features = false }
 clap_lex-6f8ce4dd05d13bba = { package = "clap_lex", version = "0.2", default-features = false }
+clap_lex-d8f496e17d97b5cb = { package = "clap_lex", version = "0.5", default-features = false }
 clear_on_drop = { version = "0.2", default-features = false }
 codespan = { version = "0.11", default-features = false, features = ["serialization"] }
 codespan-reporting = { version = "0.11", default-features = false, features = ["serialization"] }
 collectable = { version = "0.0.2", default-features = false }
+colorchoice = { version = "1", default-features = false }
 colored = { version = "2", default-features = false }
 colored-diff = { version = "0.2", default-features = false }
 combine = { version = "4" }
@@ -983,7 +998,7 @@ httpdate = { version = "1", default-features = false }
 humansize = { version = "1", default-features = false }
 humantime = { version = "2", default-features = false }
 hyper = { version = "0.14", features = ["full"] }
-hyper-rustls = { version = "0.23", features = ["http2", "webpki-tokio"] }
+hyper-rustls-2b5c6dc72f624058 = { package = "hyper-rustls", version = "0.23", features = ["http2", "webpki-tokio"] }
 hyper-timeout = { version = "0.4", default-features = false }
 ident_case = { version = "1", default-features = false }
 idna = { version = "0.3", default-features = false }
@@ -1199,6 +1214,7 @@ proc-macro-hack = { version = "0.5", default-features = false }
 proc-macro2-9fbad63c4bcf4a8f = { package = "proc-macro2", version = "0.4" }
 proc-macro2-dff4ba8e3ae991db = { package = "proc-macro2", version = "1", features = ["span-locations"] }
 prometheus = { version = "0.13" }
+prometheus-http-query = { version = "0.6", default-features = false, features = ["rustls-tls"] }
 proptest = { version = "1" }
 proptest-derive = { version = "0.3", default-features = false }
 prost = { version = "0.11" }
@@ -1300,7 +1316,8 @@ serde_test = { version = "1", default-features = false }
 serde_urlencoded = { version = "0.7", default-features = false }
 serde_with = { version = "2", features = ["hex"] }
 serde_with_macros = { version = "2", default-features = false }
-serde_yaml = { version = "0.8", default-features = false }
+serde_yaml-274715c4dabd11b0 = { package = "serde_yaml", version = "0.9", default-features = false }
+serde_yaml-c38e5c1d305a1b54 = { package = "serde_yaml", version = "0.8", default-features = false }
 sha-1-274715c4dabd11b0 = { package = "sha-1", version = "0.9", default-features = false }
 sha-1-93f6ce9d446188ac = { package = "sha-1", version = "0.10" }
 sha1 = { version = "0.10" }
@@ -1379,7 +1396,7 @@ tokio = { version = "1", features = ["full", "test-util", "tracing"] }
 tokio-io-timeout = { version = "1", default-features = false }
 tokio-macros = { version = "2", default-features = false }
 tokio-retry = { version = "0.3", default-features = false }
-tokio-rustls = { version = "0.23" }
+tokio-rustls-2b5c6dc72f624058 = { package = "tokio-rustls", version = "0.23" }
 tokio-stream = { version = "0.1", features = ["net", "sync"] }
 tokio-util = { version = "0.7", features = ["codec", "compat", "io"] }
 toml = { version = "0.5", features = ["preserve_order"] }
@@ -1428,10 +1445,11 @@ unicode-width = { version = "0.1" }
 unicode-xid-6f8ce4dd05d13bba = { package = "unicode-xid", version = "0.2" }
 unicode-xid-c65f7effa3be6d31 = { package = "unicode-xid", version = "0.1" }
 universal-hash = { version = "0.5", default-features = false }
+unsafe-libyaml = { version = "0.2", default-features = false }
 unsigned-varint = { version = "0.7", default-features = false, features = ["std"] }
 untrusted = { version = "0.7", default-features = false }
 unzip-n = { version = "0.1", default-features = false }
-url = { version = "2" }
+url = { version = "2", features = ["serde"] }
 utf8parse = { version = "0.2" }
 uuid = { version = "1", features = ["fast-rng", "v4"] }
 variant_count = { version = "1", default-features = false }
@@ -1478,6 +1496,7 @@ encoding_rs = { version = "0.8" }
 errno-468e82937335b1c9 = { package = "errno", version = "0.3", default-features = false }
 errno-6f8ce4dd05d13bba = { package = "errno", version = "0.2", default-features = false }
 findshlibs = { version = "0.10", default-features = false }
+hyper-rustls-adf3d7031871b0af = { package = "hyper-rustls", version = "0.24", default-features = false }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
 inferno = { version = "0.11", default-features = false, features = ["nameattr"] }
 ipnet = { version = "2" }
@@ -1506,6 +1525,7 @@ signal-hook-registry = { version = "1", default-features = false }
 str_stack = { version = "0.1", default-features = false }
 symbolic-common = { version = "10", default-features = false }
 symbolic-demangle = { version = "10", default-features = false, features = ["cpp", "rust"] }
+tokio-rustls-adf3d7031871b0af = { package = "tokio-rustls", version = "0.24" }
 web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 
 [target.aarch64-apple-darwin.build-dependencies]
@@ -1520,6 +1540,7 @@ encoding_rs = { version = "0.8" }
 errno-468e82937335b1c9 = { package = "errno", version = "0.3", default-features = false }
 errno-6f8ce4dd05d13bba = { package = "errno", version = "0.2", default-features = false }
 findshlibs = { version = "0.10", default-features = false }
+hyper-rustls-adf3d7031871b0af = { package = "hyper-rustls", version = "0.24", default-features = false }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
 inferno = { version = "0.11", default-features = false, features = ["nameattr"] }
 ipnet = { version = "2" }
@@ -1549,6 +1570,7 @@ signal-hook-registry = { version = "1", default-features = false }
 str_stack = { version = "0.1", default-features = false }
 symbolic-common = { version = "10", default-features = false }
 symbolic-demangle = { version = "10", default-features = false, features = ["cpp", "rust"] }
+tokio-rustls-adf3d7031871b0af = { package = "tokio-rustls", version = "0.24" }
 web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
@@ -1558,6 +1580,7 @@ cpufeatures = { version = "0.2", default-features = false }
 debugid = { version = "0.8", default-features = false }
 encoding_rs = { version = "0.8" }
 findshlibs = { version = "0.10", default-features = false }
+hyper-rustls-adf3d7031871b0af = { package = "hyper-rustls", version = "0.24", default-features = false }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
 inferno = { version = "0.11", default-features = false, features = ["nameattr"] }
 ipnet = { version = "2" }
@@ -1587,6 +1610,7 @@ signal-hook-registry = { version = "1", default-features = false }
 str_stack = { version = "0.1", default-features = false }
 symbolic-common = { version = "10", default-features = false }
 symbolic-demangle = { version = "10", default-features = false, features = ["cpp", "rust"] }
+tokio-rustls-adf3d7031871b0af = { package = "tokio-rustls", version = "0.24" }
 web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
@@ -1597,6 +1621,7 @@ cpufeatures = { version = "0.2", default-features = false }
 debugid = { version = "0.8", default-features = false }
 encoding_rs = { version = "0.8" }
 findshlibs = { version = "0.10", default-features = false }
+hyper-rustls-adf3d7031871b0af = { package = "hyper-rustls", version = "0.24", default-features = false }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
 inferno = { version = "0.11", default-features = false, features = ["nameattr"] }
 ipnet = { version = "2" }
@@ -1627,9 +1652,11 @@ signal-hook-registry = { version = "1", default-features = false }
 str_stack = { version = "0.1", default-features = false }
 symbolic-common = { version = "10", default-features = false }
 symbolic-demangle = { version = "10", default-features = false, features = ["cpp", "rust"] }
+tokio-rustls-adf3d7031871b0af = { package = "tokio-rustls", version = "0.24" }
 web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 
 [target.x86_64-pc-windows-msvc.dependencies]
+anstyle-wincon = { version = "1", default-features = false }
 clipboard-win = { version = "4", default-features = false }
 cpufeatures = { version = "0.2", default-features = false }
 crossterm_winapi-274715c4dabd11b0 = { package = "crossterm_winapi", version = "0.9", default-features = false }
@@ -1637,6 +1664,7 @@ crossterm_winapi-c38e5c1d305a1b54 = { package = "crossterm_winapi", version = "0
 encode_unicode-468e82937335b1c9 = { package = "encode_unicode", version = "0.3" }
 encoding_rs = { version = "0.8" }
 error-code = { version = "2", default-features = false }
+hyper-rustls-adf3d7031871b0af = { package = "hyper-rustls", version = "0.24", default-features = false }
 ipnet = { version = "2" }
 ntapi = { version = "0.4" }
 once_cell = { version = "1", default-features = false, features = ["unstable"] }
@@ -1645,6 +1673,7 @@ rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", defau
 raw-cpuid = { version = "10", default-features = false }
 schannel = { version = "0.1", default-features = false }
 str-buf = { version = "1", default-features = false }
+tokio-rustls-adf3d7031871b0af = { package = "tokio-rustls", version = "0.24" }
 web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 widestring = { version = "0.5" }
 winapi = { version = "0.3", default-features = false, features = ["basetsd", "cfg", "combaseapi", "consoleapi", "errhandlingapi", "evntrace", "fileapi", "handleapi", "heapapi", "ifdef", "impl-debug", "impl-default", "in6addr", "inaddr", "ioapiset", "iphlpapi", "knownfolders", "libloaderapi", "lmaccess", "lmapibuf", "lmcons", "memoryapi", "minwinbase", "minwindef", "namedpipeapi", "netioapi", "ntdef", "ntlsa", "ntsecapi", "ntstatus", "objbase", "objidl", "oleauto", "pdh", "powerbase", "processenv", "processthreadsapi", "profileapi", "psapi", "rpcdce", "securitybaseapi", "shellapi", "shlobj", "std", "stringapiset", "synchapi", "sysinfoapi", "timezoneapi", "wbemcli", "winbase", "wincon", "windef", "winerror", "winioctl", "winnt", "winreg", "winsock2", "winuser", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
@@ -1659,6 +1688,7 @@ windows_x86_64_msvc-c8eced492e86ede7 = { package = "windows_x86_64_msvc", versio
 winreg = { version = "0.10", default-features = false }
 
 [target.x86_64-pc-windows-msvc.build-dependencies]
+anstyle-wincon = { version = "1", default-features = false }
 clipboard-win = { version = "4", default-features = false }
 cpufeatures = { version = "0.2", default-features = false }
 crossterm_winapi-274715c4dabd11b0 = { package = "crossterm_winapi", version = "0.9", default-features = false }
@@ -1667,6 +1697,7 @@ ctor = { version = "0.1", default-features = false }
 encode_unicode-468e82937335b1c9 = { package = "encode_unicode", version = "0.3" }
 encoding_rs = { version = "0.8" }
 error-code = { version = "2", default-features = false }
+hyper-rustls-adf3d7031871b0af = { package = "hyper-rustls", version = "0.24", default-features = false }
 ipnet = { version = "2" }
 ntapi = { version = "0.4" }
 once_cell = { version = "1", default-features = false, features = ["unstable"] }
@@ -1675,6 +1706,7 @@ rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", defau
 raw-cpuid = { version = "10", default-features = false }
 schannel = { version = "0.1", default-features = false }
 str-buf = { version = "1", default-features = false }
+tokio-rustls-adf3d7031871b0af = { package = "tokio-rustls", version = "0.24" }
 vcpkg = { version = "0.2", default-features = false }
 web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 widestring = { version = "0.5" }


### PR DESCRIPTION
## Description 

The sui-metric-checker crate is used for querying prometheus metrics and validating the results. It will primarily be used to check for performance regressions in nightly deployments. Requires api_key, api_user & prometheus url which can be found in sui-ops repo or by asking the PE team.

Example usage:
```
RUST_LOG=debug cargo run --package sui-metric-checker --bin sui-metric-checker  -- --api-key xxxxxx --api-user incoming_metrics --config  private-testnet-performance-test.yaml
```

Example .yaml contents: 
```
queries:
  # ***** Validator ******
  # Check current epoch
  - query: 'max(current_epoch{network="private-testnet"})'
    type: Instant
  # Narwhal batch execution latency - p50
  - query: 'histogram_quantile(0.50, sum by(le) (rate(batch_execution_latency_bucket{network="private-testnet"}[15m])))'
    type: !Range
      start: "now-8h"
      end: "now"
      step: 60.0
    validate_result:
      threshold: 3.0
      failure_condition: Greater
  # TPS
  - query: 'avg(rate(total_transaction_effects{network="private-testnet"}[5m]))'
    type: !Range
      start: "now-8h"
      end: "now"
      step: 60.0
    validate_result:
      threshold: 5000.0
      failure_condition: Less
  # CPS
  - query: 'avg (rate(batch_size_sum{network="private-testnet"}[5m]))'
    type: !Range
      start: "now-8h"
      end: "now"
      step: 60.0
    validate_result:
      threshold: 5000.0
      failure_condition: Less

```

Example error output:

```
Error: Following queries failed to meet threshold conditions: [
    "After 3 retry attempts - Did not get expected response from server for histogram_quantile(0.5, sum by(le) (rate(latency_s_bucket{network=\"private-testnet\"}[15m])))",
    "After 3 retry attempts - Did not get expected response from server for histogram_quantile(0.95, sum by(le) (rate(latency_s_bucket{network=\"private-testnet\"}[15m])))",
    "After 3 retry attempts - Did not get expected response from server for sum(rate(num_success{network=\"private-testnet\"}[5m]))",
    "Query \"histogram_quantile(0.50, sum by(le) (rate(batch_execution_latency_bucket{network=\"private-testnet\"}[15m])))\" returned value of 3.112150385622982 which is Greater 3",
    "Query \"avg(rate(total_transaction_effects{network=\"private-testnet\"}[5m]))\" returned value of 1.081275647819765 which is Less 5500",
    "Query \"avg (rate(batch_size_sum{network=\"private-testnet\"}[5m]))\" returned value of 0.24698238962944846 which is Less 5500",
]
```


