### PR TITLE
Multiple small refactor to blob related code

### DIFF
--- a/crates/sui-archival/src/tests.rs
+++ b/crates/sui-archival/src/tests.rs
@@ -1,10 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::writer::ArchiveWriterV1;
-use crate::{
-    read_manifest, write_manifest, FileCompression, Manifest, StorageFormat, EPOCH_DIR_PREFIX,
-};
+use crate::writer::ArchiveWriter;
+use crate::{read_manifest, write_manifest, Manifest, EPOCH_DIR_PREFIX};
 use anyhow::Result;
 use object_store::path::Path;
 use object_store::DynObjectStore;
@@ -15,13 +13,14 @@ use std::time::Duration;
 use sui_macros::sim_test;
 use sui_storage::object_store::util::path_to_filesystem;
 use sui_storage::object_store::{ObjectStoreConfig, ObjectStoreType};
+use sui_storage::{FileCompression, StorageFormat};
 use sui_swarm_config::test_utils::{empty_contents, CommitteeFixture};
 use sui_types::messages_checkpoint::VerifiedCheckpoint;
 use sui_types::storage::SharedInMemoryStore;
 use tempfile::tempdir;
 
 struct TestState {
-    archive_writer: ArchiveWriterV1,
+    archive_writer: ArchiveWriter,
     local_path: PathBuf,
     remote_path: PathBuf,
     local_store: Arc<DynObjectStore>,
@@ -71,7 +70,7 @@ async fn setup_checkpoint_writer(temp_dir: PathBuf) -> anyhow::Result<TestState>
         ..Default::default()
     };
     let committee = CommitteeFixture::generate(rand::rngs::OsRng, 0, 4);
