### PR TITLE
Enable simtests for checkpoint pruning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9571,6 +9571,7 @@ dependencies = [
  "sui-protocol-config",
  "sui-sdk",
  "sui-simulator",
+ "sui-swarm",
  "sui-swarm-config",
  "sui-test-transaction-builder",
  "sui-tool",

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -252,7 +252,6 @@ mod test {
         test_simulated_load(TestInitData::new(&test_cluster).await, 120).await;
     }
 
-    #[ignore]
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_checkpoint_pruning() {
         let test_cluster = build_test_cluster(4, 1000).await;

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -476,6 +476,7 @@ impl AuthorityStorePruningConfig {
         // TODO: Remove this after aggressive pruning is enabled by default
         let num_epochs_to_retain = if cfg!(msim) { 0 } else { 2 };
         let pruning_run_delay_seconds = if cfg!(msim) { Some(2) } else { None };
+        let num_epochs_to_retain_for_checkpoints = if cfg!(msim) { Some(1) } else { None };
         Self {
             num_latest_epoch_dbs_to_retain: 3,
             epoch_db_pruning_period_secs: 60 * 60,
@@ -484,13 +485,14 @@ impl AuthorityStorePruningConfig {
             max_checkpoints_in_batch: 10,
             max_transactions_in_batch: 1000,
             periodic_compaction_threshold_days: None,
-            num_epochs_to_retain_for_checkpoints: None,
+            num_epochs_to_retain_for_checkpoints,
         }
     }
     pub fn fullnode_config() -> Self {
         // TODO: Remove this after aggressive pruning is enabled by default
         let num_epochs_to_retain = if cfg!(msim) { 0 } else { 2 };
         let pruning_run_delay_seconds = if cfg!(msim) { Some(2) } else { None };
+        let num_epochs_to_retain_for_checkpoints = if cfg!(msim) { Some(1) } else { None };
         Self {
             num_latest_epoch_dbs_to_retain: 3,
             epoch_db_pruning_period_secs: 60 * 60,
@@ -499,7 +501,7 @@ impl AuthorityStorePruningConfig {
             max_checkpoints_in_batch: 10,
             max_transactions_in_batch: 1000,
             periodic_compaction_threshold_days: None,
-            num_epochs_to_retain_for_checkpoints: None,
+            num_epochs_to_retain_for_checkpoints,
         }
     }
 }

--- a/crates/sui-e2e-tests/Cargo.toml
+++ b/crates/sui-e2e-tests/Cargo.toml
@@ -47,6 +47,7 @@ sui-protocol-config = { path = "../sui-protocol-config" }
 sui-types = { path = "../sui-types" }
 sui-move-build = { path = "../sui-move-build" }
 sui-swarm-config = { path = "../sui-swarm-config" }
+sui-swarm = { path = "../sui-swarm" }
 sui-test-transaction-builder = { path = "../sui-test-transaction-builder" }
 sui-config = { path = "../sui-config" }
 sui-json-rpc-types = { path = "../sui-json-rpc-types" }

--- a/crates/sui-swarm-config/src/network_config_builder.rs
+++ b/crates/sui-swarm-config/src/network_config_builder.rs
@@ -50,6 +50,7 @@ pub struct ConfigBuilder<R = OsRng> {
     genesis_config: Option<GenesisConfig>,
     reference_gas_price: Option<u64>,
     additional_objects: Vec<Object>,
+    num_unpruned_validators: Option<usize>,
 }
 
 impl ConfigBuilder {
@@ -62,6 +63,7 @@ impl ConfigBuilder {
             genesis_config: None,
             reference_gas_price: None,
             additional_objects: vec![],
+            num_unpruned_validators: None,
         }
     }
 
@@ -94,6 +96,11 @@ impl<R> ConfigBuilder<R> {
     pub fn with_genesis_config(mut self, genesis_config: GenesisConfig) -> Self {
         assert!(self.genesis_config.is_none(), "Genesis config already set");
         self.genesis_config = Some(genesis_config);
+        self
+    }
+
+    pub fn with_num_unpruned_validators(mut self, n: usize) -> Self {
+        self.num_unpruned_validators = Some(n);
         self
     }
 
@@ -153,6 +160,7 @@ impl<R> ConfigBuilder<R> {
             genesis_config: self.genesis_config,
             reference_gas_price: self.reference_gas_price,
             additional_objects: self.additional_objects,
+            num_unpruned_validators: self.num_unpruned_validators,
         }
     }
 
@@ -280,6 +288,11 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                         }
                     };
                     builder = builder.with_supported_protocol_versions(supported_versions);
+                }
+                if let Some(num_unpruned_validators) = self.num_unpruned_validators {
+                    if idx < num_unpruned_validators {
+                        builder = builder.with_unpruned_checkpoints();
+                    }
                 }
                 builder.build(validator, genesis.clone())
             })

