### PR TITLE
wallet-ext: qredo connect add organization field

### DIFF
--- a/apps/wallet/src/background/qredo/index.ts
+++ b/apps/wallet/src/background/qredo/index.ts
@@ -45,11 +45,13 @@ export async function requestUserApproval(
     message: Message
 ) {
     const origin = connection.origin;
-    const { service, apiUrl, token } = validateInputOrThrow(input);
+    const { service, apiUrl, token, organization } =
+        validateInputOrThrow(input);
     const connectionIdentity = {
         service,
         apiUrl,
         origin,
+        organization,
     };
     const existingPendingRequest = await getPendingRequest(connectionIdentity);
     if (existingPendingRequest) {
@@ -90,6 +92,7 @@ export async function requestUserApproval(
             origin,
             originFavIcon: connection.originFavIcon,
             accessToken: null,
+            organization,
         },
         message.id
     );
@@ -222,12 +225,14 @@ export async function acceptQredoConnection({
             `Accepting Qredo connection failed, pending request ${qredoID} not found`
         );
     }
-    const { apiUrl, origin, originFavIcon, service } = pendingRequest;
+    const { apiUrl, origin, originFavIcon, service, organization } =
+        pendingRequest;
     // make sure we replace an existing connection when it's the same
     const existingConnection = await getQredoConnection({
         apiUrl,
         origin,
         service,
+        organization,
     });
     const qredoIDToUse = existingConnection?.id || qredoID;
     await keyring.storeQredoConnection(
@@ -244,6 +249,7 @@ export async function acceptQredoConnection({
         service,
         accounts,
         accessToken: null,
+        organization,
     });
     await deletePendingRequest(pendingRequest);
     qredoEvents.emit('onConnectionResponse', {

--- a/apps/wallet/src/background/qredo/types.ts
+++ b/apps/wallet/src/background/qredo/types.ts
@@ -7,6 +7,7 @@ export type QredoConnectIdentity = {
     service: string;
     apiUrl: string;
     origin: string;
+    organization: string;
 };
 
 export type QredoConnectPendingRequest = {
@@ -20,7 +21,7 @@ export type QredoConnectPendingRequest = {
 
 export type UIQredoPendingRequest = Pick<
     QredoConnectPendingRequest,
-    'id' | 'service' | 'apiUrl' | 'origin' | 'originFavIcon'
+    'id' | 'service' | 'apiUrl' | 'origin' | 'originFavIcon' | 'organization'
 > & { partialToken: `…${string}` };
 
 export type UIQredoInfo = {

--- a/apps/wallet/src/background/qredo/utils.ts
+++ b/apps/wallet/src/background/qredo/utils.ts
@@ -46,6 +46,7 @@ export function validateInputOrThrow(input: QredoConnectInput) {
         service,
         apiUrl: apiUrl.toString(),
         token,
+        organization: trimString(input.organization),
     };
 }
 
@@ -61,6 +62,7 @@ export function toUIQredoPendingRequest(
         origin: stored.origin,
         originFavIcon: stored.originFavIcon,
         partialToken: `…${stored.token.slice(-UI_TOKEN_MAX_LENGTH)}`,
+        organization: stored.organization || '',
     };
 }
 
@@ -73,6 +75,7 @@ export function isSameQredoConnection<T1 extends QredoConnectIdentity | string>(
         (typeof a === 'object' &&
             a.apiUrl === b.apiUrl &&
             a.origin === b.origin &&
-            a.service === b.service)
+            a.service === b.service &&
+            a.organization === b.organization)
     );
 }

--- a/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
+++ b/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
@@ -74,6 +74,7 @@ export type QredoConnectInput = {
     service: string;
     apiUrl: string;
     token: string;
+    organization: string;
 };
 type QredoConnectFeature = {
     'qredo:connect': {

--- a/apps/wallet/src/ui/app/pages/qredo-connect/QredoConnectInfoPage.tsx
+++ b/apps/wallet/src/ui/app/pages/qredo-connect/QredoConnectInfoPage.tsx
@@ -97,6 +97,10 @@ export function QredoConnectInfoPage() {
                                     value={data.service}
                                 />
                                 <LabelValueItem
+                                    label="Organization"
+                                    value={data.organization || '-'}
+                                />
+                                <LabelValueItem
                                     label="Token"
                                     value={data.partialToken}
                                 />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,8 +1,4 @@
-lockfileVersion: '6.1'
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
+lockfileVersion: '6.0'
 
 overrides:
   node-notifier: 10.0.0
@@ -1125,10 +1121,10 @@ importers:
         version: 13.3.0(react-dom@18.2.0)(react@18.2.0)
       nextra:
         specifier: latest
-        version: 2.5.2(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
+        version: 2.3.0(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
       nextra-theme-docs:
         specifier: latest
-        version: 2.5.2(next@13.3.0)(nextra@2.5.2)(react-dom@18.2.0)(react@18.2.0)
+        version: 2.3.0(next@13.3.0)(nextra@2.3.0)(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -14856,8 +14852,8 @@ packages:
       - supports-color
     dev: false
 
-  /next-seo@6.0.0(next@13.3.0)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-jKKt1p1z4otMA28AyeoAONixVjdYmgFCWwpEFtu+DwRHQDllVX3RjtyXbuCQiUZEfQ9rFPBpAI90vDeLZlMBdg==}
+  /next-seo@5.15.0(next@13.3.0)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-LGbcY91yDKGMb7YI+28n3g+RuChUkt6pXNpa8FkfKkEmNiJkeRDEXTnnjVtwT9FmMhG6NH8qwHTelGrlYm9rgg==}
     peerDependencies:
       next: ^8.1.1-canary.54 || >=9.0.0
       react: '>=16.0.0'
@@ -14924,11 +14920,11 @@ packages:
       - babel-plugin-macros
     dev: false
 
-  /nextra-theme-docs@2.5.2(next@13.3.0)(nextra@2.5.2)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-DLrAtMtlUx3y3QsHcnIHhkb8b/VUFSvU5Cgb0Tzm7VlngKJW8ftPg9IxgoRZouqgQvkvvxbMLTPgBw+8n0VZTw==}
+  /nextra-theme-docs@2.3.0(next@13.3.0)(nextra@2.3.0)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-KMvHhGOvaKIqR71Gnx+w/1c9LLfpQJ3+fnCAgg9qfjXo2agr1zRKyRDROyY8cGINdslpzmEGgs/MH2gDSAI6nw==}
     peerDependencies:
       next: '>=9.5.3'
-      nextra: 2.5.2
+      nextra: 2.3.0
       react: '>=16.13.1'
       react-dom: '>=16.13.1'
     dependencies:
@@ -14941,17 +14937,17 @@ packages:
       intersection-observer: 0.12.2
       match-sorter: 6.3.1
       next: 13.3.0(react-dom@18.2.0)(react@18.2.0)
-      next-seo: 6.0.0(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
+      next-seo: 5.15.0(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
       next-themes: 0.2.1(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
-      nextra: 2.5.2(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
+      nextra: 2.3.0(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       scroll-into-view-if-needed: 3.0.10
       zod: 3.21.4
     dev: false
 
-  /nextra@2.5.2(next@13.3.0)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-22kw8s2OShvA625cKi3P9JioUybL5hEcCn1txXyQh+Mn3jmQXlXdbzmuT4BdYRNWo5lGqmYwm2h73igXjbssRQ==}
+  /nextra@2.3.0(next@13.3.0)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-v17vMq2bJa15iKKt9+6AidSeIoKcK1ZlXmwqFqTgc0pQmRrl6pTJaSR36UZKcpMwvvLZ/7/xWuWV/OQB599O3g==}
     engines: {node: '>=16'}
     peerDependencies:
       next: '>=9.5.3'
@@ -14972,7 +14968,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       rehype-katex: 6.0.3
-      rehype-pretty-code: 0.9.4(shiki@0.14.2)
+      rehype-pretty-code: 0.9.3(shiki@0.14.2)
       remark-gfm: 3.0.1
       remark-math: 5.1.1
       remark-reading-time: 2.0.1
@@ -17235,8 +17231,8 @@ packages:
       unist-util-visit: 4.1.2
     dev: false
 
-  /rehype-pretty-code@0.9.4(shiki@0.14.2):
-    resolution: {integrity: sha512-3m4aQT15n8C+UizcZL0enaahoZwCDm5K1qKQ3DGgHE7U8l/DEEEJ/hm+uDe9yyK4sxVOSfZcRIMHrpJwLQi+Rg==}
+  /rehype-pretty-code@0.9.3(shiki@0.14.2):
+    resolution: {integrity: sha512-57i+ifrttqpeQxub0NZ2pRw0aiUPYeBpr234NLWfZ4BfbEaP+29+iCXB1rUMkzoPi6IBC4w4I93mUPgw36IajQ==}
     engines: {node: ^12.16.0 || >=13.2.0}
     peerDependencies:
       shiki: '*'
@@ -20282,7 +20278,6 @@ packages:
 
   /which@1.3.1:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
-    hasBin: true
     dependencies:
       isexe: 2.0.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 overrides:
   node-notifier: 10.0.0
@@ -1121,10 +1125,10 @@ importers:
         version: 13.3.0(react-dom@18.2.0)(react@18.2.0)
       nextra:
         specifier: latest
-        version: 2.3.0(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
+        version: 2.5.2(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
       nextra-theme-docs:
         specifier: latest
-        version: 2.3.0(next@13.3.0)(nextra@2.3.0)(react-dom@18.2.0)(react@18.2.0)
+        version: 2.5.2(next@13.3.0)(nextra@2.5.2)(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -14852,8 +14856,8 @@ packages:
       - supports-color
     dev: false
 
-  /next-seo@5.15.0(next@13.3.0)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-LGbcY91yDKGMb7YI+28n3g+RuChUkt6pXNpa8FkfKkEmNiJkeRDEXTnnjVtwT9FmMhG6NH8qwHTelGrlYm9rgg==}
+  /next-seo@6.0.0(next@13.3.0)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-jKKt1p1z4otMA28AyeoAONixVjdYmgFCWwpEFtu+DwRHQDllVX3RjtyXbuCQiUZEfQ9rFPBpAI90vDeLZlMBdg==}
     peerDependencies:
       next: ^8.1.1-canary.54 || >=9.0.0
       react: '>=16.0.0'
@@ -14920,11 +14924,11 @@ packages:
       - babel-plugin-macros
     dev: false
 
-  /nextra-theme-docs@2.3.0(next@13.3.0)(nextra@2.3.0)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-KMvHhGOvaKIqR71Gnx+w/1c9LLfpQJ3+fnCAgg9qfjXo2agr1zRKyRDROyY8cGINdslpzmEGgs/MH2gDSAI6nw==}
+  /nextra-theme-docs@2.5.2(next@13.3.0)(nextra@2.5.2)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-DLrAtMtlUx3y3QsHcnIHhkb8b/VUFSvU5Cgb0Tzm7VlngKJW8ftPg9IxgoRZouqgQvkvvxbMLTPgBw+8n0VZTw==}
     peerDependencies:
       next: '>=9.5.3'
-      nextra: 2.3.0
+      nextra: 2.5.2
       react: '>=16.13.1'
       react-dom: '>=16.13.1'
     dependencies:
@@ -14937,17 +14941,17 @@ packages:
       intersection-observer: 0.12.2
       match-sorter: 6.3.1
       next: 13.3.0(react-dom@18.2.0)(react@18.2.0)
-      next-seo: 5.15.0(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
+      next-seo: 6.0.0(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
       next-themes: 0.2.1(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
-      nextra: 2.3.0(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
+      nextra: 2.5.2(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       scroll-into-view-if-needed: 3.0.10
       zod: 3.21.4
     dev: false
 
-  /nextra@2.3.0(next@13.3.0)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-v17vMq2bJa15iKKt9+6AidSeIoKcK1ZlXmwqFqTgc0pQmRrl6pTJaSR36UZKcpMwvvLZ/7/xWuWV/OQB599O3g==}
+  /nextra@2.5.2(next@13.3.0)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-22kw8s2OShvA625cKi3P9JioUybL5hEcCn1txXyQh+Mn3jmQXlXdbzmuT4BdYRNWo5lGqmYwm2h73igXjbssRQ==}
     engines: {node: '>=16'}
     peerDependencies:
       next: '>=9.5.3'
@@ -14968,7 +14972,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       rehype-katex: 6.0.3
-      rehype-pretty-code: 0.9.3(shiki@0.14.2)
+      rehype-pretty-code: 0.9.4(shiki@0.14.2)
       remark-gfm: 3.0.1
       remark-math: 5.1.1
       remark-reading-time: 2.0.1
@@ -17231,8 +17235,8 @@ packages:
       unist-util-visit: 4.1.2
     dev: false
 
-  /rehype-pretty-code@0.9.3(shiki@0.14.2):
-    resolution: {integrity: sha512-57i+ifrttqpeQxub0NZ2pRw0aiUPYeBpr234NLWfZ4BfbEaP+29+iCXB1rUMkzoPi6IBC4w4I93mUPgw36IajQ==}
+  /rehype-pretty-code@0.9.4(shiki@0.14.2):
+    resolution: {integrity: sha512-3m4aQT15n8C+UizcZL0enaahoZwCDm5K1qKQ3DGgHE7U8l/DEEEJ/hm+uDe9yyK4sxVOSfZcRIMHrpJwLQi+Rg==}
     engines: {node: ^12.16.0 || >=13.2.0}
     peerDependencies:
       shiki: '*'
@@ -20278,6 +20282,7 @@ packages:
 
   /which@1.3.1:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
+    hasBin: true
     dependencies:
       isexe: 2.0.0
 

--- a/sdk/wallet-adapter/example/src/QredoConnectButton.tsx
+++ b/sdk/wallet-adapter/example/src/QredoConnectButton.tsx
@@ -3,7 +3,12 @@
 
 import { useWalletKit, type WalletWithFeatures } from "@mysten/wallet-kit";
 
-type QredoConnectInput = { service: string; apiUrl: string; token: string };
+type QredoConnectInput = {
+  service: string;
+  apiUrl: string;
+  token: string;
+  organization: string;
+};
 type QredoConnectFeature = {
   "qredo:connect": {
     version: "0.0.1";
@@ -36,8 +41,9 @@ export function QredoConnectButton() {
         try {
           await qredoConnectWallet.features["qredo:connect"]?.qredoConnect({
             service: "qredo-testing",
-            apiUrl: "http://localhost:8080/",
+            apiUrl: "http://localhost:8080/connect/sui",
             token: "aToken",
+            organization: "org1",
           });
         } catch (e) {
           console.log(e);


### PR DESCRIPTION
* add organization field in injected inputs
* this changes the way wallet identifies that 2 connections are different (to be the same must also have the same organization)
* this fixes the issue when injecting accounts with the same service and apiUrl, but different organization was replacing the existing connected wallets

<img width="363" alt="Screenshot 2023-06-05 at 14 22 25" src="https://github.com/MystenLabs/sui/assets/10210143/741176bb-9810-47ae-bd9b-37491da6fa9d">


closes APPS-1215