-    let archive_writer = ArchiveWriterV1::new(
+    let archive_writer = ArchiveWriter::new(
         local_store_config.clone(),
         remote_store_config.clone(),
         FileCompression::Zstd,

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -43,8 +43,7 @@ use mysten_metrics::{spawn_monitored_task, RegistryService};
 use mysten_network::server::ServerBuilder;
 use narwhal_network::metrics::MetricsMakeCallbackHandler;
 use narwhal_network::metrics::{NetworkConnectionMetrics, NetworkMetrics};
-use sui_archival::writer::ArchiveWriterV1;
-use sui_archival::StorageFormat;
+use sui_archival::writer::ArchiveWriter;
 use sui_config::node::DBCheckpointConfig;
 use sui_config::node_config_metrics::NodeConfigMetrics;
 use sui_config::{ConsensusConfig, NodeConfig};
@@ -94,7 +93,7 @@ use sui_network::discovery::TrustedPeerChangeEvent;
 use sui_network::state_sync;
 use sui_protocol_config::{ProtocolConfig, SupportedProtocolVersions};
 use sui_storage::object_store::{ObjectStoreConfig, ObjectStoreType};
-use sui_storage::{FileCompression, IndexStore};
+use sui_storage::{FileCompression, IndexStore, StorageFormat};
 use sui_types::base_types::{AuthorityName, EpochId, TransactionDigest};
 use sui_types::committee::Committee;
 use sui_types::crypto::KeypairTraits;
@@ -385,7 +384,7 @@ impl SuiNode {
                     directory: Some(config.archive_path()),
                     ..Default::default()
                 };
-                let archive_writer = ArchiveWriterV1::new(
+                let archive_writer = ArchiveWriter::new(
                     local_store_config,
                     remote_store_config.clone(),
                     FileCompression::Zstd,

--- a/crates/sui-snapshot/src/reader.rs
+++ b/crates/sui-snapshot/src/reader.rs
@@ -24,9 +24,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use sui_core::authority::authority_store_tables::{AuthorityPerpetualTables, LiveObject};
 use sui_core::authority::AuthorityStore;
+use sui_storage::blob::{Blob, BlobEncoding};
 use sui_storage::object_store::util::{copy_file, copy_files, path_to_filesystem};
 use sui_storage::object_store::ObjectStoreConfig;
-use sui_storage::{Blob, Encoding};
 use sui_types::base_types::{ObjectDigest, ObjectID, ObjectRef, SequenceNumber};
 use tokio::sync::Mutex;
 
@@ -390,7 +390,7 @@ impl LiveObjectIter {
         self.reader.read_exact(&mut data)?;
         let blob = Blob {
             data,
-            encoding: Encoding::try_from(encoding)?,
+            encoding: BlobEncoding::try_from(encoding)?,
         };
         blob.decode()
     }

--- a/crates/sui-snapshot/src/writer.rs
+++ b/crates/sui-snapshot/src/writer.rs
@@ -23,9 +23,9 @@ use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::sync::Arc;
 use sui_core::authority::authority_store_tables::{AuthorityPerpetualTables, LiveObject};
+use sui_storage::blob::{Blob, BlobEncoding, BLOB_ENCODING_BYTES};
 use sui_storage::object_store::util::{copy_file, delete_recursively, path_to_filesystem};
 use sui_storage::object_store::ObjectStoreConfig;
-use sui_storage::{Blob, Encoding, BLOB_ENCODING_BYTES};
 use sui_types::base_types::{ObjectID, ObjectRef};
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::{Receiver, Sender};
@@ -183,7 +183,7 @@ impl LiveObjectSetWriterV1 {
         Ok(())
     }
     async fn write_object(&mut self, object: &LiveObject) -> Result<()> {
-        let blob = Blob::encode(object, Encoding::Bcs)?;
+        let blob = Blob::encode(object, BlobEncoding::Bcs)?;
         let mut blob_size = blob.data.len().required_space();
         blob_size += BLOB_ENCODING_BYTES;
         blob_size += blob.data.len();

--- a/crates/sui-storage/src/blob.rs
+++ b/crates/sui-storage/src/blob.rs
@@ -1,0 +1,111 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{anyhow, Result};
+use byteorder::ReadBytesExt;
+use integer_encoding::{VarInt, VarIntReader};
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use std::io::{Read, Write};
+use std::marker::PhantomData;
+
+pub const MAX_VARINT_LENGTH: usize = 10;
+pub const BLOB_ENCODING_BYTES: usize = 1;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, TryFromPrimitive, IntoPrimitive)]
+#[repr(u8)]
+pub enum BlobEncoding {
+    Bcs = 1,
+}
+
+pub struct Blob {
+    pub data: Vec<u8>,
+    pub encoding: BlobEncoding,
+}
+
+impl Blob {
+    pub fn encode<T: Serialize>(value: &T, encoding: BlobEncoding) -> Result<Self> {
+        let value_buf = bcs::to_bytes(value)?;
+        let (data, encoding) = match encoding {
+            BlobEncoding::Bcs => (value_buf, encoding),
+        };
+        Ok(Blob { data, encoding })
+    }
+    pub fn decode<T: DeserializeOwned>(self) -> Result<T> {
+        let data = match &self.encoding {
+            BlobEncoding::Bcs => self.data,
+        };
+        let res = bcs::from_bytes(&data)?;
+        Ok(res)
+    }
+    pub fn read<R: Read>(rbuf: &mut R) -> Result<Blob> {
+        let len = rbuf.read_varint::<u64>()? as usize;
+        if len == 0 {
+            return Err(anyhow!("Invalid object length of 0 in file"));
+        }
+        let encoding = rbuf.read_u8()?;
+        let mut data = vec![0u8; len];
+        rbuf.read_exact(&mut data)?;
+        let blob = Blob {
+            data,
+            encoding: BlobEncoding::try_from(encoding)?,
+        };
+        Ok(blob)
+    }
+    pub fn write<W: Write>(&self, wbuf: &mut W) -> Result<usize> {
+        let mut buf = [0u8; MAX_VARINT_LENGTH];
+        let mut counter = 0;
+        let n = (self.data.len() as u64).encode_var(&mut buf);
+        wbuf.write_all(&buf[0..n])?;
+        counter += n;
+        buf[0] = self.encoding.into();
+        wbuf.write_all(&buf[0..BLOB_ENCODING_BYTES])?;
+        counter += 1;
+        wbuf.write_all(&self.data)?;
+        counter += self.data.len();
+        Ok(counter)
+    }
+    pub fn size(&self) -> usize {
+        let mut blob_size = self.data.len().required_space();
+        blob_size += BLOB_ENCODING_BYTES;
+        blob_size += self.data.len();
+        blob_size
+    }
+}
+
+/// An iterator over blobs in a blob file.
+pub struct BlobIter<T> {
+    reader: Box<dyn Read>,
+    _phantom: PhantomData<T>,
+}
+
+impl<T: DeserializeOwned> BlobIter<T> {
+    pub fn new(reader: Box<dyn Read>) -> Self {
+        Self {
+            reader,
+            _phantom: PhantomData,
+        }
+    }
+    fn next_blob(&mut self) -> Result<T> {
+        let len = self.reader.read_varint::<u64>()? as usize;
+        if len == 0 {
+            return Err(anyhow!("Invalid blob length of 0 in file"));
+        }
+        let encoding = self.reader.read_u8()?;
+        let mut data = vec![0u8; len];
+        self.reader.read_exact(&mut data)?;
+        let blob = Blob {
+            data,
+            encoding: BlobEncoding::try_from(encoding)?,
+        };
+        blob.decode()
+    }
+}
+
+impl<T: DeserializeOwned> Iterator for BlobIter<T> {
+    type Item = T;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next_blob().ok()
+    }
+}

--- a/crates/sui-storage/src/lib.rs
+++ b/crates/sui-storage/src/lib.rs
@@ -3,11 +3,11 @@
 
 pub mod indexes;
 
+use crate::blob::BlobIter;
 use anyhow::{anyhow, Result};
-use byteorder::ReadBytesExt;
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use bytes::{Buf, Bytes};
 pub use indexes::{IndexStore, IndexStoreTables};
-use integer_encoding::{VarInt, VarIntReader};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -17,6 +17,7 @@ use std::path::PathBuf;
 use std::{fs, io};
 use sui_simulator::fastcrypto::hash::{HashFunction, Sha3_256};
 
+pub mod blob;
 pub mod mutex_table;
 pub mod object_store;
 pub mod package_object_cache;
@@ -24,8 +25,14 @@ pub mod sharded_lru;
 pub mod write_path_pending_tx_log;
 
 pub const SHA3_BYTES: usize = 32;
-pub const MAX_VARINT_LENGTH: usize = 10;
-pub const BLOB_ENCODING_BYTES: usize = 1;
+
+#[derive(
+    Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, TryFromPrimitive, IntoPrimitive,
+)]
+#[repr(u8)]
+pub enum StorageFormat {
+    Blob = 0,
+}
 
 #[derive(
     Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, TryFromPrimitive, IntoPrimitive,
