### PR TITLE
[explorer] Allow viewing old object versions in explorer

### DIFF
--- a/apps/explorer/src/components/Object/ObjectFieldsCard.tsx
+++ b/apps/explorer/src/components/Object/ObjectFieldsCard.tsx
@@ -21,10 +21,11 @@ import { ListItem, VerticalList } from '~/ui/VerticalList';
 
 interface ObjectFieldsProps {
     id: string;
+    version?: string;
 }
 
-export function ObjectFieldsCard({ id }: ObjectFieldsProps) {
-    const { data, isLoading, isError } = useGetObject(id);
+export function ObjectFieldsCard({ id, version }: ObjectFieldsProps) {
+    const { data, isLoading, isError } = useGetObject(id, version);
     const [query, setQuery] = useState('');
     const [activeFieldName, setActiveFieldName] = useState('');
     const objectType = getObjectType(data!);

--- a/apps/explorer/src/pages/index.tsx
+++ b/apps/explorer/src/pages/index.tsx
@@ -36,7 +36,7 @@ export const router = sentryCreateBrowserRouter([
         children: [
             { path: '/', element: <Home /> },
             { path: 'recent', element: <Recent /> },
-            { path: 'object/:id', element: <ObjectResult /> },
+            { path: 'object/:id/:version?', element: <ObjectResult /> },
             { path: 'checkpoint/:id', element: <CheckpointDetail /> },
             { path: 'epoch/current', element: <EpochDetail /> },
             { path: 'txblock/:id', element: <TransactionResult /> },

--- a/apps/explorer/src/pages/object-result/ObjectResult.tsx
+++ b/apps/explorer/src/pages/object-result/ObjectResult.tsx
@@ -25,8 +25,8 @@ function Fail({ objID }: { objID: string | undefined }) {
 }
 
 export function ObjectResult() {
-    const { id: objID } = useParams();
-    const { data, isLoading, isError, isFetched } = useGetObject(objID!);
+    const { id, version } = useParams();
+    const { data, isLoading, isError, isFetched } = useGetObject(id, version);
 
     if (isLoading) {
         return (
@@ -37,12 +37,12 @@ export function ObjectResult() {
     }
 
     if (isError) {
-        return <Fail objID={objID} />;
+        return <Fail objID={id} />;
     }
 
     // TODO: Handle status better NotExists, Deleted, Other
     if (data.error || (isFetched && !data)) {
-        return <Fail objID={objID} />;
+        return <Fail objID={id} />;
     }
 
     const resp = translate(data);
@@ -60,7 +60,7 @@ export function ObjectResult() {
                     {isPackage ? (
                         <PkgView data={resp} />
                     ) : (
-                        <TokenView data={data} />
+                        <TokenView data={data} version={version} />
                     )}
                 </div>
             </ErrorBoundary>

--- a/apps/explorer/src/pages/object-result/views/TokenView.tsx
+++ b/apps/explorer/src/pages/object-result/views/TokenView.tsx
@@ -33,7 +33,13 @@ import {
     parseObjectType,
 } from '~/utils/objectUtils';
 
-export function TokenView({ data }: { data: SuiObjectResponse }) {
+export function TokenView({
+    data,
+    version,
+}: {
+    data: SuiObjectResponse;
+    version?: string;
+}) {
     const display = getObjectDisplay(data)?.data;
     const imgUrl = parseImageURL(display);
     const objOwner = getObjectOwner(data);
@@ -210,7 +216,7 @@ export function TokenView({ data }: { data: SuiObjectResponse }) {
                     </TabPanel>
                 </TabPanels>
             </TabGroup>
-            <ObjectFieldsCard id={objectId} />
+            <ObjectFieldsCard id={objectId} version={version} />
             <DynamicFieldsCard id={objectId} />
             <TransactionBlocksForAddress address={objectId} isObject />
         </div>

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -380,6 +380,7 @@ export class JsonRpcProvider {
     if (!input.id || !isValidSuiObjectId(normalizeSuiObjectId(input.id))) {
       throw new Error('Invalid Sui Object id');
     }
+
     return await this.client.requestWithType(
       'sui_getObject',
       [input.id, input.options],


### PR DESCRIPTION
## Description 

This adds the ability to view an old object version in the explorer. This isn't exposed in any UI, but at least there's a mechanism to do this now.

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
