### PR TITLE
move: source service scaffolding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,207 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
+name = "actix-codec"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617a8268e3537fe1d8c9ead925fca49ef6400927ee7bc26750e90ecee14ce4b8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util 0.7.4",
+ "tracing",
+]
+
+[[package]]
+name = "actix-http"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2079246596c18b4a33e274ae10c0e50613f4d32a4198e09c7b93771013fed74"
+dependencies = [
+ "actix-codec",
+ "actix-rt",
+ "actix-service",
+ "actix-tls",
+ "actix-utils",
+ "ahash 0.8.2",
+ "base64 0.21.2",
+ "bitflags",
+ "brotli",
+ "bytes",
+ "bytestring",
+ "derive_more",
+ "encoding_rs",
+ "flate2",
+ "futures-core",
+ "h2",
+ "http",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "language-tags",
+ "local-channel",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "sha1",
+ "smallvec",
+ "tokio",
+ "tokio-util 0.7.4",
+ "tracing",
+ "zstd",
+]
+
+[[package]]
+name = "actix-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465a6172cf69b960917811022d8f29bc0b7fa1398bc4f78b3c466673db1213b6"
+dependencies = [
+ "quote 1.0.26",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "actix-router"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66ff4d247d2b160861fa2866457e85706833527840e4133f8f49aa423a38799"
+dependencies = [
+ "bytestring",
+ "http",
+ "regex",
+ "serde 1.0.152",
+ "tracing",
+]
+
+[[package]]
+name = "actix-rt"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15265b6b8e2347670eb363c47fc8c75208b4a4994b27192f345fcbe707804f3e"
+dependencies = [
+ "futures-core",
+ "tokio",
+]
+
+[[package]]
+name = "actix-server"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e8613a75dd50cc45f473cee3c34d59ed677c0f7b44480ce3b8247d7dc519327"
+dependencies = [
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "futures-core",
+ "futures-util",
+ "mio 0.8.5",
+ "num_cpus",
+ "socket2 0.4.9",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "actix-service"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b894941f818cfdc7ccc4b9e60fa7e53b5042a2e8567270f9147d5591893373a"
+dependencies = [
+ "futures-core",
+ "paste",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "actix-tls"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fde0cf292f7cdc7f070803cb9a0d45c018441321a78b1042ffbbb81ec333297"
+dependencies = [
+ "actix-codec",
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "futures-core",
+ "log",
+ "pin-project-lite",
+ "tokio-rustls 0.23.4",
+ "tokio-util 0.7.4",
+ "webpki-roots",
+]
+
+[[package]]
+name = "actix-utils"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a1dcdff1466e3c2488e1cb5c36a71822750ad43839937f85d2f4d9f8b705d8"
+dependencies = [
+ "local-waker",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "actix-web"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3cb42f9566ab176e1ef0b8b3a896529062b4efc6be0123046095914c4c1c96"
+dependencies = [
+ "actix-codec",
+ "actix-http",
+ "actix-macros",
+ "actix-router",
+ "actix-rt",
+ "actix-server",
+ "actix-service",
+ "actix-tls",
+ "actix-utils",
+ "actix-web-codegen",
+ "ahash 0.7.6",
+ "bytes",
+ "bytestring",
+ "cfg-if",
+ "cookie",
+ "derive_more",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "itoa",
+ "language-tags",
+ "log",
+ "mime",
+ "once_cell",
+ "pin-project-lite",
+ "regex",
+ "serde 1.0.152",
+ "serde_json",
+ "serde_urlencoded",
+ "smallvec",
+ "socket2 0.4.9",
+ "time 0.3.17",
+ "url",
+]
+
+[[package]]
+name = "actix-web-codegen"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2262160a7ae29e3415554a3f1fc04c764b1540c116aa524683208078b7a75bc9"
+dependencies = [
+ "actix-router",
+ "proc-macro2 1.0.58",
+ "quote 1.0.26",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1525,6 +1726,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytestring"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "238e4886760d98c4f899360c834fa93e62cf7f721ac3c2da375cbdf4b8679aae"
+dependencies = [
+ "bytes",
+]
+
+[[package]]
 name = "bzip2-sys"
 version = "0.1.11+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2035,6 +2245,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "cookie"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
+dependencies = [
+ "percent-encoding",
+ "time 0.3.17",
+ "version_check",
 ]
 
 [[package]]
@@ -4532,6 +4753,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "language-tags"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
+
+[[package]]
 name = "lazy_static"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4657,6 +4884,24 @@ name = "linux-raw-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
+
+[[package]]
+name = "local-channel"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f303ec0e94c6c54447f84f3b0ef7af769858a9c4ef56ef2a986d3dcd4c3fc9c"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "local-waker",
+]
+
+[[package]]
+name = "local-waker"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e34f76eb3611940e0e7d53a9aaa4e6a3151f69541a282fd0dad5571420c53ff1"
 
 [[package]]
 name = "lock_api"
@@ -10479,6 +10724,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "sui-source-validation-service"
+version = "0.1.0"
+dependencies = [
+ "actix-web",
+ "anyhow",
+ "expect-test",
+ "move-package",
+ "reqwest",
+ "serde 1.0.152",
+ "serde_json",
+ "sui-config",
+ "sui-move",
+ "sui-move-build",
+ "sui-sdk",
+ "sui-source-validation",
+ "test-utils",
+ "tokio",
+ "workspace-hack",
+]
+
+[[package]]
 name = "sui-storage"
 version = "0.1.0"
 dependencies = [
@@ -12583,6 +12849,17 @@ name = "workspace-hack"
 version = "0.1.0"
 dependencies = [
  "Inflector",
+ "actix-codec",
+ "actix-http",
+ "actix-macros",
+ "actix-router",
+ "actix-rt",
+ "actix-server",
+ "actix-service",
+ "actix-tls",
+ "actix-utils",
+ "actix-web",
+ "actix-web-codegen",
  "addr2line",
  "adler",
  "aead",
@@ -12689,6 +12966,7 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "bytes",
+ "bytestring",
  "bzip2-sys",
  "cached",
  "cached_proc_macro",
@@ -12738,6 +13016,7 @@ dependencies = [
  "constant_time_eq",
  "convert_case 0.4.0",
  "convert_case 0.6.0",
+ "cookie",
  "core-foundation",
  "core-foundation-sys",
  "core2",
@@ -12952,6 +13231,7 @@ dependencies = [
  "jsonrpsee-ws-client",
  "k256",
  "keccak",
+ "language-tags",
  "lazy_static 0.2.11",
  "lazy_static 1.4.0",
  "lazycell",
@@ -12966,6 +13246,8 @@ dependencies = [
  "linked-hash-map",
  "linux-raw-sys 0.1.4",
  "linux-raw-sys 0.3.1",
+ "local-channel",
+ "local-waker",
  "lock_api",
  "log",
  "lru",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,7 @@ members = [
     "crates/sui-simulator",
     "crates/sui-snapshot",
     "crates/sui-source-validation",
+    "crates/sui-source-validation-service",
     "crates/sui-storage",
     "crates/sui-surfer",
     "crates/sui-swarm",

--- a/crates/sui-source-validation-service/Cargo.toml
+++ b/crates/sui-source-validation-service/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "sui-source-validation-service"
+version = "0.1.0"
+authors = ["Mysten Labs <build@mystenlabs.com>"]
+license = "Apache-2.0"
+publish = false
+edition = "2021"
+
+[lib]
+path = "src/lib.rs"
+
+[[bin]]
+path = "src/main.rs"
+name = "sui-source-validation-service"
+
+[dependencies]
+actix-web = { version = "4", features = ["rustls"] }
+anyhow = { version = "1.0.64", features = ["backtrace"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+serde = { version = "1.0.144", features = ["derive"] }
+serde_json = "1.0.88"
+
+sui-config = { path = "../../crates/sui-config" }
+sui-move = { path = "../../crates/sui-move", features = ["all"] }
+sui-move-build = { path = "../../crates/sui-move-build" }
+sui-sdk = { path = "../../crates/sui-sdk" }
+sui-source-validation = { path = "../sui-source-validation" }
+
+move-package.workspace = true
+workspace-hack = { version = "0.1", path = "../../crates/workspace-hack" }
+
+[dev-dependencies]
+expect-test = "1.4.0"
+reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
+
+test-utils = { path = "../test-utils" }

--- a/crates/sui-source-validation-service/src/lib.rs
+++ b/crates/sui-source-validation-service/src/lib.rs
@@ -1,0 +1,64 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::{Path, PathBuf};
+
+use actix_web::{dev::Server, web, App, HttpRequest, HttpServer, Responder};
+
+use move_package::BuildConfig as MoveBuildConfig;
+use sui_move::build::resolve_lock_file_path;
+use sui_move_build::{BuildConfig, SuiPackageHooks};
+use sui_sdk::wallet_context::WalletContext;
+use sui_source_validation::{BytecodeSourceVerifier, SourceMode};
+
+pub async fn verify_package(
+    context: &WalletContext,
+    package_path: impl AsRef<Path>,
+) -> anyhow::Result<()> {
+    move_package::package_hooks::register_package_hooks(Box::new(SuiPackageHooks));
+    let config = resolve_lock_file_path(
+        MoveBuildConfig::default(),
+        Some(package_path.as_ref().to_path_buf()),
+    )
+    .unwrap();
+    let build_config = BuildConfig {
+        config,
+        run_bytecode_verifier: false, /* no need to run verifier if code is on-chain */
+        print_diags_to_stderr: false,
+    };
+    let compiled_package = build_config
+        .build(package_path.as_ref().to_path_buf())
+        .unwrap();
+
+    let client = context.get_client().await?;
+    BytecodeSourceVerifier::new(client.read_api())
+        .verify_package(
+            &compiled_package,
+            /* verify_deps */ false,
+            SourceMode::Verify,
+        )
+        .await
+        .map_err(anyhow::Error::from)
+}
+
+pub async fn initialize(
+    context: &WalletContext,
+    package_paths: Vec<PathBuf>,
+) -> anyhow::Result<()> {
+    for p in package_paths {
+        verify_package(context, p).await?
+    }
+    Ok(())
+}
+
+pub fn serve() -> anyhow::Result<Server> {
+    Ok(
+        HttpServer::new(|| App::new().route("/api", web::get().to(api_route)))
+            .bind("0.0.0.0:8000")?
+            .run(),
+    )
+}
+
+async fn api_route(_request: HttpRequest) -> impl Responder {
+    "{\"source\": \"code\"}"
+}

--- a/crates/sui-source-validation-service/src/main.rs
+++ b/crates/sui-source-validation-service/src/main.rs
@@ -1,0 +1,15 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use sui_config::{sui_config_dir, SUI_CLIENT_CONFIG};
+use sui_sdk::wallet_context::WalletContext;
+use sui_source_validation_service::{initialize, serve};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let config = sui_config_dir()?.join(SUI_CLIENT_CONFIG);
+    let context = WalletContext::new(&config, None, None).await?;
+    let package_paths = vec![];
+    initialize(&context, package_paths).await?;
+    serve()?.await.map_err(anyhow::Error::from)
+}

--- a/crates/sui-source-validation-service/tests/tests.rs
+++ b/crates/sui-source-validation-service/tests/tests.rs
@@ -1,0 +1,37 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use expect_test::expect;
+use reqwest::Client;
+use serde::Deserialize;
+
+use sui_source_validation_service::{initialize, serve};
+
+use test_utils::network::TestClusterBuilder;
+
+#[derive(Deserialize)]
+struct Response {
+    source: String,
+}
+
+#[tokio::test]
+async fn test_api_route() -> anyhow::Result<()> {
+    let mut cluster = TestClusterBuilder::new().build().await;
+    let context = &mut cluster.wallet;
+
+    initialize(context, vec![]).await?;
+    tokio::spawn(serve().expect("Cannot start service."));
+
+    let client = Client::new();
+    let json = client
+        .get("http://0.0.0.0:8000/api")
+        .send()
+        .await
+        .expect("Request failed.")
+        .json::<Response>()
+        .await?;
+
+    let expected = expect!["code"];
+    expected.assert_eq(&json.source);
+    Ok(())
+}

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -15,12 +15,21 @@ publish = false
 
 ### BEGIN HAKARI SECTION
 [dependencies]
+actix-codec = { version = "0.5", default-features = false }
+actix-http = { version = "3", features = ["compress-brotli", "compress-gzip", "compress-zstd", "http2", "rustls", "ws"] }
+actix-router = { version = "0.5" }
+actix-rt = { version = "2", default-features = false }
+actix-server = { version = "2" }
+actix-service = { version = "2", default-features = false }
+actix-tls = { version = "3", default-features = false, features = ["accept", "rustls"] }
+actix-utils = { version = "3", default-features = false }
+actix-web = { version = "4", features = ["rustls"] }
 addr2line = { version = "0.19", default-features = false }
 adler = { version = "1", default-features = false }
 aead = { version = "0.5", default-features = false, features = ["alloc", "getrandom"] }
 aes = { version = "0.8", default-features = false }
 aes-gcm = { version = "0.10" }
-ahash-c38e5c1d305a1b54 = { package = "ahash", version = "0.8", default-features = false }
+ahash-c38e5c1d305a1b54 = { package = "ahash", version = "0.8" }
 ahash-ca01ad9e24f5d932 = { package = "ahash", version = "0.7" }
 aho-corasick-ca01ad9e24f5d932 = { package = "aho-corasick", version = "0.7" }
 aho-corasick-dff4ba8e3ae991db = { package = "aho-corasick", version = "1" }
@@ -96,7 +105,7 @@ block-buffer-93f6ce9d446188ac = { package = "block-buffer", version = "0.10", de
 block-padding-468e82937335b1c9 = { package = "block-padding", version = "0.3", default-features = false, features = ["std"] }
 block-padding-6f8ce4dd05d13bba = { package = "block-padding", version = "0.2", default-features = false }
 blst = { version = "0.3", features = ["no-threads"] }
-brotli = { version = "3", default-features = false, features = ["std"] }
+brotli = { version = "3" }
 brotli-decompressor = { version = "2", default-features = false, features = ["std"] }
 bs58 = { version = "0.4", features = ["check"] }
 bstr = { version = "1" }
@@ -106,6 +115,7 @@ bytecode-interpreter-crypto = { path = "../../external-crates/move/move-prover/i
 bytemuck = { version = "1", default-features = false }
 byteorder = { version = "1", features = ["i128"] }
 bytes = { version = "1", features = ["serde"] }
+bytestring = { version = "1", default-features = false }
 bzip2-sys = { version = "0.1", default-features = false, features = ["static"] }
 cached = { version = "0.43" }
 cached_proc_macro_types = { version = "0.1", default-features = false }
@@ -145,6 +155,7 @@ console-subscriber = { version = "0.1" }
 const-oid = { version = "0.9", default-features = false }
 const-str = { version = "0.5" }
 constant_time_eq = { version = "0.2", default-features = false }
+cookie = { version = "0.16", default-features = false, features = ["percent-encode"] }
 core2 = { version = "0.4", default-features = false, features = ["alloc"] }
 crc32fast = { version = "1" }
 criterion = { version = "0.4", features = ["async_tokio", "html_reports"] }
@@ -205,6 +216,7 @@ either = { version = "1" }
 elliptic-curve-594e8ee84c453af0 = { package = "elliptic-curve", version = "0.13", features = ["hash2curve", "hazmat", "pem", "std"] }
 elliptic-curve-5ef9efb8ec2df382 = { package = "elliptic-curve", version = "0.12", default-features = false, features = ["arithmetic", "digest", "hazmat", "sec1"] }
 encode_unicode-dff4ba8e3ae991db = { package = "encode_unicode", version = "1" }
+encoding_rs = { version = "0.8" }
 endian-type = { version = "0.1", default-features = false }
 enum-compat-util = { path = "../../external-crates/move/testing-infra/enum-compat-util", default-features = false }
 ethnum = { version = "1", default-features = false }
@@ -313,6 +325,7 @@ jsonrpsee-wasm-client = { git = "https://github.com/wlmyng/jsonrpsee.git", rev =
 jsonrpsee-ws-client = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8" }
 k256 = { version = "0.11", default-features = false, features = ["ecdsa", "keccak256"] }
 keccak = { version = "0.1", default-features = false }
+language-tags = { version = "0.3", default-features = false }
 lazy_static-6f8ce4dd05d13bba = { package = "lazy_static", version = "0.2", default-features = false }
 lazy_static-dff4ba8e3ae991db = { package = "lazy_static", version = "1", default-features = false, features = ["spin_no_std"] }
 leb128 = { version = "0.2", default-features = false }
@@ -323,6 +336,8 @@ librocksdb-sys = { version = "0.11", features = ["bzip2", "lz4", "snappy", "zlib
 libtest-mimic = { version = "0.5", default-features = false }
 libz-sys = { version = "1", default-features = false, features = ["static"] }
 linked-hash-map = { version = "0.5", default-features = false }
+local-channel = { version = "0.1", default-features = false }
+local-waker = { version = "0.1", default-features = false }
 lock_api = { version = "0.4", default-features = false }
 log = { version = "0.4", default-features = false, features = ["serde", "std"] }
 lru = { version = "0.10" }
@@ -696,12 +711,23 @@ zstd-sys = { version = "2", features = ["std"] }
 
 [build-dependencies]
 Inflector = { version = "0.11", default-features = false }
+actix-codec = { version = "0.5", default-features = false }
+actix-http = { version = "3", features = ["compress-brotli", "compress-gzip", "compress-zstd", "http2", "rustls", "ws"] }
+actix-macros = { version = "0.2", default-features = false }
+actix-router = { version = "0.5" }
+actix-rt = { version = "2", default-features = false }
+actix-server = { version = "2" }
+actix-service = { version = "2", default-features = false }
+actix-tls = { version = "3", default-features = false, features = ["accept", "rustls"] }
+actix-utils = { version = "3", default-features = false }
+actix-web = { version = "4", features = ["rustls"] }
+actix-web-codegen = { version = "4", default-features = false }
 addr2line = { version = "0.19", default-features = false }
 adler = { version = "1", default-features = false }
 aead = { version = "0.5", default-features = false, features = ["alloc", "getrandom"] }
 aes = { version = "0.8", default-features = false }
 aes-gcm = { version = "0.10" }
-ahash-c38e5c1d305a1b54 = { package = "ahash", version = "0.8", default-features = false }
+ahash-c38e5c1d305a1b54 = { package = "ahash", version = "0.8" }
 ahash-ca01ad9e24f5d932 = { package = "ahash", version = "0.7" }
 aho-corasick-ca01ad9e24f5d932 = { package = "aho-corasick", version = "0.7" }
 aho-corasick-dff4ba8e3ae991db = { package = "aho-corasick", version = "1" }
@@ -789,7 +815,7 @@ block-buffer-93f6ce9d446188ac = { package = "block-buffer", version = "0.10", de
 block-padding-468e82937335b1c9 = { package = "block-padding", version = "0.3", default-features = false, features = ["std"] }
 block-padding-6f8ce4dd05d13bba = { package = "block-padding", version = "0.2", default-features = false }
 blst = { version = "0.3", features = ["no-threads"] }
-brotli = { version = "3", default-features = false, features = ["std"] }
+brotli = { version = "3" }
 brotli-decompressor = { version = "2", default-features = false, features = ["std"] }
 bs58 = { version = "0.4", features = ["check"] }
 bstr = { version = "1" }
@@ -800,6 +826,7 @@ bytecode-interpreter-crypto = { path = "../../external-crates/move/move-prover/i
 bytemuck = { version = "1", default-features = false }
 byteorder = { version = "1", features = ["i128"] }
 bytes = { version = "1", features = ["serde"] }
+bytestring = { version = "1", default-features = false }
 bzip2-sys = { version = "0.1", default-features = false, features = ["static"] }
 cached = { version = "0.43" }
 cached_proc_macro = { version = "0.16", default-features = false }
@@ -848,6 +875,7 @@ const-str = { version = "0.5" }
 constant_time_eq = { version = "0.2", default-features = false }
 convert_case-3b31131e45eafb45 = { package = "convert_case", version = "0.6", default-features = false }
 convert_case-9fbad63c4bcf4a8f = { package = "convert_case", version = "0.4", default-features = false }
+cookie = { version = "0.16", default-features = false, features = ["percent-encode"] }
 core2 = { version = "0.4", default-features = false, features = ["alloc"] }
 crc32fast = { version = "1" }
 criterion = { version = "0.4", features = ["async_tokio", "html_reports"] }
@@ -921,6 +949,7 @@ either = { version = "1" }
 elliptic-curve-594e8ee84c453af0 = { package = "elliptic-curve", version = "0.13", features = ["hash2curve", "hazmat", "pem", "std"] }
 elliptic-curve-5ef9efb8ec2df382 = { package = "elliptic-curve", version = "0.12", default-features = false, features = ["arithmetic", "digest", "hazmat", "sec1"] }
 encode_unicode-dff4ba8e3ae991db = { package = "encode_unicode", version = "1" }
+encoding_rs = { version = "0.8" }
 endian-type = { version = "0.1", default-features = false }
 enum-compat-util = { path = "../../external-crates/move/testing-infra/enum-compat-util", default-features = false }
 enum_dispatch = { version = "0.3", default-features = false }
@@ -1042,6 +1071,7 @@ jsonrpsee-wasm-client = { git = "https://github.com/wlmyng/jsonrpsee.git", rev =
 jsonrpsee-ws-client = { git = "https://github.com/wlmyng/jsonrpsee.git", rev = "b1b300784795f6a64d0fcdf8f03081a9bc38bde8" }
 k256 = { version = "0.11", default-features = false, features = ["ecdsa", "keccak256"] }
 keccak = { version = "0.1", default-features = false }
+language-tags = { version = "0.3", default-features = false }
 lazy_static-6f8ce4dd05d13bba = { package = "lazy_static", version = "0.2", default-features = false }
 lazy_static-dff4ba8e3ae991db = { package = "lazy_static", version = "1", default-features = false, features = ["spin_no_std"] }
 lazycell = { version = "1", default-features = false }
@@ -1054,6 +1084,8 @@ librocksdb-sys = { version = "0.11", features = ["bzip2", "lz4", "snappy", "zlib
 libtest-mimic = { version = "0.5", default-features = false }
 libz-sys = { version = "1", default-features = false, features = ["static"] }
 linked-hash-map = { version = "0.5", default-features = false }
+local-channel = { version = "0.1", default-features = false }
+local-waker = { version = "0.1", default-features = false }
 lock_api = { version = "0.4", default-features = false }
 log = { version = "0.4", default-features = false, features = ["serde", "std"] }
 lru = { version = "0.10" }
@@ -1496,13 +1528,11 @@ zstd-safe = { version = "6", default-features = false, features = ["arrays", "le
 zstd-sys = { version = "2", features = ["std"] }
 
 [target.aarch64-apple-darwin.dependencies]
-ahash-c38e5c1d305a1b54 = { package = "ahash", version = "0.8" }
 core-foundation = { version = "0.9", default-features = false }
 core-foundation-sys = { version = "0.8", default-features = false }
 cpp_demangle = { version = "0.4" }
 cpufeatures = { version = "0.2", default-features = false }
 debugid = { version = "0.8", default-features = false }
-encoding_rs = { version = "0.8" }
 errno-468e82937335b1c9 = { package = "errno", version = "0.3", default-features = false }
 errno-6f8ce4dd05d13bba = { package = "errno", version = "0.2", default-features = false }
 findshlibs = { version = "0.10", default-features = false }
@@ -1539,14 +1569,12 @@ tokio-rustls-adf3d7031871b0af = { package = "tokio-rustls", version = "0.24" }
 web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 
 [target.aarch64-apple-darwin.build-dependencies]
-ahash-c38e5c1d305a1b54 = { package = "ahash", version = "0.8" }
 autotools = { version = "0.2", default-features = false }
 core-foundation = { version = "0.9", default-features = false }
 core-foundation-sys = { version = "0.8", default-features = false }
 cpp_demangle = { version = "0.4" }
 cpufeatures = { version = "0.2", default-features = false }
 debugid = { version = "0.8", default-features = false }
-encoding_rs = { version = "0.8" }
 errno-468e82937335b1c9 = { package = "errno", version = "0.3", default-features = false }
 errno-6f8ce4dd05d13bba = { package = "errno", version = "0.2", default-features = false }
 findshlibs = { version = "0.10", default-features = false }
@@ -1584,11 +1612,9 @@ tokio-rustls-adf3d7031871b0af = { package = "tokio-rustls", version = "0.24" }
 web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
-ahash-c38e5c1d305a1b54 = { package = "ahash", version = "0.8" }
 cpp_demangle = { version = "0.4" }
 cpufeatures = { version = "0.2", default-features = false }
 debugid = { version = "0.8", default-features = false }
-encoding_rs = { version = "0.8" }
 findshlibs = { version = "0.10", default-features = false }
 hyper-rustls-adf3d7031871b0af = { package = "hyper-rustls", version = "0.24", default-features = false }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
@@ -1624,12 +1650,10 @@ tokio-rustls-adf3d7031871b0af = { package = "tokio-rustls", version = "0.24" }
 web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
-ahash-c38e5c1d305a1b54 = { package = "ahash", version = "0.8" }
 autotools = { version = "0.2", default-features = false }
 cpp_demangle = { version = "0.4" }
 cpufeatures = { version = "0.2", default-features = false }
 debugid = { version = "0.8", default-features = false }
-encoding_rs = { version = "0.8" }
 findshlibs = { version = "0.10", default-features = false }
 hyper-rustls-adf3d7031871b0af = { package = "hyper-rustls", version = "0.24", default-features = false }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
@@ -1672,7 +1696,6 @@ cpufeatures = { version = "0.2", default-features = false }
 crossterm_winapi-274715c4dabd11b0 = { package = "crossterm_winapi", version = "0.9", default-features = false }
 crossterm_winapi-c38e5c1d305a1b54 = { package = "crossterm_winapi", version = "0.8", default-features = false }
 encode_unicode-468e82937335b1c9 = { package = "encode_unicode", version = "0.3" }
-encoding_rs = { version = "0.8" }
 error-code = { version = "2", default-features = false }
 hyper-rustls-adf3d7031871b0af = { package = "hyper-rustls", version = "0.24", default-features = false }
 ipnet = { version = "2" }
@@ -1703,7 +1726,6 @@ crossterm_winapi-274715c4dabd11b0 = { package = "crossterm_winapi", version = "0
 crossterm_winapi-c38e5c1d305a1b54 = { package = "crossterm_winapi", version = "0.8", default-features = false }
 ctor = { version = "0.1", default-features = false }
 encode_unicode-468e82937335b1c9 = { package = "encode_unicode", version = "0.3" }
-encoding_rs = { version = "0.8" }
 error-code = { version = "2", default-features = false }
 hyper-rustls-adf3d7031871b0af = { package = "hyper-rustls", version = "0.24", default-features = false }
 ipnet = { version = "2" }


### PR DESCRIPTION
## Description 

This adds a basic server (with `actix`) for serving source. The intent is just to get the package and directory structure sorted out. I:

- added a `main.rs` for the binary
- `lib.rs` where the main implementation will go
- `tests/tests.rs` for tests
- placed in `crates/sui-source-validation-service` tomirror `crates/sui-source-validation`

Feedback welcome on this structure.

See [reference doc](https://www.notion.so/mystenlabs/Move-Source-Provider-Service-91ec291be3b94c0f8133e981b76988c0) for background on this work.

Thanks to @mystenmark for unblocking `actix` dependency with https://github.com/MystenLabs/sui/pull/12583!

## Test Plan 

Added a basic test that will exercise end-to-end functionality later.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
