### PR TITLE
Cherry pick unwrapped then deleted simplification to release branch

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_never_stored.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_never_stored.exp
@@ -16,4 +16,5 @@ gas summary: computation_cost: 1000000, storage_cost: 2439600,  storage_rebate: 
 task 3 'run'. lines 43-43:
 mutated: object(0,0)
 deleted: object(2,0)
+unwrapped_then_deleted: object(_)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 2415204, non_refundable_storage_fee: 24396

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/unwrap_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/unwrap_object.exp
@@ -33,6 +33,7 @@ gas summary: computation_cost: 1000000, storage_cost: 4157200,  storage_rebate: 
 task 6 'run'. lines 52-52:
 mutated: object(0,0), object(5,0)
 deleted: object(5,1)
+unwrapped_then_deleted: object(_)
 gas summary: computation_cost: 1000000, storage_cost: 2211600,  storage_rebate: 4115628, non_refundable_storage_fee: 41572
 
 task 7 'run'. lines 55-55:

--- a/crates/sui-adapter-transactional-tests/tests/sui/unwrap_then_delete.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/unwrap_then_delete.exp
@@ -1,0 +1,36 @@
+processed 7 tasks
+
+init:
+A: object(0,0)
+
+task 1 'publish'. lines 14-65:
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 7516400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2 'run'. lines 67-67:
+created: object(2,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 2386400,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3 'run'. lines 69-69:
+created: object(3,0)
+mutated: object(0,1)
+wrapped: object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2637200,  storage_rebate: 2362536, non_refundable_storage_fee: 23864
+
+task 4 'run'. lines 71-71:
+mutated: object(0,1)
+deleted: object(3,0)
+unwrapped_then_deleted: object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 2610828, non_refundable_storage_fee: 26372
+
+task 5 'run'. lines 73-73:
+created: object(5,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 2637200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6 'run'. lines 75-75:
+mutated: object(0,1)
+deleted: object(5,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 2610828, non_refundable_storage_fee: 26372

--- a/crates/sui-adapter-transactional-tests/tests/sui/unwrap_then_delete.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/unwrap_then_delete.exp
@@ -33,4 +33,5 @@ gas summary: computation_cost: 1000000, storage_cost: 2637200,  storage_rebate: 
 task 6 'run'. lines 75-75:
 mutated: object(0,1)
 deleted: object(5,0)
+unwrapped_then_deleted: object(_)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 2610828, non_refundable_storage_fee: 26372

--- a/crates/sui-adapter-transactional-tests/tests/sui/unwrap_then_delete.move
+++ b/crates/sui-adapter-transactional-tests/tests/sui/unwrap_then_delete.move
@@ -1,0 +1,75 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Exercise test functions that wrap an object and subsequently unwrap and delete it.
+// There are two cases:
+// 1. In the first case, we first create the object, wrap it in a separate transaction (so that there will be a wrapped
+//    tombstone), and then unwrap and delete it in a third transaction. In this case we expect the object to show up
+//    in the unwrapped_then_deleted in the effects.
+// 2. In the second case, we create and wrap the object in a single transaction, and then unwrap and delete it in a
+//    second transaction. In this case we expect the object to not show up in the unwrapped_then_deleted in the effects.
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+
+module test::object_basics {
+    use sui::object::{Self, UID};
+    use sui::tx_context::{Self, TxContext};
+    use sui::transfer;
+
+    struct Object has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    struct Wrapper has key {
+        id: UID,
+        o: Object
+    }
+
+    public entry fun create(value: u64, ctx: &mut TxContext) {
+        transfer::transfer(
+            Object { id: object::new(ctx), value },
+            tx_context::sender(ctx)
+        )
+    }
+
+    public entry fun wrap(o: Object, ctx: &mut TxContext) {
+        transfer::transfer(
+            Wrapper { id: object::new(ctx), o },
+            tx_context::sender(ctx)
+        )
+    }
+
+    public entry fun create_and_wrap(value: u64, ctx: &mut TxContext) {
+        let o = Object { id: object::new(ctx), value };
+        transfer::transfer(
+            Wrapper { id: object::new(ctx), o },
+            tx_context::sender(ctx)
+        )
+    }
+
+    public entry fun unwrap(w: Wrapper, ctx: &mut TxContext) {
+        let Wrapper { id, o } = w;
+        object::delete(id);
+        transfer::transfer(o, tx_context::sender(ctx))
+    }
+
+    public entry fun unwrap_and_delete(w: Wrapper) {
+        let Wrapper { id, o } = w;
+        object::delete(id);
+        let Object { id, value: _ } = o;
+        object::delete(id);
+    }
+}
+
+//# run test::object_basics::create --args 10
+
+//# run test::object_basics::wrap --args object(2,0)
+
+//# run test::object_basics::unwrap_and_delete --args object(3,0)
+
+//# run test::object_basics::create_and_wrap --args 10
+
+//# run test::object_basics::unwrap_and_delete --args object(5,0)

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -288,6 +288,17 @@ impl AuthorityStore {
         Ok(acc.1.digest().into())
     }
 
+    pub fn get_root_state_accumulator(
+        &self,
+        epoch: EpochId,
+    ) -> (CheckpointSequenceNumber, Accumulator) {
+        self.perpetual_tables
+            .root_state_hash_by_epoch
+            .get(&epoch)
+            .unwrap()
+            .unwrap()
+    }
+
     pub fn get_recovery_epoch_at_restart(&self) -> SuiResult<EpochId> {
         self.perpetual_tables.get_recovery_epoch_at_restart()
     }
@@ -1596,8 +1607,12 @@ impl AuthorityStore {
         get_sui_system_state(self.perpetual_tables.as_ref())
     }
 
-    pub fn iter_live_object_set(&self) -> impl Iterator<Item = LiveObject> + '_ {
-        self.perpetual_tables.iter_live_object_set()
+    pub fn iter_live_object_set(
+        &self,
+        include_wrapped_object: bool,
+    ) -> impl Iterator<Item = LiveObject> + '_ {
+        self.perpetual_tables
+            .iter_live_object_set(include_wrapped_object)
     }
 
     pub fn expensive_check_sui_conservation(
@@ -1630,7 +1645,7 @@ impl AuthorityStore {
         let package_cache = PackageObjectCache::new(self.clone());
         let (mut total_sui, mut total_storage_rebate) = thread::scope(|s| {
             let pending_tasks = FuturesUnordered::new();
-            for o in self.iter_live_object_set() {
+            for o in self.iter_live_object_set(false) {
                 match o {
                     LiveObject::Normal(object) => {
                         pending_objects.push(object);
@@ -1659,7 +1674,9 @@ impl AuthorityStore {
                             }));
                         }
                     }
-                    LiveObject::Wrapped(_) => (),
+                    LiveObject::Wrapped(_) => {
+                        unreachable!("Explicitly asked to not include wrapped tombstones")
+                    }
                 }
             }
             pending_tasks.into_iter().fold((0, 0), |init, result| {
@@ -1758,13 +1775,17 @@ impl AuthorityStore {
         &self,
         checkpoint_executor: &CheckpointExecutor,
         accumulator: Arc<StateAccumulator>,
-        epoch: EpochId,
+        cur_epoch_store: &AuthorityPerEpochStore,
         panic: bool,
     ) {
-        let live_object_set_hash = accumulator.digest_live_object_set();
+        let live_object_set_hash = accumulator.digest_live_object_set(
+            !cur_epoch_store
+                .protocol_config()
+                .simplified_unwrap_then_delete(),
+        );
 
         let root_state_hash = self
-            .get_root_state_hash(epoch)
+            .get_root_state_hash(cur_epoch_store.epoch())
             .expect("Retrieving root state hash cannot fail");
 
         let is_inconsistent = root_state_hash != live_object_set_hash;
@@ -1787,6 +1808,18 @@ impl AuthorityStore {
         if !panic {
             checkpoint_executor.set_inconsistent_state(is_inconsistent);
         }
+    }
+
+    #[cfg(msim)]
+    pub fn remove_all_versions_of_object(&self, object_id: ObjectID) {
+        let entries: Vec<_> = self
+            .perpetual_tables
+            .objects
+            .unbounded_iter()
+            .filter_map(|(key, _)| if key.0 == object_id { Some(key) } else { None })
+            .collect();
+        info!("Removing all versions of object: {:?}", entries);
+        self.perpetual_tables.objects.multi_remove(entries).unwrap();
     }
 }
 

--- a/crates/sui-core/src/authority/authority_test_utils.rs
+++ b/crates/sui-core/src/authority/authority_test_utils.rs
@@ -88,9 +88,13 @@ pub async fn send_and_confirm_transaction_with_execution_error(
     // We also check the incremental effects of the transaction on the live object set against StateAccumulator
     // for testing and regression detection
     let state_acc = StateAccumulator::new(authority.database.clone());
-    let mut state = state_acc.accumulate_live_object_set();
+    let include_wrapped_tombstone = !authority
+        .epoch_store_for_testing()
+        .protocol_config()
+        .simplified_unwrap_then_delete();
+    let mut state = state_acc.accumulate_live_object_set(include_wrapped_tombstone);
     let (result, execution_error_opt) = authority.try_execute_for_test(&certificate).await?;
-    let state_after = state_acc.accumulate_live_object_set();
+    let state_after = state_acc.accumulate_live_object_set(include_wrapped_tombstone);
     let effects_acc = state_acc.accumulate_effects(
         vec![result.inner().data().clone()],
         epoch_store.protocol_config(),

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -77,9 +77,13 @@ pub async fn send_and_confirm_transaction(
     // We also check the incremental effects of the transaction on the live object set against StateAccumulator
     // for testing and regression detection
     let state_acc = StateAccumulator::new(authority.database.clone());
-    let mut state = state_acc.accumulate_live_object_set();
+    let include_wrapped_tombstone = !authority
+        .epoch_store_for_testing()
+        .protocol_config()
+        .simplified_unwrap_then_delete();
+    let mut state = state_acc.accumulate_live_object_set(include_wrapped_tombstone);
     let (result, _execution_error_opt) = authority.try_execute_for_test(&certificate).await?;
-    let state_after = state_acc.accumulate_live_object_set();
+    let state_after = state_acc.accumulate_live_object_set(include_wrapped_tombstone);
     let effects_acc = state_acc.accumulate_effects(
         vec![result.inner().data().clone()],
         epoch_store.protocol_config(),

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -3811,8 +3811,7 @@ async fn test_iter_live_object_set() {
     let obj_id = ObjectID::random();
     let authority = init_state_with_ids(vec![(sender, gas), (sender, obj_id)]).await;
     let starting_live_set: HashSet<_> = authority
-        .database
-        .iter_live_object_set()
+        .iter_live_object_set_for_testing()
         .filter_map(|object| {
             let id = object.object_id();
             if id != gas && id != obj_id {
@@ -3995,8 +3994,7 @@ fn check_live_set(
     expected.sort();
 
     let actual: Vec<_> = authority
-        .database
-        .iter_live_object_set()
+        .iter_live_object_set_for_testing()
         .filter_map(|object| {
             let id = object.object_id();
             if ignore.contains(&id) {

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -560,8 +560,8 @@ async fn test_create_then_delete_parent_child_wrap() {
     // The parent and field are considered deleted, the child doesn't count because it wasn't
     // considered created in the first place.
     assert_eq!(effects.deleted().len(), 2);
-    // The child was never created so it is not unwrapped.
-    assert_eq!(effects.unwrapped_then_deleted().len(), 0);
+    // The child is considered as unwrapped and deleted, even though it was wrapped since creation.
+    assert_eq!(effects.unwrapped_then_deleted().len(), 1);
 
     assert_eq!(
         effects

--- a/crates/sui-e2e-tests/tests/unwrapped_then_deleted_tests.rs
+++ b/crates/sui-e2e-tests/tests/unwrapped_then_deleted_tests.rs
@@ -1,0 +1,292 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(msim)]
+mod sim_only_tests {
+    use std::path::PathBuf;
+    use sui_core::authority::authority_store_tables::LiveObject;
+    use sui_json_rpc_types::{SuiTransactionBlockEffects, SuiTransactionBlockEffectsAPI};
+    use sui_macros::sim_test;
+    use sui_node::SuiNode;
+    use sui_protocol_config::{ProtocolConfig, ProtocolVersion, SupportedProtocolVersions};
+    use sui_types::base_types::ObjectID;
+    use test_utils::network::{TestCluster, TestClusterBuilder};
+
+    // This test exercise the protocol upgrade where we flip the feature flag
+    // simplified_unwrap_then_delete. It demonstrates the behavior difference before and after
+    // this upgrade in unwrapped_then_deleted and modified_at_versions fields in effects.
+    #[sim_test]
+    async fn test_simplified_unwrap_then_delete_protocol_upgrade() {
+        let mut _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+            config.set_simplified_unwrap_then_delete(false);
+            config
+        });
+
+        let test_cluster = TestClusterBuilder::new()
+            .with_supported_protocol_versions(SupportedProtocolVersions::new_for_testing(
+                ProtocolVersion::MAX.as_u64(),
+                ProtocolVersion::MAX_ALLOWED.as_u64(),
+            ))
+            .build()
+            .await;
+
+        let (package_id, object_id) = publish_package_and_create_parent_object(&test_cluster).await;
+
+        create_and_wrap_child(&test_cluster, package_id, object_id).await;
+        assert_eq!(count_fullnode_wrapped_tombstones(&test_cluster), 0);
+
+        let effects = unwrap_and_delete_child(&test_cluster, package_id, object_id).await;
+        assert!(effects.unwrapped_then_deleted().is_empty());
+        // Only include gas and object.
+        assert_eq!(effects.modified_at_versions().len(), 2);
+        assert_eq!(count_fullnode_wrapped_tombstones(&test_cluster), 0);
+
+        let child = create_owned_child(&test_cluster, package_id).await;
+        wrap_child(&test_cluster, package_id, object_id, child).await;
+        assert_eq!(count_fullnode_wrapped_tombstones(&test_cluster), 1);
+
+        let effects = unwrap_and_delete_child(&test_cluster, package_id, object_id).await;
+        // modified_at_versions includes: gas, object, child.
+        assert_eq!(effects.modified_at_versions().len(), 3);
+        assert_eq!(effects.unwrapped_then_deleted().len(), 1);
+        assert_eq!(count_fullnode_wrapped_tombstones(&test_cluster), 0);
+        assert!(test_cluster
+            .get_object_or_tombstone_from_fullnode_store(child)
+            .await
+            .2
+            .is_deleted());
+
+        drop(_guard);
+        let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+            config.set_simplified_unwrap_then_delete(true);
+            config
+        });
+        test_cluster.trigger_reconfiguration().await;
+
+        create_and_wrap_child(&test_cluster, package_id, object_id).await;
+        assert_eq!(count_fullnode_wrapped_tombstones(&test_cluster), 0);
+
+        let effects = unwrap_and_delete_child(&test_cluster, package_id, object_id).await;
+        // This is where it becomes different after the protocol upgrade.
+        assert_eq!(effects.unwrapped_then_deleted().len(), 1);
+        // Only include gas and object.
+        assert_eq!(effects.modified_at_versions().len(), 2);
+        assert_eq!(count_fullnode_wrapped_tombstones(&test_cluster), 0);
+
+        let child_id = create_owned_child(&test_cluster, package_id).await;
+        wrap_child(&test_cluster, package_id, object_id, child_id).await;
+        assert_eq!(count_fullnode_wrapped_tombstones(&test_cluster), 1);
+
+        let effects = unwrap_and_delete_child(&test_cluster, package_id, object_id).await;
+        // This is also different after the protocol upgrade.
+        // modified_at_versions only include gas and object, does not include child.
+        assert_eq!(effects.modified_at_versions().len(), 2);
+        assert_eq!(effects.unwrapped_then_deleted().len(), 1);
+        assert_eq!(count_fullnode_wrapped_tombstones(&test_cluster), 0);
+        assert!(test_cluster
+            .get_object_or_tombstone_from_fullnode_store(child_id)
+            .await
+            .2
+            .is_deleted());
+    }
+
+    /// This test checks that after we enable simplified_unwrap_then_delete, we no longer depend
+    /// on wrapped tombstones when generating effects and using effects.
+    #[sim_test]
+    async fn test_no_more_dependency_on_wrapped_tombstone() {
+        let mut _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+            config.set_simplified_unwrap_then_delete(false);
+            config
+        });
+
+        let test_cluster = TestClusterBuilder::new()
+            .with_supported_protocol_versions(SupportedProtocolVersions::new_for_testing(
+                ProtocolVersion::MAX.as_u64(),
+                ProtocolVersion::MAX_ALLOWED.as_u64(),
+            ))
+            .build()
+            .await;
+
+        let (package_id, object_id) = publish_package_and_create_parent_object(&test_cluster).await;
+
+        let child_id = create_owned_child(&test_cluster, package_id).await;
+        wrap_child(&test_cluster, package_id, object_id, child_id).await;
+        assert_eq!(count_fullnode_wrapped_tombstones(&test_cluster), 1);
+
+        // At this point, we should have a wrapped tombstone in the db of every node.
+
+        drop(_guard);
+        let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+            config.set_simplified_unwrap_then_delete(true);
+            config
+        });
+        // At this epoch change, we should be re-accumulating without wrapped tombstone and now
+        // flips the feature flag simplified_unwrap_then_delete to true.
+        test_cluster.trigger_reconfiguration().await;
+
+        // Remove the wrapped tombstone on some nodes but not all.
+        for (idx, validator) in test_cluster.swarm.validator_nodes().enumerate() {
+            validator.get_node_handle().unwrap().with(|node| {
+                let db = node.state().db();
+                assert_eq!(count_wrapped_tombstone(&node), 1);
+                if idx % 2 == 0 {
+                    db.remove_all_versions_of_object(child_id);
+                    assert_eq!(count_wrapped_tombstone(&node), 0);
+                }
+            })
+        }
+
+        let effects = unwrap_and_delete_child(&test_cluster, package_id, object_id).await;
+        assert_eq!(effects.modified_at_versions().len(), 2);
+        assert_eq!(effects.unwrapped_then_deleted().len(), 1);
+
+        test_cluster.trigger_reconfiguration().await;
+    }
+
+    async fn publish_package_and_create_parent_object(
+        test_cluster: &TestCluster,
+    ) -> (ObjectID, ObjectID) {
+        let package_id = test_cluster
+            .wallet
+            .publish_package(
+                PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                    .join("../sui-surfer/tests/move_building_blocks"),
+            )
+            .await
+            .0;
+
+        let object_id = test_cluster
+            .sign_and_execute_transaction(
+                &test_cluster
+                    .test_transaction_builder()
+                    .await
+                    .move_call(package_id, "objects", "create_owned_object", vec![])
+                    .build(),
+            )
+            .await
+            .effects
+            .unwrap()
+            .created()[0]
+            .reference
+            .object_id;
+
+        (package_id, object_id)
+    }
+
+    async fn create_and_wrap_child(
+        test_cluster: &TestCluster,
+        package_id: ObjectID,
+        object_id: ObjectID,
+    ) -> SuiTransactionBlockEffects {
+        let object = test_cluster.wallet.get_object_ref(object_id).await.unwrap();
+        let effects = test_cluster
+            .sign_and_execute_transaction(
+                &test_cluster
+                    .test_transaction_builder()
+                    .await
+                    .move_call(
+                        package_id,
+                        "objects",
+                        "create_and_wrap_child",
+                        vec![object.into(), true.into()],
+                    )
+                    .build(),
+            )
+            .await
+            .effects
+            .unwrap();
+        assert!(effects.created().is_empty() && effects.wrapped().is_empty());
+        effects
+    }
+
+    async fn create_owned_child(test_cluster: &TestCluster, package_id: ObjectID) -> ObjectID {
+        test_cluster
+            .sign_and_execute_transaction(
+                &test_cluster
+                    .test_transaction_builder()
+                    .await
+                    .move_call(package_id, "objects", "create_owned_child", vec![])
+                    .build(),
+            )
+            .await
+            .effects
+            .unwrap()
+            .created()[0]
+            .reference
+            .to_object_ref()
+            .0
+    }
+
+    async fn wrap_child(
+        test_cluster: &TestCluster,
+        package_id: ObjectID,
+        object_id: ObjectID,
+        child_id: ObjectID,
+    ) -> SuiTransactionBlockEffects {
+        let object = test_cluster.wallet.get_object_ref(object_id).await.unwrap();
+        let child = test_cluster.wallet.get_object_ref(child_id).await.unwrap();
+        let effects = test_cluster
+            .sign_and_execute_transaction(
+                &test_cluster
+                    .test_transaction_builder()
+                    .await
+                    .move_call(
+                        package_id,
+                        "objects",
+                        "wrap_child",
+                        vec![object.into(), child.into(), true.into()],
+                    )
+                    .build(),
+            )
+            .await
+            .effects
+            .unwrap();
+        assert_eq!(effects.wrapped().len(), 1);
+        assert!(test_cluster
+            .get_object_or_tombstone_from_fullnode_store(child_id)
+            .await
+            .2
+            .is_wrapped());
+        effects
+    }
+
+    async fn unwrap_and_delete_child(
+        test_cluster: &TestCluster,
+        package_id: ObjectID,
+        object_id: ObjectID,
+    ) -> SuiTransactionBlockEffects {
+        let object = test_cluster.wallet.get_object_ref(object_id).await.unwrap();
+        let effects = test_cluster
+            .sign_and_execute_transaction(
+                &test_cluster
+                    .test_transaction_builder()
+                    .await
+                    .move_call(
+                        package_id,
+                        "objects",
+                        "unwrap_and_delete_child",
+                        vec![object.into()],
+                    )
+                    .build(),
+            )
+            .await
+            .effects
+            .unwrap();
+        assert!(effects.deleted().is_empty());
+        effects
+    }
+
+    fn count_fullnode_wrapped_tombstones(test_cluster: &TestCluster) -> usize {
+        test_cluster
+            .fullnode_handle
+            .sui_node
+            .with(|node| count_wrapped_tombstone(node))
+    }
+
+    fn count_wrapped_tombstone(node: &SuiNode) -> usize {
+        let db = node.state().db();
+        db.iter_live_object_set(true)
+            .filter(|o| matches!(o, LiveObject::Wrapped(_)))
+            .count()
+    }
+}

--- a/crates/sui-e2e-tests/tests/unwrapped_then_deleted_tests.rs
+++ b/crates/sui-e2e-tests/tests/unwrapped_then_deleted_tests.rs
@@ -28,7 +28,8 @@ mod sim_only_tests {
                 ProtocolVersion::MAX_ALLOWED.as_u64(),
             ))
             .build()
-            .await;
+            .await
+            .unwrap();
 
         let (package_id, object_id) = publish_package_and_create_parent_object(&test_cluster).await;
 
@@ -105,7 +106,8 @@ mod sim_only_tests {
                 ProtocolVersion::MAX_ALLOWED.as_u64(),
             ))
             .build()
-            .await;
+            .await
+            .unwrap();
 
         let (package_id, object_id) = publish_package_and_create_parent_object(&test_cluster).await;
 

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1347,7 +1347,7 @@
             "name": "Result",
             "value": {
               "minSupportedProtocolVersion": "1",
-              "maxSupportedProtocolVersion": "15",
+              "maxSupportedProtocolVersion": "16",
               "protocolVersion": "6",
               "featureFlags": {
                 "advance_epoch_start_time_in_safe_mode": true,

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1365,6 +1365,7 @@
                 "package_digest_hash_module": false,
                 "package_upgrades": true,
                 "scoring_decision_with_validity_cutoff": true,
+                "simplified_unwrap_then_delete": false,
                 "zklogin_auth": false
               },
               "attributes": {

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -10,7 +10,7 @@ use tracing::{info, warn};
 
 /// The minimum and maximum protocol versions supported by this build.
 const MIN_PROTOCOL_VERSION: u64 = 1;
-const MAX_PROTOCOL_VERSION: u64 = 15;
+const MAX_PROTOCOL_VERSION: u64 = 16;
 
 // Record history of protocol version allocations here:
 //
@@ -47,6 +47,9 @@ const MAX_PROTOCOL_VERSION: u64 = 15;
 //             decides whether rounding is applied or not.
 // Version 15: Add reordering of user transactions by gas price after consensus.
 //             Add `sui::table_vec::drop` to the framework via a system package upgrade.
+// Version 16: Enabled simplified_unwrap_then_delete feature flag, which allows the execution engine
+//             to no longer consult the object store when generating unwrapped_then_deleted in the
+//             effects; this also allows us to stop including wrapped tombstones in accumulator.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -1244,6 +1247,11 @@ impl ProtocolConfig {
                 let mut cfg = Self::get_for_version_impl(version - 1, chain);
                 cfg.feature_flags.consensus_transaction_ordering =
                     ConsensusTransactionOrdering::ByGasPrice;
+                cfg
+            }
+            16 => {
+                let mut cfg = Self::get_for_version_impl(version - 1, chain);
+                cfg.feature_flags.simplified_unwrap_then_delete = true;
                 cfg
             }
             // Use this template when making changes:

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -216,6 +216,16 @@ struct FeatureFlags {
     // How we order transactions coming out of consensus before sending to execution.
     #[serde(skip_serializing_if = "ConsensusTransactionOrdering::is_none")]
     consensus_transaction_ordering: ConsensusTransactionOrdering,
+
+    // Previously, the unwrapped_then_deleted field in TransactionEffects makes a distinction between
+    // whether an object has existed in the store previously (i.e. whether there is a tombstone).
+    // Such dependency makes effects generation inefficient, and requires us to include wrapped
+    // tombstone in state root hash.
+    // To prepare for effects V2, with this flag set to true, we simplify the definition of
+    // unwrapped_then_deleted to always include unwrapped then deleted objects,
+    // regardless of their previous state in the store.
+    #[serde(skip_serializing_if = "is_false")]
+    simplified_unwrap_then_delete: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -771,6 +781,10 @@ impl ProtocolConfig {
     pub fn consensus_transaction_ordering(&self) -> ConsensusTransactionOrdering {
         self.feature_flags.consensus_transaction_ordering
     }
+
+    pub fn simplified_unwrap_then_delete(&self) -> bool {
+        self.feature_flags.simplified_unwrap_then_delete
+    }
 }
 
 #[cfg(not(msim))]
@@ -1289,6 +1303,10 @@ impl ProtocolConfig {
     }
     pub fn set_max_tx_gas_for_testing(&mut self, max_tx_gas: u64) {
         self.max_tx_gas = Some(max_tx_gas)
+    }
+    #[cfg(msim)]
+    pub fn set_simplified_unwrap_then_delete(&mut self, val: bool) {
+        self.feature_flags.simplified_unwrap_then_delete = val
     }
 }
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_16.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_16.snap
@@ -1,0 +1,184 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 16
+feature_flags:
+  package_upgrades: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 128
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 6
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 256
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 2000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+gas_model_version: 6
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 52
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 52
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 52
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 52
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 52
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 52
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 52
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 52
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 52
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 52
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 52
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 52
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 52
+groth16_prepare_verifying_key_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 52
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 52
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+scoring_decision_mad_divisor: 2.3
+scoring_decision_cutoff_value: 2.5
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_16.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_16.snap
@@ -1,0 +1,185 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 16
+feature_flags:
+  package_upgrades: true
+  commit_root_state_digest: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 128
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 6
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 256
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 2000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+gas_model_version: 6
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 52
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 52
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 52
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 52
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 52
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 52
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 52
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 52
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 52
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 52
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 52
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 52
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 52
+groth16_prepare_verifying_key_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 52
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 52
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+scoring_decision_mad_divisor: 2.3
+scoring_decision_cutoff_value: 2.5
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_16.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_16.snap
@@ -1,0 +1,186 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 16
+feature_flags:
+  package_upgrades: true
+  commit_root_state_digest: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  zklogin_auth: true
+  consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 128
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 6
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_tx_gas: 50000000000
+max_gas_price: 100000
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 256
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 2000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+gas_model_version: 6
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+max_transactions_per_checkpoint: 10000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+dynamic_field_hash_type_and_key_cost_base: 100
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 100
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 10
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 100
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 10
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 100
+dynamic_field_remove_child_object_child_cost_per_byte: 2
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 100
+dynamic_field_has_child_object_with_ty_cost_base: 100
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+tx_context_derive_id_cost_base: 52
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 52
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 52
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 52
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 52
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 52
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 52
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 52
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 52
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 52
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 52
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 52
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 52
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 52
+groth16_prepare_verifying_key_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 52
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_bn254_cost_base: 52
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 2
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 52
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 52
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+scoring_decision_mad_divisor: 2.3
+scoring_decision_cutoff_value: 2.5
+

--- a/crates/sui-sdk/src/wallet_context.rs
+++ b/crates/sui-sdk/src/wallet_context.rs
@@ -426,6 +426,18 @@ impl WalletContext {
         )
     }
 
+    pub async fn publish_package(&self, path: PathBuf) -> ObjectRef {
+        let (sender, gas_object) = self.get_one_gas_object().await.unwrap().unwrap();
+        let gas_price = self.get_reference_gas_price().await.unwrap();
+        let txn = self.sign_transaction(
+            &TestTransactionBuilder::new(sender, gas_object, gas_price)
+                .publish(path)
+                .build(),
+        );
+        let resp = self.execute_transaction_must_succeed(txn).await;
+        get_new_package_obj_from_response(&resp).unwrap()
+    }
+
     /// Executes a transaction to publish the `basics` package and returns the package object ref.
     pub async fn publish_basics_package(&self) -> ObjectRef {
         let (sender, gas_object) = self.get_one_gas_object().await.unwrap().unwrap();

--- a/crates/sui-surfer/src/surfer_task.rs
+++ b/crates/sui-surfer/src/surfer_task.rs
@@ -46,7 +46,7 @@ impl SurferTask {
             .get_node_handle()
             .unwrap();
         let all_live_objects: Vec<_> =
-            validator.with(|node| node.state().db().iter_live_object_set().collect());
+            validator.with(|node| node.state().db().iter_live_object_set(false).collect());
         for obj in all_live_objects {
             match obj {
                 LiveObject::Normal(obj) => {
@@ -89,7 +89,7 @@ impl SurferTask {
                         }
                     }
                 }
-                LiveObject::Wrapped(_) => (),
+                LiveObject::Wrapped(_) => unreachable!("Explicitly skipped wrapped objects"),
             }
         }
         let entry_functions = Arc::new(RwLock::new(vec![]));

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -6,7 +6,7 @@ ssfn_config_info: ~
 validator_config_info: ~
 parameters:
   chain_start_timestamp_ms: 0
-  protocol_version: 15
+  protocol_version: 16
   allow_insertion_of_extra_objects: true
   epoch_duration_ms: 86400000
   stake_subsidy_start_epoch: 0

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -3,7 +3,7 @@ source: crates/sui-swarm-config/tests/snapshot_tests.rs
 expression: genesis.sui_system_object().into_genesis_version_for_tooling()
 ---
 epoch: 0
-protocol_version: 15
+protocol_version: 16
 system_state_version: 1
 validators:
   total_stake: 20000000000000000
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0xb67b0a175b21bdd3a72268275d73a30f6c60239572320dbf961436510c2b14f1"
+            id: "0xf771d809b991cd7e3a25c1fc943ed28fbf6663721a83f08311c6940973d55b49"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0x2642e7b3c31b3e1e5da73c9d4b1e9c4b4b8774163b7922e176b9221d651325f0"
+      operation_cap_id: "0xa83d3dd8458e0da65ce07fd170172a7809f2d8fdee53c7e61392828599a3de6e"
       gas_price: 1000
       staking_pool:
-        id: "0x371ca77f31fc28fe5f40b951953356e0c966f11799dde71854de5c62f01dca29"
+        id: "0xf1b97970792a3c84ad867bf68a986d4373930779659f299b9b82f5c7dbe3ce7f"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0xd697163f087687a17adbeb3b0473695ce5e2bdfce8e63d23912eecf371d1b56f"
+          id: "0x3e535ba3e3037a83fed76b7d79174051dc671bc724af0d840acfbec0cbfb1264"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0xef17017571ae8ccfc43823097c1cd3a7d25f90328047be195ad983c508234cec"
+            id: "0xdc1112aef4a5483a9ab29b43ca66f230206a37ee86a985af4c0046c439d845d0"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0xf9ff725bc99164ace247dae283ed817bc96d46728557c84da2d250e25508c282"
+          id: "0x07be66829a96181e92a4a2be6aa9d7aff889849e44fc26aeaf69cfc2aa8b3cd4"
         size: 0
   pending_active_validators:
     contents:
-      id: "0xf72cdc4c3d6e41fd8dd78a90fed7e7fe15a96544ef0d24b26f8fa98d3af106f3"
+      id: "0x182c6b32d0d95697244e60dadb857a44527ebb69af173e19fe2f6af7a875308e"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0xea08cd5aa2a4c4952e1bd676ca371cc5e670bb54afc86552a1c5d501b6278953"
+    id: "0x6cbe0b1d1e5bc70f9ed0545ac8a49ac6c90844f8889277daeb079152fffab310"
     size: 1
   inactive_validators:
-    id: "0xa85a8deffbbbcbec3fe70ae2a24e20b031dd67ed270e5195ac0c5ed34a4706bd"
+    id: "0xe162599bd30584c7731ca6a2e55ca1472980ffcab5babe23cc647e72be96c4a4"
     size: 0
   validator_candidates:
-    id: "0xa6bd0d13591193f137b8695dc8b7cafc1b6e801afa978e2ce972ab63396c964d"
+    id: "0x07e54852e26a69873540576d9bf6d722ddce1e110fbdcdc2d174b8403afef5dd"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0x7b2d69267ddd666b2b319e04d883fcb16d7e69c20bd82b790fb029a81879259b"
+      id: "0x3f72551f9f8586524a45cf21140e3973a28096ca0ff010bee0a96768c862578e"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x15a5aa6c541fc58653abfa77c110fb20db2db3edc36fa88b74a048ba8afa815a"
+      id: "0x222ead1ec8df162d8eac5ec34881af1116c0f70b6d536d9e51eb4a63da540008"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0x895f484f2bce2e11be5fa8ca53ac6562f19f68f77041fa31f43995a09eb74fba"
+      id: "0x20ef8f70de67adc6ab41b63cfe66edd4d0394bcdfad047522568636206748e71"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,6 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0xc7ace433bfa22a7b12ce722b347eeac8ecd69597db8c3d3e5360f8b79939040d"
+    id: "0x5636453c059512fa24dbafa002322e0fc3304a016e62c6facabf6c2b964ddd85"
   size: 0
 


### PR DESCRIPTION
## Description 

This PR cherry-picks the change to enable simplified_unwrapped_then_delete.

## Test Plan 

CI + devnet

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [x] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [x] breaking change for FNs (FN binary must upgrade)
- [x] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Prior to this change, unwrapped_then_deleted field in TransactionEffects only contain unwrapped then deleted objects that previously existed in the store (i.e. was once unwrapped in its lifetime). If an object was always wrapped since creation and was never unwrapped ever, it wouldn't show up in unwrapped_then_deleted. This this change, we no longer makes such distinction. As long as an object is unwrapped then deleted in a transaction, it would show up in effects regardless of its history. This simplifies the logic of handling them significantly.
To properly maintain the state of the system accurately with this change, at the epoch boundary when this upgrades happens, we must re-accumulate the state root hash of all objects in the store. This process takes a few seconds on mainnet. Testnet can take a much longer time (30s-1min) since it contains significantly more objects. Users may observe a brief slow down of the network during epoch change when this is applied.
