### PR TITLE
[deepbook] Introducing the implementation of self-matching prevention. 

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -91,6 +91,7 @@ mod test {
         test_simulated_load(TestInitData::new(&test_cluster).await, 120).await;
     }
 
+    #[ignore("Disabled due to flakiness - re-enable when failure is fixed")]
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_reconfig_restarts() {
         // TODO added to invalidate a failing test seed in CI. Remove me

--- a/crates/sui-framework/packages/deepbook/tests/clob_tests.move
+++ b/crates/sui-framework/packages/deepbook/tests/clob_tests.move
@@ -28,13 +28,19 @@ module deepbook::clob_test {
     const E_ORDER_CANNOT_BE_FULLY_FILLED: u64 = 9;
     const CLIENT_ID_ALICE: u64 = 0;
     const CLIENT_ID_BOB: u64 = 1;
-    const SELF_MATCHING_PREVENTION_DEFAULT: u8 = 0;
+    const CANCEL_OLDEST: u8 = 0;
 
     #[test] fun test_full_transaction() { let _ = test_full_transaction_(scenario()); }
+
+    #[test] fun test_place_market_buy_order_with_skipping_self_matching() { let _ = test_place_market_buy_order_with_skipping_self_matching_(scenario()); }
+
+    #[test] fun test_place_market_sell_order_with_skipping_self_matching() { let _ = test_place_market_sell_order_with_skipping_self_matching_(scenario()); }
 
     #[test] fun test_place_limit_order_fill_or_kill() { let _ = test_place_limit_order_fill_or_kill_(scenario()); }
 
     #[test] fun test_place_limit_order_post_or_abort() { let _ = test_place_limit_order_post_or_abort_(scenario()); }
+
+    #[test] fun test_place_limit_order_with_skipping_self_matching() { let _ = test_place_limit_order_with_skipping_self_matching_(scenario()); }
 
     #[test] fun test_absorb_all_liquidity_bid_side_with_customized_tick(
     ) { let _ = test_absorb_all_liquidity_bid_side_with_customized_tick_(scenario()); }
@@ -44,6 +50,9 @@ module deepbook::clob_test {
 
     #[test] fun test_swap_exact_quote_for_base(
     ) { let _ = test_swap_exact_quote_for_base_(scenario()); }
+
+    #[test] fun test_swap_exact_quote_for_base_with_skipping_self_matching(
+    ) { let _ = test_swap_exact_quote_for_base_with_skipping_self_matching_(scenario()); }
 
     #[test] fun test_swap_exact_base_for_quote(
     ) { let _ = test_swap_exact_base_for_quote_(scenario()); }
@@ -61,10 +70,14 @@ module deepbook::clob_test {
 
     #[test] fun test_inject_and_match_taker_bid() { let _ = test_inject_and_match_taker_bid_(scenario()); }
 
+    #[test] fun test_inject_and_match_taker_bid_with_skip_self_matching() { let _ = test_inject_and_match_taker_bid_with_skipping_self_matching_(scenario()); }
+
     #[test] fun test_inject_and_match_taker_bid_with_maker_order_not_fully_filled(
     ) { let _ = test_inject_and_match_taker_bid_with_maker_order_not_fully_filled_(scenario()); }
 
     #[test] fun test_inject_and_match_taker_ask() { let _ = test_inject_and_match_taker_ask_(scenario()); }
+
+    #[test] fun test_inject_and_match_taker_ask_with_skipping_self_matching() { let _ = test_inject_and_match_taker_ask_with_skipping_self_matching_(scenario()); }
 
     #[test] fun test_inject_and_match_taker_bid_with_expiration(
     ) { let _ = test_inject_and_match_taker_bid_with_expiration_(scenario()); }
