### PR TITLE
Authority Aggregator exits early when there are too many conflicting txes

### DIFF
--- a/crates/sui-core/src/quorum_driver/mod.rs
+++ b/crates/sui-core/src/quorum_driver/mod.rs
@@ -363,24 +363,21 @@ where
             Err(err) => {
                 debug!(
                     ?tx_digest,
-                    "Encountered error while attempting conflicting transaction: {:?}", err
+                    ?conflicting_tx_digest,
+                    "Encountered error while attempting conflicting transaction: {:?}",
+                    err
                 );
-                let err = Err(Some(QuorumDriverError::ObjectsDoubleUsed {
+                Err(Some(QuorumDriverError::ObjectsDoubleUsed {
                     conflicting_txes: conflicting_tx_digests,
                     retried_tx: None,
                     retried_tx_success: None,
-                }));
-                debug!(
-                    ?tx_digest,
-                    "Non retryable error when getting original tx cert: {err:?}"
-                );
-                err
+                }))
             }
             Ok(success) => {
                 debug!(
                     ?tx_digest,
                     ?conflicting_tx_digest,
-                    "Retried conflicting transaction success: {}",
+                    "Retried conflicting transaction. Success: {}",
                     success
                 );
                 if success {

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -286,6 +286,9 @@ impl AuthorityAPI for MockAuthorityApi {
 #[derive(Clone)]
 pub struct HandleTransactionTestAuthorityClient {
     pub tx_info_resp_to_return: SuiResult<HandleTransactionResponse>,
+    // If set, sleep for this duration before responding to a request.
+    // This is useful in testing a timeout scenario.
+    pub sleep_duration_before_responding: Option<Duration>,
 }
 
 #[async_trait]
@@ -294,6 +297,9 @@ impl AuthorityAPI for HandleTransactionTestAuthorityClient {
         &self,
         _transaction: Transaction,
     ) -> Result<HandleTransactionResponse, SuiError> {
+        if let Some(duration) = self.sleep_duration_before_responding {
+            tokio::time::sleep(duration).await;
+        }
         self.tx_info_resp_to_return.clone()
     }
 
@@ -344,6 +350,7 @@ impl HandleTransactionTestAuthorityClient {
     pub fn new() -> Self {
         Self {
             tx_info_resp_to_return: Err(SuiError::Unknown("".to_string())),
+            sleep_duration_before_responding: None,
         }
     }
 
@@ -357,6 +364,10 @@ impl HandleTransactionTestAuthorityClient {
 
     pub fn reset_tx_info_response(&mut self) {
         self.tx_info_resp_to_return = Err(SuiError::Unknown("".to_string()));
+    }
+
+    pub fn set_sleep_duration_before_responding(&mut self, duration: Duration) {
+        self.sleep_duration_before_responding = Some(duration);
     }
 }
 

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -767,6 +767,7 @@ async fn test_handle_transaction_panic() {
 
 #[tokio::test]
 async fn test_handle_transaction_response() {
+    telemetry_subscribers::init_for_testing();
     let mut authorities = BTreeMap::new();
     let mut clients = BTreeMap::new();
     let mut authority_keys = Vec::new();


### PR DESCRIPTION
## Description 

Currently, if a tx has a lot of conflicts, it's likely that we don't exit until we talk to every validator, which isn't effective, most times than not. This PR adds an early exit point, when the stake of most staked tx  + retryable stake is less than the quorum stake, we know for sure this object is equivocated. One example it tackles with is, when one obj has two txes, each with f+1 stake. 

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Authority Aggregator exits early when there are too many conflicting txes