### PR TITLE
[sui cli] Optional network_key_pair to ssfn_genesis_config

### DIFF
--- a/crates/sui-swarm-config/src/genesis_config.rs
+++ b/crates/sui-swarm-config/src/genesis_config.rs
@@ -23,6 +23,7 @@ use tracing::info;
 #[derive(Serialize, Deserialize, Debug)]
 pub struct SsfnGenesisConfig {
     pub p2p_address: Multiaddr,
+    pub network_key_pair: Option<NetworkKeyPair>,
 }
 
 // All information needed to build a NodeConfig for a validator.

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -459,6 +459,7 @@ async fn genesis(
             let ssfn_config = FullnodeConfigBuilder::new()
                 .with_config_directory(FULL_NODE_DB_PATH.into())
                 .with_p2p_external_address(ssfn.p2p_address)
+                .with_network_key_pair(ssfn.network_key_pair)
                 .with_p2p_listen_address("0.0.0.0:8084".parse().unwrap())
                 .with_db_path(PathBuf::from("/opt/sui/db/authorities_db/full_node_db"))
                 .with_network_address("/ip4/0.0.0.0/tcp/8080/http".parse().unwrap())


### PR DESCRIPTION
## Description 

Adds a optional network key to ssfn_genesis_config, eg:
```
ssfn_config_info:
  - p2p_address: /dns/lax-ssfn-2.testing.sui.io/udp/8084
    network_key_pair: abcdefg123
 ```
 
This allows the fullnodes which consume from the ssfn's to use a static list of peer id's

## Test Plan 

Tested locally
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes