### PR TITLE
sui cli: support ssfn config generation

### DIFF
--- a/crates/sui-config/src/lib.rs
+++ b/crates/sui-config/src/lib.rs
@@ -53,6 +53,10 @@ pub fn validator_config_file(i: usize) -> String {
     format!("validator-config-{}.yaml", i)
 }
 
+pub fn ssfn_config_file(i: usize) -> String {
+    format!("ssfn-config-{}.yaml", i)
+}
+
 pub trait Config
 where
     Self: DeserializeOwned + Serialize,

--- a/crates/sui-swarm-config/src/genesis_config.rs
+++ b/crates/sui-swarm-config/src/genesis_config.rs
@@ -19,6 +19,12 @@ use sui_types::crypto::{
 use sui_types::multiaddr::Multiaddr;
 use tracing::info;
 
+// All information needed to build a NodeConfig for a state sync fullnode.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SsfnGenesisConfig {
+    pub p2p_address: Multiaddr,
+}
+
 // All information needed to build a NodeConfig for a validator.
 #[derive(Serialize, Deserialize)]
 pub struct ValidatorGenesisConfig {
@@ -154,6 +160,7 @@ impl ValidatorGenesisConfigBuilder {
 
 #[derive(Serialize, Deserialize, Default)]
 pub struct GenesisConfig {
+    pub ssfn_config_info: Option<Vec<SsfnGenesisConfig>>,
     pub validator_config_info: Option<Vec<ValidatorGenesisConfig>>,
     pub parameters: GenesisCeremonyParameters,
     pub accounts: Vec<AccountConfig>,
@@ -309,6 +316,7 @@ impl GenesisConfig {
 
         // Make a new genesis configuration.
         GenesisConfig {
+            ssfn_config_info: None,
             validator_config_info: Some(validator_config_info),
             parameters,
             accounts: vec![account_config],

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -2,6 +2,7 @@
 source: crates/sui-swarm-config/tests/snapshot_tests.rs
 expression: genesis_config
 ---
+ssfn_config_info: ~
 validator_config_info: ~
 parameters:
   chain_start_timestamp_ms: 0

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -381,7 +381,6 @@ async fn genesis(
     let network_path = sui_config_dir.join(SUI_NETWORK_CONFIG);
     let genesis_path = sui_config_dir.join(SUI_GENESIS_FILENAME);
 
-    // genesis_conf is read from genesis.yaml - that's the place we probably want to grab the new ssfn configs from
     let mut genesis_conf = match from_config {
         Some(path) => PersistedConfig::read(&path)?,
         None => {
@@ -453,8 +452,8 @@ async fn genesis(
 
     fullnode_config.save(sui_config_dir.join(SUI_FULLNODE_CONFIG))?;
     let mut ssfn_nodes = vec![];
-    if ssfn_info.is_some() {
-        for (i, ssfn) in ssfn_info.unwrap().into_iter().enumerate() {
+    if let Some(ssfn_info) = ssfn_info {
+        for (i, ssfn) in ssfn_info.into_iter().enumerate() {
             let path = sui_config_dir.join(sui_config::ssfn_config_file(i));
             // join base fullnode config with each SsfnGenesisConfig entry
             let ssfn_config = FullnodeConfigBuilder::new()

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -16,6 +16,7 @@ use std::io::{stderr, stdout, Write};
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::{fs, io};
+use sui_config::p2p::SeedPeer;
 use sui_config::{
     sui_config_dir, Config, PersistedConfig, FULL_NODE_DB_PATH, SUI_CLIENT_CONFIG,
     SUI_FULLNODE_CONFIG, SUI_NETWORK_CONFIG,
@@ -379,6 +380,7 @@ async fn genesis(
     let network_path = sui_config_dir.join(SUI_NETWORK_CONFIG);
     let genesis_path = sui_config_dir.join(SUI_GENESIS_FILENAME);
 
+    // genesis_conf is read from genesis.yaml - that's the place we probably want to grab the new ssfn configs from
     let mut genesis_conf = match from_config {
         Some(path) => PersistedConfig::read(&path)?,
         None => {
@@ -408,6 +410,8 @@ async fn genesis(
     }
 
     let validator_info = genesis_conf.validator_config_info.take();
+    let ssfn_info = genesis_conf.ssfn_config_info.take();
+
     let builder = ConfigBuilder::new(sui_config_dir);
     if let Some(epoch_duration_ms) = epoch_duration_ms {
         genesis_conf.parameters.epoch_duration_ms = epoch_duration_ms;
@@ -447,14 +451,49 @@ async fn genesis(
         .build(&mut OsRng, &network_config);
 
     fullnode_config.save(sui_config_dir.join(SUI_FULLNODE_CONFIG))?;
+    let mut ssfn_nodes = vec![];
+    if ssfn_info.is_some() {
+        for (i, ssfn) in ssfn_info.unwrap().into_iter().enumerate() {
+            let path = sui_config_dir.join(sui_config::ssfn_config_file(i));
+            // join base fullnode config with each SsfnGenesisConfig entry
+            let ssfn_config = FullnodeConfigBuilder::new()
+                .with_config_directory(FULL_NODE_DB_PATH.into())
+                .with_p2p_external_address(ssfn.p2p_address)
+                .build(&mut OsRng, &network_config);
+            ssfn_nodes.push(ssfn_config.clone());
+            ssfn_config.save(path)?;
+        }
 
-    for (i, validator) in network_config
-        .into_validator_configs()
-        .into_iter()
-        .enumerate()
-    {
-        let path = sui_config_dir.join(sui_config::validator_config_file(i));
-        validator.save(path)?;
+        let ssfn_seed_peers: Vec<SeedPeer> = ssfn_nodes
+            .iter()
+            .map(|config| SeedPeer {
+                peer_id: Some(anemo::PeerId(
+                    config.network_key_pair().public().0.to_bytes(),
+                )),
+                address: config.p2p_config.external_address.clone().unwrap(),
+            })
+            .collect();
+
+        for (i, mut validator) in network_config
+            .into_validator_configs()
+            .into_iter()
+            .enumerate()
+        {
+            let path = sui_config_dir.join(sui_config::validator_config_file(i));
+            let mut val_p2p = validator.p2p_config.clone();
+            val_p2p.seed_peers = ssfn_seed_peers.clone();
+            validator.p2p_config = val_p2p;
+            validator.save(path)?;
+        }
+    } else {
+        for (i, validator) in network_config
+            .into_validator_configs()
+            .into_iter()
+            .enumerate()
+        {
+            let path = sui_config_dir.join(sui_config::validator_config_file(i));
+            validator.save(path)?;
+        }
     }
 
     let mut client_config = if client_path.exists() {

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -16,6 +16,7 @@ use std::io::{stderr, stdout, Write};
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::{fs, io};
+use sui_config::node::Genesis;
 use sui_config::p2p::SeedPeer;
 use sui_config::{
     sui_config_dir, Config, PersistedConfig, FULL_NODE_DB_PATH, SUI_CLIENT_CONFIG,
@@ -459,6 +460,13 @@ async fn genesis(
             let ssfn_config = FullnodeConfigBuilder::new()
                 .with_config_directory(FULL_NODE_DB_PATH.into())
                 .with_p2p_external_address(ssfn.p2p_address)
+                .with_p2p_listen_address("0.0.0.0:8084".parse().unwrap())
+                .with_db_path(PathBuf::from("/opt/sui/db/authorities_db/full_node_db"))
+                .with_network_address("/ip4/0.0.0.0/tcp/8080/http".parse().unwrap())
+                .with_metrics_address("0.0.0.0:9184".parse().unwrap())
+                .with_admin_interface_port(1337)
+                .with_json_rpc_address("0.0.0.0:9000".parse().unwrap())
+                .with_genesis(Genesis::new_from_file("/opt/sui/config/genesis.blob"))
                 .build(&mut OsRng, &network_config);
             ssfn_nodes.push(ssfn_config.clone());
             ssfn_config.save(path)?;


### PR DESCRIPTION
## Description 

Adding state sync fullnodes to internal test networks means needing a set of up-to-date peer ids within both validator configs and ssfn configs, eg:
**ssfn-config-0.yaml**
```
p2p-config:
  listen-address: "0.0.0.0:8084"
  external-address: /dns/lax-ssfn-2.ci.sui.io/udp/8084
  seed-peers:
    - peer-id: 61ff2d5b789815986984f132404bc81ca7e0d7aedfb5d6dea94d477ee2dfbd2a
      address: /dns/lax-suival-f9471.ci.sui.io/udp/8084
    - peer-id: a1df08a64bec30bddfed076c038d5104b0dcb03932c58128c4aa073c1a068f2f
      address: /dns/lax-suival-add2f.ci.sui.io/udp/8084
    - peer-id: c7cd54ebfed347df9831ebbf690711ba628cf9ca02aa2e5388907b918be6de8f
```

**validator-config-0.yaml**
```
p2p-config:
  listen-address: "0.0.0.0:8084"
  external-address: /dns/lax-suival-f9471.ci.sui.io/udp/8084
  seed-peers:
    - peer-id: c9f0aae2d154496c36c581fd0c4c4f1e6c996df754ebb82eaa1547f549d62158
      address: /dns/lax-ssfn-2.ci.sui.io/udp/8084
    - peer-id: 440ec833f766fc9159c48aa8bc8b21a4885a4db2fc356921e7f33cda5cb3b39c
      address: /dns/lax-ssfn-1.ci.sui.io/udp/8084
```

This PR supports generating the two sets of peer-ids, it also makes `FullnodeConfigBuilder::new()` a bit more flexible with regard to supporting different input generation.

## Test Plan 

I'll test this works with an internal network before shipping 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Adding support for an optional `ssfn_config_info` to the `sui genesis --from-config genesis.yaml` cli command. Using the additional `ssfn_config_info:`, a list of ssfn hosts can be passed to the `sui genesis` cli, creating `ssfn-config-0.yaml` files which be used by state sync fullnodes. 