### PR TITLE
explorer: gas reference price graph hide epochs select

### DIFF
--- a/apps/explorer/src/components/GasPriceCard/index.tsx
+++ b/apps/explorer/src/components/GasPriceCard/index.tsx
@@ -105,11 +105,13 @@ export function GasPriceCard({ useLargeSpacing }: { useLargeSpacing: boolean }) 
 						<Heading variant="heading4/semibold" color="steel-darker">
 							Reference Gas Price
 						</Heading>
-						<ListboxSelect
-							value={selectedGraphDuration}
-							options={GRAPH_DURATIONS}
-							onSelect={setSelectedGraphsDuration}
-						/>
+						{GRAPH_DURATIONS.length > 1 ? (
+							<ListboxSelect
+								value={selectedGraphDuration}
+								options={GRAPH_DURATIONS}
+								onSelect={setSelectedGraphsDuration}
+							/>
+						) : null}
 					</div>
 					<FilterList<UnitsType>
 						lessSpacing

--- a/apps/explorer/src/components/GasPriceCard/utils.ts
+++ b/apps/explorer/src/components/GasPriceCard/utils.ts
@@ -7,9 +7,8 @@ import { SUI_DECIMALS } from '@mysten/sui.js';
 import { type EpochGasInfo, type GraphDurationsType } from './types';
 
 export const UNITS = ['MIST', 'SUI'] as const;
-export const GRAPH_DURATIONS = ['7 Epochs', '30 Epochs'] as const;
+export const GRAPH_DURATIONS = ['30 Epochs'] as const;
 export const GRAPH_DURATIONS_MAP: Record<GraphDurationsType, number> = {
-	'7 Epochs': 7,
 	'30 Epochs': 30,
 };
 


### PR DESCRIPTION
## Description 

show only 30 epochs and remove the select box

| before | after |
| - | - |
| <img width="461" alt="Screenshot 2023-06-21 at 11 48 45" src="https://github.com/MystenLabs/sui/assets/10210143/4a0fb410-cdfa-4f23-b7a5-7c3e7a85f44e"> | <img width="461" alt="Screenshot 2023-06-21 at 11 48 57" src="https://github.com/MystenLabs/sui/assets/10210143/988c5ec8-5547-4bda-881b-71c0f7a16f77"> |

## Test Plan 

Manual testing 

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
