### PR TITLE
indexer: changed objects for tx query migrations

### DIFF
--- a/crates/sui-indexer/benches/indexer_benchmark.rs
+++ b/crates/sui-indexer/benches/indexer_benchmark.rs
@@ -38,7 +38,7 @@ fn indexer_benchmark(c: &mut Criterion) {
     let db_url = format!("postgres://postgres:{pw}@{pg_host}:{pg_port}");
 
     let rt: Runtime = Runtime::new().unwrap();
-    let (mut checkpoints, store) = rt.block_on(async {
+    let (mut _checkpoints, store) = rt.block_on(async {
         let blocking_cp = new_pg_connection_pool(&db_url).await.unwrap();
         reset_database(&mut blocking_cp.get().unwrap(), true).unwrap();
         let registry = Registry::default();
@@ -50,10 +50,7 @@ fn indexer_benchmark(c: &mut Criterion) {
         (checkpoints, store)
     });
 
-    c.bench_function("persist_checkpoint", |b| {
-        b.iter(|| store.persist_all_checkpoint_data(&checkpoints.pop().unwrap()))
-    });
-
+    // TODO(gegaowp): add updated data ingestion benchmarking steps here.
     let mut checkpoints = (20..100).cycle().map(CheckpointId::SequenceNumber);
     c.bench_function("get_checkpoint", |b| {
         b.to_async(Runtime::new().unwrap())
@@ -92,6 +89,7 @@ fn create_checkpoint(sequence_number: i64) -> TemporaryCheckpointStore {
         }],
         packages: vec![],
         input_objects: vec![],
+        changed_objects: vec![],
         move_calls: vec![],
         recipients: vec![],
     }

--- a/crates/sui-indexer/migrations/2023-03-05-165748_transaction_index/down.sql
+++ b/crates/sui-indexer/migrations/2023-03-05-165748_transaction_index/down.sql
@@ -1,3 +1,4 @@
 DROP TABLE IF EXISTS input_objects;
 DROP TABLE IF EXISTS move_calls;
 DROP TABLE IF EXISTS recipients;
+DROP TABLE IF EXISTS changed_objects;

--- a/crates/sui-indexer/migrations/2023-03-05-165748_transaction_index/up.sql
+++ b/crates/sui-indexer/migrations/2023-03-05-165748_transaction_index/up.sql
@@ -35,3 +35,15 @@ CREATE TABLE input_objects (
 );
 CREATE INDEX input_objects_transaction_digest ON input_objects (transaction_digest);
 CREATE INDEX input_objects_object_id ON input_objects (object_id);
+
+CREATE TABLE changed_objects (
+    id                         BIGSERIAL       PRIMARY KEY,
+    transaction_digest         base58digest    NOT NULL,
+    checkpoint_sequence_number BIGINT          NOT NULL,
+    epoch                      BIGINT          NOT NULL,
+    object_id                  address         NOT NULL,
+    object_change_type         TEXT            NOT NULL,
+    object_version             BIGINT          NOT NULL
+);
+CREATE INDEX changed_objects_transaction_digest ON changed_objects (transaction_digest);
+CREATE INDEX changed_objects_object_id ON changed_objects (object_id);

--- a/crates/sui-indexer/src/models/transaction_index.rs
+++ b/crates/sui-indexer/src/models/transaction_index.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::schema::{input_objects, move_calls, recipients};
+use crate::schema::{changed_objects, input_objects, move_calls, recipients};
 use diesel::prelude::*;
 
 #[derive(Queryable, Insertable, Debug, Clone, Default)]
@@ -37,4 +37,17 @@ pub struct Recipient {
     pub epoch: i64,
     pub sender: String,
     pub recipient: String,
+}
+
+#[derive(Queryable, Insertable, Debug, Clone, Default)]
+#[diesel(table_name = changed_objects)]
+pub struct ChangedObject {
+    pub id: Option<i64>,
+    pub transaction_digest: String,
+    pub checkpoint_sequence_number: i64,
+    pub epoch: i64,
+    pub object_id: String,
+    // object_change_type could be `mutated`, `created` or `unwrapped`.
+    pub object_change_type: String,
+    pub object_version: i64,
 }

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -57,6 +57,18 @@ diesel::table! {
 }
 
 diesel::table! {
+    changed_objects (id) {
+        id -> Int8,
+        transaction_digest -> Varchar,
+        checkpoint_sequence_number -> Int8,
+        epoch -> Int8,
+        object_id -> Varchar,
+        object_change_type -> Text,
+        object_version -> Int8,
+    }
+}
+
+diesel::table! {
     checkpoints (sequence_number) {
         sequence_number -> Int8,
         checkpoint_digest -> Varchar,
@@ -326,6 +338,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     address_stats,
     addresses,
     at_risk_validators,
+    changed_objects,
     checkpoints,
     epochs,
     events,


### PR DESCRIPTION
## Description 

Before this change, tx query via changed object needed to scan the whole transactions table, b/c changed objects is a vector, which cannot be indexed for querying an element in the vector.

## Test Plan 

1. local indexer writer to make sure tables including newly added changed_objects can be populated properly;
2. spot check tx query endpoints to make sure endpoints can return consistent results with reasonable latency;
3. repro steps 1 & 2 with testing indexer writer-2 k8 pod.

```
curl --location --request POST http://127.0.0.1:3030 \
--header 'Content-Type: application/json' \
--data-raw '{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "suix_queryTransactionBlocks",
    "params": [
        {
            "filter": {
                "FromOrToAddress": {"addr": "0x3dc7a8a21f5d3bc17337260079688d8aefb76f27978e7ec082a5fb0d06bc8b39"}
            }
        },
        null,
        10,
        false
    ]
}'
{"jsonrpc":"2.0","result":{"data":[{"digest":"7CuBm1AnLgkBMB6GiEn5d3RizznF5LbawjJTs8A5dcXF","timestampMs":"1681318800000","checkpoint":"0"}],"nextCursor":"7CuBm1AnLgkBMB6GiEn5d3RizznF5LbawjJTs8A5dcXF","hasNextPage":false},"id":1}%

curl --location --request POST http://127.0.0.1:3030 \
--header 'Content-Type: application/json' \
--data-raw '{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "suix_queryTransactionBlocks",
    "params": [
        {
            "filter": {
                "ToAddress": "0x3dc7a8a21f5d3bc17337260079688d8aefb76f27978e7ec082a5fb0d06bc8b39"
            }
        },
        null,
        10,
        false
    ]
}'

curl --location --request POST http://127.0.0.1:3030 \
--header 'Content-Type: application/json' \
--data-raw '{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "suix_queryTransactionBlocks",
    "params": [
        {
            "filter": {
               "Checkpoint": "100"
            }
        },
        null,
        10,
        false
    ]
}'
{"jsonrpc":"2.0","result":{"data":[{"digest":"1WbvW7Rc6CShJfr2muw1HzBXrvAYLHj8mB8VUTJ88u7","timestampMs":"1681392329903","checkpoint":"100"}],"nextCursor":"1WbvW7Rc6CShJfr2muw1HzBXrvAYLHj8mB8VUTJ88u7","hasNextPage":false},"id":1}%

curl --location --request POST http://127.0.0.1:3030 \
--header 'Content-Type: application/json' \
--data-raw '{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "suix_queryTransactionBlocks",
    "params": [
        {
            "filter": {
               "ChangedObject": "0x0000000000000000000000000000000000000000000000000000000000000006"
            }
        },
        null,
        10,
        false
    ]
}'
{"jsonrpc":"2.0","result":{"data":[{"digest":"7CuBm1AnLgkBMB6GiEn5d3RizznF5LbawjJTs8A5dcXF","timestampMs":"1681318800000","checkpoint":"0"},{"digest":"2JxYGfYyqvUCJLtkqF71oVFQVk7CasppV6BswFW8J2vs","timestampMs":"1681392093366","checkpoint":"1"},{"digest":"9qH4LRaMcmyTUobd9nvU3LbxfXGE5kqS2QGgk86zH49g","timestampMs":"1681392096867","checkpoint":"2"},{"digest":"FVPW55XaHRDY5zppd1GzaepWTK9tfQUqiqcPepXZogjN","timestampMs":"1681392099295","checkpoint":"3"},{"digest":"Admk95nixMyx8EpCZi1uxuV1ih9EXMDzkpx6NDbKJ8VM","timestampMs":"1681392112441","checkpoint":"4"},{"digest":"41NwRrDpMBhWWUL7U9KRktNMaWc7MKCaPk4V2m9LUzJp","timestampMs":"1681392119329","checkpoint":"5"},{"digest":"6vQdDechVHbCo1huExkt9QDNwjLJghQJBhh1pm4xRnq7","timestampMs":"1681392121917","checkpoint":"6"},{"digest":"BDRa4cqHWWbHgQQJQ51Qx4a8baXCLryd8JPcGEwvikqF","timestampMs":"1681392123171","checkpoint":"7"},{"digest":"8mhf8kB67HB14RciaqNAEWCVG14muYiEcVTYk4mU6LUp","timestampMs":"1681392130242","checkpoint":"8"},{"digest":"D2XXLRxxvYLsTTmN8ZZZhYikjKaRRPyWWC8AJEsvwvyE","timestampMs":"1681392134159","checkpoint":"9"}],"nextCursor":"D2XXLRxxvYLsTTmN8ZZZhYikjKaRRPyWWC8AJEsvwvyE","hasNextPage":true},"id":1}%


curl --location --request POST http://127.0.0.1:3030 \
--header 'Content-Type: application/json' \
--data-raw '{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "suix_queryTransactionBlocks",
    "params": [
        {
            "filter": {
               "MoveFunction": {"package": "0x0000000000000000000000000000000000000000000000000000000000000003", "module": null, "function": null }
            }
        },
        null,
        10,
        false
    ]
}'
{"jsonrpc":"2.0","result":{"data":[{"digest":"ESV1NY1SY47TSEy85LxRfQaVc1rs9v1FGBg7Qd1a8Xtw","timestampMs":"1681432083797","checkpoint":"32960"}],"nextCursor":"ESV1NY1SY47TSEy85LxRfQaVc1rs9v1FGBg7Qd1a8Xtw","hasNextPage":false},"id":1}%

```
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
