### PR TITLE
[Kiosk SDK] Fixed typeArguments on createTransferPolicy method

### DIFF
--- a/.changeset/fair-bags-shout.md
+++ b/.changeset/fair-bags-shout.md
@@ -1,0 +1,5 @@
+---
+"@mysten/kiosk": patch
+---
+
+Fix on createTransferPolicy method. Updated type arguments for public_share_object command.

--- a/sdk/kiosk/src/tx/transfer-policy.ts
+++ b/sdk/kiosk/src/tx/transfer-policy.ts
@@ -8,6 +8,7 @@ import {
   ObjectArgument,
   RulesEnvironmentParam,
   TRANSFER_POLICY_MODULE,
+  TRANSFER_POLICY_TYPE,
 } from '../types';
 
 /**
@@ -27,7 +28,7 @@ export function createTransferPolicy(
 
   tx.moveCall({
     target: `0x2::transfer::public_share_object`,
-    typeArguments: [itemType],
+    typeArguments: [`${TRANSFER_POLICY_TYPE}<${itemType}>`],
     arguments: [transferPolicy],
   });
 


### PR DESCRIPTION
## Description 

Updated the type argument in the programmable transaction command that transfers the `TransferPolicy` on method `createTransferPolicy`

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
