### PR TITLE
[easy/chore] Use `range_iter ` over `unbounded_iter `

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -666,9 +666,7 @@ impl AuthorityPerEpochStore {
         Ok(self
             .tables
             .state_hash_by_checkpoint
-            .unbounded_iter()
-            .skip_to(&from_checkpoint)?
-            .take_while(|(checkpoint, _)| *checkpoint <= to_checkpoint)
+            .range_iter(from_checkpoint..=to_checkpoint)
             .collect())
     }
 

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -314,9 +314,7 @@ impl AuthorityStore {
         let data = self
             .perpetual_tables
             .events
-            .unbounded_iter()
-            .skip_to(&(*event_digest, 0))?
-            .take_while(|((digest, _), _)| digest == event_digest)
+            .range_iter((*event_digest, 0)..=(*event_digest, usize::MAX))
             .map(|(_, e)| e)
             .collect::<Vec<_>>();
         Ok(data.is_empty().not().then_some(TransactionEvents { data }))


### PR DESCRIPTION
## Description 

Use `range_iter ` over `unbounded_iter ` in parts of authority

## Test Plan 

Normal tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
