### PR TITLE
wallet-ext: poll rpc for tx result of qredo transaction

### DIFF
--- a/apps/wallet/src/ui/app/QredoSigner.ts
+++ b/apps/wallet/src/ui/app/QredoSigner.ts
@@ -136,7 +136,7 @@ export class QredoSigner extends WalletSigner {
     };
 
     signAndExecuteTransactionBlock: WalletSigner['signAndExecuteTransactionBlock'] =
-        async ({ transactionBlock }, clientIdentifier) => {
+        async ({ transactionBlock, options }, clientIdentifier) => {
             let txInfo = await this.#createQredoTransaction(
                 messageWithIntent(
                     IntentScope.TransactionData,
@@ -177,7 +177,10 @@ export class QredoSigner extends WalletSigner {
                     `Digest is not set in Qredo transaction ${txInfo.txID}`
                 );
             }
-            return { digest: txInfo.txHash };
+            return this.provider.waitForTransactionBlock({
+                digest: txInfo.txHash,
+                options: options,
+            });
         };
 
     connect(provider: JsonRpcProvider): WalletSigner {


### PR DESCRIPTION
* wait for the wallet rpc to return the transaction result before completing a qredo sign and execute transaction

| tx result before | tx result after |
| -- | -- |
| <img width="440" alt="Screenshot 2023-06-05 at 16 39 25" src="https://github.com/MystenLabs/sui/assets/10210143/6a004bae-dbb8-4dfd-aa81-789680d16f82"> | <img width="883" alt="Screenshot 2023-06-05 at 16 38 32" src="https://github.com/MystenLabs/sui/assets/10210143/6357eca5-9ba5-4d14-b769-43f7e0ff0398"> |

NOTE: this adds some extra time since we wait for the FN of the wallet to receive the transaction + some polling delays

closes APPS-1058