### PR TITLE
[move-compiler] Beginnings of a visitor framework. Expose Abstract Interpreter framework 

### DIFF
--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -16,6 +16,7 @@ use move_binary_format::{
 };
 use move_bytecode_utils::{layout::SerdeLayoutBuilder, module_cache::GetModule};
 use move_compiler::{
+    cfgir::visitor::SimpleAbsInt,
     compiled_unit::{
         AnnotatedCompiledModule, AnnotatedCompiledScript, CompiledUnitEnum, NamedCompiledModule,
     },
@@ -121,7 +122,7 @@ impl BuildConfig {
         let build_plan = BuildPlan::create(resolution_graph)?;
         let mut fn_info = None;
         let compiled_pkg = build_plan.compile_with_driver(writer, |compiler| {
-            let (files, units_res) = compiler.build()?;
+            let (files, units_res) = compiler.add_visitors(sui_visitors()).build()?;
             match units_res {
                 Ok((units, warning_diags)) => {
                     report_warnings(&files, warning_diags);
@@ -215,6 +216,10 @@ pub fn build_from_resolution_graph(
         dependency_ids,
         path,
     })
+}
+
+pub fn sui_visitors() -> Vec<move_compiler::command_line::compiler::Visitor> {
+    vec![move_compiler::sui_mode::id_leak::IDLeakVerifier::visitor()]
 }
 
 impl CompiledPackage {

--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -16,7 +16,6 @@ use move_binary_format::{
 };
 use move_bytecode_utils::{layout::SerdeLayoutBuilder, module_cache::GetModule};
 use move_compiler::{
-    cfgir::visitor::SimpleAbsInt,
     compiled_unit::{
         AnnotatedCompiledModule, AnnotatedCompiledScript, CompiledUnitEnum, NamedCompiledModule,
     },
@@ -122,7 +121,7 @@ impl BuildConfig {
         let build_plan = BuildPlan::create(resolution_graph)?;
         let mut fn_info = None;
         let compiled_pkg = build_plan.compile_with_driver(writer, |compiler| {
-            let (files, units_res) = compiler.add_visitors(sui_visitors()).build()?;
+            let (files, units_res) = compiler.build()?;
             match units_res {
                 Ok((units, warning_diags)) => {
                     report_warnings(&files, warning_diags);
@@ -216,10 +215,6 @@ pub fn build_from_resolution_graph(
         dependency_ids,
         path,
     })
-}
-
-pub fn sui_visitors() -> Vec<move_compiler::command_line::compiler::Visitor> {
-    vec![move_compiler::sui_mode::id_leak::IDLeakVerifier::visitor()]
 }
 
 impl CompiledPackage {

--- a/external-crates/move/move-analyzer/src/diagnostics.rs
+++ b/external-crates/move/move-analyzer/src/diagnostics.rs
@@ -14,7 +14,7 @@ use url::Url;
 pub fn lsp_diagnostics(
     diagnostics: &Vec<(
         codespan_reporting::diagnostic::Severity,
-        &'static str,
+        Symbol,
         (Loc, String),
         Vec<(Loc, String)>,
         Vec<String>,

--- a/external-crates/move/move-analyzer/src/diagnostics.rs
+++ b/external-crates/move/move-analyzer/src/diagnostics.rs
@@ -14,7 +14,7 @@ use url::Url;
 pub fn lsp_diagnostics(
     diagnostics: &Vec<(
         codespan_reporting::diagnostic::Severity,
-        Symbol,
+        &'static str,
         (Loc, String),
         Vec<(Loc, String)>,
         Vec<String>,

--- a/external-crates/move/move-compiler/src/cfgir/borrows/mod.rs
+++ b/external-crates/move/move-compiler/src/cfgir/borrows/mod.rs
@@ -81,7 +81,7 @@ impl AbstractInterpreter for BorrowSafety {}
 pub fn verify(
     compilation_env: &mut CompilationEnv,
     context: &super::CFGContext,
-    cfg: &super::cfg::BlockCFG,
+    cfg: &super::cfg::MutForwardCFG,
 ) -> BTreeMap<Label, BorrowState> {
     let super::CFGContext {
         signature,

--- a/external-crates/move/move-compiler/src/cfgir/borrows/mod.rs
+++ b/external-crates/move/move-compiler/src/cfgir/borrows/mod.rs
@@ -8,10 +8,9 @@ use super::absint::*;
 use crate::{
     diagnostics::Diagnostics,
     hlir::ast::*,
-    parser::ast::{BinOp_, StructName},
+    parser::ast::BinOp_,
     shared::{unique_map::UniqueMap, CompilationEnv},
 };
-use move_ir_types::location::*;
 use state::{Value, *};
 use std::collections::BTreeMap;
 
@@ -81,11 +80,16 @@ impl AbstractInterpreter for BorrowSafety {}
 
 pub fn verify(
     compilation_env: &mut CompilationEnv,
-    signature: &FunctionSignature,
-    acquires: &BTreeMap<StructName, Loc>,
-    locals: &UniqueMap<Var, SingleType>,
+    context: &super::CFGContext,
     cfg: &super::cfg::BlockCFG,
 ) -> BTreeMap<Label, BorrowState> {
+    let super::CFGContext {
+        signature,
+        acquires,
+        locals,
+        ..
+    } = context;
+    let acquires = *acquires;
     // check for existing errors
     let has_errors = compilation_env.has_errors();
     let mut initial_state = BorrowState::initial(locals, acquires.clone(), has_errors);

--- a/external-crates/move/move-compiler/src/cfgir/liveness/mod.rs
+++ b/external-crates/move/move-compiler/src/cfgir/liveness/mod.rs
@@ -169,10 +169,14 @@ fn exp_list_item(state: &mut LivenessState, item: &ExpListItem) {
 
 pub fn last_usage(
     compilation_env: &mut CompilationEnv,
-    locals: &UniqueMap<Var, SingleType>,
+    context: &super::CFGContext,
     cfg: &mut BlockCFG,
-    infinite_loop_starts: &BTreeSet<Label>,
 ) {
+    let super::CFGContext {
+        locals,
+        infinite_loop_starts,
+        ..
+    } = context;
     let (final_invariants, per_command_states) = analyze(cfg, infinite_loop_starts);
     for (lbl, block) in cfg.blocks_mut() {
         let final_invariant = final_invariants
@@ -408,11 +412,15 @@ mod last_usage {
 /// satisfies (1) and (2)
 
 pub fn release_dead_refs(
+    context: &super::CFGContext,
     locals_pre_states: &BTreeMap<Label, locals::state::LocalStates>,
-    locals: &UniqueMap<Var, SingleType>,
     cfg: &mut BlockCFG,
-    infinite_loop_starts: &BTreeSet<Label>,
 ) {
+    let super::CFGContext {
+        locals,
+        infinite_loop_starts,
+        ..
+    } = context;
     let (liveness_pre_states, _per_command_states) = analyze(cfg, infinite_loop_starts);
     let forward_intersections = build_forward_intersections(cfg, &liveness_pre_states);
     for (lbl, block) in cfg.blocks_mut() {

--- a/external-crates/move/move-compiler/src/cfgir/locals/mod.rs
+++ b/external-crates/move/move-compiler/src/cfgir/locals/mod.rs
@@ -112,12 +112,15 @@ impl<'a> AbstractInterpreter for LocalsSafety<'a> {}
 
 pub fn verify(
     compilation_env: &mut CompilationEnv,
-    struct_declared_abilities: &UniqueMap<ModuleIdent, UniqueMap<StructName, AbilitySet>>,
-    signature: &FunctionSignature,
-    _acquires: &BTreeMap<StructName, Loc>,
-    locals: &UniqueMap<Var, SingleType>,
+    context: &super::CFGContext,
     cfg: &super::cfg::BlockCFG,
 ) -> BTreeMap<Label, LocalStates> {
+    let super::CFGContext {
+        struct_declared_abilities,
+        signature,
+        locals,
+        ..
+    } = context;
     let initial_state = LocalStates::initial(&signature.parameters, locals);
     let mut locals_safety = LocalsSafety::new(struct_declared_abilities, locals, signature);
     let (final_state, ds) = locals_safety.analyze_function(cfg, initial_state);

--- a/external-crates/move/move-compiler/src/cfgir/locals/mod.rs
+++ b/external-crates/move/move-compiler/src/cfgir/locals/mod.rs
@@ -113,7 +113,7 @@ impl<'a> AbstractInterpreter for LocalsSafety<'a> {}
 pub fn verify(
     compilation_env: &mut CompilationEnv,
     context: &super::CFGContext,
-    cfg: &super::cfg::BlockCFG,
+    cfg: &super::cfg::MutForwardCFG,
 ) -> BTreeMap<Label, LocalStates> {
     let super::CFGContext {
         struct_declared_abilities,

--- a/external-crates/move/move-compiler/src/cfgir/mod.rs
+++ b/external-crates/move/move-compiler/src/cfgir/mod.rs
@@ -10,39 +10,59 @@ mod liveness;
 mod locals;
 mod remove_no_ops;
 pub(crate) mod translate;
+pub mod visitor;
 
 mod optimize;
 
 use crate::{
+    diagnostics::Diagnostics,
     expansion::ast::{AbilitySet, ModuleIdent},
     hlir::ast::*,
     parser::ast::StructName,
-    shared::{unique_map::UniqueMap, CompilationEnv},
+    shared::{unique_map::UniqueMap, CompilationEnv, Name},
 };
 use cfg::*;
 use move_ir_types::location::*;
 use optimize::optimize;
 use std::collections::{BTreeMap, BTreeSet};
 
-pub fn refine_inference_and_verify(
-    compilation_env: &mut CompilationEnv,
-    struct_declared_abilities: &UniqueMap<ModuleIdent, UniqueMap<StructName, AbilitySet>>,
-    signature: &FunctionSignature,
-    acquires: &BTreeMap<StructName, Loc>,
-    locals: &UniqueMap<Var, SingleType>,
-    cfg: &mut BlockCFG,
-    infinite_loop_starts: &BTreeSet<Label>,
-) {
-    liveness::last_usage(compilation_env, locals, cfg, infinite_loop_starts);
-    let locals_states = locals::verify(
-        compilation_env,
-        struct_declared_abilities,
-        signature,
-        acquires,
-        locals,
-        cfg,
-    );
+pub struct CFGContext<'a> {
+    pub module: Option<ModuleIdent>,
+    pub member: MemberName,
+    pub struct_declared_abilities: &'a UniqueMap<ModuleIdent, UniqueMap<StructName, AbilitySet>>,
+    pub signature: &'a FunctionSignature,
+    pub acquires: &'a BTreeMap<StructName, Loc>,
+    pub locals: &'a UniqueMap<Var, SingleType>,
+    pub infinite_loop_starts: &'a BTreeSet<Label>,
+}
 
-    liveness::release_dead_refs(&locals_states, locals, cfg, infinite_loop_starts);
-    borrows::verify(compilation_env, signature, acquires, locals, cfg);
+pub enum MemberName {
+    Constant(Name),
+    Function(Name),
+}
+
+pub fn refine_inference_and_verify(
+    env: &mut CompilationEnv,
+    context: &CFGContext,
+    cfg: &mut BlockCFG,
+) {
+    liveness::last_usage(env, context, cfg);
+    let locals_states = locals::verify(env, context, cfg);
+
+    liveness::release_dead_refs(context, &locals_states, cfg);
+    borrows::verify(env, context, cfg);
+    let mut ds = Diagnostics::new();
+    for visitor in &env.visitors().abs_int {
+        let mut f = visitor.borrow_mut();
+        ds.extend(f(context, cfg));
+    }
+    env.add_diags(ds)
+}
+
+impl MemberName {
+    pub fn name(&self) -> Name {
+        match self {
+            MemberName::Constant(n) | MemberName::Function(n) => *n,
+        }
+    }
 }

--- a/external-crates/move/move-compiler/src/cfgir/mod.rs
+++ b/external-crates/move/move-compiler/src/cfgir/mod.rs
@@ -54,7 +54,7 @@ pub fn refine_inference_and_verify(
     let mut ds = Diagnostics::new();
     for visitor in &env.visitors().abs_int {
         let mut f = visitor.borrow_mut();
-        ds.extend(f(context, cfg));
+        ds.extend(f.verify(context, cfg));
     }
     env.add_diags(ds)
 }

--- a/external-crates/move/move-compiler/src/cfgir/mod.rs
+++ b/external-crates/move/move-compiler/src/cfgir/mod.rs
@@ -2,7 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-mod absint;
+pub mod absint;
 pub mod ast;
 mod borrows;
 pub(crate) mod cfg;

--- a/external-crates/move/move-compiler/src/cfgir/optimize/constant_fold.rs
+++ b/external-crates/move/move-compiler/src/cfgir/optimize/constant_fold.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    cfgir::cfg::BlockCFG,
+    cfgir::cfg::MutForwardCFG,
     hlir::ast::{
         BaseType, BaseType_, Command, Command_, Exp, ExpListItem, FunctionSignature, SingleType,
         TypeName, TypeName_, UnannotatedExp_, Value, Value_, Var,
@@ -19,7 +19,7 @@ use std::convert::TryFrom;
 pub fn optimize(
     _signature: &FunctionSignature,
     _locals: &UniqueMap<Var, SingleType>,
-    cfg: &mut BlockCFG,
+    cfg: &mut MutForwardCFG,
 ) -> bool {
     let mut changed = false;
     for block_ref in cfg.blocks_mut().values_mut() {

--- a/external-crates/move/move-compiler/src/cfgir/optimize/eliminate_locals.rs
+++ b/external-crates/move/move-compiler/src/cfgir/optimize/eliminate_locals.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    cfgir::{cfg::BlockCFG, remove_no_ops},
+    cfgir::{cfg::MutForwardCFG, remove_no_ops},
     hlir::ast::{FunctionSignature, SingleType, Var},
     shared::unique_map::UniqueMap,
 };
@@ -13,7 +13,7 @@ use std::collections::BTreeSet;
 pub fn optimize(
     signature: &FunctionSignature,
     _locals: &UniqueMap<Var, SingleType>,
-    cfg: &mut BlockCFG,
+    cfg: &mut MutForwardCFG,
 ) -> bool {
     let changed = remove_no_ops::optimize(cfg);
     let ssa_temps = {
@@ -34,7 +34,7 @@ pub fn optimize(
 // Count assignment and usage
 //**************************************************************************************************
 
-fn count(signature: &FunctionSignature, cfg: &BlockCFG) -> BTreeSet<Var> {
+fn count(signature: &FunctionSignature, cfg: &MutForwardCFG) -> BTreeSet<Var> {
     let mut context = count::Context::new(signature);
     for block in cfg.blocks().values() {
         for cmd in block {
@@ -256,7 +256,7 @@ mod count {
 // Eliminate
 //**************************************************************************************************
 
-fn eliminate(cfg: &mut BlockCFG, ssa_temps: BTreeSet<Var>) {
+fn eliminate(cfg: &mut MutForwardCFG, ssa_temps: BTreeSet<Var>) {
     let context = &mut eliminate::Context::new(ssa_temps);
     loop {
         for block in cfg.blocks_mut().values_mut() {

--- a/external-crates/move/move-compiler/src/cfgir/optimize/inline_blocks.rs
+++ b/external-crates/move/move-compiler/src/cfgir/optimize/inline_blocks.rs
@@ -5,7 +5,7 @@
 use crate::{
     cfgir::{
         ast::remap_labels,
-        cfg::{BlockCFG, CFG},
+        cfg::{MutForwardCFG, CFG},
     },
     hlir::ast::{BasicBlocks, Command_, FunctionSignature, Label, SingleType, Var},
     shared::unique_map::UniqueMap,
@@ -16,7 +16,7 @@ use std::collections::{BTreeMap, BTreeSet};
 pub fn optimize(
     _signature: &FunctionSignature,
     _locals: &UniqueMap<Var, SingleType>,
-    cfg: &mut BlockCFG,
+    cfg: &mut MutForwardCFG,
 ) -> bool {
     let changed = optimize_(cfg.start_block(), cfg.blocks_mut());
     if changed {

--- a/external-crates/move/move-compiler/src/cfgir/optimize/mod.rs
+++ b/external-crates/move/move-compiler/src/cfgir/optimize/mod.rs
@@ -6,9 +6,10 @@ mod eliminate_locals;
 mod inline_blocks;
 mod simplify_jumps;
 
-use crate::{cfgir::cfg::BlockCFG, hlir::ast::*, shared::unique_map::UniqueMap};
+use crate::{cfgir::cfg::MutForwardCFG, hlir::ast::*, shared::unique_map::UniqueMap};
 
-pub type Optimization = fn(&FunctionSignature, &UniqueMap<Var, SingleType>, &mut BlockCFG) -> bool;
+pub type Optimization =
+    fn(&FunctionSignature, &UniqueMap<Var, SingleType>, &mut MutForwardCFG) -> bool;
 
 const OPTIMIZATIONS: &[Optimization] = &[
     eliminate_locals::optimize,
@@ -20,7 +21,7 @@ const OPTIMIZATIONS: &[Optimization] = &[
 pub fn optimize(
     signature: &FunctionSignature,
     locals: &UniqueMap<Var, SingleType>,
-    cfg: &mut BlockCFG,
+    cfg: &mut MutForwardCFG,
 ) {
     let mut count = 0;
     for optimization in OPTIMIZATIONS.iter().cycle() {

--- a/external-crates/move/move-compiler/src/cfgir/optimize/simplify_jumps.rs
+++ b/external-crates/move/move-compiler/src/cfgir/optimize/simplify_jumps.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    cfgir::cfg::BlockCFG,
+    cfgir::cfg::MutForwardCFG,
     hlir::ast::{
         Command, Command_, Exp, FunctionSignature, SingleType, UnannotatedExp_, Value_, Var,
     },
@@ -14,7 +14,7 @@ use crate::{
 pub fn optimize(
     _signature: &FunctionSignature,
     _locals: &UniqueMap<Var, SingleType>,
-    cfg: &mut BlockCFG,
+    cfg: &mut MutForwardCFG,
 ) -> bool {
     let mut changed = false;
     for block in cfg.blocks_mut().values_mut() {

--- a/external-crates/move/move-compiler/src/cfgir/remove_no_ops.rs
+++ b/external-crates/move/move-compiler/src/cfgir/remove_no_ops.rs
@@ -2,10 +2,10 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{ast::*, cfg::BlockCFG};
+use super::{ast::*, cfg::MutForwardCFG};
 
 /// Returns true if anything changed
-pub fn optimize(cfg: &mut BlockCFG) -> bool {
+pub fn optimize(cfg: &mut MutForwardCFG) -> bool {
     let mut changed = false;
     for block in cfg.blocks_mut().values_mut() {
         let old_block = std::mem::take(block);

--- a/external-crates/move/move-compiler/src/cfgir/translate.rs
+++ b/external-crates/move/move-compiler/src/cfgir/translate.rs
@@ -236,7 +236,7 @@ fn script(context: &mut Context, hscript: H::Script) -> G::Script {
     } = hscript;
     context.env.add_warning_filter_scope(warning_filter.clone());
     let constants = hconstants.map(|name, c| constant(context, None, name, c));
-    let function = function(context, function_name, hfunction);
+    let function = function(context, None, function_name, hfunction);
     context.env.pop_warning_filter_scope();
     G::Script {
         warning_filter,

--- a/external-crates/move/move-compiler/src/cfgir/visitor.rs
+++ b/external-crates/move/move-compiler/src/cfgir/visitor.rs
@@ -1,0 +1,389 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::BTreeMap, fmt::Debug};
+
+use crate::{
+    cfgir::{
+        absint::{AbstractInterpreter, JoinResult, TransferFunctions},
+        cfg::BlockCFG,
+        CFGContext,
+    },
+    diagnostics::{Diagnostic, Diagnostics},
+    hlir::ast::{
+        Command, Command_, Exp, ExpListItem, LValue, LValue_, Label, ModuleCall, Type, Type_,
+        UnannotatedExp_, Var,
+    },
+};
+use move_ir_types::location::*;
+
+use super::absint::AbstractDomain;
+
+pub trait AbsIntVisitor: AbstractInterpreter {
+    fn init_state(context: &CFGContext) -> <Self as TransferFunctions>::State;
+    fn new(context: &CFGContext, init_state: &mut <Self as TransferFunctions>::State) -> Self;
+    fn finish(
+        &mut self,
+        final_states: BTreeMap<Label, <Self as TransferFunctions>::State>,
+        diags: Diagnostics,
+    ) -> Diagnostics;
+}
+
+pub type AbsIntVisitorFn = Box<dyn FnMut(&CFGContext, &BlockCFG) -> Diagnostics>;
+
+pub fn visitor<T: AbsIntVisitor>() -> AbsIntVisitorFn {
+    Box::new(|context, cfg| {
+        let mut init_state = T::init_state(context);
+        let mut ai = T::new(context, &mut init_state);
+        let (final_state, ds) = ai.analyze_function(cfg, init_state);
+        ai.finish(final_state, ds)
+    })
+}
+
+//**************************************************************************************************
+// simple visitor
+//**************************************************************************************************
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum SimpleValue<V: Clone + Debug> {
+    Default,
+    Specified(V),
+}
+
+pub type SimpleValues<V> = Vec<SimpleValue<V>>;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum UnavailableReason {
+    Unassigned,
+    Moved,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum LocalState<V: Clone + Debug> {
+    Unavailable(Loc, UnavailableReason),
+    Available(Loc, SimpleValue<V>),
+    MaybeUnavailable {
+        available: Loc,
+        unavailable: Loc,
+        unavailable_reason: UnavailableReason,
+    },
+}
+
+pub trait SimpleExecutionContext {
+    type State;
+    fn add_diag(&mut self, diag: Diagnostic);
+    fn state(&mut self) -> &mut Self::State;
+}
+
+pub trait SimpleDomain: AbstractDomain {
+    type Value: Clone + Debug;
+    fn new(context: &CFGContext, locals: BTreeMap<Var, LocalState<Self::Value>>) -> Self;
+    fn locals_mut(&mut self) -> &mut BTreeMap<Var, LocalState<Self::Value>>;
+    fn locals(&self) -> &BTreeMap<Var, LocalState<Self::Value>>;
+    fn join_value(
+        result: &mut JoinResult,
+        v1: &SimpleValue<Self::Value>,
+        v2: &SimpleValue<Self::Value>,
+    ) -> SimpleValue<Self::Value>;
+    // join implementation called after locals have been joined
+    fn join_impl(&mut self, other: &Self, result: &mut JoinResult);
+    fn join(&mut self, other: &Self) -> JoinResult {
+        use LocalState as L;
+        let self_locals = self.locals();
+        let other_locals = other.locals();
+        assert!(
+            self_locals.keys().all(|v| other_locals.contains_key(v)),
+            "ICE. Incorrectly implemented abstract interpreter. \
+            Local variables should not be removed from the map"
+        );
+        assert!(
+            other_locals.keys().all(|v| self_locals.contains_key(v)),
+            "ICE. Incorrectly implemented abstract interpreter. \
+            Local variables should not be removed from the map"
+        );
+        let mut result = JoinResult::Unchanged;
+        for (local, other_state) in other_locals {
+            match (self.locals().get(&local).unwrap(), other_state) {
+                // both available, join the value
+                (L::Available(loc, v1), L::Available(_, v2)) => {
+                    let loc = *loc;
+                    let joined = Self::join_value(&mut result, v1, v2);
+                    self.locals_mut().insert(*local, L::Available(loc, joined));
+                }
+                // equal so nothing to do
+                (L::Unavailable(_, _), L::Unavailable(_, _))
+                | (L::MaybeUnavailable { .. }, L::MaybeUnavailable { .. }) => (),
+                // if its partially assigned, stays partially assigned
+                (L::MaybeUnavailable { .. }, _) => (),
+
+                // if was partially assigned in other, its now partially assigned
+                (_, L::MaybeUnavailable { .. }) => {
+                    result = JoinResult::Changed;
+                    self.locals_mut().insert(*local, other_state.clone());
+                }
+
+                // Available in one but not the other, so maybe unavailable
+                (L::Available(available, _), L::Unavailable(unavailable, reason))
+                | (L::Unavailable(unavailable, reason), L::Available(available, _)) => {
+                    result = JoinResult::Changed;
+                    let available = *available;
+                    let unavailable = *unavailable;
+                    let state = L::MaybeUnavailable {
+                        available,
+                        unavailable,
+                        unavailable_reason: *reason,
+                    };
+                    self.locals_mut().insert(*local, state);
+                }
+            }
+        }
+        self.join_impl(other, &mut result);
+        result
+    }
+}
+
+pub trait SimpleAbsInt: AbstractInterpreter + Sized
+where
+    Self::State: SimpleDomain,
+{
+    type ExecutionContext: SimpleExecutionContext<State = Self::State>;
+
+    fn new(context: &CFGContext, init_state: &mut <Self as TransferFunctions>::State) -> Self;
+
+    fn finish(
+        &mut self,
+        final_states: BTreeMap<Label, <Self as TransferFunctions>::State>,
+        diags: Diagnostics,
+    ) -> Diagnostics;
+
+    fn verify(context: &CFGContext, cfg: &BlockCFG) -> Diagnostics {
+        let mut locals = context
+            .locals
+            .key_cloned_iter()
+            .map(|(v, _)| {
+                (
+                    v,
+                    LocalState::Unavailable(v.0.loc, UnavailableReason::Unassigned),
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+        for (param, _) in &context.signature.parameters {
+            locals.insert(
+                *param,
+                LocalState::Available(param.0.loc, SimpleValue::Default),
+            );
+        }
+        let mut init_state = Self::State::new(context, locals);
+        let mut ai = Self::new(context, &mut init_state);
+        let (final_state, ds) = ai.analyze_function(cfg, init_state);
+        ai.finish(final_state, ds)
+    }
+
+    fn start_command(&self, pre: &Self::State) -> Self::ExecutionContext;
+
+    fn finish_command(&self, context: Self::ExecutionContext) -> Diagnostics;
+
+    fn execute(
+        &mut self,
+        pre: &mut Self::State,
+        _lbl: Label,
+        _idx: usize,
+        cmd: &Command,
+    ) -> Diagnostics {
+        let mut context = self.start_command(pre);
+        self.command(&mut context, cmd);
+        self.finish_command(context)
+    }
+
+    /// custom visit for a command. It will skip `command` if `command_custom` returns true.
+    fn command_custom(&self, context: &mut Self::ExecutionContext, cmd: &Command) -> bool;
+    fn command(&self, context: &mut Self::ExecutionContext, cmd: &Command) {
+        use Command_ as C;
+        if self.command_custom(context, cmd) {
+            return;
+        }
+        let sp!(_, cmd_) = cmd;
+        match cmd_ {
+            C::Assign(ls, e) => {
+                let values = self.exp(context, e);
+                self.lvalues(context, ls, values);
+            }
+            C::Mutate(el, er) => {
+                self.exp(context, er);
+                self.exp(context, el);
+            }
+            C::JumpIf { cond: e, .. }
+            | C::IgnoreAndPop { exp: e, .. }
+            | C::Return { exp: e, .. }
+            | C::Abort(e) => {
+                self.exp(context, e);
+            }
+            C::Jump { .. } => (),
+            C::Break | C::Continue => panic!("ICE break/continue not translated to jumps"),
+        }
+    }
+
+    fn lvalues(
+        &self,
+        context: &mut Self::ExecutionContext,
+        ls: &[LValue],
+        values: SimpleValues<<Self::State as SimpleDomain>::Value>,
+    ) {
+        // pad with defautl to account for errors
+        let padded_values = values
+            .into_iter()
+            .chain(std::iter::repeat(SimpleValue::Default));
+        for (l, value) in ls.iter().zip(padded_values) {
+            self.lvalue(context, l, value)
+        }
+    }
+
+    /// custom visit for an lvalue. It will skip `lvalue` if `lvalue_custom` returns true.
+    fn lvalue_custom(
+        &self,
+        context: &mut Self::ExecutionContext,
+        l: &LValue,
+        value: &SimpleValue<<Self::State as SimpleDomain>::Value>,
+    ) -> bool;
+    fn lvalue(
+        &self,
+        context: &mut Self::ExecutionContext,
+        l: &LValue,
+        value: SimpleValue<<Self::State as SimpleDomain>::Value>,
+    ) {
+        use LValue_ as L;
+        if self.lvalue_custom(context, l, &value) {
+            return;
+        }
+        let sp!(loc, l_) = l;
+        match l_ {
+            L::Ignore => (),
+            L::Var(v, _) => {
+                let locals = context.state().locals_mut();
+                locals.insert(*v, LocalState::Available(*loc, value));
+            }
+            L::Unpack(_, _, fields) => {
+                for (_, l) in fields {
+                    self.lvalue(context, l, SimpleValue::Default)
+                }
+            }
+        }
+    }
+
+    /// custom visit for an exp. It will skip `exp` and `call_custom` if `exp_custom` returns Some.
+    fn exp_custom(
+        &self,
+        context: &mut Self::ExecutionContext,
+        parent_e: &Exp,
+    ) -> Option<SimpleValues<<Self::State as SimpleDomain>::Value>>;
+    fn call_custom(
+        &self,
+        context: &mut Self::ExecutionContext,
+        f: &ModuleCall,
+        args: SimpleValues<<Self::State as SimpleDomain>::Value>,
+    ) -> Option<SimpleValues<<Self::State as SimpleDomain>::Value>>;
+    fn exp(
+        &self,
+        context: &mut Self::ExecutionContext,
+        parent_e: &Exp,
+    ) -> SimpleValues<<Self::State as SimpleDomain>::Value> {
+        use UnannotatedExp_ as E;
+        if let Some(vs) = self.exp_custom(context, parent_e) {
+            return vs;
+        }
+        let eloc = &parent_e.exp.loc;
+        match &parent_e.exp.value {
+            E::Move { var, .. } => {
+                let locals = context.state().locals_mut();
+                let prev = locals.insert(
+                    *var,
+                    LocalState::Unavailable(*eloc, UnavailableReason::Moved),
+                );
+                match prev {
+                    Some(LocalState::Available(_, value)) => {
+                        vec![value]
+                    }
+                    // Possible error case
+                    _ => default_values(1),
+                }
+            }
+            E::Copy { var, .. } => {
+                let locals = context.state().locals_mut();
+                match locals.get(var) {
+                    Some(LocalState::Available(_, value)) => vec![value.clone()],
+                    // Possible error case
+                    _ => default_values(1),
+                }
+            }
+            E::BorrowLocal(_, _) => default_values(1),
+            E::Freeze(e)
+            | E::Dereference(e)
+            | E::Borrow(_, e, _)
+            | E::Cast(e, _)
+            | E::UnaryExp(_, e) => {
+                self.exp(context, e);
+                default_values(1)
+            }
+            E::Builtin(_, e) => {
+                self.exp(context, e);
+                default_values_for_ty(&parent_e.ty)
+            }
+            E::Vector(_, n, _, e) => {
+                self.exp(context, e);
+                default_values(*n)
+            }
+            E::ModuleCall(mcall) => {
+                let evalues = self.exp(context, &mcall.arguments);
+                if let Some(vs) = self.call_custom(context, &mcall, evalues) {
+                    return vs;
+                }
+
+                default_values_for_ty(&parent_e.ty)
+            }
+
+            E::Unit { .. } => vec![],
+            E::Value(_) | E::Constant(_) | E::Spec(_, _) | E::UnresolvedError => default_values(1),
+
+            E::BinopExp(e1, _, e2) => {
+                self.exp(context, e1);
+                self.exp(context, e2);
+                default_values(1)
+            }
+            E::Pack(_, _, fields) => {
+                for (_, _, e) in fields {
+                    self.exp(context, e);
+                }
+                default_values(1)
+            }
+            E::ExpList(es) => es
+                .iter()
+                .flat_map(|item| self.exp_list_item(context, item))
+                .collect(),
+
+            E::Unreachable => panic!("ICE should not analyze dead code"),
+        }
+    }
+
+    fn exp_list_item(
+        &self,
+        context: &mut Self::ExecutionContext,
+        item: &ExpListItem,
+    ) -> SimpleValues<<Self::State as SimpleDomain>::Value> {
+        match item {
+            ExpListItem::Single(e, _) | ExpListItem::Splat(_, e, _) => self.exp(context, e),
+        }
+    }
+}
+
+pub fn default_values_for_ty<V: Clone + Debug>(ty: &Type) -> SimpleValues<V> {
+    match &ty.value {
+        Type_::Unit => vec![],
+        Type_::Single(_) => default_values(1),
+        Type_::Multiple(ts) => default_values(ts.len()),
+    }
+}
+
+#[inline(always)]
+pub fn default_values<V: Clone + Debug>(c: usize) -> SimpleValues<V> {
+    vec![SimpleValue::Default; c]
+}

--- a/external-crates/move/move-compiler/src/cfgir/visitor.rs
+++ b/external-crates/move/move-compiler/src/cfgir/visitor.rs
@@ -5,10 +5,11 @@ use std::{collections::BTreeMap, fmt::Debug};
 
 use crate::{
     cfgir::{
-        absint::{AbstractInterpreter, JoinResult, TransferFunctions},
+        absint::{AbstractDomain, AbstractInterpreter, JoinResult, TransferFunctions},
         cfg::BlockCFG,
         CFGContext,
     },
+    command_line::compiler::Visitor,
     diagnostics::{Diagnostic, Diagnostics},
     hlir::ast::{
         Command, Command_, Exp, ExpListItem, LValue, LValue_, Label, ModuleCall, Type, Type_,
@@ -17,51 +18,53 @@ use crate::{
 };
 use move_ir_types::location::*;
 
-use super::absint::AbstractDomain;
+pub type AbsIntVisitorFn = Box<dyn FnMut(&CFGContext, &BlockCFG) -> Diagnostics>;
 
-pub trait AbsIntVisitor: AbstractInterpreter {
+/// A trait for custom abstract interpreter visitors. Use `SimpleAbsIntVisitor` if extensive custom
+/// logic is not needed. For example, if just visiting specific function calls,
+/// `SimpleAbsIntVisitor` should be sufficient.
+pub trait AbsIntVisitor: AbstractInterpreter + Sized {
+    /// Called to initialize the abstract state before any code is visited
     fn init_state(context: &CFGContext) -> <Self as TransferFunctions>::State;
+
+    /// Construct an abstract interpreter pass given the initial state
     fn new(context: &CFGContext, init_state: &mut <Self as TransferFunctions>::State) -> Self;
+
+    /// A hook for an additional processing after visiting all codes. The `final_states` are the
+    /// pre-states for each block (keyed by the label for the block). The `diags` are collected from
+    /// all code visited
     fn finish(
         &mut self,
         final_states: BTreeMap<Label, <Self as TransferFunctions>::State>,
         diags: Diagnostics,
     ) -> Diagnostics;
-}
 
-pub type AbsIntVisitorFn = Box<dyn FnMut(&CFGContext, &BlockCFG) -> Diagnostics>;
-
-pub fn visitor<T: AbsIntVisitor>() -> AbsIntVisitorFn {
-    Box::new(|context, cfg| {
-        let mut init_state = T::init_state(context);
-        let mut ai = T::new(context, &mut init_state);
-        let (final_state, ds) = ai.analyze_function(cfg, init_state);
-        ai.finish(final_state, ds)
-    })
+    fn visitor() -> Visitor {
+        Visitor::AbsIntVisitor(Box::new(|context, cfg| {
+            let mut init_state = Self::init_state(context);
+            let mut ai = Self::new(context, &mut init_state);
+            let (final_state, ds) = ai.analyze_function(cfg, init_state);
+            ai.finish(final_state, ds)
+        }))
+    }
 }
 
 //**************************************************************************************************
 // simple visitor
 //**************************************************************************************************
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum SimpleValue<V: Clone + Debug> {
-    Default,
-    Specified(V),
-}
-
-pub type SimpleValues<V> = Vec<SimpleValue<V>>;
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+/// The reason why a local variable is unavailable (mostly useful for error messages)
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum UnavailableReason {
     Unassigned,
     Moved,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum LocalState<V: Clone + Debug> {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// The state of a local variable, with its abstract value if it has one.
+pub enum LocalState<V: Clone + Debug + Default> {
     Unavailable(Loc, UnavailableReason),
-    Available(Loc, SimpleValue<V>),
+    Available(Loc, V),
     MaybeUnavailable {
         available: Loc,
         unavailable: Loc,
@@ -69,24 +72,38 @@ pub enum LocalState<V: Clone + Debug> {
     },
 }
 
+/// A trait for a the context when visiting a `Command` in a block. At a minimum it must hold the diagnostics
+/// and the abstract state
 pub trait SimpleExecutionContext {
-    type State;
+    /// Add a diagnostic
     fn add_diag(&mut self, diag: Diagnostic);
-    fn state(&mut self) -> &mut Self::State;
 }
 
+/// The domain used for the simple abstract interpreter template. Accessors for the local variables
+/// must be provided, but it will manage the joining of the locals (given a way to join values).
 pub trait SimpleDomain: AbstractDomain {
-    type Value: Clone + Debug;
+    /// The non-default abstract value
+    type Value: Clone + Debug + Default + Eq;
+
+    /// Constructs a new domain, given all locals where unassiagned locals have
+    /// `LocalState::Unavailable` and parameters have
+    /// `LocalState::Available(_, SimpleValue::Default)`
     fn new(context: &CFGContext, locals: BTreeMap<Var, LocalState<Self::Value>>) -> Self;
+
+    /// Mutable access for the states of local variables
     fn locals_mut(&mut self) -> &mut BTreeMap<Var, LocalState<Self::Value>>;
+
+    /// Immutable access for the states of local variables
     fn locals(&self) -> &BTreeMap<Var, LocalState<Self::Value>>;
-    fn join_value(
-        result: &mut JoinResult,
-        v1: &SimpleValue<Self::Value>,
-        v2: &SimpleValue<Self::Value>,
-    ) -> SimpleValue<Self::Value>;
-    // join implementation called after locals have been joined
+
+    /// Joining values. Called during joining if a local is available in both states
+    fn join_value(v1: &Self::Value, v2: &Self::Value) -> Self::Value;
+
+    /// `join_impl` is called after joining locals in `join` if any custom joining logic is needed
     fn join_impl(&mut self, other: &Self, result: &mut JoinResult);
+}
+
+impl<V: SimpleDomain> AbstractDomain for V {
     fn join(&mut self, other: &Self) -> JoinResult {
         use LocalState as L;
         let self_locals = self.locals();
@@ -107,7 +124,10 @@ pub trait SimpleDomain: AbstractDomain {
                 // both available, join the value
                 (L::Available(loc, v1), L::Available(_, v2)) => {
                     let loc = *loc;
-                    let joined = Self::join_value(&mut result, v1, v2);
+                    let joined = Self::join_value(v1, v2);
+                    if v1 != &joined {
+                        result = JoinResult::Changed
+                    }
                     self.locals_mut().insert(*local, L::Available(loc, joined));
                 }
                 // equal so nothing to do
@@ -142,19 +162,17 @@ pub trait SimpleDomain: AbstractDomain {
     }
 }
 
-pub trait SimpleAbsInt: AbstractInterpreter + Sized
-where
-    Self::State: SimpleDomain,
-{
-    type ExecutionContext: SimpleExecutionContext<State = Self::State>;
+/// Trait for simple abstract interpreter passes. Custom hooks can be implemented with additional
+/// logic as needed. The provided implementation will do all of the plumbing of abstract values
+/// through the expressions, commands, and locals.
+pub trait SimpleAbsInt: Sized {
+    type State: SimpleDomain;
+    /// The execution context local to a command
+    type ExecutionContext: SimpleExecutionContext;
 
-    fn new(context: &CFGContext, init_state: &mut <Self as TransferFunctions>::State) -> Self;
-
-    fn finish(
-        &mut self,
-        final_states: BTreeMap<Label, <Self as TransferFunctions>::State>,
-        diags: Diagnostics,
-    ) -> Diagnostics;
+    /// Given the initial state/domain, construct a new abstract interpreter.
+    /// Return None if it should not be run given this context
+    fn new(context: &CFGContext, init_state: &mut Self::State) -> Option<Self>;
 
     fn verify(context: &CFGContext, cfg: &BlockCFG) -> Diagnostics {
         let mut locals = context
@@ -170,53 +188,75 @@ where
         for (param, _) in &context.signature.parameters {
             locals.insert(
                 *param,
-                LocalState::Available(param.0.loc, SimpleValue::Default),
+                LocalState::Available(
+                    param.0.loc,
+                    <<Self as SimpleAbsInt>::State as SimpleDomain>::Value::default(),
+                ),
             );
         }
         let mut init_state = Self::State::new(context, locals);
-        let mut ai = Self::new(context, &mut init_state);
+        let Some(mut ai) = Self::new(context, &mut init_state) else {
+            return Diagnostics::new();
+        };
         let (final_state, ds) = ai.analyze_function(cfg, init_state);
         ai.finish(final_state, ds)
     }
 
-    fn start_command(&self, pre: &Self::State) -> Self::ExecutionContext;
-
-    fn finish_command(&self, context: Self::ExecutionContext) -> Diagnostics;
-
-    fn execute(
-        &mut self,
-        pre: &mut Self::State,
-        _lbl: Label,
-        _idx: usize,
-        cmd: &Command,
-    ) -> Diagnostics {
-        let mut context = self.start_command(pre);
-        self.command(&mut context, cmd);
-        self.finish_command(context)
+    fn visitor() -> Visitor {
+        Visitor::AbsIntVisitor(Box::new(|context, cfg| Self::verify(context, cfg)))
     }
 
+    /// A hook for an additional processing after visiting all codes. The `final_states` are the
+    /// pre-states for each block (keyed by the label for the block). The `diags` are collected from
+    /// all code visited.
+    fn finish(
+        &mut self,
+        final_states: BTreeMap<Label, Self::State>,
+        diags: Diagnostics,
+    ) -> Diagnostics;
+
+    /// A hook for any pre-processing at the start of a command
+    fn start_command(&self, pre: &mut Self::State) -> Self::ExecutionContext;
+
+    /// A hook for any post-processing after a command has been visited
+    fn finish_command(
+        &self,
+        context: Self::ExecutionContext,
+        state: &mut Self::State,
+    ) -> Diagnostics;
+
     /// custom visit for a command. It will skip `command` if `command_custom` returns true.
-    fn command_custom(&self, context: &mut Self::ExecutionContext, cmd: &Command) -> bool;
-    fn command(&self, context: &mut Self::ExecutionContext, cmd: &Command) {
+    fn command_custom(
+        &self,
+        context: &mut Self::ExecutionContext,
+        state: &mut Self::State,
+        cmd: &Command,
+    ) -> bool;
+    fn command(
+        &self,
+        context: &mut Self::ExecutionContext,
+        state: &mut Self::State,
+        cmd: &Command,
+    ) {
         use Command_ as C;
-        if self.command_custom(context, cmd) {
+        if self.command_custom(context, state, cmd) {
             return;
         }
         let sp!(_, cmd_) = cmd;
         match cmd_ {
             C::Assign(ls, e) => {
-                let values = self.exp(context, e);
-                self.lvalues(context, ls, values);
+                let values = self.exp(context, state, e);
+                self.lvalues(context, state, ls, values);
             }
             C::Mutate(el, er) => {
-                self.exp(context, er);
-                self.exp(context, el);
+                self.exp(context, state, er);
+                self.exp(context, state, el);
             }
             C::JumpIf { cond: e, .. }
             | C::IgnoreAndPop { exp: e, .. }
             | C::Return { exp: e, .. }
             | C::Abort(e) => {
-                self.exp(context, e);
+                self.exp(context, state, e);
             }
             C::Jump { .. } => (),
             C::Break | C::Continue => panic!("ICE break/continue not translated to jumps"),
@@ -226,15 +266,16 @@ where
     fn lvalues(
         &self,
         context: &mut Self::ExecutionContext,
+        state: &mut Self::State,
         ls: &[LValue],
-        values: SimpleValues<<Self::State as SimpleDomain>::Value>,
+        values: Vec<<Self::State as SimpleDomain>::Value>,
     ) {
         // pad with defautl to account for errors
-        let padded_values = values
-            .into_iter()
-            .chain(std::iter::repeat(SimpleValue::Default));
+        let padded_values = values.into_iter().chain(std::iter::repeat(
+            <Self::State as SimpleDomain>::Value::default(),
+        ));
         for (l, value) in ls.iter().zip(padded_values) {
-            self.lvalue(context, l, value)
+            self.lvalue(context, state, l, value)
         }
     }
 
@@ -242,29 +283,32 @@ where
     fn lvalue_custom(
         &self,
         context: &mut Self::ExecutionContext,
+        state: &mut Self::State,
         l: &LValue,
-        value: &SimpleValue<<Self::State as SimpleDomain>::Value>,
+        value: &<Self::State as SimpleDomain>::Value,
     ) -> bool;
     fn lvalue(
         &self,
         context: &mut Self::ExecutionContext,
+        state: &mut Self::State,
         l: &LValue,
-        value: SimpleValue<<Self::State as SimpleDomain>::Value>,
+        value: <Self::State as SimpleDomain>::Value,
     ) {
         use LValue_ as L;
-        if self.lvalue_custom(context, l, &value) {
+        if self.lvalue_custom(context, state, l, &value) {
             return;
         }
         let sp!(loc, l_) = l;
         match l_ {
             L::Ignore => (),
             L::Var(v, _) => {
-                let locals = context.state().locals_mut();
+                let locals = state.locals_mut();
                 locals.insert(*v, LocalState::Available(*loc, value));
             }
             L::Unpack(_, _, fields) => {
                 for (_, l) in fields {
-                    self.lvalue(context, l, SimpleValue::Default)
+                    let v = <Self::State as SimpleDomain>::Value::default();
+                    self.lvalue(context, state, l, v)
                 }
             }
         }
@@ -274,27 +318,32 @@ where
     fn exp_custom(
         &self,
         context: &mut Self::ExecutionContext,
+        state: &mut Self::State,
         parent_e: &Exp,
-    ) -> Option<SimpleValues<<Self::State as SimpleDomain>::Value>>;
+    ) -> Option<Vec<<Self::State as SimpleDomain>::Value>>;
     fn call_custom(
         &self,
         context: &mut Self::ExecutionContext,
+        state: &mut Self::State,
+        loc: &Loc,
+        return_ty: &Type,
         f: &ModuleCall,
-        args: SimpleValues<<Self::State as SimpleDomain>::Value>,
-    ) -> Option<SimpleValues<<Self::State as SimpleDomain>::Value>>;
+        args: Vec<<Self::State as SimpleDomain>::Value>,
+    ) -> Option<Vec<<Self::State as SimpleDomain>::Value>>;
     fn exp(
         &self,
         context: &mut Self::ExecutionContext,
+        state: &mut Self::State,
         parent_e: &Exp,
-    ) -> SimpleValues<<Self::State as SimpleDomain>::Value> {
+    ) -> Vec<<Self::State as SimpleDomain>::Value> {
         use UnannotatedExp_ as E;
-        if let Some(vs) = self.exp_custom(context, parent_e) {
+        if let Some(vs) = self.exp_custom(context, state, parent_e) {
             return vs;
         }
         let eloc = &parent_e.exp.loc;
         match &parent_e.exp.value {
             E::Move { var, .. } => {
-                let locals = context.state().locals_mut();
+                let locals = state.locals_mut();
                 let prev = locals.insert(
                     *var,
                     LocalState::Unavailable(*eloc, UnavailableReason::Moved),
@@ -308,7 +357,7 @@ where
                 }
             }
             E::Copy { var, .. } => {
-                let locals = context.state().locals_mut();
+                let locals = state.locals_mut();
                 match locals.get(var) {
                     Some(LocalState::Available(_, value)) => vec![value.clone()],
                     // Possible error case
@@ -321,20 +370,22 @@ where
             | E::Borrow(_, e, _)
             | E::Cast(e, _)
             | E::UnaryExp(_, e) => {
-                self.exp(context, e);
+                self.exp(context, state, e);
                 default_values(1)
             }
             E::Builtin(_, e) => {
-                self.exp(context, e);
+                self.exp(context, state, e);
                 default_values_for_ty(&parent_e.ty)
             }
             E::Vector(_, n, _, e) => {
-                self.exp(context, e);
+                self.exp(context, state, e);
                 default_values(*n)
             }
             E::ModuleCall(mcall) => {
-                let evalues = self.exp(context, &mcall.arguments);
-                if let Some(vs) = self.call_custom(context, &mcall, evalues) {
+                let evalues = self.exp(context, state, &mcall.arguments);
+                if let Some(vs) =
+                    self.call_custom(context, state, eloc, &parent_e.ty, &mcall, evalues)
+                {
                     return vs;
                 }
 
@@ -345,19 +396,19 @@ where
             E::Value(_) | E::Constant(_) | E::Spec(_, _) | E::UnresolvedError => default_values(1),
 
             E::BinopExp(e1, _, e2) => {
-                self.exp(context, e1);
-                self.exp(context, e2);
+                self.exp(context, state, e1);
+                self.exp(context, state, e2);
                 default_values(1)
             }
             E::Pack(_, _, fields) => {
                 for (_, _, e) in fields {
-                    self.exp(context, e);
+                    self.exp(context, state, e);
                 }
                 default_values(1)
             }
             E::ExpList(es) => es
                 .iter()
-                .flat_map(|item| self.exp_list_item(context, item))
+                .flat_map(|item| self.exp_list_item(context, state, item))
                 .collect(),
 
             E::Unreachable => panic!("ICE should not analyze dead code"),
@@ -367,15 +418,17 @@ where
     fn exp_list_item(
         &self,
         context: &mut Self::ExecutionContext,
+        state: &mut Self::State,
         item: &ExpListItem,
-    ) -> SimpleValues<<Self::State as SimpleDomain>::Value> {
+    ) -> Vec<<Self::State as SimpleDomain>::Value> {
         match item {
-            ExpListItem::Single(e, _) | ExpListItem::Splat(_, e, _) => self.exp(context, e),
+            ExpListItem::Single(e, _) | ExpListItem::Splat(_, e, _) => self.exp(context, state, e),
         }
     }
 }
 
-pub fn default_values_for_ty<V: Clone + Debug>(ty: &Type) -> SimpleValues<V> {
+/// Provides default values depending on the arity of the type
+pub fn default_values_for_ty<V: Clone + Default>(ty: &Type) -> Vec<V> {
     match &ty.value {
         Type_::Unit => vec![],
         Type_::Single(_) => default_values(1),
@@ -384,6 +437,24 @@ pub fn default_values_for_ty<V: Clone + Debug>(ty: &Type) -> SimpleValues<V> {
 }
 
 #[inline(always)]
-pub fn default_values<V: Clone + Debug>(c: usize) -> SimpleValues<V> {
-    vec![SimpleValue::Default; c]
+/// A simple constructor for n default values
+pub fn default_values<V: Clone + Default>(c: usize) -> Vec<V> {
+    vec![V::default(); c]
 }
+
+impl<V: SimpleAbsInt> TransferFunctions for V {
+    type State = V::State;
+
+    fn execute(
+        &mut self,
+        pre: &mut Self::State,
+        _lbl: Label,
+        _idx: usize,
+        cmd: &Command,
+    ) -> Diagnostics {
+        let mut context = self.start_command(pre);
+        self.command(&mut context, pre, cmd);
+        self.finish_command(context, pre)
+    }
+}
+impl<V: SimpleAbsInt> AbstractInterpreter for V {}

--- a/external-crates/move/move-compiler/src/command_line/compiler.rs
+++ b/external-crates/move/move-compiler/src/command_line/compiler.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    cfgir::{self, visitor::AbsIntVisitorFn},
+    cfgir::{self, visitor::AbsIntVisitorObj},
     command_line::{DEFAULT_OUTPUT_DIR, MOVE_COMPILED_INTERFACES_DIR},
     compiled_unit,
     compiled_unit::AnnotatedCompiledUnit,
@@ -86,7 +86,7 @@ pub struct FullyCompiledProgram {
 }
 
 pub enum Visitor {
-    AbsIntVisitor(AbsIntVisitorFn),
+    AbsIntVisitor(AbsIntVisitorObj),
 }
 
 //**************************************************************************************************
@@ -847,8 +847,8 @@ fn run(
 // traits
 //**************************************************************************************************
 
-impl From<AbsIntVisitorFn> for Visitor {
-    fn from(f: AbsIntVisitorFn) -> Self {
+impl From<AbsIntVisitorObj> for Visitor {
+    fn from(f: AbsIntVisitorObj) -> Self {
         Self::AbsIntVisitor(f)
     }
 }

--- a/external-crates/move/move-compiler/src/command_line/compiler.rs
+++ b/external-crates/move/move-compiler/src/command_line/compiler.rs
@@ -199,8 +199,14 @@ impl<'a> Compiler<'a> {
         self
     }
 
-    pub fn add_visitor(mut self, pass: impl Into<Visitor>) {
-        self.visitors.push(pass.into())
+    pub fn add_visitor(mut self, pass: impl Into<Visitor>) -> Self {
+        self.visitors.push(pass.into());
+        self
+    }
+
+    pub fn add_visitors(mut self, passes: impl IntoIterator<Item = Visitor>) -> Self {
+        self.visitors.extend(passes);
+        self
     }
 
     pub fn run<const TARGET: Pass>(

--- a/external-crates/move/move-compiler/src/command_line/compiler.rs
+++ b/external-crates/move/move-compiler/src/command_line/compiler.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    cfgir,
+    cfgir::{self, visitor::AbsIntVisitorFn},
     command_line::{DEFAULT_OUTPUT_DIR, MOVE_COMPILED_INTERFACES_DIR},
     compiled_unit,
     compiled_unit::AnnotatedCompiledUnit,
@@ -42,6 +42,7 @@ pub struct Compiler<'a> {
     pre_compiled_lib: Option<&'a FullyCompiledProgram>,
     compiled_module_named_address_mapping: BTreeMap<CompiledModuleId, String>,
     flags: Flags,
+    visitors: Vec<Visitor>,
 }
 
 pub struct SteppedCompiler<'a, const P: Pass> {
@@ -82,6 +83,10 @@ pub struct FullyCompiledProgram {
     pub hlir: hlir::ast::Program,
     pub cfgir: cfgir::ast::Program,
     pub compiled: Vec<AnnotatedCompiledUnit>,
+}
+
+pub enum Visitor {
+    AbsIntVisitor(AbsIntVisitorFn),
 }
 
 //**************************************************************************************************
@@ -130,6 +135,7 @@ impl<'a> Compiler<'a> {
             pre_compiled_lib: None,
             compiled_module_named_address_mapping: BTreeMap::new(),
             flags: Flags::empty(),
+            visitors: vec![],
         }
     }
 
@@ -193,6 +199,10 @@ impl<'a> Compiler<'a> {
         self
     }
 
+    pub fn add_visitor(mut self, pass: impl Into<Visitor>) {
+        self.visitors.push(pass.into())
+    }
+
     pub fn run<const TARGET: Pass>(
         self,
     ) -> anyhow::Result<(
@@ -207,13 +217,14 @@ impl<'a> Compiler<'a> {
             pre_compiled_lib,
             compiled_module_named_address_mapping,
             flags,
+            visitors,
         } = self;
         generate_interface_files_for_deps(
             &mut deps,
             interface_files_dir_opt,
             &compiled_module_named_address_mapping,
         )?;
-        let mut compilation_env = CompilationEnv::new(flags);
+        let mut compilation_env = CompilationEnv::new(flags, visitors);
         let (source_text, pprog_and_comments_res) =
             parse_program(&mut compilation_env, maps, targets, deps)?;
         let res: Result<_, Diagnostics> = pprog_and_comments_res.and_then(|(pprog, comments)| {
@@ -823,5 +834,15 @@ fn run(
             )
         }
         PassResult::Compilation(_, _) => unreachable!("ICE Pass::Compilation is >= all passes"),
+    }
+}
+
+//**************************************************************************************************
+// traits
+//**************************************************************************************************
+
+impl From<AbsIntVisitorFn> for Visitor {
+    fn from(f: AbsIntVisitorFn) -> Self {
+        Self::AbsIntVisitor(f)
     }
 }

--- a/external-crates/move/move-compiler/src/diagnostics/codes.rs
+++ b/external-crates/move/move-compiler/src/diagnostics/codes.rs
@@ -93,6 +93,16 @@ macro_rules! codes {
             $($cat,)*
         }
 
+        impl TryFrom<u8> for Category {
+            type Error = ();
+            fn try_from(value: u8) -> Result<Self, Self::Error> {
+                match () {
+                    $(_ if value == (Category::$cat as u8) => Ok(Category::$cat),)*
+                    _ => Err(()),
+                }
+            }
+        }
+
         $(
             #[derive(PartialEq, Eq, Clone, Copy, Debug, Hash)]
             #[repr(u8)]
@@ -357,7 +367,7 @@ impl DiagnosticInfo {
         self.severity
     }
 
-    pub fn category(&self) -> Category {
+    pub fn category(&self) -> u8 {
         self.category
     }
 
@@ -367,6 +377,10 @@ impl DiagnosticInfo {
 
     pub fn message(&self) -> &'static str {
         self.message
+    }
+
+    pub fn is_external(&self) -> bool {
+        self.external_prefix.is_some()
     }
 }
 

--- a/external-crates/move/move-compiler/src/diagnostics/mod.rs
+++ b/external-crates/move/move-compiler/src/diagnostics/mod.rs
@@ -254,7 +254,7 @@ impl Diagnostics {
         self,
     ) -> Vec<(
         codespan_reporting::diagnostic::Severity,
-        Symbol,
+        &'static str,
         (Loc, String),
         Vec<(Loc, String)>,
         Vec<String>,

--- a/external-crates/move/move-compiler/src/expansion/ast.rs
+++ b/external-crates/move/move-compiler/src/expansion/ast.rs
@@ -580,11 +580,28 @@ impl Address {
             Self::NamedUnassigned(_) => NumericalAddress::DEFAULT_ERROR_ADDRESS,
         }
     }
+
+    pub fn is(&self, address: impl AsRef<str>) -> bool {
+        match self {
+            Self::Numerical(Some(n), _) | Self::NamedUnassigned(n) => {
+                n.value.as_str() == address.as_ref()
+            }
+            Self::Numerical(None, _) => false,
+        }
+    }
 }
 
 impl ModuleIdent_ {
     pub fn new(address: Address, module: ModuleName) -> Self {
         Self { address, module }
+    }
+
+    pub fn is(&self, address: impl AsRef<str>, module: impl AsRef<str>) -> bool {
+        let Self {
+            address: a,
+            module: m,
+        } = self;
+        a.is(address) && m == module.as_ref()
     }
 }
 

--- a/external-crates/move/move-compiler/src/hlir/ast.rs
+++ b/external-crates/move/move-compiler/src/hlir/ast.rs
@@ -211,7 +211,7 @@ pub struct Label(pub usize);
 // Commands
 //**************************************************************************************************
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum Command_ {
     Assign(Vec<LValue>, Box<Exp>),
@@ -239,7 +239,7 @@ pub enum Command_ {
 }
 pub type Command = Spanned<Command_>;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum LValue_ {
     Ignore,
     Var(Var, Box<SingleType>),
@@ -258,7 +258,7 @@ pub enum UnitCase {
     FromUser,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ModuleCall {
     pub module: ModuleIdent,
     pub name: FunctionName,
@@ -310,7 +310,7 @@ pub enum MoveOpAnnotation {
     InferredNoCopy,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum UnannotatedExp_ {
     Unit {
         case: UnitCase,
@@ -350,7 +350,7 @@ pub enum UnannotatedExp_ {
     UnresolvedError,
 }
 pub type UnannotatedExp = Spanned<UnannotatedExp_>;
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Exp {
     pub ty: Type,
     pub exp: UnannotatedExp,
@@ -359,7 +359,7 @@ pub fn exp(ty: Type, exp: UnannotatedExp) -> Exp {
     Exp { ty, exp }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum ExpListItem {
     Single(Exp, Box<SingleType>),
     Splat(Loc, Exp, Vec<SingleType>),

--- a/external-crates/move/move-compiler/src/hlir/ast.rs
+++ b/external-crates/move/move-compiler/src/hlir/ast.rs
@@ -5,8 +5,8 @@
 use crate::{
     diagnostics::WarningFilters,
     expansion::ast::{
-        ability_modifiers_ast_debug, AbilitySet, Attributes, Friend, ModuleIdent, SpecId,
-        Visibility,
+        ability_modifiers_ast_debug, AbilitySet, Address, Attributes, Friend, ModuleIdent,
+        ModuleIdent_, SpecId, Visibility,
     },
     naming::ast::{BuiltinTypeName, BuiltinTypeName_, StructTypeParameter, TParam},
     parser::ast::{BinOp, ConstantName, Field, FunctionName, StructName, UnaryOp, ENTRY_MODIFIER},
@@ -654,6 +654,29 @@ impl TName for Var {
 
     fn borrow(&self) -> (&Loc, &Symbol) {
         (&self.0.loc, &self.0.value)
+    }
+}
+
+impl ModuleCall {
+    pub fn is(
+        &self,
+        address: Address,
+        module: impl Into<Symbol>,
+        function: impl Into<Symbol>,
+    ) -> bool {
+        let Self {
+            module:
+                sp!(
+                    _,
+                    ModuleIdent_ {
+                        address: a,
+                        module: m,
+                    }
+                ),
+            name: f,
+            ..
+        } = self;
+        a == &address && m.0.value == module.into() && f.0.value == function.into()
     }
 }
 

--- a/external-crates/move/move-compiler/src/lib.rs
+++ b/external-crates/move/move-compiler/src/lib.rs
@@ -19,6 +19,7 @@ pub mod ir_translation;
 pub mod naming;
 pub mod parser;
 pub mod shared;
+pub mod sui_mode;
 mod to_bytecode;
 pub mod typing;
 pub mod unit_test;

--- a/external-crates/move/move-compiler/src/parser/ast.rs
+++ b/external-crates/move/move-compiler/src/parser/ast.rs
@@ -33,6 +33,12 @@ macro_rules! new_name {
             }
         }
 
+        impl PartialEq<str> for $n {
+            fn eq(&self, s: &str) -> bool {
+                self.0.value.as_str() == s
+            }
+        }
+
         impl Identifier for $n {
             fn value(&self) -> Symbol {
                 self.0.value

--- a/external-crates/move/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/move-compiler/src/shared/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     cfgir::visitor::AbsIntVisitorFn,
     command_line as cli,
     diagnostics::{
-        codes::{Severity, WarningFilter, WARNING_FILTER_ATTR},
+        codes::{Category, Severity, WarningFilter, WARNING_FILTER_ATTR},
         Diagnostic, Diagnostics, WarningFilters,
     },
     naming::ast::ModuleDefinition,
@@ -204,9 +204,11 @@ impl CompilationEnv {
         if !is_filtered {
             // add help to suppress warning, if applicable
             // TODO do we want a centralized place for tips like this?
-            if diag.info().severity() == Severity::Warning {
-                let possible_filter =
-                    WarningFilter::Code(diag.info().category(), diag.info().code());
+            if diag.info().severity() == Severity::Warning && !diag.info().is_external() {
+                let possible_filter = WarningFilter::Code(
+                    Category::try_from(diag.info().category()).unwrap(),
+                    diag.info().code(),
+                );
                 if let Some(filter_name) = possible_filter.to_str() {
                     let help = format!(
                         "This warning can be suppressed with '#[{}({})]' \

--- a/external-crates/move/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/move-compiler/src/shared/mod.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    cfgir::visitor::AbsIntVisitorFn,
+    cfgir::visitor::AbsIntVisitorObj,
     command_line as cli,
     diagnostics::{
         codes::{Category, Severity, WarningFilter, WARNING_FILTER_ATTR},
@@ -464,7 +464,7 @@ impl Flags {
 //**************************************************************************************************
 
 pub struct Visitors {
-    pub abs_int: Vec<RefCell<AbsIntVisitorFn>>,
+    pub abs_int: Vec<RefCell<AbsIntVisitorObj>>,
 }
 
 impl Visitors {

--- a/external-crates/move/move-compiler/src/sui_mode/id_leak.rs
+++ b/external-crates/move/move-compiler/src/sui_mode/id_leak.rs
@@ -5,10 +5,10 @@ use move_ir_types::location::*;
 
 use crate::{
     cfgir::{
+        self,
         absint::JoinResult,
         visitor::{
-             LocalState, SimpleAbsInt, SimpleAbsIntConstructor, SimpleDomain,
-            SimpleExecutionContext,
+            LocalState, SimpleAbsInt, SimpleAbsIntConstructor, SimpleDomain, SimpleExecutionContext,
         },
         CFGContext, MemberName,
     },
@@ -60,6 +60,7 @@ impl SimpleAbsIntConstructor for IDLeakVerifier {
     type AI<'a> = IDLeakVerifierAI<'a>;
 
     fn new<'a>(
+        _program: &'a cfgir::ast::Program,
         context: &'a CFGContext<'a>,
         _init_state: &mut <Self::AI<'a> as SimpleAbsInt>::State,
     ) -> Option<Self::AI<'a>> {

--- a/external-crates/move/move-compiler/src/sui_mode/id_leak.rs
+++ b/external-crates/move/move-compiler/src/sui_mode/id_leak.rs
@@ -1,0 +1,227 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use move_ir_types::location::*;
+
+use crate::{
+    cfgir::{
+        absint::JoinResult,
+        visitor::{LocalState, SimpleAbsInt, SimpleDomain, SimpleExecutionContext},
+        CFGContext, MemberName,
+    },
+    diag,
+    diagnostics::{Diagnostic, Diagnostics},
+    expansion::ast::AbilitySet,
+    hlir::ast::{Command, Exp, LValue, Label, ModuleCall, SingleType, Type, Type_, Var},
+    parser::ast::{Ability_, StructName},
+    shared::{unique_map::UniqueMap, Identifier},
+    sui_mode::{OBJECT_NEW, TEST_SCENARIO_MODULE_NAME, TS_NEW_OBJECT},
+};
+use std::collections::BTreeMap;
+
+use super::{
+    FRESH_ID_FUNCTIONS, FUNCTIONS_TO_SKIP, ID_LEAK_DIAG, OBJECT_MODULE_NAME, SUI_ADDR_NAME,
+    UID_TYPE_NAME,
+};
+
+//**************************************************************************************************
+// types
+//**************************************************************************************************
+
+pub struct IDLeakVerifier {
+    declared_abilities: UniqueMap<StructName, AbilitySet>,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Value {
+    FreshID(Loc),
+    NotFresh(Loc),
+    Other,
+}
+
+pub struct ExecutionContext {
+    diags: Diagnostics,
+}
+
+#[derive(Clone, Debug)]
+pub struct State {
+    locals: BTreeMap<Var, LocalState<Value>>,
+}
+
+//**************************************************************************************************
+// impls
+//**************************************************************************************************
+
+impl<'a> SimpleAbsInt for IDLeakVerifier {
+    type State = State;
+    type ExecutionContext = ExecutionContext;
+
+    fn new(context: &CFGContext, _init_state: &mut State) -> Option<Self> {
+        let Some(module) = &context.module else {
+            return None
+        };
+        if let MemberName::Function(n) = &context.member {
+            let should_skip = FUNCTIONS_TO_SKIP.iter().any(|to_skip| {
+                module.value.is(to_skip.0, to_skip.1) && n.value.as_str() == to_skip.2
+            });
+            if should_skip {
+                return None;
+            }
+        }
+        // TODO find a way to pass in the CFGContext to remove the clones
+        let declared_abilities = context
+            .struct_declared_abilities
+            .get(module)
+            .unwrap()
+            .clone();
+        Some(IDLeakVerifier { declared_abilities })
+    }
+
+    fn finish(&mut self, _final_states: BTreeMap<Label, State>, diags: Diagnostics) -> Diagnostics {
+        diags
+    }
+
+    fn start_command(&self, _: &mut State) -> ExecutionContext {
+        ExecutionContext {
+            diags: Diagnostics::new(),
+        }
+    }
+
+    fn finish_command(&self, context: ExecutionContext, _state: &mut State) -> Diagnostics {
+        let ExecutionContext { diags } = context;
+        diags
+    }
+
+    fn exp_custom(
+        &self,
+        context: &mut ExecutionContext,
+        state: &mut State,
+        e: &Exp,
+    ) -> Option<Vec<Value>> {
+        use crate::hlir::ast::UnannotatedExp_ as E;
+
+        let e__ = &e.exp.value;
+        let E::Pack(s, _tys, fields) = e__ else {
+            return None;
+        };
+        let abilities = self.declared_abilities.get(s).unwrap();
+        if !abilities.has_ability_(Ability_::Key) {
+            return None;
+        }
+
+        let mut fields_iter = fields.iter();
+        let (f, _, first_e) = fields_iter.next().unwrap();
+        let first_value = self.exp(context, state, first_e).pop().unwrap_or_default();
+        if !matches!(first_value, Value::FreshID(_)) {
+            let msg = format!("Invalid object creation without a newly created UID.");
+            let uid_msg = format!(
+                "The UID must come directly from {sui}::{object}::{new}. \
+                Or for tests, it can come from {sui}::{ts}::{ts_new}",
+                sui = SUI_ADDR_NAME,
+                object = OBJECT_MODULE_NAME,
+                new = OBJECT_NEW,
+                ts = TEST_SCENARIO_MODULE_NAME,
+                ts_new = TS_NEW_OBJECT,
+            );
+            let mut d = diag!(ID_LEAK_DIAG, (e.exp.loc, msg), (f.loc(), uid_msg));
+            if let Value::NotFresh(stale) = first_value {
+                d.add_secondary_label((stale, "Non fresh UID from this position"))
+            }
+            context.add_diag(d)
+        }
+
+        for (_, _, inner) in fields_iter {
+            self.exp(context, state, inner);
+        }
+
+        Some(vec![Value::default()])
+    }
+
+    fn call_custom(
+        &self,
+        _context: &mut ExecutionContext,
+        _state: &mut State,
+        loc: &Loc,
+        return_ty: &Type,
+        f: &ModuleCall,
+        _args: Vec<Value>,
+    ) -> Option<Vec<Value>> {
+        if FRESH_ID_FUNCTIONS
+            .iter()
+            .any(|makes_fresh| f.is(makes_fresh.0, makes_fresh.1, makes_fresh.2))
+        {
+            return Some(vec![Value::FreshID(*loc)]);
+        }
+        Some(match &return_ty.value {
+            Type_::Unit => vec![],
+            Type_::Single(t) => vec![value_for_ty(loc, t)],
+            Type_::Multiple(ts) => ts.iter().map(|t| value_for_ty(loc, t)).collect(),
+        })
+    }
+
+    fn command_custom(&self, _: &mut ExecutionContext, _: &mut State, _: &Command) -> bool {
+        false
+    }
+
+    fn lvalue_custom(
+        &self,
+        _: &mut ExecutionContext,
+        _: &mut State,
+        _: &LValue,
+        _: &Value,
+    ) -> bool {
+        false
+    }
+}
+
+fn value_for_ty(loc: &Loc, sp!(_, t): &SingleType) -> Value {
+    if t.is_apply(SUI_ADDR_NAME, OBJECT_MODULE_NAME, UID_TYPE_NAME)
+        .is_some()
+    {
+        Value::NotFresh(*loc)
+    } else {
+        Value::Other
+    }
+}
+
+impl SimpleDomain for State {
+    type Value = Value;
+
+    fn new(_: &CFGContext, locals: BTreeMap<Var, LocalState<Value>>) -> Self {
+        State { locals }
+    }
+
+    fn locals_mut(&mut self) -> &mut BTreeMap<Var, LocalState<Value>> {
+        &mut self.locals
+    }
+
+    fn locals(&self) -> &BTreeMap<Var, LocalState<Value>> {
+        &self.locals
+    }
+
+    fn join_value(v1: &Value, v2: &Value) -> Value {
+        match (v1, v2) {
+            (stale @ Value::NotFresh(_), _) | (_, stale @ Value::NotFresh(_)) => *stale,
+
+            (Value::FreshID(_), Value::FreshID(_)) => *v1,
+
+            (Value::FreshID(_), Value::Other)
+            | (Value::Other, Value::FreshID(_))
+            | (Value::Other, Value::Other) => Value::Other,
+        }
+    }
+
+    fn join_impl(&mut self, _: &Self, _: &mut JoinResult) {}
+}
+
+impl SimpleExecutionContext for ExecutionContext {
+    fn add_diag(&mut self, diag: Diagnostic) {
+        self.diags.add(diag)
+    }
+}
+
+impl Default for Value {
+    fn default() -> Self {
+        Value::Other
+    }
+}

--- a/external-crates/move/move-compiler/src/sui_mode/mod.rs
+++ b/external-crates/move/move-compiler/src/sui_mode/mod.rs
@@ -1,0 +1,42 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::diagnostics::codes::{custom, DiagnosticInfo, Severity};
+
+pub mod id_leak;
+
+const SUI_ADDR_NAME: &str = "sui";
+const OBJECT_MODULE_NAME: &str = "object";
+const OBJECT_NEW: &str = "new";
+const OBJECT_NEW_UID_FROM_HASH: &str = "new_uid_from_hash";
+const TEST_SCENARIO_MODULE_NAME: &str = "test_scenario";
+const TS_NEW_OBJECT: &str = "new_object";
+const UID_TYPE_NAME: &str = "UID";
+
+const SUI_SYSTEM_ADDR_NAME: &str = "sui_system";
+const SUI_SYSTEM_MODULE_NAME: &str = "sui_system";
+const SUI_SYSTEM_CREATE: &str = "create";
+const CLOCK_MODULE_NAME: &str = "clock";
+const SUI_CLOCK_CREATE: &str = "create";
+
+const FRESH_ID_FUNCTIONS: &[(&str, &str, &str)] = &[
+    (SUI_ADDR_NAME, OBJECT_MODULE_NAME, OBJECT_NEW),
+    (SUI_ADDR_NAME, OBJECT_MODULE_NAME, OBJECT_NEW_UID_FROM_HASH),
+    (SUI_ADDR_NAME, TEST_SCENARIO_MODULE_NAME, TS_NEW_OBJECT),
+];
+const FUNCTIONS_TO_SKIP: &[(&str, &str, &str)] = &[
+    (
+        SUI_SYSTEM_ADDR_NAME,
+        SUI_SYSTEM_MODULE_NAME,
+        SUI_SYSTEM_CREATE,
+    ),
+    (SUI_ADDR_NAME, CLOCK_MODULE_NAME, SUI_CLOCK_CREATE),
+];
+
+const ID_LEAK_DIAG: DiagnosticInfo = custom(
+    "Sui ",
+    Severity::NonblockingError,
+    /* category */ 1,
+    /* code */ 1,
+    "invalid object construction",
+);

--- a/external-crates/move/move-compiler/src/to_bytecode/translate.rs
+++ b/external-crates/move/move-compiler/src/to_bytecode/translate.rs
@@ -630,7 +630,7 @@ fn function(
         G::FunctionBody_::Defined {
             locals,
             start,
-            loop_heads,
+            block_info,
             blocks,
         } => {
             let (locals, code) = function_body(
@@ -638,7 +638,7 @@ fn function(
                 &f,
                 parameters.clone(),
                 locals,
-                loop_heads,
+                block_info,
                 start,
                 blocks,
             );
@@ -736,7 +736,7 @@ fn function_body(
     f: &FunctionName,
     parameters: Vec<(Var, H::SingleType)>,
     mut locals_map: UniqueMap<Var, H::SingleType>,
-    loop_heads: BTreeSet<H::Label>,
+    block_info: BTreeMap<H::Label, G::BlockInfo>,
     start: H::Label,
     blocks_map: H::BasicBlocks,
 ) -> (Vec<(IR::Var, IR::Type)>, IR::BytecodeBlocks) {
@@ -770,7 +770,11 @@ fn function_body(
         bytecode_blocks.push((label(lbl), code));
     }
 
-    let loop_heads = loop_heads.into_iter().map(label).collect();
+    let loop_heads = block_info
+        .into_iter()
+        .filter(|(_lbl, info)| matches!(info, G::BlockInfo::LoopHead(_)))
+        .map(|(lbl, _)| label(lbl))
+        .collect();
     optimize::code(f, &loop_heads, &mut locals, &mut bytecode_blocks);
 
     (locals, bytecode_blocks)

--- a/external-crates/move/move-model/src/lib.rs
+++ b/external-crates/move/move-model/src/lib.rs
@@ -351,7 +351,7 @@ fn add_move_lang_diagnostics(env: &mut GlobalEnv, diags: Diagnostics) {
     for (severity, msg, primary_label, secondary_labels, notes) in diags.into_codespan_format() {
         let diag = Diagnostic::new(severity)
             .with_labels(vec![mk_label(true, primary_label)])
-            .with_message(msg)
+            .with_message(msg.to_string())
             .with_labels(
                 secondary_labels
                     .into_iter()


### PR DESCRIPTION
## Description 

- Added a notion of visitors to the compiler, but it is only currently implemented for the abstract interpreter 
- Added a Helper trait for simple abstract interpreter passes 
- Implemented the ID leak verifier as an example of that interpreter
  - Will hook it up in a future PR
  
Example output (when I turned off the filtering)
```
  error[Sui E01001]: invalid object construction
     ┌─ /Users/tmn/sui/crates/sui-framework/packages/sui-framework/sources/clock.move:42:32
     │  
  42 │           transfer::share_object(Clock {
     │ ╭────────────────────────────────^
  43 │ │             id: object::clock(),
     │ │             --  --------------- Non fresh UID from this position
     │ │             │    
     │ │             
                  The UID must come directly from sui::object::new. Or for tests, it can come from sui::test_scenario::new_object
  44 │ │             // Initialised to zero, but set to a real timestamp by a
  45 │ │             // system transaction before it can be witnessed by a move
  46 │ │             // call.
  47 │ │             timestamp_ms: 0,
  48 │ │         })
     │ ╰─────────^ Invalid object creation without a newly created UID.
```

## Test Plan 

Tested with the ID leak verifier 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
