### PR TITLE
Increase reference gas price slightly to avoid failure after epoch change

### DIFF
--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -210,7 +210,7 @@ pub async fn metadata(
     env.check_network_identifier(&request.network_identifier)?;
     let option = request.options.ok_or(Error::MissingMetadata)?;
     let sender = option.internal_operation.sender();
-    let gas_price = context
+    let mut gas_price = context
         .client
         .governance_api()
         .get_reference_gas_price()

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -215,7 +215,9 @@ pub async fn metadata(
         .governance_api()
         .get_reference_gas_price()
         .await?;
-    gas_price += 100; // to make sure it works over epoch changes
+    // make sure it works over epoch changes
+    gas_price += 100;
+
     // Get amount, objects, for the operation
     let (total_required_amount, objects) = match &option.internal_operation {
         InternalOperation::PaySui { amounts, .. } => {

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -215,7 +215,7 @@ pub async fn metadata(
         .governance_api()
         .get_reference_gas_price()
         .await?;
-
+    gas_price += 100; // to make sure it works over epoch changes
     // Get amount, objects, for the operation
     let (total_required_amount, objects) = match &option.internal_operation {
         InternalOperation::PaySui { amounts, .. } => {


### PR DESCRIPTION
## Description 

On epoch change, a transaction that will be retried might fail due to having too low reference_gas_price set. This increases the gas_price slightly. Today there is no other consequence, in the future this might mean that the gas payed for the transaction will be slightly higher than lowest possible.

## Test Plan 

Existing tests.

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
