### PR TITLE
Switch to tokio::spawn_blocking for archive task which does blocking file i/o

### DIFF
--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -398,7 +398,7 @@ impl SuiNode {
                     &prometheus_registry,
                 )
                 .await?;
-                Some(archive_writer.start(state_sync_store)?)
+                Some(archive_writer.start(state_sync_store).await?)
             } else {
                 None
             };


### PR DESCRIPTION
## Description 

The checkpoint tailer task does blocking file i/o in tight loop and yet it was being invoked in the async context. This would cause the receiver to not receive mpsc channel messages (or receive them after a very long delay) as it was likely assigned to the same thread as tailer (the one invoking blocking calls) and the tailer would not yield the thread (since it tails checkpoints in a loop). This was causing the archive files to wait a long time on local fs before they could get uploaded to s3.

The fix is simple - just move the tailer to `spawn_blocking` instead of `spawn` and that fixes the problem. After this change, I see no such issue and receiver receives channel messages instantly and files are getting uploaded without any delay.
As an added bonus, the code is a little simpler too now as I was able to eliminate one function call.

## Test Plan 

Existing tests. Unfortunately, it seems like usage of `spawn_blocking` is incompatible with simulator because I keep getting deadlock detected error messages and this log line seems to indicate why:
```
2022-01-03T02:04:56.000000Z  WARN node{id=1 name="client"}: tokio::sim::runtime: /Users/sadhansood/.cargo/git/checkouts/mysten-sim-6c6e892b5d19dc47/e4b1466/msim-tokio/src/sim/runtime.rs:62: spawn_blocking() call in simulator may cause deadlocks if spawned task attempts to do I/O
```
Switching sim tests to tokio tests to make them work.
