### PR TITLE
move: source service config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10735,6 +10735,7 @@ version = "0.1.0"
 dependencies = [
  "actix-web",
  "anyhow",
+ "clap 3.2.23",
  "expect-test",
  "move-package",
  "reqwest",
@@ -10747,6 +10748,7 @@ dependencies = [
  "sui-source-validation",
  "test-utils",
  "tokio",
+ "toml 0.7.4",
  "workspace-hack",
 ]
 

--- a/crates/sui-source-validation-service/Cargo.toml
+++ b/crates/sui-source-validation-service/Cargo.toml
@@ -16,7 +16,9 @@ name = "sui-source-validation-service"
 [dependencies]
 actix-web = { version = "4", features = ["rustls"] }
 anyhow = { version = "1.0.64", features = ["backtrace"] }
+clap = { version = "3.2.17", features = ["derive"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+toml = { version = "0.7.4", features = ["preserve_order"] }
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.88"
 

--- a/crates/sui-source-validation-service/config.toml
+++ b/crates/sui-source-validation-service/config.toml
@@ -1,0 +1,8 @@
+[[packages]]
+repository = "https://github.com/mystenlabs/sui"
+paths = [
+    "crates/sui-framework/packages/deepbook",
+    "crates/sui-framework/packages/move-stdlib",
+    "crates/sui-framework/packages/sui-framework",
+    "crates/sui-framework/packages/sui-system",
+]

--- a/crates/sui-source-validation-service/src/lib.rs
+++ b/crates/sui-source-validation-service/src/lib.rs
@@ -1,15 +1,30 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::path::{Path, PathBuf};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 use actix_web::{dev::Server, web, App, HttpRequest, HttpServer, Responder};
+use serde::Deserialize;
 
 use move_package::BuildConfig as MoveBuildConfig;
 use sui_move::build::resolve_lock_file_path;
 use sui_move_build::{BuildConfig, SuiPackageHooks};
 use sui_sdk::wallet_context::WalletContext;
 use sui_source_validation::{BytecodeSourceVerifier, SourceMode};
+
+#[derive(Deserialize, Debug)]
+pub struct Config {
+    pub packages: Vec<Packages>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct Packages {
+    repository: String,
+    paths: Vec<String>,
+}
 
 pub async fn verify_package(
     context: &WalletContext,
@@ -41,7 +56,26 @@ pub async fn verify_package(
         .map_err(anyhow::Error::from)
 }
 
-pub async fn initialize(
+pub fn parse_config(config_path: impl AsRef<Path>) -> anyhow::Result<Config> {
+    let contents = fs::read_to_string(config_path)?;
+    toml::from_str(&contents).map_err(anyhow::Error::from)
+}
+
+pub async fn clone_repositories(config: &Config) -> anyhow::Result<()> {
+    for p in &config.packages {
+        let _ = p.repository;
+        let _ = p.paths;
+    }
+    Ok(())
+}
+
+pub async fn initialize(context: &WalletContext, config: &Config) -> anyhow::Result<()> {
+    clone_repositories(config).await?;
+    verify_packages(context, vec![]).await?;
+    Ok(())
+}
+
+pub async fn verify_packages(
     context: &WalletContext,
     package_paths: Vec<PathBuf>,
 ) -> anyhow::Result<()> {

--- a/crates/sui-source-validation-service/src/lib.rs
+++ b/crates/sui-source-validation-service/src/lib.rs
@@ -58,7 +58,7 @@ pub async fn verify_package(
 
 pub fn parse_config(config_path: impl AsRef<Path>) -> anyhow::Result<Config> {
     let contents = fs::read_to_string(config_path)?;
-    toml::from_str(&contents).map_err(anyhow::Error::from)
+    Ok(toml::from_str(&contents)?)
 }
 
 pub async fn clone_repositories(config: &Config) -> anyhow::Result<()> {

--- a/crates/sui-source-validation-service/src/main.rs
+++ b/crates/sui-source-validation-service/src/main.rs
@@ -1,15 +1,26 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::path::PathBuf;
+
+use clap::Parser;
+
 use sui_config::{sui_config_dir, SUI_CLIENT_CONFIG};
 use sui_sdk::wallet_context::WalletContext;
-use sui_source_validation_service::{initialize, serve};
+
+use sui_source_validation_service::{initialize, parse_config, serve};
+
+#[derive(Parser, Debug)]
+struct Args {
+    config_path: PathBuf,
+}
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
-    let config = sui_config_dir()?.join(SUI_CLIENT_CONFIG);
-    let context = WalletContext::new(&config, None, None).await?;
-    let package_paths = vec![];
-    initialize(&context, package_paths).await?;
+pub async fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    let package_config = parse_config(args.config_path)?;
+    let sui_config = sui_config_dir()?.join(SUI_CLIENT_CONFIG);
+    let context = WalletContext::new(&sui_config, None, None).await?;
+    initialize(&context, &package_config).await?;
     serve()?.await.map_err(anyhow::Error::from)
 }

--- a/crates/sui-source-validation-service/tests/tests.rs
+++ b/crates/sui-source-validation-service/tests/tests.rs
@@ -5,7 +5,7 @@ use expect_test::expect;
 use reqwest::Client;
 use serde::Deserialize;
 
-use sui_source_validation_service::{initialize, serve};
+use sui_source_validation_service::{initialize, serve, Config};
 
 use test_utils::network::TestClusterBuilder;
 
@@ -18,8 +18,9 @@ struct Response {
 async fn test_api_route() -> anyhow::Result<()> {
     let mut cluster = TestClusterBuilder::new().build().await;
     let context = &mut cluster.wallet;
+    let config = Config { packages: vec![] };
 
-    initialize(context, vec![]).await?;
+    initialize(context, &config).await?;
     tokio::spawn(serve().expect("Cannot start service."));
 
     let client = Client::new();
@@ -33,5 +34,38 @@ async fn test_api_route() -> anyhow::Result<()> {
 
     let expected = expect!["code"];
     expected.assert_eq(&json.source);
+    Ok(())
+}
+
+#[test]
+fn test_parse_package_config() -> anyhow::Result<()> {
+    let config = r#"
+    [[packages]]
+    repository = "https://github.com/mystenlabs/sui"
+    paths = [
+        "crates/sui-framework/packages/deepbook",
+        "crates/sui-framework/packages/move-stdlib",
+        "crates/sui-framework/packages/sui-framework",
+        "crates/sui-framework/packages/sui-system",
+    ]
+"#;
+
+    let config: Config = toml::from_str(config).unwrap();
+    let expect = expect![
+        r#"Config {
+    packages: [
+        Packages {
+            repository: "https://github.com/mystenlabs/sui",
+            paths: [
+                "crates/sui-framework/packages/deepbook",
+                "crates/sui-framework/packages/move-stdlib",
+                "crates/sui-framework/packages/sui-framework",
+                "crates/sui-framework/packages/sui-system",
+            ],
+        },
+    ],
+}"#
+    ];
+    expect.assert_eq(&format!("{:#?}", config));
     Ok(())
 }


### PR DESCRIPTION
## Description 

This adds a basic config file to initialize the server with. It takes a list of `Packages`, where `Packages` comprise a repository and one or more paths to Move package in that repository. 

## Test Plan 

Added a basic test to parse a config file.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
