### PR TITLE
Revert "make sui CLI log file gated by env flag (#12095)"

### DIFF
--- a/crates/sui/src/main.rs
+++ b/crates/sui/src/main.rs
@@ -3,12 +3,9 @@
 
 use clap::*;
 use colored::Colorize;
-use std::env;
 use sui::sui_commands::SuiCommand;
 use sui_types::exit_main;
 use tracing::debug;
-
-const SUI_CLI_LOG_FILE_ENABLE: &str = "SUI_CLI_LOG_FILE_ENABLE";
 
 const GIT_REVISION: &str = {
     if let Some(revision) = option_env!("GIT_REVISION") {
@@ -26,10 +23,6 @@ const GIT_REVISION: &str = {
     }
 };
 const VERSION: &str = const_str::concat!(env!("CARGO_PKG_VERSION"), "-", GIT_REVISION);
-
-pub fn read_log_file_flag_env() -> Option<u8> {
-    env::var(SUI_CLI_LOG_FILE_ENABLE).ok()?.parse::<u8>().ok()
-}
 
 #[derive(Parser)]
 #[clap(
@@ -53,13 +46,10 @@ async fn main() {
     let args = Args::parse();
     let _guard = match args.command {
         SuiCommand::Console { .. } | SuiCommand::Client { .. } => {
-            let mut t = telemetry_subscribers::TelemetryConfig::new().with_env();
-            if let Some(flag) = read_log_file_flag_env() {
-                if flag > 0 {
-                    t = t.with_log_file(&format!("{bin_name}.log"));
-                }
-            };
-            t.init()
+            telemetry_subscribers::TelemetryConfig::new()
+                .with_log_file(&format!("{bin_name}.log"))
+                .with_env()
+                .init()
         }
         _ => telemetry_subscribers::TelemetryConfig::new()
             .with_env()


### PR DESCRIPTION
## Description 

This reverts commit 8ff1005df0a6c093905d0dc7c903442ef9488a90.

Following the previous fix, logs were showing up in terminal output even when `RUST_LOG` was not enabled.

## Test Plan 

```
sui$ cargo build --bin sui
sui$ ./target/debug/sui client active-address
sui/crates/sui$ cargo nextest run 
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Revert behaviour where log output was controlled by an env flag, because when it was gated off, logs started showing up in command-line output. CLI now behaves as it did before: Producing a log file in the current working directory, but not displaying logs in line under normal operation.