### PR TITLE
[Kiosk SDK] Query all kiosk contents on `fetchKiosk`

### DIFF
--- a/.changeset/brown-trains-arrive.md
+++ b/.changeset/brown-trains-arrive.md
@@ -1,0 +1,5 @@
+---
+"@mysten/kiosk": patch
+---
+
+Refactor the fetchKiosk function to return all content instead of paginating, to prevent missing data

--- a/sdk/kiosk/README.md
+++ b/sdk/kiosk/README.md
@@ -33,20 +33,14 @@ const provider = new JsonRpcProvider(
 const getKiosk = async () => {
   const kioskAddress = `0xSomeKioskAddress`;
 
-  const {
-    data: res,
-    nextCursor,
-    hasNextPage,
-  } = await fetchKiosk(
+  const { data } = await fetchKiosk(
     provider,
     kioskAddress,
-    { limit: 100 },
+    {}, // empty pagination, currently disabled.
     { withListingPrices: true, withKioskFields: true },
-  ); // could also add `cursor` for pagination
+  );
 
-  console.log(res); // { items: [],  itemIds: [],  listingIds: [], kiosk: {...} }
-  console.log(nextCursor); // null
-  console.log(hasNextPage); // false
+  console.log(data); // { items: [],  itemIds: [],  listingIds: [], kiosk: {...} }
 };
 ```
 

--- a/sdk/kiosk/src/query/kiosk.ts
+++ b/sdk/kiosk/src/query/kiosk.ts
@@ -81,7 +81,7 @@ export async function fetchKiosk(
   // TODO: Replace the `getAllDynamicFields` with a paginated
   // response, once we have better RPC support for
   // type filtering & batch fetching.
-  // This can't work otherwise.
+  // This can't work with pagination currently.
   const data = await getAllDynamicFields(provider, kioskId, pagination);
 
   const listings: KioskListing[] = [];

--- a/sdk/kiosk/src/query/kiosk.ts
+++ b/sdk/kiosk/src/query/kiosk.ts
@@ -12,6 +12,7 @@ import {
   attachListingsAndPrices,
   attachLockedItems,
   extractKioskData,
+  getAllDynamicFields,
   getKioskObject,
 } from '../utils';
 import { Kiosk } from '../types';
@@ -77,10 +78,11 @@ export async function fetchKiosk(
   pagination: PaginationArguments<string>,
   options: FetchKioskOptions,
 ): Promise<PagedKioskData> {
-  const { data, nextCursor, hasNextPage } = await provider.getDynamicFields({
-    parentId: kioskId,
-    ...pagination,
-  });
+  // TODO: Replace the `getAllDynamicFields` with a paginated
+  // response, once we have better RPC support for
+  // type filtering & batch fetching.
+  // This can't work otherwise.
+  const data = await getAllDynamicFields(provider, kioskId, pagination);
 
   const listings: KioskListing[] = [];
   const lockedItemIds: ObjectId[] = [];
@@ -113,7 +115,7 @@ export async function fetchKiosk(
 
   return {
     data: kioskData,
-    nextCursor,
-    hasNextPage,
+    nextCursor: null,
+    hasNextPage: false,
   };
 }

--- a/sdk/kiosk/src/utils.ts
+++ b/sdk/kiosk/src/utils.ts
@@ -4,6 +4,7 @@
 import {
   JsonRpcProvider,
   ObjectId,
+  PaginationArguments,
   SharedObjectRef,
   SuiObjectRef,
   SuiObjectResponse,
@@ -185,4 +186,32 @@ export function getRulePackageAddress(
     return environment.address;
   }
   return rulesPackageAddresses[environment.env];
+}
+
+/**
+ * A helper to fetch all DF pages.
+ * We need that to fetch the kiosk DFs consistently, until we have
+ * RPC calls that allow filtering of Type / batch fetching of spec
+ */
+export async function getAllDynamicFields(
+  provider: JsonRpcProvider,
+  parentId: ObjectId,
+  pagination: PaginationArguments<string>,
+) {
+  let hasNextPage = true;
+  let cursor = undefined;
+  const data: DynamicFieldInfo[] = [];
+
+  while (hasNextPage) {
+    const result = await provider.getDynamicFields({
+      parentId,
+      limit: pagination.limit || undefined,
+      cursor,
+    });
+    data.push(...result.data);
+    hasNextPage = result.hasNextPage;
+    cursor = result.nextCursor;
+  }
+
+  return data;
 }


### PR DESCRIPTION
## Description 

Change the `fetchKiosk` function to return all kiosk contents.

That's the most query-efficient way to get the full contents of a kiosk, including the locked items, listings etc, without any missing data.

We can't offer pagination before there's availability for type filtering.

## Test Plan 

How did you test the new or updated feature?

Used on Kiosk demo dapp.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
