### PR TITLE
wallet-ext: use mnemonic seed to derive accounts

### DIFF
--- a/.changeset/thick-bottles-repeat.md
+++ b/.changeset/thick-bottles-repeat.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui.js': patch
+---
+
+add method to create Ed25519Keypair from a mnemonic seed

--- a/apps/wallet/src/background/keyring/VaultStorage.test.ts
+++ b/apps/wallet/src/background/keyring/VaultStorage.test.ts
@@ -17,7 +17,6 @@ import {
 	testDataVault1,
 	testDataVault2,
 	testEntropySerialized,
-	testMnemonic,
 	testEd25519,
 	testMnemonicSeedHex,
 } from '_src/test-utils/vault';

--- a/apps/wallet/src/background/keyring/VaultStorage.test.ts
+++ b/apps/wallet/src/background/keyring/VaultStorage.test.ts
@@ -19,6 +19,7 @@ import {
 	testEntropySerialized,
 	testMnemonic,
 	testEd25519,
+	testMnemonicSeedHex,
 } from '_src/test-utils/vault';
 
 vi.mock('../storage-utils');
@@ -56,7 +57,7 @@ describe('VaultStorage', () => {
 			const storedStore = vi.mocked(setToLocalStorage).mock.calls[0][1];
 			vi.mocked(getFromLocalStorage).mockResolvedValue(storedStore);
 			await VaultStorage.unlock('12345');
-			expect(await VaultStorage.getMnemonic()).toBe(testMnemonic);
+			expect(await VaultStorage.getMnemonicSeedHex()).toBe(testMnemonicSeedHex);
 		});
 	});
 
