### PR TITLE
[sdk] Fix `TimeRange` event query type

### DIFF
--- a/.changeset/strong-ways-dance.md
+++ b/.changeset/strong-ways-dance.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui.js': patch
+---
+
+Update `SuiEventFilter` structure for `TimeRange` query.

--- a/sdk/typescript/src/types/events.ts
+++ b/sdk/typescript/src/types/events.ts
@@ -64,9 +64,9 @@ export type SuiEventFilter =
 	| {
 			TimeRange: {
 				// left endpoint of time interval, milliseconds since epoch, inclusive
-				start_time: number;
+				startTime: string;
 				// right endpoint of time interval, milliseconds since epoch, exclusive
-				end_time: number;
+				endTime: string;
 			};
 	  }
 	| { Sender: SuiAddress }


### PR DESCRIPTION
## Description

`TimeRange` expects its parameters to be given in `camelCase` and accepts its numeric arguments as strings.

## Test Plan

The following should work:

```
const provider = new JsonRpcProvider(mainnetConnection);
console.log(await provider.queryEvents({
    query: {
        TimeRange: {
            startTime: "1686050221271",
            endTime: "1686690000000",
        },
    },
    limit: 1000
}));
```