### PR TITLE
[TestCluster] Add validator management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10462,6 +10462,7 @@ dependencies = [
  "bcs",
  "move-core-types",
  "shared-crypto",
+ "sui-genesis-builder",
  "sui-move-build",
  "sui-types",
  "workspace-hack",

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -242,6 +242,10 @@ impl NodeConfig {
     pub fn genesis(&self) -> Result<&genesis::Genesis> {
         self.genesis.genesis()
     }
+
+    pub fn sui_address(&self) -> SuiAddress {
+        (&self.account_key_pair.keypair().public()).into()
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
@@ -1,52 +1,32 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use fastcrypto::ed25519::Ed25519KeyPair;
 use futures::future::join_all;
-use move_core_types::ident_str;
-use mysten_metrics::RegistryService;
-use prometheus::Registry;
-use rand::{rngs::StdRng, SeedableRng};
-use std::collections::{BTreeMap, HashMap, HashSet};
+use rand::rngs::OsRng;
+use std::collections::{BTreeSet, HashSet};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
-use sui_config::NodeConfig;
-use sui_core::authority_aggregator::{AuthAggMetrics, AuthorityAggregator};
+use std::time::Duration;
 use sui_core::consensus_adapter::position_submit_certificate;
-use sui_core::safe_client::SafeClientMetricsBase;
 use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
 use sui_macros::sim_test;
 use sui_node::SuiNodeHandle;
 use sui_protocol_config::ProtocolConfig;
-use sui_swarm_config::network_config_builder::ConfigBuilder;
+use sui_swarm_config::genesis_config::{ValidatorGenesisConfig, ValidatorGenesisConfigBuilder};
 use sui_test_transaction_builder::TestTransactionBuilder;
-use sui_types::base_types::{AuthorityName, ObjectRef, SuiAddress};
-use sui_types::crypto::{
-    generate_proof_of_possession, get_key_pair_from_rng, AccountKeyPair, KeypairTraits, ToFromBytes,
-};
-use sui_types::effects::{CertifiedTransactionEffects, TransactionEffectsAPI};
+use sui_types::base_types::SuiAddress;
+use sui_types::effects::TransactionEffectsAPI;
 use sui_types::error::SuiError;
 use sui_types::gas::GasCostSummary;
+use sui_types::governance::MIN_VALIDATOR_JOINING_STAKE_MIST;
 use sui_types::message_envelope::Message;
-use sui_types::object::{
-    generate_test_gas_objects_with_owner, generate_test_gas_objects_with_owner_and_value, Object,
-};
-use sui_types::sui_system_state::sui_system_state_inner_v1::VerifiedValidatorMetadataV1;
 use sui_types::sui_system_state::{
     get_validator_from_table, sui_system_state_summary::get_validator_by_pool_id,
     SuiSystemStateTrait,
 };
-use sui_types::transaction::{
-    CallArg, ObjectArg, TransactionData, TransactionDataAPI, TransactionExpiration,
-    VerifiedTransaction, TEST_ONLY_GAS_UNIT_FOR_GENERIC, TEST_ONLY_GAS_UNIT_FOR_STAKING,
-    TEST_ONLY_GAS_UNIT_FOR_VALIDATOR,
-};
-use sui_types::utils::to_sender_signed_transaction;
-use sui_types::SUI_SYSTEM_PACKAGE_ID;
-use test_utils::authority::start_node;
-use test_utils::{authority::spawn_test_authorities, network::TestClusterBuilder};
-use tokio::time::{sleep, timeout};
-use tracing::{info, warn};
+use sui_types::transaction::{TransactionDataAPI, TransactionExpiration};
+use test_utils::network::TestCluster;
+use test_utils::network::TestClusterBuilder;
+use tokio::time::sleep;
 
 #[sim_test]
 async fn advance_epoch_tx_test() {
@@ -323,6 +303,7 @@ async fn test_create_advance_epoch_tx_race() {
     use std::sync::Arc;
     use sui_macros::{register_fail_point, register_fail_point_async};
     use tokio::sync::broadcast;
+    use tracing::info;
 
     telemetry_subscribers::init_for_testing();
     sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
@@ -453,77 +434,24 @@ async fn test_validator_resign_effects() {
 
 #[sim_test]
 async fn test_validator_candidate_pool_read() {
-    let new_validator_key = gen_keys(5).pop().unwrap();
-    let new_validator_address: SuiAddress = new_validator_key.public().into();
-
-    let gas_objects =
-        generate_test_gas_objects_with_owner_and_value(4, new_validator_address, 100_000_000_000);
-
-    let init_configs = ConfigBuilder::new_with_temp_dir()
-        .rng(StdRng::from_seed([0; 32]))
-        .with_validator_account_keys(gen_keys(4))
-        .with_objects(gas_objects.clone())
-        .build();
-
-    let new_configs = ConfigBuilder::new_with_temp_dir()
-        .rng(StdRng::from_seed([0; 32]))
-        .with_validator_account_keys(gen_keys(5))
-        .with_objects(gas_objects.clone())
-        .build();
-
-    let gas_objects: Vec<_> = gas_objects
-        .into_iter()
-        .map(|o| init_configs.genesis.object(o.id()).unwrap())
-        .collect();
-
-    // Generate a new validator config.
-    let public_keys: HashSet<_> = init_configs
-        .validator_configs
-        .iter()
-        .map(|config| config.protocol_public_key())
-        .collect();
-    // Node configs contain things such as private keys, which we need to send transactions.
-    let new_node_config = new_configs
-        .validator_configs
-        .iter()
-        .find(|v| !public_keys.contains(&v.protocol_public_key()))
+    let new_validator = ValidatorGenesisConfigBuilder::new().build(&mut OsRng);
+    let address: SuiAddress = (&new_validator.account_key_pair.public()).into();
+    let test_cluster = TestClusterBuilder::new()
+        .with_validator_candidates([address])
+        .build()
+        .await
         .unwrap();
-    // Validator information from genesis contains public network addresses that we need to commit on-chain.
-    let new_validator = new_configs
-        .genesis
-        .validator_set_for_tooling()
-        .into_iter()
-        .find(|v| {
-            let name: AuthorityName = v.verified_metadata().sui_pubkey_bytes();
-            !public_keys.contains(&name)
-        })
-        .unwrap();
-
-    let authorities = spawn_test_authorities(&init_configs).await;
-    let _effects = execute_add_validator_candidate_tx(
-        &authorities,
-        gas_objects[3].compute_object_reference(),
-        new_node_config,
-        new_validator.verified_metadata(),
-        &new_validator_key,
-    )
-    .await;
-
-    // Trigger reconfiguration so that the candidate adding txn is executed on all authorities.
-    trigger_reconfiguration(&authorities).await;
-
-    // Check that the candidate can be found in the candidate table now.
-    authorities[0].with(|node| {
+    add_validator_candidate(&test_cluster, &new_validator).await;
+    test_cluster.fullnode_handle.sui_node.with(|node| {
         let system_state = node
             .state()
             .get_sui_system_state_object_for_testing()
             .unwrap();
         let system_state_summary = system_state.clone().into_sui_system_state_summary();
-        assert_eq!(system_state_summary.validator_candidates_size, 1);
         let staking_pool_id = get_validator_from_table(
             node.state().db().as_ref(),
             system_state_summary.validator_candidates_id,
-            &new_validator_address,
+            &address,
         )
         .unwrap()
         .staking_pool_id;
@@ -534,35 +462,21 @@ async fn test_validator_candidate_pool_read() {
             staking_pool_id,
         )
         .unwrap();
-        assert_eq!(validator.sui_address, new_validator_address);
+        assert_eq!(validator.sui_address, address);
     });
 }
 
 #[sim_test]
 async fn test_inactive_validator_pool_read() {
-    let leaving_validator_account_key = gen_keys(5).pop().unwrap();
-    let address: SuiAddress = leaving_validator_account_key.public().into();
-
-    let gas_objects = generate_test_gas_objects_with_owner(1, address);
-    let stake = Object::new_gas_with_balance_and_owner_for_testing(25_000_000_000_000_000, address);
-    let mut genesis_objects = vec![stake];
-    genesis_objects.extend(gas_objects.clone());
-
-    let init_configs = ConfigBuilder::new_with_temp_dir()
-        .rng(StdRng::from_seed([0; 32]))
-        .with_validator_account_keys(gen_keys(5))
-        .with_objects(genesis_objects.clone())
-        .build();
-
-    let gas_objects: Vec<_> = gas_objects
-        .into_iter()
-        .map(|o| init_configs.genesis.object(o.id()).unwrap())
-        .collect();
-
-    let authorities = spawn_test_authorities(&init_configs).await;
-    let rgp = init_configs.genesis.reference_gas_price();
-
-    let staking_pool_id = authorities[0].with(|node| {
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(5)
+        .build()
+        .await
+        .unwrap();
+    // Pick the first validator.
+    let validator = test_cluster.swarm.validator_node_handles().pop().unwrap();
+    let address = validator.with(|node| node.get_config().sui_address());
+    let staking_pool_id = test_cluster.fullnode_handle.sui_node.with(|node| {
         node.state()
             .get_sui_system_state_object_for_testing()
             .unwrap()
@@ -573,7 +487,7 @@ async fn test_inactive_validator_pool_read() {
             .unwrap()
             .staking_pool_id
     });
-    authorities[0].with(|node| {
+    test_cluster.fullnode_handle.sui_node.with(|node| {
         let system_state = node
             .state()
             .get_sui_system_state_object_for_testing()
@@ -589,34 +503,31 @@ async fn test_inactive_validator_pool_read() {
         .unwrap();
         assert_eq!(validator.sui_address, address);
     });
+    execute_remove_validator_tx(&test_cluster, &validator).await;
 
-    let tx_data = TransactionData::new_move_call(
-        address,
-        SUI_SYSTEM_PACKAGE_ID,
-        ident_str!("sui_system").to_owned(),
-        ident_str!("request_remove_validator").to_owned(),
-        vec![],
-        gas_objects[0].compute_object_reference(),
-        vec![CallArg::SUI_SYSTEM_MUT],
-        rgp * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
-        rgp,
-    )
-    .unwrap();
-    let transaction = to_sender_signed_transaction(tx_data, &leaving_validator_account_key);
-    let effects = execute_transaction_block(&authorities, transaction)
-        .await
-        .unwrap();
-    assert!(effects.status().is_ok());
+    test_cluster.trigger_reconfiguration().await;
 
-    trigger_reconfiguration(&authorities).await;
+    // Check that this node is no longer a validator.
+    validator.with(|node| {
+        assert!(node
+            .state()
+            .is_fullnode(&node.state().epoch_store_for_testing()));
+    });
 
     // Check that the validator that just left now shows up in the inactive_validators,
     // and we can still deserialize it and get the inactive staking pool.
-    authorities[0].with(|node| {
+    test_cluster.fullnode_handle.sui_node.with(|node| {
         let system_state = node
             .state()
             .get_sui_system_state_object_for_testing()
             .unwrap();
+        assert_eq!(
+            system_state
+                .get_current_epoch_committee()
+                .committee
+                .num_members(),
+            4
+        );
         let system_state_summary = system_state.clone().into_sui_system_state_summary();
         let validator = get_validator_by_pool_id(
             node.state().db().as_ref(),
@@ -630,127 +541,24 @@ async fn test_inactive_validator_pool_read() {
     })
 }
 
-// generate N keys - use a fixed RNG so we can regenerate the same set again later (keypairs
-// are not Clone)
-fn gen_keys(count: usize) -> Vec<AccountKeyPair> {
-    let mut rng = StdRng::from_seed([0; 32]);
-    (0..count)
-        .map(|_| get_key_pair_from_rng::<AccountKeyPair, _>(&mut rng).1)
-        .collect()
-}
-
 #[sim_test]
 async fn test_reconfig_with_committee_change_basic() {
     // This test exercise the full flow of a validator joining the network, catch up and then leave.
 
-    let new_validator_key = gen_keys(5).pop().unwrap();
-    let new_validator_address: SuiAddress = new_validator_key.public().into();
-
-    // TODO: In order to better "test" this flow we probably want to set the validators to ignore
-    // all p2p peer connections so that we can verify that new nodes joining can really "talk" with the
-    // other validators in the set.
-    let gas_objects =
-        generate_test_gas_objects_with_owner_and_value(4, new_validator_address, 100_000_000_000);
-    let stake = Object::new_gas_with_balance_and_owner_for_testing(
-        30_000_000_000_000_000,
-        new_validator_address,
-    );
-    let mut objects = vec![stake.clone()];
-    objects.extend(gas_objects.clone());
-
-    let init_configs = ConfigBuilder::new_with_temp_dir()
-        .rng(StdRng::from_seed([0; 32]))
-        .with_validator_account_keys(gen_keys(4))
-        .with_objects(objects.clone())
-        .build();
-
-    let new_configs = ConfigBuilder::new_with_temp_dir()
-        .rng(StdRng::from_seed([0; 32]))
-        .with_validator_account_keys(gen_keys(5))
-        .with_objects(objects.clone())
-        .build();
-
-    let gas_objects: Vec<_> = gas_objects
-        .into_iter()
-        .map(|o| init_configs.genesis.object(o.id()).unwrap())
-        .collect();
-
-    let stake = init_configs.genesis.object(stake.id()).unwrap();
-
-    // Generate a new validator config.
-    // Our committee generation uses a fixed seed, so we need to generate a new committee
-    // with one extra validator.
-    // Furthermore, since the order is not fixed, we need to find the new validator
-    // that doesn't exist in the previous committee manually.
-    // The order of validator_set() and validator_configs() is also different.
-    // TODO: We should really fix the above inconveniences.
-    let public_keys: HashSet<_> = init_configs
-        .validator_configs
-        .iter()
-        .map(|config| config.protocol_public_key())
-        .collect();
-    // Node configs contain things such as private keys, which we need to send transactions.
-    let new_node_config = new_configs
-        .validator_configs
-        .iter()
-        .find(|v| !public_keys.contains(&v.protocol_public_key()))
+    let new_validator = ValidatorGenesisConfigBuilder::new().build(&mut OsRng);
+    let address = (&new_validator.account_key_pair.public()).into();
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_validator_candidates([address])
+        .build()
+        .await
         .unwrap();
-    // Validator information from genesis contains public network addresses that we need to commit on-chain.
-    let new_validator = new_configs
-        .genesis
-        .validator_set_for_tooling()
-        .into_iter()
-        .find(|v| {
-            let name: AuthorityName = v.verified_metadata().sui_pubkey_bytes();
-            !public_keys.contains(&name)
-        })
-        .unwrap();
-    info!(
-        "New validator is: {:?}",
-        new_validator
-            .verified_metadata()
-            .sui_pubkey_bytes()
-            .concise()
-    );
 
-    let mut authorities = spawn_test_authorities(&init_configs).await;
+    execute_add_validator_transactions(&test_cluster, &new_validator).await;
 
-    let _effects = execute_join_committee_txes(
-        &authorities,
-        gas_objects
-            .clone()
-            .into_iter()
-            .map(|obj| obj.compute_object_reference())
-            .collect::<Vec<_>>(),
-        stake.compute_object_reference(),
-        new_node_config,
-        new_validator.verified_metadata(),
-        &new_validator_key,
-    )
-    .await;
+    test_cluster.trigger_reconfiguration().await;
 
-    // Give the nodes enough time to execute the joining txns.
-    sleep(Duration::from_secs(5)).await;
-
-    // Check that we can get the pending validator from 0x5.
-    authorities[0].with(|node| {
-        let system_state = node
-            .state()
-            .get_sui_system_state_object_for_testing()
-            .unwrap();
-        let pending_active_validators = system_state
-            .get_pending_active_validators(node.state().db().as_ref())
-            .unwrap();
-        assert_eq!(pending_active_validators.len(), 1);
-        assert_eq!(
-            pending_active_validators[0].sui_address,
-            new_validator_address
-        );
-    });
-
-    trigger_reconfiguration(&authorities).await;
     // Check that a new validator has joined the committee.
-    authorities[0].with(|node| {
+    test_cluster.fullnode_handle.sui_node.with(|node| {
         assert_eq!(
             node.state()
                 .epoch_store_for_testing()
@@ -759,37 +567,18 @@ async fn test_reconfig_with_committee_change_basic() {
             5
         );
     });
+    let new_validator_handle = test_cluster.spawn_new_validator(new_validator).await;
+    test_cluster.wait_for_epoch_all_nodes(1).await;
 
-    let mut new_node_config_clone = new_node_config.clone();
-    // Make sure that the new validator config shares the same genesis as the initial one.
-    new_node_config_clone.genesis = init_configs.validator_configs[0].genesis.clone();
-    let handle = start_node(
-        &new_node_config_clone,
-        RegistryService::new(Registry::new()),
-    )
-    .await;
-    // Give the new validator enough time to catch up and sync.
-    // TODO: 30s is still flaky.
-    tokio::time::sleep(Duration::from_secs(30)).await;
-    handle.with(|node| {
-        // Eventually the validator will catch up to the new epoch and become part of the committee.
+    new_validator_handle.with(|node| {
         assert!(node
             .state()
             .is_validator(&node.state().epoch_store_for_testing()));
     });
 
-    let _effects = execute_leave_committee_tx(
-        &authorities,
-        gas_objects[3].compute_object_reference(),
-        &new_validator_key,
-    )
-    .await;
-
-    authorities.push(handle);
-    trigger_reconfiguration(&authorities).await;
-
-    // Check that this validator has left the committee, and is no longer a validator.
-    authorities[4].with(|node| {
+    execute_remove_validator_tx(&test_cluster, &new_validator_handle).await;
+    test_cluster.trigger_reconfiguration().await;
+    test_cluster.fullnode_handle.sui_node.with(|node| {
         assert_eq!(
             node.state()
                 .epoch_store_for_testing()
@@ -797,285 +586,49 @@ async fn test_reconfig_with_committee_change_basic() {
                 .num_members(),
             4
         );
-        assert!(node
-            .state()
-            .is_fullnode(&node.state().epoch_store_for_testing()));
-    })
+    });
 }
 
 #[sim_test]
 async fn test_reconfig_with_committee_change_stress() {
-    // This needs to be written to genesis for all validators, present and future
-    // (either that or we create these objects via Transaction later, but that's more work)
-    let all_validator_keys = gen_keys(11);
-    let address_key_mapping: BTreeMap<SuiAddress, Ed25519KeyPair> = all_validator_keys
+    let mut candidates = (0..6)
+        .map(|_| ValidatorGenesisConfigBuilder::new().build(&mut OsRng))
+        .collect::<Vec<_>>();
+    let addresses = candidates
         .iter()
-        .map(|key| (key.public().into(), key.copy()))
-        .collect();
-
-    let object_set: HashMap<SuiAddress, (Vec<Object>, Object)> = all_validator_keys
-        .iter()
-        .map(|key| {
-            let sender: SuiAddress = key.public().into();
-            let gas_objects =
-                generate_test_gas_objects_with_owner_and_value(4, sender, 100_000_000_000);
-            let stake =
-                Object::new_gas_with_balance_and_owner_for_testing(30_000_000_000_000_000, sender);
-            (sender, (gas_objects, stake))
-        })
-        .collect();
-
-    let genesis_objects: Vec<_> = object_set
-        .values()
-        .flat_map(|(g, s)| {
-            let mut objs = g.clone();
-            objs.push(s.clone());
-            objs
-        })
-        .collect();
-
-    let initial_network = ConfigBuilder::new_with_temp_dir()
-        .rng(StdRng::from_seed([0; 32]))
-        .with_validator_account_keys(gen_keys(5))
-        .with_objects(genesis_objects.clone())
-        .build();
-
-    let mut object_map: HashMap<SuiAddress, (Vec<ObjectRef>, ObjectRef)> = object_set
-        .into_iter()
-        .map(|(sender, (gas, stake))| {
-            (
-                sender,
-                (
-                    gas.into_iter()
-                        .map(|obj| {
-                            initial_network
-                                .genesis
-                                .object(obj.id())
-                                .unwrap()
-                                .compute_object_reference()
-                        })
-                        .collect::<Vec<_>>(),
-                    initial_network
-                        .genesis
-                        .object(stake.id())
-                        .unwrap()
-                        .compute_object_reference(),
-                ),
-            )
-        })
-        .collect();
-
-    // Network config composed of the join of all committees that will
-    // exist at any point during this test. Each NetworkConfig epoch committee
-    // will be a subset of this
-    let validator_superset = ConfigBuilder::new_with_temp_dir()
-        .rng(StdRng::from_seed([0; 32]))
-        .with_validator_account_keys(all_validator_keys)
-        .with_objects(genesis_objects.clone())
-        .build();
-    let validator_superset_mapping = validator_superset
-        .genesis
-        .validator_set_for_tooling()
-        .into_iter()
-        .map(|v| {
-            let name: AuthorityName = v.verified_metadata().sui_pubkey_bytes();
-            (name, v.verified_metadata().sui_address)
-        })
-        .collect::<HashMap<_, _>>();
-
-    let mut validator_handles = spawn_test_authorities(&initial_network).await;
-    assert_eq!(validator_handles.len(), 5);
-
-    let initial_keys: HashSet<_> = initial_network
-        .validator_configs()
-        .iter()
-        .map(|config| config.protocol_public_key())
-        .collect();
-
-    // start all the other nodes (they should start as fullnodes as they are not
-    // yet in the committee)
-    let fullnode_futures: Vec<_> = validator_superset
-        .validator_configs()
-        .iter()
-        .filter(|config| !initial_keys.contains(&config.protocol_public_key()))
-        .map(|config| async {
-            // Make sure that the new validator config shares the same genesis as the initial one.
-            let mut new_config = config.clone();
-            new_config.genesis = initial_network.validator_configs()[0].genesis.clone();
-            start_node(&new_config, RegistryService::new(Registry::new())).await
-        })
-        .collect();
-    let mut fullnode_handles = futures::future::join_all(fullnode_futures).await;
-    for handle in &fullnode_handles {
-        handle.with(|node| {
-            assert!(node
-                .state()
-                .is_fullnode(&node.state().epoch_store_for_testing()));
-        });
-    }
-
-    assert_eq!(validator_handles.len(), 5);
-    assert_eq!(fullnode_handles.len(), 6);
-
-    // give time for authorities to startup and genesis
-    tokio::time::sleep(Duration::from_secs(5)).await;
-
-    let initial_pubkeys: Vec<_> = initial_network
-        .genesis
-        .validator_set_for_tooling()
-        .iter()
-        .map(|v| v.verified_metadata().sui_pubkey_bytes())
-        .collect();
-    let mut standby_nodes: Vec<_> = validator_superset
-        .genesis
-        .validator_set_for_tooling()
-        .into_iter()
-        .map(|val| {
-            let node_config = validator_superset
-                .validator_configs()
-                .iter()
-                .find(|config| {
-                    config.protocol_public_key() == val.verified_metadata().sui_pubkey_bytes()
-                })
-                .unwrap();
-            (val, node_config)
-        })
-        .filter(|(val, _node)| {
-            !initial_pubkeys.contains(&val.verified_metadata().sui_pubkey_bytes())
-        })
-        .collect();
-    assert_eq!(standby_nodes.len(), 6);
-
-    let mut epoch = 0;
-
-    while !standby_nodes.is_empty() {
-        // Add 2 validators and remove 2 validators to/from the committee
-        // per iteration (epoch)
-
-        let joining_validators = standby_nodes.split_off(standby_nodes.len() - 2);
-        assert_eq!(joining_validators.len(), 2);
-
-        // request to add new validators
-        for (validator, node_config) in joining_validators.clone() {
-            let sender = validator.verified_metadata().sui_address;
-            let (gas_objects, stake) = object_map.get(&sender).unwrap();
-            let effects = execute_join_committee_txes(
-                &validator_handles,
-                gas_objects.clone(),
-                *stake,
-                node_config,
-                validator.verified_metadata(),
-                address_key_mapping.get(&sender).unwrap(),
-            )
-            .await;
-
-            let gas_objects = vec![
-                effects[0].gas_object().0,
-                effects[1].gas_object().0,
-                effects[2].gas_object().0,
-                gas_objects[3],
-            ];
-            object_map.insert(sender, (gas_objects, *stake));
+        .map(|c| (&c.account_key_pair.public()).into())
+        .collect::<Vec<SuiAddress>>();
+    let mut test_cluster = TestClusterBuilder::new()
+        .with_num_validators(5)
+        .with_validator_candidates(addresses)
+        .build()
+        .await
+        .unwrap();
+    while !candidates.is_empty() {
+        let v1 = candidates.pop().unwrap();
+        let v2 = candidates.pop().unwrap();
+        execute_add_validator_transactions(&test_cluster, &v1).await;
+        execute_add_validator_transactions(&test_cluster, &v2).await;
+        let mut removed_validators = vec![];
+        for v in test_cluster.swarm.active_validators().take(2) {
+            let h = v.get_node_handle().unwrap();
+            removed_validators.push(h.state().name);
+            execute_remove_validator_tx(&test_cluster, &h).await;
         }
-
-        // last 2 validators request to leave
-        let auth_len = validator_handles.len();
-        for auth in &validator_handles[auth_len - 2..] {
-            let name = auth.with(|node| node.state().name);
-            let sender = validator_superset_mapping.get(&name).unwrap();
-            let (gas_objects, stake) = object_map.get(sender).unwrap();
-            let effects = execute_leave_committee_tx(
-                &validator_handles,
-                gas_objects[3],
-                address_key_mapping.get(sender).unwrap(),
-            )
-            .await;
-
-            let gas_objects = vec![
-                gas_objects[0],
-                gas_objects[1],
-                gas_objects[2],
-                effects.gas_object().0,
-            ];
-            object_map.insert(*sender, (gas_objects, *stake));
-        }
-
-        trigger_reconfiguration(&validator_handles).await;
-        epoch += 1;
-
-        // allow time for reconfig
-        tokio::time::sleep(Duration::from_secs(30)).await;
-
-        // bookkeeping and verification for joined validators
-        let joined_auths: Vec<_> = joining_validators
+        let handle1 = test_cluster.spawn_new_validator(v1).await;
+        let handle2 = test_cluster.spawn_new_validator(v2).await;
+        test_cluster.trigger_reconfiguration().await;
+        let committee = test_cluster
+            .fullnode_handle
+            .sui_node
+            .with(|node| node.state().epoch_store_for_testing().committee().clone());
+        assert_eq!(committee.num_members(), 5);
+        assert!(committee.authority_exists(&handle1.state().name));
+        assert!(committee.authority_exists(&handle2.state().name));
+        removed_validators
             .iter()
-            .map(|(val, _node)| val.verified_metadata().sui_pubkey_bytes())
-            .collect();
-
-        assert_eq!(joined_auths.len(), 2);
-
-        // find handles for nodes that joined, check that they are now
-        // fullnodes, and if so, remove them from the fullnodes list
-        // and add to the validator list
-        for name in joined_auths.into_iter() {
-            let pos = fullnode_handles
-                .iter()
-                .position(|handle| handle.with(|node| node.state().name == name))
-                .unwrap();
-            let handle = fullnode_handles.remove(pos);
-            handle
-                .with_async(|node| async {
-                    assert_eq!(node.state().epoch_store_for_testing().epoch(), epoch);
-                    assert!(node
-                        .state()
-                        .is_validator(&node.state().epoch_store_for_testing()));
-                })
-                .await;
-
-            // insert to the beginning, as the end currently contains the validators
-            // that requested to leave
-            validator_handles.insert(0, handle);
-        }
-
-        // Bookkeeping and verification for left validators
-
-        // The last two validator_handles were the ones that left the committee
-        let mut left_auth_handles = validator_handles.split_off(validator_handles.len() - 2);
-        assert_eq!(left_auth_handles.len(), 2);
-
-        for handle in &left_auth_handles {
-            handle.with(|node| {
-                assert!(node
-                    .state()
-                    .is_fullnode(&node.state().epoch_store_for_testing()));
-            });
-        }
-        fullnode_handles.push(left_auth_handles.pop().unwrap());
-        fullnode_handles.push(left_auth_handles.pop().unwrap());
-
-        // Check that new validators have joined the committee.
-        let valdator_pubkeys: Vec<_> = validator_handles
-            .iter()
-            .map(|auth| auth.with(|node| node.state().name))
-            .collect();
-        validator_handles.last().unwrap().with(|node| {
-            assert_eq!(
-                node.state()
-                    .epoch_store_for_testing()
-                    .committee()
-                    .num_members(),
-                5
-            );
-            for key in valdator_pubkeys.iter() {
-                assert!(node
-                    .state()
-                    .epoch_store_for_testing()
-                    .committee()
-                    .authority_exists(key));
-            }
-        });
+            .all(|v| !committee.authority_exists(v));
     }
-    assert_eq!(epoch, 3);
 }
 
 #[cfg(msim)]
@@ -1143,219 +696,129 @@ async fn safe_mode_reconfig_test() {
     assert_eq!(system_state.system_state_version(), 2);
 }
 
-async fn execute_add_validator_candidate_tx(
-    authorities: &[SuiNodeHandle],
-    gas_object: ObjectRef,
-    node_config: &NodeConfig,
-    val: &VerifiedValidatorMetadataV1,
-    account_kp: &Ed25519KeyPair,
-) -> CertifiedTransactionEffects {
-    let sender = val.sui_address;
-    let proof_of_possession = generate_proof_of_possession(node_config.protocol_key_pair(), sender);
-    let rgp = authorities[0]
-        .with(|node| node.state().reference_gas_price_for_testing())
-        .unwrap();
-    let candidate_tx_data = TransactionData::new_move_call(
-        sender,
-        SUI_SYSTEM_PACKAGE_ID,
-        ident_str!("sui_system").to_owned(),
-        ident_str!("request_add_validator_candidate").to_owned(),
-        vec![],
-        gas_object,
-        vec![
-            CallArg::SUI_SYSTEM_MUT,
-            CallArg::Pure(bcs::to_bytes(val.protocol_pubkey.as_bytes()).unwrap()),
-            CallArg::Pure(bcs::to_bytes(val.network_pubkey.as_bytes()).unwrap()),
-            CallArg::Pure(bcs::to_bytes(val.worker_pubkey.as_bytes()).unwrap()),
-            CallArg::Pure(bcs::to_bytes(proof_of_possession.as_ref()).unwrap()),
-            CallArg::Pure(bcs::to_bytes(val.name.as_bytes()).unwrap()),
-            CallArg::Pure(bcs::to_bytes(val.description.as_bytes()).unwrap()),
-            CallArg::Pure(bcs::to_bytes(val.image_url.as_bytes()).unwrap()),
-            CallArg::Pure(bcs::to_bytes(val.project_url.as_bytes()).unwrap()),
-            CallArg::Pure(bcs::to_bytes(&val.net_address).unwrap()),
-            CallArg::Pure(bcs::to_bytes(&val.p2p_address).unwrap()),
-            CallArg::Pure(bcs::to_bytes(&val.primary_address).unwrap()),
-            CallArg::Pure(bcs::to_bytes(&val.worker_address).unwrap()),
-            CallArg::Pure(bcs::to_bytes(&1u64).unwrap()), // gas_price
-            CallArg::Pure(bcs::to_bytes(&0u64).unwrap()), // commission_rate
-        ],
-        rgp * TEST_ONLY_GAS_UNIT_FOR_VALIDATOR,
-        rgp,
-    )
-    .unwrap();
-    let transaction = to_sender_signed_transaction(candidate_tx_data, account_kp);
-    let effects = execute_transaction_block(authorities, transaction)
+async fn add_validator_candidate(
+    test_cluster: &TestCluster,
+    new_validator: &ValidatorGenesisConfig,
+) {
+    let cur_validator_candidate_count = test_cluster.fullnode_handle.sui_node.with(|node| {
+        node.state()
+            .get_sui_system_state_object_for_testing()
+            .unwrap()
+            .into_sui_system_state_summary()
+            .validator_candidates_size
+    });
+    let address = (&new_validator.account_key_pair.public()).into();
+    let gas = test_cluster
+        .wallet
+        .get_one_gas_object_owned_by_address(address)
         .await
+        .unwrap()
         .unwrap();
-    assert!(effects.status().is_ok(), "{:?}", effects.status());
-    effects
+
+    let tx =
+        TestTransactionBuilder::new(address, gas, test_cluster.get_reference_gas_price().await)
+            .call_request_add_validator_candidate(
+                &new_validator.to_validator_info_with_random_name().into(),
+            )
+            .build_and_sign(&new_validator.account_key_pair);
+    test_cluster.execute_transaction(tx).await;
+
+    // Check that the candidate can be found in the candidate table now.
+    test_cluster.fullnode_handle.sui_node.with(|node| {
+        let system_state = node
+            .state()
+            .get_sui_system_state_object_for_testing()
+            .unwrap();
+        let system_state_summary = system_state.into_sui_system_state_summary();
+        assert_eq!(
+            system_state_summary.validator_candidates_size,
+            cur_validator_candidate_count + 1
+        );
+    });
 }
 
-async fn execute_join_committee_txes(
-    authorities: &[SuiNodeHandle],
-    gas_objects: Vec<ObjectRef>,
-    stake: ObjectRef,
-    node_config: &NodeConfig,
-    val: &VerifiedValidatorMetadataV1,
-    account_kp: &Ed25519KeyPair,
-) -> Vec<CertifiedTransactionEffects> {
-    assert_eq!(node_config.protocol_public_key(), val.sui_pubkey_bytes());
-    let mut effects_ret = vec![];
-    let sender = val.sui_address;
-    let rgp = authorities[0]
-        .with(|node| node.state().reference_gas_price_for_testing())
-        .unwrap();
-    // Step 1: Add the new node as a validator candidate.
-    let effects = execute_add_validator_candidate_tx(
-        authorities,
-        gas_objects[0],
-        node_config,
-        val,
-        account_kp,
-    )
-    .await;
-
-    effects_ret.push(effects);
-
-    // Step 2: Give the candidate enough stake.
-    let stake_tx_data = TransactionData::new_move_call(
-        sender,
-        SUI_SYSTEM_PACKAGE_ID,
-        ident_str!("sui_system").to_owned(),
-        ident_str!("request_add_stake").to_owned(),
-        vec![],
-        gas_objects[1],
-        vec![
-            CallArg::SUI_SYSTEM_MUT,
-            CallArg::Object(ObjectArg::ImmOrOwnedObject(stake)),
-            CallArg::Pure(bcs::to_bytes(&sender).unwrap()),
-        ],
-        rgp * TEST_ONLY_GAS_UNIT_FOR_STAKING,
-        rgp,
-    )
-    .unwrap();
-    let transaction = to_sender_signed_transaction(stake_tx_data, account_kp);
-    let effects = execute_transaction_block(authorities, transaction)
+async fn execute_remove_validator_tx(test_cluster: &TestCluster, handle: &SuiNodeHandle) {
+    let address = handle.with(|node| node.get_config().sui_address());
+    let gas = test_cluster
+        .wallet
+        .get_one_gas_object_owned_by_address(address)
         .await
+        .unwrap()
         .unwrap();
-    assert!(effects.status().is_ok(), "{:?}", effects);
 
-    effects_ret.push(effects);
-
-    // Step 3: Convert the candidate to an active valdiator.
-    let activation_tx_data = TransactionData::new_move_call(
-        sender,
-        SUI_SYSTEM_PACKAGE_ID,
-        ident_str!("sui_system").to_owned(),
-        ident_str!("request_add_validator").to_owned(),
-        vec![],
-        gas_objects[2],
-        vec![CallArg::SUI_SYSTEM_MUT],
-        rgp * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
-        rgp,
-    )
-    .unwrap();
-    let transaction = to_sender_signed_transaction(activation_tx_data, account_kp);
-    let effects = execute_transaction_block(authorities, transaction)
-        .await
-        .unwrap();
-    assert!(effects.status().is_ok(), "{:?}", effects.status());
-    effects_ret.push(effects);
-
-    effects_ret
+    let rgp = test_cluster.get_reference_gas_price().await;
+    let tx = handle.with(|node| {
+        TestTransactionBuilder::new(address, gas, rgp)
+            .call_request_remove_validator()
+            .build_and_sign(node.get_config().account_key_pair.keypair())
+    });
+    test_cluster.execute_transaction(tx).await;
 }
 
-async fn execute_leave_committee_tx(
-    authorities: &[SuiNodeHandle],
-    gas: ObjectRef,
-    account_kp: &Ed25519KeyPair,
-) -> CertifiedTransactionEffects {
-    let sui_address: SuiAddress = account_kp.public().into();
-    let rgp = authorities[0]
-        .with(|node| node.state().reference_gas_price_for_testing())
-        .unwrap();
-    let tx_data = TransactionData::new_move_call(
-        sui_address,
-        SUI_SYSTEM_PACKAGE_ID,
-        ident_str!("sui_system").to_owned(),
-        ident_str!("request_remove_validator").to_owned(),
-        vec![],
-        gas,
-        vec![CallArg::SUI_SYSTEM_MUT],
-        rgp * TEST_ONLY_GAS_UNIT_FOR_VALIDATOR,
-        rgp,
-    )
-    .unwrap();
+/// Execute a sequence of transactions to add a validator, including adding candidate, adding stake
+/// and activate the validator.
+/// It does not however trigger reconfiguration yet.
+async fn execute_add_validator_transactions(
+    test_cluster: &TestCluster,
+    new_validator: &ValidatorGenesisConfig,
+) {
+    let pending_active_count = test_cluster.fullnode_handle.sui_node.with(|node| {
+        let system_state = node
+            .state()
+            .get_sui_system_state_object_for_testing()
+            .unwrap();
+        system_state
+            .get_pending_active_validators(node.state().db().as_ref())
+            .unwrap()
+            .len()
+    });
+    add_validator_candidate(test_cluster, new_validator).await;
 
-    let transaction = to_sender_signed_transaction(tx_data, account_kp);
-    let effects = execute_transaction_block(authorities, transaction)
+    let address = (&new_validator.account_key_pair.public()).into();
+    let stake_coin = test_cluster
+        .wallet
+        .gas_for_owner_budget(
+            address,
+            MIN_VALIDATOR_JOINING_STAKE_MIST,
+            Default::default(),
+        )
         .await
-        .unwrap();
-    assert!(effects.status().is_ok(), "{:?}", effects.status());
-    effects
-}
-
-async fn trigger_reconfiguration(authorities: &[SuiNodeHandle]) {
-    info!("Starting reconfiguration");
-    let start = Instant::now();
-
-    // Close epoch on 2f+1 validators.
-    let cur_committee =
-        authorities[0].with(|node| node.state().epoch_store_for_testing().committee().clone());
-    let mut cur_stake = 0;
-    for handle in authorities {
-        handle
-            .with_async(|node| async {
-                node.close_epoch_for_testing().await.unwrap();
-                cur_stake += cur_committee.weight(&node.state().name);
-            })
-            .await;
-        if cur_stake >= cur_committee.quorum_threshold() {
-            break;
-        }
-    }
-    info!("close_epoch complete after {:?}", start.elapsed());
-
-    // Wait for all nodes to reach the next epoch.
-    let handles: Vec<_> = authorities
-        .iter()
-        .map(|handle| {
-            handle.with_async(|node| async {
-                let mut retries = 0;
-                loop {
-                    if node.state().epoch_store_for_testing().epoch() == cur_committee.epoch + 1 {
-                        break;
-                    }
-                    tokio::time::sleep(Duration::from_secs(1)).await;
-                    retries += 1;
-                    if retries % 5 == 0 {
-                        warn!(validator=?node.state().name.concise(), "Waiting for {:?} seconds for epoch change", retries);
-                    }
-                }
-            })
-        })
-        .collect();
-
-    timeout(Duration::from_secs(40), join_all(handles))
+        .unwrap()
+        .1
+        .object_ref();
+    let gas = test_cluster
+        .wallet
+        .gas_for_owner_budget(address, 0, BTreeSet::from([stake_coin.0]))
         .await
-        .expect("timed out waiting for reconfiguration to complete");
+        .unwrap()
+        .1
+        .object_ref();
 
-    info!("reconfiguration complete after {:?}", start.elapsed());
-}
+    let rgp = test_cluster.get_reference_gas_price().await;
+    let stake_tx = TestTransactionBuilder::new(address, gas, rgp)
+        .call_staking(stake_coin, address)
+        .build_and_sign(&new_validator.account_key_pair);
+    test_cluster.execute_transaction(stake_tx).await;
 
-async fn execute_transaction_block(
-    authorities: &[SuiNodeHandle],
-    transaction: VerifiedTransaction,
-) -> anyhow::Result<CertifiedTransactionEffects> {
-    let registry = Registry::new();
-    let net = AuthorityAggregator::new_from_local_system_state(
-        &authorities[0].with(|node| node.state().db()),
-        &authorities[0].with(|node| node.state().committee_store().clone()),
-        SafeClientMetricsBase::new(&registry),
-        AuthAggMetrics::new(&registry),
-    )
-    .unwrap();
-    net.execute_transaction_block(&transaction)
-        .await
-        .map(|e| e.into_inner())
+    let gas = test_cluster.wallet.get_object_ref(gas.0).await.unwrap();
+    let tx = TestTransactionBuilder::new(address, gas, rgp)
+        .call_request_add_validator()
+        .build_and_sign(&new_validator.account_key_pair);
+    test_cluster.execute_transaction(tx).await;
+
+    // Check that we can get the pending validator from 0x5.
+    test_cluster.fullnode_handle.sui_node.with(|node| {
+        let system_state = node
+            .state()
+            .get_sui_system_state_object_for_testing()
+            .unwrap();
+        let pending_active_validators = system_state
+            .get_pending_active_validators(node.state().db().as_ref())
+            .unwrap();
+        assert_eq!(pending_active_validators.len(), pending_active_count + 1);
+        assert_eq!(
+            pending_active_validators[pending_active_validators.len() - 1].sui_address,
+            address
+        );
+    });
 }

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1282,6 +1282,10 @@ impl SuiNode {
     pub fn get_sim_node_id(&self) -> sui_simulator::task::NodeId {
         self.sim_node.id()
     }
+
+    pub fn get_config(&self) -> &NodeConfig {
+        &self.config
+    }
 }
 
 /// Notify state-sync that a new list of trusted peers are now available.

--- a/crates/sui-swarm-config/src/node_config_builder.rs
+++ b/crates/sui-swarm-config/src/node_config_builder.rs
@@ -24,18 +24,21 @@ use sui_types::crypto::{AuthorityKeyPair, AuthorityPublicKeyBytes, SuiKeyPair};
 
 /// This builder contains information that's not included in ValidatorGenesisConfig for building
 /// a validator NodeConfig. It can be used to build either a genesis validator or a new validator.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct ValidatorConfigBuilder {
-    config_directory: PathBuf,
+    config_directory: Option<PathBuf>,
     supported_protocol_versions: Option<SupportedProtocolVersions>,
 }
 
 impl ValidatorConfigBuilder {
-    pub fn new(config_directory: PathBuf) -> Self {
-        Self {
-            config_directory,
-            supported_protocol_versions: None,
-        }
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_config_directory(mut self, config_directory: PathBuf) -> Self {
+        assert!(self.config_directory.is_none());
+        self.config_directory = Some(config_directory);
+        self
     }
 
     pub fn with_supported_protocol_versions(
@@ -53,7 +56,9 @@ impl ValidatorConfigBuilder {
         genesis: sui_config::genesis::Genesis,
     ) -> NodeConfig {
         let key_path = get_key_path(&validator.key_pair);
-        let config_directory = self.config_directory;
+        let config_directory = self
+            .config_directory
+            .unwrap_or_else(|| tempfile::tempdir().unwrap().into_path());
         let db_path = config_directory
             .join(AUTHORITIES_DB_NAME)
             .join(key_path.clone());

--- a/crates/sui-swarm/src/memory/swarm.rs
+++ b/crates/sui-swarm/src/memory/swarm.rs
@@ -368,7 +368,7 @@ impl Swarm {
             .filter(|node| node.config.consensus_config.is_none())
     }
 
-    pub async fn spawn_new_fullnode(&mut self, config: NodeConfig) -> SuiNodeHandle {
+    pub async fn spawn_new_node(&mut self, config: NodeConfig) -> SuiNodeHandle {
         let name = config.protocol_public_key();
         let node = Node::new(config);
         node.start().await.unwrap();

--- a/crates/sui-test-transaction-builder/Cargo.toml
+++ b/crates/sui-test-transaction-builder/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 bcs = "0.1.4"
 
 shared-crypto = { path = "../shared-crypto" }
+sui-genesis-builder = { path = "../sui-genesis-builder" }
 sui-move-build = { path = "../sui-move-build" }
 sui-types = { path = "../sui-types" }
 

--- a/crates/sui-test-transaction-builder/src/lib.rs
+++ b/crates/sui-test-transaction-builder/src/lib.rs
@@ -4,13 +4,14 @@
 use move_core_types::ident_str;
 use shared_crypto::intent::Intent;
 use std::path::PathBuf;
+use sui_genesis_builder::validator_info::GenesisValidatorMetadata;
 use sui_move_build::BuildConfig;
 use sui_types::base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress};
 use sui_types::crypto::{Signature, Signer};
 use sui_types::sui_system_state::SUI_SYSTEM_MODULE_NAME;
 use sui_types::transaction::{
     CallArg, ObjectArg, Transaction, TransactionData, VerifiedTransaction,
-    TEST_ONLY_GAS_UNIT_FOR_GENERIC, TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+    DEFAULT_VALIDATOR_GAS_PRICE, TEST_ONLY_GAS_UNIT_FOR_GENERIC, TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
 };
 use sui_types::{TypeTag, SUI_SYSTEM_PACKAGE_ID};
 
@@ -105,6 +106,52 @@ impl TestTransactionBuilder {
                 CallArg::Object(ObjectArg::ImmOrOwnedObject(stake_coin)),
                 CallArg::Pure(bcs::to_bytes(&validator).unwrap()),
             ],
+        )
+    }
+
+    pub fn call_request_add_validator(self) -> Self {
+        self.move_call(
+            SUI_SYSTEM_PACKAGE_ID,
+            SUI_SYSTEM_MODULE_NAME.as_str(),
+            "request_add_validator",
+            vec![CallArg::SUI_SYSTEM_MUT],
+        )
+    }
+
+    pub fn call_request_add_validator_candidate(
+        self,
+        validator: &GenesisValidatorMetadata,
+    ) -> Self {
+        self.move_call(
+            SUI_SYSTEM_PACKAGE_ID,
+            SUI_SYSTEM_MODULE_NAME.as_str(),
+            "request_add_validator_candidate",
+            vec![
+                CallArg::SUI_SYSTEM_MUT,
+                CallArg::Pure(bcs::to_bytes(&validator.protocol_public_key).unwrap()),
+                CallArg::Pure(bcs::to_bytes(&validator.network_public_key).unwrap()),
+                CallArg::Pure(bcs::to_bytes(&validator.worker_public_key).unwrap()),
+                CallArg::Pure(bcs::to_bytes(&validator.proof_of_possession).unwrap()),
+                CallArg::Pure(bcs::to_bytes(validator.name.as_bytes()).unwrap()),
+                CallArg::Pure(bcs::to_bytes(validator.description.as_bytes()).unwrap()),
+                CallArg::Pure(bcs::to_bytes(validator.image_url.as_bytes()).unwrap()),
+                CallArg::Pure(bcs::to_bytes(validator.project_url.as_bytes()).unwrap()),
+                CallArg::Pure(bcs::to_bytes(&validator.network_address).unwrap()),
+                CallArg::Pure(bcs::to_bytes(&validator.p2p_address).unwrap()),
+                CallArg::Pure(bcs::to_bytes(&validator.primary_address).unwrap()),
+                CallArg::Pure(bcs::to_bytes(&validator.worker_address).unwrap()),
+                CallArg::Pure(bcs::to_bytes(&DEFAULT_VALIDATOR_GAS_PRICE).unwrap()), // gas_price
+                CallArg::Pure(bcs::to_bytes(&0u64).unwrap()), // commission_rate
+            ],
+        )
+    }
+
+    pub fn call_request_remove_validator(self) -> Self {
+        self.move_call(
+            SUI_SYSTEM_PACKAGE_ID,
+            SUI_SYSTEM_MODULE_NAME.as_str(),
+            "request_remove_validator",
+            vec![CallArg::SUI_SYSTEM_MUT],
         )
     }
 


### PR DESCRIPTION
## Description 

This PR makes it easy to introduce new validators and remove validators from a test cluster:
1. Added `with_validator_candidates` function in TestCluster to make sure we give enough tokens to them in genesis.
2. Added a few functions in TestTransactionBuilder to generate validator management related transactions, such as validator candidate, activating candidate, staking, leaving and etc.
3. Some cleanups in validator genesis config to make config construction easier.

Update all dynamic committee change tests in reconfiguration_tests to use the new way.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
