### PR TITLE
Cherry pick 652fa40 (deep book change) to release

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -91,6 +91,7 @@ mod test {
         test_simulated_load(TestInitData::new(&test_cluster).await, 120).await;
     }
 
+    #[ignore("Disabled due to flakiness - re-enable when failure is fixed")]
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_reconfig_restarts() {
         // TODO added to invalidate a failing test seed in CI. Remove me

--- a/crates/sui-framework/packages/deepbook/tests/clob_tests.move
+++ b/crates/sui-framework/packages/deepbook/tests/clob_tests.move
@@ -28,13 +28,19 @@ module deepbook::clob_test {
     const E_ORDER_CANNOT_BE_FULLY_FILLED: u64 = 9;
     const CLIENT_ID_ALICE: u64 = 0;
     const CLIENT_ID_BOB: u64 = 1;
-    const SELF_MATCHING_PREVENTION_DEFAULT: u8 = 0;
+    const CANCEL_OLDEST: u8 = 0;
 
     #[test] fun test_full_transaction() { let _ = test_full_transaction_(scenario()); }
+
+    #[test] fun test_place_market_buy_order_with_skipping_self_matching() { let _ = test_place_market_buy_order_with_skipping_self_matching_(scenario()); }
+
+    #[test] fun test_place_market_sell_order_with_skipping_self_matching() { let _ = test_place_market_sell_order_with_skipping_self_matching_(scenario()); }
 
     #[test] fun test_place_limit_order_fill_or_kill() { let _ = test_place_limit_order_fill_or_kill_(scenario()); }
 
     #[test] fun test_place_limit_order_post_or_abort() { let _ = test_place_limit_order_post_or_abort_(scenario()); }
+
+    #[test] fun test_place_limit_order_with_skipping_self_matching() { let _ = test_place_limit_order_with_skipping_self_matching_(scenario()); }
 
     #[test] fun test_absorb_all_liquidity_bid_side_with_customized_tick(
     ) { let _ = test_absorb_all_liquidity_bid_side_with_customized_tick_(scenario()); }
@@ -44,6 +50,9 @@ module deepbook::clob_test {
 
     #[test] fun test_swap_exact_quote_for_base(
     ) { let _ = test_swap_exact_quote_for_base_(scenario()); }
+
+    #[test] fun test_swap_exact_quote_for_base_with_skipping_self_matching(
+    ) { let _ = test_swap_exact_quote_for_base_with_skipping_self_matching_(scenario()); }
 
     #[test] fun test_swap_exact_base_for_quote(
     ) { let _ = test_swap_exact_base_for_quote_(scenario()); }
@@ -61,10 +70,14 @@ module deepbook::clob_test {
 
     #[test] fun test_inject_and_match_taker_bid() { let _ = test_inject_and_match_taker_bid_(scenario()); }
 
+    #[test] fun test_inject_and_match_taker_bid_with_skip_self_matching() { let _ = test_inject_and_match_taker_bid_with_skipping_self_matching_(scenario()); }
+
     #[test] fun test_inject_and_match_taker_bid_with_maker_order_not_fully_filled(
     ) { let _ = test_inject_and_match_taker_bid_with_maker_order_not_fully_filled_(scenario()); }
 
     #[test] fun test_inject_and_match_taker_ask() { let _ = test_inject_and_match_taker_ask_(scenario()); }
+
+    #[test] fun test_inject_and_match_taker_ask_with_skipping_self_matching() { let _ = test_inject_and_match_taker_ask_with_skipping_self_matching_(scenario()); }
 
     #[test] fun test_inject_and_match_taker_bid_with_expiration(
     ) { let _ = test_inject_and_match_taker_bid_with_expiration_(scenario()); }
