### PR TITLE
[bcs] Fix a bcs decoding bug for u128 and u256 values

### DIFF
--- a/.changeset/friendly-plums-promise.md
+++ b/.changeset/friendly-plums-promise.md
@@ -1,0 +1,5 @@
+---
+'@mysten/bcs': patch
+---
+
+Fix a bcs decoding bug for u128 and u256 values

--- a/sdk/bcs/src/index.ts
+++ b/sdk/bcs/src/index.ts
@@ -146,7 +146,7 @@ export class BcsReader {
   read128(): string {
     let value1 = BigInt(this.read64());
     let value2 = BigInt(this.read64());
-    let result = value2.toString(16) + value1.toString(16).padStart(8, "0");
+    let result = value2.toString(16) + value1.toString(16).padStart(16, "0");
 
     return BigInt("0x" + result).toString(10);
   }
@@ -157,7 +157,7 @@ export class BcsReader {
   read256(): string {
     let value1 = BigInt(this.read128());
     let value2 = BigInt(this.read128());
-    let result = value2.toString(16) + value1.toString(16).padStart(16, "0");
+    let result = value2.toString(16) + value1.toString(16).padStart(32, "0");
 
     return BigInt("0x" + result).toString(10);
   }

--- a/sdk/bcs/tests/serde.test.ts
+++ b/sdk/bcs/tests/serde.test.ts
@@ -15,7 +15,21 @@ describe("BCS: Serde", () => {
 
     expect(serde(bcs, "u16", "10000").toString(10)).toEqual("10000");
     expect(serde(bcs, "u32", "10000").toString(10)).toEqual("10000");
-    expect(serde(bcs, "u256", "10000").toString(10)).toEqual("10000");
+    expect(
+      serde(
+        bcs,
+        "u128",
+        "154386538175093611946334810",
+      ).toString(10),
+    ).toEqual("154386538175093611946334810");
+
+    expect(
+      serde(
+        bcs,
+        "u256",
+        "154386538175093611946334810000000000000000000000122",
+      ).toString(10),
+    ).toEqual("154386538175093611946334810000000000000000000000122");
 
     expect(bcs.ser("u256", "100000").toString("hex")).toEqual(
       "a086010000000000000000000000000000000000000000000000000000000000"


### PR DESCRIPTION
## Description 

fixes #12470

When parsing u128 and u256 values we were incorrectly padding the lower bits.  This resulted in incorrectly decoding values in the following ranges:
* u128 values with bytes 9-16 being 0x00
* u256 values with bytes 17-32 all being 0x00
* u256 values with bytes 9-16 all being 0x00

## Test Plan 

Updated a couple test cases that triggered this issue

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