@@ -155,19 +168,19 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 4 * FLOAT_SCALING, 500, 500, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 4 * FLOAT_SCALING, 500, 500, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 3 * FLOAT_SCALING, 1000, 1000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -183,19 +196,19 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 15 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 15 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 14 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 14 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 13 * FLOAT_SCALING, 1000, 1000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 12 * FLOAT_SCALING, 1000, 1000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 12 * FLOAT_SCALING, 1000, 1000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -253,21 +266,21 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 4 * FLOAT_SCALING, 500, 500, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 4 * FLOAT_SCALING, 500, 500, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order_with_expiration(&mut pool, CLIENT_ID_ALICE, 3_500_000_000, 1000, 1000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, 0, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, 0, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 3 * FLOAT_SCALING, 1000, 1000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order_with_expiration(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, 0, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, 0, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -340,21 +353,21 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 4 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 4 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order_with_expiration(&mut pool, CLIENT_ID_ALICE, 3_500_000_000, 1000, 1000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, 0, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, 0, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 3 * FLOAT_SCALING, 1000, 1000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order_with_expiration(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, 0, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, 0, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -412,13 +425,13 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 1 * FLOAT_SCALING, 10000, 10000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -495,7 +508,13 @@ module deepbook::clob_test {
         next_tx(&mut test, owner);
         {
             clob::setup_test(5000000, 2500000, &mut test, owner);
+        };
+        next_tx(&mut test, alice);
+        {
             mint_account_cap_transfer(alice, test::ctx(&mut test));
+        };
+        next_tx(&mut test, bob);
+        {
             mint_account_cap_transfer(bob, test::ctx(&mut test));
         };
         next_tx(&mut test, alice);
@@ -509,13 +528,13 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 10 * FLOAT_SCALING, 10000, 10000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -657,13 +676,13 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
 
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 10 * FLOAT_SCALING, 10000, 10000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -794,7 +813,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 5 * FLOAT_SCALING,
                 200 * 100000000,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 true,
                 TIMESTAMP_INF,
                 0,
@@ -807,7 +826,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 4 * FLOAT_SCALING,
                 200 * 100000000,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 true,
                 TIMESTAMP_INF,
                 0,
@@ -820,7 +839,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 4 * FLOAT_SCALING,
                 200 * 100000000,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 true,
                 TIMESTAMP_INF,
                 0,
@@ -833,7 +852,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 10 * FLOAT_SCALING,
                 1000 * 100000000,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 false,
                 TIMESTAMP_INF,
                 0,
@@ -886,7 +905,7 @@ module deepbook::clob_test {
                 CLIENT_ID_BOB,
                 4 * FLOAT_SCALING,
                 300 * 100000000,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 false,
                 TIMESTAMP_INF,
                 0,
@@ -991,7 +1010,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 5 * FLOAT_SCALING,
                 200,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 true,
                 TIMESTAMP_INF,
                 0,
@@ -1004,7 +1023,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 5 * FLOAT_SCALING,
                 300,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 true,
                 TIMESTAMP_INF,
                 0,
@@ -1017,7 +1036,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 2 * FLOAT_SCALING,
                 1000,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 true,
                 TIMESTAMP_INF,
                 0,
@@ -1030,7 +1049,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 20 * FLOAT_SCALING,
                 1000,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 false,
                 TIMESTAMP_INF,
                 0,
@@ -1118,7 +1137,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 5 * FLOAT_SCALING,
                 200,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 true,
                 TIMESTAMP_INF,
                 0,
@@ -1131,7 +1150,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 5 * FLOAT_SCALING,
                 300,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 true,
                 TIMESTAMP_INF,
                 0,
@@ -1144,7 +1163,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 2 * FLOAT_SCALING,
                 1000,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 true,
                 TIMESTAMP_INF,
                 0,
@@ -1157,7 +1176,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 20 * FLOAT_SCALING,
                 1000,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 false,
                 TIMESTAMP_INF,
                 0,
@@ -1205,7 +1224,7 @@ module deepbook::clob_test {
                 CLIENT_ID_BOB,
                 4 * FLOAT_SCALING,
                 400,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 false,
                 TIMESTAMP_INF,
                 FILL_OR_KILL,
@@ -1283,7 +1302,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 5 * FLOAT_SCALING,
                 200,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 true,
                 TIMESTAMP_INF,
                 0,
@@ -1296,7 +1315,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 5 * FLOAT_SCALING,
                 300,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 true,
                 TIMESTAMP_INF,
                 0,
@@ -1309,7 +1328,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 2 * FLOAT_SCALING,
                 1000,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 true,
                 TIMESTAMP_INF,
                 0,
@@ -1322,7 +1341,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 20 * FLOAT_SCALING,
                 1000,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 false,
                 TIMESTAMP_INF,
                 0,
@@ -1370,7 +1389,7 @@ module deepbook::clob_test {
                 CLIENT_ID_BOB,
                 6 * FLOAT_SCALING,
                 400,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 false,
                 TIMESTAMP_INF,
                 POST_OR_ABORT,
@@ -1447,7 +1466,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 5 * FLOAT_SCALING,
                 200,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 true,
                 TIMESTAMP_INF,
                 0,
@@ -1460,7 +1479,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 5 * FLOAT_SCALING,
                 300,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 true,
                 TIMESTAMP_INF,
                 0,
@@ -1473,7 +1492,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 2 * FLOAT_SCALING,
                 1000,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 true,
                 TIMESTAMP_INF,
                 0,
@@ -1486,7 +1505,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 20 * FLOAT_SCALING,
                 1000,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 false,
                 TIMESTAMP_INF,
                 0,
@@ -1572,7 +1591,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 5 * FLOAT_SCALING,
                 500,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 false,
                 TIMESTAMP_INF,
                 0,
@@ -1585,7 +1604,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 5 * FLOAT_SCALING,
                 500,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 false,
                 TIMESTAMP_INF,
                 0,
@@ -1598,7 +1617,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 2 * FLOAT_SCALING,
                 1000,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 false,
                 TIMESTAMP_INF,
                 0,
@@ -1611,7 +1630,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 1 * FLOAT_SCALING,
                 1000,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 true,
                 TIMESTAMP_INF,
                 0,
@@ -1685,13 +1704,13 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE,1 * FLOAT_SCALING, 10000, 10000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -1748,13 +1767,13 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE,5 * FLOAT_SCALING, 500, 500, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE,5 * FLOAT_SCALING, 500, 500, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE,2 * FLOAT_SCALING, 1000, 1000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE,10 * FLOAT_SCALING, 10000, 10000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -1808,15 +1827,15 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
 
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 2, 2, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 3, 3, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 10, 10, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 10, 10, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 20 * FLOAT_SCALING, 10, 10, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -2043,13 +2062,13 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE,  2 * FLOAT_SCALING, 1000, 1000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE,  1 * FLOAT_SCALING, 10000, 10000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -2253,13 +2272,13 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 1 * FLOAT_SCALING, 10000, 10000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -2376,13 +2395,13 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 1 * FLOAT_SCALING, 10000, 10000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -2488,13 +2507,13 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 1 * FLOAT_SCALING, 10000, 10000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -2628,13 +2647,13 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 1 * FLOAT_SCALING, 10000, 10000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -2781,13 +2800,13 @@ module deepbook::clob_test {
             let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
             let account_cap = test::take_from_address<AccountCap>(&test, alice);
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 10 * FLOAT_SCALING, 10000, 10000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -2934,7 +2953,7 @@ module deepbook::clob_test {
                 500,
                 500,
                 false,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 TIMESTAMP_INF,
                 &account_cap,
                 ctx(&mut test)
@@ -2946,7 +2965,7 @@ module deepbook::clob_test {
                 500,
                 500,
                 false,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 0,
                 &account_cap,
                 ctx(&mut test)
@@ -2958,7 +2977,7 @@ module deepbook::clob_test {
                 1000,
                 1000,
                 false,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 TIMESTAMP_INF,
                 &account_cap,
                 ctx(&mut test)
@@ -2970,7 +2989,7 @@ module deepbook::clob_test {
                 10000,
                 10000,
                 true,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 0,
                 &account_cap,
                 ctx(&mut test)
@@ -3136,7 +3155,7 @@ module deepbook::clob_test {
                 500,
                 500,
                 false,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 TIMESTAMP_INF,
                 &account_cap,
                 ctx(&mut test)
@@ -3148,7 +3167,7 @@ module deepbook::clob_test {
                 500,
                 500,
                 false,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 0,
                 &account_cap,
                 ctx(&mut test)
@@ -3160,7 +3179,7 @@ module deepbook::clob_test {
                 1000,
                 1000,
                 false,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 TIMESTAMP_INF,
                 &account_cap,
                 ctx(&mut test)
@@ -3172,7 +3191,7 @@ module deepbook::clob_test {
                 10000,
                 10000,
                 true,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 0,
                 &account_cap,
                 ctx(&mut test)
@@ -3341,7 +3360,7 @@ module deepbook::clob_test {
                 500,
                 500,
                 true,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 TIMESTAMP_INF,
                 &account_cap,
                 ctx(&mut test)
@@ -3353,7 +3372,7 @@ module deepbook::clob_test {
                 1000,
                 1000,
                 true,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 0,
                 &account_cap,
                 ctx(&mut test)
@@ -3365,7 +3384,7 @@ module deepbook::clob_test {
                 1000,
                 1000,
                 true,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 TIMESTAMP_INF,
                 &account_cap,
                 ctx(&mut test)
@@ -3377,7 +3396,7 @@ module deepbook::clob_test {
                 10000,
                 10000,
                 false,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 TIMESTAMP_INF,
                 &account_cap,
                 ctx(&mut test)
@@ -3552,13 +3571,13 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 2, 2, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 3, 3, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 10, 10, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 1 * FLOAT_SCALING, 10, 10, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -3699,13 +3718,13 @@ module deepbook::clob_test {
             let account_cap = test::take_from_address<AccountCap>(&test, alice);
             // let account_cap_user = get_account_cap_user(&account_cap);
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 2, 2, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 3, 3, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 10, 10, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 20 * FLOAT_SCALING, 10, 10, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -3836,15 +3855,15 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
 
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 2, 2, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 3, 3, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 10, 10, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 10, 10, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 20 * FLOAT_SCALING, 10, 10, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
 
             {
                 let open_orders = vector::empty<Order>();
@@ -3985,15 +4004,15 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
 
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 2, 2, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 3, 3, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 10, 10, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 10, 10, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 20 * FLOAT_SCALING, 10, 10, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
 
             {
                 let open_orders = vector::empty<Order>();
@@ -4083,6 +4102,697 @@ module deepbook::clob_test {
                 assert!(base_locked == 0, 0);
                 assert!(quote_avail == 100, 0);
                 assert!(quote_locked == 0, 0);
+            };
+            test::return_shared(pool);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+        end(test)
+    }
+
+    // This test covers the following scenario:
+    // In an order book, there are only some limit buy orders placed by Alice.
+    // When Alice uses a market sell order to consume liquidity from the order book
+    // and matches her own limit buy orders,
+    // we needs to cancel all the previous limit buy orders
+    // and correctly refunding to her custodian account
+    fun test_place_market_sell_order_with_skipping_self_matching_(test: Scenario): TransactionEffects {
+        let (alice, _) = people();
+        let owner: address = @0xF;
+        // setup pool and custodian
+        next_tx(&mut test, owner);
+        {
+            clob::setup_test(5000000, 2500000, &mut test, owner);
+        };
+        next_tx(&mut test, alice);
+        {
+            mint_account_cap_transfer(alice, test::ctx(&mut test));
+        };
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let account_cap = test::take_from_sender<AccountCap>(&test);
+            let account_cap_user = account_owner(&account_cap);
+            let (base_custodian, quote_custodian) = clob::borrow_mut_custodian(&mut pool);
+            custodian::deposit(base_custodian, mint_for_testing<SUI>(1000, ctx(&mut test)), account_cap_user);
+            custodian::deposit(quote_custodian, mint_for_testing<USD>(10000, ctx(&mut test)), account_cap_user);
+            test::return_shared(pool);
+            test::return_to_sender<AccountCap>(&test, account_cap);
+        };
+
+        // alice places limit orders
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let account_cap = test::take_from_address<AccountCap>(&test, alice);
+            let clock = test::take_shared<Clock>(&mut test);
+            clob::place_limit_order<SUI, USD>(
+                &mut pool,
+                CLIENT_ID_ALICE,
+                5 * FLOAT_SCALING,
+                200,
+                CANCEL_OLDEST,
+                true,
+                TIMESTAMP_INF,
+                0,
+                &clock,
+                &account_cap,
+                ctx(&mut test)
+            );
+            clob::place_limit_order<SUI, USD>(
+                &mut pool,
+                CLIENT_ID_ALICE,
+                5 * FLOAT_SCALING,
+                300,
+                CANCEL_OLDEST,
+                true,
+                TIMESTAMP_INF,
+                0,
+                &clock,
+                &account_cap,
+                ctx(&mut test)
+            );
+            clob::place_limit_order<SUI, USD>(
+                &mut pool,
+                CLIENT_ID_ALICE,
+                2 * FLOAT_SCALING,
+                1000,
+                CANCEL_OLDEST,
+                true,
+                TIMESTAMP_INF,
+                0,
+                &clock,
+                &account_cap,
+                ctx(&mut test)
+            );
+            clob::place_limit_order<SUI, USD>(
+                &mut pool,
+                CLIENT_ID_ALICE,
+                20 * FLOAT_SCALING,
+                1000,
+                CANCEL_OLDEST,
+                false,
+                TIMESTAMP_INF,
+                0,
+                &clock,
+                &account_cap,
+                ctx(&mut test)
+            );
+            let (next_bid_order_id, next_ask_order_id, _, _) = clob::get_pool_stat(&pool);
+            assert!(next_bid_order_id == clob::order_id(3, true), 0);
+            assert!(next_ask_order_id == clob::order_id(1, false), 0);
+            let account_cap_user = account_owner(&account_cap);
+            let (base_custodian, quote_custodian) = clob::borrow_custodian(&pool);
+            custodian::assert_user_balance(base_custodian, account_cap_user, 0, 1000);
+            custodian::assert_user_balance(quote_custodian, account_cap_user, 5500, 4500);
+            let (base_avail, base_locked, quote_avail, quote_locked) = account_balance(&pool, &account_cap);
+            assert!(base_avail == 0, 0);
+            assert!(base_locked == 1000, 0);
+            assert!(quote_avail == 5500, 0);
+            assert!(quote_locked == 4500, 0);
+            test::return_shared(pool);
+            test::return_shared(clock);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+
+        // alice places market order
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let clock = test::take_shared<Clock>(&mut test);
+            let account_cap = test::take_from_address<AccountCap>(&test, alice);
+            let (coin1, coin2) =clob::place_market_order<SUI, USD>(&mut pool, &account_cap, CLIENT_ID_ALICE, 600,
+                false,
+                mint_for_testing<SUI>(600, ctx(&mut test)),
+                mint_for_testing<USD>(0, ctx(&mut test)),
+                &clock,
+                ctx(&mut test));
+            assert!(coin::value<SUI>(&coin1) == 600, 0);
+            assert!(coin::value<USD>(&coin2) == 0, 0);
+            burn_for_testing(coin1);
+            burn_for_testing(coin2);
+
+            let account_cap_user = account_owner(&account_cap);
+            let (base_custodian, quote_custodian) = clob::borrow_custodian(&pool);
+            custodian::assert_user_balance(base_custodian, account_cap_user, 0, 1000);
+            custodian::assert_user_balance(quote_custodian, account_cap_user, 10000, 0);
+            test::return_shared(pool);
+            test::return_shared(clock);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+        end(test)
+    }
+
+    // This test covers the following scenario:
+    // In an order book, there are only some limit sell orders placed by Alice.
+    // When Alice uses a market buy order to consume liquidity from the order book
+    // and matches her own limit sell orders,
+    // we needs to cancel all the previous limit sell orders
+    // and correctly refunding to her custodian account
+    fun test_place_market_buy_order_with_skipping_self_matching_(test: Scenario): TransactionEffects {
+        let (alice, _) = people();
+        let owner: address = @0xF;
+        // setup pool and custodian
+        next_tx(&mut test, owner);
+        {
+            clob::setup_test(5000000, 2500000, &mut test, owner);
+        };
+        next_tx(&mut test, alice);
+        {
+            mint_account_cap_transfer(alice, test::ctx(&mut test));
+        };
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let account_cap = test::take_from_sender<AccountCap>(&test);
+            let account_cap_user = account_owner(&account_cap);
+            let (base_custodian, quote_custodian) = clob::borrow_mut_custodian(&mut pool);
+            custodian::deposit(base_custodian, mint_for_testing<SUI>(1500, ctx(&mut test)), account_cap_user);
+            custodian::deposit(quote_custodian, mint_for_testing<USD>(10000, ctx(&mut test)), account_cap_user);
+            test::return_shared(pool);
+            test::return_to_sender<AccountCap>(&test, account_cap);
+        };
+
+        // alice places limit orders
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let account_cap = test::take_from_address<AccountCap>(&test, alice);
+            let clock = test::take_shared<Clock>(&mut test);
+            clob::place_limit_order<SUI, USD>(
+                &mut pool,
+                CLIENT_ID_ALICE,
+                5 * FLOAT_SCALING,
+                200,
+                CANCEL_OLDEST,
+                false,
+                TIMESTAMP_INF,
+                0,
+                &clock,
+                &account_cap,
+                ctx(&mut test)
+            );
+            clob::place_limit_order<SUI, USD>(
+                &mut pool,
+                CLIENT_ID_ALICE,
+                5 * FLOAT_SCALING,
+                300,
+                CANCEL_OLDEST,
+                false,
+                TIMESTAMP_INF,
+                0,
+                &clock,
+                &account_cap,
+                ctx(&mut test)
+            );
+            clob::place_limit_order<SUI, USD>(
+                &mut pool,
+                CLIENT_ID_ALICE,
+                2 * FLOAT_SCALING,
+                1000,
+                CANCEL_OLDEST,
+                false,
+                TIMESTAMP_INF,
+                0,
+                &clock,
+                &account_cap,
+                ctx(&mut test)
+            );
+            clob::place_limit_order<SUI, USD>(
+                &mut pool,
+                CLIENT_ID_ALICE,
+                1 * FLOAT_SCALING,
+                1000,
+                CANCEL_OLDEST,
+                true,
+                TIMESTAMP_INF,
+                0,
+                &clock,
+                &account_cap,
+                ctx(&mut test)
+            );
+            let (next_bid_order_id, next_ask_order_id, _, _) = clob::get_pool_stat(&pool);
+            assert!(next_bid_order_id == clob::order_id(1, true), 0);
+            assert!(next_ask_order_id == clob::order_id(3, false), 0);
+            let account_cap_user = account_owner(&account_cap);
+            let (base_custodian, quote_custodian) = clob::borrow_custodian(&pool);
+            custodian::assert_user_balance(base_custodian, account_cap_user, 0, 1500);
+            custodian::assert_user_balance(quote_custodian, account_cap_user, 9000, 1000);
+            let (base_avail, base_locked, quote_avail, quote_locked) = account_balance(&pool, &account_cap);
+            assert!(base_avail == 0, 0);
+            assert!(base_locked == 1500, 0);
+            assert!(quote_avail == 9000, 0);
+            assert!(quote_locked == 1000, 0);
+            test::return_shared(pool);
+            test::return_shared(clock);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+
+        // alice places market buy order
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let clock = test::take_shared<Clock>(&mut test);
+            let account_cap = test::take_from_address<AccountCap>(&test, alice);
+            let (coin1, coin2) =clob::place_market_order<SUI, USD>(&mut pool, &account_cap, CLIENT_ID_ALICE, 1,
+                true,
+                mint_for_testing<SUI>(0, ctx(&mut test)),
+                mint_for_testing<USD>(1, ctx(&mut test)),
+                &clock,
+                ctx(&mut test));
+            assert!(coin::value<SUI>(&coin1) == 0, 0);
+            assert!(coin::value<USD>(&coin2) == 1, 0);
+            burn_for_testing(coin1);
+            burn_for_testing(coin2);
+
+            let account_cap_user = account_owner(&account_cap);
+            let (base_custodian, quote_custodian) = clob::borrow_custodian(&pool);
+            custodian::assert_user_balance(base_custodian, account_cap_user, 1500, 0);
+            custodian::assert_user_balance(quote_custodian, account_cap_user, 9000, 1000);
+            test::return_shared(pool);
+            test::return_shared(clock);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+        end(test)
+    }
+
+    // This test covers the following scenario:
+    // there are some limit buy orders placed by Alice.
+    // When Alice continue to place a limit sell order
+    // and it can be matched with her own previous limit buy order
+    // We need to cancel all limit buy orders within the range of matching with the limit sell order.
+    // and correctly refunding to her custodian account
+    fun test_place_limit_order_with_skipping_self_matching_(test: Scenario): TransactionEffects {
+        let (alice, _) = people();
+        let owner: address = @0xF;
+        // setup pool and custodian
+        next_tx(&mut test, owner);
+        {
+            clob::setup_test(5000000, 2500000, &mut test, owner);
+        };
+        next_tx(&mut test, alice);
+        {
+            mint_account_cap_transfer(alice, test::ctx(&mut test));
+        };
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let account_cap = test::take_from_sender<AccountCap>(&test);
+            let account_cap_user = account_owner(&account_cap);
+            let (base_custodian, quote_custodian) = clob::borrow_mut_custodian(&mut pool);
+            custodian::deposit(base_custodian, mint_for_testing<SUI>(1000, ctx(&mut test)), account_cap_user);
+            custodian::deposit(quote_custodian, mint_for_testing<USD>(10000, ctx(&mut test)), account_cap_user);
+            test::return_shared(pool);
+            test::return_to_sender<AccountCap>(&test, account_cap);
+        };
+        // alice places limit orders
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let account_cap = test::take_from_address<AccountCap>(&test, alice);
+            let clock = test::take_shared<Clock>(&mut test);
+            clob::place_limit_order<SUI, USD>(
+                &mut pool,
+                CLIENT_ID_ALICE,
+                5 * FLOAT_SCALING,
+                200,
+                CANCEL_OLDEST,
+                true,
+                TIMESTAMP_INF,
+                0,
+                &clock,
+                &account_cap,
+                ctx(&mut test)
+            );
+            clob::place_limit_order<SUI, USD>(
+                &mut pool,
+                CLIENT_ID_ALICE,
+                5 * FLOAT_SCALING,
+                300,
+                CANCEL_OLDEST,
+                true,
+                TIMESTAMP_INF,
+                0,
+                &clock,
+                &account_cap,
+                ctx(&mut test)
+            );
+            clob::place_limit_order<SUI, USD>(
+                &mut pool,
+                CLIENT_ID_ALICE,
+                2 * FLOAT_SCALING,
+                1000,
+                CANCEL_OLDEST,
+                true,
+                TIMESTAMP_INF,
+                0,
+                &clock,
+                &account_cap,
+                ctx(&mut test)
+            );
+            clob::place_limit_order<SUI, USD>(
+                &mut pool,
+                CLIENT_ID_ALICE,
+                20 * FLOAT_SCALING,
+                1000,
+                CANCEL_OLDEST,
+                false,
+                TIMESTAMP_INF,
+                0,
+                &clock,
+                &account_cap,
+                ctx(&mut test)
+            );
+            let (next_bid_order_id, next_ask_order_id, _, _) = clob::get_pool_stat(&pool);
+            assert!(next_bid_order_id == clob::order_id(3, true), 0);
+            assert!(next_ask_order_id == clob::order_id(1, false), 0);
+            let account_cap_user = account_owner(&account_cap);
+            let (base_custodian, quote_custodian) = clob::borrow_custodian(&pool);
+            custodian::assert_user_balance(base_custodian, account_cap_user, 0, 1000);
+            custodian::assert_user_balance(quote_custodian, account_cap_user, 5500, 4500);
+            let (base_avail, base_locked, quote_avail, quote_locked) = account_balance(&pool, &account_cap);
+            assert!(base_avail == 0, 0);
+            assert!(base_locked == 1000, 0);
+            assert!(quote_avail == 5500, 0);
+            assert!(quote_locked == 4500, 0);
+            test::return_shared(pool);
+            test::return_shared(clock);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let account_cap = test::take_from_sender<AccountCap>(&test);
+            let account_cap_user = account_owner(&account_cap);
+            let (base_custodian, _) = clob::borrow_mut_custodian(&mut pool);
+            custodian::deposit(base_custodian, mint_for_testing<SUI>(400, ctx(&mut test)), account_cap_user);
+            test::return_shared(pool);
+            test::return_to_sender<AccountCap>(&test, account_cap);
+        };
+        // alice places limit order
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let account_cap = test::take_from_sender<AccountCap>(&test);
+            let clock = test::take_shared<Clock>(&mut test);
+            let (base_quantity_filled, quote_quantity_filled, is_placed, order_id) = clob::place_limit_order<SUI, USD>(
+                &mut pool,
+                CLIENT_ID_ALICE,
+                4 * FLOAT_SCALING,
+                400,
+                CANCEL_OLDEST,
+                false,
+                TIMESTAMP_INF,
+                POST_OR_ABORT,
+                &clock,
+                &account_cap,
+                ctx(&mut test)
+            );
+            assert!(base_quantity_filled == 0, 0);
+            assert!(quote_quantity_filled == 0, 0);
+            assert!(is_placed == true, 0);
+            assert!(order_id == MIN_ASK_ORDER_ID + 1, 0);
+
+            test::return_shared(pool);
+            test::return_shared(clock);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+
+        // check alice's balance
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let account_cap = test::take_from_sender<AccountCap>(&test);
+            let clock = test::take_shared<Clock>(&mut test);
+
+            let  (base_avail, base_locked, quote_avail, quote_locked) = account_balance<SUI, USD>(&pool, &account_cap);
+            assert!(base_avail == 0, 0);
+            assert!(base_locked == 1000 + 400, 0);
+            assert!(quote_avail == 8000, 0);
+            assert!(quote_locked == 2000, 0);
+
+            test::return_shared(pool);
+            test::return_shared(clock);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+        end(test)
+    }
+
+    // This test scenario is similar to "test_place_market_order_with_skipping_self_matching_",
+    // but it verifies the logic when we want to swap the exact quote asset for the base asset.
+    fun test_swap_exact_quote_for_base_with_skipping_self_matching_(test: Scenario): TransactionEffects {
+        let (alice, _) = people();
+        let owner = @0xF;
+        // setup pool and custodian
+        next_tx(&mut test, owner);
+        {
+            clob::setup_test(5000000, 2500000, &mut test, owner);
+        };
+        next_tx(&mut test, alice);
+        {
+            mint_account_cap_transfer(alice, test::ctx(&mut test));
+        };
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let account_cap = test::take_from_address<AccountCap>(&test, alice);
+            let account_cap_user = account_owner(&account_cap);
+            let (base_custodian, quote_custodian) = clob::borrow_mut_custodian(&mut pool);
+            let alice_deposit_WSUI: u64 = 10000;
+            let alice_deposit_USDC: u64 = 10000;
+            custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
+            custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
+            clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
+            clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
+            clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, false,
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
+            clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE,1 * FLOAT_SCALING, 10000, 10000, true,
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
+            test::return_shared(pool);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let clock = test::take_shared<Clock>(&mut test);
+            let account_cap = test::take_from_address<AccountCap>(&test, alice);
+            let (base_coin, quote_coin, _) = clob::swap_exact_quote_for_base(
+                &mut pool,
+                CLIENT_ID_ALICE,
+                &account_cap,
+                4500,
+                &clock,
+                mint_for_testing<USD>(4500, ctx(&mut test)),
+                ctx(&mut test)
+            );
+            assert!(coin::value(&base_coin) == 0, 0);
+            assert!(coin::value(&quote_coin) == 4500, 0);
+            burn_for_testing(base_coin);
+            burn_for_testing(quote_coin);
+
+            let account_cap_user = account_owner(&account_cap);
+            let (base_custodian, quote_custodian) = clob::borrow_custodian(&pool);
+            custodian::assert_user_balance<SUI>(base_custodian, account_cap_user, 10000, 0);
+            custodian::assert_user_balance<USD>(quote_custodian, account_cap_user, 0, 10000);
+
+            test::return_shared(clock);
+            test::return_shared(pool);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+        end(test)
+    }
+
+    // This test covers the following scenario:
+    // there are some limit sell orders placed by invoking inject_limit_order
+    // And directly perform the matching using the match_bid method.
+    // When encountering self-matching, we should cancel all the oldest sell orders
+    // and check if the order status in the order book and the user balance in the custodian account are correct.
+    fun test_inject_and_match_taker_bid_with_skipping_self_matching_(test: Scenario): TransactionEffects {
+        let (alice, _) = people();
+        let owner = @0xF;
+        // setup pool and custodian
+        next_tx(&mut test, owner);
+        {
+            clob::setup_test(5000000, 2500000, &mut test, owner);
+        };
+        next_tx(&mut test, alice);
+        {
+            mint_account_cap_transfer(alice, test::ctx(&mut test));
+        };
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let account_cap = test::take_from_address<AccountCap>(&test, alice);
+            let account_cap_user = account_owner(&account_cap);
+            let (base_custodian, quote_custodian) = clob::borrow_mut_custodian(&mut pool);
+            let alice_deposit_WSUI: u64 = 10000;
+            let alice_deposit_USDC: u64 = 10000;
+            custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
+            custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
+            clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
+            clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
+            clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, false,
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
+            clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 1 * FLOAT_SCALING, 10000, 10000, true,
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
+            test::return_shared(pool);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+        // test match (bid side)
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let account_cap = test::take_from_address<AccountCap>(&test, alice);
+            let (base_quantity_filled, quote_quantity_filled) = clob::test_match_bid(
+                &mut pool,
+                &account_cap,
+                CLIENT_ID_ALICE,
+                1,
+                MAX_PRICE,
+                0,
+            );
+            assert!(base_quantity_filled == 0, 0);
+            assert!(quote_quantity_filled == 0, 0);
+            test::return_shared(pool);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let account_cap = test::take_from_address<AccountCap>(&test, alice);
+            let account_cap_user = account_owner(&account_cap);
+            let (base_custodian, quote_custodian) = clob::borrow_custodian(&pool);
+            custodian::assert_user_balance<SUI>(base_custodian, account_cap_user, 10000, 0);
+            custodian::assert_user_balance<USD>(quote_custodian, account_cap_user, 0, 10000);
+            let (next_bid_order_id, next_ask_order_id, _, _) = clob::get_pool_stat(&pool);
+            assert!(next_bid_order_id == clob::order_id(1, true), 0);
+            assert!(next_ask_order_id == clob::order_id(3, false), 0);
+            {
+                let (_, _, _, asks) = get_pool_stat(&pool);
+                clob::check_empty_tick_level(asks, 2 * FLOAT_SCALING);
+            };
+            {
+                let (_, _, _, asks) = get_pool_stat(&pool);
+                clob::check_empty_tick_level(asks, 5 * FLOAT_SCALING);
+            };
+            {
+                let open_orders = vector::empty<Order>();
+                vector::push_back(
+                    &mut open_orders,
+                    clob::test_construct_order(0, CLIENT_ID_ALICE,1 * FLOAT_SCALING, 10000, 10000, true, account_cap_user)
+                );
+                let (_, _, bid, _) = get_pool_stat(&pool);
+                clob::check_tick_level(bid, 1 * FLOAT_SCALING, &open_orders);
+            };
+            test::return_shared(pool);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+        end(test)
+    }
+
+    // This test covers the following scenario:
+    // there are some limit buy orders placed by invoking inject_limit_order
+    // And  directly perform the matching using the match_ask method.
+    // When encountering self-matching, we should cancel all the oldest buy orders
+    // and check if the order status in the order book and the user balance in the custodian account are correct.
+    fun test_inject_and_match_taker_ask_with_skipping_self_matching_(test: Scenario): TransactionEffects {
+        let (alice, _) = people();
+        let owner = @0xF;
+        // setup pool and custodian
+        next_tx(&mut test, owner);
+        {
+            clob::setup_test(5000000, 2500000, &mut test, owner);
+        };
+        next_tx(&mut test, alice);
+        {
+            mint_account_cap_transfer(alice, test::ctx(&mut test));
+        };
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let account_cap = test::take_from_address<AccountCap>(&test, alice);
+            let account_cap_user = account_owner(&account_cap);
+            let (base_custodian, quote_custodian) = clob::borrow_mut_custodian(&mut pool);
+            let alice_deposit_WSUI: u64 = 10000;
+            let alice_deposit_USDC: u64 = 10000;
+            custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
+            custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
+            test::return_shared(pool);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+        // test inject limit order and match (ask side)
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let account_cap = test::take_from_address<AccountCap>(&test, alice);
+            clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, true,
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
+            clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, true,
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
+            clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, true,
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
+            clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 10 * FLOAT_SCALING, 10000, 10000, false,
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
+            test::return_shared(pool);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+
+        // test match (ask side)
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let account_cap = test::take_from_address<AccountCap>(&test, alice);
+            let (base_quantity_filled, quote_quantity_filled) = clob::test_match_ask(
+                &mut pool,
+                &account_cap,
+                CLIENT_ID_ALICE,
+                1500,
+                MIN_PRICE,
+                0,
+            );
+            assert!(base_quantity_filled == 0, 0);
+            assert!(quote_quantity_filled == 0, 0);
+            test::return_shared(pool);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let account_cap = test::take_from_address<AccountCap>(&test, alice);
+            let account_cap_user = account_owner(&account_cap);
+            let (base_custodian, quote_custodian) = clob::borrow_custodian(&pool);
+            custodian::assert_user_balance<USD>(
+                quote_custodian,
+                account_cap_user,
+                10000,
+                0
+            );
+            custodian::assert_user_balance<SUI>(
+                base_custodian,
+                account_cap_user,
+                0,
+                10000
+            );
+            {
+                let (_, _, bids, _) = get_pool_stat(&pool);
+                clob::check_empty_tick_level(bids, 5 * FLOAT_SCALING);
+            };
+            {
+                let (_, _, bids, _) = get_pool_stat(&pool);
+                clob::check_empty_tick_level(bids, 2 * FLOAT_SCALING);
+            };
+            {
+                let open_orders = vector::empty<Order>();
+                vector::push_back(
+                    &mut open_orders,
+                    clob::test_construct_order(0, CLIENT_ID_ALICE, 10 * FLOAT_SCALING, 10000, 10000, false, account_cap_user)
+                );
+                let (_, _, _, asks) = get_pool_stat(&pool);
+                clob::check_tick_level(asks, 10 * FLOAT_SCALING, &open_orders);
             };
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1347,7 +1347,7 @@
             "name": "Result",
             "value": {
               "minSupportedProtocolVersion": "1",
-              "maxSupportedProtocolVersion": "15",
+              "maxSupportedProtocolVersion": "16",
               "protocolVersion": "6",
               "featureFlags": {
                 "advance_epoch_start_time_in_safe_mode": true,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -10,7 +10,7 @@ use tracing::{info, warn};
 
 /// The minimum and maximum protocol versions supported by this build.
 const MIN_PROTOCOL_VERSION: u64 = 1;
-const MAX_PROTOCOL_VERSION: u64 = 15;
+const MAX_PROTOCOL_VERSION: u64 = 16;
 
 // Record history of protocol version allocations here:
 //
@@ -47,6 +47,7 @@ const MAX_PROTOCOL_VERSION: u64 = 15;
 //             decides whether rounding is applied or not.
 // Version 15: Add reordering of user transactions by gas price after consensus.
 //             Add `sui::table_vec::drop` to the framework via a system package upgrade.
+// Version 16: Add self-matching prevention for deepbook.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -1246,6 +1247,7 @@ impl ProtocolConfig {
                     ConsensusTransactionOrdering::ByGasPrice;
                 cfg
             }
+            16 => Self::get_for_version_impl(version - 1, chain),
             // Use this template when making changes:
             //
             //     // modify an existing constant.

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_16.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_16.snap
@@ -1,0 +1,183 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 16
+feature_flags:
+  package_upgrades: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  consensus_transaction_ordering: ByGasPrice
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 128
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 6
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 256
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 2000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+gas_model_version: 6
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 52
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 52
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 52
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 52
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 52
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 52
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 52
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 52
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 52
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 52
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 52
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 52
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 52
+groth16_prepare_verifying_key_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 52
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 52
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+scoring_decision_mad_divisor: 2.3
+scoring_decision_cutoff_value: 2.5
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_16.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_16.snap
@@ -1,0 +1,184 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 16
+feature_flags:
+  package_upgrades: true
+  commit_root_state_digest: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  consensus_transaction_ordering: ByGasPrice
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 128
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 6
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 256
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 2000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+gas_model_version: 6
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 52
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 52
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 52
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 52
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 52
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 52
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 52
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 52
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 52
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 52
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 52
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 52
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 52
+groth16_prepare_verifying_key_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 52
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 52
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+scoring_decision_mad_divisor: 2.3
+scoring_decision_cutoff_value: 2.5
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_16.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_16.snap
@@ -1,0 +1,185 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 16
+feature_flags:
+  package_upgrades: true
+  commit_root_state_digest: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  zklogin_auth: true
+  consensus_transaction_ordering: ByGasPrice
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 128
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 6
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 256
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 2000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+gas_model_version: 6
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 52
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 52
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 52
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 52
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 52
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 52
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 52
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 52
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 52
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 52
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 52
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 52
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 52
+groth16_prepare_verifying_key_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 52
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 52
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+scoring_decision_mad_divisor: 2.3
+scoring_decision_cutoff_value: 2.5
+

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -6,7 +6,7 @@ ssfn_config_info: ~
 validator_config_info: ~
 parameters:
   chain_start_timestamp_ms: 0
-  protocol_version: 15
+  protocol_version: 16
   allow_insertion_of_extra_objects: true
   epoch_duration_ms: 86400000
   stake_subsidy_start_epoch: 0

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -3,7 +3,7 @@ source: crates/sui-swarm-config/tests/snapshot_tests.rs
 expression: genesis.sui_system_object().into_genesis_version_for_tooling()
 ---
 epoch: 0
-protocol_version: 15
+protocol_version: 16
 system_state_version: 1
 validators:
   total_stake: 20000000000000000
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0xb67b0a175b21bdd3a72268275d73a30f6c60239572320dbf961436510c2b14f1"
+            id: "0xbd2bdc9724d0aae78b2dd02c8fc412bd7bee96ea0c98d6b1332cb2dcc3973acf"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0x2642e7b3c31b3e1e5da73c9d4b1e9c4b4b8774163b7922e176b9221d651325f0"
+      operation_cap_id: "0x7990ef7b1237e77b251900f9434f1bceb60ef5100a2abcb75e78c595775131d1"
       gas_price: 1000
       staking_pool:
-        id: "0x371ca77f31fc28fe5f40b951953356e0c966f11799dde71854de5c62f01dca29"
+        id: "0x6a2f79eac6652389813d145bf691005a37d3746ee4372918124f45d4fc2abd30"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0xd697163f087687a17adbeb3b0473695ce5e2bdfce8e63d23912eecf371d1b56f"
+          id: "0x52e460b45fbb7adb3df22461e13b0a3f1f67e58933a082008c61c8670449a388"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0xef17017571ae8ccfc43823097c1cd3a7d25f90328047be195ad983c508234cec"
+            id: "0x749e1f37b8f6cd84e09b7e02b45d817e56ecbbb8dcde4baf6e69f5cc667a9f9e"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0xf9ff725bc99164ace247dae283ed817bc96d46728557c84da2d250e25508c282"
+          id: "0xdc3e7d20e585326ff46461a1b399b7cdb94cbfa7b3c6cba0600c5c1c2b83bc36"
         size: 0
   pending_active_validators:
     contents:
-      id: "0xf72cdc4c3d6e41fd8dd78a90fed7e7fe15a96544ef0d24b26f8fa98d3af106f3"
+      id: "0x80c044602f5407bda7246d4acb805e0761715db80da5390489587b416054ee3c"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0xea08cd5aa2a4c4952e1bd676ca371cc5e670bb54afc86552a1c5d501b6278953"
+    id: "0xc9f10341a396ae41f60350c0b1ad8a07fc3d5bb5e391983a2f4374ddab15c968"
     size: 1
   inactive_validators:
-    id: "0xa85a8deffbbbcbec3fe70ae2a24e20b031dd67ed270e5195ac0c5ed34a4706bd"
+    id: "0x67fb5ad6d089b382f65ae03ac011183949e098497793f0678f888d6fd7c8de8b"
     size: 0
   validator_candidates:
-    id: "0xa6bd0d13591193f137b8695dc8b7cafc1b6e801afa978e2ce972ab63396c964d"
+    id: "0x1d38e6606fb1e0f53bc7ca1b94ca087375a08352630b411187ac4cf2c0242e8c"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0x7b2d69267ddd666b2b319e04d883fcb16d7e69c20bd82b790fb029a81879259b"
+      id: "0x6aa1fd57ab6daada2319cbc22c821460f028693c4758b0b221530460c547d1ce"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x15a5aa6c541fc58653abfa77c110fb20db2db3edc36fa88b74a048ba8afa815a"
+      id: "0xbc1c49382e991a85d9ccd8d6297b058d12bfb8e01e57c1d397511bd075f9a331"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0x895f484f2bce2e11be5fa8ca53ac6562f19f68f77041fa31f43995a09eb74fba"
+      id: "0xfca9a397dc614ba6d72e55097765016c5c6ca3f623e5d9d6480e54d9b71e6291"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,6 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0xc7ace433bfa22a7b12ce722b347eeac8ecd69597db8c3d3e5360f8b79939040d"
+    id: "0x168991dc3f3567ae67bb69e9741ccc3b45a7a32d58b43a5a6ec618cfc24a3800"
   size: 0
 


### PR DESCRIPTION
## Description

The self-matching prevention mechanism ensures that the matching engine
takes measures to avoid unnecessary trades
when matching a user's buy/sell order with their own sell/buy order.

There are four Self-Trade Prevention Options.
1. Decrement & cancel: Cancel smaller order and decrement larger order by the smaller size.
                                         If the same size, cancel both.
2. Cancel oldest: Cancel older (resting) order in full.
                              Continue to execute the newer taking order.
3. Cancel newest: Cancel newer (taking) order in full.
                                Let the old resting order remain on the order book.
4. Cancel both: Cancel both orders immediately.

For now, we have only implemented the behavior of canceling the oldest order.
However, we have reserved the self_matching_prevention option as a parameter
in case we need to implement other behaviors in the future.
This approach allows us to maintain backward compatibility
and provides us with the capability to extend functionality.

## Test Plan

cd to deepbook dir and run "sui move test"

---
If your changes are not user-facing and not a breaking change, you can
skip the following section. Otherwise, please indicate what changed, and
then add to the Release Notes section as highlighted during the release
process.

### Type of Change (Check all that apply)

- [✅] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [✅] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes

Implemented Self-matching prevention through canceling the oldest order.

---------