### PR TITLE
Always use test cluster for tests

### DIFF
--- a/crates/sui-e2e-tests/tests/protocol_version_tests.rs
+++ b/crates/sui-e2e-tests/tests/protocol_version_tests.rs
@@ -1,26 +1,22 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use mysten_metrics::RegistryService;
-use prometheus::Registry;
 use sui_protocol_config::{ProtocolConfig, ProtocolVersion, SupportedProtocolVersions};
-use test_utils::authority::start_node;
+use test_utils::network::TestClusterBuilder;
 
 #[tokio::test]
 #[should_panic]
 async fn test_validator_panics_on_unsupported_protocol_version() {
-    let dir = tempfile::TempDir::new().unwrap();
     let latest_version = ProtocolVersion::MAX;
-    let network_config = sui_swarm_config::network_config_builder::ConfigBuilder::new(&dir)
+    let _test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
         .with_protocol_version(ProtocolVersion::new(latest_version.as_u64() + 1))
         .with_supported_protocol_versions(SupportedProtocolVersions::new_for_testing(
             latest_version.as_u64(),
             latest_version.as_u64(),
         ))
-        .build();
-
-    let registry_service = RegistryService::new(Registry::new());
-    let _sui_node = start_node(&network_config.validator_configs[0], registry_service).await;
+        .build()
+        .await;
 }
 
 #[test]

--- a/crates/sui-e2e-tests/tests/zklogin_tests.rs
+++ b/crates/sui-e2e-tests/tests/zklogin_tests.rs
@@ -2,32 +2,23 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use sui_core::authority_client::AuthorityAPI;
+use sui_macros::sim_test;
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::utils::make_zklogin_tx;
-use test_utils::authority::{spawn_test_authorities, test_authority_configs_with_objects};
-
-use sui_core::{authority_aggregator::AuthorityAggregatorBuilder, authority_client::AuthorityAPI};
-use sui_macros::sim_test;
-use sui_types::object::generate_test_gas_objects;
+use test_utils::network::TestClusterBuilder;
 
 async fn do_zklogin_test() -> SuiResult {
-    let gas_objects = generate_test_gas_objects();
-
-    // Get the authority configs and spawn them. Note that it is important to not drop
-    // the handles (or the authorities will stop).
-    let (config, _) = test_authority_configs_with_objects(gas_objects);
-    let _handles = spawn_test_authorities(&config).await;
-
+    let test_cluster = TestClusterBuilder::new().build().await;
     let (_, tx, _) = make_zklogin_tx();
 
-    let (_agg, clients) = AuthorityAggregatorBuilder::from_network_config(&config)
-        .build()
-        .unwrap();
-
-    clients
+    test_cluster
+        .authority_aggregator()
+        .authority_clients
         .values()
         .next()
         .unwrap()
+        .authority_client()
         .handle_transaction(tx)
         .await
         .map(|_| ())


### PR DESCRIPTION
## Description 

This PR replaces many uses of `spawn_test_authorities` with TestCluster. There are still a few left but they require some more dedicated effort to remove, so will do in a separate PR.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
