### PR TITLE
[Kiosk SDK] Adds `getOwnedKiosks` query

### DIFF
--- a/.changeset/brown-candles-suffer.md
+++ b/.changeset/brown-candles-suffer.md
@@ -1,0 +1,5 @@
+---
+"@mysten/kiosk": patch
+---
+
+Add `getOwnedKiosks` query to easily get owned kiosks and their ownerCaps for an address

--- a/sdk/kiosk/src/query/kiosk.ts
+++ b/sdk/kiosk/src/query/kiosk.ts
@@ -115,7 +115,7 @@ export async function getOwnedKiosks(
     nextCursor,
     hasNextPage,
     kioskOwnerCaps: data.map((x, idx) => ({
-      digest: x?.data?.digest || '',
+      digest: x?.data?.digest,
       version: getObjectVersion(x),
       objectId: getObjectId(x),
       kioskId: kioskIdList[idx],

--- a/sdk/kiosk/src/query/kiosk.ts
+++ b/sdk/kiosk/src/query/kiosk.ts
@@ -4,9 +4,11 @@
 import {
   JsonRpcProvider,
   ObjectId,
-  ObjectType,
   PaginationArguments,
   SuiAddress,
+  SuiObjectResponse,
+  getObjectFields,
+  getObjectId,
 } from '@mysten/sui.js';
 import {
   attachListingsAndPrices,
@@ -15,62 +17,13 @@ import {
   getAllDynamicFields,
   getKioskObject,
 } from '../utils';
-import { Kiosk } from '../types';
-
-/**
- * A dynamic field `Listing { ID, isExclusive }` attached to the Kiosk.
- * Holds a `u64` value - the price of the item.
- */
-export type KioskListing = {
-  /** The ID of the Item */
-  objectId: ObjectId;
-  /**
-   * Whether or not there's a `PurchaseCap` issued. `true` means that
-   * the listing is controlled by some logic and can't be purchased directly.
-   *
-   * TODO: consider renaming the field for better indication.
-   */
-  isExclusive: boolean;
-  /** The ID of the listing */
-  listingId: ObjectId;
-  price?: string;
-};
-
-/**
- * A dynamic field `Item { ID }` attached to the Kiosk.
- * Holds an Item `T`. The type of the item is known upfront.
- */
-export type KioskItem = {
-  /** The ID of the Item */
-  objectId: ObjectId;
-  /** The type of the Item */
-  type: ObjectType;
-  /** Whether the item is Locked (there must be a `Lock` Dynamic Field) */
-  isLocked: boolean;
-  /** Optional listing */
-  listing?: KioskListing;
-};
-/**
- * Aggregated data from the Kiosk.
- */
-export type KioskData = {
-  items: KioskItem[];
-  itemIds: ObjectId[];
-  listingIds: ObjectId[];
-  kiosk?: Kiosk;
-  extensions: any[]; // type will be defined on later versions of the SDK.
-};
-
-export type PagedKioskData = {
-  data: KioskData;
-  nextCursor: string | null;
-  hasNextPage: boolean;
-};
-
-export type FetchKioskOptions = {
-  withKioskFields?: boolean;
-  withListingPrices?: boolean;
-};
+import {
+  FetchKioskOptions,
+  KIOSK_OWNER_CAP,
+  KioskListing,
+  OwnedKiosks,
+  PagedKioskData,
+} from '../types';
 
 export async function fetchKiosk(
   provider: JsonRpcProvider,
@@ -117,5 +70,52 @@ export async function fetchKiosk(
     data: kioskData,
     nextCursor: null,
     hasNextPage: false,
+  };
+}
+
+/**
+ * A function to fetch all the user's kiosk Caps
+ * And a list of the kiosk address ids.
+ * Returns a list of `kioskOwnerCapIds` and `kioskIds`.
+ * Extra options allow pagination.
+ */
+export async function getOwnedKiosks(
+  provider: JsonRpcProvider,
+  address: SuiAddress,
+  options?: {
+    pagination?: PaginationArguments<string>;
+  },
+): Promise<OwnedKiosks> {
+  if (!address)
+    return {
+      nextCursor: null,
+      hasNextPage: false,
+      kioskOwnerCaps: [],
+      kioskIds: [],
+    };
+
+  // fetch owned kiosk caps, paginated.
+  const { data, hasNextPage, nextCursor } = await provider.getOwnedObjects({
+    owner: address,
+    filter: { StructType: `${KIOSK_OWNER_CAP}` },
+    options: {
+      showContent: true,
+    },
+    ...(options?.pagination || {}),
+  });
+
+  // get unique kioskIds.
+  const kioskIdList = data?.map(
+    (x: SuiObjectResponse) => getObjectFields(x)?.for,
+  );
+
+  return {
+    nextCursor,
+    hasNextPage,
+    kioskOwnerCaps: data.map((x, idx) => ({
+      objectId: getObjectId(x),
+      kioskId: kioskIdList[idx],
+    })),
+    kioskIds: kioskIdList,
   };
 }

--- a/sdk/kiosk/src/query/kiosk.ts
+++ b/sdk/kiosk/src/query/kiosk.ts
@@ -104,7 +104,7 @@ export async function getOwnedKiosks(
     ...(options?.pagination || {}),
   });
 
-  // get unique kioskIds.
+  // get kioskIds from the OwnerCaps.
   const kioskIdList = data?.map(
     (x: SuiObjectResponse) => getObjectFields(x)?.for,
   );

--- a/sdk/kiosk/src/query/kiosk.ts
+++ b/sdk/kiosk/src/query/kiosk.ts
@@ -6,10 +6,9 @@ import {
   ObjectId,
   PaginationArguments,
   SuiAddress,
+  SuiObjectData,
   SuiObjectResponse,
   getObjectFields,
-  getObjectId,
-  getObjectVersion,
   isValidSuiAddress,
 } from '@mysten/sui.js';
 import {
@@ -111,13 +110,19 @@ export async function getOwnedKiosks(
     (x: SuiObjectResponse) => getObjectFields(x)?.for,
   );
 
+  // clean up data that might have an error in them.
+  // only return valid objects.
+  const filteredData = data
+    .filter((x) => 'data' in x)
+    .map((x) => x.data) as SuiObjectData[];
+
   return {
     nextCursor,
     hasNextPage,
-    kioskOwnerCaps: data.map((x, idx) => ({
-      digest: x?.data?.digest,
-      version: getObjectVersion(x),
-      objectId: getObjectId(x),
+    kioskOwnerCaps: filteredData.map((x, idx) => ({
+      digest: x.digest,
+      version: x.version,
+      objectId: x.objectId,
       kioskId: kioskIdList[idx],
     })),
     kioskIds: kioskIdList,

--- a/sdk/kiosk/src/query/kiosk.ts
+++ b/sdk/kiosk/src/query/kiosk.ts
@@ -9,6 +9,8 @@ import {
   SuiObjectResponse,
   getObjectFields,
   getObjectId,
+  getObjectVersion,
+  isValidSuiAddress,
 } from '@mysten/sui.js';
 import {
   attachListingsAndPrices,
@@ -86,7 +88,7 @@ export async function getOwnedKiosks(
     pagination?: PaginationArguments<string>;
   },
 ): Promise<OwnedKiosks> {
-  if (!address)
+  if (!isValidSuiAddress(address))
     return {
       nextCursor: null,
       hasNextPage: false,
@@ -97,7 +99,7 @@ export async function getOwnedKiosks(
   // fetch owned kiosk caps, paginated.
   const { data, hasNextPage, nextCursor } = await provider.getOwnedObjects({
     owner: address,
-    filter: { StructType: `${KIOSK_OWNER_CAP}` },
+    filter: { StructType: KIOSK_OWNER_CAP },
     options: {
       showContent: true,
     },
@@ -113,6 +115,8 @@ export async function getOwnedKiosks(
     nextCursor,
     hasNextPage,
     kioskOwnerCaps: data.map((x, idx) => ({
+      digest: x?.data?.digest || '',
+      version: getObjectVersion(x),
       objectId: getObjectId(x),
       kioskId: kioskIdList[idx],
     })),

--- a/sdk/kiosk/src/types/kiosk.ts
+++ b/sdk/kiosk/src/types/kiosk.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+  ObjectDigest,
   ObjectId,
   ObjectType,
   PaginatedObjectsResponse,
@@ -133,4 +134,6 @@ export type OwnedKiosks = {
 export type KioskOwnerCap = {
   objectId: ObjectId;
   kioskId: ObjectId;
+  digest: ObjectDigest;
+  version: number | string | undefined;
 };

--- a/sdk/kiosk/src/types/kiosk.ts
+++ b/sdk/kiosk/src/types/kiosk.ts
@@ -134,6 +134,6 @@ export type OwnedKiosks = {
 export type KioskOwnerCap = {
   objectId: ObjectId;
   kioskId: ObjectId;
-  digest: ObjectDigest | undefined;
-  version: number | string | undefined;
+  digest: ObjectDigest;
+  version: string;
 };

--- a/sdk/kiosk/src/types/kiosk.ts
+++ b/sdk/kiosk/src/types/kiosk.ts
@@ -134,6 +134,6 @@ export type OwnedKiosks = {
 export type KioskOwnerCap = {
   objectId: ObjectId;
   kioskId: ObjectId;
-  digest: ObjectDigest;
+  digest: ObjectDigest | undefined;
   version: number | string | undefined;
 };

--- a/sdk/kiosk/src/types/kiosk.ts
+++ b/sdk/kiosk/src/types/kiosk.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { TransactionArgument } from '@mysten/sui.js';
+import {
+  ObjectId,
+  ObjectType,
+  PaginatedObjectsResponse,
+  TransactionArgument,
+} from '@mysten/sui.js';
 import { ObjectArgument } from '.';
 
 /** The Kiosk module. */
@@ -63,4 +68,69 @@ export type PurchaseAndResolvePoliciesResponse = {
 export type PurchaseOptionalParams = {
   ownedKiosk?: ObjectArgument;
   ownedKioskCap?: ObjectArgument;
+};
+
+/**
+ * A dynamic field `Listing { ID, isExclusive }` attached to the Kiosk.
+ * Holds a `u64` value - the price of the item.
+ */
+export type KioskListing = {
+  /** The ID of the Item */
+  objectId: ObjectId;
+  /**
+   * Whether or not there's a `PurchaseCap` issued. `true` means that
+   * the listing is controlled by some logic and can't be purchased directly.
+   *
+   * TODO: consider renaming the field for better indication.
+   */
+  isExclusive: boolean;
+  /** The ID of the listing */
+  listingId: ObjectId;
+  price?: string;
+};
+
+/**
+ * A dynamic field `Item { ID }` attached to the Kiosk.
+ * Holds an Item `T`. The type of the item is known upfront.
+ */
+export type KioskItem = {
+  /** The ID of the Item */
+  objectId: ObjectId;
+  /** The type of the Item */
+  type: ObjectType;
+  /** Whether the item is Locked (there must be a `Lock` Dynamic Field) */
+  isLocked: boolean;
+  /** Optional listing */
+  listing?: KioskListing;
+};
+/**
+ * Aggregated data from the Kiosk.
+ */
+export type KioskData = {
+  items: KioskItem[];
+  itemIds: ObjectId[];
+  listingIds: ObjectId[];
+  kiosk?: Kiosk;
+  extensions: any[]; // type will be defined on later versions of the SDK.
+};
+
+export type PagedKioskData = {
+  data: KioskData;
+  nextCursor: string | null;
+  hasNextPage: boolean;
+};
+
+export type FetchKioskOptions = {
+  withKioskFields?: boolean;
+  withListingPrices?: boolean;
+};
+
+export type OwnedKiosks = {
+  kioskOwnerCaps: KioskOwnerCap[];
+  kioskIds: ObjectId[];
+} & Omit<PaginatedObjectsResponse, 'data'>;
+
+export type KioskOwnerCap = {
+  objectId: ObjectId;
+  kioskId: ObjectId;
 };

--- a/sdk/kiosk/src/utils.ts
+++ b/sdk/kiosk/src/utils.ts
@@ -12,10 +12,15 @@ import {
   TransactionBlock,
   getObjectFields,
 } from '@mysten/sui.js';
-import { KioskData, KioskListing } from './query/kiosk';
 import { DynamicFieldInfo } from '@mysten/sui.js/dist/types/dynamic_fields';
 import { bcs } from './bcs';
-import { KIOSK_TYPE, Kiosk, RulesEnvironmentParam } from './types';
+import {
+  KIOSK_TYPE,
+  Kiosk,
+  KioskData,
+  KioskListing,
+  RulesEnvironmentParam,
+} from './types';
 import {
   MAINNET_RULES_PACKAGE_ADDRESS,
   TESTNET_RULES_PACKAGE_ADDRESS,


### PR DESCRIPTION
## Description 

- Adds `getOwnedKiosks` to Kiosk SDK to simplify finding kiosks owned by an address.
- Moves some types to the correct place.
- Updates the kiosk demo to reflect these changes.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
