### PR TITLE
docs: fix link to event filter anchor

### DIFF
--- a/crates/sui-json-rpc/src/api/indexer.rs
+++ b/crates/sui-json-rpc/src/api/indexer.rs
@@ -55,7 +55,7 @@ pub trait IndexerApi {
     #[method(name = "queryEvents")]
     async fn query_events(
         &self,
-        /// the event query criteria.
+        /// The event query criteria. See [Event filter](https://docs.sui.io/build/event_api#event-filters) documentation for examples.
         query: EventFilter,
         /// optional paging cursor
         cursor: Option<EventID>,
@@ -69,7 +69,7 @@ pub trait IndexerApi {
     #[subscription(name = "subscribeEvent", item = SuiEvent)]
     fn subscribe_event(
         &self,
-        /// the filter criteria of the event stream, see the [Sui docs](https://docs.sui.io/build/pubsub#event-filters) for detailed examples.
+        /// The filter criteria of the event stream. See [Event filter](https://docs.sui.io/build/event_api#event-filters) documentation for examples.
         filter: EventFilter,
     );
 

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -3913,7 +3913,7 @@
       "params": [
         {
           "name": "query",
-          "description": "the event query criteria.",
+          "description": "The event query criteria. See [Event filter](https://docs.sui.io/build/event_api#event-filters) documentation for examples.",
           "required": true,
           "schema": {
             "$ref": "#/components/schemas/EventFilter"
@@ -4266,7 +4266,7 @@
       "params": [
         {
           "name": "filter",
-          "description": "the filter criteria of the event stream, see the [Sui docs](https://docs.sui.io/build/pubsub#event-filters) for detailed examples.",
+          "description": "The filter criteria of the event stream. See [Event filter](https://docs.sui.io/build/event_api#event-filters) documentation for examples.",
           "required": true,
           "schema": {
             "$ref": "#/components/schemas/EventFilter"


### PR DESCRIPTION
## Description 

See title.

Side question: is there a command to generate `openrpc.json` from the `indexer.rs` file, because it looks like `openrpc.json` descriptions are generated from there? I didn't discover one and just made the manual corresponding changes.

## Test Plan 

Just a doc link fix (manually checked the correct link works at https://docs.sui.io/build/event_api#event-filters)

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Doc fix for broken link.
