### PR TITLE
move: add basic telemetry to source service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10746,10 +10746,12 @@ dependencies = [
  "sui-move-build",
  "sui-sdk",
  "sui-source-validation",
+ "telemetry-subscribers",
  "tempfile",
  "test-utils",
  "tokio",
  "toml 0.7.4",
+ "tracing",
  "url",
  "workspace-hack",
 ]

--- a/crates/sui-source-validation-service/Cargo.toml
+++ b/crates/sui-source-validation-service/Cargo.toml
@@ -20,6 +20,7 @@ clap = { version = "3.2.17", features = ["derive"] }
 tempfile = "3.3.0"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 toml = { version = "0.7.4", features = ["preserve_order"] }
+tracing = "0.1.36"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.88"
 url = "2.3.1"
@@ -31,6 +32,7 @@ sui-sdk = { path = "../../crates/sui-sdk" }
 sui-source-validation = { path = "../sui-source-validation" }
 
 move-package.workspace = true
+telemetry-subscribers.workspace = true
 workspace-hack = { version = "0.1", path = "../../crates/workspace-hack" }
 
 [dev-dependencies]

--- a/crates/sui-source-validation-service/src/lib.rs
+++ b/crates/sui-source-validation-service/src/lib.rs
@@ -11,6 +11,7 @@ use std::{
 use actix_web::{dev::Server, web, App, HttpRequest, HttpServer, Responder};
 use anyhow::{anyhow, bail};
 use serde::Deserialize;
+use tracing::info;
 use url::Url;
 
 use move_package::BuildConfig as MoveBuildConfig;
@@ -153,6 +154,7 @@ pub async fn clone_repositories(config: &Config, dir: &Path) -> anyhow::Result<(
     let mut tasks = vec![];
     for p in &config.packages {
         let command = CloneCommand::new(p, dir)?;
+        info!("cloning {} to {}", &p.repository, dir.display());
         let t = tokio::spawn(async move { command.run().await });
         tasks.push(t);
     }

--- a/crates/sui-source-validation-service/src/main.rs
+++ b/crates/sui-source-validation-service/src/main.rs
@@ -7,6 +7,7 @@ use clap::Parser;
 
 use sui_config::{sui_config_dir, SUI_CLIENT_CONFIG};
 use sui_sdk::wallet_context::WalletContext;
+use telemetry_subscribers::TelemetryConfig;
 
 use sui_source_validation_service::{initialize, parse_config, serve};
 
@@ -18,6 +19,7 @@ struct Args {
 #[tokio::main]
 pub async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
+    let _logging_guard = TelemetryConfig::new().with_env().init();
     let package_config = parse_config(args.config_path)?;
     let sui_config = sui_config_dir()?.join(SUI_CLIENT_CONFIG);
     let context = WalletContext::new(&sui_config, None, None).await?;


### PR DESCRIPTION
## Description 

Stacked on https://github.com/MystenLabs/sui/pull/12590

Adds telemetry dependency with basic `info` logging as we clone repos. Running the binary you'll now see like

![Screen Shot 2023-06-21 at 6 31 13 PM](https://github.com/MystenLabs/sui/assets/888624/a46f69d3-e8da-4c73-b081-59b1acf4b33b)


## Test Plan 

Tested manually, not straightforward to unit test and also overkill for logging

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
