### PR TITLE
Map errors to `-32000`, `-32602`, and `-32603`

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2349,11 +2349,12 @@ impl AuthorityState {
                     "Object with in parent_entry is missing from object store, datastore is \
                      inconsistent",
                 );
-                Err(UserInputError::ObjectNotFound {
-                    object_id: *object_id,
-                    version: Some(obj_ref.1),
-                }
-                .into())
+                Err(SuiError::GenericStorageError(format!(
+                    "Object with in parent_entry is missing from object store, datastore is \
+                     inconsistent. Object id: {}, version: {:?}",
+                    object_id,
+                    Some(obj_ref.1)
+                )))
             }
         }
     }
@@ -2382,6 +2383,7 @@ impl AuthorityState {
         if let Some(move_object) = o.data.try_as_move() {
             Ok(bcs::from_bytes(move_object.contents()).map_err(|e| {
                 SuiError::DeserializationError {
+                    // error from state
                     input_type: "object".to_string(),
                     error: format!("{e}"),
                 }
@@ -2579,6 +2581,7 @@ impl AuthorityState {
             })?;
             move_objects.push(bcs::from_bytes(move_object.contents()).map_err(|e| {
                 SuiError::DeserializationError {
+                    // error from state
                     input_type: "object".to_string(),
                     error: format!("{e}"),
                 }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -65,7 +65,7 @@ use sui_types::crypto::{
 };
 use sui_types::digests::ChainIdentifier;
 use sui_types::digests::TransactionEventsDigest;
-use sui_types::dynamic_field::{DynamicFieldInfo, DynamicFieldName, DynamicFieldType, Field};
+use sui_types::dynamic_field::{DynamicFieldInfo, DynamicFieldName, DynamicFieldType};
 use sui_types::effects::{
     SignedTransactionEffects, TransactionEffects, TransactionEffectsAPI, TransactionEvents,
     VerifiedCertifiedTransactionEffects, VerifiedSignedTransactionEffects,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1361,7 +1361,7 @@ impl AuthorityState {
                         input_type: "transaction".to_string(),
                         output_type: "SuiTransactionBlockData".to_string(),
                         error: e.to_string(),
-                    })?, // TODO: replace the underlying try_from to SuiError. This one goes deep
+                    })?, // TODO(wlmyng): replace the underlying try_from to SuiError. This one goes deep
                 effects: effects.clone().try_into()?,
                 events: SuiTransactionBlockEvents::try_from(
                     inner_temp_store.events.clone(),
@@ -1679,7 +1679,7 @@ impl AuthorityState {
 
         let bcs_name = bcs::to_bytes(&name_value.clone().undecorate()).map_err(|e| {
             SuiError::SerializationError {
-                input_type: "object".to_string(),
+                format: "bcs_name".to_string(),
                 error: format!("{e}"),
             }
         })?;
@@ -2546,7 +2546,7 @@ impl AuthorityState {
             })?;
             move_objects.push(bcs::from_bytes(move_object.contents()).map_err(|e| {
                 SuiError::DeserializationError {
-                    input_type: "object".to_string(),
+                    format: type_.to_string(),
                     error: format!("{e}"),
                 }
             })?);

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2546,7 +2546,6 @@ impl AuthorityState {
             })?;
             move_objects.push(bcs::from_bytes(move_object.contents()).map_err(|e| {
                 SuiError::DeserializationError {
-                    // error from state
                     input_type: "object".to_string(),
                     error: format!("{e}"),
                 }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1357,11 +1357,10 @@ impl AuthorityState {
         Ok((
             DryRunTransactionBlockResponse {
                 input: SuiTransactionBlockData::try_from(transaction.clone(), &module_cache)
-                    .map_err(|e| SuiError::TransactionSerializationError {
-                        error: format!(
-                            "Failed to convert transaction to SuiTransactionBlockData: {}",
-                            e
-                        ),
+                    .map_err(|e| SuiError::ConversionError {
+                        input_type: "transaction".to_string(),
+                        output_type: "SuiTransactionBlockData".to_string(),
+                        error: e.to_string(),
                     })?, // TODO: replace the underlying try_from to SuiError. This one goes deep
                 effects: effects.clone().try_into()?,
                 events: SuiTransactionBlockEvents::try_from(
@@ -1679,7 +1678,8 @@ impl AuthorityState {
         let name_type = move_object.type_().try_extract_field_name(&type_)?;
 
         let bcs_name = bcs::to_bytes(&name_value.clone().undecorate()).map_err(|e| {
-            SuiError::ObjectSerializationError {
+            SuiError::SerializationError {
+                input_type: "object".to_string(),
                 error: format!("{e}"),
             }
         })?;
@@ -2381,7 +2381,8 @@ impl AuthorityState {
         let o = self.get_object_read(object_id)?.into_object()?;
         if let Some(move_object) = o.data.try_as_move() {
             Ok(bcs::from_bytes(move_object.contents()).map_err(|e| {
-                SuiError::ObjectDeserializationError {
+                SuiError::DeserializationError {
+                    input_type: "object".to_string(),
                     error: format!("{e}"),
                 }
             })?)
@@ -2577,7 +2578,8 @@ impl AuthorityState {
                 SuiError::from(UserInputError::MovePackageAsObject { object_id: id.0 })
             })?;
             move_objects.push(bcs::from_bytes(move_object.contents()).map_err(|e| {
-                SuiError::ObjectDeserializationError {
+                SuiError::DeserializationError {
+                    input_type: "object".to_string(),
                     error: format!("{e}"),
                 }
             })?);

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2386,7 +2386,7 @@ impl AuthorityState {
                 }
             })?)
         } else {
-            Err(SuiError::ObjectDeserializationError {
+            Err(SuiError::TypeError {
                 error: format!("Provided object : [{object_id}] is not a Move object."),
             })
         }

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1796,7 +1796,7 @@ impl BackingPackageStore for AuthorityStore {
         if let Some(obj) = &package {
             fp_ensure!(
                 obj.is_package(),
-                SuiError::BadObjectType {
+                SuiError::TypeError {
                     error: format!("Package expected, Move object found: {package_id}"),
                 }
             );

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -311,11 +311,11 @@ impl ValidatorService {
         }
 
         // Enforce overall transaction size limit.
-        let tx_size = bcs::serialized_size(&transaction).map_err(|e| {
-            SuiError::TransactionSerializationError {
+        let tx_size =
+            bcs::serialized_size(&transaction).map_err(|e| SuiError::SerializationError {
+                input_type: "transaction".to_string(),
                 error: e.to_string(),
-            }
-        })?;
+            })?;
         let max_tx_size_bytes = epoch_store.protocol_config().max_tx_size_bytes();
         fp_ensure!(
             tx_size as u64 <= max_tx_size_bytes,

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -313,7 +313,7 @@ impl ValidatorService {
         // Enforce overall transaction size limit.
         let tx_size =
             bcs::serialized_size(&transaction).map_err(|e| SuiError::SerializationError {
-                input_type: "transaction".to_string(),
+                format: "tx_size".to_string(),
                 error: e.to_string(),
             })?;
         let max_tx_size_bytes = epoch_store.protocol_config().max_tx_size_bytes();

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -368,9 +368,7 @@ where
                     "Executing tx locally by orchestrator failed with error: {:?}", err
                 );
                 metrics.local_execution_failure.inc();
-                Err(SuiError::TransactionOrchestratorLocalExecutionError {
-                    error: err.to_string(),
-                })
+                Err(err)
             }
             Ok(Ok(_)) => {
                 metrics.local_execution_success.inc();

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -2777,7 +2777,7 @@ async fn test_object_no_id_error() {
     path.extend(["src", "unit_tests", "data", "object_no_id"]);
     let res = build_config.build(path);
 
-    matches!(res.err(), Some(SuiError::ExecutionError(err_str, status)) if
+    matches!(res.err(), Some(SuiError::ExecutionError(err_str, _status)) if
                  err_str.contains("SuiMoveVerificationError")
                  && err_str.contains("First field of struct NotObject must be 'id'"));
 }

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -2777,7 +2777,7 @@ async fn test_object_no_id_error() {
     path.extend(["src", "unit_tests", "data", "object_no_id"]);
     let res = build_config.build(path);
 
-    matches!(res.err(), Some(SuiError::ExecutionError(err_str)) if
+    matches!(res.err(), Some(SuiError::ExecutionError(err_str, status)) if
                  err_str.contains("SuiMoveVerificationError")
                  && err_str.contains("First field of struct NotObject must be 'id'"));
 }

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -320,7 +320,7 @@ impl CoinReadApiServer for CoinReadApi {
                 let treasury_cap = TreasuryCap::from_bcs_bytes(
                     treasury_cap_object.data.try_as_move().unwrap().contents(),
                 )
-                .map_err(Error::from)?;
+                .map_err(Error::SuiRpcInternalError)?;
                 treasury_cap.total_supply
             })
         })

--- a/crates/sui-json-rpc/src/error.rs
+++ b/crates/sui-json-rpc/src/error.rs
@@ -5,7 +5,7 @@ use fastcrypto::error::FastCryptoError;
 use hyper::header::InvalidHeaderValue;
 use jsonrpsee::core::Error as RpcError;
 use jsonrpsee::types::error::CallError;
-use jsonrpsee::types::{ErrorObject, ErrorObjectOwned};
+use jsonrpsee::types::ErrorObject;
 use sui_types::error::{SuiError, SuiObjectResponseError, UserInputError};
 use sui_types::quorum_driver_types::QuorumDriverError;
 use thiserror::Error;
@@ -136,21 +136,22 @@ pub enum SuiRpcInputError {
 * TypeError
 * ModuleDeserializationFailure
 * FailObjectLayout
-* DynamicFieldReadError
 * SuiSystemStateReadError
 * ObjectDeserializationError
 
 */
 
 /*
- * Depends on where this happens. This error enum to be used when error stems from us trying to deserialize something
- * ServerDeserializationError
- * ModuleDeserializationFailure
- * FailObjectLayout
- * DynamicFieldReadError
- * SuiSystemStateReadError
- * ObjectDeserializationError
- */
+* Depends on where this happens. This error enum to be used when error stems from us trying to deserialize something
+* ServerDeserializationError
+* ModuleDeserializationFailure
+* FailObjectLayout
+
+* ObjectDeserializationError
+*/
+
+#[derive(Debug, Error)]
+pub enum ServerDeserializationError {}
 
 pub fn match_sui_error(sui_error: SuiError) -> RpcError {
     match sui_error {
@@ -190,8 +191,6 @@ pub fn match_sui_error(sui_error: SuiError) -> RpcError {
         | SuiError::TransactionEventsNotFound { .. }
         | SuiError::TransactionAlreadyExecuted { .. }
         | SuiError::InvalidChildObjectAccess { .. }
-        | SuiError::TransactionSerializationError { .. }
-        | SuiError::ObjectSerializationError { .. }
         | SuiError::UnexpectedVersion { .. }
         | SuiError::WrongMessageVersion { .. }
         | SuiError::FullNodeCantHandleCertificate
@@ -213,6 +212,7 @@ pub fn match_sui_error(sui_error: SuiError) -> RpcError {
         | SuiError::FileIOError { .. }
         | SuiError::JWKRetrievalError
         | SuiError::ExecutionInvariantViolation
+        | SuiError::SuiSystemStateReadError(_)
         | SuiError::Unknown { .. } => to_internal_error(sui_error),
         _ => RpcError::Call(CallError::Failed(sui_error.into())),
     }

--- a/crates/sui-json-rpc/src/error.rs
+++ b/crates/sui-json-rpc/src/error.rs
@@ -6,7 +6,6 @@ use hyper::header::InvalidHeaderValue;
 use jsonrpsee::core::Error as RpcError;
 use jsonrpsee::types::error::CallError;
 use jsonrpsee::types::ErrorObject;
-use serde::Serialize;
 use sui_types::error::{SuiError, SuiObjectResponseError, UserInputError};
 use sui_types::quorum_driver_types::QuorumDriverError;
 use thiserror::Error;

--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -51,7 +51,7 @@ impl GovernanceReadApi {
             state
                 .get_move_objects(owner, MoveObjectType::staked_sui())
                 .await
-                .map_err(Error::SuiRpcInternalError)
+                .map_err(|e| Error::Server(ServerError::SuiError(e)))
         })
         .await??;
 
@@ -379,7 +379,7 @@ async fn exchange_rates(
                     .map_err(|e| ServerError::Serde(e.to_string()))?;
                 let exchange_rate: PoolTokenExchangeRate =
                     get_dynamic_field_from_store(state.db().as_ref(), exchange_rates_id, &epoch)
-                        .map_err(Error::SuiRpcInternalError)?;
+                        .map_err(ServerError::SuiError)?;
 
                 Ok::<_, Error>((epoch, exchange_rate))
             })

--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -354,7 +354,8 @@ async fn exchange_rates(
         system_state_summary.inactive_pools_size as usize,
     )? {
         let pool_id: ID =
-            bcs::from_bytes(&df.1.bcs_name).map_err(|e| SuiError::ObjectDeserializationError {
+            bcs::from_bytes(&df.1.bcs_name).map_err(|e| SuiError::DeserializationError {
+                input_type: "object".to_string(),
                 error: e.to_string(),
             })?;
         let validator = get_validator_from_table(
@@ -379,7 +380,8 @@ async fn exchange_rates(
             .into_iter()
             .map(|df| {
                 let epoch: EpochId = bcs::from_bytes(&df.1.bcs_name).map_err(|e| {
-                    SuiError::ObjectDeserializationError {
+                    SuiError::DeserializationError {
+                        input_type: "object".to_string(),
                         error: e.to_string(),
                     }
                 })?;

--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -356,7 +356,7 @@ async fn exchange_rates(
     )? {
         let pool_id: ID =
             bcs::from_bytes(&df.1.bcs_name).map_err(|e| SuiError::DeserializationError {
-                input_type: "object".to_string(),
+                format: "ID".to_string(),
                 error: e.to_string(),
             })?;
         let validator = get_validator_from_table(
@@ -382,7 +382,7 @@ async fn exchange_rates(
             .map(|df| {
                 let epoch: EpochId = bcs::from_bytes(&df.1.bcs_name).map_err(|e| {
                     SuiError::DeserializationError {
-                        input_type: "object".to_string(),
+                        format: "EpochId".to_string(),
                         error: e.to_string(),
                     }
                 })?;

--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -49,7 +49,7 @@ impl GovernanceReadApi {
         let state = self.state.clone();
         let result = spawn_monitored_task!(async move {
             state
-                .get_move_objects(owner, MoveObjectType::staked_sui()) // error: server-side if DeserializationError
+                .get_move_objects(owner, MoveObjectType::staked_sui())
                 .await
         })
         .await??;
@@ -356,7 +356,6 @@ async fn exchange_rates(
     )? {
         let pool_id: ID =
             bcs::from_bytes(&df.1.bcs_name).map_err(|e| SuiError::DeserializationError {
-                // error from state
                 input_type: "object".to_string(),
                 error: e.to_string(),
             })?;
@@ -383,7 +382,6 @@ async fn exchange_rates(
             .map(|df| {
                 let epoch: EpochId = bcs::from_bytes(&df.1.bcs_name).map_err(|e| {
                     SuiError::DeserializationError {
-                        // error from state
                         input_type: "object".to_string(),
                         error: e.to_string(),
                     }

--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -148,7 +148,8 @@ impl GovernanceReadApi {
             system_state.clone().into_sui_system_state_summary();
 
         let rates = exchange_rates(&self.state, system_state_summary.epoch)
-            .await?
+            .await
+            .map_err(Error::SuiRpcInternalError)?
             .into_iter()
             .map(|rates| (rates.pool_id, rates))
             .collect::<BTreeMap<_, _>>();
@@ -268,7 +269,7 @@ impl GovernanceReadApiServer for GovernanceReadApi {
 
         let exchange_rate_table = exchange_rates(&self.state, system_state_summary.epoch)
             .await
-            .map_err(Error::from)?;
+            .map_err(Error::SuiRpcInternalError)?;
 
         let mut apys = vec![];
 

--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -49,7 +49,7 @@ impl GovernanceReadApi {
         let state = self.state.clone();
         let result = spawn_monitored_task!(async move {
             state
-                .get_move_objects(owner, MoveObjectType::staked_sui())
+                .get_move_objects(owner, MoveObjectType::staked_sui()) // error: server-side if DeserializationError
                 .await
         })
         .await??;
@@ -355,6 +355,7 @@ async fn exchange_rates(
     )? {
         let pool_id: ID =
             bcs::from_bytes(&df.1.bcs_name).map_err(|e| SuiError::DeserializationError {
+                // error from state
                 input_type: "object".to_string(),
                 error: e.to_string(),
             })?;
@@ -381,6 +382,7 @@ async fn exchange_rates(
             .map(|df| {
                 let epoch: EpochId = bcs::from_bytes(&df.1.bcs_name).map_err(|e| {
                     SuiError::DeserializationError {
+                        // error from state
                         input_type: "object".to_string(),
                         error: e.to_string(),
                     }

--- a/crates/sui-json-rpc/src/metrics.rs
+++ b/crates/sui-json-rpc/src/metrics.rs
@@ -221,7 +221,7 @@ impl Logger for MetricsLogger {
             .observe(req_latency_secs);
 
         if let Some(code) = error_code {
-            if code == -32000 {
+            if code == -32603 {
                 self.metrics
                     .server_errors_by_route
                     .with_label_values(&[method_name])

--- a/crates/sui-json-rpc/src/move_utils.rs
+++ b/crates/sui-json-rpc/src/move_utils.rs
@@ -146,14 +146,14 @@ impl MoveUtilsServer for MoveUtils {
         with_tracing!(async move {
             let module = self.internal.get_move_module(package, module_name).await?;
             let structs = module.structs;
-            let identifier = Identifier::new(struct_name.as_str()).map_err(|e| {
-                Error::SuiRpcInputError(SuiRpcInputError::GenericInvalid(format!("{e}")))
-            })?;
+            let identifier = Identifier::new(struct_name.as_str())
+                .map_err(|e| Error::Client(SuiRpcInputError::GenericInvalid(format!("{e}"))))?;
             Ok(match structs.get(&identifier) {
                 Some(struct_) => Ok(struct_.clone().into()),
-                None => Err(Error::SuiRpcInputError(SuiRpcInputError::GenericNotFound(
-                    format!("No struct was found with struct name {}", struct_name),
-                ))),
+                None => Err(Error::Client(SuiRpcInputError::GenericNotFound(format!(
+                    "No struct was found with struct name {}",
+                    struct_name
+                )))),
             }?)
         })
     }
@@ -168,14 +168,14 @@ impl MoveUtilsServer for MoveUtils {
         with_tracing!(async move {
             let module = self.internal.get_move_module(package, module_name).await?;
             let functions = module.functions;
-            let identifier = Identifier::new(function_name.as_str()).map_err(|e| {
-                Error::SuiRpcInputError(SuiRpcInputError::GenericInvalid(format!("{e}")))
-            })?;
+            let identifier = Identifier::new(function_name.as_str())
+                .map_err(|e| Error::Client(SuiRpcInputError::GenericInvalid(format!("{e}"))))?;
             Ok(match functions.get(&identifier) {
                 Some(function) => Ok(function.clone().into()),
-                None => Err(Error::SuiRpcInputError(SuiRpcInputError::GenericNotFound(
-                    format!("No function was found with function name {}", function_name),
-                ))),
+                None => Err(Error::Client(SuiRpcInputError::GenericNotFound(format!(
+                    "No function was found with function name {}",
+                    function_name
+                )))),
             }?)
         })
     }
@@ -202,18 +202,19 @@ impl MoveUtilsServer for MoveUtils {
                         )
                         .map_err(Error::SuiRpcInternalError)
                     }
-                    _ => Err(Error::SuiRpcInputError(SuiRpcInputError::GenericInvalid(
-                        format!("Object is not a package with ID {}", package),
-                    ))),
+                    _ => Err(Error::Client(SuiRpcInputError::GenericInvalid(format!(
+                        "Object is not a package with ID {}",
+                        package
+                    )))),
                 },
-                _ => Err(Error::SuiRpcInputError(SuiRpcInputError::GenericNotFound(
-                    format!("Package object does not exist with ID {}", package),
-                ))),
+                _ => Err(Error::Client(SuiRpcInputError::GenericNotFound(format!(
+                    "Package object does not exist with ID {}",
+                    package
+                )))),
             }?;
 
-            let identifier = Identifier::new(function.as_str()).map_err(|e| {
-                Error::SuiRpcInputError(SuiRpcInputError::GenericInvalid(format!("{e}")))
-            })?;
+            let identifier = Identifier::new(function.as_str())
+                .map_err(|e| Error::Client(SuiRpcInputError::GenericInvalid(format!("{e}"))))?;
             let parameters = normalized
                 .get(&module)
                 .and_then(|m| m.functions.get(&identifier).map(|f| f.parameters.clone()));
@@ -237,9 +238,10 @@ impl MoveUtilsServer for MoveUtils {
                         _ => MoveFunctionArgType::Pure,
                     })
                     .collect::<Vec<MoveFunctionArgType>>()),
-                None => Err(Error::SuiRpcInputError(SuiRpcInputError::GenericNotFound(
-                    format!("No parameters found for function {}", function),
-                ))),
+                None => Err(Error::Client(SuiRpcInputError::GenericNotFound(format!(
+                    "No parameters found for function {}",
+                    function
+                )))),
             }?)
         })
     }
@@ -289,7 +291,7 @@ mod tests {
             let mut mock_internal = MockMoveUtilsInternalTrait::new();
             let error_string = format!("No module found with module name {module_name}");
             let expected_error =
-                Error::SuiRpcInputError(SuiRpcInputError::GenericNotFound(error_string.clone()));
+                Error::Client(SuiRpcInputError::GenericNotFound(error_string.clone()));
             mock_internal
                 .expect_get_move_module()
                 .return_once(move |_package, _module_name| Err(expected_error));

--- a/crates/sui-json-rpc/src/move_utils.rs
+++ b/crates/sui-json-rpc/src/move_utils.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::api::MoveUtilsServer;
-use crate::error::{Error, SuiRpcInputError};
+use crate::error::{Error, ServerError, SuiRpcInputError};
 use crate::read_api::{get_move_module, get_move_modules_by_package};
 use crate::{with_tracing, SuiRpcModule};
 use async_trait::async_trait;
@@ -200,7 +200,7 @@ impl MoveUtilsServer for MoveUtils {
                             /* max_binary_format_version */ VERSION_MAX,
                             /* no_extraneous_module_bytes */ false,
                         )
-                        .map_err(Error::SuiRpcInternalError)
+                        .map_err(|e| Error::Server(ServerError::SuiError(e)))
                     }
                     _ => Err(Error::Client(SuiRpcInputError::GenericInvalid(format!(
                         "Object is not a package with ID {}",

--- a/crates/sui-json-rpc/src/move_utils.rs
+++ b/crates/sui-json-rpc/src/move_utils.rs
@@ -200,7 +200,7 @@ impl MoveUtilsServer for MoveUtils {
                             /* max_binary_format_version */ VERSION_MAX,
                             /* no_extraneous_module_bytes */ false,
                         )
-                        .map_err(|e| Error::SuiRpcInternalError(e.to_string()))
+                        .map_err(Error::SuiRpcInternalError)
                     }
                     _ => Err(Error::SuiRpcInputError(SuiRpcInputError::GenericInvalid(
                         format!("Object is not a package with ID {}", package),

--- a/crates/sui-json-rpc/src/move_utils.rs
+++ b/crates/sui-json-rpc/src/move_utils.rs
@@ -200,7 +200,7 @@ impl MoveUtilsServer for MoveUtils {
                             /* max_binary_format_version */ VERSION_MAX,
                             /* no_extraneous_module_bytes */ false,
                         )
-                        .map_err(Error::from)
+                        .map_err(|e| Error::SuiRpcInternalError(e.to_string()))
                     }
                     _ => Err(Error::SuiRpcInputError(SuiRpcInputError::GenericInvalid(
                         format!("Object is not a package with ID {}", package),

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -1098,7 +1098,7 @@ pub async fn get_move_modules_by_package(
                 )
                 .map_err(|e| {
                     error!("Failed to call get_move_modules_by_package for package: {package:?}");
-                    Error::SuiRpcInternalError(e)
+                    Error::Server(ServerError::SuiError(e))
                 })
             }
             _ => Err(Error::Client(SuiRpcInputError::GenericInvalid(format!(

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -659,7 +659,7 @@ impl ReadApiServer for ReadApi {
             if let Some((_, seq)) = spawn_monitored_task!(async move {
                 // TODO: this is reading from a deprecated DB. The replacement DB however
                 // is in the epoch store, and thus we risk breaking the read API for txes
-                // from old epochs. Should be migrated once we have indexer support, or 
+                // from old epochs. Should be migrated once we have indexer support, or
                 // when we can tolerate returning None for old txes.
                 state.database.deprecated_get_transaction_checkpoint(&digest)
                     .map_err(|e| {
@@ -1101,7 +1101,7 @@ pub async fn get_move_modules_by_package(
                 )
                 .map_err(|e| {
                     error!("Failed to call get_move_modules_by_package for package: {package:?}");
-                    Error::from(e)
+                    Error::SuiRpcInternalError(e.to_string()) // TODO(wlmyng): circle back to determine how we can better do this
                 })
             }
             _ => Err(Error::SuiRpcInputError(SuiRpcInputError::GenericInvalid(

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -1101,7 +1101,7 @@ pub async fn get_move_modules_by_package(
                 )
                 .map_err(|e| {
                     error!("Failed to call get_move_modules_by_package for package: {package:?}");
-                    Error::SuiRpcInternalError(e.to_string()) // TODO(wlmyng): circle back to determine how we can better do this
+                    Error::SuiRpcInternalError(e)
                 })
             }
             _ => Err(Error::SuiRpcInputError(SuiRpcInputError::GenericInvalid(

--- a/crates/sui-storage/src/indexes.rs
+++ b/crates/sui-storage/src/indexes.rs
@@ -1328,10 +1328,7 @@ impl IndexStore {
                 )
             })
             .await
-            .unwrap()
-            .map_err(|e| {
-                SuiError::ExecutionError(format!("Failed to read balance frm DB: {:?}", e))
-            });
+            .unwrap();
         }
 
         self.metrics.balance_lookup_from_total.inc();
@@ -1367,9 +1364,6 @@ impl IndexStore {
                 })
                 .await
                 .unwrap()
-                .map_err(|e| {
-                    SuiError::ExecutionError(format!("Failed to read balance frm DB: {:?}", e))
-                })
             })
             .await
     }
@@ -1391,10 +1385,7 @@ impl IndexStore {
                 Self::get_all_balances_from_db(metrics_cloned, coin_index_cloned, owner)
             })
             .await
-            .unwrap()
-            .map_err(|e| {
-                SuiError::ExecutionError(format!("Failed to read all balance from DB: {:?}", e))
-            });
+            .unwrap();
         }
 
         self.metrics.all_balance_lookup_from_total.inc();
@@ -1408,9 +1399,6 @@ impl IndexStore {
                 })
                 .await
                 .unwrap()
-                .map_err(|e| {
-                    SuiError::ExecutionError(format!("Failed to read all balance from DB: {:?}", e))
-                })
             })
             .await
     }
@@ -1457,7 +1445,7 @@ impl IndexStore {
             }
             let coin_type =
                 TypeTag::Struct(Box::new(parse_sui_struct_tag(&coin_type).map_err(|e| {
-                    SuiError::ExecutionError(format!(
+                    SuiError::GenericStorageError(format!(
                         "Failed to parse event sender address: {:?}",
                         e
                     ))

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -289,8 +289,7 @@ impl MoveObjectType {
     pub fn try_extract_field_name(&self, type_: &DynamicFieldType) -> SuiResult<TypeTag> {
         match &self.0 {
             MoveObjectType_::GasCoin | MoveObjectType_::StakedSui | MoveObjectType_::Coin(_) => {
-                Err(SuiError::DeserializationError {
-                    input_type: "object".to_string(),
+                Err(SuiError::TypeError {
                     error: "Error extracting dynamic object name from Coin object".to_string(),
                 })
             }

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -289,7 +289,8 @@ impl MoveObjectType {
     pub fn try_extract_field_name(&self, type_: &DynamicFieldType) -> SuiResult<TypeTag> {
         match &self.0 {
             MoveObjectType_::GasCoin | MoveObjectType_::StakedSui | MoveObjectType_::Coin(_) => {
-                Err(SuiError::ObjectDeserializationError {
+                Err(SuiError::DeserializationError {
+                    input_type: "object".to_string(),
                     error: "Error extracting dynamic object name from Coin object".to_string(),
                 })
             }

--- a/crates/sui-types/src/coin.rs
+++ b/crates/sui-types/src/coin.rs
@@ -152,7 +152,7 @@ impl TreasuryCap {
     /// Create a TreasuryCap from BCS bytes
     pub fn from_bcs_bytes(content: &[u8]) -> Result<Self, SuiError> {
         bcs::from_bytes(content).map_err(|err| SuiError::DeserializationError {
-            input_type: "object".to_string(),
+            format: "TreasuryCap".to_string(),
             error: format!("Unable to deserialize TreasuryCap object: {:?}", err),
         })
     }
@@ -209,7 +209,7 @@ impl CoinMetadata {
     /// Create a coin from BCS bytes
     pub fn from_bcs_bytes(content: &[u8]) -> Result<Self, SuiError> {
         bcs::from_bytes(content).map_err(|err| SuiError::DeserializationError {
-            input_type: "object".to_string(),
+            format: "CoinMetadata".to_string(),
             error: format!("Unable to deserialize CoinMetadata object: {:?}", err),
         })
     }

--- a/crates/sui-types/src/coin.rs
+++ b/crates/sui-types/src/coin.rs
@@ -151,7 +151,8 @@ pub struct TreasuryCap {
 impl TreasuryCap {
     /// Create a TreasuryCap from BCS bytes
     pub fn from_bcs_bytes(content: &[u8]) -> Result<Self, SuiError> {
-        bcs::from_bytes(content).map_err(|err| SuiError::ObjectDeserializationError {
+        bcs::from_bytes(content).map_err(|err| SuiError::DeserializationError {
+            input_type: "object".to_string(),
             error: format!("Unable to deserialize TreasuryCap object: {:?}", err),
         })
     }
@@ -207,7 +208,8 @@ impl CoinMetadata {
 
     /// Create a coin from BCS bytes
     pub fn from_bcs_bytes(content: &[u8]) -> Result<Self, SuiError> {
-        bcs::from_bytes(content).map_err(|err| SuiError::ObjectDeserializationError {
+        bcs::from_bytes(content).map_err(|err| SuiError::DeserializationError {
+            input_type: "object".to_string(),
             error: format!("Unable to deserialize CoinMetadata object: {:?}", err),
         })
     }

--- a/crates/sui-types/src/coin.rs
+++ b/crates/sui-types/src/coin.rs
@@ -151,7 +151,7 @@ pub struct TreasuryCap {
 impl TreasuryCap {
     /// Create a TreasuryCap from BCS bytes
     pub fn from_bcs_bytes(content: &[u8]) -> Result<Self, SuiError> {
-        bcs::from_bytes(content).map_err(|err| SuiError::TypeError {
+        bcs::from_bytes(content).map_err(|err| SuiError::ObjectDeserializationError {
             error: format!("Unable to deserialize TreasuryCap object: {:?}", err),
         })
     }
@@ -207,7 +207,7 @@ impl CoinMetadata {
 
     /// Create a coin from BCS bytes
     pub fn from_bcs_bytes(content: &[u8]) -> Result<Self, SuiError> {
-        bcs::from_bytes(content).map_err(|err| SuiError::TypeError {
+        bcs::from_bytes(content).map_err(|err| SuiError::ObjectDeserializationError {
             error: format!("Unable to deserialize CoinMetadata object: {:?}", err),
         })
     }

--- a/crates/sui-types/src/coin.rs
+++ b/crates/sui-types/src/coin.rs
@@ -152,7 +152,6 @@ impl TreasuryCap {
     /// Create a TreasuryCap from BCS bytes
     pub fn from_bcs_bytes(content: &[u8]) -> Result<Self, SuiError> {
         bcs::from_bytes(content).map_err(|err| SuiError::DeserializationError {
-            // not enough context here
             input_type: "object".to_string(),
             error: format!("Unable to deserialize TreasuryCap object: {:?}", err),
         })
@@ -210,7 +209,6 @@ impl CoinMetadata {
     /// Create a coin from BCS bytes
     pub fn from_bcs_bytes(content: &[u8]) -> Result<Self, SuiError> {
         bcs::from_bytes(content).map_err(|err| SuiError::DeserializationError {
-            // not enough context here?
             input_type: "object".to_string(),
             error: format!("Unable to deserialize CoinMetadata object: {:?}", err),
         })

--- a/crates/sui-types/src/coin.rs
+++ b/crates/sui-types/src/coin.rs
@@ -152,6 +152,7 @@ impl TreasuryCap {
     /// Create a TreasuryCap from BCS bytes
     pub fn from_bcs_bytes(content: &[u8]) -> Result<Self, SuiError> {
         bcs::from_bytes(content).map_err(|err| SuiError::DeserializationError {
+            // not enough context here
             input_type: "object".to_string(),
             error: format!("Unable to deserialize TreasuryCap object: {:?}", err),
         })
@@ -209,6 +210,7 @@ impl CoinMetadata {
     /// Create a coin from BCS bytes
     pub fn from_bcs_bytes(content: &[u8]) -> Result<Self, SuiError> {
         bcs::from_bytes(content).map_err(|err| SuiError::DeserializationError {
+            // not enough context here?
             input_type: "object".to_string(),
             error: format!("Unable to deserialize CoinMetadata object: {:?}", err),
         })

--- a/crates/sui-types/src/dynamic_field.rs
+++ b/crates/sui-types/src/dynamic_field.rs
@@ -302,12 +302,12 @@ where
     V: Serialize + DeserializeOwned,
 {
     let object = get_dynamic_field_object_from_store(object_store, parent_id, key)?;
-    let move_object = object.data.try_as_move().ok_or_else(|| {
-        SuiError::DynamicFieldReadError(format!(
-            "Dynamic field {:?} is not a Move object",
-            object.id()
-        ))
-    })?;
+    let move_object = object
+        .data
+        .try_as_move()
+        .ok_or_else(|| SuiError::TypeError {
+            error: format!("Dynamic field {:?} is not a Move object", object.id()),
+        })?;
     Ok(bcs::from_bytes::<Field<K, V>>(move_object.contents())
         .map_err(|err| SuiError::DynamicFieldReadError(err.to_string()))?
         .value)

--- a/crates/sui-types/src/dynamic_field.rs
+++ b/crates/sui-types/src/dynamic_field.rs
@@ -120,14 +120,12 @@ impl DynamicFieldInfo {
             (DynamicFieldType::DynamicObject, Some(TypeTag::Struct(s))) => Ok(s
                 .type_params
                 .first()
-                .ok_or_else(|| SuiError::DeserializationError {
-                    input_type: "object".to_string(),
-                    error: format!("Error extracting dynamic object name from object: {tag}"),
+                .ok_or_else(|| SuiError::TypeError {
+                    error: format!("Expected at least one TypeParam, none found for {tag}"),
                 })?
                 .clone()),
-            _ => Err(SuiError::DeserializationError {
-                input_type: "object".to_string(),
-                error: format!("Error extracting dynamic object name from object: {tag}"),
+            _ => Err(SuiError::TypeError {
+                error: format!("Error extracting dynamic object name from object: expected DynamicField or DynamicObject, received: {tag}"),
             }),
         }
     }
@@ -136,15 +134,13 @@ impl DynamicFieldInfo {
         move_struct: &MoveStruct,
     ) -> SuiResult<(MoveValue, DynamicFieldType, ObjectID)> {
         let name = extract_field_from_move_struct(move_struct, "name").ok_or_else(|| {
-            SuiError::DeserializationError {
-                input_type: "object".to_string(),
+            SuiError::TypeError {
                 error: "Cannot extract [name] field from sui::dynamic_field::Field".to_string(),
             }
         })?;
 
         let value = extract_field_from_move_struct(move_struct, "value").ok_or_else(|| {
-            SuiError::DeserializationError {
-                input_type: "object".to_string(),
+            SuiError::TypeError {
                 error: "Cannot extract [value] field from sui::dynamic_field::Field".to_string(),
             }
         })?;

--- a/crates/sui-types/src/dynamic_field.rs
+++ b/crates/sui-types/src/dynamic_field.rs
@@ -152,31 +152,28 @@ impl DynamicFieldInfo {
                 }
                 _ => None,
             }
-            .ok_or_else(|| SuiError::DeserializationError {
-                input_type: "object".to_string(),
-                error: "Cannot extract [name] field from sui::dynamic_object_field::Wrapper."
-                    .to_string(),
+            .ok_or_else(|| {
+                SuiError::MoveStructParseError(
+                    "Cannot extract [name] field from sui::dynamic_object_field::Wrapper."
+                        .to_string(),
+                )
             })?;
             // ID extracted from the wrapper object
-            let object_id =
-                extract_id_value(value).ok_or_else(|| SuiError::DeserializationError {
-                    input_type: "object".to_string(),
-                    error: format!(
-                        "Cannot extract dynamic object's object id from \
+            let object_id = extract_id_value(value).ok_or_else(|| {
+                SuiError::MoveStructParseError(format!(
+                    "Cannot extract dynamic object's object id from \
                         sui::dynamic_field::Field, {value:?}"
-                    ),
-                })?;
+                ))
+            })?;
             (name.clone(), DynamicFieldType::DynamicObject, object_id)
         } else {
             // ID of the Field object
-            let object_id =
-                extract_object_id(move_struct).ok_or_else(|| SuiError::DeserializationError {
-                    input_type: "object".to_string(),
-                    error: format!(
-                        "Cannot extract dynamic object's object id from \
+            let object_id = extract_object_id(move_struct).ok_or_else(|| {
+                SuiError::MoveStructParseError(format!(
+                    "Cannot extract dynamic object's object id from \
                         sui::dynamic_field::Field, {move_struct:?}",
-                    ),
-                })?;
+                ))
+            })?;
             (name.clone(), DynamicFieldType::DynamicField, object_id)
         })
     }
@@ -283,7 +280,7 @@ where
 {
     let id = derive_dynamic_field_id(parent_id, &K::get_type_tag(), &bcs::to_bytes(key).unwrap())
         .map_err(|err| SuiError::SerializationError {
-        input_type: "object_id".to_string(),
+        format: "ObjectID".to_string(),
         error: err.to_string(),
     })?;
     let object = object_store.get_object(&id)?.ok_or_else(|| {
@@ -316,7 +313,7 @@ where
         })?;
     Ok(bcs::from_bytes::<Field<K, V>>(move_object.contents())
         .map_err(|err| SuiError::DeserializationError {
-            input_type: "dynamic_field".to_string(),
+            format: "DynamicField".to_string(),
             error: err.to_string(),
         })?
         .value)

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -454,9 +454,6 @@ pub enum SuiError {
     #[error("Failed to dispatch subscription: {error:?}")]
     FailedToDispatchSubscription { error: String },
 
-    #[error("Failed to execute transaction locally by Orchestrator: {error:?}")]
-    TransactionOrchestratorLocalExecutionError { error: String },
-
     // Errors returned by authority and client read API's
     #[error(
         "Failed to serialize {input_type} in the requested format: {:?}",

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -98,6 +98,17 @@ pub enum UserInputError {
         object_id: ObjectID,
         version: Option<SequenceNumber>,
     },
+    #[error(
+        "Could not find the dynamic field object {:?} with key {:?} on parent {:?}",
+        id,
+        key,
+        parent_id
+    )]
+    DynamicFieldObjectNotFound {
+        id: ObjectID,
+        key: String,
+        parent_id: ObjectID,
+    },
     #[error("Object {provided_obj_ref:?} is not available for consumption, its current version: {current_version:?}.")]
     ObjectVersionUnavailableForConsumption {
         provided_obj_ref: ObjectRef,
@@ -447,12 +458,22 @@ pub enum SuiError {
     TransactionOrchestratorLocalExecutionError { error: String },
 
     // Errors returned by authority and client read API's
-    #[error("Failure serializing transaction in the requested format: {:?}", error)]
-    TransactionSerializationError { error: String },
-    #[error("Failure serializing object in the requested format: {:?}", error)]
-    ObjectSerializationError { error: String },
-    #[error("Failure deserializing object in the requested format: {:?}", error)]
-    ObjectDeserializationError { error: String },
+    #[error(
+        "Failed to serialize {input_type} in the requested format: {:?}",
+        error
+    )]
+    SerializationError { input_type: String, error: String },
+    #[error(
+        "Failed to deserialize {input_type} in the requested format: {:?}",
+        error
+    )]
+    DeserializationError { input_type: String, error: String },
+    #[error("Failed to convert {input_type} to {output_type}: {:?}", error)]
+    ConversionError {
+        input_type: String,
+        output_type: String,
+        error: String,
+    },
 
     // Client side error
     #[error("Too many authority errors were detected for {}: {:?}", action, errors)]
@@ -519,9 +540,6 @@ pub enum SuiError {
 
     #[error("Index store not available on this Fullnode.")]
     IndexStoreNotAvailable,
-
-    #[error("Failed to read dynamic field from table in the object store: {0}")]
-    DynamicFieldReadError(String),
 
     #[error("Failed to read or deserialize system state related data structures on-chain: {0}")]
     SuiSystemStateReadError(String),

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -411,8 +411,6 @@ pub enum SuiError {
         digest
     )]
     TransactionAlreadyExecuted { digest: TransactionDigest },
-    #[error("Object ID did not have the expected type")]
-    BadObjectType { error: String },
     #[error("Fail to retrieve Object layout for {st}")]
     FailObjectLayout { st: String },
 
@@ -448,12 +446,6 @@ pub enum SuiError {
     #[error("Failed to dispatch subscription: {error:?}")]
     FailedToDispatchSubscription { error: String },
 
-    #[error("Failed to serialize Owner: {error:?}")]
-    OwnerFailedToSerialize { error: String },
-
-    #[error("Failed to deserialize fields into JSON: {error:?}")]
-    ExtraFieldFailedToDeserialize { error: String },
-
     #[error("Failed to execute transaction locally by Orchestrator: {error:?}")]
     TransactionOrchestratorLocalExecutionError { error: String },
 
@@ -464,8 +456,6 @@ pub enum SuiError {
     ObjectSerializationError { error: String },
     #[error("Failure deserializing object in the requested format: {:?}", error)]
     ObjectDeserializationError { error: String },
-    #[error("Event store component is not active on this node")]
-    NoEventStore,
 
     // Client side error
     #[error("Too many authority errors were detected for {}: {:?}", action, errors)]
@@ -473,8 +463,6 @@ pub enum SuiError {
         errors: Vec<(AuthorityName, SuiError)>,
         action: String,
     },
-    #[error("Invalid transaction range query to the fullnode: {:?}", error)]
-    FullNodeInvalidTxRangeQuery { error: String },
 
     // Errors related to the authority-consensus interface.
     #[error("Failed to submit transaction to consensus: {0}")]
@@ -483,8 +471,6 @@ pub enum SuiError {
     ConsensusConnectionBroken(String),
     #[error("Failed to hear back from consensus: {0}")]
     FailedToHearBackFromConsensus(String),
-    #[error("Failed to execute handle_consensus_transaction on Sui: {0}")]
-    HandleConsensusTransactionFailure(String),
 
     // Cryptography errors.
     #[error("Signature seed invalid length, input byte size was: {0}")]

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -530,7 +530,7 @@ pub enum SuiError {
     TimeoutError,
 
     #[error("Error executing {0}")]
-    ExecutionError(String),
+    ExecutionError(String, ExecutionErrorKind),
 
     #[error("Invalid committee composition")]
     InvalidCommittee(String),
@@ -595,7 +595,7 @@ impl From<sui_protocol_config::Error> for SuiError {
 
 impl From<ExecutionError> for SuiError {
     fn from(error: ExecutionError) -> Self {
-        SuiError::ExecutionError(error.to_string())
+        SuiError::ExecutionError(error.to_string(), error.kind().clone())
     }
 }
 
@@ -617,12 +617,6 @@ impl From<SuiError> for Status {
     fn from(error: SuiError) -> Self {
         let bytes = bcs::to_bytes(&error).unwrap();
         Status::with_details(tonic::Code::Internal, error.to_string(), bytes.into())
-    }
-}
-
-impl From<ExecutionErrorKind> for SuiError {
-    fn from(kind: ExecutionErrorKind) -> Self {
-        ExecutionError::from_kind(kind).into()
     }
 }
 

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -455,22 +455,18 @@ pub enum SuiError {
     FailedToDispatchSubscription { error: String },
 
     // Errors returned by authority and client read API's
-    #[error(
-        "Failed to serialize {input_type} in the requested format: {:?}",
-        error
-    )]
-    SerializationError { input_type: String, error: String },
-    #[error(
-        "Failed to deserialize {input_type} in the requested format: {:?}",
-        error
-    )]
-    DeserializationError { input_type: String, error: String },
+    #[error("Failed to serialize into requested format {format}: {:?}", error)]
+    SerializationError { format: String, error: String },
+    #[error("Failed to deserialize into requested format {format}: {:?}", error)]
+    DeserializationError { format: String, error: String },
     #[error("Failed to convert {input_type} to {output_type}: {:?}", error)]
     ConversionError {
         input_type: String,
         output_type: String,
         error: String,
     },
+    #[error("{0}")]
+    MoveStructParseError(String),
 
     // Client side error
     #[error("Too many authority errors were detected for {}: {:?}", action, errors)]

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -360,9 +360,6 @@ pub enum SuiError {
     #[error("Invalid transaction digest.")]
     InvalidTransactionDigest,
 
-    #[error("Unexpected message.")]
-    UnexpectedMessage,
-
     // Move module publishing related errors
     #[error("Failed to verify the Move module, reason: {error:?}.")]
     ModuleVerificationFailure { error: String },

--- a/crates/sui-types/src/event.rs
+++ b/crates/sui-types/src/event.rs
@@ -135,7 +135,7 @@ impl Event {
         )?;
         MoveStruct::simple_deserialize(contents, &layout).map_err(|e| {
             SuiError::SerializationError {
-                input_type: "object".to_string(),
+                format: "MoveStruct".to_string(),
                 error: e.to_string(),
             }
         })

--- a/crates/sui-types/src/event.rs
+++ b/crates/sui-types/src/event.rs
@@ -134,7 +134,8 @@ impl Event {
             resolver,
         )?;
         MoveStruct::simple_deserialize(contents, &layout).map_err(|e| {
-            SuiError::ObjectSerializationError {
+            SuiError::SerializationError {
+                input_type: "object".to_string(),
                 error: e.to_string(),
             }
         })

--- a/crates/sui-types/src/execution_status.rs
+++ b/crates/sui-types/src/execution_status.rs
@@ -25,7 +25,7 @@ pub enum ExecutionStatus {
     },
 }
 
-#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, Error, EnumVariantOrder)]
+#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, Error, EnumVariantOrder, Hash)]
 pub enum ExecutionFailureStatus {
     //
     // General transaction errors

--- a/crates/sui-types/src/governance.rs
+++ b/crates/sui-types/src/governance.rs
@@ -97,8 +97,10 @@ impl TryFrom<&Object> for StakedSui {
         match &object.data {
             Data::Move(o) => {
                 if o.type_().is_staked_sui() {
-                    return bcs::from_bytes(o.contents()).map_err(|err| SuiError::TypeError {
-                        error: format!("Unable to deserialize StakedSui object: {:?}", err),
+                    return bcs::from_bytes(o.contents()).map_err(|err| {
+                        SuiError::ObjectDeserializationError {
+                            error: format!("Unable to deserialize StakedSui object: {:?}", err),
+                        }
                     });
                 }
             }

--- a/crates/sui-types/src/governance.rs
+++ b/crates/sui-types/src/governance.rs
@@ -99,7 +99,7 @@ impl TryFrom<&Object> for StakedSui {
                 if o.type_().is_staked_sui() {
                     return bcs::from_bytes(o.contents()).map_err(|err| {
                         SuiError::DeserializationError {
-                            input_type: "object".to_string(),
+                            format: "StakedSui".to_string(),
                             error: format!("Unable to deserialize StakedSui object: {:?}", err),
                         }
                     });

--- a/crates/sui-types/src/governance.rs
+++ b/crates/sui-types/src/governance.rs
@@ -98,7 +98,8 @@ impl TryFrom<&Object> for StakedSui {
             Data::Move(o) => {
                 if o.type_().is_staked_sui() {
                     return bcs::from_bytes(o.contents()).map_err(|err| {
-                        SuiError::ObjectDeserializationError {
+                        SuiError::DeserializationError {
+                            input_type: "object".to_string(),
                             error: format!("Unable to deserialize StakedSui object: {:?}", err),
                         }
                     });

--- a/crates/sui-types/src/move_package.rs
+++ b/crates/sui-types/src/move_package.rs
@@ -618,12 +618,12 @@ where
         let view = BinaryIndexedView::Module(&module);
         let d = Disassembler::from_view(view, Spanned::unsafe_no_loc(()).loc).map_err(|e| {
             SuiError::SerializationError {
-                input_type: "object".to_string(),
+                format: "module".to_string(),
                 error: e.to_string(),
             }
         })?;
         let bytecode_str = d.disassemble().map_err(|e| SuiError::SerializationError {
-            input_type: "object".to_string(),
+            format: "module".to_string(),
             error: e.to_string(),
         })?;
         disassembled.insert(module.name().to_string(), Value::String(bytecode_str));

--- a/crates/sui-types/src/move_package.rs
+++ b/crates/sui-types/src/move_package.rs
@@ -617,15 +617,15 @@ where
         })?;
         let view = BinaryIndexedView::Module(&module);
         let d = Disassembler::from_view(view, Spanned::unsafe_no_loc(()).loc).map_err(|e| {
-            SuiError::ObjectSerializationError {
+            SuiError::SerializationError {
+                input_type: "object".to_string(),
                 error: e.to_string(),
             }
         })?;
-        let bytecode_str = d
-            .disassemble()
-            .map_err(|e| SuiError::ObjectSerializationError {
-                error: e.to_string(),
-            })?;
+        let bytecode_str = d.disassemble().map_err(|e| SuiError::SerializationError {
+            input_type: "object".to_string(),
+            error: e.to_string(),
+        })?;
         disassembled.insert(module.name().to_string(), Value::String(bytecode_str));
     }
     Ok(disassembled)

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -292,7 +292,7 @@ impl MoveObject {
 
     /// Get a `MoveStructLayout` for `self`.
     /// The `resolver` value must contain the module that declares `self.type_` and the (transitive)
-    /// dependencies of `self.type_` in order for this to succeed. Failure will result in an `ObjectSerializationError`
+    /// dependencies of `self.type_` in order for this to succeed. Failure will result in a `SerializationError`
     pub fn get_layout(
         &self,
         format: ObjectFormatOptions,
@@ -312,7 +312,8 @@ impl MoveObject {
         } else {
             TypeLayoutBuilder::build_with_fields(&type_, resolver)
         }
-        .map_err(|e| SuiError::ObjectSerializationError {
+        .map_err(|e| SuiError::SerializationError {
+            input_type: "object".to_string(),
             error: e.to_string(),
         })?;
         match layout {
@@ -326,7 +327,8 @@ impl MoveObject {
     /// Convert `self` to the JSON representation dictated by `layout`.
     pub fn to_move_struct(&self, layout: &MoveStructLayout) -> Result<MoveStruct, SuiError> {
         MoveStruct::simple_deserialize(&self.contents, layout).map_err(|e| {
-            SuiError::ObjectSerializationError {
+            SuiError::SerializationError {
+                input_type: "object".to_string(),
                 error: e.to_string(),
             }
         })
@@ -795,7 +797,7 @@ impl Object {
 
     /// Get a `MoveStructLayout` for `self`.
     /// The `resolver` value must contain the module that declares `self.type_` and the (transitive)
-    /// dependencies of `self.type_` in order for this to succeed. Failure will result in an `ObjectSerializationError`
+    /// dependencies of `self.type_` in order for this to succeed. Failure will result in a `SerializationError`
     pub fn get_layout(
         &self,
         format: ObjectFormatOptions,

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -313,7 +313,7 @@ impl MoveObject {
             TypeLayoutBuilder::build_with_fields(&type_, resolver)
         }
         .map_err(|e| SuiError::SerializationError {
-            input_type: "object".to_string(),
+            format: "MoveStructLayout".to_string(),
             error: e.to_string(),
         })?;
         match layout {
@@ -328,7 +328,7 @@ impl MoveObject {
     pub fn to_move_struct(&self, layout: &MoveStructLayout) -> Result<MoveStruct, SuiError> {
         MoveStruct::simple_deserialize(&self.contents, layout).map_err(|e| {
             SuiError::SerializationError {
-                input_type: "object".to_string(),
+                format: "MoveStruct".to_string(),
                 error: e.to_string(),
             }
         })

--- a/crates/sui-types/src/sui_system_state/mod.rs
+++ b/crates/sui-types/src/sui_system_state/mod.rs
@@ -244,7 +244,7 @@ pub fn get_sui_system_state(object_store: &dyn ObjectStore) -> Result<SuiSystemS
             let result: SuiSystemStateInnerV1 =
                 get_dynamic_field_from_store(object_store, id, &wrapper.version).map_err(
                     |err| {
-                        SuiError::DynamicFieldReadError(format!(
+                        SuiError::SuiSystemStateReadError(format!(
                             "Failed to load sui system state inner object with ID {:?} and version {:?}: {:?}",
                             id, wrapper.version, err
                         ))
@@ -256,7 +256,7 @@ pub fn get_sui_system_state(object_store: &dyn ObjectStore) -> Result<SuiSystemS
             let result: SuiSystemStateInnerV2 =
                 get_dynamic_field_from_store(object_store, id, &wrapper.version).map_err(
                     |err| {
-                        SuiError::DynamicFieldReadError(format!(
+                        SuiError::SuiSystemStateReadError(format!(
                             "Failed to load sui system state inner object with ID {:?} and version {:?}: {:?}",
                             id, wrapper.version, err
                         ))
@@ -269,7 +269,7 @@ pub fn get_sui_system_state(object_store: &dyn ObjectStore) -> Result<SuiSystemS
             let result: SimTestSuiSystemStateInnerV1 =
                 get_dynamic_field_from_store(object_store, id, &wrapper.version).map_err(
                     |err| {
-                        SuiError::DynamicFieldReadError(format!(
+                        SuiError::SuiSystemStateReadError(format!(
                             "Failed to load sui system state inner object with ID {:?} and version {:?}: {:?}",
                             id, wrapper.version, err
                         ))
@@ -282,7 +282,7 @@ pub fn get_sui_system_state(object_store: &dyn ObjectStore) -> Result<SuiSystemS
             let result: SimTestSuiSystemStateInnerShallowV2 =
                 get_dynamic_field_from_store(object_store, id, &wrapper.version).map_err(
                     |err| {
-                        SuiError::DynamicFieldReadError(format!(
+                        SuiError::SuiSystemStateReadError(format!(
                             "Failed to load sui system state inner object with ID {:?} and version {:?}: {:?}",
                             id, wrapper.version, err
                         ))
@@ -295,7 +295,7 @@ pub fn get_sui_system_state(object_store: &dyn ObjectStore) -> Result<SuiSystemS
             let result: SimTestSuiSystemStateInnerDeepV2 =
                 get_dynamic_field_from_store(object_store, id, &wrapper.version).map_err(
                     |err| {
-                        SuiError::DynamicFieldReadError(format!(
+                        SuiError::SuiSystemStateReadError(format!(
                             "Failed to load sui system state inner object with ID {:?} and version {:?}: {:?}",
                             id, wrapper.version, err
                         ))

--- a/crates/sui-types/src/temporary_store.rs
+++ b/crates/sui-types/src/temporary_store.rs
@@ -1595,7 +1595,7 @@ impl<'backing> ModuleResolver for TemporaryStore<'backing> {
                 .serialized_module_map()
                 .get(module_id.name().as_str())
                 .cloned()),
-            _ => Err(SuiError::BadObjectType {
+            _ => Err(SuiError::TypeError {
                 error: "Expected module object".to_string(),
             }),
         }


### PR DESCRIPTION
## Description 

Map variants in `sui_json_rpc::Error` to `-32000`, `-32602`, and `-32603`, and clean up some errors along the way.
* removed NoEventStore, FullNodeInvalidTxRangeQuery, HandleConsensusTransactionFailure as these are not used
* Metrics logger now increments server error metric only on `-32603`
* QuorumDriverError wraps an inner SuiError - this inner SuiError is now used to determine error code
* Consolidate most serde-related errors into one `SuiError::SerializationError` and `DeserializationError`
* Removed `DynamicFieldReadError` as it was obscuring underlying errors - mapped errors to `DeserializationError`, `DynamicFieldObjectNotFound`, or `SuiSystemStateReadError` instead
* Similarly remove TransactionOrchestratorLocalExecutionError to surface underlying `SuiError`
* `SuiError::DeserializationError` gets mapped to `sui_json_rpc::Error::SuiRpcInternalError` where applicable (in scenarios where the deserialization error occurs on an object read from chain, which should not happen).
* Remove `BcsError` in favor of `SuiRpcInputError::Serialization` and `::Deserialization` for client-responsible errors, and `ServerError::Serde(String)` for error from server.

These are the errors that map to `-32603` and will increment the metric:
```
            Error::InternalError(err) => to_internal_error(err),
            Error::BcsError(err) => to_internal_error(err),
            Error::UnexpectedError(err) => to_internal_error(err),
            Error::EncodingError(err) => to_internal_error(err),
            Error::TokioJoinError(err) => to_internal_error(err),
                QuorumDriverError::SystemOverload { .. } => to_internal_error(err),

            Error::SuiRpcInternalError(err) => match err {
                SuiError::ModuleDeserializationFailure { .. }
                | SuiError::DeserializationError { .. } => to_internal_error(err),
                _ => match_sui_error(err),
            },

        SuiError::ExecutionError(_err, status) => match status {
            ExecutionFailureStatus::VMInvariantViolation => to_internal_error(status),

        SuiError::StorageError { .. }
        | SuiError::GenericStorageError { .. }
        | SuiError::StorageMissingFieldError { .. }
        | SuiError::StorageCorruptedFieldError { .. }
        | SuiError::GenericAuthorityError { .. }
        | SuiError::MissingCommitteeAtEpoch { .. }
        | SuiError::FileIOError { .. }
        | SuiError::JWKRetrievalError
        | SuiError::ExecutionInvariantViolation
        | SuiError::SuiSystemStateReadError(_)
        | SuiError::FailObjectLayout { .. }
        | SuiError::Unknown { .. } => to_internal_error(sui_error),
```
Some of these already have existing alerts, such as `InvariantViolation`. To avoid redundancy, these could occupy their own custom error codes, so they won't be confused with the three designated error codes and tallied into the server error metric. 

## Test Plan 

Existing tests + ci

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [x] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
* removed NoEventStore, FullNodeInvalidTxRangeQuery, HandleConsensusTransactionFailure as these are not used
* Metrics logger now increments server error metric only on `-32603`
* QuorumDriverError wraps an inner SuiError - this inner SuiError is now used to determine error code
* Consolidate most serde-related errors into one `SuiError::SerializationError` and `DeserializationError`
* Removed `DynamicFieldReadError` as it was obscuring underlying errors - mapped errors to `DeserializationError`, `DynamicFieldObjectNotFound`, or `SuiSystemStateReadError` instead
* Similarly removed TransactionOrchestratorLocalExecutionError to surface underlying `SuiError`
* `SuiError::DeserializationError` gets mapped to `sui_json_rpc::Error::SuiRpcInternalError` where applicable (in scenarios where the deserialization error occurs on an object read from chain, which should not happen)
