### PR TITLE
[APPS-1267]: fix format address for str less than 6 chars

### DIFF
--- a/sdk/typescript/src/utils/format.ts
+++ b/sdk/typescript/src/utils/format.ts
@@ -4,6 +4,10 @@
 const ELLIPSIS = '\u{2026}';
 
 export function formatAddress(address: string) {
+  if (address.length <= 6) {
+    return address;
+  }
+
   const offset = address.startsWith('0x') ? 2 : 0;
 
   return `0x${address.slice(offset, offset + 4)}${ELLIPSIS}${address.slice(


### PR DESCRIPTION
## Description 

https://mysten.atlassian.net/browse/APPS-1276
- For string at 6 chars or less, the formatting currently truncates incorrectly
- ie: '123456' will be truncated to '123...456', '123' will be truncated to '123...123'

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
