### PR TITLE
[sui-execution] Scaffold script to automate cutting new features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,7 +172,7 @@ dependencies = [
  "anemo-build",
  "anemo-tower",
  "anyhow",
- "clap 4.1.4",
+ "clap 4.3.1",
  "mysten-network",
  "rand 0.8.5",
  "sui-types",
@@ -201,7 +201,7 @@ dependencies = [
  "anemo",
  "anemo-tower",
  "bytes",
- "clap 4.1.4",
+ "clap 4.3.1",
  "dashmap",
  "rand 0.8.5",
  "tokio",
@@ -243,10 +243,59 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.69"
+name = "anstream"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 dependencies = [
  "backtrace",
 ]
@@ -1724,17 +1773,26 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.4"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
+checksum = "b4ed2379f8603fa2b7509891660e802b88c70a79a6427a70abb5968054de2c28"
 dependencies = [
- "bitflags",
- "clap_derive 4.1.0",
- "clap_lex 0.3.1",
- "is-terminal",
+ "clap_builder",
+ "clap_derive 4.3.1",
  "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72394f3339a76daf211e57d4bcb374410f3965dcc606dd0e03738c7888766980"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
+ "clap_lex 0.5.0",
  "strsim 0.10.0",
- "termcolor",
 ]
 
 [[package]]
@@ -1752,15 +1810,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.1.0"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
+checksum = "59e9ef9a08ee1c0e1f2e162121665ac45ac3783b0f897db7244ae75ad9a8f65b"
 dependencies = [
  "heck 0.4.0",
- "proc-macro-error",
  "proc-macro2 1.0.58",
  "quote 1.0.26",
- "syn 1.0.107",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -1780,6 +1837,12 @@ checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "clear_on_drop"
@@ -1827,6 +1890,12 @@ name = "collectable"
 version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08abddbaad209601e53c7dd4308d8c04c06f17bb7df006434e586a22b83be45a"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colored"
@@ -1884,7 +1953,7 @@ dependencies = [
  "serde 1.0.152",
  "serde-hjson",
  "serde_json",
- "toml",
+ "toml 0.5.10",
  "yaml-rust",
 ]
 
@@ -2559,7 +2628,7 @@ dependencies = [
  "petgraph 0.6.2",
  "rayon",
  "serde 1.0.152",
- "toml",
+ "toml 0.5.10",
 ]
 
 [[package]]
@@ -3609,7 +3678,7 @@ dependencies = [
  "smallvec",
  "static_assertions",
  "target-spec",
- "toml",
+ "toml 0.5.10",
 ]
 
 [[package]]
@@ -3624,7 +3693,7 @@ dependencies = [
  "guppy-workspace-hack",
  "semver 1.0.16",
  "serde 1.0.152",
- "toml",
+ "toml 0.5.10",
 ]
 
 [[package]]
@@ -3675,7 +3744,7 @@ dependencies = [
  "serde 1.0.152",
  "tabular",
  "target-spec",
- "toml",
+ "toml 0.5.10",
  "toml_edit 0.15.0",
  "twox-hash",
 ]
@@ -4716,7 +4785,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c493c09323068c01e54c685f7da41a9ccf9219735c3766fbfd6099806ea08fbc"
 dependencies = [
  "serde 1.0.152",
- "toml",
+ "toml 0.5.10",
 ]
 
 [[package]]
@@ -5210,7 +5279,7 @@ dependencies = [
  "serde_yaml",
  "sha2 0.9.9",
  "tempfile",
- "toml",
+ "toml 0.5.10",
  "walkdir",
  "whoami",
 ]
@@ -5258,7 +5327,7 @@ dependencies = [
  "serde_json",
  "simplelog",
  "tokio",
- "toml",
+ "toml 0.5.10",
 ]
 
 [[package]]
@@ -5538,7 +5607,7 @@ dependencies = [
  "socket2 0.4.9",
  "tap",
  "tokio-util 0.7.7",
- "toml",
+ "toml 0.5.10",
  "tracing",
  "tracing-subscriber 0.3.16",
 ]
@@ -6179,7 +6248,7 @@ dependencies = [
  "nexlint",
  "regex",
  "serde 1.0.152",
- "toml",
+ "toml 0.5.10",
 ]
 
 [[package]]
@@ -7171,7 +7240,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
 dependencies = [
  "thiserror",
- "toml",
+ "toml 0.5.10",
 ]
 
 [[package]]
@@ -8529,6 +8598,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
+dependencies = [
+ "serde 1.0.152",
+]
+
+[[package]]
 name = "serde_test"
 version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9499,6 +9577,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sui-execution-cut"
+version = "0.1.0"
+dependencies = [
+ "clap 4.3.1",
+ "expect-test",
+ "tempfile",
+ "thiserror",
+ "toml 0.7.4",
+]
+
+[[package]]
 name = "sui-faucet"
 version = "1.4.0"
 dependencies = [
@@ -10095,7 +10184,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "bcs",
- "clap 4.1.4",
+ "clap 4.3.1",
  "colored",
  "futures",
  "jsonrpsee",
@@ -10553,7 +10642,7 @@ dependencies = [
  "anemo-cli",
  "anyhow",
  "bcs",
- "clap 4.1.4",
+ "clap 4.3.1",
  "colored",
  "comfy-table",
  "eyre",
@@ -11051,22 +11140,22 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2 1.0.58",
  "quote 1.0.26",
- "syn 1.0.107",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -11306,10 +11395,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6135d499e69981f9ff0ef2167955a5333c35e36f6937d382974566b3d5b94ec"
+dependencies = [
+ "indexmap",
+ "serde 1.0.152",
+ "serde_spanned",
+ "toml_datetime 0.6.2",
+ "toml_edit 0.19.10",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4553f467ac8e3d374bc9a177a26801e5d0f9b211aa1673fb137a403afd1c9cf5"
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
+dependencies = [
+ "serde 1.0.152",
+]
 
 [[package]]
 name = "toml_edit"
@@ -11332,7 +11443,20 @@ dependencies = [
  "combine",
  "indexmap",
  "itertools",
- "toml_datetime",
+ "toml_datetime 0.5.1",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
+dependencies = [
+ "indexmap",
+ "serde 1.0.152",
+ "serde_spanned",
+ "toml_datetime 0.6.2",
+ "winnow",
 ]
 
 [[package]]
@@ -12345,6 +12469,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
+name = "winnow"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12483,9 +12616,9 @@ dependencies = [
  "clang-sys",
  "clap 2.34.0",
  "clap 3.2.23",
- "clap 4.1.4",
+ "clap 4.3.1",
  "clap_derive 3.2.18",
- "clap_derive 4.1.0",
+ "clap_derive 4.3.1",
  "clap_lex 0.2.4",
  "clap_lex 0.3.1",
  "clear_on_drop",
@@ -13109,8 +13242,8 @@ dependencies = [
  "tokio-rustls",
  "tokio-stream",
  "tokio-util 0.7.4",
- "toml",
- "toml_datetime",
+ "toml 0.5.10",
+ "toml_datetime 0.5.1",
  "toml_edit 0.14.4",
  "toml_edit 0.15.0",
  "tonic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1831,15 +1831,6 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
-dependencies = [
- "os_str_bytes",
-]
-
-[[package]]
-name = "clap_lex"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
@@ -9585,6 +9576,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "toml 0.7.4",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -12509,6 +12501,11 @@ dependencies = [
  "anemo-tower",
  "anes",
  "ansi_term",
+ "anstream",
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
  "anyhow",
  "arbitrary",
  "arc-swap",
@@ -12617,15 +12614,17 @@ dependencies = [
  "clap 2.34.0",
  "clap 3.2.23",
  "clap 4.3.1",
+ "clap_builder",
  "clap_derive 3.2.18",
  "clap_derive 4.3.1",
  "clap_lex 0.2.4",
- "clap_lex 0.3.1",
+ "clap_lex 0.5.0",
  "clear_on_drop",
  "clipboard-win",
  "codespan",
  "codespan-reporting",
  "collectable",
+ "colorchoice",
  "colored",
  "colored-diff",
  "combine",
@@ -13149,6 +13148,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_repr",
+ "serde_spanned",
  "serde_test",
  "serde_urlencoded",
  "serde_with",
@@ -13243,9 +13243,12 @@ dependencies = [
  "tokio-stream",
  "tokio-util 0.7.4",
  "toml 0.5.10",
+ "toml 0.7.4",
  "toml_datetime 0.5.1",
+ "toml_datetime 0.6.2",
  "toml_edit 0.14.4",
  "toml_edit 0.15.0",
+ "toml_edit 0.19.10",
  "tonic",
  "tonic-build",
  "tonic-health",
@@ -13326,6 +13329,7 @@ dependencies = [
  "windows-targets 0.48.0",
  "windows_x86_64_msvc 0.42.2",
  "windows_x86_64_msvc 0.48.0",
+ "winnow",
  "winreg",
  "wyz",
  "x509-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,7 @@ members = [
     "narwhal/types",
     "narwhal/worker",
     "sui-execution",
+    "sui-execution/cut",
     "sui-execution/latest/sui-adapter",
     "sui-execution/latest/sui-move-natives",
     "sui-execution/latest/sui-verifier",

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -32,6 +32,10 @@ anemo-cli = { git = "https://github.com/mystenlabs/anemo.git", rev = "0f0ae8d8f2
 anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "0f0ae8d8f222820a20b586088ea7a2941478a159", default-features = false }
 anes = { version = "0.1" }
 ansi_term = { version = "0.12", default-features = false }
+anstream = { version = "0.3" }
+anstyle = { version = "1" }
+anstyle-parse = { version = "0.2" }
+anstyle-query = { version = "1", default-features = false }
 anyhow = { version = "1", features = ["backtrace"] }
 arbitrary = { version = "1", default-features = false, features = ["derive_arbitrary"] }
 arc-swap = { version = "1", default-features = false, features = ["serde"] }
@@ -122,12 +126,14 @@ cipher = { version = "0.4", default-features = false, features = ["block-padding
 clap-164d15cefe24d7eb = { package = "clap", version = "4", features = ["derive"] }
 clap-7b89eefb6aaa9bf3 = { package = "clap", version = "3", features = ["derive"] }
 clap-f595c2ba2a3f28df = { package = "clap", version = "2" }
-clap_lex-468e82937335b1c9 = { package = "clap_lex", version = "0.3", default-features = false }
+clap_builder = { version = "4", default-features = false, features = ["color", "help", "std", "suggestions", "usage"] }
 clap_lex-6f8ce4dd05d13bba = { package = "clap_lex", version = "0.2", default-features = false }
+clap_lex-d8f496e17d97b5cb = { package = "clap_lex", version = "0.5", default-features = false }
 clear_on_drop = { version = "0.2", default-features = false }
 codespan = { version = "0.11", default-features = false, features = ["serialization"] }
 codespan-reporting = { version = "0.11", default-features = false, features = ["serialization"] }
 collectable = { version = "0.0.2", default-features = false }
+colorchoice = { version = "1", default-features = false }
 colored = { version = "2", default-features = false }
 colored-diff = { version = "0.2", default-features = false }
 combine = { version = "4" }
@@ -535,6 +541,7 @@ serde-value = { version = "0.7", default-features = false }
 serde_bytes = { version = "0.11" }
 serde_json = { version = "1", features = ["alloc", "arbitrary_precision", "preserve_order", "raw_value", "unbounded_depth"] }
 serde_path_to_error = { version = "0.1", default-features = false }
+serde_spanned = { version = "0.6", default-features = false, features = ["serde"] }
 serde_test = { version = "1", default-features = false }
 serde_urlencoded = { version = "0.7", default-features = false }
 serde_with = { version = "2", features = ["hex"] }
@@ -610,10 +617,13 @@ tokio-retry = { version = "0.3", default-features = false }
 tokio-rustls = { version = "0.23" }
 tokio-stream = { version = "0.1", features = ["net", "sync"] }
 tokio-util = { version = "0.7", features = ["codec", "compat", "io"] }
-toml = { version = "0.5", features = ["preserve_order"] }
-toml_datetime = { version = "0.5", default-features = false }
+toml-ca01ad9e24f5d932 = { package = "toml", version = "0.7", features = ["preserve_order"] }
+toml-d8f496e17d97b5cb = { package = "toml", version = "0.5", features = ["preserve_order"] }
+toml_datetime-3b31131e45eafb45 = { package = "toml_datetime", version = "0.6", default-features = false, features = ["serde"] }
+toml_datetime-d8f496e17d97b5cb = { package = "toml_datetime", version = "0.5", default-features = false }
 toml_edit-3575ec1268b04181 = { package = "toml_edit", version = "0.15" }
 toml_edit-582f2526e08bb6a0 = { package = "toml_edit", version = "0.14", features = ["easy"] }
+toml_edit-cdcf2f9584511fe6 = { package = "toml_edit", version = "0.19", features = ["serde"] }
 tonic = { version = "0.8", features = ["tls"] }
 tonic-health = { version = "0.8" }
 tower = { version = "0.4", features = ["full"] }
@@ -669,6 +679,7 @@ web-sys = { version = "0.3", default-features = false, features = ["AddEventList
 webpki = { version = "0.22", default-features = false, features = ["std"] }
 webpki-roots = { version = "0.22", default-features = false }
 whoami = { version = "1" }
+winnow = { version = "0.4" }
 wyz = { version = "0.2", default-features = false, features = ["alloc"] }
 x509-parser = { version = "0.14" }
 xml-rs = { version = "0.8", default-features = false }
@@ -700,6 +711,10 @@ anemo-cli = { git = "https://github.com/mystenlabs/anemo.git", rev = "0f0ae8d8f2
 anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "0f0ae8d8f222820a20b586088ea7a2941478a159", default-features = false }
 anes = { version = "0.1" }
 ansi_term = { version = "0.12", default-features = false }
+anstream = { version = "0.3" }
+anstyle = { version = "1" }
+anstyle-parse = { version = "0.2" }
+anstyle-query = { version = "1", default-features = false }
 anyhow = { version = "1", features = ["backtrace"] }
 arbitrary = { version = "1", default-features = false, features = ["derive_arbitrary"] }
 arc-swap = { version = "1", default-features = false, features = ["serde"] }
@@ -807,14 +822,16 @@ clang-sys = { version = "1", default-features = false, features = ["clang_6_0", 
 clap-164d15cefe24d7eb = { package = "clap", version = "4", features = ["derive"] }
 clap-7b89eefb6aaa9bf3 = { package = "clap", version = "3", features = ["derive"] }
 clap-f595c2ba2a3f28df = { package = "clap", version = "2" }
+clap_builder = { version = "4", default-features = false, features = ["color", "help", "std", "suggestions", "usage"] }
 clap_derive-164d15cefe24d7eb = { package = "clap_derive", version = "4" }
 clap_derive-7b89eefb6aaa9bf3 = { package = "clap_derive", version = "3" }
-clap_lex-468e82937335b1c9 = { package = "clap_lex", version = "0.3", default-features = false }
 clap_lex-6f8ce4dd05d13bba = { package = "clap_lex", version = "0.2", default-features = false }
+clap_lex-d8f496e17d97b5cb = { package = "clap_lex", version = "0.5", default-features = false }
 clear_on_drop = { version = "0.2", default-features = false }
 codespan = { version = "0.11", default-features = false, features = ["serialization"] }
 codespan-reporting = { version = "0.11", default-features = false, features = ["serialization"] }
 collectable = { version = "0.0.2", default-features = false }
+colorchoice = { version = "1", default-features = false }
 colored = { version = "2", default-features = false }
 colored-diff = { version = "0.2", default-features = false }
 combine = { version = "4" }
@@ -1296,6 +1313,7 @@ serde_derive_internals = { version = "0.26", default-features = false }
 serde_json = { version = "1", features = ["alloc", "arbitrary_precision", "preserve_order", "raw_value", "unbounded_depth"] }
 serde_path_to_error = { version = "0.1", default-features = false }
 serde_repr = { version = "0.1", default-features = false }
+serde_spanned = { version = "0.6", default-features = false, features = ["serde"] }
 serde_test = { version = "1", default-features = false }
 serde_urlencoded = { version = "0.7", default-features = false }
 serde_with = { version = "2", features = ["hex"] }
@@ -1382,10 +1400,13 @@ tokio-retry = { version = "0.3", default-features = false }
 tokio-rustls = { version = "0.23" }
 tokio-stream = { version = "0.1", features = ["net", "sync"] }
 tokio-util = { version = "0.7", features = ["codec", "compat", "io"] }
-toml = { version = "0.5", features = ["preserve_order"] }
-toml_datetime = { version = "0.5", default-features = false }
+toml-ca01ad9e24f5d932 = { package = "toml", version = "0.7", features = ["preserve_order"] }
+toml-d8f496e17d97b5cb = { package = "toml", version = "0.5", features = ["preserve_order"] }
+toml_datetime-3b31131e45eafb45 = { package = "toml_datetime", version = "0.6", default-features = false, features = ["serde"] }
+toml_datetime-d8f496e17d97b5cb = { package = "toml_datetime", version = "0.5", default-features = false }
 toml_edit-3575ec1268b04181 = { package = "toml_edit", version = "0.15" }
 toml_edit-582f2526e08bb6a0 = { package = "toml_edit", version = "0.14", features = ["easy"] }
+toml_edit-cdcf2f9584511fe6 = { package = "toml_edit", version = "0.19", features = ["serde"] }
 tonic = { version = "0.8", features = ["tls"] }
 tonic-build = { version = "0.8" }
 tonic-health = { version = "0.8" }
@@ -1455,6 +1476,7 @@ webpki = { version = "0.22", default-features = false, features = ["std"] }
 webpki-roots = { version = "0.22", default-features = false }
 which = { version = "4", default-features = false }
 whoami = { version = "1" }
+winnow = { version = "0.4" }
 wyz = { version = "0.2", default-features = false, features = ["alloc"] }
 x509-parser = { version = "0.14" }
 xml-rs = { version = "0.8", default-features = false }
@@ -1630,6 +1652,7 @@ symbolic-demangle = { version = "10", default-features = false, features = ["cpp
 web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 
 [target.x86_64-pc-windows-msvc.dependencies]
+anstyle-wincon = { version = "1", default-features = false }
 clipboard-win = { version = "4", default-features = false }
 cpufeatures = { version = "0.2", default-features = false }
 crossterm_winapi-274715c4dabd11b0 = { package = "crossterm_winapi", version = "0.9", default-features = false }
@@ -1659,6 +1682,7 @@ windows_x86_64_msvc-c8eced492e86ede7 = { package = "windows_x86_64_msvc", versio
 winreg = { version = "0.10", default-features = false }
 
 [target.x86_64-pc-windows-msvc.build-dependencies]
+anstyle-wincon = { version = "1", default-features = false }
 clipboard-win = { version = "4", default-features = false }
 cpufeatures = { version = "0.2", default-features = false }
 crossterm_winapi-274715c4dabd11b0 = { package = "crossterm_winapi", version = "0.9", default-features = false }

--- a/sui-execution/cut/Cargo.toml
+++ b/sui-execution/cut/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 clap = { version = "4.3.1", features = ["derive"] }
 thiserror = "1.0.40"
 toml = { version = "0.7.4", features = ["preserve_order"] }
+workspace-hack = { version = "0.1", path = "../../crates/workspace-hack" }
 
 [dev-dependencies]
 expect-test = "1.4.0"

--- a/sui-execution/cut/Cargo.toml
+++ b/sui-execution/cut/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "sui-execution-cut"
+version = "0.1.0"
+edition = "2021"
+authors = ["Mysten Labs <build@mystenlabs.com>"]
+license = "Apache-2.0"
+publish = false
+
+[dependencies]
+clap = { version = "4.3.1", features = ["derive"] }
+thiserror = "1.0.40"
+toml = { version = "0.7.4", features = ["preserve_order"] }
+
+[dev-dependencies]
+expect-test = "1.4.0"
+tempfile = "3.3.0"
+
+[[bin]]
+name = "cut"
+path = "src/main.rs"

--- a/sui-execution/cut/src/args.rs
+++ b/sui-execution/cut/src/args.rs
@@ -67,7 +67,7 @@ impl FromStr for Directory {
     type Err = DirectoryParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut parts = s.split(":");
+        let mut parts = s.split(':');
 
         let Some(src_part) = parts.next() else {
             return Err(DirectoryParseError::NoSrc(s.to_string()))

--- a/sui-execution/cut/src/args.rs
+++ b/sui-execution/cut/src/args.rs
@@ -1,0 +1,156 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use clap::Parser;
+use std::env;
+use std::io;
+use std::path::PathBuf;
+use std::str::FromStr;
+use thiserror::Error;
+
+/// Tool for cutting duplicate versions of a subset of crates in a git repository.
+///
+/// Duplicated crate dependencies are redirected so that if a crate is duplicated with its
+/// dependency, the duplicate's dependency points to the duplicated dependency.  Package names are
+/// updated to avoid conflicts with their original. Duplicates respect membership or exclusion from
+/// a workspace.
+#[derive(Parser)]
+#[command(author, version, rename_all = "kebab-case")]
+pub(crate) struct Args {
+    /// Name of the feature the crates are being cut for -- duplicated crate package names will be
+    /// suffixed with a hyphen followed by this feature name.
+    #[arg(short, long)]
+    pub feature: String,
+
+    /// Root of repository -- all source and destination paths must be within this path, and it must
+    /// contain the repo's [workspace] configuration.  Defaults to the parent of the working
+    /// directory that contains a .git directory.
+    pub root: Option<PathBuf>,
+
+    /// Add a directory to duplicate crates from, along with the destination to duplicate it to, and
+    /// optionally a suffix to remove from package names within this directory, all separated by
+    /// colons.
+    ///
+    /// Only crates (directories containing a `Cargo.toml` file) found under the source (first) path
+    /// whose package names were supplied as a `--package` will be duplicated at the destination
+    /// (second) path.  Copying will preserve the directory structure from the source directory to
+    /// the destination directory.
+    #[arg(short, long = "dir")]
+    pub directories: Vec<Directory>,
+
+    /// Package names to include in the cut (this must match the package name in its source
+    /// location, including any suffixes)
+    #[arg(short, long = "package")]
+    pub packages: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct Directory {
+    pub src: PathBuf,
+    pub dst: PathBuf,
+    pub suffix: Option<String>,
+}
+
+#[derive(Error, Debug)]
+pub(crate) enum DirectoryParseError {
+    #[error("Can't parse an existing source directory from {0}")]
+    NoSrc(String),
+
+    #[error("Can't parse a destination directory from {0}")]
+    NoDst(String),
+
+    #[error("IO Error: {0}")]
+    IO(#[from] io::Error),
+}
+
+impl FromStr for Directory {
+    type Err = DirectoryParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut parts = s.split(":");
+
+        let Some(src_part) = parts.next() else {
+            return Err(DirectoryParseError::NoSrc(s.to_string()))
+        };
+
+        let Some(dst_part) = parts.next() else {
+            return Err(DirectoryParseError::NoDst(s.to_string()))
+        };
+
+        let suffix = parts.next().map(|sfx| sfx.to_string());
+
+        let cwd = env::current_dir()?;
+        let src = cwd.join(src_part);
+        let dst = cwd.join(dst_part);
+
+        if !src.is_dir() {
+            return Err(DirectoryParseError::NoSrc(src_part.to_string()));
+        }
+
+        Ok(Self { src, dst, suffix })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_directory_parsing_everything() {
+        // Source directory relative to CARGO_MANIFEST_DIR
+        let dir = Directory::from_str("src:dst:suffix").unwrap();
+
+        let cwd = env::current_dir().unwrap();
+        let src = cwd.join("src");
+        let dst = cwd.join("dst");
+
+        assert_eq!(
+            dir,
+            Directory {
+                src,
+                dst,
+                suffix: Some("suffix".to_string()),
+            }
+        )
+    }
+
+    #[test]
+    fn test_directory_parsing_no_suffix() {
+        // Source directory relative to CARGO_MANIFEST_DIR
+        let dir = Directory::from_str("src:dst").unwrap();
+
+        let cwd = env::current_dir().unwrap();
+        let src = cwd.join("src");
+        let dst = cwd.join("dst");
+
+        assert_eq!(
+            dir,
+            Directory {
+                src,
+                dst,
+                suffix: None,
+            }
+        )
+    }
+
+    #[test]
+    fn test_directory_parsing_no_dst() {
+        // Source directory relative to CARGO_MANIFEST_DIR
+        let err = Directory::from_str("src").unwrap_err();
+        assert!(matches!(err, DirectoryParseError::NoDst(_)), "{err:?}")
+    }
+
+    #[test]
+    fn test_directory_parsing_src_non_existent() {
+        // Source directory relative to CARGO_MANIFEST_DIR
+        let err = Directory::from_str("i_dont_exist:dst").unwrap_err();
+        assert!(matches!(err, DirectoryParseError::NoSrc(_)), "{err:?}")
+    }
+
+    #[test]
+    fn test_directory_parsing_empty() {
+        // Source directory relative to CARGO_MANIFEST_DIR
+        let err = Directory::from_str("").unwrap_err();
+        assert!(matches!(err, DirectoryParseError::NoDst(_)), "{err:?}")
+    }
+}

--- a/sui-execution/cut/src/args.rs
+++ b/sui-execution/cut/src/args.rs
@@ -23,7 +23,7 @@ pub(crate) struct Args {
     pub feature: String,
 
     /// Root of repository -- all source and destination paths must be within this path, and it must
-    /// contain the repo's [workspace] configuration.  Defaults to the parent of the working
+    /// contain the repo's `workspace` configuration.  Defaults to the parent of the working
     /// directory that contains a .git directory.
     pub root: Option<PathBuf>,
 

--- a/sui-execution/cut/src/main.rs
+++ b/sui-execution/cut/src/main.rs
@@ -1,0 +1,18 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use args::Args;
+use clap::Parser;
+use plan::CutPlan;
+
+mod args;
+mod plan;
+
+fn main() {
+    let args = Args::parse();
+    println!("Cutting directories: {:#?}\n", args.directories);
+    println!("Including packages: {:#?}\n", args.packages);
+
+    let plan = CutPlan::discover(args);
+    println!("Plan: {:#?}\n", plan);
+}

--- a/sui-execution/cut/src/plan.rs
+++ b/sui-execution/cut/src/plan.rs
@@ -12,7 +12,7 @@ use toml::value::Value;
 use crate::args::Args;
 
 /// Description of where packages should be copied to, what their new names should be, and whether
-/// they should be added to the [workspace] `members` or `exclude` fields.
+/// they should be added to the `workspace` `members` or `exclude` fields.
 #[derive(Debug)]
 pub(crate) struct CutPlan(BTreeMap<String, CutPackage>);
 
@@ -34,7 +34,7 @@ pub(crate) enum WorkspaceState {
     Unknown,
 }
 
-/// Relevant contents of a Cargo.toml [workspace] section.
+/// Relevant contents of a Cargo.toml `workspace` section.
 #[derive(Debug)]
 struct Workspace {
     /// Canonicalized paths of workspace members
@@ -186,8 +186,8 @@ impl CutPlan {
 }
 
 impl Workspace {
-    /// Read `members` and `exclude` from the [workspace] section of the `Cargo.toml` file in
-    /// directory `root`.  Fails if there isn't a manifest, it doesn't contain a [workspace]
+    /// Read `members` and `exclude` from the `workspace` section of the `Cargo.toml` file in
+    /// directory `root`.  Fails if there isn't a manifest, it doesn't contain a `workspace`
     /// section, or the relevant fields are not formatted as expected.
     fn read<P: AsRef<Path>>(root: P) -> PlanResult<Self> {
         let path = root.as_ref().join("Cargo.toml");

--- a/sui-execution/cut/src/plan.rs
+++ b/sui-execution/cut/src/plan.rs
@@ -1,0 +1,626 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::env;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+use toml::value::Value;
+
+use crate::args::Args;
+
+/// Description of where packages should be copied to, what their new names should be, and whether
+/// they should be added to the [workspace] `members` or `exclude` fields.
+#[derive(Debug)]
+pub(crate) struct CutPlan(BTreeMap<String, CutPackage>);
+
+/// Details for an individual copied package in the feature being cut.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct CutPackage {
+    dst_name: String,
+    src_path: PathBuf,
+    dst_path: PathBuf,
+    ws_state: WorkspaceState,
+}
+
+/// Whether the package in question is an explicit member of the workspace, an explicit exclude of
+/// the workspace, or neither (in which case it could still transitively be one or the other).
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum WorkspaceState {
+    Member,
+    Exclude,
+    Unknown,
+}
+
+/// Relevant contents of a Cargo.toml [workspace] section.
+#[derive(Debug)]
+struct Workspace {
+    /// Canonicalized paths of workspace members
+    members: HashSet<PathBuf>,
+    /// Canonicalized paths of workspace excludes
+    exclude: HashSet<PathBuf>,
+}
+
+#[derive(Error, Debug)]
+pub(crate) enum PlanError {
+    #[error("Could not find repository root, please supply one")]
+    NoRoot,
+
+    #[error("No [workspace] found at {}/Cargo.toml", .0.display())]
+    NoWorkspace(PathBuf),
+
+    #[error("Both member and exclude of [workspace]: {}", .0.display())]
+    WorkspaceConflict(PathBuf),
+
+    #[error("Packages '{0}' and '{1}' map to the same cut package name")]
+    PackageConflictName(String, String),
+
+    #[error("Packages '{0}' and '{1}' map to the same cut package path")]
+    PackageConflictPath(String, String),
+
+    #[error("Expected '{0}' field to be an array of strings")]
+    NotAStringArray(&'static str),
+
+    #[error("TOML Parsing Error: {0}")]
+    TOML(#[from] toml::de::Error),
+
+    #[error("IO Error: {0}")]
+    IO(#[from] io::Error),
+}
+
+type PlanResult<T> = Result<T, PlanError>;
+
+impl CutPlan {
+    /// Scan `args.directories` looking for `args.packages` to produce a new plan.
+    pub(crate) fn discover(args: Args) -> PlanResult<Self> {
+        let cwd = env::current_dir()?;
+
+        let Some(root) = args.root.or_else(|| discover_root(cwd)) else {
+            return Err(PlanError::NoRoot);
+        };
+
+        struct Walker {
+            feature: String,
+            ws: Workspace,
+            planned_packages: BTreeMap<String, CutPackage>,
+            pending_packages: HashSet<String>,
+        }
+
+        impl Walker {
+            fn walk(
+                &mut self,
+                src: &PathBuf,
+                dst: &PathBuf,
+                suffix: &Option<String>,
+            ) -> PlanResult<()> {
+                self.try_insert_package(src, dst, suffix)?;
+
+                for entry in fs::read_dir(src)? {
+                    let entry = entry?;
+                    if entry.file_type()?.is_dir() {
+                        self.walk(
+                            &src.join(entry.file_name()),
+                            &dst.join(entry.file_name()),
+                            suffix,
+                        )?;
+                    }
+                }
+
+                Ok(())
+            }
+
+            fn try_insert_package(
+                &mut self,
+                src: &PathBuf,
+                dst: &PathBuf,
+                suffix: &Option<String>,
+            ) -> PlanResult<()> {
+                let toml = src.join("Cargo.toml");
+
+                let Some(pkg_name) = package_name(&toml)? else {
+                    return Ok(())
+                };
+
+                if !self.pending_packages.remove(&pkg_name) {
+                    return Ok(());
+                }
+
+                let mut dst_name = suffix
+                    .as_ref()
+                    .and_then(|s| pkg_name.strip_suffix(s))
+                    .unwrap_or(&pkg_name)
+                    .to_string();
+
+                dst_name.push('-');
+                dst_name.push_str(&self.feature);
+
+                self.planned_packages.insert(
+                    pkg_name,
+                    CutPackage {
+                        dst_name: dst_name.clone(),
+                        src_path: src.clone(),
+                        dst_path: dst.clone(),
+                        ws_state: self.ws.state(src)?,
+                    },
+                );
+
+                Ok(())
+            }
+
+            fn finish(self) -> BTreeMap<String, CutPackage> {
+                self.planned_packages
+            }
+        }
+
+        let mut walker = Walker {
+            feature: args.feature,
+            ws: Workspace::read(root)?,
+            planned_packages: BTreeMap::new(),
+            pending_packages: args.packages.into_iter().collect(),
+        };
+
+        for dir in args.directories {
+            walker.walk(&fs::canonicalize(dir.src)?, &dir.dst, &dir.suffix)?;
+        }
+
+        // Emit warnings for packages that were not found
+        for pending in &walker.pending_packages {
+            eprintln!("WARNING: Package '{pending}' not found during scan.");
+        }
+
+        let packages = walker.finish();
+
+        //  Check for conflicts in the resulting plan
+        let mut rev_name = HashMap::new();
+        let mut rev_path = HashMap::new();
+
+        for (name, pkg) in &packages {
+            if let Some(prev) = rev_name.insert(pkg.dst_name.clone(), name.clone()) {
+                return Err(PlanError::PackageConflictName(name.clone(), prev));
+            }
+
+            if let Some(prev) = rev_path.insert(pkg.dst_path.clone(), name.clone()) {
+                return Err(PlanError::PackageConflictPath(name.clone(), prev));
+            }
+        }
+
+        Ok(Self(packages))
+    }
+}
+
+impl Workspace {
+    /// Read `members` and `exclude` from the [workspace] section of the `Cargo.toml` file in
+    /// directory `root`.  Fails if there isn't a manifest, it doesn't contain a [workspace]
+    /// section, or the relevant fields are not formatted as expected.
+    fn read<P: AsRef<Path>>(root: P) -> PlanResult<Self> {
+        let path = root.as_ref().join("Cargo.toml");
+        if !path.exists() {
+            return Err(PlanError::NoWorkspace(path.to_owned()));
+        }
+
+        let toml = toml::de::from_str::<Value>(&fs::read_to_string(&path)?)?;
+        let Some(workspace) = toml.get("workspace") else {
+            return Err(PlanError::NoWorkspace(path.to_owned()));
+        };
+
+        let members = toml_path_array_to_set(root.as_ref(), workspace, "members")?;
+        let exclude = toml_path_array_to_set(root.as_ref(), workspace, "exclude")?;
+
+        Ok(Self { members, exclude })
+    }
+
+    /// Determine the state of the path insofar as whether it is a direct member or exclude of this
+    /// `Workspace`.
+    fn state(&self, path: &PathBuf) -> PlanResult<WorkspaceState> {
+        match (self.members.contains(path), self.exclude.contains(path)) {
+            (true, true) => Err(PlanError::WorkspaceConflict(path.clone())),
+
+            (true, false) => Ok(WorkspaceState::Member),
+            (false, true) => Ok(WorkspaceState::Exclude),
+            (false, false) => Ok(WorkspaceState::Unknown),
+        }
+    }
+}
+
+/// Find the root of the git repository containing `cwd`, if it exists, return `None` otherwise.
+/// This function only searches prefixes of the provided path for the git repo, so if the path is
+/// given as a relative path within the repository, the root will not be found.
+fn discover_root(mut cwd: PathBuf) -> Option<PathBuf> {
+    cwd.extend(["_", ".git"]);
+    while {
+        cwd.pop();
+        cwd.pop()
+    } {
+        cwd.push(".git");
+        if cwd.is_dir() {
+            cwd.pop();
+            return Some(cwd);
+        }
+    }
+
+    return None;
+}
+
+/// Read `[field]` from `table`, as an array of strings, and interpret as a set of paths,
+/// canonicalized relative to a `root` path.
+///
+/// Fails if the field does not exist, does not consist of all strings, or if a path fails to
+/// canonicalize.
+fn toml_path_array_to_set<P: AsRef<Path>>(
+    root: P,
+    table: &Value,
+    field: &'static str,
+) -> PlanResult<HashSet<PathBuf>> {
+    let mut set = HashSet::new();
+
+    let Some(array) = table.get(field) else { return Ok(set) };
+    let Some(array) = array.as_array() else {
+        return Err(PlanError::NotAStringArray(field))
+    };
+
+    for val in array {
+        let Some(path) = val.as_str() else {
+            return Err(PlanError::NotAStringArray(field));
+        };
+
+        set.insert(fs::canonicalize(root.as_ref().join(path))?);
+    }
+
+    Ok(set)
+}
+
+fn package_name<P: AsRef<Path>>(path: P) -> PlanResult<Option<String>> {
+    if !path.as_ref().is_file() {
+        return Ok(None);
+    }
+
+    let content = fs::read_to_string(&path)?;
+    let toml = toml::de::from_str::<Value>(&content)?;
+
+    let Some(package) = toml.get("package") else {
+        return Ok(None);
+    };
+
+    let Some(name) = package.get("name") else {
+        return Ok(None);
+    };
+
+    Ok(name.as_str().map(str::to_string))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::args::Directory;
+
+    use super::*;
+
+    use expect_test::expect;
+    use std::fmt;
+    use std::fs;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_discover_root() {
+        let cut = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+
+        let Some(root) = discover_root(cut.clone()) else {
+            panic!("Failed to discover root from: {}", cut.display());
+        };
+
+        assert!(cut.starts_with(root));
+    }
+
+    #[test]
+    fn test_discover_root_idempotence() {
+        let cut = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+
+        let Some(root) = discover_root(cut.clone()) else {
+            panic!("Failed to discover root from: {}", cut.display());
+        };
+
+        let Some(root_again) = discover_root(root.clone()) else {
+            panic!("Failed to discover root from itself: {}", root.display());
+        };
+
+        assert_eq!(root, root_again);
+    }
+
+    #[test]
+    fn test_discover_root_non_existent() {
+        let tmp = tempdir().unwrap();
+        assert_eq!(None, discover_root(tmp.path().to_owned()));
+    }
+
+    #[test]
+    fn test_workspace_read() {
+        let cut = fs::canonicalize(env!("CARGO_MANIFEST_DIR")).unwrap();
+        let root = discover_root(cut.clone()).unwrap();
+
+        let sui_execution = root.join("sui-execution");
+        let move_vm_types = root.join("external-crates/move/move-vm/types");
+
+        let ws = Workspace::read(&root).unwrap();
+
+        // This crate is a member of the workspace
+        assert!(ws.members.contains(&cut));
+
+        // Other examples
+        assert!(ws.members.contains(&sui_execution));
+        assert!(ws.exclude.contains(&move_vm_types));
+    }
+
+    #[test]
+    fn test_no_workspace() {
+        expect!["No [workspace] found at $PATH/sui-execution/cut/Cargo.toml/Cargo.toml"].assert_eq(
+            &display_for_test(&Workspace::read(env!("CARGO_MANIFEST_DIR")).unwrap_err()),
+        );
+    }
+
+    #[test]
+    fn test_empty_workspace() {
+        let tmp = tempdir().unwrap();
+        let toml = tmp.path().join("Cargo.toml");
+
+        fs::write(
+            &toml,
+            r#"
+              [workspace]
+            "#,
+        )
+        .unwrap();
+
+        let ws = Workspace::read(&tmp).unwrap();
+        assert!(ws.members.is_empty());
+        assert!(ws.exclude.is_empty());
+    }
+
+    #[test]
+    fn test_bad_workspace_field() {
+        let tmp = tempdir().unwrap();
+        let toml = tmp.path().join("Cargo.toml");
+
+        fs::write(
+            &toml,
+            r#"
+              [workspace]
+              members = [1, 2, 3]
+            "#,
+        )
+        .unwrap();
+
+        expect!["Expected 'members' field to be an array of strings"]
+            .assert_eq(&display_for_test(&Workspace::read(&tmp).unwrap_err()));
+    }
+
+    #[test]
+    fn test_bad_workspace_path() {
+        let tmp = tempdir().unwrap();
+        let toml = tmp.path().join("Cargo.toml");
+
+        fs::write(
+            &toml,
+            r#"
+              [workspace]
+              members = ["i_dont_exist"]
+            "#,
+        )
+        .unwrap();
+
+        expect!["IO Error: No such file or directory (os error 2)"]
+            .assert_eq(&display_for_test(&Workspace::read(&tmp).unwrap_err()));
+    }
+
+    #[test]
+    fn test_cut_plan_discover() {
+        let cut = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+
+        let plan = CutPlan::discover(Args {
+            feature: "feature".to_string(),
+            root: None,
+            directories: vec![
+                Directory {
+                    src: cut.join("../latest"),
+                    dst: cut.join("../exec-cut"),
+                    suffix: Some("-latest".to_string()),
+                },
+                Directory {
+                    src: cut.clone(),
+                    dst: cut.join("../cut-cut"),
+                    suffix: None,
+                },
+                Directory {
+                    src: cut.join("../../external-crates/move/move-core"),
+                    dst: cut.join("../cut-move-core"),
+                    suffix: None,
+                },
+            ],
+            packages: vec![
+                "move-core-types".to_string(),
+                "sui-adapter-latest".to_string(),
+                "sui-execution-cut".to_string(),
+                "sui-verifier-latest".to_string(),
+            ],
+        })
+        .unwrap();
+
+        expect![[r#"
+            CutPlan(
+                {
+                    "move-core-types": CutPackage {
+                        dst_name: "move-core-types-feature",
+                        src_path: "$PATH/external-crates/move/move-core/types",
+                        dst_path: "$PATH/sui-execution/cut/../cut-move-core/types",
+                        ws_state: Exclude,
+                    },
+                    "sui-adapter-latest": CutPackage {
+                        dst_name: "sui-adapter-feature",
+                        src_path: "$PATH/sui-execution/latest/sui-adapter",
+                        dst_path: "$PATH/sui-execution/cut/../exec-cut/sui-adapter",
+                        ws_state: Member,
+                    },
+                    "sui-execution-cut": CutPackage {
+                        dst_name: "sui-execution-cut-feature",
+                        src_path: "$PATH/sui-execution/cut",
+                        dst_path: "$PATH/sui-execution/cut/../cut-cut",
+                        ws_state: Member,
+                    },
+                    "sui-verifier-latest": CutPackage {
+                        dst_name: "sui-verifier-feature",
+                        src_path: "$PATH/sui-execution/latest/sui-verifier",
+                        dst_path: "$PATH/sui-execution/cut/../exec-cut/sui-verifier",
+                        ws_state: Member,
+                    },
+                },
+            )"#]]
+        .assert_eq(&debug_for_test(&plan));
+    }
+
+    #[test]
+    fn test_cut_plan_worksplace_conflict() {
+        let tmp = tempdir().unwrap();
+        fs::create_dir(tmp.path().join("foo")).unwrap();
+
+        fs::write(
+            &tmp.path().join("Cargo.toml"),
+            r#"
+              [workspace]
+              members = ["foo"]
+              exclude = ["foo"]
+            "#,
+        )
+        .unwrap();
+
+        fs::write(
+            &tmp.path().join("foo/Cargo.toml"),
+            r#"
+              [package]
+              name = "foo"
+            "#,
+        )
+        .unwrap();
+
+        let err = CutPlan::discover(Args {
+            feature: "feature".to_string(),
+            root: Some(tmp.path().to_owned()),
+            directories: vec![Directory {
+                src: tmp.path().to_owned(),
+                dst: tmp.path().join("cut"),
+                suffix: None,
+            }],
+            packages: vec!["foo".to_string()],
+        })
+        .unwrap_err();
+
+        expect!["Both member and exclude of [workspace]: $PATH/foo"]
+            .assert_eq(&scrub_path(&format!("{}", err), &tmp.path().to_owned()));
+    }
+
+    #[test]
+    fn test_cut_plan_package_name_conflict() {
+        let tmp = tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join("foo/bar-latest")).unwrap();
+        fs::create_dir_all(tmp.path().join("baz/bar")).unwrap();
+
+        fs::write(&tmp.path().join("Cargo.toml"), "[workspace]").unwrap();
+
+        fs::write(
+            &tmp.path().join("foo/bar-latest/Cargo.toml"),
+            r#"package.name = "bar-latest""#,
+        )
+        .unwrap();
+
+        fs::write(
+            &tmp.path().join("baz/bar/Cargo.toml"),
+            r#"package.name = "bar""#,
+        )
+        .unwrap();
+
+        let err = CutPlan::discover(Args {
+            feature: "feature".to_string(),
+            root: Some(tmp.path().to_owned()),
+            directories: vec![
+                Directory {
+                    src: tmp.path().join("foo"),
+                    dst: tmp.path().join("cut"),
+                    suffix: Some("-latest".to_string()),
+                },
+                Directory {
+                    src: tmp.path().join("baz"),
+                    dst: tmp.path().join("cut"),
+                    suffix: None,
+                },
+            ],
+            packages: vec!["bar-latest".to_string(), "bar".to_string()],
+        })
+        .unwrap_err();
+
+        expect!["Packages 'bar-latest' and 'bar' map to the same cut package name"]
+            .assert_eq(&scrub_path(&format!("{}", err), &tmp.path().to_owned()));
+    }
+
+    #[test]
+    fn test_cut_plan_package_path_conflict() {
+        let tmp = tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join("foo/bar")).unwrap();
+        fs::create_dir_all(tmp.path().join("baz/bar")).unwrap();
+
+        fs::write(&tmp.path().join("Cargo.toml"), "[workspace]").unwrap();
+
+        fs::write(
+            &tmp.path().join("foo/bar/Cargo.toml"),
+            r#"package.name = "foo-bar""#,
+        )
+        .unwrap();
+
+        fs::write(
+            &tmp.path().join("baz/bar/Cargo.toml"),
+            r#"package.name = "baz-bar""#,
+        )
+        .unwrap();
+
+        let err = CutPlan::discover(Args {
+            feature: "feature".to_string(),
+            root: Some(tmp.path().to_owned()),
+            directories: vec![
+                Directory {
+                    src: tmp.path().join("foo"),
+                    dst: tmp.path().join("cut"),
+                    suffix: None,
+                },
+                Directory {
+                    src: tmp.path().join("baz"),
+                    dst: tmp.path().join("cut"),
+                    suffix: None,
+                },
+            ],
+            packages: vec!["foo-bar".to_string(), "baz-bar".to_string()],
+        })
+        .unwrap_err();
+
+        expect!["Packages 'foo-bar' and 'baz-bar' map to the same cut package path"]
+            .assert_eq(&scrub_path(&format!("{}", err), &tmp.path().to_owned()));
+    }
+
+    /// Print with pretty-printed debug formatting, with repo paths scrubbed out for consistency.
+    fn debug_for_test<T: fmt::Debug>(x: &T) -> String {
+        scrub_path(&format!("{x:#?}"), &repo_root())
+    }
+
+    /// Display with repo paths scrubbed out for consistency.
+    fn display_for_test<T: fmt::Display>(x: &T) -> String {
+        scrub_path(&format!("{x}"), &repo_root())
+    }
+
+    fn scrub_path<P: AsRef<Path>>(x: &str, p: P) -> String {
+        let canonical = fs::canonicalize(p).unwrap();
+        let path = canonical.into_os_string().into_string().unwrap();
+        x.replace(&path, "$PATH")
+    }
+
+    fn repo_root() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+    }
+}

--- a/sui-execution/cut/src/plan.rs
+++ b/sui-execution/cut/src/plan.rs
@@ -361,7 +361,7 @@ mod tests {
         let toml = tmp.path().join("Cargo.toml");
 
         fs::write(
-            &toml,
+            toml,
             r#"
               [workspace]
             "#,
@@ -379,7 +379,7 @@ mod tests {
         let toml = tmp.path().join("Cargo.toml");
 
         fs::write(
-            &toml,
+            toml,
             r#"
               [workspace]
               members = [1, 2, 3]
@@ -397,7 +397,7 @@ mod tests {
         let toml = tmp.path().join("Cargo.toml");
 
         fs::write(
-            &toml,
+            toml,
             r#"
               [workspace]
               members = ["i_dont_exist"]
@@ -480,7 +480,7 @@ mod tests {
         fs::create_dir(tmp.path().join("foo")).unwrap();
 
         fs::write(
-            &tmp.path().join("Cargo.toml"),
+            tmp.path().join("Cargo.toml"),
             r#"
               [workspace]
               members = ["foo"]
@@ -490,7 +490,7 @@ mod tests {
         .unwrap();
 
         fs::write(
-            &tmp.path().join("foo/Cargo.toml"),
+            tmp.path().join("foo/Cargo.toml"),
             r#"
               [package]
               name = "foo"
@@ -511,7 +511,7 @@ mod tests {
         .unwrap_err();
 
         expect!["Both member and exclude of [workspace]: $PATH/foo"]
-            .assert_eq(&scrub_path(&format!("{}", err), &tmp.path().to_owned()));
+            .assert_eq(&scrub_path(&format!("{}", err), tmp.path()));
     }
 
     #[test]
@@ -520,16 +520,16 @@ mod tests {
         fs::create_dir_all(tmp.path().join("foo/bar-latest")).unwrap();
         fs::create_dir_all(tmp.path().join("baz/bar")).unwrap();
 
-        fs::write(&tmp.path().join("Cargo.toml"), "[workspace]").unwrap();
+        fs::write(tmp.path().join("Cargo.toml"), "[workspace]").unwrap();
 
         fs::write(
-            &tmp.path().join("foo/bar-latest/Cargo.toml"),
+            tmp.path().join("foo/bar-latest/Cargo.toml"),
             r#"package.name = "bar-latest""#,
         )
         .unwrap();
 
         fs::write(
-            &tmp.path().join("baz/bar/Cargo.toml"),
+            tmp.path().join("baz/bar/Cargo.toml"),
             r#"package.name = "bar""#,
         )
         .unwrap();
@@ -554,7 +554,7 @@ mod tests {
         .unwrap_err();
 
         expect!["Packages 'bar-latest' and 'bar' map to the same cut package name"]
-            .assert_eq(&scrub_path(&format!("{}", err), &tmp.path().to_owned()));
+            .assert_eq(&scrub_path(&format!("{}", err), tmp.path()));
     }
 
     #[test]
@@ -563,16 +563,16 @@ mod tests {
         fs::create_dir_all(tmp.path().join("foo/bar")).unwrap();
         fs::create_dir_all(tmp.path().join("baz/bar")).unwrap();
 
-        fs::write(&tmp.path().join("Cargo.toml"), "[workspace]").unwrap();
+        fs::write(tmp.path().join("Cargo.toml"), "[workspace]").unwrap();
 
         fs::write(
-            &tmp.path().join("foo/bar/Cargo.toml"),
+            tmp.path().join("foo/bar/Cargo.toml"),
             r#"package.name = "foo-bar""#,
         )
         .unwrap();
 
         fs::write(
-            &tmp.path().join("baz/bar/Cargo.toml"),
+            tmp.path().join("baz/bar/Cargo.toml"),
             r#"package.name = "baz-bar""#,
         )
         .unwrap();
@@ -597,17 +597,17 @@ mod tests {
         .unwrap_err();
 
         expect!["Packages 'foo-bar' and 'baz-bar' map to the same cut package path"]
-            .assert_eq(&scrub_path(&format!("{}", err), &tmp.path().to_owned()));
+            .assert_eq(&scrub_path(&format!("{}", err), tmp.path()));
     }
 
     /// Print with pretty-printed debug formatting, with repo paths scrubbed out for consistency.
     fn debug_for_test<T: fmt::Debug>(x: &T) -> String {
-        scrub_path(&format!("{x:#?}"), &repo_root())
+        scrub_path(&format!("{x:#?}"), repo_root())
     }
 
     /// Display with repo paths scrubbed out for consistency.
     fn display_for_test<T: fmt::Display>(x: &T) -> String {
-        scrub_path(&format!("{x}"), &repo_root())
+        scrub_path(&format!("{x}"), repo_root())
     }
 
     fn scrub_path<P: AsRef<Path>>(x: &str, p: P) -> String {


### PR DESCRIPTION
## Description

The scaffolding deals with argument parsing, and building a "plan" of which packages to duplicate based on that.

## Test Plan:

New unit tests:

```
sui/sui-execution/cut$ cargo nextest run
```

Running the plan that would create a new sui-execution cut:

```
sui$ cargo run --bin cut -- --feature v1 \
     -d sui-execution/latest:sui-execution/v1:-latest \
     -d external-crates/move:external-crates/move-execution \
     -p sui-adapter-latest \
     -p sui-move-natives-latest \
     -p sui-verifier-latest \
     -p move-bytecode-verifier \
     -p move-stdlib \
     -p move-vm-runtime
```

Which produces the following output (locally):

```
Cutting directories: [
    Directory {
        src: "/Users/ashokmenon/sui/sui-execution/latest",
        dst: "/Users/ashokmenon/sui/sui-execution/v1",
        suffix: Some(
            "-latest",
        ),
    },
    Directory {
        src: "/Users/ashokmenon/sui/external-crates/move",
        dst: "/Users/ashokmenon/sui/external-crates/move-execution",
        suffix: None,
    },
]

Including packages: [
    "sui-adapter-latest",
    "sui-move-natives-latest",
    "sui-verifier-latest",
    "move-bytecode-verifier",
    "move-stdlib",
    "move-vm-runtime",
]

Plan: Ok(
    CutPlan(
        {
            "move-bytecode-verifier": CutPackage {
                dst_name: "move-bytecode-verifier-v1",
                src_path: "/Users/ashokmenon/sui/external-crates/move/move-bytecode-verifier",
                dst_path: "/Users/ashokmenon/sui/external-crates/move-execution/move-bytecode-verifier",
                ws_state: Exclude,
            },
            "move-stdlib": CutPackage {
                dst_name: "move-stdlib-v1",
                src_path: "/Users/ashokmenon/sui/external-crates/move/move-stdlib",
                dst_path: "/Users/ashokmenon/sui/external-crates/move-execution/move-stdlib",
                ws_state: Exclude,
            },
            "move-vm-runtime": CutPackage {
                dst_name: "move-vm-runtime-v1",
                src_path: "/Users/ashokmenon/sui/external-crates/move/move-vm/runtime",
                dst_path: "/Users/ashokmenon/sui/external-crates/move-execution/move-vm/runtime",
                ws_state: Exclude,
            },
            "sui-adapter-latest": CutPackage {
                dst_name: "sui-adapter-v1",
                src_path: "/Users/ashokmenon/sui/sui-execution/latest/sui-adapter",
                dst_path: "/Users/ashokmenon/sui/sui-execution/v1/sui-adapter",
                ws_state: Member,
            },
            "sui-move-natives-latest": CutPackage {
                dst_name: "sui-move-natives-v1",
                src_path: "/Users/ashokmenon/sui/sui-execution/latest/sui-move-natives",
                dst_path: "/Users/ashokmenon/sui/sui-execution/v1/sui-move-natives",
                ws_state: Member,
            },
            "sui-verifier-latest": CutPackage {
                dst_name: "sui-verifier-v1",
                src_path: "/Users/ashokmenon/sui/sui-execution/latest/sui-verifier",
                dst_path: "/Users/ashokmenon/sui/sui-execution/v1/sui-verifier",
                ws_state: Member,
            },
        },
    ),
)
```