### PR TITLE
[wallet-ext] set the deviceId param when linking out to Mysten-owned applications

### DIFF
--- a/apps/wallet/src/shared/analytics/amplitude.ts
+++ b/apps/wallet/src/shared/analytics/amplitude.ts
@@ -31,7 +31,6 @@ export function getUrlWithDeviceId(url: URL) {
     const amplitudeDeviceId = ampli.client.getDeviceId();
     if (amplitudeDeviceId) {
         url.searchParams.append('deviceId', amplitudeDeviceId);
-        return url;
     }
     return url;
 }

--- a/apps/wallet/src/shared/analytics/amplitude.ts
+++ b/apps/wallet/src/shared/analytics/amplitude.ts
@@ -26,3 +26,12 @@ export async function initAmplitude() {
         },
     });
 }
+
+export function getUrlWithDeviceId(url: URL) {
+    const amplitudeDeviceId = ampli.client.getDeviceId();
+    if (amplitudeDeviceId) {
+        url.searchParams.append('deviceId', amplitudeDeviceId);
+        return url;
+    }
+    return url;
+}

--- a/apps/wallet/src/shared/utils/index.ts
+++ b/apps/wallet/src/shared/utils/index.ts
@@ -58,7 +58,7 @@ export function isValidUrl(url: string | null) {
     }
 }
 
