### PR TITLE
wallet-ext: expose public key of account to dapps

### DIFF
--- a/apps/wallet/src/background/keyring/Account.ts
+++ b/apps/wallet/src/background/keyring/Account.ts
@@ -25,6 +25,7 @@ export interface Account {
 	readonly type: AccountType;
 	readonly address: SuiAddress;
 	toJSON(): SerializedAccount;
+	getPublicKey(): string | null;
 }
 
 export function isImportedOrDerivedAccount(

--- a/apps/wallet/src/background/keyring/DerivedAccount.ts
+++ b/apps/wallet/src/background/keyring/DerivedAccount.ts
@@ -32,4 +32,8 @@ export class DerivedAccount implements Account {
 			derivationPath: this.derivationPath,
 		};
 	}
+
+	getPublicKey() {
+		return this.accountKeypair.publicKey.toBase64();
+	}
 }

--- a/apps/wallet/src/background/keyring/ImportedAccount.ts
+++ b/apps/wallet/src/background/keyring/ImportedAccount.ts
@@ -30,4 +30,8 @@ export class ImportedAccount implements Account {
 			derivationPath: null,
 		};
 	}
+
+	getPublicKey() {
+		return this.accountKeypair.publicKey.toBase64();
+	}
 }

--- a/apps/wallet/src/background/keyring/LedgerAccount.ts
+++ b/apps/wallet/src/background/keyring/LedgerAccount.ts
@@ -9,17 +9,28 @@ export type SerializedLedgerAccount = {
 	type: AccountType.LEDGER;
 	address: SuiAddress;
 	derivationPath: string;
+	publicKey: string | null;
 };
 
 export class LedgerAccount implements Account {
 	readonly type: AccountType;
 	readonly address: SuiAddress;
 	readonly derivationPath: string;
+	#publicKey: string | null;
 
-	constructor({ address, derivationPath }: { address: SuiAddress; derivationPath: string }) {
+	constructor({
+		address,
+		derivationPath,
+		publicKey,
+	}: {
+		address: SuiAddress;
+		derivationPath: string;
+		publicKey: string | null;
+	}) {
 		this.type = AccountType.LEDGER;
 		this.address = normalizeSuiAddress(address);
 		this.derivationPath = derivationPath;
+		this.#publicKey = publicKey;
 	}
 
 	toJSON(): SerializedLedgerAccount {
@@ -27,6 +38,15 @@ export class LedgerAccount implements Account {
 			type: AccountType.LEDGER,
 			address: this.address,
 			derivationPath: this.derivationPath,
+			publicKey: this.#publicKey,
 		};
+	}
+
+	getPublicKey() {
+		return this.#publicKey;
+	}
+
+	setPublicKey(publicKey: string) {
+		this.#publicKey = publicKey;
 	}
 }

--- a/apps/wallet/src/background/keyring/QredoAccount.ts
+++ b/apps/wallet/src/background/keyring/QredoAccount.ts
@@ -13,6 +13,7 @@ export type SerializedQredoAccount = {
 	qredoWalletID: string;
 	labels?: Wallet['labels'];
 	derivationPath: null;
+	publicKey: string;
 };
 
 export class QredoAccount implements Account {
@@ -21,17 +22,20 @@ export class QredoAccount implements Account {
 	readonly qredoConnectionID: string;
 	readonly qredoWalletID: string;
 	readonly labels: Wallet['labels'];
+	readonly publicKey: string;
 
 	constructor({
 		address,
 		qredoConnectionID,
 		qredoWalletID,
 		labels = [],
+		publicKey,
 	}: Omit<SerializedQredoAccount, 'type' | 'derivationPath'>) {
 		this.address = normalizeSuiAddress(address);
 		this.qredoConnectionID = qredoConnectionID;
 		this.qredoWalletID = qredoWalletID;
 		this.labels = labels;
+		this.publicKey = publicKey;
 	}
 
 	toJSON(): SerializedQredoAccount {
@@ -42,6 +46,11 @@ export class QredoAccount implements Account {
 			qredoWalletID: this.qredoWalletID,
 			labels: this.labels,
 			derivationPath: null,
+			publicKey: this.publicKey,
 		};
+	}
+
+	getPublicKey() {
+		return this.publicKey;
 	}
 }

--- a/apps/wallet/src/background/keyring/accounts.tsx
+++ b/apps/wallet/src/background/keyring/accounts.tsx
@@ -1,0 +1,61 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { type SuiAddress } from '@mysten/sui.js';
+
+import { getFromLocalStorage, setToLocalStorage } from '../storage-utils';
+
+export type AccountPublicInfo = {
+	// base64 of the public key - always ed25519 key
+	publicKey: string | null;
+};
+
+const STORE_KEY = 'accountsPublicInfo';
+
+type AccountsPublicInfo = Record<SuiAddress, AccountPublicInfo>;
+
+export async function getStoredAccountsPublicInfo(): Promise<AccountsPublicInfo> {
+	return (await getFromLocalStorage(STORE_KEY, {})) || {};
+}
+
+export function storeAccountsPublicInfo(accountsPublicInfo: AccountsPublicInfo) {
+	return setToLocalStorage(STORE_KEY, accountsPublicInfo);
+}
+
+export async function getAccountPublicInfo(
+	accountAddress: SuiAddress,
+): Promise<AccountPublicInfo | null> {
+	return (await getStoredAccountsPublicInfo())[accountAddress] || null;
+}
+
+export type AccountsPublicInfoUpdates = {
+	accountAddress: SuiAddress;
+	changes: Partial<AccountPublicInfo>;
+}[];
+
+export async function updateAccountsPublicInfo(accountsUpdates: AccountsPublicInfoUpdates) {
+	const allAccountsPublicInfo = await getStoredAccountsPublicInfo();
+	for (const { accountAddress, changes } of accountsUpdates) {
+		allAccountsPublicInfo[accountAddress] = {
+			...allAccountsPublicInfo[accountAddress],
+			...changes,
+		};
+	}
+	return storeAccountsPublicInfo(allAccountsPublicInfo);
+}
+
+export async function deleteAccountsPublicInfo(
+	accounts: { toDelete: SuiAddress[] } | { toKeep: SuiAddress[] },
+) {
+	const allAccountsPublicInfo = await getStoredAccountsPublicInfo();
+	const newAccountsPublicInfo: AccountsPublicInfo = {};
+	for (const [anAddress, anAccountInfo] of Object.entries(allAccountsPublicInfo)) {
+		if (
+			('toDelete' in accounts && !accounts.toDelete.includes(anAddress)) ||
+			('toKeep' in accounts && accounts.toKeep.includes(anAddress))
+		) {
+			newAccountsPublicInfo[anAddress] = anAccountInfo;
+		}
+	}
+	return storeAccountsPublicInfo(newAccountsPublicInfo);
+}

--- a/apps/wallet/src/background/keyring/index.ts
+++ b/apps/wallet/src/background/keyring/index.ts
@@ -7,12 +7,22 @@ import { throttle } from 'throttle-debounce';
 
 import { getAllQredoConnections } from '../qredo/storage';
 import { getFromLocalStorage, setToLocalStorage } from '../storage-utils';
-import { type Account, isImportedOrDerivedAccount, isQredoAccount } from './Account';
+import {
+	type Account,
+	isImportedOrDerivedAccount,
+	isQredoAccount,
+	isLedgerAccount,
+} from './Account';
 import { DerivedAccount } from './DerivedAccount';
 import { ImportedAccount } from './ImportedAccount';
 import { LedgerAccount, type SerializedLedgerAccount } from './LedgerAccount';
 import { QredoAccount } from './QredoAccount';
 import { VaultStorage } from './VaultStorage';
+import {
+	type AccountsPublicInfoUpdates,
+	getStoredAccountsPublicInfo,
+	updateAccountsPublicInfo,
+} from './accounts';
 import { createMessage } from '_messages';
 import { isKeyringPayload } from '_payloads/keyring';
 import { entropyToSerialized } from '_shared/utils/bip39';
@@ -132,14 +142,20 @@ export class Keyring {
 		}
 
 		await this.storeLedgerAccounts(ledgerAccounts);
-
+		const accountsPublicInfoUpdates = [];
 		for (const ledgerAccount of ledgerAccounts) {
 			const account = new LedgerAccount({
 				derivationPath: ledgerAccount.derivationPath,
 				address: ledgerAccount.address,
+				publicKey: ledgerAccount.publicKey,
+			});
+			accountsPublicInfoUpdates.push({
+				accountAddress: account.address,
+				changes: { publicKey: ledgerAccount.publicKey },
 			});
 			this.#accountsMap.set(ledgerAccount.address, account);
 		}
+		await updateAccountsPublicInfo(accountsPublicInfoUpdates);
 		this.notifyAccountsChanged();
 	}
 
@@ -204,6 +220,14 @@ export class Keyring {
 				keypair: added,
 			});
 			this.#accountsMap.set(importedAccount.address, importedAccount);
