### PR TITLE
[fix] fix failing test in the long running suite

### DIFF
--- a/narwhal/primary/tests/nodes_bootstrapping_tests.rs
+++ b/narwhal/primary/tests/nodes_bootstrapping_tests.rs
@@ -267,14 +267,14 @@ async fn test_loss_of_liveness_without_recovery() {
     cluster.authority(2).start(true, Some(1)).await;
     cluster.authority(3).start(true, Some(1)).await;
 
-    // wait and fetch the latest commit round
+    // wait and fetch the latest commit round. All of them should have advanced and we allow a small
+    // threshold in case some node is faster than the others
     tokio::time::sleep(node_advance_delay).await;
-    let rounds_3 = cluster.assert_progress(4, 0).await;
+    let rounds_3 = cluster.assert_progress(4, 2).await;
 
+    // we test that nodes 0 & 1 have actually advanced in rounds compared to before.
     assert!(rounds_3.get(&0) > rounds_2.get(&0));
     assert!(rounds_3.get(&1) > rounds_2.get(&1));
-    assert_eq!(rounds_3.get(&0), rounds_3.get(&2));
-    assert_eq!(rounds_3.get(&0), rounds_3.get(&3));
 }
 
 #[ignore]


### PR DESCRIPTION
## Description 

`test_loss_of_liveness_without_recovery` test has been failing lately in the Narwhal nightly https://github.com/MystenLabs/sui/actions/runs/5184155035 . I've added some extra threshold in the acceptable commits as some node might be a little bit faster than the others - still valid though.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
