### PR TITLE
explorer: gas reference price fix decimal ticks

### DIFF
--- a/apps/explorer/src/components/GasPriceCard/GraphAxisRight.tsx
+++ b/apps/explorer/src/components/GasPriceCard/GraphAxisRight.tsx
@@ -40,15 +40,14 @@ export function GraphAxisRight({
     selectedUnit,
     isHovered,
 }: AxisRightProps<number>) {
-    let ticks = scale.nice(6).ticks(6);
+    let ticks = Array.from(
+        new Set(scale.nice(6).ticks(6).map(Math.floor)).values()
+    );
     return (
         <g>
             <g>
                 {ticks
-                    .filter(
-                        (_, index) =>
-                            (index + 1) % 2 === 0 || ticks.length === 1
-                    )
+                    .filter((_, index) => index % 2 !== 0 || ticks.length <= 3)
                     .map((value) => (
                         <GasPriceValue
                             key={value}
@@ -58,10 +57,7 @@ export function GraphAxisRight({
             </g>
             <g>
                 {ticks
-                    .filter(
-                        (_, index) =>
-                            (index + 1) % 2 !== 0 && ticks.length !== 1
-                    )
+                    .filter((_, index) => index % 2 === 0 && ticks.length > 3)
                     .map((value) => (
                         <circle
                             key={value}


### PR DESCRIPTION
## Description 

Forces integer values for gas price ticks to avoid BigInt conversion errors

before
<img width="466" alt="Screenshot 2023-06-14 at 18 59 55" src="https://github.com/MystenLabs/sui/assets/10210143/bf30b048-4c85-41a4-82ff-85863ec88e46">

after
<img width="466" alt="Screenshot 2023-06-14 at 19 00 22" src="https://github.com/MystenLabs/sui/assets/10210143/2afa545c-dd33-46ca-96d2-4535f9946d85">


Also shows the tick value instead of the dot when the number of ticks is 3 or less

## Test Plan 

Manual testing

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
