### PR TITLE
[sui-execution] Add dry-run option

### DIFF
--- a/sui-execution/cut/src/args.rs
+++ b/sui-execution/cut/src/args.rs
@@ -42,6 +42,10 @@ pub(crate) struct Args {
     /// location, including any suffixes)
     #[arg(short, long = "package")]
     pub packages: Vec<String>,
+
+    /// Don't execute the cut, just display it.
+    #[arg(long)]
+    pub dry_run: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/sui-execution/cut/src/main.rs
+++ b/sui-execution/cut/src/main.rs
@@ -9,13 +9,16 @@ mod args;
 mod path;
 mod plan;
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     let args = Args::parse();
-    println!("Cutting directories: {:#?}\n", args.directories);
-    println!("Including packages: {:#?}\n", args.packages);
+    let dry_run = args.dry_run;
+    let plan = CutPlan::discover(args)?;
 
-    let plan = CutPlan::discover(args).expect("plan discovery should succeed");
+    if dry_run {
+        println!("{plan}");
+    } else {
+        plan.execute()?;
+    }
 
-    println!("Plan: {:#?}\n", plan);
-    plan.execute().expect("plan execution should succeed");
+    Ok(())
 }

--- a/sui-execution/cut/src/plan.rs
+++ b/sui-execution/cut/src/plan.rs
@@ -851,6 +851,33 @@ mod tests {
                 },
             }"#]]
         .assert_eq(&debug_for_test(&plan));
+
+        expect![[r#"
+            Copying packages in: $PATH
+
+            new [workspace] members:
+             - to:   sui-adapter-feature
+                     sui-execution/exec-cut/sui-adapter
+               from: sui-adapter-latest
+                     sui-execution/latest/sui-adapter
+             - to:   sui-execution-cut-feature
+                     sui-execution/cut-cut
+               from: sui-execution-cut
+                     sui-execution/cut
+             - to:   sui-verifier-feature
+                     sui-execution/exec-cut/sui-verifier
+               from: sui-verifier-latest
+                     sui-execution/latest/sui-verifier
+
+            new [workspace] excludes:
+             - to:   move-core-types-feature
+                     sui-execution/cut-move-core/types
+               from: move-core-types
+                     external-crates/move/move-core/types
+
+            other packages:
+        "#]]
+        .assert_eq(&display_for_test(&plan));
     }
 
     #[test]
@@ -1257,6 +1284,11 @@ mod tests {
     /// Print with pretty-printed debug formatting, with repo paths scrubbed out for consistency.
     fn debug_for_test<T: fmt::Debug>(x: &T) -> String {
         scrub_path(&format!("{x:#?}"), repo_root())
+    }
+
+    /// Print with display formatting, with repo paths scrubbed out for consistency.
+    fn display_for_test<T: fmt::Display>(x: &T) -> String {
+        scrub_path(&format!("{x}"), repo_root())
     }
 
     /// Read multiple files into one string.


### PR DESCRIPTION
## Description

Add a flag to display the cut plan without executing it.

## Test Plan

```
sui$ cargo run --bin cut -- --dry-run --feature v1          \
     -d sui-execution/latest:sui-execution/v1:-latest       \
     -d external-crates/move:external-crates/move-execution \
     -p sui-adapter-latest                                  \
     -p sui-move-natives-latest                             \
     -p sui-verifier-latest                                 \
     -p move-bytecode-verifier                              \
     -p move-stdlib                                         \
     -p move-vm-runtime

Copying packages in: /Users/ashokmenon/sui

new [workspace] members:
 - to:   sui-adapter-v1
         sui-execution/v1/sui-adapter
   from: sui-adapter-latest
         sui-execution/latest/sui-adapter
 - to:   sui-move-natives-v1
         sui-execution/v1/sui-move-natives
   from: sui-move-natives-latest
         sui-execution/latest/sui-move-natives
 - to:   sui-verifier-v1
         sui-execution/v1/sui-verifier
   from: sui-verifier-latest
         sui-execution/latest/sui-verifier

new [workspace] excludes:
 - to:   move-bytecode-verifier-v1
         external-crates/move-execution/move-bytecode-verifier
   from: move-bytecode-verifier
         external-crates/move/move-bytecode-verifier
 - to:   move-stdlib-v1
         external-crates/move-execution/move-stdlib
   from: move-stdlib
         external-crates/move/move-stdlib
 - to:   move-vm-runtime-v1
         external-crates/move-execution/move-vm/runtime
   from: move-vm-runtime
         external-crates/move/move-vm/runtime

other packages:
```

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
