### PR TITLE
Make checkpoints pruner archival watermark aware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9457,6 +9457,7 @@ dependencies = [
  "serde_yaml 0.8.26",
  "shared-crypto",
  "signature 1.6.4",
+ "sui-archival",
  "sui-config",
  "sui-execution",
  "sui-framework",

--- a/crates/sui-archival/src/tests.rs
+++ b/crates/sui-archival/src/tests.rs
@@ -86,6 +86,7 @@ async fn setup_test_state(temp_dir: PathBuf) -> anyhow::Result<TestState> {
     let archive_reader_config = ArchiveReaderConfig {
         remote_store_config: remote_store_config.clone(),
         download_concurrency: NonZeroUsize::new(2).unwrap(),
+        use_for_pruning_watermark: false,
     };
     let archive_reader = ArchiveReader::new(archive_reader_config)?;
     let local_store = local_store_config.make()?;

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -264,6 +264,7 @@ impl NodeConfig {
                         remote_store_config: remote_store_config.clone(),
                         download_concurrency: NonZeroUsize::new(config.concurrency)
                             .unwrap_or(NonZeroUsize::new(5).unwrap()),
+                        use_for_pruning_watermark: config.use_for_pruning_watermark,
                     })
             })
             .collect()
@@ -575,6 +576,7 @@ pub struct StateArchiveConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub object_store_config: Option<ObjectStoreConfig>,
     pub concurrency: usize,
+    pub use_for_pruning_watermark: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Eq)]

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -62,6 +62,7 @@ narwhal-node = { path = "../../narwhal/node" }
 narwhal-types = { path = "../../narwhal/types" }
 narwhal-worker = { path = "../../narwhal/worker" }
 shared-crypto = { path = "../shared-crypto" }
+sui-archival = { path = "../sui-archival" }
 sui-config = { path = "../sui-config" }
 sui-execution = { path = "../../sui-execution" }
 sui-framework = { path = "../sui-framework" }

--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -14,6 +14,7 @@ use fastcrypto::traits::KeyPair;
 use prometheus::Registry;
 use std::path::PathBuf;
 use std::sync::Arc;
+use sui_archival::reader::ArchiveReaderBalancer;
 use sui_config::certificate_deny_config::CertificateDenyConfig;
 use sui_config::genesis::Genesis;
 use sui_config::node::StateDebugDumpConfig;
@@ -233,6 +234,7 @@ impl<'a> TestAuthorityBuilder<'a> {
             StateDebugDumpConfig {
                 dump_file_directory: Some(tempdir().unwrap().into_path()),
             },
+            ArchiveReaderBalancer::default(),
         )
         .await;
         // For any type of local testing that does not actually spawn a node, the checkpoint executor

--- a/crates/sui-network/src/state_sync/mod.rs
+++ b/crates/sui-network/src/state_sync/mod.rs
@@ -48,6 +48,7 @@
 //! of the newly synchronized checkpoint so that it can help other peers synchronize.
 
 use anemo::{types::PeerEvent, PeerId, Request, Response, Result};
+use anyhow::anyhow;
 use futures::{stream::FuturesOrdered, FutureExt, StreamExt};
 use rand::Rng;
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/crates/sui-network/src/state_sync/mod.rs
+++ b/crates/sui-network/src/state_sync/mod.rs
@@ -48,7 +48,6 @@
 //! of the newly synchronized checkpoint so that it can help other peers synchronize.
 
 use anemo::{types::PeerEvent, PeerId, Request, Response, Result};
