### PR TITLE
[Faucet] Adding new API with old function call for fallback

### DIFF
--- a/crates/sui-faucet/src/faucet/mod.rs
+++ b/crates/sui-faucet/src/faucet/mod.rs
@@ -111,6 +111,9 @@ pub struct FaucetConfig {
 
     #[clap(long, default_value_t = 300)]
     pub ttl_expiration: u64,
+
+    #[clap(long, default_value_t = false)]
+    pub batch_enabled: bool,
 }
 
 impl Default for FaucetConfig {
@@ -128,6 +131,7 @@ impl Default for FaucetConfig {
             max_request_queue_length: 10000,
             batch_request_size: 500,
             ttl_expiration: 300,
+            batch_enabled: false,
         }
     }
 }

--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -1754,10 +1754,7 @@ mod tests {
         let amounts = vec![1, 2, 3];
         let uuid_test = Uuid::new_v4();
 
-        faucet
-            .send(uuid_test.clone(), recipient, &amounts)
-            .await
-            .unwrap();
+        faucet.send(uuid_test, recipient, &amounts).await.unwrap();
 
         let status = faucet.get_batch_send_status(uuid_test).await.unwrap();
         let mut actual_amounts: Vec<u64> = status

--- a/crates/sui-faucet/src/main.rs
+++ b/crates/sui-faucet/src/main.rs
@@ -92,7 +92,6 @@ async fn main() -> Result<(), anyhow::Error> {
         .route("/gas", post(request_gas))
         .route("/v1/gas", post(batch_request_gas))
         .route("/v1/status", post(request_status))
-        .route("/v1/gas_old", post(request_gas_v1_interface))
         .layer(
             ServiceBuilder::new()
                 .layer(HandleErrorLayer::new(handle_error))
@@ -136,45 +135,88 @@ async fn batch_request_gas(
     Extension(state): Extension<Arc<AppState>>,
     Json(payload): Json<FaucetRequest>,
 ) -> impl IntoResponse {
-    // ID for traceability
     let id = Uuid::new_v4();
+    // ID for traceability
     info!(uuid = ?id, "Got new gas request.");
-    let result = match payload {
-        FaucetRequest::FixedAmountRequest(requests) => {
-            // TODO: get ride of this task spawning since recycled coins are now handled by the batching task.
-            spawn_monitored_task!(async move {
-                state
-                    .faucet
-                    .batch_send(
-                        id,
-                        requests.recipient,
-                        &vec![state.config.amount; state.config.num_coins],
-                    )
-                    .await
-            })
-            .await
-            .unwrap()
+    if state.config.batch_enabled {
+        let result = match payload {
+            FaucetRequest::FixedAmountRequest(requests) => {
+                // TODO: get ride of this task spawning since recycled coins are now handled by the batching task.
+                spawn_monitored_task!(async move {
+                    state
+                        .faucet
+                        .batch_send(
+                            id,
+                            requests.recipient,
+                            &vec![state.config.amount; state.config.num_coins],
+                        )
+                        .await
+                })
+                .await
+                .unwrap()
+            }
+            _ => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(BatchFaucetResponse::from(FaucetError::Internal(
+                        "Input Error.".to_string(),
+                    ))),
+                )
+            }
+        };
+        match result {
+            Ok(v) => {
+                info!(uuid =?id, "Request is successfully served");
+                (StatusCode::ACCEPTED, Json(BatchFaucetResponse::from(v)))
+            }
+            Err(v) => {
+                warn!(uuid =?id, "Failed to request gas: {:?}", v);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(BatchFaucetResponse::from(v)),
+                )
+            }
         }
-        _ => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(BatchFaucetResponse::from(FaucetError::Internal(
-                    "Input Error.".to_string(),
-                ))),
-            )
-        }
-    };
-    match result {
-        Ok(v) => {
-            info!(uuid =?id, "Request is successfully served");
-            (StatusCode::ACCEPTED, Json(BatchFaucetResponse::from(v)))
-        }
-        Err(v) => {
-            warn!(uuid =?id, "Failed to request gas: {:?}", v);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(BatchFaucetResponse::from(v)),
-            )
+    } else {
+        // TODO (jian): remove this feature gate when batch has proven to be baked long enough
+        let result = match payload {
+            FaucetRequest::FixedAmountRequest(requests) => {
+                // We spawn a tokio task for this such that connection drop will not interrupt
+                // it and impact the recycling of coins
+                spawn_monitored_task!(async move {
+                    state
+                        .faucet
+                        .send(
+                            id,
+                            requests.recipient,
+                            &vec![state.config.amount; state.config.num_coins],
+                        )
+                        .await
+                })
+                .await
+                .unwrap()
+            }
+            _ => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(BatchFaucetResponse::from(FaucetError::Internal(
+                        "Input Error.".to_string(),
+                    ))),
+                )
+            }
+        };
+        match result {
+            Ok(_) => {
+                info!(uuid =?id, "Request is successfully served");
+                (StatusCode::CREATED, Json(BatchFaucetResponse::from(id)))
+            }
+            Err(v) => {
+                warn!(uuid =?id, "Failed to request gas: {:?}", v);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(BatchFaucetResponse::from(v)),
+                )
+            }
         }
     }
 }
