### PR TITLE
Change cost tables for gas

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/size_limits/deleted_id_limits_tests.exp
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/deleted_id_limits_tests.exp
@@ -11,11 +11,11 @@ gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 9
 
 task 3 'run'. lines 39-41:
 mutated: object(0,0)
-gas summary: computation_cost: 10000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 4 'run'. lines 42-44:
 mutated: object(0,0)
-gas summary: computation_cost: 96000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 5000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 5 'run'. lines 45-47:
 Error: Transaction Effects Status: Move Primitive Runtime Error. Location: sui::tx_context::derive_id (function index 6) at offset 0. Arithmetic error, stack overflow, max value depth, etc.

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/event_limits_tests.exp
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/event_limits_tests.exp
@@ -13,7 +13,7 @@ gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 9
 task 3 'run'. lines 61-63:
 events: 50
 mutated: 1
-gas summary: computation_cost: 11000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 4 'run'. lines 64-66:
 Error: Transaction Effects Status: Move Primitive Runtime Error. Location: sui::event::emit (function index 0) at offset 0. Arithmetic error, stack overflow, max value depth, etc.
@@ -26,12 +26,12 @@ Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { k
 task 6 'run'. lines 70-72:
 events: 1
 mutated: 1
-gas summary: computation_cost: 1521000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1413000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 7 'run'. lines 73-75:
 events: 1
 mutated: 1
-gas summary: computation_cost: 1948000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1840000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 8 'run'. lines 76-78:
 Error: Transaction Effects Status: Move Primitive Runtime Error. Location: sui::event::emit (function index 0) at offset 0. Arithmetic error, stack overflow, max value depth, etc.

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/move_object_size_limit.exp
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/move_object_size_limit.exp
@@ -15,9 +15,9 @@ Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { k
 task 3 'run'. lines 86-88:
 created: object(3,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1996000000, storage_cost: 1947553200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1888000000, storage_cost: 1947553200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 4 'run'. lines 89-89:
 created: object(4,0)
 mutated: object(0,0)
-gas summary: computation_cost: 1996000000, storage_cost: 1947560800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1888000000, storage_cost: 1947560800,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/new_id_limits_tests.exp
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/new_id_limits_tests.exp
@@ -11,11 +11,11 @@ gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 9
 
 task 3 'run'. lines 40-42:
 mutated: object(0,0)
-gas summary: computation_cost: 10000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 4 'run'. lines 43-45:
 mutated: object(0,0)
-gas summary: computation_cost: 96000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 5000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 5 'run'. lines 46-48:
 Error: Transaction Effects Status: Move Primitive Runtime Error. Location: sui::tx_context::derive_id (function index 6) at offset 0. Arithmetic error, stack overflow, max value depth, etc.

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/object_runtime_limits.exp
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/object_runtime_limits.exp
@@ -11,12 +11,12 @@ gas summary: computation_cost: 1000000, storage_cost: 5821600,  storage_rebate: 
 task 2 'run'. lines 30-30:
 created: 200
 mutated: 1
-gas summary: computation_cost: 9000000, storage_cost: 270028000,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 270028000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 3 'run'. lines 32-32:
 created: 2000
 mutated: 1
-gas summary: computation_cost: 106000000, storage_cost: 2691388000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 7000000, storage_cost: 2691388000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 4 'run'. lines 34-34:
 Error: Transaction Effects Status: Move Primitive Runtime Error. Location: sui::dynamic_field::has_child_object (function index 14) at offset 0. Arithmetic error, stack overflow, max value depth, etc.

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/transfered_id_limits_tests.exp
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/transfered_id_limits_tests.exp
@@ -13,12 +13,12 @@ gas summary: computation_cost: 1000000, storage_cost: 2219200,  storage_rebate: 
 task 3 'run'. lines 39-41:
 created: 256
 mutated: 1
-gas summary: computation_cost: 10000000, storage_cost: 316175200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1000000, storage_cost: 316175200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 4 'run'. lines 42-44:
 created: 2048
 mutated: 1
-gas summary: computation_cost: 94000000, storage_cost: 2522485600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 4000000, storage_cost: 2522485600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 5 'run'. lines 45-47:
 Error: Transaction Effects Status: Move Primitive Runtime Error. Location: sui::tx_context::derive_id (function index 6) at offset 0. Arithmetic error, stack overflow, max value depth, etc.

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/vector_len_limits.exp
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/vector_len_limits.exp
@@ -11,11 +11,11 @@ gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 9
 
 task 3 'run'. lines 36-38:
 mutated: object(0,0)
-gas summary: computation_cost: 2000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 4 'run'. lines 39-41:
 mutated: object(0,0)
-gas summary: computation_cost: 4196000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 4088000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 5 'run'. lines 42-42:
 Error: Transaction Effects Status: Move Primitive Runtime Error. Location: Test::M1::push_n_items (function index 0) at offset 11. Arithmetic error, stack overflow, max value depth, etc.

--- a/crates/sui-cost-tables/src/tier_based/tables.rs
+++ b/crates/sui-cost-tables/src/tier_based/tables.rs
@@ -898,12 +898,42 @@ pub fn initial_cost_schedule_v3() -> CostTable {
     }
 }
 
+pub fn initial_cost_schedule_v4() -> CostTable {
+    let instruction_tiers: BTreeMap<u64, u64> = vec![
+        (0, 1),
+        (20_000, 2),
+        (50_000, 10),
+        (100_000, 50),
+        (200_000, 100),
+    ]
+    .into_iter()
+    .collect();
+
+    let stack_height_tiers: BTreeMap<u64, u64> =
+        vec![(0, 1), (1_000, 2), (10_000, 10)].into_iter().collect();
+
+    let stack_size_tiers: BTreeMap<u64, u64> = vec![
+        (0, 1),
+        (100_000, 2),     // ~100K
+        (500_000, 5),     // ~500K
+        (1_000_000, 100), // ~1M
+    ]
+    .into_iter()
+    .collect();
+
+    CostTable {
+        instruction_tiers,
+        stack_size_tiers,
+        stack_height_tiers,
+    }
+}
+
 // Convert from our representation of gas costs to the type that the MoveVM expects for unit tests.
 // We don't want our gas depending on the MoveVM test utils and we don't want to fix our
 // representation to whatever is there, so instead we perform this translation from our gas units
 // and cost schedule to the one expected by the Move unit tests.
 pub fn initial_cost_schedule_for_unit_tests() -> move_vm_test_utils::gas_schedule::CostTable {
-    let table = initial_cost_schedule_v3();
+    let table = initial_cost_schedule_v4();
     move_vm_test_utils::gas_schedule::CostTable {
         instruction_tiers: table
             .instruction_tiers

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1222,6 +1222,7 @@ impl ProtocolConfig {
             14 => {
                 let mut cfg = Self::get_for_version_impl(version - 1, chain);
                 cfg.gas_rounding_step = Some(1_000);
+                cfg.gas_model_version = Some(6);
                 cfg.feature_flags.consensus_transaction_ordering =
                     ConsensusTransactionOrdering::ByGasPrice;
                 cfg

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_14.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_14.snap
@@ -77,7 +77,7 @@ obj_access_cost_read_per_byte: 15
 obj_access_cost_mutate_per_byte: 40
 obj_access_cost_delete_per_byte: 40
 obj_access_cost_verify_per_byte: 200
-gas_model_version: 5
+gas_model_version: 6
 obj_data_cost_refundable: 100
 obj_metadata_cost_non_refundable: 50
 storage_rebate_rate: 9900

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_14.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_14.snap
@@ -78,7 +78,7 @@ obj_access_cost_read_per_byte: 15
 obj_access_cost_mutate_per_byte: 40
 obj_access_cost_delete_per_byte: 40
 obj_access_cost_verify_per_byte: 200
-gas_model_version: 5
+gas_model_version: 6
 obj_data_cost_refundable: 100
 obj_metadata_cost_non_refundable: 50
 storage_rebate_rate: 9900

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_14.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_14.snap
@@ -79,7 +79,7 @@ obj_access_cost_read_per_byte: 15
 obj_access_cost_mutate_per_byte: 40
 obj_access_cost_delete_per_byte: 40
 obj_access_cost_verify_per_byte: 200
-gas_model_version: 5
+gas_model_version: 6
 obj_data_cost_refundable: 100
 obj_metadata_cost_non_refundable: 50
 storage_rebate_rate: 9900

--- a/crates/sui-types/src/gas_model/gas_v2.rs
+++ b/crates/sui-types/src/gas_model/gas_v2.rs
@@ -11,8 +11,8 @@ use crate::{
 use move_core_types::vm_status::StatusCode;
 use std::iter;
 use sui_cost_tables::bytecode_tables::{
-    initial_cost_schedule_v1, initial_cost_schedule_v2, initial_cost_schedule_v3, GasStatus,
-    ZERO_COST_SCHEDULE,
+    initial_cost_schedule_v1, initial_cost_schedule_v2, initial_cost_schedule_v3,
+    initial_cost_schedule_v4, GasStatus, ZERO_COST_SCHEDULE,
 };
 use sui_cost_tables::units_types::CostTable;
 use sui_protocol_config::*;
@@ -156,8 +156,10 @@ fn cost_table_for_version(config: &ProtocolConfig) -> CostTable {
         initial_cost_schedule_v1()
     } else if gas_model == 4 {
         initial_cost_schedule_v2()
-    } else {
+    } else if gas_model == 5 {
         initial_cost_schedule_v3()
+    } else {
+        initial_cost_schedule_v4()
     }
 }
 


### PR DESCRIPTION
## Description 

Change gas cost tables to reduce cost of transactions.
Rationale: 
- instructions start affecting time of execution on the upper end. Some natives are more important than instructions. Also the change is still protecting against DOS attacks by making the cost rise abruptly after a certain point
- stack height does not seem to have a strong correlation to execution time, so we are making it matter less
- for memory size we are going with the intuition that up to approx 1M cost is pretty linear. 1k transaction executing concurrently at the same time (which we do not do and it's pretty foolish requiring 1k threads) would take up to 1G of RAM. All those numbers do not seem problematic

Going to evaluate the impact against existing transactions

## Test Plan 

Existing tests and manual checks against transaction executed to see the impact

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
