### PR TITLE
disable blobdb

### DIFF
--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -579,7 +579,6 @@ fn objects_table_default_config() -> DBOptions {
 fn transactions_table_default_config() -> DBOptions {
     default_db_options()
         .optimize_for_write_throughput()
-        .optimize_for_large_values_no_scan(4 << 10)
         .optimize_for_point_lookup(
             read_size_from_env(ENV_VAR_TRANSACTIONS_BLOCK_CACHE_SIZE).unwrap_or(512),
         )
@@ -588,7 +587,6 @@ fn transactions_table_default_config() -> DBOptions {
 fn effects_table_default_config() -> DBOptions {
     default_db_options()
         .optimize_for_write_throughput()
-        .optimize_for_large_values_no_scan(4 << 10)
         .optimize_for_point_lookup(
             read_size_from_env(ENV_VAR_EFFECTS_BLOCK_CACHE_SIZE).unwrap_or(1024),
         )
@@ -597,7 +595,6 @@ fn effects_table_default_config() -> DBOptions {
 fn events_table_default_config() -> DBOptions {
     default_db_options()
         .optimize_for_write_throughput()
-        .optimize_for_large_values_no_scan(4 << 10)
         .optimize_for_read(read_size_from_env(ENV_VAR_EVENTS_BLOCK_CACHE_SIZE).unwrap_or(1024))
 }
 


### PR DESCRIPTION
BlobDB needs to be disabled (and the node needs to be resynced from scratch) before enabling effects pruning. 
The combination of BlobDB and pruning leads to high CPU utilization on the host, to the extent that the node stops making any progress. 
This happens because once a range delete is observed by a compaction job, RocksDB needs to deserialize the blob, remove the entry, serialize it again, and create a new blob multiple times 