### PR TITLE
support segmented network with access type and allowlisted peers

### DIFF
--- a/crates/sui-config/src/p2p.rs
+++ b/crates/sui-config/src/p2p.rs
@@ -225,6 +225,14 @@ impl StateSyncConfig {
     }
 }
 
+/// Access Type of a node.
+/// AccessType info is shared in the discovery process.
+/// * If the node marks itself as Public, other nodes may try to connect to it.
+/// * If the node marks itself as Private, only nodes that have it in
+///     their `allowlisted_peers` or `seed_peers` will try to connect to it.
+/// * If not set, defaults to Public.
+/// AccessType is useful when a network of nodes want to stay private. To achieve this,
+/// mark every node in this network as `Private` and allowlist/seed them to each other.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum AccessType {
     Public,
@@ -261,10 +269,7 @@ pub struct DiscoveryConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub get_known_peers_rate_limit: Option<NonZeroU32>,
 
-    /// Access Type of this node.
-    /// If the node is Public, anyone could access it.
-    /// If the node is Private, only preferred/allowlisted peers could access it.
-    /// If not set, defaults to Public.
+    /// See docstring for `AccessType`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub access_type: Option<AccessType>,
 
@@ -301,9 +306,6 @@ impl DiscoveryConfig {
 
     pub fn access_type(&self) -> AccessType {
         // defaults None to Public
-        match self.access_type {
-            Some(AccessType::Private) => AccessType::Private,
-            _ => AccessType::Public,
-        }
+        self.access_type.unwrap_or(AccessType::Public)
     }
 }

--- a/crates/sui-network/src/discovery/mod.rs
+++ b/crates/sui-network/src/discovery/mod.rs
@@ -10,7 +10,7 @@ use std::{
     sync::{Arc, RwLock},
     time::Duration,
 };
-use sui_config::p2p::{DiscoveryConfig, P2pConfig, SeedPeer};
+use sui_config::p2p::{AccessType, DiscoveryConfig, P2pConfig, SeedPeer};
 use sui_types::multiaddr::Multiaddr;
 use tap::{Pipe, TapFallible};
 use tokio::sync::broadcast::error::RecvError;
