### PR TITLE
[ts][bcs] fix nested type parsing in BCS

### DIFF
--- a/.changeset/beige-sheep-draw.md
+++ b/.changeset/beige-sheep-draw.md
@@ -1,0 +1,5 @@
+---
+"@mysten/bcs": patch
+---
+
+Fix an issue with parsing struct types with nested type parameters

--- a/sdk/bcs/src/index.ts
+++ b/sdk/bcs/src/index.ts
@@ -1421,12 +1421,40 @@ export class BCS {
     }
 
     let typeName = name.slice(0, l_bound);
-    let params = name
-      .slice(l_bound + 1, name.length - r_bound - 1)
-      .split(",")
-      .map((e) => e.trim());
+    let params = this.splitArgsWithinGenericSep(
+      name.slice(l_bound + 1, name.length - r_bound - 1)
+    );
 
     return { name: typeName, params };
+  }
+
+  // split `str` by all `,` outside generic separators
+  // e.g. `T, U<A, B>` -> `[ 'T', 'U<A, B>' ]`
+  splitArgsWithinGenericSep(str: string): string[] {
+    const [left, right] = this.schema.genericSeparators || ["<", ">"];
+
+    const tok = [];
+    let word = "";
+    let nestedAngleBrackets = 0;
+    for (let i = 0; i < str.length; i++) {
+      const char = str[i];
+      if (char === left) {
+        nestedAngleBrackets++;
+      }
+      if (char === right) {
+        nestedAngleBrackets--;
+      }
+      if (nestedAngleBrackets == 0 && char === ',') {
+        tok.push(word.trim());
+        word = '';
+        continue;
+      }
+      word += char;
+    }
+
+    tok.push(word.trim());
+
+    return tok;
   }
 }
 

--- a/sdk/bcs/tests/parse-type-name.test.ts
+++ b/sdk/bcs/tests/parse-type-name.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+
+import { BCS, getSuiMoveConfig } from "../src";
+
+describe("parseTypeName", () => {
+  it("parses nested struct type from a string", () => {
+    const bcs = new BCS(getSuiMoveConfig());
+
+    const type = "0x5::foo::Foo<0x5::bar::Bar, 0x6::amm::LP<0x2::sui::SUI, 0x7::example_coin::EXAMPLE_COIN>>";
+    expect(bcs.parseTypeName(type)).toEqual(
+      {
+        name: "0x5::foo::Foo",
+        params: [
+          "0x5::bar::Bar",
+          "0x6::amm::LP<0x2::sui::SUI, 0x7::example_coin::EXAMPLE_COIN>"
+        ]
+      }
+    );
+  })
+})


### PR DESCRIPTION
## Description 

Fixed a problem in `parseTypeName` method in BCS where it naively assumes that type's type args aren't nested and just splits them by `,` causing the nested types to be improperly split.

E.g. parsing the type `0x5::foo::Foo<0x5::bar::Bar, 0x6::amm::LP<0x2::sui::SUI, 0x7::example_coin::EXAMPLE_COIN>>` would result in:
```
{
  name: '0x5::foo::Foo',
  params: [
    '0x5::bar::Bar',
    '0x6::amm::LP<0x2::sui::SUI',
    '0x7::example_coin::EXAMPLE_COIN>',
  ],
}
```

instead of
```
{
  name: "0x5::foo::Foo",
  params: [
    "0x5::bar::Bar",
    "0x6::amm::LP<0x2::sui::SUI, 0x7::example_coin::EXAMPLE_COIN>"
  ]
}
```

cc @damirka 

## Test Plan 

Added a unit test.
