### PR TITLE
TestClusterBuilder::build() do not return Result

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -340,8 +340,7 @@ mod test {
             .with_objects(init_framework.into_iter().map(|p| p.genesis_object()))
             .with_stake_subsidy_start_epoch(10)
             .build()
-            .await
-            .unwrap();
+            .await;
 
         let test_init_data = TestInitData::new(&test_cluster).await;
         let test_init_data_clone = test_init_data.clone();
@@ -407,7 +406,6 @@ mod test {
         init_test_cluster_builder(default_num_validators, default_epoch_duration_ms)
             .build()
             .await
-            .unwrap()
     }
 
     fn init_test_cluster_builder(

--- a/crates/sui-cluster-test/src/cluster.rs
+++ b/crates/sui-cluster-test/src/cluster.rs
@@ -189,7 +189,7 @@ impl Cluster for LocalNewCluster {
             cluster_builder = cluster_builder.with_fullnode_rpc_port(rpc_port);
         }
 
-        let mut test_cluster = cluster_builder.build().await?;
+        let mut test_cluster = cluster_builder.build().await;
 
         // Use the wealthy account for faucet
         let faucet_key = test_cluster.swarm.config_mut().account_keys.swap_remove(0);

--- a/crates/sui-e2e-tests/tests/checkpoint_tests.rs
+++ b/crates/sui-e2e-tests/tests/checkpoint_tests.rs
@@ -7,7 +7,7 @@ use test_utils::network::TestClusterBuilder;
 
 #[sim_test]
 async fn basic_checkpoints_integration_test() {
-    let test_cluster = TestClusterBuilder::new().build().await.unwrap();
+    let test_cluster = TestClusterBuilder::new().build().await;
     let tx = test_cluster
         .wallet
         .make_transfer_sui_transaction(None, None)

--- a/crates/sui-e2e-tests/tests/full_node_tests.rs
+++ b/crates/sui-e2e-tests/tests/full_node_tests.rs
@@ -55,7 +55,7 @@ use tracing::info;
 
 #[sim_test]
 async fn test_full_node_follows_txes() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await?;
+    let mut test_cluster = TestClusterBuilder::new().build().await;
     let fullnode = test_cluster.spawn_new_fullnode().await.sui_node;
 
     let context = &mut test_cluster.wallet;
@@ -86,7 +86,7 @@ async fn test_full_node_follows_txes() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_full_node_shared_objects() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await?;
+    let mut test_cluster = TestClusterBuilder::new().build().await;
     let handle = test_cluster.spawn_new_fullnode().await;
 
     let context = &mut test_cluster.wallet;
@@ -106,7 +106,7 @@ async fn test_full_node_shared_objects() -> Result<(), anyhow::Error> {
 #[sim_test]
 async fn test_sponsored_transaction() -> Result<(), anyhow::Error> {
     telemetry_subscribers::init_for_testing();
-    let test_cluster = TestClusterBuilder::new().build().await?;
+    let test_cluster = TestClusterBuilder::new().build().await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let sender = test_cluster.get_address_0();
     let sponsor = test_cluster.get_address_1();
@@ -175,7 +175,7 @@ async fn test_sponsored_transaction() -> Result<(), anyhow::Error> {
 #[sim_test]
 async fn test_full_node_move_function_index() -> Result<(), anyhow::Error> {
     telemetry_subscribers::init_for_testing();
-    let mut test_cluster = TestClusterBuilder::new().build().await?;
+    let mut test_cluster = TestClusterBuilder::new().build().await;
     let node = &test_cluster.fullnode_handle.sui_node;
     let sender = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -241,7 +241,7 @@ async fn test_full_node_indexes() -> Result<(), anyhow::Error> {
     let mut test_cluster = TestClusterBuilder::new()
         .enable_fullnode_events()
         .build()
-        .await?;
+        .await;
     let node = &test_cluster.fullnode_handle.sui_node;
     let context = &mut test_cluster.wallet;
 
@@ -446,7 +446,7 @@ async fn test_full_node_indexes() -> Result<(), anyhow::Error> {
 // Test for syncing a node to an authority that already has many txes.
 #[sim_test]
 async fn test_full_node_cold_sync() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await?;
+    let mut test_cluster = TestClusterBuilder::new().build().await;
 
     let context = &mut test_cluster.wallet;
     let _ = transfer_coin(context).await?;
@@ -476,7 +476,7 @@ async fn test_full_node_cold_sync() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_full_node_sync_flood() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await?;
+    let mut test_cluster = TestClusterBuilder::new().build().await;
 
     // Start a new fullnode that is not on the write path
     let fullnode = test_cluster.spawn_new_fullnode().await.sui_node;
@@ -569,7 +569,7 @@ async fn test_full_node_sub_and_query_move_event_ok() -> Result<(), anyhow::Erro
     let mut test_cluster = TestClusterBuilder::new()
         .enable_fullnode_events()
         .build()
-        .await?;
+        .await;
 
     // Start a new fullnode that is not on the write path
     let fullnode = test_cluster.spawn_new_fullnode().await;
@@ -668,8 +668,7 @@ async fn test_full_node_event_read_api_ok() {
         .with_fullnode_rpc_port(50000)
         .enable_fullnode_events()
         .build()
-        .await
-        .unwrap();
+        .await;
 
     let context = &mut test_cluster.wallet;
     let node = &test_cluster.fullnode_handle.sui_node;
@@ -727,8 +726,7 @@ async fn test_full_node_event_query_by_module_ok() {
     let mut test_cluster = TestClusterBuilder::new()
         .enable_fullnode_events()
         .build()
-        .await
-        .unwrap();
+        .await;
 
     let context = &mut test_cluster.wallet;
     let node = &test_cluster.fullnode_handle.sui_node;
@@ -760,7 +758,7 @@ async fn test_full_node_event_query_by_module_ok() {
 
 #[sim_test]
 async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await?;
+    let mut test_cluster = TestClusterBuilder::new().build().await;
     let fullnode = test_cluster.spawn_new_fullnode().await.sui_node;
 
     let context = &mut test_cluster.wallet;
@@ -860,7 +858,7 @@ async fn test_validator_node_has_no_transaction_orchestrator() {
 
 #[sim_test]
 async fn test_execute_tx_with_serialized_signature() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await?;
+    let mut test_cluster = TestClusterBuilder::new().build().await;
     let context = &mut test_cluster.wallet;
     context
         .config
@@ -902,7 +900,7 @@ async fn test_execute_tx_with_serialized_signature() -> Result<(), anyhow::Error
 
 #[sim_test]
 async fn test_full_node_transaction_orchestrator_rpc_ok() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await?;
+    let mut test_cluster = TestClusterBuilder::new().build().await;
     let context = &mut test_cluster.wallet;
     let jsonrpc_client = &test_cluster.fullnode_handle.rpc_client;
 
@@ -995,7 +993,7 @@ async fn get_past_obj_read_from_node(
 #[sim_test]
 async fn test_get_objects_read() -> Result<(), anyhow::Error> {
     telemetry_subscribers::init_for_testing();
-    let test_cluster = TestClusterBuilder::new().build().await?;
+    let test_cluster = TestClusterBuilder::new().build().await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let node = &test_cluster.fullnode_handle.sui_node;
     let package_id = test_cluster.wallet.publish_nfts_package().await.0;
@@ -1101,7 +1099,7 @@ async fn test_full_node_bootstrap_from_snapshot() -> Result<(), anyhow::Error> {
         // This will also do aggressive pruning and compaction of the snapshot
         .with_enable_db_checkpoints_fullnodes()
         .build()
-        .await?;
+        .await;
     let checkpoint_path = test_cluster
         .fullnode_handle
         .sui_node
@@ -1153,7 +1151,7 @@ async fn test_full_node_bootstrap_from_snapshot() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_pass_back_clock_object() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await?;
+    let mut test_cluster = TestClusterBuilder::new().build().await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let fullnode = test_cluster.spawn_new_fullnode().await.sui_node;
 

--- a/crates/sui-e2e-tests/tests/onsite_reconfig_observer_tests.rs
+++ b/crates/sui-e2e-tests/tests/onsite_reconfig_observer_tests.rs
@@ -17,8 +17,7 @@ async fn test_onsite_reconfig_observer_basic() {
     let test_cluster = TestClusterBuilder::new()
         .with_epoch_duration_ms(10000)
         .build()
-        .await
-        .unwrap();
+        .await;
 
     let fullnode = &test_cluster.fullnode_handle.sui_node;
 

--- a/crates/sui-e2e-tests/tests/protocol_version_tests.rs
+++ b/crates/sui-e2e-tests/tests/protocol_version_tests.rs
@@ -103,8 +103,7 @@ mod sim_only_tests {
                 START, FINISH,
             ))
             .build()
-            .await
-            .unwrap();
+            .await;
 
         expect_upgrade_succeeded(&test_cluster).await;
     }
@@ -124,8 +123,7 @@ mod sim_only_tests {
                 START, FINISH,
             ))
             .build()
-            .await
-            .unwrap();
+            .await;
 
         let validator = test_cluster.get_validator_pubkeys()[0].clone();
         test_cluster.stop_node(&validator);
@@ -179,8 +177,7 @@ mod sim_only_tests {
                 }
             }))
             .build()
-            .await
-            .unwrap();
+            .await;
 
         expect_upgrade_succeeded(&test_cluster).await;
 
@@ -214,8 +211,7 @@ mod sim_only_tests {
                 }
             }))
             .build()
-            .await
-            .unwrap();
+            .await;
 
         test_cluster.swarm.validator_nodes().for_each(|v| {
             let node_handle = v.get_node_handle().expect("node should be running");
@@ -248,8 +244,7 @@ mod sim_only_tests {
                 }
             }))
             .build()
-            .await
-            .unwrap();
+            .await;
 
         test_cluster.swarm.validator_nodes().for_each(|v| {
             let node_handle = v.get_node_handle().expect("node should be running");
@@ -292,8 +287,7 @@ mod sim_only_tests {
                 }
             }))
             .build()
-            .await
-            .unwrap();
+            .await;
 
         expect_upgrade_failed(&test_cluster).await;
     }
@@ -385,8 +379,7 @@ mod sim_only_tests {
                 START, FINISH,
             ))
             .build()
-            .await
-            .unwrap();
+            .await;
 
         expect_upgrade_succeeded(&cluster).await;
 
@@ -440,7 +433,6 @@ mod sim_only_tests {
             ))
             .build()
             .await
-            .unwrap()
     }
 
     async fn call_canary(cluster: &TestCluster) -> u64 {
@@ -548,8 +540,7 @@ mod sim_only_tests {
                 START, START,
             ))
             .build()
-            .await
-            .unwrap();
+            .await;
 
         expect_upgrade_failed(&test_cluster).await;
     }
@@ -568,8 +559,7 @@ mod sim_only_tests {
             ))
             .with_epoch_duration_ms(40000)
             .build()