@@ -59,6 +59,11 @@ pub struct NodeInfo {
     ///
     /// This is used to determine which of two NodeInfo's from the same PeerId should be retained.
     pub timestamp_ms: u64,
+
+    /// Access Type of this node.
+    /// If the node is Public, anyone could access it.
+    /// If the node is Private, only preferred/allowlisted peers could access it.
+    pub access_type: AccessType,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -68,7 +73,8 @@ pub struct TrustedPeerChangeEvent {
 
 struct DiscoveryEventLoop {
     config: P2pConfig,
-    discovery_config: DiscoveryConfig,
+    discovery_config: Arc<DiscoveryConfig>,
+    allowlisted_peers: Arc<HashMap<PeerId, Option<Multiaddr>>>,
     network: Network,
     tasks: JoinSet<()>,
     pending_dials: HashMap<PeerId, AbortHandle>,
@@ -145,28 +151,38 @@ impl DiscoveryEventLoop {
             peer_id: self.network.peer_id(),
             addresses: address,
             timestamp_ms: now_unix(),
+            access_type: self.discovery_config.access_type(),
         };
 
         self.state.write().unwrap().our_info = Some(our_info);
     }
 
     fn configure_preferred_peers(&mut self) {
-        for SeedPeer { peer_id, address } in self.config.seed_peers.iter() {
-            let Some(peer_id) = *peer_id else {
-                continue;
-            };
-
-            let Ok(address) = address.to_anemo_address() else {
-                debug!(p2p_address=?address, "Can't convert p2p address to anemo address");
-                continue;
+        for (peer_id, address) in self
+            .discovery_config
+            .allowlisted_peers
+            .iter()
+            .map(|sp| (sp.peer_id, sp.address.clone()))
+            .chain(self.config.seed_peers.iter().filter_map(|ap| {
+                ap.peer_id
+                    .map(|peer_id| (peer_id, Some(ap.address.clone())))
+            }))
+        {
+            let anemo_address = if let Some(address) = address {
+                let Ok(address) = address.to_anemo_address() else {
+                    debug!(p2p_address=?address, "Can't convert p2p address to anemo address");
+                    continue;
+                };
+                Some(address)
+            } else {
+                None
             };
 
             let peer_info = anemo::types::PeerInfo {
                 peer_id,
                 affinity: anemo::types::PeerAffinity::High,
-                address: vec![address],
+                address: anemo_address.into_iter().collect(),
             };
-
             self.network.known_peers().insert(peer_info);
         }
     }
@@ -200,8 +216,11 @@ impl DiscoveryEventLoop {
                         .insert(peer_id, ());
 
                     // Query the new node for any peers
-                    self.tasks
-                        .spawn(query_peer_for_their_known_peers(peer, self.state.clone()));
+                    self.tasks.spawn(query_peer_for_their_known_peers(
+                        peer,
+                        self.state.clone(),
+                        self.allowlisted_peers.clone(),
+                    ));
                 }
             }
             Ok(PeerEvent::LostPeer(peer_id, _)) => {
@@ -226,6 +245,7 @@ impl DiscoveryEventLoop {
                 self.network.clone(),
                 self.discovery_config.clone(),
                 self.state.clone(),
+                self.allowlisted_peers.clone(),
             ));
 
         // Cull old peers older than a day
@@ -321,7 +341,7 @@ async fn try_to_connect_to_peer(network: Network, info: NodeInfo) {
 
 async fn try_to_connect_to_seed_peers(
     network: Network,
-    config: DiscoveryConfig,
+    config: Arc<DiscoveryConfig>,
     seed_peers: Vec<SeedPeer>,
 ) {
     let network = &network;
@@ -347,7 +367,11 @@ async fn try_to_connect_to_seed_peers(
     .await;
 }
 
-async fn query_peer_for_their_known_peers(peer: Peer, state: Arc<RwLock<State>>) {
+async fn query_peer_for_their_known_peers(
+    peer: Peer,
+    state: Arc<RwLock<State>>,
+    allowlisted_peers: Arc<HashMap<PeerId, Option<Multiaddr>>>,
+) {
     let mut client = DiscoveryClient::new(peer);
 
     let request = Request::new(()).with_timeout(TIMEOUT);
@@ -368,14 +392,15 @@ async fn query_peer_for_their_known_peers(peer: Peer, state: Arc<RwLock<State>>)
             },
         )
     {
-        update_known_peers(state, found_peers);
+        update_known_peers(state, found_peers, allowlisted_peers);
     }
 }
 
 async fn query_connected_peers_for_their_known_peers(
     network: Network,
-    config: DiscoveryConfig,
+    config: Arc<DiscoveryConfig>,
     state: Arc<RwLock<State>>,
+    allowlisted_peers: Arc<HashMap<PeerId, Option<Multiaddr>>>,
 ) {
     use rand::seq::IteratorRandom;
 
@@ -412,10 +437,14 @@ async fn query_connected_peers_for_their_known_peers(
         .collect::<Vec<_>>()
         .await;
 
-    update_known_peers(state, found_peers);
+    update_known_peers(state, found_peers, allowlisted_peers);
 }
 
-fn update_known_peers(state: Arc<RwLock<State>>, found_peers: Vec<NodeInfo>) {
+fn update_known_peers(
+    state: Arc<RwLock<State>>,
+    found_peers: Vec<NodeInfo>,
+    allowlisted_peers: Arc<HashMap<PeerId, Option<Multiaddr>>>,
+) {
     use std::collections::hash_map::Entry;
 
     let now_unix = now_unix();
@@ -431,6 +460,12 @@ fn update_known_peers(state: Arc<RwLock<State>>, found_peers: Vec<NodeInfo>) {
         }
 
         if peer.peer_id == our_peer_id {
+            continue;
+        }
+
+        // If Peer is Private, and not in our allowlist, skip it.
+        if peer.access_type == AccessType::Private && !allowlisted_peers.contains_key(&peer.peer_id)
+        {
             continue;
         }
 

--- a/crates/sui-network/src/discovery/mod.rs
+++ b/crates/sui-network/src/discovery/mod.rs
@@ -176,6 +176,8 @@ impl DiscoveryEventLoop {
                 None
             };
 
+            // TODO: once we have `PeerAffinity::Allowlisted` we should update allowlisted peers'
+            // affinity.
             let peer_info = anemo::types::PeerInfo {
                 peer_id,
                 affinity: anemo::types::PeerAffinity::High,

--- a/crates/sui-network/src/discovery/mod.rs
+++ b/crates/sui-network/src/discovery/mod.rs
@@ -60,9 +60,7 @@ pub struct NodeInfo {
     /// This is used to determine which of two NodeInfo's from the same PeerId should be retained.
     pub timestamp_ms: u64,
 
-    /// Access Type of this node.
-    /// If the node is Public, anyone could access it.
-    /// If the node is Private, only preferred/allowlisted peers could access it.
+    /// See docstring for `AccessType`.
     pub access_type: AccessType,
 }
 

--- a/crates/sui-network/src/discovery/tests.rs
+++ b/crates/sui-network/src/discovery/tests.rs
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crate::utils::build_network;
+use crate::utils::{build_network, build_network_with_anemo_config};
 use anemo::types::PeerAffinity;
 use anemo::Result;
 use fastcrypto::ed25519::Ed25519PublicKey;
 use futures::stream::FuturesUnordered;
 use std::collections::HashSet;
+use sui_config::p2p::AllowlistedPeer;
 use tokio::time::timeout;
 
 #[tokio::test]
@@ -25,6 +26,7 @@ async fn get_known_peers() -> Result<()> {
         peer_id: PeerId([9; 32]),
         addresses: Vec::new(),
         timestamp_ms: now_unix(),
+        access_type: AccessType::Public,
     };
     state.write().unwrap().our_info = Some(our_info.clone());
     let response = server
@@ -40,6 +42,7 @@ async fn get_known_peers() -> Result<()> {
         peer_id: PeerId([13; 32]),
         addresses: Vec::new(),
         timestamp_ms: now_unix(),
+        access_type: AccessType::Public,
     };
     state
         .write()
@@ -246,11 +249,463 @@ async fn peers_are_added_from_reocnfig_channel() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn test_access_types() {
+    // This test case constructs a mesh graph of 11 nodes, with the following topology.
+    // For allowlisted nodes, `+` means the peer is allowlisted with an address, otherwise not.
+    // An allowlisted peer with address will be proactively connected in anemo network.
+    //
+    //
+    // The topology:
+    //                                      ------------  11 (private, seed: 1, allowed: 7, 8)
+    //                                     /
+    //                       ------ 1 (public) ------
+    //                      /                        \
+    //    2 (public, seed: 1, allowed: 7, 8)          3 (private, seed: 1, allowed: 4+, 5+)
+    //       |                                       /             \
+    //       |                 4 (private, allowed: 3+, 5, 6)     5 (private, allowed: 3, 4+)
+    //       |                                        \
+    //       |                                      6 (private, allowed: 4+)
+    //     7 (private, allowed: 2+, 8+)
+    //       |
+    //       |
+    //     8 (private, allowed: 7+, 9+)  p.s. 8's max connection is 0
+    //       |
+    //       |
+    //     9 (public)
+    //       |
+    //       |
+    //    10 (private, seed: 9)
+
+    telemetry_subscribers::init_for_testing();
+
+    let default_discovery_config = DiscoveryConfig {
+        target_concurrent_connections: Some(100),
+        interval_period_ms: Some(1000),
+        ..Default::default()
+    };
+    let default_p2p_config = P2pConfig {
+        discovery: Some(default_discovery_config.clone()),
+        ..Default::default()
+    };
+    let default_private_discovery_config = DiscoveryConfig {
+        target_concurrent_connections: Some(100),
+        interval_period_ms: Some(1000),
+        access_type: Some(AccessType::Private),
+        ..Default::default()
+    };
+
+    // None 1, public
+    let (builder_1, network_1) = set_up_network(default_p2p_config.clone());
+
+    let mut config = default_p2p_config.clone();
+    config.seed_peers.push(SeedPeer {
+        peer_id: Some(network_1.peer_id()),
+        address: format!("/dns/localhost/udp/{}", network_1.local_addr().port())
+            .parse()
+            .unwrap(),
+    });
+
+    // Node 2, public, seed: Node 1, allowlist: Node 7, Node 8
+    let (mut builder_2, network_2) = set_up_network(config.clone());
+
+    // Node 3, private, seed: Node 1
+    let (mut builder_3, network_3) = set_up_network(config.clone());
+
+    // Node 4, private, allowlist: Node 3, 5, and 6
+    let (mut builder_4, network_4) = set_up_network(P2pConfig::default());
+
+    // Node 5, private, allowlisted: Node 3 and Node 4
+    let (builder_5, network_5) = {
+        let mut private_discovery_config = default_private_discovery_config.clone();
+        private_discovery_config.allowlisted_peers = vec![
+            // Intitially 5 does not know how to contact 3 or 4.
+            local_allowlisted_peer(network_3.peer_id(), None),
+            local_allowlisted_peer(network_4.peer_id(), Some(network_4.local_addr().port())),
+        ];
+        set_up_network(P2pConfig::default().set_discovery_config(private_discovery_config))
+    };
+
+    // Node 6, private, allowlisted: Node 4
+    let (builder_6, network_6) = {
+        let mut private_discovery_config = default_private_discovery_config.clone();
+        private_discovery_config.allowlisted_peers = vec![local_allowlisted_peer(
+            network_4.peer_id(),
+            Some(network_4.local_addr().port()),
+        )];
+        set_up_network(P2pConfig::default().set_discovery_config(private_discovery_config))
+    };
+
+    // Node 3: Add Node 4 and Node 5 to allowlist
+    let mut private_discovery_config = default_private_discovery_config.clone();
+    private_discovery_config.allowlisted_peers = vec![
+        local_allowlisted_peer(network_4.peer_id(), Some(network_4.local_addr().port())),
+        local_allowlisted_peer(network_5.peer_id(), Some(network_5.local_addr().port())),
+    ];
+    builder_3.config.discovery = Some(private_discovery_config);
+
+    // Node 4: Add Node 3, Node 5, and Node 6 to allowlist
+    let mut private_discovery_config = default_private_discovery_config.clone();
+    private_discovery_config.allowlisted_peers = vec![
+        local_allowlisted_peer(network_3.peer_id(), Some(network_3.local_addr().port())),
+        local_allowlisted_peer(network_5.peer_id(), None),
+        local_allowlisted_peer(network_6.peer_id(), None),
+    ];
+    builder_4.config.discovery = Some(private_discovery_config);
+
+    // Node 7, private, allowlisted: Node 2, Node 8
+    let (mut builder_7, network_7) = set_up_network(
+        P2pConfig::default().set_discovery_config(default_private_discovery_config.clone()),
+    );
+
+    // Node 9, public
+    let (builder_9, network_9) = set_up_network(default_p2p_config.clone());
+
+    // Node 8, private, allowlisted: Node 7, Node 9
+    let (builder_8, network_8) = {
+        let mut private_discovery_config = default_private_discovery_config.clone();
+        private_discovery_config.allowlisted_peers = vec![
+            local_allowlisted_peer(network_7.peer_id(), Some(network_7.local_addr().port())),
+            local_allowlisted_peer(network_9.peer_id(), Some(network_9.local_addr().port())),
+        ];
+        let mut p2p_config = P2pConfig::default();
+        let mut anemo_config = anemo::Config::default();
+        anemo_config.max_concurrent_connections = Some(0);
+        p2p_config.anemo_config = Some(anemo_config);
+        set_up_network(p2p_config.set_discovery_config(private_discovery_config))
+    };
+
+    // Node 2, Add Node 7 and Node 8 to allowlist
+    let mut discovery_config = default_discovery_config.clone();
+    discovery_config.allowlisted_peers = vec![
+        local_allowlisted_peer(network_7.peer_id(), None),
+        local_allowlisted_peer(network_8.peer_id(), None),
+    ];
+    builder_2.config.discovery = Some(discovery_config);
+
+    // Node 7: Add Node 2, and Node 8 to allowlist
+    let mut private_discovery_config = default_private_discovery_config.clone();
+    private_discovery_config.allowlisted_peers = vec![
+        local_allowlisted_peer(network_2.peer_id(), Some(network_2.local_addr().port())),
+        local_allowlisted_peer(network_8.peer_id(), Some(network_8.local_addr().port())),
+    ];
+    builder_7.config.discovery = Some(private_discovery_config);
+
+    // Node 10, private, seed: 9
+    let (builder_10, network_10) = {
+        let mut p2p_config = default_p2p_config.clone();
+        p2p_config.seed_peers.push(SeedPeer {
+            peer_id: Some(network_9.peer_id()),
+            address: format!("/dns/localhost/udp/{}", network_9.local_addr().port())
+                .parse()
+                .unwrap(),
+        });
+        p2p_config.discovery = Some(default_private_discovery_config.clone());
+        set_up_network(p2p_config.clone())
+    };
+
+    // Node 11, private, seed: 1, allow: 7, 8
+    let (builder_11, network_11) = {
+        let mut p2p_config = default_p2p_config.clone();
+        p2p_config.seed_peers.push(SeedPeer {
+            peer_id: Some(network_1.peer_id()),
+            address: format!("/dns/localhost/udp/{}", network_1.local_addr().port())
+                .parse()
+                .unwrap(),
+        });
+        let mut private_discovery_config = default_private_discovery_config.clone();
+        private_discovery_config.allowlisted_peers = vec![
+            local_allowlisted_peer(network_8.peer_id(), None),
+            local_allowlisted_peer(network_7.peer_id(), None),
+        ];
+        p2p_config.discovery = Some(private_discovery_config);
+        set_up_network(p2p_config)
+    };
+
+    let (event_loop_1, _handle_1, state_1) = start_network(builder_1, network_1.clone());
+    let (event_loop_2, _handle_2, state_2) = start_network(builder_2, network_2.clone());
+    let (event_loop_3, _handle_3, state_3) = start_network(builder_3, network_3.clone());
+    let (event_loop_4, _handle_4, state_4) = start_network(builder_4, network_4.clone());
+    let (event_loop_5, _handle_5, state_5) = start_network(builder_5, network_5.clone());
+    let (event_loop_6, _handle_6, state_6) = start_network(builder_6, network_6.clone());
+    let (event_loop_7, _handle_7, state_7) = start_network(builder_7, network_7.clone());
+    let (event_loop_8, _handle_8, state_8) = start_network(builder_8, network_8.clone());
+    let (event_loop_9, _handle_9, state_9) = start_network(builder_9, network_9.clone());
+    let (event_loop_10, _handle_10, state_10) = start_network(builder_10, network_10.clone());
+    let (event_loop_11, _handle_11, state_11) = start_network(builder_11, network_11.clone());
+
+    // Start all the event loops
+    tokio::spawn(event_loop_1.start());
+    tokio::spawn(event_loop_2.start());
+    tokio::spawn(event_loop_3.start());
+    tokio::spawn(event_loop_4.start());
+    tokio::spawn(event_loop_5.start());
+    tokio::spawn(event_loop_6.start());
+    tokio::spawn(event_loop_7.start());
+    tokio::spawn(event_loop_8.start());
+    tokio::spawn(event_loop_9.start());
+    tokio::spawn(event_loop_10.start());
+    tokio::spawn(event_loop_11.start());
+
+    let peer_id_1 = network_1.peer_id();
+    let peer_id_2 = network_2.peer_id();
+    let peer_id_3 = network_3.peer_id();
+    let peer_id_4 = network_4.peer_id();
+    let peer_id_5 = network_5.peer_id();
+    let peer_id_6 = network_6.peer_id();
+    let peer_id_7 = network_7.peer_id();
+    let peer_id_8 = network_8.peer_id();
+    let peer_id_9 = network_9.peer_id();
+    let peer_id_10 = network_10.peer_id();
+    let peer_id_11 = network_11.peer_id();
+
+    info!("peer_id_1: {:?}", peer_id_1);
+    info!("peer_id_2: {:?}", peer_id_2);
+    info!("peer_id_3: {:?}", peer_id_3);
+    info!("peer_id_4: {:?}", peer_id_4);
+    info!("peer_id_5: {:?}", peer_id_5);
+    info!("peer_id_6: {:?}", peer_id_6);
+    info!("peer_id_7: {:?}", peer_id_7);
+    info!("peer_id_8: {:?}", peer_id_8);
+    info!("peer_id_9: {:?}", peer_id_9);
+    info!("peer_id_10: {:?}", peer_id_10);
+    info!("peer_id_11: {:?}", peer_id_11);
+
+    // Let them fully connect
+    tokio::time::sleep(Duration::from_secs(10)).await;
+
+    // Node 1 is connected to everyone. But it does not "know" private nodes.
+    assert_peers(
+        "Node 1",
+        &network_1,
+        &state_1,
+        HashSet::from_iter(vec![]),
+        HashSet::from_iter(vec![
+            peer_id_2, peer_id_3, peer_id_4, peer_id_5, peer_id_6, peer_id_7, peer_id_8, peer_id_9,
+            peer_id_10, peer_id_11,
+        ]),
+        HashSet::from_iter(vec![peer_id_2, peer_id_9]),
+        HashSet::from_iter(vec![
+            peer_id_2, peer_id_3, peer_id_4, peer_id_5, peer_id_6, peer_id_7, peer_id_8, peer_id_9,
+            peer_id_10, peer_id_11,
+        ]),
+    );
+
+    // Node 1 is connected to everyone. But it does not "know" private nodes except the allowlisted ones 7 and 8.
+    assert_peers(
+        "Node 2",
+        &network_2,
+        &state_2,
+        HashSet::from_iter(vec![peer_id_1, peer_id_7, peer_id_8]),
+        HashSet::from_iter(vec![
+            peer_id_1, peer_id_3, peer_id_4, peer_id_5, peer_id_6, peer_id_7, peer_id_8, peer_id_9,
+            peer_id_10, peer_id_11,
+        ]),
+        HashSet::from_iter(vec![peer_id_1, peer_id_7, peer_id_8, peer_id_9]),
+        HashSet::from_iter(vec![
+            peer_id_1, peer_id_3, peer_id_4, peer_id_5, peer_id_6, peer_id_7, peer_id_8, peer_id_9,
+            peer_id_10, peer_id_11,
+        ]),
+    );
+
+    assert_peers(
+        "Node 3",
+        &network_3,
+        &state_3,
+        HashSet::from_iter(vec![peer_id_1, peer_id_4, peer_id_5]),
+        HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_4, peer_id_5, peer_id_9]),
+        HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_4, peer_id_5, peer_id_9]),
+        HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_4, peer_id_5, peer_id_9]),
+    );
+
+    assert_peers(
+        "Node 4",
+        &network_4,
+        &state_4,
+        HashSet::from_iter(vec![peer_id_3, peer_id_5, peer_id_6]),
+        HashSet::from_iter(vec![
+            peer_id_1, peer_id_2, peer_id_3, peer_id_5, peer_id_6, peer_id_9,
+        ]),
+        HashSet::from_iter(vec![
+            peer_id_1, peer_id_2, peer_id_3, peer_id_5, peer_id_6, peer_id_9,
+        ]),
+        HashSet::from_iter(vec![
+            peer_id_1, peer_id_2, peer_id_3, peer_id_5, peer_id_6, peer_id_9,
+        ]),
+    );
+
+    assert_peers(
+        "Node 5",
+        &network_5,
+        &state_5,
+        HashSet::from_iter(vec![peer_id_3, peer_id_4]),
+        HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_3, peer_id_4, peer_id_9]),
+        HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_3, peer_id_4, peer_id_9]),
+        HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_3, peer_id_4, peer_id_9]),
+    );
+
+    assert_peers(
+        "Node 6",
+        &network_6,
+        &state_6,
+        HashSet::from_iter(vec![peer_id_4]),
+        HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_4, peer_id_9]),
+        HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_4, peer_id_9]),
+        HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_4, peer_id_9]),
+    );
+
+    // Node 11 finds Node 7 via Node 2, and invites Node 7 to connect. Node 7 says yes.
+    assert_peers(
+        "Node 7",
+        &network_7,
+        &state_7,
+        HashSet::from_iter(vec![peer_id_2, peer_id_8]),
+        HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_8, peer_id_9, peer_id_11]),
+        HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_8, peer_id_9]),
+        HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_8, peer_id_9, peer_id_11]),
+    );
+
+    // Node 11 finds Node 8 via Node 2, and invites Node 8 to connect. Node 8 said No
+    // because its `max_concurrent_connections` is 0.
+    assert_peers(
+        "Node 8",
+        &network_8,
+        &state_8,
+        HashSet::from_iter(vec![peer_id_7, peer_id_9]),
+        HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_7, peer_id_9]),
+        HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_7, peer_id_9]),
+        HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_7, peer_id_9]),
+    );
+
+    assert_peers(
+        "Node 9",
+        &network_9,
+        &state_9,
+        HashSet::from_iter(vec![]),
+        HashSet::from_iter(vec![
+            peer_id_1, peer_id_2, peer_id_3, peer_id_4, peer_id_5, peer_id_6, peer_id_7, peer_id_8,
+            peer_id_10, peer_id_11,
+        ]),
+        HashSet::from_iter(vec![peer_id_1, peer_id_2]),
+        HashSet::from_iter(vec![
+            peer_id_1, peer_id_2, peer_id_3, peer_id_4, peer_id_5, peer_id_6, peer_id_7, peer_id_8,
+            peer_id_10, peer_id_11,
+        ]),
+    );
+
+    // Node 10 does not talk to any other private nodes.
+    assert_peers(
+        "Node 10",
+        &network_10,
+        &state_10,
+        HashSet::from_iter(vec![peer_id_9]),
+        HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_9]),
+        HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_9]),
+        HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_9]),
+    );
+
+    // 11 allowlists 8 but 8 does not 11, so they can't connect
+    // although 8 is still in 11's known peer list
+    assert_peers(
+        "Node 11",
+        &network_11,
+        &state_11,
+        HashSet::from_iter(vec![peer_id_1, peer_id_7, peer_id_8]),
+        HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_7, peer_id_9]),
+        HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_7, peer_id_8, peer_id_9]),
+        HashSet::from_iter(vec![peer_id_1, peer_id_2, peer_id_7, peer_id_9]),
+    );
+}
+
+fn assert_peers(
+    self_name: &str,
+    network: &Network,
+    state: &Arc<RwLock<State>>,
+    expected_network_known_peers: HashSet<PeerId>,
+    expected_network_connected_peers: HashSet<PeerId>,
+    expected_discovery_known_peers: HashSet<PeerId>,
+    expected_discovery_connected_peers: HashSet<PeerId>,
+) {
+    let actual = network
+        .known_peers()
+        .get_all()
+        .iter()
+        .map(|pi| pi.peer_id)
+        .collect::<HashSet<_>>();
+    assert_eq!(
+        actual, expected_network_known_peers,
+        "{} network known peers mismatch. Expected: {:#?}, actual: {:#?}",
+        self_name, expected_network_known_peers, actual,
+    );
+    let actual = network.peers().iter().copied().collect::<HashSet<_>>();
+    assert_eq!(
+        actual, expected_network_connected_peers,
+        "{} network connected peers mismatch. Expected: {:#?}, actual: {:#?}",
+        self_name, expected_network_connected_peers, actual,
+    );
+    let actual = state
+        .read()
+        .unwrap()
+        .known_peers
+        .keys()
+        .cloned()
+        .collect::<HashSet<_>>();
+    assert_eq!(
+        actual, expected_discovery_known_peers,
+        "{} discovery known peers mismatch. Expected: {:#?}, actual: {:#?}",
+        self_name, expected_discovery_known_peers, actual,
+    );
+
+    let actual = state
+        .read()
+        .unwrap()
+        .connected_peers
+        .keys()
+        .cloned()
+        .collect::<HashSet<_>>();
+    assert_eq!(
+        actual, expected_discovery_connected_peers,
+        "{} discovery connected peers mismatch. Expected: {:#?}, actual: {:#?}",
+        self_name, expected_discovery_connected_peers, actual,
+    );
+}
+
 fn unwrap_new_peer_event(event: PeerEvent) -> PeerId {
     match event {
         PeerEvent::NewPeer(peer_id) => peer_id,
         e => panic!("unexpected event: {e:?}"),
     }
+}
+
+fn local_allowlisted_peer(peer_id: PeerId, port: Option<u16>) -> AllowlistedPeer {
+    AllowlistedPeer {
+        peer_id,
+        address: port.map(|port| format!("/dns/localhost/udp/{}", port).parse().unwrap()),
+    }
+}
+
+fn set_up_network(p2p_config: P2pConfig) -> (UnstartedDiscovery, Network) {
+    let anemo_config = p2p_config.anemo_config.clone().unwrap_or_default();
+    let (builder, server) = Builder::new(create_test_channel().1)
+        .config(p2p_config)
+        .build();
+    let network =
+        build_network_with_anemo_config(|router| router.add_rpc_service(server), anemo_config);
+    (builder, network)
+}
+
+fn start_network(
+    builder: UnstartedDiscovery,
+    network: Network,
+) -> (DiscoveryEventLoop, Handle, Arc<RwLock<State>>) {
+    let (mut event_loop, handle) = builder.build(network.clone());
+    event_loop.config.external_address = Some(
+        format!("/dns/localhost/udp/{}", network.local_addr().port())
+            .parse()
+            .unwrap(),
+    );
+    let state = event_loop.state.clone();
+    (event_loop, handle, state)
 }
 
 fn create_test_channel() -> (

--- a/crates/sui-network/src/utils.rs
+++ b/crates/sui-network/src/utils.rs
@@ -3,9 +3,26 @@
 
 #[cfg(test)]
 pub fn build_network(f: impl FnOnce(anemo::Router) -> anemo::Router) -> anemo::Network {
+    build_network_impl(f, None)
+}
+
+#[cfg(test)]
+pub fn build_network_with_anemo_config(
+    f: impl FnOnce(anemo::Router) -> anemo::Router,
+    anemo_config: anemo::Config,
+) -> anemo::Network {
+    build_network_impl(f, Some(anemo_config))
+}
+
+#[cfg(test)]
+fn build_network_impl(
+    f: impl FnOnce(anemo::Router) -> anemo::Router,
+    anemo_config: Option<anemo::Config>,
+) -> anemo::Network {
     let router = f(anemo::Router::new());
     let network = anemo::Network::bind("localhost:0")
         .private_key(random_key())
+        .config(anemo_config.unwrap_or_default())
         .server_name("test")
         .start(router)
         .unwrap();
@@ -15,7 +32,6 @@ pub fn build_network(f: impl FnOnce(anemo::Router) -> anemo::Router) -> anemo::N
         network.local_addr(),
         network.peer_id(),
     );
-
     network
 }
 


### PR DESCRIPTION
## Description 

This PR adds support segmented discovery network. Now with `AccessType::Private`  a node could declare its being private. Other nodes would not contact it unless it's in their `allowlisted_peers` list. `allowlisted_peers` differs from `seed_peers` in that it only treat the specified peers as `PeersAffinity::High`, but won't necessarily proactively contact them for state sync.

`AccessType` is configurable in `DiscoveryConfig` and defaults to public.

## Test Plan 

Extensive unit test case.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
This PR adds support segmented discovery network.