+			await updateAccountsPublicInfo([
+				{
+					accountAddress: importedAccount.address,
+					changes: {
+						publicKey: importedAccount.accountKeypair.publicKey.toBase64(),
+					},
+				},
+			]);
 			this.notifyAccountsChanged();
 		}
 		return added;
@@ -224,15 +248,22 @@ export class Keyring {
 				this.#accountsMap.delete(anAccount.address);
 			}
 		});
-		newAccounts.forEach(({ address, labels, walletID }) => {
+		const accountsPublicInfoUpdates: AccountsPublicInfoUpdates = [];
+		newAccounts.forEach(({ address, labels, walletID, publicKey }) => {
 			const newAccount = new QredoAccount({
 				address,
 				qredoConnectionID: qredoID,
 				qredoWalletID: walletID,
 				labels,
+				publicKey,
+			});
+			accountsPublicInfoUpdates.push({
+				accountAddress: newAccount.address,
+				changes: { publicKey: newAccount.publicKey },
 			});
 			this.#accountsMap.set(newAccount.address, newAccount);
 		});
+		await updateAccountsPublicInfo(accountsPublicInfoUpdates);
 		this.notifyAccountsChanged();
 	}
 
@@ -337,6 +368,14 @@ export class Keyring {
 				if (!nextAccount) {
 					throw new Error('Failed to derive next account');
 				}
+				await updateAccountsPublicInfo([
+					{
+						accountAddress: nextAccount.address,
+						changes: {
+							publicKey: nextAccount.accountKeypair.publicKey.toBase64(),
+						},
+					},
+				]);
 				uiConnection.send(
 					createMessage<KeyringPayload<'deriveNextAccount'>>(
 						{
@@ -381,6 +420,31 @@ export class Keyring {
 				);
 				if (!imported) {
 					throw new Error('Duplicate account not imported');
+				}
+				uiConnection.send(createMessage({ type: 'done' }, id));
+			} else if (isKeyringPayload(payload, 'updateAccountPublicInfo') && payload.args) {
+				const { updates } = payload.args;
+				await updateAccountsPublicInfo(payload.args.updates);
+				const ledgerUpdates: Record<SuiAddress, string> = {};
+				for (const {
+					accountAddress,
+					changes: { publicKey },
+				} of updates) {
+					const anAccount = this.#accountsMap.get(accountAddress);
+					if (publicKey && anAccount && isLedgerAccount(anAccount) && !anAccount.getPublicKey()) {
+						anAccount.setPublicKey(publicKey);
+						ledgerUpdates[accountAddress] = publicKey;
+					}
+				}
+				if (Object.keys(ledgerUpdates).length) {
+					const allStoredLedgerAccounts = await this.getSavedLedgerAccounts();
+					for (let anAccount of allStoredLedgerAccounts) {
+						if (!anAccount.publicKey && ledgerUpdates[anAccount.address]) {
+							anAccount.publicKey = ledgerUpdates[anAccount.address];
+						}
+					}
+					await this.storeLedgerAccounts(allStoredLedgerAccounts);
+					this.notifyAccountsChanged();
 				}
 				uiConnection.send(createMessage({ type: 'done' }, id));
 			}
@@ -443,16 +507,18 @@ export class Keyring {
 				new LedgerAccount({
 					derivationPath: savedLedgerAccount.derivationPath,
 					address: savedLedgerAccount.address,
+					publicKey: savedLedgerAccount.publicKey || null,
 				}),
 			);
 		}
 		for (const aQredoConnection of await getAllQredoConnections()) {
-			aQredoConnection.accounts.forEach(({ address, labels, walletID }) => {
+			aQredoConnection.accounts.forEach(({ address, labels, walletID, publicKey }) => {
 				const account = new QredoAccount({
 					address,
 					qredoConnectionID: aQredoConnection.id,
 					labels,
 					qredoWalletID: walletID,
+					publicKey,
 				});
 				this.#accountsMap.set(account.address, account);
 			});
@@ -469,6 +535,7 @@ export class Keyring {
 		});
 		mnemonic = null;
 		this.#locked = false;
+		this.storeAccountsPublicInfo();
 		this.notifyLockedStatusUpdate(this.#locked);
 	}
 
@@ -509,6 +576,24 @@ export class Keyring {
 
 	private notifyAccountsChanged() {
 		this.#events.emit('accountsChanged', this.getAccounts() || []);
+	}
+
+	/**
+	 * Do this on first unlock after the account is created to store the public info of the accounts
+	 * the first derived if it's a new one (or for accounts that already have been created before this to migrate the storage)
+	 */
+	private async storeAccountsPublicInfo() {
+		if (!Object.keys(await getStoredAccountsPublicInfo()).length) {
+			const allAccounts = this.getAccounts();
+			if (allAccounts) {
+				await updateAccountsPublicInfo(
+					allAccounts.map((anAccount) => ({
+						accountAddress: anAccount.address,
+						changes: { publicKey: anAccount.getPublicKey() },
+					})),
+				);
+			}
+		}
 	}
 }
 

--- a/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
+++ b/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { type SuiAddress, toB64, TransactionBlock } from '@mysten/sui.js';
+import { toB64, TransactionBlock, fromB64 } from '@mysten/sui.js';
 import {
 	SUI_CHAINS,
 	ReadonlyWalletAccount,
@@ -154,13 +154,12 @@ export class SuiWallet implements Wallet {
 		return this.#accounts;
 	}
 
-	#setAccounts(addresses: SuiAddress[]) {
-		this.#accounts = addresses.map(
-			(address) =>
+	#setAccounts(accounts: GetAccountResponse['accounts']) {
+		this.#accounts = accounts.map(
+			({ address, publicKey }) =>
 				new ReadonlyWalletAccount({
 					address,
-					// TODO: Expose public key instead of address:
-					publicKey: new Uint8Array(),
+					publicKey: publicKey ? fromB64(publicKey) : new Uint8Array(),
 					chains: this.#activeChain ? [this.#activeChain] : [],
 					features: ['sui:signAndExecuteTransaction'],
 				}),

--- a/apps/wallet/src/shared/messaging/messages/payloads/account/GetAccountResponse.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/account/GetAccountResponse.ts
@@ -6,5 +6,5 @@ import type { BasePayload } from '_payloads';
 
 export interface GetAccountResponse extends BasePayload {
 	type: 'get-account-response';
-	accounts: SuiAddress[];
+	accounts: { address: SuiAddress; publicKey: string | null }[];
 }

--- a/apps/wallet/src/shared/messaging/messages/payloads/keyring/index.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/keyring/index.ts
@@ -3,6 +3,7 @@
 
 import { isBasePayload } from '_payloads';
 import { type SerializedLedgerAccount } from '_src/background/keyring/LedgerAccount';
+import { type AccountsPublicInfoUpdates } from '_src/background/keyring/accounts';
 
 import type { ExportedKeypair, SerializedSignature, SuiAddress } from '@mysten/sui.js';
 import type { BasePayload, Payload } from '_payloads';
@@ -72,6 +73,10 @@ type MethodToPayloads = {
 	};
 	importPrivateKey: {
 		args: { password: string; keyPair: ExportedKeypair };
+		return: void;
+	};
+	updateAccountPublicInfo: {
+		args: { updates: AccountsPublicInfoUpdates };
 		return: void;
 	};
 };

--- a/apps/wallet/src/shared/messaging/messages/payloads/wallet-status-change/index.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/wallet-status-change/index.ts
@@ -9,7 +9,7 @@ import type { NetworkEnvType } from '_src/background/NetworkEnv';
 
 export type WalletStatusChange = {
 	network?: NetworkEnvType;
-	accounts?: SuiAddress[];
+	accounts?: { address: SuiAddress; publicKey: string | null }[];
 };
 
 export interface WalletStatusChangePayload extends BasePayload, WalletStatusChange {

--- a/apps/wallet/src/ui/app/background-client/index.ts
+++ b/apps/wallet/src/ui/app/background-client/index.ts
@@ -25,6 +25,7 @@ import { setActiveOrigin, changeActiveNetwork } from '_redux/slices/app';
 import { setPermissions } from '_redux/slices/permissions';
 import { setTransactionRequests } from '_redux/slices/transaction-requests';
 import { type SerializedLedgerAccount } from '_src/background/keyring/LedgerAccount';
+import { type AccountsPublicInfoUpdates } from '_src/background/keyring/accounts';
 import { type QredoConnectIdentity } from '_src/background/qredo/types';
 import {
 	isQredoConnectPayload,
@@ -404,6 +405,18 @@ export class BackgroundClient {
 					type: 'qredo-connect',
 					method: 'rejectQredoConnection',
 					args,
+				}),
+			).pipe(take(1)),
+		);
+	}
+
+	public updateAccountsPublicInfo(updates: AccountsPublicInfoUpdates) {
+		return lastValueFrom(
+			this.sendMessage(
+				createMessage<KeyringPayload<'updateAccountPublicInfo'>>({
+					type: 'keyring',
+					method: 'updateAccountPublicInfo',
+					args: { updates },
 				}),
 			).pipe(take(1)),
 		);

--- a/apps/wallet/src/ui/app/components/ledger/useDeriveLedgerAccounts.ts
+++ b/apps/wallet/src/ui/app/components/ledger/useDeriveLedgerAccounts.ts
@@ -47,6 +47,7 @@ async function deriveAccountsFromLedger(
 			type: AccountType.LEDGER,
 			address: suiAddress,
 			derivationPath,
+			publicKey: publicKey.toBase64(),
 		});
 	}
 


### PR DESCRIPTION
## Description 

* silently migrate storage to save the public key of the wallet accounts when the wallet unlocks (only the first time when no public keys are stored)
* save public keys when adding new accounts
* try to get the public keys of ledger accounts every time the wallet loads or when user switches active account or tries to sign with a ledger account etc and there are ledger accounts without public key

closes APPS-1293

## Test Plan 

manual testing

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
