### PR TITLE
Release Notes PR checker and generator

### DIFF
--- a/.github/workflows/generate-release-notes.yml
+++ b/.github/workflows/generate-release-notes.yml
@@ -1,0 +1,27 @@
+name: Generate Release Notes
+
+on:
+  workflow_dispatch:
+    inputs:
+      previous_branch:
+        description: 'Previous Release Branch (releases/sui-vX.X.X-release)'
+        type: string
+        required: true
+      new_branch:
+        description: 'New Release Branch (releases/sui-vX.X.X-release)'
+        type: string
+        required: true
+
+jobs:
+  generate-release-notes:
+    name: Generate Release Notes
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Run script
+      shell: bash
+      run: |
+        ./scripts/generate-release-notes.sh ${{ inputs.new_branch }} ${{ inputs.previous_branch }}

--- a/.github/workflows/release-notes-checker.yml
+++ b/.github/workflows/release-notes-checker.yml
@@ -1,0 +1,33 @@
+name: Release Notes PR Checker
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - 'crates/*'
+      - 'dashboards/*'
+      - 'doc/*'
+      - 'docker/*'
+      - 'external-crates/*'
+      - 'kiosk/*'
+      - 'narwhal/*'
+      - 'nre/*'
+      - 'sui-execution/*'
+
+jobs:
+  verify_description:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check Pull Request Description
+        shell: bash
+        run: |
+          PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+          DESCRIPTION=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/MystenLabs/sui/pulls//pulls/$PR_NUMBER" \
+            | jq --raw-output .body)
+          
+          if [[ $DESCRIPTION =~ \[x\].*Release[[:space:]]notes.*[[:space:]]+.* ]]; then
+            echo "At least one '[x]' was checked under 'Type of Change (Check all that apply)', you need to add a blob under the 'Release Notes' section."
+            exit 1
+          fi

--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Generate Release Notes
+
+if [ $# -lt 2 ];
+then
+    echo "./generate-release-notes.sh [previous branch] [new branch]"
+    exit
+else
+    prev_branch=$1
+    new_branch=$2
+fi
+
+for pr_number in $(git log --grep "\[x\]" --pretty=oneline --abbrev-commit origin/"${new_branch}"...origin/"${prev_branch}" -- crates dashboards doc docker external-crates kiosk narwhal nre sui-execution | grep -o '#[0-9]\+' | grep -o '[0-9]\+')
+do
+    pr_body=$(gh api -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/MystenLabs/sui/pulls/"${pr_number}" --jq ".body")
+    release_notes="${pr_body#*### Release notes}"
+    echo "https://github.com/MystenLabs/sui/pull/${pr_number}: ${release_notes}"
+done


### PR DESCRIPTION
## Description 
Release Notes PR checker and generator

## Test Plan
```
eugene@mac-studio ~/code/sui (eugene/create_release_notes_workflow) $ ./scripts/generate-release-notes.sh releases/sui-v1.3.0-release releases/sui-v1.2.0-release
https://github.com/MystenLabs/sui/pull/12359:
https://github.com/MystenLabs/sui/pull/12444:

Introduce new modules: `clob_v2` and `custodian_v2` and deprecate `clob` and `custodian`.
https://github.com/MystenLabs/sui/pull/12231:
Adds the checkpoint low watermark for state sync. This lets a node to know who to query checkpoint contents according to the watermarks, once checkpoint pruning is enabled.
https://github.com/MystenLabs/sui/pull/12321:
https://github.com/MystenLabs/sui/pull/12251:
https://github.com/MystenLabs/sui/pull/12092:

Added a version of stake withdraw function that returns the withdrawn SUI tokens, for better composability.
https://github.com/MystenLabs/sui/pull/12258:
https://github.com/MystenLabs/sui/pull/12171:
update anemo to https://github.com/MystenLabs/anemo/commit/1bfa7842f66a85d35345b5ada358df90c3efd579 which includes the `alternate_server_name` change. Set primary server name as `sui-{chain-id}`.  Note that if node starts to run this version in testnet/mainnet before the update is officially rolled out, it's likely the node won't be able to state sync.
https://github.com/MystenLabs/sui/pull/12043:

- adds `sui::kiosk::default()` function for easy Kiosk setup
```
Will test the workflows once this PR lands