### PR TITLE
[narwhal] use the LeaderSwapTable in the leader schedule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5896,6 +5896,7 @@ dependencies = [
  "narwhal-storage",
  "narwhal-test-utils",
  "narwhal-types",
+ "parking_lot 0.12.1",
  "pprof",
  "prometheus",
  "rand 0.8.5",

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1360,6 +1360,7 @@
                 "disallow_change_struct_type_params_on_upgrade": false,
                 "loaded_child_objects_fixed": true,
                 "missing_type_is_compatibility_error": true,
+                "narwhal_new_leader_election_schedule": false,
                 "narwhal_versioned_metadata": false,
                 "no_extraneous_module_bytes": false,
                 "package_digest_hash_module": false,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -241,6 +241,10 @@ struct FeatureFlags {
     // If true minimum txn charge is a multiplier of the gas price
     #[serde(skip_serializing_if = "is_false")]
     txn_base_cost_as_multiplier: bool,
+
+    // If true, then the new algorithm for the leader election schedule will be used
+    #[serde(skip_serializing_if = "is_false")]
+    narwhal_new_leader_election_schedule: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -814,6 +818,10 @@ impl ProtocolConfig {
 
     pub fn txn_base_cost_as_multiplier(&self) -> bool {
         self.feature_flags.txn_base_cost_as_multiplier
+    }
+
+    pub fn narwhal_new_leader_election_schedule(&self) -> bool {
+        self.feature_flags.narwhal_new_leader_election_schedule
     }
 }
 

--- a/narwhal/consensus/Cargo.toml
+++ b/narwhal/consensus/Cargo.toml
@@ -14,6 +14,7 @@ rand = { workspace = true, optional = true }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["sync"] }
 tracing.workspace = true
+parking_lot = "0.12.1"
 
 config = { path = "../config", package = "narwhal-config" }
 fastcrypto.workspace = true

--- a/narwhal/consensus/benches/process_certificates.rs
+++ b/narwhal/consensus/benches/process_certificates.rs
@@ -7,6 +7,7 @@ use criterion::{
 };
 use fastcrypto::hash::Hash;
 use narwhal_consensus as consensus;
+use narwhal_consensus::consensus::{LeaderSchedule, LeaderSwapTable};
 use pprof::criterion::{Output, PProfProfiler};
 use prometheus::Registry;
 use std::{collections::BTreeSet, sync::Arc};
@@ -62,6 +63,7 @@ pub fn process_certificates(c: &mut Criterion) {
             last_successful_leader_election_timestamp: Instant::now(),
             max_inserted_certificate_round: 0,
             num_sub_dags_per_schedule: 100,
+            leader_schedule: LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
         };
         consensus_group.bench_with_input(
             BenchmarkId::new("batched", certificates.len()),

--- a/narwhal/consensus/src/bullshark.rs
+++ b/narwhal/consensus/src/bullshark.rs
@@ -377,11 +377,16 @@ impl Bullshark {
         {
             let previous_leader_round = certificate_round - 2;
 
-            // The metric's authority label can not be considered fully accurate when we do change schedules,
-            // as we'll try to calculate the previous leader round by using the updated scores and
-            // consequently swap table. For now not a huge issue as it will be affect either:
+            // This metric reports the leader election success for the last leader election round.
+            // Our goal is to identify the rate of missed/failed leader elections which are a source
+            // of tx latency. The metric's authority label can not be considered fully accurate when
+            // we do change schedule as we'll try to calculate the previous leader round by using the
+            // updated scores and consequently the new swap table. If the leader for that position has
+            // changed, then a different hostname will be erroneously reported. For now not a huge
+            // issue as it will be affect either:
             // * only the round where we switch schedules
             // * on long periods of asynchrony where we end up changing schedules late
+            // and we don't really expect it to happen frequently.
             let authority = self.leader_schedule.leader(previous_leader_round);
 
             if state.last_round.committed_round < previous_leader_round {

--- a/narwhal/consensus/src/bullshark.rs
+++ b/narwhal/consensus/src/bullshark.rs
@@ -377,7 +377,7 @@ impl Bullshark {
         {
             let previous_leader_round = certificate_round - 2;
 
-            // This metric will not be accurate anymore on the border when we do change schedules,
+            // The metric's authority label can not be considered fully accurate when we do change schedules,
             // as we'll try to calculate the previous leader round by using the updated scores and
             // consequently swap table. For now not a huge issue as it will be affect either:
             // * only the round where we switch schedules

--- a/narwhal/consensus/src/tests/bullshark_tests.rs
+++ b/narwhal/consensus/src/tests/bullshark_tests.rs
@@ -79,6 +79,7 @@ async fn commit_one() {
         latest_protocol_version(),
         metrics.clone(),
         NUM_SUB_DAGS_PER_SCHEDULE,
+        LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
     );
 
     let _consensus_handle = Consensus::spawn(
@@ -165,6 +166,7 @@ async fn dead_node() {
         latest_protocol_version(),
         metrics.clone(),
         NUM_SUB_DAGS_PER_SCHEDULE,
+        LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
     );
 
     let _consensus_handle = Consensus::spawn(
@@ -364,6 +366,7 @@ async fn not_enough_support() {
         latest_protocol_version(),
         metrics.clone(),
         NUM_SUB_DAGS_PER_SCHEDULE,
+        LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
     );
 
     let _consensus_handle = Consensus::spawn(
@@ -502,6 +505,7 @@ async fn missing_leader() {
         latest_protocol_version(),
         metrics.clone(),
         NUM_SUB_DAGS_PER_SCHEDULE,
+        LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
     );
 
     let _consensus_handle = Consensus::spawn(
@@ -590,6 +594,7 @@ async fn committed_round_after_restart() {
             latest_protocol_version(),
             metrics.clone(),
             NUM_SUB_DAGS_PER_SCHEDULE,
+            LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
         );
 
         let handle = Consensus::spawn(
@@ -679,11 +684,12 @@ async fn delayed_certificates_are_rejected() {
     let store = make_consensus_store(&test_utils::temp_dir());
     let mut state = ConsensusState::new(metrics.clone(), gc_depth);
     let mut bullshark = Bullshark::new(
-        committee,
+        committee.clone(),
         store,
         latest_protocol_version(),
         metrics,
         NUM_SUB_DAGS_PER_SCHEDULE,
+        LeaderSchedule::new(committee, LeaderSwapTable::default()),
     );
 
     // Populate DAG with the rounds up to round 5 so we trigger commits
@@ -742,6 +748,7 @@ async fn submitting_equivocating_certificate_should_error() {
         latest_protocol_version(),
         metrics,
         NUM_SUB_DAGS_PER_SCHEDULE,
+        LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
     );
 
     // Populate DAG with all the certificates
@@ -812,11 +819,12 @@ async fn reset_consensus_scores_on_every_schedule_change() {
     let store = make_consensus_store(&test_utils::temp_dir());
     let mut state = ConsensusState::new(metrics.clone(), gc_depth);
     let mut bullshark = Bullshark::new(
-        committee,
+        committee.clone(),
         store,
         latest_protocol_version(),
         metrics,
         NUM_SUB_DAGS_PER_SCHEDULE,
+        LeaderSchedule::new(committee, LeaderSwapTable::default()),
     );
 
     // Populate DAG with the rounds up to round 50 so we trigger commits
@@ -889,6 +897,7 @@ async fn restart_with_new_committee() {
             latest_protocol_version(),
             metrics.clone(),
             NUM_SUB_DAGS_PER_SCHEDULE,
+            LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
         );
 
         let handle = Consensus::spawn(
@@ -1010,11 +1019,12 @@ async fn garbage_collection_basic() {
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
     let mut state = ConsensusState::new(metrics.clone(), GC_DEPTH);
     let mut bullshark = Bullshark::new(
-        committee,
+        committee.clone(),
         store,
         latest_protocol_version(),
         metrics,
         NUM_SUB_DAGS_PER_SCHEDULE,
+        LeaderSchedule::new(committee, LeaderSwapTable::default()),
     );
 
     // Now start feeding the certificates per round
@@ -1122,6 +1132,7 @@ async fn slow_node() {
         latest_protocol_version(),
         metrics,
         NUM_SUB_DAGS_PER_SCHEDULE,
+        LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
     );
 
     // Now start feeding the certificates per round up to 8. We expect to have
@@ -1311,11 +1322,12 @@ async fn not_enough_support_and_missing_leaders_and_gc() {
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
     let mut state = ConsensusState::new(metrics.clone(), GC_DEPTH);
     let mut bullshark = Bullshark::new(
-        committee,
+        committee.clone(),
         store,
         latest_protocol_version(),
         metrics,
         NUM_SUB_DAGS_PER_SCHEDULE,
+        LeaderSchedule::new(committee, LeaderSwapTable::default()),
     );
 
     let mut committed = false;

--- a/narwhal/consensus/src/tests/consensus_tests.rs
+++ b/narwhal/consensus/src/tests/consensus_tests.rs
@@ -425,7 +425,7 @@ async fn test_leader_schedule() {
     // The returned leader should not be the one of position 0
     assert_ne!(leader_2.id(), original_leader);
 
-    // The returned leader should be the one returned by the swap table when using the
+    // The returned leader should be the one returned by the swap table when using the updated leader scores.
     let swapped_leader = table.swap(&original_leader, 2).unwrap().id();
     assert_eq!(leader_2.id(), table.swap(&original_leader, 2).unwrap().id());
 

--- a/narwhal/consensus/src/tests/randomized_tests.rs
+++ b/narwhal/consensus/src/tests/randomized_tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crate::bullshark::Bullshark;
-use crate::consensus::ConsensusState;
+use crate::consensus::{ConsensusState, LeaderSchedule, LeaderSwapTable};
 use crate::consensus_utils::make_consensus_store;
 use crate::consensus_utils::NUM_SUB_DAGS_PER_SCHEDULE;
 use crate::metrics::ConsensusMetrics;
@@ -503,6 +503,7 @@ fn generate_and_run_execution_plans(
             latest_protocol_version(),
             metrics.clone(),
             NUM_SUB_DAGS_PER_SCHEDULE,
+            LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
         );
 
         let mut inserted_certificates = HashSet::new();

--- a/narwhal/executor/tests/consensus_integration_tests.rs
+++ b/narwhal/executor/tests/consensus_integration_tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use bytes::Bytes;
 use consensus::bullshark::Bullshark;
-use consensus::consensus::ConsensusRound;
+use consensus::consensus::{ConsensusRound, LeaderSchedule, LeaderSwapTable};
 use consensus::metrics::ConsensusMetrics;
 use consensus::Consensus;
 use fastcrypto::hash::Hash;
@@ -82,6 +82,7 @@ async fn test_recovery() {
         latest_protocol_version(),
         metrics.clone(),
         NUM_SUB_DAGS_PER_SCHEDULE,
+        LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
     );
 
     let _consensus_handle = Consensus::spawn(

--- a/narwhal/node/src/primary_node.rs
+++ b/narwhal/node/src/primary_node.rs
@@ -364,8 +364,9 @@ impl PrimaryNodeInner {
 
         // TODO: restore the LeaderSchedule when recovering from storage to ensure that the correct one
         // will be used
-        // Using a LeaderSwapTable::default() will make the leader schedule algorithm work as originally -
-        // no swaps will happen if we don't update them.
+        // Using a LeaderSwapTable::default() will just adhere to the original schedule without any swaps.
+        // That means, whatever authority is elected for a round from the Committee::leader method, that's the
+        // one that will be used.
         let leader_schedule = LeaderSchedule::new(committee.clone(), LeaderSwapTable::default());
 
         // Spawn the consensus core who only sequences transactions.

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -27,7 +27,7 @@ use anemo_tower::{
 };
 use async_trait::async_trait;
 use config::{Authority, AuthorityIdentifier, Committee, Parameters, WorkerCache};
-use consensus::consensus::ConsensusRound;
+use consensus::consensus::{ConsensusRound, LeaderSchedule};
 use consensus::dag::Dag;
 use crypto::traits::EncodeDecodeBase64;
 use crypto::{KeyPair, NetworkKeyPair, NetworkPublicKey, Signature};
@@ -115,6 +115,7 @@ impl Primary {
         tx_shutdown: &mut PreSubscribedBroadcastSender,
         tx_committed_certificates: Sender<(Round, Vec<Certificate>)>,
         registry: &Registry,
+        leader_schedule: LeaderSchedule,
     ) -> Vec<JoinHandle<()>> {
         // Write the parameters to the logs.
         parameters.tracing();
@@ -501,6 +502,7 @@ impl Primary {
             tx_narwhal_round_updates,
             rx_committed_own_headers,
             node_metrics,
+            leader_schedule,
         );
 
         let mut handles = vec![

--- a/narwhal/primary/src/tests/primary_tests.rs
+++ b/narwhal/primary/src/tests/primary_tests.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use bincode::Options;
 use config::{AuthorityIdentifier, Committee, Parameters, WorkerId};
-use consensus::consensus::ConsensusRound;
+use consensus::consensus::{ConsensusRound, LeaderSchedule, LeaderSwapTable};
 use consensus::{dag::Dag, metrics::ConsensusMetrics};
 use fastcrypto::{
     encoding::{Encoding, Hex},
@@ -117,6 +117,7 @@ async fn get_network_peers_from_admin_server() {
         &mut tx_shutdown,
         tx_feedback,
         &Registry::new(),
+        LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
     );
 
     // Wait for tasks to start
@@ -242,6 +243,7 @@ async fn get_network_peers_from_admin_server() {
         &mut tx_shutdown_2,
         tx_feedback_2,
         &Registry::new(),
+        LeaderSchedule::new(committee, LeaderSwapTable::default()),
     );
 
     // Wait for tasks to start

--- a/narwhal/primary/src/tests/proposer_tests.rs
+++ b/narwhal/primary/src/tests/proposer_tests.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
 use crate::NUM_SHUTDOWN_RECEIVERS;
+use consensus::consensus::LeaderSwapTable;
 use indexmap::IndexMap;
 use prometheus::Registry;
 use test_utils::{fixture_payload, latest_protocol_version, CommitteeFixture};
@@ -42,6 +43,7 @@ async fn propose_empty() {
         tx_narwhal_round_updates,
         rx_committed_own_headers,
         metrics,
+        LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
     );
 
     // Ensure the proposer makes a correct empty header.
@@ -90,6 +92,7 @@ async fn propose_payload_and_repropose_after_n_seconds() {
         tx_narwhal_round_updates,
         rx_committed_own_headers,
         metrics,
+        LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
     );
 
     // Send enough digests for the header payload.
@@ -211,6 +214,7 @@ async fn equivocation_protection() {
         tx_narwhal_round_updates,
         rx_committed_own_headers,
         metrics,
+        LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
     );
 
     // Send enough digests for the header payload.
@@ -282,6 +286,7 @@ async fn equivocation_protection() {
         tx_narwhal_round_updates,
         rx_committed_own_headers,
         metrics,
+        LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
     );
 
     // Send enough digests for the header payload.

--- a/narwhal/primary/tests/integration_tests_proposer_api.rs
+++ b/narwhal/primary/tests/integration_tests_proposer_api.rs
@@ -3,7 +3,7 @@
 
 use bytes::Bytes;
 use config::{AuthorityIdentifier, CommitteeBuilder, Epoch, Parameters};
-use consensus::consensus::ConsensusRound;
+use consensus::consensus::{ConsensusRound, LeaderSchedule, LeaderSwapTable};
 use consensus::{dag::Dag, metrics::ConsensusMetrics};
 use crypto::KeyPair;
 use fastcrypto::{
@@ -139,6 +139,7 @@ async fn test_rounds_errors() {
         &mut tx_shutdown,
         tx_feedback,
         &Registry::new(),
+        LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
     );
 
     // AND Wait for tasks to start
@@ -233,6 +234,7 @@ async fn test_rounds_return_successful_response() {
         &mut tx_shutdown,
         tx_feedback,
         &Registry::new(),
+        LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
     );
 
     // AND Wait for tasks to start
@@ -403,6 +405,7 @@ async fn test_node_read_causal_signed_certificates() {
         &mut tx_shutdown,
         tx_feedback,
         &Registry::new(),
+        LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
     );
 
     let (tx_new_certificates_2, rx_new_certificates_2) =
@@ -451,6 +454,7 @@ async fn test_node_read_causal_signed_certificates() {
         &mut tx_shutdown_2,
         tx_feedback_2,
         &Registry::new(),
+        LeaderSchedule::new(committee, LeaderSwapTable::default()),
     );
 
     // Wait for tasks to start

--- a/narwhal/primary/tests/integration_tests_validator_api.rs
+++ b/narwhal/primary/tests/integration_tests_validator_api.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use config::{AuthorityIdentifier, BlockSynchronizerParameters, Committee, Parameters};
-use consensus::consensus::ConsensusRound;
+use consensus::consensus::{ConsensusRound, LeaderSchedule, LeaderSwapTable};
 use consensus::{dag::Dag, metrics::ConsensusMetrics};
 use fastcrypto::{hash::Hash, traits::KeyPair as _};
 use indexmap::IndexMap;
@@ -134,6 +134,7 @@ async fn test_get_collections() {
         &mut tx_shutdown,
         tx_feedback,
         &Registry::new(),
+        LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
     );
 
     let registry = Registry::new();
@@ -334,6 +335,7 @@ async fn test_remove_collections() {
         &mut tx_shutdown,
         tx_feedback,
         &Registry::new(),
+        LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
     );
 
     // Wait for tasks to start
@@ -593,6 +595,7 @@ async fn test_read_causal_signed_certificates() {
         &mut tx_shutdown,
         tx_feedback,
         &Registry::new(),
+        LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
     );
 
     let (tx_new_certificates_2, rx_new_certificates_2) =
@@ -642,6 +645,7 @@ async fn test_read_causal_signed_certificates() {
         &mut tx_shutdown_2,
         tx_feedback_2,
         &Registry::new(),
+        LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
     );
 
     // Wait for tasks to start
@@ -822,6 +826,7 @@ async fn test_read_causal_unsigned_certificates() {
         &mut tx_shutdown,
         tx_feedback,
         &Registry::new(),
+        LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
     );
 
     let (tx_new_certificates_2, rx_new_certificates_2) =
@@ -865,6 +870,7 @@ async fn test_read_causal_unsigned_certificates() {
         &mut tx_shutdown_2,
         tx_feedback_2,
         &Registry::new(),
+        LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
     );
 
     // Wait for tasks to start
@@ -1045,6 +1051,7 @@ async fn test_get_collections_with_missing_certificates() {
         &mut tx_shutdown,
         tx_feedback_1,
         &Registry::new(),
+        LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
     );
 
     let registry_1 = Registry::new();
@@ -1110,6 +1117,7 @@ async fn test_get_collections_with_missing_certificates() {
         &mut tx_shutdown_2,
         tx_feedback_2,
         &Registry::new(),
+        LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
     );
 
     let registry_2 = Registry::new();

--- a/narwhal/types/src/consensus.rs
+++ b/narwhal/types/src/consensus.rs
@@ -550,17 +550,22 @@ mod tests {
         scores.add_score(ids[8], 40);
         scores.add_score(ids[9], 40);
 
+        // the expected authorities
+        let expected_authorities = vec![
+            (ids[9], 40),
+            (ids[8], 40),
+            (ids[7], 30),
+            (ids[6], 30),
+            (ids[5], 20),
+            (ids[4], 10),
+            (ids[3], 10),
+            (ids[2], 10),
+            (ids[1], 10),
+            (ids[0], 0),
+        ];
+
         // sorting the authorities
         let sorted_authorities = scores.authorities_by_score_desc();
-        assert_eq!(sorted_authorities[0], (ids[9], 40));
-        assert_eq!(sorted_authorities[1], (ids[8], 40));
-        assert_eq!(sorted_authorities[2], (ids[7], 30));
-        assert_eq!(sorted_authorities[3], (ids[6], 30));
-        assert_eq!(sorted_authorities[4], (ids[5], 20));
-        assert_eq!(sorted_authorities[5], (ids[4], 10));
-        assert_eq!(sorted_authorities[6], (ids[3], 10));
-        assert_eq!(sorted_authorities[7], (ids[2], 10));
-        assert_eq!(sorted_authorities[8], (ids[1], 10));
-        assert_eq!(sorted_authorities[9], (ids[0], 0));
+        assert_eq!(sorted_authorities, expected_authorities);
     }
 }

--- a/narwhal/worker/Cargo.toml
+++ b/narwhal/worker/Cargo.toml
@@ -32,6 +32,7 @@ store = { path = "../../crates/typed-store", package = "typed-store" }
 mysten-network = { path = "../../crates/mysten-network"}
 mysten-metrics = { path = "../../crates/mysten-metrics" }
 sui-protocol-config = { path = "../../crates/sui-protocol-config" }
+consensus = { path = "../consensus", package = "narwhal-consensus" }
 
 anemo.workspace = true
 anemo-tower.workspace = true

--- a/narwhal/worker/src/tests/worker_tests.rs
+++ b/narwhal/worker/src/tests/worker_tests.rs
@@ -6,7 +6,7 @@ use crate::LocalNarwhalClient;
 use crate::{metrics::initialise_metrics, TrivialTransactionValidator};
 use async_trait::async_trait;
 use bytes::Bytes;
-use consensus::consensus::ConsensusRound;
+use consensus::consensus::{ConsensusRound, LeaderSchedule, LeaderSwapTable};
 use consensus::{dag::Dag, metrics::ConsensusMetrics};
 use fastcrypto::{
     encoding::{Encoding, Hex},
@@ -434,6 +434,7 @@ async fn get_network_peers_from_admin_server() {
         &mut tx_shutdown,
         tx_feedback,
         &Registry::new(),
+        LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
     );
 
     // Wait for tasks to start
@@ -559,6 +560,7 @@ async fn get_network_peers_from_admin_server() {
         &mut tx_shutdown_2,
         tx_feedback_2,
         &Registry::new(),
+        LeaderSchedule::new(committee.clone(), LeaderSwapTable::default()),
     );
 
     // Wait for tasks to start


### PR DESCRIPTION
## Description 

Follow up of https://github.com/MystenLabs/sui/pull/12465

This PR is:
* Introducing a new `protocol_config` feature flag `narwhal_new_leader_election_schedule` , so we keep all the new changes disabled until we decide to enable on a new protocol version
* Introducing the `LeaderSchedule` which from now on will be responsible for crafting the leader schedule and used to perform the leader election. 
* Is updating the leader schedule with the new scores every `K` commit rounds
* Is injecting the `LeaderSchedule` to the primary node so it can be used from the `proposer` module as well since the schedule now can be updated 

Next steps:

- [x] calculate the swap table on every K committed subdags & wire into the leader election algorithm
- [x] ensure whole feature is gated behind a protocol config feature flag - and probably a config switch as we might need to have it disabled for longer than a release cycle.
- [ ] restore correct swap table after crash/recovery
- [ ] modify the commit path so we repeat the leader election when we commit recursively
- [ ] modify the proposer to support the new leader election capabilities
- [ ] add testing

## Test Plan 

Added unit tests

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
