### PR TITLE
Use TestCluster in zklogin tests

### DIFF
--- a/crates/sui-e2e-tests/tests/zklogin_tests.rs
+++ b/crates/sui-e2e-tests/tests/zklogin_tests.rs
@@ -2,32 +2,23 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use sui_core::authority_client::AuthorityAPI;
+use sui_macros::sim_test;
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::utils::make_zklogin_tx;
-use test_utils::authority::{spawn_test_authorities, test_authority_configs_with_objects};
-
-use sui_core::{authority_aggregator::AuthorityAggregatorBuilder, authority_client::AuthorityAPI};
-use sui_macros::sim_test;
-use sui_types::object::generate_test_gas_objects;
+use test_utils::network::TestClusterBuilder;
 
 async fn do_zklogin_test() -> SuiResult {
-    let gas_objects = generate_test_gas_objects();
-
-    // Get the authority configs and spawn them. Note that it is important to not drop
-    // the handles (or the authorities will stop).
-    let (config, _) = test_authority_configs_with_objects(gas_objects);
-    let _handles = spawn_test_authorities(&config).await;
-
+    let test_cluster = TestClusterBuilder::new().build().await;
     let (_, tx, _) = make_zklogin_tx();
 
-    let (_agg, clients) = AuthorityAggregatorBuilder::from_network_config(&config)
-        .build()
-        .unwrap();
-
-    clients
+    test_cluster
+        .authority_aggregator()
+        .authority_clients
         .values()
         .next()
         .unwrap()
+        .authority_client()
         .handle_transaction(tx)
         .await
         .map(|_| ())


### PR DESCRIPTION
## Description 

Use TestCluster in zklogin tests.

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
