### PR TITLE
Use TestCluster in shared_objects_version_tests

### DIFF
--- a/crates/sui-e2e-tests/tests/shared_objects_version_tests.rs
+++ b/crates/sui-e2e-tests/tests/shared_objects_version_tests.rs
@@ -2,36 +2,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::path::PathBuf;
-use std::time::Duration;
 use sui_macros::*;
-use sui_node::SuiNodeHandle;
-use sui_swarm_config::network_config::NetworkConfig;
-use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_types::base_types::{ObjectID, ObjectRef, SequenceNumber};
-use sui_types::crypto::deterministic_random_account_key;
-use sui_types::effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents};
-use sui_types::error::SuiResult;
+use sui_types::effects::TransactionEffectsAPI;
+use sui_types::effects::{TransactionEffects, TransactionEvents};
 use sui_types::execution_status::{ExecutionFailureStatus, ExecutionStatus};
-use sui_types::multiaddr::Multiaddr;
-use sui_types::object::{generate_test_gas_objects, Object, Owner, OBJECT_START_VERSION};
+use sui_types::object::{Object, Owner, OBJECT_START_VERSION};
 use sui_types::transaction::{CallArg, ObjectArg};
 use sui_types::SUI_FRAMEWORK_ADDRESS;
-use test_utils::authority::{spawn_test_authorities, test_authority_configs_with_objects};
-use test_utils::transaction::{
-    publish_package, submit_shared_object_transaction, submit_single_owner_transaction,
-};
-use tokio::time::timeout;
+use test_utils::network::{TestCluster, TestClusterBuilder};
 
 #[sim_test]
 async fn fresh_shared_object_initial_version_matches_current() {
-    let mut env = TestEnvironment::new().await;
+    let env = TestEnvironment::new().await;
     let ((_, curr, _), owner) = env.create_shared_counter().await;
     assert!(is_shared_at(&owner, curr));
 }
 
 #[sim_test]
 async fn objects_transitioning_to_shared_remember_their_previous_version() {
-    let mut env = TestEnvironment::new().await;
+    let env = TestEnvironment::new().await;
     let (counter, _) = env.create_counter().await;
 
     let (counter, _) = env.increment_owned_counter(counter).await;
@@ -42,13 +32,11 @@ async fn objects_transitioning_to_shared_remember_their_previous_version() {
     assert_eq!(location.module.address(), &SUI_FRAMEWORK_ADDRESS);
     assert_eq!(location.module.name().as_str(), "transfer");
     assert_eq!(code, 0 /* ESharedNonNewObject */);
-    // assert_ne!(counter.1, OBJECT_START_VERSION);
-    // assert!(is_shared_at(&owner, counter.1));
 }
 
 #[sim_test]
 async fn shared_object_owner_doesnt_change_on_write() {
-    let mut env = TestEnvironment::new().await;
+    let env = TestEnvironment::new().await;
     let (counter, _) = env.create_counter().await;
 
     let (inc_counter, _) = env.increment_owned_counter(counter).await;
@@ -57,17 +45,11 @@ async fn shared_object_owner_doesnt_change_on_write() {
     assert_eq!(location.module.address(), &SUI_FRAMEWORK_ADDRESS);
     assert_eq!(location.module.name().as_str(), "transfer");
     assert_eq!(code, 0 /* ESharedNonNewObject */);
-    // let (_, new_owner) = env
-    //     .increment_shared_counter(counter.0, counter.1)
-    //     .await
-    //     .expect("Successful shared increment");
-
-    // assert_eq!(new_owner, old_owner);
 }
 
 #[sim_test]
 async fn initial_shared_version_mismatch_start_version() {
-    let mut env = TestEnvironment::new().await;
+    let env = TestEnvironment::new().await;
     let (counter, _) = env.create_counter().await;
 
     let (counter, _) = env.increment_owned_counter(counter).await;
@@ -80,7 +62,7 @@ async fn initial_shared_version_mismatch_start_version() {
 
 #[sim_test]
 async fn initial_shared_version_mismatch_current_version() {
-    let mut env = TestEnvironment::new().await;
+    let env = TestEnvironment::new().await;
     let (counter, _) = env.create_counter().await;
 
     let ExecutionFailureStatus::MoveAbort(location, code) =
@@ -92,18 +74,13 @@ async fn initial_shared_version_mismatch_current_version() {
 
 #[sim_test]
 async fn shared_object_not_found() {
-    let mut env = TestEnvironment::new().await;
+    let env = TestEnvironment::new().await;
     let nonexistent_id = ObjectID::random();
     let initial_shared_seq = SequenceNumber::from_u64(42);
-    if timeout(
-        Duration::from_secs(10),
-        env.increment_shared_counter(nonexistent_id, initial_shared_seq),
-    )
-    .await
-    .is_ok()
-    {
-        panic!("Executing transaction with nonexistent input should not return!");
-    };
+    assert!(env
+        .increment_shared_counter(nonexistent_id, initial_shared_seq)
+        .await
+        .is_err());
 }
 
 fn is_shared_at(owner: &Owner, version: SequenceNumber) -> bool {
@@ -118,79 +95,46 @@ fn is_shared_at(owner: &Owner, version: SequenceNumber) -> bool {
 }
 
 struct TestEnvironment {
-    gas_objects: Vec<Object>,
-    configs: NetworkConfig,
-    #[allow(dead_code)]
-    node_handles: Vec<SuiNodeHandle>,
+    test_cluster: TestCluster,
     move_package: ObjectID,
 }
 
 impl TestEnvironment {
     async fn new() -> Self {
-        let gas_objects = generate_test_gas_objects();
-        let (configs, mut gas_objects) = test_authority_configs_with_objects(gas_objects);
-        let rgp = configs.genesis.reference_gas_price();
-        let node_handles = spawn_test_authorities(&configs).await;
+        let test_cluster = TestClusterBuilder::new().build().await;
 
-        let move_package =
-            publish_move_package(gas_objects.pop().unwrap(), &configs.net_addresses(), rgp)
-                .await
-                .0;
+        let move_package = publish_move_package(&test_cluster).await.0;
 
         Self {
-            gas_objects,
-            configs,
-            node_handles,
+            test_cluster,
             move_package,
         }
     }
 
-    async fn owned_move_call(
-        &mut self,
+    async fn move_call(
+        &self,
         function: &'static str,
         arguments: Vec<CallArg>,
-    ) -> (TransactionEffects, TransactionEvents, Vec<Object>) {
-        let rgp = self.configs.genesis.reference_gas_price();
-        let (sender, keypair) = deterministic_random_account_key();
-        let transaction = TestTransactionBuilder::new(
-            sender,
-            self.gas_objects.pop().unwrap().compute_object_reference(),
-            rgp,
-        )
-        .move_call(
-            self.move_package,
-            "shared_objects_version",
-            function,
-            arguments,
-        )
-        .build_and_sign(&keypair);
-        submit_single_owner_transaction(transaction, &self.configs.net_addresses()).await
+    ) -> anyhow::Result<(TransactionEffects, TransactionEvents, Vec<Object>)> {
+        let transaction = self
+            .test_cluster
+            .test_transaction_builder()
+            .await
+            .move_call(
+                self.move_package,
+                "shared_objects_version",
+                function,
+                arguments,
+            )
+            .build();
+        let transaction = self.test_cluster.wallet.sign_transaction(&transaction);
+        self.test_cluster
+            .execute_transaction_return_raw_effects(transaction)
+            .await
     }
 
-    async fn shared_move_call(
-        &mut self,
-        function: &'static str,
-        arguments: Vec<CallArg>,
-    ) -> SuiResult<(TransactionEffects, TransactionEvents, Vec<Object>)> {
-        let rgp = self.configs.genesis.reference_gas_price();
-        let (sender, keypair) = deterministic_random_account_key();
-        let transaction = TestTransactionBuilder::new(
-            sender,
-            self.gas_objects.pop().unwrap().compute_object_reference(),
-            rgp,
-        )
-        .move_call(
-            self.move_package,
-            "shared_objects_version",
-            function,
-            arguments,
-        )
-        .build_and_sign(&keypair);
-        submit_shared_object_transaction(transaction, &self.configs.net_addresses()).await
-    }
-
-    async fn create_counter(&mut self) -> (ObjectRef, Owner) {
-        let (fx, _, _) = self.owned_move_call("create_counter", vec![]).await;
+    async fn create_counter(&self) -> (ObjectRef, Owner) {
+        let (fx, _, _) = self.move_call("create_counter", vec![]).await.unwrap();
         assert!(fx.status().is_ok());
 
         *fx.created()
@@ -199,8 +143,11 @@ impl TestEnvironment {
             .expect("Owned object created")
     }
 
-    async fn create_shared_counter(&mut self) -> (ObjectRef, Owner) {
-        let (fx, _, _) = self.owned_move_call("create_shared_counter", vec![]).await;
+    async fn create_shared_counter(&self) -> (ObjectRef, Owner) {
+        let (fx, _, _) = self
+            .move_call("create_shared_counter", vec![])
+            .await
+            .unwrap();
         assert!(fx.status().is_ok());
 
         *fx.created()
@@ -210,15 +157,16 @@ impl TestEnvironment {
     }
 
     async fn share_counter(
-        &mut self,
+        &self,
         counter: ObjectRef,
     ) -> Result<(ObjectRef, Owner), ExecutionFailureStatus> {
         let (fx, _, _) = self
-            .owned_move_call(
+            .move_call(
                 "share_counter",
                 vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(counter))],
             )
-            .await;
+            .await
+            .unwrap();
 
         if let ExecutionStatus::Failure { error, .. } = fx.status() {
             return Err(error.clone());
@@ -231,15 +179,14 @@ impl TestEnvironment {
             .expect("Counter mutated"))
     }
 
-    async fn increment_owned_counter(&mut self, counter: ObjectRef) -> (ObjectRef, Owner) {
+    async fn increment_owned_counter(&self, counter: ObjectRef) -> (ObjectRef, Owner) {
         let (fx, _, _) = self
-            .owned_move_call(
+            .move_call(
                 "increment_counter",
                 vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(counter))],
             )
-            .await;
-
-        assert!(fx.status().is_ok());
+            .await
+            .unwrap();
 
         *fx.mutated()
             .iter()
@@ -248,12 +195,12 @@ impl TestEnvironment {
     }
 
     async fn increment_shared_counter(
-        &mut self,
+        &self,
         counter: ObjectID,
         initial_shared_version: SequenceNumber,
-    ) -> SuiResult<(ObjectRef, Owner)> {
+    ) -> anyhow::Result<(ObjectRef, Owner)> {
         let (fx, _, _) = self
-            .shared_move_call(
+            .move_call(
                 "increment_counter",
                 vec![CallArg::Object(ObjectArg::SharedObject {
                     id: counter,
@@ -263,8 +210,6 @@ impl TestEnvironment {
             )
             .await?;
 
-        assert!(fx.status().is_ok());
-
         Ok(*fx
             .mutated()
             .iter()
@@ -273,12 +218,8 @@ impl TestEnvironment {
     }
 }
 
-async fn publish_move_package(
-    gas: Object,
-    net_addresses: &[Multiaddr],
-    gas_price: u64,
-) -> ObjectRef {
+async fn publish_move_package(test_cluster: &TestCluster) -> ObjectRef {
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push("tests/move_test_code");
-    publish_package(gas, path, net_addresses, gas_price).await
+    test_cluster.wallet.publish_package(path).await
 }


### PR DESCRIPTION
## Description 

Use TestCluster in shared_objects_version_tests

## Test Plan 

CI

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
