### PR TITLE
[sui-execution] Add to isRust check in CI

### DIFF
--- a/.github/actions/diffs/action.yml
+++ b/.github/actions/diffs/action.yml
@@ -24,6 +24,7 @@ runs:
           - 'crates/**'
           - 'external-crates/**'
           - 'narwhal/**'
+          - 'sui-execution/**'
           - '.github/workflows/bench.yml'
           - '.github/workflows/codecov.yml'
           - '.github/workflows/rust.yml'


### PR DESCRIPTION
## Description

Treat changes to `sui-execution` as rust changes to trigger the appropriate CI.  This directory contains all crates that are relevant to the execution layer plus utilities to create copies of those crates.

## Test Plan

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
