### PR TITLE
move: source service clone packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10746,9 +10746,11 @@ dependencies = [
  "sui-move-build",
  "sui-sdk",
  "sui-source-validation",
+ "tempfile",
  "test-utils",
  "tokio",
  "toml 0.7.4",
+ "url",
  "workspace-hack",
 ]
 

--- a/crates/sui-source-validation-service/Cargo.toml
+++ b/crates/sui-source-validation-service/Cargo.toml
@@ -17,10 +17,12 @@ name = "sui-source-validation-service"
 actix-web = { version = "4", features = ["rustls"] }
 anyhow = { version = "1.0.64", features = ["backtrace"] }
 clap = { version = "3.2.17", features = ["derive"] }
+tempfile = "3.3.0"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 toml = { version = "0.7.4", features = ["preserve_order"] }
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.88"
+url = "2.3.1"
 
 sui-config = { path = "../../crates/sui-config" }
 sui-move = { path = "../../crates/sui-move", features = ["all"] }

--- a/crates/sui-source-validation-service/src/lib.rs
+++ b/crates/sui-source-validation-service/src/lib.rs
@@ -85,39 +85,38 @@ impl CloneCommand {
 	};
         let dest = dest.join(repo_name).into_os_string();
 
-        macro_rules! append {
-            ($args:ident, $arg:expr) => {
-                $args.push(OsString::from($arg));
+        macro_rules! ostr {
+            ($arg:expr) => {
+                OsString::from($arg)
             };
         }
 
         let mut args = vec![];
         // Args to clone empty repository
-        let mut cmd_args: Vec<OsString> = vec![];
-        append!(cmd_args, "clone");
-        append!(cmd_args, "-n");
-        append!(cmd_args, "--depth=1");
-        append!(cmd_args, "--filter=tree:0");
-        append!(cmd_args, &p.repository);
-        append!(cmd_args, dest.clone());
+        let cmd_args: Vec<OsString> = vec![
+            ostr!("clone"),
+            ostr!("-n"),
+            ostr!("--depth=1"),
+            ostr!("--filter=tree:0"),
+            ostr!(&p.repository),
+            dest.clone(),
+        ];
         args.push(cmd_args);
 
         // Args to sparse checkout the package set
-        let mut cmd_args: Vec<OsString> = vec![];
-        append!(cmd_args, "-C");
-        append!(cmd_args, dest.clone());
-        append!(cmd_args, "sparse-checkout");
-        append!(cmd_args, "set");
-        append!(cmd_args, "--no-cone");
-        let path_args: Vec<OsString> = p.paths.iter().map(|s| OsString::from(s)).collect();
+        let mut cmd_args: Vec<OsString> = vec![
+            ostr!("-C"),
+            dest.clone(),
+            ostr!("sparse-checkout"),
+            ostr!("set"),
+            ostr!("--no-cone"),
+        ];
+        let path_args: Vec<OsString> = p.paths.iter().map(OsString::from).collect();
         cmd_args.extend_from_slice(&path_args);
         args.push(cmd_args);
 
         // Args to checkout the default branch.
-        let mut cmd_args: Vec<OsString> = vec![];
-        append!(cmd_args, "-C");
-        append!(cmd_args, dest);
-        append!(cmd_args, "checkout");
+        let cmd_args: Vec<OsString> = vec![ostr!("-C"), dest, ostr!("checkout")];
         args.push(cmd_args);
 
         Ok(Self {

--- a/crates/sui-source-validation-service/src/lib.rs
+++ b/crates/sui-source-validation-service/src/lib.rs
@@ -4,10 +4,13 @@
 use std::{
     fs,
     path::{Path, PathBuf},
+    process::Command,
 };
 
 use actix_web::{dev::Server, web, App, HttpRequest, HttpServer, Responder};
+use anyhow::{anyhow, bail};
 use serde::Deserialize;
+use url::Url;
 
 use move_package::BuildConfig as MoveBuildConfig;
 use sui_move::build::resolve_lock_file_path;
@@ -20,10 +23,10 @@ pub struct Config {
     pub packages: Vec<Packages>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct Packages {
-    repository: String,
-    paths: Vec<String>,
+    pub repository: String,
+    pub paths: Vec<String>,
 }
 
 pub async fn verify_package(
@@ -61,16 +64,108 @@ pub fn parse_config(config_path: impl AsRef<Path>) -> anyhow::Result<Config> {
     Ok(toml::from_str(&contents)?)
 }
 
-pub async fn clone_repositories(config: &Config) -> anyhow::Result<()> {
+#[derive(Debug)]
+/// Represents a sequence of git commands to clone a repository and sparsely checkout Move packages within.
+pub struct CloneCommand {
+    /// git args
+    args: Vec<Vec<String>>,
+    /// report repository url in error messages
+    repo_url: String,
+}
+
+impl CloneCommand {
+    pub fn new(p: &Packages, dest: &Path) -> anyhow::Result<CloneCommand> {
+        let repo_url = Url::parse(&p.repository)?;
+        let Some(components) = repo_url.path_segments().map(|c| c.collect::<Vec<_>>()) else {
+	    bail!("Could not discover repository path in url {}", &p.repository)
+	};
+        let Some(repo_name) = components.last() else {
+	    bail!("Could not discover repository name in url {}", &p.repository)
+	};
+        let dest = dest
+            .join(repo_name)
+            .into_os_string()
+            .into_string()
+            .map_err(|_| {
+                anyhow!(
+                    "Could not create path to clone repsository {}",
+                    &p.repository
+                )
+            })?;
+
+        let mut args = vec![];
+        // Args to clone empty repository
+        args.push(
+            [
+                "clone",
+                "-n",
+                "--depth=1",
+                "--filter=tree:0",
+                &p.repository,
+                &dest,
+            ]
+            .iter()
+            .map(|&s| s.into())
+            .collect(),
+        );
+
+        // Args to sparse checkout the package set
+        let mut prefix: Vec<String> = ["-C", &dest, "sparse-checkout", "set", "--no-cone"]
+            .iter()
+            .map(|&s| s.into())
+            .collect();
+        prefix.extend_from_slice(&p.paths);
+        args.push(prefix);
+
+        // Args to checkout the default branch.
+        args.push(
+            ["-C", &dest, "checkout"]
+                .iter()
+                .map(|&s| s.into())
+                .collect(),
+        );
+
+        Ok(Self {
+            args,
+            repo_url: p.repository.clone(),
+        })
+    }
+
+    pub async fn run(&self) -> anyhow::Result<()> {
+        for args in &self.args {
+            Command::new("git").args(args).output().map_err(|_| {
+                anyhow!(
+                    "Error cloning package(s) for {} with command git {:#?}",
+                    self.repo_url,
+                    args
+                )
+            })?;
+        }
+        Ok(())
+    }
+}
+
+/// Clones repositories and checks out packages as per `config` at the directory `dir`.
+pub async fn clone_repositories(config: &Config, dir: &Path) -> anyhow::Result<()> {
+    let mut tasks = vec![];
     for p in &config.packages {
-        let _ = p.repository;
-        let _ = p.paths;
+        let command = CloneCommand::new(p, dir)?;
+        let t = tokio::spawn(async move { command.run().await });
+        tasks.push(t);
+    }
+
+    for t in tasks {
+        t.await.unwrap()?;
     }
     Ok(())
 }
 
-pub async fn initialize(context: &WalletContext, config: &Config) -> anyhow::Result<()> {
-    clone_repositories(config).await?;
+pub async fn initialize(
+    context: &WalletContext,
+    config: &Config,
+    dir: &Path,
+) -> anyhow::Result<()> {
+    clone_repositories(config, dir).await?;
     verify_packages(context, vec![]).await?;
     Ok(())
 }

--- a/crates/sui-source-validation-service/src/lib.rs
+++ b/crates/sui-source-validation-service/src/lib.rs
@@ -133,13 +133,22 @@ impl CloneCommand {
 
     pub async fn run(&self) -> anyhow::Result<()> {
         for args in &self.args {
-            Command::new("git").args(args).output().map_err(|_| {
+            let result = Command::new("git").args(args).output().map_err(|_| {
                 anyhow!(
-                    "Error cloning package(s) for {} with command git {:#?}",
+                    "Error cloning {} with command `git {:#?}`",
                     self.repo_url,
                     args
                 )
             })?;
+            if !result.status.success() {
+                bail!(
+                    "Nonzero exit status when cloning {} with command `git {:#?}`.\
+		     Stderr: {:?}",
+                    self.repo_url,
+                    args,
+                    result.stderr
+                )
+            }
         }
         Ok(())
     }

--- a/crates/sui-source-validation-service/src/main.rs
+++ b/crates/sui-source-validation-service/src/main.rs
@@ -21,6 +21,7 @@ pub async fn main() -> anyhow::Result<()> {
     let package_config = parse_config(args.config_path)?;
     let sui_config = sui_config_dir()?.join(SUI_CLIENT_CONFIG);
     let context = WalletContext::new(&sui_config, None, None).await?;
-    initialize(&context, &package_config).await?;
+    let tmp_dir = tempfile::tempdir()?;
+    initialize(&context, &package_config, tmp_dir.path()).await?;
     serve()?.await.map_err(anyhow::Error::from)
 }

--- a/crates/sui-source-validation-service/tests/tests.rs
+++ b/crates/sui-source-validation-service/tests/tests.rs
@@ -1,11 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::path::PathBuf;
+
 use expect_test::expect;
 use reqwest::Client;
 use serde::Deserialize;
 
-use sui_source_validation_service::{initialize, serve, Config};
+use sui_source_validation_service::{initialize, serve, CloneCommand, Config, Packages};
 
 use test_utils::network::TestClusterBuilder;
 
@@ -19,8 +21,9 @@ async fn test_api_route() -> anyhow::Result<()> {
     let mut cluster = TestClusterBuilder::new().build().await;
     let context = &mut cluster.wallet;
     let config = Config { packages: vec![] };
+    let tmp_dir = tempfile::tempdir()?;
 
-    initialize(context, &config).await?;
+    initialize(context, &config, tmp_dir.path()).await?;
     tokio::spawn(serve().expect("Cannot start service."));
 
     let client = Client::new();
@@ -67,5 +70,46 @@ fn test_parse_package_config() -> anyhow::Result<()> {
 }"#
     ];
     expect.assert_eq(&format!("{:#?}", config));
+    Ok(())
+}
+
+#[test]
+fn test_clone_command() -> anyhow::Result<()> {
+    let packages = Packages {
+        repository: "https://github.com/user/repo".into(),
+        paths: vec!["a".into(), "b".into()],
+    };
+
+    let command = CloneCommand::new(&packages, PathBuf::from("/tmp").as_path())?;
+    let expect = expect![
+        r#"CloneCommand {
+    args: [
+        [
+            "clone",
+            "-n",
+            "--depth=1",
+            "--filter=tree:0",
+            "https://github.com/user/repo",
+            "/tmp/repo",
+        ],
+        [
+            "-C",
+            "/tmp/repo",
+            "sparse-checkout",
+            "set",
+            "--no-cone",
+            "a",
+            "b",
+        ],
+        [
+            "-C",
+            "/tmp/repo",
+            "checkout",
+        ],
+    ],
+    repo_url: "https://github.com/user/repo",
+}"#
+    ];
+    expect.assert_eq(&format!("{:#?}", command));
     Ok(())
 }


### PR DESCRIPTION
## Description 

Stacked on https://github.com/MystenLabs/sui/pull/12552

On start, the server clones repositories and does sparse-checkout for package paths as specified in config. Tasks are spawned separately for each repository.

Example: The sequence of `git` commands for the `mystenlabs/sui` repo and its packages look as follows:

```
git clone -n --depth=1 --filter=tree:0 https://github.com/mystenlabs/sui $TMPDIR
git sparse-checkout -C $TMPDIR set --no-cone crates/sui-framework/packages/deepbook crates/sui-framework/packages/move-stdlib crates/sui-framework/packages/sui-framework crates/sui-framework/packages/sui-system
git -C $TMPDIR checkout
```

I ended up using `std::process::Command` after investigating:

- `libgit2` -- appears to have [no sparse-checkout support](https://github.com/libgit2/libgit2/issues/2263)
- [`gitoxide`/`gix`](https://github.com/Byron/gitoxide) -- couldn't figure out how to perform the equivalent of the above `git` commands after digging for a while. Also hesitate on how much this would bloat our dependencies for something ~relatively simple

## Test Plan 

Test checks we produce `git` clone and checkout commands faithfully

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