@@ -261,55 +303,6 @@ async fn request_gas(
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(FaucetResponse::from(v)),
-            )
-        }
-    }
-}
-
-/// This function takes the old gas API and has a response that matches the new batch API interface.
-async fn request_gas_v1_interface(
-    Extension(state): Extension<Arc<AppState>>,
-    Json(payload): Json<FaucetRequest>,
-) -> impl IntoResponse {
-    // ID for traceability
-    let id = Uuid::new_v4();
-    info!(uuid = ?id, "Got new gas request.");
-    let result = match payload {
-        FaucetRequest::FixedAmountRequest(requests) => {
-            // We spawn a tokio task for this such that connection drop will not interrupt
-            // it and impact the recycling of coins
-            spawn_monitored_task!(async move {
-                state
-                    .faucet
-                    .send(
-                        id,
-                        requests.recipient,
-                        &vec![state.config.amount; state.config.num_coins],
-                    )
-                    .await
-            })
-            .await
-            .unwrap()
-        }
-        _ => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(BatchFaucetResponse::from(FaucetError::Internal(
-                    "Input Error.".to_string(),
-                ))),
-            )
-        }
-    };
-    match result {
-        Ok(_) => {
-            info!(uuid =?id, "Request is successfully served");
-            (StatusCode::CREATED, Json(BatchFaucetResponse::from(id)))
-        }
-        Err(v) => {
-            warn!(uuid =?id, "Failed to request gas: {:?}", v);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(BatchFaucetResponse::from(v)),
             )
         }
     }

--- a/crates/sui-faucet/src/main.rs
+++ b/crates/sui-faucet/src/main.rs
@@ -92,7 +92,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .route("/gas", post(request_gas))
         .route("/v1/gas", post(batch_request_gas))
         .route("/v1/status", post(request_status))
-        .route("/v1/gas_old", post(request_gas_V1_interface))
+        .route("/v1/gas_old", post(request_gas_v1_interface))
         .layer(
             ServiceBuilder::new()
                 .layer(HandleErrorLayer::new(handle_error))
@@ -267,7 +267,7 @@ async fn request_gas(
 }
 
 /// This function takes the old gas API and has a response that matches the new batch API interface.
-async fn request_gas_V1_interface(
+async fn request_gas_v1_interface(
     Extension(state): Extension<Arc<AppState>>,
     Json(payload): Json<FaucetRequest>,
 ) -> impl IntoResponse {

--- a/crates/sui-faucet/src/responses.rs
+++ b/crates/sui-faucet/src/responses.rs
@@ -3,6 +3,7 @@
 
 use crate::*;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -50,6 +51,15 @@ impl From<BatchFaucetReceipt> for BatchFaucetResponse {
     fn from(v: BatchFaucetReceipt) -> Self {
         Self {
             task: Some(v.task),
+            error: None,
+        }
+    }
+}
+
+impl From<Uuid> for BatchFaucetResponse {
+    fn from(v: Uuid) -> Self {
+        Self {
+            task: Some(v.to_string()),
             error: None,
         }
     }


### PR DESCRIPTION
## Description 

Addition of a feature flag to gate the batch api behavior

## Test Plan 

Unit testing to make sure the send UUID can be found.
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [x] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