@@ -155,19 +168,19 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 4 * FLOAT_SCALING, 500, 500, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 4 * FLOAT_SCALING, 500, 500, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 3 * FLOAT_SCALING, 1000, 1000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -183,19 +196,19 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 15 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 15 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 14 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 14 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 13 * FLOAT_SCALING, 1000, 1000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 12 * FLOAT_SCALING, 1000, 1000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 12 * FLOAT_SCALING, 1000, 1000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -253,21 +266,21 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 4 * FLOAT_SCALING, 500, 500, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 4 * FLOAT_SCALING, 500, 500, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order_with_expiration(&mut pool, CLIENT_ID_ALICE, 3_500_000_000, 1000, 1000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, 0, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, 0, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 3 * FLOAT_SCALING, 1000, 1000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order_with_expiration(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, 0, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, 0, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -340,21 +353,21 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 4 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 4 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order_with_expiration(&mut pool, CLIENT_ID_ALICE, 3_500_000_000, 1000, 1000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, 0, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, 0, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 3 * FLOAT_SCALING, 1000, 1000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order_with_expiration(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, 0, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, 0, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -412,13 +425,13 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 1 * FLOAT_SCALING, 10000, 10000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -495,7 +508,13 @@ module deepbook::clob_test {
         next_tx(&mut test, owner);
         {
             clob::setup_test(5000000, 2500000, &mut test, owner);
+        };
+        next_tx(&mut test, alice);
+        {
             mint_account_cap_transfer(alice, test::ctx(&mut test));
+        };
+        next_tx(&mut test, bob);
+        {
             mint_account_cap_transfer(bob, test::ctx(&mut test));
         };
         next_tx(&mut test, alice);
@@ -509,13 +528,13 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 10 * FLOAT_SCALING, 10000, 10000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -657,13 +676,13 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
 
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 10 * FLOAT_SCALING, 10000, 10000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -794,7 +813,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 5 * FLOAT_SCALING,
                 200 * 100000000,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 true,
                 TIMESTAMP_INF,
                 0,
@@ -807,7 +826,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 4 * FLOAT_SCALING,
                 200 * 100000000,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 true,
                 TIMESTAMP_INF,
                 0,
@@ -820,7 +839,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 4 * FLOAT_SCALING,
                 200 * 100000000,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 true,
                 TIMESTAMP_INF,
                 0,
@@ -833,7 +852,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 10 * FLOAT_SCALING,
                 1000 * 100000000,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 false,
                 TIMESTAMP_INF,
                 0,
@@ -886,7 +905,7 @@ module deepbook::clob_test {
                 CLIENT_ID_BOB,
                 4 * FLOAT_SCALING,
                 300 * 100000000,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 false,
                 TIMESTAMP_INF,
                 0,
@@ -991,7 +1010,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 5 * FLOAT_SCALING,
                 200,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 true,
                 TIMESTAMP_INF,
                 0,
@@ -1004,7 +1023,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 5 * FLOAT_SCALING,
                 300,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 true,
                 TIMESTAMP_INF,
                 0,
@@ -1017,7 +1036,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 2 * FLOAT_SCALING,
                 1000,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 true,
                 TIMESTAMP_INF,
                 0,
@@ -1030,7 +1049,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 20 * FLOAT_SCALING,
                 1000,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 false,
                 TIMESTAMP_INF,
                 0,
@@ -1118,7 +1137,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 5 * FLOAT_SCALING,
                 200,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 true,
                 TIMESTAMP_INF,
                 0,
@@ -1131,7 +1150,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 5 * FLOAT_SCALING,
                 300,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 true,
                 TIMESTAMP_INF,
                 0,
@@ -1144,7 +1163,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 2 * FLOAT_SCALING,
                 1000,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 true,
                 TIMESTAMP_INF,
                 0,
@@ -1157,7 +1176,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 20 * FLOAT_SCALING,
                 1000,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 false,
                 TIMESTAMP_INF,
                 0,
@@ -1205,7 +1224,7 @@ module deepbook::clob_test {
                 CLIENT_ID_BOB,
                 4 * FLOAT_SCALING,
                 400,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 false,
                 TIMESTAMP_INF,
                 FILL_OR_KILL,
@@ -1283,7 +1302,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 5 * FLOAT_SCALING,
                 200,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 true,
                 TIMESTAMP_INF,
                 0,
@@ -1296,7 +1315,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 5 * FLOAT_SCALING,
                 300,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 true,
                 TIMESTAMP_INF,
                 0,
@@ -1309,7 +1328,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 2 * FLOAT_SCALING,
                 1000,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 true,
                 TIMESTAMP_INF,
                 0,
@@ -1322,7 +1341,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 20 * FLOAT_SCALING,
                 1000,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 false,
                 TIMESTAMP_INF,
                 0,
@@ -1370,7 +1389,7 @@ module deepbook::clob_test {
                 CLIENT_ID_BOB,
                 6 * FLOAT_SCALING,
                 400,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 false,
                 TIMESTAMP_INF,
                 POST_OR_ABORT,
@@ -1447,7 +1466,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 5 * FLOAT_SCALING,
                 200,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 true,
                 TIMESTAMP_INF,
                 0,
@@ -1460,7 +1479,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 5 * FLOAT_SCALING,
                 300,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 true,
                 TIMESTAMP_INF,
                 0,
@@ -1473,7 +1492,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 2 * FLOAT_SCALING,
                 1000,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 true,
                 TIMESTAMP_INF,
                 0,
@@ -1486,7 +1505,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 20 * FLOAT_SCALING,
                 1000,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 false,
                 TIMESTAMP_INF,
                 0,
@@ -1572,7 +1591,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 5 * FLOAT_SCALING,
                 500,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 false,
                 TIMESTAMP_INF,
                 0,
@@ -1585,7 +1604,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 5 * FLOAT_SCALING,
                 500,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 false,
                 TIMESTAMP_INF,
                 0,
@@ -1598,7 +1617,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 2 * FLOAT_SCALING,
                 1000,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 false,
                 TIMESTAMP_INF,
                 0,
@@ -1611,7 +1630,7 @@ module deepbook::clob_test {
                 CLIENT_ID_ALICE,
                 1 * FLOAT_SCALING,
                 1000,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 true,
                 TIMESTAMP_INF,
                 0,
@@ -1685,13 +1704,13 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE,1 * FLOAT_SCALING, 10000, 10000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -1748,13 +1767,13 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE,5 * FLOAT_SCALING, 500, 500, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE,5 * FLOAT_SCALING, 500, 500, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE,2 * FLOAT_SCALING, 1000, 1000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE,10 * FLOAT_SCALING, 10000, 10000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -1808,15 +1827,15 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
 
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 2, 2, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 3, 3, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 10, 10, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 10, 10, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 20 * FLOAT_SCALING, 10, 10, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -2043,13 +2062,13 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE,  2 * FLOAT_SCALING, 1000, 1000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE,  1 * FLOAT_SCALING, 10000, 10000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -2253,13 +2272,13 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 1 * FLOAT_SCALING, 10000, 10000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -2376,13 +2395,13 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 1 * FLOAT_SCALING, 10000, 10000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -2488,13 +2507,13 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 1 * FLOAT_SCALING, 10000, 10000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -2628,13 +2647,13 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 1 * FLOAT_SCALING, 10000, 10000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -2781,13 +2800,13 @@ module deepbook::clob_test {
             let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
             let account_cap = test::take_from_address<AccountCap>(&test, alice);
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 10 * FLOAT_SCALING, 10000, 10000, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -2934,7 +2953,7 @@ module deepbook::clob_test {
                 500,
                 500,
                 false,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 TIMESTAMP_INF,
                 &account_cap,
                 ctx(&mut test)
@@ -2946,7 +2965,7 @@ module deepbook::clob_test {
                 500,
                 500,
                 false,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 0,
                 &account_cap,
                 ctx(&mut test)
@@ -2958,7 +2977,7 @@ module deepbook::clob_test {
                 1000,
                 1000,
                 false,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 TIMESTAMP_INF,
                 &account_cap,
                 ctx(&mut test)
@@ -2970,7 +2989,7 @@ module deepbook::clob_test {
                 10000,
                 10000,
                 true,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 0,
                 &account_cap,
                 ctx(&mut test)
@@ -3136,7 +3155,7 @@ module deepbook::clob_test {
                 500,
                 500,
                 false,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 TIMESTAMP_INF,
                 &account_cap,
                 ctx(&mut test)
@@ -3148,7 +3167,7 @@ module deepbook::clob_test {
                 500,
                 500,
                 false,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 0,
                 &account_cap,
                 ctx(&mut test)
@@ -3160,7 +3179,7 @@ module deepbook::clob_test {
                 1000,
                 1000,
                 false,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 TIMESTAMP_INF,
                 &account_cap,
                 ctx(&mut test)
@@ -3172,7 +3191,7 @@ module deepbook::clob_test {
                 10000,
                 10000,
                 true,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 0,
                 &account_cap,
                 ctx(&mut test)
@@ -3341,7 +3360,7 @@ module deepbook::clob_test {
                 500,
                 500,
                 true,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 TIMESTAMP_INF,
                 &account_cap,
                 ctx(&mut test)
@@ -3353,7 +3372,7 @@ module deepbook::clob_test {
                 1000,
                 1000,
                 true,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 0,
                 &account_cap,
                 ctx(&mut test)
@@ -3365,7 +3384,7 @@ module deepbook::clob_test {
                 1000,
                 1000,
                 true,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 TIMESTAMP_INF,
                 &account_cap,
                 ctx(&mut test)
@@ -3377,7 +3396,7 @@ module deepbook::clob_test {
                 10000,
                 10000,
                 false,
-                SELF_MATCHING_PREVENTION_DEFAULT,
+                CANCEL_OLDEST,
                 TIMESTAMP_INF,
                 &account_cap,
                 ctx(&mut test)
@@ -3552,13 +3571,13 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 2, 2, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 3, 3, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 10, 10, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 1 * FLOAT_SCALING, 10, 10, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -3699,13 +3718,13 @@ module deepbook::clob_test {
             let account_cap = test::take_from_address<AccountCap>(&test, alice);
             // let account_cap_user = get_account_cap_user(&account_cap);
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 2, 2, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 3, 3, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 10, 10, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 20 * FLOAT_SCALING, 10, 10, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);
         };
@@ -3836,15 +3855,15 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
 
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 2, 2, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 3, 3, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 10, 10, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 10, 10, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 20 * FLOAT_SCALING, 10, 10, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
 
             {
                 let open_orders = vector::empty<Order>();
@@ -3985,15 +4004,15 @@ module deepbook::clob_test {
             custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
 
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 2, 2, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 3, 3, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 10, 10, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 10, 10, true,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
             clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 20 * FLOAT_SCALING, 10, 10, false,
-                SELF_MATCHING_PREVENTION_DEFAULT, &account_cap, ctx(&mut test));
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
 
             {
                 let open_orders = vector::empty<Order>();
@@ -4083,6 +4102,697 @@ module deepbook::clob_test {
                 assert!(base_locked == 0, 0);
                 assert!(quote_avail == 100, 0);
                 assert!(quote_locked == 0, 0);
+            };
+            test::return_shared(pool);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+        end(test)
+    }
+
+    // This test covers the following scenario:
+    // In an order book, there are only some limit buy orders placed by Alice.
+    // When Alice uses a market sell order to consume liquidity from the order book
+    // and matches her own limit buy orders,
+    // we needs to cancel all the previous limit buy orders
+    // and correctly refunding to her custodian account
+    fun test_place_market_sell_order_with_skipping_self_matching_(test: Scenario): TransactionEffects {
+        let (alice, _) = people();
+        let owner: address = @0xF;
+        // setup pool and custodian
+        next_tx(&mut test, owner);
+        {
+            clob::setup_test(5000000, 2500000, &mut test, owner);
+        };
+        next_tx(&mut test, alice);
+        {
+            mint_account_cap_transfer(alice, test::ctx(&mut test));
+        };
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let account_cap = test::take_from_sender<AccountCap>(&test);
+            let account_cap_user = account_owner(&account_cap);
+            let (base_custodian, quote_custodian) = clob::borrow_mut_custodian(&mut pool);
+            custodian::deposit(base_custodian, mint_for_testing<SUI>(1000, ctx(&mut test)), account_cap_user);
+            custodian::deposit(quote_custodian, mint_for_testing<USD>(10000, ctx(&mut test)), account_cap_user);
+            test::return_shared(pool);
+            test::return_to_sender<AccountCap>(&test, account_cap);
+        };
+
+        // alice places limit orders
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let account_cap = test::take_from_address<AccountCap>(&test, alice);
+            let clock = test::take_shared<Clock>(&mut test);
+            clob::place_limit_order<SUI, USD>(
+                &mut pool,
+                CLIENT_ID_ALICE,
+                5 * FLOAT_SCALING,
+                200,
+                CANCEL_OLDEST,
+                true,
+                TIMESTAMP_INF,
+                0,
+                &clock,
+                &account_cap,
+                ctx(&mut test)
+            );
+            clob::place_limit_order<SUI, USD>(
+                &mut pool,
+                CLIENT_ID_ALICE,
+                5 * FLOAT_SCALING,
+                300,
+                CANCEL_OLDEST,
+                true,
+                TIMESTAMP_INF,
+                0,
+                &clock,
+                &account_cap,
+                ctx(&mut test)
+            );
+            clob::place_limit_order<SUI, USD>(
+                &mut pool,
+                CLIENT_ID_ALICE,
+                2 * FLOAT_SCALING,
+                1000,
+                CANCEL_OLDEST,
+                true,
+                TIMESTAMP_INF,
+                0,
+                &clock,
+                &account_cap,
+                ctx(&mut test)
+            );
+            clob::place_limit_order<SUI, USD>(
+                &mut pool,
+                CLIENT_ID_ALICE,
+                20 * FLOAT_SCALING,
+                1000,
+                CANCEL_OLDEST,
+                false,
+                TIMESTAMP_INF,
+                0,
+                &clock,
+                &account_cap,
+                ctx(&mut test)
+            );
+            let (next_bid_order_id, next_ask_order_id, _, _) = clob::get_pool_stat(&pool);
+            assert!(next_bid_order_id == clob::order_id(3, true), 0);
+            assert!(next_ask_order_id == clob::order_id(1, false), 0);
+            let account_cap_user = account_owner(&account_cap);
+            let (base_custodian, quote_custodian) = clob::borrow_custodian(&pool);
+            custodian::assert_user_balance(base_custodian, account_cap_user, 0, 1000);
+            custodian::assert_user_balance(quote_custodian, account_cap_user, 5500, 4500);
+            let (base_avail, base_locked, quote_avail, quote_locked) = account_balance(&pool, &account_cap);
+            assert!(base_avail == 0, 0);
+            assert!(base_locked == 1000, 0);
+            assert!(quote_avail == 5500, 0);
+            assert!(quote_locked == 4500, 0);
+            test::return_shared(pool);
+            test::return_shared(clock);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+
+        // alice places market order
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let clock = test::take_shared<Clock>(&mut test);
+            let account_cap = test::take_from_address<AccountCap>(&test, alice);
+            let (coin1, coin2) =clob::place_market_order<SUI, USD>(&mut pool, &account_cap, CLIENT_ID_ALICE, 600,
+                false,
+                mint_for_testing<SUI>(600, ctx(&mut test)),
+                mint_for_testing<USD>(0, ctx(&mut test)),
+                &clock,
+                ctx(&mut test));
+            assert!(coin::value<SUI>(&coin1) == 600, 0);
+            assert!(coin::value<USD>(&coin2) == 0, 0);
+            burn_for_testing(coin1);
+            burn_for_testing(coin2);
+
+            let account_cap_user = account_owner(&account_cap);
+            let (base_custodian, quote_custodian) = clob::borrow_custodian(&pool);
+            custodian::assert_user_balance(base_custodian, account_cap_user, 0, 1000);
+            custodian::assert_user_balance(quote_custodian, account_cap_user, 10000, 0);
+            test::return_shared(pool);
+            test::return_shared(clock);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+        end(test)
+    }
+
+    // This test covers the following scenario:
+    // In an order book, there are only some limit sell orders placed by Alice.
+    // When Alice uses a market buy order to consume liquidity from the order book
+    // and matches her own limit sell orders,
+    // we needs to cancel all the previous limit sell orders
+    // and correctly refunding to her custodian account
+    fun test_place_market_buy_order_with_skipping_self_matching_(test: Scenario): TransactionEffects {
+        let (alice, _) = people();
+        let owner: address = @0xF;
+        // setup pool and custodian
+        next_tx(&mut test, owner);
+        {
+            clob::setup_test(5000000, 2500000, &mut test, owner);
+        };
+        next_tx(&mut test, alice);
+        {
+            mint_account_cap_transfer(alice, test::ctx(&mut test));
+        };
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let account_cap = test::take_from_sender<AccountCap>(&test);
+            let account_cap_user = account_owner(&account_cap);
+            let (base_custodian, quote_custodian) = clob::borrow_mut_custodian(&mut pool);
+            custodian::deposit(base_custodian, mint_for_testing<SUI>(1500, ctx(&mut test)), account_cap_user);
+            custodian::deposit(quote_custodian, mint_for_testing<USD>(10000, ctx(&mut test)), account_cap_user);
+            test::return_shared(pool);
+            test::return_to_sender<AccountCap>(&test, account_cap);
+        };
+
+        // alice places limit orders
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let account_cap = test::take_from_address<AccountCap>(&test, alice);
+            let clock = test::take_shared<Clock>(&mut test);
+            clob::place_limit_order<SUI, USD>(
+                &mut pool,
+                CLIENT_ID_ALICE,
+                5 * FLOAT_SCALING,
+                200,
+                CANCEL_OLDEST,
+                false,
+                TIMESTAMP_INF,
+                0,
+                &clock,
+                &account_cap,
+                ctx(&mut test)
+            );
+            clob::place_limit_order<SUI, USD>(
+                &mut pool,
+                CLIENT_ID_ALICE,
+                5 * FLOAT_SCALING,
+                300,
+                CANCEL_OLDEST,
+                false,
+                TIMESTAMP_INF,
+                0,
+                &clock,
+                &account_cap,
+                ctx(&mut test)
+            );
+            clob::place_limit_order<SUI, USD>(
+                &mut pool,
+                CLIENT_ID_ALICE,
+                2 * FLOAT_SCALING,
+                1000,
+                CANCEL_OLDEST,
+                false,
+                TIMESTAMP_INF,
+                0,
+                &clock,
+                &account_cap,
+                ctx(&mut test)
+            );
+            clob::place_limit_order<SUI, USD>(
+                &mut pool,
+                CLIENT_ID_ALICE,
+                1 * FLOAT_SCALING,
+                1000,
+                CANCEL_OLDEST,
+                true,
+                TIMESTAMP_INF,
+                0,
+                &clock,
+                &account_cap,
+                ctx(&mut test)
+            );
+            let (next_bid_order_id, next_ask_order_id, _, _) = clob::get_pool_stat(&pool);
+            assert!(next_bid_order_id == clob::order_id(1, true), 0);
+            assert!(next_ask_order_id == clob::order_id(3, false), 0);
+            let account_cap_user = account_owner(&account_cap);
+            let (base_custodian, quote_custodian) = clob::borrow_custodian(&pool);
+            custodian::assert_user_balance(base_custodian, account_cap_user, 0, 1500);
+            custodian::assert_user_balance(quote_custodian, account_cap_user, 9000, 1000);
+            let (base_avail, base_locked, quote_avail, quote_locked) = account_balance(&pool, &account_cap);
+            assert!(base_avail == 0, 0);
+            assert!(base_locked == 1500, 0);
+            assert!(quote_avail == 9000, 0);
+            assert!(quote_locked == 1000, 0);
+            test::return_shared(pool);
+            test::return_shared(clock);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+
+        // alice places market buy order
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let clock = test::take_shared<Clock>(&mut test);
+            let account_cap = test::take_from_address<AccountCap>(&test, alice);
+            let (coin1, coin2) =clob::place_market_order<SUI, USD>(&mut pool, &account_cap, CLIENT_ID_ALICE, 1,
+                true,
+                mint_for_testing<SUI>(0, ctx(&mut test)),
+                mint_for_testing<USD>(1, ctx(&mut test)),
+                &clock,
+                ctx(&mut test));
+            assert!(coin::value<SUI>(&coin1) == 0, 0);
+            assert!(coin::value<USD>(&coin2) == 1, 0);
+            burn_for_testing(coin1);
+            burn_for_testing(coin2);
+
+            let account_cap_user = account_owner(&account_cap);
+            let (base_custodian, quote_custodian) = clob::borrow_custodian(&pool);
+            custodian::assert_user_balance(base_custodian, account_cap_user, 1500, 0);
+            custodian::assert_user_balance(quote_custodian, account_cap_user, 9000, 1000);
+            test::return_shared(pool);
+            test::return_shared(clock);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+        end(test)
+    }
+
+    // This test covers the following scenario:
+    // there are some limit buy orders placed by Alice.
+    // When Alice continue to place a limit sell order
+    // and it can be matched with her own previous limit buy order
+    // We need to cancel all limit buy orders within the range of matching with the limit sell order.
+    // and correctly refunding to her custodian account
+    fun test_place_limit_order_with_skipping_self_matching_(test: Scenario): TransactionEffects {
+        let (alice, _) = people();
+        let owner: address = @0xF;
+        // setup pool and custodian
+        next_tx(&mut test, owner);
+        {
+            clob::setup_test(5000000, 2500000, &mut test, owner);
+        };
+        next_tx(&mut test, alice);
+        {
+            mint_account_cap_transfer(alice, test::ctx(&mut test));
+        };
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let account_cap = test::take_from_sender<AccountCap>(&test);
+            let account_cap_user = account_owner(&account_cap);
+            let (base_custodian, quote_custodian) = clob::borrow_mut_custodian(&mut pool);
+            custodian::deposit(base_custodian, mint_for_testing<SUI>(1000, ctx(&mut test)), account_cap_user);
+            custodian::deposit(quote_custodian, mint_for_testing<USD>(10000, ctx(&mut test)), account_cap_user);
+            test::return_shared(pool);
+            test::return_to_sender<AccountCap>(&test, account_cap);
+        };
+        // alice places limit orders
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let account_cap = test::take_from_address<AccountCap>(&test, alice);
+            let clock = test::take_shared<Clock>(&mut test);
+            clob::place_limit_order<SUI, USD>(
+                &mut pool,
+                CLIENT_ID_ALICE,
+                5 * FLOAT_SCALING,
+                200,
+                CANCEL_OLDEST,
+                true,
+                TIMESTAMP_INF,
+                0,
+                &clock,
+                &account_cap,
+                ctx(&mut test)
+            );
+            clob::place_limit_order<SUI, USD>(
+                &mut pool,
+                CLIENT_ID_ALICE,
+                5 * FLOAT_SCALING,
+                300,
+                CANCEL_OLDEST,
+                true,
+                TIMESTAMP_INF,
+                0,
+                &clock,
+                &account_cap,
+                ctx(&mut test)
+            );
+            clob::place_limit_order<SUI, USD>(
+                &mut pool,
+                CLIENT_ID_ALICE,
+                2 * FLOAT_SCALING,
+                1000,
+                CANCEL_OLDEST,
+                true,
+                TIMESTAMP_INF,
+                0,
+                &clock,
+                &account_cap,
+                ctx(&mut test)
+            );
+            clob::place_limit_order<SUI, USD>(
+                &mut pool,
+                CLIENT_ID_ALICE,
+                20 * FLOAT_SCALING,
+                1000,
+                CANCEL_OLDEST,
+                false,
+                TIMESTAMP_INF,
+                0,
+                &clock,
+                &account_cap,
+                ctx(&mut test)
+            );
+            let (next_bid_order_id, next_ask_order_id, _, _) = clob::get_pool_stat(&pool);
+            assert!(next_bid_order_id == clob::order_id(3, true), 0);
+            assert!(next_ask_order_id == clob::order_id(1, false), 0);
+            let account_cap_user = account_owner(&account_cap);
+            let (base_custodian, quote_custodian) = clob::borrow_custodian(&pool);
+            custodian::assert_user_balance(base_custodian, account_cap_user, 0, 1000);
+            custodian::assert_user_balance(quote_custodian, account_cap_user, 5500, 4500);
+            let (base_avail, base_locked, quote_avail, quote_locked) = account_balance(&pool, &account_cap);
+            assert!(base_avail == 0, 0);
+            assert!(base_locked == 1000, 0);
+            assert!(quote_avail == 5500, 0);
+            assert!(quote_locked == 4500, 0);
+            test::return_shared(pool);
+            test::return_shared(clock);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let account_cap = test::take_from_sender<AccountCap>(&test);
+            let account_cap_user = account_owner(&account_cap);
+            let (base_custodian, _) = clob::borrow_mut_custodian(&mut pool);
+            custodian::deposit(base_custodian, mint_for_testing<SUI>(400, ctx(&mut test)), account_cap_user);
+            test::return_shared(pool);
+            test::return_to_sender<AccountCap>(&test, account_cap);
+        };
+        // alice places limit order
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let account_cap = test::take_from_sender<AccountCap>(&test);
+            let clock = test::take_shared<Clock>(&mut test);
+            let (base_quantity_filled, quote_quantity_filled, is_placed, order_id) = clob::place_limit_order<SUI, USD>(
+                &mut pool,
+                CLIENT_ID_ALICE,
+                4 * FLOAT_SCALING,
+                400,
+                CANCEL_OLDEST,
+                false,
+                TIMESTAMP_INF,
+                POST_OR_ABORT,
+                &clock,
+                &account_cap,
+                ctx(&mut test)
+            );
+            assert!(base_quantity_filled == 0, 0);
+            assert!(quote_quantity_filled == 0, 0);
+            assert!(is_placed == true, 0);
+            assert!(order_id == MIN_ASK_ORDER_ID + 1, 0);
+
+            test::return_shared(pool);
+            test::return_shared(clock);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+
+        // check alice's balance
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let account_cap = test::take_from_sender<AccountCap>(&test);
+            let clock = test::take_shared<Clock>(&mut test);
+
+            let  (base_avail, base_locked, quote_avail, quote_locked) = account_balance<SUI, USD>(&pool, &account_cap);
+            assert!(base_avail == 0, 0);
+            assert!(base_locked == 1000 + 400, 0);
+            assert!(quote_avail == 8000, 0);
+            assert!(quote_locked == 2000, 0);
+
+            test::return_shared(pool);
+            test::return_shared(clock);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+        end(test)
+    }
+
+    // This test scenario is similar to "test_place_market_order_with_skipping_self_matching_",
+    // but it verifies the logic when we want to swap the exact quote asset for the base asset.
+    fun test_swap_exact_quote_for_base_with_skipping_self_matching_(test: Scenario): TransactionEffects {
+        let (alice, _) = people();
+        let owner = @0xF;
+        // setup pool and custodian
+        next_tx(&mut test, owner);
+        {
+            clob::setup_test(5000000, 2500000, &mut test, owner);
+        };
+        next_tx(&mut test, alice);
+        {
+            mint_account_cap_transfer(alice, test::ctx(&mut test));
+        };
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let account_cap = test::take_from_address<AccountCap>(&test, alice);
+            let account_cap_user = account_owner(&account_cap);
+            let (base_custodian, quote_custodian) = clob::borrow_mut_custodian(&mut pool);
+            let alice_deposit_WSUI: u64 = 10000;
+            let alice_deposit_USDC: u64 = 10000;
+            custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
+            custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
+            clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
+            clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
+            clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, false,
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
+            clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE,1 * FLOAT_SCALING, 10000, 10000, true,
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
+            test::return_shared(pool);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let clock = test::take_shared<Clock>(&mut test);
+            let account_cap = test::take_from_address<AccountCap>(&test, alice);
+            let (base_coin, quote_coin, _) = clob::swap_exact_quote_for_base(
+                &mut pool,
+                CLIENT_ID_ALICE,
+                &account_cap,
+                4500,
+                &clock,
+                mint_for_testing<USD>(4500, ctx(&mut test)),
+                ctx(&mut test)
+            );
+            assert!(coin::value(&base_coin) == 0, 0);
+            assert!(coin::value(&quote_coin) == 4500, 0);
+            burn_for_testing(base_coin);
+            burn_for_testing(quote_coin);
+
+            let account_cap_user = account_owner(&account_cap);
+            let (base_custodian, quote_custodian) = clob::borrow_custodian(&pool);
+            custodian::assert_user_balance<SUI>(base_custodian, account_cap_user, 10000, 0);
+            custodian::assert_user_balance<USD>(quote_custodian, account_cap_user, 0, 10000);
+
+            test::return_shared(clock);
+            test::return_shared(pool);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+        end(test)
+    }
+
+    // This test covers the following scenario:
+    // there are some limit sell orders placed by invoking inject_limit_order
+    // And directly perform the matching using the match_bid method.
+    // When encountering self-matching, we should cancel all the oldest sell orders
+    // and check if the order status in the order book and the user balance in the custodian account are correct.
+    fun test_inject_and_match_taker_bid_with_skipping_self_matching_(test: Scenario): TransactionEffects {
+        let (alice, _) = people();
+        let owner = @0xF;
+        // setup pool and custodian
+        next_tx(&mut test, owner);
+        {
+            clob::setup_test(5000000, 2500000, &mut test, owner);
+        };
+        next_tx(&mut test, alice);
+        {
+            mint_account_cap_transfer(alice, test::ctx(&mut test));
+        };
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let account_cap = test::take_from_address<AccountCap>(&test, alice);
+            let account_cap_user = account_owner(&account_cap);
+            let (base_custodian, quote_custodian) = clob::borrow_mut_custodian(&mut pool);
+            let alice_deposit_WSUI: u64 = 10000;
+            let alice_deposit_USDC: u64 = 10000;
+            custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
+            custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
+            clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
+            clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, false,
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
+            clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, false,
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
+            clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 1 * FLOAT_SCALING, 10000, 10000, true,
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
+            test::return_shared(pool);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+        // test match (bid side)
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let account_cap = test::take_from_address<AccountCap>(&test, alice);
+            let (base_quantity_filled, quote_quantity_filled) = clob::test_match_bid(
+                &mut pool,
+                &account_cap,
+                CLIENT_ID_ALICE,
+                1,
+                MAX_PRICE,
+                0,
+            );
+            assert!(base_quantity_filled == 0, 0);
+            assert!(quote_quantity_filled == 0, 0);
+            test::return_shared(pool);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let account_cap = test::take_from_address<AccountCap>(&test, alice);
+            let account_cap_user = account_owner(&account_cap);
+            let (base_custodian, quote_custodian) = clob::borrow_custodian(&pool);
+            custodian::assert_user_balance<SUI>(base_custodian, account_cap_user, 10000, 0);
+            custodian::assert_user_balance<USD>(quote_custodian, account_cap_user, 0, 10000);
+            let (next_bid_order_id, next_ask_order_id, _, _) = clob::get_pool_stat(&pool);
+            assert!(next_bid_order_id == clob::order_id(1, true), 0);
+            assert!(next_ask_order_id == clob::order_id(3, false), 0);
+            {
+                let (_, _, _, asks) = get_pool_stat(&pool);
+                clob::check_empty_tick_level(asks, 2 * FLOAT_SCALING);
+            };
+            {
+                let (_, _, _, asks) = get_pool_stat(&pool);
+                clob::check_empty_tick_level(asks, 5 * FLOAT_SCALING);
+            };
+            {
+                let open_orders = vector::empty<Order>();
+                vector::push_back(
+                    &mut open_orders,
+                    clob::test_construct_order(0, CLIENT_ID_ALICE,1 * FLOAT_SCALING, 10000, 10000, true, account_cap_user)
+                );
+                let (_, _, bid, _) = get_pool_stat(&pool);
+                clob::check_tick_level(bid, 1 * FLOAT_SCALING, &open_orders);
+            };
+            test::return_shared(pool);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+        end(test)
+    }
+
+    // This test covers the following scenario:
+    // there are some limit buy orders placed by invoking inject_limit_order
+    // And  directly perform the matching using the match_ask method.
+    // When encountering self-matching, we should cancel all the oldest buy orders
+    // and check if the order status in the order book and the user balance in the custodian account are correct.
+    fun test_inject_and_match_taker_ask_with_skipping_self_matching_(test: Scenario): TransactionEffects {
+        let (alice, _) = people();
+        let owner = @0xF;
+        // setup pool and custodian
+        next_tx(&mut test, owner);
+        {
+            clob::setup_test(5000000, 2500000, &mut test, owner);
+        };
+        next_tx(&mut test, alice);
+        {
+            mint_account_cap_transfer(alice, test::ctx(&mut test));
+        };
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let account_cap = test::take_from_address<AccountCap>(&test, alice);
+            let account_cap_user = account_owner(&account_cap);
+            let (base_custodian, quote_custodian) = clob::borrow_mut_custodian(&mut pool);
+            let alice_deposit_WSUI: u64 = 10000;
+            let alice_deposit_USDC: u64 = 10000;
+            custodian::test_increase_user_available_balance<SUI>(base_custodian, account_cap_user, alice_deposit_WSUI);
+            custodian::test_increase_user_available_balance<USD>(quote_custodian, account_cap_user, alice_deposit_USDC);
+            test::return_shared(pool);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+        // test inject limit order and match (ask side)
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let account_cap = test::take_from_address<AccountCap>(&test, alice);
+            clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, true,
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
+            clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 5 * FLOAT_SCALING, 500, 500, true,
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
+            clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 2 * FLOAT_SCALING, 1000, 1000, true,
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
+            clob::test_inject_limit_order(&mut pool, CLIENT_ID_ALICE, 10 * FLOAT_SCALING, 10000, 10000, false,
+                CANCEL_OLDEST, &account_cap, ctx(&mut test));
+            test::return_shared(pool);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+
+        // test match (ask side)
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let account_cap = test::take_from_address<AccountCap>(&test, alice);
+            let (base_quantity_filled, quote_quantity_filled) = clob::test_match_ask(
+                &mut pool,
+                &account_cap,
+                CLIENT_ID_ALICE,
+                1500,
+                MIN_PRICE,
+                0,
+            );
+            assert!(base_quantity_filled == 0, 0);
+            assert!(quote_quantity_filled == 0, 0);
+            test::return_shared(pool);
+            test::return_to_address<AccountCap>(alice, account_cap);
+        };
+        next_tx(&mut test, alice);
+        {
+            let pool = test::take_shared<Pool<SUI, USD>>(&mut test);
+            let account_cap = test::take_from_address<AccountCap>(&test, alice);
+            let account_cap_user = account_owner(&account_cap);
+            let (base_custodian, quote_custodian) = clob::borrow_custodian(&pool);
+            custodian::assert_user_balance<USD>(
+                quote_custodian,
+                account_cap_user,
+                10000,
+                0
+            );
+            custodian::assert_user_balance<SUI>(
+                base_custodian,
+                account_cap_user,
+                0,
+                10000
+            );
+            {
+                let (_, _, bids, _) = get_pool_stat(&pool);
+                clob::check_empty_tick_level(bids, 5 * FLOAT_SCALING);
+            };
+            {
+                let (_, _, bids, _) = get_pool_stat(&pool);
+                clob::check_empty_tick_level(bids, 2 * FLOAT_SCALING);
+            };
+            {
+                let open_orders = vector::empty<Order>();
+                vector::push_back(
+                    &mut open_orders,
+                    clob::test_construct_order(0, CLIENT_ID_ALICE, 10 * FLOAT_SCALING, 10000, 10000, false, account_cap_user)
+                );
+                let (_, _, _, asks) = get_pool_stat(&pool);
+                clob::check_tick_level(asks, 10 * FLOAT_SCALING, &open_orders);
             };
             test::return_shared(pool);
             test::return_to_address<AccountCap>(alice, account_cap);

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -50,6 +50,7 @@ const MAX_PROTOCOL_VERSION: u64 = 16;
 // Version 16: Enabled simplified_unwrap_then_delete feature flag, which allows the execution engine
 //             to no longer consult the object store when generating unwrapped_then_deleted in the
 //             effects; this also allows us to stop including wrapped tombstones in accumulator.
+//             Add self-matching prevention for deepbook.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0xf771d809b991cd7e3a25c1fc943ed28fbf6663721a83f08311c6940973d55b49"
+            id: "0xbd2bdc9724d0aae78b2dd02c8fc412bd7bee96ea0c98d6b1332cb2dcc3973acf"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0xa83d3dd8458e0da65ce07fd170172a7809f2d8fdee53c7e61392828599a3de6e"
+      operation_cap_id: "0x7990ef7b1237e77b251900f9434f1bceb60ef5100a2abcb75e78c595775131d1"
       gas_price: 1000
       staking_pool:
-        id: "0xf1b97970792a3c84ad867bf68a986d4373930779659f299b9b82f5c7dbe3ce7f"
+        id: "0x6a2f79eac6652389813d145bf691005a37d3746ee4372918124f45d4fc2abd30"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0x3e535ba3e3037a83fed76b7d79174051dc671bc724af0d840acfbec0cbfb1264"
+          id: "0x52e460b45fbb7adb3df22461e13b0a3f1f67e58933a082008c61c8670449a388"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0xdc1112aef4a5483a9ab29b43ca66f230206a37ee86a985af4c0046c439d845d0"
+            id: "0x749e1f37b8f6cd84e09b7e02b45d817e56ecbbb8dcde4baf6e69f5cc667a9f9e"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0x07be66829a96181e92a4a2be6aa9d7aff889849e44fc26aeaf69cfc2aa8b3cd4"
+          id: "0xdc3e7d20e585326ff46461a1b399b7cdb94cbfa7b3c6cba0600c5c1c2b83bc36"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x182c6b32d0d95697244e60dadb857a44527ebb69af173e19fe2f6af7a875308e"
+      id: "0x80c044602f5407bda7246d4acb805e0761715db80da5390489587b416054ee3c"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0x6cbe0b1d1e5bc70f9ed0545ac8a49ac6c90844f8889277daeb079152fffab310"
+    id: "0xc9f10341a396ae41f60350c0b1ad8a07fc3d5bb5e391983a2f4374ddab15c968"
     size: 1
   inactive_validators:
-    id: "0xe162599bd30584c7731ca6a2e55ca1472980ffcab5babe23cc647e72be96c4a4"
+    id: "0x67fb5ad6d089b382f65ae03ac011183949e098497793f0678f888d6fd7c8de8b"
     size: 0
   validator_candidates:
-    id: "0x07e54852e26a69873540576d9bf6d722ddce1e110fbdcdc2d174b8403afef5dd"
+    id: "0x1d38e6606fb1e0f53bc7ca1b94ca087375a08352630b411187ac4cf2c0242e8c"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0x3f72551f9f8586524a45cf21140e3973a28096ca0ff010bee0a96768c862578e"
+      id: "0x6aa1fd57ab6daada2319cbc22c821460f028693c4758b0b221530460c547d1ce"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x222ead1ec8df162d8eac5ec34881af1116c0f70b6d536d9e51eb4a63da540008"
+      id: "0xbc1c49382e991a85d9ccd8d6297b058d12bfb8e01e57c1d397511bd075f9a331"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0x20ef8f70de67adc6ab41b63cfe66edd4d0394bcdfad047522568636206748e71"
+      id: "0xfca9a397dc614ba6d72e55097765016c5c6ca3f623e5d9d6480e54d9b71e6291"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,6 +332,6 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0x5636453c059512fa24dbafa002322e0fc3304a016e62c6facabf6c2b964ddd85"
+    id: "0x168991dc3f3567ae67bb69e9741ccc3b45a7a32d58b43a5a6ec618cfc24a3800"
   size: 0
 


### PR DESCRIPTION
## Description 

Cherry-pick https://github.com/MystenLabs/sui/pull/12464 to release branch.

The self-matching prevention mechanism ensures that the matching engine
takes measures to avoid unnecessary trades
when matching a user's buy/sell order with their own sell/buy order.

There are four Self-Trade Prevention Options.

Decrement & cancel: Cancel smaller order and decrement larger order by the smaller size.
If the same size, cancel both.
Cancel oldest: Cancel older (resting) order in full.
Continue to execute the newer taking order.
Cancel newest: Cancel newer (taking) order in full.
Let the old resting order remain on the order book.
Cancel both: Cancel both orders immediately.
For now, we have only implemented the behavior of canceling the oldest order.
However, we have reserved the self_matching_prevention option as a parameter
in case we need to implement other behaviors in the future.
This approach allows us to maintain backward compatibility
and provides us with the capability to extend functionality.

## Test Plan 

cd to deepbook dir and run "sui move test"

---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [X ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [X ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
Implemented Self-matching prevention through canceling the oldest order.
