### PR TITLE
multisig: add tool to verify a multisig locally

### DIFF
--- a/doc/src/learn/cryptography/sui-multisig.md
+++ b/doc/src/learn/cryptography/sui-multisig.md
@@ -92,7 +92,7 @@ The response resembles the following:
 This section demonstrates how to use an object that belongs to a MultiSig address and serialize a transfer to be signed. Note that the tx_bytes can be *ANY* serialized transaction data where the sender is the MultiSig address, simply use the `--serialize-unsigned-transaction` flag for supported commands in `sui client -h` (e.g. `publish`, `upgrade`, `call`, `transfer`, `transfer-sui`, `pay`, `pay-all-sui`, `pay-sui`, `split`, `merge-coin`) to output the Base64 encoded transaction bytes. 
 
 ```shell
-$SUI_BINARY client transfer --to $MULTISIG_ADDR --object-id $OBJECT_ID --gas-budget 100000 --serialize-unsigned-transaction
+$SUI_BINARY client transfer --to $SOME_ADDR --object-id $OBJECT_ID --gas-budget 100000 --serialize-unsigned-transaction
 
 Raw tx_bytes to execute: $TX_BYTES
 ```


### PR DESCRIPTION
## Description 

Add a keytool to optionally verify the multisig against tx data. 

## Test Plan 

```
target/debug/sui keytool multi-sig-combine-partial-sig --pks ADaQdaIciOWgJW5OJA2thgNqdZVpxhIuOwf1cdaqkSv+ AQO4mqrF7ivphT0dZrfLzlsbik69uWDRsHaTmeR26cFXHg== AgOPrEEZEEkA684HidCE7Gs4UVFiZ4LqqMrzIt52gCFQFw== --weights 1 2 3 --threshold 3 --sigs AOANKYYgDFcU94E//oQ/GQ2cUJc5yzA/P4tTKsB1+kZGrxX9t3Xab37pgnG+LpNu3QHOlkGtuoY90j+SXGSYSgw2kHWiHIjloCVuTiQNrYYDanWVacYSLjsH9XHWqpEr/g== AQg68A6ExNRI2k7E9L4JWdp16lufhFYUScESMSvqf/B69ws31u94kTei73fz4YfvkVmuC2vF1YmPdkbpLxPy3TwDuJqqxe4r6YU9HWa3y85bG4pOvblg0bB2k5nkdunBVx4= --tx-byt
es AAABAAgCAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIDcGF5D2RpdmlkZV9hbmRfa2VlcAEHAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIDc3VpA1NVSQACAAEAAHcz9q8NRvbeKdQliqr4M6vNibf0qFjcQN4KKtebPMqaAR8uJNV17ycsTxV8fOtsfIpWyCP7fvCeRQ/k7M2pSC3pEAAAAAAAAAAg6vLb1BfFG8NkZUWPQvEAidm/Dl77jOjUNXaEGFjXwlx3M/avDUb23inUJYqq+DOrzYm39KhY3EDeCirXmzzKmugDAAAAAAAAAGktAAAAAAAA

Verify multisig: Err(InvalidSignature { error: "Invalid signature for pk=Secp256k1(BytesRepresentation([3, 184, 154, 170, 197, 238, 43, 233, 133, 61, 29, 102, 183, 203, 206, 91, 27, 138, 78, 189, 185, 96, 209, 176, 118, 147, 153, 228, 118, 233, 193, 87, 30]))" })
```
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