@@ -72,7 +73,7 @@ describe('VaultStorage', () => {
 
 		it('unlocks and locks updating vault session storage', async () => {
 			await VaultStorage.unlock(testDataVault1.password);
-			expect(VaultStorage.getMnemonic()).toBe(testDataVault1.mnemonic);
+			expect(VaultStorage.getMnemonicSeedHex()).toBe(testDataVault1.testMnemonicSeedHex);
 			expect(setToSessionStorage).toBeCalledTimes(2);
 			expect(setToSessionStorage).toHaveBeenNthCalledWith(
 				1,
@@ -85,7 +86,7 @@ describe('VaultStorage', () => {
 			});
 			vi.mocked(setToSessionStorage).mockClear();
 			await VaultStorage.lock();
-			expect(VaultStorage.getMnemonic()).toBe(null);
+			expect(VaultStorage.getMnemonicSeedHex()).toBe(null);
 			expect(setToSessionStorage).toBeCalledTimes(2);
 			expect(setToSessionStorage).toHaveBeenNthCalledWith(1, EPHEMERAL_PASSWORD_KEY, null);
 			expect(setToSessionStorage).toHaveBeenNthCalledWith(2, EPHEMERAL_VAULT_KEY, null);
@@ -100,13 +101,13 @@ describe('VaultStorage', () => {
 			);
 			const isUnlocked = await VaultStorage.revive();
 			expect(isUnlocked).toBe(true);
-			expect(VaultStorage.getMnemonic()).toBe(testDataVault1.mnemonic);
+			expect(VaultStorage.getMnemonicSeedHex()).toBe(testDataVault1.testMnemonicSeedHex);
 		});
 
 		it('keeps vault locked when encrypted vault is not found in session storage', async () => {
 			vi.mocked(getFromSessionStorage).mockResolvedValue(null);
 			await expect(VaultStorage.revive()).resolves.toBe(false);
-			expect(VaultStorage.getMnemonic()).toBe(null);
+			expect(VaultStorage.getMnemonicSeedHex()).toBe(null);
 		});
 	});
 
@@ -202,13 +203,13 @@ describe('VaultStorage no session storage', () => {
 
 	it('unlocks & locks vault', async () => {
 		await VaultStorage.unlock(testDataVault1.password);
-		expect(VaultStorage.getMnemonic()).toBe(testDataVault1.mnemonic);
+		expect(VaultStorage.getMnemonicSeedHex()).toBe(testDataVault1.testMnemonicSeedHex);
 		await VaultStorage.lock();
-		expect(VaultStorage.getMnemonic()).toBe(null);
+		expect(VaultStorage.getMnemonicSeedHex()).toBe(null);
 	});
 
 	it('keeps vault locked when session storage in not defined', async () => {
 		await expect(VaultStorage.revive()).resolves.toBe(false);
-		expect(VaultStorage.getMnemonic()).toBe(null);
+		expect(VaultStorage.getMnemonicSeedHex()).toBe(null);
 	});
 });

--- a/apps/wallet/src/background/keyring/VaultStorage.ts
+++ b/apps/wallet/src/background/keyring/VaultStorage.ts
@@ -97,12 +97,12 @@ class VaultStorageClass {
 		return !!(await getFromLocalStorage<StoredData>(VAULT_KEY));
 	}
 
-	public getMnemonic() {
-		return this.#vault?.getMnemonic() || null;
-	}
-
 	public get entropy() {
 		return this.#vault?.entropy || null;
+	}
+
+	public getMnemonicSeedHex() {
+		return this.#vault?.mnemonicSeedHex || null;
 	}
 
 	public async verifyPassword(password: string) {

--- a/apps/wallet/src/background/keyring/index.test.ts
+++ b/apps/wallet/src/background/keyring/index.test.ts
@@ -11,7 +11,7 @@ import Alarm from '_src/background/Alarms';
 import {
 	testEd25519,
 	testEd25519Serialized,
-	testMnemonic,
+	testMnemonicSeedHex,
 	testSecp256k1,
 	testSecp256k1Address,
 	testSecp256k1Serialized,
@@ -46,7 +46,7 @@ describe('Keyring', () => {
 
 		beforeEach(async () => {
 			vaultStorageMock.revive.mockResolvedValue(true);
-			vaultStorageMock.getMnemonic.mockReturnValue(testMnemonic);
+			vaultStorageMock.getMnemonicSeedHex.mockReturnValue(testMnemonicSeedHex);
 			vaultStorageMock.getImportedKeys.mockReturnValue([testSecp256k1]);
 			k = new Keyring();
 			await k.reviveDone;

--- a/apps/wallet/src/test-utils/vault.ts
+++ b/apps/wallet/src/test-utils/vault.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { fromExportedKeypair } from '@mysten/sui.js';
+import { fromExportedKeypair, mnemonicToSeedHex } from '@mysten/sui.js';
 
 import { EPHEMERAL_PASSWORD_KEY, EPHEMERAL_VAULT_KEY } from '_src/background/keyring/VaultStorage';
 import { toEntropy } from '_src/shared/utils/bip39';
@@ -10,6 +10,7 @@ import type { Keypair } from '@mysten/sui.js';
 
 export const testMnemonic =
 	'loud eye weather change muffin brisk episode dance mirror smart image energy';
+export const testMnemonicSeedHex = mnemonicToSeedHex(testMnemonic);
 export const testEntropySerialized = '842a27e29319123892f9ba8d9991c525';
 export const testEntropy = toEntropy(testEntropySerialized);
 export const testEd25519SerializedLegacy = Object.freeze({
@@ -40,6 +41,7 @@ type TestDataVault = typeof testDataVault1;
  */
 export const testDataVault1 = Object.freeze({
 	mnemonic: testMnemonic as string,
+	testMnemonicSeedHex,
 	entropy: testEntropy,
 	entropySerialized: testEntropySerialized as string,
 	keypairs: [testEd25519, testSecp256k1] as Keypair[],
@@ -52,7 +54,7 @@ export const testDataVault1 = Object.freeze({
 		},
 		v2: {
 			v: 2 as const,
-			data: '{"data":"2A1AuR8RUzdfcrKuAm+AgOsCHkA+6XHpxHI8SrWKSmzzCyHbUdxPXI65lR55+uHPVKi9Sk9q+wTaM3Dgr9hzUFJ2wX43bcjZxhBJ2Xo/RqNI5tLQWyx4Y6xKSrB8MjbDf/Zq29AEArIPOoTz36Tsr8GR0m92y/9xAtskctOIlQKKiNgvZ8z3eN7AfeO0PgTJVTiEkBxruqzL0A9XDNW4xNySKkig5UbzfhNXa1pBieDyXWcmpNnOe+7RVxXMZX9FAro31+KI5SexoAJ6TE3L/hv9b0zQgND1otAjPu6AB5d3VG6BaOKlEHxqBeoGNya4iCoYSg0CB6kViGCwhWyjiylkABJ3Q++dDxxXyCP2nuw0rxbiB6VoElEEIwaraVS/c8Q0","iv":"bBKS/FT16UqyHPNnjnBS5Q==","salt":"1ViXZMKEQ2kxwq761j2SY8SHgHxQ8kiWil8hd3Ni5CI="}',
+			data: '{"data":"duteNkmpItSCH53t2qJB2DS2i0tmavGhVHf5zBZP+2C+2dtsrZ8MWcAh2V7HgKJjPJ5sqiZf/ZULa0qtSdYKDhPTXNQNe14Q0IXza+6McUBZIzscWVzRkiSPoQLz72rOiIswgtBOW8pmn4tFlkApClIksRVeENJzkHPFOz8MqQWzipXVXpcYzv0lpBgQtOm1H+8ArAD+TATM1ggvgv9WXvDvsKqBPO6n1+fLysDqT6OQUoLZoGtvDxrAD/50bnOn5tcASVF5P2IeHVlep/fjHY8dL9f8elbwtA42FDGbXv8vKnSIRIGWNyqjRpkiMxjQwibBEOAyyl15Xjmn5ydyHUmXhu+TXy5SRFANy8Dy/MX0nxRGAoH+RCE8mGnMZJcsn/cdm0ZQ9YMuZB0ng9lCGRpkKONOmNfeeM4nirAsPbQ0f05DwCCzIp1jHQJuPEgy/OwJFYWQIBeAHsiBD9Ivi0+WIQC3z1hBA9yVmL1nThQ700InZOK2qCwuTJOpd/FOkqnO/94AYmq1v/t4HasptkjpvuxJOFxB6X0DwPY=","iv":"pW8cbFYE1mbAC0Nml4d35A==","salt":"s1Qfqw+7pJx04zDfRsFHGIu9Xv9LTizvTDRNOKhFAEs="}',
 		},
 	},
 	sessionStorage: {
@@ -69,6 +71,7 @@ export const testDataVault1 = Object.freeze({
  */
 export const testDataVault2: TestDataVault = Object.freeze({
 	mnemonic: testMnemonic,
+	testMnemonicSeedHex,
 	entropy: testEntropy,
 	entropySerialized: testEntropySerialized,
 	keypairs: [],
@@ -78,7 +81,7 @@ export const testDataVault2: TestDataVault = Object.freeze({
 		v1: testDataVault1.encrypted.v1,
 		v2: {
 			v: 2 as const,
-			data: '{"data":"5Oua+5DkH7OWWkvNseCqAECC9PF6Csxl5E4zDEdV5/uthNgI3/c1WjZCswsYEXMxeBoxnfUIzjKLthAHKvZOdYbvISzlCjtXmDoWeRnFvrWiXKWV","iv":"K5uVmJUkArzVzU58VGzIuw==","salt":"IM7Y1aRpJ5WQajQbmdGHI8+D2cZXHblEc58aoHfISfg="}',
+			data: '{"data":"KYIbJX9kKqFXoG5cxHluU6dcmaYtuAoJNaJ++RxBBJX3OapJluLj9dJ+xkUy8bm63jxATyfE2RzRKYRnxzn5uLIkpBgXvh46nIumKM9ehat2IZTCgAxA8/RN5QLh59+4TeNpMv8CwnNkNLPTA1Ve7bXI5uhv3Kd2xQ1n1VvqsY2xrt8QROyESQNRpmTec3dOAzA5U+ztoXfvp5itKLDVTcAgeceNwKgR2qdu7QF45yKTDWDCxqrPMHPuYnxTq2iJ9EgYLMpvMIoZ3nXcrP1/4gSI3idwA+rma3j+uVQpneDvVp5x7NUajDfyH44fkrN0cOtwRNoVclqDZg==","iv":"W++5n5xGIJJtbhbGUo3LeA==","salt":"PN3JEwTAO5aGi60zmXU0P6b6sWZDX7IdJVudnbHpv6w="}',
 		},
 	},
 	sessionStorage: {

--- a/sdk/typescript/src/cryptography/ed25519-keypair.ts
+++ b/sdk/typescript/src/cryptography/ed25519-keypair.ts
@@ -133,6 +133,24 @@ export class Ed25519Keypair implements Keypair {
 	}
 
 	/**
+	 * Derive Ed25519 keypair from mnemonicSeed and path.
+	 *
+	 * If path is none, it will default to m/44'/784'/0'/0'/0', otherwise the path must
+	 * be compliant to SLIP-0010 in form m/44'/784'/{account_index}'/{change_index}'/{address_index}'.
+	 */
+	static deriveKeypairFromSeed(seedHex: string, path?: string): Ed25519Keypair {
+		if (path == null) {
+			path = DEFAULT_ED25519_DERIVATION_PATH;
+		}
+		if (!isValidHardenedPath(path)) {
+			throw new Error('Invalid derivation path');
+		}
+		const { key } = derivePath(path, seedHex);
+
+		return Ed25519Keypair.fromSecretKey(key);
+	}
+
+	/**
 	 * This returns an exported keypair object, the private key field is the pure 32-byte seed.
 	 */
 	export(): ExportedKeypair {


### PR DESCRIPTION
## Description 

minimise usage of mnemonic phrase and use the mnemonic seed instead to derive wallet key pairs

* sdk add method to created Ed25519Keypair from a mnemonic seed
* wallet store the mnemonic seed in storage to avoid generating the mnemonic to derive key pairs
* this will minimise the times that mnemonic phrase exists in memory

closes [APPS-1098](https://mysten.atlassian.net/browse/APPS-1098)

## Test Plan 

How did you test the new or updated feature?

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
