### PR TITLE
wallet-ext: clean up transaction requests storage

### DIFF
--- a/apps/wallet/src/background/Alarms.ts
+++ b/apps/wallet/src/background/Alarms.ts
@@ -10,6 +10,7 @@ import {
 } from '_src/shared/constants';
 
 export const LOCK_ALARM_NAME = 'lock-keyring-alarm';
+export const CLEAN_UP_ALARM_NAME = 'clean-up-storage-alarm';
 
 class Alarms {
 	public async setLockAlarm() {
@@ -21,6 +22,10 @@ class Alarms {
 
 	public clearLockAlarm() {
 		return Browser.alarms.clear(LOCK_ALARM_NAME);
+	}
+
+	public async setCleanUpAlarm() {
+		await Browser.alarms.create(CLEAN_UP_ALARM_NAME, { periodInMinutes: 60 * 6 }); //  every 6 hours
 	}
 }
 

--- a/apps/wallet/src/background/index.ts
+++ b/apps/wallet/src/background/index.ts
@@ -4,9 +4,10 @@
 import { lte, coerce } from 'semver';
 import Browser from 'webextension-polyfill';
 
-import { LOCK_ALARM_NAME } from './Alarms';
+import Alarms, { CLEAN_UP_ALARM_NAME, LOCK_ALARM_NAME } from './Alarms';
 import NetworkEnv from './NetworkEnv';
 import Permissions from './Permissions';
+import Transactions from './Transactions';
 import { Connections } from './connections';
 import Keyring from './keyring';
 import * as Qredo from './qredo';
@@ -20,7 +21,7 @@ Browser.runtime.onInstalled.addListener(async ({ reason, previousVersion }) => {
 	if (navigator.userAgent === 'Playwright') {
 		return;
 	}
-
+	Alarms.setCleanUpAlarm();
 	// TODO: Our versions don't use semver, and instead are date-based. Instead of using the semver
 	// library, we can use some combination of parsing into a date + inspecting patch.
 	const previousVersionSemver = coerce(previousVersion)?.version;
@@ -87,6 +88,8 @@ Keyring.on('accountsChanged', async (accounts) => {
 Browser.alarms.onAlarm.addListener((alarm) => {
 	if (alarm.name === LOCK_ALARM_NAME) {
 		Keyring.reviveDone.finally(() => Keyring.lock());
+	} else if (alarm.name === CLEAN_UP_ALARM_NAME) {
+		Transactions.clearStaleTransactions();
 	}
 });
 


### PR DESCRIPTION
## Description 

* setup an alarm to clean up stale transaction requests
* stop storing approved transactions

closes APPS-956

## Test Plan 

Manual testing

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
