### PR TITLE
add wait for finality times out metrics in transaction orchestrator

### DIFF
--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -183,6 +183,14 @@ where
                     .start_timer(),
             )
         };
+
+        // TODO: refactor all the gauge and timer metrics with `monitored_scope`
+        let wait_for_finality_gauge = self.metrics.wait_for_finality_in_flight.clone();
+        wait_for_finality_gauge.inc();
+        let _wait_for_finality_gauge = scopeguard::guard(wait_for_finality_gauge, |in_flight| {
+            in_flight.dec();
+        });
+
         let ticket = self.submit(transaction.clone()).await.map_err(|e| {
             warn!(?tx_digest, "QuorumDriverInternalError: {e:?}");
             QuorumDriverError::QuorumDriverInternalError(e)
@@ -198,9 +206,14 @@ where
             ticket,
         ).await else {
             debug!(?tx_digest, "Timeout waiting for transaction finality.");
+            self.metrics.wait_for_finality_timeout.inc();
             return Err(QuorumDriverError::TimeoutBeforeFinality);
         };
+
         drop(_txn_finality_timer);
+        drop(_wait_for_finality_gauge);
+        self.metrics.wait_for_finality_finished.inc();
+
         match result {
             Err(err) => Err(err),
             Ok(response) => {
@@ -289,6 +302,7 @@ where
         if validator_state.is_tx_already_executed(tx_digest)? {
             return Ok(());
         }
+        metrics.local_execution_in_flight.inc();
         let _metrics_guard =
             scopeguard::guard(metrics.local_execution_in_flight.clone(), |in_flight| {
                 in_flight.dec();
@@ -470,6 +484,10 @@ pub struct TransactionOrchestratorMetrics {
     req_in_flight_single_writer: GenericGauge<AtomicI64>,
     req_in_flight_shared_object: GenericGauge<AtomicI64>,
 
+    wait_for_finality_in_flight: GenericGauge<AtomicI64>,
+    wait_for_finality_finished: GenericCounter<AtomicU64>,
+    wait_for_finality_timeout: GenericCounter<AtomicU64>,
+
     local_execution_in_flight: GenericGauge<AtomicI64>,
     local_execution_success: GenericCounter<AtomicU64>,
     local_execution_timeout: GenericCounter<AtomicU64>,
@@ -551,6 +569,24 @@ impl TransactionOrchestratorMetrics {
             good_response_shared_object,
             req_in_flight_single_writer,
             req_in_flight_shared_object,
+            wait_for_finality_in_flight: register_int_gauge_with_registry!(
+                "tx_orchestrator_wait_for_finality_in_flight",
+                "Number of in flight txns Transaction Orchestrator are waiting for finality for",
+                registry,
+            )
+            .unwrap(),
+            wait_for_finality_finished: register_int_counter_with_registry!(
+                "tx_orchestrator_wait_for_finality_fnished",
+                "Total number of txns Transaction Orchestrator gets responses from Quorum Driver before timeout, either success or failure",
+                registry,
+            )
+            .unwrap(),
+            wait_for_finality_timeout: register_int_counter_with_registry!(
+                "tx_orchestrator_wait_for_finality_timeout",
+                "Total number of txns timing out in waiting for finality Transaction Orchestrator handles",
+                registry,
+            )
+            .unwrap(),
             local_execution_in_flight: register_int_gauge_with_registry!(
                 "tx_orchestrator_local_execution_in_flight",
                 "Number of local execution txns in flights Transaction Orchestrator handles",


### PR DESCRIPTION
## Description 

The timeout metric is worth alerting on.

## Test Plan 

👀 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
add wait for finality times out metrics in transaction orchestrator
