### PR TITLE
wallet-ext: fix showing confirmation modal when rejecting a transaction request

### DIFF
--- a/apps/wallet/src/ui/app/pages/approval-request/transaction-request/index.tsx
+++ b/apps/wallet/src/ui/app/pages/approval-request/transaction-request/index.tsx
@@ -60,7 +60,7 @@ export function TransactionRequest({ txRequest }: TransactionRequestProps) {
 					if (isLoading) {
 						return;
 					}
-					if (isError) {
+					if (approved && isError) {
 						setConfirmationVisible(true);
 						return;
 					}


### PR DESCRIPTION
## Description 

in transaction request view, don't show the confirmation modal when user rejects the transaction

Before

https://github.com/MystenLabs/sui/assets/10210143/3529df6a-2c72-4e74-95a8-3ad67a44497d

After

https://github.com/MystenLabs/sui/assets/10210143/e29bc9cb-c3b8-4719-9a3a-23db6386fdc3


closes APPS-1331

## Test Plan 

Manual testing
---
If your changes are not user-facing and not a breaking change, you can skip the following section. Otherwise, please indicate what changed, and then add to the Release Notes section as highlighted during the release process.

### Type of Change (Check all that apply)

- [ ] protocol change
- [ ] user-visible impact
- [ ] breaking change for a client SDKs
- [ ] breaking change for FNs (FN binary must upgrade)
- [ ] breaking change for validators or node operators (must upgrade binaries)
- [ ] breaking change for on-chain data layout
- [ ] necessitate either a data wipe or data migration

### Release notes
