### PR TITLE
call get_highest_pruned_checkpoint_seq_number to get the lowest available checkpoint for state sync

### DIFF
--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -82,9 +82,9 @@ impl ReadStore for RocksDbStore {
     }
 
     fn get_lowest_available_checkpoint(&self) -> Result<CheckpointSequenceNumber, Self::Error> {
-        // TODO: use checkpoint_store.get_highest_pruned_checkpoint_seq_number once
-        // https://github.com/MystenLabs/sui/pull/12067 lands
-        Ok(0)
+        self.checkpoint_store
+            .get_highest_pruned_checkpoint_seq_number()
+            .map(|seq| seq + 1)
     }
 
     fn get_full_checkpoint_contents_by_sequence_number(


### PR DESCRIPTION
## Description 

Wire things up.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
State sync now answer checkpoint availability inquiry by calling checkpoint_store.get_highest_pruned_checkpoint_seq_number