### PR TITLE
[sdk] fixes nested generic vector reading

### DIFF
--- a/.changeset/tame-carpets-battle.md
+++ b/.changeset/tame-carpets-battle.md
@@ -1,0 +1,5 @@
+---
+"@mysten/bcs": patch
+---
+
+Fixes an issue with a top level generic in a nested vector

--- a/sdk/bcs/src/index.ts
+++ b/sdk/bcs/src/index.ts
@@ -974,7 +974,8 @@ export class BCS {
           let { name: innerName, params: innerParams } = this.parseTypeName(
             typeMap[name]
           );
-          this.getTypeInterface(innerName)._decodeRaw.call(
+
+          return this.getTypeInterface(innerName)._decodeRaw.call(
             this,
             reader,
             innerParams,

--- a/sdk/bcs/tests/alias.test.ts
+++ b/sdk/bcs/tests/alias.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, it, expect } from "vitest";
 import { BCS, getSuiMoveConfig } from "../src/index";
+import { serde } from "./utils";
 
 describe("BCS: Aliases", () => {
   it("should support type aliases", () => {
@@ -38,9 +39,3 @@ describe("BCS: Aliases", () => {
     expect(error).toBeInstanceOf(Error);
   });
 });
-
-function serde(bcs, type, data) {
-  let ser = bcs.ser(type, data).toString("hex");
-  let de = bcs.de(type, ser, "hex");
-  return de;
-}

--- a/sdk/bcs/tests/array.type.test.ts
+++ b/sdk/bcs/tests/array.type.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, it, expect } from "vitest";
 import { BCS, getSuiMoveConfig } from "../src/index";
+import { serde } from "./utils";
 
 describe("BCS: Array type", () => {
   it.skip("should support destructured type name in ser/de", () => {
@@ -114,9 +115,3 @@ describe("BCS: Array type", () => {
     expect(serde(bcs, ["VecMap", ["Option", "string"], ["vector", "string"]], value)).toEqual(value);
   });
 });
-
-function serde(bcs, type, data) {
-  let ser = bcs.ser(type, data).toString("hex");
-  let de = bcs.de(type, ser, "hex");
-  return de;
-}

--- a/sdk/bcs/tests/config.test.ts
+++ b/sdk/bcs/tests/config.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, it, expect } from "vitest";
 import { BCS, getRustConfig, getSuiMoveConfig } from "../src/index";
+import { serde } from "./utils";
 
 describe("BCS: Config", () => {
   it("should work with Rust config", () => {
@@ -54,9 +55,3 @@ describe("BCS: Config", () => {
     expect(serde(bcs, "Option[array[string]]", value_2)).toEqual(value_2);
   });
 });
-
-function serde(bcs, type, data) {
-  let ser = bcs.ser(type, data).toString("hex");
-  let de = bcs.de(type, ser, "hex");
-  return de;
-}

--- a/sdk/bcs/tests/generics.test.ts
+++ b/sdk/bcs/tests/generics.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect } from "vitest";
-import { BCS, fromB64, getSuiMoveConfig } from "./../src/index";
+import { BCS, getSuiMoveConfig } from "./../src/index";
 
 describe("BCS: Generics", () => {
   it("should handle generics", () => {

--- a/sdk/bcs/tests/inline-definition.test.ts
+++ b/sdk/bcs/tests/inline-definition.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, it, expect } from "vitest";
 import { BCS, getSuiMoveConfig } from "../src/index";
+import { serde } from "./utils";
 
 describe("BCS: Inline struct definitions", () => {
   it("should de/serialize inline definition", () => {
@@ -46,9 +47,3 @@ describe("BCS: Inline struct definitions", () => {
     expect(sr).toEqual({ b0: { a0: 0 } });
   });
 });
-
-function serde(bcs, type, data) {
-  let ser = bcs.ser(type, data).toString("hex");
-  let de = bcs.de(type, ser, "hex");
-  return de;
-}

--- a/sdk/bcs/tests/nested.object.test.ts
+++ b/sdk/bcs/tests/nested.object.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, it, expect } from "vitest";
 import { BCS, getSuiMoveConfig } from "../src/index";
+import { serde } from "./utils";
 
 describe("BCS: Nested temp object", () => {
   it("should support object as a type", () => {
@@ -73,9 +74,3 @@ describe("BCS: Nested temp object", () => {
     expect(serde(bcs, "Option", value)).toEqual(value);
   });
 });
-
-function serde(bcs, type, data) {
-  let ser = bcs.ser(type, data).toString("hex");
-  let de = bcs.de(type, ser, "hex");
-  return de;
-}

--- a/sdk/bcs/tests/readme.test.ts
+++ b/sdk/bcs/tests/readme.test.ts
@@ -6,7 +6,7 @@
  * the README. Manual needs to be correct for the best DevX.
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it } from "vitest";
 import { SUI_ADDRESS_LENGTH } from "../../typescript/src";
 import {
   BCS,
@@ -37,7 +37,7 @@ describe("BCS: README Examples", () => {
         value: 1000000n,
       })
       .toBytes();
-  
+
     let coin = bcs.de("Coin", bytes);
 
     // serialization: Object into bytes

--- a/sdk/bcs/tests/utils.ts
+++ b/sdk/bcs/tests/utils.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { BCS } from "../src/index";
+
+/** Serialize and deserialize the result. */
+export function serde(bcs: BCS, type: any, data: any): any {
+    let ser = bcs.ser(type, data).toString("hex");
+    let de = bcs.de(type, ser, "hex");
+    return de;
+  }

--- a/sdk/bcs/tests/vector.generics.test.ts
+++ b/sdk/bcs/tests/vector.generics.test.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { BCS, getSuiMoveConfig } from "../src/index";
+import { serde } from "./utils";
+
+describe("BCS: Inline struct definitions", () => {
+  it("should de/serialize inline definition", () => {
+    const bcs = new BCS(getSuiMoveConfig());
+
+    // reported by kklas: vector<T> returns [undefined]
+    bcs.registerStructType(['FooType', 'T'], {
+        generic_vec: ['vector', 'T'],
+    });
+
+    const value = { generic_vec: [ '1', '2', '3' ] };
+    expect(serde(bcs, ['FooType', 'u64'], value)).toEqual(value);
+  });
+});


### PR DESCRIPTION
## Description 

Fixes an issue reported by @kklas: incorrect vector deserialization when T is passed through a higher-type generic.

## Test Plan 

The case is covered with tests.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

- @mysten/bcs - fixes nested vector generic in deserialization