### PR TITLE
indexer: exact tx count

### DIFF
--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -718,14 +718,21 @@ where
 
             let event = event.as_ref();
 
+            let last_epoch = system_state.epoch as i64 - 1;
+            let network_tx_count_prev_epoch = self
+                .state
+                .count_network_transaction_previous_epoch(last_epoch)
+                .await?;
+
             Some(TemporaryEpochStore {
                 last_epoch: Some(DBEpochInfo {
-                    epoch: system_state.epoch as i64 - 1,
+                    epoch: last_epoch,
                     first_checkpoint_id: 0,
                     last_checkpoint_id: Some(checkpoint.sequence_number as i64),
                     epoch_start_timestamp: 0,
                     epoch_end_timestamp: Some(checkpoint.timestamp_ms as i64),
-                    epoch_total_transactions: 0,
+                    epoch_total_transactions: checkpoint.network_total_transactions as i64
+                        - network_tx_count_prev_epoch,
                     next_epoch_version: Some(
                         end_of_epoch_data.next_epoch_protocol_version.as_u64() as i64,
                     ),

--- a/crates/sui-indexer/src/store/indexer_store.rs
+++ b/crates/sui-indexer/src/store/indexer_store.rs
@@ -235,6 +235,10 @@ pub trait IndexerStore {
     ) -> Result<(), IndexerError>;
 
     async fn persist_epoch(&self, data: &TemporaryEpochStore) -> Result<(), IndexerError>;
+    async fn count_network_transaction_previous_epoch(
+        &self,
+        epoch: i64,
+    ) -> Result<i64, IndexerError>;
 
     async fn get_epochs(
         &self,

--- a/crates/sui-indexer/src/store/pg_indexer_store.rs
+++ b/crates/sui-indexer/src/store/pg_indexer_store.rs
@@ -1337,12 +1337,13 @@ impl IndexerStore for PgIndexerStore {
         object_deletion_latency: Histogram,
     ) -> Result<(), IndexerError> {
         transactional_blocking!(&self.blocking_cp, |conn| {
-            // update epoch transaction count
+            // update epoch transaction count within an epoch;
+            // do no update after end-of-epoch commit to avoid double counting
             let sql = "UPDATE epochs e1
-SET epoch_total_transactions = e2.epoch_total_transactions + $1
-FROM epochs e2
-WHERE e1.epoch = e2.epoch
-  AND e1.epoch = $2;";
+                        SET epoch_total_transactions = e2.epoch_total_transactions + $1
+                        FROM epochs e2
+                        WHERE e1.epoch = e2.epoch
+                        AND e1.epoch = $2 AND e1.last_checkpoint_id != 0;";
             diesel::sql_query(sql)
                 .bind::<BigInt, _>(checkpoint.transactions.len() as i64)
                 .bind::<BigInt, _>(checkpoint.epoch)
@@ -1497,6 +1498,20 @@ WHERE e1.epoch = e2.epoch
         Ok(())
     }
 
+    async fn count_network_transaction_previous_epoch(
+        &self,
+        epoch: i64,
+    ) -> Result<i64, IndexerError> {
+        read_only_blocking!(&self.blocking_cp, |conn| {
+            checkpoints::table
+                .filter(checkpoints::epoch.eq(epoch - 1))
+                .select(max(checkpoints::network_total_transactions))
+                .first::<Option<i64>>(conn)
+                .map(|o| o.unwrap_or(0))
+        })
+        .context("Failed to count network transactions in previous epoch")
+    }
+
     async fn persist_epoch(&self, data: &TemporaryEpochStore) -> Result<(), IndexerError> {
         // MUSTFIX(gegaowp): temporarily disable the epoch advance logic.
         // let last_epoch_cp_id = if data.last_epoch.is_none() {
@@ -1510,8 +1525,8 @@ WHERE e1.epoch = e2.epoch
                 .advance_epoch(&data.new_epoch, last_epoch_cp_id)
                 .await?;
         }
-        let epoch = data.new_epoch.epoch;
-        info!("Persisting epoch {}", epoch);
+        let last_epoch_number = data.new_epoch.epoch;
+        info!("Persisting epoch {}", last_epoch_number);
 
         transactional_blocking!(&self.blocking_cp, |conn| {
             if let Some(last_epoch) = &data.last_epoch {
@@ -1559,7 +1574,7 @@ WHERE e1.epoch = e2.epoch
                 .on_conflict_do_nothing()
                 .execute(conn)
         })?;
-        info!("Persisted epoch {}", epoch);
+        info!("Persisted epoch {}", last_epoch_number);
         Ok(())
     }
 


### PR DESCRIPTION
## Description 

Before this PR, tx count was updated within an epoch. This is problematic on backfill when data racing happens, as a result, epoch tx count is not accurate.

This PR fixed that using the `network_total_transaction` such that
1. at the end of epoch, it always calculate accurate epoch tx count
2. after end of epoch, the tx count will not be updated any more, even with delayed commits

## Test Plan 

Build image and test with mainnet, verify in the DB.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