-export function getAppUrl(appUrl: string) {
+export function getDAppUrl(appUrl: string) {
     const url = new URL(appUrl);
     const isMystenLabsDApp = MYSTEN_LABS_DAPPS.includes(url.hostname);
     return isMystenLabsDApp ? getUrlWithDeviceId(url) : url;
@@ -66,7 +66,7 @@ export function getAppUrl(appUrl: string) {
 
 export function getValidDAppUrl(appUrl: string) {
     try {
-        return getAppUrl(appUrl);
+        return getDAppUrl(appUrl);
     } catch (error) {
         /* empty */
     }

--- a/apps/wallet/src/shared/utils/index.ts
+++ b/apps/wallet/src/shared/utils/index.ts
@@ -7,11 +7,14 @@ import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import Browser from 'webextension-polyfill';
 
+import { getUrlWithDeviceId } from '../analytics/amplitude';
 import { trackPageview, trackEvent } from '../plausible';
 import { useAppSelector } from '_hooks';
 import { setAttributes } from '_src/shared/experimentation/features';
 
 export const MAIN_UI_URL = Browser.runtime.getURL('ui.html');
+
+const MYSTEN_LABS_DAPPS = ['suifrens.com', 'suins.io'];
 
 export function openInNewTab() {
     return Browser.tabs.create({ url: MAIN_UI_URL });
@@ -53,6 +56,21 @@ export function isValidUrl(url: string | null) {
     } catch (e) {
         return false;
     }
+}
+
+export function getAppUrl(appUrl: string) {
+    const url = new URL(appUrl);
+    const isMystenLabsDApp = MYSTEN_LABS_DAPPS.includes(url.hostname);
+    return isMystenLabsDApp ? getUrlWithDeviceId(url) : url;
+}
+
+export function getValidDAppUrl(appUrl: string) {
+    try {
+        return getAppUrl(appUrl);
+    } catch (error) {
+        /* empty */
+    }
+    return null;
 }
 
 export function prepareLinkToCompare(link: string) {

--- a/apps/wallet/src/ui/app/components/DAppInfoCard.tsx
+++ b/apps/wallet/src/ui/app/components/DAppInfoCard.tsx
@@ -4,13 +4,13 @@
 import { ArrowUpRight12 } from '@mysten/icons';
 import { type SuiAddress } from '@mysten/sui.js';
 import { cx } from 'class-variance-authority';
-import { useMemo } from 'react';
 
 import { Link } from '../shared/Link';
 import { Heading } from '../shared/heading';
 import { Text } from '../shared/text';
 import { AccountAddress } from './AccountAddress';
 import { SummaryCard } from './SummaryCard';
+import { getValidDAppUrl } from '_src/shared/utils';
 
 export type DAppInfoCardProps = {
     name: string;
@@ -18,20 +18,16 @@ export type DAppInfoCardProps = {
     iconUrl?: string;
     connectedAddress?: SuiAddress;
 };
+
 export function DAppInfoCard({
     name,
     url,
     iconUrl,
     connectedAddress,
 }: DAppInfoCardProps) {
-    const hostname = useMemo(() => {
-        try {
-            return new URL(url).hostname;
-        } catch (e) {
-            // do nothing
-        }
-        return url;
-    }, [url]);
+    const validDAppUrl = getValidDAppUrl(url);
+    const appHostname = validDAppUrl?.hostname ?? url;
+
     return (
         <SummaryCard
             minimalPadding
@@ -62,7 +58,7 @@ export function DAppInfoCard({
                                 weight="medium"
                                 color="steel-dark"
                             >
-                                {hostname}
+                                {appHostname}
                             </Text>
                         </div>
                     </div>
@@ -74,7 +70,7 @@ export function DAppInfoCard({
                     >
                         <div>
                             <Link
-                                href={url}
+                                href={validDAppUrl?.toString() ?? url}
                                 title={name}
                                 text="View Website"
                                 after={<ArrowUpRight12 />}

--- a/apps/wallet/src/ui/app/components/explorer-link/Explorer.ts
+++ b/apps/wallet/src/ui/app/components/explorer-link/Explorer.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { DEFAULT_API_ENV } from '_app/ApiProvider';
+import { getUrlWithDeviceId } from '_src/shared/analytics/amplitude';
 import { API_ENV } from '_src/shared/api-env';
 
 import type { ObjectId, SuiAddress, TransactionDigest } from '@mysten/sui.js';
@@ -25,12 +26,11 @@ function getExplorerUrl(
     const explorerEnv =
         apiEnv === 'customRPC' ? customRPC : API_ENV_TO_EXPLORER_ENV[apiEnv];
 
-    const url = new URL(path, EXPLORER_LINK);
-    const searchParams = new URLSearchParams(url.search);
+    const url = getUrlWithDeviceId(new URL(path, EXPLORER_LINK));
     if (explorerEnv) {
-        searchParams.set('network', explorerEnv);
-        url.search = searchParams.toString();
+        url.searchParams.append('network', explorerEnv);
     }
+
     return url.href;
 }
 

--- a/apps/wallet/src/ui/app/components/sui-apps/SuiApp.tsx
+++ b/apps/wallet/src/ui/app/components/sui-apps/SuiApp.tsx
@@ -7,6 +7,7 @@ import { useState } from 'react';
 import DisconnectApp from './DisconnectApp';
 import ExternalLink from '_components/external-link';
 import { trackEvent } from '_src/shared/plausible';
+import { getAppUrl } from '_src/shared/utils';
 
 import st from './SuiApp.module.scss';
 
@@ -33,7 +34,9 @@ export function SuiApp({
     permissionID,
 }: SuiAppProps) {
     const [showDisconnectApp, setShowDisconnectApp] = useState(false);
-    const originLabel = new URL(link).hostname;
+    const appUrl = getAppUrl(link);
+    const originLabel = appUrl.hostname;
+
     const AppDetails = (
         <div className={cl(st.suiApp, st[displayType])}>
             <div className={st.icon}>
@@ -85,7 +88,7 @@ export function SuiApp({
                 </div>
             ) : (
                 <ExternalLink
-                    href={link}
+                    href={appUrl?.toString() ?? link}
                     title={name}
                     className={st.ecosystemApp}
                     onClick={() => {

--- a/apps/wallet/src/ui/app/components/sui-apps/SuiApp.tsx
+++ b/apps/wallet/src/ui/app/components/sui-apps/SuiApp.tsx
@@ -7,7 +7,7 @@ import { useState } from 'react';
 import DisconnectApp from './DisconnectApp';
 import ExternalLink from '_components/external-link';
 import { trackEvent } from '_src/shared/plausible';
-import { getAppUrl } from '_src/shared/utils';
+import { getDAppUrl } from '_src/shared/utils';
 
 import st from './SuiApp.module.scss';
 
@@ -34,7 +34,7 @@ export function SuiApp({
     permissionID,
 }: SuiAppProps) {
     const [showDisconnectApp, setShowDisconnectApp] = useState(false);
-    const appUrl = getAppUrl(link);
+    const appUrl = getDAppUrl(link);
     const originLabel = appUrl.hostname;
 
     const AppDetails = (


### PR DESCRIPTION
## Description 
When someone clicks out to a Mysten-owned app from the wallet extension, we want to be able to tie together user actions from the extension and Sui Explorer/SuiNS/SuiFrens (https://www.docs.developers.amplitude.com/data/sdks/typescript-browser/#cross-domain-tracking).

## Test Plan 
- The Explorer link is structured correctly: https://suiexplorer.com/address/0x8be60572d904409dbe7978ea6c7bce11974f54362b8c0c5afb71a24f9fba81bd?network=mainnet&deviceId=0cae5482-de65-4e70-8fc9-c17795cd7a83
- The SuiFrens link is structured correctly: https://suifrens.com/?deviceId=0cae5482-de65-4e70-8fc9-c17795cd7a83
- The SuiNS link is structured correctly: https://suins.io/?deviceId=0cae5482-de65-4e70-8fc9-c17795cd7a83
- Other apps (e.g. Wormhole) are structured correctly: https://www.portalbridge.com/sui
- Tested that Sui Explorer uses the device ID from above correctly

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
