### PR TITLE
[ts][bcs] fix nested type parsing in BCS 

### DIFF
--- a/.changeset/beige-sheep-draw.md
+++ b/.changeset/beige-sheep-draw.md
@@ -1,0 +1,5 @@
+---
+"@mysten/bcs": patch
+---
+
+Fix an issue with parsing struct types with nested type parameters

--- a/.changeset/forty-games-yawn.md
+++ b/.changeset/forty-games-yawn.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui.js': patch
+---
+
+Use splitGenericParamaters util from bcs

--- a/sdk/bcs/src/index.ts
+++ b/sdk/bcs/src/index.ts
@@ -1422,40 +1422,12 @@ export class BCS {
     }
 
     let typeName = name.slice(0, l_bound);
-    let params = this.splitArgsWithinGenericSep(
-      name.slice(l_bound + 1, name.length - r_bound - 1)
+    let params = splitGenericParameters(
+      name.slice(l_bound + 1, name.length - r_bound - 1),
+      this.schema.genericSeparators
     );
 
     return { name: typeName, params };
-  }
-
-  // split `str` by all `,` outside generic separators
-  // e.g. `T, U<A, B>` -> `[ 'T', 'U<A, B>' ]`
-  splitArgsWithinGenericSep(str: string): string[] {
-    const [left, right] = this.schema.genericSeparators || ["<", ">"];
-
-    const tok = [];
-    let word = "";
-    let nestedAngleBrackets = 0;
-    for (let i = 0; i < str.length; i++) {
-      const char = str[i];
-      if (char === left) {
-        nestedAngleBrackets++;
-      }
-      if (char === right) {
-        nestedAngleBrackets--;
-      }
-      if (nestedAngleBrackets == 0 && char === ',') {
-        tok.push(word.trim());
-        word = '';
-        continue;
-      }
-      word += char;
-    }
-
-    tok.push(word.trim());
-
-    return tok;
   }
 }
 
@@ -1654,4 +1626,31 @@ export function getSuiMoveConfig(): BcsConfig {
     addressLength: SUI_ADDRESS_LENGTH,
     addressEncoding: "hex",
   };
+}
+
+export function splitGenericParameters(str: string, genericSeparators: [string, string] = ["<", ">"]) {
+  const [left, right] = genericSeparators;
+  const tok = [];
+  let word = "";
+  let nestedAngleBrackets = 0;
+
+  for (let i = 0; i < str.length; i++) {
+    const char = str[i];
+    if (char === left) {
+      nestedAngleBrackets++;
+    }
+    if (char === right) {
+      nestedAngleBrackets--;
+    }
+    if (nestedAngleBrackets === 0 && char === ',') {
+      tok.push(word.trim());
+      word = '';
+      continue;
+    }
+    word += char;
+  }
+
+  tok.push(word.trim());
+
+  return tok;
 }

--- a/sdk/bcs/src/index.ts
+++ b/sdk/bcs/src/index.ts
@@ -1422,12 +1422,40 @@ export class BCS {
     }
 
     let typeName = name.slice(0, l_bound);
-    let params = name
-      .slice(l_bound + 1, name.length - r_bound - 1)
-      .split(",")
-      .map((e) => e.trim());
+    let params = this.splitArgsWithinGenericSep(
+      name.slice(l_bound + 1, name.length - r_bound - 1)
+    );
 
     return { name: typeName, params };
+  }
+
+  // split `str` by all `,` outside generic separators
+  // e.g. `T, U<A, B>` -> `[ 'T', 'U<A, B>' ]`
+  splitArgsWithinGenericSep(str: string): string[] {
+    const [left, right] = this.schema.genericSeparators || ["<", ">"];
+
+    const tok = [];
+    let word = "";
+    let nestedAngleBrackets = 0;
+    for (let i = 0; i < str.length; i++) {
+      const char = str[i];
+      if (char === left) {
+        nestedAngleBrackets++;
+      }
+      if (char === right) {
+        nestedAngleBrackets--;
+      }
+      if (nestedAngleBrackets == 0 && char === ',') {
+        tok.push(word.trim());
+        word = '';
+        continue;
+      }
+      word += char;
+    }
+
+    tok.push(word.trim());
+
+    return tok;
   }
 }
 

--- a/sdk/bcs/tests/parse-type-name.test.ts
+++ b/sdk/bcs/tests/parse-type-name.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+
+import { BCS, getSuiMoveConfig } from "../src";
+
+describe("parseTypeName", () => {
+  it("parses nested struct type from a string", () => {
+    const bcs = new BCS(getSuiMoveConfig());
+
+    const type = "0x5::foo::Foo<0x5::bar::Bar, 0x6::amm::LP<0x2::sui::SUI, 0x7::example_coin::EXAMPLE_COIN>>";
+    expect(bcs.parseTypeName(type)).toEqual(
+      {
+        name: "0x5::foo::Foo",
+        params: [
+          "0x5::bar::Bar",
+          "0x6::amm::LP<0x2::sui::SUI, 0x7::example_coin::EXAMPLE_COIN>"
+        ]
+      }
+    );
+  })
+})