-            .await
-            .unwrap();
+            .await;
 
         // We must stop the validators before overriding the system modules, otherwise the validators
         // may start running before the override and hence send capabilities indicating that they
@@ -621,8 +611,7 @@ mod sim_only_tests {
                 START, FINISH,
             ))
             .build()
-            .await
-            .unwrap();
+            .await;
 
         test_cluster.stop_all_validators().await;
         let mut validators = test_cluster.swarm.validator_nodes();
@@ -651,8 +640,7 @@ mod sim_only_tests {
                 START, FINISH,
             ))
             .build()
-            .await
-            .unwrap();
+            .await;
         let genesis_epoch_start_time = test_cluster
             .swarm
             .validator_nodes()
@@ -698,8 +686,7 @@ mod sim_only_tests {
             ))
             .with_objects([sui_system_package_object("mock_sui_systems/base")])
             .build()
-            .await
-            .unwrap();
+            .await;
         // Make sure we can survive at least one epoch.
         test_cluster.wait_for_epoch(None).await;
     }
@@ -715,8 +702,7 @@ mod sim_only_tests {
             ))
             .with_objects([sui_system_package_object("mock_sui_systems/base")])
             .build()
-            .await
-            .unwrap();
+            .await;
         // Wait for the upgrade to finish. After the upgrade, the new framework will be installed,
         // but the system state object hasn't been upgraded yet.
         let system_state = test_cluster.wait_for_epoch(Some(1)).await;
@@ -748,8 +734,7 @@ mod sim_only_tests {
             ))
             .with_objects([sui_system_package_object("mock_sui_systems/base")])
             .build()
-            .await
-            .unwrap();
+            .await;
         // Wait for the upgrade to finish. After the upgrade, the new framework will be installed,
         // but the system state object hasn't been upgraded yet.
         let system_state = test_cluster.wait_for_epoch(Some(1)).await;
@@ -804,8 +789,7 @@ mod sim_only_tests {
                 START, FINISH,
             ))
             .build()
-            .await
-            .unwrap();
+            .await;
         // TODO: Replace the path with the new framework path when we test it for real.
         override_sui_system_modules("../../../sui-framework/packages/sui-system");
         // Wait for the upgrade to finish. After the upgrade, the new framework will be installed,

