### PR TITLE
wallet-ext: preselect already connected qredo accounts

### DIFF
--- a/apps/wallet/src/background/connections/UiConnection.ts
+++ b/apps/wallet/src/background/connections/UiConnection.ts
@@ -148,7 +148,7 @@ export class UiConnection extends Connection {
 							method: 'getQredoInfoResponse',
 							args: {
 								qredoInfo: await getUIQredoInfo(
-									payload.args.qredoID,
+									payload.args.filter,
 									payload.args.refreshAccessToken,
 								),
 							},

--- a/apps/wallet/src/shared/messaging/messages/payloads/QredoConnect.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/QredoConnect.ts
@@ -3,7 +3,11 @@
 
 import { type BasePayload, isBasePayload } from './BasePayload';
 import { type Payload } from './Payload';
-import { type UIQredoInfo, type UIQredoPendingRequest } from '_src/background/qredo/types';
+import {
+	type QredoConnectIdentity,
+	type UIQredoInfo,
+	type UIQredoPendingRequest,
+} from '_src/background/qredo/types';
 import { type QredoConnectInput } from '_src/dapp-interface/WalletStandardInterface';
 import { type Wallet } from '_src/shared/qredo-api';
 
@@ -12,7 +16,10 @@ type Methods = {
 	connectResponse: { allowed: boolean };
 	getPendingRequest: { requestID: string };
 	getPendingRequestResponse: { request: UIQredoPendingRequest | null };
-	getQredoInfo: { qredoID: string; refreshAccessToken: boolean };
+	getQredoInfo: {
+		filter: { qredoID: string } | { identity: QredoConnectIdentity };
+		refreshAccessToken: boolean;
+	};
 	getQredoInfoResponse: { qredoInfo: UIQredoInfo | null };
 	acceptQredoConnection: {
 		qredoID: string;

--- a/apps/wallet/src/ui/app/background-client/index.ts
+++ b/apps/wallet/src/ui/app/background-client/index.ts
@@ -25,6 +25,7 @@ import { setActiveOrigin, changeActiveNetwork } from '_redux/slices/app';
 import { setPermissions } from '_redux/slices/permissions';
 import { setTransactionRequests } from '_redux/slices/transaction-requests';
 import { type SerializedLedgerAccount } from '_src/background/keyring/LedgerAccount';
+import { type QredoConnectIdentity } from '_src/background/qredo/types';
 import {
 	isQredoConnectPayload,
 	type QredoConnectPayload,
@@ -361,13 +362,16 @@ export class BackgroundClient {
 		);
 	}
 
-	public getQredoConnectionInfo(qredoID: string, refreshAccessToken = false) {
+	public getQredoConnectionInfo(
+		filter: { qredoID: string } | { identity: QredoConnectIdentity },
+		refreshAccessToken = false,
+	) {
 		return lastValueFrom(
 			this.sendMessage(
 				createMessage<QredoConnectPayload<'getQredoInfo'>>({
 					type: 'qredo-connect',
 					method: 'getQredoInfo',
-					args: { qredoID, refreshAccessToken },
+					args: { filter, refreshAccessToken },
 				}),
 			).pipe(
 				take(1),

--- a/apps/wallet/src/ui/app/hooks/useQredoAPI.ts
+++ b/apps/wallet/src/ui/app/hooks/useQredoAPI.ts
@@ -11,7 +11,7 @@ const API_INSTANCES: Record<string, QredoAPI> = {};
 
 export function useQredoAPI(qredoID?: string) {
 	const backgroundClient = useBackgroundClient();
-	const { data, isLoading, error } = useQredoInfo(qredoID);
+	const { data, isLoading, error } = useQredoInfo(qredoID ? { qredoID } : null);
 	const [api, setAPI] = useState(() => (qredoID && API_INSTANCES[qredoID]) || null);
 	useEffect(() => {
 		if (data?.qredoInfo?.apiUrl && data?.qredoInfo?.accessToken && qredoID) {
@@ -21,8 +21,8 @@ export function useQredoAPI(qredoID?: string) {
 			} else if (!instance) {
 				API_INSTANCES[qredoID] = new QredoAPI(qredoID, data.qredoInfo.apiUrl, {
 					accessTokenRenewalFN: async (qredoID) =>
-						(await backgroundClient.getQredoConnectionInfo(qredoID, true)).qredoInfo?.accessToken ||
-						null,
+						(await backgroundClient.getQredoConnectionInfo({ qredoID }, true)).qredoInfo
+							?.accessToken || null,
 					accessToken: data.qredoInfo.accessToken,
 				});
 			}

--- a/apps/wallet/src/ui/app/hooks/useQredoInfo.ts
+++ b/apps/wallet/src/ui/app/hooks/useQredoInfo.ts
@@ -4,13 +4,16 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { useBackgroundClient } from './useBackgroundClient';
+import { type QredoConnectIdentity } from '_src/background/qredo/types';
 
-export function useQredoInfo(qredoID?: string) {
+export function useQredoInfo(
+	filter: { qredoID: string } | { identity: QredoConnectIdentity } | null,
+) {
 	const backgroundClient = useBackgroundClient();
 	return useQuery({
-		queryKey: ['qredo', 'info', qredoID],
-		queryFn: async () => backgroundClient.getQredoConnectionInfo(qredoID!),
-		enabled: !!qredoID,
+		queryKey: ['qredo', 'info', filter],
+		queryFn: async () => backgroundClient.getQredoConnectionInfo(filter!),
+		enabled: !!filter,
 		staleTime: 0,
 		refetchInterval: 1000,
 		meta: { skipPersistedCache: true },

--- a/apps/wallet/src/ui/app/pages/qredo-connect/SelectQredoAccountsPage.tsx
+++ b/apps/wallet/src/ui/app/pages/qredo-connect/SelectQredoAccountsPage.tsx
@@ -7,6 +7,7 @@ import { toast } from 'react-hot-toast';
 import { useParams, useLocation, Navigate, useNavigate } from 'react-router-dom';
 
 import { useBackgroundClient } from '../../hooks/useBackgroundClient';
+import { useQredoInfo } from '../../hooks/useQredoInfo';
 import { Button } from '../../shared/ButtonUI';
 import { SelectQredoAccountsSummaryCard } from './components/SelectQredoAccountsSummaryCard';
 import { useQredoUIPendingRequest } from './hooks';
@@ -25,8 +26,25 @@ export function SelectQredoAccountsPage() {
 	// do not call the api if user has not clicked continue in Qredo Connect Info page
 	const fetchAccountsEnabled =
 		!isQredoRequestLoading && (!qredoPendingRequest || qredoRequestReviewed);
-
+	const { data: qredoInfoData } = useQredoInfo(
+		qredoPendingRequest
+			? {
+					identity: {
+						apiUrl: qredoPendingRequest.apiUrl,
+						organization: qredoPendingRequest.organization,
+						origin: qredoPendingRequest.origin,
+						service: qredoPendingRequest.service,
+					},
+			  }
+			: null,
+	);
 	const [selectedAccounts, setSelectedAccounts] = useState<Wallet[]>([]);
+	useEffect(() => {
+		const accounts = qredoInfoData?.qredoInfo?.accounts;
+		if (accounts?.length) {
+			setSelectedAccounts((value) => Array.from(new Set([...value, ...accounts])));
+		}
+	}, [qredoInfoData?.qredoInfo?.accounts]);
 	const [showPassword, setShowPassword] = useState(false);
 	const shouldCloseWindow = (!isQredoRequestLoading && !qredoPendingRequest) || !id;
 	useEffect(() => {


### PR DESCRIPTION
## Description 

* when injecting a new qredo connection show any existing connected accounts as selected

https://github.com/MystenLabs/sui/assets/10210143/ad12cb42-f7a8-4419-aee4-2aa3ae3b30a7

## Test Plan 

Manual testing
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