--- a/sdk/bcs/tests/parse-type-name.test.ts
+++ b/sdk/bcs/tests/parse-type-name.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from "vitest";
 
 import { BCS, getSuiMoveConfig } from "../src";

--- a/sdk/typescript/src/signers/txn-data-serializers/type-tag-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/type-tag-serializer.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { splitGenericParameters } from '@mysten/bcs';
 import { normalizeSuiAddress, TypeTag } from '../../types';
 
 const VECTOR_REGEX = /^vector<(.+)>$/;
@@ -64,29 +65,7 @@ export class TypeTagSerializer {
   }
 
   static parseStructTypeArgs(str: string, normalizeAddress = false): TypeTag[] {
-    // split `str` by all `,` outside angle brackets
-    const tok: Array<string> = [];
-    let word = '';
-    let nestedAngleBrackets = 0;
-    for (let i = 0; i < str.length; i++) {
-      const char = str[i];
-      if (char === '<') {
-        nestedAngleBrackets++;
-      }
-      if (char === '>') {
-        nestedAngleBrackets--;
-      }
-      if (nestedAngleBrackets === 0 && char === ',') {
-        tok.push(word.trim());
-        word = '';
-        continue;
-      }
-      word += char;
-    }
-
-    tok.push(word.trim());
-
-    return tok.map((tok) =>
+    return splitGenericParameters(str).map((tok) =>
       TypeTagSerializer.parseFromStr(tok, normalizeAddress),
     );
   }

--- a/sdk/typescript/src/types/__tests__/common.test.ts
+++ b/sdk/typescript/src/types/__tests__/common.test.ts
@@ -16,7 +16,9 @@ describe('parseStructTag', () => {
     `);
 
     expect(
-      parseStructTag('0x2::foo::bar<0x3::baz::qux<0x4::nested::result>, bool>'),
+      parseStructTag(
+        '0x2::foo::bar<0x3::baz::qux<0x4::nested::result, 0x4::nested::other>, bool>',
+      ),
     ).toMatchInlineSnapshot(`
       {
         "address": "0x0000000000000000000000000000000000000000000000000000000000000002",
@@ -32,6 +34,12 @@ describe('parseStructTag', () => {
                 "address": "0x0000000000000000000000000000000000000000000000000000000000000004",
                 "module": "nested",
                 "name": "result",
+                "typeParams": [],
+              },
+              {
+                "address": "0x0000000000000000000000000000000000000000000000000000000000000004",
+                "module": "nested",
+                "name": "other",
                 "typeParams": [],
               },
             ],

--- a/sdk/typescript/src/types/common.ts
+++ b/sdk/typescript/src/types/common.ts
@@ -14,7 +14,7 @@ import {
   union,
 } from 'superstruct';
 import { CallArg } from './sui-bcs';
-import { fromB58 } from '@mysten/bcs';
+import { fromB58, splitGenericParameters } from '@mysten/bcs';
 
 export const TransactionDigest = string();
 export type TransactionDigest = Infer<typeof TransactionDigest>;
@@ -124,10 +124,9 @@ export function parseStructTag(type: string): StructTag {
   const rest = type.slice(address.length + module.length + 4);
   const name = rest.includes('<') ? rest.slice(0, rest.indexOf('<')) : rest;
   const typeParams = rest.includes('<')
-    ? rest
-        .slice(rest.indexOf('<') + 1, rest.lastIndexOf('>'))
-        .split(',')
-        .map((typeParam) => parseTypeTag(typeParam.trim()))
+    ? splitGenericParameters(
+        rest.slice(rest.indexOf('<') + 1, rest.lastIndexOf('>')),
+      ).map((typeParam) => parseTypeTag(typeParam.trim()))
     : [];
 
   return {


### PR DESCRIPTION
## Description 

This is a small cleanup of the PR originally opened by @kklas (#12373)

Fixed a problem in parseTypeName method in BCS where it naively assumes that type's type args aren't nested and just splits them by , causing the nested types to be improperly split.

E.g. parsing the type `0x5::foo::Foo<0x5::bar::Bar, 0x6::amm::LP<0x2::sui::SUI, 0x7::example_coin::EXAMPLE_COIN>> `would result in:
```js
{
  name: '0x5::foo::Foo',
  params: [
    '0x5::bar::Bar',
    '0x6::amm::LP<0x2::sui::SUI',
    '0x7::example_coin::EXAMPLE_COIN>',
  ],
}
```
instead of
```js
{
  name: "0x5::foo::Foo",
  params: [
    "0x5::bar::Bar",
    "0x6::amm::LP<0x2::sui::SUI, 0x7::example_coin::EXAMPLE_COIN>"
  ]
}
````


## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
