### PR TITLE
[dapps] Kiosk demo - search by address & support multiple owned kiosks

### DIFF
--- a/dapps/kiosk/src/components/Inventory/OwnedObject.tsx
+++ b/dapps/kiosk/src/components/Inventory/OwnedObject.tsx
@@ -6,37 +6,40 @@ import { DisplayObject } from '../DisplayObject';
 import { Button } from '../Base/Button';
 import { KioskFnType } from '../../hooks/kiosk';
 import { usePlaceMutation } from '../../mutations/kiosk';
+import { ObjectId } from '@mysten/sui.js';
 
 export function OwnedObject({
-	object,
-	onListSuccess,
-	listFn,
+  object,
+  onListSuccess,
+  listFn,
+  kioskId,
 }: {
-	onListSuccess: () => void;
-	listFn: KioskFnType;
-	object: OwnedObjectType;
+  onListSuccess: () => void;
+  listFn: KioskFnType;
+  object: OwnedObjectType;
+  kioskId: ObjectId;
 }) {
 	const placeToKioskMutation = usePlaceMutation({
 		onSuccess: onListSuccess,
 	});
 
-	return (
-		<DisplayObject item={object}>
-			<>
-				<Button
-					className="bg-gray-200 hover:bg-primary hover:text-white"
-					loading={placeToKioskMutation.isLoading}
-					onClick={() => placeToKioskMutation.mutate(object)}
-				>
-					Place in kiosk
-				</Button>
-				<Button
-					className="border-gray-400 bg-transparent hover:bg-primary hover:text-white"
-					onClick={() => listFn(object)}
-				>
-					List For Sale
-				</Button>
-			</>
-		</DisplayObject>
-	);
+  return (
+    <DisplayObject item={object}>
+      <>
+        <Button
+          className="bg-gray-200 hover:bg-primary hover:text-white"
+          loading={placeToKioskMutation.isLoading}
+          onClick={() => placeToKioskMutation.mutate({ item: object, kioskId })}
+        >
+          Place in kiosk
+        </Button>
+        <Button
+          className="border-gray-400 bg-transparent hover:bg-primary hover:text-white"
+          onClick={() => listFn(object)}
+        >
+          List For Sale
+        </Button>
+      </>
+    </DisplayObject>
+  );
 }

--- a/dapps/kiosk/src/components/Inventory/OwnedObject.tsx
+++ b/dapps/kiosk/src/components/Inventory/OwnedObject.tsx
@@ -9,37 +9,37 @@ import { usePlaceMutation } from '../../mutations/kiosk';
 import { ObjectId } from '@mysten/sui.js';
 
 export function OwnedObject({
-  object,
-  onListSuccess,
-  listFn,
-  kioskId,
+	object,
+	onListSuccess,
+	listFn,
+	kioskId,
 }: {
-  onListSuccess: () => void;
-  listFn: KioskFnType;
-  object: OwnedObjectType;
-  kioskId: ObjectId;
+	onListSuccess: () => void;
+	listFn: KioskFnType;
+	object: OwnedObjectType;
+	kioskId: ObjectId;
 }) {
 	const placeToKioskMutation = usePlaceMutation({
 		onSuccess: onListSuccess,
 	});
 
-  return (
-    <DisplayObject item={object}>
-      <>
-        <Button
-          className="bg-gray-200 hover:bg-primary hover:text-white"
-          loading={placeToKioskMutation.isLoading}
-          onClick={() => placeToKioskMutation.mutate({ item: object, kioskId })}
-        >
-          Place in kiosk
-        </Button>
-        <Button
-          className="border-gray-400 bg-transparent hover:bg-primary hover:text-white"
-          onClick={() => listFn(object)}
-        >
-          List For Sale
-        </Button>
-      </>
-    </DisplayObject>
-  );
+	return (
+		<DisplayObject item={object}>
+			<>
+				<Button
+					className="bg-gray-200 hover:bg-primary hover:text-white"
+					loading={placeToKioskMutation.isLoading}
+					onClick={() => placeToKioskMutation.mutate({ item: object, kioskId })}
+				>
+					Place in kiosk
+				</Button>
+				<Button
+					className="border-gray-400 bg-transparent hover:bg-primary hover:text-white"
+					onClick={() => listFn(object)}
+				>
+					List For Sale
+				</Button>
+			</>
+		</DisplayObject>
+	);
 }

--- a/dapps/kiosk/src/components/Inventory/OwnedObjects.tsx
+++ b/dapps/kiosk/src/components/Inventory/OwnedObjects.tsx
@@ -14,14 +14,8 @@ export type OwnedObjectType = KioskItem & {
 	display: Record<string, string>;
 };
 