@@ -37,23 +44,21 @@ pub enum FileCompression {
 }
 
 impl FileCompression {
-    fn zstd_compress(source: &std::path::Path) -> io::Result<()> {
-        let mut file = File::open(source)?;
-        let tmp_file_name = source.with_extension("obj.tmp");
-        let mut encoder = {
-            let target = File::create(&tmp_file_name)?;
-            // TODO: Add zstd compression level as function argument
-            zstd::Encoder::new(target, 1)?
-        };
-        io::copy(&mut file, &mut encoder)?;
+    pub fn zstd_compress<R: Read, W: Write>(reader: &mut R, writer: &mut W) -> io::Result<()> {
+        // TODO: Add zstd compression level as function argument
+        let mut encoder = zstd::Encoder::new(writer, 1)?;
+        io::copy(reader, &mut encoder)?;
         encoder.finish()?;
-        fs::rename(tmp_file_name, source)?;
         Ok(())
     }
     pub fn compress(&self, source: &std::path::Path) -> io::Result<()> {
         match self {
             FileCompression::Zstd => {
-                Self::zstd_compress(source)?;
+                let mut input = File::open(source)?;
+                let tmp_file_name = source.with_extension("tmp");
+                let mut output = File::create(&tmp_file_name)?;
+                Self::zstd_compress(&mut input, &mut output)?;
+                fs::rename(tmp_file_name, source)?;
             }
             FileCompression::None => {}
         }
@@ -76,67 +81,6 @@ impl FileCompression {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, TryFromPrimitive, IntoPrimitive)]
-#[repr(u8)]
-pub enum Encoding {
-    Bcs = 1,
-}
-
-pub struct Blob {
-    pub data: Vec<u8>,
-    pub encoding: Encoding,
-}
-
-impl Blob {
-    pub fn encode<T: Serialize>(value: &T, encoding: Encoding) -> Result<Self> {
-        let value_buf = bcs::to_bytes(value)?;
-        let (data, encoding) = match encoding {
-            Encoding::Bcs => (value_buf, encoding),
-        };
-        Ok(Blob { data, encoding })
-    }
-    pub fn decode<T: DeserializeOwned>(self) -> Result<T> {
-        let data = match &self.encoding {
-            Encoding::Bcs => self.data,
-        };
-        let res = bcs::from_bytes(&data)?;
-        Ok(res)
-    }
-    pub fn read<R: Read>(rbuf: &mut R) -> Result<Blob> {
-        let len = rbuf.read_varint::<u64>()? as usize;
-        if len == 0 {
-            return Err(anyhow!("Invalid object length of 0 in file"));
-        }
-        let encoding = rbuf.read_u8()?;
-        let mut data = vec![0u8; len];
-        rbuf.read_exact(&mut data)?;
-        let blob = Blob {
-            data,
-            encoding: Encoding::try_from(encoding)?,
-        };
-        Ok(blob)
-    }
-    pub fn write<W: Write>(&self, wbuf: &mut W) -> Result<usize> {
-        let mut buf = [0u8; MAX_VARINT_LENGTH];
-        let mut counter = 0;
-        let n = (self.data.len() as u64).encode_var(&mut buf);
-        wbuf.write_all(&buf[0..n])?;
-        counter += n;
-        buf[0] = self.encoding.into();
-        wbuf.write_all(&buf[0..BLOB_ENCODING_BYTES])?;
-        counter += 1;
-        wbuf.write_all(&self.data)?;
-        counter += self.data.len();
-        Ok(counter)
-    }
-    pub fn size(&self) -> usize {
-        let mut blob_size = self.data.len().required_space();
-        blob_size += BLOB_ENCODING_BYTES;
-        blob_size += self.data.len();
-        blob_size
-    }
-}
-
 pub fn compute_sha3_checksum_for_file(file: &mut File) -> Result<[u8; 32]> {
     let mut hasher = Sha3_256::default();
     io::copy(file, &mut hasher)?;
@@ -146,4 +90,52 @@ pub fn compute_sha3_checksum_for_file(file: &mut File) -> Result<[u8; 32]> {
 pub fn compute_sha3_checksum(source: &std::path::Path) -> Result<[u8; 32]> {
     let mut file = fs::File::open(source)?;
     compute_sha3_checksum_for_file(&mut file)
+}
+
+pub fn compress<R: Read, W: Write>(reader: &mut R, writer: &mut W) -> Result<()> {
+    let magic = reader.read_u32::<BigEndian>()?;
+    writer.write_u32::<BigEndian>(magic)?;
+    let storage_format = reader.read_u8()?;
+    writer.write_u8(storage_format)?;
+    let file_compression = FileCompression::try_from(reader.read_u8()?)?;
+    writer.write_u8(file_compression.into())?;
+    match file_compression {
+        FileCompression::Zstd => {
+            FileCompression::zstd_compress(reader, writer)?;
+        }
+        FileCompression::None => {}
+    }
+    Ok(())
+}
+
+pub fn read<R: Read + 'static>(
+    expected_magic: u32,
+    mut reader: R,
+) -> Result<(Box<dyn Read>, StorageFormat)> {
+    let magic = reader.read_u32::<BigEndian>()?;
+    if magic != expected_magic {
+        Err(anyhow!(
+            "Unexpected magic string in file: {:?}, expected: {:?}",
+            magic,
+            expected_magic
+        ))
+    } else {
+        let storage_format = StorageFormat::try_from(reader.read_u8()?)?;
+        let file_compression = FileCompression::try_from(reader.read_u8()?)?;
+        let reader: Box<dyn Read> = match file_compression {
+            FileCompression::Zstd => Box::new(zstd::stream::Decoder::new(reader)?),
+            FileCompression::None => Box::new(BufReader::new(reader)),
+        };
+        Ok((reader, storage_format))
+    }
+}
+
+pub fn make_iterator<T: DeserializeOwned, R: Read + 'static>(
+    expected_magic: u32,
+    reader: R,
+) -> Result<impl Iterator<Item = T>> {
+    let (reader, storage_format) = read(expected_magic, reader)?;
+    match storage_format {
+        StorageFormat::Blob => Ok(BlobIter::new(reader)),
+    }
 }


### PR DESCRIPTION
## Description 

This PR mostly cleans up some existing code. Primarily the main changes are:
1. Move `blob` related code to blob.rs
2. Have one single file format which is used for both summary and content files. It is already written as blobs, so just introduce a common abstraction
3. Stop writing individual file's storage format and file compression in manifest. It can be read from the file header directly

5. ## Test Plan 

Existing tests