--- a/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
@@ -30,7 +30,7 @@ use tokio::time::sleep;
 
 #[sim_test]
 async fn advance_epoch_tx_test() {
-    let test_cluster = TestClusterBuilder::new().build().await.unwrap();
+    let test_cluster = TestClusterBuilder::new().build().await;
     let states = test_cluster
         .swarm
         .validator_node_handles()
@@ -73,13 +73,13 @@ async fn advance_epoch_tx_test() {
 async fn basic_reconfig_end_to_end_test() {
     // TODO remove this sleep when this test passes consistently
     sleep(Duration::from_secs(1)).await;
-    let test_cluster = TestClusterBuilder::new().build().await.unwrap();
+    let test_cluster = TestClusterBuilder::new().build().await;
     test_cluster.trigger_reconfiguration().await;
 }
 
 #[sim_test]
 async fn test_transaction_expiration() {
-    let test_cluster = TestClusterBuilder::new().build().await.unwrap();
+    let test_cluster = TestClusterBuilder::new().build().await;
     test_cluster.trigger_reconfiguration().await;
 
     let (sender, gas) = test_cluster
@@ -125,7 +125,7 @@ async fn test_transaction_expiration() {
 // may not always be tested.
 #[sim_test]
 async fn reconfig_with_revert_end_to_end_test() {
-    let test_cluster = TestClusterBuilder::new().build().await.unwrap();
+    let test_cluster = TestClusterBuilder::new().build().await;
     let authorities = test_cluster.swarm.validator_node_handles();
     let rgp = test_cluster.get_reference_gas_price().await;
     let (sender, mut gas_objects) = test_cluster.wallet.get_one_account().await.unwrap();
@@ -269,8 +269,7 @@ async fn test_passive_reconfig() {
     let test_cluster = TestClusterBuilder::new()
         .with_epoch_duration_ms(1000)
         .build()
-        .await
-        .unwrap();
+        .await;
 
     let target_epoch: u64 = std::env::var("RECONFIG_TARGET_EPOCH")
         .ok()
@@ -354,8 +353,7 @@ async fn test_create_advance_epoch_tx_race() {
     let test_cluster = TestClusterBuilder::new()
         .with_epoch_duration_ms(1000)
         .build()
-        .await
-        .unwrap();
+        .await;
 
     test_cluster.wait_for_epoch(None).await;
 
@@ -379,8 +377,7 @@ async fn test_reconfig_with_failing_validator() {
         TestClusterBuilder::new()
             .with_epoch_duration_ms(5000)
             .build()
-            .await
-            .unwrap(),
+            .await,
     );
 
     test_cluster
@@ -405,7 +402,7 @@ async fn test_validator_resign_effects() {
     // This test checks that validators are able to re-sign transaction effects that were finalized
     // in previous epochs. This allows authority aggregator to form a new effects certificate
     // in the new epoch.
-    let test_cluster = TestClusterBuilder::new().build().await.unwrap();
+    let test_cluster = TestClusterBuilder::new().build().await;
     let tx = test_cluster
         .wallet
         .make_transfer_sui_transaction(None, None)
@@ -439,8 +436,7 @@ async fn test_validator_candidate_pool_read() {
     let test_cluster = TestClusterBuilder::new()
         .with_validator_candidates([address])
         .build()
-        .await
-        .unwrap();
+        .await;
     add_validator_candidate(&test_cluster, &new_validator).await;
     test_cluster.fullnode_handle.sui_node.with(|node| {
         let system_state = node
@@ -471,8 +467,7 @@ async fn test_inactive_validator_pool_read() {
     let test_cluster = TestClusterBuilder::new()
         .with_num_validators(5)
         .build()
-        .await
-        .unwrap();
+        .await;
     // Pick the first validator.
     let validator = test_cluster.swarm.validator_node_handles().pop().unwrap();
     let address = validator.with(|node| node.get_config().sui_address());
@@ -550,8 +545,7 @@ async fn test_reconfig_with_committee_change_basic() {
     let mut test_cluster = TestClusterBuilder::new()
         .with_validator_candidates([address])
         .build()
-        .await
-        .unwrap();
+        .await;
 
     execute_add_validator_transactions(&test_cluster, &new_validator).await;
 
@@ -603,8 +597,7 @@ async fn test_reconfig_with_committee_change_stress() {
         .with_validator_candidates(addresses)
         .with_num_unpruned_validators(2)
         .build()
-        .await
-        .unwrap();
+        .await;
 
     while !candidates.is_empty() {
         let v1 = candidates.pop().unwrap();
@@ -660,8 +653,7 @@ async fn safe_mode_reconfig_test() {
     let test_cluster = TestClusterBuilder::new()
         .with_epoch_duration_ms(EPOCH_DURATION)
         .build()
-        .await
-        .unwrap();
+        .await;
 
     let system_state = test_cluster
         .sui_client()

--- a/crates/sui-e2e-tests/tests/simulator_tests.rs
+++ b/crates/sui-e2e-tests/tests/simulator_tests.rs
@@ -124,7 +124,7 @@ async fn test_hash_collections() {
 // repeatable and deterministic.
 #[sim_test(check_determinism)]
 async fn test_net_determinism() {
-    let mut test_cluster = TestClusterBuilder::new().build().await.unwrap();
+    let mut test_cluster = TestClusterBuilder::new().build().await;
 
     let txn = test_cluster
         .wallet

--- a/crates/sui-e2e-tests/tests/snapshot_tests.rs
+++ b/crates/sui-e2e-tests/tests/snapshot_tests.rs
@@ -55,7 +55,7 @@ async fn run_one(
 #[ignore]
 #[sim_test]
 async fn basic_read_cmd_snapshot_tests() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await?;
+    let mut test_cluster = TestClusterBuilder::new().build().await;
     let context = &mut test_cluster.wallet;
 
     let cmds = vec![
@@ -68,7 +68,7 @@ async fn basic_read_cmd_snapshot_tests() -> Result<(), anyhow::Error> {
         // "sui client object 0x3b5121a0603ef7ab4cb57827fceca17db3338ef2cd76126cc1523b681df27cee", // valid object
         // "sui client object 0x3b5121a0603ef7ab4cb57827fceca17db3338ef2cd76126cc1523b681df27cee --bcs", // valid object BCS
         "sui client object 0x0000000000000000000000000000000000000000000000000000000000000000", // non-existent object
-        "sui client tx-block Duwr9uSk9ZvNdEa8oDHunx345i6oyrp3e78MYHVAbYdv", // valid tx digest
+        "sui client tx-block Duwr9uSk9ZvAndEa8oDHunx345i6oyrp3e78MYHVAbYdv", // valid tx digest
         "sui client tx-block EgMTHQygMi6SRsBqrPHAEKZCNrpShXurCp9rcb9qbSg8", // non-existent tx digest
     ];
     assert_json_snapshot!(run_one(cmds, context).await?);

--- a/crates/sui-e2e-tests/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui-e2e-tests/tests/transaction_orchestrator_tests.rs
@@ -18,7 +18,7 @@ use tracing::info;
 
 #[sim_test]
 async fn test_blocking_execution() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await?;
+    let mut test_cluster = TestClusterBuilder::new().build().await;
     let context = &mut test_cluster.wallet;
     let handle = &test_cluster.fullnode_handle.sui_node;
 
@@ -87,7 +87,7 @@ async fn test_fullnode_wal_log() -> Result<(), anyhow::Error> {
     let mut test_cluster = TestClusterBuilder::new()
         .with_epoch_duration_ms(600000)
         .build()
-        .await?;
+        .await;
 
     let handle = &test_cluster.fullnode_handle.sui_node;
 
@@ -172,7 +172,7 @@ async fn test_fullnode_wal_log() -> Result<(), anyhow::Error> {
 #[sim_test]
 async fn test_transaction_orchestrator_reconfig() {
     telemetry_subscribers::init_for_testing();
-    let test_cluster = TestClusterBuilder::new().build().await.unwrap();
+    let test_cluster = TestClusterBuilder::new().build().await;
     let epoch = test_cluster.fullnode_handle.sui_node.with(|node| {
         node.transaction_orchestrator()
             .unwrap()
@@ -219,7 +219,7 @@ async fn test_tx_across_epoch_boundaries() {
     let total_tx_cnt = 1;
     let (result_tx, mut result_rx) = tokio::sync::mpsc::channel::<FinalizedEffects>(total_tx_cnt);
 
-    let test_cluster = TestClusterBuilder::new().build().await.unwrap();
+    let test_cluster = TestClusterBuilder::new().build().await;
     let tx = test_cluster
         .wallet
         .make_transfer_sui_transaction(None, None)

--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -682,7 +682,7 @@ impl SimpleFaucet {
         // Assert that the number of times a sui_address occurs is the number of times the coins
         // come up in the vector.
         let mut request_count: HashMap<SuiAddress, u64> = HashMap::new();
-        // Aquire lock and update all of the request Uuids
+        // Acquire lock and update all of the request Uuids
         let mut task_map = self.task_id_cache.lock().await;
         for (uuid, addy, amounts) in requests {
             let number_of_coins = amounts.len();
@@ -725,7 +725,7 @@ impl SimpleFaucet {
             );
         }
 
-        // We use a seperate map to figure out which index should correlate to the
+        // We use a separate map to figure out which index should correlate to the
         Ok(())
     }
 
@@ -995,7 +995,7 @@ mod tests {
     #[tokio::test]
     async fn simple_faucet_basic_interface_should_work() {
         telemetry_subscribers::init_for_testing();
-        let test_cluster = TestClusterBuilder::new().build().await.unwrap();
+        let test_cluster = TestClusterBuilder::new().build().await;
 
         let tmp = tempfile::tempdir().unwrap();
         let prom_registry = Registry::new();
@@ -1023,7 +1023,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_init_gas_queue() {
-        let test_cluster = TestClusterBuilder::new().build().await.unwrap();
+        let test_cluster = TestClusterBuilder::new().build().await;
         let address = test_cluster.get_address_0();
         let mut context = test_cluster.wallet;
         let gases = get_current_gases(address, &mut context).await;
@@ -1056,7 +1056,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_transfer_state() {
-        let test_cluster = TestClusterBuilder::new().build().await.unwrap();
+        let test_cluster = TestClusterBuilder::new().build().await;
         let address = test_cluster.get_address_0();
         let mut context = test_cluster.wallet;
         let gases = get_current_gases(address, &mut context).await;
@@ -1105,7 +1105,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_batch_transfer_interface() {
-        let test_cluster = TestClusterBuilder::new().build().await.unwrap();
+        let test_cluster = TestClusterBuilder::new().build().await;
         let context = test_cluster.wallet;
         let config: FaucetConfig = Default::default();
         let coin_amount = config.amount;
@@ -1182,7 +1182,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_ttl_cache_expires_after_duration() {
-        let test_cluster = TestClusterBuilder::new().build().await.unwrap();
+        let test_cluster = TestClusterBuilder::new().build().await;
         let context = test_cluster.wallet;
         // We set it to a fast expiration for the purposes of testing and so these requests don't have time to pass
         // through the batch process.
@@ -1233,7 +1233,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_discard_invalid_gas() {
-        let test_cluster = TestClusterBuilder::new().build().await.unwrap();
+        let test_cluster = TestClusterBuilder::new().build().await;
         let address = test_cluster.get_address_0();
         let mut context = test_cluster.wallet;
         let mut gases = get_current_gases(address, &mut context).await;
@@ -1310,7 +1310,7 @@ mod tests {
     #[tokio::test]
     async fn test_clear_wal() {
         telemetry_subscribers::init_for_testing();
-        let test_cluster = TestClusterBuilder::new().build().await.unwrap();
+        let test_cluster = TestClusterBuilder::new().build().await;
         let context = test_cluster.wallet;
         let tmp = tempfile::tempdir().unwrap();
         let prom_registry = Registry::new();
@@ -1373,7 +1373,7 @@ mod tests {
     #[tokio::test]
     async fn test_discard_smaller_amount_gas() {
         telemetry_subscribers::init_for_testing();
-        let test_cluster = TestClusterBuilder::new().build().await.unwrap();
+        let test_cluster = TestClusterBuilder::new().build().await;
         let address = test_cluster.get_address_0();
         let mut context = test_cluster.wallet;
         let gases = get_current_gases(address, &mut context).await;
@@ -1459,7 +1459,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_insufficient_balance_will_retry_success() {
-        let test_cluster = TestClusterBuilder::new().build().await.unwrap();
+        let test_cluster = TestClusterBuilder::new().build().await;
         let address = test_cluster.get_address_0();
         let mut context = test_cluster.wallet;
         let gases = get_current_gases(address, &mut context).await;
@@ -1532,7 +1532,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_faucet_no_loop_forever() {
-        let test_cluster = TestClusterBuilder::new().build().await.unwrap();
+        let test_cluster = TestClusterBuilder::new().build().await;
         let address = test_cluster.get_address_0();
         let mut context = test_cluster.wallet;
         let gases = get_current_gases(address, &mut context).await;
@@ -1595,7 +1595,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_faucet_restart_clears_wal() {
-        let test_cluster = TestClusterBuilder::new().build().await.unwrap();
+        let test_cluster = TestClusterBuilder::new().build().await;
         let context = test_cluster.wallet;
         let tmp = tempfile::tempdir().unwrap();
         let prom_registry = Registry::new();
@@ -1665,7 +1665,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_amounts_transferred_on_batch() {
-        let test_cluster = TestClusterBuilder::new().build().await.unwrap();
+        let test_cluster = TestClusterBuilder::new().build().await;
         let context = test_cluster.wallet;
         let config: FaucetConfig = Default::default();
 

--- a/crates/sui-indexer/tests/integration_tests.rs
+++ b/crates/sui-indexer/tests/integration_tests.rs
@@ -1264,9 +1264,8 @@ pub mod pg_integration_test {
                 .with_epoch_duration_ms(epoch)
                 .build()
                 .await
-                .unwrap()
         } else {
-            TestClusterBuilder::new().build().await.unwrap()
+            TestClusterBuilder::new().build().await
         };
 
         let config = IndexerConfig {

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -34,7 +34,7 @@ use tokio::time::sleep;
 
 #[sim_test]
 async fn test_get_objects() -> Result<(), anyhow::Error> {
-    let cluster = TestClusterBuilder::new().build().await?;
+    let cluster = TestClusterBuilder::new().build().await;
 
     let http_client = cluster.rpc_client();
     let address = cluster.get_address_0();
@@ -65,7 +65,7 @@ async fn test_get_objects() -> Result<(), anyhow::Error> {
 
 #[tokio::test]
 async fn test_get_package_with_display_should_not_fail() -> Result<(), anyhow::Error> {
-    let cluster = TestClusterBuilder::new().build().await?;
+    let cluster = TestClusterBuilder::new().build().await;
     let http_client = cluster.rpc_client();
     let response = http_client
         .get_object(
@@ -87,7 +87,7 @@ async fn test_get_package_with_display_should_not_fail() -> Result<(), anyhow::E
 
 #[sim_test]
 async fn test_public_transfer_object() -> Result<(), anyhow::Error> {
-    let cluster = TestClusterBuilder::new().build().await?;
+    let cluster = TestClusterBuilder::new().build().await;
     let http_client = cluster.rpc_client();
     let address = cluster.get_address_0();
 
@@ -169,7 +169,7 @@ fn assert_same_object_changes_ignoring_version_and_digest(
 
 #[sim_test]
 async fn test_publish() -> Result<(), anyhow::Error> {
-    let cluster = TestClusterBuilder::new().build().await?;
+    let cluster = TestClusterBuilder::new().build().await;
     let http_client = cluster.rpc_client();
     let address = cluster.get_address_0();
 
@@ -223,7 +223,7 @@ async fn test_publish() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_move_call() -> Result<(), anyhow::Error> {
-    let cluster = TestClusterBuilder::new().build().await?;
+    let cluster = TestClusterBuilder::new().build().await;
     let http_client = cluster.rpc_client();
     let address = cluster.get_address_0();
 
@@ -284,7 +284,7 @@ async fn test_move_call() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_get_object_info() -> Result<(), anyhow::Error> {
-    let cluster = TestClusterBuilder::new().build().await?;
+    let cluster = TestClusterBuilder::new().build().await;
     let http_client = cluster.rpc_client();
     let address = cluster.get_address_0();
     let objects = http_client
@@ -319,7 +319,7 @@ async fn test_get_object_info() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_get_object_data_with_content() -> Result<(), anyhow::Error> {
-    let cluster = TestClusterBuilder::new().build().await?;
+    let cluster = TestClusterBuilder::new().build().await;
     let http_client = cluster.rpc_client();
     let address = cluster.get_address_0();
     let objects = http_client
@@ -351,7 +351,7 @@ async fn test_get_object_data_with_content() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_get_coins() -> Result<(), anyhow::Error> {
-    let cluster = TestClusterBuilder::new().build().await?;
+    let cluster = TestClusterBuilder::new().build().await;
     let http_client = cluster.rpc_client();
     let address = cluster.get_address_0();
 
@@ -404,7 +404,7 @@ async fn test_get_coins() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_get_balance() -> Result<(), anyhow::Error> {
-    let cluster = TestClusterBuilder::new().build().await?;
+    let cluster = TestClusterBuilder::new().build().await;
     let http_client = cluster.rpc_client();
     let address = cluster.get_address_0();
 
@@ -423,7 +423,7 @@ async fn test_get_balance() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_get_metadata() -> Result<(), anyhow::Error> {
-    let cluster = TestClusterBuilder::new().build().await?;
+    let cluster = TestClusterBuilder::new().build().await;
 
     let http_client = cluster.rpc_client();
     let address = cluster.get_address_0();
@@ -507,7 +507,7 @@ async fn test_get_metadata() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_get_total_supply() -> Result<(), anyhow::Error> {
-    let cluster = TestClusterBuilder::new().build().await?;
+    let cluster = TestClusterBuilder::new().build().await;
 
     let http_client = cluster.rpc_client();
     let address = cluster.get_address_0();
@@ -643,7 +643,7 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_staking() -> Result<(), anyhow::Error> {
-    let cluster = TestClusterBuilder::new().build().await?;
+    let cluster = TestClusterBuilder::new().build().await;
 
     let http_client = cluster.rpc_client();
     let address = cluster.get_address_0();
@@ -724,7 +724,7 @@ async fn test_unstaking() -> Result<(), anyhow::Error> {
     let cluster = TestClusterBuilder::new()
         .with_epoch_duration_ms(10000)
         .build()
-        .await?;
+        .await;
 
     let http_client = cluster.rpc_client();
     let address = cluster.get_address_0();
@@ -857,7 +857,7 @@ async fn test_unstaking() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_staking_multiple_coins() -> Result<(), anyhow::Error> {
-    let cluster = TestClusterBuilder::new().build().await?;
+    let cluster = TestClusterBuilder::new().build().await;
 
     let http_client = cluster.rpc_client();
     let address = cluster.get_address_0();

--- a/crates/sui-json-rpc/src/unit_tests/transaction_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/transaction_tests.rs
@@ -16,7 +16,7 @@ use crate::api::{IndexerApiClient, TransactionBuilderClient, WriteApiClient};
 
 #[sim_test]
 async fn test_get_transaction_block() -> Result<(), anyhow::Error> {
-    let cluster = TestClusterBuilder::new().build().await?;
+    let cluster = TestClusterBuilder::new().build().await;
     let http_client = cluster.rpc_client();
     let address = cluster.get_address_0();
 
@@ -102,7 +102,7 @@ async fn test_get_transaction_block() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_get_raw_transaction() -> Result<(), anyhow::Error> {
-    let cluster = TestClusterBuilder::new().build().await?;
+    let cluster = TestClusterBuilder::new().build().await;
     let http_client = cluster.rpc_client();
     let address = cluster.get_address_0();
 
@@ -150,7 +150,7 @@ async fn test_get_raw_transaction() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
-    let cluster = TestClusterBuilder::new().build().await.unwrap();
+    let cluster = TestClusterBuilder::new().build().await;
 
     let context = &cluster.wallet;
 

--- a/crates/sui-json-rpc/tests/balance_changes_tests.rs
+++ b/crates/sui-json-rpc/tests/balance_changes_tests.rs
@@ -10,7 +10,7 @@ use test_utils::network::TestClusterBuilder;
 
 #[tokio::test]
 async fn test_dry_run_publish_with_mocked_coin() -> Result<(), anyhow::Error> {
-    let cluster = TestClusterBuilder::new().build().await.unwrap();
+    let cluster = TestClusterBuilder::new().build().await;
     let context = &cluster.wallet;
 
     let address = cluster.get_address_0();

--- a/crates/sui-json-rpc/tests/subscription_tests.rs
+++ b/crates/sui-json-rpc/tests/subscription_tests.rs
@@ -15,7 +15,7 @@ use test_utils::network::TestClusterBuilder;
 
 #[tokio::test]
 async fn test_subscribe_transaction() -> Result<(), anyhow::Error> {
-    let cluster = TestClusterBuilder::new().build().await.unwrap();
+    let cluster = TestClusterBuilder::new().build().await;
 
     let address = &cluster.get_address_0();
     let wallet = cluster.wallet;

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -38,7 +38,7 @@ use test_utils::network::TestClusterBuilder;
 
 #[tokio::test]
 async fn test_transfer_sui() {
-    let network = TestClusterBuilder::new().build().await.unwrap();
+    let network = TestClusterBuilder::new().build().await;
     let client = network.wallet.get_client().await.unwrap();
     let keystore = &network.wallet.config.keystore;
     let rgp = network.get_reference_gas_price().await;
@@ -68,7 +68,7 @@ async fn test_transfer_sui() {
 
 #[tokio::test]
 async fn test_transfer_sui_whole_coin() {
-    let network = TestClusterBuilder::new().build().await.unwrap();
+    let network = TestClusterBuilder::new().build().await;
     let client = network.wallet.get_client().await.unwrap();
     let keystore = &network.wallet.config.keystore;
     let rgp = network.get_reference_gas_price().await;
@@ -98,7 +98,7 @@ async fn test_transfer_sui_whole_coin() {
 
 #[tokio::test]
 async fn test_transfer_object() {
-    let network = TestClusterBuilder::new().build().await.unwrap();
+    let network = TestClusterBuilder::new().build().await;
     let client = network.wallet.get_client().await.unwrap();
     let keystore = &network.wallet.config.keystore;
     let rgp = network.get_reference_gas_price().await;
@@ -129,7 +129,7 @@ async fn test_transfer_object() {
 
 #[tokio::test]
 async fn test_publish_and_move_call() {
-    let network = TestClusterBuilder::new().build().await.unwrap();
+    let network = TestClusterBuilder::new().build().await;
     let client = network.wallet.get_client().await.unwrap();
     let keystore = &network.wallet.config.keystore;
     let rgp = network.get_reference_gas_price().await;
@@ -219,7 +219,7 @@ async fn test_publish_and_move_call() {
 
 #[tokio::test]
 async fn test_split_coin() {
-    let network = TestClusterBuilder::new().build().await.unwrap();
+    let network = TestClusterBuilder::new().build().await;
     let client = network.wallet.get_client().await.unwrap();
     let keystore = &network.wallet.config.keystore;
     let rgp = network.get_reference_gas_price().await;
@@ -252,7 +252,7 @@ async fn test_split_coin() {
 
 #[tokio::test]
 async fn test_merge_coin() {
-    let network = TestClusterBuilder::new().build().await.unwrap();
+    let network = TestClusterBuilder::new().build().await;
     let client = network.wallet.get_client().await.unwrap();
     let keystore = &network.wallet.config.keystore;
     let rgp = network.get_reference_gas_price().await;
@@ -286,7 +286,7 @@ async fn test_merge_coin() {
 
 #[tokio::test]
 async fn test_pay() {
-    let network = TestClusterBuilder::new().build().await.unwrap();
+    let network = TestClusterBuilder::new().build().await;
     let client = network.wallet.get_client().await.unwrap();
     let keystore = &network.wallet.config.keystore;
     let rgp = network.get_reference_gas_price().await;
@@ -319,7 +319,7 @@ async fn test_pay() {
 
 #[tokio::test]
 async fn test_pay_multiple_coin_multiple_recipient() {
-    let network = TestClusterBuilder::new().build().await.unwrap();
+    let network = TestClusterBuilder::new().build().await;
     let client = network.wallet.get_client().await.unwrap();
     let keystore = &network.wallet.config.keystore;
     let rgp = network.get_reference_gas_price().await;
@@ -358,7 +358,7 @@ async fn test_pay_multiple_coin_multiple_recipient() {
 
 #[tokio::test]
 async fn test_pay_sui_multiple_coin_same_recipient() {
-    let network = TestClusterBuilder::new().build().await.unwrap();
+    let network = TestClusterBuilder::new().build().await;
     let client = network.wallet.get_client().await.unwrap();
     let keystore = &network.wallet.config.keystore;
     let rgp = network.get_reference_gas_price().await;
@@ -395,7 +395,7 @@ async fn test_pay_sui_multiple_coin_same_recipient() {
 
 #[tokio::test]
 async fn test_pay_sui() {
-    let network = TestClusterBuilder::new().build().await.unwrap();
+    let network = TestClusterBuilder::new().build().await;
     let client = network.wallet.get_client().await.unwrap();
     let keystore = &network.wallet.config.keystore;
     let rgp = network.get_reference_gas_price().await;
@@ -430,7 +430,7 @@ async fn test_pay_sui() {
 
 #[tokio::test]
 async fn test_failed_pay_sui() {
-    let network = TestClusterBuilder::new().build().await.unwrap();
+    let network = TestClusterBuilder::new().build().await;
     let client = network.wallet.get_client().await.unwrap();
     let keystore = &network.wallet.config.keystore;
     let rgp = network.get_reference_gas_price().await;
@@ -465,7 +465,7 @@ async fn test_failed_pay_sui() {
 
 #[tokio::test]
 async fn test_stake_sui() {
-    let network = TestClusterBuilder::new().build().await.unwrap();
+    let network = TestClusterBuilder::new().build().await;
     let client = network.wallet.get_client().await.unwrap();
     let keystore = &network.wallet.config.keystore;
     let rgp = network.get_reference_gas_price().await;
@@ -513,7 +513,7 @@ async fn test_stake_sui() {
 
 #[tokio::test]
 async fn test_stake_sui_with_none_amount() {
-    let network = TestClusterBuilder::new().build().await.unwrap();
+    let network = TestClusterBuilder::new().build().await;
     let client = network.wallet.get_client().await.unwrap();
     let keystore = &network.wallet.config.keystore;
     let rgp = network.get_reference_gas_price().await;
@@ -561,7 +561,7 @@ async fn test_stake_sui_with_none_amount() {
 
 #[tokio::test]
 async fn test_pay_all_sui() {
-    let network = TestClusterBuilder::new().build().await.unwrap();
+    let network = TestClusterBuilder::new().build().await;
     let client = network.wallet.get_client().await.unwrap();
     let keystore = &network.wallet.config.keystore;
     let rgp = network.get_reference_gas_price().await;
@@ -593,7 +593,7 @@ async fn test_pay_all_sui() {
 
 #[tokio::test]
 async fn test_delegation_parsing() -> Result<(), anyhow::Error> {
-    let network = TestClusterBuilder::new().build().await.unwrap();
+    let network = TestClusterBuilder::new().build().await;
     let rgp = network.get_reference_gas_price().await;
     let client = network.wallet.get_client().await.unwrap();
     let sender = get_random_address(&network.get_addresses(), vec![]);

--- a/crates/sui-rosetta/tests/end_to_end_tests.rs
+++ b/crates/sui-rosetta/tests/end_to_end_tests.rs
@@ -25,7 +25,7 @@ mod rosetta_client;
 
 #[tokio::test]
 async fn test_get_staked_sui() {
-    let test_cluster = TestClusterBuilder::new().build().await.unwrap();
+    let test_cluster = TestClusterBuilder::new().build().await;
     let address = test_cluster.get_address_0();
     let client = test_cluster.wallet.get_client().await.unwrap();
     let keystore = &test_cluster.wallet.config.keystore;
@@ -126,7 +126,7 @@ async fn test_get_staked_sui() {
 
 #[tokio::test]
 async fn test_stake() {
-    let test_cluster = TestClusterBuilder::new().build().await.unwrap();
+    let test_cluster = TestClusterBuilder::new().build().await;
     let sender = test_cluster.get_address_0();
     let client = test_cluster.wallet.get_client().await.unwrap();
     let keystore = &test_cluster.wallet.config.keystore;
@@ -187,7 +187,7 @@ async fn test_stake() {
 
 #[tokio::test]
 async fn test_stake_all() {
-    let test_cluster = TestClusterBuilder::new().build().await.unwrap();
+    let test_cluster = TestClusterBuilder::new().build().await;
     let sender = test_cluster.get_address_0();
     let client = test_cluster.wallet.get_client().await.unwrap();
     let keystore = &test_cluster.wallet.config.keystore;
@@ -250,8 +250,7 @@ async fn test_withdraw_stake() {
     let test_cluster = TestClusterBuilder::new()
         .with_epoch_duration_ms(10000)
         .build()
-        .await
-        .unwrap();
+        .await;
     let sender = test_cluster.get_address_0();
     let client = test_cluster.wallet.get_client().await.unwrap();
     let keystore = &test_cluster.wallet.config.keystore;
@@ -374,7 +373,7 @@ async fn test_withdraw_stake() {
 
 #[tokio::test]
 async fn test_pay_sui() {
-    let test_cluster = TestClusterBuilder::new().build().await.unwrap();
+    let test_cluster = TestClusterBuilder::new().build().await;
     let sender = test_cluster.get_address_0();
     let recipient = test_cluster.get_address_1();
     let client = test_cluster.wallet.get_client().await.unwrap();
@@ -432,8 +431,7 @@ async fn test_pay_sui_multiple_times() {
     let test_cluster = TestClusterBuilder::new()
         .with_epoch_duration_ms(36000000)
         .build()
-        .await
-        .unwrap();
+        .await;
     let sender = test_cluster.get_address_0();
     let recipient = test_cluster.get_address_1();
     let client = test_cluster.wallet.get_client().await.unwrap();

--- a/crates/sui-sdk/tests/stream_tests.rs
+++ b/crates/sui-sdk/tests/stream_tests.rs
@@ -83,7 +83,7 @@ use test_utils::network::TestClusterBuilder;
 
 #[tokio::test]
 async fn test_coins_stream() -> Result<(), anyhow::Error> {
-    let test_cluster = TestClusterBuilder::new().build().await?;
+    let test_cluster = TestClusterBuilder::new().build().await;
     let address = test_cluster.get_address_0();
     let rpc_url = test_cluster.rpc_url();
 

--- a/crates/sui-source-validation/src/tests.rs
+++ b/crates/sui-source-validation/src/tests.rs
@@ -24,7 +24,7 @@ use crate::{BytecodeSourceVerifier, SourceMode};
 
 #[tokio::test]
 async fn successful_verification() -> anyhow::Result<()> {
-    let mut cluster = TestClusterBuilder::new().build().await?;
+    let mut cluster = TestClusterBuilder::new().build().await;
     let context = &mut cluster.wallet;
 
     let b_ref = {
@@ -84,7 +84,7 @@ async fn successful_verification() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn successful_verification_unpublished_deps() -> anyhow::Result<()> {
-    let mut cluster = TestClusterBuilder::new().build().await?;
+    let mut cluster = TestClusterBuilder::new().build().await;
     let context = &mut cluster.wallet;
     let fixtures = tempfile::tempdir()?;
 
@@ -110,7 +110,7 @@ async fn successful_verification_unpublished_deps() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn successful_verification_module_ordering() -> anyhow::Result<()> {
-    let mut cluster = TestClusterBuilder::new().build().await?;
+    let mut cluster = TestClusterBuilder::new().build().await;
     let context = &mut cluster.wallet;
 
     // This package contains a module that refers to itself, and also to the sui framework.  Its
@@ -147,7 +147,7 @@ async fn successful_verification_module_ordering() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn successful_verification_upgrades() -> anyhow::Result<()> {
-    let mut cluster = TestClusterBuilder::new().build().await?;
+    let mut cluster = TestClusterBuilder::new().build().await;
     let context = &mut cluster.wallet;
 
     let (b_v1, b_cap) = {
@@ -187,7 +187,7 @@ async fn successful_verification_upgrades() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn fail_verification_bad_address() -> anyhow::Result<()> {
-    let mut cluster = TestClusterBuilder::new().build().await?;
+    let mut cluster = TestClusterBuilder::new().build().await;
     let context = &mut cluster.wallet;
 
     let b_ref = {
@@ -221,7 +221,7 @@ async fn fail_verification_bad_address() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn fail_to_verify_unpublished_root() -> anyhow::Result<()> {
-    let mut cluster = TestClusterBuilder::new().build().await?;
+    let mut cluster = TestClusterBuilder::new().build().await;
     let context = &mut cluster.wallet;
 
     let b_pkg = {
@@ -249,7 +249,7 @@ async fn fail_to_verify_unpublished_root() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn rpc_call_failed_during_verify() -> anyhow::Result<()> {
-    let mut cluster = TestClusterBuilder::new().build().await?;
+    let mut cluster = TestClusterBuilder::new().build().await;
     let context = &mut cluster.wallet;
 
     let b_ref = {
@@ -301,7 +301,7 @@ async fn rpc_call_failed_during_verify() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn package_not_found() -> anyhow::Result<()> {
-    let mut cluster = TestClusterBuilder::new().build().await?;
+    let mut cluster = TestClusterBuilder::new().build().await;
     let context = &mut cluster.wallet;
     let mut stable_addrs = HashMap::new();
 
@@ -358,7 +358,7 @@ async fn package_not_found() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn dependency_is_an_object() -> anyhow::Result<()> {
-    let mut cluster = TestClusterBuilder::new().build().await?;
+    let mut cluster = TestClusterBuilder::new().build().await;
     let context = &mut cluster.wallet;
 
     let a_pkg = {
@@ -385,7 +385,7 @@ async fn dependency_is_an_object() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn module_not_found_on_chain() -> anyhow::Result<()> {
-    let mut cluster = TestClusterBuilder::new().build().await?;
+    let mut cluster = TestClusterBuilder::new().build().await;
     let context = &mut cluster.wallet;
 
     let b_ref = {
@@ -416,7 +416,7 @@ async fn module_not_found_on_chain() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn module_not_found_locally() -> anyhow::Result<()> {
-    let mut cluster = TestClusterBuilder::new().build().await?;
+    let mut cluster = TestClusterBuilder::new().build().await;
     let context = &mut cluster.wallet;
     let mut stable_addrs = HashMap::new();
 
@@ -451,7 +451,7 @@ async fn module_not_found_locally() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn module_bytecode_mismatch() -> anyhow::Result<()> {
-    let mut cluster = TestClusterBuilder::new().build().await?;
+    let mut cluster = TestClusterBuilder::new().build().await;
     let context = &mut cluster.wallet;
     let mut stable_addrs = HashMap::new();
 
@@ -511,7 +511,7 @@ async fn module_bytecode_mismatch() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn multiple_failures() -> anyhow::Result<()> {
-    let mut cluster = TestClusterBuilder::new().build().await?;
+    let mut cluster = TestClusterBuilder::new().build().await;
     let context = &mut cluster.wallet;
     let mut stable_addrs = HashMap::new();
 

--- a/crates/sui-surfer/src/lib.rs
+++ b/crates/sui-surfer/src/lib.rs
@@ -44,8 +44,7 @@ pub async fn run<S: SurfStrategy + Default>(
                 ACCOUNT_NUM
             ])
             .build()
-            .await
-            .unwrap(),
+            .await,
     );
     info!(
         "Started cluster with {} validators and epoch duration of {:?}ms",

--- a/crates/sui/src/unit_tests/validator_tests.rs
+++ b/crates/sui/src/unit_tests/validator_tests.rs
@@ -18,7 +18,7 @@ use test_utils::network::TestClusterBuilder;
 
 #[tokio::test]
 async fn test_print_raw_rgp_txn() -> Result<(), anyhow::Error> {
-    let test_cluster = TestClusterBuilder::new().build().await?;
+    let test_cluster = TestClusterBuilder::new().build().await;
     let keypair: &SuiKeyPair = test_cluster
         .swarm
         .config()

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -179,7 +179,7 @@ async fn test_genesis_for_benchmarks() -> Result<(), anyhow::Error> {
 
 #[tokio::test]
 async fn test_addresses_command() -> Result<(), anyhow::Error> {
-    let test_cluster = TestClusterBuilder::new().build().await?;
+    let test_cluster = TestClusterBuilder::new().build().await;
     let mut context = test_cluster.wallet;
 
     // Add 3 accounts
@@ -202,7 +202,7 @@ async fn test_addresses_command() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_objects_command() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await?;
+    let mut test_cluster = TestClusterBuilder::new().build().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
 
@@ -235,7 +235,7 @@ async fn test_objects_command() -> Result<(), anyhow::Error> {
 // fixing issue https://github.com/MystenLabs/sui/issues/6546
 #[tokio::test]
 async fn test_regression_6546() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await?;
+    let mut test_cluster = TestClusterBuilder::new().build().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
 
@@ -282,7 +282,7 @@ async fn test_custom_genesis() -> Result<(), anyhow::Error> {
     let mut cluster = TestClusterBuilder::new()
         .set_genesis_config(config)
         .build()
-        .await?;
+        .await;
     let address = cluster.get_address_0();
     let context = cluster.wallet_mut();
 
@@ -301,7 +301,7 @@ async fn test_custom_genesis() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_object_info_get_command() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await?;
+    let mut test_cluster = TestClusterBuilder::new().build().await;
 
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -344,7 +344,7 @@ async fn test_object_info_get_command() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_gas_command() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await?;
+    let mut test_cluster = TestClusterBuilder::new().build().await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -405,7 +405,7 @@ async fn test_gas_command() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await?;
+    let mut test_cluster = TestClusterBuilder::new().build().await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address1 = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -622,7 +622,7 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_package_publish_command() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await?;
+    let mut test_cluster = TestClusterBuilder::new().build().await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -693,7 +693,7 @@ async fn test_package_publish_command_with_unpublished_dependency_succeeds(
 ) -> Result<(), anyhow::Error> {
     let with_unpublished_dependencies = true; // Value under test, results in successful response.
 
-    let mut test_cluster = TestClusterBuilder::new().build().await?;
+    let mut test_cluster = TestClusterBuilder::new().build().await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -762,7 +762,7 @@ async fn test_package_publish_command_with_unpublished_dependency_fails(
 ) -> Result<(), anyhow::Error> {
     let with_unpublished_dependencies = false; // Value under test, results in error response.
 
-    let mut test_cluster = TestClusterBuilder::new().build().await?;
+    let mut test_cluster = TestClusterBuilder::new().build().await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -817,7 +817,7 @@ async fn test_package_publish_command_non_zero_unpublished_dep_fails() -> Result
 {
     let with_unpublished_dependencies = true; // Value under test, incompatible with dependencies that specify non-zero address.
 
-    let mut test_cluster = TestClusterBuilder::new().build().await?;
+    let mut test_cluster = TestClusterBuilder::new().build().await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -862,7 +862,7 @@ async fn test_package_publish_command_non_zero_unpublished_dep_fails() -> Result
 async fn test_package_publish_command_failure_invalid() -> Result<(), anyhow::Error> {
     let with_unpublished_dependencies = true; // Invalid packages should fail to publish, even if we allow unpublished dependencies.
 
-    let mut test_cluster = TestClusterBuilder::new().build().await?;
+    let mut test_cluster = TestClusterBuilder::new().build().await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -915,7 +915,7 @@ async fn test_package_publish_command_failure_invalid() -> Result<(), anyhow::Er
 
 #[sim_test]
 async fn test_package_publish_nonexistent_dependency() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await?;
+    let mut test_cluster = TestClusterBuilder::new().build().await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -959,7 +959,7 @@ async fn test_package_publish_nonexistent_dependency() -> Result<(), anyhow::Err
 #[ignore]
 async fn test_package_upgrade_command() -> Result<(), anyhow::Error> {
     move_package::package_hooks::register_package_hooks(Box::new(SuiPackageHooks));
-    let mut test_cluster = TestClusterBuilder::new().build().await?;
+    let mut test_cluster = TestClusterBuilder::new().build().await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -1098,7 +1098,7 @@ async fn test_package_upgrade_command() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_native_transfer() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await?;
+    let mut test_cluster = TestClusterBuilder::new().build().await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -1288,7 +1288,7 @@ fn test_bug_1078() {
 
 #[sim_test]
 async fn test_switch_command() -> Result<(), anyhow::Error> {
-    let mut cluster = TestClusterBuilder::new().build().await?;
+    let mut cluster = TestClusterBuilder::new().build().await;
     let addr2 = cluster.get_address_1();
     let context = cluster.wallet_mut();
 
@@ -1386,7 +1386,7 @@ async fn test_switch_command() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_new_address_command_by_flag() -> Result<(), anyhow::Error> {
-    let mut cluster = TestClusterBuilder::new().build().await?;
+    let mut cluster = TestClusterBuilder::new().build().await;
     let context = cluster.wallet_mut();
 
     // keypairs loaded from config are Ed25519
@@ -1426,7 +1426,7 @@ async fn test_new_address_command_by_flag() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_active_address_command() -> Result<(), anyhow::Error> {
-    let mut cluster = TestClusterBuilder::new().build().await?;
+    let mut cluster = TestClusterBuilder::new().build().await;
     let context = cluster.wallet_mut();
 
     // Get the active address
@@ -1487,7 +1487,7 @@ async fn get_parsed_object_assert_existence(
 
 #[sim_test]
 async fn test_merge_coin() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await?;
+    let mut test_cluster = TestClusterBuilder::new().build().await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -1611,7 +1611,7 @@ async fn test_merge_coin() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_split_coin() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await?;
+    let mut test_cluster = TestClusterBuilder::new().build().await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
@@ -1842,7 +1842,7 @@ async fn test_signature_flag() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_execute_signed_tx() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await?;
+    let mut test_cluster = TestClusterBuilder::new().build().await;
     let context = &mut test_cluster.wallet;
     let mut txns = context.batch_make_transfer_transactions(1).await;
     let txn = txns.swap_remove(0);
@@ -1859,7 +1859,7 @@ async fn test_execute_signed_tx() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_serialize_tx() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await?;
+    let mut test_cluster = TestClusterBuilder::new().build().await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let address = test_cluster.get_address_0();
     let address1 = test_cluster.get_address_1();
@@ -1908,7 +1908,7 @@ async fn test_serialize_tx() -> Result<(), anyhow::Error> {
 
 #[tokio::test]
 async fn test_stake_with_none_amount() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await?;
+    let mut test_cluster = TestClusterBuilder::new().build().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
 
@@ -1960,7 +1960,7 @@ async fn test_stake_with_none_amount() -> Result<(), anyhow::Error> {
 
 #[tokio::test]
 async fn test_stake_with_u64_amount() -> Result<(), anyhow::Error> {
-    let mut test_cluster = TestClusterBuilder::new().build().await?;
+    let mut test_cluster = TestClusterBuilder::new().build().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
 
@@ -2025,7 +2025,7 @@ async fn test_with_sui_binary(args: &[&str]) -> Result<(), anyhow::Error> {
 #[sim_test]
 async fn test_get_owned_objects_owned_by_address_and_check_pagination() -> Result<(), anyhow::Error>
 {
-    let mut test_cluster = TestClusterBuilder::new().build().await?;
+    let mut test_cluster = TestClusterBuilder::new().build().await;
     let address = test_cluster.get_address_0();
     let context = &mut test_cluster.wallet;
 

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -576,19 +576,12 @@ impl TestClusterBuilder {
         self
     }
 
-    pub async fn build(self) -> anyhow::Result<TestCluster> {
-        let cluster = self.start_test_network_with_customized_ports().await?;
-        Ok(cluster)
-    }
-
-    async fn start_test_network_with_customized_ports(
-        mut self,
-    ) -> Result<TestCluster, anyhow::Error> {
-        let swarm = self.start_swarm().await?;
+    pub async fn build(mut self) -> TestCluster {
+        let swarm = self.start_swarm().await.unwrap();
         let working_dir = swarm.dir();
 
         let mut wallet_conf: SuiClientConfig =
-            PersistedConfig::read(&working_dir.join(SUI_CLIENT_CONFIG))?;
+            PersistedConfig::read(&working_dir.join(SUI_CLIENT_CONFIG)).unwrap();
 
         let fullnode = swarm.fullnodes().next().unwrap();
         let json_rpc_address = fullnode.config.json_rpc_address;
@@ -604,16 +597,17 @@ impl TestClusterBuilder {
 
         wallet_conf
             .persisted(&working_dir.join(SUI_CLIENT_CONFIG))
-            .save()?;
+            .save()
+            .unwrap();
 
         let wallet_conf = swarm.dir().join(SUI_CLIENT_CONFIG);
-        let wallet = WalletContext::new(&wallet_conf, None, None).await?;
+        let wallet = WalletContext::new(&wallet_conf, None, None).await.unwrap();
 
-        Ok(TestCluster {
+        TestCluster {
             swarm,
             wallet,
             fullnode_handle,
-        })
+        }
     }
 
     /// Start a Swarm and set up WalletConfig

--- a/crates/test-utils/tests/network_tests.rs
+++ b/crates/test-utils/tests/network_tests.rs
@@ -20,8 +20,7 @@ async fn test_additional_objects() {
     let cluster = TestClusterBuilder::new()
         .with_objects([Object::immutable_with_id_for_testing(id)])
         .build()
-        .await
-        .unwrap();
+        .await;
 
     let client = cluster.rpc_client();
     let resp = client.get_object(id, None).await.unwrap();
@@ -32,7 +31,7 @@ async fn test_additional_objects() {
 async fn test_package_override() {
     // `with_objects` can be used to override existing packages.
     let framework_ref = {
-        let default_cluster = TestClusterBuilder::new().build().await.unwrap();
+        let default_cluster = TestClusterBuilder::new().build().await;
         let client = default_cluster.rpc_client();
         let obj = client
             .get_object(SUI_SYSTEM_PACKAGE_ID, None)
@@ -74,8 +73,7 @@ async fn test_package_override() {
         let modified_cluster = TestClusterBuilder::new()
             .with_objects([package_override])
             .build()
-            .await
-            .unwrap();
+            .await;
 
         let client = modified_cluster.rpc_client();
         let obj = client


### PR DESCRIPTION
## Description 

There is no point to return Result and then always unwrap.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
