### PR TITLE
[narwhal] introduce the LeaderSwapTable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5824,6 +5824,7 @@ dependencies = [
  "pprof",
  "prometheus",
  "rand 0.8.5",
+ "sui-protocol-config",
  "telemetry-subscribers",
  "thiserror",
  "tokio",

--- a/narwhal/consensus/Cargo.toml
+++ b/narwhal/consensus/Cargo.toml
@@ -26,6 +26,8 @@ workspace-hack = { version = "0.1", path = "../../crates/workspace-hack" }
 cfg-if = "1.0.0"
 mysten-metrics = { path = "../../crates/mysten-metrics" }
 store = { path = "../../crates/typed-store", package = "typed-store" }
+sui-protocol-config = { path = "../../crates/sui-protocol-config" }
+
 telemetry-subscribers.workspace = true
 
 [dev-dependencies]

--- a/narwhal/consensus/benches/process_certificates.rs
+++ b/narwhal/consensus/benches/process_certificates.rs
@@ -57,6 +57,7 @@ pub fn process_certificates(c: &mut Criterion) {
         let mut ordering_engine = Bullshark {
             committee: committee.clone(),
             store: store.consensus_store,
+            protocol_config: latest_protocol_version(),
             metrics,
             last_successful_leader_election_timestamp: Instant::now(),
             max_inserted_certificate_round: 0,

--- a/narwhal/consensus/src/bullshark.rs
+++ b/narwhal/consensus/src/bullshark.rs
@@ -10,6 +10,7 @@ use config::{Authority, Committee, Stake};
 use fastcrypto::hash::Hash;
 use std::sync::Arc;
 use storage::ConsensusStore;
+use sui_protocol_config::ProtocolConfig;
 use tokio::time::Instant;
 use tracing::{debug, error_span};
 use types::{Certificate, CertificateAPI, CommittedSubDag, HeaderAPI, ReputationScores, Round};
@@ -25,6 +26,9 @@ pub mod randomized_tests;
 pub struct Bullshark {
     /// The committee information.
     pub committee: Committee,
+    /// The protocol config settings allowing us to enable/disable features and support properties
+    /// according to the supported protocol version.
+    pub protocol_config: ProtocolConfig,
     /// Persistent storage to safe ensure crash-recovery.
     pub store: Arc<ConsensusStore>,
     /// The most recent round of inserted certificate
@@ -42,11 +46,13 @@ impl Bullshark {
     pub fn new(
         committee: Committee,
         store: Arc<ConsensusStore>,
+        protocol_config: ProtocolConfig,
         metrics: Arc<ConsensusMetrics>,
         num_sub_dags_per_schedule: u64,
     ) -> Self {
         Self {
             committee,
+            protocol_config,
             store,
             last_successful_leader_election_timestamp: Instant::now(),
             max_inserted_certificate_round: 0,

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -54,17 +54,22 @@ impl LeaderSwapTable {
         assert!(reputation_scores.final_of_schedule, "Only reputation scores that have been calculated on the end of a schedule are accepted");
 
         // calculating the good nodes
-        let authorities = reputation_scores.authorities_by_score_desc();
-        let good_nodes = Self::retrieve_first_nodes(committee, authorities.into_iter());
+        let good_nodes = Self::retrieve_first_nodes(
+            committee,
+            reputation_scores.authorities_by_score_desc().into_iter(),
+        );
 
         // calculating the bad nodes
-        let authorities = reputation_scores.authorities_by_score_desc();
-
         // we revert the sorted authorities to score ascending so we get the first f low scorers
-        let bad_authorities = Self::retrieve_first_nodes(committee, authorities.into_iter().rev());
-        let bad_nodes = bad_authorities
-            .into_iter()
-            .collect::<HashSet<AuthorityIdentifier>>();
+        let bad_nodes = Self::retrieve_first_nodes(
+            committee,
+            reputation_scores
+                .authorities_by_score_desc()
+                .into_iter()
+                .rev(),
+        )
+        .into_iter()
+        .collect::<HashSet<AuthorityIdentifier>>();
 
         debug!("Reputation scores on round {round}: {reputation_scores:?}");
         debug!("Good nodes: {good_nodes:?}");

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -59,7 +59,9 @@ impl LeaderSwapTable {
     /// with a good performer. If not, then the method returns None. Otherwise the leader to swap with
     /// is returned instead. The `leader_round` represents the DAG round on which the provided AuthorityIdentifier
     /// is a leader on and is used as a seed to random function in order to calculate the good node that
-    /// will swap for that round the bad node.
+    /// will swap for that round the bad node. We are intentionally not doing weighted randomness as
+    /// we want to give to all the good nodes equal opportunity to get swapped with bad nodes and not
+    /// have one node with enough stake dominating on the final schedule.
     pub fn swap(
         &self,
         leader: &AuthorityIdentifier,

--- a/narwhal/consensus/src/tests/bullshark_tests.rs
+++ b/narwhal/consensus/src/tests/bullshark_tests.rs
@@ -76,6 +76,7 @@ async fn commit_one() {
     let bullshark = Bullshark::new(
         committee.clone(),
         store.clone(),
+        latest_protocol_version(),
         metrics.clone(),
         NUM_SUB_DAGS_PER_SCHEDULE,
     );
@@ -161,6 +162,7 @@ async fn dead_node() {
     let bullshark = Bullshark::new(
         committee.clone(),
         store.clone(),
+        latest_protocol_version(),
         metrics.clone(),
         NUM_SUB_DAGS_PER_SCHEDULE,
     );
@@ -359,6 +361,7 @@ async fn not_enough_support() {
     let bullshark = Bullshark::new(
         committee.clone(),
         store.clone(),
+        latest_protocol_version(),
         metrics.clone(),
         NUM_SUB_DAGS_PER_SCHEDULE,
     );
@@ -496,6 +499,7 @@ async fn missing_leader() {
     let bullshark = Bullshark::new(
         committee.clone(),
         store.clone(),
+        latest_protocol_version(),
         metrics.clone(),
         NUM_SUB_DAGS_PER_SCHEDULE,
     );
@@ -583,6 +587,7 @@ async fn committed_round_after_restart() {
         let bullshark = Bullshark::new(
             committee.clone(),
             store.clone(),
+            latest_protocol_version(),
             metrics.clone(),
             NUM_SUB_DAGS_PER_SCHEDULE,
         );
@@ -673,7 +678,13 @@ async fn delayed_certificates_are_rejected() {
 
     let store = make_consensus_store(&test_utils::temp_dir());
     let mut state = ConsensusState::new(metrics.clone(), gc_depth);
-    let mut bullshark = Bullshark::new(committee, store, metrics, NUM_SUB_DAGS_PER_SCHEDULE);
+    let mut bullshark = Bullshark::new(
+        committee,
+        store,
+        latest_protocol_version(),
+        metrics,
+        NUM_SUB_DAGS_PER_SCHEDULE,
+    );
 
     // Populate DAG with the rounds up to round 5 so we trigger commits
     let mut all_subdags = Vec::new();
@@ -725,8 +736,13 @@ async fn submitting_equivocating_certificate_should_error() {
 
     let store = make_consensus_store(&test_utils::temp_dir());
     let mut state = ConsensusState::new(metrics.clone(), gc_depth);
-    let mut bullshark =
-        Bullshark::new(committee.clone(), store, metrics, NUM_SUB_DAGS_PER_SCHEDULE);
+    let mut bullshark = Bullshark::new(
+        committee.clone(),
+        store,
+        latest_protocol_version(),
+        metrics,
+        NUM_SUB_DAGS_PER_SCHEDULE,
+    );
 
     // Populate DAG with all the certificates
     for certificate in certificates.clone() {
@@ -795,7 +811,13 @@ async fn reset_consensus_scores_on_every_schedule_change() {
 
     let store = make_consensus_store(&test_utils::temp_dir());
     let mut state = ConsensusState::new(metrics.clone(), gc_depth);
-    let mut bullshark = Bullshark::new(committee, store, metrics, NUM_SUB_DAGS_PER_SCHEDULE);
+    let mut bullshark = Bullshark::new(
+        committee,
+        store,
+        latest_protocol_version(),
+        metrics,
+        NUM_SUB_DAGS_PER_SCHEDULE,
+    );
 
     // Populate DAG with the rounds up to round 50 so we trigger commits
     let mut all_subdags = Vec::new();
@@ -864,6 +886,7 @@ async fn restart_with_new_committee() {
         let bullshark = Bullshark::new(
             committee.clone(),
             store.clone(),
+            latest_protocol_version(),
             metrics.clone(),
             NUM_SUB_DAGS_PER_SCHEDULE,
         );
@@ -986,7 +1009,13 @@ async fn garbage_collection_basic() {
 
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
     let mut state = ConsensusState::new(metrics.clone(), GC_DEPTH);
-    let mut bullshark = Bullshark::new(committee, store, metrics, NUM_SUB_DAGS_PER_SCHEDULE);
+    let mut bullshark = Bullshark::new(
+        committee,
+        store,
+        latest_protocol_version(),
+        metrics,
+        NUM_SUB_DAGS_PER_SCHEDULE,
+    );
 
     // Now start feeding the certificates per round
     for c in certificates {
@@ -1087,8 +1116,13 @@ async fn slow_node() {
     let store = make_consensus_store(&test_utils::temp_dir());
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
     let mut state = ConsensusState::new(metrics.clone(), GC_DEPTH);
-    let mut bullshark =
-        Bullshark::new(committee.clone(), store, metrics, NUM_SUB_DAGS_PER_SCHEDULE);
+    let mut bullshark = Bullshark::new(
+        committee.clone(),
+        store,
+        latest_protocol_version(),
+        metrics,
+        NUM_SUB_DAGS_PER_SCHEDULE,
+    );
 
     // Now start feeding the certificates per round up to 8. We expect to have
     // triggered a commit up to round 6 and gc round 1 & 2.
@@ -1276,7 +1310,13 @@ async fn not_enough_support_and_missing_leaders_and_gc() {
     let store = make_consensus_store(&test_utils::temp_dir());
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
     let mut state = ConsensusState::new(metrics.clone(), GC_DEPTH);
-    let mut bullshark = Bullshark::new(committee, store, metrics, NUM_SUB_DAGS_PER_SCHEDULE);
+    let mut bullshark = Bullshark::new(
+        committee,
+        store,
+        latest_protocol_version(),
+        metrics,
+        NUM_SUB_DAGS_PER_SCHEDULE,
+    );
 
     let mut committed = false;
     for c in &certificates {

--- a/narwhal/consensus/src/tests/consensus_tests.rs
+++ b/narwhal/consensus/src/tests/consensus_tests.rs
@@ -75,6 +75,7 @@ async fn test_consensus_recovery_with_bullshark() {
     let bullshark = Bullshark::new(
         committee.clone(),
         consensus_store.clone(),
+        latest_protocol_version(),
         metrics.clone(),
         NUM_SUB_DAGS_PER_SCHEDULE,
     );
@@ -170,6 +171,7 @@ async fn test_consensus_recovery_with_bullshark() {
     let bullshark = Bullshark::new(
         committee.clone(),
         consensus_store.clone(),
+        latest_protocol_version(),
         metrics.clone(),
         NUM_SUB_DAGS_PER_SCHEDULE,
     );
@@ -239,6 +241,7 @@ async fn test_consensus_recovery_with_bullshark() {
     let bullshark = Bullshark::new(
         committee.clone(),
         consensus_store.clone(),
+        latest_protocol_version(),
         metrics.clone(),
         NUM_SUB_DAGS_PER_SCHEDULE,
     );

--- a/narwhal/consensus/src/tests/consensus_tests.rs
+++ b/narwhal/consensus/src/tests/consensus_tests.rs
@@ -3,9 +3,11 @@
 
 #![allow(clippy::mutable_key_type)]
 
+use config::AuthorityIdentifier;
 use fastcrypto::hash::Hash;
 use prometheus::Registry;
 use std::collections::BTreeSet;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use storage::NodeStorage;
 use telemetry_subscribers::TelemetryGuards;
@@ -14,13 +16,13 @@ use test_utils::{temp_dir, CommitteeFixture};
 use tokio::sync::watch;
 
 use crate::bullshark::Bullshark;
-use crate::consensus::ConsensusRound;
+use crate::consensus::{ConsensusRound, LeaderSwapTable};
 use crate::consensus_utils::NUM_SUB_DAGS_PER_SCHEDULE;
 use crate::metrics::ConsensusMetrics;
 use crate::Consensus;
 use crate::NUM_SHUTDOWN_RECEIVERS;
 use types::{
-    Certificate, CertificateAPI, HeaderAPI, PreSubscribedBroadcastSender, ReputationScores,
+    Certificate, CertificateAPI, HeaderAPI, PreSubscribedBroadcastSender, ReputationScores, Round,
 };
 
 /// This test is trying to compare the output of the Consensus algorithm when:
@@ -311,6 +313,77 @@ async fn test_consensus_recovery_with_bullshark() {
             .count(),
         4
     );
+}
+
+#[tokio::test]
+async fn test_leader_swap_table() {
+    // GIVEN
+    let fixture = CommitteeFixture::builder().build();
+    let committee = fixture.committee();
+
+    // the authority ids
+    let authority_ids: Vec<AuthorityIdentifier> = fixture.authorities().map(|a| a.id()).collect();
+
+    // Adding some scores
+    let mut scores = ReputationScores::new(&committee);
+    scores.final_of_schedule = true;
+    for (score, id) in authority_ids.iter().enumerate() {
+        scores.add_score(*id, score as u64);
+    }
+
+    let table = LeaderSwapTable::new(&committee, scores);
+
+    // Only one bad authority should be calculated since all have equal stake
+    assert_eq!(table.bad_nodes.len(), 1);
+
+    // now first three should be swapped, whereas the others should not return anything
+    for (index, id) in authority_ids.iter().enumerate() {
+        if index < 1 {
+            let s = table.swap(id, index as Round).unwrap();
+
+            // make sure that the returned node is amongst the good nodes
+            assert!(table.good_nodes.iter().any(|n| *n == s));
+        } else {
+            assert!(table.swap(id, index as Round).is_none());
+        }
+    }
+
+    // Now we create a larger committee with more score variation - still all the authorities have
+    // equal stake.
+    let fixture = CommitteeFixture::builder()
+        .committee_size(NonZeroUsize::new(10).unwrap())
+        .build();
+    let committee = fixture.committee();
+
+    // the authority ids
+    let authority_ids: Vec<AuthorityIdentifier> = fixture.authorities().map(|a| a.id()).collect();
+
+    // Adding some scores
+    let mut scores = ReputationScores::new(&committee);
+    scores.final_of_schedule = true;
+    for (score, id) in authority_ids.iter().enumerate() {
+        scores.add_score(*id, score as u64);
+    }
+
+    // We expect the first 3 authorities (f) to be amongst the bad nodes
+    let table = LeaderSwapTable::new(&committee, scores);
+
+    assert_eq!(table.bad_nodes.len(), 3);
+    assert!(table.bad_nodes.contains(&authority_ids[0]));
+    assert!(table.bad_nodes.contains(&authority_ids[1]));
+    assert!(table.bad_nodes.contains(&authority_ids[2]));
+
+    // now first three should be swapped, whereas the others should not return anything
+    for (index, id) in authority_ids.iter().enumerate() {
+        if index < 3 {
+            let s = table.swap(id, index as Round).unwrap();
+
+            // make sure that the returned node is amongst the good nodes
+            assert!(table.good_nodes.iter().any(|n| *n == s));
+        } else {
+            assert!(table.swap(id, index as Round).is_none());
+        }
+    }
 }
 
 fn setup_tracing() -> TelemetryGuards {

--- a/narwhal/consensus/src/tests/consensus_tests.rs
+++ b/narwhal/consensus/src/tests/consensus_tests.rs
@@ -331,7 +331,7 @@ async fn test_leader_swap_table() {
         scores.add_score(*id, score as u64);
     }
 
-    let table = LeaderSwapTable::new(&committee, scores);
+    let table = LeaderSwapTable::new(&committee, 2, scores);
 
     // Only one bad authority should be calculated since all have equal stake
     assert_eq!(table.bad_nodes.len(), 1);
@@ -366,7 +366,7 @@ async fn test_leader_swap_table() {
     }
 
     // We expect the first 3 authorities (f) to be amongst the bad nodes
-    let table = LeaderSwapTable::new(&committee, scores);
+    let table = LeaderSwapTable::new(&committee, 2, scores);
 
     assert_eq!(table.bad_nodes.len(), 3);
     assert!(table.bad_nodes.contains(&authority_ids[0]));

--- a/narwhal/consensus/src/tests/randomized_tests.rs
+++ b/narwhal/consensus/src/tests/randomized_tests.rs
@@ -500,6 +500,7 @@ fn generate_and_run_execution_plans(
         let mut bullshark = Bullshark::new(
             committee.clone(),
             store.clone(),
+            latest_protocol_version(),
             metrics.clone(),
             NUM_SUB_DAGS_PER_SCHEDULE,
         );

--- a/narwhal/executor/tests/consensus_integration_tests.rs
+++ b/narwhal/executor/tests/consensus_integration_tests.rs
@@ -79,6 +79,7 @@ async fn test_recovery() {
     let bullshark = Bullshark::new(
         committee.clone(),
         consensus_store.clone(),
+        latest_protocol_version(),
         metrics.clone(),
         NUM_SUB_DAGS_PER_SCHEDULE,
     );

--- a/narwhal/node/src/primary_node.rs
+++ b/narwhal/node/src/primary_node.rs
@@ -360,6 +360,7 @@ impl PrimaryNodeInner {
         let ordering_engine = Bullshark::new(
             committee.clone(),
             store.consensus_store.clone(),
+            protocol_config.clone(),
             consensus_metrics.clone(),
             Self::CONSENSUS_SCHEDULE_CHANGE_SUB_DAGS,
         );

--- a/narwhal/types/src/consensus.rs
+++ b/narwhal/types/src/consensus.rs
@@ -172,7 +172,7 @@ impl ReputationScores {
             match a2.1.cmp(&a1.1) {
                 Ordering::Equal => {
                     // we resolve the score equality deterministically by ordering in authority
-                    // identifier order ascending.
+                    // identifier order descending.
                     a2.0.cmp(&a1.0)
                 }
                 result => result,


### PR DESCRIPTION
## Description 

As part of the leader election schedule change epic https://www.notion.so/mystenlabs/Leader-election-schedule-31e9abd06477436b9a38fd3282879093?pvs=4 , the first step is to build a "swap" table based on the calculated reputation scores. As a reminder we do calculate the leader reputation scores every K commit rounds. Our goal is based on those scores to come up with a set of good & bad nodes. Then for next K commit rounds we do swap the occurrences of leaders of the bad nodes with the ones of the good nodes. 

This PR is the first step. As part of the upcoming work we'll need to 
- [ ] calculate the swap table on every K committed subdags & wire into the leader election algorithm
- [ ] restore correct swap table after crash/recovery
- [ ] modify the commit path so we repeat the leader election when we commit recursively
- [ ] modify the proposer to support the new leader election capabilities
- [ ] ensure whole feature is gated behind a protocol config feature flag - and probably a config switch as we might need to have it disabled for longer than a release cycle.
- [ ] add testing

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
