### PR TITLE
Line up min gas charges with min computation charges

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/runtime_behavior/error_locations.move
+++ b/crates/sui-adapter-transactional-tests/tests/runtime_behavior/error_locations.move
@@ -31,7 +31,7 @@ module test::m {
 
 //# run test::m::abort_
 
-//# run test::m::loop_ --gas-budget 100000
+//# run test::m::loop_ --gas-budget 1000000
 
 //# run test::m::math
 

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -233,7 +233,7 @@ async fn check_gas(
         }
 
         // check balance and coins consistency
-        let cost_table = SuiCostTable::new(protocol_config);
+        let cost_table = SuiCostTable::new(protocol_config, reference_gas_price);
         cost_table.check_gas_balance(gas_object, more_gas_objects, gas_budget, gas_price)?;
         Ok(SuiGasStatus::new_with_budget(
             gas_budget,

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -1811,14 +1811,15 @@ async fn test_publish_dependent_module_ok() {
 #[tokio::test]
 async fn test_publish_module_no_dependencies_ok() {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let authority = init_state_with_objects(vec![]).await;
+    let rgp = authority.reference_gas_price_for_testing().unwrap();
     let gas_payment_object_id = ObjectID::random();
     // Use the max budget to avoid running out of gas.
-    let gas_balance = SuiCostTable::new_for_testing().max_gas_budget();
+    let gas_balance = SuiCostTable::new_for_testing(rgp).max_gas_budget();
     let gas_payment_object =
         Object::with_id_owner_gas_for_testing(gas_payment_object_id, sender, gas_balance);
     let gas_payment_object_ref = gas_payment_object.compute_object_reference();
-    let authority = init_state_with_objects(vec![gas_payment_object]).await;
-    let rgp = authority.reference_gas_price_for_testing().unwrap();
+    authority.insert_genesis_object(gas_payment_object).await;
 
     let module = file_format::empty_module();
     let mut module_bytes = Vec::new();

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -21,22 +21,26 @@ use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{base_types::dbg_addr, crypto::get_key_pair};
 
-static MAX_GAS_BUDGET: Lazy<u64> = Lazy::new(|| SuiCostTable::new_for_testing().max_gas_budget());
-static MIN_GAS_BUDGET: Lazy<u64> = Lazy::new(|| SuiCostTable::new_for_testing().min_gas_budget());
+// The cost table is used only to get the max budget available which is not dependent on
+// the gas price
+static MAX_GAS_BUDGET: Lazy<u64> = Lazy::new(|| SuiCostTable::new_for_testing(1).max_gas_budget());
+// MIN_GAS_BUDGET_PRE_RGP has to be multiplied by the RGP to get the proper minimum
+static MIN_GAS_BUDGET_PRE_RGP: Lazy<u64> =
+    Lazy::new(|| SuiCostTable::new_for_testing(1).min_gas_budget());
 
 #[tokio::test]
 async fn test_tx_less_than_minimum_gas_budget() {
     // This test creates a transaction that sets a gas_budget less than the minimum
     // transaction requirement. It's expected to fail early during transaction
     // handling phase.
-    let budget = *MIN_GAS_BUDGET - 1;
-    let result = execute_transfer(*MAX_GAS_BUDGET, budget, false).await;
+    let budget = *MIN_GAS_BUDGET_PRE_RGP - 1;
+    let result = execute_transfer(*MAX_GAS_BUDGET, budget, false, true).await;
 
     assert_eq!(
         UserInputError::try_from(result.response.unwrap_err()).unwrap(),
         UserInputError::GasBudgetTooLow {
-            gas_budget: budget,
-            min_budget: *MIN_GAS_BUDGET
+            gas_budget: budget * result.rgp,
+            min_budget: *MIN_GAS_BUDGET_PRE_RGP * result.rgp,
         }
     );
 }
@@ -47,7 +51,7 @@ async fn test_tx_more_than_maximum_gas_budget() {
     // budget (which could lead to overflow). It's expected to fail early during transaction
     // handling phase.
     let budget = *MAX_GAS_BUDGET + 1;
-    let result = execute_transfer(*MAX_GAS_BUDGET, budget, false).await;
+    let result = execute_transfer(*MAX_GAS_BUDGET, budget, false, false).await;
 
     assert_eq!(
         UserInputError::try_from(result.response.unwrap_err()).unwrap(),
@@ -374,7 +378,7 @@ async fn test_computation_ok_oog_storage_minimal_ok() -> SuiResult {
 #[tokio::test]
 async fn test_computation_ok_oog_storage() -> SuiResult {
     const GAS_PRICE: u64 = 1001;
-    const BUDGET: u64 = 35_000;
+    const BUDGET: u64 = 500_000;
     let (sender, sender_key) = get_key_pair();
     check_oog_transaction(
         sender,
@@ -436,9 +440,9 @@ async fn test_tx_gas_balance_less_than_budget() {
     // This test creates a transaction that uses a gas object whose balance
     // is not even enough to pay for the gas budget. This should fail early
     // during handle transaction phase.
-    let gas_balance = *MIN_GAS_BUDGET - 1;
-    let budget = *MIN_GAS_BUDGET;
-    let result = execute_transfer_with_price(gas_balance, budget, 1, false).await;
+    let gas_balance = *MIN_GAS_BUDGET_PRE_RGP - 1;
+    let budget = *MIN_GAS_BUDGET_PRE_RGP;
+    let result = execute_transfer_with_price(gas_balance, budget, 1, false, true).await;
     assert!(matches!(
         UserInputError::try_from(result.response.unwrap_err()).unwrap(),
         UserInputError::GasBalanceTooLow { .. }
@@ -449,14 +453,14 @@ async fn test_tx_gas_balance_less_than_budget() {
 async fn test_native_transfer_sufficient_gas() -> SuiResult {
     // This test does a native transfer with sufficient gas budget and balance.
     // It's expected to succeed. We check that gas was charged properly.
-    let result = execute_transfer(*MAX_GAS_BUDGET, *MAX_GAS_BUDGET, true).await;
+    let result = execute_transfer(*MAX_GAS_BUDGET, *MAX_GAS_BUDGET, true, false).await;
     let effects = result
         .response
         .unwrap()
         .into_effects_for_testing()
         .into_data();
     let gas_cost = effects.gas_cost_summary();
-    assert!(gas_cost.net_gas_usage() as u64 > *MIN_GAS_BUDGET);
+    assert!(gas_cost.net_gas_usage() as u64 > *MIN_GAS_BUDGET_PRE_RGP);
     assert!(gas_cost.computation_cost > 0);
     assert!(gas_cost.storage_cost > 0);
     // Removing genesis object does not have rebate.
@@ -476,7 +480,8 @@ async fn test_native_transfer_sufficient_gas() -> SuiResult {
 
 #[tokio::test]
 async fn test_native_transfer_gas_price_is_used() {
-    let result = execute_transfer_with_price(*MAX_GAS_BUDGET, *MAX_GAS_BUDGET, 1, true).await;
+    let result =
+        execute_transfer_with_price(*MAX_GAS_BUDGET, *MAX_GAS_BUDGET, 1, true, false).await;
     let effects = result
         .response
         .unwrap()
@@ -484,7 +489,8 @@ async fn test_native_transfer_gas_price_is_used() {
         .into_data();
     let gas_summary_1 = effects.gas_cost_summary();
 
-    let result = execute_transfer_with_price(*MAX_GAS_BUDGET, *MAX_GAS_BUDGET, 2, true).await;
+    let result =
+        execute_transfer_with_price(*MAX_GAS_BUDGET, *MAX_GAS_BUDGET, 2, true, false).await;
     let effects = result
         .response
         .unwrap()
@@ -500,7 +506,7 @@ async fn test_native_transfer_gas_price_is_used() {
     // test overflow with insufficient gas
     let gas_balance = *MAX_GAS_BUDGET - 1;
     let gas_budget = *MAX_GAS_BUDGET;
-    let result = execute_transfer_with_price(gas_balance, gas_budget, 1, true).await;
+    let result = execute_transfer_with_price(gas_balance, gas_budget, 1, true, false).await;
     assert!(matches!(
         UserInputError::try_from(result.response.unwrap_err()).unwrap(),
         UserInputError::GasBalanceTooLow { .. }
@@ -511,10 +517,10 @@ async fn test_native_transfer_gas_price_is_used() {
 async fn test_transfer_sui_insufficient_gas() {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
     let recipient = dbg_addr(2);
-    let gas_object_id = ObjectID::random();
-    let gas_object = Object::with_id_owner_gas_for_testing(gas_object_id, sender, *MIN_GAS_BUDGET);
-    let gas_object_ref = gas_object.compute_object_reference();
     let authority_state = TestAuthorityBuilder::new().build().await;
+    let gas_object_id = ObjectID::random();
+    let gas_object = Object::with_id_owner_gas_for_testing(gas_object_id, sender, *MAX_GAS_BUDGET);
+    let gas_object_ref = gas_object.compute_object_reference();
     authority_state.insert_genesis_object(gas_object).await;
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
 
@@ -524,7 +530,13 @@ async fn test_transfer_sui_insufficient_gas() {
         builder.finish()
     };
     let kind = TransactionKind::ProgrammableTransaction(pt);
-    let data = TransactionData::new(kind, sender, gas_object_ref, *MIN_GAS_BUDGET, rgp);
+    let data = TransactionData::new(
+        kind,
+        sender,
+        gas_object_ref,
+        *MIN_GAS_BUDGET_PRE_RGP * rgp,
+        rgp,
+    );
     let tx = to_sender_signed_transaction(data, &sender_key);
 
     let effects = send_and_confirm_transaction(&authority_state, tx)
@@ -655,8 +667,8 @@ async fn test_native_transfer_insufficient_gas_reading_objects() {
     // This test creates a transfer transaction with a gas budget, that's more than
     // the minimum budget requirement, but not enough to even read the objects from db.
     // This will lead to failure in lock check step during handle transaction phase.
-    let balance = *MIN_GAS_BUDGET + 1;
-    let result = execute_transfer(balance, balance, true).await;
+    let balance = *MIN_GAS_BUDGET_PRE_RGP + 1;
+    let result = execute_transfer(*MAX_GAS_BUDGET, balance, true, true).await;
     // The transaction should still execute to effects, but with execution status as failure.
     let effects = result
         .response
@@ -675,7 +687,7 @@ async fn test_native_transfer_insufficient_gas_execution() {
     // to finalize the transfer object mutation effects. It will fail during
     // execution phase, and hence gas object will still be mutated and all budget
     // will be charged.
-    let result = execute_transfer(*MAX_GAS_BUDGET, *MAX_GAS_BUDGET, true).await;
+    let result = execute_transfer(*MAX_GAS_BUDGET, *MAX_GAS_BUDGET, true, false).await;
     let total_gas = result
         .response
         .unwrap()
@@ -684,7 +696,7 @@ async fn test_native_transfer_insufficient_gas_execution() {
         .gas_cost_summary()
         .gas_used();
     let budget = total_gas - 1;
-    let result = execute_transfer(budget, budget, true).await;
+    let result = execute_transfer(budget, budget, true, false).await;
     let effects = result
         .response
         .unwrap()
@@ -865,8 +877,8 @@ async fn test_move_call_gas() -> SuiResult {
 #[tokio::test]
 async fn test_tx_gas_price_less_than_reference_gas_price() {
     let gas_balance = *MAX_GAS_BUDGET;
-    let budget = *MIN_GAS_BUDGET;
-    let result = execute_transfer_with_price(gas_balance, budget, 0, false).await;
+    let budget = *MIN_GAS_BUDGET_PRE_RGP;
+    let result = execute_transfer_with_price(gas_balance, budget, 0, false, true).await;
     assert!(matches!(
         UserInputError::try_from(result.response.unwrap_err()).unwrap(),
         UserInputError::GasPriceUnderRGP { .. }
@@ -877,10 +889,16 @@ struct TransferResult {
     pub authority_state: Arc<AuthorityState>,
     pub gas_object_id: ObjectID,
     pub response: SuiResult<TransactionStatus>,
+    pub rgp: u64,
 }
 
-async fn execute_transfer(gas_balance: u64, gas_budget: u64, run_confirm: bool) -> TransferResult {
-    execute_transfer_with_price(gas_balance, gas_budget, 1, run_confirm).await
+async fn execute_transfer(
+    gas_balance: u64,
+    gas_budget: u64,
+    run_confirm: bool,
+    min_budget_pre_rgp: bool,
+) -> TransferResult {
+    execute_transfer_with_price(gas_balance, gas_budget, 1, run_confirm, min_budget_pre_rgp).await
 }
 
 async fn execute_transfer_with_price(
@@ -888,12 +906,18 @@ async fn execute_transfer_with_price(
     gas_budget: u64,
     rgp_multiple: u64,
     run_confirm: bool,
+    min_budget_pre_rgp: bool,
 ) -> TransferResult {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
     let object_id: ObjectID = ObjectID::random();
     let recipient = dbg_addr(2);
     let authority_state = init_state_with_ids(vec![(sender, object_id)]).await;
     let rgp = authority_state.reference_gas_price_for_testing().unwrap() * rgp_multiple;
+    let gas_budget = if min_budget_pre_rgp {
+        gas_budget * rgp
+    } else {
+        gas_budget
+    };
     let epoch_store = authority_state.load_epoch_store_one_call_per_task();
     let gas_object_id = ObjectID::random();
     let gas_object = Object::with_id_owner_gas_for_testing(gas_object_id, sender, gas_balance);
@@ -936,5 +960,6 @@ async fn execute_transfer_with_price(
         authority_state,
         gas_object_id,
         response,
+        rgp,
     }
 }

--- a/crates/sui-core/src/unit_tests/pay_sui_tests.rs
+++ b/crates/sui-core/src/unit_tests/pay_sui_tests.rs
@@ -49,7 +49,7 @@ async fn test_pay_sui_failure_insufficient_gas_balance_one_input_coin() {
         vec![100, 100],
         sender,
         sender_key,
-        2200,
+        2200000,
     )
     .await;
 
@@ -57,7 +57,7 @@ async fn test_pay_sui_failure_insufficient_gas_balance_one_input_coin() {
         UserInputError::try_from(res.txn_result.unwrap_err()).unwrap(),
         UserInputError::GasBalanceTooLow {
             gas_balance: 2000,
-            needed_gas_amount: 2200,
+            needed_gas_amount: 2200000,
         }
     );
 }
@@ -65,7 +65,7 @@ async fn test_pay_sui_failure_insufficient_gas_balance_one_input_coin() {
 #[tokio::test]
 async fn test_pay_sui_failure_insufficient_total_balance_one_input_coin() {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
-    let coin1 = Object::with_id_owner_gas_for_testing(ObjectID::random(), sender, 2600);
+    let coin1 = Object::with_id_owner_gas_for_testing(ObjectID::random(), sender, 500100);
     let recipient1 = dbg_addr(1);
     let recipient2 = dbg_addr(2);
 
@@ -75,7 +75,7 @@ async fn test_pay_sui_failure_insufficient_total_balance_one_input_coin() {
         vec![100, 100],
         sender,
         sender_key,
-        2500,
+        500000,
     )
     .await;
 
@@ -102,7 +102,7 @@ async fn test_pay_sui_failure_insufficient_gas_balance_multiple_input_coins() {
         vec![100, 100],
         sender,
         sender_key,
-        2000,
+        2000000,
     )
     .await;
 
@@ -110,7 +110,7 @@ async fn test_pay_sui_failure_insufficient_gas_balance_multiple_input_coins() {
         UserInputError::try_from(res.txn_result.unwrap_err()).unwrap(),
         UserInputError::GasBalanceTooLow {
             gas_balance: 1500,
-            needed_gas_amount: 2000,
+            needed_gas_amount: 2000000,
         }
     );
 }
@@ -118,8 +118,8 @@ async fn test_pay_sui_failure_insufficient_gas_balance_multiple_input_coins() {
 #[tokio::test]
 async fn test_pay_sui_failure_insufficient_total_balance_multiple_input_coins() {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
-    let coin1 = Object::with_id_owner_gas_for_testing(ObjectID::random(), sender, 14000);
-    let coin2 = Object::with_id_owner_gas_for_testing(ObjectID::random(), sender, 13000);
+    let coin1 = Object::with_id_owner_gas_for_testing(ObjectID::random(), sender, 204000);
+    let coin2 = Object::with_id_owner_gas_for_testing(ObjectID::random(), sender, 303000);
     let recipient1 = dbg_addr(1);
     let recipient2 = dbg_addr(2);
 
@@ -129,7 +129,7 @@ async fn test_pay_sui_failure_insufficient_total_balance_multiple_input_coins() 
         vec![4000, 4000],
         sender,
         sender_key,
-        20000,
+        500000,
     )
     .await;
     assert_eq!(
@@ -294,13 +294,13 @@ async fn test_pay_all_sui_failure_insufficient_gas_one_input_coin() {
     let coin1 = Object::with_id_owner_gas_for_testing(ObjectID::random(), sender, 1800);
     let recipient = dbg_addr(2);
 
-    let res = execute_pay_all_sui(vec![&coin1], recipient, sender, sender_key, 2000).await;
+    let res = execute_pay_all_sui(vec![&coin1], recipient, sender, sender_key, 2000000).await;
 
     assert_eq!(
         UserInputError::try_from(res.txn_result.unwrap_err()).unwrap(),
         UserInputError::GasBalanceTooLow {
             gas_balance: 1800,
-            needed_gas_amount: 2000,
+            needed_gas_amount: 2000000,
         }
     );
 }
@@ -311,13 +311,14 @@ async fn test_pay_all_sui_failure_insufficient_gas_budget_multiple_input_coins()
     let coin1 = Object::with_id_owner_gas_for_testing(ObjectID::random(), sender, 1000);
     let coin2 = Object::with_id_owner_gas_for_testing(ObjectID::random(), sender, 1000);
     let recipient = dbg_addr(2);
-    let res = execute_pay_all_sui(vec![&coin1, &coin2], recipient, sender, sender_key, 2500).await;
+    let res =
+        execute_pay_all_sui(vec![&coin1, &coin2], recipient, sender, sender_key, 2500000).await;
 
     assert_eq!(
         UserInputError::try_from(res.txn_result.unwrap_err()).unwrap(),
         UserInputError::GasBalanceTooLow {
             gas_balance: 2000,
-            needed_gas_amount: 2500,
+            needed_gas_amount: 2500000,
         }
     );
 }

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -110,7 +110,7 @@ async fn test_public_transfer_object() -> Result<(), anyhow::Error> {
     let gas = objects.clone().last().unwrap().object().unwrap().object_id;
 
     let transaction_bytes: TransactionBlockBytes = http_client
-        .transfer_object(address, obj, Some(gas), 10_000.into(), address)
+        .transfer_object(address, obj, Some(gas), 1_000_000.into(), address)
         .await?;
 
     let tx = cluster
@@ -200,7 +200,7 @@ async fn test_publish() -> Result<(), anyhow::Error> {
             compiled_modules_bytes,
             dependencies,
             Some(gas.object_id),
-            10000.into(),
+            100_000_000.into(),
         )
         .await?;
 
@@ -259,7 +259,7 @@ async fn test_move_call() -> Result<(), anyhow::Error> {
             type_args![GAS::type_tag()]?,
             call_args!(coin.object_id, 10)?,
             Some(gas.object_id),
-            10_000.into(),
+            10_000_000.into(),
             None,
         )
         .await?;

--- a/crates/sui-json-rpc/src/unit_tests/transaction_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/transaction_tests.rs
@@ -45,7 +45,7 @@ async fn test_get_transaction_block() -> Result<(), anyhow::Error> {
                 address,
                 oref.object_id,
                 Some(gas_id),
-                100_000.into(),
+                1_000_000.into(),
                 address,
             )
             .await?;
@@ -121,7 +121,7 @@ async fn test_get_raw_transaction() -> Result<(), anyhow::Error> {
 
     // Make a transfer transactions
     let transaction_bytes: TransactionBlockBytes = http_client
-        .transfer_object(address, object_to_transfer, None, 10_000.into(), address)
+        .transfer_object(address, object_to_transfer, None, 1_000_000.into(), address)
         .await?;
     let tx = cluster
         .wallet
@@ -181,7 +181,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
             let oref = obj.object().unwrap();
             let data = client
                 .transaction_builder()
-                .transfer_object(address, oref.object_id, Some(gas_id), 100_000, address)
+                .transfer_object(address, oref.object_id, Some(gas_id), 1_000_000, address)
                 .await?;
             let tx = cluster.wallet.sign_transaction(&data);
 

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1347,7 +1347,7 @@
             "name": "Result",
             "value": {
               "minSupportedProtocolVersion": "1",
-              "maxSupportedProtocolVersion": "16",
+              "maxSupportedProtocolVersion": "17",
               "protocolVersion": "6",
               "featureFlags": {
                 "advance_epoch_start_time_in_safe_mode": true,
@@ -1366,6 +1366,7 @@
                 "package_upgrades": true,
                 "scoring_decision_with_validity_cutoff": true,
                 "simplified_unwrap_then_delete": false,
+                "txn_base_cost_as_multiplier": false,
                 "zklogin_auth": false
               },
               "attributes": {

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_17.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_17.snap
@@ -1,0 +1,184 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 17
+feature_flags:
+  package_upgrades: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  consensus_transaction_ordering: ByGasPrice
+  txn_base_cost_as_multiplier: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 128
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 6
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 256
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+gas_model_version: 6
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 52
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 52
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 52
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 52
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 52
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 52
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 52
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 52
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 52
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 52
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 52
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 52
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 52
+groth16_prepare_verifying_key_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 52
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 52
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+scoring_decision_mad_divisor: 2.3
+scoring_decision_cutoff_value: 2.5
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_17.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_17.snap
@@ -1,0 +1,185 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 17
+feature_flags:
+  package_upgrades: true
+  commit_root_state_digest: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  consensus_transaction_ordering: ByGasPrice
+  txn_base_cost_as_multiplier: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 128
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 6
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 256
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+gas_model_version: 6
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 52
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 52
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 52
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 52
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 52
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 52
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 52
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 52
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 52
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 52
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 52
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 52
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 52
+groth16_prepare_verifying_key_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 52
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 52
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+scoring_decision_mad_divisor: 2.3
+scoring_decision_cutoff_value: 2.5
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_17.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_17.snap
@@ -1,0 +1,186 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 17
+feature_flags:
+  package_upgrades: true
+  commit_root_state_digest: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  zklogin_auth: true
+  consensus_transaction_ordering: ByGasPrice
+  txn_base_cost_as_multiplier: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 128
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 6
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 256
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+gas_model_version: 6
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 52
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 52
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 52
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 52
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 52
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 52
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 52
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 52
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 52
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 52
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 52
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 52
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 52
+groth16_prepare_verifying_key_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 52
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 52
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+scoring_decision_mad_divisor: 2.3
+scoring_decision_cutoff_value: 2.5
+

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -456,7 +456,7 @@ async fn test_failed_pay_sui() {
         sender,
         pt,
         vec![coin1, coin2],
-        2000,
+        2000000,
         rgp,
         true,
     )

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -6,7 +6,7 @@ ssfn_config_info: ~
 validator_config_info: ~
 parameters:
   chain_start_timestamp_ms: 0
-  protocol_version: 16
+  protocol_version: 17
   allow_insertion_of_extra_objects: true
   epoch_duration_ms: 86400000
   stake_subsidy_start_epoch: 0

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -3,7 +3,7 @@ source: crates/sui-swarm-config/tests/snapshot_tests.rs
 expression: genesis.sui_system_object().into_genesis_version_for_tooling()
 ---
 epoch: 0
-protocol_version: 16
+protocol_version: 17
 system_state_version: 1
 validators:
   total_stake: 20000000000000000
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0xbd2bdc9724d0aae78b2dd02c8fc412bd7bee96ea0c98d6b1332cb2dcc3973acf"
+            id: "0x88af11d3d405c4840519b30cd5e4c3f3b91eea1de7db521b0aa1ac90c0641924"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0x7990ef7b1237e77b251900f9434f1bceb60ef5100a2abcb75e78c595775131d1"
+      operation_cap_id: "0x7640efd9b6200f6e35d5f84624b9d76651982c3216799aedda623722a1ef774b"
       gas_price: 1000
       staking_pool:
-        id: "0x6a2f79eac6652389813d145bf691005a37d3746ee4372918124f45d4fc2abd30"
+        id: "0xe6d1a7503d43dd1faa4b28215a1fd36d3ede08f3e7bd674cdadef5124a18f6b9"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0x52e460b45fbb7adb3df22461e13b0a3f1f67e58933a082008c61c8670449a388"
+          id: "0x2c6df5b12bbad486c6b412fe8b6172dc67731a1d438553b654aacdf9007a90df"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0x749e1f37b8f6cd84e09b7e02b45d817e56ecbbb8dcde4baf6e69f5cc667a9f9e"
+            id: "0xac8d944d3fdbaf1eec180dfa43dcc4a99b1007835e4d48e4d2ea2868f55a1202"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0xdc3e7d20e585326ff46461a1b399b7cdb94cbfa7b3c6cba0600c5c1c2b83bc36"
+          id: "0xf814998f5103a3ca872f7d4cd4ffcebd17f01b925d1ad1506e9f0cce79c4eecf"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x80c044602f5407bda7246d4acb805e0761715db80da5390489587b416054ee3c"
+      id: "0xd0c614a46521f4d56472520c98a6667a76bb1edce32c90ba3fbde2f9687ab004"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0xc9f10341a396ae41f60350c0b1ad8a07fc3d5bb5e391983a2f4374ddab15c968"
+    id: "0xe9d1abefabc772b02d471aecd9fd33b23901838bf2e1a48165dd100fef3d6257"
     size: 1
   inactive_validators:
-    id: "0x67fb5ad6d089b382f65ae03ac011183949e098497793f0678f888d6fd7c8de8b"
+    id: "0xd0e1791b800885a4acc0d98f6f505ab1ce901bf4fcb378fd0dc468ecfb5d47c4"
     size: 0
   validator_candidates:
-    id: "0x1d38e6606fb1e0f53bc7ca1b94ca087375a08352630b411187ac4cf2c0242e8c"
+    id: "0xe4a396b1f1e0202d5fd4af7d7ba4e790d5dfa67bf2f9eaba4fbec58627cc9025"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0x6aa1fd57ab6daada2319cbc22c821460f028693c4758b0b221530460c547d1ce"
+      id: "0xe67a40a9383af3305830bfe66dc5eb20e4501c60bcf61181e15084ed8a349a15"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0xbc1c49382e991a85d9ccd8d6297b058d12bfb8e01e57c1d397511bd075f9a331"
+      id: "0x23ea9b70458b24a387035b1903c3962760f906406d0655d774eb553f80ca3d00"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0xfca9a397dc614ba6d72e55097765016c5c6ca3f623e5d9d6480e54d9b71e6291"
+      id: "0x9dd7c7ff41c43ec27bda1f95bfea5b2f761e5700ab00c97fc15893ba90b3a3cc"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,6 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0x168991dc3f3567ae67bb69e9741ccc3b45a7a32d58b43a5a6ec618cfc24a3800"
+    id: "0x26371f33c0d32a07c6eeb6f0e88fbdf906e33f010cfaa3c317bfab4a557d65c3"
   size: 0
 

--- a/crates/sui-types/src/gas.rs
+++ b/crates/sui-types/src/gas.rs
@@ -83,16 +83,16 @@ pub enum SuiCostTable {
 }
 
 impl SuiCostTable {
-    pub fn new(config: &ProtocolConfig) -> Self {
+    pub fn new(config: &ProtocolConfig, gas_price: u64) -> Self {
         if config.gas_model_version() <= 1 {
             Self::V1(SuiCostTableV1::new(config))
         } else {
-            Self::V2(SuiCostTableV2::new(config))
+            Self::V2(SuiCostTableV2::new(config, gas_price))
         }
     }
 
-    pub fn new_for_testing() -> Self {
-        Self::new(&ProtocolConfig::get_for_max_version())
+    pub fn new_for_testing(gas_price: u64) -> Self {
+        Self::new(&ProtocolConfig::get_for_max_version(), gas_price)
     }
 
     pub fn unmetered(config: &ProtocolConfig) -> Self {


### PR DESCRIPTION
## Description 

Make the minimum gas budget at least as much as the minimum computation charges.
That makes the gas charging story more consistent

## Test Plan 

Existing tests
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