--- a/crates/sui-swarm/src/memory/swarm.rs
+++ b/crates/sui-swarm/src/memory/swarm.rs
@@ -41,6 +41,7 @@ pub struct SwarmBuilder<R = OsRng> {
     // Default to supported_protocol_versions_config, but can be overridden.
     fullnode_supported_protocol_versions_config: Option<ProtocolVersionsConfig>,
     db_checkpoint_config: DBCheckpointConfig,
+    num_unpruned_validators: Option<usize>,
 }
 
 impl SwarmBuilder {
@@ -59,6 +60,7 @@ impl SwarmBuilder {
             supported_protocol_versions_config: ProtocolVersionsConfig::Default,
             fullnode_supported_protocol_versions_config: None,
             db_checkpoint_config: DBCheckpointConfig::default(),
+            num_unpruned_validators: None,
         }
     }
 }
@@ -79,6 +81,7 @@ impl<R> SwarmBuilder<R> {
             fullnode_supported_protocol_versions_config: self
                 .fullnode_supported_protocol_versions_config,
             db_checkpoint_config: self.db_checkpoint_config,
+            num_unpruned_validators: self.num_unpruned_validators,
         }
     }
 
@@ -108,6 +111,12 @@ impl<R> SwarmBuilder<R> {
     pub fn with_genesis_config(mut self, genesis_config: GenesisConfig) -> Self {
         assert!(self.network_config.is_none() && self.genesis_config.is_none());
         self.genesis_config = Some(genesis_config);
+        self
+    }
+
+    pub fn with_num_unpruned_validators(mut self, n: usize) -> Self {
+        assert!(self.network_config.is_none());
+        self.num_unpruned_validators = Some(n);
         self
     }
 
@@ -212,6 +221,11 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
 
             if let Some(genesis_config) = self.genesis_config {
                 config_builder = config_builder.with_genesis_config(genesis_config);
+            }
+
+            if let Some(num_unpruned_validators) = self.num_unpruned_validators {
+                config_builder =
+                    config_builder.with_num_unpruned_validators(num_unpruned_validators);
             }
 
             config_builder

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -290,13 +290,14 @@ impl TestCluster {
                 handle.with_async(|node| async {
                     let mut retries = 0;
                     loop {
-                        if node.state().epoch_store_for_testing().epoch() == target_epoch {
+                        let epoch = node.state().epoch_store_for_testing().epoch();
+                        if epoch == target_epoch {
                             break;
                         }
                         tokio::time::sleep(Duration::from_secs(1)).await;
                         retries += 1;
                         if retries % 5 == 0 {
-                            tracing::warn!(validator=?node.state().name.concise(), "Waiting for {:?} seconds for epoch change", retries);
+                            tracing::warn!(validator=?node.state().name.concise(), "Waiting for {:?} seconds to reach epoch {:?}. Currently at epoch {:?}", retries, target_epoch, epoch);
                         }
                     }
                 })
@@ -442,6 +443,7 @@ pub struct TestClusterBuilder {
     fullnode_supported_protocol_versions_config: Option<ProtocolVersionsConfig>,
     db_checkpoint_config_validators: DBCheckpointConfig,
     db_checkpoint_config_fullnodes: DBCheckpointConfig,
+    num_unpruned_validators: Option<usize>,
 }
 
 impl TestClusterBuilder {
@@ -456,6 +458,7 @@ impl TestClusterBuilder {
             fullnode_supported_protocol_versions_config: None,
             db_checkpoint_config_validators: DBCheckpointConfig::default(),
             db_checkpoint_config_fullnodes: DBCheckpointConfig::default(),
+            num_unpruned_validators: None,
         }
     }
 
@@ -563,6 +566,11 @@ impl TestClusterBuilder {
         self
     }
 
+    pub fn with_num_unpruned_validators(mut self, n: usize) -> Self {
+        self.num_unpruned_validators = Some(n);
+        self
+    }
+
     pub fn with_accounts(mut self, accounts: Vec<AccountConfig>) -> Self {
         self.get_or_init_genesis_config().accounts = accounts;
         self
@@ -632,6 +640,9 @@ impl TestClusterBuilder {
         }
         if let Some(fullnode_rpc_port) = self.fullnode_rpc_port {
             builder = builder.with_fullnode_rpc_port(fullnode_rpc_port);
+        }
+        if let Some(num_unpruned_validators) = self.num_unpruned_validators {
+            builder = builder.with_num_unpruned_validators(num_unpruned_validators);
         }
 
         let mut swarm = builder.build();


### PR DESCRIPTION
## Description 

* Enable pruning in `msim`
* Introduce builder methods for setting n validators in a `TestCluster`/ `Swarm` / `NetworkConfig` to be unpruned
* Fixes up committe change stress test to keep 2/7 validators unpruned in order to allow new validators to catchup via state sync (without use of archival node)

## Test Plan 

Existing tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
