### PR TITLE
move out interpreter match

### DIFF
--- a/external-crates/move/move-vm/runtime/src/interpreter.rs
+++ b/external-crates/move/move-vm/runtime/src/interpreter.rs
@@ -60,6 +60,12 @@ macro_rules! set_err_info {
     }};
 }
 
+enum InstrRet {
+    Ok,
+    ExitCode(ExitCode),
+    Branch,
+}
+
 /// `Interpreter` instances can execute Move functions.
 ///
 /// An `Interpreter` instance is a stand alone execution context for a function.
@@ -1729,13 +1735,17 @@ impl Frame {
         Ok(())
     }
 
-    fn execute_code_impl(
-        &mut self,
+    fn execute_instruction(
+        pc: &mut u16,
+        locals: &mut Locals,
+        ty_args: &[Type],
+        function: &Arc<Function>,
         resolver: &Resolver,
         interpreter: &mut Interpreter,
         data_store: &mut impl DataStore,
         gas_meter: &mut impl GasMeter,
-    ) -> PartialVMResult<ExitCode> {
+        instruction: &Bytecode,
+    ) -> PartialVMResult<InstrRet> {
         use SimpleInstruction as S;
 
         macro_rules! make_ty {
@@ -1747,6 +1757,540 @@ impl Frame {
             };
         }
 
+        match instruction {
+            Bytecode::Pop => {
+                let popped_val = interpreter.operand_stack.pop()?;
+                gas_meter.charge_pop(popped_val)?;
+            }
+            Bytecode::Ret => {
+                gas_meter.charge_simple_instr(S::Ret)?;
+                return Ok(InstrRet::ExitCode(ExitCode::Return));
+            }
+            Bytecode::BrTrue(offset) => {
+                gas_meter.charge_simple_instr(S::BrTrue)?;
+                if interpreter.operand_stack.pop_as::<bool>()? {
+                    *pc = *offset;
+                    return Ok(InstrRet::Branch);
+                }
+            }
+            Bytecode::BrFalse(offset) => {
+                gas_meter.charge_simple_instr(S::BrFalse)?;
+                if !interpreter.operand_stack.pop_as::<bool>()? {
+                    *pc = *offset;
+                    return Ok(InstrRet::Branch);
+                }
+            }
+            Bytecode::Branch(offset) => {
+                gas_meter.charge_simple_instr(S::Branch)?;
+                *pc = *offset;
+                return Ok(InstrRet::Branch);
+            }
+            Bytecode::LdU8(int_const) => {
+                gas_meter.charge_simple_instr(S::LdU8)?;
+                interpreter.operand_stack.push(Value::u8(*int_const))?;
+            }
+            Bytecode::LdU16(int_const) => {
+                gas_meter.charge_simple_instr(S::LdU16)?;
+                interpreter.operand_stack.push(Value::u16(*int_const))?;
+            }
+            Bytecode::LdU32(int_const) => {
+                gas_meter.charge_simple_instr(S::LdU32)?;
+                interpreter.operand_stack.push(Value::u32(*int_const))?;
+            }
+            Bytecode::LdU64(int_const) => {
+                gas_meter.charge_simple_instr(S::LdU64)?;
+                interpreter.operand_stack.push(Value::u64(*int_const))?;
+            }
+            Bytecode::LdU128(int_const) => {
+                gas_meter.charge_simple_instr(S::LdU128)?;
+                interpreter.operand_stack.push(Value::u128(*int_const))?;
+            }
+            Bytecode::LdU256(int_const) => {
+                gas_meter.charge_simple_instr(S::LdU256)?;
+                interpreter.operand_stack.push(Value::u256(*int_const))?;
+            }
+            Bytecode::LdConst(idx) => {
+                let constant = resolver.constant_at(*idx);
+                gas_meter.charge_ld_const(NumBytes::new(constant.data.len() as u64))?;
+
+                let val = Value::deserialize_constant(constant).ok_or_else(|| {
+                    PartialVMError::new(StatusCode::VERIFIER_INVARIANT_VIOLATION).with_message(
+                        "Verifier failed to verify the deserialization of constants".to_owned(),
+                    )
+                })?;
+
+                gas_meter.charge_ld_const_after_deserialization(&val)?;
+
+                interpreter.operand_stack.push(val)?
+            }
+            Bytecode::LdTrue => {
+                gas_meter.charge_simple_instr(S::LdTrue)?;
+                interpreter.operand_stack.push(Value::bool(true))?;
+            }
+            Bytecode::LdFalse => {
+                gas_meter.charge_simple_instr(S::LdFalse)?;
+                interpreter.operand_stack.push(Value::bool(false))?;
+            }
+            Bytecode::CopyLoc(idx) => {
+                // TODO(Gas): We should charge gas before copying the value.
+                let local = locals.copy_loc(*idx as usize)?;
+                gas_meter.charge_copy_loc(&local)?;
+                interpreter.operand_stack.push(local)?;
+            }
+            Bytecode::MoveLoc(idx) => {
+                let local = locals.move_loc(
+                    *idx as usize,
+                    resolver
+                        .loader()
+                        .vm_config()
+                        .enable_invariant_violation_check_in_swap_loc,
+                )?;
+                gas_meter.charge_move_loc(&local)?;
+
+                interpreter.operand_stack.push(local)?;
+            }
+            Bytecode::StLoc(idx) => {
+                let value_to_store = interpreter.operand_stack.pop()?;
+                gas_meter.charge_store_loc(&value_to_store)?;
+                locals.store_loc(
+                    *idx as usize,
+                    value_to_store,
+                    resolver
+                        .loader()
+                        .vm_config()
+                        .enable_invariant_violation_check_in_swap_loc,
+                )?;
+            }
+            Bytecode::Call(idx) => {
+                return Ok(InstrRet::ExitCode(ExitCode::Call(*idx)));
+            }
+            Bytecode::CallGeneric(idx) => {
+                return Ok(InstrRet::ExitCode(ExitCode::CallGeneric(*idx)));
+            }
+            Bytecode::MutBorrowLoc(idx) | Bytecode::ImmBorrowLoc(idx) => {
+                let instr = match instruction {
+                    Bytecode::MutBorrowLoc(_) => S::MutBorrowLoc,
+                    _ => S::ImmBorrowLoc,
+                };
+                gas_meter.charge_simple_instr(instr)?;
+                interpreter
+                    .operand_stack
+                    .push(locals.borrow_loc(*idx as usize)?)?;
+            }
+            Bytecode::ImmBorrowField(fh_idx) | Bytecode::MutBorrowField(fh_idx) => {
+                let instr = match instruction {
+                    Bytecode::MutBorrowField(_) => S::MutBorrowField,
+                    _ => S::ImmBorrowField,
+                };
+                gas_meter.charge_simple_instr(instr)?;
+
+                let reference = interpreter.operand_stack.pop_as::<StructRef>()?;
+
+                let offset = resolver.field_offset(*fh_idx);
+                let field_ref = reference.borrow_field(offset)?;
+                interpreter.operand_stack.push(field_ref)?;
+            }
+            Bytecode::ImmBorrowFieldGeneric(fi_idx) | Bytecode::MutBorrowFieldGeneric(fi_idx) => {
+                let instr = match instruction {
+                    Bytecode::MutBorrowField(_) => S::MutBorrowFieldGeneric,
+                    _ => S::ImmBorrowFieldGeneric,
+                };
+                gas_meter.charge_simple_instr(instr)?;
+
+                let reference = interpreter.operand_stack.pop_as::<StructRef>()?;
+
+                let offset = resolver.field_instantiation_offset(*fi_idx);
+                let field_ref = reference.borrow_field(offset)?;
+                interpreter.operand_stack.push(field_ref)?;
+            }
+            Bytecode::Pack(sd_idx) => {
+                let field_count = resolver.field_count(*sd_idx);
+                let struct_type = resolver.get_struct_type(*sd_idx);
+                Self::check_depth_of_type(resolver, &struct_type)?;
+                gas_meter.charge_pack(
+                    false,
+                    interpreter.operand_stack.last_n(field_count as usize)?,
+                )?;
+                let args = interpreter.operand_stack.popn(field_count)?;
+                interpreter
+                    .operand_stack
+                    .push(Value::struct_(Struct::pack(args)))?;
+            }
+            Bytecode::PackGeneric(si_idx) => {
+                let field_count = resolver.field_instantiation_count(*si_idx);
+                let ty = resolver.instantiate_generic_type(*si_idx, ty_args)?;
+                Self::check_depth_of_type(resolver, &ty)?;
+                gas_meter.charge_pack(
+                    true,
+                    interpreter.operand_stack.last_n(field_count as usize)?,
+                )?;
+                let args = interpreter.operand_stack.popn(field_count)?;
+                interpreter
+                    .operand_stack
+                    .push(Value::struct_(Struct::pack(args)))?;
+            }
+            Bytecode::Unpack(_sd_idx) => {
+                let struct_ = interpreter.operand_stack.pop_as::<Struct>()?;
+
+                gas_meter.charge_unpack(false, struct_.field_views())?;
+
+                for value in struct_.unpack()? {
+                    interpreter.operand_stack.push(value)?;
+                }
+            }
+            Bytecode::UnpackGeneric(_si_idx) => {
+                let struct_ = interpreter.operand_stack.pop_as::<Struct>()?;
+
+                gas_meter.charge_unpack(true, struct_.field_views())?;
+
+                // TODO: Whether or not we want this gas metering in the loop is
+                // questionable.  However, if we don't have it in the loop we could wind up
+                // doing a fair bit of work before charging for it.
+                for value in struct_.unpack()? {
+                    interpreter.operand_stack.push(value)?;
+                }
+            }
+            Bytecode::ReadRef => {
+                let reference = interpreter.operand_stack.pop_as::<Reference>()?;
+                gas_meter.charge_read_ref(reference.value_view())?;
+                let value = reference.read_ref()?;
+                interpreter.operand_stack.push(value)?;
+            }
+            Bytecode::WriteRef => {
+                let reference = interpreter.operand_stack.pop_as::<Reference>()?;
+                let value = interpreter.operand_stack.pop()?;
+                gas_meter.charge_write_ref(&value, reference.value_view())?;
+                reference.write_ref(value)?;
+            }
+            Bytecode::CastU8 => {
+                gas_meter.charge_simple_instr(S::CastU8)?;
+                let integer_value = interpreter.operand_stack.pop_as::<IntegerValue>()?;
+                interpreter
+                    .operand_stack
+                    .push(Value::u8(integer_value.cast_u8()?))?;
+            }
+            Bytecode::CastU16 => {
+                gas_meter.charge_simple_instr(S::CastU16)?;
+                let integer_value = interpreter.operand_stack.pop_as::<IntegerValue>()?;
+                interpreter
+                    .operand_stack
+                    .push(Value::u16(integer_value.cast_u16()?))?;
+            }
+            Bytecode::CastU32 => {
+                gas_meter.charge_simple_instr(S::CastU16)?;
+                let integer_value = interpreter.operand_stack.pop_as::<IntegerValue>()?;
+                interpreter
+                    .operand_stack
+                    .push(Value::u32(integer_value.cast_u32()?))?;
+            }
+            Bytecode::CastU64 => {
+                gas_meter.charge_simple_instr(S::CastU64)?;
+                let integer_value = interpreter.operand_stack.pop_as::<IntegerValue>()?;
+                interpreter
+                    .operand_stack
+                    .push(Value::u64(integer_value.cast_u64()?))?;
+            }
+            Bytecode::CastU128 => {
+                gas_meter.charge_simple_instr(S::CastU128)?;
+                let integer_value = interpreter.operand_stack.pop_as::<IntegerValue>()?;
+                interpreter
+                    .operand_stack
+                    .push(Value::u128(integer_value.cast_u128()?))?;
+            }
+            Bytecode::CastU256 => {
+                gas_meter.charge_simple_instr(S::CastU16)?;
+                let integer_value = interpreter.operand_stack.pop_as::<IntegerValue>()?;
+                interpreter
+                    .operand_stack
+                    .push(Value::u256(integer_value.cast_u256()?))?;
+            }
+            // Arithmetic Operations
+            Bytecode::Add => {
+                gas_meter.charge_simple_instr(S::Add)?;
+                interpreter.binop_int(IntegerValue::add_checked)?
+            }
+            Bytecode::Sub => {
+                gas_meter.charge_simple_instr(S::Sub)?;
+                interpreter.binop_int(IntegerValue::sub_checked)?
+            }
+            Bytecode::Mul => {
+                gas_meter.charge_simple_instr(S::Mul)?;
+                interpreter.binop_int(IntegerValue::mul_checked)?
+            }
+            Bytecode::Mod => {
+                gas_meter.charge_simple_instr(S::Mod)?;
+                interpreter.binop_int(IntegerValue::rem_checked)?
+            }
+            Bytecode::Div => {
+                gas_meter.charge_simple_instr(S::Div)?;
+                interpreter.binop_int(IntegerValue::div_checked)?
+            }
+            Bytecode::BitOr => {
+                gas_meter.charge_simple_instr(S::BitOr)?;
+                interpreter.binop_int(IntegerValue::bit_or)?
+            }
+            Bytecode::BitAnd => {
+                gas_meter.charge_simple_instr(S::BitAnd)?;
+                interpreter.binop_int(IntegerValue::bit_and)?
+            }
+            Bytecode::Xor => {
+                gas_meter.charge_simple_instr(S::Xor)?;
+                interpreter.binop_int(IntegerValue::bit_xor)?
+            }
+            Bytecode::Shl => {
+                gas_meter.charge_simple_instr(S::Shl)?;
+                let rhs = interpreter.operand_stack.pop_as::<u8>()?;
+                let lhs = interpreter.operand_stack.pop_as::<IntegerValue>()?;
+                interpreter
+                    .operand_stack
+                    .push(lhs.shl_checked(rhs)?.into_value())?;
+            }
+            Bytecode::Shr => {
+                gas_meter.charge_simple_instr(S::Shr)?;
+                let rhs = interpreter.operand_stack.pop_as::<u8>()?;
+                let lhs = interpreter.operand_stack.pop_as::<IntegerValue>()?;
+                interpreter
+                    .operand_stack
+                    .push(lhs.shr_checked(rhs)?.into_value())?;
+            }
+            Bytecode::Or => {
+                gas_meter.charge_simple_instr(S::Or)?;
+                interpreter.binop_bool(|l, r| Ok(l || r))?
+            }
+            Bytecode::And => {
+                gas_meter.charge_simple_instr(S::And)?;
+                interpreter.binop_bool(|l, r| Ok(l && r))?
+            }
+            Bytecode::Lt => {
+                gas_meter.charge_simple_instr(S::Lt)?;
+                interpreter.binop_bool(IntegerValue::lt)?
+            }
+            Bytecode::Gt => {
+                gas_meter.charge_simple_instr(S::Gt)?;
+                interpreter.binop_bool(IntegerValue::gt)?
+            }
+            Bytecode::Le => {
+                gas_meter.charge_simple_instr(S::Le)?;
+                interpreter.binop_bool(IntegerValue::le)?
+            }
+            Bytecode::Ge => {
+                gas_meter.charge_simple_instr(S::Ge)?;
+                interpreter.binop_bool(IntegerValue::ge)?
+            }
+            Bytecode::Abort => {
+                gas_meter.charge_simple_instr(S::Abort)?;
+                let error_code = interpreter.operand_stack.pop_as::<u64>()?;
+                let error = PartialVMError::new(StatusCode::ABORTED)
+                    .with_sub_status(error_code)
+                    .with_message(format!("{} at offset {}", function.pretty_string(), *pc,));
+                return Err(error);
+            }
+            Bytecode::Eq => {
+                let lhs = interpreter.operand_stack.pop()?;
+                let rhs = interpreter.operand_stack.pop()?;
+                gas_meter.charge_eq(&lhs, &rhs)?;
+                interpreter
+                    .operand_stack
+                    .push(Value::bool(lhs.equals(&rhs)?))?;
+            }
+            Bytecode::Neq => {
+                let lhs = interpreter.operand_stack.pop()?;
+                let rhs = interpreter.operand_stack.pop()?;
+                gas_meter.charge_neq(&lhs, &rhs)?;
+                interpreter
+                    .operand_stack
+                    .push(Value::bool(!lhs.equals(&rhs)?))?;
+            }
+            Bytecode::MutBorrowGlobal(sd_idx) | Bytecode::ImmBorrowGlobal(sd_idx) => {
+                let is_mut = matches!(instruction, Bytecode::MutBorrowGlobal(_));
+                let addr = interpreter.operand_stack.pop_as::<AccountAddress>()?;
+                let ty = resolver.get_struct_type(*sd_idx);
+                interpreter.borrow_global(
+                    is_mut,
+                    false,
+                    resolver.loader(),
+                    gas_meter,
+                    data_store,
+                    addr,
+                    &ty,
+                )?;
+            }
+            Bytecode::MutBorrowGlobalGeneric(si_idx) | Bytecode::ImmBorrowGlobalGeneric(si_idx) => {
+                let is_mut = matches!(instruction, Bytecode::MutBorrowGlobalGeneric(_));
+                let addr = interpreter.operand_stack.pop_as::<AccountAddress>()?;
+                let ty = resolver.instantiate_generic_type(*si_idx, ty_args)?;
+                interpreter.borrow_global(
+                    is_mut,
+                    true,
+                    resolver.loader(),
+                    gas_meter,
+                    data_store,
+                    addr,
+                    &ty,
+                )?;
+            }
+            Bytecode::Exists(sd_idx) => {
+                let addr = interpreter.operand_stack.pop_as::<AccountAddress>()?;
+                let ty = resolver.get_struct_type(*sd_idx);
+                interpreter.exists(false, resolver.loader(), gas_meter, data_store, addr, &ty)?;
+            }
+            Bytecode::ExistsGeneric(si_idx) => {
+                let addr = interpreter.operand_stack.pop_as::<AccountAddress>()?;
+                let ty = resolver.instantiate_generic_type(*si_idx, ty_args)?;
+                interpreter.exists(true, resolver.loader(), gas_meter, data_store, addr, &ty)?;
+            }
+            Bytecode::MoveFrom(sd_idx) => {
+                let addr = interpreter.operand_stack.pop_as::<AccountAddress>()?;
+                let ty = resolver.get_struct_type(*sd_idx);
+                interpreter.move_from(
+                    false,
+                    resolver.loader(),
+                    gas_meter,
+                    data_store,
+                    addr,
+                    &ty,
+                )?;
+            }
+            Bytecode::MoveFromGeneric(si_idx) => {
+                let addr = interpreter.operand_stack.pop_as::<AccountAddress>()?;
+                let ty = resolver.instantiate_generic_type(*si_idx, ty_args)?;
+                interpreter.move_from(true, resolver.loader(), gas_meter, data_store, addr, &ty)?;
+            }
+            Bytecode::MoveTo(sd_idx) => {
+                let resource = interpreter.operand_stack.pop()?;
+                let signer_reference = interpreter.operand_stack.pop_as::<StructRef>()?;
+                let addr = signer_reference
+                    .borrow_field(0)?
+                    .value_as::<Reference>()?
+                    .read_ref()?
+                    .value_as::<AccountAddress>()?;
+                let ty = resolver.get_struct_type(*sd_idx);
+                // REVIEW: Can we simplify Interpreter::move_to?
+                interpreter.move_to(
+                    false,
+                    resolver.loader(),
+                    gas_meter,
+                    data_store,
+                    addr,
+                    &ty,
+                    resource,
+                )?;
+            }
+            Bytecode::MoveToGeneric(si_idx) => {
+                let resource = interpreter.operand_stack.pop()?;
+                let signer_reference = interpreter.operand_stack.pop_as::<StructRef>()?;
+                let addr = signer_reference
+                    .borrow_field(0)?
+                    .value_as::<Reference>()?
+                    .read_ref()?
+                    .value_as::<AccountAddress>()?;
+                let ty = resolver.instantiate_generic_type(*si_idx, ty_args)?;
+                interpreter.move_to(
+                    true,
+                    resolver.loader(),
+                    gas_meter,
+                    data_store,
+                    addr,
+                    &ty,
+                    resource,
+                )?;
+            }
+            Bytecode::FreezeRef => {
+                gas_meter.charge_simple_instr(S::FreezeRef)?;
+                // FreezeRef should just be a null op as we don't distinguish between mut
+                // and immut ref at runtime.
+            }
+            Bytecode::Not => {
+                gas_meter.charge_simple_instr(S::Not)?;
+                let value = !interpreter.operand_stack.pop_as::<bool>()?;
+                interpreter.operand_stack.push(Value::bool(value))?;
+            }
+            Bytecode::Nop => {
+                gas_meter.charge_simple_instr(S::Nop)?;
+            }
+            Bytecode::VecPack(si, num) => {
+                let ty = resolver.instantiate_single_type(*si, ty_args)?;
+                Self::check_depth_of_type(resolver, &ty)?;
+                gas_meter.charge_vec_pack(
+                    make_ty!(&ty),
+                    interpreter.operand_stack.last_n(*num as usize)?,
+                )?;
+                let elements = interpreter.operand_stack.popn(*num as u16)?;
+                let value = Vector::pack(&ty, elements)?;
+                interpreter.operand_stack.push(value)?;
+            }
+            Bytecode::VecLen(si) => {
+                let vec_ref = interpreter.operand_stack.pop_as::<VectorRef>()?;
+                let ty = &resolver.instantiate_single_type(*si, ty_args)?;
+                gas_meter.charge_vec_len(TypeWithLoader {
+                    ty,
+                    loader: resolver.loader(),
+                })?;
+                let value = vec_ref.len(ty)?;
+                interpreter.operand_stack.push(value)?;
+            }
+            Bytecode::VecImmBorrow(si) => {
+                let idx = interpreter.operand_stack.pop_as::<u64>()? as usize;
+                let vec_ref = interpreter.operand_stack.pop_as::<VectorRef>()?;
+                let ty = resolver.instantiate_single_type(*si, ty_args)?;
+                let res = vec_ref.borrow_elem(idx, &ty);
+                gas_meter.charge_vec_borrow(false, make_ty!(&ty), res.is_ok())?;
+                interpreter.operand_stack.push(res?)?;
+            }
+            Bytecode::VecMutBorrow(si) => {
+                let idx = interpreter.operand_stack.pop_as::<u64>()? as usize;
+                let vec_ref = interpreter.operand_stack.pop_as::<VectorRef>()?;
+                let ty = &resolver.instantiate_single_type(*si, ty_args)?;
+                let res = vec_ref.borrow_elem(idx, ty);
+                gas_meter.charge_vec_borrow(true, make_ty!(ty), res.is_ok())?;
+                interpreter.operand_stack.push(res?)?;
+            }
+            Bytecode::VecPushBack(si) => {
+                let elem = interpreter.operand_stack.pop()?;
+                let vec_ref = interpreter.operand_stack.pop_as::<VectorRef>()?;
+                let ty = &resolver.instantiate_single_type(*si, ty_args)?;
+                gas_meter.charge_vec_push_back(make_ty!(ty), &elem)?;
+                vec_ref.push_back(elem, ty, interpreter.runtime_limits_config().vector_len_max)?;
+            }
+            Bytecode::VecPopBack(si) => {
+                let vec_ref = interpreter.operand_stack.pop_as::<VectorRef>()?;
+                let ty = &resolver.instantiate_single_type(*si, ty_args)?;
+                let res = vec_ref.pop(ty);
+                gas_meter.charge_vec_pop_back(make_ty!(ty), res.as_ref().ok())?;
+                interpreter.operand_stack.push(res?)?;
+            }
+            Bytecode::VecUnpack(si, num) => {
+                let vec_val = interpreter.operand_stack.pop_as::<Vector>()?;
+                let ty = &resolver.instantiate_single_type(*si, ty_args)?;
+                gas_meter.charge_vec_unpack(
+                    make_ty!(ty),
+                    NumArgs::new(*num),
+                    vec_val.elem_views(),
+                )?;
+                let elements = vec_val.unpack(ty, *num)?;
+                for value in elements {
+                    interpreter.operand_stack.push(value)?;
+                }
+            }
+            Bytecode::VecSwap(si) => {
+                let idx2 = interpreter.operand_stack.pop_as::<u64>()? as usize;
+                let idx1 = interpreter.operand_stack.pop_as::<u64>()? as usize;
+                let vec_ref = interpreter.operand_stack.pop_as::<VectorRef>()?;
+                let ty = &resolver.instantiate_single_type(*si, ty_args)?;
+                gas_meter.charge_vec_swap(make_ty!(ty))?;
+                vec_ref.swap(idx1, idx2, ty)?;
+            }
+        }
+
+        Ok(InstrRet::Ok)
+    }
+    fn execute_code_impl(
+        &mut self,
+        resolver: &Resolver,
+        interpreter: &mut Interpreter,
+        data_store: &mut impl DataStore,
+        gas_meter: &mut impl GasMeter,
+    ) -> PartialVMResult<ExitCode> {
         let code = self.function.code();
         loop {
             for instruction in &code[self.pc as usize..] {
@@ -1787,563 +2331,24 @@ impl Frame {
                     )?;
                 }
 
-                match instruction {
-                    Bytecode::Pop => {
-                        let popped_val = interpreter.operand_stack.pop()?;
-                        gas_meter.charge_pop(popped_val)?;
+                match Self::execute_instruction(
+                    &mut self.pc,
+                    &mut self.locals,
+                    &self.ty_args,
+                    &self.function,
+                    resolver,
+                    interpreter,
+                    data_store,
+                    gas_meter,
+                    instruction,
+                )? {
+                    InstrRet::Ok => (),
+                    InstrRet::ExitCode(exit_code) => {
+                        return Ok(exit_code);
                     }
-                    Bytecode::Ret => {
-                        gas_meter.charge_simple_instr(S::Ret)?;
-                        return Ok(ExitCode::Return);
-                    }
-                    Bytecode::BrTrue(offset) => {
-                        gas_meter.charge_simple_instr(S::BrTrue)?;
-                        if interpreter.operand_stack.pop_as::<bool>()? {
-                            self.pc = *offset;
-                            break;
-                        }
-                    }
-                    Bytecode::BrFalse(offset) => {
-                        gas_meter.charge_simple_instr(S::BrFalse)?;
-                        if !interpreter.operand_stack.pop_as::<bool>()? {
-                            self.pc = *offset;
-                            break;
-                        }
-                    }
-                    Bytecode::Branch(offset) => {
-                        gas_meter.charge_simple_instr(S::Branch)?;
-                        self.pc = *offset;
-                        break;
-                    }
-                    Bytecode::LdU8(int_const) => {
-                        gas_meter.charge_simple_instr(S::LdU8)?;
-                        interpreter.operand_stack.push(Value::u8(*int_const))?;
-                    }
-                    Bytecode::LdU16(int_const) => {
-                        gas_meter.charge_simple_instr(S::LdU16)?;
-                        interpreter.operand_stack.push(Value::u16(*int_const))?;
-                    }
-                    Bytecode::LdU32(int_const) => {
-                        gas_meter.charge_simple_instr(S::LdU32)?;
-                        interpreter.operand_stack.push(Value::u32(*int_const))?;
-                    }
-                    Bytecode::LdU64(int_const) => {
-                        gas_meter.charge_simple_instr(S::LdU64)?;
-                        interpreter.operand_stack.push(Value::u64(*int_const))?;
-                    }
-                    Bytecode::LdU128(int_const) => {
-                        gas_meter.charge_simple_instr(S::LdU128)?;
-                        interpreter.operand_stack.push(Value::u128(*int_const))?;
-                    }
-                    Bytecode::LdU256(int_const) => {
-                        gas_meter.charge_simple_instr(S::LdU256)?;
-                        interpreter.operand_stack.push(Value::u256(*int_const))?;
-                    }
-                    Bytecode::LdConst(idx) => {
-                        let constant = resolver.constant_at(*idx);
-                        gas_meter.charge_ld_const(NumBytes::new(constant.data.len() as u64))?;
+                    InstrRet::Branch => break,
+                };
 
-                        let val = Value::deserialize_constant(constant).ok_or_else(|| {
-                            PartialVMError::new(StatusCode::VERIFIER_INVARIANT_VIOLATION)
-                                .with_message(
-                                    "Verifier failed to verify the deserialization of constants"
-                                        .to_owned(),
-                                )
-                        })?;
-
-                        gas_meter.charge_ld_const_after_deserialization(&val)?;
-
-                        interpreter.operand_stack.push(val)?
-                    }
-                    Bytecode::LdTrue => {
-                        gas_meter.charge_simple_instr(S::LdTrue)?;
-                        interpreter.operand_stack.push(Value::bool(true))?;
-                    }
-                    Bytecode::LdFalse => {
-                        gas_meter.charge_simple_instr(S::LdFalse)?;
-                        interpreter.operand_stack.push(Value::bool(false))?;
-                    }
-                    Bytecode::CopyLoc(idx) => {
-                        // TODO(Gas): We should charge gas before copying the value.
-                        let local = self.locals.copy_loc(*idx as usize)?;
-                        gas_meter.charge_copy_loc(&local)?;
-                        interpreter.operand_stack.push(local)?;
-                    }
-                    Bytecode::MoveLoc(idx) => {
-                        let local = self.locals.move_loc(
-                            *idx as usize,
-                            resolver
-                                .loader()
-                                .vm_config()
-                                .enable_invariant_violation_check_in_swap_loc,
-                        )?;
-                        gas_meter.charge_move_loc(&local)?;
-
-                        interpreter.operand_stack.push(local)?;
-                    }
-                    Bytecode::StLoc(idx) => {
-                        let value_to_store = interpreter.operand_stack.pop()?;
-                        gas_meter.charge_store_loc(&value_to_store)?;
-                        self.locals.store_loc(
-                            *idx as usize,
-                            value_to_store,
-                            resolver
-                                .loader()
-                                .vm_config()
-                                .enable_invariant_violation_check_in_swap_loc,
-                        )?;
-                    }
-                    Bytecode::Call(idx) => {
-                        return Ok(ExitCode::Call(*idx));
-                    }
-                    Bytecode::CallGeneric(idx) => {
-                        return Ok(ExitCode::CallGeneric(*idx));
-                    }
-                    Bytecode::MutBorrowLoc(idx) | Bytecode::ImmBorrowLoc(idx) => {
-                        let instr = match instruction {
-                            Bytecode::MutBorrowLoc(_) => S::MutBorrowLoc,
-                            _ => S::ImmBorrowLoc,
-                        };
-                        gas_meter.charge_simple_instr(instr)?;
-                        interpreter
-                            .operand_stack
-                            .push(self.locals.borrow_loc(*idx as usize)?)?;
-                    }
-                    Bytecode::ImmBorrowField(fh_idx) | Bytecode::MutBorrowField(fh_idx) => {
-                        let instr = match instruction {
-                            Bytecode::MutBorrowField(_) => S::MutBorrowField,
-                            _ => S::ImmBorrowField,
-                        };
-                        gas_meter.charge_simple_instr(instr)?;
-
-                        let reference = interpreter.operand_stack.pop_as::<StructRef>()?;
-
-                        let offset = resolver.field_offset(*fh_idx);
-                        let field_ref = reference.borrow_field(offset)?;
-                        interpreter.operand_stack.push(field_ref)?;
-                    }
-                    Bytecode::ImmBorrowFieldGeneric(fi_idx)
-                    | Bytecode::MutBorrowFieldGeneric(fi_idx) => {
-                        let instr = match instruction {
-                            Bytecode::MutBorrowField(_) => S::MutBorrowFieldGeneric,
-                            _ => S::ImmBorrowFieldGeneric,
-                        };
-                        gas_meter.charge_simple_instr(instr)?;
-
-                        let reference = interpreter.operand_stack.pop_as::<StructRef>()?;
-
-                        let offset = resolver.field_instantiation_offset(*fi_idx);
-                        let field_ref = reference.borrow_field(offset)?;
-                        interpreter.operand_stack.push(field_ref)?;
-                    }
-                    Bytecode::Pack(sd_idx) => {
-                        let field_count = resolver.field_count(*sd_idx);
-                        let struct_type = resolver.get_struct_type(*sd_idx);
-                        self.check_depth_of_type(resolver, &struct_type)?;
-                        gas_meter.charge_pack(
-                            false,
-                            interpreter.operand_stack.last_n(field_count as usize)?,
-                        )?;
-                        let args = interpreter.operand_stack.popn(field_count)?;
-                        interpreter
-                            .operand_stack
-                            .push(Value::struct_(Struct::pack(args)))?;
-                    }
-                    Bytecode::PackGeneric(si_idx) => {
-                        let field_count = resolver.field_instantiation_count(*si_idx);
-                        let ty = resolver.instantiate_generic_type(*si_idx, self.ty_args())?;
-                        self.check_depth_of_type(resolver, &ty)?;
-                        gas_meter.charge_pack(
-                            true,
-                            interpreter.operand_stack.last_n(field_count as usize)?,
-                        )?;
-                        let args = interpreter.operand_stack.popn(field_count)?;
-                        interpreter
-                            .operand_stack
-                            .push(Value::struct_(Struct::pack(args)))?;
-                    }
-                    Bytecode::Unpack(_sd_idx) => {
-                        let struct_ = interpreter.operand_stack.pop_as::<Struct>()?;
-
-                        gas_meter.charge_unpack(false, struct_.field_views())?;
-
-                        for value in struct_.unpack()? {
-                            interpreter.operand_stack.push(value)?;
-                        }
-                    }
-                    Bytecode::UnpackGeneric(_si_idx) => {
-                        let struct_ = interpreter.operand_stack.pop_as::<Struct>()?;
-
-                        gas_meter.charge_unpack(true, struct_.field_views())?;
-
-                        // TODO: Whether or not we want this gas metering in the loop is
-                        // questionable.  However, if we don't have it in the loop we could wind up
-                        // doing a fair bit of work before charging for it.
-                        for value in struct_.unpack()? {
-                            interpreter.operand_stack.push(value)?;
-                        }
-                    }
-                    Bytecode::ReadRef => {
-                        let reference = interpreter.operand_stack.pop_as::<Reference>()?;
-                        gas_meter.charge_read_ref(reference.value_view())?;
-                        let value = reference.read_ref()?;
-                        interpreter.operand_stack.push(value)?;
-                    }
-                    Bytecode::WriteRef => {
-                        let reference = interpreter.operand_stack.pop_as::<Reference>()?;
-                        let value = interpreter.operand_stack.pop()?;
-                        gas_meter.charge_write_ref(&value, reference.value_view())?;
-                        reference.write_ref(value)?;
-                    }
-                    Bytecode::CastU8 => {
-                        gas_meter.charge_simple_instr(S::CastU8)?;
-                        let integer_value = interpreter.operand_stack.pop_as::<IntegerValue>()?;
-                        interpreter
-                            .operand_stack
-                            .push(Value::u8(integer_value.cast_u8()?))?;
-                    }
-                    Bytecode::CastU16 => {
-                        gas_meter.charge_simple_instr(S::CastU16)?;
-                        let integer_value = interpreter.operand_stack.pop_as::<IntegerValue>()?;
-                        interpreter
-                            .operand_stack
-                            .push(Value::u16(integer_value.cast_u16()?))?;
-                    }
-                    Bytecode::CastU32 => {
-                        gas_meter.charge_simple_instr(S::CastU16)?;
-                        let integer_value = interpreter.operand_stack.pop_as::<IntegerValue>()?;
-                        interpreter
-                            .operand_stack
-                            .push(Value::u32(integer_value.cast_u32()?))?;
-                    }
-                    Bytecode::CastU64 => {
-                        gas_meter.charge_simple_instr(S::CastU64)?;
-                        let integer_value = interpreter.operand_stack.pop_as::<IntegerValue>()?;
-                        interpreter
-                            .operand_stack
-                            .push(Value::u64(integer_value.cast_u64()?))?;
-                    }
-                    Bytecode::CastU128 => {
-                        gas_meter.charge_simple_instr(S::CastU128)?;
-                        let integer_value = interpreter.operand_stack.pop_as::<IntegerValue>()?;
-                        interpreter
-                            .operand_stack
-                            .push(Value::u128(integer_value.cast_u128()?))?;
-                    }
-                    Bytecode::CastU256 => {
-                        gas_meter.charge_simple_instr(S::CastU16)?;
-                        let integer_value = interpreter.operand_stack.pop_as::<IntegerValue>()?;
-                        interpreter
-                            .operand_stack
-                            .push(Value::u256(integer_value.cast_u256()?))?;
-                    }
-                    // Arithmetic Operations
-                    Bytecode::Add => {
-                        gas_meter.charge_simple_instr(S::Add)?;
-                        interpreter.binop_int(IntegerValue::add_checked)?
-                    }
-                    Bytecode::Sub => {
-                        gas_meter.charge_simple_instr(S::Sub)?;
-                        interpreter.binop_int(IntegerValue::sub_checked)?
-                    }
-                    Bytecode::Mul => {
-                        gas_meter.charge_simple_instr(S::Mul)?;
-                        interpreter.binop_int(IntegerValue::mul_checked)?
-                    }
-                    Bytecode::Mod => {
-                        gas_meter.charge_simple_instr(S::Mod)?;
-                        interpreter.binop_int(IntegerValue::rem_checked)?
-                    }
-                    Bytecode::Div => {
-                        gas_meter.charge_simple_instr(S::Div)?;
-                        interpreter.binop_int(IntegerValue::div_checked)?
-                    }
-                    Bytecode::BitOr => {
-                        gas_meter.charge_simple_instr(S::BitOr)?;
-                        interpreter.binop_int(IntegerValue::bit_or)?
-                    }
-                    Bytecode::BitAnd => {
-                        gas_meter.charge_simple_instr(S::BitAnd)?;
-                        interpreter.binop_int(IntegerValue::bit_and)?
-                    }
-                    Bytecode::Xor => {
-                        gas_meter.charge_simple_instr(S::Xor)?;
-                        interpreter.binop_int(IntegerValue::bit_xor)?
-                    }
-                    Bytecode::Shl => {
-                        gas_meter.charge_simple_instr(S::Shl)?;
-                        let rhs = interpreter.operand_stack.pop_as::<u8>()?;
-                        let lhs = interpreter.operand_stack.pop_as::<IntegerValue>()?;
-                        interpreter
-                            .operand_stack
-                            .push(lhs.shl_checked(rhs)?.into_value())?;
-                    }
-                    Bytecode::Shr => {
-                        gas_meter.charge_simple_instr(S::Shr)?;
-                        let rhs = interpreter.operand_stack.pop_as::<u8>()?;
-                        let lhs = interpreter.operand_stack.pop_as::<IntegerValue>()?;
-                        interpreter
-                            .operand_stack
-                            .push(lhs.shr_checked(rhs)?.into_value())?;
-                    }
-                    Bytecode::Or => {
-                        gas_meter.charge_simple_instr(S::Or)?;
-                        interpreter.binop_bool(|l, r| Ok(l || r))?
-                    }
-                    Bytecode::And => {
-                        gas_meter.charge_simple_instr(S::And)?;
-                        interpreter.binop_bool(|l, r| Ok(l && r))?
-                    }
-                    Bytecode::Lt => {
-                        gas_meter.charge_simple_instr(S::Lt)?;
-                        interpreter.binop_bool(IntegerValue::lt)?
-                    }
-                    Bytecode::Gt => {
-                        gas_meter.charge_simple_instr(S::Gt)?;
-                        interpreter.binop_bool(IntegerValue::gt)?
-                    }
-                    Bytecode::Le => {
-                        gas_meter.charge_simple_instr(S::Le)?;
-                        interpreter.binop_bool(IntegerValue::le)?
-                    }
-                    Bytecode::Ge => {
-                        gas_meter.charge_simple_instr(S::Ge)?;
-                        interpreter.binop_bool(IntegerValue::ge)?
-                    }
-                    Bytecode::Abort => {
-                        gas_meter.charge_simple_instr(S::Abort)?;
-                        let error_code = interpreter.operand_stack.pop_as::<u64>()?;
-                        let error = PartialVMError::new(StatusCode::ABORTED)
-                            .with_sub_status(error_code)
-                            .with_message(format!(
-                                "{} at offset {}",
-                                self.function.pretty_string(),
-                                self.pc,
-                            ));
-                        return Err(error);
-                    }
-                    Bytecode::Eq => {
-                        let lhs = interpreter.operand_stack.pop()?;
-                        let rhs = interpreter.operand_stack.pop()?;
-                        gas_meter.charge_eq(&lhs, &rhs)?;
-                        interpreter
-                            .operand_stack
-                            .push(Value::bool(lhs.equals(&rhs)?))?;
-                    }
-                    Bytecode::Neq => {
-                        let lhs = interpreter.operand_stack.pop()?;
-                        let rhs = interpreter.operand_stack.pop()?;
-                        gas_meter.charge_neq(&lhs, &rhs)?;
-                        interpreter
-                            .operand_stack
-                            .push(Value::bool(!lhs.equals(&rhs)?))?;
-                    }
-                    Bytecode::MutBorrowGlobal(sd_idx) | Bytecode::ImmBorrowGlobal(sd_idx) => {
-                        let is_mut = matches!(instruction, Bytecode::MutBorrowGlobal(_));
-                        let addr = interpreter.operand_stack.pop_as::<AccountAddress>()?;
-                        let ty = resolver.get_struct_type(*sd_idx);
-                        interpreter.borrow_global(
-                            is_mut,
-                            false,
-                            resolver.loader(),
-                            gas_meter,
-                            data_store,
-                            addr,
-                            &ty,
-                        )?;
-                    }
-                    Bytecode::MutBorrowGlobalGeneric(si_idx)
-                    | Bytecode::ImmBorrowGlobalGeneric(si_idx) => {
-                        let is_mut = matches!(instruction, Bytecode::MutBorrowGlobalGeneric(_));
-                        let addr = interpreter.operand_stack.pop_as::<AccountAddress>()?;
-                        let ty = resolver.instantiate_generic_type(*si_idx, self.ty_args())?;
-                        interpreter.borrow_global(
-                            is_mut,
-                            true,
-                            resolver.loader(),
-                            gas_meter,
-                            data_store,
-                            addr,
-                            &ty,
-                        )?;
-                    }
-                    Bytecode::Exists(sd_idx) => {
-                        let addr = interpreter.operand_stack.pop_as::<AccountAddress>()?;
-                        let ty = resolver.get_struct_type(*sd_idx);
-                        interpreter.exists(
-                            false,
-                            resolver.loader(),
-                            gas_meter,
-                            data_store,
-                            addr,
-                            &ty,
-                        )?;
-                    }
-                    Bytecode::ExistsGeneric(si_idx) => {
-                        let addr = interpreter.operand_stack.pop_as::<AccountAddress>()?;
-                        let ty = resolver.instantiate_generic_type(*si_idx, self.ty_args())?;
-                        interpreter.exists(
-                            true,
-                            resolver.loader(),
-                            gas_meter,
-                            data_store,
-                            addr,
-                            &ty,
-                        )?;
-                    }
-                    Bytecode::MoveFrom(sd_idx) => {
-                        let addr = interpreter.operand_stack.pop_as::<AccountAddress>()?;
-                        let ty = resolver.get_struct_type(*sd_idx);
-                        interpreter.move_from(
-                            false,
-                            resolver.loader(),
-                            gas_meter,
-                            data_store,
-                            addr,
-                            &ty,
-                        )?;
-                    }
-                    Bytecode::MoveFromGeneric(si_idx) => {
-                        let addr = interpreter.operand_stack.pop_as::<AccountAddress>()?;
-                        let ty = resolver.instantiate_generic_type(*si_idx, self.ty_args())?;
-                        interpreter.move_from(
-                            true,
-                            resolver.loader(),
-                            gas_meter,
-                            data_store,
-                            addr,
-                            &ty,
-                        )?;
-                    }
-                    Bytecode::MoveTo(sd_idx) => {
-                        let resource = interpreter.operand_stack.pop()?;
-                        let signer_reference = interpreter.operand_stack.pop_as::<StructRef>()?;
-                        let addr = signer_reference
-                            .borrow_field(0)?
-                            .value_as::<Reference>()?
-                            .read_ref()?
-                            .value_as::<AccountAddress>()?;
-                        let ty = resolver.get_struct_type(*sd_idx);
-                        // REVIEW: Can we simplify Interpreter::move_to?
-                        interpreter.move_to(
-                            false,
-                            resolver.loader(),
-                            gas_meter,
-                            data_store,
-                            addr,
-                            &ty,
-                            resource,
-                        )?;
-                    }
-                    Bytecode::MoveToGeneric(si_idx) => {
-                        let resource = interpreter.operand_stack.pop()?;
-                        let signer_reference = interpreter.operand_stack.pop_as::<StructRef>()?;
-                        let addr = signer_reference
-                            .borrow_field(0)?
-                            .value_as::<Reference>()?
-                            .read_ref()?
-                            .value_as::<AccountAddress>()?;
-                        let ty = resolver.instantiate_generic_type(*si_idx, self.ty_args())?;
-                        interpreter.move_to(
-                            true,
-                            resolver.loader(),
-                            gas_meter,
-                            data_store,
-                            addr,
-                            &ty,
-                            resource,
-                        )?;
-                    }
-                    Bytecode::FreezeRef => {
-                        gas_meter.charge_simple_instr(S::FreezeRef)?;
-                        // FreezeRef should just be a null op as we don't distinguish between mut
-                        // and immut ref at runtime.
-                    }
-                    Bytecode::Not => {
-                        gas_meter.charge_simple_instr(S::Not)?;
-                        let value = !interpreter.operand_stack.pop_as::<bool>()?;
-                        interpreter.operand_stack.push(Value::bool(value))?;
-                    }
-                    Bytecode::Nop => {
-                        gas_meter.charge_simple_instr(S::Nop)?;
-                    }
-                    Bytecode::VecPack(si, num) => {
-                        let ty = resolver.instantiate_single_type(*si, self.ty_args())?;
-                        self.check_depth_of_type(resolver, &ty)?;
-                        gas_meter.charge_vec_pack(
-                            make_ty!(&ty),
-                            interpreter.operand_stack.last_n(*num as usize)?,
-                        )?;
-                        let elements = interpreter.operand_stack.popn(*num as u16)?;
-                        let value = Vector::pack(&ty, elements)?;
-                        interpreter.operand_stack.push(value)?;
-                    }
-                    Bytecode::VecLen(si) => {
-                        let vec_ref = interpreter.operand_stack.pop_as::<VectorRef>()?;
-                        let ty = &resolver.instantiate_single_type(*si, self.ty_args())?;
-                        gas_meter.charge_vec_len(TypeWithLoader {
-                            ty,
-                            loader: resolver.loader(),
-                        })?;
-                        let value = vec_ref.len(ty)?;
-                        interpreter.operand_stack.push(value)?;
-                    }
-                    Bytecode::VecImmBorrow(si) => {
-                        let idx = interpreter.operand_stack.pop_as::<u64>()? as usize;
-                        let vec_ref = interpreter.operand_stack.pop_as::<VectorRef>()?;
-                        let ty = resolver.instantiate_single_type(*si, self.ty_args())?;
-                        let res = vec_ref.borrow_elem(idx, &ty);
-                        gas_meter.charge_vec_borrow(false, make_ty!(&ty), res.is_ok())?;
-                        interpreter.operand_stack.push(res?)?;
-                    }
-                    Bytecode::VecMutBorrow(si) => {
-                        let idx = interpreter.operand_stack.pop_as::<u64>()? as usize;
-                        let vec_ref = interpreter.operand_stack.pop_as::<VectorRef>()?;
-                        let ty = &resolver.instantiate_single_type(*si, self.ty_args())?;
-                        let res = vec_ref.borrow_elem(idx, ty);
-                        gas_meter.charge_vec_borrow(true, make_ty!(ty), res.is_ok())?;
-                        interpreter.operand_stack.push(res?)?;
-                    }
-                    Bytecode::VecPushBack(si) => {
-                        let elem = interpreter.operand_stack.pop()?;
-                        let vec_ref = interpreter.operand_stack.pop_as::<VectorRef>()?;
-                        let ty = &resolver.instantiate_single_type(*si, self.ty_args())?;
-                        gas_meter.charge_vec_push_back(make_ty!(ty), &elem)?;
-                        vec_ref.push_back(
-                            elem,
-                            ty,
-                            interpreter.runtime_limits_config().vector_len_max,
-                        )?;
-                    }
-                    Bytecode::VecPopBack(si) => {
-                        let vec_ref = interpreter.operand_stack.pop_as::<VectorRef>()?;
-                        let ty = &resolver.instantiate_single_type(*si, self.ty_args())?;
-                        let res = vec_ref.pop(ty);
-                        gas_meter.charge_vec_pop_back(make_ty!(ty), res.as_ref().ok())?;
-                        interpreter.operand_stack.push(res?)?;
-                    }
-                    Bytecode::VecUnpack(si, num) => {
-                        let vec_val = interpreter.operand_stack.pop_as::<Vector>()?;
-                        let ty = &resolver.instantiate_single_type(*si, self.ty_args())?;
-                        gas_meter.charge_vec_unpack(
-                            make_ty!(ty),
-                            NumArgs::new(*num),
-                            vec_val.elem_views(),
-                        )?;
-                        let elements = vec_val.unpack(ty, *num)?;
-                        for value in elements {
-                            interpreter.operand_stack.push(value)?;
-                        }
-                    }
-                    Bytecode::VecSwap(si) => {
-                        let idx2 = interpreter.operand_stack.pop_as::<u64>()? as usize;
-                        let idx1 = interpreter.operand_stack.pop_as::<u64>()? as usize;
-                        let vec_ref = interpreter.operand_stack.pop_as::<VectorRef>()?;
-                        let ty = &resolver.instantiate_single_type(*si, self.ty_args())?;
-                        gas_meter.charge_vec_swap(make_ty!(ty))?;
-                        vec_ref.swap(idx1, idx2, ty)?;
-                    }
-                }
                 if interpreter.paranoid_type_checks {
                     Self::post_execution_type_stack_transition(
                         &self.local_tys,
@@ -2390,7 +2395,7 @@ impl Frame {
         }
     }
 
-    fn check_depth_of_type(&self, resolver: &Resolver, ty: &Type) -> PartialVMResult<u64> {
+    fn check_depth_of_type(resolver: &Resolver, ty: &Type) -> PartialVMResult<u64> {
         let Some(max_depth) = resolver
             .loader()
             .vm_config()
@@ -2398,11 +2403,10 @@ impl Frame {
             .max_value_nest_depth else {
             return Ok(1);
         };
-        self.check_depth_of_type_impl(resolver, ty, 0, max_depth)
+        Self::check_depth_of_type_impl(resolver, ty, 0, max_depth)
     }
 
     fn check_depth_of_type_impl(
-        &self,
         resolver: &Resolver,
         ty: &Type,
         current_depth: u64,
@@ -2432,7 +2436,7 @@ impl Frame {
             // Even though this is recursive this is OK since the depth of this recursion is
             // bounded by the depth of the type arguments, which we have already checked.
             Type::Reference(ty) | Type::MutableReference(ty) | Type::Vector(ty) => {
-                self.check_depth_of_type_impl(resolver, ty, check_depth!(1), max_depth)?
+                Self::check_depth_of_type_impl(resolver, ty, check_depth!(1), max_depth)?
             }
             Type::Struct(si) => {
                 let struct_type = resolver.loader().get_struct_type(*si).ok_or_else(|| {
@@ -2451,7 +2455,7 @@ impl Frame {
                     .iter()
                     .map(|ty| {
                         // Ty args should be fully resolved and not need any type arguments
-                        self.check_depth_of_type_impl(resolver, ty, check_depth!(0), max_depth)
+                        Self::check_depth_of_type_impl(resolver, ty, check_depth!(0), max_depth)
                     })
                     .collect::<PartialVMResult<Vec<_>>>()?;
                 let struct_type = resolver.loader().get_struct_type(*si).ok_or_else(|| {


### PR DESCRIPTION
## Description 

Moves out the interpreter instr match into a func so its simpler to add pre/post hooks, and overall cleaner.

## Test Plan 

existing unit tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
