### PR TITLE
[WIP][Feedback needed] Keytool json and pretty print to table prototype

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,12 +234,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "ansi-str"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cf4578926a981ab0ca955dc023541d19de37112bc24c1a197bd806d3d86ad1d"
+dependencies = [
+ "ansitok",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "ansitok"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220044e6a1bb31ddee4e3db724d29767f352de47445a6cd75e1a173142136c83"
+dependencies = [
+ "nom 7.1.2",
+ "vte",
 ]
 
 [[package]]
@@ -1436,6 +1455,12 @@ dependencies = [
  "sha2 0.9.9",
  "sha3 0.9.1",
 ]
+
+[[package]]
+name = "bytecount"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 
 [[package]]
 name = "bytemuck"
@@ -4277,6 +4302,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "json_to_table"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e233e3750bac7edc04e1e1b03741cd1e37b59a8aff781fbed41cbcca79b2b06e"
+dependencies = [
+ "serde_json",
+ "tabled",
+]
+
+[[package]]
 name = "jsonrpsee"
 version = "0.16.2"
 source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=b1b300784795f6a64d0fcdf8f03081a9bc38bde8#b1b300784795f6a64d0fcdf8f03081a9bc38bde8"
@@ -6637,6 +6672,19 @@ dependencies = [
  "elliptic-curve 0.13.4",
  "primeorder",
  "sha2 0.10.6",
+]
+
+[[package]]
+name = "papergrid"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae7891b22598926e4398790c8fe6447930c72a67d36d983a49d6ce682ce83290"
+dependencies = [
+ "ansi-str",
+ "ansitok",
+ "bytecount",
+ "fnv",
+ "unicode-width",
 ]
 
 [[package]]
@@ -9054,6 +9102,7 @@ dependencies = [
  "git-version",
  "inquire",
  "jemalloc-ctl",
+ "json_to_table",
  "move-bytecode-verifier",
  "move-core-types",
  "move-package",
@@ -9090,6 +9139,7 @@ dependencies = [
  "sui-swarm-config",
  "sui-types",
  "sui-verifier-latest",
+ "tabled",
  "tap",
  "telemetry-subscribers",
  "tempfile",
@@ -10826,6 +10876,32 @@ dependencies = [
  "once_cell",
  "rayon",
  "winapi",
+]
+
+[[package]]
+name = "tabled"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "994ca3cfbe91dd1756a82a605a150fd7c9d9196cddc7af0612c1999cef224588"
+dependencies = [
+ "ansi-str",
+ "ansitok",
+ "papergrid",
+ "tabled_derive",
+ "unicode-width",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99f688a08b54f4f02f0a3c382aefdb7884d3d69609f785bd253dc033243e3fe4"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2 1.0.58",
+ "quote 1.0.26",
+ "syn 1.0.107",
 ]
 
 [[package]]

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -31,6 +31,8 @@ prometheus = "0.13.3"
 git-version = "0.3.5"
 const-str = "0.5.3"
 num-bigint = "0.4.3"
+json_to_table = "*"
+tabled = { version = "*", features = ["color"] } 
 
 move-bytecode-verifier = { path = "../../external-crates/move/move-bytecode-verifier" }
 sui-adapter = { path = "../../sui-execution/latest/sui-adapter", package = "sui-adapter-latest" }

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -7,13 +7,14 @@ use fastcrypto::ed25519::Ed25519KeyPair;
 use fastcrypto::encoding::{decode_bytes_hex, Base64, Encoding, Hex};
 use fastcrypto::hash::HashFunction;
 use fastcrypto::secp256k1::recoverable::Secp256k1Sig;
-use fastcrypto::traits::KeyPair;
+use fastcrypto::traits::{KeyPair, ToFromBytes};
 use fastcrypto_zkp::bn254::api::Bn254Fr;
 use fastcrypto_zkp::bn254::poseidon::PoseidonWrapper;
 use fastcrypto_zkp::bn254::zk_login::OAuthProvider;
 use fastcrypto_zkp::bn254::zk_login::{
     big_int_str_to_bytes, AuxInputs, PublicInputs, SupportedKeyClaim, ZkLoginProof,
 };
+use json_to_table::{json_to_table, Orientation};
 use num_bigint::{BigInt, Sign};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
@@ -22,11 +23,10 @@ use rusoto_kms::{Kms, KmsClient, SignRequest};
 use serde::Serialize;
 use serde_json::json;
 use shared_crypto::intent::{Intent, IntentMessage};
-use std::fmt::Write;
 use std::fmt::{Debug, Display, Formatter};
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use std::{convert, fs};
 use sui_keys::key_derive::generate_new_key;
 use sui_keys::keypair_file::{
     read_authority_keypair_from_file, read_keypair_from_file, write_authority_keypair_to_file,
@@ -44,8 +44,6 @@ use sui_types::transaction::TransactionData;
 use sui_types::zk_login_authenticator::ZkLoginAuthenticator;
 use sui_types::zk_login_util::AddressParams;
 use tracing::info;
-
-use json_to_table::{json_to_table, Orientation};
 
 #[cfg(test)]
 #[path = "unit_tests/keytool_tests.rs"]
@@ -77,8 +75,8 @@ pub enum KeyToolCommand {
         file: PathBuf,
     },
     /// This takes [enum SuiKeyPair] of Base64 encoded of 33-byte `flag || privkey`). It
-    /// outputs the keypair into a file at the current directory, and prints out its Sui
-    /// address, Base64 encoded public key, and the key scheme flag.
+    /// outputs the keypair into a file at the current directory where the address is the filename,
+    /// and prints out its Sui address, Base64 encoded public key, the key scheme, and the key scheme flag.
     Unpack {
         keypair: SuiKeyPair,
     },
@@ -104,7 +102,7 @@ pub enum KeyToolCommand {
     /// Generate PubKey from pem using MystenLabs/base64pemkey
     /// Any signature commits to a [struct IntentMessage] consisting of the Base64 encoded
     /// of the BCS serialized transaction bytes itself (the result of
-    /// [transaction builder API](https://docs.sui.io/sui-jsonrpc) and its intent. If
+    /// [transaction builder API](https://docs.sui.io/sui-jsonrpc)) and its intent. If
     /// intent is absent, default will be used. See [struct IntentMessage] and [struct Intent]
     /// for more details.
     SignKMS {
@@ -243,58 +241,108 @@ pub enum KeyToolCommand {
 impl KeyToolCommand {
     pub async fn execute(self, keystore: &mut Keystore) -> Result<CommandOutput, anyhow::Error> {
         let cmd_result = Ok(match self {
-            // KeyToolCommand::Generate {
-            //     key_scheme,
-            //     derivation_path,
-            //     word_length,
-            // } => {
-            //     if "bls12381" == key_scheme.to_string() {
-            //         // Generate BLS12381 key for authority without key derivation.
-            //         // The saved keypair is encoded `privkey || pubkey` without the scheme flag.
-            //         let (address, keypair) = get_authority_key_pair();
-            //         let file_name = format!("bls-{address}.key");
-            //         write_authority_keypair_to_file(&keypair, file_name)?;
-            //     } else {
-            //         let (address, kp, scheme, phrase) =
-            //             generate_new_key(key_scheme, derivation_path, word_length)?;
-            //         let file = format!("{address}.key");
-            //         write_keypair_to_file(&kp, &file)?;
-            //         println!(
-            //             "Created new keypair for address wrote to file path {:?} with scheme {:?}: [{address}]",
-            //             file, scheme
-            //         );
-            //         println!("Secret Recovery Phrase : [{phrase}]");
-            //     }
-            // }
-            // KeyToolCommand::Show { file } => {
-            //     let res = read_keypair_from_file(&file);
-            //     match res {
-            //         Ok(keypair) => {
-            //             println!("Public Key: {}", keypair.public().encode_base64());
-            //             println!("Flag: {}", keypair.public().flag());
-            //             if let PublicKey::Ed25519(public_key) = keypair.public() {
-            //                 let peer_id = anemo::PeerId(public_key.0);
-            //                 println!("PeerId: {}", peer_id);
-            //             }
-            //         }
-            //         Err(_) => {
-            //             let res = read_authority_keypair_from_file(&file);
-            //             match res {
-            //                 Ok(keypair) => {
-            //                     println!("Public Key: {}", keypair.public().encode_base64());
-            //                     println!("Flag: {}", SignatureScheme::BLS12381);
-            //                 }
-            //                 Err(e) => {
-            //                     println!("Failed to read keypair at path {:?} err: {:?}", file, e)
-            //                 }
-            //             }
-            //         }
-            //     }
-            // }
+            KeyToolCommand::Generate {
+                key_scheme,
+                derivation_path,
+                word_length,
+            } => match key_scheme {
+                SignatureScheme::BLS12381 => {
+                    let (sui_address, kp) = get_authority_key_pair();
+                    let public_base64_key = kp.encode_base64();
+                    let file_name = format!("bls-{sui_address}.key");
+                    write_authority_keypair_to_file(&kp, file_name)?;
+                    CommandOutput::Generate(Key {
+                        sui_address: sui_address.to_string(),
+                        public_base64_key,
+                        key_scheme: key_scheme.to_string(),
+                        flag: SignatureScheme::BLS12381.flag(),
+                        mnemonic: None,
+                        peer_id: None,
+                    })
+                }
+                _ => {
+                    let (sui_address, kp, scheme, phrase) =
+                        generate_new_key(key_scheme, derivation_path, word_length)?;
+                    let public_base64_key = kp.encode_base64();
+                    let file = format!("{sui_address}.key");
+                    let peer_id = if let PublicKey::Ed25519(public_key) = kp.public() {
+                        Some(anemo::PeerId(public_key.0).to_string())
+                    } else {
+                        None
+                    };
+                    write_keypair_to_file(&kp, file)?;
+                    CommandOutput::Generate(Key {
+                        sui_address: sui_address.to_string(),
+                        public_base64_key,
+                        key_scheme: scheme.to_string(),
+                        flag: kp.public().flag(),
+                        mnemonic: Some(phrase),
+                        peer_id,
+                    })
+                }
+            },
+            KeyToolCommand::Show { file } => {
+                let res = read_keypair_from_file(&file);
+                match res {
+                    Ok(keypair) => {
+                        let sui_address: SuiAddress = (&keypair.public()).into();
+                        let peer_id = if let PublicKey::Ed25519(public_key) = keypair.public() {
+                            Some(anemo::PeerId(public_key.0).to_string())
+                        } else {
+                            None
+                        };
+                        CommandOutput::Show(Key {
+                            sui_address: sui_address.to_string(),
+                            public_base64_key: keypair.encode_base64(),
+                            key_scheme: keypair.public().scheme().to_string(),
+                            peer_id,
+                            flag: keypair.public().flag(),
+                            mnemonic: None,
+                        })
+                    }
+                    Err(_) => match read_authority_keypair_from_file(&file) {
+                        Ok(keypair) => {
+                            let public_base64_key = keypair.public().encode_base64();
+                            eprintln!("Flag: {}", SignatureScheme::BLS12381);
+                            CommandOutput::Show(Key {
+                                sui_address: "".to_string(),
+                                public_base64_key,
+                                key_scheme: SignatureScheme::BLS12381.to_string(),
+                                flag: SignatureScheme::BLS12381.flag(),
+                                peer_id: None,
+                                mnemonic: None,
+                            })
+                        }
+                        Err(e) => CommandOutput::Error(format!(
+                            "Failed to read keypair at path {:?}, err: {e}",
+                            file
+                        )),
+                    },
+                }
+            }
 
-            // KeyToolCommand::Unpack { keypair } => {
-            //     store_and_print_keypair((&keypair.public()).into(), keypair)
-            // }
+            KeyToolCommand::Unpack { keypair } => {
+                let sui_address: SuiAddress = (&keypair.public()).into();
+                let path_str = format!("{}.key", sui_address).to_lowercase();
+                let path = Path::new(&path_str);
+                let sui_address = format!("{}", sui_address);
+                let key_scheme = keypair.public().scheme().to_string();
+                let public_base64_key = keypair.encode_base64();
+                let flag = keypair.public().flag();
+                let out_str = format!(
+                    "address: {}\nkeypair: {}\nflag: {}",
+                    sui_address, public_base64_key, flag
+                );
+                fs::write(path, out_str).unwrap();
+                CommandOutput::Show(Key {
+                    sui_address,
+                    public_base64_key,
+                    flag,
+                    key_scheme,
+                    mnemonic: None,
+                    peer_id: None,
+                })
+            }
             KeyToolCommand::List => {
                 let keys = keystore
                     .keys()
@@ -303,189 +351,291 @@ impl KeyToolCommand {
                         sui_address: Into::<SuiAddress>::into(&key).to_string(),
                         public_base64_key: key.encode_base64(),
                         key_scheme: key.scheme().to_string(),
+                        mnemonic: None,
+                        flag: key.flag(),
+                        peer_id: {
+                            if let PublicKey::Ed25519(public_key) = key {
+                                Some(anemo::PeerId(public_key.0).to_string())
+                            } else {
+                                None
+                            }
+                        },
                     })
                     .collect::<Vec<_>>();
 
                 CommandOutput::List(keys)
             }
-            // KeyToolCommand::Sign {
-            //     address,
-            //     data,
-            //     intent,
-            // } => {
-            //     println!("Signer address: {}", address);
-            //     println!("Raw tx_bytes to execute: {}", data);
-            //     let intent = intent.unwrap_or_else(Intent::sui_transaction);
-            //     println!("Intent: {:?}", intent);
-            //     let msg: TransactionData =
-            //         bcs::from_bytes(&Base64::decode(&data).map_err(|e| {
-            //             anyhow!("Cannot deserialize data as TransactionData {:?}", e)
-            //         })?)?;
-            //     let intent_msg = IntentMessage::new(intent, msg);
-            //     println!(
-            //         "Raw intent message: {:?}",
-            //         Base64::encode(bcs::to_bytes(&intent_msg)?)
-            //     );
-            //     let mut hasher = DefaultHash::default();
-            //     hasher.update(bcs::to_bytes(&intent_msg)?);
-            //     let digest = hasher.finalize().digest;
-            //     println!("Digest to sign: {:?}", Base64::encode(digest));
-            //     let sui_signature =
-            //         keystore.sign_secure(&address, &intent_msg.value, intent_msg.intent)?;
-            //     println!(
-            //         "Serialized signature (`flag || sig || pk` in Base64): {:?}",
-            //         sui_signature.encode_base64()
-            //     );
-            // }
+
+            KeyToolCommand::Sign {
+                address,
+                data,
+                intent,
+            } => {
+                eprintln!("Signer address: {}", address);
+                eprintln!("Raw tx_bytes to execute: {}", data);
+                let intent = intent.unwrap_or_else(Intent::sui_transaction);
+                let intent_clone = intent.clone();
+                eprintln!("Intent: {:?}", intent);
+                let msg: TransactionData =
+                    bcs::from_bytes(&Base64::decode(&data).map_err(|e| {
+                        anyhow!("Cannot deserialize data as TransactionData {:?}", e)
+                    })?)?;
+                let intent_msg = IntentMessage::new(intent, msg);
+                let raw_intent_msg = Base64::encode(bcs::to_bytes(&intent_msg)?);
+                eprintln!("Raw intent message: {:?}", raw_intent_msg);
+                let mut hasher = DefaultHash::default();
+                hasher.update(bcs::to_bytes(&intent_msg)?);
+                let digest = hasher.finalize().digest;
+
+                eprintln!("Digest to sign: {:?}", Base64::encode(digest));
+                let sui_signature =
+                    keystore.sign_secure(&address, &intent_msg.value, intent_msg.intent)?;
+                eprintln!(
+                    "Serialized signature (`flag || sig || pk` in Base64): {:?}",
+                    sui_signature.encode_base64()
+                );
+                CommandOutput::Sign(SignData {
+                    sui_address: address,
+                    raw_tx_data: data,
+                    intent: intent_clone,
+                    raw_intent_msg,
+                    digest: Base64::encode(digest),
+                    sui_signature: sui_signature.encode_base64(),
+                })
+            }
+
             KeyToolCommand::Import {
                 input_string,
                 key_scheme,
                 derivation_path,
             } => {
                 let scheme = key_scheme.to_string();
-                let sui_address =
-                    keystore.import_from_mnemonic(&input_string, key_scheme, derivation_path)?;
-                let pk = keystore.get_key(&sui_address)?;
-                CommandOutput::Import(Key {
-                    sui_address: sui_address.to_string(),
-                    public_base64_key: pk.public().encode_base64().to_string(),
-                    key_scheme: scheme,
-                })
+                // check if input is a private key -- should start with 0x
+                if input_string.starts_with("0x") {
+                    let bytes = Hex::decode(&input_string).map_err(|_| {
+                        anyhow!("Private key is malformed. Importing private key failed.")
+                    })?;
+                    match key_scheme {
+                            SignatureScheme::ED25519 => {
+                                let kp: Ed25519KeyPair = Ed25519KeyPair::from_bytes(&bytes).map_err(|_| anyhow!("Cannot decode ed25519 keypair from the private key. Importing private key failed."))?;
+                                let skp = SuiKeyPair::Ed25519(kp);
+                                let peer_id = if let PublicKey::Ed25519(public_key) = skp.public() {
+                                    Some(anemo::PeerId(public_key.0).to_string())
+                                } else {
+                                    None
+                                };
+                                eprintln!("Private key imported successfully.");
+                                keystore.add_key(skp)?;
+                                // we need these two because keystore.add_key takes ownership of skp
+                                let kp: Ed25519KeyPair = Ed25519KeyPair::from_bytes(&bytes).map_err(|_| anyhow!("Cannot decode ed25519 keypair from the private key. Importing private key failed."))?;
+                                let skp = SuiKeyPair::Ed25519(kp);
+                                let address: SuiAddress = Into::<SuiAddress>::into(&skp.public());
+                                eprintln!("{address}");
+
+                                CommandOutput::Import(Key {
+                                    sui_address: address.to_string(),
+                                    public_base64_key: skp.public().encode_base64(),
+                                    key_scheme: scheme,
+                                    mnemonic: None,
+                                    flag: skp.public().flag(),
+                                    peer_id,
+                                })
+                            }
+                            _ => return Err(anyhow!(
+                                "Only ed25519 signature scheme is supported for importing private keys at the moment."
+                            ))
+                        }
+                } else {
+                    let sui_address = keystore.import_from_mnemonic(
+                        &input_string,
+                        key_scheme,
+                        derivation_path,
+                    )?;
+                    let pk = keystore.get_key(&sui_address)?;
+                    let peer_id = if let PublicKey::Ed25519(public_key) = pk.public() {
+                        Some(anemo::PeerId(public_key.0).to_string())
+                    } else {
+                        None
+                    };
+
+                    CommandOutput::Import(Key {
+                        sui_address: sui_address.to_string(),
+                        public_base64_key: pk.public().encode_base64(),
+                        key_scheme: scheme,
+                        mnemonic: None,
+                        flag: pk.public().flag(),
+                        peer_id,
+                    })
+                }
             }
 
             KeyToolCommand::Convert { value } => {
                 let result = convert_private_key_to_base64(value)?;
-                CommandOutput::ConvertedPrivateKey(result)
+                CommandOutput::PrivateKeyBase64(PrivateKeyBase64 { base64: result })
             }
 
-            // KeyToolCommand::Base64PubKeyToAddress { base64_key } => {
-            //     let pk = PublicKey::decode_base64(&base64_key)
-            //         .map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
-            //     let address = SuiAddress::from(&pk);
-            //     println!("Address {:?}", address);
-            // }
+            KeyToolCommand::Base64PubKeyToAddress { base64_key } => {
+                let pk = PublicKey::decode_base64(&base64_key)
+                    .map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
+                let address = SuiAddress::from(&pk);
+                CommandOutput::Base64PubKeyToAddress(address)
+            }
 
-            // KeyToolCommand::Base64ToHex { base64 } => {
-            //     let bytes =
-            //         Base64::decode(&base64).map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
-            //     let hex = Hex::from_bytes(&bytes);
-            //     println!("{:?}", hex);
-            // }
+            KeyToolCommand::Base64ToHex { base64 } => {
+                let bytes =
+                    Base64::decode(&base64).map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
+                let hex = Hex::from_bytes(&bytes);
+                CommandOutput::Base64ToHex(hex)
+            }
 
-            // KeyToolCommand::HexToBase64 { hex } => {
-            //     let bytes =
-            //         Hex::decode(&hex).map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
-            //     let base64 = Base64::from_bytes(&bytes);
-            //     println!("{:?}", base64);
-            // }
+            KeyToolCommand::HexToBase64 { hex } => {
+                let bytes =
+                    Hex::decode(&hex).map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
+                let base64 = Base64::from_bytes(&bytes);
+                CommandOutput::HexToBase64(base64)
+            }
 
-            // KeyToolCommand::HexToBytes { hex } => {
-            //     let bytes =
-            //         Hex::decode(&hex).map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
-            //     println!("Bytes {:?}", bytes);
-            // }
+            KeyToolCommand::HexToBytes { hex } => {
+                let bytes =
+                    Hex::decode(&hex).map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
+                // println!("Bytes {:?}", bytes);
+                CommandOutput::HexToBytes(bytes)
+            }
 
-            // KeyToolCommand::BytesToHex { bytes } => {
-            //     let hex = Hex::from_bytes(&bytes);
-            //     println!("{:?}", hex);
-            // }
+            KeyToolCommand::BytesToHex { bytes } => {
+                let hex = Hex::from_bytes(&bytes);
+                // println!("{:?}", hex);
+                CommandOutput::BytesToHex(hex)
+            }
 
-            // KeyToolCommand::Base64ToBytes { base64 } => {
-            //     let bytes =
-            //         Base64::decode(&base64).map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
-            //     println!("Bytes {:?}", bytes);
-            // }
+            KeyToolCommand::Base64ToBytes { base64 } => {
+                let bytes =
+                    Base64::decode(&base64).map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
+                // println!("Bytes {:?}", bytes);
+                CommandOutput::Base64ToBytes(bytes)
+            }
 
-            // KeyToolCommand::BytesToBase64 { bytes } => {
-            //     let base64 = Base64::from_bytes(&bytes);
-            //     println!("{:?}", base64);
-            // }
+            KeyToolCommand::BytesToBase64 { bytes } => {
+                let base64 = Base64::from_bytes(&bytes);
+                // println!("{:?}", base64);
+                CommandOutput::BytesToBase64(base64)
+            }
 
-            // KeyToolCommand::LoadKeypair { file } => {
-            //     match read_keypair_from_file(&file) {
-            //         Ok(keypair) => {
-            //             // Account keypair is encoded with the key scheme flag {},
-            //             // and network and worker keypair are not.
-            //             println!("Account Keypair: {}", keypair.encode_base64());
-            //             if let SuiKeyPair::Ed25519(kp) = keypair {
-            //                 println!("Network Keypair: {}", kp.encode_base64());
-            //                 println!("Worker Keypair: {}", kp.encode_base64());
-            //             };
-            //         }
-            //         Err(_) => {
-            //             // Authority keypair file is not stored with the flag, it will try read as BLS keypair..
-            //             match read_authority_keypair_from_file(&file) {
-            //                 Ok(kp) => println!("Protocol Keypair: {}", kp.encode_base64()),
-            //                 Err(e) => {
-            //                     println!("Failed to read keypair at path {:?} err: {:?}", file, e)
-            //                 }
-            //             }
-            //         }
-            //     }
-            // }
-            // KeyToolCommand::SignKMS {
-            //     data,
-            //     keyid,
-            //     intent,
-            //     base64pk,
-            // } => {
-            //     // Currently only supports secp256k1 keys
-            //     let pk_owner = PublicKey::decode_base64(&base64pk)
-            //         .map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
-            //     let address_owner = SuiAddress::from(&pk_owner);
-            //     println!("Address For Corresponding KMS Key: {}", address_owner);
-            //     println!("Raw tx_bytes to execute: {}", data);
-            //     let intent = intent.unwrap_or_else(Intent::sui_transaction);
-            //     println!("Intent: {:?}", intent);
-            //     let msg: TransactionData =
-            //         bcs::from_bytes(&Base64::decode(&data).map_err(|e| {
-            //             anyhow!("Cannot deserialize data as TransactionData {:?}", e)
-            //         })?)?;
-            //     let intent_msg = IntentMessage::new(intent, msg);
-            //     println!(
-            //         "Raw intent message: {:?}",
-            //         Base64::encode(bcs::to_bytes(&intent_msg)?)
-            //     );
-            //     let mut hasher = DefaultHash::default();
-            //     hasher.update(bcs::to_bytes(&intent_msg)?);
-            //     let digest = hasher.finalize().digest;
-            //     println!("Digest to sign: {:?}", Base64::encode(digest));
+            KeyToolCommand::LoadKeypair { file } => {
+                let output = match read_keypair_from_file(&file) {
+                    Ok(keypair) => {
+                        // Account keypair is encoded with the key scheme flag {},
+                        // and network and worker keypair are not.
+                        let mut data = KeypairData {
+                            account_keypair: keypair.encode_base64(),
+                            network_keypair: None,
+                            worker_keypair: None,
+                            key_scheme: keypair.public().scheme().to_string(),
+                        };
+                        match keypair {
+                            SuiKeyPair::Ed25519(kp) => {
+                                data.network_keypair = Some(kp.encode_base64());
+                                data.worker_keypair = Some(kp.encode_base64());
+                            }
+                            SuiKeyPair::Secp256k1(kp) => {
+                                data.network_keypair = Some(kp.encode_base64());
+                                data.worker_keypair = Some(kp.encode_base64());
+                            }
+                            SuiKeyPair::Secp256r1(kp) => {
+                                data.network_keypair = Some(kp.encode_base64());
+                                data.worker_keypair = Some(kp.encode_base64());
+                            }
+                        }
+                        data
+                    }
+                    Err(_) => {
+                        // Authority keypair file is not stored with the flag, it will try read as BLS keypair..
+                        match read_authority_keypair_from_file(&file) {
+                            Ok(keypair) => KeypairData {
+                                account_keypair: keypair.encode_base64(),
+                                network_keypair: None,
+                                worker_keypair: None,
+                                key_scheme: SignatureScheme::BLS12381.to_string(),
+                            },
+                            Err(e) => {
+                                return Err(anyhow!(format!(
+                                    "Failed to read keypair at path {:?} err: {:?}",
+                                    file, e
+                                )));
+                            }
+                        }
+                    }
+                };
+                CommandOutput::LoadKeypair(output)
+            }
 
-            //     // Set up the KMS client in default region.
-            //     let region: Region = Region::default();
-            //     let kms: KmsClient = KmsClient::new(region);
+            KeyToolCommand::SignKMS {
+                data,
+                keyid,
+                intent,
+                base64pk,
+            } => {
+                // Currently only supports secp256k1 keys
+                let pk_owner = PublicKey::decode_base64(&base64pk)
+                    .map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
+                let address_owner = SuiAddress::from(&pk_owner);
+                eprintln!("Address For Corresponding KMS Key: {}", address_owner);
+                eprintln!("Raw tx_bytes to execute: {}", data);
+                let intent = intent.unwrap_or_else(Intent::sui_transaction);
+                eprintln!("Intent: {:?}", intent);
+                let msg: TransactionData =
+                    bcs::from_bytes(&Base64::decode(&data).map_err(|e| {
+                        anyhow!("Cannot deserialize data as TransactionData {:?}", e)
+                    })?)?;
+                let intent_msg = IntentMessage::new(intent, msg);
+                eprintln!(
+                    "Raw intent message: {:?}",
+                    Base64::encode(bcs::to_bytes(&intent_msg)?)
+                );
+                let mut hasher = DefaultHash::default();
+                hasher.update(bcs::to_bytes(&intent_msg)?);
+                let digest = hasher.finalize().digest;
+                eprintln!("Digest to sign: {:?}", Base64::encode(digest));
 
-            //     // Construct the signing request.
-            //     let request: SignRequest = SignRequest {
-            //         key_id: keyid.to_string(),
-            //         message: digest.to_vec().into(),
-            //         message_type: Some("RAW".to_string()),
-            //         signing_algorithm: "ECDSA_SHA_256".to_string(),
-            //         ..Default::default()
-            //     };
+                // Set up the KMS client in default region.
+                let region: Region = Region::default();
+                let kms: KmsClient = KmsClient::new(region);
 
-            //     // Sign the message, normalize the signature and then compacts it
-            //     // serialize_compact is loaded as bytes for Secp256k1Sinaturere
-            //     let response = kms.sign(request).await?;
-            //     let sig_bytes_der = response
-            //         .signature
-            //         .map(|b| b.to_vec())
-            //         .expect("Requires Asymmetric Key Generated in KMS");
+                // Construct the signing request.
+                let request: SignRequest = SignRequest {
+                    key_id: keyid.to_string(),
+                    message: digest.to_vec().into(),
+                    message_type: Some("RAW".to_string()),
+                    signing_algorithm: "ECDSA_SHA_256".to_string(),
+                    ..Default::default()
+                };
 
-            //     let mut external_sig = Secp256k1Sig::from_der(&sig_bytes_der)?;
-            //     external_sig.normalize_s();
-            //     let sig_compact = external_sig.serialize_compact();
+                // Sign the message, normalize the signature and then compacts it
+                // serialize_compact is loaded as bytes for Secp256k1Sinaturere
+                let response = kms.sign(request).await?;
+                let sig_bytes_der = response
+                    .signature
+                    .map(|b| b.to_vec())
+                    .expect("Requires Asymmetric Key Generated in KMS");
 
-            //     let mut serialized_sig = vec![SignatureScheme::Secp256k1.flag()];
-            //     serialized_sig.extend_from_slice(&sig_compact);
-            //     serialized_sig.extend_from_slice(pk_owner.as_ref());
-            //     let serialized_sig = Base64::encode(&serialized_sig);
-            //     println!(
-            //         "Serialized signature (`flag || sig || pk` in Base64): {:?}",
-            //         serialized_sig
-            //     );
-            //     // return Ok(());
-            // }
+                let mut external_sig = Secp256k1Sig::from_der(&sig_bytes_der)?;
+                external_sig.normalize_s();
+                let sig_compact = external_sig.serialize_compact();
+
+                let mut serialized_sig = vec![SignatureScheme::Secp256k1.flag()];
+                serialized_sig.extend_from_slice(&sig_compact);
+                serialized_sig.extend_from_slice(pk_owner.as_ref());
+                let serialized_sig = Base64::encode(&serialized_sig);
+                eprintln!(
+                    "Serialized signature (`flag || sig || pk` in Base64): {:?}",
+                    serialized_sig
+                );
+                CommandOutput::SignKMS(SerializedSig {
+                    serialized_sig_base64: serialized_sig,
+                })
+            }
+
+            // DO NOT KNOW HOW TO USE IT YET
             // KeyToolCommand::MultiSigAddress {
             //     threshold,
             //     pks,
@@ -510,122 +660,142 @@ impl KeyToolCommand {
             //         );
             //     }
             // }
-            // KeyToolCommand::MultiSigCombinePartialSig {
-            //     sigs,
-            //     pks,
-            //     weights,
-            //     threshold,
-            // } => {
-            //     let multisig_pk = MultiSigPublicKey::new(pks, weights, threshold)?;
-            //     let address: SuiAddress = (&multisig_pk).into();
-            //     let multisig = MultiSig::combine(sigs, multisig_pk)?;
-            //     let generic_sig: GenericSignature = multisig.into();
-            //     println!("MultiSig address: {address}");
-            //     println!("MultiSig parsed: {:?}", generic_sig);
-            //     println!("MultiSig serialized: {:?}", generic_sig.encode_base64());
-            // }
+            KeyToolCommand::MultiSigCombinePartialSig {
+                sigs,
+                pks,
+                weights,
+                threshold,
+            } => {
+                let multisig_pk = MultiSigPublicKey::new(pks, weights, threshold)?;
+                let address: SuiAddress = (&multisig_pk).into();
+                let multisig = MultiSig::combine(sigs, multisig_pk)?;
+                let generic_sig: GenericSignature = multisig.into();
+                let multisig_serialized = generic_sig.encode_base64();
+                eprintln!("MultiSig address: {address}");
+                eprintln!("MultiSig parsed: {:?}", &generic_sig);
+                eprintln!("MultiSig serialized: {:?}", multisig_serialized);
+                CommandOutput::MultiSigCombinePartialSig(MultiSigCombinePartialSig {
+                    multisig_address: address,
+                    multisig_parsed: generic_sig,
+                    multisig_serialized,
+                })
+            }
 
-            // KeyToolCommand::DecodeMultiSig { multisig } => {
-            //     let pks = multisig.get_pk().pubkeys();
-            //     let sigs = multisig.get_sigs();
-            //     let bitmap = multisig.get_bitmap();
-            //     println!(
-            //         "All pubkeys: {:?}, threshold: {:?}",
-            //         pks.iter()
-            //             .map(|(pk, w)| format!("{:?} - {:?}", pk.encode_base64(), w))
-            //             .collect::<Vec<String>>(),
-            //         multisig.get_pk().threshold()
-            //     );
-            //     println!("Participating signatures and pubkeys");
-            //     println!(
-            //         " {0: ^45} | {1: ^45} | {2: ^6}",
-            //         "Public Key (Base64)", "Sig (Base64)", "Weight"
-            //     );
-            //     println!("{}", ["-"; 100].join(""));
-            //     for (sig, i) in sigs.iter().zip(bitmap) {
-            //         let (pk, w) = pks
-            //             .get(i as usize)
-            //             .ok_or(anyhow!("Invalid public keys index".to_string()))?;
-            //         println!(
-            //             " {0: ^45} | {1: ^45} | {2: ^6}",
-            //             Base64::encode(sig.as_ref()),
-            //             pk.encode_base64(),
-            //             w
-            //         );
-            //     }
-            //     println!(
-            //         "Multisig address: {:?}",
-            //         SuiAddress::from(multisig.get_pk())
-            //     );
-            // }
+            KeyToolCommand::DecodeMultiSig { multisig } => {
+                let pks = &multisig.get_pk().pubkeys();
+                let sigs = &multisig.get_sigs();
+                let bitmap = &multisig.get_bitmap();
+                eprintln!(
+                    "All pubkeys: {:?}, threshold: {:?}",
+                    pks.iter()
+                        .map(|(pk, w)| format!("{:?} - {:?}", pk.encode_base64(), w))
+                        .collect::<Vec<String>>(),
+                    multisig.get_pk().threshold()
+                );
+                eprintln!("Participating signatures and pubkeys");
+                eprintln!(
+                    " {0: ^45} | {1: ^45} | {2: ^6}",
+                    "Public Key (Base64)", "Sig (Base64)", "Weight"
+                );
+                eprintln!("{}", ["-"; 100].join(""));
+                let mut output: Vec<DecodedMultiSig> = vec![];
+                for (sig, i) in sigs.iter().zip(*bitmap) {
+                    let (pk, weight) = pks
+                        .get(i as usize)
+                        .ok_or(anyhow!("Invalid public keys index".to_string()))?;
+                    eprintln!(
+                        " {0: ^45} | {1: ^45} | {2: ^6}",
+                        Base64::encode(sig.as_ref()),
+                        pk.encode_base64(),
+                        weight
+                    );
 
-            // KeyToolCommand::DecodeTxBytes { tx_bytes } => {
-            //     let tx_bytes = Base64::decode(&tx_bytes)
-            //         .map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
-            //     let tx_data: TransactionData = bcs::from_bytes(&tx_bytes)?;
-            //     println!("Transaction data: {:?}", tx_data);
-            // }
+                    output.push(DecodedMultiSig {
+                        public_base64_key: Base64::encode(sig.as_ref()).clone(),
+                        sig_base64: pk.encode_base64().clone(),
+                        weight: weight.to_string(),
+                    })
+                }
+                eprintln!(
+                    "Multisig address: {:?}",
+                    SuiAddress::from(multisig.get_pk())
+                );
+                CommandOutput::DecodeMultiSig(output)
+            }
+            KeyToolCommand::DecodeTxBytes { tx_bytes } => {
+                let tx_bytes = Base64::decode(&tx_bytes)
+                    .map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
+                let tx_data: TransactionData = bcs::from_bytes(&tx_bytes)?;
+                println!("Transaction data: {:?}", tx_data);
+                CommandOutput::DecodeTxBytes(tx_data)
+            }
 
-            // KeyToolCommand::ZkLogInPrepare { max_epoch } => {
-            //     // todo: unhardcode keypair and jwt_randomness and max_epoch.
-            //     let kp: Ed25519KeyPair = get_key_pair_from_rng(&mut StdRng::from_seed([0; 32])).1;
-            //     let skp = SuiKeyPair::Ed25519(kp.copy());
-            //     println!("Ephemeral pubkey: {:?}", skp.public().encode_base64());
-            //     println!("Ephemeral keypair: {:?}", skp.encode_base64());
+            KeyToolCommand::ZkLogInPrepare { max_epoch } => {
+                // todo: unhardcode keypair and jwt_randomness and max_epoch.
+                let kp: Ed25519KeyPair = get_key_pair_from_rng(&mut StdRng::from_seed([0; 32])).1;
+                let skp = SuiKeyPair::Ed25519(kp.copy());
+                println!("Ephemeral pubkey: {:?}", skp.public().encode_base64());
+                println!("Ephemeral keypair: {:?}", skp.encode_base64());
 
-            //     // Nonce is defined as the base64Url encoded of the poseidon hash of 4 inputs:
-            //     // first half of eph_pubkey bytes in BigInt, second half, max_epoch, randomness.
-            //     let bytes = kp.public().as_ref();
-            //     let (first_half, second_half) = bytes.split_at(bytes.len() / 2);
-            //     let first_bigint = BigInt::from_bytes_be(Sign::Plus, first_half);
-            //     let second_bigint = BigInt::from_bytes_be(Sign::Plus, second_half);
+                // Nonce is defined as the base64Url encoded of the poseidon hash of 4 inputs:
+                // first half of eph_pubkey bytes in BigInt, second half, max_epoch, randomness.
+                let bytes = kp.public().as_ref();
+                let (first_half, second_half) = bytes.split_at(bytes.len() / 2);
+                let first_bigint = BigInt::from_bytes_be(Sign::Plus, first_half);
+                let second_bigint = BigInt::from_bytes_be(Sign::Plus, second_half);
 
-            //     let mut poseidon = PoseidonWrapper::new();
-            //     let first = Bn254Fr::from_str(&first_bigint.to_string()).unwrap();
-            //     let second = Bn254Fr::from_str(&second_bigint.to_string()).unwrap();
-            //     let max_epoch = Bn254Fr::from_str(max_epoch.as_str()).unwrap();
-            //     let jwt_randomness = Bn254Fr::from_str(
-            //         "50683480294434968413708503290439057629605340925620961559740848568164438166",
-            //     )
-            //     .unwrap();
-            //     let hash = poseidon.hash(vec![first, second, max_epoch, jwt_randomness])?;
-            //     println!("Nonce: {:?}", hash.to_string());
-            // }
+                let mut poseidon = PoseidonWrapper::new();
+                let first = Bn254Fr::from_str(&first_bigint.to_string()).unwrap();
+                let second = Bn254Fr::from_str(&second_bigint.to_string()).unwrap();
+                let max_epoch = Bn254Fr::from_str(max_epoch.as_str()).unwrap();
+                let jwt_randomness = Bn254Fr::from_str(
+                    "50683480294434968413708503290439057629605340925620961559740848568164438166",
+                )
+                .unwrap();
+                let hash = poseidon.hash(vec![first, second, max_epoch, jwt_randomness])?;
+                println!("Nonce: {:?}", hash.to_string());
+                CommandOutput::ZkLogInPrepare(ZkLogInPrepare {
+                    ephemeral_pubkey: skp.public().encode_base64(),
+                    ephemeral_keypair: skp.encode_base64(),
+                    nonce: hash.to_string(),
+                })
+            }
+            KeyToolCommand::GenerateZkLoginAddress { address_seed } => {
+                let mut hasher = DefaultHash::default();
+                hasher.update([SignatureScheme::ZkLoginAuthenticator.flag()]);
+                let address_params = AddressParams::new(
+                    OAuthProvider::Google.get_config().0.to_owned(),
+                    SupportedKeyClaim::Sub.to_string(),
+                );
+                println!("Address params: {:?}", address_params);
+                hasher.update(bcs::to_bytes(&address_params).unwrap());
+                hasher.update(big_int_str_to_bytes(&address_seed));
+                let user_address = SuiAddress::from_bytes(hasher.finalize().digest)?;
+                println!("Sui Address: {:?}", user_address);
+                CommandOutput::GenerateZkLoginAddress(user_address, address_params)
+            }
 
-            // KeyToolCommand::GenerateZkLoginAddress { address_seed } => {
-            //     let mut hasher = DefaultHash::default();
-            //     hasher.update([SignatureScheme::ZkLoginAuthenticator.flag()]);
-            //     let address_params = AddressParams::new(
-            //         OAuthProvider::Google.get_config().0.to_owned(),
-            //         SupportedKeyClaim::Sub.to_string(),
-            //     );
-            //     println!("Address params: {:?}", address_params);
-            //     hasher.update(bcs::to_bytes(&address_params).unwrap());
-            //     hasher.update(big_int_str_to_bytes(&address_seed));
-            //     let user_address = SuiAddress::from_bytes(hasher.finalize().digest)?;
-            //     println!("Sui Address: {:?}", user_address);
-            // }
-
-            // KeyToolCommand::SerializeZkLoginAuthenticator {
-            //     proof_str,
-            //     public_inputs_str,
-            //     aux_inputs_str,
-            //     user_signature,
-            // } => {
-            //     let authenticator = ZkLoginAuthenticator::new(
-            //         ZkLoginProof::from_json(&proof_str)?,
-            //         PublicInputs::from_json(&public_inputs_str)?,
-            //         AuxInputs::from_json(&aux_inputs_str)?,
-            //         Signature::from_str(&user_signature).map_err(|e| anyhow!(e))?,
-            //     );
-            //     let sig = GenericSignature::from(authenticator);
-            //     println!(
-            //         "ZkLogin Authenticator Signature Serialized: {:?}",
-            //         sig.encode_base64()
-            //     );
-            // }
-
-            // Ok(())
+            KeyToolCommand::SerializeZkLoginAuthenticator {
+                proof_str,
+                public_inputs_str,
+                aux_inputs_str,
+                user_signature,
+            } => {
+                let authenticator = ZkLoginAuthenticator::new(
+                    ZkLoginProof::from_json(&proof_str)?,
+                    PublicInputs::from_json(&public_inputs_str)?,
+                    AuxInputs::from_json(&aux_inputs_str)?,
+                    Signature::from_str(&user_signature).map_err(|e| anyhow!(e))?,
+                );
+                let sig = GenericSignature::from(authenticator);
+                println!(
+                    "ZkLogin Authenticator Signature Serialized: {:?}",
+                    sig.encode_base64()
+                );
+                CommandOutput::SerializeZkLoginAuthenticator(SerializedSig {
+                    serialized_sig_base64: sig.encode_base64(),
+                })
+            }
             _ => todo!(),
         });
 
@@ -656,51 +826,107 @@ fn convert_private_key_to_base64(value: String) -> Result<String, anyhow::Error>
     }
 }
 
-fn store_and_print_keypair(address: SuiAddress, keypair: SuiKeyPair) {
-    let path_str = format!("{}.key", address).to_lowercase();
-    let path = Path::new(&path_str);
-    let address = format!("{}", address);
-    let kp = keypair.encode_base64();
-    let flag = keypair.public().flag();
-    let out_str = format!("address: {}\nkeypair: {}\nflag: {}", address, kp, flag);
-    fs::write(path, out_str).unwrap();
-    println!(
-        "Address, keypair and key scheme written to {}",
-        path.to_str().unwrap()
-    );
-}
-
-impl Display for CommandOutput {
-    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
-        let json_obj = json![self];
-        let mut table = json_to_table(&json_obj);
-        table.with(tabled::settings::Style::rounded());
-        table.object_orientation(Orientation::Row);
-        // table.array_orientation(Orientation::Row);
-        // if table.count_tables() <= 3 {
-        //     table.transpose
-        // }
-        write!(formatter, "{}", table)
-    }
-}
-
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Key {
     sui_address: String,
     public_base64_key: String,
     key_scheme: String,
+    flag: u8,
+    mnemonic: Option<String>,
+    peer_id: Option<String>,
+}
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PrivateKeyBase64 {
+    base64: String,
+}
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ZkLogInPrepare {
+    ephemeral_pubkey: String,
+    ephemeral_keypair: String,
+    nonce: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SignData {
+    sui_address: SuiAddress,
+    raw_tx_data: String,
+    intent: Intent,
+    raw_intent_msg: String,
+    digest: String,
+    sui_signature: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MultiSigCombinePartialSig {
+    multisig_address: SuiAddress,
+    multisig_parsed: GenericSignature,
+    multisig_serialized: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SerializedSig {
+    serialized_sig_base64: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DecodedMultiSig {
+    public_base64_key: String,
+    sig_base64: String,
+    weight: String,
+}
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct KeypairData {
+    account_keypair: String,
+    network_keypair: Option<String>,
+    worker_keypair: Option<String>,
+    key_scheme: String,
 }
 
 #[derive(Serialize)]
 #[serde(untagged)]
 pub enum CommandOutput {
-    GenerateZkLoginAddress(SuiAddress),
-    List(Vec<Key>),
-    ConvertedPrivateKey(String),
-    Import(Key),
+    Base64ToBytes(Vec<u8>),
+    Base64PubKeyToAddress(SuiAddress),
+    Base64ToHex(Hex),
+    BytesToHex(Hex),
+    BytesToBase64(Base64),
+    DecodeTxBytes(TransactionData),
+    DecodeMultiSig(Vec<DecodedMultiSig>),
     Error(String),
-    Warning(String),
+    HexToBase64(Base64),
+    HexToBytes(Vec<u8>),
+    Generate(Key),
+    GenerateZkLoginAddress(SuiAddress, AddressParams),
+    Import(Key),
+    List(Vec<Key>),
+    LoadKeypair(KeypairData),
+    MultiSigCombinePartialSig(MultiSigCombinePartialSig),
+    PrivateKeyBase64(PrivateKeyBase64),
+    SignKMS(SerializedSig),
+    SerializeZkLoginAuthenticator(SerializedSig),
+    Show(Key),
+    Sign(SignData),
+    ZkLogInPrepare(ZkLogInPrepare),
+}
+
+impl Display for CommandOutput {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        let json_obj = json![self];
+        let mut table = json_to_table(&json_obj);
+        let style = tabled::settings::Style::rounded().horizontals([]);
+        table.with(style);
+        table.array_orientation(Orientation::Column);
+
+        write!(formatter, "{}", table)
+    }
 }
 
 impl CommandOutput {
@@ -722,9 +948,7 @@ impl CommandOutput {
 // when --json flag is used, any output result is transformed into a JSON pretty string and sent to std output
 impl Debug for CommandOutput {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let s = unwrap_err_to_string(|| match self {
-            _ => Ok(serde_json::to_string_pretty(self)?),
-        });
+        let s = unwrap_err_to_string(|| Ok(serde_json::to_string_pretty(self)?));
         write!(f, "{}", s)
     }
 }
@@ -732,6 +956,6 @@ impl Debug for CommandOutput {
 fn unwrap_err_to_string<T: Display, F: FnOnce() -> Result<T, anyhow::Error>>(func: F) -> String {
     match func() {
         Ok(s) => format!("{s}"),
-        Err(err) => format!("{err}").to_string(),
+        Err(err) => format!("{err}"),
     }
 }

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -20,9 +20,10 @@ use rand::SeedableRng;
 use rusoto_core::Region;
 use rusoto_kms::{Kms, KmsClient, SignRequest};
 use serde::Serialize;
+use serde_json::json;
 use shared_crypto::intent::{Intent, IntentMessage};
 use std::fmt::{Debug, Formatter, Display};
-use std::fs;
+use std::{fs, convert};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use sui_keys::key_derive::generate_new_key;
@@ -43,6 +44,8 @@ use sui_types::zk_login_authenticator::ZkLoginAuthenticator;
 use sui_types::zk_login_util::AddressParams;
 use tracing::info;
 use std::fmt::Write;
+
+use json_to_table::{json_to_table, Orientation};
 
 #[cfg(test)]
 #[path = "unit_tests/keytool_tests.rs"]
@@ -114,11 +117,11 @@ pub enum KeyToolCommand {
         #[clap(long)]
         base64pk: String,
     },
-    /// Add a new key to sui.keystore based on the input mnemonic phrase, the key scheme flag {ed25519 | secp256k1 | secp256r1}
+    /// Add a new key to sui.keystore based on the input mnemonic phrase or private key, the key scheme flag {ed25519 | secp256k1 | secp256r1}
     /// and an optional derivation path, default to m/44'/784'/0'/0'/0' for ed25519 or m/54'/784'/0'/0/0 for secp256k1
     /// or m/74'/784'/0'/0/0 for secp256r1. Supports mnemonic phrase of word length 12, 15, 18`, 21, 24.
     Import {
-        mnemonic_phrase: String,
+        input_string: String,
         key_scheme: SignatureScheme,
         #[serde(skip_serializing)]
         derivation_path: Option<DerivationPath>,
@@ -238,418 +241,434 @@ pub enum KeyToolCommand {
 }
 
 impl KeyToolCommand {
-    pub async fn execute(self, keystore: &mut Keystore) -> Result<SuiKeytoolCommandResult, anyhow::Error> {
+    pub async fn execute(self, keystore: &mut Keystore) -> Result<KeyToolCmdResult, anyhow::Error> {
         let cmd_result = Ok(match self {
+            // KeyToolCommand::Generate {
+            //     key_scheme,
+            //     derivation_path,
+            //     word_length,
+            // } => {
+            //     if "bls12381" == key_scheme.to_string() {
+            //         // Generate BLS12381 key for authority without key derivation.
+            //         // The saved keypair is encoded `privkey || pubkey` without the scheme flag.
+            //         let (address, keypair) = get_authority_key_pair();
+            //         let file_name = format!("bls-{address}.key");
+            //         write_authority_keypair_to_file(&keypair, file_name)?;
+            //     } else {
+            //         let (address, kp, scheme, phrase) =
+            //             generate_new_key(key_scheme, derivation_path, word_length)?;
+            //         let file = format!("{address}.key");
+            //         write_keypair_to_file(&kp, &file)?;
+            //         println!(
+            //             "Created new keypair for address wrote to file path {:?} with scheme {:?}: [{address}]",
+            //             file, scheme
+            //         );
+            //         println!("Secret Recovery Phrase : [{phrase}]");
+            //     }
+            // }
+            // KeyToolCommand::Show { file } => {
+            //     let res = read_keypair_from_file(&file);
+            //     match res {
+            //         Ok(keypair) => {
+            //             println!("Public Key: {}", keypair.public().encode_base64());
+            //             println!("Flag: {}", keypair.public().flag());
+            //             if let PublicKey::Ed25519(public_key) = keypair.public() {
+            //                 let peer_id = anemo::PeerId(public_key.0);
+            //                 println!("PeerId: {}", peer_id);
+            //             }
+            //         }
+            //         Err(_) => {
+            //             let res = read_authority_keypair_from_file(&file);
+            //             match res {
+            //                 Ok(keypair) => {
+            //                     println!("Public Key: {}", keypair.public().encode_base64());
+            //                     println!("Flag: {}", SignatureScheme::BLS12381);
+            //                 }
+            //                 Err(e) => {
+            //                     println!("Failed to read keypair at path {:?} err: {:?}", file, e)
+            //                 }
+            //             }
+            //         }
+            //     }
+            // }
+
+            // KeyToolCommand::Unpack { keypair } => {
+            //     store_and_print_keypair((&keypair.public()).into(), keypair)
+            // }
             KeyToolCommand::List => {
-                let keys = keystore.keys().into_iter().map(|key| {
-                    KeystoreList{sui_address: Into::<SuiAddress>::into(&key),
-                                base64:  key.encode_base64().to_string(),
-                                scheme: key.scheme().to_string()}
+                let keys = keystore.keys().into_iter().map(|key| Key {
+                    sui_address: Into::<SuiAddress>::into(&key).to_string(),
+                    public_base64_key: key.encode_base64(),
+                    scheme: key.scheme().to_string()
                 }).collect::<Vec<_>>();
-                SuiKeytoolCommandResult::List(keys)
-            },
-            _ => todo!()
-        });
-        cmd_result
-        //     KeyToolCommand::Generate {
-        //         key_scheme,
-        //         derivation_path,
-        //         word_length,
-        //     } => {
-        //         if "bls12381" == key_scheme.to_string() {
-        //             // Generate BLS12381 key for authority without key derivation.
-        //             // The saved keypair is encoded `privkey || pubkey` without the scheme flag.
-        //             let (address, keypair) = get_authority_key_pair();
-        //             let file_name = format!("bls-{address}.key");
-        //             write_authority_keypair_to_file(&keypair, file_name)?;
-        //         } else {
-        //             let (address, kp, scheme, phrase) =
-        //                 generate_new_key(key_scheme, derivation_path, word_length)?;
-        //             let file = format!("{address}.key");
-        //             write_keypair_to_file(&kp, &file)?;
-        //             println!(
-        //                 "Created new keypair for address wrote to file path {:?} with scheme {:?}: [{address}]",
-        //                 file, scheme
-        //             );
-        //             println!("Secret Recovery Phrase : [{phrase}]");
-        //         }
-        //     }
-        //     KeyToolCommand::Show { file } => {
-        //         let res = read_keypair_from_file(&file);
-        //         match res {
-        //             Ok(keypair) => {
-        //                 println!("Public Key: {}", keypair.public().encode_base64());
-        //                 println!("Flag: {}", keypair.public().flag());
-        //                 if let PublicKey::Ed25519(public_key) = keypair.public() {
-        //                     let peer_id = anemo::PeerId(public_key.0);
-        //                     println!("PeerId: {}", peer_id);
-        //                 }
-        //             }
-        //             Err(_) => {
-        //                 let res = read_authority_keypair_from_file(&file);
-        //                 match res {
-        //                     Ok(keypair) => {
-        //                         println!("Public Key: {}", keypair.public().encode_base64());
-        //                         println!("Flag: {}", SignatureScheme::BLS12381);
-        //                     }
-        //                     Err(e) => {
-        //                         println!("Failed to read keypair at path {:?} err: {:?}", file, e)
-        //                     }
-        //                 }
-        //             }
-        //         }
-        //     }
+                
+                KeyToolCmdResult::List(keys)
+            }
+            // KeyToolCommand::Sign {
+            //     address,
+            //     data,
+            //     intent,
+            // } => {
+            //     println!("Signer address: {}", address);
+            //     println!("Raw tx_bytes to execute: {}", data);
+            //     let intent = intent.unwrap_or_else(Intent::sui_transaction);
+            //     println!("Intent: {:?}", intent);
+            //     let msg: TransactionData =
+            //         bcs::from_bytes(&Base64::decode(&data).map_err(|e| {
+            //             anyhow!("Cannot deserialize data as TransactionData {:?}", e)
+            //         })?)?;
+            //     let intent_msg = IntentMessage::new(intent, msg);
+            //     println!(
+            //         "Raw intent message: {:?}",
+            //         Base64::encode(bcs::to_bytes(&intent_msg)?)
+            //     );
+            //     let mut hasher = DefaultHash::default();
+            //     hasher.update(bcs::to_bytes(&intent_msg)?);
+            //     let digest = hasher.finalize().digest;
+            //     println!("Digest to sign: {:?}", Base64::encode(digest));
+            //     let sui_signature =
+            //         keystore.sign_secure(&address, &intent_msg.value, intent_msg.intent)?;
+            //     println!(
+            //         "Serialized signature (`flag || sig || pk` in Base64): {:?}",
+            //         sui_signature.encode_base64()
+            //     );
+            // }
 
-        //     KeyToolCommand::Unpack { keypair } => {
-        //         store_and_print_keypair((&keypair.public()).into(), keypair)
-        //     }
-        //     KeyToolCommand::List => {
-        //         println!(
-        //             " {0: ^42} | {1: ^45} | {2: ^6}",
-        //             "Sui Address", "Public Key (Base64)", "Scheme"
-        //         );
-        //         println!("{}", ["-"; 100].join(""));
-        //         for pub_key in keystore.keys() {
-        //             println!(
-        //                 " {0: ^42} | {1: ^45} | {2: ^6}",
-        //                 Into::<SuiAddress>::into(&pub_key),
-        //                 pub_key.encode_base64(),
-        //                 pub_key.scheme().to_string()
-        //             );
-        //         }
-        //     }
-        //     KeyToolCommand::Sign {
-        //         address,
-        //         data,
-        //         intent,
-        //     } => {
-        //         println!("Signer address: {}", address);
-        //         println!("Raw tx_bytes to execute: {}", data);
-        //         let intent = intent.unwrap_or_else(Intent::sui_transaction);
-        //         println!("Intent: {:?}", intent);
-        //         let msg: TransactionData =
-        //             bcs::from_bytes(&Base64::decode(&data).map_err(|e| {
-        //                 anyhow!("Cannot deserialize data as TransactionData {:?}", e)
-        //             })?)?;
-        //         let intent_msg = IntentMessage::new(intent, msg);
-        //         println!(
-        //             "Raw intent message: {:?}",
-        //             Base64::encode(bcs::to_bytes(&intent_msg)?)
-        //         );
-        //         let mut hasher = DefaultHash::default();
-        //         hasher.update(bcs::to_bytes(&intent_msg)?);
-        //         let digest = hasher.finalize().digest;
-        //         println!("Digest to sign: {:?}", Base64::encode(digest));
-        //         let sui_signature =
-        //             keystore.sign_secure(&address, &intent_msg.value, intent_msg.intent)?;
-        //         println!(
-        //             "Serialized signature (`flag || sig || pk` in Base64): {:?}",
-        //             sui_signature.encode_base64()
-        //         );
-        //     }
+            KeyToolCommand::Import {
+                input_string,
+                key_scheme,
+                derivation_path,
+            } => {
+                    // sui address: 0xfd233cd9a5dd7e577f16fa523427c75fbc382af1583c39fdf1c6747d2ed807a3
+                    // private key: 0xeea84be738c59f56ee94dae8fd5a68082d4579ed38548d6ec4017da6c5619bf3 
+                    if input_string.starts_with("0x") && input_string.len() == 66 {
+                        let base64 = convert_private_key_to_base64(input_string)?;
+                        let skp = SuiKeyPair::decode_base64(&base64);
+                        if let Ok(skp) = skp {
+                            let pk = skp.public();
+                            keystore.add_key(skp)?;
+                            KeyToolCmdResult::Import( Key {
+                                sui_address: Into::<SuiAddress>::into(&pk).to_string(),
+                                public_base64_key: base64,
+                                scheme: pk.scheme().to_string()})
+                        }
+                        else {
+                            KeyToolCmdResult::Error("Cannot decode base64 from private key".to_string())
+                        }
+                    } else {
+                        let sui_address = keystore.import_from_mnemonic(&input_string, key_scheme, derivation_path)?;
+                        let pk = keystore.get_key(&sui_address)?;
+                            KeyToolCmdResult::Import( Key {
+                                sui_address: sui_address.to_string(),
+                                public_base64_key: pk.encode_base64(),
+                                scheme: pk.public().scheme().to_string()
+                            })
+                    }
+            }
 
-        //     KeyToolCommand::Import {
-        //         mnemonic_phrase,
-        //         key_scheme,
-        //         derivation_path,
-        //     } => {
-        //         let address =
-        //             keystore.import_from_mnemonic(&mnemonic_phrase, key_scheme, derivation_path)?;
-        //         info!("Key imported for address [{address}]");
-        //     }
+            KeyToolCommand::Convert { value } => {
+                let result = convert_private_key_to_base64(value)?;
+                KeyToolCmdResult::ConvertedPrivateKey(result)
+            }
 
-        //     KeyToolCommand::Convert { value } => match Base64::decode(&value) {
-        //         Ok(decoded) => {
-        //             assert_eq!(decoded.len(), 33);
-        //             info!(
-        //                 "Wallet formatted private key: 0x{}",
-        //                 Hex::encode(&decoded[1..])
-        //             );
-        //         }
-        //         Err(_) => match Hex::decode(&value) {
-        //             Ok(decoded) => {
-        //                 assert_eq!(decoded.len(), 32);
-        //                 let mut res = Vec::new();
-        //                 res.extend_from_slice(&[SignatureScheme::ED25519.flag()]);
-        //                 res.extend_from_slice(&decoded);
-        //                 info!("Keystore formatted private key: {:?}", Base64::encode(&res));
-        //             }
-        //             Err(_) => {
-        //                 info!("Invalid private key format");
-        //             }
-        //         },
-        //     },
+            // KeyToolCommand::Base64PubKeyToAddress { base64_key } => {
+            //     let pk = PublicKey::decode_base64(&base64_key)
+            //         .map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
+            //     let address = SuiAddress::from(&pk);
+            //     println!("Address {:?}", address);
+            // }
 
-        //     KeyToolCommand::Base64PubKeyToAddress { base64_key } => {
-        //         let pk = PublicKey::decode_base64(&base64_key)
-        //             .map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
-        //         let address = SuiAddress::from(&pk);
-        //         println!("Address {:?}", address);
-        //     }
+            // KeyToolCommand::Base64ToHex { base64 } => {
+            //     let bytes =
+            //         Base64::decode(&base64).map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
+            //     let hex = Hex::from_bytes(&bytes);
+            //     println!("{:?}", hex);
+            // }
 
-        //     KeyToolCommand::Base64ToHex { base64 } => {
-        //         let bytes =
-        //             Base64::decode(&base64).map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
-        //         let hex = Hex::from_bytes(&bytes);
-        //         println!("{:?}", hex);
-        //     }
+            // KeyToolCommand::HexToBase64 { hex } => {
+            //     let bytes =
+            //         Hex::decode(&hex).map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
+            //     let base64 = Base64::from_bytes(&bytes);
+            //     println!("{:?}", base64);
+            // }
 
-        //     KeyToolCommand::HexToBase64 { hex } => {
-        //         let bytes =
-        //             Hex::decode(&hex).map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
-        //         let base64 = Base64::from_bytes(&bytes);
-        //         println!("{:?}", base64);
-        //     }
+            // KeyToolCommand::HexToBytes { hex } => {
+            //     let bytes =
+            //         Hex::decode(&hex).map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
+            //     println!("Bytes {:?}", bytes);
+            // }
 
-        //     KeyToolCommand::HexToBytes { hex } => {
-        //         let bytes =
-        //             Hex::decode(&hex).map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
-        //         println!("Bytes {:?}", bytes);
-        //     }
+            // KeyToolCommand::BytesToHex { bytes } => {
+            //     let hex = Hex::from_bytes(&bytes);
+            //     println!("{:?}", hex);
+            // }
 
-        //     KeyToolCommand::BytesToHex { bytes } => {
-        //         let hex = Hex::from_bytes(&bytes);
-        //         println!("{:?}", hex);
-        //     }
+            // KeyToolCommand::Base64ToBytes { base64 } => {
+            //     let bytes =
+            //         Base64::decode(&base64).map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
+            //     println!("Bytes {:?}", bytes);
+            // }
 
-        //     KeyToolCommand::Base64ToBytes { base64 } => {
-        //         let bytes =
-        //             Base64::decode(&base64).map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
-        //         println!("Bytes {:?}", bytes);
-        //     }
+            // KeyToolCommand::BytesToBase64 { bytes } => {
+            //     let base64 = Base64::from_bytes(&bytes);
+            //     println!("{:?}", base64);
+            // }
 
-        //     KeyToolCommand::BytesToBase64 { bytes } => {
-        //         let base64 = Base64::from_bytes(&bytes);
-        //         println!("{:?}", base64);
-        //     }
+            // KeyToolCommand::LoadKeypair { file } => {
+            //     match read_keypair_from_file(&file) {
+            //         Ok(keypair) => {
+            //             // Account keypair is encoded with the key scheme flag {},
+            //             // and network and worker keypair are not.
+            //             println!("Account Keypair: {}", keypair.encode_base64());
+            //             if let SuiKeyPair::Ed25519(kp) = keypair {
+            //                 println!("Network Keypair: {}", kp.encode_base64());
+            //                 println!("Worker Keypair: {}", kp.encode_base64());
+            //             };
+            //         }
+            //         Err(_) => {
+            //             // Authority keypair file is not stored with the flag, it will try read as BLS keypair..
+            //             match read_authority_keypair_from_file(&file) {
+            //                 Ok(kp) => println!("Protocol Keypair: {}", kp.encode_base64()),
+            //                 Err(e) => {
+            //                     println!("Failed to read keypair at path {:?} err: {:?}", file, e)
+            //                 }
+            //             }
+            //         }
+            //     }
+            // }
+            // KeyToolCommand::SignKMS {
+            //     data,
+            //     keyid,
+            //     intent,
+            //     base64pk,
+            // } => {
+            //     // Currently only supports secp256k1 keys
+            //     let pk_owner = PublicKey::decode_base64(&base64pk)
+            //         .map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
+            //     let address_owner = SuiAddress::from(&pk_owner);
+            //     println!("Address For Corresponding KMS Key: {}", address_owner);
+            //     println!("Raw tx_bytes to execute: {}", data);
+            //     let intent = intent.unwrap_or_else(Intent::sui_transaction);
+            //     println!("Intent: {:?}", intent);
+            //     let msg: TransactionData =
+            //         bcs::from_bytes(&Base64::decode(&data).map_err(|e| {
+            //             anyhow!("Cannot deserialize data as TransactionData {:?}", e)
+            //         })?)?;
+            //     let intent_msg = IntentMessage::new(intent, msg);
+            //     println!(
+            //         "Raw intent message: {:?}",
+            //         Base64::encode(bcs::to_bytes(&intent_msg)?)
+            //     );
+            //     let mut hasher = DefaultHash::default();
+            //     hasher.update(bcs::to_bytes(&intent_msg)?);
+            //     let digest = hasher.finalize().digest;
+            //     println!("Digest to sign: {:?}", Base64::encode(digest));
 
-        //     KeyToolCommand::LoadKeypair { file } => {
-        //         match read_keypair_from_file(&file) {
-        //             Ok(keypair) => {
-        //                 // Account keypair is encoded with the key scheme flag {},
-        //                 // and network and worker keypair are not.
-        //                 println!("Account Keypair: {}", keypair.encode_base64());
-        //                 if let SuiKeyPair::Ed25519(kp) = keypair {
-        //                     println!("Network Keypair: {}", kp.encode_base64());
-        //                     println!("Worker Keypair: {}", kp.encode_base64());
-        //                 };
-        //             }
-        //             Err(_) => {
-        //                 // Authority keypair file is not stored with the flag, it will try read as BLS keypair..
-        //                 match read_authority_keypair_from_file(&file) {
-        //                     Ok(kp) => println!("Protocol Keypair: {}", kp.encode_base64()),
-        //                     Err(e) => {
-        //                         println!("Failed to read keypair at path {:?} err: {:?}", file, e)
-        //                     }
-        //                 }
-        //             }
-        //         }
-        //     }
-        //     KeyToolCommand::SignKMS {
-        //         data,
-        //         keyid,
-        //         intent,
-        //         base64pk,
-        //     } => {
-        //         // Currently only supports secp256k1 keys
-        //         let pk_owner = PublicKey::decode_base64(&base64pk)
-        //             .map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
-        //         let address_owner = SuiAddress::from(&pk_owner);
-        //         println!("Address For Corresponding KMS Key: {}", address_owner);
-        //         println!("Raw tx_bytes to execute: {}", data);
-        //         let intent = intent.unwrap_or_else(Intent::sui_transaction);
-        //         println!("Intent: {:?}", intent);
-        //         let msg: TransactionData =
-        //             bcs::from_bytes(&Base64::decode(&data).map_err(|e| {
-        //                 anyhow!("Cannot deserialize data as TransactionData {:?}", e)
-        //             })?)?;
-        //         let intent_msg = IntentMessage::new(intent, msg);
-        //         println!(
-        //             "Raw intent message: {:?}",
-        //             Base64::encode(bcs::to_bytes(&intent_msg)?)
-        //         );
-        //         let mut hasher = DefaultHash::default();
-        //         hasher.update(bcs::to_bytes(&intent_msg)?);
-        //         let digest = hasher.finalize().digest;
-        //         println!("Digest to sign: {:?}", Base64::encode(digest));
+            //     // Set up the KMS client in default region.
+            //     let region: Region = Region::default();
+            //     let kms: KmsClient = KmsClient::new(region);
 
-        //         // Set up the KMS client in default region.
-        //         let region: Region = Region::default();
-        //         let kms: KmsClient = KmsClient::new(region);
+            //     // Construct the signing request.
+            //     let request: SignRequest = SignRequest {
+            //         key_id: keyid.to_string(),
+            //         message: digest.to_vec().into(),
+            //         message_type: Some("RAW".to_string()),
+            //         signing_algorithm: "ECDSA_SHA_256".to_string(),
+            //         ..Default::default()
+            //     };
 
-        //         // Construct the signing request.
-        //         let request: SignRequest = SignRequest {
-        //             key_id: keyid.to_string(),
-        //             message: digest.to_vec().into(),
-        //             message_type: Some("RAW".to_string()),
-        //             signing_algorithm: "ECDSA_SHA_256".to_string(),
-        //             ..Default::default()
-        //         };
+            //     // Sign the message, normalize the signature and then compacts it
+            //     // serialize_compact is loaded as bytes for Secp256k1Sinaturere
+            //     let response = kms.sign(request).await?;
+            //     let sig_bytes_der = response
+            //         .signature
+            //         .map(|b| b.to_vec())
+            //         .expect("Requires Asymmetric Key Generated in KMS");
 
-        //         // Sign the message, normalize the signature and then compacts it
-        //         // serialize_compact is loaded as bytes for Secp256k1Sinaturere
-        //         let response = kms.sign(request).await?;
-        //         let sig_bytes_der = response
-        //             .signature
-        //             .map(|b| b.to_vec())
-        //             .expect("Requires Asymmetric Key Generated in KMS");
+            //     let mut external_sig = Secp256k1Sig::from_der(&sig_bytes_der)?;
+            //     external_sig.normalize_s();
+            //     let sig_compact = external_sig.serialize_compact();
 
-        //         let mut external_sig = Secp256k1Sig::from_der(&sig_bytes_der)?;
-        //         external_sig.normalize_s();
-        //         let sig_compact = external_sig.serialize_compact();
+            //     let mut serialized_sig = vec![SignatureScheme::Secp256k1.flag()];
+            //     serialized_sig.extend_from_slice(&sig_compact);
+            //     serialized_sig.extend_from_slice(pk_owner.as_ref());
+            //     let serialized_sig = Base64::encode(&serialized_sig);
+            //     println!(
+            //         "Serialized signature (`flag || sig || pk` in Base64): {:?}",
+            //         serialized_sig
+            //     );
+            //     // return Ok(());
+            // }
+            // KeyToolCommand::MultiSigAddress {
+            //     threshold,
+            //     pks,
+            //     weights,
+            // } => {
+            //     let multisig_pk = MultiSigPublicKey::new(pks.clone(), weights.clone(), threshold)?;
+            //     let address: SuiAddress = (&multisig_pk).into();
+            //     println!("MultiSig address: {address}");
 
-        //         let mut serialized_sig = vec![SignatureScheme::Secp256k1.flag()];
-        //         serialized_sig.extend_from_slice(&sig_compact);
-        //         serialized_sig.extend_from_slice(pk_owner.as_ref());
-        //         let serialized_sig = Base64::encode(&serialized_sig);
-        //         println!(
-        //             "Serialized signature (`flag || sig || pk` in Base64): {:?}",
-        //             serialized_sig
-        //         );
-        //         // return Ok(());
-        //     }
-        //     KeyToolCommand::MultiSigAddress {
-        //         threshold,
-        //         pks,
-        //         weights,
-        //     } => {
-        //         let multisig_pk = MultiSigPublicKey::new(pks.clone(), weights.clone(), threshold)?;
-        //         let address: SuiAddress = (&multisig_pk).into();
-        //         println!("MultiSig address: {address}");
+            //     println!("Participating parties:");
+            //     println!(
+            //         " {0: ^42} | {1: ^50} | {2: ^6}",
+            //         "Sui Address", "Public Key (Base64)", "Weight"
+            //     );
+            //     println!("{}", ["-"; 100].join(""));
+            //     for (pk, w) in pks.into_iter().zip(weights.into_iter()) {
+            //         println!(
+            //             " {0: ^42} | {1: ^45} | {2: ^6}",
+            //             Into::<SuiAddress>::into(&pk),
+            //             pk.encode_base64(),
+            //             w
+            //         );
+            //     }
+            // }
+            // KeyToolCommand::MultiSigCombinePartialSig {
+            //     sigs,
+            //     pks,
+            //     weights,
+            //     threshold,
+            // } => {
+            //     let multisig_pk = MultiSigPublicKey::new(pks, weights, threshold)?;
+            //     let address: SuiAddress = (&multisig_pk).into();
+            //     let multisig = MultiSig::combine(sigs, multisig_pk)?;
+            //     let generic_sig: GenericSignature = multisig.into();
+            //     println!("MultiSig address: {address}");
+            //     println!("MultiSig parsed: {:?}", generic_sig);
+            //     println!("MultiSig serialized: {:?}", generic_sig.encode_base64());
+            // }
 
-        //         println!("Participating parties:");
-        //         println!(
-        //             " {0: ^42} | {1: ^50} | {2: ^6}",
-        //             "Sui Address", "Public Key (Base64)", "Weight"
-        //         );
-        //         println!("{}", ["-"; 100].join(""));
-        //         for (pk, w) in pks.into_iter().zip(weights.into_iter()) {
-        //             println!(
-        //                 " {0: ^42} | {1: ^45} | {2: ^6}",
-        //                 Into::<SuiAddress>::into(&pk),
-        //                 pk.encode_base64(),
-        //                 w
-        //             );
-        //         }
-        //     }
-        //     KeyToolCommand::MultiSigCombinePartialSig {
-        //         sigs,
-        //         pks,
-        //         weights,
-        //         threshold,
-        //     } => {
-        //         let multisig_pk = MultiSigPublicKey::new(pks, weights, threshold)?;
-        //         let address: SuiAddress = (&multisig_pk).into();
-        //         let multisig = MultiSig::combine(sigs, multisig_pk)?;
-        //         let generic_sig: GenericSignature = multisig.into();
-        //         println!("MultiSig address: {address}");
-        //         println!("MultiSig parsed: {:?}", generic_sig);
-        //         println!("MultiSig serialized: {:?}", generic_sig.encode_base64());
-        //     }
+            // KeyToolCommand::DecodeMultiSig { multisig } => {
+            //     let pks = multisig.get_pk().pubkeys();
+            //     let sigs = multisig.get_sigs();
+            //     let bitmap = multisig.get_bitmap();
+            //     println!(
+            //         "All pubkeys: {:?}, threshold: {:?}",
+            //         pks.iter()
+            //             .map(|(pk, w)| format!("{:?} - {:?}", pk.encode_base64(), w))
+            //             .collect::<Vec<String>>(),
+            //         multisig.get_pk().threshold()
+            //     );
+            //     println!("Participating signatures and pubkeys");
+            //     println!(
+            //         " {0: ^45} | {1: ^45} | {2: ^6}",
+            //         "Public Key (Base64)", "Sig (Base64)", "Weight"
+            //     );
+            //     println!("{}", ["-"; 100].join(""));
+            //     for (sig, i) in sigs.iter().zip(bitmap) {
+            //         let (pk, w) = pks
+            //             .get(i as usize)
+            //             .ok_or(anyhow!("Invalid public keys index".to_string()))?;
+            //         println!(
+            //             " {0: ^45} | {1: ^45} | {2: ^6}",
+            //             Base64::encode(sig.as_ref()),
+            //             pk.encode_base64(),
+            //             w
+            //         );
+            //     }
+            //     println!(
+            //         "Multisig address: {:?}",
+            //         SuiAddress::from(multisig.get_pk())
+            //     );
+            // }
 
-        //     KeyToolCommand::DecodeMultiSig { multisig } => {
-        //         let pks = multisig.get_pk().pubkeys();
-        //         let sigs = multisig.get_sigs();
-        //         let bitmap = multisig.get_bitmap();
-        //         println!(
-        //             "All pubkeys: {:?}, threshold: {:?}",
-        //             pks.iter()
-        //                 .map(|(pk, w)| format!("{:?} - {:?}", pk.encode_base64(), w))
-        //                 .collect::<Vec<String>>(),
-        //             multisig.get_pk().threshold()
-        //         );
-        //         println!("Participating signatures and pubkeys");
-        //         println!(
-        //             " {0: ^45} | {1: ^45} | {2: ^6}",
-        //             "Public Key (Base64)", "Sig (Base64)", "Weight"
-        //         );
-        //         println!("{}", ["-"; 100].join(""));
-        //         for (sig, i) in sigs.iter().zip(bitmap) {
-        //             let (pk, w) = pks
-        //                 .get(i as usize)
-        //                 .ok_or(anyhow!("Invalid public keys index".to_string()))?;
-        //             println!(
-        //                 " {0: ^45} | {1: ^45} | {2: ^6}",
-        //                 Base64::encode(sig.as_ref()),
-        //                 pk.encode_base64(),
-        //                 w
-        //             );
-        //         }
-        //         println!(
-        //             "Multisig address: {:?}",
-        //             SuiAddress::from(multisig.get_pk())
-        //         );
-        //     }
+            // KeyToolCommand::DecodeTxBytes { tx_bytes } => {
+            //     let tx_bytes = Base64::decode(&tx_bytes)
+            //         .map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
+            //     let tx_data: TransactionData = bcs::from_bytes(&tx_bytes)?;
+            //     println!("Transaction data: {:?}", tx_data);
+            // }
 
-        //     KeyToolCommand::DecodeTxBytes { tx_bytes } => {
-        //         let tx_bytes = Base64::decode(&tx_bytes)
-        //             .map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
-        //         let tx_data: TransactionData = bcs::from_bytes(&tx_bytes)?;
-        //         println!("Transaction data: {:?}", tx_data);
-        //     }
+            // KeyToolCommand::ZkLogInPrepare { max_epoch } => {
+            //     // todo: unhardcode keypair and jwt_randomness and max_epoch.
+            //     let kp: Ed25519KeyPair = get_key_pair_from_rng(&mut StdRng::from_seed([0; 32])).1;
+            //     let skp = SuiKeyPair::Ed25519(kp.copy());
+            //     println!("Ephemeral pubkey: {:?}", skp.public().encode_base64());
+            //     println!("Ephemeral keypair: {:?}", skp.encode_base64());
 
-        //     KeyToolCommand::ZkLogInPrepare { max_epoch } => {
-        //         // todo: unhardcode keypair and jwt_randomness and max_epoch.
-        //         let kp: Ed25519KeyPair = get_key_pair_from_rng(&mut StdRng::from_seed([0; 32])).1;
-        //         let skp = SuiKeyPair::Ed25519(kp.copy());
-        //         println!("Ephemeral pubkey: {:?}", skp.public().encode_base64());
-        //         println!("Ephemeral keypair: {:?}", skp.encode_base64());
+            //     // Nonce is defined as the base64Url encoded of the poseidon hash of 4 inputs:
+            //     // first half of eph_pubkey bytes in BigInt, second half, max_epoch, randomness.
+            //     let bytes = kp.public().as_ref();
+            //     let (first_half, second_half) = bytes.split_at(bytes.len() / 2);
+            //     let first_bigint = BigInt::from_bytes_be(Sign::Plus, first_half);
+            //     let second_bigint = BigInt::from_bytes_be(Sign::Plus, second_half);
 
-        //         // Nonce is defined as the base64Url encoded of the poseidon hash of 4 inputs:
-        //         // first half of eph_pubkey bytes in BigInt, second half, max_epoch, randomness.
-        //         let bytes = kp.public().as_ref();
-        //         let (first_half, second_half) = bytes.split_at(bytes.len() / 2);
-        //         let first_bigint = BigInt::from_bytes_be(Sign::Plus, first_half);
-        //         let second_bigint = BigInt::from_bytes_be(Sign::Plus, second_half);
+            //     let mut poseidon = PoseidonWrapper::new();
+            //     let first = Bn254Fr::from_str(&first_bigint.to_string()).unwrap();
+            //     let second = Bn254Fr::from_str(&second_bigint.to_string()).unwrap();
+            //     let max_epoch = Bn254Fr::from_str(max_epoch.as_str()).unwrap();
+            //     let jwt_randomness = Bn254Fr::from_str(
+            //         "50683480294434968413708503290439057629605340925620961559740848568164438166",
+            //     )
+            //     .unwrap();
+            //     let hash = poseidon.hash(vec![first, second, max_epoch, jwt_randomness])?;
+            //     println!("Nonce: {:?}", hash.to_string());
+            // }
 
-        //         let mut poseidon = PoseidonWrapper::new();
-        //         let first = Bn254Fr::from_str(&first_bigint.to_string()).unwrap();
-        //         let second = Bn254Fr::from_str(&second_bigint.to_string()).unwrap();
-        //         let max_epoch = Bn254Fr::from_str(max_epoch.as_str()).unwrap();
-        //         let jwt_randomness = Bn254Fr::from_str(
-        //             "50683480294434968413708503290439057629605340925620961559740848568164438166",
-        //         )
-        //         .unwrap();
-        //         let hash = poseidon.hash(vec![first, second, max_epoch, jwt_randomness])?;
-        //         println!("Nonce: {:?}", hash.to_string());
-        //     }
+            // KeyToolCommand::GenerateZkLoginAddress { address_seed } => {
+            //     let mut hasher = DefaultHash::default();
+            //     hasher.update([SignatureScheme::ZkLoginAuthenticator.flag()]);
+            //     let address_params = AddressParams::new(
+            //         OAuthProvider::Google.get_config().0.to_owned(),
+            //         SupportedKeyClaim::Sub.to_string(),
+            //     );
+            //     println!("Address params: {:?}", address_params);
+            //     hasher.update(bcs::to_bytes(&address_params).unwrap());
+            //     hasher.update(big_int_str_to_bytes(&address_seed));
+            //     let user_address = SuiAddress::from_bytes(hasher.finalize().digest)?;
+            //     println!("Sui Address: {:?}", user_address);
+            // }
 
-        //     KeyToolCommand::GenerateZkLoginAddress { address_seed } => {
-        //         let mut hasher = DefaultHash::default();
-        //         hasher.update([SignatureScheme::ZkLoginAuthenticator.flag()]);
-        //         let address_params = AddressParams::new(
-        //             OAuthProvider::Google.get_config().0.to_owned(),
-        //             SupportedKeyClaim::Sub.to_string(),
-        //         );
-        //         println!("Address params: {:?}", address_params);
-        //         hasher.update(bcs::to_bytes(&address_params).unwrap());
-        //         hasher.update(big_int_str_to_bytes(&address_seed));
-        //         let user_address = SuiAddress::from_bytes(hasher.finalize().digest)?;
-        //         println!("Sui Address: {:?}", user_address);
-        //     }
-
-        //     KeyToolCommand::SerializeZkLoginAuthenticator {
-        //         proof_str,
-        //         public_inputs_str,
-        //         aux_inputs_str,
-        //         user_signature,
-        //     } => {
-        //         let authenticator = ZkLoginAuthenticator::new(
-        //             ZkLoginProof::from_json(&proof_str)?,
-        //             PublicInputs::from_json(&public_inputs_str)?,
-        //             AuxInputs::from_json(&aux_inputs_str)?,
-        //             Signature::from_str(&user_signature).map_err(|e| anyhow!(e))?,
-        //         );
-        //         let sig = GenericSignature::from(authenticator);
-        //         println!(
-        //             "ZkLogin Authenticator Signature Serialized: {:?}",
-        //             sig.encode_base64()
-        //         );
-        //     }
-        // }
+            // KeyToolCommand::SerializeZkLoginAuthenticator {
+            //     proof_str,
+            //     public_inputs_str,
+            //     aux_inputs_str,
+            //     user_signature,
+            // } => {
+            //     let authenticator = ZkLoginAuthenticator::new(
+            //         ZkLoginProof::from_json(&proof_str)?,
+            //         PublicInputs::from_json(&public_inputs_str)?,
+            //         AuxInputs::from_json(&aux_inputs_str)?,
+            //         Signature::from_str(&user_signature).map_err(|e| anyhow!(e))?,
+            //     );
+            //     let sig = GenericSignature::from(authenticator);
+            //     println!(
+            //         "ZkLogin Authenticator Signature Serialized: {:?}",
+            //         sig.encode_base64()
+            //     );
+            // }
+        
         // Ok(())
-    
+        _ => todo!()
+            });
+        
+        cmd_result
     }
+}
+
+fn convert_private_key_to_base64(value: String) -> Result<String, anyhow::Error>{
+    match Base64::decode(&value) {
+            Ok(decoded) => {
+                if decoded.len() != 33 {
+                    return Err(anyhow!(format!("Private key is malformed and cannot base64 decode it. Expected 33 length but got {}", decoded.len())))
+                }
+                Ok(Hex::encode(&decoded[1..]))
+            },
+            Err(_) => match Hex::decode(&value) {
+                Ok(decoded) => {
+                    if decoded.len() != 32 {
+                        return Err(anyhow!(format!("Private key is malformed and cannot hex decode it. Expected 32 length but got {}", decoded.len())))
+                    }
+                    let mut res = Vec::new();
+                    res.extend_from_slice(&[SignatureScheme::ED25519.flag()]);
+                    res.extend_from_slice(&decoded);
+                    Ok(Base64::encode(&res))
+                }
+                Err(_) => {
+                    Err(anyhow!("Invalid private key format".to_string()))
+                }
+            },
+}
 }
 
 fn store_and_print_keypair(address: SuiAddress, keypair: SuiKeyPair) {
@@ -666,38 +685,47 @@ fn store_and_print_keypair(address: SuiAddress, keypair: SuiKeyPair) {
     );
 }
 
+fn format_to_table(obj: &KeyToolCmdResult) -> String{
+    let table = json_to_table(&json![obj]).collapse().to_string();//array_orientation(Orientation::Column).with(tabled::settings::Style::sharp()).to_string();
+    table
+}
 
-impl Display for SuiKeytoolCommandResult {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl Display for KeyToolCmdResult {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
         let mut writer = String::new();
         match self {
-            SuiKeytoolCommandResult::List(keys) => {
-                write!(writer, "{}", "mykeys")?;
-            },
-            _ => todo!()
+            _ => {
+                let table = format_to_table(self);
+                write!(formatter, "{}", table);
+            }
         }
 
-        write!(f, "{}", writer.trim_end_matches('\n'))
+        write!(formatter, "{}", writer.trim_end_matches('\n'))
 
     }
 
 }
 #[derive(Serialize)]
-pub struct KeystoreList {
-    sui_address: SuiAddress,
-    base64: String,
+#[serde(rename_all = "camelCase")]
+pub struct Key {
+    sui_address: String,
+    public_base64_key: String,
     scheme: String
 }
 
 
 #[derive(Serialize)]
 #[serde(untagged)]
-pub enum SuiKeytoolCommandResult {
+pub enum KeyToolCmdResult {
     GenerateZkLoginAddress(SuiAddress),
-    List(Vec<KeystoreList>)
+    List(Vec<Key>),
+    ConvertedPrivateKey(String),
+    Import(Key),
+    Error(String),
+    Warning(String)
 }
 
-impl SuiKeytoolCommandResult {
+impl KeyToolCmdResult {
     pub fn print(&self, pretty: bool) {
         let line = if pretty {
             format!("{self}")
@@ -713,7 +741,8 @@ impl SuiKeytoolCommandResult {
     }
 }
 
-impl Debug for SuiKeytoolCommandResult {
+// when --json flag is used, any output result is transformed into a JSON pretty string and sent to std output
+impl Debug for KeyToolCmdResult {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let s = unwrap_err_to_string(|| match self {
             _ => Ok(serde_json::to_string_pretty(self)?),

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -726,7 +726,7 @@ impl KeyToolCommand {
                 let tx_bytes = Base64::decode(&tx_bytes)
                     .map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
                 let tx_data: TransactionData = bcs::from_bytes(&tx_bytes)?;
-                println!("Transaction data: {:?}", tx_data);
+                eprintln!("Transaction data: {:?}", tx_data);
                 CommandOutput::DecodeTxBytes(tx_data)
             }
 
@@ -734,8 +734,8 @@ impl KeyToolCommand {
                 // todo: unhardcode keypair and jwt_randomness and max_epoch.
                 let kp: Ed25519KeyPair = get_key_pair_from_rng(&mut StdRng::from_seed([0; 32])).1;
                 let skp = SuiKeyPair::Ed25519(kp.copy());
-                println!("Ephemeral pubkey: {:?}", skp.public().encode_base64());
-                println!("Ephemeral keypair: {:?}", skp.encode_base64());
+                eprintln!("Ephemeral pubkey: {:?}", skp.public().encode_base64());
+                eprintln!("Ephemeral keypair: {:?}", skp.encode_base64());
 
                 // Nonce is defined as the base64Url encoded of the poseidon hash of 4 inputs:
                 // first half of eph_pubkey bytes in BigInt, second half, max_epoch, randomness.
@@ -753,7 +753,7 @@ impl KeyToolCommand {
                 )
                 .unwrap();
                 let hash = poseidon.hash(vec![first, second, max_epoch, jwt_randomness])?;
-                println!("Nonce: {:?}", hash.to_string());
+                eprintln!("Nonce: {:?}", hash.to_string());
                 CommandOutput::ZkLogInPrepare(ZkLogInPrepare {
                     ephemeral_pubkey: skp.public().encode_base64(),
                     ephemeral_keypair: skp.encode_base64(),
@@ -767,11 +767,11 @@ impl KeyToolCommand {
                     OAuthProvider::Google.get_config().0.to_owned(),
                     SupportedKeyClaim::Sub.to_string(),
                 );
-                println!("Address params: {:?}", address_params);
+                eprintln!("Address params: {:?}", address_params);
                 hasher.update(bcs::to_bytes(&address_params).unwrap());
                 hasher.update(big_int_str_to_bytes(&address_seed));
                 let user_address = SuiAddress::from_bytes(hasher.finalize().digest)?;
-                println!("Sui Address: {:?}", user_address);
+                eprintln!("Sui Address: {:?}", user_address);
                 CommandOutput::GenerateZkLoginAddress(user_address, address_params)
             }
 
@@ -788,7 +788,7 @@ impl KeyToolCommand {
                     Signature::from_str(&user_signature).map_err(|e| anyhow!(e))?,
                 );
                 let sig = GenericSignature::from(authenticator);
-                println!(
+                eprintln!(
                     "ZkLogin Authenticator Signature Serialized: {:?}",
                     sig.encode_base64()
                 );

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -434,7 +434,7 @@ impl KeyToolCommand {
 
                                 CommandOutput::Import(Key {
                                     sui_address: address.to_string(),
-                                    public_base64_key: skp.public().encode_base64(),
+                                    public_base64_key: skp.encode_base64(),
                                     key_scheme: scheme,
                                     mnemonic: None,
                                     flag: skp.public().flag(),
@@ -460,7 +460,7 @@ impl KeyToolCommand {
 
                     CommandOutput::Import(Key {
                         sui_address: sui_address.to_string(),
-                        public_base64_key: pk.public().encode_base64(),
+                        public_base64_key: pk.encode_base64(),
                         key_scheme: scheme,
                         mnemonic: None,
                         flag: pk.public().flag(),

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -19,7 +19,9 @@ use rand::rngs::StdRng;
 use rand::SeedableRng;
 use rusoto_core::Region;
 use rusoto_kms::{Kms, KmsClient, SignRequest};
+use serde::Serialize;
 use shared_crypto::intent::{Intent, IntentMessage};
+use std::fmt::{Debug, Formatter, Display};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -40,13 +42,14 @@ use sui_types::transaction::TransactionData;
 use sui_types::zk_login_authenticator::ZkLoginAuthenticator;
 use sui_types::zk_login_util::AddressParams;
 use tracing::info;
+use std::fmt::Write;
 
 #[cfg(test)]
 #[path = "unit_tests/keytool_tests.rs"]
 mod keytool_tests;
 
 #[allow(clippy::large_enum_variant)]
-#[derive(Subcommand)]
+#[derive(Subcommand, Serialize)]
 #[clap(rename_all = "kebab-case")]
 pub enum KeyToolCommand {
     /// Generate a new keypair with key scheme flag {ed25519 | secp256k1 | secp256r1}
@@ -61,6 +64,7 @@ pub enum KeyToolCommand {
     Generate {
         key_scheme: SignatureScheme,
         word_length: Option<String>,
+        #[serde(skip_serializing)]
         derivation_path: Option<DerivationPath>,
     },
     /// This reads the content at the provided file path. The accepted format can be
@@ -116,6 +120,7 @@ pub enum KeyToolCommand {
     Import {
         mnemonic_phrase: String,
         key_scheme: SignatureScheme,
+        #[serde(skip_serializing)]
         derivation_path: Option<DerivationPath>,
     },
     /// Convert private key from wallet format (hex of 32 byte private key) to sui.keystore format
@@ -233,405 +238,417 @@ pub enum KeyToolCommand {
 }
 
 impl KeyToolCommand {
-    pub async fn execute(self, keystore: &mut Keystore) -> Result<(), anyhow::Error> {
-        match self {
-            KeyToolCommand::Generate {
-                key_scheme,
-                derivation_path,
-                word_length,
-            } => {
-                if "bls12381" == key_scheme.to_string() {
-                    // Generate BLS12381 key for authority without key derivation.
-                    // The saved keypair is encoded `privkey || pubkey` without the scheme flag.
-                    let (address, keypair) = get_authority_key_pair();
-                    let file_name = format!("bls-{address}.key");
-                    write_authority_keypair_to_file(&keypair, file_name)?;
-                } else {
-                    let (address, kp, scheme, phrase) =
-                        generate_new_key(key_scheme, derivation_path, word_length)?;
-                    let file = format!("{address}.key");
-                    write_keypair_to_file(&kp, &file)?;
-                    println!(
-                        "Created new keypair for address wrote to file path {:?} with scheme {:?}: [{address}]",
-                        file, scheme
-                    );
-                    println!("Secret Recovery Phrase : [{phrase}]");
-                }
-            }
-            KeyToolCommand::Show { file } => {
-                let res = read_keypair_from_file(&file);
-                match res {
-                    Ok(keypair) => {
-                        println!("Public Key: {}", keypair.public().encode_base64());
-                        println!("Flag: {}", keypair.public().flag());
-                        if let PublicKey::Ed25519(public_key) = keypair.public() {
-                            let peer_id = anemo::PeerId(public_key.0);
-                            println!("PeerId: {}", peer_id);
-                        }
-                    }
-                    Err(_) => {
-                        let res = read_authority_keypair_from_file(&file);
-                        match res {
-                            Ok(keypair) => {
-                                println!("Public Key: {}", keypair.public().encode_base64());
-                                println!("Flag: {}", SignatureScheme::BLS12381);
-                            }
-                            Err(e) => {
-                                println!("Failed to read keypair at path {:?} err: {:?}", file, e)
-                            }
-                        }
-                    }
-                }
-            }
-
-            KeyToolCommand::Unpack { keypair } => {
-                store_and_print_keypair((&keypair.public()).into(), keypair)
-            }
+    pub async fn execute(self, keystore: &mut Keystore) -> Result<SuiKeytoolCommandResult, anyhow::Error> {
+        let cmd_result = Ok(match self {
             KeyToolCommand::List => {
-                println!(
-                    " {0: ^42} | {1: ^45} | {2: ^6}",
-                    "Sui Address", "Public Key (Base64)", "Scheme"
-                );
-                println!("{}", ["-"; 100].join(""));
-                for pub_key in keystore.keys() {
-                    println!(
-                        " {0: ^42} | {1: ^45} | {2: ^6}",
-                        Into::<SuiAddress>::into(&pub_key),
-                        pub_key.encode_base64(),
-                        pub_key.scheme().to_string()
-                    );
-                }
-            }
-            KeyToolCommand::Sign {
-                address,
-                data,
-                intent,
-            } => {
-                println!("Signer address: {}", address);
-                println!("Raw tx_bytes to execute: {}", data);
-                let intent = intent.unwrap_or_else(Intent::sui_transaction);
-                println!("Intent: {:?}", intent);
-                let msg: TransactionData =
-                    bcs::from_bytes(&Base64::decode(&data).map_err(|e| {
-                        anyhow!("Cannot deserialize data as TransactionData {:?}", e)
-                    })?)?;
-                let intent_msg = IntentMessage::new(intent, msg);
-                println!(
-                    "Raw intent message: {:?}",
-                    Base64::encode(bcs::to_bytes(&intent_msg)?)
-                );
-                let mut hasher = DefaultHash::default();
-                hasher.update(bcs::to_bytes(&intent_msg)?);
-                let digest = hasher.finalize().digest;
-                println!("Digest to sign: {:?}", Base64::encode(digest));
-                let sui_signature =
-                    keystore.sign_secure(&address, &intent_msg.value, intent_msg.intent)?;
-                println!(
-                    "Serialized signature (`flag || sig || pk` in Base64): {:?}",
-                    sui_signature.encode_base64()
-                );
-            }
-
-            KeyToolCommand::Import {
-                mnemonic_phrase,
-                key_scheme,
-                derivation_path,
-            } => {
-                let address =
-                    keystore.import_from_mnemonic(&mnemonic_phrase, key_scheme, derivation_path)?;
-                info!("Key imported for address [{address}]");
-            }
-
-            KeyToolCommand::Convert { value } => match Base64::decode(&value) {
-                Ok(decoded) => {
-                    assert_eq!(decoded.len(), 33);
-                    info!(
-                        "Wallet formatted private key: 0x{}",
-                        Hex::encode(&decoded[1..])
-                    );
-                }
-                Err(_) => match Hex::decode(&value) {
-                    Ok(decoded) => {
-                        assert_eq!(decoded.len(), 32);
-                        let mut res = Vec::new();
-                        res.extend_from_slice(&[SignatureScheme::ED25519.flag()]);
-                        res.extend_from_slice(&decoded);
-                        info!("Keystore formatted private key: {:?}", Base64::encode(&res));
-                    }
-                    Err(_) => {
-                        info!("Invalid private key format");
-                    }
-                },
+                let keys = keystore.keys().into_iter().map(|key| {
+                    KeystoreList{sui_address: Into::<SuiAddress>::into(&key),
+                                base64:  key.encode_base64().to_string(),
+                                scheme: key.scheme().to_string()}
+                }).collect::<Vec<_>>();
+                SuiKeytoolCommandResult::List(keys)
             },
+            _ => todo!()
+        });
+        cmd_result
+        //     KeyToolCommand::Generate {
+        //         key_scheme,
+        //         derivation_path,
+        //         word_length,
+        //     } => {
+        //         if "bls12381" == key_scheme.to_string() {
+        //             // Generate BLS12381 key for authority without key derivation.
+        //             // The saved keypair is encoded `privkey || pubkey` without the scheme flag.
+        //             let (address, keypair) = get_authority_key_pair();
+        //             let file_name = format!("bls-{address}.key");
+        //             write_authority_keypair_to_file(&keypair, file_name)?;
+        //         } else {
+        //             let (address, kp, scheme, phrase) =
+        //                 generate_new_key(key_scheme, derivation_path, word_length)?;
+        //             let file = format!("{address}.key");
+        //             write_keypair_to_file(&kp, &file)?;
+        //             println!(
+        //                 "Created new keypair for address wrote to file path {:?} with scheme {:?}: [{address}]",
+        //                 file, scheme
+        //             );
+        //             println!("Secret Recovery Phrase : [{phrase}]");
+        //         }
+        //     }
+        //     KeyToolCommand::Show { file } => {
+        //         let res = read_keypair_from_file(&file);
+        //         match res {
+        //             Ok(keypair) => {
+        //                 println!("Public Key: {}", keypair.public().encode_base64());
+        //                 println!("Flag: {}", keypair.public().flag());
+        //                 if let PublicKey::Ed25519(public_key) = keypair.public() {
+        //                     let peer_id = anemo::PeerId(public_key.0);
+        //                     println!("PeerId: {}", peer_id);
+        //                 }
+        //             }
+        //             Err(_) => {
+        //                 let res = read_authority_keypair_from_file(&file);
+        //                 match res {
+        //                     Ok(keypair) => {
+        //                         println!("Public Key: {}", keypair.public().encode_base64());
+        //                         println!("Flag: {}", SignatureScheme::BLS12381);
+        //                     }
+        //                     Err(e) => {
+        //                         println!("Failed to read keypair at path {:?} err: {:?}", file, e)
+        //                     }
+        //                 }
+        //             }
+        //         }
+        //     }
 
-            KeyToolCommand::Base64PubKeyToAddress { base64_key } => {
-                let pk = PublicKey::decode_base64(&base64_key)
-                    .map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
-                let address = SuiAddress::from(&pk);
-                println!("Address {:?}", address);
-            }
+        //     KeyToolCommand::Unpack { keypair } => {
+        //         store_and_print_keypair((&keypair.public()).into(), keypair)
+        //     }
+        //     KeyToolCommand::List => {
+        //         println!(
+        //             " {0: ^42} | {1: ^45} | {2: ^6}",
+        //             "Sui Address", "Public Key (Base64)", "Scheme"
+        //         );
+        //         println!("{}", ["-"; 100].join(""));
+        //         for pub_key in keystore.keys() {
+        //             println!(
+        //                 " {0: ^42} | {1: ^45} | {2: ^6}",
+        //                 Into::<SuiAddress>::into(&pub_key),
+        //                 pub_key.encode_base64(),
+        //                 pub_key.scheme().to_string()
+        //             );
+        //         }
+        //     }
+        //     KeyToolCommand::Sign {
+        //         address,
+        //         data,
+        //         intent,
+        //     } => {
+        //         println!("Signer address: {}", address);
+        //         println!("Raw tx_bytes to execute: {}", data);
+        //         let intent = intent.unwrap_or_else(Intent::sui_transaction);
+        //         println!("Intent: {:?}", intent);
+        //         let msg: TransactionData =
+        //             bcs::from_bytes(&Base64::decode(&data).map_err(|e| {
+        //                 anyhow!("Cannot deserialize data as TransactionData {:?}", e)
+        //             })?)?;
+        //         let intent_msg = IntentMessage::new(intent, msg);
+        //         println!(
+        //             "Raw intent message: {:?}",
+        //             Base64::encode(bcs::to_bytes(&intent_msg)?)
+        //         );
+        //         let mut hasher = DefaultHash::default();
+        //         hasher.update(bcs::to_bytes(&intent_msg)?);
+        //         let digest = hasher.finalize().digest;
+        //         println!("Digest to sign: {:?}", Base64::encode(digest));
+        //         let sui_signature =
+        //             keystore.sign_secure(&address, &intent_msg.value, intent_msg.intent)?;
+        //         println!(
+        //             "Serialized signature (`flag || sig || pk` in Base64): {:?}",
+        //             sui_signature.encode_base64()
+        //         );
+        //     }
 
-            KeyToolCommand::Base64ToHex { base64 } => {
-                let bytes =
-                    Base64::decode(&base64).map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
-                let hex = Hex::from_bytes(&bytes);
-                println!("{:?}", hex);
-            }
+        //     KeyToolCommand::Import {
+        //         mnemonic_phrase,
+        //         key_scheme,
+        //         derivation_path,
+        //     } => {
+        //         let address =
+        //             keystore.import_from_mnemonic(&mnemonic_phrase, key_scheme, derivation_path)?;
+        //         info!("Key imported for address [{address}]");
+        //     }
 
-            KeyToolCommand::HexToBase64 { hex } => {
-                let bytes =
-                    Hex::decode(&hex).map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
-                let base64 = Base64::from_bytes(&bytes);
-                println!("{:?}", base64);
-            }
+        //     KeyToolCommand::Convert { value } => match Base64::decode(&value) {
+        //         Ok(decoded) => {
+        //             assert_eq!(decoded.len(), 33);
+        //             info!(
+        //                 "Wallet formatted private key: 0x{}",
+        //                 Hex::encode(&decoded[1..])
+        //             );
+        //         }
+        //         Err(_) => match Hex::decode(&value) {
+        //             Ok(decoded) => {
+        //                 assert_eq!(decoded.len(), 32);
+        //                 let mut res = Vec::new();
+        //                 res.extend_from_slice(&[SignatureScheme::ED25519.flag()]);
+        //                 res.extend_from_slice(&decoded);
+        //                 info!("Keystore formatted private key: {:?}", Base64::encode(&res));
+        //             }
+        //             Err(_) => {
+        //                 info!("Invalid private key format");
+        //             }
+        //         },
+        //     },
 
-            KeyToolCommand::HexToBytes { hex } => {
-                let bytes =
-                    Hex::decode(&hex).map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
-                println!("Bytes {:?}", bytes);
-            }
+        //     KeyToolCommand::Base64PubKeyToAddress { base64_key } => {
+        //         let pk = PublicKey::decode_base64(&base64_key)
+        //             .map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
+        //         let address = SuiAddress::from(&pk);
+        //         println!("Address {:?}", address);
+        //     }
 
-            KeyToolCommand::BytesToHex { bytes } => {
-                let hex = Hex::from_bytes(&bytes);
-                println!("{:?}", hex);
-            }
+        //     KeyToolCommand::Base64ToHex { base64 } => {
+        //         let bytes =
+        //             Base64::decode(&base64).map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
+        //         let hex = Hex::from_bytes(&bytes);
+        //         println!("{:?}", hex);
+        //     }
 
-            KeyToolCommand::Base64ToBytes { base64 } => {
-                let bytes =
-                    Base64::decode(&base64).map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
-                println!("Bytes {:?}", bytes);
-            }
+        //     KeyToolCommand::HexToBase64 { hex } => {
+        //         let bytes =
+        //             Hex::decode(&hex).map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
+        //         let base64 = Base64::from_bytes(&bytes);
+        //         println!("{:?}", base64);
+        //     }
 
-            KeyToolCommand::BytesToBase64 { bytes } => {
-                let base64 = Base64::from_bytes(&bytes);
-                println!("{:?}", base64);
-            }
+        //     KeyToolCommand::HexToBytes { hex } => {
+        //         let bytes =
+        //             Hex::decode(&hex).map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
+        //         println!("Bytes {:?}", bytes);
+        //     }
 
-            KeyToolCommand::LoadKeypair { file } => {
-                match read_keypair_from_file(&file) {
-                    Ok(keypair) => {
-                        // Account keypair is encoded with the key scheme flag {},
-                        // and network and worker keypair are not.
-                        println!("Account Keypair: {}", keypair.encode_base64());
-                        if let SuiKeyPair::Ed25519(kp) = keypair {
-                            println!("Network Keypair: {}", kp.encode_base64());
-                            println!("Worker Keypair: {}", kp.encode_base64());
-                        };
-                    }
-                    Err(_) => {
-                        // Authority keypair file is not stored with the flag, it will try read as BLS keypair..
-                        match read_authority_keypair_from_file(&file) {
-                            Ok(kp) => println!("Protocol Keypair: {}", kp.encode_base64()),
-                            Err(e) => {
-                                println!("Failed to read keypair at path {:?} err: {:?}", file, e)
-                            }
-                        }
-                    }
-                }
-            }
-            KeyToolCommand::SignKMS {
-                data,
-                keyid,
-                intent,
-                base64pk,
-            } => {
-                // Currently only supports secp256k1 keys
-                let pk_owner = PublicKey::decode_base64(&base64pk)
-                    .map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
-                let address_owner = SuiAddress::from(&pk_owner);
-                println!("Address For Corresponding KMS Key: {}", address_owner);
-                println!("Raw tx_bytes to execute: {}", data);
-                let intent = intent.unwrap_or_else(Intent::sui_transaction);
-                println!("Intent: {:?}", intent);
-                let msg: TransactionData =
-                    bcs::from_bytes(&Base64::decode(&data).map_err(|e| {
-                        anyhow!("Cannot deserialize data as TransactionData {:?}", e)
-                    })?)?;
-                let intent_msg = IntentMessage::new(intent, msg);
-                println!(
-                    "Raw intent message: {:?}",
-                    Base64::encode(bcs::to_bytes(&intent_msg)?)
-                );
-                let mut hasher = DefaultHash::default();
-                hasher.update(bcs::to_bytes(&intent_msg)?);
-                let digest = hasher.finalize().digest;
-                println!("Digest to sign: {:?}", Base64::encode(digest));
+        //     KeyToolCommand::BytesToHex { bytes } => {
+        //         let hex = Hex::from_bytes(&bytes);
+        //         println!("{:?}", hex);
+        //     }
 
-                // Set up the KMS client in default region.
-                let region: Region = Region::default();
-                let kms: KmsClient = KmsClient::new(region);
+        //     KeyToolCommand::Base64ToBytes { base64 } => {
+        //         let bytes =
+        //             Base64::decode(&base64).map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
+        //         println!("Bytes {:?}", bytes);
+        //     }
 
-                // Construct the signing request.
-                let request: SignRequest = SignRequest {
-                    key_id: keyid.to_string(),
-                    message: digest.to_vec().into(),
-                    message_type: Some("RAW".to_string()),
-                    signing_algorithm: "ECDSA_SHA_256".to_string(),
-                    ..Default::default()
-                };
+        //     KeyToolCommand::BytesToBase64 { bytes } => {
+        //         let base64 = Base64::from_bytes(&bytes);
+        //         println!("{:?}", base64);
+        //     }
 
-                // Sign the message, normalize the signature and then compacts it
-                // serialize_compact is loaded as bytes for Secp256k1Sinaturere
-                let response = kms.sign(request).await?;
-                let sig_bytes_der = response
-                    .signature
-                    .map(|b| b.to_vec())
-                    .expect("Requires Asymmetric Key Generated in KMS");
+        //     KeyToolCommand::LoadKeypair { file } => {
+        //         match read_keypair_from_file(&file) {
+        //             Ok(keypair) => {
+        //                 // Account keypair is encoded with the key scheme flag {},
+        //                 // and network and worker keypair are not.
+        //                 println!("Account Keypair: {}", keypair.encode_base64());
+        //                 if let SuiKeyPair::Ed25519(kp) = keypair {
+        //                     println!("Network Keypair: {}", kp.encode_base64());
+        //                     println!("Worker Keypair: {}", kp.encode_base64());
+        //                 };
+        //             }
+        //             Err(_) => {
+        //                 // Authority keypair file is not stored with the flag, it will try read as BLS keypair..
+        //                 match read_authority_keypair_from_file(&file) {
+        //                     Ok(kp) => println!("Protocol Keypair: {}", kp.encode_base64()),
+        //                     Err(e) => {
+        //                         println!("Failed to read keypair at path {:?} err: {:?}", file, e)
+        //                     }
+        //                 }
+        //             }
+        //         }
+        //     }
+        //     KeyToolCommand::SignKMS {
+        //         data,
+        //         keyid,
+        //         intent,
+        //         base64pk,
+        //     } => {
+        //         // Currently only supports secp256k1 keys
+        //         let pk_owner = PublicKey::decode_base64(&base64pk)
+        //             .map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
+        //         let address_owner = SuiAddress::from(&pk_owner);
+        //         println!("Address For Corresponding KMS Key: {}", address_owner);
+        //         println!("Raw tx_bytes to execute: {}", data);
+        //         let intent = intent.unwrap_or_else(Intent::sui_transaction);
+        //         println!("Intent: {:?}", intent);
+        //         let msg: TransactionData =
+        //             bcs::from_bytes(&Base64::decode(&data).map_err(|e| {
+        //                 anyhow!("Cannot deserialize data as TransactionData {:?}", e)
+        //             })?)?;
+        //         let intent_msg = IntentMessage::new(intent, msg);
+        //         println!(
+        //             "Raw intent message: {:?}",
+        //             Base64::encode(bcs::to_bytes(&intent_msg)?)
+        //         );
+        //         let mut hasher = DefaultHash::default();
+        //         hasher.update(bcs::to_bytes(&intent_msg)?);
+        //         let digest = hasher.finalize().digest;
+        //         println!("Digest to sign: {:?}", Base64::encode(digest));
 
-                let mut external_sig = Secp256k1Sig::from_der(&sig_bytes_der)?;
-                external_sig.normalize_s();
-                let sig_compact = external_sig.serialize_compact();
+        //         // Set up the KMS client in default region.
+        //         let region: Region = Region::default();
+        //         let kms: KmsClient = KmsClient::new(region);
 
-                let mut serialized_sig = vec![SignatureScheme::Secp256k1.flag()];
-                serialized_sig.extend_from_slice(&sig_compact);
-                serialized_sig.extend_from_slice(pk_owner.as_ref());
-                let serialized_sig = Base64::encode(&serialized_sig);
-                println!(
-                    "Serialized signature (`flag || sig || pk` in Base64): {:?}",
-                    serialized_sig
-                );
-                return Ok(());
-            }
-            KeyToolCommand::MultiSigAddress {
-                threshold,
-                pks,
-                weights,
-            } => {
-                let multisig_pk = MultiSigPublicKey::new(pks.clone(), weights.clone(), threshold)?;
-                let address: SuiAddress = (&multisig_pk).into();
-                println!("MultiSig address: {address}");
+        //         // Construct the signing request.
+        //         let request: SignRequest = SignRequest {
+        //             key_id: keyid.to_string(),
+        //             message: digest.to_vec().into(),
+        //             message_type: Some("RAW".to_string()),
+        //             signing_algorithm: "ECDSA_SHA_256".to_string(),
+        //             ..Default::default()
+        //         };
 
-                println!("Participating parties:");
-                println!(
-                    " {0: ^42} | {1: ^50} | {2: ^6}",
-                    "Sui Address", "Public Key (Base64)", "Weight"
-                );
-                println!("{}", ["-"; 100].join(""));
-                for (pk, w) in pks.into_iter().zip(weights.into_iter()) {
-                    println!(
-                        " {0: ^42} | {1: ^45} | {2: ^6}",
-                        Into::<SuiAddress>::into(&pk),
-                        pk.encode_base64(),
-                        w
-                    );
-                }
-            }
-            KeyToolCommand::MultiSigCombinePartialSig {
-                sigs,
-                pks,
-                weights,
-                threshold,
-            } => {
-                let multisig_pk = MultiSigPublicKey::new(pks, weights, threshold)?;
-                let address: SuiAddress = (&multisig_pk).into();
-                let multisig = MultiSig::combine(sigs, multisig_pk)?;
-                let generic_sig: GenericSignature = multisig.into();
-                println!("MultiSig address: {address}");
-                println!("MultiSig parsed: {:?}", generic_sig);
-                println!("MultiSig serialized: {:?}", generic_sig.encode_base64());
-            }
+        //         // Sign the message, normalize the signature and then compacts it
+        //         // serialize_compact is loaded as bytes for Secp256k1Sinaturere
+        //         let response = kms.sign(request).await?;
+        //         let sig_bytes_der = response
+        //             .signature
+        //             .map(|b| b.to_vec())
+        //             .expect("Requires Asymmetric Key Generated in KMS");
 
-            KeyToolCommand::DecodeMultiSig { multisig } => {
-                let pks = multisig.get_pk().pubkeys();
-                let sigs = multisig.get_sigs();
-                let bitmap = multisig.get_bitmap();
-                println!(
-                    "All pubkeys: {:?}, threshold: {:?}",
-                    pks.iter()
-                        .map(|(pk, w)| format!("{:?} - {:?}", pk.encode_base64(), w))
-                        .collect::<Vec<String>>(),
-                    multisig.get_pk().threshold()
-                );
-                println!("Participating signatures and pubkeys");
-                println!(
-                    " {0: ^45} | {1: ^45} | {2: ^6}",
-                    "Public Key (Base64)", "Sig (Base64)", "Weight"
-                );
-                println!("{}", ["-"; 100].join(""));
-                for (sig, i) in sigs.iter().zip(bitmap) {
-                    let (pk, w) = pks
-                        .get(i as usize)
-                        .ok_or(anyhow!("Invalid public keys index".to_string()))?;
-                    println!(
-                        " {0: ^45} | {1: ^45} | {2: ^6}",
-                        Base64::encode(sig.as_ref()),
-                        pk.encode_base64(),
-                        w
-                    );
-                }
-                println!(
-                    "Multisig address: {:?}",
-                    SuiAddress::from(multisig.get_pk())
-                );
-            }
+        //         let mut external_sig = Secp256k1Sig::from_der(&sig_bytes_der)?;
+        //         external_sig.normalize_s();
+        //         let sig_compact = external_sig.serialize_compact();
 
-            KeyToolCommand::DecodeTxBytes { tx_bytes } => {
-                let tx_bytes = Base64::decode(&tx_bytes)
-                    .map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
-                let tx_data: TransactionData = bcs::from_bytes(&tx_bytes)?;
-                println!("Transaction data: {:?}", tx_data);
-            }
+        //         let mut serialized_sig = vec![SignatureScheme::Secp256k1.flag()];
+        //         serialized_sig.extend_from_slice(&sig_compact);
+        //         serialized_sig.extend_from_slice(pk_owner.as_ref());
+        //         let serialized_sig = Base64::encode(&serialized_sig);
+        //         println!(
+        //             "Serialized signature (`flag || sig || pk` in Base64): {:?}",
+        //             serialized_sig
+        //         );
+        //         // return Ok(());
+        //     }
+        //     KeyToolCommand::MultiSigAddress {
+        //         threshold,
+        //         pks,
+        //         weights,
+        //     } => {
+        //         let multisig_pk = MultiSigPublicKey::new(pks.clone(), weights.clone(), threshold)?;
+        //         let address: SuiAddress = (&multisig_pk).into();
+        //         println!("MultiSig address: {address}");
 
-            KeyToolCommand::ZkLogInPrepare { max_epoch } => {
-                // todo: unhardcode keypair and jwt_randomness and max_epoch.
-                let kp: Ed25519KeyPair = get_key_pair_from_rng(&mut StdRng::from_seed([0; 32])).1;
-                let skp = SuiKeyPair::Ed25519(kp.copy());
-                println!("Ephemeral pubkey: {:?}", skp.public().encode_base64());
-                println!("Ephemeral keypair: {:?}", skp.encode_base64());
+        //         println!("Participating parties:");
+        //         println!(
+        //             " {0: ^42} | {1: ^50} | {2: ^6}",
+        //             "Sui Address", "Public Key (Base64)", "Weight"
+        //         );
+        //         println!("{}", ["-"; 100].join(""));
+        //         for (pk, w) in pks.into_iter().zip(weights.into_iter()) {
+        //             println!(
+        //                 " {0: ^42} | {1: ^45} | {2: ^6}",
+        //                 Into::<SuiAddress>::into(&pk),
+        //                 pk.encode_base64(),
+        //                 w
+        //             );
+        //         }
+        //     }
+        //     KeyToolCommand::MultiSigCombinePartialSig {
+        //         sigs,
+        //         pks,
+        //         weights,
+        //         threshold,
+        //     } => {
+        //         let multisig_pk = MultiSigPublicKey::new(pks, weights, threshold)?;
+        //         let address: SuiAddress = (&multisig_pk).into();
+        //         let multisig = MultiSig::combine(sigs, multisig_pk)?;
+        //         let generic_sig: GenericSignature = multisig.into();
+        //         println!("MultiSig address: {address}");
+        //         println!("MultiSig parsed: {:?}", generic_sig);
+        //         println!("MultiSig serialized: {:?}", generic_sig.encode_base64());
+        //     }
 
-                // Nonce is defined as the base64Url encoded of the poseidon hash of 4 inputs:
-                // first half of eph_pubkey bytes in BigInt, second half, max_epoch, randomness.
-                let bytes = kp.public().as_ref();
-                let (first_half, second_half) = bytes.split_at(bytes.len() / 2);
-                let first_bigint = BigInt::from_bytes_be(Sign::Plus, first_half);
-                let second_bigint = BigInt::from_bytes_be(Sign::Plus, second_half);
+        //     KeyToolCommand::DecodeMultiSig { multisig } => {
+        //         let pks = multisig.get_pk().pubkeys();
+        //         let sigs = multisig.get_sigs();
+        //         let bitmap = multisig.get_bitmap();
+        //         println!(
+        //             "All pubkeys: {:?}, threshold: {:?}",
+        //             pks.iter()
+        //                 .map(|(pk, w)| format!("{:?} - {:?}", pk.encode_base64(), w))
+        //                 .collect::<Vec<String>>(),
+        //             multisig.get_pk().threshold()
+        //         );
+        //         println!("Participating signatures and pubkeys");
+        //         println!(
+        //             " {0: ^45} | {1: ^45} | {2: ^6}",
+        //             "Public Key (Base64)", "Sig (Base64)", "Weight"
+        //         );
+        //         println!("{}", ["-"; 100].join(""));
+        //         for (sig, i) in sigs.iter().zip(bitmap) {
+        //             let (pk, w) = pks
+        //                 .get(i as usize)
+        //                 .ok_or(anyhow!("Invalid public keys index".to_string()))?;
+        //             println!(
+        //                 " {0: ^45} | {1: ^45} | {2: ^6}",
+        //                 Base64::encode(sig.as_ref()),
+        //                 pk.encode_base64(),
+        //                 w
+        //             );
+        //         }
+        //         println!(
+        //             "Multisig address: {:?}",
+        //             SuiAddress::from(multisig.get_pk())
+        //         );
+        //     }
 
-                let mut poseidon = PoseidonWrapper::new();
-                let first = Bn254Fr::from_str(&first_bigint.to_string()).unwrap();
-                let second = Bn254Fr::from_str(&second_bigint.to_string()).unwrap();
-                let max_epoch = Bn254Fr::from_str(max_epoch.as_str()).unwrap();
-                let jwt_randomness = Bn254Fr::from_str(
-                    "50683480294434968413708503290439057629605340925620961559740848568164438166",
-                )
-                .unwrap();
-                let hash = poseidon.hash(vec![first, second, max_epoch, jwt_randomness])?;
-                println!("Nonce: {:?}", hash.to_string());
-            }
+        //     KeyToolCommand::DecodeTxBytes { tx_bytes } => {
+        //         let tx_bytes = Base64::decode(&tx_bytes)
+        //             .map_err(|e| anyhow!("Invalid base64 key: {:?}", e))?;
+        //         let tx_data: TransactionData = bcs::from_bytes(&tx_bytes)?;
+        //         println!("Transaction data: {:?}", tx_data);
+        //     }
 
-            KeyToolCommand::GenerateZkLoginAddress { address_seed } => {
-                let mut hasher = DefaultHash::default();
-                hasher.update([SignatureScheme::ZkLoginAuthenticator.flag()]);
-                let address_params = AddressParams::new(
-                    OAuthProvider::Google.get_config().0.to_owned(),
-                    SupportedKeyClaim::Sub.to_string(),
-                );
-                println!("Address params: {:?}", address_params);
-                hasher.update(bcs::to_bytes(&address_params).unwrap());
-                hasher.update(big_int_str_to_bytes(&address_seed));
-                let user_address = SuiAddress::from_bytes(hasher.finalize().digest)?;
-                println!("Sui Address: {:?}", user_address);
-            }
+        //     KeyToolCommand::ZkLogInPrepare { max_epoch } => {
+        //         // todo: unhardcode keypair and jwt_randomness and max_epoch.
+        //         let kp: Ed25519KeyPair = get_key_pair_from_rng(&mut StdRng::from_seed([0; 32])).1;
+        //         let skp = SuiKeyPair::Ed25519(kp.copy());
+        //         println!("Ephemeral pubkey: {:?}", skp.public().encode_base64());
+        //         println!("Ephemeral keypair: {:?}", skp.encode_base64());
 
-            KeyToolCommand::SerializeZkLoginAuthenticator {
-                proof_str,
-                public_inputs_str,
-                aux_inputs_str,
-                user_signature,
-            } => {
-                let authenticator = ZkLoginAuthenticator::new(
-                    ZkLoginProof::from_json(&proof_str)?,
-                    PublicInputs::from_json(&public_inputs_str)?,
-                    AuxInputs::from_json(&aux_inputs_str)?,
-                    Signature::from_str(&user_signature).map_err(|e| anyhow!(e))?,
-                );
-                let sig = GenericSignature::from(authenticator);
-                println!(
-                    "ZkLogin Authenticator Signature Serialized: {:?}",
-                    sig.encode_base64()
-                );
-            }
-        }
-        Ok(())
+        //         // Nonce is defined as the base64Url encoded of the poseidon hash of 4 inputs:
+        //         // first half of eph_pubkey bytes in BigInt, second half, max_epoch, randomness.
+        //         let bytes = kp.public().as_ref();
+        //         let (first_half, second_half) = bytes.split_at(bytes.len() / 2);
+        //         let first_bigint = BigInt::from_bytes_be(Sign::Plus, first_half);
+        //         let second_bigint = BigInt::from_bytes_be(Sign::Plus, second_half);
+
+        //         let mut poseidon = PoseidonWrapper::new();
+        //         let first = Bn254Fr::from_str(&first_bigint.to_string()).unwrap();
+        //         let second = Bn254Fr::from_str(&second_bigint.to_string()).unwrap();
+        //         let max_epoch = Bn254Fr::from_str(max_epoch.as_str()).unwrap();
+        //         let jwt_randomness = Bn254Fr::from_str(
+        //             "50683480294434968413708503290439057629605340925620961559740848568164438166",
+        //         )
+        //         .unwrap();
+        //         let hash = poseidon.hash(vec![first, second, max_epoch, jwt_randomness])?;
+        //         println!("Nonce: {:?}", hash.to_string());
+        //     }
+
+        //     KeyToolCommand::GenerateZkLoginAddress { address_seed } => {
+        //         let mut hasher = DefaultHash::default();
+        //         hasher.update([SignatureScheme::ZkLoginAuthenticator.flag()]);
+        //         let address_params = AddressParams::new(
+        //             OAuthProvider::Google.get_config().0.to_owned(),
+        //             SupportedKeyClaim::Sub.to_string(),
+        //         );
+        //         println!("Address params: {:?}", address_params);
+        //         hasher.update(bcs::to_bytes(&address_params).unwrap());
+        //         hasher.update(big_int_str_to_bytes(&address_seed));
+        //         let user_address = SuiAddress::from_bytes(hasher.finalize().digest)?;
+        //         println!("Sui Address: {:?}", user_address);
+        //     }
+
+        //     KeyToolCommand::SerializeZkLoginAuthenticator {
+        //         proof_str,
+        //         public_inputs_str,
+        //         aux_inputs_str,
+        //         user_signature,
+        //     } => {
+        //         let authenticator = ZkLoginAuthenticator::new(
+        //             ZkLoginProof::from_json(&proof_str)?,
+        //             PublicInputs::from_json(&public_inputs_str)?,
+        //             AuxInputs::from_json(&aux_inputs_str)?,
+        //             Signature::from_str(&user_signature).map_err(|e| anyhow!(e))?,
+        //         );
+        //         let sig = GenericSignature::from(authenticator);
+        //         println!(
+        //             "ZkLogin Authenticator Signature Serialized: {:?}",
+        //             sig.encode_base64()
+        //         );
+        //     }
+        // }
+        // Ok(())
+    
     }
 }
 
@@ -647,4 +664,67 @@ fn store_and_print_keypair(address: SuiAddress, keypair: SuiKeyPair) {
         "Address, keypair and key scheme written to {}",
         path.to_str().unwrap()
     );
+}
+
+
+impl Display for SuiKeytoolCommandResult {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut writer = String::new();
+        match self {
+            SuiKeytoolCommandResult::List(keys) => {
+                write!(writer, "{}", "mykeys")?;
+            },
+            _ => todo!()
+        }
+
+        write!(f, "{}", writer.trim_end_matches('\n'))
+
+    }
+
+}
+#[derive(Serialize)]
+pub struct KeystoreList {
+    sui_address: SuiAddress,
+    base64: String,
+    scheme: String
+}
+
+
+#[derive(Serialize)]
+#[serde(untagged)]
+pub enum SuiKeytoolCommandResult {
+    GenerateZkLoginAddress(SuiAddress),
+    List(Vec<KeystoreList>)
+}
+
+impl SuiKeytoolCommandResult {
+    pub fn print(&self, pretty: bool) {
+        let line = if pretty {
+            format!("{self}")
+        } else {
+            format!("{:?}", self)
+        };
+        // Log line by line
+        for line in line.lines() {
+            // Logs write to a file on the side.  Print to stdout and also log to file, for tests to pass.
+            println!("{line}");
+            info!("{line}")
+        }
+    }
+}
+
+impl Debug for SuiKeytoolCommandResult {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let s = unwrap_err_to_string(|| match self {
+            _ => Ok(serde_json::to_string_pretty(self)?),
+        });
+        write!(f, "{}", s)
+    }
+}
+
+fn unwrap_err_to_string<T: Display, F: FnOnce() -> Result<T, anyhow::Error>>(func: F) -> String {
+    match func() {
+        Ok(s) => format!("{s}"),
+        Err(err) => format!("{err}").to_string(),
+    }
 }

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -43,6 +43,9 @@ use sui_types::signature::GenericSignature;
 use sui_types::transaction::TransactionData;
 use sui_types::zk_login_authenticator::ZkLoginAuthenticator;
 use sui_types::zk_login_util::AddressParams;
+use tabled::builder::Builder;
+use tabled::settings::Rotate;
+use tabled::settings::{object::Rows, Modify, Width};
 use tracing::info;
 
 #[cfg(test)]
@@ -460,7 +463,7 @@ impl KeyToolCommand {
 
                     CommandOutput::Import(Key {
                         sui_address: sui_address.to_string(),
-                        public_base64_key: pk.public().encode_base64(),
+                        public_base64_key: pk.encode_base64(),
                         key_scheme: scheme,
                         mnemonic: None,
                         flag: pk.public().flag(),
@@ -919,13 +922,50 @@ pub enum CommandOutput {
 
 impl Display for CommandOutput {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
-        let json_obj = json![self];
-        let mut table = json_to_table(&json_obj);
-        let style = tabled::settings::Style::rounded().horizontals([]);
-        table.with(style);
-        table.array_orientation(Orientation::Column);
+        match self {
+            // Sign needs to be manually built because we need to wrap the very long rawTxData string and rawIntentMsg strings into some table length, which we cannot do with a JsonTable
+            CommandOutput::Sign(data) => {
+                // let mut table = Table::new(vec![data]);
+                // table.with(Rotate::Left);
+                // table.with(tabled::settings::Style::rounded().horizontals([]));
+                // table.with(Modify::new(Rows::new(0..)).with(Width::wrap(160).keep_words()));
+                let intent_table = json_to_table(&json!(&data.intent))
+                    .with(tabled::settings::Style::rounded().horizontals([]))
+                    .to_string();
 
-        write!(formatter, "{}", table)
+                let mut builder = Builder::default();
+                builder
+                    .set_header([
+                        "suiSignature",
+                        "digest",
+                        "rawIntentMsg",
+                        "intent",
+                        "rawTxData",
+                        "suiAddress",
+                    ])
+                    .push_record([
+                        &data.sui_signature,
+                        &data.digest,
+                        &data.raw_intent_msg,
+                        &intent_table,
+                        &data.raw_tx_data,
+                        &data.sui_address.to_string(),
+                    ]);
+                let mut table = builder.build();
+                table.with(Rotate::Left);
+                table.with(tabled::settings::Style::rounded().horizontals([]));
+                table.with(Modify::new(Rows::new(0..)).with(Width::wrap(160).keep_words()));
+                write!(formatter, "{}", table)
+            }
+            _ => {
+                let json_obj = json![self];
+                let mut table = json_to_table(&json_obj);
+                let style = tabled::settings::Style::rounded().horizontals([]);
+                table.with(style);
+                table.array_orientation(Orientation::Column);
+                write!(formatter, "{}", table)
+            }
+        }
     }
 }
 

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -251,7 +251,11 @@ impl SuiCommand {
                 .await
             }
             SuiCommand::GenesisCeremony(cmd) => run(cmd),
-            SuiCommand::KeyTool { keystore_path, json, cmd } => {
+            SuiCommand::KeyTool {
+                keystore_path,
+                json,
+                cmd,
+            } => {
                 let keystore_path =
                     keystore_path.unwrap_or(sui_config_dir()?.join(SUI_KEYSTORE_FILENAME));
                 let mut keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -87,6 +87,9 @@ pub enum SuiCommand {
     KeyTool {
         #[clap(long)]
         keystore_path: Option<PathBuf>,
+        /// Return command outputs in json format.
+        #[clap(long, global = true)]
+        json: bool,
         /// Subcommands.
         #[clap(subcommand)]
         cmd: KeyToolCommand,
@@ -248,11 +251,12 @@ impl SuiCommand {
                 .await
             }
             SuiCommand::GenesisCeremony(cmd) => run(cmd),
-            SuiCommand::KeyTool { keystore_path, cmd } => {
+            SuiCommand::KeyTool { keystore_path, json, cmd } => {
                 let keystore_path =
                     keystore_path.unwrap_or(sui_config_dir()?.join(SUI_KEYSTORE_FILENAME));
                 let mut keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
-                cmd.execute(&mut keystore).await
+                cmd.execute(&mut keystore).await?.print(!json);
+                Ok(())
             }
             SuiCommand::Console { config } => {
                 let config = config.unwrap_or(sui_config_dir()?.join(SUI_CLIENT_CONFIG));

--- a/crates/sui/src/unit_tests/keytool_tests.rs
+++ b/crates/sui/src/unit_tests/keytool_tests.rs
@@ -205,7 +205,7 @@ async fn test_mnemonics_ed25519() -> Result<(), anyhow::Error> {
     for t in TEST_CASES {
         let mut keystore = Keystore::from(InMemKeystore::new_insecure_for_tests(0));
         KeyToolCommand::Import {
-            mnemonic_phrase: t[0].to_string(),
+            input_string: t[0].to_string(),
             key_scheme: SignatureScheme::ED25519,
             derivation_path: None,
         }
@@ -229,7 +229,7 @@ async fn test_mnemonics_secp256k1() -> Result<(), anyhow::Error> {
     for t in TEST_CASES {
         let mut keystore = Keystore::from(InMemKeystore::new_insecure_for_tests(0));
         KeyToolCommand::Import {
-            mnemonic_phrase: t[0].to_string(),
+            input_string: t[0].to_string(),
             key_scheme: SignatureScheme::Secp256k1,
             derivation_path: None,
         }
@@ -267,7 +267,7 @@ async fn test_mnemonics_secp256r1() -> Result<(), anyhow::Error> {
     for t in TEST_CASES {
         let mut keystore = Keystore::from(InMemKeystore::new_insecure_for_tests(0));
         KeyToolCommand::Import {
-            mnemonic_phrase: t[0].to_string(),
+            input_string: t[0].to_string(),
             key_scheme: SignatureScheme::Secp256r1,
             derivation_path: None,
         }
@@ -288,7 +288,7 @@ async fn test_mnemonics_secp256r1() -> Result<(), anyhow::Error> {
 async fn test_invalid_derivation_path() -> Result<(), anyhow::Error> {
     let mut keystore = Keystore::from(InMemKeystore::new_insecure_for_tests(0));
     assert!(KeyToolCommand::Import {
-        mnemonic_phrase: TEST_MNEMONIC.to_string(),
+        input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::ED25519,
         derivation_path: Some("m/44'/1'/0'/0/0".parse().unwrap()),
     }
@@ -297,7 +297,7 @@ async fn test_invalid_derivation_path() -> Result<(), anyhow::Error> {
     .is_err());
 
     assert!(KeyToolCommand::Import {
-        mnemonic_phrase: TEST_MNEMONIC.to_string(),
+        input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::ED25519,
         derivation_path: Some("m/0'/784'/0'/0/0".parse().unwrap()),
     }
@@ -306,7 +306,7 @@ async fn test_invalid_derivation_path() -> Result<(), anyhow::Error> {
     .is_err());
 
     assert!(KeyToolCommand::Import {
-        mnemonic_phrase: TEST_MNEMONIC.to_string(),
+        input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::ED25519,
         derivation_path: Some("m/54'/784'/0'/0/0".parse().unwrap()),
     }
@@ -315,7 +315,7 @@ async fn test_invalid_derivation_path() -> Result<(), anyhow::Error> {
     .is_err());
 
     assert!(KeyToolCommand::Import {
-        mnemonic_phrase: TEST_MNEMONIC.to_string(),
+        input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::Secp256k1,
         derivation_path: Some("m/54'/784'/0'/0'/0'".parse().unwrap()),
     }
@@ -324,7 +324,7 @@ async fn test_invalid_derivation_path() -> Result<(), anyhow::Error> {
     .is_err());
 
     assert!(KeyToolCommand::Import {
-        mnemonic_phrase: TEST_MNEMONIC.to_string(),
+        input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::Secp256k1,
         derivation_path: Some("m/44'/784'/0'/0/0".parse().unwrap()),
     }
@@ -339,7 +339,7 @@ async fn test_invalid_derivation_path() -> Result<(), anyhow::Error> {
 async fn test_valid_derivation_path() -> Result<(), anyhow::Error> {
     let mut keystore = Keystore::from(InMemKeystore::new_insecure_for_tests(0));
     assert!(KeyToolCommand::Import {
-        mnemonic_phrase: TEST_MNEMONIC.to_string(),
+        input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::ED25519,
         derivation_path: Some("m/44'/784'/0'/0'/0'".parse().unwrap()),
     }
@@ -348,7 +348,7 @@ async fn test_valid_derivation_path() -> Result<(), anyhow::Error> {
     .is_ok());
 
     assert!(KeyToolCommand::Import {
-        mnemonic_phrase: TEST_MNEMONIC.to_string(),
+        input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::ED25519,
         derivation_path: Some("m/44'/784'/0'/0'/1'".parse().unwrap()),
     }
@@ -357,7 +357,7 @@ async fn test_valid_derivation_path() -> Result<(), anyhow::Error> {
     .is_ok());
 
     assert!(KeyToolCommand::Import {
-        mnemonic_phrase: TEST_MNEMONIC.to_string(),
+        input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::ED25519,
         derivation_path: Some("m/44'/784'/1'/0'/1'".parse().unwrap()),
     }
@@ -366,7 +366,7 @@ async fn test_valid_derivation_path() -> Result<(), anyhow::Error> {
     .is_ok());
 
     assert!(KeyToolCommand::Import {
-        mnemonic_phrase: TEST_MNEMONIC.to_string(),
+        input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::Secp256k1,
         derivation_path: Some("m/54'/784'/0'/0/1".parse().unwrap()),
     }
@@ -375,7 +375,7 @@ async fn test_valid_derivation_path() -> Result<(), anyhow::Error> {
     .is_ok());
 
     assert!(KeyToolCommand::Import {
-        mnemonic_phrase: TEST_MNEMONIC.to_string(),
+        input_string: TEST_MNEMONIC.to_string(),
         key_scheme: SignatureScheme::Secp256k1,
         derivation_path: Some("m/54'/784'/1'/0/1".parse().unwrap()),
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 overrides:
   node-notifier: 10.0.0
@@ -1298,10 +1302,10 @@ importers:
         version: 13.3.0(react-dom@18.2.0)(react@18.2.0)
       nextra:
         specifier: latest
-        version: 2.7.1(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
+        version: 2.6.2(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
       nextra-theme-docs:
         specifier: latest
-        version: 2.7.1(next@13.3.0)(nextra@2.7.1)(react-dom@18.2.0)(react@18.2.0)
+        version: 2.6.2(next@13.3.0)(nextra@2.6.2)(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -2990,10 +2994,6 @@ packages:
   /@blakeembrey/template@1.1.0:
     resolution: {integrity: sha512-iZf+UWfL+DogJVpd/xMQyP6X6McYd6ArdYoPMiv/zlOTzeXXfQbYxBNJJBF6tThvsjLMbA8tLjkCdm9RWMFCCw==}
     dev: true
-
-  /@braintree/sanitize-url@6.0.2:
-    resolution: {integrity: sha512-Tbsj02wXCbqGmzdnXNk0SOF19ChhRU70BsroIi4Pm6Ehp56in6vch94mfbdQ17DozxkL3BAVjbZ4Qc1a0HFRAg==}
-    dev: false
 
   /@changesets/apply-release-plan@6.1.3:
     resolution: {integrity: sha512-ECDNeoc3nfeAe1jqJb5aFQX7CqzQhD2klXRez2JDb/aVpGUbX673HgKrnrgJRuQR/9f2TtLoYIzrGB9qwD77mg==}
@@ -6663,18 +6663,6 @@ packages:
       '@testing-library/dom': 9.2.0
     dev: true
 
-  /@theguild/remark-mermaid@0.0.1(react@18.2.0):
-    resolution: {integrity: sha512-MbLi7CIn25r0MypN1yaTrvuQHBE/UXy/DKfVjaLlXx5ut4PasOwzGIJihzM4d9kqNADJKilHpQWcd66ivbvJEQ==}
-    peerDependencies:
-      react: ^18.2.0
-    dependencies:
-      mermaid: 10.2.1
-      react: 18.2.0
-      unist-util-visit: 4.1.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /@trysound/sax@0.2.0:
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
@@ -9379,6 +9367,7 @@ packages:
   /commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
+    dev: true
 
   /commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
@@ -9596,18 +9585,6 @@ packages:
   /core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
     dev: true
-
-  /cose-base@1.0.3:
-    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
-    dependencies:
-      layout-base: 1.0.2
-    dev: false
-
-  /cose-base@2.2.0:
-    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
-    dependencies:
-      layout-base: 2.0.1
-    dev: false
 
   /cosmiconfig-typescript-loader@4.3.0(@types/node@18.15.11)(cosmiconfig@8.1.3)(ts-node@10.9.1)(typescript@5.0.4):
     resolution: {integrity: sha512-NTxV1MFfZDLPiBMjxbHRwSh5LaLcPMwNdCutmnHJCKoVnlvldPWlllonKwrsRJ5pYZBIBGRWWU2tfvzxgeSW5Q==}
@@ -9840,32 +9817,6 @@ packages:
       stream-transform: 2.1.3
     dev: true
 
-  /cytoscape-cose-bilkent@4.1.0(cytoscape@3.25.0):
-    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
-    peerDependencies:
-      cytoscape: ^3.2.0
-    dependencies:
-      cose-base: 1.0.3
-      cytoscape: 3.25.0
-    dev: false
-
-  /cytoscape-fcose@2.2.0(cytoscape@3.25.0):
-    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
-    peerDependencies:
-      cytoscape: ^3.2.0
-    dependencies:
-      cose-base: 2.2.0
-      cytoscape: 3.25.0
-    dev: false
-
-  /cytoscape@3.25.0:
-    resolution: {integrity: sha512-7MW3Iz57mCUo6JQCho6CmPBCbTlJr7LzyEtIkutG255HLVd4XuBg2I9BkTZLI/e4HoaOB/BiAzXuQybQ95+r9Q==}
-    engines: {node: '>=0.10'}
-    dependencies:
-      heap: 0.2.7
-      lodash: 4.17.21
-    dev: false
-
   /d3-array@1.2.4:
     resolution: {integrity: sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==}
     dev: false
@@ -9883,90 +9834,9 @@ packages:
       internmap: 2.0.3
     dev: false
 
-  /d3-axis@3.0.0:
-    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
-    engines: {node: '>=12'}
-    dev: false
-
-  /d3-brush@3.0.0:
-    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
-    engines: {node: '>=12'}
-    dependencies:
-      d3-dispatch: 3.0.1
-      d3-drag: 3.0.0
-      d3-interpolate: 3.0.1
-      d3-selection: 3.0.0
-      d3-transition: 3.0.1(d3-selection@3.0.0)
-    dev: false
-
-  /d3-chord@3.0.1:
-    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
-    engines: {node: '>=12'}
-    dependencies:
-      d3-path: 3.1.0
-    dev: false
-
   /d3-color@3.1.0:
     resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
     engines: {node: '>=12'}
-    dev: false
-
-  /d3-contour@4.0.2:
-    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
-    engines: {node: '>=12'}
-    dependencies:
-      d3-array: 3.2.3
-    dev: false
-
-  /d3-delaunay@6.0.4:
-    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
-    engines: {node: '>=12'}
-    dependencies:
-      delaunator: 5.0.0
-    dev: false
-
-  /d3-dispatch@3.0.1:
-    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
-    engines: {node: '>=12'}
-    dev: false
-
-  /d3-drag@3.0.0:
-    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
-    engines: {node: '>=12'}
-    dependencies:
-      d3-dispatch: 3.0.1
-      d3-selection: 3.0.0
-    dev: false
-
-  /d3-dsv@3.0.1:
-    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
-    engines: {node: '>=12'}
-    hasBin: true
-    dependencies:
-      commander: 7.2.0
-      iconv-lite: 0.6.3
-      rw: 1.3.3
-    dev: false
-
-  /d3-ease@3.0.1:
-    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
-    engines: {node: '>=12'}
-    dev: false
-
-  /d3-fetch@3.0.1:
-    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
-    engines: {node: '>=12'}
-    dependencies:
-      d3-dsv: 3.0.1
-    dev: false
-
-  /d3-force@3.0.0:
-    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
-    engines: {node: '>=12'}
-    dependencies:
-      d3-dispatch: 3.0.1
-      d3-quadtree: 3.0.1
-      d3-timer: 3.0.1
     dev: false
 
   /d3-format@3.1.0:
@@ -9980,18 +9850,6 @@ packages:
       d3-array: 1.2.4
     dev: false
 
-  /d3-geo@3.1.0:
-    resolution: {integrity: sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==}
-    engines: {node: '>=12'}
-    dependencies:
-      d3-array: 3.2.3
-    dev: false
-
-  /d3-hierarchy@3.1.2:
-    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
-    engines: {node: '>=12'}
-    dev: false
-
   /d3-interpolate@3.0.1:
     resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
     engines: {node: '>=12'}
@@ -10001,34 +9859,6 @@ packages:
 
   /d3-path@1.0.9:
     resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
-    dev: false
-
-  /d3-path@3.1.0:
-    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
-    engines: {node: '>=12'}
-    dev: false
-
-  /d3-polygon@3.0.1:
-    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
-    engines: {node: '>=12'}
-    dev: false
-
-  /d3-quadtree@3.0.1:
-    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
-    engines: {node: '>=12'}
-    dev: false
-
-  /d3-random@3.0.1:
-    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
-    engines: {node: '>=12'}
-    dev: false
-
-  /d3-scale-chromatic@3.0.0:
-    resolution: {integrity: sha512-Lx9thtxAKrO2Pq6OO2Ua474opeziKr279P/TKZsMAhYyNDD3EnCffdbgeSYN5O7m2ByQsxtuP2CSDczNUIZ22g==}
-    engines: {node: '>=12'}
-    dependencies:
-      d3-color: 3.1.0
-      d3-interpolate: 3.0.1
     dev: false
 
   /d3-scale@4.0.2:
@@ -10042,22 +9872,10 @@ packages:
       d3-time-format: 4.1.0
     dev: false
 
-  /d3-selection@3.0.0:
-    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
-    engines: {node: '>=12'}
-    dev: false
-
   /d3-shape@1.3.7:
     resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
     dependencies:
       d3-path: 1.0.9
-    dev: false
-
-  /d3-shape@3.2.0:
-    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
-    engines: {node: '>=12'}
-    dependencies:
-      d3-path: 3.1.0
     dev: false
 
   /d3-time-format@4.1.0:
@@ -10078,79 +9896,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       d3-array: 3.2.3
-    dev: false
-
-  /d3-timer@3.0.1:
-    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
-    engines: {node: '>=12'}
-    dev: false
-
-  /d3-transition@3.0.1(d3-selection@3.0.0):
-    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      d3-selection: 2 - 3
-    dependencies:
-      d3-color: 3.1.0
-      d3-dispatch: 3.0.1
-      d3-ease: 3.0.1
-      d3-interpolate: 3.0.1
-      d3-selection: 3.0.0
-      d3-timer: 3.0.1
-    dev: false
-
-  /d3-zoom@3.0.0:
-    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
-    engines: {node: '>=12'}
-    dependencies:
-      d3-dispatch: 3.0.1
-      d3-drag: 3.0.0
-      d3-interpolate: 3.0.1
-      d3-selection: 3.0.0
-      d3-transition: 3.0.1(d3-selection@3.0.0)
-    dev: false
-
-  /d3@7.8.5:
-    resolution: {integrity: sha512-JgoahDG51ncUfJu6wX/1vWQEqOflgXyl4MaHqlcSruTez7yhaRKR9i8VjjcQGeS2en/jnFivXuaIMnseMMt0XA==}
-    engines: {node: '>=12'}
-    dependencies:
-      d3-array: 3.2.3
-      d3-axis: 3.0.0
-      d3-brush: 3.0.0
-      d3-chord: 3.0.1
-      d3-color: 3.1.0
-      d3-contour: 4.0.2
-      d3-delaunay: 6.0.4
-      d3-dispatch: 3.0.1
-      d3-drag: 3.0.0
-      d3-dsv: 3.0.1
-      d3-ease: 3.0.1
-      d3-fetch: 3.0.1
-      d3-force: 3.0.0
-      d3-format: 3.1.0
-      d3-geo: 3.1.0
-      d3-hierarchy: 3.1.2
-      d3-interpolate: 3.0.1
-      d3-path: 3.1.0
-      d3-polygon: 3.0.1
-      d3-quadtree: 3.0.1
-      d3-random: 3.0.1
-      d3-scale: 4.0.2
-      d3-scale-chromatic: 3.0.0
-      d3-selection: 3.0.0
-      d3-shape: 3.2.0
-      d3-time: 3.1.0
-      d3-time-format: 4.1.0
-      d3-timer: 3.0.1
-      d3-transition: 3.0.1(d3-selection@3.0.0)
-      d3-zoom: 3.0.0
-    dev: false
-
-  /dagre-d3-es@7.0.10:
-    resolution: {integrity: sha512-qTCQmEhcynucuaZgY5/+ti3X/rnszKZhEQH/ZdWdtP1tA/y3VoHJzcVrO9pjjJCNpigfscAtoUB5ONcd2wNn0A==}
-    dependencies:
-      d3: 7.8.5
-      lodash-es: 4.17.21
     dev: false
 
   /damerau-levenshtein@1.0.8:
@@ -10184,10 +9929,6 @@ packages:
     dependencies:
       time-zone: 1.0.0
     dev: true
-
-  /dayjs@1.11.8:
-    resolution: {integrity: sha512-LcgxzFoWMEPO7ggRv1Y2N31hUf2R0Vj7fuy/m+Bg1K8rr+KAs1AEy4y9jd5DXe8pbHgX+srkHNS7TH6Q6ZhYeQ==}
-    dev: false
 
   /debounce-fn@3.0.1:
     resolution: {integrity: sha512-aBoJh5AhpqlRoHZjHmOzZlRx+wz2xVwGL9rjs+Kj0EWUrL4/h4K7OD176thl2Tdoqui/AaA4xhHrNArGLAaI3Q==}
@@ -10383,12 +10124,6 @@ packages:
       slash: 3.0.0
     dev: true
 
-  /delaunator@5.0.0:
-    resolution: {integrity: sha512-AyLvtyJdbv/U1GkiS6gUUzclRoAY4Gs75qkMygJJhU75LW4DNuSF2RMzpxs9jw9Oz1BobHjTdkG3zdP55VxAqw==}
-    dependencies:
-      robust-predicates: 3.0.2
-    dev: false
-
   /delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
@@ -10523,10 +10258,6 @@ packages:
       domelementtype: 2.3.0
     dev: true
 
-  /dompurify@3.0.3:
-    resolution: {integrity: sha512-axQ9zieHLnAnHh0sfAamKYiqXMJAVwu+LM/alQ7WDagoWessyWvMSFyW65CqF3owufNu8HBcE4cM2Vflu7YWcQ==}
-    dev: false
-
   /domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
     dependencies:
@@ -10652,10 +10383,6 @@ packages:
   /electron-to-chromium@1.4.332:
     resolution: {integrity: sha512-c1Vbv5tuUlBFp0mb3mCIjw+REEsgthRgNE8BlbEDKmvzb8rxjcVki6OkQP83vLN34s0XCxpSkq7AZNep1a6xhw==}
     dev: true
-
-  /elkjs@0.8.2:
-    resolution: {integrity: sha512-L6uRgvZTH+4OF5NE/MBbzQx/WYpru1xCBE9respNj6qznEewGUIfhzmm7horWWxbNO2M0WckQypGctR8lH79xQ==}
-    dev: false
 
   /emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -12777,10 +12504,6 @@ packages:
     resolution: {integrity: sha512-tWCK4biJ6hcLqTviLXVR9DTRfYGQMXEIUj3gwJ2rZ5wO/at3XtkI4g8mCvFdUF9l1KMBNCfmNAdnahm1cgavQA==}
     dev: true
 
-  /heap@0.2.7:
-    resolution: {integrity: sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==}
-    dev: false
-
   /hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
     dependencies:
@@ -12952,6 +12675,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       safer-buffer: 2.1.2
+    dev: true
 
   /icss-utils@5.1.0(postcss@8.4.24):
     resolution: {integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==}
@@ -13992,10 +13716,6 @@ packages:
       json-buffer: 3.0.1
     dev: true
 
-  /khroma@2.0.0:
-    resolution: {integrity: sha512-2J8rDNlQWbtiNYThZRvmMv5yt44ZakX+Tz5ZIp/mN1pt4snn+m030Va5Z4v8xA0cQFDXBwO/8i42xL4QPsVk3g==}
-    dev: false
-
   /kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
@@ -14034,14 +13754,6 @@ packages:
     dependencies:
       package-json: 8.1.0
     dev: true
-
-  /layout-base@1.0.2:
-    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
-    dev: false
-
-  /layout-base@2.0.1:
-    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
-    dev: false
 
   /lazy-ass@1.6.0:
     resolution: {integrity: sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==}
@@ -14695,30 +14407,6 @@ packages:
   /merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
-
-  /mermaid@10.2.1:
-    resolution: {integrity: sha512-gziwXLuAidRxPJxcA0LqPhToirGZ2J2gD+UrDEtGNeKb98BtcQde28UUcCUCmNplkQOwE7oynrzKcMe9i29AMw==}
-    dependencies:
-      '@braintree/sanitize-url': 6.0.2
-      cytoscape: 3.25.0
-      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.25.0)
-      cytoscape-fcose: 2.2.0(cytoscape@3.25.0)
-      d3: 7.8.5
-      dagre-d3-es: 7.0.10
-      dayjs: 1.11.8
-      dompurify: 3.0.3
-      elkjs: 0.8.2
-      khroma: 2.0.0
-      lodash-es: 4.17.21
-      mdast-util-from-markdown: 1.3.1
-      non-layered-tidy-tree-layout: 2.0.2
-      stylis: 4.2.0
-      ts-dedent: 2.2.0
-      uuid: 9.0.0
-      web-worker: 1.2.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -15462,11 +15150,11 @@ packages:
       - babel-plugin-macros
     dev: false
 
-  /nextra-theme-docs@2.7.1(next@13.3.0)(nextra@2.7.1)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-C2DtoGH15q22t4r2JC89lvvajmnyiqsv3PaqHJpoHRlF2eR5giuLhZC5Oahb9AENRDcnUIUvqVi/8NlfiIM0yQ==}
+  /nextra-theme-docs@2.6.2(next@13.3.0)(nextra@2.6.2)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-yvoLSf6rzeD3f6GA/vQabgEkwX3db7DOy87XhtwmqVip2O2XsW3DoMDuU7rzlCtCUmrsC583vymhd3YS6KKehg==}
     peerDependencies:
       next: '>=9.5.3'
-      nextra: 2.7.1
+      nextra: 2.6.2
       react: '>=16.13.1'
       react-dom: '>=16.13.1'
     dependencies:
@@ -15481,15 +15169,15 @@ packages:
       next: 13.3.0(react-dom@18.2.0)(react@18.2.0)
       next-seo: 6.0.0(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
       next-themes: 0.2.1(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
-      nextra: 2.7.1(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
+      nextra: 2.6.2(next@13.3.0)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       scroll-into-view-if-needed: 3.0.10
       zod: 3.21.4
     dev: false
 
-  /nextra@2.7.1(next@13.3.0)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-qchTb7XSm357XAHf9MV9UlUSGolPEPE8iFnC/9KMwvhIoE4seyPYWMrnH84XraZCcGERvy9TrkFD30VE7Qv1MA==}
+  /nextra@2.6.2(next@13.3.0)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-1Rxb04AB9eIieJZq7LQTlcTUdXZcJ4g5rjPBnQ2EGUA8d7jCBhGyQoqDuZtblr8lDTRjIeMnJXCZo2HxIAtWhA==}
     engines: {node: '>=16'}
     peerDependencies:
       next: '>=9.5.3'
@@ -15499,7 +15187,6 @@ packages:
       '@mdx-js/mdx': 2.3.0
       '@mdx-js/react': 2.3.0(react@18.2.0)
       '@napi-rs/simple-git': 0.1.8
-      '@theguild/remark-mermaid': 0.0.1(react@18.2.0)
       clsx: 1.2.1
       github-slugger: 2.0.0
       graceful-fs: 4.2.11
@@ -15624,10 +15311,6 @@ packages:
   /node-releases@2.0.10:
     resolution: {integrity: sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==}
     dev: true
-
-  /non-layered-tidy-tree-layout@2.0.2:
-    resolution: {integrity: sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw==}
-    dev: false
 
   /normalize-package-data@2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
@@ -18064,10 +17747,6 @@ packages:
       glob: 10.0.0
     dev: true
 
-  /robust-predicates@3.0.2:
-    resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==}
-    dev: false
-
   /rollup@3.23.1:
     resolution: {integrity: sha512-ybRdFVHOoljGEFILHLd2g/qateqUdjE6YS41WXq4p3C/WwD3xtWxV4FYWETA1u9TeXQc5K8L8zHE5d/scOvrOQ==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
@@ -18084,10 +17763,6 @@ packages:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
       queue-microtask: 1.2.3
-
-  /rw@1.3.3:
-    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
-    dev: false
 
   /rxjs@6.6.7:
     resolution: {integrity: sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==}
@@ -18143,6 +17818,7 @@ packages:
 
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+    dev: true
 
   /sass-loader@13.2.2(sass@1.62.0)(webpack@5.79.0):
     resolution: {integrity: sha512-nrIdVAAte3B9icfBiGWvmMhT/D+eCDwnk+yA7VE/76dp/WkHX+i44Q/pfo71NYbwj0Ap+PGsn0ekOuU1WFJ2AA==}
@@ -19105,10 +18781,6 @@ packages:
       - supports-color
     dev: true
 
-  /stylis@4.2.0:
-    resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
-    dev: false
-
   /sucrase@3.29.0:
     resolution: {integrity: sha512-bZPAuGA5SdFHuzqIhTAqt9fvNEo9rESqXIG3oiKdF8K4UmkQxC4KlNL3lVyAErXp+mPvUqZ5l13qx6TrDIGf3A==}
     engines: {node: '>=8'}
@@ -19545,6 +19217,7 @@ packages:
   /ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
+    dev: true
 
   /ts-expect@1.3.0:
     resolution: {integrity: sha512-e4g0EJtAjk64xgnFPD6kTBUtpnMVzDrMb12N1YZV0VvSlhnVT3SGxiYTLdGy8Q5cYHOIC/FAHmZ10eGrAguicQ==}
@@ -20666,10 +20339,6 @@ packages:
     resolution: {integrity: sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==}
     engines: {node: '>= 8'}
     dev: true
-
-  /web-worker@1.2.0:
-    resolution: {integrity: sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA==}
-    dev: false
 
   /webextension-polyfill@0.10.0:
     resolution: {integrity: sha512-c5s35LgVa5tFaHhrZDnr3FpQpjj1BB+RXhLTYUxGqBVN460HkbM8TBtEqdXWbpTKfzwCcjAZVF7zXCYSKtcp9g==}


### PR DESCRIPTION
## Description 

As part of our efforts on moving to a more standardized output for the CLI, we have a first iteration of the `keytool` command to demonstrate some ideas and gather feedback. Each command will has a specific output type, which can be serialized as JSON to be used in other commands / as needed. By default, each command will be pretty printed into a table with the output data.

- [ ] decide how we handle progress messages (via eprintln! macro?) 
- [ ] get feedback on each command's output type
- [ ] fix fields names in commands' output types
- [ ] make sure the "cryptography" stuff still works properly. Need help here as I don't understand the intention of some of these commands.
- [ ] get examples for each command, particularly for those involving signing and multi key signing
- [ ] add better error support than clap's standard support
- [ ] add tests

## Screenshots of some commands

**`keytool generate ed25519`**

<img width="684" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/580c8731-5d77-4787-bc8e-6b62803980da">
<img width="636" alt="Screenshot 2023-06-20 at 4 09 51 PM" src="https://github.com/MystenLabs/sui/assets/135084671/a266137a-72ca-4d55-9147-8a9e716c8060">


**`keytool list`** 

<img width="672" alt="Screenshot 2023-06-20 at 4 05 33 PM" src="https://github.com/MystenLabs/sui/assets/135084671/7b281b54-168d-4b59-94b1-50d73e048ecd">

<img width="612" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/1ebd6e7c-bc47-4151-8b27-480b9e3b8abb">

**`keytool show [...].key`**

<img width="1088" alt="Screenshot 2023-06-20 at 4 11 48 PM" src="https://github.com/MystenLabs/sui/assets/135084671/37bf5b7f-18ad-4fa6-bae6-872617af72ed">

<img width="987" alt="image" src="https://github.com/MystenLabs/sui/assets/135084671/029ef840-5197-4120-942d-550ba572729c">




## Test Plan 

All previous tests still pass. Will need to add more tests. 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