-use anyhow::anyhow;
 use futures::{stream::FuturesOrdered, FutureExt, StreamExt};
 use rand::Rng;
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/crates/sui-network/src/state_sync/tests.rs
+++ b/crates/sui-network/src/state_sync/tests.rs
@@ -310,6 +310,7 @@ async fn test_state_sync_using_archive() -> anyhow::Result<()> {
     let archive_reader_config = ArchiveReaderConfig {
         remote_store_config,
         download_concurrency: NonZeroUsize::new(1).unwrap(),
+        use_for_pruning_watermark: false,
     };
     // We will delete all checkpoints older than this checkpoint on Node 2
     let oldest_checkpoint_to_keep: u64 = 10;

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -373,7 +373,7 @@ impl SuiNode {
             state_sync_store.clone(),
             chain_identifier,
             trusted_peer_change_rx,
-            archive_readers,
+            archive_readers.clone(),
             &prometheus_registry,
         )?;
         // We must explicitly send this instead of relying on the initial value to trigger
@@ -455,6 +455,7 @@ impl SuiNode {
             config.certificate_deny_config.clone(),
             config.indirect_objects_threshold,
             config.state_debug_dump_config.clone(),
+            archive_readers,
         )
         .await;
         // ensure genesis txn was executed

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -384,7 +384,6 @@ impl SuiNode {
             epoch_store.epoch_start_state(),
         )
         .expect("Initial trusted peers must be set");
-
         let state_archive_handle = if let Some(remote_store_config) =
             &config.state_archive_write_config.object_store_config
         {

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -92,6 +92,7 @@ validator_configs:
     state-debug-dump-config: {}
     state-archive-write-config:
       concurrency: 0
+      use-for-pruning-watermark: false
     state-archive-read-config: []
   - protocol-key-pair:
       value: avYcyVgYMXTyaUYh9IRwLK0gSzl7YF6ZQDAbrS1Bhvo=
@@ -182,6 +183,7 @@ validator_configs:
     state-debug-dump-config: {}
     state-archive-write-config:
       concurrency: 0
+      use-for-pruning-watermark: false
     state-archive-read-config: []
   - protocol-key-pair:
       value: OXnx3yM1C/ppgnDMx/o1d49fJs7E05kq11mXNae/O+I=
@@ -272,6 +274,7 @@ validator_configs:
     state-debug-dump-config: {}
     state-archive-write-config:
       concurrency: 0
+      use-for-pruning-watermark: false
     state-archive-read-config: []
   - protocol-key-pair:
       value: CyNkjqNVr3HrHTH7f/NLs7u5lUHJzuPAw0PqMTD2y2s=
@@ -362,6 +365,7 @@ validator_configs:
     state-debug-dump-config: {}
     state-archive-write-config:
       concurrency: 0
+      use-for-pruning-watermark: false
     state-archive-read-config: []
   - protocol-key-pair:
       value: X/I/kM+KvHcxAKEf2UU6Sr7SpN3bhiE9nP5CuM/iIY0=
@@ -452,6 +456,7 @@ validator_configs:
     state-debug-dump-config: {}
     state-archive-write-config:
       concurrency: 0
+      use-for-pruning-watermark: false
     state-archive-read-config: []
   - protocol-key-pair:
       value: N272EiFDyKtxRbDKbyN6ujenJ+skPcRoc/XolpOLGnU=
@@ -542,6 +547,7 @@ validator_configs:
     state-debug-dump-config: {}
     state-archive-write-config:
       concurrency: 0
+      use-for-pruning-watermark: false
     state-archive-read-config: []
   - protocol-key-pair:
       value: a74f03IOjL8ZFSWFChFVEi+wiMwHNwNCPDGIYkGfgjs=
@@ -632,6 +638,7 @@ validator_configs:
     state-debug-dump-config: {}
     state-archive-write-config:
       concurrency: 0
+      use-for-pruning-watermark: false
     state-archive-read-config: []
 account_keys:
   - Hloy4pnf8pWEHGP+4OFsXz56bLdIJhkD2O+OdKMqCA4=

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -684,6 +684,7 @@ pub async fn state_sync_from_archive(
     let archive_reader_config = ArchiveReaderConfig {
         remote_store_config,
         download_concurrency: NonZeroUsize::new(concurrency).unwrap(),
+        use_for_pruning_watermark: false,
     };
     let archive_reader = ArchiveReader::new(archive_reader_config)?;
     archive_reader.sync_manifest_once().await?;


### PR DESCRIPTION
## Description 

Ensure that checkpoints pruner never prunes checkpoints beyond the latest archived checkpoint. A node can mark certain archives as the ones to use for archival watermark computation by setting the flag `use_for_pruning_watermark: true`. 
1. A node may have multiple archives that it can read checkpoints from but only mark certain ones to use for watermark calculation
2. If none of the archive configs have the flag `use_for_pruning_watermark: true` set, pruning works as is (it doesn't take into consideration any archive watermark)
3. Nodes who are just users of other archives (and not actually the ones archiving the data for examples validators, community run full nodes, etc) will not need to set `use_for_pruning_watermark: true` and for them pruning works as is. Whereas mysten run validators and FNs will set `use_for_pruning_watermark: true` 

## Test Plan 

Existing tests
