### PR TITLE
[refactor] using instead of unbounded iterators ranges

### DIFF
--- a/narwhal/storage/src/certificate_store.rs
+++ b/narwhal/storage/src/certificate_store.rs
@@ -487,8 +487,6 @@ impl<T: Cache> CertificateStore<T> {
     /// Retrieves all the certificates with round >= the provided round.
     /// The result is returned with certificates sorted in round asc order
     pub fn after_round(&self, round: Round) -> StoreResult<Vec<Certificate>> {
-        // Skip to a row at or before the requested round.
-        // TODO: Add a more efficient seek method to typed store.
         let digests = self
             .certificate_id_by_round
             .iter_with_bounds(Some((round, AuthorityIdentifier::default())), None)
@@ -515,8 +513,6 @@ impl<T: Cache> CertificateStore<T> {
         &self,
         round: Round,
     ) -> StoreResult<BTreeMap<Round, Vec<AuthorityIdentifier>>> {
-        // Skip to a row at or before the requested round.
-        // TODO: Add a more efficient seek method to typed store.
         let iter = self
             .certificate_id_by_round
             .iter_with_bounds(Some((round, AuthorityIdentifier::default())), None);

--- a/narwhal/storage/src/consensus_store.rs
+++ b/narwhal/storage/src/consensus_store.rs
@@ -137,15 +137,13 @@ impl ConsensusStore {
         // start from the previous table first to ensure we haven't missed anything.
         let mut sub_dags = self
             .committed_sub_dags_by_index
-            .unbounded_iter()
-            .skip_to(from)?
+            .iter_with_bounds(Some(*from), None)
             .map(|(_, sub_dag)| ConsensusCommit::V1(sub_dag))
             .collect::<Vec<ConsensusCommit>>();
 
         sub_dags.extend(
             self.committed_sub_dags_by_index_v2
-                .unbounded_iter()
-                .skip_to(from)?
+                .iter_with_bounds(Some(*from), None)
                 .map(|(_, sub_dag)| sub_dag)
                 .collect::<Vec<ConsensusCommit>>(),
         );


### PR DESCRIPTION
## Description 

Follow recent recommendations of avoiding unbounded iterations this PR is converting some iterators to range ones (although they do expand to an open upper bound it's still valuable to define via ranges)

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