-export function OwnedObjects({
-  address,
-  kioskId,
-}: {
-  address: string;
-  kioskId: ObjectId;
-}) {
-  const [modalItem, setModalItem] = useState<OwnedObjectType | null>(null);
+export function OwnedObjects({ address, kioskId }: { address: string; kioskId: ObjectId }) {
+	const [modalItem, setModalItem] = useState<OwnedObjectType | null>(null);
 
 	const {
 		data: ownedObjects,
@@ -33,39 +27,37 @@ export function OwnedObjects({
 
 	if (isLoading) return <Loading />;
 
-  return (
-    <div className="grid grid-cols-2 lg:grid-cols-4 gap-5 pt-12">
-      {/* Only shows item with an image_url to make it easier to understand the flows. */}
-      {ownedObjects
-        ?.filter((x) => !!x.display && !!x.display.image_url)
-        .map((item) => (
-          <OwnedObject
-            kioskId={kioskId}
-            key={item.objectId}
-            object={item}
-            onListSuccess={() => {
-              toast.success('Item listed successfully.');
-              getOwnedObjects();
-            }}
-            listFn={(selectedItem: OwnedObjectType) =>
-              setModalItem(selectedItem)
-            }
-          />
-        ))}
+	return (
+		<div className="grid grid-cols-2 lg:grid-cols-4 gap-5 pt-12">
+			{/* Only shows item with an image_url to make it easier to understand the flows. */}
+			{ownedObjects
+				?.filter((x) => !!x.display && !!x.display.image_url)
+				.map((item) => (
+					<OwnedObject
+						kioskId={kioskId}
+						key={item.objectId}
+						object={item}
+						onListSuccess={() => {
+							toast.success('Item listed successfully.');
+							getOwnedObjects();
+						}}
+						listFn={(selectedItem: OwnedObjectType) => setModalItem(selectedItem)}
+					/>
+				))}
 
-      {modalItem && (
-        <ListPrice
-          kioskId={kioskId}
-          item={modalItem}
-          listAndPlace
-          onSuccess={() => {
-            toast.success('Item listed for sale successfully!');
-            getOwnedObjects();
-            setModalItem(null); // replace modal.
-          }}
-          closeModal={() => setModalItem(null)}
-        />
-      )}
-    </div>
-  );
+			{modalItem && (
+				<ListPrice
+					kioskId={kioskId}
+					item={modalItem}
+					listAndPlace
+					onSuccess={() => {
+						toast.success('Item listed for sale successfully!');
+						getOwnedObjects();
+						setModalItem(null); // replace modal.
+					}}
+					closeModal={() => setModalItem(null)}
+				/>
+			)}
+		</div>
+	);
 }

--- a/dapps/kiosk/src/components/Inventory/OwnedObjects.tsx
+++ b/dapps/kiosk/src/components/Inventory/OwnedObjects.tsx
@@ -26,22 +26,24 @@ export function OwnedObjects({ address }: { address: string }) {
 
 	if (isLoading) return <Loading />;
 
-	return (
-		<div className="grid grid-cols-2 lg:grid-cols-4 gap-5">
-			{/* Only shows item with an image_url to make it easier to understand the flows. */}
-			{ownedObjects
-				?.filter((x) => !!x.display && !!x.display.image_url)
-				.map((item) => (
-					<OwnedObject
-						key={item.objectId}
-						object={item}
-						onListSuccess={() => {
-							toast.success('Item listed successfully.');
-							getOwnedObjects();
-						}}
-						listFn={(selectedItem: OwnedObjectType) => setModalItem(selectedItem)}
-					/>
-				))}
+  return (
+    <div className="grid grid-cols-2 lg:grid-cols-4 gap-5 pt-12">
+      {/* Only shows item with an image_url to make it easier to understand the flows. */}
+      {ownedObjects
+        ?.filter((x) => !!x.display && !!x.display.image_url)
+        .map((item) => (
+          <OwnedObject
+            key={item.objectId}
+            object={item}
+            onListSuccess={() => {
+              toast.success('Item listed successfully.');
+              getOwnedObjects();
+            }}
+            listFn={(selectedItem: OwnedObjectType) =>
+              setModalItem(selectedItem)
+            }
+          />
+        ))}
 
 			{modalItem && (
 				<ListPrice

--- a/dapps/kiosk/src/components/Inventory/OwnedObjects.tsx
+++ b/dapps/kiosk/src/components/Inventory/OwnedObjects.tsx
@@ -8,13 +8,20 @@ import { ListPrice } from '../Modals/ListPrice';
 import { Loading } from '../Base/Loading';
 import { useOwnedObjects } from '../../hooks/useOwnedObjects';
 import { toast } from 'react-hot-toast';
+import { ObjectId } from '@mysten/sui.js';
 
 export type OwnedObjectType = KioskItem & {
 	display: Record<string, string>;
 };
 
-export function OwnedObjects({ address }: { address: string }) {
-	const [modalItem, setModalItem] = useState<OwnedObjectType | null>(null);
+export function OwnedObjects({
+  address,
+  kioskId,
+}: {
+  address: string;
+  kioskId: ObjectId;
+}) {
+  const [modalItem, setModalItem] = useState<OwnedObjectType | null>(null);
 
 	const {
 		data: ownedObjects,
@@ -33,6 +40,7 @@ export function OwnedObjects({ address }: { address: string }) {
         ?.filter((x) => !!x.display && !!x.display.image_url)
         .map((item) => (
           <OwnedObject
+            kioskId={kioskId}
             key={item.objectId}
             object={item}
             onListSuccess={() => {
@@ -45,18 +53,19 @@ export function OwnedObjects({ address }: { address: string }) {
           />
         ))}
 
-			{modalItem && (
-				<ListPrice
-					item={modalItem}
-					listAndPlace
-					onSuccess={() => {
-						toast.success('Item listed for sale successfully!');
-						getOwnedObjects();
-						setModalItem(null); // replace modal.
-					}}
-					closeModal={() => setModalItem(null)}
-				/>
-			)}
-		</div>
-	);
+      {modalItem && (
+        <ListPrice
+          kioskId={kioskId}
+          item={modalItem}
+          listAndPlace
+          onSuccess={() => {
+            toast.success('Item listed for sale successfully!');
+            getOwnedObjects();
+            setModalItem(null); // replace modal.
+          }}
+          closeModal={() => setModalItem(null)}
+        />
+      )}
+    </div>
+  );
 }

--- a/dapps/kiosk/src/components/Kiosk/FindKiosk.tsx
+++ b/dapps/kiosk/src/components/Kiosk/FindKiosk.tsx
@@ -4,30 +4,32 @@
 import { FormEvent, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import classnames from 'classnames';
+import { normalizeSuiAddress } from '@mysten/sui.js';
 
 export default function FindKiosk() {
-	const { kioskId } = useParams();
+  const { id } = useParams();
 
-	const [searchKiosk, setSearchKioskId] = useState<string>(kioskId || '');
-	const navigate = useNavigate();
+  const [searchKiosk, setSearchKioskId] = useState<string>(id || '');
+  const navigate = useNavigate();
 
 	const viewKiosk = (e?: FormEvent<HTMLFormElement>) => {
 		if (!searchKiosk || viewingSearchKiosk) return;
 		e?.preventDefault();
 
-		const id = searchKiosk.length === 64 ? `0x${searchKiosk}` : searchKiosk;
-		navigate(`/kiosk/${id}`);
-		setSearchKioskId(id);
-	};
+    const id = normalizeSuiAddress(searchKiosk);
+    navigate(`/kiosk/${id}`);
+    setSearchKioskId(id);
+  };
 
-	const viewingSearchKiosk = searchKiosk === kioskId;
-	const isObjectIdInput = (val: string | undefined) => val?.length === 66 || val?.length === 64;
+  const viewingSearchKiosk = searchKiosk === id;
+  const isObjectIdInput = (val: string | undefined) =>
+    val?.length === 66 || val?.length === 64;
 
 	const onInput = (e: any) => {
 		setSearchKioskId(e.target.value);
 	};
 
-	const canSearch = !(kioskId === searchKiosk || !isObjectIdInput(searchKiosk));
+  const canSearch = !(id === searchKiosk || !isObjectIdInput(searchKiosk));
 
 	return (
 		<form onSubmit={viewKiosk} className="text-center lg:min-w-[700px]">
@@ -42,21 +44,21 @@ export default function FindKiosk() {
 						className="bg-gray-100 border lg:min-w-[600px] text-gray-900 placeholder:text-gray-500 text-sm rounded rounded-r-none
              focus:ring-transparent 
             focus:border-primary block w-full p-2.5 outline-primary"
-						placeholder="Enter a Sui Kiosk ID to search for a kiosk..."
-						required
-					/>
-				</div>
-				<button
-					type="submit"
-					className={classnames(
-						'basis-2/12 w-full h-[42px] text-primary text-xs mx-auto disabled:opacity-60 !rounded-l-none',
-						canSearch && 'bg-primary !text-white',
-					)}
-					disabled={!canSearch}
-				>
-					Search
-				</button>
-			</div>
-		</form>
-	);
+            placeholder="Enter an address or a Sui Kiosk ID to search for a kiosk..."
+            required
+          />
+        </div>
+        <button
+          type="submit"
+          className={classnames(
+            'basis-2/12 w-full h-[42px] text-primary text-xs mx-auto disabled:opacity-60 !rounded-l-none',
+            canSearch && 'bg-primary !text-white',
+          )}
+          disabled={!canSearch}
+        >
+          Search
+        </button>
+      </div>
+    </form>
+  );
 }

--- a/dapps/kiosk/src/components/Kiosk/FindKiosk.tsx
+++ b/dapps/kiosk/src/components/Kiosk/FindKiosk.tsx
@@ -7,29 +7,28 @@ import classnames from 'classnames';
 import { normalizeSuiAddress } from '@mysten/sui.js';
 
 export default function FindKiosk() {
-  const { id } = useParams();
+	const { id } = useParams();
 
-  const [searchKiosk, setSearchKioskId] = useState<string>(id || '');
-  const navigate = useNavigate();
+	const [searchKiosk, setSearchKioskId] = useState<string>(id || '');
+	const navigate = useNavigate();
 
 	const viewKiosk = (e?: FormEvent<HTMLFormElement>) => {
 		if (!searchKiosk || viewingSearchKiosk) return;
 		e?.preventDefault();
 
-    const id = normalizeSuiAddress(searchKiosk);
-    navigate(`/kiosk/${id}`);
-    setSearchKioskId(id);
-  };
+		const id = normalizeSuiAddress(searchKiosk);
+		navigate(`/kiosk/${id}`);
+		setSearchKioskId(id);
+	};
 
-  const viewingSearchKiosk = searchKiosk === id;
-  const isObjectIdInput = (val: string | undefined) =>
-    val?.length === 66 || val?.length === 64;
+	const viewingSearchKiosk = searchKiosk === id;
+	const isObjectIdInput = (val: string | undefined) => val?.length === 66 || val?.length === 64;
 
 	const onInput = (e: any) => {
 		setSearchKioskId(e.target.value);
 	};
 
-  const canSearch = !(id === searchKiosk || !isObjectIdInput(searchKiosk));
+	const canSearch = !(id === searchKiosk || !isObjectIdInput(searchKiosk));
 
 	return (
 		<form onSubmit={viewKiosk} className="text-center lg:min-w-[700px]">
@@ -44,21 +43,21 @@ export default function FindKiosk() {
 						className="bg-gray-100 border lg:min-w-[600px] text-gray-900 placeholder:text-gray-500 text-sm rounded rounded-r-none
              focus:ring-transparent 
             focus:border-primary block w-full p-2.5 outline-primary"
-            placeholder="Enter an address or a Sui Kiosk ID to search for a kiosk..."
-            required
-          />
-        </div>
-        <button
-          type="submit"
-          className={classnames(
-            'basis-2/12 w-full h-[42px] text-primary text-xs mx-auto disabled:opacity-60 !rounded-l-none',
-            canSearch && 'bg-primary !text-white',
-          )}
-          disabled={!canSearch}
-        >
-          Search
-        </button>
-      </div>
-    </form>
-  );
+						placeholder="Enter an address or a Sui Kiosk ID to search for a kiosk..."
+						required
+					/>
+				</div>
+				<button
+					type="submit"
+					className={classnames(
+						'basis-2/12 w-full h-[42px] text-primary text-xs mx-auto disabled:opacity-60 !rounded-l-none',
+						canSearch && 'bg-primary !text-white',
+					)}
+					disabled={!canSearch}
+				>
+					Search
+				</button>
+			</div>
+		</form>
+	);
 }

--- a/dapps/kiosk/src/components/Kiosk/KioskData.tsx
+++ b/dapps/kiosk/src/components/Kiosk/KioskData.tsx
@@ -5,21 +5,19 @@ import { useWalletKit } from '@mysten/wallet-kit';
 import { Tab } from '@headlessui/react';
 import { OwnedObjects } from '../Inventory/OwnedObjects';
 import { KioskItems } from './KioskItems';
-import { formatAddress } from '@mysten/sui.js';
+import { ObjectId, formatAddress } from '@mysten/sui.js';
 import { ExplorerLink } from '../Base/ExplorerLink';
 import { formatSui, mistToSui } from '../../utils/utils';
 import { toast } from 'react-hot-toast';
-import { useKioskDetails, useOwnedKiosk } from '../../hooks/kiosk';
+import { useKioskDetails } from '../../hooks/kiosk';
 import { Loading } from '../Base/Loading';
 import { useQueryClient } from '@tanstack/react-query';
 import { TANSTACK_KIOSK_DATA_KEY } from '../../utils/constants';
 import { Button } from '../Base/Button';
 import { useWithdrawMutation } from '../../mutations/kiosk';
 
-export function KioskData() {
+export function KioskData({ kioskId }: { kioskId: ObjectId }) {
   const { currentAccount } = useWalletKit();
-  const { data: ownedKiosk } = useOwnedKiosk(currentAccount?.address);
-  const kioskId = ownedKiosk?.kioskId;
 
 	const { data: kiosk, isLoading } = useKioskDetails(kioskId);
 
@@ -77,7 +75,10 @@ export function KioskData() {
           </Tab.Panel>
           <Tab.Panel>
             {currentAccount && (
-              <OwnedObjects address={currentAccount.address}></OwnedObjects>
+              <OwnedObjects
+                kioskId={kioskId}
+                address={currentAccount.address}
+              ></OwnedObjects>
             )}
           </Tab.Panel>
         </Tab.Panels>

--- a/dapps/kiosk/src/components/Kiosk/KioskData.tsx
+++ b/dapps/kiosk/src/components/Kiosk/KioskData.tsx
@@ -17,9 +17,9 @@ import { Button } from '../Base/Button';
 import { useWithdrawMutation } from '../../mutations/kiosk';
 
 export function KioskData() {
-	const { currentAccount } = useWalletKit();
-	const { data: ownedKiosk } = useOwnedKiosk();
-	const kioskId = ownedKiosk?.kioskId;
+  const { currentAccount } = useWalletKit();
+  const { data: ownedKiosk } = useOwnedKiosk(currentAccount?.address);
+  const kioskId = ownedKiosk?.kioskId;
 
 	const { data: kiosk, isLoading } = useKioskDetails(kioskId);
 
@@ -66,31 +66,22 @@ export function KioskData() {
 				)}
 			</div>
 
-			<Tab.Group vertical defaultIndex={0}>
-				<Tab.List>
-					<Tab className="tab-title">My Kiosk</Tab>
-					<Tab className="tab-title">My Wallet</Tab>
-				</Tab.List>
-				<Tab.Panels>
-					<Tab.Panel>
-						<p className="pt-6 lg:w-6/12">
-							Your kiosk holds the items displayed here. You can perform the following actions:{' '}
-							<strong>Take from kiosk</strong>, <strong>List for sale</strong>, and{' '}
-							<strong>Remove listing</strong>. You are charged a gas fee for each action you take.
-						</p>
-						{kioskId && <KioskItems kioskId={kioskId}></KioskItems>}
-					</Tab.Panel>
-					<Tab.Panel>
-						<p className="py-6 lg:w-6/12">
-							To add an item to your kiosk, click <strong>Place in kiosk</strong>. To add an item
-							and list it for sale, click <strong>List for sale</strong>. You can also add an item
-							and then list it after you add it. You are changed a gas fee each time you place,
-							list, or remove an item.
-						</p>
-						{currentAccount && <OwnedObjects address={currentAccount.address}></OwnedObjects>}
-					</Tab.Panel>
-				</Tab.Panels>
-			</Tab.Group>
-		</div>
-	);
+      <Tab.Group vertical defaultIndex={0}>
+        <Tab.List>
+          <Tab className="tab-title">My Kiosk</Tab>
+          <Tab className="tab-title">My Wallet</Tab>
+        </Tab.List>
+        <Tab.Panels>
+          <Tab.Panel>
+            {kioskId && <KioskItems kioskId={kioskId}></KioskItems>}
+          </Tab.Panel>
+          <Tab.Panel>
+            {currentAccount && (
+              <OwnedObjects address={currentAccount.address}></OwnedObjects>
+            )}
+          </Tab.Panel>
+        </Tab.Panels>
+      </Tab.Group>
+    </div>
+  );
 }

--- a/dapps/kiosk/src/components/Kiosk/KioskData.tsx
+++ b/dapps/kiosk/src/components/Kiosk/KioskData.tsx
@@ -17,7 +17,7 @@ import { Button } from '../Base/Button';
 import { useWithdrawMutation } from '../../mutations/kiosk';
 
 export function KioskData({ kioskId }: { kioskId: ObjectId }) {
-  const { currentAccount } = useWalletKit();
+	const { currentAccount } = useWalletKit();
 
 	const { data: kiosk, isLoading } = useKioskDetails(kioskId);
 
@@ -64,25 +64,20 @@ export function KioskData({ kioskId }: { kioskId: ObjectId }) {
 				)}
 			</div>
 
-      <Tab.Group vertical defaultIndex={0}>
-        <Tab.List>
-          <Tab className="tab-title">My Kiosk</Tab>
-          <Tab className="tab-title">My Wallet</Tab>
-        </Tab.List>
-        <Tab.Panels>
-          <Tab.Panel>
-            {kioskId && <KioskItems kioskId={kioskId}></KioskItems>}
-          </Tab.Panel>
-          <Tab.Panel>
-            {currentAccount && (
-              <OwnedObjects
-                kioskId={kioskId}
-                address={currentAccount.address}
-              ></OwnedObjects>
-            )}
-          </Tab.Panel>
-        </Tab.Panels>
-      </Tab.Group>
-    </div>
-  );
+			<Tab.Group vertical defaultIndex={0}>
+				<Tab.List>
+					<Tab className="tab-title">My Kiosk</Tab>
+					<Tab className="tab-title">My Wallet</Tab>
+				</Tab.List>
+				<Tab.Panels>
+					<Tab.Panel>{kioskId && <KioskItems kioskId={kioskId}></KioskItems>}</Tab.Panel>
+					<Tab.Panel>
+						{currentAccount && (
+							<OwnedObjects kioskId={kioskId} address={currentAccount.address}></OwnedObjects>
+						)}
+					</Tab.Panel>
+				</Tab.Panels>
+			</Tab.Group>
+		</div>
+	);
 }

--- a/dapps/kiosk/src/components/Kiosk/KioskItem.tsx
+++ b/dapps/kiosk/src/components/Kiosk/KioskItem.tsx
@@ -11,23 +11,23 @@ import { toast } from 'react-hot-toast';
 import { ObjectId } from '@mysten/sui.js';
 
 export type KioskItemProps = {
-  isGuest?: boolean;
-  listing?: KioskListing | null;
-  kioskId: ObjectId;
-  hasKiosk: boolean;
-  onSuccess: () => void; // parent component onSuccess handler.
-  listFn: KioskFnType;
-  item: OwnedObjectType;
+	isGuest?: boolean;
+	listing?: KioskListing | null;
+	kioskId: ObjectId;
+	hasKiosk: boolean;
+	onSuccess: () => void; // parent component onSuccess handler.
+	listFn: KioskFnType;
+	item: OwnedObjectType;
 };
 
 export function KioskItem({
-  item,
-  kioskId,
-  listing = null,
-  isGuest = false,
-  hasKiosk = false,
-  onSuccess,
-  listFn,
+	item,
+	kioskId,
+	listing = null,
+	isGuest = false,
+	hasKiosk = false,
+	onSuccess,
+	listFn,
 }: KioskItemProps) {
 	const takeMutation = useTakeMutation({
 		onSuccess: () => {
@@ -50,75 +50,75 @@ export function KioskItem({
 		},
 	});
 
-  if (isGuest)
-    return (
-      <DisplayObject item={item} listing={listing}>
-        <>
-          {listing && hasKiosk && (
-            <Button
-              loading={purchaseMutation.isLoading}
-              className="border-gray-400 bg-transparent hover:bg-primary hover:text-white md:col-span-2"
-              onClick={() =>
-                purchaseMutation.mutate({
-                  item: {
-                    ...item,
-                    listing,
-                  },
-                  kioskId: kioskId,
-                })
-              }
-            >
-              Purchase
-            </Button>
-          )}
-        </>
-      </DisplayObject>
-    );
-  return (
-    <DisplayObject item={item} listing={listing}>
-      <>
-        {!listing && !isGuest && (
-          <>
-            <Button
-              className="border-transparent hover:bg-primary hover:text-white disabled:opacity-30 "
-              loading={takeMutation.isLoading}
-              disabled={item.isLocked}
-              onClick={() =>
-                takeMutation.mutate({
-                  item,
-                  kioskId: kioskId,
-                })
-              }
-            >
-              Take from Kiosk
-            </Button>
+	if (isGuest)
+		return (
+			<DisplayObject item={item} listing={listing}>
+				<>
+					{listing && hasKiosk && (
+						<Button
+							loading={purchaseMutation.isLoading}
+							className="border-gray-400 bg-transparent hover:bg-primary hover:text-white md:col-span-2"
+							onClick={() =>
+								purchaseMutation.mutate({
+									item: {
+										...item,
+										listing,
+									},
+									kioskId: kioskId,
+								})
+							}
+						>
+							Purchase
+						</Button>
+					)}
+				</>
+			</DisplayObject>
+		);
+	return (
+		<DisplayObject item={item} listing={listing}>
+			<>
+				{!listing && !isGuest && (
+					<>
+						<Button
+							className="border-transparent hover:bg-primary hover:text-white disabled:opacity-30 "
+							loading={takeMutation.isLoading}
+							disabled={item.isLocked}
+							onClick={() =>
+								takeMutation.mutate({
+									item,
+									kioskId: kioskId,
+								})
+							}
+						>
+							Take from Kiosk
+						</Button>
 
-            <Button
-              className="border-gray-400 bg-transparent hover:bg-primary hover:text-white"
-              onClick={() => listFn(item)}
-            >
-              List for Sale
-            </Button>
-          </>
-        )}
-        {listing && !isGuest && (
-          <Button
-            loading={delistMutation.isLoading}
-            className="border-gray-400 bg-transparent hover:bg-primary hover:text-white md:col-span-2"
-            onClick={() =>
-              delistMutation.mutate({
-                item: {
-                  ...item,
-                  listing,
-                },
-                kioskId: kioskId,
-              })
-            }
-          >
-            Delist item
-          </Button>
-        )}
-      </>
-    </DisplayObject>
-  );
+						<Button
+							className="border-gray-400 bg-transparent hover:bg-primary hover:text-white"
+							onClick={() => listFn(item)}
+						>
+							List for Sale
+						</Button>
+					</>
+				)}
+				{listing && !isGuest && (
+					<Button
+						loading={delistMutation.isLoading}
+						className="border-gray-400 bg-transparent hover:bg-primary hover:text-white md:col-span-2"
+						onClick={() =>
+							delistMutation.mutate({
+								item: {
+									...item,
+									listing,
+								},
+								kioskId: kioskId,
+							})
+						}
+					>
+						Delist item
+					</Button>
+				)}
+			</>
+		</DisplayObject>
+	);
 }

--- a/dapps/kiosk/src/components/Kiosk/KioskItem.tsx
+++ b/dapps/kiosk/src/components/Kiosk/KioskItem.tsx
@@ -11,21 +11,23 @@ import { toast } from 'react-hot-toast';
 import { ObjectId } from '@mysten/sui.js';
 
 export type KioskItemProps = {
-	isGuest?: boolean;
-	listing?: KioskListing | null;
-	kioskId: ObjectId;
-	onSuccess: () => void; // parent component onSuccess handler.
-	listFn: KioskFnType;
-	item: OwnedObjectType;
+  isGuest?: boolean;
+  listing?: KioskListing | null;
+  kioskId: ObjectId;
+  hasKiosk: boolean;
+  onSuccess: () => void; // parent component onSuccess handler.
+  listFn: KioskFnType;
+  item: OwnedObjectType;
 };
 
 export function KioskItem({
-	item,
-	kioskId,
-	listing = null,
-	isGuest = false,
-	onSuccess,
-	listFn,
+  item,
+  kioskId,
+  listing = null,
+  isGuest = false,
+  hasKiosk = false,
+  onSuccess,
+  listFn,
 }: KioskItemProps) {
 	const takeMutation = useTakeMutation({
 		onSuccess: () => {
@@ -48,62 +50,75 @@ export function KioskItem({
 		},
 	});
 
-	if (isGuest)
-		return (
-			<DisplayObject item={item} listing={listing}>
-				<>
-					{listing && (
-						<Button
-							loading={purchaseMutation.isLoading}
-							className="border-gray-400 bg-transparent hover:bg-primary hover:text-white md:col-span-2"
-							onClick={() =>
-								purchaseMutation.mutate({
-									item: {
-										...item,
-										listing,
-									},
-									kioskId: kioskId,
-								})
-							}
-						>
-							Purchase
-						</Button>
-					)}
-				</>
-			</DisplayObject>
-		);
-	return (
-		<DisplayObject item={item} listing={listing}>
-			<>
-				{!listing && !isGuest && (
-					<>
-						<Button
-							className="border-transparent hover:bg-primary hover:text-white disabled:opacity-30 "
-							loading={takeMutation.isLoading}
-							disabled={item.isLocked}
-							onClick={() => takeMutation.mutate(item)}
-						>
-							Take from Kiosk
-						</Button>
+  if (isGuest)
+    return (
+      <DisplayObject item={item} listing={listing}>
+        <>
+          {listing && hasKiosk && (
+            <Button
+              loading={purchaseMutation.isLoading}
+              className="border-gray-400 bg-transparent hover:bg-primary hover:text-white md:col-span-2"
+              onClick={() =>
+                purchaseMutation.mutate({
+                  item: {
+                    ...item,
+                    listing,
+                  },
+                  kioskId: kioskId,
+                })
+              }
+            >
+              Purchase
+            </Button>
+          )}
+        </>
+      </DisplayObject>
+    );
+  return (
+    <DisplayObject item={item} listing={listing}>
+      <>
+        {!listing && !isGuest && (
+          <>
+            <Button
+              className="border-transparent hover:bg-primary hover:text-white disabled:opacity-30 "
+              loading={takeMutation.isLoading}
+              disabled={item.isLocked}
+              onClick={() =>
+                takeMutation.mutate({
+                  item,
+                  kioskId: kioskId,
+                })
+              }
+            >
+              Take from Kiosk
+            </Button>
 
-						<Button
-							className="border-gray-400 bg-transparent hover:bg-primary hover:text-white"
-							onClick={() => listFn(item)}
-						>
-							List for Sale
-						</Button>
-					</>
-				)}
-				{listing && !isGuest && (
-					<Button
-						loading={delistMutation.isLoading}
-						className="border-gray-400 bg-transparent hover:bg-primary hover:text-white md:col-span-2"
-						onClick={() => delistMutation.mutate(item)}
-					>
-						Delist item
-					</Button>
-				)}
-			</>
-		</DisplayObject>
-	);
+            <Button
+              className="border-gray-400 bg-transparent hover:bg-primary hover:text-white"
+              onClick={() => listFn(item)}
+            >
+              List for Sale
+            </Button>
+          </>
+        )}
+        {listing && !isGuest && (
+          <Button
+            loading={delistMutation.isLoading}
+            className="border-gray-400 bg-transparent hover:bg-primary hover:text-white md:col-span-2"
+            onClick={() =>
+              delistMutation.mutate({
+                item: {
+                  ...item,
+                  listing,
+                },
+                kioskId: kioskId,
+              })
+            }
+          >
+            Delist item
+          </Button>
+        )}
+      </>
+    </DisplayObject>
+  );
 }

--- a/dapps/kiosk/src/components/Kiosk/KioskItem.tsx
+++ b/dapps/kiosk/src/components/Kiosk/KioskItem.tsx
@@ -6,9 +6,16 @@ import { DisplayObject } from '../DisplayObject';
 import { Button } from '../Base/Button';
 import { KioskListing } from '@mysten/kiosk';
 import { KioskFnType } from '../../hooks/kiosk';
-import { useDelistMutation, usePurchaseItemMutation, useTakeMutation } from '../../mutations/kiosk';
+import {
+	useCreateKioskMutation,
+	useDelistMutation,
+	usePurchaseItemMutation,
+	useTakeMutation,
+} from '../../mutations/kiosk';
 import { toast } from 'react-hot-toast';
 import { ObjectId } from '@mysten/sui.js';
+import { useQueryClient } from '@tanstack/react-query';
+import { TANSTACK_OWNED_KIOSK_KEY } from '../../utils/constants';
 
 export type KioskItemProps = {
 	isGuest?: boolean;
@@ -29,6 +36,14 @@ export function KioskItem({
 	onSuccess,
 	listFn,
 }: KioskItemProps) {
+	const queryClient = useQueryClient();
+	const createKiosk = useCreateKioskMutation({
+		onSuccess: () => {
+			queryClient.invalidateQueries([TANSTACK_OWNED_KIOSK_KEY]);
+			toast.success('Kiosk created successfully');
+		},
+	});
+
 	const takeMutation = useTakeMutation({
 		onSuccess: () => {
 			toast.success('Item was transferred back to the address.');
@@ -70,6 +85,19 @@ export function KioskItem({
 						>
 							Purchase
 						</Button>
+					)}
+					{listing && !hasKiosk && (
+						<div className="md:col-span-2 text-xs">
+							<p>Create a kiosk to interact with other kiosks.</p>
+
+							<Button
+								className="mt-2"
+								loading={createKiosk.isLoading}
+								onClick={() => createKiosk.mutate()}
+							>
+								Click here to create.
+							</Button>
+						</div>
 					)}
 				</>
 			</DisplayObject>

--- a/dapps/kiosk/src/components/Kiosk/KioskItems.tsx
+++ b/dapps/kiosk/src/components/Kiosk/KioskItems.tsx
@@ -10,20 +10,24 @@ import { toast } from 'react-hot-toast';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useKiosk, useOwnedKiosk } from '../../hooks/kiosk';
 import { KioskNotFound } from './KioskNotFound';
+import { useWalletKit } from '@mysten/wallet-kit';
+import { normalizeSuiAddress } from '@mysten/sui.js';
 
 export function KioskItems({ kioskId }: { kioskId?: string }) {
-	const location = useLocation();
-	const isKioskPage = location.pathname.startsWith('/kiosk/');
+  const location = useLocation();
+  const isKioskPage = location.pathname.startsWith('/kiosk/');
+  const { currentAccount } = useWalletKit();
 
-	const { data: walletKiosk } = useOwnedKiosk();
-	const ownedKiosk = walletKiosk?.kioskId;
+  const { data: walletKiosk } = useOwnedKiosk(currentAccount?.address);
 
-	// checks if this is an owned kiosk.
-	// We are depending on currentAccount too, as this is what triggers the `getOwnedKioskCap()` function to change
-	// using endsWith because we support it with both 0x prefix and without.
-	const isOwnedKiosk = () => {
-		return ownedKiosk?.endsWith(kioskId || '~');
-	};
+  // checks if this is an owned kiosk.
+  // We are depending on currentAccount too, as this is what triggers the `getOwnedKioskCap()` function to change
+  // using endsWith because we support it with both 0x prefix and without.
+  const isOwnedKiosk = () => {
+    return walletKiosk?.caps?.find(
+      (x) => kioskId && normalizeSuiAddress(x.kioskId).endsWith(kioskId),
+    );
+  };
 
 	const [modalItem, setModalItem] = useState<OwnedObjectType | null>(null);
 

--- a/dapps/kiosk/src/components/Kiosk/KioskItems.tsx
+++ b/dapps/kiosk/src/components/Kiosk/KioskItems.tsx
@@ -45,50 +45,54 @@ export function KioskItems({ kioskId }: { kioskId?: string }) {
 	const kioskItems = kioskData?.items || [];
 	const kioskListings = kioskData?.listings || {};
 
-	if (isError && isKioskPage) return <KioskNotFound />;
+  if (!kioskId)
+    return <div className="py-12">Supply a kiosk ID to continue.</div>;
+
+  if (isError && isKioskPage) return <KioskNotFound />;
 
 	if (isLoading) return <Loading />;
 
-	if (kioskItems.length === 0)
-		return <div className="py-12">The kiosk you are viewing is empty!</div>;
+  if (!kioskId || kioskItems.length === 0)
+    return <div className="py-12">The kiosk you are viewing is empty!</div>;
 
-	return (
-		<div className="mt-12">
-			{
-				// We're hiding this when we've clicked "view kiosk" for our own kiosk.
-				isOwnedKiosk() && isKioskPage && (
-					<div className="bg-yellow-300 text-black rounded px-3 py-2 mb-6">
-						You're viewing your own kiosk
-					</div>
-				)
-			}
-			<div className="grid sm:grid-cols-2 xl:grid-cols-4 gap-5">
-				{kioskId &&
-					kioskItems.map((item: OwnedObjectType) => (
-						<KioskItemCmp
-							key={item.objectId}
-							kioskId={kioskId}
-							item={item}
-							isGuest={!isOwnedKiosk()}
-							onSuccess={() => {
-								getKioskData();
-							}}
-							listing={kioskListings && kioskListings[item.objectId]}
-							listFn={(item: OwnedObjectType) => setModalItem(item)}
-						/>
-					))}
-				{modalItem && (
-					<ListPrice
-						item={modalItem}
-						onSuccess={() => {
-							toast.success('Item listed successfully.');
-							getKioskData(); // replace with single kiosk Item search here and replace
-							setModalItem(null); // replace modal.
-						}}
-						closeModal={() => setModalItem(null)}
-					/>
-				)}
-			</div>
-		</div>
-	);
+  return (
+    <div className="mt-12">
+      {
+        // We're hiding this when we've clicked "view kiosk" for our own kiosk.
+        isOwnedKiosk() && isKioskPage && (
+          <div className="bg-yellow-300 text-black rounded px-3 py-2 mb-6">
+            You're viewing your own kiosk
+          </div>
+        )
+      }
+      <div className="grid sm:grid-cols-2 xl:grid-cols-4 gap-5">
+        {kioskItems.map((item: OwnedObjectType) => (
+          <KioskItemCmp
+            key={item.objectId}
+            kioskId={kioskId}
+            item={item}
+            isGuest={!isOwnedKiosk()}
+            hasKiosk={!!walletKiosk?.kioskId}
+            onSuccess={() => {
+              getKioskData();
+            }}
+            listing={kioskListings && kioskListings[item.objectId]}
+            listFn={(item: OwnedObjectType) => setModalItem(item)}
+          />
+        ))}
+        {modalItem && (
+          <ListPrice
+            kioskId={kioskId}
+            item={modalItem}
+            onSuccess={() => {
+              toast.success('Item listed successfully.');
+              getKioskData(); // replace with single kiosk Item search here and replace
+              setModalItem(null); // replace modal.
+            }}
+            closeModal={() => setModalItem(null)}
+          />
+        )}
+      </div>
+    </div>
+  );
 }

--- a/dapps/kiosk/src/components/Kiosk/KioskItems.tsx
+++ b/dapps/kiosk/src/components/Kiosk/KioskItems.tsx
@@ -14,20 +14,20 @@ import { useWalletKit } from '@mysten/wallet-kit';
 import { normalizeSuiAddress } from '@mysten/sui.js';
 
 export function KioskItems({ kioskId }: { kioskId?: string }) {
-  const location = useLocation();
-  const isKioskPage = location.pathname.startsWith('/kiosk/');
-  const { currentAccount } = useWalletKit();
+	const location = useLocation();
+	const isKioskPage = location.pathname.startsWith('/kiosk/');
+	const { currentAccount } = useWalletKit();
 
-  const { data: walletKiosk } = useOwnedKiosk(currentAccount?.address);
+	const { data: walletKiosk } = useOwnedKiosk(currentAccount?.address);
 
-  // checks if this is an owned kiosk.
-  // We are depending on currentAccount too, as this is what triggers the `getOwnedKioskCap()` function to change
-  // using endsWith because we support it with both 0x prefix and without.
-  const isOwnedKiosk = () => {
-    return walletKiosk?.caps?.find(
-      (x) => kioskId && normalizeSuiAddress(x.kioskId).endsWith(kioskId),
-    );
-  };
+	// checks if this is an owned kiosk.
+	// We are depending on currentAccount too, as this is what triggers the `getOwnedKioskCap()` function to change
+	// using endsWith because we support it with both 0x prefix and without.
+	const isOwnedKiosk = () => {
+		return walletKiosk?.caps?.find(
+			(x) => kioskId && normalizeSuiAddress(x.kioskId).endsWith(kioskId),
+		);
+	};
 
 	const [modalItem, setModalItem] = useState<OwnedObjectType | null>(null);
 
@@ -45,54 +45,53 @@ export function KioskItems({ kioskId }: { kioskId?: string }) {
 	const kioskItems = kioskData?.items || [];
 	const kioskListings = kioskData?.listings || {};
 
-  if (!kioskId)
-    return <div className="py-12">Supply a kiosk ID to continue.</div>;
+	if (!kioskId) return <div className="py-12">Supply a kiosk ID to continue.</div>;
 
-  if (isError && isKioskPage) return <KioskNotFound />;
+	if (isError && isKioskPage) return <KioskNotFound />;
 
 	if (isLoading) return <Loading />;
 
-  if (!kioskId || kioskItems.length === 0)
-    return <div className="py-12">The kiosk you are viewing is empty!</div>;
+	if (!kioskId || kioskItems.length === 0)
+		return <div className="py-12">The kiosk you are viewing is empty!</div>;
 
-  return (
-    <div className="mt-12">
-      {
-        // We're hiding this when we've clicked "view kiosk" for our own kiosk.
-        isOwnedKiosk() && isKioskPage && (
-          <div className="bg-yellow-300 text-black rounded px-3 py-2 mb-6">
-            You're viewing your own kiosk
-          </div>
-        )
-      }
-      <div className="grid sm:grid-cols-2 xl:grid-cols-4 gap-5">
-        {kioskItems.map((item: OwnedObjectType) => (
-          <KioskItemCmp
-            key={item.objectId}
-            kioskId={kioskId}
-            item={item}
-            isGuest={!isOwnedKiosk()}
-            hasKiosk={!!walletKiosk?.kioskId}
-            onSuccess={() => {
-              getKioskData();
-            }}
-            listing={kioskListings && kioskListings[item.objectId]}
-            listFn={(item: OwnedObjectType) => setModalItem(item)}
-          />
-        ))}
-        {modalItem && (
-          <ListPrice
-            kioskId={kioskId}
-            item={modalItem}
-            onSuccess={() => {
-              toast.success('Item listed successfully.');
-              getKioskData(); // replace with single kiosk Item search here and replace
-              setModalItem(null); // replace modal.
-            }}
-            closeModal={() => setModalItem(null)}
-          />
-        )}
-      </div>
-    </div>
-  );
+	return (
+		<div className="mt-12">
+			{
+				// We're hiding this when we've clicked "view kiosk" for our own kiosk.
+				isOwnedKiosk() && isKioskPage && (
+					<div className="bg-yellow-300 text-black rounded px-3 py-2 mb-6">
+						You're viewing your own kiosk
+					</div>
+				)
+			}
+			<div className="grid sm:grid-cols-2 xl:grid-cols-4 gap-5">
+				{kioskItems.map((item: OwnedObjectType) => (
+					<KioskItemCmp
+						key={item.objectId}
+						kioskId={kioskId}
+						item={item}
+						isGuest={!isOwnedKiosk()}
+						hasKiosk={!!walletKiosk?.kioskId}
+						onSuccess={() => {
+							getKioskData();
+						}}
+						listing={kioskListings && kioskListings[item.objectId]}
+						listFn={(item: OwnedObjectType) => setModalItem(item)}
+					/>
+				))}
+				{modalItem && (
+					<ListPrice
+						kioskId={kioskId}
+						item={modalItem}
+						onSuccess={() => {
+							toast.success('Item listed successfully.');
+							getKioskData(); // replace with single kiosk Item search here and replace
+							setModalItem(null); // replace modal.
+						}}
+						closeModal={() => setModalItem(null)}
+					/>
+				)}
+			</div>
+		</div>
+	);
 }

--- a/dapps/kiosk/src/components/Kiosk/KioskSelector.tsx
+++ b/dapps/kiosk/src/components/Kiosk/KioskSelector.tsx
@@ -8,21 +8,21 @@ import { formatAddress } from '@mysten/sui.js';
 import classNames from 'classnames';
 
 export function KioskSelector({
-  caps,
-  selected,
-  setSelected,
+	caps,
+	selected,
+	setSelected,
 }: {
-  caps: KioskOwnerCap[];
-  selected: KioskOwnerCap;
-  setSelected: (item: KioskOwnerCap) => void;
+	caps: KioskOwnerCap[];
+	selected: KioskOwnerCap;
+	setSelected: (item: KioskOwnerCap) => void;
 }) {
-  return (
-    <div className="max-w-[175px] z-50 relative my-3">
-      <label className="font-semibold text-xs">Select a kiosk:</label>
-      <Listbox value={selected} onChange={setSelected}>
-        <div className="relative mt-1">
-          <Listbox.Button
-            className="relative w-full rounded-lg
+	return (
+		<div className="max-w-[175px] z-50 relative my-3">
+			<label className="font-semibold text-xs">Select a kiosk:</label>
+			<Listbox value={selected} onChange={setSelected}>
+				<div className="relative mt-1">
+					<Listbox.Button
+						className="relative w-full rounded-lg
            bg-white py-2 pl-3 pr-10 text-left focus:outline-none 
            border border-primary
            focus-visible:border-primary focus-visible:ring-2 
@@ -30,64 +30,58 @@ export function KioskSelector({
             focus-visible:ring-offset-primary sm:text-sm z-50
             cursor-pointer
             "
-          >
-            <span className="block truncate">
-              {formatAddress(selected.kioskId)}
-            </span>
-            <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
-              {/* <ChevronUpDownIcon
+					>
+						<span className="block truncate">{formatAddress(selected.kioskId)}</span>
+						<span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
+							{/* <ChevronUpDownIcon
                 className="h-5 w-5 text-gray-400"
                 aria-hidden="true"
               /> */}
-            </span>
-          </Listbox.Button>
-          <Transition
-            as={Fragment}
-            leave="transition ease-in duration-100"
-            leaveFrom="opacity-100"
-            leaveTo="opacity-0"
-          >
-            <Listbox.Options
-              className="absolute mt-1 max-h-60 w-full overflow-y-auto overflow-x-hidden rounded-md
+						</span>
+					</Listbox.Button>
+					<Transition
+						as={Fragment}
+						leave="transition ease-in duration-100"
+						leaveFrom="opacity-100"
+						leaveTo="opacity-0"
+					>
+						<Listbox.Options
+							className="absolute mt-1 max-h-60 w-full overflow-y-auto overflow-x-hidden rounded-md
              bg-white text-base shadow-lg ring-1 
              border border-primary
              ring-black ring-opacity-5 focus:outline-none sm:text-sm"
-            >
-              {caps.map((cap) => (
-                <Listbox.Option
-                  key={cap.objectId}
-                  className={({ active, selected }) =>
-                    classNames(
-                      selected || active
-                        ? 'bg-primary text-white'
-                        : 'text-primary',
-                      'relative select-none cursor-pointer py-2 my-1 px-4',
-                    )
-                  }
-                  value={cap}
-                >
-                  {({ selected }) => (
-                    <>
-                      <span
-                        className={`block truncate ${
-                          selected ? 'font-medium' : 'font-normal'
-                        }`}
-                      >
-                        {formatAddress(cap.kioskId)}
-                      </span>
-                      {selected ? (
-                        <span className="absolute inset-y-0 left-0 flex items-center text-primary">
-                          {/* <CheckIcon className="h-5 w-5" aria-hidden="true" /> */}
-                        </span>
-                      ) : null}
-                    </>
-                  )}
-                </Listbox.Option>
-              ))}
-            </Listbox.Options>
-          </Transition>
-        </div>
-      </Listbox>
-    </div>
-  );
+						>
+							{caps.map((cap) => (
+								<Listbox.Option
+									key={cap.objectId}
+									className={({ active, selected }) =>
+										classNames(
+											selected || active ? 'bg-primary text-white' : 'text-primary',
+											'relative select-none cursor-pointer py-2 my-1 px-4',
+										)
+									}
+									value={cap}
+								>
+									{({ selected }) => (
+										<>
+											<span
+												className={`block truncate ${selected ? 'font-medium' : 'font-normal'}`}
+											>
+												{formatAddress(cap.kioskId)}
+											</span>
+											{selected ? (
+												<span className="absolute inset-y-0 left-0 flex items-center text-primary">
+													{/* <CheckIcon className="h-5 w-5" aria-hidden="true" /> */}
+												</span>
+											) : null}
+										</>
+									)}
+								</Listbox.Option>
+							))}
+						</Listbox.Options>
+					</Transition>
+				</div>
+			</Listbox>
+		</div>
+	);
 }

--- a/dapps/kiosk/src/components/Kiosk/KioskSelector.tsx
+++ b/dapps/kiosk/src/components/Kiosk/KioskSelector.tsx
@@ -1,0 +1,93 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Fragment } from 'react';
+import { Listbox, Transition } from '@headlessui/react';
+import { KioskOwnerCap } from '@mysten/kiosk';
+import { formatAddress } from '@mysten/sui.js';
+import classNames from 'classnames';
+
+export function KioskSelector({
+  caps,
+  selected,
+  setSelected,
+}: {
+  caps: KioskOwnerCap[];
+  selected: KioskOwnerCap;
+  setSelected: (item: KioskOwnerCap) => void;
+}) {
+  return (
+    <div className="max-w-[175px] z-50 relative my-3">
+      <label className="font-semibold text-xs">Select a kiosk:</label>
+      <Listbox value={selected} onChange={setSelected}>
+        <div className="relative mt-1">
+          <Listbox.Button
+            className="relative w-full rounded-lg
+           bg-white py-2 pl-3 pr-10 text-left focus:outline-none 
+           border border-primary
+           focus-visible:border-primary focus-visible:ring-2 
+           focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2
+            focus-visible:ring-offset-primary sm:text-sm z-50
+            cursor-pointer
+            "
+          >
+            <span className="block truncate">
+              {formatAddress(selected.kioskId)}
+            </span>
+            <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
+              {/* <ChevronUpDownIcon
+                className="h-5 w-5 text-gray-400"
+                aria-hidden="true"
+              /> */}
+            </span>
+          </Listbox.Button>
+          <Transition
+            as={Fragment}
+            leave="transition ease-in duration-100"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+          >
+            <Listbox.Options
+              className="absolute mt-1 max-h-60 w-full overflow-y-auto overflow-x-hidden rounded-md
+             bg-white text-base shadow-lg ring-1 
+             border border-primary
+             ring-black ring-opacity-5 focus:outline-none sm:text-sm"
+            >
+              {caps.map((cap) => (
+                <Listbox.Option
+                  key={cap.objectId}
+                  className={({ active, selected }) =>
+                    classNames(
+                      selected || active
+                        ? 'bg-primary text-white'
+                        : 'text-primary',
+                      'relative select-none cursor-pointer py-2 my-1 px-4',
+                    )
+                  }
+                  value={cap}
+                >
+                  {({ selected }) => (
+                    <>
+                      <span
+                        className={`block truncate ${
+                          selected ? 'font-medium' : 'font-normal'
+                        }`}
+                      >
+                        {formatAddress(cap.kioskId)}
+                      </span>
+                      {selected ? (
+                        <span className="absolute inset-y-0 left-0 flex items-center text-primary">
+                          {/* <CheckIcon className="h-5 w-5" aria-hidden="true" /> */}
+                        </span>
+                      ) : null}
+                    </>
+                  )}
+                </Listbox.Option>
+              ))}
+            </Listbox.Options>
+          </Transition>
+        </div>
+      </Listbox>
+    </div>
+  );
+}

--- a/dapps/kiosk/src/components/Modals/ListPrice.tsx
+++ b/dapps/kiosk/src/components/Modals/ListPrice.tsx
@@ -10,20 +10,14 @@ import { MIST_PER_SUI, ObjectId } from '@mysten/sui.js';
 import { usePlaceAndListMutation } from '../../mutations/kiosk';
 
 export interface ListPriceProps {
-  item: OwnedObjectType;
-  onSuccess: () => void;
-  closeModal: () => void;
-  listAndPlace?: boolean;
-  kioskId: ObjectId;
+	item: OwnedObjectType;
+	onSuccess: () => void;
+	closeModal: () => void;
+	listAndPlace?: boolean;
+	kioskId: ObjectId;
 }
-export function ListPrice({
-  item,
-  onSuccess,
-  closeModal,
-  listAndPlace,
-  kioskId,
-}: ListPriceProps) {
-  const [price, setPrice] = useState<string>('');
+export function ListPrice({ item, onSuccess, closeModal, listAndPlace, kioskId }: ListPriceProps) {
+	const [price, setPrice] = useState<string>('');
 
 	const placeAndListToKioskMutation = usePlaceAndListMutation({
 		onSuccess: onSuccess,
@@ -47,23 +41,23 @@ export function ListPrice({
 					></input>
 				</div>
 
-        <div className="mt-6">
-          <Button
-            loading={placeAndListToKioskMutation.isLoading}
-            className="ease-in-out duration-300 rounded py-2 px-4 bg-primary text-white hover:opacity-70 w-full"
-            onClick={() =>
-              placeAndListToKioskMutation.mutate({
-                item,
-                price: (Number(price) * Number(MIST_PER_SUI)).toString(),
-                shouldPlace: listAndPlace,
-                kioskId,
-              })
-            }
-          >
-            List Item
-          </Button>
-        </div>
-      </>
-    </ModalBase>
-  );
+				<div className="mt-6">
+					<Button
+						loading={placeAndListToKioskMutation.isLoading}
+						className="ease-in-out duration-300 rounded py-2 px-4 bg-primary text-white hover:opacity-70 w-full"
+						onClick={() =>
+							placeAndListToKioskMutation.mutate({
+								item,
+								price: (Number(price) * Number(MIST_PER_SUI)).toString(),
+								shouldPlace: listAndPlace,
+								kioskId,
+							})
+						}
+					>
+						List Item
+					</Button>
+				</div>
+			</>
+		</ModalBase>
+	);
 }

--- a/dapps/kiosk/src/components/Modals/ListPrice.tsx
+++ b/dapps/kiosk/src/components/Modals/ListPrice.tsx
@@ -6,17 +6,24 @@ import { ModalBase } from './Base';
 import { OwnedObjectType } from '../Inventory/OwnedObjects';
 import { DisplayObjectThumbnail } from '../DisplayObjectThumbnail';
 import { Button } from '../Base/Button';
-import { MIST_PER_SUI } from '@mysten/sui.js';
+import { MIST_PER_SUI, ObjectId } from '@mysten/sui.js';
 import { usePlaceAndListMutation } from '../../mutations/kiosk';
 
 export interface ListPriceProps {
-	item: OwnedObjectType;
-	onSuccess: () => void;
-	closeModal: () => void;
-	listAndPlace?: boolean;
+  item: OwnedObjectType;
+  onSuccess: () => void;
+  closeModal: () => void;
+  listAndPlace?: boolean;
+  kioskId: ObjectId;
 }
-export function ListPrice({ item, onSuccess, closeModal, listAndPlace }: ListPriceProps) {
-	const [price, setPrice] = useState<string>('');
+export function ListPrice({
+  item,
+  onSuccess,
+  closeModal,
+  listAndPlace,
+  kioskId,
+}: ListPriceProps) {
+  const [price, setPrice] = useState<string>('');
 
 	const placeAndListToKioskMutation = usePlaceAndListMutation({
 		onSuccess: onSuccess,
@@ -40,22 +47,23 @@ export function ListPrice({ item, onSuccess, closeModal, listAndPlace }: ListPri
 					></input>
 				</div>
 
-				<div className="mt-6">
-					<Button
-						loading={placeAndListToKioskMutation.isLoading}
-						className="ease-in-out duration-300 rounded py-2 px-4 bg-primary text-white hover:opacity-70 w-full"
-						onClick={() =>
-							placeAndListToKioskMutation.mutate({
-								item,
-								price: (Number(price) * Number(MIST_PER_SUI)).toString(),
-								shouldPlace: listAndPlace,
-							})
-						}
-					>
-						List Item
-					</Button>
-				</div>
-			</>
-		</ModalBase>
-	);
+        <div className="mt-6">
+          <Button
+            loading={placeAndListToKioskMutation.isLoading}
+            className="ease-in-out duration-300 rounded py-2 px-4 bg-primary text-white hover:opacity-70 w-full"
+            onClick={() =>
+              placeAndListToKioskMutation.mutate({
+                item,
+                price: (Number(price) * Number(MIST_PER_SUI)).toString(),
+                shouldPlace: listAndPlace,
+                kioskId,
+              })
+            }
+          >
+            List Item
+          </Button>
+        </div>
+      </>
+    </ModalBase>
+  );
 }

--- a/dapps/kiosk/src/hooks/kiosk.ts
+++ b/dapps/kiosk/src/hooks/kiosk.ts
@@ -38,8 +38,8 @@ export function useOwnedKiosk(address: SuiAddress | undefined) {
     retry: false,
     queryFn: async (): Promise<{
       caps: KioskOwnerCap[];
-      kioskId: SuiAddress | null;
-      kioskCap: SuiAddress | null;
+      kioskId: SuiAddress | undefined;
+      kioskCap: SuiAddress | undefined;
     } | null> => {
       if (!address) return null;
 

--- a/dapps/kiosk/src/hooks/kiosk.ts
+++ b/dapps/kiosk/src/hooks/kiosk.ts
@@ -11,14 +11,14 @@ import {
 import { useRpc } from '../context/RpcClientContext';
 import { ObjectId, SuiAddress, SuiObjectResponse } from '@mysten/sui.js';
 import {
-  Kiosk,
-  KioskData,
-  KioskItem,
-  KioskListing,
-  KioskOwnerCap,
-  fetchKiosk,
-  getKioskObject,
-  getOwnedKiosks,
+	Kiosk,
+	KioskData,
+	KioskItem,
+	KioskListing,
+	KioskOwnerCap,
+	fetchKiosk,
+	getKioskObject,
+	getOwnedKiosks,
 } from '@mysten/kiosk';
 import { parseObjectDisplays, processKioskListings } from '../utils/utils';
 import { OwnedObjectType } from '../components/Inventory/OwnedObjects';
@@ -30,31 +30,28 @@ export type KioskFnType = (item: OwnedObjectType, price?: string) => Promise<voi
  * If the user doesn't have a kiosk, the return is an object with null values.
  */
 export function useOwnedKiosk(address: SuiAddress | undefined) {
-  const provider = useRpc();
+	const provider = useRpc();
 
-  return useQuery({
-    queryKey: [TANSTACK_OWNED_KIOSK_KEY, address],
-    refetchOnMount: false,
-    retry: false,
-    queryFn: async (): Promise<{
-      caps: KioskOwnerCap[];
-      kioskId: SuiAddress | undefined;
-      kioskCap: SuiAddress | undefined;
-    } | null> => {
-      if (!address) return null;
+	return useQuery({
+		queryKey: [TANSTACK_OWNED_KIOSK_KEY, address],
+		refetchOnMount: false,
+		retry: false,
+		queryFn: async (): Promise<{
+			caps: KioskOwnerCap[];
+			kioskId: SuiAddress | undefined;
+			kioskCap: SuiAddress | undefined;
+		} | null> => {
+			if (!address) return null;
 
-      const { kioskOwnerCaps, kioskIds } = await getOwnedKiosks(
-        provider,
-        address,
-      );
+			const { kioskOwnerCaps, kioskIds } = await getOwnedKiosks(provider, address);
 
-      return {
-        caps: kioskOwnerCaps,
-        kioskId: kioskIds[0],
-        kioskCap: kioskOwnerCaps[0]?.objectId,
-      };
-    },
-  });
+			return {
+				caps: kioskOwnerCaps,
+				kioskId: kioskIds[0],
+				kioskCap: kioskOwnerCaps[0]?.objectId,
+			};
+		},
+	});
 }
 
 /**

--- a/dapps/kiosk/src/hooks/useKioskSelector.ts
+++ b/dapps/kiosk/src/hooks/useKioskSelector.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { KioskOwnerCap } from '@mysten/kiosk';
 import { SuiAddress } from '@mysten/sui.js';
 import { useEffect, useState } from 'react';

--- a/dapps/kiosk/src/hooks/useKioskSelector.ts
+++ b/dapps/kiosk/src/hooks/useKioskSelector.ts
@@ -7,31 +7,30 @@ import { useEffect, useState } from 'react';
 import { useOwnedKiosk } from './kiosk';
 
 export function useKioskSelector(address: SuiAddress | undefined) {
-  const [selected, setSelected] = useState<KioskOwnerCap | undefined>();
+	const [selected, setSelected] = useState<KioskOwnerCap | undefined>();
 
-  // tries to find an owned kiosk for the supplied id.
-  // will fail if it's a direct kioskId and pass it down directly.
-  const { data: ownedKiosk, isLoading } = useOwnedKiosk(address);
+	// tries to find an owned kiosk for the supplied id.
+	// will fail if it's a direct kioskId and pass it down directly.
+	const { data: ownedKiosk, isLoading } = useOwnedKiosk(address);
 
-  // show kiosk selector in the following conditions:
-  // 1. It's an address lookup.
-  // 2. The address has more than 1 kiosks.
-  const showKioskSelector =
-    ownedKiosk?.caps && ownedKiosk.caps.length > 1 && selected;
+	// show kiosk selector in the following conditions:
+	// 1. It's an address lookup.
+	// 2. The address has more than 1 kiosks.
+	const showKioskSelector = ownedKiosk?.caps && ownedKiosk.caps.length > 1 && selected;
 
-  useEffect(() => {
-    // reset when kiosk caps change,
-    // (on logout / or if a cap is transferred away).
-    if (!ownedKiosk?.caps.find((x) => x.objectId === selected?.objectId))
-      setSelected(ownedKiosk?.caps[0]);
+	useEffect(() => {
+		// reset when kiosk caps change,
+		// (on logout / or if a cap is transferred away).
+		if (!ownedKiosk?.caps.find((x) => x.objectId === selected?.objectId))
+			setSelected(ownedKiosk?.caps[0]);
 
-    if (isLoading || selected) return;
-    setSelected(ownedKiosk?.caps[0]);
-  }, [isLoading, selected, ownedKiosk?.caps, setSelected]);
+		if (isLoading || selected) return;
+		setSelected(ownedKiosk?.caps[0]);
+	}, [isLoading, selected, ownedKiosk?.caps, setSelected]);
 
-  return {
-    selected,
-    setSelected,
-    showKioskSelector,
-  };
+	return {
+		selected,
+		setSelected,
+		showKioskSelector,
+	};
 }

--- a/dapps/kiosk/src/hooks/useKioskSelector.ts
+++ b/dapps/kiosk/src/hooks/useKioskSelector.ts
@@ -3,12 +3,12 @@ import { SuiAddress } from '@mysten/sui.js';
 import { useEffect, useState } from 'react';
 import { useOwnedKiosk } from './kiosk';
 
-export function useKioskSelector(kioskId: SuiAddress | undefined) {
+export function useKioskSelector(address: SuiAddress | undefined) {
   const [selected, setSelected] = useState<KioskOwnerCap | undefined>();
 
   // tries to find an owned kiosk for the supplied id.
   // will fail if it's a direct kioskId and pass it down directly.
-  const { data: ownedKiosk, isLoading } = useOwnedKiosk(kioskId);
+  const { data: ownedKiosk, isLoading } = useOwnedKiosk(address);
 
   // show kiosk selector in the following conditions:
   // 1. It's an address lookup.
@@ -17,6 +17,11 @@ export function useKioskSelector(kioskId: SuiAddress | undefined) {
     ownedKiosk?.caps && ownedKiosk.caps.length > 1 && selected;
 
   useEffect(() => {
+    // reset when kiosk caps change,
+    // (on logout / or if a cap is transferred away).
+    if (!ownedKiosk?.caps.find((x) => x.objectId === selected?.objectId))
+      setSelected(ownedKiosk?.caps[0]);
+
     if (isLoading || selected) return;
     setSelected(ownedKiosk?.caps[0]);
   }, [isLoading, selected, ownedKiosk?.caps, setSelected]);

--- a/dapps/kiosk/src/hooks/useKioskSelector.ts
+++ b/dapps/kiosk/src/hooks/useKioskSelector.ts
@@ -1,0 +1,29 @@
+import { KioskOwnerCap } from '@mysten/kiosk';
+import { SuiAddress } from '@mysten/sui.js';
+import { useEffect, useState } from 'react';
+import { useOwnedKiosk } from './kiosk';
+
+export function useKioskSelector(kioskId: SuiAddress | undefined) {
+  const [selected, setSelected] = useState<KioskOwnerCap | undefined>();
+
+  // tries to find an owned kiosk for the supplied id.
+  // will fail if it's a direct kioskId and pass it down directly.
+  const { data: ownedKiosk, isLoading } = useOwnedKiosk(kioskId);
+
+  // show kiosk selector in the following conditions:
+  // 1. It's an address lookup.
+  // 2. The address has more than 1 kiosks.
+  const showKioskSelector =
+    ownedKiosk?.caps && ownedKiosk.caps.length > 1 && selected;
+
+  useEffect(() => {
+    if (isLoading || selected) return;
+    setSelected(ownedKiosk?.caps[0]);
+  }, [isLoading, selected, ownedKiosk?.caps, setSelected]);
+
+  return {
+    selected,
+    setSelected,
+    showKioskSelector,
+  };
+}

--- a/dapps/kiosk/src/mutations/kiosk.ts
+++ b/dapps/kiosk/src/mutations/kiosk.ts
@@ -58,44 +58,32 @@ export function useCreateKioskMutation({ onSuccess, onError }: MutationParams) {
 /**
  * Place & List or List for sale in kiosk.
  */
-export function usePlaceAndListMutation({
-  onSuccess,
-  onError,
-}: MutationParams) {
-  const { currentAccount } = useWalletKit();
-  const { data: ownedKiosk } = useOwnedKiosk(currentAccount?.address);
-  const { signAndExecute } = useTransactionExecution();
+export function usePlaceAndListMutation({ onSuccess, onError }: MutationParams) {
+	const { currentAccount } = useWalletKit();
+	const { data: ownedKiosk } = useOwnedKiosk(currentAccount?.address);
+	const { signAndExecute } = useTransactionExecution();
 
-  return useMutation({
-    mutationFn: ({
-      item,
-      price,
-      shouldPlace,
-      kioskId,
-    }: {
-      item: OwnedObjectType;
-      price: string;
-      shouldPlace?: boolean;
-      kioskId: ObjectId;
-    }) => {
-      // find active kiosk cap.
-      const cap = findActiveCap(ownedKiosk?.caps, kioskId);
+	return useMutation({
+		mutationFn: ({
+			item,
+			price,
+			shouldPlace,
+			kioskId,
+		}: {
+			item: OwnedObjectType;
+			price: string;
+			shouldPlace?: boolean;
+			kioskId: ObjectId;
+		}) => {
+			// find active kiosk cap.
+			const cap = findActiveCap(ownedKiosk?.caps, kioskId);
 
-      if (!cap || !currentAccount?.address)
-        throw new Error('Missing account, kiosk or kiosk cap');
+			if (!cap || !currentAccount?.address) throw new Error('Missing account, kiosk or kiosk cap');
 
 			const tx = new TransactionBlock();
 
-      if (shouldPlace)
-        placeAndList(
-          tx,
-          item.type,
-          cap.kioskId,
-          cap.objectId,
-          item.objectId,
-          price,
-        );
-      else list(tx, item.type, cap.kioskId, cap.objectId, item.objectId, price);
+			if (shouldPlace) placeAndList(tx, item.type, cap.kioskId, cap.objectId, item.objectId, price);
+			else list(tx, item.type, cap.kioskId, cap.objectId, item.objectId, price);
 
 			return signAndExecute({ tx });
 		},
@@ -108,26 +96,19 @@ export function usePlaceAndListMutation({
  * Mutation to place an item in the kiosk.
  */
 export function usePlaceMutation({ onSuccess, onError }: MutationParams) {
-  const { currentAccount } = useWalletKit();
-  const { data: ownedKiosk } = useOwnedKiosk(currentAccount?.address);
-  const { signAndExecute } = useTransactionExecution();
+	const { currentAccount } = useWalletKit();
+	const { data: ownedKiosk } = useOwnedKiosk(currentAccount?.address);
+	const { signAndExecute } = useTransactionExecution();
 
-  return useMutation({
-    mutationFn: ({
-      item,
-      kioskId,
-    }: {
-      item: OwnedObjectType;
-      kioskId: string;
-    }) => {
-      // find active kiosk cap.
-      const cap = findActiveCap(ownedKiosk?.caps, kioskId);
+	return useMutation({
+		mutationFn: ({ item, kioskId }: { item: OwnedObjectType; kioskId: string }) => {
+			// find active kiosk cap.
+			const cap = findActiveCap(ownedKiosk?.caps, kioskId);
 
-      if (!cap || !currentAccount?.address)
-        throw new Error('Missing account, kiosk or kiosk cap');
+			if (!cap || !currentAccount?.address) throw new Error('Missing account, kiosk or kiosk cap');
 
-      const tx = new TransactionBlock();
-      place(tx, item.type, cap.kioskId, cap.objectId, item.objectId);
+			const tx = new TransactionBlock();
+			place(tx, item.type, cap.kioskId, cap.objectId, item.objectId);
 
 			return signAndExecute({ tx });
 		},
@@ -140,25 +121,19 @@ export function usePlaceMutation({ onSuccess, onError }: MutationParams) {
  * Withdraw profits from kiosk
  */
 export function useWithdrawMutation({ onError, onSuccess }: MutationParams) {
-  const { currentAccount } = useWalletKit();
-  const { data: ownedKiosk } = useOwnedKiosk(currentAccount?.address);
-  const { signAndExecute } = useTransactionExecution();
+	const { currentAccount } = useWalletKit();
+	const { data: ownedKiosk } = useOwnedKiosk(currentAccount?.address);
+	const { signAndExecute } = useTransactionExecution();
 
-  return useMutation({
-    mutationFn: (kiosk: Kiosk) => {
-      // find active kiosk cap.
-      const cap = findActiveCap(ownedKiosk?.caps, kiosk.id);
+	return useMutation({
+		mutationFn: (kiosk: Kiosk) => {
+			// find active kiosk cap.
+			const cap = findActiveCap(ownedKiosk?.caps, kiosk.id);
 
-      if (!cap || !currentAccount?.address)
-        throw new Error('Missing account, kiosk or kiosk cap');
+			if (!cap || !currentAccount?.address) throw new Error('Missing account, kiosk or kiosk cap');
 
-      const tx = new TransactionBlock();
-      const coin = withdrawFromKiosk(
-        tx,
-        cap.kioskId,
-        cap.objectId,
-        kiosk.profits,
-      );
+			const tx = new TransactionBlock();
+			const coin = withdrawFromKiosk(tx, cap.kioskId, cap.objectId, kiosk.profits);
 
 			tx.transferObjects([coin], tx.pure(currentAccount.address, 'address'));
 
@@ -173,29 +148,22 @@ export function useWithdrawMutation({ onError, onSuccess }: MutationParams) {
  * Mutation to take an item from the kiosk.
  */
 export function useTakeMutation({ onSuccess, onError }: MutationParams) {
-  const { currentAccount } = useWalletKit();
-  const { data: ownedKiosk } = useOwnedKiosk(currentAccount?.address);
-  const { signAndExecute } = useTransactionExecution();
+	const { currentAccount } = useWalletKit();
+	const { data: ownedKiosk } = useOwnedKiosk(currentAccount?.address);
+	const { signAndExecute } = useTransactionExecution();
 
-  return useMutation({
-    mutationFn: ({
-      item,
-      kioskId,
-    }: {
-      item: OwnedObjectType;
-      kioskId: string;
-    }) => {
-      // find active kiosk cap.
-      const cap = findActiveCap(ownedKiosk?.caps, kioskId);
+	return useMutation({
+		mutationFn: ({ item, kioskId }: { item: OwnedObjectType; kioskId: string }) => {
+			// find active kiosk cap.
+			const cap = findActiveCap(ownedKiosk?.caps, kioskId);
 
-      if (!cap || !currentAccount?.address)
-        throw new Error('Missing account, kiosk or kiosk cap');
+			if (!cap || !currentAccount?.address) throw new Error('Missing account, kiosk or kiosk cap');
 
-      if (!item?.objectId) throw new Error('Missing item.');
+			if (!item?.objectId) throw new Error('Missing item.');
 
 			const tx = new TransactionBlock();
 
-      const obj = take(tx, item.type, cap.kioskId, cap.objectId, item.objectId);
+			const obj = take(tx, item.type, cap.kioskId, cap.objectId, item.objectId);
 
 			tx.transferObjects([obj], tx.pure(currentAccount?.address));
 
@@ -210,29 +178,22 @@ export function useTakeMutation({ onSuccess, onError }: MutationParams) {
  * Mutation to delist an item.
  */
 export function useDelistMutation({ onSuccess, onError }: MutationParams) {
-  const { currentAccount } = useWalletKit();
-  const { data: ownedKiosk } = useOwnedKiosk(currentAccount?.address);
-  const { signAndExecute } = useTransactionExecution();
+	const { currentAccount } = useWalletKit();
+	const { data: ownedKiosk } = useOwnedKiosk(currentAccount?.address);
+	const { signAndExecute } = useTransactionExecution();
 
-  return useMutation({
-    mutationFn: ({
-      item,
-      kioskId,
-    }: {
-      item: OwnedObjectType;
-      kioskId: string;
-    }) => {
-      // find active kiosk cap.
-      const cap = findActiveCap(ownedKiosk?.caps, kioskId);
+	return useMutation({
+		mutationFn: ({ item, kioskId }: { item: OwnedObjectType; kioskId: string }) => {
+			// find active kiosk cap.
+			const cap = findActiveCap(ownedKiosk?.caps, kioskId);
 
-      if (!cap || !currentAccount?.address)
-        throw new Error('Missing account, kiosk or kiosk cap');
+			if (!cap || !currentAccount?.address) throw new Error('Missing account, kiosk or kiosk cap');
 
-      if (!item?.objectId) throw new Error('Missing item.');
+			if (!item?.objectId) throw new Error('Missing item.');
 
 			const tx = new TransactionBlock();
 
-      delist(tx, item.type, cap.kioskId, cap.objectId, item.objectId);
+			delist(tx, item.type, cap.kioskId, cap.objectId, item.objectId);
 
 			return signAndExecute({ tx });
 		},
@@ -244,14 +205,11 @@ export function useDelistMutation({ onSuccess, onError }: MutationParams) {
 /**
  * Mutation to delist an item.
  */
-export function usePurchaseItemMutation({
-  onSuccess,
-  onError,
-}: MutationParams) {
-  const { currentAccount } = useWalletKit();
-  const { data: ownedKiosk } = useOwnedKiosk(currentAccount?.address);
-  const { signAndExecute } = useTransactionExecution();
-  const provider = useRpc();
+export function usePurchaseItemMutation({ onSuccess, onError }: MutationParams) {
+	const { currentAccount } = useWalletKit();
+	const { data: ownedKiosk } = useOwnedKiosk(currentAccount?.address);
+	const { signAndExecute } = useTransactionExecution();
+	const provider = useRpc();
 
 	return useMutation({
 		mutationFn: async ({ item, kioskId }: { item: OwnedObjectType; kioskId: string }) => {

--- a/dapps/kiosk/src/mutations/kiosk.ts
+++ b/dapps/kiosk/src/mutations/kiosk.ts
@@ -79,7 +79,7 @@ export function usePlaceAndListMutation({
       kioskId: ObjectId;
     }) => {
       // find active kiosk cap.
-      const cap = findActiveCap(ownedKiosk?.caps || [], kioskId);
+      const cap = findActiveCap(ownedKiosk?.caps, kioskId);
 
       if (!cap || !currentAccount?.address)
         throw new Error('Missing account, kiosk or kiosk cap');
@@ -121,7 +121,7 @@ export function usePlaceMutation({ onSuccess, onError }: MutationParams) {
       kioskId: string;
     }) => {
       // find active kiosk cap.
-      const cap = findActiveCap(ownedKiosk?.caps || [], kioskId);
+      const cap = findActiveCap(ownedKiosk?.caps, kioskId);
 
       if (!cap || !currentAccount?.address)
         throw new Error('Missing account, kiosk or kiosk cap');
@@ -147,7 +147,7 @@ export function useWithdrawMutation({ onError, onSuccess }: MutationParams) {
   return useMutation({
     mutationFn: (kiosk: Kiosk) => {
       // find active kiosk cap.
-      const cap = findActiveCap(ownedKiosk?.caps || [], kiosk.id);
+      const cap = findActiveCap(ownedKiosk?.caps, kiosk.id);
 
       if (!cap || !currentAccount?.address)
         throw new Error('Missing account, kiosk or kiosk cap');
@@ -186,7 +186,7 @@ export function useTakeMutation({ onSuccess, onError }: MutationParams) {
       kioskId: string;
     }) => {
       // find active kiosk cap.
-      const cap = findActiveCap(ownedKiosk?.caps || [], kioskId);
+      const cap = findActiveCap(ownedKiosk?.caps, kioskId);
 
       if (!cap || !currentAccount?.address)
         throw new Error('Missing account, kiosk or kiosk cap');
@@ -223,7 +223,7 @@ export function useDelistMutation({ onSuccess, onError }: MutationParams) {
       kioskId: string;
     }) => {
       // find active kiosk cap.
-      const cap = findActiveCap(ownedKiosk?.caps || [], kioskId);
+      const cap = findActiveCap(ownedKiosk?.caps, kioskId);
 
       if (!cap || !currentAccount?.address)
         throw new Error('Missing account, kiosk or kiosk cap');

--- a/dapps/kiosk/src/mutations/kiosk.ts
+++ b/dapps/kiosk/src/mutations/kiosk.ts
@@ -57,9 +57,13 @@ export function useCreateKioskMutation({ onSuccess, onError }: MutationParams) {
 /**
  * Place & List or List for sale in kiosk.
  */
-export function usePlaceAndListMutation({ onSuccess, onError }: MutationParams) {
-	const { data: ownedKiosk } = useOwnedKiosk();
-	const { signAndExecute } = useTransactionExecution();
+export function usePlaceAndListMutation({
+  onSuccess,
+  onError,
+}: MutationParams) {
+  const { currentAccount } = useWalletKit();
+  const { data: ownedKiosk } = useOwnedKiosk(currentAccount?.address);
+  const { signAndExecute } = useTransactionExecution();
 
 	return useMutation({
 		mutationFn: ({
@@ -91,8 +95,9 @@ export function usePlaceAndListMutation({ onSuccess, onError }: MutationParams) 
  * Mutation to place an item in the kiosk.
  */
 export function usePlaceMutation({ onSuccess, onError }: MutationParams) {
-	const { data: ownedKiosk } = useOwnedKiosk();
-	const { signAndExecute } = useTransactionExecution();
+  const { currentAccount } = useWalletKit();
+  const { data: ownedKiosk } = useOwnedKiosk(currentAccount?.address);
+  const { signAndExecute } = useTransactionExecution();
 
 	return useMutation({
 		mutationFn: (item: OwnedObjectType) => {
@@ -113,9 +118,9 @@ export function usePlaceMutation({ onSuccess, onError }: MutationParams) {
  * Withdraw profits from kiosk
  */
 export function useWithdrawMutation({ onError, onSuccess }: MutationParams) {
-	const { currentAccount } = useWalletKit();
-	const { data: ownedKiosk } = useOwnedKiosk();
-	const { signAndExecute } = useTransactionExecution();
+  const { currentAccount } = useWalletKit();
+  const { data: ownedKiosk } = useOwnedKiosk(currentAccount?.address);
+  const { signAndExecute } = useTransactionExecution();
 
 	return useMutation({
 		mutationFn: (kiosk: Kiosk) => {
@@ -138,9 +143,9 @@ export function useWithdrawMutation({ onError, onSuccess }: MutationParams) {
  * Mutation to take an item from the kiosk.
  */
 export function useTakeMutation({ onSuccess, onError }: MutationParams) {
-	const { data: ownedKiosk } = useOwnedKiosk();
-	const { currentAccount } = useWalletKit();
-	const { signAndExecute } = useTransactionExecution();
+  const { currentAccount } = useWalletKit();
+  const { data: ownedKiosk } = useOwnedKiosk(currentAccount?.address);
+  const { signAndExecute } = useTransactionExecution();
 
 	return useMutation({
 		mutationFn: (item: OwnedObjectType) => {
@@ -165,9 +170,9 @@ export function useTakeMutation({ onSuccess, onError }: MutationParams) {
  * Mutation to delist an item.
  */
 export function useDelistMutation({ onSuccess, onError }: MutationParams) {
-	const { data: ownedKiosk } = useOwnedKiosk();
-	const { currentAccount } = useWalletKit();
-	const { signAndExecute } = useTransactionExecution();
+  const { currentAccount } = useWalletKit();
+  const { data: ownedKiosk } = useOwnedKiosk(currentAccount?.address);
+  const { signAndExecute } = useTransactionExecution();
 
 	return useMutation({
 		mutationFn: (item: OwnedObjectType) => {
@@ -189,11 +194,14 @@ export function useDelistMutation({ onSuccess, onError }: MutationParams) {
 /**
  * Mutation to delist an item.
  */
-export function usePurchaseItemMutation({ onSuccess, onError }: MutationParams) {
-	const { data: ownedKiosk } = useOwnedKiosk();
-	const { currentAccount } = useWalletKit();
-	const { signAndExecute } = useTransactionExecution();
-	const provider = useRpc();
+export function usePurchaseItemMutation({
+  onSuccess,
+  onError,
+}: MutationParams) {
+  const { currentAccount } = useWalletKit();
+  const { data: ownedKiosk } = useOwnedKiosk(currentAccount?.address);
+  const { signAndExecute } = useTransactionExecution();
+  const provider = useRpc();
 
 	return useMutation({
 		mutationFn: async ({ item, kioskId }: { item: OwnedObjectType; kioskId: string }) => {

--- a/dapps/kiosk/src/routes/Home.tsx
+++ b/dapps/kiosk/src/routes/Home.tsx
@@ -11,7 +11,11 @@ import { KioskCreation } from '../components/Kiosk/KioskCreation';
 function Home() {
 	const { currentAccount } = useWalletKit();
 
-	const { data: ownedKiosk, isLoading, refetch: refetchOwnedKiosk } = useOwnedKiosk();
+  const {
+    data: ownedKiosk,
+    isLoading,
+    refetch: refetchOwnedKiosk,
+  } = useOwnedKiosk(currentAccount?.address);
 
 	// Return loading state.
 	if (isLoading) return <Loading />;

--- a/dapps/kiosk/src/routes/Home.tsx
+++ b/dapps/kiosk/src/routes/Home.tsx
@@ -20,7 +20,7 @@ function Home() {
   } = useOwnedKiosk(currentAccount?.address);
 
   const { selected, setSelected, showKioskSelector } = useKioskSelector(
-    ownedKiosk?.kioskId,
+    currentAccount?.address,
   );
 
   // Return loading state.

--- a/dapps/kiosk/src/routes/Home.tsx
+++ b/dapps/kiosk/src/routes/Home.tsx
@@ -7,13 +7,11 @@ import { Loading } from '../components/Base/Loading';
 import { useOwnedKiosk } from '../hooks/kiosk';
 import { WalletNotConnected } from '../components/Base/WalletNotConnected';
 import { KioskCreation } from '../components/Kiosk/KioskCreation';
-import { useEffect, useState } from 'react';
-import { KioskOwnerCap } from '@mysten/kiosk';
 import { KioskSelector } from '../components/Kiosk/KioskSelector';
+import { useKioskSelector } from '../hooks/useKioskSelector';
 
 function Home() {
   const { currentAccount } = useWalletKit();
-  const [selected, setSelected] = useState<KioskOwnerCap | undefined>();
 
   const {
     data: ownedKiosk,
@@ -21,16 +19,9 @@ function Home() {
     refetch: refetchOwnedKiosk,
   } = useOwnedKiosk(currentAccount?.address);
 
-  // show kiosk selector in the following conditions:
-  // 1. It's an address lookup.
-  // 2. The address has more than 1 kiosks.
-  const showKioskSelector =
-    ownedKiosk?.caps && ownedKiosk.caps.length > 1 && selected;
-
-  useEffect(() => {
-    if (isLoading || selected) return;
-    setSelected(ownedKiosk?.caps[0]);
-  }, [isLoading, selected, ownedKiosk?.caps, setSelected]);
+  const { selected, setSelected, showKioskSelector } = useKioskSelector(
+    ownedKiosk?.kioskId,
+  );
 
   // Return loading state.
   if (isLoading) return <Loading />;
@@ -44,7 +35,7 @@ function Home() {
   // kiosk management screen.
   return (
     <div className="container">
-      {showKioskSelector && (
+      {showKioskSelector && selected && (
         <div className="px-4">
           <KioskSelector
             caps={ownedKiosk.caps}

--- a/dapps/kiosk/src/routes/Home.tsx
+++ b/dapps/kiosk/src/routes/Home.tsx
@@ -11,20 +11,18 @@ import { KioskSelector } from '../components/Kiosk/KioskSelector';
 import { useKioskSelector } from '../hooks/useKioskSelector';
 
 function Home() {
-  const { currentAccount } = useWalletKit();
+	const { currentAccount } = useWalletKit();
 
-  const {
-    data: ownedKiosk,
-    isLoading,
-    refetch: refetchOwnedKiosk,
-  } = useOwnedKiosk(currentAccount?.address);
+	const {
+		data: ownedKiosk,
+		isLoading,
+		refetch: refetchOwnedKiosk,
+	} = useOwnedKiosk(currentAccount?.address);
 
-  const { selected, setSelected, showKioskSelector } = useKioskSelector(
-    currentAccount?.address,
-  );
+	const { selected, setSelected, showKioskSelector } = useKioskSelector(currentAccount?.address);
 
-  // Return loading state.
-  if (isLoading) return <Loading />;
+	// Return loading state.
+	if (isLoading) return <Loading />;
 
 	// Return wallet not connected state.
 	if (!currentAccount?.address) return <WalletNotConnected />;
@@ -32,23 +30,17 @@ function Home() {
 	// if the account doesn't have a kiosk.
 	if (!ownedKiosk?.kioskId) return <KioskCreation onCreate={refetchOwnedKiosk} />;
 
-  // kiosk management screen.
-  return (
-    <div className="container">
-      {showKioskSelector && selected && (
-        <div className="px-4">
-          <KioskSelector
-            caps={ownedKiosk.caps}
-            selected={selected}
-            setSelected={setSelected}
-          />
-        </div>
-      )}
-      {selected && currentAccount?.address && (
-        <KioskData kioskId={selected.kioskId} />
-      )}
-    </div>
-  );
+	// kiosk management screen.
+	return (
+		<div className="container">
+			{showKioskSelector && selected && (
+				<div className="px-4">
+					<KioskSelector caps={ownedKiosk.caps} selected={selected} setSelected={setSelected} />
+				</div>
+			)}
+			{selected && currentAccount?.address && <KioskData kioskId={selected.kioskId} />}
+		</div>
+	);
 }
 
 export default Home;

--- a/dapps/kiosk/src/routes/SingleKiosk.tsx
+++ b/dapps/kiosk/src/routes/SingleKiosk.tsx
@@ -1,22 +1,46 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useNavigate, useParams } from 'react-router-dom';
-import { useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
 import { KioskItems } from '../components/Kiosk/KioskItems';
+import { Loading } from '../components/Base/Loading';
+import { useOwnedKiosk } from '../hooks/kiosk';
+import { KioskSelector } from '../components/Kiosk/KioskSelector';
+import { KioskOwnerCap } from '@mysten/kiosk';
 
 export default function SingleKiosk() {
-	const { kioskId } = useParams();
-	const navigate = useNavigate();
+  const { id } = useParams();
 
-	useEffect(() => {
-		if (kioskId) return;
-		navigate('/');
-	}, [navigate, kioskId]);
+  // tries to find an owned kiosk for the supplied id.
+  // will fail if it's a direct kioskId and pass it down directly.
+  const { data: ownedKiosk, isLoading } = useOwnedKiosk(id);
 
-	return (
-		<div className="container">
-			<KioskItems kioskId={kioskId}></KioskItems>
-		</div>
-	);
+  const [selected, setSelected] = useState<KioskOwnerCap | undefined>();
+
+  // show kiosk selector in the following conditions:
+  // 1. It's an address lookup.
+  // 2. The address has more than 1 kiosks.
+  const showKioskSelector =
+    ownedKiosk?.caps && ownedKiosk.caps.length > 1 && selected;
+
+  useEffect(() => {
+    if (isLoading) return;
+    setSelected(ownedKiosk?.caps[0]);
+  }, [isLoading, ownedKiosk?.caps, setSelected]);
+
+  if (isLoading) return <Loading />;
+
+  return (
+    <div className="container">
+      {showKioskSelector && (
+        <KioskSelector
+          caps={ownedKiosk.caps}
+          selected={selected}
+          setSelected={setSelected}
+        />
+      )}
+      <KioskItems kioskId={selected?.kioskId || id}></KioskItems>
+    </div>
+  );
 }

--- a/dapps/kiosk/src/routes/SingleKiosk.tsx
+++ b/dapps/kiosk/src/routes/SingleKiosk.tsx
@@ -2,12 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useParams } from 'react-router-dom';
-import { useEffect, useState } from 'react';
 import { KioskItems } from '../components/Kiosk/KioskItems';
 import { Loading } from '../components/Base/Loading';
 import { useOwnedKiosk } from '../hooks/kiosk';
 import { KioskSelector } from '../components/Kiosk/KioskSelector';
-import { KioskOwnerCap } from '@mysten/kiosk';
+import { useKioskSelector } from '../hooks/useKioskSelector';
 
 export default function SingleKiosk() {
   const { id } = useParams();
@@ -15,25 +14,13 @@ export default function SingleKiosk() {
   // tries to find an owned kiosk for the supplied id.
   // will fail if it's a direct kioskId and pass it down directly.
   const { data: ownedKiosk, isLoading } = useOwnedKiosk(id);
-
-  const [selected, setSelected] = useState<KioskOwnerCap | undefined>();
-
-  // show kiosk selector in the following conditions:
-  // 1. It's an address lookup.
-  // 2. The address has more than 1 kiosks.
-  const showKioskSelector =
-    ownedKiosk?.caps && ownedKiosk.caps.length > 1 && selected;
-
-  useEffect(() => {
-    if (isLoading || selected) return;
-    setSelected(ownedKiosk?.caps[0]);
-  }, [isLoading, selected, ownedKiosk?.caps, setSelected]);
+  const { selected, setSelected, showKioskSelector } = useKioskSelector(id);
 
   if (isLoading) return <Loading />;
 
   return (
     <div className="container">
-      {showKioskSelector && (
+      {showKioskSelector && selected && ownedKiosk && (
         <KioskSelector
           caps={ownedKiosk.caps}
           selected={selected}

--- a/dapps/kiosk/src/routes/SingleKiosk.tsx
+++ b/dapps/kiosk/src/routes/SingleKiosk.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useParams } from 'react-router-dom';
+
 import { KioskItems } from '../components/Kiosk/KioskItems';
 import { Loading } from '../components/Base/Loading';
 import { useOwnedKiosk } from '../hooks/kiosk';

--- a/dapps/kiosk/src/routes/SingleKiosk.tsx
+++ b/dapps/kiosk/src/routes/SingleKiosk.tsx
@@ -25,9 +25,9 @@ export default function SingleKiosk() {
     ownedKiosk?.caps && ownedKiosk.caps.length > 1 && selected;
 
   useEffect(() => {
-    if (isLoading) return;
+    if (isLoading || selected) return;
     setSelected(ownedKiosk?.caps[0]);
-  }, [isLoading, ownedKiosk?.caps, setSelected]);
+  }, [isLoading, selected, ownedKiosk?.caps, setSelected]);
 
   if (isLoading) return <Loading />;
 

--- a/dapps/kiosk/src/routes/SingleKiosk.tsx
+++ b/dapps/kiosk/src/routes/SingleKiosk.tsx
@@ -10,25 +10,21 @@ import { KioskSelector } from '../components/Kiosk/KioskSelector';
 import { useKioskSelector } from '../hooks/useKioskSelector';
 
 export default function SingleKiosk() {
-  const { id } = useParams();
+	const { id } = useParams();
 
-  // tries to find an owned kiosk for the supplied id.
-  // will fail if it's a direct kioskId and pass it down directly.
-  const { data: ownedKiosk, isLoading } = useOwnedKiosk(id);
-  const { selected, setSelected, showKioskSelector } = useKioskSelector(id);
+	// tries to find an owned kiosk for the supplied id.
+	// will fail if it's a direct kioskId and pass it down directly.
+	const { data: ownedKiosk, isLoading } = useOwnedKiosk(id);
+	const { selected, setSelected, showKioskSelector } = useKioskSelector(id);
 
-  if (isLoading) return <Loading />;
+	if (isLoading) return <Loading />;
 
-  return (
-    <div className="container">
-      {showKioskSelector && selected && ownedKiosk && (
-        <KioskSelector
-          caps={ownedKiosk.caps}
-          selected={selected}
-          setSelected={setSelected}
-        />
-      )}
-      <KioskItems kioskId={selected?.kioskId || id}></KioskItems>
-    </div>
-  );
+	return (
+		<div className="container">
+			{showKioskSelector && selected && ownedKiosk && (
+				<KioskSelector caps={ownedKiosk.caps} selected={selected} setSelected={setSelected} />
+			)}
+			<KioskItems kioskId={selected?.kioskId || id}></KioskItems>
+		</div>
+	);
 }

--- a/dapps/kiosk/src/routes/index.tsx
+++ b/dapps/kiosk/src/routes/index.tsx
@@ -8,18 +8,18 @@ import Home from './Home';
 import SingleKiosk from './SingleKiosk';
 
 export const router = createBrowserRouter([
-  {
-    path: '/',
-    element: <Root />,
-    children: [
-      {
-        path: '',
-        element: <Home />,
-      },
-      {
-        path: '/kiosk/:id',
-        element: <SingleKiosk />,
-      },
-    ],
-  },
+	{
+		path: '/',
+		element: <Root />,
+		children: [
+			{
+				path: '',
+				element: <Home />,
+			},
+			{
+				path: '/kiosk/:id',
+				element: <SingleKiosk />,
+			},
+		],
+	},
 ]);

--- a/dapps/kiosk/src/routes/index.tsx
+++ b/dapps/kiosk/src/routes/index.tsx
@@ -8,18 +8,18 @@ import Home from './Home';
 import SingleKiosk from './SingleKiosk';
 
 export const router = createBrowserRouter([
-	{
-		path: '/',
-		element: <Root />,
-		children: [
-			{
-				path: '',
-				element: <Home />,
-			},
-			{
-				path: '/kiosk/:kioskId',
-				element: <SingleKiosk />,
-			},
-		],
-	},
+  {
+    path: '/',
+    element: <Root />,
+    children: [
+      {
+        path: '',
+        element: <Home />,
+      },
+      {
+        path: '/kiosk/:id',
+        element: <SingleKiosk />,
+      },
+    ],
+  },
 ]);

--- a/dapps/kiosk/src/utils/utils.ts
+++ b/dapps/kiosk/src/utils/utils.ts
@@ -3,12 +3,12 @@
 
 import { KioskListing, KioskOwnerCap } from '@mysten/kiosk';
 import {
-  MIST_PER_SUI,
-  ObjectId,
-  SuiObjectResponse,
-  getObjectDisplay,
-  getObjectId,
-  normalizeSuiAddress,
+	MIST_PER_SUI,
+	ObjectId,
+	SuiObjectResponse,
+	getObjectDisplay,
+	getObjectId,
+	normalizeSuiAddress,
 } from '@mysten/sui.js';
 // Parse the display of a list of objects into a simple {object_id: display} map
 // to use throughout the app.
@@ -55,10 +55,8 @@ export const formatSui = (amount: number) => {
  * address owned kiosks.
  */
 export const findActiveCap = (
-  caps: KioskOwnerCap[] = [],
-  kioskId: ObjectId,
+	caps: KioskOwnerCap[] = [],
+	kioskId: ObjectId,
 ): KioskOwnerCap | undefined => {
-  return caps.find(
-    (x) => normalizeSuiAddress(x.kioskId) === normalizeSuiAddress(kioskId),
-  );
+	return caps.find((x) => normalizeSuiAddress(x.kioskId) === normalizeSuiAddress(kioskId));
 };

--- a/dapps/kiosk/src/utils/utils.ts
+++ b/dapps/kiosk/src/utils/utils.ts
@@ -55,7 +55,7 @@ export const formatSui = (amount: number) => {
  * address owned kiosks.
  */
 export const findActiveCap = (
-  caps: KioskOwnerCap[],
+  caps: KioskOwnerCap[] = [],
   kioskId: ObjectId,
 ): KioskOwnerCap | undefined => {
   return caps.find(

--- a/dapps/kiosk/src/utils/utils.ts
+++ b/dapps/kiosk/src/utils/utils.ts
@@ -3,11 +3,12 @@
 
 import { KioskListing, KioskOwnerCap } from '@mysten/kiosk';
 import {
-	MIST_PER_SUI,
-	ObjectId,
-	SuiObjectResponse,
-	getObjectDisplay,
-	getObjectId,
+  MIST_PER_SUI,
+  ObjectId,
+  SuiObjectResponse,
+  getObjectDisplay,
+  getObjectId,
+  normalizeSuiAddress,
 } from '@mysten/sui.js';
 // Parse the display of a list of objects into a simple {object_id: display} map
 // to use throughout the app.
@@ -57,5 +58,7 @@ export const findActiveCap = (
   caps: KioskOwnerCap[],
   kioskId: ObjectId,
 ): KioskOwnerCap | undefined => {
-  return caps.find((x) => x.kioskId === kioskId);
+  return caps.find(
+    (x) => normalizeSuiAddress(x.kioskId) === normalizeSuiAddress(kioskId),
+  );
 };

--- a/dapps/kiosk/src/utils/utils.ts
+++ b/dapps/kiosk/src/utils/utils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { KioskListing } from '@mysten/kiosk';
+import { KioskListing, KioskOwnerCap } from '@mysten/kiosk';
 import {
 	MIST_PER_SUI,
 	ObjectId,
@@ -47,4 +47,15 @@ export const formatSui = (amount: number) => {
 		minimumFractionDigits: 2,
 		maximumFractionDigits: 5,
 	}).format(amount);
+};
+
+/**
+ * Finds an active owner cap for a kioskId based on the
+ * address owned kiosks.
+ */
+export const findActiveCap = (
+  caps: KioskOwnerCap[],
+  kioskId: ObjectId,
+): KioskOwnerCap | undefined => {
+  return caps.find((x) => x.kioskId === kioskId);
 };

--- a/dapps/kiosk/vercel.json
+++ b/dapps/kiosk/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}

--- a/dapps/kiosk/vercel.json
+++ b/dapps/kiosk/vercel.json
@@ -1,4 +1,4 @@
 {
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+	"$schema": "https://openapi.vercel.sh/vercel.json",
+	"rewrites": [{ "source": "/(.*)", "destination": "/" }]
 }


### PR DESCRIPTION
## Description 

- Searching a kiosk by an `address`, instead of just using a `kioskId`
- Adds support for multiple kiosks (You can select which kiosk to view, if an address has more than one).
- Manage multiple kiosks (list/delist/take/withdraw from any of the addresses' owned kiosks)


## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

