### PR TITLE
[CLI] Import wallet private key

### DIFF
--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -345,11 +345,12 @@ impl KeyToolCommand {
             } => {
                 // check if input is a private key -- should start with 0x
                 if input_string.starts_with("0x") {
-                    let bytes = Hex::decode(&input_string)
-                        .map_err(|_| anyhow!("Private key is malformed. Importing failed"))?;
+                    let bytes = Hex::decode(&input_string).map_err(|_| {
+                        anyhow!("Private key is malformed. Importing private key failed.")
+                    })?;
                     match key_scheme {
                         SignatureScheme::ED25519 => {
-                            let kp = Ed25519KeyPair::from_bytes(&bytes).map_err(|_| anyhow!("Cannot decode ed25519 keypair from the private key. Import failed."))?;
+                            let kp = Ed25519KeyPair::from_bytes(&bytes).map_err(|_| anyhow!("Cannot decode ed25519 keypair from the private key. Importing private key failed."))?;
                             let skp = SuiKeyPair::Ed25519(kp);
                             let address = Into::<SuiAddress>::into(&skp.public()).to_string();
                             keystore.add_key(skp)?;

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -346,12 +346,10 @@ impl KeyToolCommand {
                 // check if input is a private key -- should start with 0x
                 if input_string.starts_with("0x") {
                     let bytes = Hex::decode(&input_string)
-                        .or_else(|_| Err(anyhow!("Private key is malformed. Importing failed")))?;
+                        .map_err(|_| anyhow!("Private key is malformed. Importing failed"))?;
                     match key_scheme {
                         SignatureScheme::ED25519 => {
-                            let kp = Ed25519KeyPair::from_bytes(&bytes).or_else(|_| Err(anyhow!(
-                                "Cannot decode ed25519 keypair from private key. Importing failed."
-                            )))?;
+                            let kp = Ed25519KeyPair::from_bytes(&bytes).map_err(|_| anyhow!("Cannot decode ed25519 keypair from the private key. Import failed."))?;
                             let skp = SuiKeyPair::Ed25519(kp);
                             let address = Into::<SuiAddress>::into(&skp.public()).to_string();
                             keystore.add_key(skp)?;

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -352,7 +352,7 @@ impl KeyToolCommand {
                         SignatureScheme::ED25519 => {
                             let kp = Ed25519KeyPair::from_bytes(&bytes).map_err(|_| anyhow!("Cannot decode ed25519 keypair from the private key. Importing private key failed."))?;
                             let skp = SuiKeyPair::Ed25519(kp);
-                            let address = Into::<SuiAddress>::into(&skp.public()).to_string();
+                            let address: SuiAddress = Into::<SuiAddress>::into(&skp.public());
                             keystore.add_key(skp)?;
                             eprintln!("Private key imported successfully.");
                             println!("{address}")

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -110,7 +110,7 @@ pub enum KeyToolCommand {
         #[clap(long)]
         base64pk: String,
     },
-    /// Add a new key to sui.keystore based on the input mnemonic phrase, the key scheme flag {ed25519 | secp256k1 | secp256r1}
+    /// Add a new key to sui.keystore uisng either the input mnemonic phrase or a private key (from the Wallet), the key scheme flag {ed25519 | secp256k1 | secp256r1}
     /// and an optional derivation path, default to m/44'/784'/0'/0'/0' for ed25519 or m/54'/784'/0'/0/0 for secp256k1
     /// or m/74'/784'/0'/0/0 for secp256r1. Supports mnemonic phrase of word length 12, 15, 18`, 21, 24.
     Import {
@@ -351,13 +351,15 @@ impl KeyToolCommand {
                         keystore.add_key(skp)?;
                         println!("Private key imported successfully.")
                     } else {
-                        println!("Cannot decode base64 from private key. Importing failed.")
+                        return Err(anyhow!(
+                            "Cannot decode base64 from private key. Importing failed."
+                        ));
                     }
                 } else if input_string.starts_with("0x") && input_string.len() != 66 {
-                    println!(
-                        "Private key is malformed. Expected length of 66 but got {}",
+                    return Err(anyhow!(
+                        "Private key is malformed. Expected key length of 66 but got {}",
                         input_string.len()
-                    )
+                    ));
                 } else {
                     keystore.import_from_mnemonic(&input_string, key_scheme, derivation_path)?;
                     println!("Mnemonic imported successfully.")

--- a/crates/sui/src/unit_tests/keytool_tests.rs
+++ b/crates/sui/src/unit_tests/keytool_tests.rs
@@ -197,45 +197,45 @@ async fn test_load_keystore_err() {
 
 #[test]
 async fn test_private_keys_ed25519() -> Result<(), anyhow::Error> {
-    // private key, address
-    const TEST_CASES: [[&str; 3]; 3] = [
-        [
+    // private key, base64, address
+    const TEST_CASES: &[(&str, &str, &str)] = &[
+        (
             "0x9dd9ae36ee51b912a0364c58c1f21333bcdad2d91911aa127226c512be285102",
             "AJ3ZrjbuUbkSoDZMWMHyEzO82tLZGRGqEnImxRK+KFEC",
             "0x90f3e6d73b5730f16974f4df1d3441394ebae62186baf83608599f226455afa7",
-        ],
-        [
+        ),
+        (
             "0xeea84be738c59f56ee94dae8fd5a68082d4579ed38548d6ec4017da6c5619bf3",
             "AO6oS+c4xZ9W7pTa6P1aaAgtRXntOFSNbsQBfabFYZvz",
             "0xfd233cd9a5dd7e577f16fa523427c75fbc382af1583c39fdf1c6747d2ed807a3",
-        ],
-        [
+        ),
+        (
             "0x91e8808c489ee0cc99c2edf79e63be6a144f8f600c7411bc2e806f7255710674",
             "AJHogIxInuDMmcLt955jvmoUT49gDHQRvC6Ab3JVcQZ0",
             "0x81aaefa4a883e72e8b6ccd3bec307e25fe3d79b14e43b778695c55dcec42f4f0",
-        ],
+        ),
     ];
     // assert correctness
-    for t in TEST_CASES {
+    for (private_key, base64, address) in TEST_CASES {
         let mut keystore = Keystore::from(InMemKeystore::new_insecure_for_tests(0));
         KeyToolCommand::Import {
-            input_string: t[0].to_string(),
+            input_string: private_key.to_string(),
             key_scheme: SignatureScheme::ED25519,
             derivation_path: None,
         }
         .execute(&mut keystore)
         .await?;
-        let kp = SuiKeyPair::decode_base64(t[1]).unwrap();
-        let addr = SuiAddress::from_str(t[2]).unwrap();
+        let kp = SuiKeyPair::decode_base64(base64).unwrap();
+        let addr = SuiAddress::from_str(address).unwrap();
         assert_eq!(SuiAddress::from(&kp.public()), addr);
         assert!(keystore.addresses().contains(&addr));
     }
 
     // assert failure when private key is malformed
-    for t in TEST_CASES {
+    for (private_key, _, _) in TEST_CASES {
         let mut keystore = Keystore::from(InMemKeystore::new_insecure_for_tests(0));
         let output = KeyToolCommand::Import {
-            input_string: t[0][..25].to_string(),
+            input_string: private_key[..25].to_string(),
             key_scheme: SignatureScheme::ED25519,
             derivation_path: None,
         }

--- a/crates/sui/src/unit_tests/keytool_tests.rs
+++ b/crates/sui/src/unit_tests/keytool_tests.rs
@@ -196,6 +196,44 @@ async fn test_load_keystore_err() {
 }
 
 #[test]
+async fn test_private_keys_ed25519() -> Result<(), anyhow::Error> {
+    // private key, address
+    const TEST_CASES: [[&str; 3]; 3] = [
+        [
+            "0x9dd9ae36ee51b912a0364c58c1f21333bcdad2d91911aa127226c512be285102",
+            "AJ3ZrjbuUbkSoDZMWMHyEzO82tLZGRGqEnImxRK+KFEC",
+            "0x90f3e6d73b5730f16974f4df1d3441394ebae62186baf83608599f226455afa7",
+        ],
+        [
+            "0xeea84be738c59f56ee94dae8fd5a68082d4579ed38548d6ec4017da6c5619bf3",
+            "AO6oS+c4xZ9W7pTa6P1aaAgtRXntOFSNbsQBfabFYZvz",
+            "0xfd233cd9a5dd7e577f16fa523427c75fbc382af1583c39fdf1c6747d2ed807a3",
+        ],
+        [
+            "0x91e8808c489ee0cc99c2edf79e63be6a144f8f600c7411bc2e806f7255710674",
+            "AJHogIxInuDMmcLt955jvmoUT49gDHQRvC6Ab3JVcQZ0",
+            "0x81aaefa4a883e72e8b6ccd3bec307e25fe3d79b14e43b778695c55dcec42f4f0",
+        ],
+    ];
+
+    for t in TEST_CASES {
+        let mut keystore = Keystore::from(InMemKeystore::new_insecure_for_tests(0));
+        KeyToolCommand::Import {
+            input_string: t[0].to_string(),
+            key_scheme: SignatureScheme::ED25519,
+            derivation_path: None,
+        }
+        .execute(&mut keystore)
+        .await?;
+        let kp = SuiKeyPair::decode_base64(t[1]).unwrap();
+        let addr = SuiAddress::from_str(t[2]).unwrap();
+        assert_eq!(SuiAddress::from(&kp.public()), addr);
+        assert!(keystore.addresses().contains(&addr));
+    }
+    Ok(())
+}
+
+#[test]
 async fn test_mnemonics_ed25519() -> Result<(), anyhow::Error> {
     // Test case matches with /mysten/sui/sdk/typescript/test/unit/cryptography/ed25519-keypair.test.ts
     const TEST_CASES: [[&str; 3]; 3] = [["film crazy soon outside stand loop subway crumble thrive popular green nuclear struggle pistol arm wife phrase warfare march wheat nephew ask sunny firm", "AN0JMHpDum3BhrVwnkylH0/HGRHBQ/fO/8+MYOawO8j6", "a2d14fad60c56049ecf75246a481934691214ce413e6a8ae2fe6834c173a6133"],
@@ -205,7 +243,7 @@ async fn test_mnemonics_ed25519() -> Result<(), anyhow::Error> {
     for t in TEST_CASES {
         let mut keystore = Keystore::from(InMemKeystore::new_insecure_for_tests(0));
         KeyToolCommand::Import {
-            mnemonic_phrase: t[0].to_string(),
+            input_string: t[0].to_string(),
             key_scheme: SignatureScheme::ED25519,
             derivation_path: None,
         }
@@ -229,7 +267,7 @@ async fn test_mnemonics_secp256k1() -> Result<(), anyhow::Error> {
     for t in TEST_CASES {
         let mut keystore = Keystore::from(InMemKeystore::new_insecure_for_tests(0));
         KeyToolCommand::Import {
-            mnemonic_phrase: t[0].to_string(),
+            input_string: t[0].to_string(),
             key_scheme: SignatureScheme::Secp256k1,
             derivation_path: None,
         }
@@ -267,7 +305,7 @@ async fn test_mnemonics_secp256r1() -> Result<(), anyhow::Error> {
     for t in TEST_CASES {
         let mut keystore = Keystore::from(InMemKeystore::new_insecure_for_tests(0));
         KeyToolCommand::Import {
-            mnemonic_phrase: t[0].to_string(),
+            input_string: t[0].to_string(),
             key_scheme: SignatureScheme::Secp256r1,
             derivation_path: None,
         }
@@ -288,7 +326,7 @@ async fn test_mnemonics_secp256r1() -> Result<(), anyhow::Error> {
 async fn test_invalid_derivation_path() -> Result<(), anyhow::Error> {
     let mut keystore = Keystore::from(InMemKeystore::new_insecure_for_tests(0));
     assert!(KeyToolCommand::Import {
-        mnemonic_phrase: TEST_MNEMONIC.to_string(),
+        input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::ED25519,
         derivation_path: Some("m/44'/1'/0'/0/0".parse().unwrap()),
     }
@@ -297,7 +335,7 @@ async fn test_invalid_derivation_path() -> Result<(), anyhow::Error> {
     .is_err());
 
     assert!(KeyToolCommand::Import {
-        mnemonic_phrase: TEST_MNEMONIC.to_string(),
+        input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::ED25519,
         derivation_path: Some("m/0'/784'/0'/0/0".parse().unwrap()),
     }
@@ -306,7 +344,7 @@ async fn test_invalid_derivation_path() -> Result<(), anyhow::Error> {
     .is_err());
 
     assert!(KeyToolCommand::Import {
-        mnemonic_phrase: TEST_MNEMONIC.to_string(),
+        input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::ED25519,
         derivation_path: Some("m/54'/784'/0'/0/0".parse().unwrap()),
     }
@@ -315,7 +353,7 @@ async fn test_invalid_derivation_path() -> Result<(), anyhow::Error> {
     .is_err());
 
     assert!(KeyToolCommand::Import {
-        mnemonic_phrase: TEST_MNEMONIC.to_string(),
+        input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::Secp256k1,
         derivation_path: Some("m/54'/784'/0'/0'/0'".parse().unwrap()),
     }
@@ -324,7 +362,7 @@ async fn test_invalid_derivation_path() -> Result<(), anyhow::Error> {
     .is_err());
 
     assert!(KeyToolCommand::Import {
-        mnemonic_phrase: TEST_MNEMONIC.to_string(),
+        input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::Secp256k1,
         derivation_path: Some("m/44'/784'/0'/0/0".parse().unwrap()),
     }
@@ -339,7 +377,7 @@ async fn test_invalid_derivation_path() -> Result<(), anyhow::Error> {
 async fn test_valid_derivation_path() -> Result<(), anyhow::Error> {
     let mut keystore = Keystore::from(InMemKeystore::new_insecure_for_tests(0));
     assert!(KeyToolCommand::Import {
-        mnemonic_phrase: TEST_MNEMONIC.to_string(),
+        input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::ED25519,
         derivation_path: Some("m/44'/784'/0'/0'/0'".parse().unwrap()),
     }
@@ -348,7 +386,7 @@ async fn test_valid_derivation_path() -> Result<(), anyhow::Error> {
     .is_ok());
 
     assert!(KeyToolCommand::Import {
-        mnemonic_phrase: TEST_MNEMONIC.to_string(),
+        input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::ED25519,
         derivation_path: Some("m/44'/784'/0'/0'/1'".parse().unwrap()),
     }
@@ -357,7 +395,7 @@ async fn test_valid_derivation_path() -> Result<(), anyhow::Error> {
     .is_ok());
 
     assert!(KeyToolCommand::Import {
-        mnemonic_phrase: TEST_MNEMONIC.to_string(),
+        input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::ED25519,
         derivation_path: Some("m/44'/784'/1'/0'/1'".parse().unwrap()),
     }
@@ -366,7 +404,7 @@ async fn test_valid_derivation_path() -> Result<(), anyhow::Error> {
     .is_ok());
 
     assert!(KeyToolCommand::Import {
-        mnemonic_phrase: TEST_MNEMONIC.to_string(),
+        input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::Secp256k1,
         derivation_path: Some("m/54'/784'/0'/0/1".parse().unwrap()),
     }
@@ -375,7 +413,7 @@ async fn test_valid_derivation_path() -> Result<(), anyhow::Error> {
     .is_ok());
 
     assert!(KeyToolCommand::Import {
-        mnemonic_phrase: TEST_MNEMONIC.to_string(),
+        input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::Secp256k1,
         derivation_path: Some("m/54'/784'/1'/0/1".parse().unwrap()),
     }

--- a/crates/sui/src/unit_tests/keytool_tests.rs
+++ b/crates/sui/src/unit_tests/keytool_tests.rs
@@ -215,7 +215,7 @@ async fn test_private_keys_ed25519() -> Result<(), anyhow::Error> {
             "0x81aaefa4a883e72e8b6ccd3bec307e25fe3d79b14e43b778695c55dcec42f4f0",
         ],
     ];
-
+    // assert correctness
     for t in TEST_CASES {
         let mut keystore = Keystore::from(InMemKeystore::new_insecure_for_tests(0));
         KeyToolCommand::Import {
@@ -230,6 +230,20 @@ async fn test_private_keys_ed25519() -> Result<(), anyhow::Error> {
         assert_eq!(SuiAddress::from(&kp.public()), addr);
         assert!(keystore.addresses().contains(&addr));
     }
+
+    // assert failure when private key is malformed
+    for t in TEST_CASES {
+        let mut keystore = Keystore::from(InMemKeystore::new_insecure_for_tests(0));
+        let output = KeyToolCommand::Import {
+            input_string: t[0][..25].to_string(),
+            key_scheme: SignatureScheme::ED25519,
+            derivation_path: None,
+        }
+        .execute(&mut keystore)
+        .await;
+        assert!(output.is_err());
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
## Description 

The Sui CLI `keytool import` command now accepts either a MNEMONIC or a private key (from the Sui Wallet). The user exports a private key associated with an account in the Wallet, and uses that private key in the `keytool import` command in the CLI to import the account in the CLI. 

## Test Plan 

There is a new function to test the new private key code (`test_private_keys_ed25519`)

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Add support to the `keytool import` command to allow for importing a private key (from the wallet) in addition to the existing support of importing an account via a mnemonic. 