### PR TITLE
[docs/package-upgrades] Cannot add abilities to structs

### DIFF
--- a/doc/src/build/package-upgrades.md
+++ b/doc/src/build/package-upgrades.md
@@ -239,7 +239,6 @@ To upgrade a package, your package must satisfy the following requirements:
 * Your changes must be layout-compatible with the previous version. 
     * Existing `public` function signatures and struct layouts must remain the same.
     * You can add new structs and functions.
-    * You can add abilities to existing structs.
     * You can remove generic type constraints from existing functions (public or otherwise).
     * You can change function implementations.
     * You can change non-`public` function signatures, including `friend` and `entry` function signatures.


### PR DESCRIPTION
## Description

Remove the bullet that indicates that adding abilities to structs during upgrades is supported -- it is not possible to support this without struct version constraints.

## Test Plan 

👀 , also spot checked other locations that mention upgrades and abilities to make sure they are also up-to-date -- they already were, we must have just missed this reference.