### PR TITLE
[ci] run eslint and prettier from root rather than through turbo to ensure all packages are checked

### DIFF
--- a/.github/workflows/turborepo.yml
+++ b/.github/workflows/turborepo.yml
@@ -24,7 +24,7 @@ jobs:
         run: pnpm audit --prod --audit-level moderate
 
   build:
-    name: Lint, Build, and Test
+    name: Build, Test, and Lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -51,12 +51,12 @@ jobs:
           key: turbo-${{ runner.os }}-${{ github.sha }}
           restore-keys: |
             turbo-${{ runner.os }}-
-      - name: Lint
-        run: pnpm turbo lint
       - name: Build
         run: pnpm turbo build
       - name: Test
         run: pnpm turbo test
+      - name: Lint
+        run: pnpm lint
 
       # Pack wallet extension and upload it as an artifact for easy developer use:
       - name: Wallet Extension Has Changes?


### PR DESCRIPTION
## Description 

run eslint and prettier from root rather than through turbo to ensure all packages are checked

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
