### PR TITLE
Remove sui-core's dep to test-utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9485,7 +9485,6 @@ dependencies = [
  "telemetry-subscribers",
  "tempfile",
  "test-fuzz",
- "test-utils",
  "thiserror",
  "tokio",
  "tokio-retry",

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -99,7 +99,6 @@ test-fuzz = "3.0.4"
 
 sui-macros = { path = "../sui-macros" }
 sui-protocol-config = { path = "../sui-protocol-config" }
-test-utils = { path = "../test-utils" }
 
 [[example]]
 name = "generate-format"

--- a/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/narwhal_manager_tests.rs
@@ -15,9 +15,9 @@ use narwhal_worker::TrivialTransactionValidator;
 use prometheus::Registry;
 use std::sync::Arc;
 use std::time::Duration;
+use sui_swarm_config::network_config_builder::ConfigBuilder;
 use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait;
 use sui_types::sui_system_state::SuiSystemStateTrait;
-use test_utils::authority::test_and_configure_authority_configs;
 use tokio::sync::broadcast;
 use tokio::time::{interval, sleep};
 
@@ -88,7 +88,9 @@ async fn send_transactions(
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_narwhal_manager() {
-    let configs = test_and_configure_authority_configs(1);
+    let configs = ConfigBuilder::new_with_temp_dir()
+        .committee_size(1.try_into().unwrap())
+        .build();
     let mut narwhal_managers = Vec::new();
     let mut shutdown_senders = Vec::new();
 


### PR DESCRIPTION
## Description 

The last use is in narwhal manager tests. Removing it as it just creates a config.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
