### PR TITLE
Enable simplified_unwrap_then_delete

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_never_stored.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_never_stored.exp
@@ -16,4 +16,5 @@ gas summary: computation_cost: 1000000, storage_cost: 2439600,  storage_rebate: 
 task 3 'run'. lines 43-43:
 mutated: object(0,0)
 deleted: object(2,0)
+unwrapped_then_deleted: object(_)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 2415204, non_refundable_storage_fee: 24396

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/unwrap_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/unwrap_object.exp
@@ -33,6 +33,7 @@ gas summary: computation_cost: 1000000, storage_cost: 4157200,  storage_rebate: 
 task 6 'run'. lines 52-52:
 mutated: object(0,0), object(5,0)
 deleted: object(5,1)
+unwrapped_then_deleted: object(_)
 gas summary: computation_cost: 1000000, storage_cost: 2211600,  storage_rebate: 4115628, non_refundable_storage_fee: 41572
 
 task 7 'run'. lines 55-55:

--- a/crates/sui-adapter-transactional-tests/tests/sui/unwrap_then_delete.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/unwrap_then_delete.exp
@@ -33,4 +33,5 @@ gas summary: computation_cost: 1000000, storage_cost: 2637200,  storage_rebate: 
 task 6 'run'. lines 75-75:
 mutated: object(0,1)
 deleted: object(5,0)
+unwrapped_then_deleted: object(_)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 2610828, non_refundable_storage_fee: 26372

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -560,8 +560,8 @@ async fn test_create_then_delete_parent_child_wrap() {
     // The parent and field are considered deleted, the child doesn't count because it wasn't
     // considered created in the first place.
     assert_eq!(effects.deleted().len(), 2);
-    // The child was never created so it is not unwrapped.
-    assert_eq!(effects.unwrapped_then_deleted().len(), 0);
+    // The child is considered as unwrapped and deleted, even though it was wrapped since creation.
+    assert_eq!(effects.unwrapped_then_deleted().len(), 1);
 
     assert_eq!(
         effects

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -47,7 +47,10 @@ const MAX_PROTOCOL_VERSION: u64 = 16;
 //             decides whether rounding is applied or not.
 // Version 15: Add reordering of user transactions by gas price after consensus.
 //             Add `sui::table_vec::drop` to the framework via a system package upgrade.
-// Version 16: Add self-matching prevention for deepbook.
+// Version 16: Enabled simplified_unwrap_then_delete feature flag, which allows the execution engine
+//             to no longer consult the object store when generating unwrapped_then_deleted in the
+//             effects; this also allows us to stop including wrapped tombstones in accumulator.
+//             Add self-matching prevention for deepbook.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -1247,7 +1250,11 @@ impl ProtocolConfig {
                     ConsensusTransactionOrdering::ByGasPrice;
                 cfg
             }
-            16 => Self::get_for_version_impl(version - 1, chain),
+            16 => {
+                let mut cfg = Self::get_for_version_impl(version - 1, chain);
+                cfg.feature_flags.simplified_unwrap_then_delete = true;
+                cfg
+            }
             // Use this template when making changes:
             //
             //     // modify an existing constant.

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_16.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_16.snap
@@ -19,6 +19,7 @@ feature_flags:
   no_extraneous_module_bytes: true
   narwhal_versioned_metadata: true
   consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_16.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_16.snap
@@ -20,6 +20,7 @@ feature_flags:
   no_extraneous_module_bytes: true
   narwhal_versioned_metadata: true
   consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_16.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_16.snap
@@ -21,6 +21,7 @@ feature_flags:
   narwhal_versioned_metadata: true
   zklogin_auth: true
   consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000


### PR DESCRIPTION
## Description 

This PR adds protocol config version 16, and enables a new feature flag simplified_unwrap_then_delete.
Under this new feature flag, we no longer consult the object store when constructing unwrapped_then_deleted in the effects, and no longer include wrapped tombstones in state accumulator. It will require a re-accumulation at epoch change during the upgrade.

## Test Plan 

Added tests in previous CI.
Will also sync testnet, and deploy this upgrade on devnet.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [X] protocol change
- [X] user-visible impact
- [ ] breaking change for a client SDKs
- [X] breaking change for FNs (FN binary must upgrade)
- [X] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Prior to this change, unwrapped_then_deleted field in TransactionEffects only contain unwrapped then deleted objects that previously existed in the store (i.e. was once unwrapped in its lifetime). If an object was always wrapped since creation and was never unwrapped ever, it wouldn't show up in unwrapped_then_deleted. This this change, we no longer makes such distinction. As long as an object is unwrapped then deleted in a transaction, it would show up in effects regardless of its history. This simplifies the logic of handling them significantly.
To properly maintain the state of the system accurately with this change, at the epoch boundary when this upgrades happens, we must re-accumulate the state root hash of all objects in the store. This process takes a few seconds on mainnet. Testnet can take a much longer time (30s-1min) since it contains significantly more objects. Users may observe a brief slow down of the network during epoch change when this is applied.